### PR TITLE
fix(data): make every CEFR row upsertable

### DIFF
--- a/arabic/A1.csv
+++ b/arabic/A1.csv
@@ -597,8 +597,8 @@ Arabic_Lemma,English_Lemma,Chinese_Lemma,POS
 عصر,afternoon,下午,NOUN
 الليلة,tonight,今晚,NOUN
 أبداً,never,从不,ADV
-سوف,will,词
-كان,was,词
+سوف,will,将,AUX
+كان,was,曾经,VERB
 أن,,أن,SCONJ
 في,,في,ADP
 إلى,,إلى,ADP

--- a/arabic/C1.csv
+++ b/arabic/C1.csv
@@ -3909,7 +3909,6 @@ Arabic_Lemma,English_Lemma,Chinese_Lemma,POS
 سلاح,weapon,武器,NOUN
 مقتل,murder scene,谋杀现场,NOUN
 برهنة,demonstration,证明,NOUN
-استنباطي,deductive,演绎的,ADJ
 تقريري,declarative,陈述的,ADJ
 إنشائي,performative,施事的,ADJ
 طلبي,directive,指令的,ADJ

--- a/chinese/A2.csv
+++ b/chinese/A2.csv
@@ -591,8 +591,6 @@ Chinese_Lemma,English_Lemma,Chinese_Lemma,POS
 万一,just in case,万一,SCONJ
 而且,moreover,而且,CCONJ
 因此,therefore,因此,ADV
-然而,however,然而,CCONJ
-另外,additionally,另外,ADV
 似乎,seemingly,似乎,ADV
 终于,finally,终于,ADV
 最近,recently,最近,ADV

--- a/chinese/C1.csv
+++ b/chinese/C1.csv
@@ -5008,7 +5008,7 @@ U盘,USB flash drive,U盘,NOUN
 今朝,,今朝,NOUN
 拔,,拔,NOUN
 好言,,好言,NOUN
-教,,,教,,NOUN
+教,teach,教,VERB
 都往,,都往,NOUN
 赶哪,,赶哪,NOUN
 游方,,游方,NOUN

--- a/dutch/C1.csv
+++ b/dutch/C1.csv
@@ -2932,7 +2932,6 @@ fragment,fragment,片段,NOUN
 fragmentatie,fragmentation,碎片化,NOUN
 fraudebestrijding,fraud prevention,反欺诈,NOUN
 frontlinie,front line,前线,NOUN
-frustratie,frustration,挫折,NOUN
 functionaliteit,functionality,功能性,NOUN
 functie,function,功能,NOUN
 fundament,foundation,基础,NOUN
@@ -3266,7 +3265,6 @@ betwist,disputed,有争议的,ADJ
 bevooroordeeld,prejudiced,有偏见的,ADJ
 bevochten,contested,受争夺的,ADJ
 bevrijdend,liberating,解放的,ADJ
-bevroren... exists.
 bevredigend,satisfying,令人满意的,ADJ
 bewerkbaar,workable,可加工的,ADJ
 bewijsbaar,provable,可证明的,ADJ
@@ -3277,20 +3275,14 @@ betrouwenswaardig,trustworthy,值得信任的,ADJ
 bezienswaardig,worth seeing,值得一看的,ADJ
 bezittig,possessive,占有欲强的,ADJ
 bezondig,guilty,有过错的,ADJ
-bibliothecaris... skip.
-biedermeier... skip.
 bijgeloovig,superstitious,迷信的,ADJ
-bijstellig,adverbial? skip.
 bijtende,corrosive,腐蚀性的,ADJ
 bijzonder,particular,特别的,ADJ
 bijkomstig,incidental,附带的,ADJ
-bijzins... skip.
 bilateraal,bilateral,双边的,ADJ
-bizar,bizarre,奇异的,ADJ
 blank,white,白皙的,ADJ
 blasé,jaded,厌倦的,ADJ
 blauw,blue,蓝色的,ADJ
-blitz... skip.
 bloeddorstig,bloodthirsty,嗜血的,ADJ
 bloedend,bleeding,流血的,ADJ
 bloeiend,flourishing,繁荣的,ADJ
@@ -3300,56 +3292,39 @@ blootvoets,barefoot,赤脚的,ADJ
 bobbelig,bumpy,凹凸不平的,ADJ
 boertig,folksy,乡土的,ADJ
 bombastisch,bombastic,夸夸其谈的,ADJ
-bonds... skip.
 booswichtig,villainous,恶棍的,ADJ
-borrel... skip.
 bossig,bushy,浓密的,ADJ
-botanicus... skip.
-bot,bone exists.
 boud,plucky,大胆的,ADJ
-boudweg... skip.
 bovendelig,multipart,多部分的,ADJ
 bovengemiddeld,above average,高于平均的,ADJ
-bovennatuurlijk... dup. Replace:
 bovenregionaal,transregional,跨区域的,ADJ
 bovenzedelijk,otherworldly,超世俗的,ADJ
 brandbaar,flammable,易燃的,ADJ
 brandend,burning,燃烧的,ADJ
-brasem... skip.
-brave... exists.
 breekbaar,fragile,易碎的,ADJ
-breek... 
 breinachtig,brainy,聪明的,ADJ
-brievenbus,mailbox? noun.
-briljant... exists.
 brutaal,cheeky,放肆的,ADJ
 brutaliserend,brutalizing,粗暴化的,ADJ
 budgettair,budgetary,预算的,ADJ
 buitenechtelijk,extramarital,婚外的,ADJ
-buitengewoon... exists.
 buitenlands,foreign,外国的,ADJ
-burgerlijk... exists.
 burgemeesterlijk,mayoral,市长的,ADJ
 burn-out,exhausted,精疲力竭的,ADJ
-cacofonisch... skip.
 calamiteus,calamitous,灾难性的,ADJ
 campusachtig,campus-like,校园式的,ADJ
 captiverend,captivating,迷人的,ADJ
 caricaturaal,caricatural,漫画式的,ADJ
 categorisch,categorical,绝对的,ADJ
-catholiek... skip.
 cauteleus,cautious,谨慎的,ADJ
 cellulair,cellular,细胞的,ADJ
 centraal,central,中央的,ADJ
 ceremonieel,ceremonial,仪式的,ADJ
 chagrijnig,grumpy,暴躁的,ADJ
 chauvinistisch,chauvinistic,沙文主义的,ADJ
-chef-kok? skip.
 chemisch,chemical,化学的,ADJ
 chirurgisch,surgical,外科的,ADJ
 cholerisch,choleric,易怒的,ADJ
 choreografisch,choreographic,编舞的,ADJ
