### PR TITLE
style: apply ruff format to all Python files

### DIFF
--- a/audit_lemmatization.py
+++ b/audit_lemmatization.py
@@ -1,4 +1,5 @@
 """Audit lemmatization: find plurals, verb forms, and other inflections."""
+
 import csv
 from pathlib import Path
 
@@ -10,7 +11,11 @@ def find_inflected_forms():
     """Scan for likely inflected forms (plurals, verb forms)."""
     for lang in ["english", "german", "spanish"]:
         print(f"\n=== {lang.upper()} ===")
-        lemma_col = {"english": "English_Lemma", "german": "German_Lemma", "spanish": "Spanish_Lemma"}[lang]
+        lemma_col = {
+            "english": "English_Lemma",
+            "german": "German_Lemma",
+            "spanish": "Spanish_Lemma",
+        }[lang]
 
         all_lemmas = {}  # lemma_lower -> list of (level, row)
 
@@ -47,9 +52,12 @@ def find_inflected_forms():
             for form, ftype, base in candidates[:20]:
                 levels = [lv for lv, _ in all_lemmas[form]]
                 base_levels = [lv for lv, _ in all_lemmas[base]]
-                print(f"  {form:20} ({ftype:10}) → {base:15} | {form}: {levels}, {base}: {base_levels}")
+                print(
+                    f"  {form:20} ({ftype:10}) → {base:15} | {form}: {levels}, {base}: {base_levels}"
+                )
         else:
             print("No obvious inflected forms found")
+
 
 if __name__ == "__main__":
     find_inflected_forms()

--- a/check_quality.py
+++ b/check_quality.py
@@ -7,6 +7,7 @@ Run from repo root:
     python check_quality.py
     python check_quality.py english   # single language
 """
+
 from __future__ import annotations
 
 import csv
@@ -125,7 +126,9 @@ def check_language(lang: str) -> int:
 
         for trans, lemmas in intra_trans.items():
             if len(lemmas) > 1:
-                print(f"    {level}: '{trans}' shared by {len(lemmas)} lemmas: {', '.join(sorted(lemmas))}")
+                print(
+                    f"    {level}: '{trans}' shared by {len(lemmas)} lemmas: {', '.join(sorted(lemmas))}"
+                )
 
     return issues
 

--- a/cleanup_inflections.py
+++ b/cleanup_inflections.py
@@ -1,4 +1,5 @@
 """Remove obvious inflected forms, keeping lemmas."""
+
 import csv
 from pathlib import Path
 
@@ -13,7 +14,11 @@ TRANS_COLS = {
 
 def cleanup_language(lang):
     """Remove same-level plurals from a language (English only for now)."""
-    lemma_col = {"english": "English_Lemma", "german": "German_Lemma", "spanish": "Spanish_Lemma"}[lang]
+    lemma_col = {
+        "english": "English_Lemma",
+        "german": "German_Lemma",
+        "spanish": "Spanish_Lemma",
+    }[lang]
 
     total_removed = 0
     for level in LEVELS:
@@ -33,7 +38,11 @@ def cleanup_language(lang):
                 skip = False
                 if lemma_lower.endswith("s") and not lemma_lower.endswith("ss"):
                     singular = lemma_lower[:-1]
-                    if singular in lemmas_in_level and len(singular) > 2 and singular != lemma_lower:
+                    if (
+                        singular in lemmas_in_level
+                        and len(singular) > 2
+                        and singular != lemma_lower
+                    ):
                         skip = True
                         removed_here += 1
 
@@ -47,7 +56,9 @@ def cleanup_language(lang):
                     writer.writeheader()
                     kept_sorted = sorted(kept, key=lambda r: r[lemma_col].lower())
                     writer.writerows(kept_sorted)
-                print(f"{lang}/{level}: removed {removed_here} plural forms ({len(kept)} rows remain)")
+                print(
+                    f"{lang}/{level}: removed {removed_here} plural forms ({len(kept)} rows remain)"
+                )
                 total_removed += removed_here
 
     return total_removed
@@ -59,4 +70,5 @@ if __name__ == "__main__":
     print(f"Total removed: {total}")
     print("\nRunning quality check...")
     import check_quality
+
     check_quality.main(["check_quality.py", "english"])

--- a/vocab_manager.py
+++ b/vocab_manager.py
@@ -11,6 +11,7 @@ Examples:
     python vocab_manager.py update german Haus --t1 house --t2 casa
     python vocab_manager.py lookup english cat   # search across all langs
 """
+
 from __future__ import annotations
 
 import argparse
@@ -63,13 +64,15 @@ def find(lang: str, lemma: str) -> list[str]:
     cfg = LANGS[lang]
     needle = lemma.lower()
     return [
-        level for level in LEVELS
+        level
+        for level in LEVELS
         if any(r[cfg["lemma_col"]].lower() == needle for r in read_level(lang, level))
     ]
 
 
 def cmd_lint(_: argparse.Namespace) -> int:
     import check_quality  # reuse logic
+
     return check_quality.main(["check_quality.py", *LANGS])
 
 
@@ -102,11 +105,13 @@ def cmd_add(args: argparse.Namespace) -> int:
         print(f"'{lemma}' already in {args.lang}: {existing}")
         return 1
     rows = read_level(args.lang, args.level)
-    rows.append({
-        cfg["lemma_col"]: lemma,
-        cfg["trans_cols"][0]: t1,
-        cfg["trans_cols"][1]: t2,
-    })
+    rows.append(
+        {
+            cfg["lemma_col"]: lemma,
+            cfg["trans_cols"][0]: t1,
+            cfg["trans_cols"][1]: t2,
+        }
+    )
     write_level(args.lang, args.level, rows)
     print(f"Added '{lemma}' to {args.lang}/{args.level}")
     return 0
@@ -215,7 +220,9 @@ def cmd_lookup(args: argparse.Namespace) -> int:
         return 1
     for lang, level, row in hits:
         cols = LANGS[lang]
-        print(f"  {lang}/{level}: {row[cols['lemma_col']]} | {row[cols['trans_cols'][0]]} | {row[cols['trans_cols'][1]]}")
+        print(
+            f"  {lang}/{level}: {row[cols['lemma_col']]} | {row[cols['trans_cols'][0]]} | {row[cols['trans_cols'][1]]}"
+        )
     return 0
 
 


### PR DESCRIPTION
## Summary
- Applied `ruff format` to all 4 Python files (audit_lemmatization.py, check_quality.py, cleanup_inflections.py, vocab_manager.py)
- No logic changes — formatting only (line breaks, string quotes, trailing commas)
- All checks pass: `ruff check`, `ruff format --check`, `pyright` (0 errors)