### PR TITLE
fix(docs): correct CLI arg names, add missing commands, fix CI claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Trilingual CEFR vocabulary database for English, German, and Spanish.
 
 ```
 VocabLevels/
-├── english/   A1-C1 CSV files
-├── german/    A1-C1 CSV files
-├── spanish/   A1-C1 CSV files
+├── english/   A1-C1 CSV files + frequency reference TSV
+├── german/    A1-C1 CSV files + frequency reference TSV
+├── spanish/   A1-C1 CSV files + frequency reference TSV
 ├── vocab_manager.py    CLI tool for managing entries
 ├── check_quality.py    Quality validation
 ├── audit_lemmatization.py
@@ -24,11 +24,13 @@ VocabLevels/
 python check_quality.py [lang]
 
 # Manage vocabulary
-python vocab_manager.py find [lang] [query]
-python vocab_manager.py add [lang] [level] [lemma] [translation]
-python vocab_manager.py remove [lang] [level] [lemma]
-python vocab_manager.py move [lang] [from_level] [to_level] [lemma]
-python vocab_manager.py update [lang] [level] [lemma] --rename [new] --translation [new]
+python vocab_manager.py lint                              # run quality checks across all languages
+python vocab_manager.py find [lang] [lemma]              # find lemma in a specific language
+python vocab_manager.py add [lang] [level] [lemma] [t1] [t2]  # add entry (t1/t2 = translations)
+python vocab_manager.py remove [lang] [lemma]            # remove from all levels
+python vocab_manager.py move [lang] [target_level] [lemma]    # move to target level (auto-detects source)
+python vocab_manager.py update [lang] [lemma] [--t1 X] [--t2 Y] [--rename X]  # update fields
+python vocab_manager.py lookup [term]                    # search across all languages
 ```
 
 ## Quality Gates

--- a/docs/architecture/ADR-004-quality-validation.md
+++ b/docs/architecture/ADR-004-quality-validation.md
@@ -19,7 +19,7 @@ checksum: 9a5131494b6697a82c0999f0d8fbac16ca9d89393fb6f2d45321c6beb10a38ee
 
 **Context:** With 24,000 manually curated vocabulary entries, data quality issues are inevitable. Duplicate lemmas, missing translations, special characters, and inflected forms (plurals, verb conjugations) degrade database quality. Automated validation is needed.
 
-**Decision:** `check_quality.py` validates all CSV files checking: header correctness, row counts vs CEFR targets, empty lemmas, multi-word lemmas, digits/special chars in lemmas, intra-level and cross-level duplicates, missing translations, whitespace issues, and shared translations. Additional scripts (`audit_lemmatization.py`, `cleanup_inflections.py`, `check_quality.py`) handle data-specific quality tasks.
+**Decision:** `check_quality.py` validates all CSV files checking: header correctness, row counts vs CEFR targets, empty lemmas, multi-word lemmas, digits/special chars in lemmas, intra-level and cross-level duplicates, missing translations, whitespace issues, and shared translations. Additional scripts (`audit_lemmatization.py`, `cleanup_inflections.py`) handle data-specific quality tasks such as inflected form detection and cleanup.
 
 **Consequences:**
 - Positive: Catches structural issues before they compound

--- a/docs/technical-due-diligence.md
+++ b/docs/technical-due-diligence.md
@@ -44,7 +44,7 @@ Trilingual vocabulary data stored in 15 CSV files (3 languages x 5 levels) with 
 
 ## Code Quality
 
-No formal test suite exists. Code quality relies on ruff linting and pyright type checking, documented in AGENTS.md but not automated in CI. The CLI tool has clean argument parsing, proper exit codes, and modular command handlers. `check_quality.py` validates 10+ criteria including structure, row counts within 5% of target, duplicates, whitespace, special characters, and translation collisions. The `LANGS` configuration dictionary is duplicated across 3 files -- any schema change requires updating all copies. No pyproject.toml exists despite using uv.
+No formal test suite exists. Code quality relies on ruff linting and pyright type checking, documented in AGENTS.md but not automated in CI. The CLI tool has clean argument parsing, proper exit codes, and modular command handlers. `check_quality.py` validates 10+ criteria including structure, row counts within 5% of target, duplicates, whitespace, special characters, and translation collisions. The `LANGS` configuration dictionary is duplicated across 4 files (vocab_manager.py, check_quality.py, audit_lemmatization.py, cleanup_inflections.py) in varying forms -- any schema change requires updating all copies. No pyproject.toml exists despite using uv.
 
 ## Security
 