-christelijk... exists.
 chronologisch,chronological,按时间顺序的,ADJ
 circa,approximately,大约,ADV
 circulair,circular,循环的,ADJ
@@ -3360,9 +3335,7 @@ clinisch,clinical,临床的,ADJ
 coherent,coherent,连贯的,ADJ
 cohortmatig,cohort-based,队列的,ADJ
 collateraal,collateral,附属的,ADJ
-collectief... exists.
 collegiaal,collegial,同事的,ADJ
-colon... 
 coloniserend,colonizing,殖民的,ADJ
 combinerend,combining,结合的,ADJ
 combinatief,combinatorial,组合的,ADJ
@@ -3377,25 +3350,21 @@ competitief,competitive,竞争的,ADJ
 complex,complex,复杂的,ADJ
 compleet,complete,完整的,ADJ
 compliant,compliant,顺从的,ADJ
-componentieel... skip.
 componibel,composable,可组合的,ADJ
 composteerbaar,compostable,可堆肥的,ADJ
 comprehensief,comprehensive,综合的,ADJ
 comprimeerbaar,compressible,可压缩的,ADJ
 compulsief,compulsive,强迫的,ADJ
-comtemporair... skip.
 concaaf,concave,凹的,ADJ
 concentrisch,concentric,同心的,ADJ
 conceptueel,conceptual,概念的,ADJ
 concessioneel,concessionary,让步的,ADJ
 concipieerbaar,conceivable,可设想的,ADJ
 concludent,concluding,推断的,ADJ
-concreet... exists.
 concurrerend,competing,竞争的,ADJ
 concurrentieel,competitive,竞争性的,ADJ
 condescendent,condescending,居高临下的,ADJ
 conditioneel,conditional,有条件的,ADJ
-condoleance... 
 conferentieel,conference-based,会议的,ADJ
 confessioneel,confessional,告解的,ADJ
 confidentieel,confidential,机密的,ADJ
@@ -3403,13 +3372,11 @@ conflictueus,conflictual,冲突的,ADJ
 conform,conforming,遵从的,ADJ
 conformistisch,conformist,从众的,ADJ
 confronterend,confronting,对峙的,ADJ
-congel,congealing? skip.
 congruent,congruent,全等的,ADJ
 conjuncturaal,cyclical,周期的,ADJ
 connectief,connective,连接的,ADJ
 connivent,conniving,纵容的,ADJ
 connotatief,connotative,内涵的,ADJ
-conservatief... exists.
 consistent,consistent,一致的,ADJ
 consolideerbaar,consolidable,可巩固的,ADJ
 consoliderend,consolidating,巩固的,ADJ
@@ -3425,7 +3392,6 @@ contemporeel,contemporary,当代的,ADJ
 contentieus,contentious,有争议的,ADJ
 contextueel,contextual,语境的,ADJ
 contingent,contingent,偶然的,ADJ
-continu... exists.
 continueel,continual,持续的,ADJ
 contractueel,contractual,合同的,ADJ
 contrair,contrary,相反的,ADJ
@@ -3435,15 +3401,12 @@ controleerbaar,controllable,可控的,ADJ
 conventioneel,conventional,常规的,ADJ
 conversief,conversional,转换的,ADJ
 convertibel,convertible,可兑换的,ADJ
-convictioneel... skip.
 convolutioneel,convolutional,卷积的,ADJ
 koelbloedig,cool-headed,冷静的,ADJ
 koersend,steering,掌舵的,ADJ
 kringlopend,circular,循环的,ADJ
 kristalhelder,crystal clear,清澈的,ADJ
 kritiekloos,uncritical,不加批判的,ADJ
-kruisvaarder... skip.
-kuis... skip.
 kunstzinnig,artistic,艺术的,ADJ
 kwadraat,square,平方的,ADJ
 kwantitatief,quantitative,定量的,ADJ
@@ -3453,35 +3416,19 @@ laborieus,laborious,费力的,ADJ
 lacunair,lacunary,残缺的,ADJ
 lamgeslagen,paralysed,瘫痪的,ADJ
 landelijk,rural,乡村的,ADJ
-landschap... noun.
-langdurig... exists.
 langlopend,long-running,长期的,ADJ
-lantare... skip.
 lapidair,lapidary,简略的,ADJ
-laten... verb.
 latent,latent,潜在的,ADJ
 lateral,lateral,侧面的,ADJ
-laatkomer...
-laatbloeier...
-laathorizontaal? skip.
-legaal... exists.
-legaalismevrij... skip.
-legenda... exists.
-legendarisch... exists.
 legislatief,legislative,立法的,ADJ
 legitiem,legitimate,合法的,ADJ
 leidinggevend,leading,主导的,ADJ
-lemma... skip.
-lemposa...
-lepra... skip.
 lesgevend,teaching,授课的,ADJ
 leugenachtig,deceitful,虚假的,ADJ
 levensgroot,life-size,真人大小的,ADJ
-levenslang... exists.
 levenslustig,full of life,充满活力的,ADJ
 levensvatbaar,viable,可行的,ADJ
 levenswerk,life's work,毕生事业,NOUN
-lichamelijk... exists.
 lichtbruin,light brown,浅棕色的,ADJ
 lichtelijk,slightly,略微,ADV
 lichtgrijs,light grey,浅灰色的,ADJ
@@ -3492,76 +3439,50 @@ liminaal,liminal,阈限的,ADJ
 lineair,linear,线性的,ADJ
 linguaal,lingual,语言的,ADJ
 linguïstisch,linguistic,语言学的,ADJ
-linker... exists.
-linoleum... skip.
 liploos,lipless,无唇的,ADJ
 liquide,liquid,液态的,ADJ
-litterair... exists.
 liturgisch,liturgical,礼拜仪式的,ADJ
 lokaal,local,本地的,ADJ
-lokaal... 
 lokatie... locatie,location,地点,NOUN
 logisch,logical,合逻辑的,ADJ
-logistiek... exists.
-loochenaar... skip.
 loos,empty,空的,ADJ
-loos... 
 losbandig,licentious,放荡的,ADJ
 louche,shady,可疑的,ADJ
 louter,merely,纯粹,ADV
 louterend,purifying,净化的,ADJ
 luidop,aloud,大声地,ADV
 luidruchtig,noisy,嘈杂的,ADJ
-luis... exists.
-luis... 
 luxe,luxurious,豪华的,ADJ
 luxueus,luxurious,奢华的,ADJ
 lyrisch,lyrical,抒情的,ADJ
 maagdelijk,virginal,处女的,ADJ
-maandelijks... exists.
 maatschappelijk,societal,社会的,ADJ
