### PR TITLE
docs: add architecture ADRs and superpowers specs

### DIFF
--- a/docs/architecture/ADR-001-csv-vocabulary-database.md
+++ b/docs/architecture/ADR-001-csv-vocabulary-database.md
@@ -1,0 +1,20 @@
+# ADR-001: CSV-Based Vocabulary Database
+
+**Status:** Accepted
+
+**Context:** The project manages trilingual vocabulary data organized by CEFR levels (A1-C1). The data must be human-readable, version-controllable, and editable without specialized tooling. A full database engine would be over-engineered for 15 files with ~24,000 entries.
+
+**Decision:** Store vocabulary data as CSV files — one file per language per CEFR level (15 files total: 3 languages × 5 levels). Each CSV has a lemma column and two translation columns. Files are sorted alphabetically by lemma. No database engine or ORM.
+
+**Consequences:**
+- Positive: Fully human-readable with any text editor or spreadsheet
+- Positive: Git-tracked with readable diffs per row
+- Positive: Zero infrastructure (no DB server, no schema migrations)
+- Negative: No referential integrity (orphaned translations, inconsistent casing)
+- Negative: No atomic writes (CSV corruption on failed write)
+- Negative: Concurrent edits unsafe (no transaction isolation)
+
+**Alternatives:**
+- SQLite: Schema enforcement but requires SQL knowledge to edit
+- JSON: Less human-editable in spreadsheets
+- YAML: Verbose for 24,000 entries

--- a/docs/architecture/ADR-002-cli-manager-architecture.md
+++ b/docs/architecture/ADR-002-cli-manager-architecture.md
@@ -1,0 +1,18 @@
+# ADR-002: CLI Manager Architecture
+
+**Status:** Accepted
+
+**Context:** Users need to add, remove, move, update, find, and lookup vocabulary entries across all language files. The CLI must be scriptable and support batch operations.
+
+**Decision:** Implement `vocab_manager.py` with `argparse` subcommands: `add`, `remove`, `move`, `update`, `find`, `lookup`, `lint`. Each subcommand is a standalone function returning an exit code. The main function dispatches to the correct handler. File operations use `csv.DictReader`/`csv.DictWriter` for schema-aware I/O.
+
+**Consequences:**
+- Positive: Each operation is a pure function of its inputs
+- Positive: Easy to add new subcommands without restructuring
+- Positive: Standard argparse means built-in --help for all commands
+- Negative: No transaction safety (mid-write failure corrupts CSV)
+- Negative: Input validation is manual and incomplete
+
+**Alternatives:**
+- GUI application: Better UX but harder to script, more dependencies
+- Database migration pattern: Over-engineered for CSV management

--- a/docs/architecture/ADR-003-three-language-schema.md
+++ b/docs/architecture/ADR-003-three-language-schema.md
@@ -1,0 +1,17 @@
+# ADR-003: Three-Language Schema Design
+
+**Status:** Accepted
+
+**Context:** The database covers English, German, and Spanish. Each language has a lemma column and two translation columns pointing to the other two languages. The schema must handle asymmetric column naming (German nouns are capitalized, English/Spanish are not).
+
+**Decision:** Each language directory uses a different column naming convention: `English_Lemma`, `German_Translation`, etc. The `LANGS` dict in both `vocab_manager.py` and `check_quality.py` maps each language to its lemma column and translation column names. Translations are directional (German entry has English_Translation and Spanish_Translation).
+
+**Consequences:**
+- Positive: Columns are self-describing (visible without schema lookup)
+- Positive: Each file has exactly 3 columns — simple to parse and validate
+- Negative: Translation reciprocity is not enforced (if English "dog" says German "Hund", German might not have "Hund" → English "dog")
+- Negative: Column names differ between languages, adding complexity to generic code
+
+**Alternatives:**
+- Unified schema (lemma, lang, translation1, translation2): Loses language-specific column names
+- Separate translation mapping table: Over-engineered for CSV

