### PR TITLE
feat(vocab): add Moroccan Arabic A1 vocabulary

### DIFF
--- a/arabic/A1.csv
+++ b/arabic/A1.csv
@@ -1,0 +1,601 @@
+Arabic_Lemma,English_Translation,Spanish_Translation
+آخر,last,último
+آه,yes,sí
+أتاي,tea,té
+أجنبي,foreigner,extranjero
+ألف,thousand,mil
+أمير,prince,príncipe
+أنا,I,yo
+أوطيل,hotel,hotel
+أول,first,primero
+إمتا,when,cuándo
+إييه,yes,sí
+اتاي,tea (traditional),té (tradicional)
+اخضر,raw/unripe,crudo/inmaduro
+باب,door,puerta
+بابا,father,padre
+بابور,ship/boat,barco
+بارد,cold,frío
+باش,with what,con qué
+باصبور,passport,pasaporte
+باطل,falsehood/void,falsedad/nulo
+باع,sell/sold,vender/vendió
+بحار,sailor/fisherman,marinero/pescador
+بحر,sea,mar
+بحرية,beach,playa
+بدا,start/begin/started,empezar/comenzar/empezó
+برا,outside,fuera
+براد,teapot,tetera
+برد,wind/cold,viento/frío
+برق,lightning,relámpago
+بزاف,very/a lot,mucho/muy
+بزناس,dealer/drug dealer,camello/traficante
+بسلامة,goodbye,adiós
+بصلة,onion,cebolla
+بطاطا,potato,patata
+بطاقة,card/ID,tarjeta
+بطل,hero/champion,héroe/campeón
+بعد,after,después
+بعيد,far/distant,lejos/distante
+بغا,want/wanted,querer/quiso
+بغرير,baghrir (pancakes),baghrir (panqueques)
+بغل,mule,mula
+بقرة,cow,vaca
+بقى,stay/remain/stayed,quedarse/permanecer/quedó
+بكري,early,temprano
+بكى,cry/cried,llorar/lloró
+بكي,cry/weep/cried,llorar/lloró
+بلاد,country/land,país
+بلغية,slippers (traditional leather),babuchas
+بنان,bananas,plátanos
+بناي,builder/mason,albañil
+بنت,girl/daughter,niña/hija
+بنفسجي,purple,morado
+بنكة,bank,banco
+بنين,delicious/tasty,delicioso/sabroso
+بوسطة,post office,oficina de correos
+بولة,lightbulb,bombilla
+بوليس,police,policía
+بوليسي,policeman,policía
+بيبي,baby/turkey,bebé/pavo
+بيت,room,habitación
+بيض,white,blanco
+بيكالة,bicycle,bicicleta
+بين,between,entre
+تأشيرة,visa,visado/visa
+تاني,second/again,segundo/otra vez
+تحت,under,debajo
+تذكرة,ticket,billete/boleto
+تراب,dirt/soil,tierra/suelo
+تران,train,tren
+تريكو,sweater/knitwear,suéter
+تسعطاش,nineteen,diecinueve
+تسعود,nine,nueve
+تسعين,ninety,noventa
+تفاح,apples,manzanas
+تفتيش,inspection/search,inspección/registro
+تفكر,remember/remembered,recordar/recordó
+تقاشر,socks,calcetines
+تقيل,slow/heavy,lento/pesado
+تلاتة,three,tres
+تلاتين,thirty,treinta
+تلتناش,thirteen,trece
+تلفزة,television,televisión
+تلميذ,student/pupil,alumno/estudiante
+تليفون,phone,teléfono
+تمانية,eight,ocho
+تمانين,eighty,ochenta
+تمشى,walk/walked,caminar/caminó
+تمنطاش,eighteen,dieciocho
+تناش,twelve,doce
+تيران,playground/field,campo de deportes
+ثانية,second,segundo
+ثعلب,fox,zorro
+ثلاجة,refrigerator,refrigerador
+ثلج,snow/ice,nieve/hielo
+ثومة,garlic,ajo
+جا,come/came,venir/vino
+جاب,bring/brought,traer/trajo
+جار,neighbor,vecino
+جامع,mosque,mezquita
+جاوب,answer/answered,responder/respondió
+جبل,mountain,montaña
+جد,grandfather,abuelo
+جدة,grandmother,abuela
+جديد,new,nuevo
+جر,pull/drag/pulled,tirar/jalar/jaló
+جرح,injure/wound/injured,herir/lastimar/hirió
+جرى,run/ran,correr/corrió
+جزار,butcher,carnicero
+جفاف,mop,fregona
+جفف,mop/mopped,fregar/trapear/fregó
+جلابة,djellaba (traditional garment),chilaba
+جلبانة,peas,guisantes
+جلد,skin,piel
+جلس,sit/sat,sentarse/sentó
+جمارك,customs,aduana
+جمع,collect/gather/collected,recoger/reunir/recogió
+جمل,camel,camello
+جنان,garden/orchard,jardín/huerto
+جوج,two,dos
+جيب,pocket,bolsillo
+حار,spicy/hot,picante
+حارس,guard/guardian,guardia/vigilante
+حامض,sour/acidic,ácido/limón
+حانوت,shop/store,tienda
+حبس,prison/jail,cárcel/prisión
+حجبان,eyebrows,cejas
+حجرة,stone/rock,piedra
+حدش,eleven,once
+حدود,borders,fronteras
+حدودية,border point,punto fronterizo
+حديقة,park/garden,parque
+حر,free/pure,libre/puro
+حرب,war,guerra
+حرق,burn/burned,quemar/quemó
+حريرة,soup (traditional),sopa (tradicional)
+حزن,be sad/was sad,entristecerse/entristeció
+حس,feel/felt,sentir/sintió
+حسق,fart/farted,pedorrear/tiró un pedo
+حط,put/place/put/placed,poner/colocar/puso
+حفرة,hole,hoyo
+حق,right/truth,derecho/verdad
+حقيبة,suitcase/bag,maleta/bolso
+حكومة,government,gobierno
+حل,open/opened,abrir/abrió
+حلم,dream/dreamed,soñar/soñó
+حلو,sweet,dulce
+حلوف,pig/boar,cerdo/jabalí
+حلوى,sweets/cake,dulces/pastel
+حليب,milk,leche
+حمار,donkey,burro
+حمامة,pigeon/dove,paloma
+حمر,red,rojo
+حنا,we,nosotros
+حنش,snake,serpiente
+حوت,fish,pescado
+حوتة,fish (individual),pez
+خاتم,ring (jewelry),anillo
+خاف,fear/feared,temer/temió
+خال,uncle (maternal),tío (maternal)
+خالة,aunt (maternal),tía (maternal)
+خامر,fermented/risen,fermentado
+خاوي,empty,vacío
+خايب,bad,mal/malo
+خباز,baker,panadero
+خبز,bread,pan
+خت,sister,hermana
+ختي,my sister,mi hermana
+خدا,take/took,tomar/llevar/tomó
+خدار,grocer/greengrocer,verdulero
+خدم,work/worked,trabajar/trabajó
+خرج,exit/exited,salir/salió
+خروف,sheep,oveja
+خسر,lose/waste/lost,perder/perdió
+خضر,green,verde
+خضرة,vegetables,verduras
+خفيف,light (weight),ligero (peso)
+خلى,leave/let/left,dejar/permitir/dejó
+خمسة,five,cinco
+خمسطاش,fifteen,quince
+خمسين,fifty,cincuenta
+خو,brother,hermano
+خواف,cowardly/fearful,cobarde/miedoso
+خوخ,peaches,melocotones
+خويا,my brother,mi hermano
+خياط,tailor,sastre
+خيزو,carrot,zanahoria
+خيط,sew/sewed,coser/cosió
+دا,take away/took away,llevarse/se llevó
+دابا,now,ahora
+داخل,inside,dentro
+دار,house,casa
+داق,taste/tasted,probar/saborear/probó
+دبانة,fly (insect),mosca
+دجاج,chicken,pollo
+دجاجة,hen/chicken,gallina
+دخل,enter/entered,entrar/entró
+درهم,dirham (currency),dírham
+دري,child,chico/niño
+دغية,quickly,rápidamente
+دفع,push/pushed,empujar/empujó
+دقيقة,minute,minuto
+دلاح,watermelon,sandía
+دم,blood,sangre
+دوا,speak/talk/spoke,hablar/conversar/habló
+دوز,pass/spend time/passed,pasar/dedicar/pasó
+ديب,wolf,lobo
+ديسير,fruit,fruta
+ديما,always,siempre
+ذهبي,gold,dorado
+رئيس,president/boss,presidente/jefe
+راجل,man,hombre
+راس,head,cabeza
+ربح,win/earn/won,ganar/ganó
+ربعة,four,cuatro
+ربعتناش,fourteen,catorce
+ربعين,forty,cuarenta
+رجع,return/go back/returned,volver/regresar/regresó
+رجل,foot/leg,pie/pierna
+رحلة,journey/flight,viaje/vuelo
+رخيص,cheap,barato
+رسم,draw/paint/drew,dibujar/pintar/dibujó
+رطب,soft/smooth,suave/blando
+رعد,thunder,trueno
+رقيق,thin/slim,delgado/flaco
+ركب,ride/board/rode/boarded,montar/subirse/montó
+ركبة,knee,rodilla
+رمادي,gray,gris
+رملة,sand,arena
+روز,rice,arroz
+رية,lung,pulmón
+ريستورا,restaurant,restaurante
+زبدة,butter,mantequilla
+زربية,carpet/rug,alfombra
+زرق,blue,azul
+زنقة,street,calle
+زوين,beautiful/pretty,hermoso/bonito
+زيت,oil,aceite
+سائح,tourist,turista
+ساروت,key,llave
+ساعة,hour,hora
+ساعةيد,wristwatch,reloj de pulsera
+ساهل,easy,fácil
+سبع,lion,león
+سبعة,seven,siete
+سبعطاش,seventeen,diecisiete
+سبعين,seventy,setenta
+سبيطار,hospital,hospital
+ستاش,sixteen,dieciséis
+ستة,six,seis
+ستيلو,pen,bolígrafo
+ستين,sixty,sesenta
+سحاب,clouds,nubes
+سخون,hot,caliente
+سد,close/closed,cerrar/cerró
+سروال,pants/trousers,pantalones
+سريع,fast/quick,rápido
+سطل,bucket,cubo
+سفارة,embassy,embajada
+سفر,travel/traveled,viajar/viajó
+سكت,be quiet/shut up/was quiet,callarse/calló
+سكتان,silent/quiet,silencioso/callado
+سكر,sugar,azúcar
+سلا,finish/end/finished,terminar/acabar/terminó
+سلاح,weapon/arms,arma
+سلام,hello,hola
+سلسلة,necklace/chain,collar
+سلم,peace,paz
+سما,sky,cielo
+سمحلي,excuse me,disculpe
+سمع,hear/heard,oír/escuchar/oyó
+سنان,teeth,dientes
+سنسلة,zipper/chain,cremallera/cadena
+سوق,market,mercado
+سول,ask/asked,preguntar/preguntó
+سياحة,tourism,turismo
+سيمانة,week,semana
+سينما,cinema,cine
+شاحن,charger,cargador
+شاطئ,shore/beach,playa
+شاف,see/saw,ver/vio
+شال,scarf/shawl,bufanda/chal
+شتا,rain/winter,lluvia/invierno
+شجاع,brave,valiente
+شجر,trees,árboles
+شحال,how much,cuánto
+شد,hold/catch/held/caught,sostener/atrapar/sostuvo
+شرا,buy/bought,comprar/compró
+شرب,drink/drank,beber/bebió
+شرجم,window,ventana
+شريبة,drink,bebida
+شطابة,broom,escoba
+شطب,sweep/swept,barrer/barrió
+شطح,dance/danced,bailar/bailó
+شعب,people/nation,pueblo/nación
+شعر,hair,pelo
+شعل,light up/turn on/lit,encender/prendió
+شفار,eyelashes,pestañas
+شكر,thank/thanked,agradecer/agradeció
+شكرا,thank you,gracias
+شكون,who,quién
+شلاظة,salad,ensalada
+شم,smell/smelled,oler/olió
+شمس,sun,sol
+شنو,what,qué
+شهر,month,mes
+شوية,a little,un poco
+شيباني,old (people),viejo (personas)
+شيفور,driver,conductor/chófer
+صابون,soap,jabón
+صاحب,friend (male),amigo
+صاحبة,friend (female),amiga
+صافي,enough/okay,suficiente/bien
+صاك,bag/handbag,bolso
+صباح,morning,mañana
+صباحالخير,good morning,buenos días
+صباط,shoes,zapatos
+صباغ,painter,pintor
+صبر,be patient/was patient,tener paciencia/esperó
+صبع,finger/toe,dedo
+صبغ,paint/dye/painted,pintar/teñir/pintó
+صبن,wash clothes/washed,lavar ropa/lavó
+صحيح,healthy/correct/strong,sano/correcto/fuerte
+صخرة,rock/cliff,roca
+صدر,chest,pecho
+صرف,change (money),cambio
+صعيب,difficult/hard,difícil/duro
+صغير,small/young,pequeño/joven
+صفر,yellow,amarillo
+صندالة,sandals,sandalias
+صهد,heat,calor
+صوفا,sofa,sofá
+صية,skirt,falda
+صيفط,send/sent,enviar/envió
+ضبابة,fog/mist,niebla
+ضحك,laugh/laughed,reír/rió
+ضعيف,weak/poor/thin,débil/pobre/delgado
+ضيف,guest,invitado
+ضيق,narrow/tight,estrecho/apretado
+طاب,be cooked/was cooked,cocerse/madurar/se cocinó
+طابلة,table,mesa
+طاجين,tagine,tajín
+طاح,fall/fell,caer/cayó
+طار,fly/flew,volar/voló
+طاقية,cap/hat,gorra/sombrero
+طاكسي,taxi,taxi
+طالب,university student,estudiante universitario
+طايب,cooked/ripe,cocido/maduro
+طباخ,cook/chef,cocinero/chef
+طبسيل,plate,plato
+طبيب,doctor/physician,médico/doctor
+طحن,grind/ground,moler/molió
+طري,fresh,fresco
+طريق,road/path,camino/carretera
+طفى,turn off/extinguish/extinguished,apagar/apagó
+طلب,request/ask/requested,pedir/solicitar/pidió
+طلع,ascend/go up/ascended,subir/ascender/subió
+طنجرة,pot,olla
+طواليت,bathroom,baño
+طومبيل,car,coche/automóvil
+طويل,long/tall,largo/alto
+طيارة,airplane,avión
+طيب,cook/cooked,cocinar/cocinó
+طير,bird,pájaro
+ظفر,nail,uña
+ظهر,back,espalda
+عائلة,family,familia
+عاش,live/lived,vivir/vivió
+عام,year,año
+عامر,full/crowded,lleno/repleto
+عاون,help/helped,ayudar/ayudó
+عجن,knead/kneaded,amasar/amasó
+عدل,justice/notary,justicia/notario
+عرف,know/knew,saber/conocer/supo
+عروبية,countryside,campo
+عريض,wide,ancho
+عسكر,army/military,ejército/militar
+عسل,honey,miel
+عشا,dinner,cena
+عشرة,ten,diez
+عشرين,twenty,veinte
+عشيب,grass/weeds,hierba
+عشية,afternoon/evening,tarde
+عصير,juice,zumo
+عطى,give/gave,dar/dio
+عظم,bone,hueso
+عفاك,please,por favor
+عقرب,scorpion,escorpión
+علاش,why,por qué
+علم,flag/science,bandera/ciencia
+عم,uncle (paternal),tío (paternal)
+عمة,aunt (paternal),tía (paternal)
+عنب,grapes,uvas
+عنق,neck,cuello
+عوج,crooked/bent,torcido/curvado
+عود,horse,caballo
+عيان,tired,cansado
+عيط,call/called,llamar/llamó
+عين,eye,ojo
+غابة,forest/woods,bosque
+غالي,expensive,caro/costoso
+غدا,tomorrow,mañana
+غداء,lunch,almuerzo
+غسل,wash/washed,lavar/lavó
+غطا,blanket,manta
+غليظ,fat/thick,gordo/grueso
+غنى,sing/sang,cantar/cantó
+غوت,shout/scream/shouted,gritar/gritó
+فار,mouse/rat,ratón
+فازڭ,wet/damp,mojado/húmedo
+فاق,wake up/woke up,despertar/despertó
+فايت,past/already,pasado/ya
+فران,oven,horno
+فرح,be happy/rejoice,alegrarse/alegró
+فرحان,happy,feliz/alegre
+فرشيطة,fork,tenedor
+فرماج,cheese,queso
+فرملي,nurse,enfermero
+فروج,rooster,gallo
+فريز,strawberries,fresas
+فريكو,freezer,congelador
+فطور,breakfast,desayuno
+فكر,think/thought/remember,pensar/recordar/pensó
+فلاح,farmer,agricultor
+فلوس,money,dinero
+فم,mouth,boca
+فهم,understand/understood,entender/entendió
+فوطة,towel,toalla
+فوق,above/on,encima/sobre
+فيستة,jacket,chaqueta
+فين,where,dónde
+قاس,touch/measure/touched,tocar/medir/tocó
+قاصح,hard/tough,duro/resistente
+قاضي,judge,juez
+قال,say/said,decir/dijo
+قانون,law/rule,ley/regla
+قبل,before,antes
+قدام,in front,delante
+قديم,old (objects),viejo (objetos)
+قرا,read/study/read,leer/estudiar/leyó
+قرد,monkey,mono
+قريب,near/close,cerca/cercano
+قصير,short,corto/bajo
+قطع,cut/sliced/cut,cortar/cortó
+قفطان,caftan (traditional dress),caftán
+قلب,heart,corazón
+قمر,moon,luna
+قميجة,shirt,camisa
+قنصلية,consulate,consulado
+قهوة,coffee,café
+قهوي,brown,marrón
+كاتب,writer/clerk,escritor/oficinista
+كاس,glass/cup,vaso/taza
+كب,pour/poured,verter/servir/vertió
+كبر,grow/grew,crecer/creció
+كبوط,coat/jacket,abrigo
+كبير,big/large,grande
+كتاب,book,libro
+كتب,write/wrote,escribir/escribió
+كتف,shoulder,hombro
+كحل,black,negro
+كرسي,chair,silla
+كرش,belly,barriga
+كسكس,couscous,cuscús
+كسوة,dress,vestido
+كلا,eat/ate,comer/comió
+كلب,dog,perro
+كوافير,barber/hairdresser,peluquero
+كورجيت,zucchini,calabacín
+كوزينة,kitchen,cocina
+كيران,buses,autobuses
+كيفاش,how,cómo
+لا,no,no
+لاباس,fine/how are you,bien/cómo estás
+لاجئ,refugee,refugiado
+لبارح,yesterday,ayer
+لحم,meat,carne
+لحية,beard,barba
+لسان,tongue,lengua
+لعب,play/played,jugar/jugó
+لقى,find/found,encontrar/encontró
+لمن,to whom,a quién
+لهيه,there,allí
+لوبية,beans,judías
+لور,behind,atrás
+ليل,night,noche
+ليمون,oranges,naranjas
+ليموني,orange (color),naranja
+ليوم,today,hoy
+ما,water,agua
+مات,die/died,morir/murió
+ماريو,closet/wardrobe,armario
+ماكلة,food/meal,comida
+مالح,salty,salado
+ماما,mother,madre
+مجهد,strong/loud,fuerte/ruidoso
+محامي,lawyer,abogado
+محطة,station/bus stop,estación/parada
+محفظة,wallet/schoolbag,cartera/mochila
+محكمة,court/courthouse,tribunal/juzgado
+محلول,open,abierto
+مخربق,messy/confused,desordenado/confuso
+مدرسة,school,escuela
+مدير,director/manager,director/gerente
+مدينة,city/town,ciudad
+مر,bitter,amargo
+مرا,woman,mujer
+مراية,mirror,espejo
+مرحبا,welcome,bienvenido
+مرضي,blessed/obedient,bendito/obediente
+مريض,sick/ill,enfermo
+مزال,still/yet,todavía/aún
+مزيان,good,bien/bueno
+مسخوط,cursed/disobedient,maldito/desobediente
+مسدود,closed/locked,cerrado
+مسمن,msemmen (flatbread),msemmen (pan plano)
+مسوس,unsalted/tasteless,desabrido/sin sal
+مش,cat,gato
+مشى,go/went,ir/fue
+مطار,airport,aeropuerto
+مطيشة,tomato,tomate
+مظل,umbrella,paraguas
+معزة,goat,cabra
+معطل,late,tarde
+معلقة,spoon,cuchara
+معلم,teacher/master,maestro/profesor
+مقاد,organized/straight,organizado/recto
+مقراج,kettle,hervidor
+مقرونية,pasta/macaroni,pasta/macarrones
+مقلة,frying pan,sartén
+مقلق,sad/worried/angry,triste/preocupado/enojado
+مكتب,office/desk,oficina/escritorio
+مكتبة,library/bookstore,biblioteca/librería
+مكينة,machine/engine,máquina
+ملحة,salt,sal
+ملك,king,rey
+مليون,million,millón
+مملوك,owned,poseído
+مناكش,earrings,pendientes
+مهندس,engineer,ingeniero
+مواطن,citizen,ciudadano
+موس,knife,cuchillo
+موسخ,dirty,sucio
+موطور,motorcycle,moto
+مية,hundred,cien
+ميكانيكي,mechanic,mecánico
+ميناء,port/harbor,puerto
+ناس,people,gente
+ناشف,dry,seco
+ناموسية,bed,cama
+نتا,you (masculine),tú (masculino)
+نتوما,you (plural),vosotros
+نتي,you (feminine),tú (femenino)
+نجار,carpenter,carpintero
+نجوم,stars,estrellas
+نحلة,bee,abeja
+نزل,descend/go down/descended,bajar/descender/bajó
+نسى,forget/forgot,olvidar/olvidó
+نشيد,anthem/song,himno/canto
+نظارات,glasses/spectacles,gafas
+نعس,sleep/slept,dormir/durmió
+نعم,yes,sí
+نقا,clean/peel/cleaned,limpiar/pelar/limpió
+نقي,clean/pure,limpio/puro
+نملة,ant,hormiga
+نهار,day,día
+نيشان,straight/direct,recto/directo
+نيف,nose,nariz
+هادو,these,estos
+هادي,this (feminine),esta
+هانية,fine/no problem,bien/no hay problema
+هداك,that (masculine),ese
+هدر,speak/spoke,hablar/habló
+هدوك,those,esos
+هديك,that (feminine),esa
+هذا,this (masculine),este
+هرب,run away/fled,escapar/huir/escapó
+هز,lift/carry/lifted/carried,levantar/llevar/levantó
+هما,they,ellos
+هنا,here,aquí
+هو,he,él
+هوا,air/wind,aire
+هي,she,ella
+واحد,one,uno
+واخا,okay,de acuerdo
+واد,river/valley,río/valle
+واسع,wide/spacious,ancho/espacioso
+واعر,cool/awesome/difficult,genial/excelente/difícil
+وجه,face,cara
+وذن,ear,oreja
+ورد,flowers/roses,flores/rosas
+وردي,pink,rosa
+ورق,leaves/paper,hojas/papel
+ورقة,paper,papel
+وزير,minister,ministro
+وسادة,pillow,almohada
+وقف,stand/stood,pararse/detenerse/paró
+ولد,boy/son,niño/hijo
+ولدعمي,cousin (paternal),primo (paternal)
+يد,hand/arm,mano/brazo
+يوم,day,día

