### PR TITLE
feat(quality): Abnahmeprüfung für den Vokabel-Datenvertrag (#48)

### DIFF
--- a/check_data_contract.py
+++ b/check_data_contract.py
@@ -1,0 +1,287 @@
+"""Acceptance checks for the vocab data contract of 2026-08-19.
+
+The contract (Vidiom docs/specs/2026-08-19-vocab-data-contract.md) makes the
+normalized English gloss the join key between languages and defines five
+acceptance criteria for every delivery. This script runs them mechanically.
+
+Run from repo root:
+    python check_data_contract.py                # measure the CSV baseline
+    python check_data_contract.py delivery/      # gate a TSV delivery
+
+The delivery directory holds one TSV per language, UTF-8, with the header:
+    lemma	pos	english_gloss	english_pos	cefr	rank	concept_key
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from vocab_schema import LEVELS
+
+ROOT = Path(__file__).parent
+
+LANG_DIRS = {
+    "english": "en",
+    "german": "de",
+    "spanish": "es",
+    "french": "fr",
+    "swedish": "sv",
+    "arabic": "ar",
+    "dutch": "nl",
+    "chinese": "zh",
+}
+CODE_TO_DIR = {code: name for name, code in LANG_DIRS.items()}
+
+GLOSS_ASCII = re.compile(r"^[A-Za-z '-]+$")
+MIN_COVERAGE = 0.60
+
+TSV_HEADER = [
+    "lemma",
+    "pos",
+    "english_gloss",
+    "english_pos",
+    "cefr",
+    "rank",
+    "concept_key",
+]
+
+
+@dataclass(frozen=True)
+class Row:
+    lang: str
+    lemma: str
+    pos: str
+    english_gloss: str
+    rank: int | None
+
+
+def normalize_gloss(gloss: str) -> str:
+    """Match the app's key: lower, drop a leading 'to ', strip spaces only."""
+    return re.sub("^to ", "", gloss.lower()).strip(" ")
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        value = value[1:-1].replace('""', '"')
+    return value
+
+
+def load_csv_rows(root: Path) -> list[Row]:
+    """Read the authored CEFR CSVs (levels A1-C1) of every language."""
+    rows: list[Row] = []
+    for name, code in LANG_DIRS.items():
+        for level in LEVELS:
+            path = root / name / f"{level}.csv"
+            if not path.exists():
+                continue
+            with path.open(newline="", encoding="utf-8") as handle:
+                reader = csv.reader(handle)
+                next(reader, None)
+                for cols in reader:
+                    lemma = _unquote(cols[0]) if len(cols) > 0 else ""
+                    if not lemma:
+                        continue
+                    gloss = _unquote(cols[1]) if len(cols) > 1 else ""
+                    pos = cols[3].strip() if len(cols) > 3 else ""
+                    rows.append(Row(code, lemma, pos, gloss, None))
+    return rows
+
+
+def load_delivery_rows(delivery: Path) -> list[Row]:
+    """Read contract TSVs; the filename is the language (dir name or code)."""
+    rows: list[Row] = []
+    for path in sorted(delivery.glob("*.tsv")):
+        code = LANG_DIRS.get(path.stem, path.stem)
+        with path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.reader(handle, delimiter="\t")
+            header = next(reader, None)
+            if header != TSV_HEADER:
+                raise ValueError(f"{path.name}: unexpected header {header}")
+            for cols in reader:
+                if not cols or not cols[0].strip():
+                    continue
+                if len(cols) < 4:
+                    raise ValueError(
+                        f"{path.name}: row has {len(cols)} columns: {cols}"
+                    )
+                rank_text = cols[5].strip() if len(cols) > 5 else ""
+                rows.append(
+                    Row(
+                        lang=code,
+                        lemma=cols[0].strip(),
+                        pos=cols[3].strip(),
+                        english_gloss=cols[2].strip(),
+                        rank=int(rank_text) if rank_text else None,
+                    )
+                )
+    return rows
+
+
+def check_shrunken_glosses(delivery: list[Row], source: list[Row]) -> list[str]:
+    """Criterion 1: a multi-word source gloss must not shrink to one word."""
+    source_gloss = {(r.lang, r.lemma): r.english_gloss for r in source}
+    violations = []
+    for row in delivery:
+        original = source_gloss.get((row.lang, row.lemma))
+        if original is None:
+            continue
+        if len(original.split()) > 1 and len(row.english_gloss.split()) == 1:
+            violations.append(
+                f"{row.lang}:{row.lemma}: '{original}' -> '{row.english_gloss}'"
+            )
+    return violations
+
+
+def check_duplicates(rows: list[Row]) -> list[str]:
+    """Criterion 2: (lang, lemma, gloss_norm) is unique."""
+    counts = Counter((r.lang, r.lemma, normalize_gloss(r.english_gloss)) for r in rows)
+    return [f"{k[0]}:{k[1]}:{k[2]}" for k, n in counts.items() if n > 1]
+
+
+def check_rank_gaps(rows: list[Row]) -> list[str]:
+    """Criterion 3: exactly one rank-1 row per (lang, gloss_norm, pos)."""
+    groups: dict[tuple[str, str, str], int] = defaultdict(int)
+    for row in rows:
+        if row.rank == 1:
+            groups[(row.lang, normalize_gloss(row.english_gloss), row.pos)] += 1
+    seen = {(r.lang, normalize_gloss(r.english_gloss), r.pos) for r in rows}
+    violations = []
+    for key in sorted(seen):
+        if groups.get(key, 0) != 1:
+            violations.append(f"{key[0]}:{key[1]}:{key[2]}")
+    return violations
+
+
+def pair_coverage(rows: list[Row], source: str, target: str) -> tuple[int, int, int]:
+    """Criterion 4 per pair: (eindeutig, mehrdeutig, ohne)."""
+    index: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for row in rows:
+        if row.lang == target:
+            index[(normalize_gloss(row.english_gloss), row.pos)].add(row.lemma)
+    eindeutig = mehrdeutig = ohne = 0
+    for row in rows:
+        if row.lang != source:
+            continue
+        gloss = normalize_gloss(row.english_gloss)
+        if not gloss:
+            ohne += 1
+            continue
+        found = len(index.get((gloss, row.pos), set()))
+        if found == 1:
+            eindeutig += 1
+        elif found > 1:
+            mehrdeutig += 1
+        else:
+            ohne += 1
+    return eindeutig, mehrdeutig, ohne
+
+
+def check_ascii(rows: list[Row]) -> list[str]:
+    """Criterion 5: the pivot gloss is English ASCII (or blank)."""
+    violations = []
+    for row in rows:
+        gloss = row.english_gloss
+        if not gloss or not GLOSS_ASCII.match(gloss):
+            violations.append(f"{row.lang}:{row.lemma}: '{gloss}'")
+    return violations
+
+
+def run_baseline(root: Path) -> int:
+    rows = load_csv_rows(root)
+    print(f"CSV baseline: {len(rows)} rows")
+    print("criterion 1: n/a (needs a delivery)")
+    dups = check_duplicates(rows)
+    print(f"criterion 2: {len(dups)} duplicate keys")
+    print("criterion 3: n/a (CSVs carry no rank)")
+    print("criterion 4: eindeutige Abdeckung je Sprachpaar")
+    codes = sorted(set(LANG_DIRS.values()))
+    for source in codes:
+        for target in codes:
+            if source == target:
+                continue
+            ein, mehr, ohne = pair_coverage(rows, source, target)
+            total = ein + mehr + ohne
+            ratio = ein / total if total else 0.0
+            print(
+                f"  {source}->{target}: {ein}/{total} = {ratio:.0%} "
+                f"(mehrdeutig {mehr}, ohne {ohne})"
+            )
+    ascii_bad = check_ascii(rows)
+    print(f"criterion 5: {len(ascii_bad)} non-ASCII or blank glosses")
+    return 0
+
+
+def run_delivery(delivery: Path, root: Path) -> int:
+    rows = load_delivery_rows(delivery)
+    if not rows:
+        print(f"no TSV rows found in {delivery}")
+        return 1
+    source = load_csv_rows(root)
+    failed = False
+
+    shrunk = check_shrunken_glosses(rows, source)
+    print(f"criterion 1: {len(shrunk)} shrunken multi-word glosses")
+    for item in shrunk[:20]:
+        print(f"  {item}")
+    failed |= bool(shrunk)
+
+    dups = check_duplicates(rows)
+    print(f"criterion 2: {len(dups)} duplicate keys")
+    for item in dups[:20]:
+        print(f"  {item}")
+    failed |= bool(dups)
+
+    gaps = check_rank_gaps(rows)
+    print(f"criterion 3: {len(gaps)} group(s) without exactly one rank 1")
+    for item in gaps[:20]:
+        print(f"  {item}")
+    failed |= bool(gaps)
+
+    print("criterion 4: eindeutige Abdeckung je Sprachpaar (>= 60 %)")
+    codes = sorted({r.lang for r in rows})
+    for source_lang in codes:
+        for target in codes:
+            if source_lang == target:
+                continue
+            ein, mehr, ohne = pair_coverage(rows, source_lang, target)
+            total = ein + mehr + ohne
+            ratio = ein / total if total else 0.0
+            status = "OK " if ratio >= MIN_COVERAGE else "LOW"
+            print(
+                f"  [{status}] {source_lang}->{target}: {ein}/{total} "
+                f"= {ratio:.0%} (mehrdeutig {mehr}, ohne {ohne})"
+            )
+            failed |= ratio < MIN_COVERAGE
+
+    ascii_bad = check_ascii(rows)
+    print(f"criterion 5: {len(ascii_bad)} non-ASCII or blank glosses")
+    for item in ascii_bad[:20]:
+        print(f"  {item}")
+    failed |= bool(ascii_bad)
+
+    print("RESULT: FAIL" if failed else "RESULT: PASS")
+    return 1 if failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "delivery",
+        nargs="?",
+        help="directory with one contract TSV per language",
+    )
+    args = parser.parse_args(argv)
+    if args.delivery:
+        return run_delivery(Path(args.delivery), ROOT)
+    return run_baseline(ROOT)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_data_contract.py
+++ b/tests/test_check_data_contract.py
@@ -1,0 +1,207 @@
+"""Tests for check_data_contract, the acceptance gate of the data contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from check_data_contract import (
+    TSV_HEADER,
+    check_ascii,
+    check_duplicates,
+    check_rank_gaps,
+    check_shrunken_glosses,
+    load_csv_rows,
+    load_delivery_rows,
+    main,
+    normalize_gloss,
+    pair_coverage,
+    run_baseline,
+    run_delivery,
+    Row,
+)
+
+
+def test_normalize_gloss_matches_the_app_backfill() -> None:
+    assert normalize_gloss("to be called") == "be called"
+    assert normalize_gloss("  House  ") == "house"
+    assert normalize_gloss("tomorrow") == "tomorrow"
+    assert normalize_gloss(" to be called ") == "to be called"
+    # btrim strips spaces only; tabs survive on both sides.
+    assert normalize_gloss("\thouse\t") == "\thouse\t"
+
+
+def make_row(
+    lang: str,
+    lemma: str,
+    gloss: str,
+    pos: str = "VERB",
+    rank: int | None = None,
+) -> Row:
+    return Row(lang, lemma, pos, gloss, rank)
+
+
+def test_check_shrunken_glosses_flags_head_reduction() -> None:
+    source = [make_row("de", "heißen", "to be called")]
+    delivery = [make_row("de", "heißen", "be")]
+    assert check_shrunken_glosses(delivery, source) == [
+        "de:heißen: 'to be called' -> 'be'"
+    ]
+
+
+def test_check_shrunken_glosses_accepts_full_gloss_and_new_lemmas() -> None:
+    source = [make_row("de", "heißen", "to be called")]
+    delivery = [
+        make_row("de", "heißen", "to be called"),
+        make_row("de", "neu", "new"),
+    ]
+    assert check_shrunken_glosses(delivery, source) == []
+
+
+def test_check_duplicates() -> None:
+    rows = [
+        make_row("de", "Bank", "bank"),
+        make_row("de", "Bank", "Bank"),
+        make_row("de", "Bank", "river bank"),
+    ]
+    assert check_duplicates(rows) == ["de:Bank:bank"]
+
+
+def test_check_rank_gaps_requires_exactly_one_rank_one() -> None:
+    rows = [
+        make_row("es", "llamar", "to call", rank=1),
+        make_row("es", "telefonear", "to call", rank=2),
+        make_row("es", "ser", "to be", rank=1),
+        make_row("es", "estar", "to be", rank=1),
+        make_row("es", "ir", "to go"),
+    ]
+    gaps = check_rank_gaps(rows)
+    assert "es:be:VERB" in gaps
+    assert "es:go:VERB" in gaps
+    assert "es:call:VERB" not in gaps
+
+
+def test_pair_coverage_counts_distinct_target_lemmas() -> None:
+    rows = [
+        make_row("de", "heißen", "to be called"),
+        make_row("de", "Haus", "house", pos="NOUN"),
+        make_row("de", "allein", "alone"),
+        make_row("es", "llamarse", "to be called"),
+        make_row("es", "casa", "house", pos="NOUN"),
+        make_row("es", "solo", "alone"),
+        make_row("es", "solo_mismo", "alone"),
+    ]
+    ein, mehr, ohne = pair_coverage(rows, "de", "es")
+    # heißen->llamarse and Haus->casa eindeutig, allein has two es rows.
+    assert (ein, mehr, ohne) == (2, 1, 0)
+
+
+def test_check_ascii_rejects_foreign_and_blank_glosses() -> None:
+    # Criterion 5 is a charset check: pure-ASCII foreign words pass it;
+    # catching them is the data author's job (rule 6), not the charset's.
+    rows = [
+        make_row("de", "a", "llamárse"),
+        make_row("de", "b", ""),
+        make_row("de", "c", "to be called"),
+        make_row("de", "d", "house (home)"),
+    ]
+    assert check_ascii(rows) == [
+        "de:a: 'llamárse'",
+        "de:b: ''",
+        "de:d: 'house (home)'",
+    ]
+
+
+def write_delivery(directory: Path, name: str, lines: list[list[str]]) -> None:
+    path = directory / name
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write("\t".join(TSV_HEADER) + "\n")
+        for line in lines:
+            handle.write("\t".join(line) + "\n")
+
+
+def make_source_csv(root: Path, lang_dir: str, rows: list[list[str]]) -> None:
+    level_dir = root / lang_dir
+    level_dir.mkdir(parents=True, exist_ok=True)
+    path = level_dir / "A1.csv"
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        handle.write("X_Lemma,English_Lemma,Chinese_Lemma,POS\n")
+        for row in rows:
+            handle.write(",".join(row) + "\n")
+
+
+def test_load_csv_rows_reads_lemma_gloss_and_pos(tmp_path: Path) -> None:
+    make_source_csv(tmp_path, "german", [["heißen", "to be called", "叫", "VERB"]])
+    rows = load_csv_rows(tmp_path)
+    assert rows == [Row("de", "heißen", "VERB", "to be called", None)]
+
+
+def test_load_delivery_rows_rejects_an_unknown_header(tmp_path: Path) -> None:
+    (tmp_path / "de.tsv").write_text("lemma\twrong\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unexpected header"):
+        load_delivery_rows(tmp_path)
+
+
+def test_load_delivery_rows_rejects_short_rows(tmp_path: Path) -> None:
+    (tmp_path / "de.tsv").write_text(
+        "\t".join(TSV_HEADER) + "\nBank\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="columns"):
+        load_delivery_rows(tmp_path)
+
+
+def test_run_delivery_passes_on_a_clean_pair(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    delivery = tmp_path / "delivery"
+    delivery.mkdir()
+    make_source_csv(source_root, "german", [["Haus", "house", "房", "NOUN"]])
+    make_source_csv(source_root, "spanish", [["casa", "house", "房", "NOUN"]])
+    write_delivery(
+        delivery,
+        "de.tsv",
+        [["Haus", "NOUN", "house", "NOUN", "A1", "1", ""]],
+    )
+    write_delivery(
+        delivery,
+        "es.tsv",
+        [["casa", "NOUN", "house", "NOUN", "A1", "1", ""]],
+    )
+    assert run_delivery(delivery, source_root) == 0
+
+
+def test_run_delivery_fails_on_coverage_and_foreign_gloss(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_root = tmp_path / "source"
+    delivery = tmp_path / "delivery"
+    delivery.mkdir()
+    make_source_csv(source_root, "german", [["einsam", "lonely", "孤", "ADJ"]])
+    write_delivery(
+        delivery,
+        "de.tsv",
+        [["einsam", "ADJ", "lonely", "ADJ", "B2", "", ""]],
+    )
+    write_delivery(
+        delivery, "es.tsv", [["solo", "ADJ", "solo_es", "ADJ", "B2", "1", ""]]
+    )
+    assert run_delivery(delivery, source_root) == 1
+    out = capsys.readouterr().out
+    assert "RESULT: FAIL" in out
+    assert "[LOW] de->es" in out
+    assert "criterion 3: 1 group(s)" in out
+
+
+def test_run_baseline_reports_and_returns_zero(tmp_path: Path) -> None:
+    make_source_csv(tmp_path, "german", [["Haus", "house", "房", "NOUN"]])
+    make_source_csv(tmp_path, "spanish", [["casa", "house", "房", "NOUN"]])
+    assert run_baseline(tmp_path) == 0
+
+
+def test_main_dispatches_between_modes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    make_source_csv(tmp_path, "german", [["Haus", "house", "房", "NOUN"]])
+    monkeypatch.setattr("check_data_contract.ROOT", tmp_path)
+    assert main([]) == 0
+    assert main([str(tmp_path / "missing")]) == 1


### PR DESCRIPTION
## Warum

Der Datenvertrag vom 19.08.2026 (Vidiom
`docs/specs/2026-08-19-vocab-data-contract.md`, Vidiom #1765/#2056) verlangt,
dass die Datenseite ihre Lieferungen selbst gegen fünf Abnahmekriterien
prüft. Dieses PR liefert die maschinelle Prüfung.

## Was

`check_data_contract.py` (Root, folgt dem Muster von `check_quality.py`):

- `python check_data_contract.py`: Messung der CSV-Baseline (Kriterien 2, 4, 5;
  Kriterium 1 braucht eine Lieferung, Kriterium 3 braucht Rank-Spalten).
- `python check_data_contract.py <delivery-dir>`: Abnahmegate für eine
  TSV-Lieferung (Kopfzeile `lemma pos english_gloss english_pos cefr rank
  concept_key`), Exit-Code 1 bei Verstoß.
- `normalize_gloss` ist byteweise äquivalent zur App
  (`btrim(regexp_replace(lower(translation), '^to ', ''))`, Leerzeichen-Trim
  wie `btrim`).

14 Pytest-Fälle, ruff + pyright sauber, volle Suite 413 passed,
Coverage 82.95 % (Gate 80 %).

## Baseline-Messung (A1-C1, 70697 Zeilen)

- Kriterium 2: 3228 (lang, lemma, gloss)-Dubletten, fast alle aus
  Level-Wiederholungen; die App kollabiert sie heute per PK.
- Kriterium 4, Auswahl: de->es 32 %, de->en 50 %, es->en 56 %, ar->zh 17 %.
  Kein Paar erreicht die geforderten 60 %; das ist der Arbeitsauftrag des
  Vertrags (Konzept-Glossen, Regel 1). en-Paare sind vorn, weil en-Zeilen
  ihre Glosse selbst sind.
- Kriterium 5: 9827 leere oder nicht-ASCII Glossen von 70697 Zeilen.

Die 60-%-Hürde ist damit der messbare Endpunkt der Daten-Nacharbeit, nicht
die Eigenschaft dieses Skripts.
