### PR TITLE
chore: gitignore .zcode/ agent session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ htmlcov/
 # Project specs
 !openspec/
 !openspec/**
+
+# ZCode agent session state
+.zcode/


### PR DESCRIPTION
## What
Adds `.zcode/` to `.gitignore`.

## Why
ZCode stores plan files under `.zcode/plans/`. These are local agent session artifacts, not project content — should not be tracked in git. No other repo in the workspace tracks them.