-maatstaf... skip.
 machinaal,machine,机械的,ADJ
 macro-economisch,macroeconomic,宏观经济学的,ADJ
 macroscopisch,macroscopic,宏观的,ADJ
 maf,nuts,疯狂的,ADJ
-magazijn... exists.
-magenta... skip.
 mager,lean,瘦的,ADJ
-magisch... exists.
 magnifiek,magnificent,壮丽的,ADJ
 mainstream,mainstream,主流的,ADJ
 majesteitelijk,majestic,庄严的,ADJ
 mal,daft,傻的,ADJ
-maledictie... skip.
 maligne,malignant,恶性的,ADJ
-mammoet... skip.
-mandaat... skip.
 mandatoir,mandatory,强制的,ADJ
 manierlijk,mannerly,有礼貌的,ADJ
-manifest... exists.
 manifold,manifold,多方面的,ADJ
 manipuleerbaar,manipulable,可操纵的,ADJ
-mannelijk... exists.
 manueel,manual,手工的,ADJ
-mar... 
 marginaal,marginal,边缘的,ADJ
 maritiem,maritime,海事的,ADJ
 marmerachtig,marbly,大理石般的,ADJ
 marxistisch,Marxist,马克思主义的,ADJ
 massaal,massive,大规模的,ADJ
-massiever... skip.
 massief,solid,坚固的,ADJ
-materieel... exists.
-matig... exists.
 matigend,mitigating,减轻的,ADJ
-matrix... skip.
-mauk... skip.
 maximaal,maximal,最大的,ADJ
 meanderend,meandering,蜿蜒的,ADJ
 mechanisch,mechanical,机械的,ADJ
 medisch,medical,医学的,ADJ
-medium... skip.
 meelevend,sympathetic,有同情心的,ADJ
 meesleurend,engrossing,引人入胜的,ADJ
 meetbaar,measurable,可测量的,ADJ
@@ -3570,13 +3491,9 @@ megalomaan,megalomanic,狂妄自大的,ADJ
 melancholisch,melancholic,忧郁的,ADJ
 melkachtig,milky,乳白色的,ADJ
 memorabel,memorable,值得纪念的,ADJ
-men... 
-menses... 
 menselijk,human,人类的,ADJ
 menselijkwaardig,humane,人道的,ADJ
-mentaal... exists.
 mercantiel,mercantile,商业的,ADJ
-meridiaan... skip.
 merkelijk,considerable,显著的,ADJ
 mesmeriserend,mesmerizing,令人着迷的,ADJ
 metabool,metabolic,代谢的,ADJ
@@ -3587,119 +3504,71 @@ metamorf,metamorphic,变形的,ADJ
 meteorologisch,meteorological,气象学的,ADJ
 methodologisch,methodological,方法论的,ADJ
 metrisch,metric,韵律的,ADJ
-metrologisch... skip.
-metropool... skip.
-mica... skip.
 microscopisch,microscopic,微观的,ADJ
 micro-economisch,microeconomic,微观经济学的,ADJ
-midden... skip.
-middeleeuws... exists.
-middenstander... skip.
-midschip... skip.
-midzomer... skip.
 mild,gentle,温和的,ADJ
 militair,military,军事的,ADJ
 militaristisch,militaristic,军国主义的,ADJ
-millennium... skip.
-minderheid... exists.
 mineur,minor,次要的,ADJ
 minimaal,minimal,最小的,ADJ
-minimierend... skip.
 ministerieel,ministerial,部长的,ADJ
 minoritair,minority,少数的,ADJ
 minuscuul,minuscule,极小的,ADJ
-minusv... skip.
 minzaam,gracious,亲切的,ADJ
-mirakel... skip.
-mirthful... skip.
-mis... 
-misbaar... skip.
-misdaad... 
 misdadig,criminal,犯罪的,ADJ
 misdadigheid,criminality,犯罪性,NOUN
 misleidend,misleading,误导的,ADJ
 misplaatst,misplaced,不合时宜的,ADJ
-mislezen... verb.
-misselijk... exists.
 misselijkheid,nausea,恶心,NOUN
-missionar...
 missionerend,missionizing,传教的,ADJ
-mistaan... skip.
 mistroostig,disconsolate,凄凉的,ADJ
 misvorm,deformed,畸形的,ADJ
 misvatting,misconception,误解,NOUN
-mits... exists.
-mode... skip.
 modieus,stylish,时髦的,ADJ
 modieusheid,chic,时髦,NOUN
 modulair,modular,模块化的,ADJ
-modulatie... noun.
-moeilijk... exists.
 moedeloos,dispirited,沮丧的,ADJ
-moedig... exists.
 moedwillig,deliberate,故意的,ADJ
 moeizaam,laborious,费力的,ADJ
 moeizaamheid,difficulty,困难,NOUN
 moerasachtig,marshy,沼泽的,ADJ
 moerassig,marshy,沼泽般的,ADJ
-moe... 
-moeilijkheid... exists.
 moeiteloos,effortless,不费力的,ADJ
 moeiterijk,laborious,费力的,ADJ
 mogelijk,possible,可能的,ADJ
 mondiaal,global,全球的,ADJ
 monetair,monetary,货币的,ADJ
-monofoneel... skip.
 monolitisch,monolithic,整块的,ADJ
 monopolistisch,monopolistic,垄断的,ADJ
 monotoon,monotonous,单调的,ADJ
 monstrueus,monstrous,怪诞的,ADJ
 montant,steep,陡峭的,ADJ
-moraal... exists.
-moraalridder... skip.
-moraalridderschap... skip.
 moraliserend,moralizing,说教的,ADJ
 moraalvast,rigidly moral,道德刻板的,ADJ
-moreel... exists.
 moreelheid,morality,道德性,NOUN
 morfo... morfologisch,morphological,形态学的,ADJ
 mortel,mortar,砂浆,NOUN
 moslim,moslem,穆斯林,NOUN
 motorisch,motor,运动的,ADJ
-motor... 
-munitie... exists.
-museum...
 museumstuk,museum piece,博物馆藏品,NOUN
-muzikaal... exists.
-mysteries...
-mystagoog... skip.
 mystiek,mysticism,神秘主义,NOUN
 mythisch,mythical,神话的,ADJ
-abstract abstract... skip — already used abstract.
 bovendimensionaal,transcendental,超维度的,ADJ
 normal,normal,正常的,ADJ
 volwaardig,full-fledged,完全的,ADJ
 schematisch,schematic,图解的,ADJ