--- a/docs/architecture/ADR-004-quality-validation.md
+++ b/docs/architecture/ADR-004-quality-validation.md
@@ -1,0 +1,17 @@
+# ADR-004: Quality Validation Tooling
+
+**Status:** Accepted
+
+**Context:** With 24,000 manually curated vocabulary entries, data quality issues are inevitable. Duplicate lemmas, missing translations, special characters, and inflected forms (plurals, verb conjugations) degrade database quality. Automated validation is needed.
+
+**Decision:** `check_quality.py` validates all CSV files checking: header correctness, row counts vs CEFR targets, empty lemmas, multi-word lemmas, digits/special chars in lemmas, intra-level and cross-level duplicates, missing translations, whitespace issues, and shared translations. Additional scripts (`audit_lemmatization.py`, `cleanup_inflections.py`, `check_quality.py`) handle data-specific quality tasks.
+
+**Consequences:**
+- Positive: Catches structural issues before they compound
+- Positive: Clear error reporting with file and line numbers
+- Negative: Does not validate translation plausibility (e.g., correct word in wrong language)
+- Negative: Target row counts (±5% tolerance) may mask level mismatches
+
+**Alternatives:**
+- Manual review: Impractical at 24,000 entries
+- Machine translation verification: Would add ML dependency

--- a/docs/architecture/ADR-005-cefr-level-system.md
+++ b/docs/architecture/ADR-005-cefr-level-system.md
@@ -1,0 +1,17 @@
+# ADR-005: CEFR Level System
+
+**Status:** Accepted
+
+**Context:** Vocabulary is organized by CEFR levels (A1, A2, B1, B2, C1). Each level has a target word count based on CEFR guidelines: A1=600, A2=600, B1=1000, B2=2000, C1=4000. Levels must be consistent across all three languages.
+
+**Decision:** Five fixed levels with per-language CSV files and target counts. The validation tool (`check_quality.py`) checks each level's row count against targets with 5% tolerance. The `move` subcommand transfers entries between levels. No sub-levels or custom levels.
+
+**Consequences:**
+- Positive: Simple, standardized level system matches CEFR specifications
+- Positive: Level targets provide clear completion criteria
+- Negative: 5% tolerance may drift over time
+- Negative: Entries at wrong level are hard to detect automatically (requires semantic understanding)
+
+**Alternatives:**
+- Frequency-based levels: More accurate but harder to define and validate
+- Dynamic level assignment: Requires ML or corpus analysis

--- a/docs/superpowers/specs/vocab-levels-design.md
+++ b/docs/superpowers/specs/vocab-levels-design.md
@@ -1,0 +1,56 @@
+# VocabLevels — Trilingual CEFR Vocabulary Manager
+
+## Overview
+
+A CLI tool and CSV database for managing trilingual (English, German, Spanish) vocabulary organized by CEFR proficiency levels (A1-C1). Provides CRUD operations, quality validation, and cross-language lookup.
+
+## Key Decisions
+
+| Decision | Choice |
+|----------|--------|
+| Data format | CSV (one file per language/level) |
+| Schema | Lemma + 2 translations (per language) |
+| Levels | A1(600), A2(600), B1(1000), B2(2000), C1(4000) |
+| CLI framework | argparse subcommands |
+| Validation | Standalone check_quality.py |
+| Package manager | uv |
+
+## Directory Structure
+
+```
+VocabLevels/
+├── english/               # A1.csv, A2.csv, B1.csv, B2.csv, C1.csv
+│   └── *.csv              # Columns: English_Lemma, German_Translation, Spanish_Translation
+├── german/                # A1.csv, A2.csv, B1.csv, B2.csv, C1.csv
+│   └── *.csv              # Columns: German_Lemma, English_Translation, Spanish_Translation
+├── spanish/               # A1.csv, A2.csv, B1.csv, B2.csv, C1.csv
+│   └── *.csv              # Columns: Spanish_Lemma, English_Translation, German_Translation
+├── vocab_manager.py       # CLI: add, remove, move, update, find, lookup, lint
+├── check_quality.py       # Structural validation
+├── audit_lemmatization.py # Inflected form detection
+└── cleanup_inflections.py # Remove/merge inflected forms
+```
+
+## CLI Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| add | Add lemma with translations | `add german A1 Haus house casa` |
+| remove | Remove lemma from all levels | `remove german Haus` |
+| move | Move lemma to different level | `move german A2 Haus` |
+| update | Update translations or rename | `update german Haus --t1 house` |
+| find | Find lemma in a language | `find german Haus` |
+| lookup | Search across all languages | `lookup house` |
+| lint | Run quality checks | `lint` |
+
+## Data Flow
+
+```
+User Input → vocab_manager.py → CSV Read/Write → File System
+                  │
+                  ├── add: read level → append → sort → write
+                  ├── remove: read all levels → filter → write
+                  ├── move: find → remove from source → add to target
+                  ├── update: find in levels → modify fields → write
+                  └── lint: check_quality.py per language
+```


### PR DESCRIPTION
Add docs/architecture/ (ADR-001 through ADR-005) and docs/superpowers/specs/ covering CSV vocabulary database, CLI manager architecture, three-language schema, quality validation, and CEFR level system.