### PR TITLE
docs: fix README — scripts are standalone, no pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,15 @@ VocabLevels/
 ## Usage
 
 ```bash
-# Install dependencies
-uv sync
-
-# Run quality check
-uv run check_quality.py [lang]
+# Run quality check (standalone scripts, no uv sync needed)
+python check_quality.py [lang]
 
 # Manage vocabulary
-uv run vocab_manager.py find [lang] [query]
-uv run vocab_manager.py add [lang] [level] [lemma] [translation]
-uv run vocab_manager.py remove [lang] [level] [lemma]
-uv run vocab_manager.py move [lang] [from_level] [to_level] [lemma]
-uv run vocab_manager.py update [lang] [level] [lemma] --rename [new] --translation [new]
+python vocab_manager.py find [lang] [query]
+python vocab_manager.py add [lang] [level] [lemma] [translation]
+python vocab_manager.py remove [lang] [level] [lemma]
+python vocab_manager.py move [lang] [from_level] [to_level] [lemma]
+python vocab_manager.py update [lang] [level] [lemma] --rename [new] --translation [new]
 ```
 
 ## Quality Gates


### PR DESCRIPTION
Removed uv sync/uv run. No pyproject.toml exists — scripts run directly with python.