-adäquat... skip.
 waterdicht,waterproof,防水的,ADJ
 luchtledig,vacuum,真空的,ADJ
 catastrofaal,catastrophic,灾难性的,ADJ
-monetair... dup. Replace:
 numismatisch,numismatic,钱币学的,ADJ
 symmetrisch,symmetrical,对称的,ADJ
 asymmetrisch,asymmetrical,不对称的,ADJ
 frictieloos,frictionless,无摩擦的,ADJ
-catastrofaal... dup. Replace:
 gravitationeel,gravitational,引力的,ADJ
 permanent,permanent,永久的,ADJ
 incidenteel,incidental,偶然的,ADJ
-fundamenteel... exists.
 wezenlijk,essential,本质的,ADJ
-zinloos... exists.
 betekenisloos,meaningless,无意义的,ADJ
-waarde... 
-waardeloos... exists.
-waardevol... exists.
 waarheidsgetrouw,truthful,忠于事实的,ADJ
 waarneembaar,observable,可观测的,ADJ
 weloverwogen,well-considered,深思熟虑的,ADJ
@@ -3708,49 +3577,35 @@ welslagen,success,成功,NOUN
 welwillend,well-disposed,善意的,ADJ
 werkelijk,actual,真实的,ADJ
 werkelijkheid,reality,现实,NOUN
-werkeloos... skip.
-werelds... exists.
 wereldwijd,worldwide,世界范围的,ADJ
 wettelijk,legal,法定的,ADJ
 wetteloos,lawless,无法的,ADJ
 wetenschappelijk,scientific,科学的,ADJ
-wicht... skip.
-willekeurig... exists.
 willens,enwetens,明知故犯地,ADV
 winddicht,windproof,挡风的,ADJ
 windstille,windless,无风的,ADJ
 wisselend,alternating,交替的,ADJ
 wrede,cruel,残酷的,ADJ
 wreedheid,cruelty,残酷,NOUN
-wreed... 
 wrijvingsloos,frictionless,无摩擦的,ADJ
 wrochtig,guilt-ridden,内疚的,ADJ
-wreedheid... dup. Replace:
-wreed... 
 wrevelig,irritable,烦躁的,ADJ
 wroeging,remorse,悔恨,NOUN
 zachtmoedig,meek,温顺的,ADJ
 zalvend,unctuous,油腔滑调的,ADJ
 zelden,rarely,很少,ADV
-zeldzaam... exists.
 zichzelf,oneself,自己,PRON
-zinloos... exists.
 zinrijk,meaningful,有意义的,ADJ
 zinspelig,allusive,暗指的,ADJ
-zodanig... exists.
 zogenaamd,so-called,所谓的,ADJ
 zondermeer,without further ado,毫不犹豫地,ADV
 zorgelijk,troubling,令人担忧的,ADJ
 zorgeloos,carefree,无忧无虑的,ADJ
-zorgvuldig... exists.
-zuidelijk... exists.
 zuidoost,southeast,东南的,ADJ
 zuidwest,southwest,西南的,ADJ
 zuinig,frugal,节俭的,ADJ
 zuchtig,sighing,叹息的,ADJ
 zuidafrikaans,South African,南非的,ADJ
-zuiver... exists.
-zuidelijk... dup. Replace:
 zuurstofrijk,oxygen-rich,富氧的,ADJ
 zwaarmoedig,melancholic,忧郁的,ADJ
 zwakbegaafd,feeble-minded,弱智的,ADJ
@@ -3759,7 +3614,6 @@ zwart,black,黑色的,ADJ
 zwevend,suspended,悬浮的,ADJ
 zwijgzaam,reticent,寡言的,ADJ
 symbolisch,symbolic,象征的,ADJ
-symmetrisch... dup. Replace:
 synthetisch,synthetic,合成的,ADJ
 synoptisch,synoptic,概要的,ADJ
 syrisch,Syrian,叙利亚的,ADJ
@@ -3767,32 +3621,25 @@ systematisch,systematic,系统的,ADJ
 systeemloos,systemless,无系统的,ADJ
 tactvol,tactful,得体的,ADJ
 tactloos,tactless,不得体的,ADJ
-tamelijk... exists.
 tandeloos,toothless,无齿的,ADJ
 tastbaar,tangible,可触知的,ADJ
 taalkundig,linguistic,语言的,ADJ
 technisch,technical,技术的,ADJ
-technologisch... exists.
 technocratisch,technocratic,技术官僚的,ADJ
 teder,tender,温柔的,ADJ
 tederheid,tenderness,温柔,NOUN
 tegenstrijdig,contradictory,矛盾的,ADJ
 tegenwoordig,present,当前的,ADJ
-teken... 
 tekenend,characteristic,典型的,ADJ
-telefonisch... exists.
 teleologisch,teleological,目的论的,ADJ
 temperamentvol,temperamental,性情的,ADJ
-temperen... verb.
 temporeel,temporal,时间的,ADJ
 tendentieus,tendentious,倾向性的,ADJ
 tenzij,unless,除非,SCONJ
 terminaal,terminal,终末的,ADJ
 terminologisch,terminological,术语的,ADJ
-terrein...
 terughoudend,reserved,矜持的,ADJ
 terwijl,while,当...时,SCONJ
-tet...
 textueel,textual,文本的,ADJ
 theatraal,theatrical,戏剧的,ADJ
 theocratisch,theocratic,神权的,ADJ
@@ -3801,31 +3648,23 @@ theoretisch,theoretical,理论的,ADJ
 therapeutisch,therapeutic,治疗的,ADJ
 thermisch,thermal,热的,ADJ
 thetisch,thetic,正题的,ADJ
-thans... exists.
 thematisch,thematic,主题的,ADJ
 typografisch,typographical,排版的,ADJ
 tiranniek,tyrannical,专横的,ADJ
-tobs... skip.
 toegankelijk,accessible,可访问的,ADJ
 toegespitst,focused,聚焦的,ADJ
 toereikend,sufficient,充分的,ADJ
-toetsen... verb.
-toezichtelijk... skip.
 toonaangevend,leading,领先的,ADJ
-topic... 
 topografisch,topographical,地形学的,ADJ
 totaal,total,总的,ADJ
-totem... skip.
 toxisch,toxic,有毒的,ADJ
 triviaal,trivial,琐碎的,ADJ
 trivialiseerbaar,trivializable,可轻描淡写的,ADJ
 trots,side,骄傲的,ADJ
-trots... 
 trouwhartig,loyal,忠诚的,ADJ
 trouwloos,disloyal,不忠的,ADJ
 trouwens,by the way,顺便说,ADV
 tsjechisch,Czech,捷克的,ADJ
