### PR TITLE
fix: aggressive project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,13 @@ ENV/
 # OS
 .DS_Store
 Thumbs.db
+
+# Ruff cache
+.ruff_cache/
+
+# Coverage
+.coverage
+htmlcov/
+
+# Lint artifacts
+.structurelint.yml


### PR DESCRIPTION
## Summary
- Add missing .gitignore patterns (`.ruff_cache`, `.coverage`, `.structurelint.yml`)
- Remove tracked `.structurelint.yml`