@@ -56,7 +56,7 @@ The data set is ~24K CSV rows across 15 files. The CLI's O(n) search over CSV fi
 
 ## Operations & DevOps
 
-No CI/CD pipeline exists. CodeRabbit is configured for AI PR review with excellent language-specific instructions for each CSV file. Quality gates (ruff check, ruff format, pyright) are documented in AGENTS.md but must be run manually. No GitHub Actions workflows are configured. No Dependabot.
+A SonarCloud GitHub Actions workflow (`.github/workflows/sonarcloud.yml`) runs on push/PR to main, providing static analysis. CodeRabbit is configured for AI PR review with excellent language-specific instructions for each CSV file. Quality gates (ruff check, ruff format, pyright) are documented in AGENTS.md but must be run manually — no CI workflow enforces them. No Dependabot.
 
 ## Dependencies & Third-Party Risk
 

--- a/docs/technical-due-diligence.md
+++ b/docs/technical-due-diligence.md
@@ -22,7 +22,7 @@ checksum: ac3a6189804fbd794d8edabcde24874ff957bea696fd3a0cd390ecee936ccc58
 
 ## Executive Summary
 
-VocabLevels is a trilingual CEFR vocabulary database containing approximately 24K entries across 15 CSV files (English, German, Spanish, levels A1-C1) managed by a 279-line Python CLI. Zero external dependencies, CodeRabbit configured for CSV-aware PR review, and ruff/pyright quality scripts are strengths. But the project has zero test files, no CI/CD pipeline, no pyproject.toml despite using uv, and duplicated configuration across three scripts. Data integrity relies entirely on `check_quality.py` rather than a formal test suite. Risk is low because the project has no network, auth, or user-input attack surface.
+VocabLevels is a trilingual CEFR vocabulary database containing approximately 24K entries across 15 CSV files (English, German, Spanish, levels A1-C1) managed by a 279-line Python CLI. Zero external dependencies, CodeRabbit configured for CSV-aware PR review, and ruff/pyright quality scripts are strengths. But the project has zero test files, no CI/CD pipeline for quality gates (SonarCloud static analysis configured), no pyproject.toml despite using uv, and duplicated configuration across four scripts. Data integrity relies entirely on `check_quality.py` rather than a formal test suite. Risk is low because the project has no network, auth, or user-input attack surface.
 
 ## Scope
 
@@ -68,7 +68,7 @@ Zero external runtime dependencies -- stdlib only. No supply chain risk. ruff an
 |------|-----------|--------|------------|
 | Zero tests -- no regression protection for CLI commands | High | Medium | Add pytest smoke tests for all 7 CLI commands |
 | No CI/CD -- quality gates are manual-only | High | Medium | Add GitHub Actions workflow for ruff + pyright + smoke tests |
-| Duplicate LANGS config in 3 files -- schema changes require 3 edits | High | Low | Extract to shared module (vocab_config.py) |
+| Duplicate LANGS config in 4 files -- schema changes require 4 edits | High | Low | Extract to shared module (vocab_config.py) |
 | No pyproject.toml -- uv lacks project metadata and tool config | High | Low | Create pyproject.toml with ruff/pyright config |
 | CSV write corruption -- no backup or transaction mechanism | Medium | Medium | Add atomic write pattern (write to temp, rename) |
 | CSV injection -- formulas starting with = or + not validated | Low | Low | Add validation for formula-like cell content |


### PR DESCRIPTION
## Summary

Documentation accuracy fixes from audit — CLI usage, directory structure, and CI/DevOps sections now match actual codebase.

## Changes

- **README CLI section**: Fix `find` arg `[query]` → `[lemma]`; fix `move` — remove non-existent `from_level` arg (auto-detects source); fix `update` — `--translation` → `--t1`/`--t2`; add missing `lint` and `lookup` commands
- **README directory structure**: Add frequency reference TSVs per language
- **ADR-004**: Remove redundant `check_quality.py` reference from additional scripts list (it's the primary validator, not an additional one)
- **technical-due-diligence**: Fix CI claims — SonarCloud workflow exists; correct LANGS duplication count (3→4 files)