-tumor...
 turbulent,turbulent,动荡的,ADJ
 tweedimensionaal,two-dimensional,二维的,ADJ
 tweedehands,second-hand,二手的,ADJ
@@ -3835,78 +3674,50 @@ tweekoppig,two-headed,双头的,ADJ
 twijfelachtig,doubtful,可疑的,ADJ
 typisch,typical,典型的,ADJ
 typerend,characteristic,典型的,ADJ
-ubie... skip.
 uitbeeldend,representational,再现的,ADJ
 uitbalancerend,balancing,平衡的,ADJ
-uitbeelding... noun.
 uitbundig,exuberant,热情洋溢的,ADJ
 uitdagend,challenging,挑战的,ADJ
 uitdrukkelijk,express,明确的,ADJ
-uiteenlopend... exists.
 uiteindelijk,final,最终的,ADJ
-uitgaand... 
 uitgesproken,pronounced,显著的,ADJ
 uitgesloten,excluded,被排除的,ADJ
 uitgestrekt,expansive,广阔的,ADJ
-uitgeverij... exists.
 uitgehold,hollowed,掏空的,ADJ
 uitkledend,stripping,剥离的,ADJ
 uitlopend,diverging,分叉的,ADJ
 uitmergelend,emaciating,消耗的,ADJ
 uitnemend,excellent,卓越的,ADJ
-uitzonderlijk... exists.
 uitsluitend,exclusive,排他的,ADJ
-uitspraakloos... skip.
 uitputtend,exhaustive,详尽的,ADJ
 uitsluitingsmatig,exclusionary,排他性的,ADJ
-uitvaagsel... skip.
-uitvaart... skip.
 uitvloeisel,consequence,后果,NOUN
 uitvoerbaar,feasible,可行的,ADJ
 uitvoerig,elaborate,详尽的,ADJ
 uitwendig,external,外部的,ADJ
-uitzonderlijk... dup. Replace:
 uitzichtloos,bleak,无望的,ADJ
-uitzonderlijk... 
 unaniem,unanimous,一致的,ADJ
 uniform,uniform,统一的,ADJ
 unisono,in unison,齐声,ADV
-universeel... exists.
 urbaan,urban,都市的,ADJ
-urgenter... skip.
 urgent,urgent,紧急的,ADJ
-urine...
 utopisch,utopian,乌托邦的,ADJ
 utopie,utopia,乌托邦,NOUN
-utopist... skip.
-uw... pron.
 vaak,often,经常,ADV
-vaandel... skip.
 vaardig,skilful,熟练的,ADJ
 vaardigheid,skill,技能,NOUN
-vaak... 
-vaandel... 
 vaderlandslievend,patriotic,爱国的,ADJ
 vaderlijk,paternal,父亲的,ADJ
-vader... 
 vadermoord,patricide,弑父,NOUN
 vage,vague,模糊的,ADJ
-vagerig... skip.
 vaker,more often,更经常,ADV
-vast... exists.
 vakbekwaam,qualified,称职的,ADJ
-valabel... skip.
-validatie... noun.
 validiteit,validity,有效性,NOUN
-vallen... verb.
 vandaar,from there,因此,ADV
-vandaags... skip.
 vanouds,of old,自古以来,ADV
-vanzelfsprekend... exists.
 variant,variant,变体,NOUN
 variabel,variable,可变的,ADJ
 variantie,variance,方差,NOUN
-variantie... dup. Replace:
 variatie,variation,变化,NOUN
 verantwoord,accountable,负责任的,ADJ
 verantwoordelijk,responsible,负责的,ADJ
@@ -3921,24 +3732,18 @@ verbondenheid,connectedness,联结,NOUN
 verborgen,hidden,隐藏的,ADJ
 verbos,verbose,冗长的,ADJ
 verbijsterd,aghast,惊骇的,ADJ
-verbonden... 
 verantwoordelijkheid,responsibility,责任,NOUN
 verdraaid,twisted,扭曲的,ADJ
 verdraagzaam,tolerant,宽容的,ADJ
-verdrag... 
 verdwijning,disappearance,消失,NOUN
-verf... exists.
 verfijnd,refined,精致的,ADJ
 verfijning,refinement,精致,NOUN
 verfoeilijk,abominable,可憎的,ADJ
-verfoeien... verb.
-vergat...
 vergevingsgezind,forgiving,宽容的,ADJ
 vergezellend,accompanying,陪同的,ADJ
 verheugd,delighted,高兴的,ADJ
 verhit,heated,激烈的,ADJ
 verholen,veiled,隐晦的,ADJ
-verhullen... verb.
 verifieerbaar,verifiable,可验证的,ADJ
 verbeeldend,depicting,描绘的,ADJ
 verkwistend,wasteful,浪费的,ADJ
@@ -3948,49 +3753,31 @@ vermaak,amusement,娱乐,NOUN
 vermeldenswaard,worth mentioning,值得一提的,ADJ
 vermijdbaar,avoidable,可避免的,ADJ
 vermoeiend,tiring,令人疲倦的,ADJ
-vermoeiend... dup. Replace:
 vermoeienis,fatigue,疲劳,NOUN
-vermogens... 
 verneembaar,audible,可听见的,ADJ
 verandering,change,改变,NOUN
 veranderlijk,variable,多变的,ADJ
 verarmd,impoverished,贫困的,ADJ
-verbrand... 
 verbreed,extended,扩展的,ADJ
 verbreding,broadening,拓宽,NOUN
-verbriefd... skip.
 verbuigbaar,declinable,可变格的,ADJ
 verdeelbaar,divisible,可分的,ADJ
-verdrag...
 vervuild,polluted,污染的,ADJ
 vervuiling,pollution,污染,NOUN
 verzameld,collected,收集的,ADJ
 verzameling,collection,集合,NOUN
 verzamelaar,collector,收藏家,NOUN
-verzamelen... verb.
 verzamelwoede,collectomania,收藏癖,NOUN
 verzorgend,caring,关怀的,ADJ
 verzwakt,weakened,减弱的,ADJ
 verzwakking,weakening,削弱,NOUN
-verantwoordelijk... dup. skip.
 verwerkbaar,processable,可处理的,ADJ
 verwerend,alienating,疏远的,ADJ
 verwijderd,removed,移除的,ADJ
 verwijtbaar,reproachable,应受责备的,ADJ
-verwijzing... exists.
 verwoestend,devastating,毁灭性的,ADJ
 verwrongen,distorted,扭曲的,ADJ
-verzamelaars...
-verzameling... dup. skip.
-verzameld... dup. skip.
-verzorgd... exists.
-verzorging... exists.
-verzorgd... 
-verzorgend... 
-verholen... 
-verhit... 
 verhitte,heated,激昂的,ADJ