--- a/audit_lemmatization.py
+++ b/audit_lemmatization.py
@@ -9,12 +9,13 @@ LEVELS = ["A1", "A2", "B1", "B2", "C1"]
 
 def find_inflected_forms():
     """Scan for likely inflected forms (plurals, verb forms)."""
-    for lang in ["english", "german", "spanish"]:
+    for lang in ["english", "german", "spanish", "arabic"]:
         print(f"\n=== {lang.upper()} ===")
         lemma_col = {
             "english": "English_Lemma",
             "german": "German_Lemma",
             "spanish": "Spanish_Lemma",
+            "arabic": "Arabic_Lemma",
         }[lang]
 
         all_lemmas = {}  # lemma_lower -> list of (level, row)

--- a/check_quality.py
+++ b/check_quality.py
@@ -32,6 +32,10 @@ LANGS = {
         "lemma_col": "Spanish_Lemma",
         "trans_cols": ("English_Translation", "German_Translation"),
     },
+    "arabic": {
+        "lemma_col": "Arabic_Lemma",
+        "trans_cols": ("English_Translation", "Spanish_Translation"),
+    },
 }
 
 SPECIAL_CHARS = re.compile(r"[?!@#$%^&*()_=+\[\]{};:\"\\|<>~`]")

--- a/cleanup_inflections.py
+++ b/cleanup_inflections.py
@@ -9,6 +9,7 @@ TRANS_COLS = {
     "english": ("German_Translation", "Spanish_Translation"),
     "german": ("English_Translation", "Spanish_Translation"),
     "spanish": ("English_Translation", "German_Translation"),
+    "arabic": ("English_Translation", "Spanish_Translation"),
 }
 
 
