### PR TITLE
fix(sonar): use lowercase org key

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.projectKey=Jonathangadeaharder_VocabLevels
-sonar.organization=Jonathangadeaharder
+sonar.organization=jonathangadeaharder
 sonar.host.url=https://sonarcloud.io
 sonar.sources=.
 


### PR DESCRIPTION
SonarCloud scan fails with 'Organization key Jonathangadeaharder does not exist'. The org key on sonarcloud.io is lowercase 'jonathangadeaharder'. Pre-existing infra issue, not a code change.