-verhitte... dup. skip.
 verhitting,heating,加热,NOUN
 verheerlijking,glorification,美化,NOUN
 verheffing,elevation,提升,NOUN

--- a/swedish/B1.csv
+++ b/swedish/B1.csv
@@ -997,8 +997,6 @@ glasögon,glasses,眼镜,NOUN
 glida,glide,滑动,VERB
 glidande,sliding,滑动的,ADJ
 svord_B1_0,swedish word 0,瑞典词0,NOUN
-svord_B1_0,swedish word 0,瑞典词0,NOUN
-svord_B1_0,swedish word 0,瑞典词0,NOUN
 bubbla,bubble,气泡,NOUN
 punktera,puncture/deflate,刺破,VERB
 skit,shit/crap,废话,NOUN

--- a/swedish/B2.csv
+++ b/swedish/B2.csv
@@ -1571,13 +1571,10 @@ avund,envy,嫉妒,NOUN
 ansvarskänsla,sense of duty,责任感,NOUN
 pliktkänsla,sense of duty,责任感,NOUN
 samvetsfråga,matter of conscience,良心问题,NOUN
-medborgerlig,civic — skip. Use:
 samhällsproblem,social problem,社会问题,NOUN
 fattigdom,poverty,贫困,NOUN
-rikedom exists. Skip. Use:
 överflöd,abundance,富足,NOUN
 brist,shortage,短缺,NOUN
-behov exists. Skip. Use:
 resursbrist,resource shortage,资源短缺,NOUN
 jämlikhet,equality,平等,NOUN
 jämställdhet,gender equality,性别平等,NOUN
@@ -1591,7 +1588,6 @@ makt,power,权力,NOUN
 myndighetsutövning,exercise of authority,权力行使,NOUN
 befogenhet,authority,职权,NOUN
 skyldighet,obligation,义务,NOUN
-rättighet exists. Skip. Use:
 medborgarrätt,citizenship right,公民权,NOUN
 yttrandefrihet,freedom of speech,言论自由,NOUN
 pressfrihet,press freedom,新闻自由,NOUN
@@ -1600,10 +1596,8 @@ religionsfrihet,freedom of religion,宗教自由,NOUN
 demonstrationsfrihet,freedom of assembly,集会自由,NOUN
 tryckfrihet,freedom of the press,出版自由,NOUN
 sekretess,secrecy,保密,NOUN
-integritet exists. Skip. Use:
 personlig integritet,personal integrity,个人隐私,NOUN
 dataskydd,data protection,数据保护,NOUN
-yttrandefrihet exists. Skip. Use:
 informationsutbyte,information exchange,信息交流,NOUN
 kunskapsutbyte,knowledge exchange,知识交流,NOUN
 kulturmöte,cultural encounter,文化交汇,NOUN
@@ -1614,17 +1608,13 @@ trosuppfattning,belief,信仰,NOUN
 övertygelse,conviction,信念,NOUN
 åskådning,viewpoint,观点,NOUN
 institution,institution,机构,NOUN
-organisation exists. Skip. Use:
 förening,association,协会,NOUN
 sammanslutning,federation,联合,NOUN
 nätverk,network,网络,NOUN
 kontakt,contact,联系,NOUN
 kontakter,contacts,人脉,NOUN
-relation exists. Skip. Use:
 förhållande,relationship,关系,NOUN
 samverkan,cooperation,协作,NOUN
-samarbete exists. Skip. Use:
-samverkan done. Use:
 interaktion,interaction,互动,NOUN
 kommunikation,communication,沟通,NOUN
 dialog,dialogue,对话,NOUN
@@ -1632,7 +1622,6 @@ förhandling,negotiation,谈判,NOUN
 överläggning,deliberation,商议,NOUN
 diskussion,discussion,讨论,NOUN
 samtal,conversation,谈话,NOUN
-utbyte exists. Skip. Use:
 erfarenhetsutbyte,experience exchange,经验交流,NOUN
 möte,meeting,会议,NOUN
 konferens,conference,会议,NOUN
@@ -1643,58 +1632,41 @@ panel,panel,小组,NOUN
 forum,forum,论坛,NOUN
 plattform,platform,平台,NOUN
 arena,arena,舞台,NOUN
-scen exists. Skip. Use:
 ramverk,framework,框架,NOUN
 struktur,structure,结构,NOUN
 system,system,系统,NOUN
 ordning,order,秩序,NOUN
 oreda,disorder,混乱,NOUN
-kaos exists. Skip. Use:
 grunden,foundation,基础,NOUN
 fundament,foundation,根基,NOUN
 bas,base,基础,NOUN
 utgångspunkt,starting point,出发点,NOUN
 utveckling,development,发展,NOUN
-framsteg exists. Skip. Use:
 landvinning,achievement,成就,NOUN
 bedrift,achievement,业绩,NOUN
 prestation,performance,表现,NOUN
 insats,effort,投入,NOUN
 arbete,work,工作,NOUN
-verksamhet exists. Skip. Use:
-verksam,active... adj. Use:
 yrkesverksam,professionally active,在职,NOUN
 gärning,deed,事迹,NOUN
-handling exists. Skip. Use:
 handlande,acting,行为,NOUN
-beteende exists. Skip. Use:
 uppträdande,conduct,举止,NOUN
 framträdande,appearance,出场,NOUN
-uppgift exists. Skip. Use:
 uppdrag,assignment,任务,NOUN
 roll,role,角色,NOUN
 funktion,function,功能,NOUN
-syfte exists. Skip. Use:
-mål,goal,目标,NOUN
 ändamål,purpose,目的,NOUN
 avsikt,intention,意图,NOUN
-mening exists. Skip. Use:
-betydelse exists. Skip. Use:
 innebörd,meaning,含义,NOUN
 innehåll,content,内容,NOUN
 sammanhang,context,上下文,NOUN
 kontext,context,语境,NOUN
-samband exists. Skip. Use:
-koppling exists. Skip. Use:
 länk,link,链接,NOUN
 band,bond,纽带,NOUN
 förbindelse,connection,连接,NOUN
-förhållande exists. Skip. Use:
 aspekt,aspect,方面,NOUN
 fasett,facet,方面,NOUN
 dimension,dimension,维度,NOUN
-nivå exists. Skip. Use:
-grad exists. Skip. Use:
 omfattning,extent,范围,NOUN
 skala,scale,规模,NOUN
 volym,volume,体量,NOUN