@@ -18,6 +19,7 @@ def cleanup_language(lang):
         "english": "English_Lemma",
         "german": "German_Lemma",
         "spanish": "Spanish_Lemma",
+        "arabic": "Arabic_Lemma",
     }[lang]
 
     total_removed = 0

--- a/tests/test_audit_lemmatization.py
+++ b/tests/test_audit_lemmatization.py
@@ -14,17 +14,19 @@ import audit_lemmatization as al
 def tmp_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Create a repo with lemmas that include inflected forms."""
     monkeypatch.setattr(al, "ROOT", tmp_path)
-    for lang in ("english", "german", "spanish"):
+    for lang in ("english", "german", "spanish", "arabic"):
         (tmp_path / lang).mkdir(exist_ok=True)
         lemma_col = {
             "english": "English_Lemma",
             "german": "German_Lemma",
             "spanish": "Spanish_Lemma",
+            "arabic": "Arabic_Lemma",
         }[lang]
         trans_cols = {
             "english": ("German_Translation", "Spanish_Translation"),
             "german": ("English_Translation", "Spanish_Translation"),
             "spanish": ("English_Translation", "German_Translation"),
+            "arabic": ("English_Translation", "Spanish_Translation"),
         }[lang]
         fields = [lemma_col, *trans_cols]
         for level in al.LEVELS:

--- a/vocab_manager.py
+++ b/vocab_manager.py
@@ -35,6 +35,10 @@ LANGS = {
         "lemma_col": "Spanish_Lemma",
         "trans_cols": ("English_Translation", "German_Translation"),
     },
+    "arabic": {
+        "lemma_col": "Arabic_Lemma",
+        "trans_cols": ("English_Translation", "Spanish_Translation"),
+    },
 }
 
 


### PR DESCRIPTION
Adds the Moroccan Arabic (Darija) A1.csv vocabulary file with 600 unique entries, matching the format and schema of the other trilingual databases. Also updates check_quality.py, vocab_manager.py, audit_lemmatization.py, cleanup_inflections.py, and tests.