@@ -1703,7 +1675,6 @@ kvantitet,quantity,数量,NOUN
 kvalitet,quality,质量,NOUN
 egenskap,property,特性,NOUN
 kännetecken,characteristic,特征,NOUN
-drag exists. Skip. Use:
 särdrag,trait,特征,NOUN
 attribut,attribute,属性,NOUN
 karaktär,character,性格,NOUN
@@ -1712,11 +1683,8 @@ temperament,temperament,气质,NOUN
 läggning,disposition,性情,NOUN
 sinnesstämning,mood,心境,NOUN
 sinneslag,disposition,心境,NOUN
-humör exists. Skip. Use:
-känslo... Use:
 känsla,feeling,感觉,NOUN
 känsloliv,emotional life,情感生活,NOUN
-sinne exists. Skip. Use:
 medvetande,consciousness,意识,NOUN
 undermedvetande,subconscious,潜意识,NOUN
 minne,memory,记忆,NOUN
@@ -1724,10 +1692,8 @@ minne,memory,记忆,NOUN
 ihågkomst,recall,回忆,NOUN
 intryck,impression,印象,NOUN
 upplevelse,experience,经历,NOUN
-erfarenhet exists. Skip. Use:
 iakttagelse,observation,观察,NOUN
 uppfattning,perception,看法,NOUN
-åsikt exists. Skip. Use:
 synpunkt,viewpoint,观点,NOUN
 perspektiv,perspective,视角,NOUN
 vinkel,angle,角度,NOUN
@@ -1738,26 +1704,20 @@ inställning,attitude,态度,NOUN
 ståndpunkt,standpoint,立场,NOUN
 position,position,立场,NOUN
 hållning,stance,立场,NOUN
-åskådning exists. Skip. Use:
-uppfattning done. Use:
 tro,belief,信仰,NOUN
 misstanke,suspicion,怀疑,NOUN
 antagande,assumption,假设,NOUN
 förmodan,conjecture,推测,NOUN
 gissning,guess,猜测,NOUN
 hypotes,hypothesis,假设,NOUN
-teori exists. Skip. Use:
 tes,thesis,论点,NOUN
 argument,argument,论据,NOUN
 motargument,counterargument,反论,NOUN
-bevisning exists. Skip. Use:
 belägg,evidence,证据,NOUN
 argumentation,argumentation,论证,NOUN
 resonemang,reasoning,推理,NOUN
 slutsats,conclusion,结论,NOUN
-följd,consequence... exists(följd). Skip. Use:
 konsekvens,consequence,后果,NOUN
-resultat exists. Skip. Use:
 utfall,outcome,结果,NOUN
 effekt,effect,效果,NOUN
 verkan,effect,作用,NOUN
@@ -1768,7 +1728,6 @@ bakgrund,background,背景,NOUN
 orsakssamband,causal link,因果关系,NOUN
 sammanträffande,coincidence,巧合,NOUN
 tillfällighet,chance,偶然,NOUN
-slump exists. Skip. Use:
 risk,risk,风险,NOUN
 fara,danger,危险,NOUN
 hot,threat,威胁,NOUN
@@ -1780,16 +1739,11 @@ barriär,barrier,屏障,NOUN
 gräns,limit/border,界限,NOUN
 gränsdragning,demarcation,划界,NOUN
 ram,frame,框架,NOUN
-begränsning exists. Skip. Use:
-inskränkning exists. Skip. Use:
-undantag exists. Skip. Use:
 preferens,preference,偏好,NOUN
-val exists. Skip. Use:
 valfrihet,freedom of choice,选择自由,NOUN
 beslut,decision,决定,NOUN
 avgörande,decision,裁决,NOUN
 bedömning,assessment,判断,NOUN
-värdering exists. Skip. Use:
 utlåtande,statement,意见,NOUN
 yttrande,statement,言论,NOUN
 uttalande,statement,声明,NOUN
@@ -1799,12 +1753,9 @@ signalement,description,描述,NOUN
 framställning,portrayal,陈述,NOUN
 redogörelse,account,报告,NOUN
 redovisning,report,汇报,NOUN
-rapport exists. Skip. Use:
-redovisa exists. Skip. Use:
 kartläggning,mapping,梳理,NOUN
 inventering,inventory,盘点,NOUN
 uppgörelse,settlement,协议,NOUN
-överenskommelse exists. Skip. Use:
 förlikning,settlement,和解,NOUN
 kompromiss,compromise,妥协,NOUN
 medgivande,consent,同意,NOUN
@@ -1812,10 +1763,8 @@ samtycke,consent,同意,NOUN
 godkännande,approval,批准,NOUN
 tilstånd,permission,许可,NOUN
 tillstånd,permission,许可,NOUN
-tillåtelse exists. Skip. Use:
 förbud,ban,禁令,NOUN
 åtgärd,measure,措施,NOUN
-insats exists. Skip. Use:
 åtgärdsprogram,action plan,行动方案,NOUN
 strategi,strategy,策略,NOUN
 taktik,tactics,战术,NOUN
@@ -1824,7 +1773,6 @@ förfaringssätt,procedure,程序,NOUN
 procedur,procedure,程序,NOUN
 process,process,过程,NOUN
 arbetsgång,procedure,工作流程,NOUN
-rutin exists. Skip. Use
 förfarande,procedure,程序,NOUN
 metodik,methodology,方法论,NOUN
 tillvägagångssätt,approach,做法,NOUN
@@ -1833,24 +1781,17 @@ arbetssätt,working method,工作方式,NOUN
 hjälpmedel,aid,辅助工具,NOUN
 redskap,tool,工具,NOUN
 anordning,device,装置,NOUN
-utrustning exists. Skip. Use:
-utrusta,equip... verb. Skip. Use:
 inrättning,establishment,机构,NOUN
 anläggning,facility,设施,NOUN
 byggnad,building,建筑,NOUN
 komplex,complex,建筑群,NOUN
-anläggning done. Use:
 fastighet,property,不动产,NOUN
-egendom exists. Skip. Use:
 mark,land,土地,NOUN
 område,area,区域,NOUN
 region,region,地区,NOUN
 distrikt,district,区,NOUN
 zon,zone,地带,NOUN
-kvarter exists. Skip. Use:
-gräns exists. Skip. Use:
 gränslinje,boundary,边界线,NOUN
-territorium exists. Skip. Use:
 län,county,省,NOUN
 landskap,province,省份,NOUN
 kommun,municipality,市,NOUN
@@ -1863,12 +1804,7 @@ periferi,periphery,边缘,NOUN
 helhet,whole,整体,NOUN
 del,part,部分,NOUN
 avdelning,department,部门,NOUN
-enhet exists. Skip. Use:
-sektion exists. Skip. Use:
-avsnitt exists. Skip. Use:
-kapitel exists. Skip. Use:
 stycke,paragraph,段落,NOUN
-mening exists. Skip. Use:
 sats,clause,从句,NOUN
 ord,word,词,NOUN
 begrepp,concept,概念,NOUN
@@ -1878,19 +1814,15 @@ fras,phrase,短语,NOUN
 ordval,word choice,措辞,NOUN
 ordlydelse,wording,措辞,NOUN
 formulering,phrasing,措辞,NOUN
-språk exists. Skip. Use:
 språkbruk,language use,语言使用,NOUN
 språkvetenskap,linguistics,语言学,NOUN
 översättning,translation,翻译,NOUN
 tolkning,interpretation,口译,NOUN
 tydning,interpretation,解读,NOUN
-betydelse exists. Skip. Use:
 betydelseinnehåll,meaning content,语义内容,NOUN
 nyans,nuance,细微差别,NOUN
 klang,sound,音,NOUN
-ton exists. Skip. Use:
 tonfall,intonation,语调,NOUN
-röst exists? röst not in list. Use:
 röst,voice,声音,NOUN
 tal,speech,演讲,NOUN
 talare,speaker,演讲者,NOUN
@@ -1899,18 +1831,10 @@ publik,audience,观众,NOUN
 åskådare,spectator,旁观者,NOUN
 åhörare,listener,听众,NOUN
 deltagare,participant,参加者,NOUN
-närvarande exists. Skip. Use:
-närvarande... Use:
-närvaro exists. Skip. Use:
 frånvaro,absence,缺席,NOUN
 uppmärksamhet,attention,关注,NOUN
-intresse exists. Skip. Use:
-engagemang exists. Skip. Use:
-engagerad,engaged... adj. Skip. Use:
 fokus,focus,焦点,NOUN
 koncentration,concentration,专注,NOUN
-uppmärksamhet done. Use:
-iakttagelse exists. Skip. Use:
 observation,observation,观察,NOUN
 bevakning,coverage,报道,NOUN
 rapportering,reporting,报道,NOUN
@@ -1926,25 +1850,14 @@ redaktör,editor,编辑,NOUN
 rubrik,headline,标题,NOUN
 titel,title,标题,NOUN
 överskrift,heading,标题,NOUN
-bildnings... Skip. Use:
-artikel exists. Skip. Use:
 krönika,column,专栏,NOUN
 essä,essay,散文,NOUN
 recension,review,评论,NOUN
-anmälan exists. Skip. Use:
-anmeldning... Skip. Use:
-bedömning exists. Skip. Use:
-recension done. Use:
 kritik,criticism,评论,NOUN
 beröm,praise,赞扬,NOUN
 tillsägelse,rebuke,责备,NOUN
 tillrättavisning,reprimand,训斥,NOUN
-varning exists. Skip. Use:
 tilltal,address,称呼,NOUN
-tilltal done. Use:
-tilltal...
-tilltal...
-tilltal...
 svword1,sv english 1,词,NOUN
 svword2,sv english 2,词,NOUN
 svword3,sv english 3,词,NOUN

--- a/tests/test_csv_row_integrity.py
+++ b/tests/test_csv_row_integrity.py
@@ -1,0 +1,50 @@
+"""Every CEFR CSV row must be upsertable: 4 columns, unique (lemma, POS).
+
+Vidiom seeds these files with ON CONFLICT (lemma, pos); a repeated key raises
+PostgreSQL cardinality_violation 21000 and aborts the whole seed round.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from vocab_schema import LANGS, LEVELS
+
+ROOT = Path(__file__).parent.parent
+COLUMNS = 4
+
+
+def _csv_paths() -> list[Path]:
+    return [
+        path
+        for lang in LANGS
+        for level in LEVELS
+        if (path := ROOT / lang / f"{level}.csv").exists()
+    ]
+
+
+@pytest.mark.parametrize("path", _csv_paths(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_rows_have_four_columns(path: Path) -> None:
+    with path.open(encoding="utf-8") as handle:
+        offenders = [
+            (idx, row)
+            for idx, row in enumerate(csv.reader(handle), start=1)
+            if row and len(row) != COLUMNS
+        ]
+    assert not offenders, f"{path}: rows with != {COLUMNS} columns: {offenders[:5]}"
+
+
+@pytest.mark.parametrize("path", _csv_paths(), ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_lemma_pos_keys_are_unique(path: Path) -> None:
+    with path.open(encoding="utf-8") as handle:
+        keys = Counter(
+            (row[0].strip(), row[3].strip())
+            for row in csv.reader(handle)
+            if row and len(row) == COLUMNS
+        )
+    duplicates = {key: count for key, count in keys.items() if count > 1}
+    assert not duplicates, f"{path}: duplicate (lemma, POS) keys: {duplicates}"


### PR DESCRIPTION
## Problem

Vidiom seeds these CSVs with `ON CONFLICT (lemma, pos)`. Duplicate keys make PostgreSQL raise `cardinality_violation 21000`, which aborts the whole seed round (Vidiom#1652). Separately, generator refusal text had leaked into the data as short rows, e.g. `rikedom exists. Skip. Use:`.

## Changes

| file | rows before | rows after | dropped | repaired | deduped |
|---|---|---|---|---|---|
| arabic/A1.csv | 629 | 629 | 0 | 2 | 0 |
| arabic/C1.csv | 4251 | 4250 | 0 | 0 | 1 |
| chinese/A2.csv | 686 | 684 | 0 | 0 | 2 |
| chinese/C1.csv | 7036 | 7036 | 0 | 1 | 0 |
| dutch/C1.csv | 4001 | 3788 | 211 | 0 | 2 |
| swedish/B1.csv | 1007 | 1005 | 0 | 0 | 2 |
| swedish/B2.csv | 2290 | 2203 | 86 | 0 | 1 |

Repaired rows: `سوف,will,词` and `كان,was,词` regained the Chinese gloss and POS column; `教,,,教,,NOUN` became `教,teach,教,VERB`.

`dutch/C1.csv` now sits at 3788 against a 4000 target. Dropping refusal text is still the right call: those rows were never usable vocabulary.

## Test

`tests/test_csv_row_integrity.py` asserts 4 columns and unique `(lemma, POS)` per file. It fails on the pre-fix data (9 failures) and passes after.

Closes #45. Refs Vidiom#1652.

## Noticed, not fixed

1809 generated placeholder lemmas (`Word_swedish_C1_1361`, `svord_C1_0`) pad swedish/C1, dutch/B2 and german/C1 → #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)