### PR TITLE
fix(contract): revert fabricated expansion data from PR 57 and harden data contract gate (closes #58)

### DIFF
--- a/arabic/expansion.csv
+++ b/arabic/expansion.csv
@@ -1,19087 +1,2619 @@
 Arabic_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
-African,African,词,ADJ,B1
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-American (noun),American,词,NOUN,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Brother He,Brother He,郃弟,NOUN,B2
-Brussels,Brussels,词,ADJ,C1
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Calvinism,Calvinism,词,NOUN,C1
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese (noun),Chinese,中文,NOUN,C1
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Christian (adj),Christian,词,ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cretaceous,Cretaceous,词,ADJ,B2
-DIY,DIY,词,NOUN,C1
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-England,England,词,PROPN,B1
-English (noun),English,词,NOUN,A2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
-Eurasian,Eurasian,词,ADJ,C1
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-Franciscan,Franciscan,词,ADJ,C1
-French-speaking world,French-speaking world,词,NOUN,B2
-Friday evening,Friday evening,词,NOUN,C1
-Gallic,Gallic,词,ADJ,C1
-German (adj),German,德国人,ADJ,C1
-Gothic,Gothic,词,ADJ,C1
-Goyaesque,Goyaesque,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gypsy,Gypsy,词,NOUN,C1
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-Iberian,Iberian,词,ADJ,C1
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Irish (noun),Irish,词,NOUN,C1
-Israeli,Israeli,词,ADJ,B2
-January evening,January evening,词,NOUN,B2
-Japanese person,Japanese person,词,NOUN,C1
-Jesuit,Jesuit,词,NOUN,C1
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Latin (noun),Latin,词,NOUN,C1
-Limburgish,Limburgish,词,ADJ,C1
-Ling,Ling,叫凌,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-Machiavellian,Machiavellian,词,ADJ,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Marxist,Marxist,词,ADJ,C1
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Mon,Mon,词,NOUN,C1
-Moroccan,Moroccan,词,ADJ,B2
-Mr. sir,Mr. sir,先生,NOUN,B2
-Mrs.,Mrs.,词,NOUN,A1
-Ms.,Ms.,词,NOUN,C1
-Murong,Murong,慕容,NOUN,B2
-Muslim (adj),Muslim,词,ADJ,B1
-National Day,National Day,国庆节,NOUN,B1
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-No.,No.,词,NOUN,C1
-Nordic,Nordic,词,ADJ,C1
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Parisian,Parisian,词,ADJ,B1
-Philippic (adj),Philippic,词,ADJ,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Polaris,Polaris,北极星,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Rotterdam,Rotterdam,词,ADJ,C1
-Russian (noun),Russian,俄国人,NOUN,B2
-Saturday evening,Saturday evening,词,NOUN,C1
-Serbian,Serbian,词,ADJ,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Surinamese,Surinamese,词,ADJ,C1
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-Swedish (adj),Swedish,瑞典的,ADJ,B2
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Thai,Thai,词,ADJ,C1
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-VIP room,VIP room,贵宾室,NOUN,C1
-Whistles,Whistles,词,NOUN,C1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-Your Highness,Your Highness,殿下,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
-abate,abate,词,VERB,B2
-abbey,abbey,词,NOUN,B2
-abbot,abbot,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aberrant,aberrant,词,ADJ,B2
-aberziehung,aberziehung,词,NOUN,B2
-abet,abet,词,VERB,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abhorrent,abhorrent,词,ADJ,B2
-abject,abject,悲惨的,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkunft,abkunft,词,NOUN,C1
-able to play,able to play,能下,NOUN,B2
-abolition,abolition,废除,NOUN,B2
-abominable,abominable,可憎的,ADJ,B2
-abominate,abominate,词,VERB,B2
-about,about,大约,ADV,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,词,NOUN,B2
-about it,about it,关于它,ADV,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about that,about that,关于那个,ADV,B2
-about thirty,about thirty,词,NOUN,B2
-about this,about this,词,ADV,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-about which,about which,词,PRON,B2
-above (noun),above,重上,NOUN,C1
-above all,above all,词,NOUN,B2
-above average,above average,词,ADJ,C1
-above-mentioned,above-mentioned,词,ADJ,B2
-abpflegung,abpflegung,词,NOUN,C1
-abrasive,abrasive,词,ADJ,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
-abroad,abroad,在国外,ADV,B2
-abrogate,abrogate,词,VERB,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
-absolution,absolution,词,NOUN,C1
-absorbed,absorbed,全神贯注的,ADJ,B2
-absprache,absprache,词,NOUN,C1
-abstemious,abstemious,有节制的,ADJ,B2
-abstinence,abstinence,节制,NOUN,B2
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-abtheilung,abtheilung,词,NOUN,C1
-abundantly,abundantly,词,ADV,C1
-abuse case,abuse case,词,NOUN,C1
-abuser,abuser,词,NOUN,B2
-abusive,abusive,滥用的,ADJ,B2
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-abysmal,abysmal,词,ADJ,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
-accede,accede,词,VERB,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-acceptable,acceptable,可接受的,ADJ,B2
-accessibility,accessibility,可达性,NOUN,B2
-accessible,accessible,易接近的,ADJ,B2
-accessory,accessory,词,NOUN,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
-accomplish,to accomplish,完成,VERB,B2
-accord with,accord with,合乎,NOUN,B2
-according to,according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordion,accordion,词,NOUN,B2
-accost,accost,词,VERB,B2
-accountable,accountable,负责任的,ADJ,B2
-accredit,to accredit,认可,VERB,B2
-accrue,to accrue,积累,VERB,B2
-accuracy,accuracy,准确性,NOUN,B2
-accurate,accurate,准确的,ADJ,B2
-accuse,to accuse,指控,VERB,B2
-accused,accused,词,NOUN,B2
-accused person,accused person,词,NOUN,B2
-accustom,to accustom,使习惯,VERB,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
-acerbate,acerbate,词,VERB,B2
-acerbic,acerbic,尖刻的,ADJ,B2
-achievable,achievable,词,ADJ,B2
-achieved,achieved,词,ADJ,B1
-acid (adj),acid,词,ADJ,B1
-acid sour,acid sour,词,ADJ,B2
-acidic,acidic,词,ADJ,B2
-acolyte,acolyte,词,NOUN,B2
-acorn,acorn,词,NOUN,B1
-acoustic,acoustic,声学的,ADJ,B2
-acquaintance,acquaintance,熟人,NOUN,B2
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
-acrimony,acrimony,尖刻,NOUN,B2
-acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,词,NOUN,B2
-across,across,越过,ADV,B2
-acrostic,acrostic,词,NOUN,C1
-act,act,行动,NOUN,B2
-act,to act,行动,VERB,B2
-act jointly,act jointly,合伙,NOUN,B2
-act of kneeling,act of kneeling,词,NOUN,C1
-action,action,行动,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
-activate,to activate,激活,VERB,B2
-activism,activism,词,NOUN,B2
-activist,activist,词,NOUN,C1
-activities,activities,词,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-actual,actual,实际的,ADJ,B2
-actually,actually,实际上,ADV,B2
-actually (noun),actually,倒也,NOUN,C1
-actuate,actuate,词,VERB,B2
-acupoint strike,acupoint strike,点穴,NOUN,B2
-adapt,to adapt,适应,VERB,B2
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
-addicted,addicted,上瘾的,ADJ,B2
-addictive,addictive,词,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
-address,to address,解决,VERB,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
-adequate,adequate,足够的,ADJ,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherence,adherence,词,NOUN,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
-adjacency,adjacency,邻接,NOUN,B2
-adjacent,adjacent,邻近的,ADJ,B2
-adjective,adjective,形容词,NOUN,B2
-adjoin,adjoin,词,VERB,B2
-adjourn,adjourn,词,VERB,B2
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjure,adjure,词,VERB,B2
-adjust,to adjust,调整,VERB,B2
-adjustability,adjustability,词,NOUN,C1
-adjustment,adjustment,调节,NOUN,B2
-administer,to administer,管理,VERB,B2
-administrative offense,administrative offense,词,NOUN,C1
-administrator,administrator,管理员,NOUN,B2
-admirable,admirable,词,ADJ,B2
-admiral,admiral,海军上将,NOUN,B2
-admire,to admire,钦佩,VERB,B2
-admirer,admirer,仰慕者,NOUN,B2
-admissible,admissible,词,ADJ,B2
-admissible eligible,admissible eligible,词,ADJ,C1
-admit,to admit,承认,VERB,B2
-admitted,admitted,词,ADJ,B2
-admittedly,admittedly,诚然,ADV,B2
-admonish,to admonish,告诫,VERB,B2
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
-adopt,to adopt,收养,VERB,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
-adoption,adoption,收养,NOUN,B2
-adorable,adorable,词,ADJ,B2
-adoration worship,adoration worship,词,NOUN,C1
-adorn,to adorn,装饰,VERB,B2
-adrenaline,adrenaline,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
-adulation,adulation,词,NOUN,C1
-adult,adult,成年的,ADJ,B2
-adulterate,to adulterate,掺杂,VERB,B2
-adultery,adultery,词,NOUN,C1
-adulthood,adulthood,成年,NOUN,B2
-advance,to advance,前进,VERB,B2
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
-advanced,advanced,高级的,ADJ,B2
-advanced study,advanced study,深造,NOUN,B2
-advanced technology,advanced technology,先进,ADJ,B2
-advancement,advancement,晋升,NOUN,B2
-advantageous,advantageous,有利的,ADJ,B2
-advent,advent,到来,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
-adversarial,adversarial,词,ADJ,B2
-adverse,adverse,不利的,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
-advertise,to advertise,做广告,VERB,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
-advise against,to advise against,劝阻,VERB,B2
-advisor,advisor,顾问,NOUN,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advisory,advisory,词,ADJ,C1
-advocate,to advocate,提倡,VERB,B2
-advocate (noun),advocate,词,NOUN,B2
-aeronautical,aeronautical,词,ADJ,B2
-affability,affability,词,NOUN,C1
-affair hall,affair hall,事殿,NOUN,B2
-affect,to affect,影响,VERB,B2
-affected,affected,受影响的,ADJ,B2
-affidavit,affidavit,词,NOUN,B2
-affiliate,affiliate,附属机构,NOUN,B2
-affinity,affinity,词,NOUN,C1
-affirm,to affirm,断言,VERB,B2
-affirmative,affirmative,词,ADJ,B2
-affix,affix,词,NOUN,B2
-afflict,to afflict,折磨,VERB,B2
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
-affordable,affordable,负担得起的,ADJ,B2
-affront,affront,冒犯,NOUN,B2
-aforementioned,aforementioned,上述的,ADJ,B2
-afraid,afraid,害怕的,ADJ,B2
-afraid (noun),afraid,词,NOUN,B2
-after,after,在...之后,SCONJ,B2
-after (adv),after,词,ADV,A1
-after all,after all,毕竟,ADV,B2
-after all just,after all just,毕竟刚,ADV,C1
-after that,after that,此后,ADV,B2
-after this,after this,词,ADV,B2
-after to,after to,词,ADP,A2
-after which,after which,之后,ADV,B2
-after-class exercises,after-class exercises,课后题,NOUN,C1
-aftereffect,aftereffect,后遗症，后果,NOUN,B2
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
-afterward,afterward,去后,NOUN,B2
-again,again,你又,NOUN,B2
-against it,against it,词,ADV,A2
-age,age,年龄,NOUN,B2
-aged,aged,年老的,ADJ,B2
-agenda item,agenda item,议题,NOUN,C1
-agglomerate,agglomerate,词,NOUN,B2
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravating,aggravating,词,ADJ,B2
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
-aggression,aggression,侵略,NOUN,B2
-aggressive,aggressive,好斗的,ADJ,B2
-aggressor,aggressor,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
-agile,agile,敏捷的,ADJ,B2
-agility,agility,敏捷,NOUN,B2
-aging,aging,老化,NOUN,B2
-agitated,agitated,焦躁的,ADJ,B2
-agnostic (adj),agnostic,词,ADJ,B2
-agnostic (noun),agnostic,词,NOUN,B2
-ago,ago,以前,ADV,B2
-agonize,agonize,词,VERB,B2
-agony,agony,极度痛苦,NOUN,B2
-agree,agree,一致,ADJ,B2
-agreeable,agreeable,词,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
-ah,ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-ahead,ahead,在前面,ADV,B2
-aid,aid,援助,NOUN,B2
-aim,to aim,瞄准,VERB,B2
-aimless,aimless,词,ADJ,C1
-air conditioner,air conditioner,词,NOUN,B1
-air conditioning,air conditioning,空调,NOUN,B2
-air defense,air defense,防空,NOUN,B2
-air force,air force,空军,NOUN,B2
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-airline,airline,词,NOUN,C1
-airs,airs,摆架子,NOUN,B2
-airtight,airtight,密封的,ADJ,B2
-ajar,ajar,半开的,ADJ,B2
-akin,akin,相似的,ADJ,B2
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
-alchemy,alchemy,词,NOUN,C1
-alcoholic,alcoholic,酒精的,ADJ,B2
-alder,alder,桤木,NOUN,B2
-alderman,alderman,词,NOUN,B2
-alibi,alibi,不在场证明,NOUN,B2
-alien (adj),alien,词,ADJ,B1
-alienable,alienable,可转让的,ADJ,B2
-alienating,alienating,使人疏远的,ADJ,B2
-alike,alike,词,ADV,B1
-alive living,alive living,活着的,ADJ,B2
-all,all,全部,DET,B2
-all (adj),all,全,ADJ,B2
-all (pron),all,全部,PRON,A2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all everyone,all everyone,所有/大家,PRON,B2
-all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,词,NOUN,B2
-all the more,all the more,词,ADV,B2
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allay,allay,词,VERB,C1
-allegation,allegation,词,NOUN,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allegiance,allegiance,词,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
-allure,allure,词,NOUN,C1
-alone,alone,单独的,ADJ,B2
-aloof,aloof,词,ADJ,C1
-aloofness,aloofness,冷漠,NOUN,B2
-aloud,aloud,出声地,ADV,B2
-alpha,alpha,阿尔法,NOUN,B2
-alphabet,alphabet,字母表,NOUN,B2
-alpine,alpine,高山的,ADJ,B2
-alright (noun),alright,好吧,NOUN,B1
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-altar,altar,词,NOUN,B2
-alteration,alteration,词,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternating,alternating,词,ADJ,B2
-alternative,alternative,替代的,ADJ,B2
-alternatively,alternatively,交替地,ADV,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-altitude,altitude,海拔,NOUN,C1
-altogether,altogether,共,ADV,B2
-altruistic,altruistic,利他的,ADJ,B2
-alumnus,alumnus,校友,NOUN,B2
-always have,always have,总有,VERB,C1
-amalgam conflation,amalgam conflation,词,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
-amber,amber,琥珀,NOUN,B2
-ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
-ambivalence,ambivalence,词,NOUN,B2
-ambulance,ambulance,救护车,NOUN,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
-amend,to amend,修订,VERB,B2
-amendable,amendable,可修正的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
-amended interior,amended interior,改内,NOUN,B2
-amended judgment,amended judgment,改断,NOUN,B2
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
-amends,amends,词,NOUN,C1
-american,american,美国的,ADJ,B2
-amicable,amicable,友好的,ADJ,B2
-amicable out-of-court,amicable out-of-court,词,ADJ,B2
-amino acid,amino acid,氨基酸,NOUN,C1
-amnesia,amnesia,健忘症,NOUN,B2
-amnesty,amnesty,大赦,NOUN,B2
-among,among,在……之中,ADP,B2
-among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amoral,amoral,词,ADJ,C1
-amorphous,amorphous,无定形的,ADJ,B2
-amortization,amortization,词,NOUN,C1
-amortize,to amortize,摊销,VERB,B2
-amount to,to amount to,总计,VERB,B2
-amphitheater lecture hall,amphitheater lecture hall,词,NOUN,B2
-ample,ample,充足的,ADJ,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
-amplitude range,amplitude range,词,NOUN,C1
-amputate,to amputate,截肢,VERB,B2
-amuse,to amuse,逗乐,VERB,B2
-amused,amused,词,ADJ,B2
-amusement,amusement,娱乐,NOUN,B2
-an,an,词,DET,A1
-an official standard,an official standard,标准,NOUN,B2
-anachronism,anachronism,时代错误,NOUN,B2
-anachronistic,anachronistic,时代错误的,ADJ,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,词,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
-analogize,analogize,词,VERB,B2
-analogous,analogous,类似的,ADJ,B2
-analogous similar,analogous similar,词,ADJ,C1
-analysis,analysis,分析,NOUN,B2
-analyst,analyst,分析师,NOUN,B2
-analytical,analytical,分析的,ADJ,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchical,anarchical,词,ADJ,C1
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
-anarchy,anarchy,无政府状态,NOUN,B2
-anathema,anathema,深恶痛绝之物,NOUN,B2
-anatomy,anatomy,解剖学,NOUN,B2
-ancestor,ancestor,祖先,NOUN,B2
-ancestors,ancestors,祖先,NOUN,B2
-ancestral,ancestral,词,ADJ,C1
-ancestry,ancestry,血统,NOUN,B2
-ancient temple,ancient temple,古寺,NOUN,C1
-ancient times,ancient times,古代,NOUN,B2
-ancillary,ancillary,辅助的,ADJ,B2
-and,and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
-and so on,and so on,之类,NOUN,B2
-and you,and you,而你…,NOUN,C1
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
-anemic,anemic,词,ADJ,C1
-anerziehung,anerziehung,词,NOUN,C1
-aneurysm,aneurysm,词,NOUN,C1
-anfahrt,anfahrt,词,NOUN,C1
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angelic,angelic,天使般的,ADJ,B2
-angestaltung,angestaltung,词,NOUN,C1
-angle of approach,angle of approach,切入点,NOUN,B2
-anguished,anguished,词,ADJ,C1
-angular,angular,有角的,ADJ,B2
-animated,animated,词,ADJ,C1
-animated film,animated film,动画片,NOUN,B2
-animosity,animosity,敌意,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
-annihilate,to annihilate,消灭,VERB,B2
-annotate,to annotate,注释,VERB,B2
-annotation,annotation,词,NOUN,C1
-announcement,announcement,公告,NOUN,B2
-annoy,to annoy,使恼怒,VERB,B2
-annoyed,annoyed,恼火的,ADJ,B2
-annoying,annoying,恼人的,ADJ,B2
-annual,annual,年度的,ADJ,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annual report,annual report,年报,NOUN,B2
-annual wage,annual wage,年薪,NOUN,B2
-annually,annually,每年,ADV,B2
-annuity private income,annuity private income,词,NOUN,C1
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
-anomalous,anomalous,词,ADJ,C1
-anomaly,anomaly,异常,NOUN,B2
-anonymity,anonymity,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anonymous,anonymous,匿名的,ADJ,B2
-anonymously,anonymously,词,ADV,B2
-anorexia,anorexia,词,NOUN,C1
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansicht,ansicht,词,NOUN,C1
-ansinnung,ansinnung,词,NOUN,C1
-ansprache,ansprache,词,NOUN,C1
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-answer questions,answer questions,答疑,VERB,C1
-answer reply,to answer reply,回答,VERB,B2
-answering machine,answering machine,邮箱,NOUN,B2
-antagonism,antagonism,对抗,NOUN,B2
-antagonistic,antagonistic,词,ADJ,C1
-antecedent,antecedent,先行词,NOUN,B2
-antediluvian,antediluvian,词,ADJ,C1
-anteilung,anteilung,词,NOUN,B2
-anteroom,anteroom,词,NOUN,B2
-antheilung,antheilung,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthill,anthill,词,NOUN,C1
-anthropological,anthropological,词,ADJ,C1
-anti-Semitic,anti-Semitic,词,ADJ,C1
-anti-abstraction,anti-abstraction,反抽,NOUN,B2
-anti-action,anti-action,反作,NOUN,B2
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
-anti-generality,anti-generality,反般,NOUN,B2
-anti-integration,anti-integration,反合,NOUN,B2
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
-anti-measure,anti-measure,反度,NOUN,B2
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
-anti-omnipresence,anti-omnipresence,反遍,NOUN,B2
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-war,anti-war,反战,NOUN,B2
-anti-work,anti-work,反功,NOUN,C1
-antibiotic,antibiotic,抗生素,NOUN,B2
-anticipatory,anticipatory,词,ADJ,C1
-anticyclone,anticyclone,反气旋,NOUN,B2
-antidote,antidote,解毒剂,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
-antinomy,antinomy,词,NOUN,C1
-antioxidant,antioxidant,抗氧化剂,NOUN,B2
-antiphrasis,antiphrasis,词,NOUN,C1
-antipode,antipode,对跖点,NOUN,B2
-antiquated,antiquated,过时的,ADJ,B2
-antique,antique,古老的,ADJ,B2
-antique (noun),antique,古董,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
-antisocial,antisocial,反社会的,ADJ,B2
-antonomasia,antonomasia,词,NOUN,C1
-antonym,antonym,反义词,NOUN,B2
-antreibung,antreibung,词,NOUN,C1
-antsy,antsy,词,ADJ,C1
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-anxious,anxious,焦虑的,ADJ,B2
-anxious eager,anxious eager,词,ADJ,B1
-any,any,任何,DET,B2
-any (adj),any,词,ADJ,B1
-any (adv),any,词,ADV,B2
-any (pron),any,任何,PRON,B2
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anyone,anyone,任何人,PRON,B2
-anything,anything,任何事,PRON,B2
-anyway,anyway,无论如何,ADV,B2
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-apart,apart,分开,ADV,B2
-apart from,apart from,除了,ADP,B2
-apart from (verb),apart from,词,VERB,C1
-apartheid,apartheid,词,NOUN,C1
-apathetic,apathetic,冷漠的,ADJ,B2
-apathy,apathy,冷漠,NOUN,B2
-apex,apex,顶点,NOUN,B2
-aphasia,aphasia,失语症,NOUN,B2
-apnea,apnea,词,NOUN,C1
-apocalypse,apocalypse,词,NOUN,C1
-apocalyptic,apocalyptic,启示录的,ADJ,B2
-apocryphal,apocryphal,杜撰的,ADJ,B2
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
-apolitical,apolitical,词,ADJ,B2
-apologetic,apologetic,道歉的,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apologist,apologist,辩护者,NOUN,B2
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-apoplexy,apoplexy,词,NOUN,C1
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
-apostate,apostate,叛教者,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostle,apostle,词,NOUN,C1
-apostrophize,apostrophize,词,VERB,C1
-apotheosis,apotheosis,词,NOUN,C1
-apotheotic,apotheotic,神化的,ADJ,B2
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
-apparatus,apparatus,仪器,NOUN,B2
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-apparently,apparently,显然,ADV,B2
-appease,to appease,安抚,VERB,B2
-append,append,词,VERB,C1
-appendix,appendix,附录,NOUN,B2
-appertain,appertain,词,VERB,C1
-applaud,to applaud,鼓掌,VERB,B2
-appliance,appliance,词,NOUN,B1
-applicability,applicability,适用性,NOUN,B2
-applicable,applicable,词,ADJ,B2
-applicant,applicant,申请人,NOUN,B2
-apply,to apply,申请,VERB,B2
-apply a cast,to apply a cast,打石膏,VERB,B2
-apply makeup,to apply makeup,化妆,VERB,B2
-appoint,to appoint,任命,VERB,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-appraise,to appraise,评估,VERB,B2
-appreciable,appreciable,词,ADJ,C1
-apprehensive,apprehensive,忧虑的,ADJ,B2
-approachable,approachable,词,ADJ,C1
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,词,NOUN,B2
-approval pleasure,approval pleasure,词,NOUN,C1
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
-approximate,approximate,近似的,ADJ,B2
-april,april,四月,NOUN,B2
-apt,apt,词,ADJ,C1
-aptitude,aptitude,天资,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-arabic (adj),arabic,阿拉伯的,ADJ,B2
-arable land,arable land,耕地,NOUN,C1
-arbitrage,arbitrage,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
-arcane,arcane,神秘的,ADJ,B2
-archaeologist,archaeologist,词,NOUN,C1
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
-archetype,archetype,原型,NOUN,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-ardent,ardent,热情的,ADJ,B2
-argentinian,argentinian,词,ADJ,B2
-arguable,arguable,词,ADJ,C1
-argumentative,argumentative,词,ADJ,C1
-arid,arid,干旱的,ADJ,B2
-aridity,aridity,词,NOUN,C1
-aristocratic,aristocratic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
-armament,armament,词,NOUN,B2
-armband,armband,词,NOUN,C1
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armored,armored,词,ADJ,C1
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arraign,arraign,词,VERB,C1
-arranged,arranged,词,ADJ,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-array,array,排列,NOUN,B2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrested,arrested,被逮捕的,ADJ,B2
-arrhythmia,arrhythmia,词,NOUN,C1
-arrived present,arrived present,到了,ADV,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
-arson,arson,纵火,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-arterial,arterial,词,ADJ,C1
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
-artichoke,artichoke,词,NOUN,B1
-articulation,articulation,清晰表达,NOUN,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,词,ADV,B2
-artillery,artillery,炮兵,NOUN,B2
-artistry,artistry,,NOUN,B2
-artless,artless,词,ADJ,C1
-artwork,artwork,词,NOUN,B2
-as a result of which,as a result of which,词,ADV,B2
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as far as,as far as,词,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as many,as many,词,NUM,B2
-as much,as much,词,ADV,A1
-as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,词,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
-as soon as,as soon as,一...就,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
-as well as (sconj),as well as,词,SCONJ,B2
-as when,as when,词,SCONJ,A1
-asbestos,asbestos,词,NOUN,C1
-ascertain,ascertain,词,VERB,C1
-ascetic,ascetic,苦行的,ADJ,B2
-ashen,ashen,灰白的,ADJ,B2
-ashes,ashes,词,NOUN,B2
-ashore,ashore,词,ADV,C1
-ashtray,ashtray,烟灰缸,NOUN,B2
-asian,asian,亚洲的,ADJ,B2
-aside (noun),aside,词,NOUN,C1
-asinine,asinine,词,ADJ,C1
-asleep,asleep,词,ADJ,A2
-asp,asp,角蝰,NOUN,B2
-asparagus,asparagus,芦笋,NOUN,B2
-aspect,aspect,方面,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-asphalt,asphalt,沥青,NOUN,B2
-asphyxia,asphyxia,窒息,NOUN,B2
-aspirant,aspirant,词,NOUN,C1
-aspire,to aspire,渴望,VERB,B2
-ass,ass,驴,NOUN,B2
-assail,assail,词,VERB,C1
-assailant,assailant,词,NOUN,C1
-assassin,assassin,刺客,NOUN,B2
-assassinate,to assassinate,暗杀,VERB,B2
-assassination,assassination,暗杀,NOUN,B2
-assemble,to assemble,集合,VERB,B2
-assent (noun),assent,词,NOUN,B2
-assertion,assertion,断言,NOUN,B2
-assess,to assess,评估,VERB,B2
-asset,asset,资产,NOUN,B2
-asshole,asshole,词,NOUN,A2
-assiduously,assiduously,词,ADV,C1
-assign,to assign,分配,VERB,B2
-assimilate,to assimilate,同化,VERB,B2
-assist,to assist,协助,VERB,B2
-assistant,assistant,助手,NOUN,B2
-associate,to associate,联想,VERB,B2
-associate (noun),associate,词,NOUN,B2
-associated,associated,相关的,ADJ,B2
-assort,assort,词,VERB,C1
-assortment,assortment,词,NOUN,C1
-assuage,assuage,词,VERB,C1
-assurance,assurance,保证,NOUN,B2
-assure,to assure,保证,VERB,B2
-asthenia,asthenia,词,NOUN,C1
-asthmatic,asthmatic,哮喘的,ADJ,B2
-astonish,to astonish,使惊讶,VERB,B2
-astonished,astonished,惊讶的,ADJ,C1
-astonishing,astonishing,令人惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astray,astray,迷路,ADJ,B2
-astride (adp),astride,词,ADP,C1
-astride (adv),astride,词,ADV,C1
-astringent (adj),astringent,词,ADJ,C1
-astringent (noun),astringent,词,NOUN,B2
-astrology,astrology,占星术,NOUN,B2
-astronaut,astronaut,宇航员,NOUN,B2
-astronomer,astronomer,词,NOUN,B1
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
-asylum shelter,asylum shelter,词,NOUN,B2
-asymmetrical,asymmetrical,不对称的,ADJ,B2
-asymptomatic,asymptomatic,词,ADJ,C1
-asyndeton,asyndeton,词,NOUN,B2
-at any time,at any time,随时,ADV,B2
-at ease,at ease,安心,ADJ,B2
-at home,at home,在家,ADV,B2
-at home (noun),at home,家里,NOUN,C1
-at it,at it,词,ADV,B2
-at least,at least,至少,ADV,B2
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,词,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the bottom,at the bottom,词,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
-at the same time,at the same time,同时,ADV,B2
-at the top,at the top,在最上面,ADV,B2
-at will,at will,任由,NOUN,B2
-at worst,at worst,大不了,ADV,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
-atheist,atheist,无神论者,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
-athletic,athletic,运动的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atm,atm,自动取款机,NOUN,B2
-atmosphere,atmosphere,大气,NOUN,B2
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atmospheric,atmospheric,大气的,ADJ,B2
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atone,to atone,赎罪,VERB,B2
-atonement,atonement,赎罪,NOUN,C1
-atony,atony,词,NOUN,C1
-atrocious,atrocious,词,ADJ,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-atrocity,atrocity,暴行,NOUN,B2
-atrophy,atrophy,萎缩,NOUN,B2
-attached,attached,词,ADJ,B2
-attack,attack,攻击,NOUN,B2
-attacked,attacked,被攻击的,ADJ,B2
-attacker,attacker,攻击者,NOUN,B2
-attainable,attainable,可获得的,ADJ,C1
-attempt,attempt,尝试,NOUN,B2
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend,to attend,出席,VERB,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
-attendant,attendant,服务员,NOUN,B2
-attention (intj),attention,词,INTJ,B2
-attentive,attentive,专心的,ADJ,B2
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attic,attic,阁楼,NOUN,B2
-attire,attire,服装,NOUN,B2
-attitude,attitude,态度,NOUN,B2
-attitude setting,attitude setting,词,NOUN,B2
-attorney,attorney,律师,NOUN,B2
-attract,to attract,吸引,VERB,B2
-attractive,attractive,有吸引力的,ADJ,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attribution,attribution,归因,NOUN,B2
-attributive,attributive,定语的,ADJ,B2
-atypical,atypical,非典型的,ADJ,B2
-auction,auction,拍卖,NOUN,B2
-audacious,audacious,大胆的,ADJ,B2
-audibility,audibility,词,NOUN,C1
-audible,audible,听得见的,ADJ,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
-audiovisual,audiovisual,视听的,ADJ,B2
-audition,audition,词,NOUN,B1
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-augury,augury,词,NOUN,C1
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspice,auspice,赞助,NOUN,B2
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
-austere,austere,严厉的,ADJ,B2
-austheilung,austheilung,词,NOUN,C1
-australian,australian,澳大利亚的,ADJ,B2
-austreibung,austreibung,词,NOUN,C1
-austrian,austrian,奥地利的,ADJ,B2
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarchy,autarchy,词,NOUN,C1
-autarky,autarky,词,NOUN,B2
-authentic,authentic,真实的,ADJ,B2
-authenticate,to authenticate,认证,VERB,B2
-authoritarian,authoritarian,独裁的,ADJ,B2
-authoritative,authoritative,权威的,ADJ,B2
-authority figure,authority figure,词,NOUN,B2
-authority structure,authority structure,词,NOUN,B2
-authorization,authorization,授权,NOUN,B2
-authorize,to authorize,授权,VERB,B2
-autistic (adj),autistic,词,ADJ,C1
-autistic (noun),autistic,词,NOUN,C1
-autobiographical,autobiographical,词,ADJ,C1
-autobiography,autobiography,自传,NOUN,B2
-autocracy,autocracy,词,NOUN,C1
-autocratic,autocratic,专制的,ADJ,C1
-autograph,autograph,亲笔签名,NOUN,B2
-automatic,automatic,自动的,ADJ,B2
-autonomous,autonomous,自治的,ADJ,B2
-autonomy,autonomy,自治,NOUN,B2
-autopsy,autopsy,尸检,NOUN,B2
-autumn start,autumn start,立秋,NOUN,C1
-auxiliary,auxiliary,词,ADJ,C1
-avail,avail,词,NOUN,C1
-availability,availability,可用性,NOUN,B2
-available,available,可获得的,ADJ,B2
-avalanche,avalanche,雪崩,NOUN,B2
-avant-garde,avant-garde,前卫的,ADJ,B2
-avaricious,avaricious,词,ADJ,C1
-avenge,to avenge,复仇,VERB,B2
-avenue,avenue,大道,NOUN,B2
-aver,aver,词,VERB,C1
-averageness,averageness,词,NOUN,B2
-averse,averse,厌恶的,ADJ,B2
-avert,avert,词,VERB,C1
-avid,avid,热切的,ADJ,B2
-avocado,avocado,牛油果,NOUN,C1
-avoid,to avoid,避免,VERB,B2
-avoidable,avoidable,可避免的,ADJ,B2
-avow,avow,词,VERB,C1
-await,to await,等待,VERB,B2
-awake,awake,醒着的,ADJ,B2
-awaken,to awaken,唤醒,VERB,B2
-award,to award,分配,VERB,B2
-award auction,award auction,词,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-away,away,离开,ADV,B2
-away (adj),away,外出,ADJ,C1
-away (adp),away,避开,ADP,B2
-away gone,away gone,不在/离开,ADV,B2
-awesome,awesome,词,ADJ,A2
-awful,awful,糟糕的,ADJ,B2
-awkward,awkward,尴尬的,ADJ,B2
-awning,awning,词,NOUN,B2
-axiology,axiology,词,NOUN,C1
-axiomatic,axiomatic,公理的,ADJ,B2
-ba zi,ba zi,八字,NOUN,B2
-babble,babble,词,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-babysitter,babysitter,保姆,NOUN,B2
-bacchanal,bacchanal,狂欢,NOUN,B2
-bachelor,bachelor,单身汉,NOUN,B2
-back,back,回来,ADV,B2
-back mountain,back mountain,后山,NOUN,C1
-back side,back side,背面,NOUN,B2
-back then,back then,词,ADV,A1
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-backache,backache,背痛,NOUN,B2
-backdrop,backdrop,背景,NOUN,B2
-backfire,backfire,词,VERB,C1
-backpacker,backpacker,词,NOUN,B1
-backside,backside,词,NOUN,B2
-backslide,backslide,词,VERB,C1
-backward,backward,词,ADV,B2
-backyard,backyard,词,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
-bactericide,bactericide,杀菌剂,NOUN,C1
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
-badge,badge,徽章,NOUN,B2
-badger,badger,词,NOUN,C1
-baffle,baffle,词,VERB,C1
-baggage,baggage,行李,NOUN,B2
-bagpiper,bagpiper,风笛手,NOUN,B2
-bags,bags,包,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
-bakery,bakery,词,NOUN,A2
-balance sheet,balance sheet,资产负债表,NOUN,B2
-balancing,balancing,平衡的,ADJ,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballad,ballad,词,NOUN,C1
-ballast,ballast,词,NOUN,C1
-balloon,balloon,气球,NOUN,B2
-ballot,ballot,选票,NOUN,B2
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balsam,balsam,香脂,NOUN,B2
-balustrade,balustrade,栏杆,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
-ban (noun),ban,ban,NOUN,B2
-band tape,band tape,带子,NOUN,B2
-band volume,band volume,词,NOUN,C1
-bang,bang,砰,INTJ,B2
-banister,banister,词,NOUN,C1
-bank card,bank card,银行卡,NOUN,B2
-baptism,baptism,词,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
-bar,bar,酒吧,NOUN,B2
-bar of soap,bar of soap,词,NOUN,B2
-barbarian,barbarian,词,NOUN,B2
-barbarism,barbarism,野蛮,NOUN,B2
-barbarity,barbarity,残暴,NOUN,B2
-barbarization,barbarization,词,NOUN,B2
-barbecue,barbecue,烧烤,NOUN,B2
-barcode,barcode,条形码,NOUN,C1
-bard,bard,吟游诗人,NOUN,B2
-bare,bare,赤裸的,ADJ,B2
-barefoot,barefoot,赤脚的,ADJ,B2
-bareheaded,bareheaded,词,ADJ,C1
-barely,barely,几乎不,ADV,B2
-bargain (noun),bargain,便宜货,NOUN,B2
-barge,barge,驳船,NOUN,B2
-bark (noun),bark,词,NOUN,B2
-barking,barking,词,NOUN,B2
-barn,barn,谷仓,NOUN,B2
-baron,baron,词,NOUN,B2
-baroness,baroness,女男爵,NOUN,B2
-barracks,barracks,词,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barrel,barrel,桶,NOUN,B2
-barren,barren,词,ADJ,C1
-barrenness,barrenness,词,NOUN,C1
-barricade,barricade,路障,NOUN,B2
-barter (verb),barter,词,VERB,C1
-basal,basal,基本的,ADJ,B2
-base,to base,基于,VERB,B2
-base fertilizer,base fertilizer,基肥,NOUN,B2
-baseball,baseball,棒球,NOUN,B2
-based,based,基于,ADJ,B2
-bash,bash,词,VERB,C1
-basic,basic,基本的,ADJ,B2
-basic attitude,basic attitude,词,NOUN,C1
-basic income,basic income,基本收入,NOUN,B2
-basically,basically,基本上,ADV,B2
-basilica,basilica,大教堂,NOUN,B2
-basing,basing,词,NOUN,C1
-basis,basis,基础,NOUN,B2
-bask,bask,词,VERB,C1
-basketball,basketball,篮球,NOUN,B2
-bass,bass,贝斯,NOUN,B2
-bastard,bastard,混蛋,NOUN,B2
-baste,baste,词,VERB,C1
-basting,basting,词,NOUN,C1
-bastion,bastion,堡垒,NOUN,B2
-batch,batch,一批,NOUN,B2
-bath mat,bath mat,浴垫,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-bathe,to bathe,洗澡,VERB,B2
-bathrobe,bathrobe,词,NOUN,A2
-bathroom,bathroom,浴室,NOUN,B2
-bathtub,bathtub,浴缸,NOUN,B2
-baton,baton,警棍,NOUN,B2
-battalion,battalion,营,NOUN,B2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
-battlefield,battlefield,战场,NOUN,B2
-battlement,battlement,城垛,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
-be,be,是,AUX,B2
-be able to,be able to,能,AUX,B2
-be addicted,to be addicted,上瘾,VERB,B2
-be allowed,be allowed,允许,AUX,B2
-be ashamed,to be ashamed,感到羞愧,VERB,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be born,to be born,出生,VERB,B2
-be brave,to be brave,勇善,VERB,B2
-be called,to be called,叫做,VERB,B2
-be crushed,be crushed,词,VERB,C1
-be damaged,to be damaged,受损,VERB,B2
-be defeated,to be defeated,会败,VERB,B2
-be eager,to be eager,心切,VERB,B2
-be eager for,to be eager for,巴不得,VERB,B2
-be elected,to be elected,当选,VERB,B2
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be rumored,be rumored,词,VERB,C1
-be shot,be shot,中弹,VERB,C1
-be sorry,be sorry,抱歉,ADJ,B2
-be tender,be tender,词,ADJ,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beaten,beaten,词,ADJ,B2
-beatitude,beatitude,词,NOUN,B2
-beautification,beautification,词,NOUN,C1
-beautifully,beautifully,美丽地,ADV,B2
-beaver,beaver,词,NOUN,C1
-because of this,because of this,词,ADV,A2
-beckon,beckon,词,VERB,C1
-become,become,成为,AUX,B2
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedsheet,bedsheet,词,NOUN,B2
-bedside,bedside,词,NOUN,C1
-beech grove,beech grove,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beehive,beehive,词,NOUN,C1
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
-befahrt,befahrt,词,NOUN,C1
-befall,befall,词,VERB,C1
-befassung,befassung,词,NOUN,C1
-befit,befit,词,VERB,C1
-beforderung,beforderung,词,NOUN,C1
-before,before,在...之前,SCONJ,B2
-before (noun),before,以前,NOUN,A1
-before previously,before previously,以前,ADV,B2
-before that,before that,词,ADV,B1
-befuddle,befuddle,词,VERB,C1
-beg for pity,beg for pity,乞怜,VERB,B2
-begabe,begabe,词,NOUN,C1
-begestaltung,begestaltung,词,NOUN,C1
-beginning primer,beginning primer,词,NOUN,C1
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
-behavioral,behavioral,词,ADJ,B2
-behavioral pattern,behavioral pattern,词,NOUN,C1
-behaviorist,behaviorist,行为主义者,NOUN,B2
-beheading,beheading,按律当斩,NOUN,C1
-behind (adv),behind,词,ADV,A1
-behind it,behind it,在后面,ADV,B2
-behoove,behoove,词,VERB,C1
-bejeweled,bejeweled,镶满宝石的,ADJ,B2
-bekunft,bekunft,词,NOUN,C1
-belabor,belabor,词,VERB,C1
-belated,belated,词,ADJ,C1
-belatedly,belatedly,词,ADV,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-beleaguered,beleaguered,受围困的,ADJ,B2
-belgian,belgian,比利时的,ADJ,B2
-belgian (noun),belgian,比利时人,NOUN,C1
-belie,belie,词,VERB,C1
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-believability,believability,词,NOUN,C1
-bell tower,bell tower,词,NOUN,A2
-belligerent,belligerent,好战的,ADJ,B2
-bellows,bellows,词,NOUN,C1
-beloved,beloved,心爱的,ADJ,B2
-below,below,下面,ADV,B2
-below (adj),below,下面的,ADJ,B1
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-benahme,benahme,词,NOUN,B2
-bench seat,bench seat,词,NOUN,C1
-beneath,beneath,词,ADP,B2
-beneficence,beneficence,词,NOUN,C1
-beneficial,beneficial,词,ADJ,B2
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-bepflegung,bepflegung,词,NOUN,B2
-bequest,bequest,词,NOUN,B2
-berate,berate,词,VERB,C1
-bereave,bereave,词,VERB,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-berichtung,berichtung,词,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beschaft,beschaft,词,NOUN,C1
-beschrift,beschrift,词,NOUN,C1
-beseech,beseech,词,VERB,C1
-beset,beset,词,VERB,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
-beside,beside,在...旁边,ADP,B2
-besides (adp),besides,之外,ADP,B2
-besides (part),besides,况,PART,A2
-besieged,besieged,词,ADJ,B2
-besinnung,besinnung,词,NOUN,C1
-besmirch,besmirch,词,VERB,C1
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-best possible,best possible,词,ADJ,C1
-bestial,bestial,词,ADJ,C1
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
-bet (noun),bet,赌注,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betray one's country,betray one's country,卖国,VERB,B2
-betreibung,betreibung,词,NOUN,C1
-betrothal,betrothal,订婚,NOUN,B2
-betrothal gift,betrothal gift,聘,NOUN,C1
-better,better,越好,NOUN,B2
-better (adv),better,词,ADV,A1
-better-off,better-off,好过,NOUN,C1
-bewail,bewail,词,VERB,C1
-bewandel,bewandel,词,NOUN,C1
-beware,beware,词,VERB,C1
-beweisung,beweisung,词,NOUN,C1
-bewilder,bewilder,词,VERB,C1
-bewirkung,bewirkung,词,NOUN,C1
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-biennial,biennial,词,NOUN,C1
-bifurcation,bifurcation,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big cat,big cat,词,NOUN,C1
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigger,bigger,更大的,ADJ,B2
-bigness,bigness,词,NOUN,B2
-bigwig,bigwig,大人物,NOUN,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
-bilateral,bilateral,双边的,ADJ,B2
-bilingual,bilingual,词,ADJ,C1
-bilingualism,bilingualism,词,NOUN,C1
-bilious,bilious,易怒的,ADJ,C1
-bilk,bilk,词,VERB,C1
-billionaire,billionaire,词,NOUN,C1
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
-binder,binder,词,NOUN,A2
-binge,binge,放纵,NOUN,C1
-bingo,bingo,词,NOUN,B2
-binoculars,binoculars,双筒望远镜,NOUN,B2
-biographical,biographical,词,ADJ,C1
-biologist,biologist,词,NOUN,B2
-biology,biology,生物学,NOUN,B2
-biomass,biomass,生物质,NOUN,B2
-biotechnology,biotechnology,生物技术,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday,birthday,生日,NOUN,B2
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-biscuit,biscuit,饼干,NOUN,A2
-bisexual,bisexual,双性恋的,ADJ,B2
-bishop,bishop,主教,NOUN,B2
-bistro,bistro,小酒馆,NOUN,B2
-bit,bit,一点,NOUN,B2
-bitch,bitch,母狗,NOUN,B2
-biting,biting,咬人,NOUN,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-biweekly,biweekly,双周的,ADJ,C1
-bizarre,bizarre,奇异的,ADJ,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-blab,blab,词,VERB,C1
-black,black,黑色的,ADJ,B2
-black market,black market,黑市,NOUN,B2
-black robe,black robe,黑衣,NOUN,B2
-blackberry,blackberry,黑莓,NOUN,B2
-blackbird,blackbird,词,NOUN,B2
-blacken,to blacken,变黑,VERB,B2
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blade,blade,刀片,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blah,blah,词,INTJ,C1
-blanch,blanch,词,VERB,C1
-bland,bland,平淡的,ADJ,B2
-blandish,blandish,词,VERB,C1
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blasphemy,blasphemy,亵渎,NOUN,B2
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blazing,blazing,词,ADJ,C1
-bleak,bleak,无望的,ADJ,B2
-bleed,to bleed,出血,VERB,B2
-bleeding,bleeding,流血的,ADJ,B2
-blemish,blemish,瑕疵,NOUN,B2
-blend,blend,词,VERB,B2
-blender,blender,词,NOUN,B2
-bless,to bless,祝福,VERB,B2
-blessed,blessed,受祝福的,ADJ,B2
-blight,blight,词,NOUN,C1
-blind,blind,盲的,ADJ,B2
-blind (noun),blind,盲人,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blister,blister,词,NOUN,C1
-blizzard,blizzard,暴风雪,NOUN,B2
-bloat,bloat,词,VERB,C1
-block,block,街区,NOUN,B2
-block,to block,阻塞,VERB,B2
-blockade,blockade,封锁,NOUN,B2
-blockade,to blockade,封锁,VERB,B2
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blockhead,blockhead,词,NOUN,B2
-blood debt,blood debt,血债,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood sea,blood sea,血海,NOUN,B2
-blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood-related,blood-related,词,ADJ,C1
-bloodless,bloodless,不流血的,ADJ,B2
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,血染,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloody,bloody,血淋淋的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
-blow,blow,打击,NOUN,B2
-blow,to blow,吹,VERB,B2
-blow (noun),blow,他打,NOUN,A2
-blow beating,blow beating,词,NOUN,B2
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blueberry,blueberry,蓝莓,NOUN,B2
-blueprint,blueprint,词,NOUN,C1
-blunder (noun),blunder,大错,NOUN,C1
-blunt,blunt,词,ADJ,B2
-bluntly,bluntly,直率地,ADV,B2
-bluntness,bluntness,直说,NOUN,B2
-blur,to blur,模糊,VERB,B2
-blurred,blurred,词,ADJ,C1
-blurriness,blurriness,词,NOUN,C1
-blurry,blurry,词,ADJ,B2
-blurt,blurt,词,VERB,C1
-bluster,bluster,词,VERB,C1
-board,board,木板,NOUN,B2
-boarder,boarder,词,NOUN,B2
-boarding,boarding,词,NOUN,C1
-boarding pass,boarding pass,登机牌,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastful,boastful,自夸的,ADJ,B2
-boastfulness,boastfulness,词,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bode,bode,词,VERB,C1
-bodily,bodily,身体上的,ADJ,B2
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-bog,bog,沼泽,NOUN,B2
-boggle,boggle,词,VERB,C1
-bohemian,bohemian,放荡不羁的,ADJ,B2
-boil (noun),boil,词,NOUN,C1
-boiled water,boiled water,开水,NOUN,C1
-boiling (adj),boiling,词,ADJ,C1
-boisterous,boisterous,喧闹的,ADJ,C1
-bolster (noun),bolster,词,NOUN,C1
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolted,bolted,词,ADJ,C1
-bombardment,bombardment,轰炸,NOUN,B2
-bomber,bomber,词,NOUN,C1
-bondholder,bondholder,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-bonfire,bonfire,篝火,NOUN,B2
-bonhomie,bonhomie,词,NOUN,C1
-bookcase,bookcase,书柜,NOUN,B2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,词,NOUN,B2
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,词,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border frontier,border frontier,词,NOUN,B1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,词,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,词,NOUN,B2
-bordering,bordering,词,ADJ,C1
-born (adj),born,词,ADJ,B2
-born (noun),born,词,NOUN,B2
-born (verb),born,词,VERB,A1
-borrowed,borrowed,词,ADJ,C1
-borrowed knife,borrowed knife,借刀,NOUN,B2
-bosom,bosom,词,NOUN,C1
-boss female,boss female,词,NOUN,B2
-boss manager,boss manager,词,NOUN,A1
-bossism,bossism,老板主义,NOUN,B2
-botanical,botanical,词,ADJ,C1
-botany,botany,词,NOUN,C1
-botched job,botched job,词,NOUN,B2
-both,both,两者,PRON,B2
-both (adj),both,两者的,ADJ,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
-both parties,both parties,双方,NOUN,B1
-bother (noun),bother,烦不,NOUN,B1
-bottle opener,bottle opener,词,NOUN,B1
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
-bounce,bounce,词,VERB,B2
-bound to,bound to,势必,ADV,B2
-boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bourgeois,bourgeois,资产阶级的,ADJ,B2
-bout,bout,阵,NOUN,B2
-bovine,bovine,词,ADJ,C1
-bow (verb),bow,词,VERB,B1
-bow tie,bow tie,词,NOUN,B2
-bower,bower,凉亭,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-boxer,boxer,拳击手,NOUN,B2
-brabant,brabant,词,ADJ,B2
-brace,brace,词,NOUN,C1
-bracket,bracket,括号,NOUN,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-bragging,bragging,吹嘘,NOUN,B2
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,词,NOUN,B2
-brainstorming,brainstorming,词,NOUN,C1
-brainwasher,brainwasher,洗脑者,NOUN,B2
-brainy,brainy,词,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakeman,brakeman,词,NOUN,C1
-braking,braking,词,NOUN,C1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-brass band,brass band,词,NOUN,B2
-brawl,brawl,斗殴,NOUN,B2
-bray,bray,词,VERB,C1
-brazen,brazen,厚颜无耻的,ADJ,C1
-brazilian,brazilian,巴西的,ADJ,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of duty,breach of duty,词,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-bread roll,bread roll,小圆面包,NOUN,B2
-breadth,breadth,词,NOUN,C1
-breadth crossing,breadth crossing,词,NOUN,C1
-break fraction,break fraction,词,NOUN,C1
-break out of prison,break out of prison,越狱,VERB,C1
-break-in,break-in,非法侵入,NOUN,B2
-breakage,breakage,词,NOUN,C1
-breakthrough,breakthrough,突破性,ADJ,B2
-breakup,breakup,分手,NOUN,B2
-breast,breast,乳房,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,词,NOUN,B2
-breathlessness,breathlessness,词,NOUN,B1
-breed (verb),breed,育种,VERB,C1
-breviary,breviary,词,NOUN,C1
-bridal attire,bridal attire,红妆,NOUN,C1
-bridegroom,bridegroom,词,NOUN,C1
-bridle,bridle,马勒,NOUN,B2
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brigade,brigade,词,NOUN,C1
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightly,brightly,词,ADV,C1
-brightness,brightness,词,NOUN,C1
-brim,brim,词,NOUN,C1
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-briskness,briskness,轻快,NOUN,B2
-bristle (noun),bristle,词,NOUN,C1
-brittle,brittle,易碎的,ADJ,B2
-bro,bro,哥们,NOUN,B2
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broadcaster,broadcaster,广播公司,NOUN,B2
-broadcasting station,broadcasting station,词,NOUN,C1
-broaden,broaden,词,VERB,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade (part),brocade,锦,PART,A1
-broccoli,broccoli,西兰花,NOUN,C1
-brochure,brochure,小册子,NOUN,C1
-broil,broil,词,VERB,C1
-broke,broke,破产的,ADJ,B2
-broken,broken,破碎的,ADV,B2
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,词,ADJ,B2
-brooch,brooch,词,NOUN,C1
-brooding (adj),brooding,词,ADJ,B2
-brooding (noun),brooding,忧思,NOUN,C1
-brook no delay,brook no delay,刻不容缓,ADJ,B2
-broom blow,broom blow,词,NOUN,C1
-brother (part),brother,兄,PART,B1
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-brow,brow,眉毛,NOUN,B2
-browbeat,browbeat,词,VERB,C1
-brusqueness,brusqueness,唐突,NOUN,C1
-brutal,brutal,词,ADJ,B2
-brutality,brutality,残暴,NOUN,B2
-brutalizing,brutalizing,词,ADJ,C1
-brutally,brutally,词,ADV,C1
-brute,brute,词,ADJ,B2
-bubbling,bubbling,冒泡的,ADJ,B2
-buccaneer,buccaneer,海盗,NOUN,B2
-buckle,buckle,词,VERB,C1
-bucolic,bucolic,词,ADJ,C1
-bud,bud,芽,NOUN,B2
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budge,budge,词,VERB,C1
-budgetable,budgetable,可预算的,ADJ,B2
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-buffoon,buffoon,小丑,NOUN,B2
-building blocks,building blocks,积木,NOUN,C1
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulge,bulge,词,NOUN,C1
-bull,bull,词,NOUN,B1
-bulldog,bulldog,斗牛犬,NOUN,B2
-bulldoze,bulldoze,词,VERB,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bulwark,bulwark,壁垒,NOUN,B2
-bum,bum,流浪汉,NOUN,B2
-bumble,bumble,词,VERB,C1
-bumblebee,bumblebee,词,NOUN,C1
-bump,bump,肿块,NOUN,B2
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bunch,bunch,词,NOUN,A2
-bundling,bundling,词,NOUN,C1
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bungler,bungler,词,NOUN,C1
-bunker,bunker,词,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-buoyant,buoyant,有浮力的,ADJ,B2
-burdened,burdened,负担重的,ADJ,B2
-burdensome,burdensome,繁重的,ADJ,C1
-bureaucratic,bureaucratic,词,ADJ,C1
-burger stand,burger stand,,NOUN,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-burlesque (adj),burlesque,词,ADJ,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burn (noun),burn,烧,NOUN,B2
-burned,burned,词,ADJ,B2
-burner,burner,燃烧器,NOUN,B2
-burp (noun),burp,词,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-burst in,burst in,词,VERB,C1
-bushy,bushy,词,ADJ,C1
-business card,business card,名片,NOUN,B1
-business sector,business sector,词,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-bust,bust,词,NOUN,B1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-busyness,busyness,事忙,NOUN,B2
-but,but,然而,ADV,B2
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but i,but i,可我,ADV,B2
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but you,but you,但您,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-butler,butler,词,NOUN,C1
-butt,butt,臀部,NOUN,B2
-buttocks,buttocks,屁股,NOUN,B2
-buttress,buttress,扶壁,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buyer purchaser,buyer purchaser,词,NOUN,B2
-buying and selling,buying and selling,词,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by,by,通过,ADP,B2
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by chance,by chance,偶然地,ADV,B2
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
-by fair means or foul,by fair means or foul,不择手段,ADV,B2
-by heart,by heart,词,ADV,B2
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
-by means of,by means of,通过,ADP,B2
-by means of (noun),by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
-by the way,by the way,顺便说一下,ADV,B2
-by year,by year,以岁,NOUN,C1
-bye,bye,再见,INTJ,B2
-bypass (noun),bypass,词,NOUN,C1
-bypass surgery,bypass surgery,搭桥手术,NOUN,B2
-byzantine,byzantine,错综复杂的,ADJ,B2
-cabin,cabin,小屋,NOUN,B2
-cabin boy,cabin boy,词,NOUN,C1
-cabinet,cabinet,内阁,NOUN,B2
-cabinetmaker,cabinetmaker,细木工匠,NOUN,C1
-cache,cache,词,NOUN,C1
-cachexia,cachexia,词,NOUN,C1
-cackle,cackle,词,VERB,C1
-cacophony,cacophony,刺耳的声音,NOUN,B2
-cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
-cadence,cadence,词,NOUN,B2
-caesura,caesura,词,NOUN,C1
-cafeteria,cafeteria,词,NOUN,B1
-caffeine,caffeine,词,NOUN,C1
-cage,cage,笼子,NOUN,B2
-cage (verb),cage,词,VERB,C1
-cajole,cajole,词,VERB,C1
-calamitous,calamitous,灾难性的,ADJ,B2
-calcareous,calcareous,词,ADJ,B2
-calculate,to calculate,计算,VERB,B2
-calculation,calculation,计算,NOUN,B2
-calculator,calculator,计算器,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
-call,call,电话,NOUN,B2
-caller,caller,词,NOUN,A2
-calligraphy,calligraphy,书法,NOUN,B2
-calling,calling,使命,NOUN,B2
-callous,callous,冷酷,ADJ,B2
-callus,callus,硬茧……,NOUN,C1
-calm,to calm,使平静,VERB,B2
-calming,calming,词,ADJ,B2
-calmly,calmly,平静地,ADV,B2
-calve,calve,词,VERB,C1
-camouflage (noun),camouflage,词,NOUN,C1
-camp (part),camp,营,PART,A2
-campaign,to campaign,积极参与活动,VERB,B2
-campfire,campfire,词,NOUN,C1
-campsite,campsite,露营地,NOUN,B2
-campus,campus,词,NOUN,B2
-campus-like,campus-like,词,ADJ,B2
-can,can,能够,AUX,B2
-can (noun),can,词,NOUN,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,词,NOUN,B2
-can may,can may,可以,AUX,A1
-can only,can only,只能,AUX,B2
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't believe,to can't believe,不敢相信,VERB,B2
-can't help,can't help,不由得,ADV,B2
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
-canadian,canadian,加拿大的,ADJ,B2
-canal,canal,运河,NOUN,B2
-canal belt,canal belt,词,NOUN,C1
-cancel,to cancel,取消,VERB,B2
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
-candid,candid,词,ADJ,C1
-candy shop,candy shop,词,NOUN,B2
-cane,cane,词,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
-canned food,canned food,罐头食品,NOUN,B2
-cannon,cannon,大炮,NOUN,B2
-cannot,cannot,不能,AUX,B2
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot bear,to cannot bear,不堪,VERB,B2
-cannot help,to cannot help,忍不住,VERB,B2
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-canonical,canonical,规范的,ADJ,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-canteen,canteen,食堂,NOUN,B2
-canvas,canvas,帆布,NOUN,B2
-canvass,canvass,词,VERB,C1
-capable,capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacitate,capacitate,词,VERB,C1
-caper (noun),caper,词,NOUN,B2
-capillary,capillary,词,ADJ,C1
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,词,NOUN,B2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
-capitalist,capitalist,词,NOUN,C1
-capitulation,capitulation,词,NOUN,C1
-capping,capping,词,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capsize,capsize,词,VERB,C1
-capsule,capsule,词,NOUN,B1
-captious,captious,词,ADJ,B2
-captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-car (part),car,车,PART,C1
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-caramelize,caramelize,词,VERB,C1
-carat,carat,克拉,NOUN,B2
-carbohydrate,carbohydrate,碳水化合物,NOUN,B2
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon trading,carbon trading,碳交易,NOUN,C1
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-cardboard,cardboard,硬纸板,NOUN,B2
-cardinal,cardinal,枢机主教,NOUN,B2
-care home,care home,,NOUN,B2
-care worker,care worker,词,NOUN,B2
-careen,careen,词,VERB,C1
-career leap,career leap,词,NOUN,C1
-carefree,carefree,无忧无虑的,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefully,carefully,仔细地,ADV,B2
-carefulness,carefulness,细心,NOUN,B2
-carelessness,carelessness,词,NOUN,C1
-carer,carer,词,NOUN,C1
-caress (noun),caress,词,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
-caricature (verb),caricature,词,VERB,B2
-caring,caring,关怀的,ADJ,B2
-carnation,carnation,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
-carp (verb),carp,词,VERB,C1
-carpet rug,carpet rug,地毯,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
-cartel,cartel,词,NOUN,B2
-cartography,cartography,词,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case law,case law,判例法,NOUN,B2
-cash,cash,现金,NOUN,B2
-cash conversion,cash conversion,改现,NOUN,B2
-cashier,cashier,出纳员,NOUN,B2
-casino,casino,词,NOUN,B2
-casket,casket,词,NOUN,C1
-cassette tape,cassette tape,磁带,NOUN,B1
-cast,cast,演员阵容,NOUN,B2
-cast iron,cast iron,词,NOUN,B2
-caste,caste,词,NOUN,B2
-castrate,castrate,词,VERB,C1
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-casuistry,casuistry,决疑法,NOUN,B2
-catachresis,catachresis,词语误用,NOUN,B2
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
-catalogue,catalogue,目录,NOUN,B2
-catapult,catapult,投石机,NOUN,C1
-cataract,cataract,词,NOUN,B2
-catastrophic,catastrophic,灾难性的,ADJ,B2
-catch thief,catch thief,抓贼,NOUN,C1
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorical,categorical,绝对的,ADJ,B2
-categorically,categorically,词,ADV,C1
-cater,cater,词,VERB,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教的,ADJ,B2
-catholic (noun),catholic,天主教徒,NOUN,C1
-cats,cats,猫,NOUN,B2
-cattle rancher,cattle rancher,词,NOUN,B2
-caught,caught,被捕获的,ADJ,B2
-cauldron,cauldron,词,NOUN,C1
-causal,causal,因果的,ADJ,B2
-causal link,causal link,词,NOUN,B2
-cause of change,cause of change,改因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-caustic,caustic,词,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
-cavil,cavil,词,VERB,C1
-cavity,cavity,腔,NOUN,B2
-cavort,cavort,词,VERB,C1
-caw (noun),caw,词,NOUN,C1
-ceasefire,ceasefire,止战,NOUN,C1
-cede,cede,词,VERB,C1
-celebrant,celebrant,词,NOUN,B2
-celerity,celerity,词,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial body,celestial body,词,NOUN,B2
-celibate,celibate,词,ADJ,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cello,cello,大提琴,NOUN,C1
-cellulose,cellulose,纤维素,NOUN,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (verb),censure,词,VERB,C1
-census,census,人口普查,NOUN,B2
-centennial,centennial,词,ADJ,B2
-centime,centime,词,NOUN,B2
-centipede,centipede,词,NOUN,B2
-cento,cento,词,NOUN,C1
-central station,central station,中央车站,NOUN,B2
-centrality,centrality,词,NOUN,C1
-centre,centre,词,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-century-old,century-old,词,ADJ,B2
-ceo,ceo,首席执行官,NOUN,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
-cereal,cereal,词,NOUN,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
-certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
-chain mail,chain mail,锁子甲,NOUN,B2
-chalice,chalice,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
-chamois,chamois,词,NOUN,C1
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chant,chant,词,VERB,C1
-chaperon,chaperon,词,NOUN,C1
-chaplain,chaplain,词,NOUN,C1
-character assassination,character assassination,人格谋杀,NOUN,B2
-characteristic,characteristic,特征,NOUN,B2
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterize,to characterize,描绘,VERB,B2
-charade,charade,词,NOUN,B2
-charades,charades,打哑谜,NOUN,B2
-charismatic,charismatic,有魅力的,ADJ,B2
-charitable,charitable,词,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
-charm,charm,魅力,NOUN,B2
-charming,charming,迷人的,ADJ,B2
-charter,to charter,租船,VERB,B2
-chase,chase,追逐,NOUN,B2
-chase,to chase,追逐,VERB,B2
-chase (noun),chase,追他,NOUN,B2
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
-chasten,chasten,词,VERB,C1
-chat,chat,聊天,NOUN,B2
-chat,to chat,聊天,VERB,B2
-chat (noun),chat,聊吧,NOUN,A2
-chatter,to chatter,喋喋不休,VERB,B2
-chatter (noun),chatter,词,NOUN,A2
-chauffeur,chauffeur,词,NOUN,C1
-chauvinism,chauvinism,词,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheaper,cheaper,更便宜的,ADJ,B2
-cheapness,cheapness,廉价,NOUN,B2
-check,check,支票,NOUN,B2
-check,to check,检查,VERB,B2
-check (noun),check,支票,NOUN,A2
-check him,check him,查他,NOUN,C1
-checkbook,checkbook,支票簿,NOUN,B2
-checked,checked,词,ADJ,C1
-checkers,checkers,词,NOUN,A2
-checkmark,checkmark,词,NOUN,C1
-checkmate,checkmate,词,NOUN,C1
-checkout,checkout,收银台,NOUN,B2
-checkup,checkup,体检,NOUN,B2
-cheekbone,cheekbone,词,NOUN,C1
-cheeky,cheeky,厚颜无耻的,ADJ,B2
-cheer up,to cheer up,使高兴,VERB,B2
-cheerful,cheerful,愉快的,ADJ,B2
-cheers,cheers,干杯,INTJ,B2
-cheers (noun),cheers,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
-chemical,chemical,化学品,NOUN,B2
-chemicals,chemicals,词,NOUN,C1
-chemist,chemist,词,NOUN,C1
-chemistry,chemistry,化学,NOUN,B2
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cherish,to cherish,珍爱,VERB,B2
-cherry,cherry,樱桃,NOUN,B2
-chest breast,chest breast,词,NOUN,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest pain,chest pain,胸痛,NOUN,B2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chestnut,chestnut,板栗,NOUN,B2
-chewing gum,chewing gum,口香糖,NOUN,B2
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chiasmus,chiasmus,词,NOUN,C1
-chic (adj),chic,词,ADJ,C1
-chic (noun),chic,词,NOUN,C1
-chick,chick,小鸡,NOUN,B2
-chide,chide,词,VERB,C1
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,词,ADV,B2
-chieftain,chieftain,酋长,NOUN,B2
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childbirth,childbirth,分娩,NOUN,B2
-childcare,childcare,词,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish,childish,幼稚的,ADJ,B2
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
-chili,chili,辣椒,NOUN,B2
-chili pepper,chili pepper,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (noun),chill,词,NOUN,B1
-chilling,chilling,词,ADJ,C1
-chime,chime,词,NOUN,C1
-chimera,chimera,词,NOUN,C1
-chimney,chimney,烟囱,NOUN,B2
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
-chin,chin,下巴,NOUN,B2
-chinese,chinese,中国的,ADJ,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
-chinese language,chinese language,华文,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chivalrous,chivalrous,词,ADJ,B2
-chivalry,chivalry,骑士精神,NOUN,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,词,NOUN,C1
-choke,choke,词,VERB,B2
-cholera,cholera,词,NOUN,C1
-choleric,choleric,易怒的,ADJ,B2
-chomp,chomp,词,VERB,C1
-chop,chop,砍,NOUN,B2
-chop,to chop,砍,VERB,B2
-chop (noun),chop,砍了,NOUN,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chore,chore,家务,NOUN,B2
-choreograph,choreograph,词,VERB,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreographic,choreographic,词,ADJ,C1
-chortle,chortle,词,VERB,C1
-chosen,chosen,精选的,ADJ,B2
-christen,christen,词,VERB,C1
-christian,christian,基督徒,NOUN,B2
-christianity,christianity,基督教,NOUN,B2
-christmas eve,christmas eve,词,NOUN,B2
-christmas porridge,christmas porridge,词,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicle,chronicle,编年史,NOUN,B2
-chronicler,chronicler,词,NOUN,B2
-chronological,chronological,词,ADJ,C1
-chronology,chronology,年表,NOUN,B2
-chubby,chubby,胖子,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-church community,church community,教会,NOUN,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn,churn,词,VERB,C1
-cider,cider,词,NOUN,B2
-cigar,cigar,雪茄,NOUN,B2
-cigarette butt,cigarette butt,烟头,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematographic,cinematographic,词,ADJ,B2
-circular (adj),circular,词,ADJ,C1
-circular (noun),circular,词,NOUN,B2
-circumlocution,circumlocution,迂回说法,NOUN,B2
-circumscription,circumscription,词,NOUN,C1
-circumspect,circumspect,谨慎的,ADJ,B2
-circumspection,circumspection,词,NOUN,B2
-circumvent,circumvent,词,VERB,C1
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
-citadel,citadel,词,NOUN,C1
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city centre,city centre,市中心,NOUN,B2
-city council,city council,市议会,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic,civic,词,ADJ,C1
-civic-mindedness,civic-mindedness,词,NOUN,B2
-civil war,civil war,词,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civility,civility,礼貌,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,词,ADJ,B2
-clamber,clamber,词,VERB,C1
-clamorous,clamorous,词,ADJ,B2
-clandestineness,clandestineness,词,NOUN,B2
-clandestinity,clandestinity,词,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clarify doubts,clarify doubts,释疑,VERB,B2
-clash (noun),clash,词,NOUN,C1
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-classic (noun),classic,经典,NOUN,C1
-classicist,classicist,词,ADJ,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
-classwork,classwork,课堂作业,NOUN,B2
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner,cleaner,清洁剂,NOUN,B2
-cleaner (adj),cleaner,词,ADJ,B2
-cleanly,cleanly,干净地,ADV,B2
-cleanse,cleanse,词,VERB,C1
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
-clear limpid,clear limpid,词,ADJ,C1
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
-clearance,clearance,词,NOUN,C1
-clearing of the throat,clearing of the throat,词,NOUN,C1
-clemency,clemency,仁慈,NOUN,B2
-clench,clench,词,VERB,C1
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
-click (noun),click,词,NOUN,C1
-clickbait,clickbait,词,NOUN,C1
-clientele,clientele,词,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-climate denial,climate denial,气候否认,NOUN,B2
-climb,to climb,攀登,VERB,B2
-clinch,clinch,词,VERB,C1
-cling,to cling,紧贴,VERB,B2
-clinical,clinical,临床的,ADJ,B2
-clink,clink,词,NOUN,C1
-clinking,clinking,词,NOUN,C1
-clip,clip,夹子,NOUN,B2
-cloak,cloak,斗篷,NOUN,B2
-cloakroom,cloakroom,衣帽间,NOUN,B2
-clobber,clobber,词,VERB,C1
-clock,clock,时钟,NOUN,B2
-clock watch,clock watch,钟表,NOUN,B2
-clog (noun),clog,词,NOUN,B2
-clog (verb),clog,词,VERB,C1
-cloister,cloister,回廊,NOUN,B2
-clone,clone,克隆体,NOUN,B2
-close,close,近的,ADJ,B2
-close a case,close a case,结案,VERB,B2
-close account,to close account,销户,VERB,B2
-close the door,to close the door,关门,VERB,B2
-close well,close well,关好,NOUN,C1
-closed,closed,关闭的,ADJ,B2
-closed disabled,closed disabled,词,ADJ,B2
-closely,closely,词,ADV,B2
-closeness,closeness,接近,NOUN,B2
-closer,closer,更近的,ADJ,B2
-closer (adv),closer,词,ADV,B2
-closing argument,closing argument,辩护词,NOUN,B2
-closing ceremony,closing ceremony,闭幕仪式,NOUN,B2
-cloth,cloth,布,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
-cloying,cloying,词,ADJ,C1
-club blow,club blow,词,NOUN,C1
-cluck,cluck,词,NOUN,C1
-clue,clue,线索,NOUN,B2
-clueless,clueless,词,ADJ,C1
-clump,clump,词,NOUN,C1
-clumsily,clumsily,词,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-clunky,clunky,词,ADJ,C1
-cluster,cluster,簇,NOUN,B2
-clutch,clutch,离合器,NOUN,B2
-clutter,clutter,词,NOUN,C1
-co-,co-,词,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-owner,co-owner,共有人,NOUN,B2
-co-ownership,co-ownership,词,NOUN,B2
-coach,to coach,辅导,VERB,B2
-coalesce,coalesce,词,VERB,C1
-coarse,coarse,粗糙的,ADJ,B2
-coarse rough,coarse rough,词,ADJ,C1
-coast road,coast road,词,NOUN,B2
-coastal (adj),coastal,沿海的,ADJ,B2
-coastline,coastline,词,NOUN,B2
-coat,coat,外套,NOUN,B2
-coat of arms,coat of arms,纹章,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-coaxing,coaxing,哄得,NOUN,B2
-cobble,cobble,词,VERB,C1
-cocaine,cocaine,可卡因,NOUN,B2
-cock,cock,词,NOUN,B2
-cocky,cocky,傲慢的,ADJ,B2
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-coddle,coddle,词,VERB,C1
-code of conduct,code of conduct,词,NOUN,C1
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-coding,coding,词,NOUN,B2
-coexist,to coexist,共存,VERB,B2
-coffee maker,coffee maker,词,NOUN,A2
-coffin,coffin,棺材,NOUN,B2
-cog,cog,词,NOUN,C1
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cognac,cognac,干邑,NOUN,B2
-cognate,cognate,词,NOUN,B2
-cognition,cognition,认知,NOUN,B2
-cognitive,cognitive,认知的,ADJ,B2
-cognizance,cognizance,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-coherent,coherent,连贯的,ADJ,B2
-cohort,cohort,队列,NOUN,B2
-cohort-based,cohort-based,队列的,ADJ,B2
-coil (noun),coil,词,NOUN,C1
-coin purse,coin purse,词,NOUN,B2
-coincide,to coincide,同时发生,VERB,B2
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coitus,coitus,词,NOUN,B2
-coke,coke,词,NOUN,B2
-cola,cola,可乐,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold blood,cold blood,冷血,NOUN,B2
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold wave,cold wave,寒潮,NOUN,B2
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
-coldly,coldly,冷淡地,ADV,B2
-coliseum,coliseum,词,NOUN,B2
-collaborate,to collaborate,合作,VERB,B2
-collaboration,collaboration,合作,NOUN,B2
-collaborator,collaborator,合作者,NOUN,B2
-collapse,to collapse,倒塌,VERB,B2
-collar,collar,衣领,NOUN,B2
-collateral,collateral,附属的,ADJ,B2
-collation,collation,词,NOUN,B2
-colleague,colleague,同事,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,词,ADJ,B2
-collectie,collectie,词,NOUN,B2
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-collectivization,collectivization,词,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
-college,college,学院,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiality,collegiality,词,NOUN,C1
-collegiate,collegiate,词,ADJ,B2
-collide,to collide,碰撞,VERB,B2
-colloquial,colloquial,词,ADJ,B2
-colloquium,colloquium,词,NOUN,B2
-collude,to collude,勾结,VERB,B2
-collusion,collusion,词,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
-colonel,colonel,上校,NOUN,B2
-colonial,colonial,词,ADJ,C1
-colonist,colonist,词,NOUN,B2
-colonization,colonization,殖民化,NOUN,B2
-colonizing,colonizing,词,ADJ,C1
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colony,colony,殖民地,NOUN,B2
-colophon,colophon,词,NOUN,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-colored,colored,有色的,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
-colorful,colorful,五颜六色的,ADJ,B2
-colorless,colorless,词,ADJ,C1
-colossal,colossal,词,ADJ,B2
-colossus,colossus,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-columnist,columnist,词,NOUN,C1
-coma,coma,昏迷,NOUN,B2
-comb,comb,梳子,NOUN,B2
-combat,combat,战斗,NOUN,B2
-combatant,combatant,词,NOUN,B2
-combative,combative,词,ADJ,B2
-combativeness,combativeness,好斗性,NOUN,B2
-combination,combination,结合,NOUN,B2
-combinatorial,combinatorial,词,ADJ,B2
-combine,to combine,结合,VERB,B2
-combining,combining,词,ADJ,B2
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come along,to come along,一起来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come back,to come back,回来,VERB,B2
-come from,to come from,来自,VERB,B2
-come in,to come in,进来,VERB,B2
-come on,come on,词,INTJ,C1
-come out,to come out,出来,VERB,B2
-come over,to come over,顺道来访,VERB,B2
-come up,to come up,出现,VERB,B2
-comfort,to comfort,安慰,VERB,B2
-comfortable,comfortable,舒适的,ADJ,B2
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comic strip,comic strip,连环画,NOUN,B2
-coming,coming,即将到来的,ADJ,B2
-coming and going,coming and going,往来,NOUN,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma,comma,逗号,PUNCT,B2
-comma (noun),comma,词,NOUN,B1
-command,command,命令,NOUN,B2
-command,to command,命令,VERB,B2
-command room,command room,指挥室,NOUN,B2
-commandeer,commandeer,词,VERB,C1
-commander,commander,指挥官,NOUN,B2
-commanding officer,commanding officer,司令,NOUN,B2
-commandment,commandment,词,NOUN,C1
-commemorate,to commemorate,纪念,VERB,B2
-commemoration,commemoration,纪念,NOUN,B2
-commence,commence,词,VERB,B2
-commencement,commencement,开始,NOUN,B2
-commend,commend,词,VERB,C1
-commendable,commendable,词,ADJ,C1
-commendation,commendation,词,NOUN,C1
-commensalism,commensalism,词,NOUN,B2
-commensurability,commensurability,词,NOUN,C1
-commentator,commentator,评论员,NOUN,B2
-commerce,commerce,商业,NOUN,B2
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commiserate,commiserate,词,VERB,C1
-commiseration,commiseration,同情,NOUN,B2
-commit a crime,to commit a crime,犯罪,VERB,B2
-commitment,commitment,承诺,NOUN,B2
-committee member,committee member,委员,NOUN,C1
-commodity,commodity,商品,NOUN,B2
-common good,common good,词,NOUN,B2
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-commonly,commonly,词,ADV,C1
-commonplace,commonplace,词,ADJ,C1
-communautarization,communautarization,社群化,NOUN,B2
-communion rail,communion rail,词,NOUN,B2
-communist,communist,共产主义者,NOUN,B2
-communitarian,communitarian,词,ADJ,C1
-community-related,community-related,词,ADJ,B2
-commuter,commuter,词,NOUN,A2
-comorbidity,comorbidity,词,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-comparability,comparability,词,NOUN,C1
-comparable,comparable,可比较的,ADJ,B2
-comparative,comparative,比较的,ADJ,B2
-compared to than,compared to than,比,ADP,A1
-compartmental,compartmental,词,ADJ,C1
-compassion sympathy,compassion sympathy,词,NOUN,B2
-compatible,compatible,词,ADJ,C1
-compelling,compelling,词,ADJ,C1
-compendious,compendious,词,ADJ,B2
-compendium,compendium,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competition bastard,competition bastard,词,NOUN,B2
-competitive,competitive,竞争的,ADJ,B2
-complacency,complacency,词,NOUN,B2
-complement,complement,补充物,NOUN,B2
-complementarity,complementarity,互补性,NOUN,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex,complex,建筑群,NOUN,B2
-complexion,complexion,肤色,NOUN,B2
-complication,complication,周折,NOUN,B2
-composable,composable,可组合的,ADJ,B2
-compostable,compostable,词,ADJ,B2
-compound (adj),compound,复合性,ADJ,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
-comprehensibility,comprehensibility,词,NOUN,C1
-compressibility,compressibility,词,NOUN,C1
-compressible,compressible,词,ADJ,C1
-comprise,comprise,词,VERB,C1
-compulsion,compulsion,词,NOUN,C1
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compunction,compunction,词,NOUN,B2
-computability,computability,词,NOUN,C1
-computer program,computer program,电脑程序,NOUN,B2
-computer science,computer science,词,NOUN,C1
-computer specialist,computer specialist,词,NOUN,B2
-concatenation,concatenation,词,NOUN,B2
-concave,concave,凹的,ADJ,B2
-concavity,concavity,词,NOUN,B2
-conceit,conceit,词,NOUN,C1
-conceivable,conceivable,可设想的,ADJ,B2
-concentrated,concentrated,浓,ADJ,B1
-concentric,concentric,词,ADJ,C1
-conception,conception,概念,NOUN,B2
-conceptual,conceptual,概念的,ADJ,B2
-conceptualize,conceptualize,词,VERB,C1
-concerned,concerned,担忧的,ADJ,B2
-concerning,concerning,关于,ADP,B2
-concerning (adj),concerning,词,ADJ,B2
-concert hall,concert hall,音乐厅,NOUN,C1
-concessionary,concessionary,让步的,ADJ,B2
-conch,conch,词,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
-conciliatory,conciliatory,调和的,ADJ,B2
-conciseness,conciseness,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,词,ADJ,B2
-concomitantly,concomitantly,词,ADV,B2
-concord,concord,和谐,NOUN,B2
-concordance,concordance,词,NOUN,B2
-concordat,concordat,词,NOUN,B2
-concrete,concrete,具体的,ADJ,B2
-concretization,concretization,词,NOUN,C1
-concubine,concubine,妾,NOUN,B2
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concur,concur,词,VERB,C1
-concurrence,concurrence,词,NOUN,B2
-concurrently,concurrently,词,ADV,C1
-concussion,concussion,脑震荡,NOUN,B2
-condemned,condemned,词,ADJ,B2
-condense,to condense,浓缩,VERB,B2
-condescending,condescending,屈尊的,ADJ,B2
-condescension,condescension,屈尊,NOUN,B2
-condition,to condition,制约,VERB,B2
-conditioning (adj),conditioning,词,ADJ,B2
-condole,to condole,哀悼,VERB,B2
-condolences,condolences,哀悼,NOUN,B2
-condom,condom,避孕套,NOUN,B2
-conducive,conducive,词,ADJ,B2
-conduciveness,conduciveness,词,NOUN,C1
-conduit,conduit,词,NOUN,B2
-confederate,confederate,同盟者,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-confessional,confessional,宗派的,ADJ,B2
-confetti,confetti,词,NOUN,C1
-confidant,confidant,词,NOUN,B2
-confide,to confide,吐露,VERB,B2
-confidence,confidence,信心,NOUN,B2
-configure,configure,词,VERB,C1
-confinement,confinement,词,NOUN,B2
-confines edges,confines edges,词,NOUN,C1
-conflictual,conflictual,词,ADJ,C1
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
-conforming,conforming,词,ADJ,B2
-conformist (adj),conformist,词,ADJ,B2
-conformist (noun),conformist,词,NOUN,B2
-confound,confound,词,VERB,C1
-confounded,confounded,该死的,ADJ,B2
-confront,to confront,面对,VERB,B2
-confronted,confronted,词,ADJ,B2
-confronting,confronting,词,ADJ,B2
-confuse,to confuse,混淆,VERB,B2
-confused,confused,困惑的,ADJ,B2
-confused (adv),confused,词,ADV,B1
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confusedly,confusedly,词,ADV,C1
-confusing,confusing,令人困惑的,ADJ,B2
-congeal,congeal,词,VERB,C1
-congenital,congenital,先天的,ADJ,B2
-conglomerate,conglomerate,词,NOUN,B2
-congratulations,congratulations,恭喜,INTJ,B2
-congratulations (noun),congratulations,祝贺,NOUN,B2
-congregate,congregate,词,VERB,C1
-congregation,congregation,集会,NOUN,B2
-congress,congress,国会,NOUN,B2
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-congruent,congruent,一致的,ADJ,B2
-conic,conic,词,NOUN,B2
-conifer,conifer,针叶树,NOUN,B2
-coniferous forest,coniferous forest,针叶林,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugal,conjugal,词,ADJ,B2
-conjunction,conjunction,连词,NOUN,B2
-conjure,to conjure,变魔术,VERB,B2
-connect,to connect,连接,VERB,B2
-connected,connected,连接的,ADJ,B2
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connivance,connivance,词,NOUN,B2
-connive,connive,词,VERB,C1
-conniving,conniving,词,ADJ,C1
-connoisseur,connoisseur,行家,NOUN,B2
-connotation,connotation,内涵,NOUN,B2
-connotative,connotative,内涵的,ADJ,B2
-conquer,to conquer,征服,VERB,B2
-conqueror,conqueror,征服者,NOUN,B2
-conquest,conquest,征服,NOUN,B2
-consanguineous,consanguineous,词,ADJ,B2
-consanguinity,consanguinity,血缘,NOUN,B2
-conscientious,conscientious,认真的,ADJ,B2
-conscientious objection,conscientious objection,词,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
-conscious,conscious,有意识的,ADJ,B2
-consciously,consciously,词,ADV,B2
-consciousness,consciousness,意识,NOUN,B2
-consecrate,to consecrate,奉献,VERB,B2
-consecration,consecration,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
-consecutive cards,consecutive cards,连牌,NOUN,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consecutively,consecutively,连续地,ADV,B2
-consent,consent,同意,NOUN,B2
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,词,ADJ,B2
-conservation,conservation,保护,NOUN,B2
-conservatory,conservatory,音乐学院,NOUN,B2
-considerable,considerable,相当大的,ADJ,B2
-considerable (noun),considerable,不小,NOUN,C1
-considerably,considerably,相当地,ADV,B2
-considerate,considerate,体贴,ADJ,B2
-consideration,consideration,考虑,NOUN,B2
-considered,considered,词,ADJ,B1
-consignment,consignment,托运,NOUN,B2
-console (noun),console,词,NOUN,B2
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consonance,consonance,词,NOUN,B2
-consortium,consortium,词,NOUN,B2
-conspirator,conspirator,词,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
-constancy,constancy,恒定,NOUN,B2
-consternation,consternation,词,NOUN,B2
-constituent,constituent,成分,NOUN,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
-constitutive,constitutive,构成的,ADJ,B2
-constrict,constrict,词,VERB,C1
-constructiveness,constructiveness,词,NOUN,C1
-constructivism,constructivism,建构主义,NOUN,B2
-construe,construe,词,VERB,C1
-consultative,consultative,咨询的,ADJ,B2
-consumerist,consumerist,词,ADJ,B2
-consummate (adj),consummate,词,ADJ,B2
-consummation,consummation,词,NOUN,B2
-consumptive,consumptive,词,ADJ,B2
-contact person,contact person,联系人,NOUN,B2
-contacts,contacts,人脉,NOUN,B2
-contactual,contactual,词,ADJ,B2
-contagion,contagion,词,NOUN,B2
-contaminated,contaminated,受污染的,ADJ,B2
-contaminating,contaminating,污染的,ADJ,B2
-contemn,contemn,蔑视,VERB,C1
-contemplation,contemplation,沉思,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contender,contender,词,NOUN,B2
-contentious,contentious,有争议的,ADJ,B2
-contents,contents,内有,NOUN,B2
-contestable,contestable,可质疑的,ADJ,B2
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,词,ADJ,B2
-continence,continence,词,NOUN,B2
-contingent,contingent,偶然的,ADJ,B2
-continual,continual,持续的,ADJ,B2
-continually,continually,词,ADV,B2
-continued,continued,持续的,ADJ,B2
-continuously,continuously,一直,ADV,A1
-contort,contort,词,VERB,C1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contraband,contraband,违禁品,NOUN,C1
-contracted,contracted,词,ADJ,B2
-contractual,contractual,合同的,ADJ,B2
-contractuality,contractuality,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
-contradictoriness,contradictoriness,词,NOUN,C1
-contraindicate,contraindicate,词,VERB,C1
-contraindication,contraindication,词,NOUN,C1
-contrary (adj),contrary,词,ADJ,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrast,contrast,对比,NOUN,B2
-contrastive,contrastive,词,ADJ,C1
-contrite,contrite,词,ADJ,B2
-contrive,contrive,词,VERB,C1
-controllability,controllability,词,NOUN,C1
-controllable,controllable,可控制的,ADJ,B2
-contumacy,contumacy,词,NOUN,C1
-contusion,contusion,词,NOUN,B2
-convalesce,convalesce,词,VERB,B2
-convalescent,convalescent,词,ADJ,B2
-convenant,convenant,词,NOUN,C1
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
-convent,convent,词,NOUN,B2
-conversation technique,conversation technique,词,NOUN,C1
-conversion,conversion,转换,NOUN,B2
-conversional,conversional,转换的,ADJ,B2
-convert (noun),convert,词,NOUN,B2
-convertibility,convertibility,可兑换性,NOUN,B2
-convertible,convertible,可兑换的,ADJ,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
-conveyance,conveyance,词,NOUN,C1
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (adj),convict,词,ADJ,B2
-convicted,convicted,词,ADJ,B2
-conviviality,conviviality,词,NOUN,B2
-convoke,convoke,词,VERB,C1
-convoluted,convoluted,词,ADJ,B2
-convolutional,convolutional,词,ADJ,B2
-convoy,convoy,词,NOUN,B2
-convulse,convulse,词,VERB,C1
-convulsive,convulsive,词,ADJ,B2
-cookbook,cookbook,词,NOUN,C1
-cooked,cooked,熟的,ADJ,B2
-cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,词,ADJ,B2
-cooler,cooler,词,ADJ,C1
-coop,coop,词,VERB,C1
-cope with,cope with,应对,VERB,B2
-copious,copious,词,ADJ,B2
-coproduction,coproduction,联合制作,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-cord,cord,词,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordiality,cordiality,词,NOUN,C1
-cordially,cordially,亲切地,ADV,B2
-core course,core course,核心课,NOUN,B2
-cornice,cornice,檐口,NOUN,B2
-corollary,corollary,推论,NOUN,B2
-corporal,corporal,下士,NOUN,B2
-corporate,corporate,公司的,ADJ,B2
-corporation,corporation,公司,NOUN,B2
-corporatism,corporatism,法团主义,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpulent,corpulent,词,ADJ,B2
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correctional,correctional,词,ADJ,C1
-corrections,corrections,词,NOUN,B2
-correctness,correctness,正确性,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlative,correlative,词,ADJ,B2
-correlatively,correlatively,词,ADV,B2
-correspondence course,correspondence course,函授,NOUN,C1
-corrigible,corrigible,词,ADJ,B2
-corroboration,corroboration,证实,NOUN,B2
-corrosive,corrosive,腐蚀性的,ADJ,B2
-corrupted,corrupted,词,NOUN,B2
-corruptibility,corruptibility,词,NOUN,C1
-cosmetic,cosmetic,化妆品的,ADJ,B2
-cosmetics,cosmetics,化妆品,NOUN,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,词,NOUN,B2
-cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
-costly,costly,昂贵的,ADJ,B2
-costs,costs,费用,NOUN,B2
-costumbrism,costumbrism,词,NOUN,B2
-cosy,cosy,词,ADJ,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couch,couch,词,NOUN,B1
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-councilor,councilor,市议员,NOUN,B2
-counsel,counsel,词,NOUN,B2
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,词,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterargument,counterargument,反论点,NOUN,B2
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,词,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-counterfeiting,counterfeiting,伪造,NOUN,B2
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterproductive,counterproductive,适得其反的,ADJ,B2
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-counterweight,counterweight,词,NOUN,B2
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
-courageous,courageous,勇敢的,ADJ,B2
-courageously,courageously,词,ADV,C1
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court clerk,court clerk,词,NOUN,C1
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courteous,courteous,有礼貌的,ADJ,B2
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-cousin female,cousin female,词,NOUN,B2
-cove,cove,词,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-coward (adj),coward,词,ADJ,A2
-cower,cower,词,VERB,C1
-coworker,coworker,同事,NOUN,B2
-crackdown,crackdown,词,NOUN,C1
-cracker,cracker,词,NOUN,B2
-cradle,cradle,摇篮,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramp,cramp,抽筋,NOUN,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crap,crap,屎,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-crass,crass,词,ADJ,B2
-cravenly,cravenly,词,ADV,C1
-craving,craving,渴求,NOUN,B2
-crayon,crayon,词,NOUN,C1
-craze,craze,狂热,NOUN,B2
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-crease,crease,词,NOUN,C1
-credentials,credentials,国书,NOUN,B2
-credible,credible,词,ADJ,C1
-creditor's rights,creditor's rights,债权,NOUN,B2
-credulity,credulity,轻信,NOUN,B2
-credulous,credulous,词,ADJ,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (verb),creep,词,VERB,B2
-creepy,creepy,令人毛骨悚然的,ADJ,B2
-cremate,cremate,词,VERB,C1
-cremation,cremation,词,NOUN,B2
-crenelate,crenelate,词,VERB,C1
-crescendo,crescendo,词,NOUN,C1
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-cricket,cricket,板球,NOUN,B2
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
-criminal law,criminal law,刑法,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-crimson,crimson,词,ADJ,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisp,crisp,词,ADJ,C1
-criticizable,criticizable,词,ADJ,B2
-critique,critique,词,NOUN,C1
-crochet,crochet,词,NOUN,C1
-crook,crook,骗子,NOUN,B2
-cross-border,cross-border,词,ADJ,B2
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crossing the border,crossing the border,词,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-croup,croup,词,NOUN,C1
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-crucible,crucible,词,NOUN,B2
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruelly,cruelly,词,ADV,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crumb,crumb,词,NOUN,C1
-crunching,crunching,词,NOUN,C1
-crusade,crusade,运动,NOUN,B2
-crusty,crusty,词,ADJ,B2
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystalline,crystalline,水晶般的,ADJ,C1
-crystallize,crystallize,词,VERB,C1
-cuckold,cuckold,词,VERB,C1
-cuddle (noun),cuddle,词,NOUN,C1
-cudgel,cudgel,棍棒,NOUN,B2
-cue,cue,词,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culminating,culminating,词,ADJ,C1
-culmination,culmination,词,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cult,cult,邪教,NOUN,B2
-cultivation,cultivation,培养,NOUN,B2
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cultured,cultured,词,ADJ,B2
-cumber,cumber,词,VERB,C1
-cumbersome,cumbersome,笨重的,ADJ,C1
-cunningly,cunningly,词,ADV,C1
-cupboard,cupboard,橱柜,NOUN,B2
-cupola,cupola,词,NOUN,C1
-curable,curable,有解,NOUN,C1
-curate,curate,词,VERB,C1
-curative,curative,有疗效的,ADJ,B2
-curator,curator,词,NOUN,B2
-curatorship,curatorship,词,NOUN,C1
-curd,curd,词,NOUN,B2
-curdle,curdle,词,VERB,C1
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
-curiously,curiously,词,ADV,C1
-curly,curly,卷曲的,ADJ,B2
-currant,currant,醋栗,NOUN,B2
-current events,current events,词,NOUN,B2
-current times,current times,词,NOUN,B2
-curry,curry,词,NOUN,B2
-cursing,cursing,骂人,NOUN,C1
-curvature,curvature,词,NOUN,B2
-curved,curved,词,ADJ,B2
-cusp,cusp,词,NOUN,B2
-customer orientation,customer orientation,词,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
-customs officer,customs officer,海关官员,NOUN,B2
-cut off,cut off,割下,NOUN,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
-cutting grass,cutting grass,斩草,NOUN,B2
-cybernetics,cybernetics,词,NOUN,C1
-cyborg,cyborg,词,NOUN,C1
-cycle path,cycle path,自行车道,NOUN,B2
-cycling,cycling,词,NOUN,C1
-cyclist,cyclist,骑自行车的人,NOUN,B2
-cykel,cykel,词,NOUN,B2
-cylindrical,cylindrical,圆柱形的,ADJ,B2
-cynicism,cynicism,犬儒主义,NOUN,B2
-cyst,cyst,词,NOUN,B2
-czech,czech,词,ADJ,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dachshund,dachshund,词,NOUN,A1
-dad father,dad father,爸爸,NOUN,A1
-daddy,daddy,爸爸,NOUN,B2
-daft,daft,傻的,ADJ,B2
-daglig,daglig,词,ADJ,C1
-daily,daily,每天,ADV,B2
-daily necessities,daily necessities,日用品,NOUN,B1
-daily wage,daily wage,词,NOUN,C1
-dairy,dairy,词,ADJ,C1
-dal,dal,山谷,NOUN,B2
-dally,dally,词,VERB,C1
-damageable,damageable,易损的,ADJ,B2
-damages,damages,损害赔偿,NOUN,B2
-damaging,damaging,有害的,ADJ,B2
-damask,damask,词,NOUN,B2
-damm,damm,词,NOUN,B2
-damn,damn,该死,INTJ,B2
-damn (adv),damn,该死的,ADV,B2
-damned,damned,词,ADJ,B2
-dance floor,dance floor,词,NOUN,B2
-dandelion,dandelion,词,NOUN,B1
-dandle,dandle,词,VERB,C1
-dandruff,dandruff,词,NOUN,B2
-dangerousness,dangerousness,危险性,NOUN,B2
-dangle,dangle,词,VERB,C1
-danish,danish,丹麦的,ADJ,B2
-dans,dans,舞蹈,NOUN,B2
-dapper,dapper,整洁的,ADJ,B2
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring bold,daring bold,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (verb),darn,词,VERB,B2
-dart (noun),dart,词,NOUN,B2
-dart (verb),dart,词,VERB,C1
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data leak,data leak,词,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-data protection,data protection,词,NOUN,B2
-databas,databas,数据库,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daub,daub,词,VERB,C1
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,词,NOUN,B2
-day by day,day by day,日日,ADV,B2
-day off,day off,词,NOUN,B2
-day out,day out,词,NOUN,B2
-day school,day school,词,NOUN,C1
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daycare,daycare,托儿所,NOUN,B2
-daydream (noun),daydream,词,NOUN,C1
-daylight,daylight,日光,NOUN,B2
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-dead person,dead person,词,NOUN,B1
-deaden,deaden,词,VERB,C1
-deadly (adv),deadly,致命地,ADV,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
-dear,dear,,NOUN,B2
-dearest,dearest,词,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
-debasement,debasement,词,NOUN,C1
-debauch,debauch,词,VERB,C1
-debilitate,debilitate,词,VERB,C1
-debit,debit,词,VERB,C1
-debrief,debrief,词,VERB,C1
-debris,debris,词,NOUN,B2
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
-decal,decal,贴花,NOUN,B2
-decalogue,decalogue,词,NOUN,B2
-decamp,decamp,词,VERB,C1
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
-deceased,deceased,已故的,ADJ,B2
-deceit,deceit,欺骗,NOUN,B2
-decelerate,decelerate,词,VERB,C1
-deceptive,deceptive,欺骗性的,ADJ,B2
-decibel,decibel,分贝,NOUN,B2
-decidedly,decidedly,坚决地,ADV,B2
-decimal,decimal,小数,NOUN,B2
-deciphering,deciphering,词,NOUN,C1
-decision-making,decision-making,决策,NOUN,B2
-deck,deck,词,NOUN,B1
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declarant,declarant,词,NOUN,B2
-declare war,declare war,宣战,VERB,B2
-declension,declension,词,NOUN,C1
-declinable,declinable,可变格的,ADJ,B2
-decoding,decoding,词,NOUN,B2
-decommission,decommission,词,VERB,C1
-decompensation,decompensation,词,NOUN,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
-decontaminate,decontaminate,词,VERB,C1
-decontamination,decontamination,去污,NOUN,B2
-decorative,decorative,装饰性的,ADJ,B2
-decorous,decorous,词,ADJ,B2
-decorum,decorum,礼仪,NOUN,B2
-decoy,decoy,词,NOUN,C1
-decrease (noun),decrease,减,NOUN,B2
-decreasing,decreasing,词,ADJ,B2
-decree,to decree,颁布法令,VERB,B2
-decrepit,decrepit,词,ADJ,B2
-dedicate,to dedicate,致力于,VERB,B2
-deduce,to deduce,推断,VERB,B2
-deduct points,deduct points,扣分,VERB,C1
-deem,deem,词,VERB,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
-deep-fry,to deep-fry,油炸,VERB,B2
-deep-frying,deep-frying,干炸,NOUN,B2
-deeply,deeply,深深地,ADV,B2
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,词,ADV,B2
-deer,deer,鹿,NOUN,B2
-deface,deface,词,VERB,C1
-defamatory,defamatory,词,ADJ,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defection,defection,词,NOUN,B2
-defective,defective,有缺陷的,ADJ,B2
-defectiveness,defectiveness,词,NOUN,C1
-defend,to defend,保卫,VERB,B2
-defend one's country,to defend one's country,卫国,VERB,B2
-defender,defender,防守者,NOUN,B2
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,词,ADJ,C1
-defensive,defensive,防御的,ADJ,B2
-deference,deference,敬意,NOUN,B2
-deferential,deferential,词,ADJ,C1
-defiant,defiant,挑衅的,ADJ,B2
-deficiency,deficiency,缺乏,NOUN,B2
-deficitary,deficitary,词,ADJ,C1
-defile,defile,词,VERB,C1
-definable,definable,词,ADJ,C1
-define,to define,定义,VERB,B2
-definite,definite,明确的,ADJ,B2
-deflation,deflation,通货紧缩,NOUN,B2
-deflationary,deflationary,词,ADJ,C1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deforestation,deforestation,森林砍伐,NOUN,B2
-deform,to deform,使变形,VERB,B2
-deformed,deformed,畸形的,ADJ,B2
-defunct,defunct,词,ADJ,C1
-degenerate,to degenerate,退化,VERB,B2
-degenerative,degenerative,词,ADJ,B2
-degrade,to degrade,贬低,VERB,B2
-degrading,degrading,词,ADJ,C1
-degrease,degrease,词,VERB,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
-dehydration,dehydration,脱水,NOUN,B2
-deice,deice,词,VERB,C1
-deification,deification,词,NOUN,C1
-deity,deity,神,NOUN,B2
-dejected,dejected,沮丧的,ADJ,B2
-dejt,dejt,约会,NOUN,B2
-del,del,词,NOUN,B2
-delay,to delay,延迟,VERB,B2
-delayed,delayed,延误的,ADJ,B2
-delete,to delete,删除,VERB,B2
-deleterious,deleterious,词,ADJ,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-deli meats,deli meats,词,NOUN,C1
-deliberate,to deliberate,深思熟虑,VERB,B2
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
-deliberatively,deliberatively,词,ADV,C1
-delicacy,delicacy,美食,NOUN,B2
-delicate,delicate,精致的,ADJ,B2
-delicately,delicately,巧妙地,ADV,B2
-delicious,delicious,美味的,ADJ,B2
-delight,delight,高兴,NOUN,B2
-delighted,delighted,高兴的,ADJ,B2
-delightful,delightful,令人愉快的,ADJ,B2
-delimitation,delimitation,词,NOUN,C1
-delinquency,delinquency,违法行为,NOUN,B2
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-deliquesce,deliquesce,词,VERB,C1
-delirious,delirious,词,ADJ,B2
-deliver,to deliver,递送,VERB,B2
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delivery van,delivery van,厢式送货车,NOUN,B2
-delouse,delouse,词,VERB,C1
-delude,delude,词,VERB,C1
-deluge flood,deluge flood,词,NOUN,B2
-delusion,delusion,幻想,NOUN,B2
-delve,delve,词,VERB,C1
-demagogue,demagogue,词,NOUN,C1
-demagogy,demagogy,蛊惑,NOUN,B2
-demand,to demand,要求,VERB,B2
-demanding,demanding,要求高的,ADJ,B2
-demarcation,demarcation,划界,NOUN,B2
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
-dement,dement,词,VERB,C1
-demented,demented,词,ADJ,C1
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demijohn,demijohn,词,NOUN,B2
-demilitarization,demilitarization,去武,NOUN,B2
-demobilize,demobilize,词,VERB,C1
-democrat,democrat,民主主义者,NOUN,B2
-demographic,demographic,人口统计的,ADJ,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demons,demons,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demoralization,demoralization,词,NOUN,C1
-demote,demote,词,VERB,C1
-demotion,demotion,降职,NOUN,B2
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-den,den,兽穴,NOUN,B2
-denationalize,denationalize,词,VERB,C1
-denial contradiction,denial contradiction,词,NOUN,C1
-denim jacket,denim jacket,词,NOUN,C1
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
-dense forest,dense forest,密林,NOUN,B2
-dent,dent,凹痕,NOUN,B2
-dental,dental,词,ADJ,C1
-dentition,dentition,牙齿,NOUN,B2
-denude,denude,词,VERB,C1
-deodorize,deodorize,词,VERB,C1
-department director,department director,司长,NOUN,C1
-departmental,departmental,词,ADJ,B2
-departure lounge,departure lounge,候机室,NOUN,B2
-dependence,dependence,依赖,NOUN,B2
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-deplete,deplete,词,VERB,C1
-deplorable,deplorable,可悲的,ADJ,B2
-depone,depone,词,VERB,C1
-depopulation,depopulation,词,NOUN,B2
-deposed,deposed,词,ADJ,C1
-deposition,deposition,证词,NOUN,B2
-depot,depot,仓库,NOUN,B2
-depravity,depravity,堕落,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-depredate,depredate,词,VERB,C1
-depredation,depredation,词,NOUN,C1
-depressing,depressing,词,ADJ,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
-deputation,deputation,词,NOUN,B2
-depute,depute,词,VERB,C1
-deputy (adj),deputy,副,ADJ,B2
-deracinate,deracinate,词,VERB,C1
-derailment,derailment,词,NOUN,C1
-derange,derange,词,VERB,C1
-deregulate,deregulate,词,VERB,C1
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-deride,deride,词,VERB,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,词,ADJ,B2
-derivation,derivation,词,NOUN,C1
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-descant,descant,词,VERB,C1
-descendants,descendants,词,NOUN,C1
-describable,describable,词,ADJ,C1
-descriptive,descriptive,描述性的,ADJ,B2
-descry,descry,词,VERB,C1
-desecrate,desecrate,词,VERB,C1
-desegregate,desegregate,词,VERB,C1
-deserter,deserter,词,NOUN,C1
-desertion,desertion,逃亡,NOUN,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desiccation,desiccation,词,NOUN,C1
-desirability,desirability,可取性,NOUN,B2
-desirable,desirable,可取的,ADJ,B2
-desire for release,desire for release,思放,NOUN,B2
-desirous,desirous,词,ADJ,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
-desolation,desolation,荒凉,NOUN,B2
-despatch,despatch,词,VERB,C1
-desperately serious,desperately serious,不得了,ADJ,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despond,despond,词,VERB,C1
-despondency,despondency,词,NOUN,C1
-despotic,despotic,词,ADJ,C1
-desquamation,desquamation,词,NOUN,C1
-destine,destine,词,VERB,C1
-destined,destined,,NOUN,B2
-destitute,destitute,词,ADJ,C1
-destroy,destroy,毁掉,NOUN,B2
-destroyed,destroyed,词,ADJ,B2
-destroyer,destroyer,词,NOUN,C1
-detachable,detachable,词,ADJ,C1
-detached house,detached house,独栋房屋,NOUN,B2
-details,details,细细,NOUN,C1
-detective force,detective force,刑警,NOUN,B2
-detector,detector,词,NOUN,C1
-detention center,detention center,拘留所,NOUN,B2
-deter,deter,词,VERB,C1
-detergent,detergent,洗涤剂,NOUN,B2
-deteriorated,deteriorated,词,ADJ,B2
-deterioration,deterioration,恶化,NOUN,B2
-determine,determine,确定,VER! B,B2
-determined definite,determined definite,确定的,ADJ,B2
-detractor,detractor,词,NOUN,C1
-detriment,detriment,损害,NOUN,B2
-detrimental,detrimental,有害的,ADJ,B2
-devaluation,devaluation,贬值,NOUN,B2
-devastated,devastated,词,ADJ,B2
-devastating,devastating,毁灭性的,ADJ,B2
-development zone,development zone,开发区,NOUN,C1
-device system,device system,词,NOUN,B1
-devices,devices,设备,NOUN,B2
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devilish,devilish,恶魔般的,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid,devoid,词,ADJ,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolve,devolve,词,VERB,C1
-devoted (adv),devoted,尽心,ADV,B2
-devourer,devourer,词,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-devoutly,devoutly,词,ADV,C1
-dexterity,dexterity,灵巧,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
-diabolical,diabolical,恶魔般的,ADJ,B2
-diaeresis,diaeresis,词,NOUN,C1
-diagonal,diagonal,对角线,NOUN,B2
-diagonally,diagonally,对角地,ADV,B2
-dial (noun),dial,词,NOUN,C1
-dial (verb),dial,词,VERB,B2
-dialectic (adj),dialectic,词,ADJ,C1
-dialectician,dialectician,词,NOUN,C1
-dialing code,dialing code,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
-diaphanous,diaphanous,词,ADJ,C1
-diatribe,diatribe,词,NOUN,C1
-dichotomy,dichotomy,二分法,NOUN,C1
-dictator,dictator,独裁者,NOUN,B2
-diction,diction,措辞,NOUN,B2
-didactic,didactic,教学的,ADJ,B2
-die,die,骰子,NOUN,B2
-dietary,dietary,词,ADJ,C1
-different (adv),different,词,ADV,B2
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
-difficult flirt,difficult flirt,,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-diffuse,diffuse,模糊的,ADJ,B2
-diffusely,diffusely,词,ADV,C1
-diffusion,diffusion,传播,NOUN,B2
-digestible,digestible,词,ADJ,C1
-digital currency,digital currency,数字货币,NOUN,C1
-diglossia,diglossia,词,NOUN,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignify,dignify,词,VERB,C1
-dignitary,dignitary,高官,NOUN,B2
-digression,digression,词,NOUN,C1
-dike,dike,词,NOUN,B2
-dilated,dilated,词,ADJ,C1
-dilatory,dilatory,拖延的,ADJ,B2
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-diminutive,diminutive,指小词,NOUN,B2
-dimmed,dimmed,词,ADJ,C1
-dimple,dimple,词,NOUN,C1
-din,din,喧嚣,NOUN,B2
-dine,dine,词,VERB,C1
-dinghy,dinghy,词,NOUN,C1
-dining hall,dining hall,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dinner party,dinner party,聚餐,NOUN,C1
-diocesan,diocesan,词,ADJ,C1
-diocese,diocese,词,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diploma,diploma,文凭,NOUN,B2
-diplomat,diplomat,词,NOUN,C1
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-dipsomaniac,dipsomaniac,词,NOUN,C1
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directness,directness,词,NOUN,C1
-director manager,director manager,主管/经理,NOUN,B2
-directorship,directorship,董事职位,NOUN,B2
-directory,directory,词,NOUN,C1
-dirt filth,dirt filth,词,NOUN,C1
-dirtier,dirtier,词,ADJ,B2
-dirty bastard,dirty bastard,词,NOUN,C1
-dirty trick,dirty trick,词,NOUN,B2
-disable,disable,词,VERB,C1
-disadvantaged,disadvantaged,词,ADJ,C1
-disadvantageous,disadvantageous,词,ADJ,B2
-disaffect,disaffect,词,VERB,C1
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disagreeing,disagreeing,不同意的,ADJ,B2
-disallow,disallow,词,VERB,C1
-disapproval,disapproval,词,NOUN,C1
-disarmament,disarmament,裁军,NOUN,B2
-disarray (noun),disarray,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-disbursement,disbursement,词,NOUN,C1
-disc,disc,光盘,NOUN,B2
-discernment,discernment,洞察力,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
-disclaim,disclaim,词,VERB,C1
-disco,disco,迪厅,NOUN,B2
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
-disconnection,disconnection,词,NOUN,C1
-disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
-disconsolation,disconsolation,词,NOUN,C1
-discontent,discontent,不满,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discouragement,discouragement,词,NOUN,C1
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit (noun),discredit,词,NOUN,B2
-discreetly,discreetly,词,ADV,B2
-discrepancy,discrepancy,差异,NOUN,B2
-discretionary,discretionary,词,ADJ,C1
-discursive,discursive,词,ADJ,C1
-disdainful,disdainful,词,ADJ,C1
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disembarkation,disembarkation,词,NOUN,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenchantment,disenchantment,词,NOUN,B2
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disgorge,disgorge,词,VERB,C1
-disgruntle,disgruntle,词,VERB,C1
-dish towel,dish towel,词,NOUN,B2
-disharmony,disharmony,词,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-dishes,dishes,词,NOUN,C1
-disheveled,disheveled,词,ADJ,B2
-dishonest,dishonest,不诚实的,ADJ,B2
-dishonor (noun),dishonor,耻辱,NOUN,C1
-dishonorable,dishonorable,词,ADJ,C1
-disillusion,disillusion,词,VERB,C1
-disillusionment,disillusionment,词,NOUN,C1
-disincline,disincline,词,VERB,C1
-disinflation,disinflation,词,NOUN,B2
-disinhibited,disinhibited,词,ADJ,C1
-disinter,disinter,词,VERB,C1
-disinvestment,disinvestment,词,NOUN,C1
-disjointed,disjointed,词,ADJ,C1
-dislike,dislike,厌恶,NOUN,B2
-disloyal,disloyal,不忠的,ADJ,B2
-disloyalty,disloyalty,词,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
-dismantle,to dismantle,拆除,VERB,B2
-dismay (noun),dismay,词,NOUN,C1
-dismember,dismember,词,VERB,C1
-dismiss,to dismiss,解雇,VERB,B2
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
-dismount,to dismount,下马,VERB,B2
-disobedient,disobedient,不服从的,ADJ,B2
-disobey,to disobey,违抗,VERB,B2
-disorder,disorder,混乱,NOUN,B2
-disorderly,disorderly,杂乱的,ADJ,B2
-disorganization,disorganization,词,NOUN,B2
-disorganize,disorganize,词,VERB,C1
-disorient,to disorient,使迷失方向,VERB,B2
-disoriented,disoriented,词,ADJ,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparate,disparate,截然不同的,ADJ,C1
-dispassionate,dispassionate,词,ADJ,C1
-dispatch,to dispatch,派遣,VERB,B2
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispense medicine,to dispense medicine,配药,VERB,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displace,displace,词,VERB,C1
-display,to display,显示,VERB,B2
-displease,to displease,使不快,VERB,B2
-displeased,displeased,词,ADJ,C1
-disport,disport,词,VERB,C1
-disposable,disposable,一次性的,ADJ,B2
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposal,disposal,处理,NOUN,B2
-disposed,disposed,词,ADJ,C1
-disposition,disposition,性情,NOUN,B2
-disproportion,disproportion,不成比例,NOUN,B2
-disproportionate,disproportionate,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
-disputed,disputed,有争议的,ADJ,B2
-disputed case,disputed case,词,NOUN,C1
-disqualification,disqualification,词,NOUN,C1
-disquiet,disquiet,词,NOUN,C1
-disquisition,disquisition,词,NOUN,B2
-disregard,to disregard,忽视,VERB,B2
-disrepair,disrepair,词,NOUN,C1
-disrepute,disrepute,坏名声,NOUN,B2
-disrespect,disrespect,不敬,NOUN,B2
-disrespectful,disrespectful,无礼的,ADJ,B2
-disrobe,disrobe,词,VERB,C1
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfied,dissatisfied,不满的,ADJ,B2
-dissatisfy,dissatisfy,词,VERB,C1
-dissect,to dissect,解剖,VERB,B2
-dissemble,dissemble,词,VERB,C1
-dissembling,dissembling,词,ADJ,C1
-disseminate,to disseminate,传播,VERB,B2
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
-dissent,dissent,异议,NOUN,B2
-dissert,dissert,词,VERB,C1
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissident,dissident,异见者,NOUN,B2
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
-dissipation,dissipation,挥霍,NOUN,B2
-dissociate,dissociate,词,VERB,C1
-dissociation,dissociation,解离,NOUN,B2
-dissolute,dissolute,词,ADJ,C1
-dissolve,to dissolve,溶解,VERB,B2
-dissonant,dissonant,词,ADJ,C1
-dissuade,to dissuade,劝阻,VERB,B2
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-distant,distant,遥远的,ADJ,B2
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distich,distich,词,NOUN,C1
-distil,distil,词,VERB,C1
-distinctive,distinctive,词,ADJ,C1
-distinctly,distinctly,词,ADV,B2
-distinguishable,distinguishable,词,ADJ,C1
-distinguished,distinguished,杰出,ADJ,B2
-distort,to distort,扭曲,VERB,B2
-distorted image,distorted image,扭曲的形象,NOUN,B2
-distract,to distract,分心,VERB,B2
-distracted,distracted,分心的,ADJ,B2
-distrain,distrain,词,VERB,C1
-distressing,distressing,词,ADJ,B1
-distribute,to distribute,分配,VERB,B2
-distributor,distributor,分销商,NOUN,B2
-district,district,地区,NOUN,B2
-district head,district head,区长,NOUN,B2
-distrust,distrust,不信任,NOUN,B2
-distrustful,distrustful,词,ADJ,C1
-disturb,to disturb,打扰,VERB,B2
-disturbed,disturbed,不安的,ADJ,B2
-disturbing,disturbing,令人不安的,ADJ,B2
-disuse,disuse,废弃,NOUN,B2
-ditch,ditch,沟渠,NOUN,B2
-dithyramb,dithyramb,词,NOUN,C1
-dive,to dive,潜水,VERB,B2
-dive appear,dive appear,词,VERB,B2
-divergence,divergence,分歧,NOUN,B2
-diverging,diverging,词,ADJ,C1
-diverse,diverse,多样的,ADJ,B2
-diversification,diversification,多样化,NOUN,B2
-divide cleavage,divide cleavage,词,NOUN,B2
-divinatory,divinatory,词,ADJ,C1
-divine,divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divisibility,divisibility,词,NOUN,C1
-divisible,divisible,词,ADJ,B2
-divisive,divisive,词,ADJ,C1
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
-do not want,do not want,不想,VERB,B2
-do one's best,do one's best,尽力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-docile,docile,温顺的,ADJ,B2
-docilely,docilely,词,ADV,C1
-doctor visit,doctor visit,,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
-doctrinaire,doctrinaire,词,ADJ,B2
-doctrine,doctrine,词,NOUN,B2
-documentation,documentation,文献,NOUN,B2
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-doggedly,doggedly,词,ADV,C1
-domain,domain,领域,NOUN,B2
-domestic,domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
-domesticate,domesticate,词,VERB,C1
-domineeringness,domineeringness,词,NOUN,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
-donation of goods,donation of goods,捐物,NOUN,C1
-doom,doom,词,VERB,C1
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door lock,door lock,门锁,NOUN,C1
-doorbell button,doorbell button,词,NOUN,B2
-doorkeeper,doorkeeper,词,NOUN,B1
-doorway,doorway,门口,NOUN,C1
-dope (noun),dope,词,NOUN,B2
-doping,doping,词,NOUN,C1
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
-dossier,dossier,档案,NOUN,B2
-dot,dot,点,NOUN,B2
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubt (noun),doubt,词,NOUN,A2
-doubtful,doubtful,可疑的,ADJ,B2
-doughy,doughy,词,ADJ,B2
-douse,douse,词,VERB,C1
-down,down,向下,ADV,B2
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downfall,downfall,毁灭,NOUN,B2
-downgrade,downgrade,词,VERB,C1
-downplay,downplay,词,VERB,C1
-downright,downright,词,ADV,B1
-downsize,downsize,词,VERB,C1
-downstairs,downstairs,词,ADV,B1
-doze (noun),doze,词,NOUN,C1
-doze (verb),doze,词,VERB,C1
-dozens,dozens,数十个,NOUN,B2
-draconian,draconian,词,ADJ,C1
-draftsman,draftsman,绘图员,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-dragoon,dragoon,词,VERB,C1
-drainage,drainage,词,NOUN,C1
-drastic,drastic,词,ADJ,C1
-draught,draught,词,NOUN,C1
-draw blood,draw blood,抽血,VERB,B2
-drawback,drawback,缺点,NOUN,B2
-drawl,drawl,词,VERB,C1
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dredge (noun),dredge,词,NOUN,B2
-dredge (verb),dredge,词,VERB,C1
-drench,drench,词,VERB,C1
-dressed,dressed,穿着的,ADJ,B2
-dressing room,dressing room,词,NOUN,B2
-dribble,dribble,词,VERB,C1
-drift (verb),drift,词,VERB,B2
-drift excess,drift excess,词,NOUN,C1
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinking water,drinking water,饮用水,NOUN,B2
-drinks,drinks,词,NOUN,C1
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-drive,drive,动力,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-drivel,drivel,词,NOUN,C1
-driven,driven,被驾驶的,ADJ,B2
-driving,driving,你来驾车,NOUN,C1
-drool,drool,口水,NOUN,B2
-droop,droop,词,VERB,C1
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropper,dropper,词,NOUN,C1
-droppings,droppings,词,NOUN,B2
-drowning,drowning,词,NOUN,C1
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drunkard,drunkard,醉翁,NOUN,C1
-dry cleaner,dry cleaner,词,NOUN,A2
-dry sausage,dry sausage,词,NOUN,B2
-dual,dual,词,ADJ,C1
-dub,dub,词,VERB,C1
-duchess,duchess,公爵夫人,NOUN,B2
-duct pipe,duct pipe,词,NOUN,B2
-ductile,ductile,词,ADJ,C1
-dude,dude,词,NOUN,A2
-duel,duel,词,NOUN,C1
-duet,duet,词,NOUN,B2
-duly,duly,词,ADV,C1
-dumbfound,dumbfound,词,VERB,C1
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dungeon,dungeon,地牢,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicate,duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
-duplicity,duplicity,口是心非,NOUN,B2
-durable,durable,词,ADJ,C1
-durian,durian,榴莲,NOUN,C1
-dust coat,dust coat,词,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-dutch (noun),dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty of care,duty of care,词,NOUN,C1
-duty of confidentiality,duty of confidentiality,词,NOUN,B2
-duvet,duvet,羽绒被,NOUN,B2
-dwell,dwell,词,VERB,C1
-dwindle,dwindle,词,VERB,C1
-dying,dying,垂死的,ADJ,B2
-dying (noun),dying,dying,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamism,dynamism,词,NOUN,B2
-e-reader,e-reader,电子阅读器,NOUN,B2
-each,each,每个,PRON,B2
-each (noun),each,一一,NOUN,C1
-each every,each every,每,DET,A1
-each one,each one,词,PRON,B2
-eagerness,eagerness,词,NOUN,B2
-earlier,earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
-early morning (adv),early morning,词,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-ears,ears,耳朵,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-easier,easier,词,ADJ,B2
-easily,easily,词,ADV,B2
-east bank,east bank,东岸,NOUN,C1
-eastward,eastward,词,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
-eating,eating,,NOUN,B2
-eating habit,eating habit,词,NOUN,C1
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-eccentric person,eccentric person,词,NOUN,C1
-eccentricity,eccentricity,古怪,NOUN,B2
-ecclesial,ecclesial,词,ADJ,C1
-eclectic,eclectic,词,ADJ,C1
-eclecticism,eclecticism,折衷主义,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-economic climate,economic climate,词,NOUN,B2
-economic cycle,economic cycle,词,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economical,economical,词,ADJ,A1
-economically,economically,词,ADV,B1
-economize,economize,词,VERB,C1
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eczema,eczema,湿疹,NOUN,B2
-eddy,eddy,词,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edging,edging,镶边,NOUN,B2
-edible,edible,词,ADJ,C1
-edifying,edifying,词,ADJ,C1
-edit,edit,重辑,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
-editorial office,editorial office,词,NOUN,B2
-educational,educational,教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
-efface,efface,词,VERB,C1
-effect-seeking,effect-seeking,词,NOUN,C1
-effectively,effectively,有效地,ADV,B2
-effectuate,effectuate,词,VERB,C1
-effervesce,effervesce,词,VERB,C1
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,词,ADJ,C1
-effigy,effigy,词,NOUN,C1
-effort bet,effort bet,努力/赌注,NOUN,B2
-effortless,effortless,不费力的,ADJ,B2
-effuse,effuse,词,VERB,C1
-egalitarian,egalitarian,词,ADJ,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-egg-laying,egg-laying,词,NOUN,B2
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egyptian,egyptian,埃及的,ADJ,B2
-eh,eh,词,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-eighteen,eighteen,十八,NUM,B2
-eighth,eighth,第八,ADJ,B2
-eighty,eighty,八十,NUM,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
-either (adv),either,词,ADV,B2
-ejection,ejection,喷射,NOUN,B2
-elaboration,elaboration,词,NOUN,C1
-elation,elation,兴高采烈,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
-eldest,eldest,词,ADJ,A2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-elective,elective,词,ADJ,C1
-elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
-electric guitar,electric guitar,词,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric power,electric power,电力,NOUN,B2
-electrical theory,electrical theory,词,NOUN,B2
-electrification,electrification,词,NOUN,C1
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electronics,electronics,电子学,NOUN,B2
-elegance,elegance,词,NOUN,C1
-elementary,elementary,基本的,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
-elevated,elevated,词,ADJ,C1
-eleven,eleven,十一,NOUN,B2
-eleventh,eleventh,词,NUM,B1
-elf,elf,词,NOUN,C1
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
-elite unit,elite unit,,NOUN,B2
-ellipsis,ellipsis,省略,NOUN,B2
-ellipsis (part),ellipsis,…,PART,C1
-elocution,elocution,演讲术,NOUN,B2
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
-else,else,词,ADV,A1
-elsewhere,elsewhere,别处,ADV,B2
-elucidation,elucidation,词,NOUN,C1
-elusive,elusive,难以捉摸的,ADJ,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciated,emaciated,词,ADJ,C1
-emaciating,emaciating,消耗的,ADJ,B2
-email address,email address,电子邮件地址,NOUN,B2
-embalm,embalm,词,VERB,C1
-embargo,embargo,禁运,NOUN,B2
-embattle,embattle,词,VERB,C1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-emblem,emblem,徽章,NOUN,B2
-emblematic,emblematic,象征性的,ADJ,B2
-embolism,embolism,栓塞,NOUN,B2
-emboss,emboss,词,VERB,C1
-embroil,embroil,词,VERB,C1
-embryo,embryo,胚胎,NOUN,B2
-emend,emend,词,VERB,B2
-emerald,emerald,祖母绿,NOUN,B2
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
-emerging,emerging,词,ADJ,C1
-emigration,emigration,移民,NOUN,B2
-eminence,eminence,词,NOUN,C1
-eminent,eminent,杰出的,ADJ,B2
-emission reduction,emission reduction,减排,NOUN,C1
-emitter,emitter,词,NOUN,C1
-emolument,emolument,词,NOUN,C1
-emote,emote,词,VERB,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
-emotional life,emotional life,词,NOUN,B2
-emotionally,emotionally,情感上,ADV,B2
-empathetic,empathetic,词,ADJ,B1
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-emphatically,emphatically,词,ADV,C1
-empirically,empirically,词,ADV,B2
-employability,employability,词,NOUN,B2
-employers,employers,词,NOUN,B1
-emporium,emporium,词,NOUN,C1
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-emulation,emulation,词,NOUN,B2
-emulsify,emulsify,词,VERB,C1
-enamel,enamel,珐琅,NOUN,B2
-enamel (verb),enamel,词,VERB,C1
-enamor,enamor,词,VERB,C1
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-encephalic,encephalic,词,ADJ,C1
-enchain,enchain,词,VERB,C1
-encirclement,encirclement,环绕,NOUN,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore (noun),encore,词,NOUN,C1
-encouraging,encouraging,词,ADJ,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encumber,encumber,词,VERB,C1
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
-endear,endear,词,VERB,C1
-endeavor (noun),endeavor,词,NOUN,B2
-endeavor (verb),endeavor,词,VERB,C1
-endemic,endemic,地方性的,ADJ,B2
-endemic disease,endemic disease,词,NOUN,B2
-ending,ending,了头,NOUN,C1
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,词,ADJ,C1
-endowed,endowed,有天赋的,ADJ,B2
-endowment,endowment,配备,NOUN,B2
-endue,endue,词,VERB,C1
-enemy army,enemy army,敌军,NOUN,C1
-enemy of the state,enemy of the state,词,NOUN,C1
-energize,energize,词,VERB,C1
-energy crisis,energy crisis,能源危机,NOUN,B2
-energy saving,energy saving,节能,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfold,enfold,词,VERB,C1
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-enfranchise,enfranchise,词,VERB,C1
-engender,engender,词,VERB,C1
-english teacher,english teacher,,NOUN,B2
-english-speaking,english-speaking,讲英语的,ADJ,B2
-engraft,engraft,词,VERB,C1
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
-engrossing,engrossing,词,ADJ,B2
-engulf,engulf,词,VERB,C1
-enigma,enigma,词,NOUN,C1
-enigmatic,enigmatic,神秘的,ADJ,B2
-enjambment,enjambment,词,NOUN,C1
-enjoin,enjoin,词,VERB,C1
-enjoyed,enjoyed,词,ADJ,C1
-enkindle,enkindle,词,VERB,C1
-enlightening,enlightening,词,ADJ,C1
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enmesh,enmesh,词,VERB,C1
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
-enough (noun),enough,就够,NOUN,C1
-enquire,enquire,词,VERB,C1
-enraged,enraged,词,ADJ,C1
-enriching,enriching,词,ADJ,C1
-ensconce,ensconce,词,VERB,C1
-enshrine,enshrine,词,VERB,C1
-enshroud,enshroud,词,VERB,C1
-ensign,ensign,词,NOUN,C1
-enslavement,enslavement,词,NOUN,B2
-ensue,ensue,词,VERB,B2
-entanglement,entanglement,缠,NOUN,C1
-entelechy,entelechy,词,NOUN,C1
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertaining,entertaining,有趣的,ADJ,B2
-entitle,entitle,词,VERB,C1
-entitled to exist,entitled to exist,词,ADJ,C1
-entomb,entomb,词,VERB,C1
-entomology,entomology,词,NOUN,C1
-entrails,entrails,内脏,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entreat,entreat,词,VERB,C1
-entrepreneurship,entrepreneurship,词,NOUN,C1
-entropy,entropy,熵,NOUN,B2
-entwine,entwine,词,VERB,C1
-enumeration,enumeration,列举,NOUN,B2
-envelop,envelop,词,VERB,C1
-envenom,envenom,词,VERB,C1
-enviable,enviable,令人羡慕的,ADJ,B2
-envious jealous,envious jealous,词,ADJ,B2
-environ,environ,词,VERB,C1
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
-enwetens,enwetens,词,ADV,C1
-ephemeral,ephemeral,短暂的,ADJ,B2
-epic,epic,史诗的,ADJ,B2
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epigraph,epigraph,题词,NOUN,B2
-epilogue,epilogue,词,NOUN,C1
-episodic,episodic,词,ADJ,C1
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,词,NOUN,B2
-epithet,epithet,词,NOUN,B2
-epitomize,epitomize,词,VERB,C1
-epoch,epoch,时代,NOUN,B2
-eponymous,eponymous,词,ADJ,C1
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally,equally,词,ADV,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equestrian,equestrian,词,ADJ,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,词,ADJ,C1
-equilibrate,equilibrate,词,VERB,C1
-equity,equity,公平,NOUN,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
-equivocate,equivocate,词,VERB,C1
-erection,erection,词,NOUN,C1
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergestaltung,ergestaltung,词,NOUN,C1
-ergonomics,ergonomics,词,NOUN,C1
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
-erotic,erotic,色情的,ADJ,B2
-eroticism,eroticism,色情,NOUN,B2
-erpflegung,erpflegung,词,NOUN,C1
-errant,errant,词,ADJ,C1
-erratic,erratic,不稳定的,ADJ,C1
-erregelung,erregelung,词,NOUN,C1
-erroneous,erroneous,词,ADJ,C1
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
-erudition,erudition,博学,NOUN,B2
-erupt,erupt,词,VERB,C1
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
-escape (noun),escape,脱不,NOUN,B1
-eschatology,eschatology,词,NOUN,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escort (noun),escort,你带人,NOUN,B2
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-esoteric,esoteric,词,ADJ,C1
-esotericism,esotericism,词,NOUN,B2
-espresso,espresso,词,NOUN,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-estrange,estrange,词,VERB,C1
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-ethereal,ethereal,飘渺的,ADJ,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
-etymology,etymology,词源学,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-eunuch,eunuch,词,NOUN,C1
-euphemistic,euphemistic,词,ADJ,B2
-euphonic,euphonic,词,ADJ,C1
-euphoric,euphoric,词,ADJ,C1
-europe,europe,词,PROPN,B2
-euthanasia,euthanasia,词,NOUN,C1
-evanesce,evanesce,词,VERB,C1
-evangelical,evangelical,词,ADJ,C1
-evangelist,evangelist,词,NOUN,C1
-eve,eve,前夕,NOUN,C1
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening meal,evening meal,词,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evenly,evenly,均匀地,ADV,B2
-eventual,eventual,词,ADJ,C1
-eventuate,eventuate,词,VERB,C1
-ever,ever,,NOUN,B2
-everlasting,everlasting,词,ADJ,C1
-every,every,每个,PRON,B2
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every other sunday,every other sunday,词,NOUN,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
-everydayness,everydayness,词,NOUN,B2
-everyone,everyone,各位,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evil (adj),evil,词,ADJ,B1
-evil (part),evil,邪,PART,B2
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evocation,evocation,唤起,NOUN,B2
-evocative,evocative,引起回忆的,ADJ,B2
-exact change,exact change,词,NOUN,C1
-exactitude,exactitude,词,NOUN,C1
-exactly just,exactly just,词,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exactness,exactness,精确,NOUN,B2
-exaltation,exaltation,词,NOUN,C1
-exalted,exalted,词,ADJ,B2
-exam evening,exam evening,词,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-excavation,excavation,词,NOUN,B2
-excavator,excavator,词,NOUN,B2
-except for,except for,除了,ADP,B2
-exceptionality,exceptionality,特殊性,NOUN,B2
-exceptionally,exceptionally,词,ADV,B2
-excess weight,excess weight,词,NOUN,C1
-excessively,excessively,词,ADV,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excision,excision,词,NOUN,C1
-excitability,excitability,词,NOUN,B2
-exclamation (punct),exclamation,词,PUNCT,A2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusivism,exclusivism,词,NOUN,C1
-excrement,excrement,排泄物,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,词,NOUN,B2
-excursion,excursion,郊游,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executive board,executive board,词,NOUN,C1
-exegete,exegete,注释家,NOUN,B2
-exemplar,exemplar,楷模,NOUN,C1
-exemplary country,exemplary country,模范国家,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhalation,exhalation,词,NOUN,C1
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhausting,exhausting,词,ADJ,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exhortation,exhortation,词,NOUN,C1
-exhumation,exhumation,词,NOUN,C1
-exigent,exigent,词,ADJ,C1
-exile (noun),exile,词,NOUN,B2
-exiled,exiled,词,ADJ,C1
-existential,existential,存在主义的,ADJ,B2
-existing,existing,现有的,ADJ,B2
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,词,ADJ,C1
-exorcism,exorcism,词,NOUN,C1
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,词,ADJ,B2
-exotic,exotic,异国情调的,ADJ,B2
-exoticism,exoticism,词,NOUN,B2
-expatiate,expatiate,词,VERB,C1
-expatriate,expatriate,移居国外者,NOUN,B2
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expedite,expedite,词,VERB,C1
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,词,ADJ,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experiential marker,experiential marker,过,PART,A2
-experimentation,experimentation,词,NOUN,C1
-expert opinion,expert opinion,词,NOUN,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiate,expiate,词,VERB,C1
-expiration,expiration,词,NOUN,C1
-explanatory,explanatory,解释的,ADJ,B2
-expletive,expletive,词,NOUN,C1
-explicable,explicable,可解释的,ADJ,B2
-explicate,explicate,词,VERB,C1
-explicitly,explicitly,明确地,ADV,B2
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
-exploration,exploration,探索,NOUN,B2
-exploratory,exploratory,词,ADJ,C1
-explosion-proof,explosion-proof,防爆,ADJ,B2
-explosives,explosives,炸药,NOUN,B2
-exponential,exponential,指数的,ADJ,B2
-expostulate,expostulate,词,VERB,C1
-express,express,明确的,ADJ,B2
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expression of opinion,expression of opinion,词,NOUN,B2
-expressiveness,expressiveness,表现力,NOUN,B2
-expunge,expunge,词,VERB,C1
-exquisiteness,exquisiteness,词,NOUN,C1
-extemporize,extemporize,词,VERB,C1
-extended,extended,广泛的,ADJ,B2
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,有外,NOUN,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinct,extinct,灭绝的,ADJ,B2
-extinguishable,extinguishable,词,ADJ,C1
-extirpation,extirpation,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
-extra (adv),extra,词,ADV,A1
-extra drink,extra drink,多喝,NOUN,C1
-extract,extract,摘录,NOUN,B2
-extramarital,extramarital,词,ADJ,C1
-extrapolation,extrapolation,词,NOUN,C1
-extraterrestrial,extraterrestrial,外星的,ADJ,B2
-extravagant,extravagant,奢侈的,ADJ,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremist,extremist,极端主义者,NOUN,B2
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-exuberance,exuberance,词,NOUN,C1
-exuberant,exuberant,繁茂的,ADJ,B2
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyes,eyes,眼中,NOUN,B2
-fabulist,fabulist,词,NOUN,B2
-fabulous,fabulous,极好的,ADJ,B2
-face towel,face towel,面巾,NOUN,C1
-facies,facies,面貌,NOUN,B2
-facticity,facticity,词,NOUN,C1
-factionalism,factionalism,派系主义,NOUN,B2
-factious,factious,词,ADJ,C1
-factoring,factoring,保理,NOUN,B2
-factotum,factotum,词,NOUN,C1
-factual,factual,事实的,ADJ,B2
-fad,fad,词,NOUN,C1
-fade away,fade away,词,VERB,C1
-fag,fag,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failed,failed,失败的,ADJ,B2
-faint,faint,微弱的,ADJ,B2
-faint (noun),faint,词,NOUN,C1
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,fair hair,NOUN,B2
-fairly,fairly,词,ADV,C1
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,词,NOUN,B2
-falconry,falconry,词,NOUN,B2
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallibility,fallibility,易错性,NOUN,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-fallout,fallout,词,NOUN,C1
-falsely,falsely,词,ADV,C1
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falsification,falsification,词,NOUN,C1
-falter,falter,词,VERB,C1
-faltering,faltering,词,ADJ,C1
-familiar with,familiar with,熟悉,ADJ,A2
-family (adj),family,词,ADJ,B1
-family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family life,family life,家庭生活,NOUN,B2
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,词,NOUN,B2
-famine,famine,饥荒,NOUN,B2
-famish,famish,词,VERB,C1
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fanatic,fanatic,词,ADJ,B2
-fanatical,fanatical,词,ADJ,C1
-fancy,fancy,词,ADJ,B1
-fancy decoration,fancy decoration,词,NOUN,C1
-fang,fang,犬齿,NOUN,B2
-fantasize,fantasize,词,VERB,C1
-far (adv),far,词,ADV,A1
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-fare,fare,车费,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farmland,farmland,农田,NOUN,C1
-farmstead,farmstead,农庄,NOUN,B2
-farrow,farrow,词,VERB,C1
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascism,fascism,法西斯主义,NOUN,B2
-fascist (adj),fascist,词,ADJ,C1
-fascist (noun),fascist,词,NOUN,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast forward,fast forward,快进,VERB,C1
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
-fatalism,fatalism,宿命论,NOUN,B2
-fatalist (noun),fatalist,词,NOUN,C1
-fatality,fatality,致命性,NOUN,B2
-fatally,fatally,词,ADV,C1
-fateful,fateful,词,ADJ,C1
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatness,fatness,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatuity,fatuity,愚昧,NOUN,B2
-fatuous,fatuous,词,ADJ,C1
-faucet,faucet,词,NOUN,C1
-faulty,faulty,词,ADJ,C1
-fauna,fauna,动物群,NOUN,B2
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favorite,favorite,最爱,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawn,fawn,词,VERB,C1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
-fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
-fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
-feast,feast,盛宴,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-feces,feces,屎,NOUN,C1
-fecundate,fecundate,词,VERB,C1
-fecundity,fecundity,词,NOUN,C1
-fed up (adj),fed up,词,ADJ,B1
-fed up (noun),fed up,词,NOUN,B2
-federalization,federalization,联邦化,NOUN,B2
-federalize,federalize,词,VERB,C1
-feeble,feeble,虚弱的,ADJ,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-felicitate,felicitate,词,VERB,C1
-felicity,felicity,词,NOUN,C1
-feline,feline,词,ADJ,C1
-fellow citizen,fellow citizen,同胞,NOUN,B2
-felt,felt,词,NOUN,C1
-female,female,雌性,NOUN,B2
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-feminine,feminine,女性的,ADJ,B2
-feminist,feminist,女权主义者,NOUN,B2
-fend,fend,词,VERB,C1
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferociously,ferociously,词,ADV,C1
-ferret (noun),ferret,词,NOUN,B2
-ferrule,ferrule,词,NOUN,C1
-fervent,fervent,词,ADJ,C1
-fervor,fervor,词,NOUN,C1
-festive,festive,节日的,ADJ,B2
-fete,fete,词,VERB,C1
-fetid,fetid,词,ADJ,C1
-fetish,fetish,恋物,NOUN,B2
-fetishism,fetishism,词,NOUN,B2
-fetter,fetter,词,VERB,C1
-feud end,feud end,仇终,NOUN,C1
-feudal ethics,feudal ethics,礼教,NOUN,B2
-feverish,feverish,词,ADJ,C1
-fewer,fewer,较少的,ADJ,B2
-fiancee,fiancee,未婚妻,NOUN,B2
-fib,fib,词,VERB,C1
-fibrous,fibrous,词,ADJ,C1
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalize,fictionalize,词,VERB,C1
-fictitious,fictitious,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fiddle (verb),fiddle,词,VERB,C1
-fidelity,fidelity,忠诚,NOUN,B2
-fidget,fidget,词,VERB,C1
-fiduciary,fiduciary,词,ADJ,C1
-fief,fief,词,NOUN,B2
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fiend,fiend,词,NOUN,C1
-fiery,fiery,热烈的,ADJ,B2
-fifteen,fifteen,十五,NUM,B2
-fifth,fifth,第五,NUM,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-figuration,figuration,词,NOUN,B2
-figurative,figurative,比喻的,ADJ,B2
-figuratively,figuratively,词,ADV,C1
-figure skating,figure skating,花样滑冰,NOUN,C1
-filament,filament,词,NOUN,C1
-filch,filch,词,VERB,C1
-file expense,file expense,报账,VERB,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
-filled,filled,充满的,ADJ,B2
-fillet (noun),fillet,词,NOUN,C1
-fillet (verb),fillet,词,VERB,C1
-film art,film art,词,NOUN,C1
-film director,film director,词,NOUN,B2
-film industry,film industry,词,NOUN,B2
-film movie,film movie,电影,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,词,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
-filth garbage,filth garbage,词,NOUN,C1
-filthy,filthy,肮脏的,ADJ,B2
-final,final,决赛,NOUN,B2
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
-finality,finality,词,NOUN,C1
-finals,finals,决赛,NOUN,B1
-finance,finance,金融,NOUN,B2
-financial center,financial center,金融中心,NOUN,B2
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financier,financier,资助者,NOUN,B2
-financing funding,financing funding,融资,NOUN,B2
-find,find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine print,fine print,词,NOUN,C1
-finely,finely,词,ADV,C1
-fingernail,fingernail,词,NOUN,B2
-finial,finial,词,NOUN,C1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
-finnish,finnish,芬兰的,ADJ,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-fire a gun,fire a gun,开枪,VERB,B2
-fire brigade,fire brigade,消防队,NOUN,B2
-fire department,fire department,词,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire kick,fire kick,词,VERB,A2
-firearms,firearms,枪支,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firedamp,firedamp,词,NOUN,C1
-firework,firework,词,NOUN,B2
-firm,firm,公司,NOUN,B2
-firm fixed,firm fixed,词,ADJ,B1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first instance,first instance,初审,NOUN,C1
-first name,first name,名字,NOUN,B2
-first of all,first of all,首先,ADV,B2
-first-class,first-class,一流,ADJ,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fish,to fish,钓鱼,VERB,B2
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisherman,fisherman,渔夫,NOUN,B2
-fishery,fishery,词,NOUN,B2
-fishing,fishing,词,NOUN,B2
-fissure,fissure,裂缝,NOUN,B2
-fist,fist,拳头,NOUN,B2
-fistula,fistula,词,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fit,to fit,适合,VERB,B2
-fit (adj),fit,适合的,ADJ,B2
-fit (noun),fit,词,NOUN,B2
-fitting,fitting,合适的,ADJ,B2
-fittings,fittings,词,NOUN,C1
-five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fix,to fix,修理,VERB,B2
-fixation,fixation,词,NOUN,C1
-fixed,fixed,固定的,ADJ,B2
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flaccid,flaccid,词,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrancy,flagrancy,现行,NOUN,B2
-flagrant,flagrant,词,ADJ,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable,flammable,易燃的,ADJ,B2
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
-flank,flank,侧翼,NOUN,B2
-flank (verb),flank,词,VERB,C1
-flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashback,flashback,词,NOUN,C1
-flashlight,flashlight,词,NOUN,B2
-flat,flat,扁平的,ADJ,B2
-flat (noun),flat,词,NOUN,B1
-flat rate,flat rate,词,NOUN,B2
-flat-nosed,flat-nosed,词,ADJ,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatter,to flatter,奉承,VERB,B2
-flatterer,flatterer,词,NOUN,C1
-flattering,flattering,词,ADJ,C1
-flaunt,flaunt,词,VERB,C1
-flaw,flaw,缺陷,NOUN,B2
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flemish,flemish,佛兰芒的,ADJ,B2
-flesh,flesh,肉,NOUN,B2
-flex,flex,词,VERB,C1
-flexion,flexion,词,NOUN,C1
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flinch,flinch,词,VERB,C1
-fling (noun),fling,词,NOUN,C1
-fling (verb),fling,词,VERB,C1
-flint,flint,燧石,NOUN,B2
-flip,flip,词,VERB,B2
-flirt (noun),flirt,词,NOUN,B2
-flirt (verb),flirt,词,VERB,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-flit,flit,词,VERB,C1
-floating,floating,漂浮的,ADJ,B2
-floating dust,floating dust,浮尘,NOUN,B2
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floorboard,floorboard,词,NOUN,C1
-flop,flop,词,VERB,C1
-flora,flora,植物群,NOUN,B2
-florid,florid,辞藻华丽的,ADJ,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-flourishing,flourishing,繁荣的,ADJ,B2
-flourishing (noun),flourishing,词,NOUN,C1
-flow,to flow,流动,VERB,B2
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,词,NOUN,B2
-flowery,flowery,华丽的,ADJ,B2
-flu,flu,流感,NOUN,B2
-fluency,fluency,流利,NOUN,B2
-fluently,fluently,词,ADV,C1
-fluff,fluff,词,NOUN,C1
-fluid,fluid,液体,NOUN,B2
-fluid (adj),fluid,词,ADJ,B2
-fluidity,fluidity,词,NOUN,C1
-fluidize,fluidize,词,VERB,C1
-fluke,fluke,词,NOUN,B2
-flunk,flunk,词,VERB,C1
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flute,flute,长笛,NOUN,B2
-flutist,flutist,词,NOUN,C1
-flux,flux,变迁,NOUN,B2
-flying,flying,词,ADJ,B2
-flyover,flyover,词,NOUN,C1
-foal,foal,马驹,NOUN,B2
-fob,fob,词,NOUN,C1
-focus,focus,焦点,NOUN,B2
-focus,to focus,聚焦,VERB,B2
-focused,focused,专注的,ADJ,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,词,NOUN,B2
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
-folk,folk,苍生,NOUN,B2
-folkloric,folkloric,词,ADJ,C1
-folksy,folksy,乡土的,ADJ,B2
-follower enthusiast,follower enthusiast,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following page,following page,,NOUN,B2
-foment,foment,词,VERB,C1
-fond of food,fond of food,词,ADJ,B1
-fondle,fondle,词,VERB,C1
-food (adj),food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
-foodstuff,foodstuff,食品,NOUN,B2
-foolish,foolish,愚蠢的,ADJ,B2
-foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,词,NOUN,B2
-football,football,足球,NOUN,B2
-football camp,football camp,词,NOUN,B2
-football player,football player,词,NOUN,C1
-footprint,footprint,足迹,NOUN,B2
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
-footwear,footwear,鞋穿,NOUN,B2
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
-for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for each other,for each other,词,ADV,B2
-for hours,for hours,词,ADJ,B2
-for it,for it,为此,ADV,B2
-for my sake,for my sake,词,ADV,C1
-for now,for now,暂时,ADV,B2
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,词,ADV,B2
-for the,for the,词,ADP,A2
-for the sake of,for the sake of,为了,ADP,B2
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what,for what,为了什么,ADV,B2
-for what purpose,for what purpose,词,ADV,B2
-for years,for years,多年,ADV,B2
-for your sake,for your sake,词,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearance,forbearance,词,NOUN,C1
-forbidden land,forbidden land,禁地,NOUN,B2
-forceful,forceful,词,ADJ,B2
-ford,ford,词,NOUN,B2
-forearm,forearm,词,NOUN,C1
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foreclosure of rights,foreclosure of rights,词,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign,foreign,外国的,ADJ,B2
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,词,ADJ,B2
-foreknow,foreknow,词,VERB,C1
-foreman,foreman,词,NOUN,B2
-forenoon,forenoon,词,NOUN,A1
-forensic,forensic,法医的,ADJ,B2
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
-foresee,to foresee,预见,VERB,B2
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forestall,forestall,词,VERB,C1
-forestry,forestry,词,ADJ,C1
-foretell,foretell,词,VERB,C1
-forever,forever,永远,ADV,B2
-forewarn,forewarn,词,VERB,C1
-foreword,foreword,词,NOUN,C1
-forfeit,forfeit,词,VERB,C1
-forfeiture,forfeiture,词,NOUN,B2
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forger,forger,词,NOUN,C1
-forgetting,forgetting,你忘,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-forgo,forgo,词,VERB,C1
-formalist (noun),formalist,词,NOUN,C1
-formally,formally,正式地,ADV,B2
-format,format,格式,NOUN,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-formulation,formulation,配方,NOUN,B2
-fornicate,fornicate,词,VERB,C1
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-fort,fort,堡垒,NOUN,B2
-forthcoming,forthcoming,词,ADJ,C1
-fortification,fortification,词,NOUN,C1
-fortlet,fortlet,词,NOUN,C1
-fortuitous,fortuitous,偶然的,ADJ,B2
-fortune teller,fortune teller,词,NOUN,B2
-forward (verb),forward,词,VERB,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-foster,foster,词,VERB,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-founding,founding,成立,NOUN,B2
-four limbs,four limbs,四肢,NOUN,B2
-fourth (num),fourth,词,NUM,B1
-fowl,fowl,词,NOUN,C1
-foyer,foyer,词,NOUN,C1
-fractal,fractal,分形,NOUN,B2
-fractional,fractional,词,ADJ,B2
-fragility,fragility,脆弱,NOUN,B2
-fragmentary,fragmentary,零碎的,ADJ,B2
-framing,framing,词,NOUN,C1
-frankly,frankly,坦率地,ADV,B2
-frantic,frantic,狂乱的,ADJ,C1
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fratricide,fratricide,杀兄弟,NOUN,B2
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudster,fraudster,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fray,fray,词,VERB,C1
-frayed,frayed,词,ADJ,C1
-frazzle,frazzle,词,VERB,C1
-free of charge,free of charge,免费,NOUN,B2
-free of charge (adj),free of charge,免费,ADJ,A2
-free off,free off,空闲的/休假,ADJ,B2
-free trade,free trade,词,NOUN,C1
-free will,free will,词,NOUN,B2
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,词,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freely,freely,自由地,ADV,B2
-freezing,freezing,极冷的,ADJ,B2
-freight,freight,货物,NOUN,B2
-french,french,法语,NOUN,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
-frequent (adj),frequent,词,ADJ,B2
-frequently,frequently,经常,ADV,B2
-fresco,fresco,词,NOUN,B2
-fresh,fresh,,NOUN,B2
-freshly,freshly,新鲜地,ADV,B2
-fret,fret,词,VERB,C1
-friar,friar,词,NOUN,C1
-frictionless,frictionless,无摩擦的,ADJ,B2
-fried food,fried food,词,NOUN,C1
-friends with,friends with,词,ADJ,B2
-frieze,frieze,檐壁,NOUN,B2
-frigate,frigate,护卫舰,NOUN,B2
-frightening,frightening,令人恐惧的,ADJ,B2
-frightful,frightful,词,ADJ,B1
-frigid,frigid,寒冷的,ADJ,B2
-frill,frill,词,NOUN,C1
-frisian,frisian,词,ADJ,B2
-frisk,frisk,词,VERB,C1
-fritter,fritter,词,VERB,C1
-frivol,frivol,词,VERB,C1
-frivolous,frivolous,轻浮的,ADJ,B2
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from above,from above,从上方,ADV,B2
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
-from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from here,from here,词,ADV,B2
-from home,from home,词,ADV,B2
-from it,from it,从中,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from there,from there,从那里,ADV,B2
-from this,from this,词,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from where,from where,从哪里,ADV,B2
-from which,from which,从中,ADV,B2
-from within,from within,从内部,ADV,B2
-front line,front line,前线,NOUN,B2
-front page,front page,头版,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontispiece,frontispiece,词,NOUN,C1
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-frosty,frosty,词,ADJ,A1
-froth,froth,泡沫,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frozen,frozen,冻僵的,ADJ,B2
-fructify,fructify,词,VERB,C1
-frugality,frugality,节俭,NOUN,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,词,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruitless,fruitless,词,ADJ,C1
-fryer,fryer,词,NOUN,C1
-fuchsia,fuchsia,词,NOUN,C1
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fulcrum,fulcrum,词,NOUN,C1
-fulfil,fulfil,词,VERB,C1
-fulfilled,fulfilled,满足的,ADJ,B2
-fulfillment,fulfillment,满足,NOUN,B2
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full fed up,full fed up,词,ADJ,B1
-full moon banquet,full moon banquet,满月酒,NOUN,C1
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full stop,full stop,词,NOUN,B2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,词,ADJ,B2
-fullness,fullness,词,NOUN,C1
-fully,fully,词,ADV,C1
-fulminate,fulminate,词,VERB,C1
-fumarole,fumarole,词,NOUN,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundamental rights,fundamental rights,词,NOUN,C1
-fundamentally,fundamentally,词,ADV,C1
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,词,NOUN,C1
-funerary,funerary,词,ADJ,B2
-funereal,funereal,丧葬的,ADJ,B2
-fungal,fungal,词,ADJ,C1
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funnel,funnel,漏斗,NOUN,B2
-funniness,funniness,,NOUN,B2
-furbish,furbish,词,VERB,C1
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnishing,furnishing,室内布置,NOUN,B2
-furrow,furrow,犁沟,NOUN,B2
-further,further,进一步,ADV,B2
-further additional,further additional,词,ADJ,B2
-further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-furthest,furthest,最远,ADV,B2
-furtive,furtive,词,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
-fussy,fussy,挑剔的,ADJ,B2
-futile,futile,词,ADJ,C1
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurist,futurist,词,NOUN,C1
-futuristic,futuristic,词,ADJ,C1
-gad,gad,词,VERB,C1
-gag,gag,词,NOUN,C1
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galician,galician,词,ADJ,B2
-gallant,gallant,英勇的,ADJ,B2
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
-galvanization,galvanization,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game play,game play,词,NOUN,B2
-game rule,game rule,游戏规则,NOUN,B2
-gamete,gamete,词,NOUN,B2
-gangrene,gangrene,坏疽,NOUN,B2
-gangster,gangster,黑帮成员,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-gaol,gaol,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garb,garb,词,NOUN,C1
-garble,garble,词,VERB,C1
-gardening,gardening,园艺,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
-gargle (verb),gargle,词,VERB,C1
-gargoyle,gargoyle,滴水嘴兽,NOUN,B2
-garland,garland,花环,NOUN,B2
-garment (part),garment,衣,PART,B2
-garment making,garment making,词,NOUN,C1
-garner,garner,词,VERB,C1
-gas flame,gas flame,词,NOUN,B2
-gas meter,gas meter,词,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
-gaseous,gaseous,气态的,ADJ,B2
-gash,gash,词,NOUN,C1
-gasp (noun),gasp,词,NOUN,B2
-gasp (verb),gasp,词,VERB,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomic,gastronomic,美食的,ADJ,B2
-gastronomy,gastronomy,美食学,NOUN,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatekeeper,gatekeeper,词,NOUN,B2
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauge (noun),gauge,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,快乐的,ADJ,B2
-gay (noun),gay,同性恋者,NOUN,B2
-gay man,gay man,男同性恋者,NOUN,B2
-gazette,gazette,词,NOUN,C1
-gearbox,gearbox,变速箱,NOUN,B2
-geek,geek,极客,NOUN,C1
-geerziehung,geerziehung,词,NOUN,C1
-gefahrt,gefahrt,词,NOUN,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gekunft,gekunft,词,NOUN,C1
-gel,gel,词,NOUN,C1
-gelatin,gelatin,词,NOUN,C1
-geld,geld,词,VERB,C1
-gem,gem,宝石,NOUN,C1
-gemstone,gemstone,词,NOUN,C1
-genahme,genahme,词,NOUN,C1
-gender equality,gender equality,性别平等,NOUN,B2
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogical,genealogical,词,ADJ,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-general practitioner,general practitioner,全科医生,NOUN,B2
-generality,generality,普遍性,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generations,generations,词,NOUN,B2
-generatrix,generatrix,词,NOUN,B2
-generic,generic,通用的,ADJ,B2
-generously,generously,慷慨地,ADV,B2
-genetic modification,genetic modification,词,NOUN,B2
-genetically,genetically,词,ADV,B2
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,词,NOUN,B2
-gentlemen,gentlemen,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-gentrification,gentrification,词,NOUN,C1
-genuflect,genuflect,词,VERB,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geocentric,geocentric,词,ADJ,C1
-geographer,geographer,词,NOUN,C1
-geographically,geographically,词,ADV,C1
-geolocation,geolocation,词,NOUN,C1
-geometer,geometer,词,NOUN,C1
-geophysics,geophysics,词,NOUN,C1
-geothermal,geothermal,地热,ADJ,C1
-gepflegung,gepflegung,词,NOUN,C1
-geregelung,geregelung,词,NOUN,C1
-geriatric,geriatric,词,ADJ,C1
-geriatrics,geriatrics,词,NOUN,B2
-gerichtung,gerichtung,词,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,词,NOUN,B2
-germanic,germanic,词,ADJ,C1
-germicidal,germicidal,词,ADJ,C1
-gerontocracy,gerontocracy,老人政治,NOUN,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-gesprache,gesprache,词,NOUN,C1
-gestation,gestation,词,NOUN,C1
-gestural,gestural,词,ADJ,C1
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-getaway,getaway,词,NOUN,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-gewandel,gewandel,词,NOUN,C1
-geweisung,geweisung,词,NOUN,C1
-gewirkung,gewirkung,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
-giant (adj),giant,巨大的,ADJ,B1
-gibber,gibber,词,VERB,C1
-gibberish,gibberish,词,NOUN,C1
-gibe,gibe,词,VERB,C1
-giddy,giddy,词,ADJ,B2
-gifted,gifted,有天赋的,ADJ,B2
-gin,gin,金酒,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-girdle,girdle,词,NOUN,C1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give you (noun),give you,送你,NOUN,C1
-given,given,给定的,ADJ,B2
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-gladden,gladden,词,VERB,C1
-gladiator,gladiator,词,NOUN,C1
-gladly,gladly,乐意地,ADV,B2
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-glamour,glamour,词,NOUN,C1
-glance,glance,一瞥,NOUN,B2
-glare,glare,词,VERB,C1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-glebe,glebe,词,NOUN,C1
-glib,glib,伶牙俐齿的,ADJ,B2
-gliding,gliding,滑翔,NOUN,B2
-glimmer,glimmer,词,NOUN,C1
-glimpse,glimpse,一瞥,NOUN,B2
-glint,glint,词,NOUN,C1
-glisten,glisten,词,VERB,C1
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-global (noun),global,全球,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-glomerulus,glomerulus,词,NOUN,C1
-gloriously,gloriously,词,ADV,C1
-gloriousness,gloriousness,光荣,NOUN,B2
-glossator,glossator,词,NOUN,C1
-glow (verb),glow,词,VERB,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glower,glower,词,VERB,C1
-glut,glut,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
-glyph,glyph,词,NOUN,C1
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
-go away,go away,词,VERB,C1
-go wrong,go wrong,词,VERB,C1
-goalkeeper,goalkeeper,词,NOUN,B2
-gobble,gobble,词,VERB,C1
-goblin,goblin,词,NOUN,C1
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-godmother,godmother,词,NOUN,C1
-godson,godson,词,NOUN,A2
-goggle,goggle,词,VERB,C1
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good day,good day,你好,INTJ,B2
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good heavens,good heavens,天哪,INTJ,B2
-good lord,good lord,词,INTJ,B2
-good medicine,good medicine,好药,NOUN,B2
-good morning,good morning,早上好,INTJ,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good night,good night,晚安,INTJ,B2
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-good-naturedness,good-naturedness,词,NOUN,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gosh,gosh,天哪,INTJ,B2
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,词,ADJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-gouge,gouge,词,VERB,C1
-govern a country,govern a country,治国,VERB,C1
-governability,governability,词,NOUN,B2
-governable,governable,词,ADJ,B2
-governess,governess,词,NOUN,C1
-governorate,governorate,词,NOUN,C1
-grab,grab,揪,NOUN,B2
-gracious,gracious,亲切的,ADJ,B2
-grade (verb),grade,分级,VERB,C1
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation,graduation,毕业,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-grail,grail,词,NOUN,B2
-grammatical,grammatical,词,ADJ,C1
-grammaticality,grammaticality,合语法性,NOUN,B2
-gramophone,gramophone,词,NOUN,C1
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand master,grand master,词,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,词,ADJ,B2
-grandiloquently,grandiloquently,词,ADV,C1
-grandiosity,grandiosity,宏伟,NOUN,B2
-grandpa,grandpa,爷爷,NOUN,B2
-grandparent,grandparent,词,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granitic,granitic,词,ADJ,C1
-granny,granny,奶奶,NOUN,B2
-granule,granule,词,NOUN,C1
-grapefruit,grapefruit,词,NOUN,A2
-graph,graph,词,NOUN,C1
-graphic artist,graphic artist,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphic designer,graphic designer,词,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-graphology,graphology,笔迹学,NOUN,B2
-grapple,grapple,词,VERB,C1
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grate,grate,词,VERB,C1
-grater,grater,词,NOUN,B2
-gratified,gratified,欣慰,ADJ,C1
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-gravely,gravely,严重地,ADV,B2
-graveyard,graveyard,墓地,NOUN,B2
-gravid,gravid,词,ADJ,B2
-gravitation,gravitation,引力,NOUN,B2
-gravitational,gravitational,引力的,ADJ,B2
-grayish,grayish,词,ADJ,C1
-grease (noun),grease,词,NOUN,C1
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,词,NOUN,B2
-greaten,greaten,词,VERB,C1
-greek,greek,希腊语,NOUN,B2
-greek (adj),greek,希腊的,ADJ,B2
-green blue,green blue,青,ADJ,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green-clad,green-clad,,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-greetings,greetings,,NOUN,B2
-gregarious,gregarious,爱社交的,ADJ,B2
-grenadier,grenadier,词,NOUN,C1
-grey area,grey area,词,NOUN,B2
-grid,grid,网格,NOUN,B2
-grieve,grieve,词,VERB,C1
-grieved,grieved,词,ADJ,B2
-grill (noun),grill,词,NOUN,B2
-grille,grille,格栅,NOUN,B2
-grimace,grimace,词,NOUN,C1
-grimness,grimness,词,NOUN,C1
-grip (noun),grip,握呀,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-gripe,gripe,词,VERB,C1
-grit,grit,词,NOUN,C1
-groan,groan,呻吟,NOUN,B2
-grocery,grocery,词,NOUN,B2
-grooming,grooming,词,NOUN,C1
-grooved,grooved,词,ADJ,C1
-grope,grope,词,VERB,C1
-grotesque,grotesque,词,ADJ,B2
-grotto,grotto,洞穴,NOUN,B2
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-groundwater pollution,groundwater pollution,词,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,词,NOUN,B2
-grouping,grouping,词,NOUN,B2
-grouse,grouse,词,VERB,C1
-grovel,grovel,词,VERB,C1
-growing,growing,词,ADJ,B2
-grown,grown,长大的,ADJ,B2
-growth rate,growth rate,词,NOUN,C1
-grub,grub,词,NOUN,C1
-grueling,grueling,词,ADJ,C1
-gruff,gruff,阴沉的,ADJ,B2
-grumbler,grumbler,爱抱怨的人,NOUN,B2
-grumpy,grumpy,脾气坏的,ADJ,B2
-grunt,grunt,词,VERB,B2
-guarding,guarding,守住,NOUN,C1
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-guerrilla,guerrilla,词,NOUN,C1
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guffaw,guffaw,哄笑,NOUN,B2
-guided tour,guided tour,导游,NOUN,B2
-guideline,guideline,指导方针,NOUN,B2
-guild,guild,行会,NOUN,B2
-guild (adj),guild,词,ADJ,C1
-guilder,guilder,盾,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-gunshot,gunshot,枪声,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-guru,guru,精神导师,NOUN,B2
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-gutter,gutter,路沟,NOUN,B2
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
-gymnast,gymnast,体操运动员,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gynaecology,gynaecology,妇科,NOUN,B2
-gynecologist,gynecologist,词,NOUN,C1
-gyroscope,gyroscope,词,NOUN,C1
-habit formation,habit formation,词,NOUN,C1
-habitability,habitability,词,NOUN,C1
-habitlessness,habitlessness,无习惯,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-hacker,hacker,黑客,NOUN,C1
-hackneyed,hackneyed,词,ADJ,C1
-hag,hag,老妇,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-hair-raising,hair-raising,词,ADJ,B2
-haircut,haircut,词,NOUN,C1
-hairy,hairy,词,ADJ,C1
-half (adj),half,词,ADJ,A1
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway,halfway,半途,ADV,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall (part),hall,殿,PART,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
-hallowed,hallowed,词,ADJ,C1
-hamburger,hamburger,汉堡包,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
-handbrake,handbrake,手刹,NOUN,C1
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handle (noun),handle,把手,NOUN,B2
-handlebars,handlebars,词,NOUN,C1
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-handyman,handyman,工匠,NOUN,B2
-hanged,hanged,被绞死的,ADJ,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hanging,hanging,绞刑,NOUN,B2
-hangover,hangover,词,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy cheerful,happy cheerful,词,ADJ,B1
-happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harbour,harbour,词,NOUN,B2
-hard,hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-harder,harder,词,ADJ,A2
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
-hare,hare,野兔,NOUN,B2
-harm intention,harm intention,想害,NOUN,C1
-harried,harried,词,ADJ,C1
-harsh,harsh,严厉的,ADJ,B2
-harshly,harshly,词,ADV,C1
-hassle,hassle,麻烦,NOUN,B2
-hastily,hastily,急忙,ADV,B2
-hatch,hatch,舱口,NOUN,B2
-hatching,hatching,词,NOUN,C1
-haughtily,haughtily,词,ADV,C1
-haughty,haughty,傲慢的,ADJ,C1
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have time,have time,词,VERB,B2
-have to,have to,必须,AUX,B2
-have to (adv),have to,不得不,ADV,A1
-having a birthday,having a birthday,过生日的,ADJ,B2
-having a cold,having a cold,词,ADJ,B2
-having item,having item,有件,NOUN,C1
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-headlight,headlight,大灯,NOUN,C1
-headline,headline,标题,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healer,healer,词,NOUN,B2
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,词,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-heap cluster,heap cluster,词,NOUN,C1
-hearing aid,hearing aid,词,NOUN,B2
-heart,heart,心,ADV,B2
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt,heartfelt,衷心的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartlessness,heartlessness,词,NOUN,B2
-heartrending,heartrending,词,ADJ,C1
-hearts,hearts,心,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
-heavily,heavily,沉重地,ADV,B2
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hectic (adj),hectic,词,ADJ,C1
-hectic (noun),hectic,忙乱,NOUN,B2
-hedonism,hedonism,享乐主义,NOUN,B2
-hedonist,hedonist,词,NOUN,C1
-hefen,hefen,河粉,NOUN,C1
-heinous,heinous,词,ADJ,C1
-hello bye,hello bye,词,INTJ,B2
-hello polite,hello polite,您好,INTJ,C1
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-hem,hem,词,NOUN,B2
-hematoma,hematoma,词,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemiplegia,hemiplegia,词,NOUN,C1
-hemisphere,hemisphere,半球,NOUN,B2
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostasis,hemostasis,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
-hence,hence,因此,ADV,B2
-henceforth,henceforth,从此以后,ADV,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,DET,B2
-her (pron),her,词,PRON,A1
-her their,her their,词,DET,A1
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
-herbaceous,herbaceous,词,ADJ,B2
-herbal tea,herbal tea,词,NOUN,B2
-herbalism,herbalism,词,NOUN,C1
-herbarium,herbarium,词,NOUN,C1
-herbicide,herbicide,除草剂,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here is,here is,词,ADV,A1
-here you go,here you go,词,INTJ,B2
-herein,herein,词,ADV,B1
-heresiarch,heresiarch,词,NOUN,C1
-heretical,heretical,词,ADJ,C1
-hermetic,hermetic,词,ADJ,C1
-hermit,hermit,隐士,NOUN,B2
-hermitage,hermitage,词,NOUN,B2
-hernia,hernia,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,词,NOUN,B1
-heron,heron,词,NOUN,C1
-hesitant,hesitant,犹豫的,ADJ,B2
-heterodox,heterodox,词,ADJ,C1
-heterodoxy,heterodoxy,词,NOUN,C1
-heterogeneity,heterogeneity,异质性,NOUN,B2
-heterosexual,heterosexual,词,ADJ,C1
-heuristic,heuristic,词,ADJ,C1
-hexagon,hexagon,词,NOUN,C1
-heyday,heyday,词,NOUN,C1
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hide-and-seek,hide-and-seek,词,NOUN,B2
-hideous,hideous,丑陋的,ADJ,B2
-hiding ambush,hiding ambush,词,NOUN,B2
-hiding place,hiding place,藏身处,NOUN,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,词,NOUN,B2
-high school student,high school student,词,NOUN,B2
-high tall,high tall,高的,ADJ,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highest,highest,最高的,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlight,highlight,亮点,NOUN,B2
-highlighter,highlighter,词,NOUN,C1
-hijack,hijack,词,VERB,C1
-hijacking,hijacking,词,NOUN,C1
-hike,hike,徒步旅行,NOUN,B2
-him,him,他,PRON,B2
-him dative,him dative,词,PRON,A2
-him her,him her,他/她,PRON,B2
-himself herself,himself herself,词,PRON,A1
-hinge,hinge,合页,NOUN,B2
-hint,hint,暗示,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
-hirsute,hirsute,词,ADJ,C1
-his,his,他的,PRON,B2
-his certainty,his certainty,他定,NOUN,C1
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,词,DET,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,词,ADJ,C1
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
-historicist,historicist,词,NOUN,C1
-historicity,historicity,历史性,NOUN,B2
-history education,history education,词,NOUN,C1
-history story,history story,历史/故事,NOUN,B2
-histrionic,histrionic,词,ADJ,C1
-hit,hit,击中,NOUN,B2
-hit beat,hit beat,词,VERB,A2
-hitch,hitch,词,NOUN,B2
-hither,hither,到这里,ADV,B2
-hmm,hmm,嗯,INTJ,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hold,hold,控制,NOUN,B2
-hold,to hold,拿着,VERB,B2
-hold (noun),hold,控制,NOUN,B2
-hold on,to hold on,抓住,VERB,B2
-hold the balance of power,hold the balance of power,举足轻重,ADJ,B2
-hold together,hold together,词,VERB,C1
-holder,holder,持有者,NOUN,B2
-holding,holding,别放,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holdup,holdup,词,NOUN,B2
-holiday,holiday,假期,NOUN,B2
-holidaymaker,holidaymaker,词,NOUN,C1
-holidays,holidays,假期,NOUN,B2
-holism,holism,整体论,NOUN,B2
-holistic,holistic,整体的,ADJ,B2
-hollowed,hollowed,掏空的,ADJ,B2
-holm oak,holm oak,词,NOUN,C1
-holocaust,holocaust,浩劫,NOUN,B2
-hologram,hologram,词,NOUN,C1
-holy,holy,神圣的,ADJ,B2
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home,home,家,NOUN,B2
-home (adv),home,词,ADV,B1
-home automation,home automation,词,NOUN,B1
-home family,home family,家,NOUN,B2
-home hearth,home hearth,词,NOUN,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,词,ADJ,B2
-homeland,homeland,家乡,NOUN,B2
-homeless,homeless,无家可归的,ADJ,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,词,NOUN,B2
-homework,homework,家庭作业,NOUN,B2
-homicide,homicide,杀人,NOUN,B2
-homiletic,homiletic,词,ADJ,C1
-homily,homily,布道,NOUN,B2
-hominization,hominization,词,NOUN,C1
-homogeneity,homogeneity,同质性,NOUN,B2
-homonym,homonym,词,NOUN,C1
-homonymy,homonymy,同音异义,NOUN,B2
-homosexuality,homosexuality,同性恋,NOUN,B2
-honestly,honestly,诚实地,ADV,B2
-honesty,honesty,诚实,NOUN,B2
-honeymoon,honeymoon,蜜月,NOUN,B2
-honor,to honor,尊敬,VERB,B2
-honor culture,honor culture,词,NOUN,B2
-honorability,honorability,词,NOUN,C1
-honorable,honorable,可敬的,ADJ,B2
-honored,honored,尊敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-hood,hood,兜帽,NOUN,B2
-hook,hook,钩子,NOUN,B2
-hooligan,hooligan,词,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
-hope to wish,to hope to wish,希望,VERB,B2
-hopeful,hopeful,词,ADJ,C1
-hopefully,hopefully,希望,ADV,B2
-hopeless,hopeless,绝望的,ADJ,B2
-hopelessly,hopelessly,词,ADV,B2
-hopelessness,hopelessness,词,NOUN,C1
-horde,horde,词,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
-horny,horny,性欲的,ADJ,B2
-horoscope,horoscope,词,NOUN,B2
-horrible,horrible,可怕的,ADJ,B2
-horrified,horrified,词,ADJ,B2
-horrify,to horrify,使惊骇,VERB,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-horse departure,horse departure,马去,NOUN,B2
-horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hose,hose,软管,NOUN,B2
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitality industry,hospitality industry,词,NOUN,B2
-hospitalization,hospitalization,词,NOUN,C1
-hospitalize,to hospitalize,使住院,VERB,B2
-host,to host,接待,VERB,B2
-host of angels,host of angels,天使群,NOUN,B2
-hostel,hostel,词,NOUN,C1
-hostess,hostess,女服务员,NOUN,B2
-hostile,hostile,敌对的,ADJ,B2
-hostility,hostility,敌意,NOUN,B2
-hot air balloon,hot air balloon,热气球,NOUN,B2
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
-hotbed,hotbed,词,NOUN,C1
-hotel,hotel,酒店,NOUN,B2
-hotel industry,hotel industry,词,NOUN,C1
-hotel room,hotel room,酒店房间,NOUN,B2
-hotelier,hotelier,旅馆老板,NOUN,B2
-hothead,hothead,急性子的人,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-house search,house search,词,NOUN,B2
-household,household,家庭,NOUN,B2
-household (adj),household,词,ADJ,B2
-household income,household income,词,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
-how many (pron),how many,多少,PRON,A1
-how much,how much,多少,ADV,B2
-how to do it,how to do it,办呢,ADV,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hubris,hubris,词,NOUN,C1
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (noun),human rights,人权,NOUN,C1
-humane,humane,人道的,ADJ,B2
-humanist,humanist,人文主义者,NOUN,B2
-humanitarian,humanitarian,人道主义的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
-humble,humble,谦逊的,ADJ,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
-humid,humid,潮湿的,ADJ,B2
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
-humiliating,humiliating,令人羞辱的,ADJ,B2
-hummingbird,hummingbird,词,NOUN,B2
-humorist,humorist,词,NOUN,C1
-humorous,humorous,幽默的,ADJ,C1
-hump,hump,词,NOUN,C1
-hunch,hunch,词,NOUN,B2
-hundred,hundred,一百,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hundreds (num),hundreds,词,NUM,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hyaline,hyaline,词,ADJ,C1
-hybridism,hybridism,词,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydraulic,hydraulic,液压的,ADJ,B2
-hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrology,hydrology,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hygienic,hygienic,词,ADJ,B2
-hymnal,hymnal,词,NOUN,C1
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbole,hyperbole,夸张,NOUN,B2
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hyperthermia,hyperthermia,词,NOUN,B2
-hypertrophy,hypertrophy,肥大,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
-hypotension,hypotension,词,NOUN,C1
-hypothesize,hypothesize,词,VERB,B2
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
-i,i,我连,NOUN,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
-ice cold,ice cold,冰冷的,ADJ,B2
-ice cube,ice cube,词,NOUN,A2
-ice pick,ice pick,词,NOUN,B2
-icicle,icicle,词,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconoclast,iconoclast,偶像破坏者,NOUN,C1
-iconoclastic,iconoclastic,词,ADJ,C1
-iconographic,iconographic,词,ADJ,C1
-ideal,ideal,理想,NOUN,B2
-idealization,idealization,词,NOUN,B2
-ideally,ideally,理想地,ADV,B2
-ideational,ideational,词,ADJ,C1
-identifier,identifier,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
-idiomatic,idiomatic,词,ADJ,C1
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncrasy,idiosyncrasy,特质,NOUN,B2
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiot (adj),idiot,词,ADJ,A2
-idiotic,idiotic,愚蠢的,ADJ,B2
-idolatry,idolatry,词,NOUN,B2
-idyllic,idyllic,词,ADJ,C1
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
-igneous,igneous,火成的,ADJ,B2
-ignominious,ignominious,词,ADJ,C1
-ignominy,ignominy,词,NOUN,B2
-iliac,iliac,词,ADJ,C1
-illegally,illegally,词,ADV,C1
-illicit,illicit,违禁的,ADJ,B2
-illiterate,illiterate,词,ADJ,B2
-illogical,illogical,词,ADJ,B2
-illumination,illumination,照明,NOUN,B2
-illuminator,illuminator,词,NOUN,B2
-illusory,illusory,词,ADJ,C1
-illustration,illustration,插图,NOUN,B2
-illustrative,illustrative,词,ADJ,C1
-illustrious,illustrious,著名的,ADJ,B2
-image formation,image formation,词,NOUN,B2
-imaginative,imaginative,富有想象力的,ADJ,B2
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
-imbecility,imbecility,词,NOUN,C1
-immaculate,immaculate,词,ADJ,C1
-immanent,immanent,词,ADJ,C1
-immature,immature,不成熟的,ADJ,B2
-immemorial,immemorial,词,ADJ,C1
-immense,immense,巨大的,ADJ,C1
-immensely,immensely,词,ADV,B2
-immensity,immensity,词,NOUN,C1
-immerse,immerse,词,VERB,C1
-immersed,immersed,词,ADJ,C1
-imminence,imminence,就将,NOUN,C1
-immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immodesty,immodesty,不贞,NOUN,B2
-immoral,immoral,不道德的,ADJ,B2
-immorality,immorality,词,NOUN,C1
-immovable,immovable,不可移动的,ADJ,B2
-impartial,impartial,词,ADJ,C1
-impartiality,impartiality,公正,NOUN,B2
-impassive,impassive,词,ADJ,C1
-impassively,impassively,词,ADV,B2
-impatience,impatience,词,NOUN,C1
-impeccable,impeccable,无瑕疵的,ADJ,B2
-imperatively,imperatively,词,ADV,C1
-imperceptible,imperceptible,词,ADJ,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperfect,imperfect,不完美的,ADJ,B2
-imperfection,imperfection,词,NOUN,C1
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,御医,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
-imperialist,imperialist,词,ADJ,C1
-imperious,imperious,词,ADJ,C1
-impersonal,impersonal,词,ADJ,C1
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbably,imperturbably,词,ADV,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implacably,implacably,毫不留情地,ADV,B2
-implantation,implantation,词,NOUN,C1
-implausible,implausible,词,ADJ,C1
-impoliteness,impoliteness,词,NOUN,C1
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
-imposing,imposing,宏伟的,ADJ,B2
-imposition,imposition,词,NOUN,C1
-impostor,impostor,词,NOUN,B2
-imposture,imposture,词,NOUN,C1
-impotence,impotence,无力,NOUN,B2
-impotent,impotent,词,ADJ,C1
-impound lot,impound lot,词,NOUN,B1
-impoverished,impoverished,词,ADJ,B2
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
-impressed,impressed,印象深刻的,ADJ,B2
-impressions,impressions,感想,NOUN,B2
-imprint,imprint,印记,NOUN,B2
-imprisoned,imprisoned,词,ADJ,B2
-impromptu,impromptu,即兴的,ADJ,B2
-improvidence,improvidence,词,NOUN,C1
-imprudence,imprudence,词,NOUN,C1
-imprudent,imprudent,词,ADJ,C1
-impunity,impunity,逍遥法外,NOUN,B2
-impure,impure,词,ADJ,C1
-imputation,imputation,词,NOUN,C1
-in,in,进来,ADV,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in addition to,in addition to,词,ADP,B2
-in agreement,in agreement,词,ADV,C1
-in book,in book,书里,NOUN,C1
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in deficit,in deficit,词,ADJ,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
-in front of before,in front of before,在...前,ADP,B2
-in here,in here,在这里面,ADV,B2
-in high spirits,in high spirits,兴高采烈,ADJ,B2
-in me,in me,我中,NOUN,C1
-in mind,in mind,词,ADV,B2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
-in private,in private,词,ADV,B2
-in question,in question,词,ADV,C1
-in return,in return,词,NOUN,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,词,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,词,ADV,B2
-in those days,in those days,当年,NOUN,B2
-in time (adj),in time,词,ADJ,B1
-in two,in two,成两半,ADV,B2
-in unison,in unison,词,ADV,B2
-in vain (noun),in vain,词,NOUN,B2
-in view of,in view of,鉴于,ADP,B2
-in which,in which,在其中,PRON,B2
-inaccessible,inaccessible,词,ADJ,C1
-inaccurate,inaccurate,词,ADJ,C1
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inactivity,inactivity,词,NOUN,B2
-inadequate,inadequate,不足的,ADJ,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadmissible,inadmissible,不可接受的,ADJ,B2
-inadvertent,inadvertent,词,ADJ,C1
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inattentive,inattentive,词,ADJ,C1
-inaudible,inaudible,词,ADJ,B2
-inboard,inboard,船内的,ADV,B2
-incandescence,incandescence,词,NOUN,C1
-incandescent,incandescent,白炽的,ADJ,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incarceration,incarceration,词,NOUN,C1
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
-inceptive,inceptive,词,ADJ,C1
-incessant,incessant,持续的,ADJ,B2
-incest,incest,词,NOUN,C1
-inchoative,inchoative,词,ADJ,C1
-incidence,incidence,发生率,NOUN,B2
-incidental,incidental,词,ADJ,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
-incipient,incipient,词,ADJ,C1
-incision,incision,切口,NOUN,B2
-incisive,incisive,深刻的,ADJ,C1
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,词,ADJ,B2
-inclined prone,inclined prone,词,ADJ,C1
-including,including,包括,ADP,B2
-including (adv),including,词,ADV,A2
-inclusion,inclusion,包含,NOUN,B2
-incognito,incognito,词,ADJ,C1
-incoherent,incoherent,不连贯的,ADJ,B2
-income tax,income tax,所得税,NOUN,B2
-incommunicado,incommunicado,词,ADJ,C1
-incompatible,incompatible,词,ADJ,C1
-incompetence,incompetence,词,NOUN,C1
-incompetent,incompetent,无能的,ADJ,B2
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,词,NOUN,B2
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable,inconceivable,不可想象的,ADJ,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,词,NOUN,B2
-incongruous,incongruous,不协调的,ADJ,B2
-inconsiderate,inconsiderate,词,ADJ,C1
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontestably,incontestably,词,ADV,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorporation,incorporation,纳入,NOUN,B2
-incorrect,incorrect,不正确的,ADJ,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increased,increased,增加的,ADJ,B2
-increasing,increasing,增加的,ADJ,B2
-incredible,incredible,难以置信的,ADJ,B2
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
-incremental,incremental,渐进性,ADJ,B2
-inculcate,inculcate,词,VERB,C1
-incumbent,incumbent,词,ADJ,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-indebted,indebted,词,ADJ,B2
-indecent,indecent,词,ADJ,C1
-indecipherable,indecipherable,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
-independently,independently,独立地,ADV,B2
-indeterminate,indeterminate,词,ADJ,C1
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
-indian (adj),indian,词,ADJ,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indigent,indigent,词,ADJ,C1
-indirect,indirect,词,ADJ,C1
-indirectly,indirectly,间接地,ADV,B2
-indiscreet,indiscreet,词,ADJ,C1
-indiscretion,indiscretion,轻率,NOUN,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinct,indistinct,词,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
-individual (adj),individual,个人的,ADJ,B2
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualization,individualization,词,NOUN,C1
-individually,individually,词,ADV,C1
-indoctrination,indoctrination,灌输,NOUN,B2
-indolent,indolent,词,ADJ,C1
-indomitable,indomitable,词,ADJ,C1
-indonesian,indonesian,词,ADJ,B2
-indoors,indoors,在室内,ADV,B2
-indulge,indulge,词,VERB,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrialization,industrialization,工业化,NOUN,B2
-industrious,industrious,词,ADJ,C1
-inedible,inedible,词,ADJ,C1
-ineffable,ineffable,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-ineffectiveness,ineffectiveness,词,NOUN,B2
-inefficiency,inefficiency,低效,NOUN,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inert,inert,惰性的,ADJ,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable (noun),inevitable,词,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexpressible,inexpressible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infamous,infamous,声名狼藉的,ADJ,B2
-infamy,infamy,恶名,NOUN,B2
-infant,infant,婴儿,NOUN,B2
-infantry,infantry,步兵,NOUN,B2
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-infected,infected,被感染的,ADJ,B2
-infidelity,infidelity,不忠,NOUN,B2
-infiltration,infiltration,混进,NOUN,C1
-infinitely,infinitely,词,ADV,B2
-infinitive marker,infinitive marker,去,PART,B2
-infinity,infinity,词,NOUN,C1
-infirmary,infirmary,医务室,NOUN,B2
-inflamed,inflamed,词,ADJ,B2
-inflammable,inflammable,易燃的,ADJ,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflationary,inflationary,词,ADJ,C1
-inflection,inflection,词,NOUN,B2
-inflexibility,inflexibility,僵化,NOUN,B2
-influential,influential,词,ADJ,C1
-influx,influx,涌入,NOUN,B2
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
-information exchange,information exchange,词,NOUN,B2
-informative,informative,词,ADJ,B2
-informed,informed,见多识广的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informer,informer,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructure,infrastructure,基础设施,NOUN,B2
-inhabited,inhabited,词,ADJ,C1
-inharmonious,inharmonious,词,ADJ,C1
-inherence,inherence,词,NOUN,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inhibited,inhibited,词,ADJ,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhuman,inhuman,不人道的,ADJ,B2
-inhumanity,inhumanity,词,NOUN,C1
-initial (noun),initial,词,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initiation,initiation,词,NOUN,C1
-injury recovery,injury recovery,好伤,NOUN,C1
-inkling,inkling,预感,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inmate,inmate,词,NOUN,C1
-inner heart,inner heart,内心,NOUN,B2
-inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
-innermost,innermost,最里面的,ADV,B2
-innocent,innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
-innocuous,innocuous,无害的,ADJ,B2
-inopportune,inopportune,词,ADJ,C1
-inpatient department,inpatient department,住院部,NOUN,B2
-inquisition,inquisition,宗教裁判所,NOUN,B2
-inquisitive,inquisitive,好奇的,ADJ,C1
-insanely,insanely,疯狂地,ADV,B2
-insatiable,insatiable,不知足的,ADJ,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect-proof,insect-proof,防虫,ADJ,C1
-insecurity,insecurity,不安全感,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensitive,insensitive,麻木的,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
-inside,inside,内部,NOUN,B2
-inside in,inside in,里,NOUN,B2
-inside of,inside of,词,ADP,B2
-insidiously,insidiously,词,ADV,B2
-insightfulness,insightfulness,洞察,NOUN,B2
-insincere,insincere,词,ADJ,C1
-insinuation,insinuation,词,NOUN,B2
-insipid,insipid,词,ADJ,C1
-insolvent,insolvent,无偿还能力的,ADJ,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
-inspired,inspired,受启发的,ADJ,B2
-inspiring,inspiring,鼓舞人心的,ADJ,B2
-instantaneous,instantaneous,瞬间的,ADJ,B2
-instantly,instantly,词,ADV,C1
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
-instigation,instigation,怂恿,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructive,instructive,有教育意义的,ADJ,B2
-instructor,instructor,讲师,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insufficiency,insufficiency,不足,NOUN,B2
-insulin,insulin,胰岛素,NOUN,B2
-insurer,insurer,词,NOUN,C1
-insurgency,insurgency,词,NOUN,C1
-intake,intake,词,NOUN,C1
-intangible,intangible,无形的,ADJ,B2
-integral,integral,不可或缺的,ADJ,B2
-integrate,to integrate,整合,VERB,B2
-integrity,integrity,正直,NOUN,B2
-intellect,intellect,智力,NOUN,B2
-intellectual,intellectual,知识的,ADJ,B2
-intellectual life,intellectual life,词,NOUN,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligently,intelligently,词,ADV,C1
-intelligible,intelligible,词,ADJ,C1
-intemperate,intemperate,词,ADJ,C1
-intended,intended,预定的,ADJ,B2
-intended (noun),intended,intended,NOUN,B2
-intense,intense,强烈的,ADJ,B2
-intensify,to intensify,加剧,VERB,B2
-intensity,intensity,强度,NOUN,B2
-intensive,intensive,强化的,ADJ,B2
-intensive care,intensive care,重症监护,NOUN,B2
-intentional,intentional,故意的,ADJ,B2
-intentionally,intentionally,故意地,ADV,B2
-interactivity,interactivity,词,NOUN,C1
-intercept,to intercept,拦截,VERB,B2
-intercourse,intercourse,性交,NOUN,B2
-interest,to interest,使感兴趣,VERB,B2
-interest rate,interest rate,利率,NOUN,B2
-interested,interested,感兴趣的,ADJ,B2
-interesting,interesting,有趣的,ADJ,B2
-interesting things,interesting things,词,NOUN,C1
-interfere,to interfere,干涉,VERB,B2
-interim (noun),interim,词,NOUN,B2
-interior,interior,内部,NOUN,B2
-interjection,interjection,词,NOUN,C1
-intermediate,intermediate,词,ADJ,C1
-intermission,intermission,词,NOUN,C1
-intern,intern,词,NOUN,C1
-internal affairs,internal affairs,内政,NOUN,C1
-internal force,internal force,内力,NOUN,B2
-internal medicine,internal medicine,内科,NOUN,B1
-international student,international student,留学生,NOUN,B2
-internship,internship,实习,NOUN,B2
-interpersonal,interpersonal,人际的,ADJ,B2
-interrogation room,interrogation room,审讯室,NOUN,B2
-interrupt,to interrupt,打断,VERB,B2
-interrupted,interrupted,词,ADJ,B2
-intertwined,intertwined,词,ADJ,C1
-interval,interval,词,NOUN,C1
-intervention,intervention,干预,NOUN,B2
-interview,to interview,采访,VERB,B2
-interviewer,interviewer,词,NOUN,C1
-intimate,intimate,亲密的,ADJ,B2
-intimately,intimately,词,ADV,C1
-intimidate,to intimidate,恐吓,VERB,B2
-into (adp),into,词,ADP,A1
-into (adv),into,词,ADV,B1
-intolerable,intolerable,词,ADJ,C1
-intolerance,intolerance,不容忍,NOUN,B2
-intolerant,intolerant,词,ADJ,B2
-intoxication,intoxication,词,NOUN,C1
-intransigent,intransigent,不妥协的,ADJ,B2
-intravenous drip,intravenous drip,输液,NOUN,B2
-intrepidity,intrepidity,词,NOUN,C1
-intricacy,intricacy,词,NOUN,C1
-intricate,intricate,错综复杂的,ADJ,B2
-intrigue,to intrigue,激起兴趣,VERB,B2
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
-intrinsic,intrinsic,固有的,ADJ,B2
-intrinsically,intrinsically,词,ADV,C1
-introduce,to introduce,介绍,VERB,B2
-introductory,introductory,词,ADJ,C1
-introverted,introverted,内向的,ADJ,B2
-intruder,intruder,入侵者,NOUN,B2
-intrusive,intrusive,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-inure,inure,词,VERB,C1
-invade,to invade,入侵,VERB,B2
-invader,invader,入侵者,NOUN,B2
-invalidity,invalidity,词,NOUN,C1
-invariable,invariable,词,ADJ,C1
-invariably,invariably,不变地,ADV,B2
-inventor,inventor,发明家,NOUN,B2
-inventorying,inventorying,清点,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-investigate,to investigate,调查,VERB,B2
-investigated,investigated,被调查的,ADJ,B2
-investigator,investigator,调查员,NOUN,B2
-invincibility,invincibility,不胜,NOUN,C1
-invincible,invincible,无敌的,ADJ,B2
-inviolate,inviolate,词,ADJ,C1
-invisible,invisible,看不见的,ADJ,B2
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite,to invite,邀请,VERB,B2
-invite offer,invite offer,词,VERB,A2
-invocation,invocation,词,NOUN,C1
-invoicing,invoicing,词,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
-involuntary,involuntary,词,ADJ,B2
-involve,to involve,涉及,VERB,B2
-involved party,involved party,词,NOUN,C1
-iodine deficiency,iodine deficiency,词,NOUN,C1
-iranian,iranian,伊朗的,ADJ,B2
-irish,irish,爱尔兰的,ADJ,B2
-irish person,irish person,爱尔兰人,NOUN,B2
-irksome,irksome,词,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
-irrational,irrational,非理性的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irregular,irregular,不规则的,ADJ,B2
-irregularity,irregularity,不规则,NOUN,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irreligious,irreligious,词,ADJ,C1
-irremediably,irremediably,词,ADV,B2
-irretrievable,irretrievable,词,ADJ,C1
-irreversibility,irreversibility,词,NOUN,C1
-irritability,irritability,词,NOUN,C1
-irritating,irritating,令人恼火的,ADJ,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamic,islamic,伊斯兰的,ADJ,B2
-islander,islander,词,NOUN,C1
-isthmus,isthmus,词,NOUN,C1
-it,it,对此,ADV,B2
-it (noun),it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
-it neuter,it neuter,它 (中性),PRON,B2
-italian,italian,意大利的,ADJ,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-itinerant,itinerant,巡回的,ADJ,B2
-itinerary,itinerary,行程,NOUN,B2
-its,its,它的,PRON,B2
-its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-jack plug,jack plug,词,NOUN,C1
-jackal,jackal,词,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
-jaded,jaded,厌倦的,ADJ,B2
-jadeite,jadeite,翡翠,NOUN,C1
-janitor,janitor,词,NOUN,B2
-january,january,一月,NOUN,B2
-japanese,japanese,日本的,ADJ,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jarring,jarring,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jasmine tea,jasmine tea,词,NOUN,C1
-jaws,jaws,词,NOUN,C1
-jeans,jeans,牛仔裤,NOUN,B2
-jersey,jersey,词,NOUN,B1
-jest,jest,词,NOUN,C1
-jet,jet,喷气式飞机,NOUN,B2
-jet-black,jet-black,乌黑,ADJ,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jewelry set,jewelry set,词,NOUN,C1
-jewelry store,jewelry store,珠宝店,NOUN,B2
-jewish,jewish,犹太的,ADJ,B2
-jews,jews,犹太人,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocular,jocular,词,ADJ,C1
-jocularity,jocularity,词,NOUN,B2
-jog,jog,词,VERB,A1
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,词,NOUN,B2
-joint examination,joint examination,联考,NOUN,B2
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-jointness,jointness,词,NOUN,C1
-joker,joker,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
-journalism,journalism,新闻业,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-joust,joust,词,NOUN,B1
-jubilant,jubilant,词,ADJ,C1
-jubilation,jubilation,欢欣,NOUN,B2
-judge sentence,judge sentence,词,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
-jujube,jujube,枣子,NOUN,B2
-jumble,jumble,词,NOUN,B2
-junction,junction,词,NOUN,C1
-juncture,juncture,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-junk,junk,破烂货,NOUN,B2
-junkie,junkie,词,NOUN,C1
-junta,junta,词,NOUN,C1
-jurisconsult,jurisconsult,法学专家,NOUN,B2
-jurisprudence,jurisprudence,法理学,NOUN,B2
-jurist,jurist,法学家,NOUN,B2
-jury,jury,陪审团,NOUN,B2
-jury service,jury service,陪审,NOUN,C1
-just,just,公正,ADJ,B2
-just as,just as,词,ADV,A2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,词,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
-justified,justified,词,ADJ,B2
-justness,justness,词,NOUN,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juxtapose,juxtapose,词,VERB,C1
-kaleidoscope,kaleidoscope,词,NOUN,B2
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenly,keenly,词,ADV,C1
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-kendo,kendo,剑道,NOUN,C1
-kept,kept,词,ADJ,B2
-kerosene,kerosene,火油,NOUN,C1
-key point,key point,要点,NOUN,C1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kidnapper,kidnapper,绑架者,NOUN,B2
-kids,kids,词,NOUN,B2
-killed,killed,词,NOUN,B2
-kin,kin,词,NOUN,B2
-kind,kind,种类,NOUN,B2
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindly,kindly,亲切地,ADV,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
-king,king,王,PART,B2
-kiosk,kiosk,亭子,NOUN,B2
-kit,kit,词,NOUN,B2
-kitten,kitten,词,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-knack,knack,窍,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knock,knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-knowledgeably,knowledgeably,词,ADV,C1
-known famous,known famous,著名的/熟悉的,ADJ,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,词,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-labor-related,labor-related,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laboriously,laboriously,词,ADV,C1
-labour market,labour market,词,NOUN,B1
-labyrinth,labyrinth,词,NOUN,C1
-labyrinthine,labyrinthine,词,ADJ,C1
-lace,lace,词,NOUN,C1
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-laconically,laconically,词,ADV,C1
-laconism,laconism,词,NOUN,B2
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-lacunary,lacunary,残缺的,ADJ,B2
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-lagoon,lagoon,词,NOUN,C1
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lament (noun),lament,词,NOUN,C1
-lamentable,lamentable,词,ADJ,C1
-lampoon,lampoon,词,NOUN,C1
-land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,词,NOUN,B2
-land register,land register,词,NOUN,B2
-land use,land use,词,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landfill,landfill,填埋,NOUN,C1
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
-language use,language use,语言使用,NOUN,B2
-languid,languid,词,ADJ,C1
-languor,languor,倦怠,NOUN,B2
-lapidary,lapidary,词,ADJ,B2
-lapse,lapse,疏忽,NOUN,B2
-lapse of time,lapse of time,词,NOUN,C1
-laptop,laptop,笔记本电脑,NOUN,B2
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large estate,large estate,词,NOUN,C1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larva,larva,幼虫,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
-lassitude,lassitude,词,NOUN,C1
-last (num),last,词,NUM,A2
-last evening,last evening,,NOUN,B2
-last name,last name,姓,NOUN,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
-lasting,lasting,词,ADJ,C1
-late,late,晚的,ADJ,B2
-late (adv),late,迟,ADV,A1
-late (noun),late,晚才,NOUN,B2
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-latent,latent,潜在的,ADJ,B2
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
-lateral side,lateral side,词,ADJ,C1
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-latin,latin,拉丁的,ADJ,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latitude leeway,latitude leeway,词,NOUN,C1
-laudable,laudable,词,ADJ,C1
-laugh (noun),laugh,词,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
-laughter,laughter,笑声,NOUN,B2
-launch,to launch,发起,VERB,B2
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,词,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
-laundry detergent,laundry detergent,词,NOUN,B2
-laundry room,laundry room,洗衣房,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
-law enforcement,law enforcement,执法,NOUN,B2
-law firm,law firm,律师事务所,NOUN,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
-lawful,lawful,合法的,ADJ,B2
-lawless,lawless,词,ADJ,B2
-lawn,lawn,草坪,NOUN,B2
-lawnmower,lawnmower,割草机,NOUN,B2
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lawyer female,lawyer female,词,NOUN,B2
-lax,lax,松懈的,ADJ,B2
-laxative,laxative,词,NOUN,C1
-laxity,laxity,松弛,NOUN,B2
-lay,lay,叙事短诗,NOUN,B2
-lay,to lay,放置,VERB,B2
-lay (adj),lay,词,ADJ,C1
-lay (noun),lay,叙事短诗,NOUN,B2
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
-layer storage,layer storage,层/仓库,NOUN,B2
-layman,layman,外行,NOUN,B2
-layout,layout,布局,NOUN,B2
-layperson,layperson,外行,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
-lead,lead,铅,NOUN,B2
-lead actor,lead actor,主演,NOUN,B2
-lead thousand,lead thousand,率千,NOUN,B2
-lead to,to lead to,通向,VERB,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
-leading,leading,领先的,ADJ,B2
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf,leaf,叶子,NOUN,B2
-leaf litter,leaf litter,词,NOUN,C1
-leaf page,leaf page,叶子,NOUN,B2
-leafiness,leafiness,词,NOUN,C1
-leaflet,leaflet,传单,NOUN,B2
-leafy,leafy,词,ADJ,B2
-leak escape,leak escape,词,NOUN,B1
-lean,lean,瘦的,ADJ,B2
-leap,leap,跳跃,NOUN,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
-learning curve,learning curve,学习曲线,NOUN,B2
-leash,leash,词,NOUN,B2
-leasing,leasing,词,NOUN,C1
-least,least,最少,ADV,B2
-least (adj),least,词,ADJ,A1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
-leave behind,to leave behind,留下,VERB,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
-leave out,to leave out,省略,VERB,B2
-lecture,to lecture,教导,VERB,B2
-led astray,led astray,词,ADJ,C1
-ledger,ledger,总账,NOUN,B2
-leek,leek,词,NOUN,A2
-left,left,左边的,ADJ,B2
-left (adv),left,左边,ADV,B2
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
-left side,left side,左侧,NOUN,B2
-left-handed,left-handed,词,ADJ,C1
-leftovers,leftovers,词,NOUN,B2
-leg,leg,腿,NOUN,B2
-leg of lamb,leg of lamb,词,NOUN,B1
-legacy,legacy,遗产,NOUN,B2
-legal expert,legal expert,词,NOUN,C1
-legalization,legalization,词,NOUN,C1
-legally,legally,合法地,ADV,B2
-legatee,legatee,受遗赠人,NOUN,B2
-legation,legation,公使馆,NOUN,B2
-legendary,legendary,传奇的,ADJ,B2
-legible,legible,词,ADJ,C1
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legion unit,legion unit,,NOUN,B2
-legislature,legislature,词,NOUN,B2
-leisure,leisure,闲暇,NOUN,B2
-leisurely,leisurely,词,ADJ,C1
-lemonade,lemonade,词,NOUN,A2
-lengthy,lengthy,词,ADJ,C1
-lens,lens,词,NOUN,C1
-lent,lent,大斋期,NOUN,B2
-lentil lens,lentil lens,词,NOUN,C1
-lesbian,lesbian,女同性恋的,ADJ,B2
-lesion,lesion,病变,NOUN,B2
-less,less,更少,ADV,B2
-less (adj),less,较少的,ADJ,A1
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
-let,let,让,AUX,B2
-let,to let,让,VERB,B2
-let alone,let alone,别说,ADV,B2
-let alone (cconj),let alone,何况,CCONJ,B1
-lethal,lethal,致命的,ADJ,B2
-lethality,lethality,词,NOUN,C1
-lethargic,lethargic,昏睡的,ADJ,B2
-letter,letter,信,NOUN,B2
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
-lettuce,lettuce,生菜,NOUN,B2
-level,to level,夷平,VERB,B2
-lever,lever,词,NOUN,B2
-leverage,leverage,词,NOUN,B2
-levity,levity,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-liable,liable,有责任的,ADJ,B2
-liaison,liaison,联络,NOUN,B2
-libel,libel,词,NOUN,C1
-liberal,liberal,自由的,ADJ,B2
-liberalize,liberalize,自由化,! VERB,B2
-liberating,liberating,解放的,ADJ,B2
-liberty,liberty,词,NOUN,B2
-librarian,librarian,图书管理员,NOUN,B2
-license plate,license plate,车牌,NOUN,B2
-license plate restriction,license plate restriction,限号,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licensor,licensor,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
-lid,lid,盖子,NOUN,B2
-lie,lie,谎言,NOUN,B2
-life (part),life,生,PART,A2
-life and death,life and death,生死,NOUN,B2
-life connection,life connection,连命,NOUN,C1
-life retribution,life retribution,偿命,NOUN,B2
-life sentence,life sentence,词,NOUN,B2
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-and-death,life-and-death,决生,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifelong,lifelong,词,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
-lifetime,lifetime,一生,NOUN,B2
-light blue,light blue,词,ADJ,A1
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb,light bulb,词,NOUN,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light grey,light grey,词,ADJ,B2
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light-year,light-year,,NOUN,B2
-lighter,lighter,打火机,NOUN,B2
-lightest,lightest,最轻,NOUN,C1
-lightness,lightness,轻盈,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
-like,like,点赞,NOUN,B2
-like,to like,喜欢,VERB,B2
-like (noun),like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like as,like as,词,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-likeable,likeable,词,ADJ,C1
-likely (adj),likely,词,ADJ,A1
-likely (adv),likely,词,ADV,A1
-likewise,likewise,同样地,ADV,B2
-lily,lily,词,NOUN,B2
-limb,limb,肢体,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-liminal,liminal,词,ADJ,B2
-limit,to limit,限制,VERB,B2
-limit border,limit border,界限,NOUN,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limp,to limp,跛行,VERB,B2
-line of conduct,line of conduct,行为方针,NOUN,B2
-line queue,line queue,词,NOUN,B1
-line up,to line up,排成一行,VERB,B2
-line-up,line-up,阵容,NOUN,B2
-linen,linen,线麻,NOUN,B2
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,词,ADJ,B2
-linguistic,linguistic,语言的,ADJ,B2
-lining understudy,lining understudy,词,NOUN,B1
-link,to link,连接,VERB,B2
-linkage (noun),linkage,词,NOUN,C1
-linking,linking,词,NOUN,C1
-lip service,lip service,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
-lipstick,lipstick,口红,NOUN,B2
-liquid,liquid,液态的,ADJ,B2
-liquor,liquor,烈酒,NOUN,B2
-list,list,列表,NOUN,B2
-list,to list,列举,VERB,B2
-listen (intj),listen,词,INTJ,B2
-listen up,listen up,听着,INTJ,B2
-listener,listener,听众,NOUN,B2
-listening,listening,也听,NOUN,B2
-listless,listless,词,ADJ,C1
-literacy,literacy,读写能力,NOUN,B2
-literal,literal,字面的,ADJ,B2
-literally,literally,字面上地,ADV,B2
-literary,literary,文学的,ADJ,B2
-lithe,lithe,词,ADJ,C1
-litotes understatement,litotes understatement,词,NOUN,C1
-litre,litre,升,NOUN,B2
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-little,little,少,DET,B2
-little (adj),little,词,ADJ,A1
-little (adv),little,词,ADV,A2
-little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,词,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
-little eleven,little eleven,小十一,NOUN,B2
-little finger,little finger,词,NOUN,B2
-little girl,little girl,词,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,词,NOUN,B2
-little nine,little nine,小九,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little sister,little sister,妹妹,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little thing,little thing,词,NOUN,B2
-little town,little town,词,NOUN,C1
-liturgical,liturgical,词,ADJ,C1
-liturgy,liturgy,词,NOUN,C1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live to,live to,活到,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
-lively,lively,热闹的,ADJ,B2
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
-lizard,lizard,蜥蜴,NOUN,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loading,loading,词,NOUN,B2
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,词,ADJ,C1
-local (noun),local,当地,NOUN,A2
-local tyrant,local tyrant,豪强,NOUN,B2
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-located,located,位于,ADJ,B2
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locker,locker,词,NOUN,C1
-locksmith,locksmith,词,NOUN,C1
-loft,loft,词,NOUN,C1
-logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,,NOUN,B2
-long absence,long absence,久违,NOUN,C1
-long lease,long lease,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance runner,long-distance runner,词,NOUN,B2
-long-lasting,long-lasting,持久的,ADJ,B2
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longevity,longevity,词,NOUN,C1
-loofah,loofah,丝瓜,NOUN,C1
-look around,look around,词,VERB,C1
-loop,loop,循环,NOUN,B2
-loose thread,loose thread,词,NOUN,C1
-looseness,looseness,词,NOUN,C1
-looting,looting,掠夺,NOUN,B2
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
-lord god,lord god,上帝,NOUN,B2
-lordship,lordship,词,NOUN,C1
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
-lost tradition,lost tradition,失传,NOUN,C1
-lots,lots,大量,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
-loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-loved,loved,被爱的,ADJ,B2
-lovely,lovely,词,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowest,lowest,最低的,ADJ,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucid,lucid,词,ADJ,C1
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck turn,luck turn,词,NOUN,A2
-lucky (noun),lucky,吉祥,NOUN,B2
-lucky find,lucky find,词,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucrative,lucrative,有利可图的,ADJ,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-lukewarm (adj),lukewarm,微温的,ADJ,B2
-lullaby,lullaby,词,NOUN,C1
-luminous,luminous,发光的,ADJ,B2
-lunar,lunar,词,ADJ,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunatic,lunatic,疯子,NOUN,B2
-lunch break,lunch break,午休,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
-lurid,lurid,词,ADJ,C1
-lust,lust,欲望,NOUN,B2
-lychee,lychee,荔枝,NOUN,C1
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyrical,lyrical,抒情的,ADJ,B2
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machination,machination,词,NOUN,C1
-machine (adj),machine,词,ADJ,B2
-machine learning,machine learning,机器学习,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-machinery,machinery,词,NOUN,C1
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
-mad,mad,词,ADJ,A1
-made,made,词,ADJ,B2
-maelstrom,maelstrom,词,NOUN,C1
-mafia,mafia,黑手党,NOUN,B2
-magically,magically,魔法地,ADV,B2
-magistrate,magistrate,法官,NOUN,B2
-magnanimous,magnanimous,宽宏大量的,ADJ,B2
-magnesium,magnesium,镁,NOUN,B2
-magnetic,magnetic,词,ADJ,B2
-magnifying glass,magnifying glass,词,NOUN,C1
-magnitude,magnitude,词,NOUN,C1
-magus,magus,词,NOUN,C1
-maieutic,maieutic,词,ADJ,C1
-mail (verb),mail,寄送,VERB,C1
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main thing,main thing,词,NOUN,B2
-mainstream,mainstream,主流的,ADJ,B2
-major,major,主要的,ADJ,B2
-major case,major case,大案,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
-make amends,make amends,词,VERB,C1
-make flexible,make flexible,词,VERB,C1
-makeover,makeover,改容,NOUN,C1
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-making,making,词,NOUN,B2
-maladjusted,maladjusted,词,ADJ,C1
-maladjustment,maladjustment,词,NOUN,C1
-malaria,malaria,词,NOUN,B2
-male,male,男性,NOUN,B2
-male goat,male goat,词,NOUN,B2
-malefic,malefic,词,ADJ,B2
-malevolence,malevolence,恶意,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malfeasance,malfeasance,渎职,NOUN,B2
-malicious,malicious,恶意的,ADJ,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
-malignity,malignity,词,NOUN,C1
-mall,mall,词,NOUN,B2
-malleable,malleable,词,ADJ,C1
-malmo,malmo,马尔默,PROPN,B2
-malnutrition,malnutrition,营养不良,NOUN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mammal,mammal,哺乳动物,NOUN,B2
-managed,managed,,NOUN,B2
-management pipe,management pipe,词,NOUN,B2
-managing director,managing director,词,NOUN,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-mane,mane,词,NOUN,C1
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-manhunt,manhunt,搜捕,NOUN,B2
-manifestly,manifestly,明显地,ADV,B2
-manifesto,manifesto,宣言,NOUN,B2
-manifold,manifold,词,ADJ,B2
-manipulable,manipulable,可操纵的,ADJ,B2
-manipulator,manipulator,词,NOUN,C1
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-mannerly,mannerly,有礼貌的,ADJ,B2
-manners,manners,词,NOUN,B2
-mannish,mannish,词,ADJ,C1
-manor,manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
-manslaughter,manslaughter,词,NOUN,C1
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manually,manually,手动地,ADV,B2
-manufacture,manufacture,制造,NOUN,B2
-manufacturing,manufacturing,词,NOUN,B1
-manure (noun),manure,词,NOUN,C1
-many,many,多……,NOUN,B2
-many (det),many,词,DET,B2
-many (pron),many,词,PRON,B1
-many a,many a,词,ADJ,C1
-many things,many things,许多事物,PRON,B2
-many times,many times,多次,ADV,B2
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapping,mapping,梳理,NOUN,B2
-marble,marble,大理石,NOUN,B2
-marbly,marbly,词,ADJ,B2
-marginal,marginal,边缘的,ADJ,B2
-marginalize,to marginalize,使边缘化,VERB,B2
-marginally,marginally,词,ADV,B2
-marine,marine,海洋的,ADJ,B2
-marine (noun),marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
-marital conjugal,marital conjugal,词,ADJ,C1
-mark,mark,标记,NOUN,B2
-mark,to mark,标记,VERB,B2
-marker,marker,词,NOUN,B2
-maroon,maroon,词,ADJ,C1
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marriageable,marriageable,适婚,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshal,marshal,元帅,NOUN,B2
-marshy,marshy,词,ADJ,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martyr,martyr,词,NOUN,C1
-martyrdom,martyrdom,殉难,NOUN,B2
-marvel (noun),marvel,词,NOUN,B2
-marvelous,marvelous,极好的,ADJ,B2
-mascot,mascot,吉祥物,NOUN,B2
-masculine (adj),masculine,词,ADJ,B2
-mash,mash,泥状食物,NOUN,B2
-mask (verb),mask,词,VERB,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,词,NOUN,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,词,NOUN,B2
-massive,massive,巨大的,ADJ,B2
-massively,massively,大量地,ADV,B2
-mast (noun),mast,词,NOUN,C1
-master,master,大师,NOUN,B2
-master,to master,掌握,VERB,B2
-master (noun),master,主人,NOUN,B2
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
-master's word,master's word,爷说,NOUN,B2
-masterly,masterly,词,ADJ,B2
-match,to match,相配,VERB,B2
-matching,matching,配套,ADJ,B2
-matching time,matching time,对时,NOUN,B2
-matching use,matching use,配用,NOUN,C1
-matchmaker,matchmaker,媒,NOUN,B2
-mate,mate,词,NOUN,A2
-material,material,材料,NOUN,B2
-maternal,maternal,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-math,math,数学,NOUN,B2
-mathematician,mathematician,词,NOUN,C1
-matriarch,matriarch,女家长,NOUN,C1
-matter,matter,事情,NOUN,B2
-matter,to matter,重要,VERB,B2
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
-mattress,mattress,床垫,NOUN,B2
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawkishness,mawkishness,词,NOUN,C1
-maxim,maxim,格言,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
-maximum,maximum,最大,ADJ,B2
-maximum (noun),maximum,词,NOUN,B2
-may,may,五月,NOUN,B2
-may (aux),may,词,AUX,A1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe,maybe,也许,ADV,B2
-maybe possible,maybe possible,可能,ADV,A1
-mayoral,mayoral,市长的,ADJ,B2
-maze,maze,词,NOUN,C1
-maze labyrinth,maze labyrinth,词,NOUN,C1
-me,me,我,PRON,B2
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-mead,mead,词,NOUN,C1
-meager,meager,词,ADJ,C1
-meal,meal,一餐,NOUN,B2
-mean,mean,刻薄的,ADJ,B2
-meander,meander,词,NOUN,C1
-meandering,meandering,词,ADJ,B2
-meaning content,meaning content,语义内容,NOUN,B2
-meaningful,meaningful,有意义的,ADJ,B2
-meaningless,meaningless,毫无意义的,ADJ,B2
-meantime,meantime,同时,NOUN,B2
-meanwhile,meanwhile,同时,ADV,B2
-measurable,measurable,词,ADJ,C1
-measure,measure,措施,NOUN,B2
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word for books,measure word for books,本,NUM,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,词,ADJ,B2
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mechanical,mechanical,机械的,ADJ,B2
-mechanically,mechanically,词,ADV,C1
-mechanistic,mechanistic,机制性,ADJ,B2
-medal awarding,medal awarding,授勋,NOUN,B2
-medallion,medallion,词,NOUN,C1
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media-related,media-related,词,ADJ,B2
-median (adj),median,词,ADJ,C1
-mediator,mediator,调解人,NOUN,C1
-medical,medical,医疗的,ADJ,B2
-medical care,medical care,医疗,NOUN,B2
-medical examiner,medical examiner,词,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,词,NOUN,C1
-medical record,medical record,病历,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication,medication,药物,NOUN,B2
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
-medieval,medieval,中世纪的,ADJ,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-meek,meek,温顺的,ADJ,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-megalomania,megalomania,词,NOUN,B2
-megalomaniac,megalomaniac,词,ADJ,C1
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
-mellifluous,mellifluous,词,ADJ,C1
-melon,melon,香瓜,NOUN,C1
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
-membrane,membrane,词,NOUN,C1
-memoir,memoir,回忆录,NOUN,B2
-memorable,memorable,难忘的,ADJ,B2
-memory loss,memory loss,词,NOUN,C1
-men,men,词,NOUN,C1
-menace,menace,词,NOUN,C1
-mendacious,mendacious,词,ADJ,C1
-meninx,meninx,词,NOUN,C1
-mental hospital,mental hospital,精神病院,NOUN,B2
-mentally,mentally,精神上地,ADV,B2
-mention (noun),mention,可言,NOUN,C1
-mentioned,mentioned,词,ADJ,B2
-mercantile,mercantile,词,ADJ,C1
-mercenary,mercenary,雇佣兵,NOUN,B2
-mercenary (adj),mercenary,词,ADJ,C1
-merchandise,merchandise,商品,NOUN,B2
-merchant ship,merchant ship,商船,NOUN,C1
-merciful,merciful,词,ADJ,B2
-mercilessly,mercilessly,词,ADV,C1
-mercurial,mercurial,词,ADJ,C1
-mercy blow,mercy blow,词,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
-merger,merger,合并,NOUN,B2
-merger fusion,merger fusion,词,NOUN,B1
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
-merriment,merriment,词,NOUN,C1
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-message errand,message errand,词,NOUN,B2
-messaging,messaging,词,NOUN,C1
-metalepsis,metalepsis,词,NOUN,C1
-metallic,metallic,金属的,ADJ,B2
-metallurgy,metallurgy,词,NOUN,C1
-metamorphic,metamorphic,变质的,ADJ,B2
-metamorphosis,metamorphosis,词,NOUN,C1
-metaphorical,metaphorical,隐喻的,ADJ,B2
-metaphysical,metaphysical,词,ADJ,C1
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteorological,meteorological,气象的,ADJ,B2
-methane,methane,词,NOUN,C1
-methodological,methodological,方法论的,ADJ,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
-metric,metric,公制的,ADJ,B2
-metropolis,metropolis,大都市,NOUN,B2
-metropolitan,metropolitan,词,ADJ,C1
-mettle,mettle,词,NOUN,C1
-mezzanine,mezzanine,夹层,NOUN,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
-microeconomic,microeconomic,词,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-microwave,microwave,微波炉,NOUN,B2
-middle (adv),middle,词,ADV,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty,mighty,词,ADJ,B1
-mighty man,mighty man,词,NOUN,B2
-mighty very,mighty very,非常,ADJ,B2
-migratory,migratory,词,ADJ,C1
-mildew,mildew,词,VERB,C1
-militant,militant,词,ADJ,C1
-militaristic,militaristic,词,ADJ,C1
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
-military merit,military merit,军功,NOUN,C1
-military pay,military pay,军饷,NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milkman,milkman,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
-millionaire,millionaire,词,NOUN,B2
-millions of,millions of,数百万的,NUM,B2
-mimicry,mimicry,词,NOUN,B2
-minatory,minatory,词,ADJ,C1
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mindset,mindset,词,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
-mineral (adj),mineral,词,ADJ,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-minibus,minibus,中巴,NOUN,B2
-minimal,minimal,微小的,ADJ,B2
-minimalism,minimalism,极简主义,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
-minister (part),minister,臣,PART,B2
-minivan,minivan,词,NOUN,B2
-minor,minor,较小的,ADJ,B2
-minority,minority,少数派的,ADJ,B2
-minority group,minority group,少数群体,NOUN,B2
-minus,minus,减,NOUN,B2
-minuscule,minuscule,极小的,ADJ,B2
-minutes,minutes,词,NOUN,B2
-miraculous,miraculous,词,ADJ,C1
-mirage,mirage,词,NOUN,C1
-mirthful,mirthful,词,ADJ,C1
-misanthrope,misanthrope,厌世者,NOUN,B2
-misanthropic,misanthropic,词,ADJ,C1
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misconception,misconception,词,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserly,miserly,吝啬的,ADJ,B2
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
-misjudge,misjudge,词,VERB,C1
-mismatch,mismatch,词,NOUN,C1
-misplaced,misplaced,不合时宜的,ADJ,B2
-miss teacher,miss teacher,词,NOUN,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-missile,missile,导弹,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missionizing,missionizing,词,ADJ,C1
-missive,missive,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-missnahme,missnahme,词,NOUN,C1
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
-mistaken,mistaken,错误的,ADJ,B2
-mistreatment,mistreatment,虐待,NOUN,B2
-misunderstood,misunderstood,词,ADJ,C1
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
-mitigating,mitigating,词,ADJ,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mitten,mitten,连指手套,NOUN,B2
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixing,mixing,词,NOUN,B2
-mob,mob,词,NOUN,B2
-mobile (noun),mobile,词,NOUN,B2
-mobility,mobility,流动性,NOUN,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
-moderate snow,moderate snow,中雪,NOUN,C1
-moderator,moderator,词,NOUN,C1
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,近代,NOUN,B2
-modestly,modestly,词,ADV,C1
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified structure,modified structure,改结,NOUN,C1
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
-module,module,词,NOUN,C1
-moisten,moisten,词,VERB,C1
-moisture,moisture,词,NOUN,B2
-moisture-proof,moisture-proof,防潮,ADJ,B2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-mollify,mollify,词,VERB,C1
-molting,molting,词,NOUN,C1
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,词,ADV,B2
-momentous,momentous,词,ADJ,C1
-mommy,mommy,词,NOUN,B1
-monarch,monarch,君主,NOUN,B2
-monarchy,monarchy,君主制,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monetization,monetization,词,NOUN,C1
-monkey ape,monkey ape,猿/猴,NOUN,B2
-monolithic,monolithic,单一的,ADJ,B2
-monstrous,monstrous,怪异的,ADJ,B2
-month ago,month ago,月前,NOUN,B2
-monthly,monthly,每月的,ADV,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-monumental,monumental,词,ADJ,C1
-moonlight,moonlight,月色,NOUN,B2
-moor,moor,荒野,NOUN,B2
-moose,moose,驼鹿,NOUN,B2
-mop (noun),mop,词,NOUN,B2
-moral,moral,道德的,ADJ,B2
-moral character,moral character,品德,NOUN,B2
-moral portrait,moral portrait,词,NOUN,C1
-morale,morale,士气,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morally,morally,词,ADV,C1
-morass,morass,词,NOUN,C1
-moratorium,moratorium,暂停,NOUN,B2
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
-more (adv),more,更,ADV,A1
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,词,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
-more personal,more personal,词,ADJ,C1
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover,moreover,而且,CCONJ,B2
-morgue,morgue,词,NOUN,B1
-morning (adj),morning,词,ADJ,C1
-morocco leather,morocco leather,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morphine,morphine,吗啡,NOUN,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortality,mortality,死亡率,NOUN,B2
-mortar,mortar,词,NOUN,C1
-moslem,moslem,词,NOUN,C1
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-most,most,大多数,DET,B2
-most (noun),most,大部分,NOUN,B2
-most (pron),most,词,PRON,C1
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-motel,motel,汽车旅馆,NOUN,B2
-mother (part),mother,娘,PART,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
-motif,motif,主题,NOUN,B2
-motion picture,motion picture,词,NOUN,C1
-motionless,motionless,静止的,ADJ,B2
-motive for murder,motive for murder,词,NOUN,C1
-motley,motley,词,ADJ,B2
-motor,motor,运动的,ADJ,B2
-motorist,motorist,词,NOUN,C1
-motorway,motorway,词,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mound,mound,土堆,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-mouth animal,mouth animal,词,NOUN,B1
-move fast,move fast,快搬,NOUN,C1
-moving,moving,感人的,ADJ,B2
-mp,mp,国会议员,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
-much (adj),much,词,ADJ,A1
-much (adv),much,词,ADV,B2
-much many,much many,许多,ADJ,B2
-mucous,mucous,词,ADJ,C1
-muddied,muddied,词,ADJ,C1
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-muffin,muffin,词,NOUN,B2
-mug (noun),mug,词,NOUN,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiple,multiple,词,ADJ,B2
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-murder (noun),murder,词,NOUN,B1
-murder case,murder case,词,NOUN,B2
-murderer female,murderer female,词,NOUN,B2
-murky,murky,词,ADJ,C1
-muscle ache,muscle ache,肌肉酸痛,NOUN,B2
-muscular,muscular,词,ADJ,C1
-muse,muse,词,VERB,B2
-museum piece,museum piece,博物馆藏品,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
-musical,musical,音乐剧,NOUN,B2
-musical instrument,musical instrument,乐器,NOUN,C1
-musk,musk,词,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustard,mustard,词,NOUN,A1
-mutable,mutable,词,ADJ,C1
-mutilate,mutilate,词,VERB,C1
-mutiny,mutiny,哗变,NOUN,B2
-muttering,muttering,念叨,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual visit,mutual visit,互访,NOUN,B2
-muzzle,muzzle,口套,NOUN,B2
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myelin,myelin,词,NOUN,C1
-myriad,myriad,词,ADJ,C1
-myself (pron),myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythical,mythical,神话般的,ADJ,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-nah,nah,不,INTJ,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-named,named,词,ADP,C1
-nape,nape,后颈,NOUN,B2
-narcissistic,narcissistic,自恋的,ADJ,B2
-narcotics,narcotics,词,NOUN,C1
-narrative (adj),narrative,词,ADJ,C1
-narrow-minded,narrow-minded,狭隘的,ADJ,B2
-narrowing,narrowing,词,NOUN,B2
-nascent,nascent,词,ADJ,C1
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-nationalist,nationalist,民族主义者,NOUN,B2
-nationwide,nationwide,全国,NOUN,B2
-native american,native american,印第安人,NOUN,B2
-natural gas,natural gas,天然气,NOUN,B2
-naturalization,naturalization,词,NOUN,B2
-naturally,naturally,自然地,ADV,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-naval,naval,词,ADJ,C1
-navel,navel,肚脐,NOUN,B2
-near,near,靠近,ADV,B2
-near (adp),near,在附近,ADP,A1
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,在附近,ADV,B2
-nearby (noun),nearby,附近,NOUN,B2
-nearest,nearest,最近的,ADJ,B2
-neatly,neatly,词,ADV,B2
-nebulous,nebulous,词,ADJ,C1
-necklace,necklace,项链,NOUN,B2
-neckline,neckline,词,NOUN,C1
-necrosis,necrosis,词,NOUN,C1
-need,need,需要,AUX,B2
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
-nefarious,nefarious,词,ADJ,C1
-negate,to negate,否定,VERB,B2
-neglect,to neglect,忽视,VERB,B2
-neglect (noun),neglect,词,NOUN,C1
-negligible,negligible,微不足道的,ADJ,B2
-negligible not,negligible not,不可忽视,ADJ,B2
-negotiate,to negotiate,谈判,VERB,B2
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
-neighboring,neighboring,邻近的,ADJ,B2
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,词,NOUN,B2
-neither,neither,也不,CCONJ,B2
-neither (adv),neither,词,ADV,A1
-neither (det),neither,词,DET,A2
-neither nor,neither nor,词,CCONJ,A2
-nemesis,nemesis,词,NOUN,C1
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
-neophyte,neophyte,新手；初学者,NOUN,B2
-nephew,nephew,侄子,NOUN,B2
-nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
-nervous,nervous,紧张的,ADJ,B2
-nest,nest,巢,NOUN,B2
-nesting box,nesting box,词,NOUN,B1
-net,net,网,NOUN,B2
-nettle,nettle,词,NOUN,C1
-network card,network card,网卡,NOUN,B2
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neurological,neurological,词,ADJ,C1
-neuron,neuron,词,NOUN,B2
-neuroscience,neuroscience,词,NOUN,C1
-nevertheless,nevertheless,尽管如此,ADV,B2
-new beginning,new beginning,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new year's day,new year's day,元旦,NOUN,B2
-newcomer,newcomer,新来者,NOUN,B2
-newly,newly,词,ADV,C1
-news report,news report,词,NOUN,B1
-news reporting,news reporting,新闻报道,NOUN,B2
-newsletter,newsletter,简报,NOUN,B2
-next,next,下一个,ADJ,B2
-next (adv),next,其次,ADV,B2
-next day,next day,词,NOUN,A2
-next door,next door,隔壁,NOUN,B2
-next door (adv),next door,在隔壁,ADV,B2
-next following,next following,词,ADJ,C1
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
-next to (adv),next to,词,ADV,B2
-next week,next week,下周,NOUN,B2
-nice,nice,好的,ADJ,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,词,NOUN,B2
-niche,niche,词,NOUN,C1
-nickel,nickel,镍,NOUN,B2
-nickname,nickname,绰号,NOUN,B2
-niece,niece,侄女,NOUN,B2
-night school,night school,夜校,NOUN,C1
-night view,night view,夜景,NOUN,B2
-nightclub,nightclub,夜总会,NOUN,B2
-nihilistic,nihilistic,词,ADJ,C1
-nimble,nimble,敏捷的,ADJ,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
-ninth,ninth,第九,ADJ,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,词,NOUN,B2
-no,no,不,ADV,B2
-no (det),no,毫无,DET,A2
-no (intj),no,词,INTJ,A1
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no harm,no harm,没事吧,NOUN,B2
-no heaven,no heaven,无天,NOUN,C1
-no matter,no matter,不论,CCONJ,B2
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no need,no need,不用,AUX,B2
-no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-nobility,nobility,贵族气质,NOUN,B2
-nobleman,nobleman,贵族,NOUN,B2
-nobody,nobody,没有人,PRON,B2
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noise row,noise row,词,NOUN,C1
-noises,noises,噪音,NOUN,B2
-noisome,noisome,词,ADJ,C1
-noisy,noisy,吵闹的,ADJ,B2
-nomad,nomad,游牧者,NOUN,B2
-nominal,nominal,词,ADJ,C1
-nominee,nominee,词,NOUN,C1
-non-ability,non-ability,非能,NOUN,B2
-non-above,non-above,非上,NOUN,C1
-non-abstraction,non-abstraction,非抽,NOUN,B2
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-action,non-action,非作,NOUN,B2
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-assistance,non-assistance,勿助,NOUN,B2
-non-belief,non-belief,非信,NOUN,B2
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
-non-concept,non-concept,非概,NOUN,B2
-non-concrete,non-concrete,非具,NOUN,C1
-non-construction,non-construction,非建,NOUN,B2
-non-contingent,non-contingent,非偶,NOUN,B2
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-evidence,non-evidence,非据,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
-non-induction,non-induction,非归,NOUN,B2
-non-inference,non-inference,非推,NOUN,B2
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-level,non-level,非级,NOUN,B2
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-management,non-management,管不,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-merit,non-merit,非功,NOUN,B2
-non-mind,non-mind,非心,NOUN,B2
-non-model,non-model,非模,NOUN,B2
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-orbit,non-orbit,非轨,NOUN,B2
-non-order,non-order,非序,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shadow,non-shadow,非影,NOUN,B2
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-sound,non-sound,非响,NOUN,B2
-non-specific,non-specific,非殊,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-state,non-state,非态,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-strategy,non-strategy,非略,NOUN,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-substance,non-substance,非质,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-thought,non-thought,非念,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-trace,non-trace,非迹,NOUN,B2
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
-non-war,non-war,非战,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
-noncompliant,noncompliant,违规,ADJ,B2
-nonconformist,nonconformist,词,NOUN,C1
-none,none,没有一个,DET,B2
-none (pron),none,没有一个,PRON,A2
-nonexistent,nonexistent,词,ADJ,C1
-nonprofit,nonprofit,非营利的,ADJ,B2
-nonviolence,nonviolence,词,NOUN,B2
-noodle,noodle,面条,NOUN,B2
-noodles,noodles,面条,NOUN,A1
-noon,noon,正午,NOUN,B2
-nope,nope,不,INTJ,B2
-nor,nor,也不,CCONJ,B2
-norm,norm,规范,NOUN,B2
-normal,normal,正常的,ADJ,B2
-normally,normally,通常地,ADV,B2
-northeast,northeast,词,NOUN,C1
-northward,northward,词,ADV,B2
-norwegian,norwegian,挪威的,ADJ,B2
-nosology,nosology,词,NOUN,C1
-nostalgia,nostalgia,怀旧,NOUN,B2
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
-nosy,nosy,爱打听的,ADJ,B2
-not,not,不,ADV,B2
-not (part),not,不,PART,A1
-not about,to not about,不关,VERB,B2
-not afraid,not afraid,不怕,VERB,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
-not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
-not catch up,not catch up,非赶,NOUN,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
-notably,notably,显著地,ADV,B2
-notarized,notarized,经公证的,ADJ,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
-note patch,note patch,词,NOUN,C1
-notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-notion,notion,词,NOUN,B2
-notoriously,notoriously,词,ADV,C1
-notwithstanding,notwithstanding,词,ADP,C1
-nourishment,nourishment,营养,NOUN,B2
-novelty,novelty,新奇事物,NOUN,B2
-novice,novice,词,NOUN,C1
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
-nuance,nuance,细微差别,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,词,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nugget,nugget,词,NOUN,C1
-nullify,nullify,词,VERB,C1
-numb,numb,麻木的,ADJ,B2
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
-numeral,numeral,词,NOUN,C1
-numismatic,numismatic,钱币学的,ADJ,B2
-nursing home,nursing home,养老院,NOUN,C1
-nuts,nuts,疯狂的,ADJ,B2
-nylon,nylon,尼龙,NOUN,C1
-o'clock (adv),o'clock,词,ADV,B2
-o'clock (noun),o'clock,点,NOUN,B2
-oats,oats,燕麦,NOUN,C1
-obdurate,obdurate,词,ADJ,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obese,obese,词,ADJ,B2
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-obligatory,obligatory,词,ADJ,C1
-obliged,obliged,被迫的,ADJ,B2
-obliging,obliging,词,ADJ,B2
-oblique,oblique,斜的,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observable,observable,词,ADJ,B2
-observation skill,observation skill,,NOUN,B2
-obsess,obsess,词,VERB,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinately,obstinately,词,ADV,C1
-obstreperous,obstreperous,词,ADJ,C1
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-occasional,occasional,词,ADJ,C1
-occult,occult,神秘的,ADJ,B2
-occultism,occultism,词,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-october,october,十月,NOUN,B2
-ocular,ocular,词,ADJ,C1
-oddball,oddball,怪人,NOUN,B2
-oddly,oddly,词,ADV,B2
-odds,odds,赔率,NOUN,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-of,of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of by,of by,的/被,ADP,B2
-of course,of course,当然,ADV,B2
-of course (intj),of course,词,INTJ,C1
-of it,of it,词,ADV,B2
-of old,of old,词,ADV,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,词,ADJ,B2
-of which,of which,关于哪个,PRON,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
-off-center,off-center,词,ADJ,C1
-off-track,off-track,词,ADJ,C1
-offence,offence,词,NOUN,B2
-offend,to offend,冒犯,VERB,B2
-offense,offense,冒犯,NOUN,B2
-offensive,offensive,冒犯的,ADJ,B2
-offensive (noun),offensive,词,NOUN,C1
-offer,offer,报价,NOUN,B2
-office work,office work,办公室工作,NOUN,B2
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-officially,officially,正式地,ADV,B2
-officious,officious,词,ADJ,C1
-offshoring,offshoring,词,NOUN,B2
-offspring,offspring,幼崽,NOUN,B2
-oh,oh,哦,INTJ,B2
-oh (part),oh,呀,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
-oh my god,oh my god,我的天,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oh well,oh well,算了,INTJ,B2
-oil painting,oil painting,油画,NOUN,C1
-oil tanker,oil tanker,词,NOUN,C1
-oilfield,oilfield,词,NOUN,C1
-ok,ok,词,INTJ,B2
-okay,okay,好的,INTJ,B2
-okay (adj),okay,词,ADJ,A1
-okay (noun),okay,好啊,NOUN,C1
-old (noun),old,夙,NOUN,B1
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old man,old man,老人,NOUN,B2
-old master,old master,老太爷,NOUN,B2
-old minister,old minister,老臣,NOUN,B2
-old person,old person,老人,NOUN,B2
-old servant,old servant,老奴,NOUN,B2
-old thief,old thief,老贼,NOUN,C1
-old-age,old-age,晚年,NOUN,C1
-old-fashioned,old-fashioned,老式的,ADJ,B2
-older,older,年长的,ADJ,B2
-older brother,older brother,大哥哥,NOUN,B2
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oldest,oldest,词,ADJ,C1
-olfactory,olfactory,词,ADJ,C1
-oligopoly,oligopoly,词,NOUN,B2
-olympic,olympic,奥林匹克的,ADJ,B2
-omelet,omelet,欧姆蛋,NOUN,B2
-omelette,omelette,煎蛋卷,NOUN,B2
-omen,omen,预兆,NOUN,B2
-ominous,ominous,不祥的,ADJ,B2
-omit,to omit,省略,VERB,B2
-omnipotent,omnipotent,词,ADJ,C1
-omnipresent,omnipresent,无所不在的,ADJ,B2
-omniscient,omniscient,词,ADJ,C1
-on,on,进行中,ADV,B2
-on behalf of,on behalf of,代表,ADP,B2
-on board,on board,在船上,ADV,B2
-on head,on head,当头,NOUN,B2
-on it,on it,在上面,ADV,B2
-on one hand,on one hand,一方面,ADV,B2
-on purpose,on purpose,故意地,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on the one hand,on the one hand,词,ADV,B2
-on the other hand,on the other hand,另一方面,ADV,B2
-on the spot,on the spot,当场,ADV,B2
-on the way,on the way,在路上,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,准时,ADV,B2
-on top,on top,在上面,ADV,B2
-on top of,on top of,在...上面,ADP,B2
-on upon,on upon,词,ADP,B2
-on what,on what,在什么上面,ADV,B2
-on which,on which,在其上,PRON,B2
-once,once,一次,ADV,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
-once more,once more,再次,ADV,B2
-oncology,oncology,词,NOUN,C1
-one,one,人们,PRON,B2
-one (adj),one,词,ADJ,A2
-one (det),one,词,DET,C1
-one after another,one after another,接连地,ADV,B2
-one and a half,one and a half,一个半,NUM,B2
-one book,one book,一本,NUM,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day,one day,一天,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one family,one family,一家,NUM,B2
-one flat,one flat,一张,NUM,B2
-one handful,one handful,一把,NUM,B2
-one head,one head,一头,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one night,one night,一晚,NUM,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
-one set,one set,一套,NUM,B2
-one shot,one shot,一枪,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
-one's heart's content,one's heart's content,尽情,ADV,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
-one-sided,one-sided,单方面的,ADJ,B2
-one-sidedness,one-sidedness,词,NOUN,B2
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
-onerous,onerous,词,ADJ,C1
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-ongoing,ongoing,进行中的,ADJ,B2
-ongoing (noun),ongoing,词,NOUN,B2
-online,online,词,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,词,NOUN,C1
-only,only,而已,SCONJ,B2
-only (adj),only,唯一,ADJ,B2
-only (det),only,词,DET,B2
-only bringing,only bringing,只带,NOUN,C1
-only son,only son,独子,NOUN,C1
-onomatopoeia,onomatopoeia,拟声词,NOUN,B2
-oops,oops,词,INTJ,C1
-opaque,opaque,词,ADJ,C1
-open (adv),open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-opportune,opportune,词,ADJ,C1
-opportunist,opportunist,词,NOUN,C1
-opportunity used,opportunity used,词,NOUN,B2
-opposing,opposing,词,ADJ,C1
-opposite,opposite,对面,ADP,B2
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
-oppressive,oppressive,压迫的,ADJ,B2
-opprobrium,opprobrium,词,NOUN,C1
-opt,opt,词,VERB,C1
-optical illusion,optical illusion,词,NOUN,C1
-optician,optician,词,NOUN,C1
-optics perspective,optics perspective,词,NOUN,C1
-optimal,optimal,最佳的,ADJ,B2
-optimization,optimization,优化,NOUN,B2
-optimum,optimum,词,NOUN,C1
-opulent,opulent,豪华的,ADJ,B2
-or,or,或是,NOUN,B2
-or (part),or,或,PART,C1
-or something,or something,词,ADV,C1
-oracle,oracle,神谕,NOUN,B2
-oracular,oracular,词,ADJ,C1
-oral cavity,oral cavity,口腔,NOUN,B2
-orange,orange,橙色的,ADJ,B2
-orange juice,orange juice,橙汁,NOUN,B2
-orator speaker,orator speaker,词,NOUN,C1
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-order mission,order mission,词,NOUN,A2
-orderliness,orderliness,有序性,NOUN,B2
-ordinance,ordinance,条例,NOUN,B2
-ore,ore,词,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organism,organism,词,NOUN,C1
-organization body,organization body,词,NOUN,B1
-orientation direction,orientation direction,词,NOUN,B1
-original (noun),original,正本,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
-originally (part),originally,原,PART,B2
-originating,originating,词,ADJ,B1
-originator,originator,词,NOUN,C1
-orison prayer,orison prayer,词,NOUN,C1
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,词,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-ostensible,ostensible,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentatious,ostentatious,词,ADJ,C1
-ostracism,ostracism,词,NOUN,C1
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
-other people,other people,旁人,NOUN,B2
-others,others,他人,PRON,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherworldly,otherworldly,词,ADJ,C1
-ought,ought,应该,AUX,B2
-ounce,ounce,词,NOUN,C1
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out (adp),out,词,ADP,B2
-out here,out here,这里外面,ADV,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,词,ADJ,B2
-out there,out there,词,ADV,B2
-outbreak,outbreak,爆发,NOUN,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoor pool,outdoor pool,词,NOUN,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,词,ADJ,B2
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outlandish,outlandish,古怪的,ADJ,B2
-outlast,outlast,词,VERB,B2
-outlaw,outlaw,歹徒,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output value,output value,产值,NOUN,C1
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outset,outset,词,NOUN,C1
-outside,outside,在外面,ADP,B2
-outside of,outside of,词,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,词,NOUN,B2
-outsider,outsider,外人,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward (adv),outward,词,ADV,B2
-outward journey,outward journey,词,NOUN,C1
-over,over,过去,ADV,B2
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbidding,overbidding,词,NOUN,C1
-overconsumption,overconsumption,词,NOUN,C1
-overdose,overdose,过量,NOUN,B2
-overdraft,overdraft,透支,NOUN,B2
-overfall,overfall,overfall,NOUN,B2
-overhead,overhead,词,NOUN,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overload surcharge,overload surcharge,词,NOUN,C1
-overly familiar,overly familiar,词,ADJ,B2
-overrule,overrule,词,VERB,C1
-overseas,overseas,词,ADV,B2
-oversight,oversight,疏忽,NOUN,C1
-overt,overt,词,ADJ,C1
-overtaking exceeding,overtaking exceeding,词,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overview,overview,概览,NOUN,B2
-overweight,overweight,词,ADJ,C1
-overwhelming,overwhelming,压倒性的,ADJ,B2
-overwork,overwork,词,NOUN,C1
-ow,ow,词,INTJ,C1
-owed,owed,欠下的,ADJ,B2
-own,own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-ox,ox,词,NOUN,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oxymoron,oxymoron,矛盾修辞法,NOUN,B2
-oyster,oyster,牡蛎,NOUN,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
-pad,pad,垫,NOUN,B2
-paddle,paddle,词,VERB,C1
-padlock,padlock,词,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pain hurt,pain hurt,词,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-painful,painful,疼痛的,ADJ,B2
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-painstakingly,painstakingly,细致地,ADV,B2
-paint,to paint,粉刷,VERB,B2
-paintbrush,paintbrush,词,NOUN,B2
-pair,pair,一对,NOUN,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-pajamas,pajamas,睡衣,NOUN,B2
-palace maid,palace maid,宫女,NOUN,C1
-palatable,palatable,词,ADJ,C1
-pale,pale,苍白的,ADJ,B2
-paleography,paleography,词,NOUN,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palimpsest,palimpsest,词,NOUN,C1
-palisade,palisade,词,NOUN,C1
-palliative,palliative,缓和的,ADJ,B2
-pallid,pallid,词,ADJ,C1
-palm,palm,手掌,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
-palpable,palpable,词,ADJ,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
-pan,pan,平底锅,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
-pancake,pancake,煎饼,NOUN,B2
-panda,panda,熊猫,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
-pant,to pant,喘气,VERB,B2
-pantheon,pantheon,先贤祠,NOUN,B2
-panther,panther,豹,NOUN,B2
-panties,panties,词,NOUN,C1
-pants,pants,裤子,NOUN,B2
-papal bull,papal bull,词,NOUN,B2
-papaya,papaya,木瓜,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
-paper cutting,paper cutting,剪纸,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paperwork,paperwork,文书工作,NOUN,B2
-parable,parable,词,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-parade,parade,游行,NOUN,B2
-paradigm,paradigm,范例,NOUN,B2
-paradise heaven,paradise heaven,词,NOUN,B1
-paradoxical,paradoxical,矛盾的,ADJ,B2
-paradoxically,paradoxically,词,ADV,C1
-paragraph,paragraph,段落,NOUN,B2
-paragraph heel,paragraph heel,词,NOUN,C1
-paralipsis,paralipsis,词,NOUN,C1
-paralogism,paralogism,词,NOUN,B2
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
-paralyze,to paralyze,使瘫痪,VERB,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
-parameter,parameter,参数,NOUN,B2
-paramount,paramount,词,ADJ,C1
-paranoia,paranoia,词,NOUN,C1
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parataxis,parataxis,意合,NOUN,B2
-parcel,parcel,包裹,NOUN,B2
-parch,parch,词,VERB,C1
-parchment,parchment,词,NOUN,C1
-pardoning,pardoning,词,NOUN,C1
-parent-friendly,parent-friendly,,NOUN,B2
-parenthesis,parenthesis,词,NOUN,C1
-parents,parents,父母,NOUN,B2
-paresis,paresis,词,NOUN,C1
-pariah,pariah,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parishioner,parishioner,词,NOUN,C1
-parishioners,parishioners,词,NOUN,C1
-parity,parity,平等,NOUN,B2
-parking,parking,停车,NOUN,B2
-parking lot,parking lot,停车场,NOUN,B2
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
-parley,parley,词,NOUN,C1
-parliamentary,parliamentary,议会的/议员,ADJ,B2
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
-parlor,parlor,词,NOUN,C1
-parole,parole,假释,NOUN,B2
-paronym,paronym,词,NOUN,C1
-paroxysm,paroxysm,发作,NOUN,B2
-parquet,parquet,词,NOUN,C1
-parse,parse,解析,VERB,B2
-parsimonious,parsimonious,吝啬的,ADJ,B2
-parsimony,parsimony,吝啬,NOUN,B2
-part,to part,分离,VERB,B2
-part by death,to part by death,死别,VERB,B2
-part forever,part forever,永别,VERB,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-partial,partial,部分的,ADJ,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial cause,partial cause,分因,NOUN,B2
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial meaning,partial meaning,分义,NOUN,B2
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-partially,partially,部分地,ADV,B2
-particle (part),particle,么,PART,B2
-particularity,particularity,特点,NOUN,B2
-particularize,particularize,词,VERB,B2
-particularly,particularly,特别地,ADV,B2
-partisan (noun),partisan,词,NOUN,C1
-partly,partly,部分地,ADV,B2
-partner female,partner female,词,NOUN,B2
-party,party,聚会,NOUN,B2
-party to the contract,party to the contract,词,NOUN,B2
-pass (noun),pass,过得,NOUN,C1
-pass away,to pass away,流逝,VERB,B2
-pass on,to pass on,转交,VERB,B2
-passed,passed,词,ADJ,B2
-passenger,passenger,乘客,NOUN,B2
-passerby,passerby,词,NOUN,C1
-passing,passing,过世,NOUN,B2
-passionate,passionate,热情的,ADJ,B2
-passive,passive,被动的,ADJ,B2
-passport,passport,护照,NOUN,B2
-past,past,经过,ADV,B2
-past (adp),past,词,ADP,B2
-past events,past events,往事,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
-pastoral (adj),pastoral,词,ADJ,C1
-pastoral (noun),pastoral,词,NOUN,C1
-pastry chef,pastry chef,词,NOUN,C1
-patch tire,patch tire,补胎,VERB,C1
-patently,patently,词,ADV,B2
-paternal,paternal,父亲的,ADJ,B2
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
-pathogenic,pathogenic,致病的,ADJ,B2
-pathology,pathology,病理学,NOUN,B2
-patient female,patient female,词,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patiently,patiently,词,ADV,C1
-patriarch,patriarch,词,NOUN,C1
-patricide,patricide,词,NOUN,B2
-patriot,patriot,词,NOUN,B2
-patrol,patrol,巡逻,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
-patronage,patronage,词,NOUN,B2
-paucity,paucity,词,NOUN,C1
-pave,pave,词,VERB,C1
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-paving,paving,词,NOUN,B2
-paving stone,paving stone,词,NOUN,A2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-pea,pea,词,NOUN,C1
-peacefully,peacefully,词,ADV,C1
-peach tree,peach tree,词,NOUN,C1
-peanut field,peanut field,词,NOUN,B2
-peat,peat,泥炭,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
-peculiarity,peculiarity,词,NOUN,B2
-pecuniary,pecuniary,词,ADJ,C1
-pedal,pedal,词,NOUN,B1
-pedantic,pedantic,词,ADJ,C1
-pedantically,pedantically,词,ADV,C1
-peddler,peddler,小贩,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-pediment,pediment,词,NOUN,C1
-peek,peek,词,VERB,C1
-peephole,peephole,门镜,NOUN,B2
-peg,peg,词,NOUN,C1
-pejorative,pejorative,词,ADJ,C1
-pellucid,pellucid,词,ADJ,C1
-pelvis basin,pelvis basin,词,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalty,penalty,惩罚,NOUN,B2
-penalty payment,penalty payment,词,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-penchant,penchant,词,NOUN,C1
-pencil case,pencil case,词,NOUN,C1
-pending,pending,词,ADJ,B1
-penguin,penguin,词,NOUN,A1
-penis,penis,词,NOUN,B2
-penitence,penitence,词,NOUN,C1
-penitent,penitent,词,ADJ,C1
-penitentiary,penitentiary,词,ADJ,C1
-pennant,pennant,词,NOUN,C1
-pensive,pensive,沉思的,ADJ,C1
-penury,penury,词,NOUN,C1
-people (pron),people,词,PRON,B2
-peppermint,peppermint,词,NOUN,C1
-per,per,每,ADP,B2
-perceptibly,perceptibly,明显地,ADV,B2
-perception opinion,perception opinion,词,NOUN,B2
-perceptual,perceptual,词,ADJ,B2
-peremptorily,peremptorily,词,ADV,C1
-peremptory,peremptory,专横的,ADJ,B2
-perennial,perennial,长期的,ADJ,B2
-perfect,perfect,完美的,ADJ,B2
-perfectly,perfectly,词,ADV,A2
-perfidious,perfidious,词,ADJ,C1
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-perform,to perform,表演,VERB,B2
-performer,performer,词,NOUN,C1
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-peri-urban,peri-urban,词,ADJ,B2
-peril,peril,危险,NOUN,B2
-perilla,perilla,紫苏,NOUN,B2
-perilous,perilous,危险的,ADJ,B2
-period (punct),period,词,PUNCT,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periphery,periphery,边缘,NOUN,B2
-periphrasis,periphrasis,词,NOUN,C1
-perishing,perishing,词,NOUN,B2
-peritoneum,peritoneum,腹膜,NOUN,B2
-perjury,perjury,伪证,NOUN,B2
-perks,perks,词,NOUN,C1
-permanently,permanently,词,ADV,C1
-permit,to permit,允许,VERB,B2
-pernicious,pernicious,有害的,ADJ,B2
-peroration,peroration,结语,NOUN,B2
-perpetual,perpetual,永久的,ADJ,B2
-perplex,perplex,词,VERB,C1
-perplexed,perplexed,困惑的,ADJ,B2
-persimmon,persimmon,柿子,NOUN,C1
-persistence,persistence,坚持,NOUN,B2
-persistent,persistent,坚持不懈的,ADJ,B2
-person honorific,person honorific,位,NOUN,B2
-person in charge,person in charge,负责人,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
-personable,personable,词,ADJ,C1
-personal,personal,私事,NOUN,B2
-personal best,personal best,词,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
-personal enmity,personal enmity,私仇,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
-personal record,personal record,个人纪录,NOUN,B2
-personalized,personalized,个性化的,ADJ,B2
-personally,personally,就个人而言,ADV,B2
-personally experience,personally experience,亲历,VERB,C1
-personification,personification,词,NOUN,C1
-personnel,personnel,人员,NOUN,B2
-perspicacious,perspicacious,词,ADJ,C1
-perspicacity,perspicacity,词,NOUN,B2
-persuade,to persuade,说服,VERB,B2
-pertinent,pertinent,词,ADJ,C1
-pertinently,pertinently,词,ADV,B2
-pervasive,pervasive,词,ADJ,C1
-perverse,perverse,任性的,ADJ,B2
-perversity,perversity,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-pet,pet,宠物,NOUN,B2
-petal,petal,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
-pettiness,pettiness,词,NOUN,C1
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-phantasmagorical,phantasmagorical,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharaoh,pharaoh,法老,NOUN,B2
-pharisee,pharisee,词,NOUN,B2
-phase,phase,阶段,NOUN,B2
-phased,phased,阶段性,ADJ,B2
-phased (adv),phased,词,ADV,B1
-pheasant,pheasant,词,NOUN,C1
-phenomenal,phenomenal,非凡的,ADJ,B2
-phew,phew,词,INTJ,C1
-philanthropic,philanthropic,词,ADJ,C1
-philanthropist,philanthropist,慈善家,NOUN,B2
-philanthropy,philanthropy,慈善,NOUN,B2
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philologist,philologist,语言学家,NOUN,B2
-philology,philology,词,NOUN,C1
-philosopher,philosopher,哲学家,NOUN,B2
-philosophical,philosophical,哲学的,ADJ,B2
-philosophy,philosophy,哲学,NOUN,B2
-philosophy of life,philosophy of life,词,NOUN,B2
-phlebitis,phlebitis,词,NOUN,C1
-phlegmatic,phlegmatic,冷静的,ADJ,B2
-phoenix,phoenix,拿凤,NOUN,B2
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,带凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
-phone,to phone,打电话,VERB,B2
-phone number,phone number,电话号码,NOUN,B2
-phony,phony,假的,ADJ,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-phosphorus,phosphorus,词,NOUN,C1
-photo,photo,照片,NOUN,B2
-photo album,photo album,影集,NOUN,C1
-photo model,photo model,词,NOUN,B2
-photocopy,photocopy,复印件,NOUN,B2
-photocopy,to photocopy,复印,VERB,B2
-photogenic,photogenic,词,ADJ,C1
-photograph,photograph,照片,NOUN,B2
-photographic,photographic,词,ADJ,C1
-photography,photography,摄影,NOUN,B2
-photogravure,photogravure,词,NOUN,C1
-photon,photon,光子,NOUN,B2
-photophobia,photophobia,词,NOUN,C1
-photosynthesis,photosynthesis,光合作用,NOUN,B2
-phototypy,phototypy,词,NOUN,C1
-phrase,phrase,短语,NOUN,B2
-phraseology,phraseology,词,NOUN,C1
-phrasing,phrasing,措辞,NOUN,B2
-physical,physical,身体的,ADJ,B2
-physical evidence,physical evidence,物证,NOUN,B2
-physically,physically,身体上地,ADV,B2
-physician,physician,内科医生,NOUN,B2
-physicist,physicist,词,NOUN,C1
-physics,physics,物理,NOUN,B2
-physiognomy,physiognomy,面相,NOUN,B2
-physiological,physiological,生理的,ADJ,B2
-physiotherapist,physiotherapist,词,NOUN,B1
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-pianist,pianist,词,NOUN,C1
-piano,piano,钢琴,NOUN,B2
-piano music,piano music,词,NOUN,B2
-picaresque,picaresque,词,ADJ,C1
-pick up a car,pick up a car,取车,VERB,B2
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickle (noun),pickle,词,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-pictorial,pictorial,绘画的,ADJ,B2
-picturesque,picturesque,如画的；别致的,ADJ,B2
-pidgin,pidgin,词,NOUN,C1
-pie,pie,派,NOUN,B2
-piecework,piecework,词,NOUN,C1
-pier,pier,码头,NOUN,B2
-piety pity,piety pity,词,NOUN,B2
-pile heap,pile heap,词,NOUN,C1
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pimp,pimp,词,NOUN,C1
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
-pioneer,pioneer,先驱,NOUN,B2
-pious,pious,虔诚的,ADJ,B2
-piously,piously,词,ADV,C1
-pipa,pipa,琵琶,NOUN,B2
-pipe dream,pipe dream,词,NOUN,C1
-piquant,piquant,词,ADJ,C1
-piracy,piracy,词,NOUN,B2
-pitch,pitch,词,NOUN,B1
-pitchfork,pitchfork,叉子,NOUN,B2
-piteous,piteous,词,ADJ,C1
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pittance,pittance,词,NOUN,C1
-pity,pity,遗憾,NOUN,B2
-pizza,pizza,词,NOUN,B1
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-placed before,placed before,词,ADJ,B2
-placid,placid,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plantain,plantain,芭蕉,NOUN,B2
-plasma,plasma,血浆,NOUN,B2
-plastic bag,plastic bag,塑料袋,NOUN,A2
-platinum,platinum,词,NOUN,B2
-platitude,platitude,词,NOUN,C1
-plausibility,plausibility,词,NOUN,B2
-plausible,plausible,似是而非的,ADJ,C1
-play game,play game,游戏/玩耍,NOUN,B2
-playable,playable,词,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playground,playground,操场,NOUN,B2
-playwright,playwright,剧作家,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please,please,请,INTJ,B2
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-plebiscite,plebiscite,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plenary,plenary,词,ADJ,C1
-plenitude,plenitude,充足,NOUN,B2
-plentiful,plentiful,词,ADJ,B2
-plenty (adv),plenty,词,ADV,B2
-pleonasm,pleonasm,词,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
-plot episode,plot episode,情节,NOUN,C1
-plot twist,plot twist,词,NOUN,C1
-plow handle,plow handle,词,NOUN,C1
-plucky,plucky,勇敢的,ADJ,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-plumb,plumb,词,NOUN,C1
-plump,plump,词,ADJ,C1
-plunge,plunge,词,VERB,C1
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
-pneumonia,pneumonia,词,NOUN,C1
-poach,poach,词,VERB,C1
-podcasting,podcasting,词,NOUN,B1
-poetic,poetic,词,ADJ,C1
-poignant,poignant,词,ADJ,C1
-point of view,point of view,词,NOUN,C1
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,词,ADV,B2
-poison,to poison,毒害,VERB,B2
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,词,NOUN,B2
-poke,poke,词,VERB,B2
-polar,polar,极地的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polemicist,polemicist,词,NOUN,C1
-police chief,police chief,警察局长,NOUN,B2
-police officer,police officer,警察,NOUN,B2
-police officer female,police officer female,词,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police report,police report,词,NOUN,B2
-police search,police search,词,NOUN,C1
-police station,police station,警察局,NOUN,B2
-policeman,policeman,警察,NOUN,B2
-policy,policy,政策,NOUN,B2
-policy-related,policy-related,词,ADJ,C1
-polish,polish,波兰的,ADJ,B2
-polish,to polish,擦亮,VERB,B2
-polish (adj),polish,波兰的,ADJ,B2
-polish (noun),polish,精炼,NOUN,C1
-polite,polite,有礼貌的,ADJ,B2
-politely,politely,礼貌地,ADV,B2
-politeness,politeness,词,NOUN,C1
-politic,politic,词,ADJ,C1
-politically,politically,在政治上,ADV,B2
-politician,politician,政治家,NOUN,B2
-pollster,pollster,词,NOUN,C1
-polyester,polyester,涤纶,NOUN,B2
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,词,NOUN,B2
-polytunnel,polytunnel,大棚,NOUN,B2
-pomelo,pomelo,柚子,NOUN,B2
-pompous,pompous,词,ADJ,C1
-pompously,pompously,词,ADV,C1
-pond,pond,池塘,NOUN,B2
-ponder,to ponder,沉思,VERB,B2
-ponderous,ponderous,词,ADJ,C1
-pool,pool,水池,NOUN,B2
-pool (part),pool,池,PART,B2
-poor devil,poor devil,可怜虫,NOUN,B2
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,词,ADJ,B2
-pop,pop,词,NOUN,B1
-pop music,pop music,流行音乐,NOUN,B2
-pope,pope,教皇,NOUN,B2
-poppy,poppy,词,NOUN,B1
-pops,pops,词,NOUN,C1
-popular,popular,受欢迎的,ADJ,B2
-popularity,popularity,流行,NOUN,B2
-popularize,to popularize,推广,VERB,B2
-populate,to populate,居住,VERB,B2
-populist,populist,民粹主义者,NOUN,B2
-populous,populous,词,ADJ,C1
-porcelain,porcelain,瓷器,NOUN,B2
-pork,pork,词,NOUN,B2
-porn,porn,色情,NOUN,B2
-pornography,pornography,色情,NOUN,B2
-porous,porous,词,ADJ,C1
-portable,portable,词,ADJ,C1
-portentous,portentous,词,ADJ,C1
-portico,portico,词,NOUN,C1
-portion,portion,部分,NOUN,B2
-portion serving,portion serving,词,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portray,to portray,描绘,VERB,B2
-portrayal,portrayal,词,NOUN,B2
-portuguese,portuguese,葡萄牙语,NOUN,B2
-posh,posh,上流的,ADJ,B2
-posit,posit,词,VERB,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
-positive,positive,积极的,ADJ,B2
-positivism,positivism,词,NOUN,C1
-possess,to possess,拥有,VERB,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-possible future,possible future,词,ADJ,C1
-possibly,possibly,可能地,ADV,B2
-post office,post office,邮局,NOUN,B2
-postage,postage,邮资,NOUN,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postal code,postal code,邮政编码,NOUN,B2
-postcard,postcard,明信片,NOUN,B2
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-posterity,posterity,词,NOUN,C1
-posthumous,posthumous,死后的,ADJ,B2
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
-posture,posture,作势,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
-potential,potential,潜力,NOUN,B2
-potential (adj),potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potion,potion,词,NOUN,B2
-pouch,pouch,词,NOUN,C1
-poultice,poultice,词,NOUN,B2
-pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power grid,power grid,电网,NOUN,B2
-power plant,power plant,发电厂,NOUN,B2
-power station,power station,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powerful,powerful,强大的,ADJ,B2
-powerful nation,powerful nation,强国,NOUN,B2
-practically,practically,几乎,ADV,B2
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-prairie,prairie,词,NOUN,C1
-praise,to praise,赞扬,VERB,B2
-praiseworthy,praiseworthy,词,ADJ,C1
-prank,prank,恶作剧,NOUN,B2
-prawn,prawn,词,NOUN,C1
-prayer room,prayer room,祈祷室,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-preach,to preach,布道,VERB,B2
-preacher,preacher,词,NOUN,B2
-precarious,precarious,不稳定的,ADJ,B2
-precarization,precarization,不稳定化,NOUN,B2
-precaution,precaution,预防措施,NOUN,B2
-precede,to precede,在...之前,VERB,B2
-precedence,precedence,也先,NOUN,C1
-precept,precept,戒律,NOUN,B2
-precinct,precinct,辖区,NOUN,B2
-precipice,precipice,词,NOUN,C1
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-precisely,precisely,确切地; 正好,ADV,B2
-preclude,preclude,词,VERB,C1
-precocious,precocious,早熟的,ADJ,B2
-preconception,preconception,词,NOUN,B2
-predictable,predictable,可预测的,ADJ,B2
-predilection,predilection,词,NOUN,C1
-predisposition,predisposition,词,NOUN,B2
-predominant,predominant,词,ADJ,B2
-predominantly,predominantly,词,ADV,C1
-preeminence,preeminence,词,NOUN,B2
-preeminent,preeminent,词,ADJ,C1
-prefect,prefect,词,NOUN,B1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-preferable,preferable,更可取的,ADJ,B2
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-prejudiced,prejudiced,词,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-prelate,prelate,词,NOUN,C1
-preliminary,preliminary,初步的,ADJ,B2
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,词,ADJ,C1
-prematurely,prematurely,词,ADV,C1
-premeditate,premeditate,词,VERB,C1
-premium,premium,溢价,NOUN,B2
-premonition,premonition,预感,NOUN,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-prepare (noun),prepare,备上,NOUN,C1
-prepared,prepared,准备好的,ADJ,B2
-preparedness,preparedness,词,NOUN,B1
-preponderant,preponderant,占优势的,ADJ,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-prerogative,prerogative,特权,NOUN,B2
-prescient,prescient,词,ADJ,C1
-present (adj),present,在场,ADJ,B2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidential election,presidential election,总统选举,NOUN,B2
-press freedom,press freedom,新闻自由,NOUN,B2
-press release,press release,公报,NOUN,B2
-prestigious,prestigious,有声望的,ADJ,B2
-presumably,presumably,据推测,ADV,B2
-presumed,presumed,词,ADJ,B2
-presumptuous,presumptuous,词,ADJ,C1
-pretender,pretender,词,NOUN,C1
-pretension,pretension,词,NOUN,C1
-pretentious,pretentious,自命不凡的,ADJ,B2
-preterition,preterition,词,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
-preview,preview,词,NOUN,C1
-previous (noun),previous,词,NOUN,B2
-prey,prey,猎物,NOUN,B2
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prickly,prickly,词,ADJ,C1
-pride arrogance,pride arrogance,词,NOUN,C1
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
-primary school,primary school,词,NOUN,B2
-primary school teacher,primary school teacher,词,NOUN,C1
-primate,primate,词,NOUN,C1
-primeval forest,primeval forest,原始森林,NOUN,C1
-princess,princess,公主,NOUN,B2
-principal (adj),principal,词,ADJ,B2
-principality,principality,词,NOUN,C1
-print,print,印记,NOUN,B2
-printed,printed,词,ADJ,C1
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-prior,prior,先前的,ADJ,B2
-priority (adj),priority,词,ADJ,B2
-pristine,pristine,词,ADJ,C1
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-private life,private life,私生活,NOUN,B2
-privileged,privileged,词,ADJ,B2
-prize,prize,奖品,NOUN,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-probable,probable,词,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probably,probably,大概,ADV,B2
-probation,probation,缓刑,NOUN,B2
-probationary,probationary,词,ADJ,B2
-probative,probative,词,ADJ,C1
-probiotic,probiotic,益生菌,NOUN,C1
-probity,probity,正直,NOUN,B2
-problematic,problematic,词,ADJ,B2
-proceed,to proceed,继续进行,VERB,B2
-process,to process,处理,VERB,B2
-process technique,process technique,词,NOUN,B1
-processable,processable,词,ADJ,C1
-processing (noun),processing,词,NOUN,B2
-procession,procession,行列,NOUN,B2
-proclaim,to proclaim,宣布,VERB,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
-procure,to procure,获取,VERB,B2
-prodigal,prodigal,词,ADJ,C1
-prodigious,prodigious,词,ADJ,C1
-prodigy,prodigy,神童,NOUN,B2
-produce,to produce,生产,VERB,B2
-producer,producer,生产者,NOUN,B2
-productive,productive,多产的,ADJ,B2
-productivist,productivist,生产至上主义的,ADJ,B2
-profane,profane,词,ADJ,C1
-profess,profess,词,VERB,B2
-professional ethics,professional ethics,词,NOUN,C1
-professional formation,professional formation,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professor,professor,教授,NOUN,B2
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
-profile,profile,简介,NOUN,B2
-profit-making,profit-making,营利性,ADJ,B2
-profitable,profitable,词,ADJ,B2
-profligate,profligate,词,ADJ,C1
-profound,profound,深刻的,ADJ,B2
-profuse,profuse,词,ADJ,C1
-prognosis,prognosis,预后,NOUN,B2
-program,program,节目,NOUN,B2
-progress,to progress,进步,VERB,B2
-progress report,progress report,进度报告,NOUN,B2
-progression,progression,词,NOUN,C1
-progressive (noun),progressive,进步人士,NOUN,B2
-progressively,progressively,逐渐地,ADV,B2
-prohibit,to prohibit,禁止,VERB,B2
-prohibition,prohibition,禁止,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
-project assignment,project assignment,项目作业,NOUN,B2
-project report,project report,项目报告,NOUN,B2
-projection,projection,词,NOUN,C1
-projector,projector,投影仪,NOUN,B2
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
-proliferate,proliferate,扩散,! VERB,B2
-proliferation,proliferation,增殖,NOUN,B2
-prolific,prolific,词,ADJ,C1
-prolong,to prolong,延长,VERB,B2
-prominent,prominent,突出的,ADJ,B2
-prominent family,prominent family,望族,NOUN,C1
-promiscuous,promiscuous,滥交的,ADJ,B2
-promise,promise,承诺,NOUN,B2
-promote,to promote,促进,VERB,B2
-promoted,promoted,词,ADJ,B1
-prompt,prompt,词,ADJ,C1
-promptness,promptness,词,NOUN,C1
-promulgate,to promulgate,颁布,VERB,B2
-prone,prone,词,ADJ,C1
-pronoun,pronoun,词,NOUN,B1
-pronounce,to pronounce,发音,VERB,B2
-pronounced,pronounced,显著的,ADJ,B2
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-proofreading,proofreading,校对,NOUN,B2
-prop,to prop,撑,VERB,B2
-propaedeutic,propaedeutic,词,ADJ,C1
-propel,propel,推动,VERB,B2
-propeller,propeller,螺旋桨,NOUN,B2
-propensity,propensity,倾向,NOUN,B2
-proper,proper,适当的,ADJ,B2
-properly,properly,适当地,ADV,B2
-property,property,性质,NOUN,B2
-property owner,property owner,房主,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophecy,prophecy,预言,NOUN,B2
-prophet,prophet,先知,NOUN,B2
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-propitious,propitious,词,ADJ,C1
-proponent,proponent,词,NOUN,C1
-proportional,proportional,成比例的,ADJ,B2
-proportionally,proportionally,词,ADV,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutor's office,prosecutor's office,词,NOUN,B2
-proselyte,proselyte,词,NOUN,C1
-proselytism,proselytism,传教,NOUN,B2
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protective cover,protective cover,词,NOUN,C1
-protector,protector,词,NOUN,B2
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proudly,proudly,词,ADV,C1
-provable,provable,可证明的,ADJ,B2
-providential,providential,词,ADJ,C1
-provincial,provincial,地方的,ADJ,B2
-provisional,provisional,临时的,ADJ,B2
-provisionally,provisionally,词,ADV,C1
-prow,prow,词,NOUN,C1
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-psalm,psalm,词,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychiatric,psychiatric,精神病的,ADJ,B2
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychological,psychological,心理的,ADJ,B2
-psychologically,psychologically,词,ADV,C1
-psychopath,psychopath,精神变态者,NOUN,B2
-public debt,public debt,公债,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publicity,publicity,宣传,NOUN,B2
-puddle,puddle,水坑,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puerperal,puerperal,词,ADJ,C1
-puff,puff,一口烟,NOUN,B2
-puff pastry,puff pastry,词,NOUN,C1
-pugnacious,pugnacious,词,ADJ,C1
-pugnacity,pugnacity,词,NOUN,C1
-puissant,puissant,词,ADJ,C1
-pull (noun),pull,别拉,NOUN,C1
-pulling,pulling,拔,NOUN,B2
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
-punch drink,punch drink,词,NOUN,C1
-punctilious,punctilious,词,ADJ,C1
-punctuality,punctuality,词,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
-puncture tap,puncture tap,词,NOUN,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
-punishable,punishable,词,ADJ,B2
-puny,puny,词,ADJ,C1
-pupil female,pupil female,词,NOUN,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-purchase price,purchase price,词,NOUN,B2
-purely,purely,纯粹地,ADV,B2
-purifying,purifying,净化的,ADJ,B2
-puritanical,puritanical,词,ADJ,C1
-purple needle,purple needle,紫阴针,NOUN,B2
-purse,purse,词,NOUN,B1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-putrid,putrid,词,ADJ,C1
-quackery,quackery,词,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualifier,qualifier,资格赛,NOUN,C1
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,词,ADJ,B2
-quantum,quantum,词,ADJ,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quasi,quasi,词,ADV,B2
-quaternary,quaternary,词,ADJ,B2
-queer,queer,词,ADJ,C1
-quench,quench,词,VERB,C1
-querulous,querulous,词,ADJ,C1
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
-questioning (adj),questioning,词,ADJ,C1
-quibble,quibble,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiescent,quiescent,词,ADJ,C1
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
-quietude,quietude,词,NOUN,C1
-quill,quill,词,NOUN,C1
-quint,quint,词,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quivering,quivering,颤抖的,ADJ,B2
-quixotic,quixotic,词,ADJ,C1
-quotable,quotable,词,ADJ,B2
-quote,quote,报价单,NOUN,B2
-quotidian,quotidian,词,ADJ,C1
-quotient,quotient,词,NOUN,B2
-rabble,rabble,词,NOUN,C1
-racist,racist,种族主义者,NOUN,B2
-racist (adj),racist,种族主义的,ADJ,C1
-racketeering,racketeering,词,NOUN,B2
-radar,radar,词,NOUN,B2
-radiant,radiant,容光焕发的,ADJ,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radically,radically,词,ADV,B2
-radio silence,radio silence,词,NOUN,C1
-radioactivity,radioactivity,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
-radiotherapy,radiotherapy,放疗,NOUN,B2
-radius,radius,半径,NOUN,B2
-rag,rag,破布,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-railroad,railroad,词,NOUN,B2
-railway,railway,铁路的,ADJ,B2
-rain shower,rain shower,阵雨,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy day,rainy day,雨天,NOUN,C1
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-rake,rake,耙子,NOUN,B2
-rally (noun),rally,词,NOUN,B2
-rallying,rallying,词,NOUN,C1
-rambunctious,rambunctious,词,ADJ,C1
-rampart,rampart,词,NOUN,C1
-ramshackle,ramshackle,词,ADJ,C1
-ran,ran,跑,ADJ,B2
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancorous,rancorous,词,ADJ,C1
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-ranger,ranger,词,NOUN,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-ranking classification,ranking classification,词,NOUN,C1
-rapacious,rapacious,词,ADJ,C1
-rapacity,rapacity,词,NOUN,C1
-rapidly,rapidly,词,ADV,B2
-rapier,rapier,词,NOUN,C1
-rapper,rapper,说唱歌手,NOUN,B2
-rapture,rapture,狂喜,NOUN,B2
-rapturous,rapturous,词,ADJ,C1
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,词,NOUN,C1
-rarity,rarity,希罕,NOUN,C1
-rascal,rascal,无赖,NOUN,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-raspberry,raspberry,覆盆子,NOUN,B2
-raspy,raspy,词,ADJ,C1
-rat-proof,rat-proof,防鼠,ADJ,B2
-rate,rate,比率,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather,rather,相当,ADV,B2
-rather than,rather than,与其,CCONJ,B1
-ratio,ratio,比率,NOUN,B2
-ration,ration,配给,NOUN,B2
-rational,rational,词,ADJ,B2
-rationality,rationality,理性,NOUN,B2
-rattling,rattling,词,NOUN,C1
-raucous,raucous,词,ADJ,C1
-ravage (noun),ravage,词,NOUN,C1
-raven,raven,乌鸦,NOUN,B2
-ravenous,ravenous,词,ADJ,C1
-ravine,ravine,词,NOUN,B2
-raw,raw,生的,ADJ,B2
-raw material,raw material,原材料,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-rays of light,rays of light,光芒,NOUN,B2
-raze,raze,词,VERB,C1
-razor,razor,剃刀,NOUN,B2
-re-ability,re-ability,再能,NOUN,C1
-re-abruptness,re-abruptness,再骤,NOUN,B2
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-battle,re-battle,重战,NOUN,B2
-re-boundary,re-boundary,重界,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-course,re-course,重途,NOUN,B2
-re-creation,re-creation,再作,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-enactment,re-enactment,再演,NOUN,B2
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-evidence,re-evidence,重据,NOUN,B2
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-fruit,re-fruit,再果,NOUN,B2
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-inner,re-inner,再内,NOUN,B2
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,重判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-layering,re-layering,改层,NOUN,B2
-re-limit,re-limit,重限,NOUN,B2
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-logic,re-logic,再逻,NOUN,B2
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-meaning,re-meaning,再义,NOUN,B2
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-order,re-order,重序,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-pace,re-pace,重骤,NOUN,B2
-re-path,re-path,重径,NOUN,B2
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-quantity,re-quantity,再量,NOUN,B2
-re-reality,re-reality,再实,NOUN,C1
-re-reason,re-reason,重理,NOUN,B2
-re-route,re-route,重路,NOUN,B2
-re-routing,re-routing,改轨,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-sequencing,re-sequencing,改骤,NOUN,B2
-re-shape,re-shape,重形,NOUN,C1
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-submission,re-submission,再上,NOUN,B2
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,重综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach,reach,范围,NOUN,B2
-reach,to reach,到达,VERB,B2
-reach (noun),reach,范围,NOUN,B1
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reachable,reachable,可到达的,ADJ,B2
-react,to react,反应,VERB,B2
-reactionary,reactionary,反动,ADJ,B2
-read out,read out,宣读,VERB,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
-reaffirm,reaffirm,词,VERB,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
-reality TV,reality TV,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rear (adj),rear,后部,ADJ,A1
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reasoned,reasoned,词,ADJ,B2
-reassuring,reassuring,词,ADJ,B1
-rebellious,rebellious,叛逆的,ADJ,B2
-rebirth,rebirth,词,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (noun),rebound,词,NOUN,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recede,recede,词,VERB,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-receiving stolen goods,receiving stolen goods,词,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-recess,recess,词,NOUN,C1
-recidivism,recidivism,词,NOUN,B2
-reciprocally,reciprocally,词,ADV,B2
-reciprocate,reciprocate,词,VERB,C1
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,词,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-recognizable,recognizable,可辨认的,ADJ,B2
-recognized,recognized,词,NOUN,B2
-recombination,recombination,再结,NOUN,C1
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconnoiter,reconnoiter,词,VERB,C1
-reconquest,reconquest,词,NOUN,C1
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recourse,recourse,词,NOUN,B2
-recreation,recreation,娱乐,NOUN,B2
-recruit (noun),recruit,词,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
-rectangular,rectangular,词,ADJ,C1
-rector,rector,词,NOUN,C1
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
-recurring,recurring,词,ADJ,C1
-recycled item,recycled item,再物,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redact,redact,词,VERB,C1
-redemption,redemption,救赎,NOUN,B2
-redesign,redesign,词,NOUN,C1
-redevelopment,redevelopment,词,NOUN,C1
-redolent,redolent,词,ADJ,C1
-redoubtable,redoubtable,词,ADJ,C1
-redrawing,redrawing,重新绘制,NOUN,B2
-redress,redress,词,VERB,B2
-redundancy,redundancy,冗余,NOUN,B2
-redundant,redundant,多余的,ADJ,B2
-reed bed,reed bed,词,NOUN,B2
-reef,reef,词,NOUN,B2
-reel,reel,词,NOUN,C1
-reference framework,reference framework,词,NOUN,C1
-referendum-related,referendum-related,词,ADJ,B2
-reflective,reflective,词,ADJ,C1
-reflex,reflex,词,NOUN,C1
-reformist,reformist,改良型,ADJ,C1
-reformulation,reformulation,重新表述,NOUN,B2
-refractory,refractory,词,ADJ,C1
-refulgent,refulgent,词,ADJ,C1
-refurbish,refurbish,词,VERB,C1
-refutable,refutable,词,ADJ,B2
-refutation,refutation,词,NOUN,C1
-regal,regal,词,ADJ,C1
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regardless,regardless,不管,ADV,B2
-regardless (adp),regardless,词,ADP,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,词,NOUN,B2
-regent,regent,词,NOUN,C1
-regimen,regimen,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
-register (noun),register,词,NOUN,B1
-registered,registered,注册的,ADJ,B2
-registered mail,registered mail,挂号信,NOUN,B2
-registration number,registration number,词,NOUN,C1
-regrettable,regrettable,词,ADJ,B2
-regularity,regularity,规律性,NOUN,B2
-regularization,regularization,词,NOUN,C1
-regularly,regularly,定期地,ADV,B2
-regulated,regulated,词,ADJ,C1
-rehabilitation,rehabilitation,康复,NOUN,B2
-rein,rein,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
-reining,reining,勒马,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
-reissue (noun),reissue,词,NOUN,C1
-relapse (verb),relapse,词,VERB,B2
-relating to birth,relating to birth,词,ADJ,C1
-relation,relation,词,NOUN,B1
-relational,relational,词,ADJ,B2
-relativity,relativity,词,NOUN,C1
-relaxed loose,relaxed loose,词,ADJ,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-released,released,词,ADJ,B2
-relentless,relentless,无情的,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
-reliance,reliance,信赖,NOUN,B2
-relic,relic,圣物,NOUN,B2
-relieve,to relieve,缓解,VERB,B2
-relieved,relieved,宽慰的,ADJ,B2
-religious,religious,宗教的,ADJ,B2
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiously,religiously,词,ADV,C1
-religiousness,religiousness,虔诚,NOUN,B2
-relinquish,relinquish,词,VERB,C1
-relinquishment,relinquishment,词,NOUN,C1
-relocate,to relocate,调动,VERB,B2
-relocation,relocation,搬家,NOUN,B2
-reluctance,reluctance,不情愿,NOUN,B2
-reluctant,reluctant,不情愿的,ADJ,B2
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
-remains,remains,残骸,NOUN,B2
-remains spoils,remains spoils,词,NOUN,B2
-remand,remand,词,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
-remark,remark,评论,NOUN,B2
-remark (verb),remark,词,VERB,B2
-remarkable,remarkable,非凡的,ADJ,B2
-remarkably,remarkably,显著地,ADV,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedy,remedy,补救措施,NOUN,B2
-remedy,to remedy,补救,VERB,B2
-remedy (noun),remedy,解方,NOUN,B1
-remind,to remind,提醒,VERB,B2
-reminder,reminder,提醒物,NOUN,B2
-reminisce,reminisce,词,VERB,C1
-reminiscence,reminiscence,词,NOUN,C1
-reminiscent,reminiscent,词,ADJ,C1
-remiss,remiss,词,ADJ,C1
-remission,remission,词,NOUN,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remnant,remnant,词,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remorseful,remorseful,悔恨的,ADJ,B2
-remote control,remote control,遥控器,NOUN,B2
-remote work,remote work,远程办公,NOUN,B2
-remote-controlled car,remote-controlled car,遥控车,NOUN,B2
-removal deletion,removal deletion,词,NOUN,C1
-remove,to remove,移除,VERB,B2
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,词,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
-remuneration,remuneration,报酬,NOUN,B2
-renascent,renascent,词,ADJ,C1
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
-rendezvous,rendezvous,约会,NOUN,B2
-rendition,rendition,词,NOUN,C1
-renegade,renegade,词,NOUN,C1
-renewable energy,renewable energy,可再生能源,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renminbi,renminbi,人民币,NOUN,B2
-renounce,renounce,词,VERB,C1
-renovate,to renovate,翻新,VERB,B2
-renowned,renowned,著名的,ADJ,B2
-rent,to rent,租用,VERB,B2
-rent a car,rent a car,租车,VERB,C1
-rental,rental,词,ADJ,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
-reopening,reopening,词,NOUN,C1
-reoperation,reoperation,再术,NOUN,B2
-reordering,reordering,改序,NOUN,B2
-reorganization,reorganization,重组,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-reparable,reparable,词,ADJ,C1
-reparation,reparation,赔偿,NOUN,B2
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repatriation,repatriation,词,NOUN,C1
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat,to repeat,重复,VERB,B2
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
-repeatedly,repeatedly,反复地,ADV,B2
-repercussion,repercussion,反响,NOUN,B2
-repertoire,repertoire,全部曲目,NOUN,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-replace,to replace,替换,VERB,B2
-replacement,replacement,替代品,NOUN,B2
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
-replanning,replanning,再策,NOUN,B2
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
-reply,reply,回复,NOUN,B2
-reply,to reply,回复,VERB,B2
-reply to your-highness,reply to your-highness,回殿下,NOUN,B2
-report,to report,报告,VERB,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report card,report card,成绩单,NOUN,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reporter,reporter,记者,NOUN,B2
-reporting,reporting,报道,NOUN,B2
-repositioning,repositioning,重新定位,NOUN,B2
-represent,to represent,代表,VERB,B2
-representational,representational,词,ADJ,C1
-repress,to repress,镇压,VERB,B2
-reprice,reprice,再价,NOUN,B2
-reprieve,reprieve,暂缓执行,NOUN,B2
-reprint,reprint,词,NOUN,C1
-reprisal,reprisal,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
-reproachable,reproachable,应受责备的,ADJ,B2
-reprobate,reprobate,词,NOUN,C1
-reproduce,to reproduce,繁殖,VERB,B2
-reproducibility,reproducibility,可重复性,NOUN,B2
-reprogramming,reprogramming,改程,NOUN,B2
-repudiate,repudiate,词,VERB,C1
-repudiation,repudiation,词,NOUN,C1
-repugnant,repugnant,词,ADJ,C1
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
-request (noun),request,绣求,NOUN,B1
-request to rest,request to rest,请息,NOUN,C1
-required course,required course,必修课,NOUN,C1
-requisite,requisite,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,词,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
-rescind,rescind,词,VERB,C1
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resection,resection,词,NOUN,B2
-resent,resent,词,VERB,C1
-reserve price,reserve price,底价,NOUN,C1
-reserves,reserves,储备,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
-resident,resident,定居的,ADJ,B2
-residual,residual,残留的,ADJ,B2
-residue,residue,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resin,resin,词,NOUN,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistant,resistant,词,ADJ,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
-resolve doubts,resolve doubts,解惑,VERB,B2
-resonant,resonant,共鸣的,ADJ,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respectful,respectful,恭敬的,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respective,respective,各自的,ADJ,B2
-respectively,respectively,词,ADV,C1
-respiration,respiration,呼吸作用,NOUN,B2
-respite,respite,喘息,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
-rest assured,rest assured,放心的,ADJ,B2
-restate,restate,词,VERB,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-restock,restock,补货,VERB,C1
-restrain,restrain,词,VERB,C1
-restriction,restriction,限制,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-resume (noun),resume,履历,NOUN,B2
-resumption,resumption,恢复,NOUN,B2
-resurgent,resurgent,词,ADJ,C1
-resuscitate,resuscitate,词,VERB,C1
-retailer,retailer,零售商,NOUN,B2
-retaliate,retaliate,词,VERB,C1
-retarded,retarded,词,ADJ,C1
-retention,retention,留你,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-reticent,reticent,沉默寡言的,ADJ,B2
-retinue,retinue,词,NOUN,B2
-retiree,retiree,退休人员,NOUN,B2
-retirement pension,retirement pension,词,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retranslation,retranslation,重译,NOUN,B2
-retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retroactive,retroactive,词,ADJ,C1
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-retrospective (noun),retrospective,词,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-reunification,reunification,重新统一,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
-revel,revel,词,VERB,C1
-revelry,revelry,词,NOUN,B2
-reverent,reverent,虔诚的,ADJ,B2
-reverentially,reverentially,词,ADV,C1
-reverie,reverie,词,NOUN,C1
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
-revile,revile,词,VERB,C1
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revival,revival,复兴,NOUN,B2
-revocation,revocation,词,NOUN,C1
-revolt,revolt,叛乱,NOUN,B2
-revolver,revolver,词,NOUN,C1
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-ribald,ribald,词,ADJ,C1
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribbon,ribbon,丝带,NOUN,B2
-ribs,ribs,肋骨,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-richer,richer,词,ADJ,B2
-rickety,rickety,词,ADJ,C1
-ricochet,ricochet,词,NOUN,C1
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridicule (noun),ridicule,词,NOUN,C1
-riding me,riding me,骑我,NOUN,C1
-rife,rife,词,ADJ,C1
-right,right,右边,ADV,B2
-right (intj),right,词,INTJ,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightly,rightly,词,ADV,B2
-rights and interests,rights and interests,权益,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
-rile,rile,词,VERB,C1
-rim,rim,词,NOUN,C1
-ringtone,ringtone,词,NOUN,C1
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-risque,risque,有伤风化的,ADJ,C1
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-rival,rival,对手,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-river-gauging,river-gauging,词,ADJ,C1
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-road (adj),road,词,ADJ,B2
-roadblock,roadblock,,NOUN,B2
-roadway,roadway,路面,NOUN,B2
-roar (noun),roar,词,NOUN,B2
-roast (noun),roast,烤透呢,NOUN,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-robber,robber,强盗,NOUN,B2
-robotics,robotics,词,NOUN,C1
-robust,robust,强健的,ADJ,B2
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rock slab,rock slab,岩板,NOUN,B2
-rockery,rockery,假山,NOUN,B2
-rocket,rocket,火箭,NOUN,B2
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rodent,rodent,啮齿动物,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
-rogue,rogue,词,NOUN,B2
-roll,to roll,滚动,VERB,B2
-roller blind,roller blind,卷帘,NOUN,B2
-roller skate,roller skate,词,NOUN,B1
-roman,roman,罗马人,NOUN,B2
-roman (adj),roman,罗马的,ADJ,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-roof,roof,屋顶,NOUN,B2
-roof,to roof,房顶,VERB,B2
-roof top,roof top,上房顶,NOUN,C1
-roominess,roominess,词,NOUN,C1
-roommate,roommate,室友,NOUN,B2
-roots,roots,词,NOUN,C1
-rose bush,rose bush,词,NOUN,B1
-roster,roster,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
-roughly,roughly,大约,ADV,B2
-round,round,圆的,ADJ,B2
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
-rouse,to rouse,唤醒,VERB,B2
-rout,rout,溃败,NOUN,B2
-routing,routing,词,NOUN,C1
-rove,rove,词,VERB,C1
-row series,row series,词,NOUN,B1
-rowboat,rowboat,词,NOUN,B2
-rowing,rowing,赛艇,NOUN,C1
-royalty,royalty,王室,NOUN,B2
-rubber,rubber,橡胶,NOUN,B2
-rubbing,rubbing,摩擦,NOUN,B2
-rubbish,rubbish,垃圾,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubble,rubble,瓦砾,NOUN,B2
-rubicund,rubicund,词,ADJ,C1
-ruby,ruby,词,NOUN,C1
-ruckus,ruckus,词,NOUN,C1
-rudely,rudely,词,ADV,C1
-rudeness,rudeness,粗鲁,NOUN,B2
-rudimentary,rudimentary,词,ADJ,C1
-rueful,rueful,词,ADJ,C1
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
-ruined,ruined,词,ADJ,B2
-rule,rule,规则,NOUN,B2
-rule of law,rule of law,法治,NOUN,B2
-rulebook,rulebook,词,NOUN,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-ruminative,ruminative,词,ADJ,C1
-rummage,rummage,词,VERB,C1
-rumors,rumors,词,NOUN,B2
-run,run,跑步,NOUN,B2
-run into,to run into,碰见,VERB,B2
-run over,to run over,碾过,VERB,B2
-run over (adj),run over,词,ADJ,B2
-run quickly,to run quickly,奔驰,VERB,B2
-run to jog,to run to jog,跑步,VERB,B2
-run-down,run-down,词,ADJ,C1
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,词,NOUN,B2
-rung,rung,词,NOUN,C1
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-rural area,rural area,农村,NOUN,A2
-ruse,ruse,词,NOUN,C1
-rush,rush,赶往,NOUN,B2
-rush about,to rush about,奔波,VERB,B2
-rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
-russian,russian,俄罗斯的,ADJ,B2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rust-proof,rust-proof,防锈,ADJ,B2
-rustic,rustic,乡村的,ADJ,B2
-rusty,rusty,词,ADJ,C1
-ruthless,ruthless,无情的,ADJ,B2
-ruthlessness,ruthlessness,无情,NOUN,B2
-sabbath,sabbath,安息日,NOUN,B2
-sabbatical,sabbatical,词,NOUN,C1
-saber,saber,词,NOUN,C1
-saccharine,saccharine,词,ADJ,C1
-sack,sack,麻袋,NOUN,B2
-sacred,sacred,神圣的,ADJ,B2
-sacrifice,sacrifice,牺牲,NOUN,B2
-sacrifice,to sacrifice,牺牲,VERB,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrilege,sacrilege,亵渎,NOUN,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
-sad sorrowful,sad sorrowful,悲伤,ADJ,B2
-saddening,saddening,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddle pad,saddle pad,词,NOUN,B2
-sadistic,sadistic,施虐的,ADJ,B2
-sadly,sadly,词,ADV,B2
-safe,safe,保险箱,NOUN,B2
-safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
-safety report,safety report,安全报告,NOUN,B2
-safflower,safflower,红花,NOUN,B2
-sagacity,sagacity,词,NOUN,B2
-sage,sage,词,NOUN,C1
-sagittarius,sagittarius,射手座,NOUN,B2
-sailboat,sailboat,,NOUN,B2
-sailor,sailor,水手,NOUN,B2
-sake,sake,缘故,NOUN,B2
-salacious,salacious,词,ADJ,C1
-salad,salad,沙拉,NOUN,B2
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salaried,salaried,词,ADJ,B2
-sales,sales,打折,NOUN,B2
-salesman,salesman,词,NOUN,B2
-salesperson,salesperson,销售人员,NOUN,B2
-salient,salient,词,ADJ,C1
-salinization,salinization,盐碱化,NOUN,C1
-salmon,salmon,三文鱼,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salt shaker,salt shaker,词,NOUN,B2
-salubrious,salubrious,词,ADJ,C1
-salutary,salutary,词,ADJ,C1
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-same,same,相同的,ADJ,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-sanctimonious,sanctimonious,伪善的,ADJ,C1
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
-sanctity,sanctity,词,NOUN,C1
-sanctuary,sanctuary,避难所,NOUN,B2
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
-sandstorm,sandstorm,沙尘暴,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sane,sane,神志正常的,ADJ,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
-santa claus,santa claus,圣诞老人,NOUN,B2
-sap,sap,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sardonic,sardonic,词,ADJ,C1
-satchel,satchel,词,NOUN,C1
-sated,sated,词,ADJ,B2
-satellite,satellite,卫星,NOUN,B2
-satiety,satiety,饱足,NOUN,B2
-satisfactory,satisfactory,令人满意的,ADJ,B2
-satisfy,to satisfy,使满意,VERB,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-saucepan,saucepan,词,NOUN,B2
-saucy,saucy,词,ADJ,B2
-sauna,sauna,词,NOUN,B2
-saunter,saunter,词,VERB,C1
-savant,savant,词,NOUN,C1
-save,to save,保存,VERB,B2
-save me,save me,救我,NOUN,C1
-saving the root,saving the root,救本,NOUN,C1
-savior,savior,救星,NOUN,B2
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-say goodbye,to say goodbye,告别,VERB,B2
-say he,say he,说他,NOUN,C1
-scald,to scald,烫伤,VERB,B2
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,词,NOUN,B2
-scallion,scallion,词,NOUN,B2
-scaly,scaly,词,ADJ,C1
-scan,scan,扫描件,NOUN,B2
-scandalous,scandalous,可耻的,ADJ,B2
-scandinavian,scandinavian,词,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarce,scarce,稀少的,ADJ,B2
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
-scarcely,scarcely,几乎不,ADV,B2
-scare,to scare,惊吓,VERB,B2
-scarecrow,scarecrow,词,NOUN,C1
-scared,scared,害怕的,ADJ,B2
-scary,scary,可怕的,ADJ,B2
-scathing,scathing,词,ADJ,C1
-scatter,to scatter,分散,VERB,B2
-scatterbrained,scatterbrained,词,ADJ,B2
-scattered,scattered,分散的,ADJ,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
-scenery,scenery,风景,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-sceptical,sceptical,词,ADJ,C1
-schedule,schedule,时间表,NOUN,B2
-schema,schema,词,NOUN,B2
-schematic,schematic,概要的,ADJ,B2
-scheme,scheme,计划,NOUN,B2
-schism,schism,分裂,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-scholar,scholar,学者,NOUN,B2
-scholar learned,scholar learned,词,NOUN,C1
-scholarship holder,scholarship holder,奖学金生,NOUN,B2
-scholing,scholing,词,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school,school,学校的,ADJ,B2
-school bag,school bag,词,NOUN,A2
-school bench,school bench,词,NOUN,A1
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-school year,school year,学年,NOUN,B2
-schoolbag,schoolbag,词,NOUN,A1
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schoolyard,schoolyard,词,NOUN,A1
-science,science,科学,NOUN,B2
-scientifically,scientifically,科学地,ADV,B2
-scientist,scientist,科学家,NOUN,B2
-scientists,scientists,科学家,NOUN,B2
-scintillate,scintillate,词,VERB,C1
-scoff (noun),scoff,词,NOUN,C1
-scoff (verb),scoff,词,VERB,C1
-scooter,scooter,踏板摩托车,NOUN,B2
-scorch,to scorch,烧焦,VERB,B2
-score,score,比分,NOUN,B2
-scorn,scorn,轻蔑,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scottish,scottish,词,ADJ,B2
-scour,scour,词,VERB,C1
-scourge,scourge,灾祸,NOUN,B2
-scout,scout,侦察员,NOUN,B2
-scouting locating,scouting locating,词,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-scratch,scratch,抓痕,NOUN,B2
-scratch,to scratch,抓,VERB,B2
-scream (noun),scream,尖叫,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
-screenwriter,screenwriter,编剧,NOUN,B2
-screw up,screw up,词,VERB,C1
-scribble (noun),scribble,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulous,scrupulous,一丝不苟的,ADJ,B2
-scrupulously,scrupulously,一丝不苟地,ADV,B2
-scrutiny,scrutiny,明察,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-scumbag,scumbag,词,NOUN,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scurvy,scurvy,词,NOUN,C1
-scuttle,scuttle,词,VERB,C1
-scythe,scythe,词,NOUN,B2
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seal,seal,海豹,NOUN,B2
-seam,seam,词,NOUN,C1
-seamless,seamless,无缝的,ADJ,B2
-seaplane,seaplane,词,NOUN,B2
-seaport,seaport,海港,NOUN,C1
-search engine,search engine,搜索引擎,NOUN,B2
-search engine optimization,search engine optimization,词,NOUN,C1
-search warrant,search warrant,词,NOUN,C1
-seaside,seaside,海滨,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seated,seated,坐着的,ADJ,B2
-seaweed,seaweed,词,NOUN,C1
-secession,secession,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-second (num),second,词,NUM,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
-secret,secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
-section chief,section chief,课长,NOUN,B2
-secular,secular,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
-secure (adj),secure,词,ADJ,B1
-security service,security service,词,NOUN,C1
-sedate,sedate,词,ADJ,C1
-sedentary,sedentary,久坐的,ADJ,C1
-sedentary lifestyle,sedentary lifestyle,词,NOUN,B2
-sediment,sediment,词,NOUN,C1
-sedition,sedition,煽动叛乱,NOUN,B2
-seditious,seditious,词,ADJ,C1
-sedulous,sedulous,词,ADJ,C1
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedy,seedy,词,ADJ,C1
-seeker,seeker,寻求者,NOUN,B2
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-segregation,segregation,隔离，分离,NOUN,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-seldom,seldom,很少,ADV,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
-selectively,selectively,词,ADV,B2
-selector,selector,词,NOUN,C1
-self,self,自己,PRON,B2
-self (adv),self,词,ADV,B2
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
-self-confident,self-confident,自信的,ADJ,B2
-self-deception,self-deception,词,NOUN,C1
-self-defense,self-defense,词,NOUN,B2
-self-denial,self-denial,自我牺牲,NOUN,B2
-self-drive,self-drive,自驾,VERB,C1
-self-employed person,self-employed person,个体经营者,NOUN,B2
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-image,self-image,自我形象,NOUN,B2
-self-interest,self-interest,词,NOUN,B2
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-sacrifice,self-sacrifice,舍己,NOUN,B2
-self-taught,self-taught,自学的,ADJ,B2
-self-worth,self-worth,词,NOUN,B2
-selfie,selfie,自拍,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfless,selfless,词,ADJ,B2
-semblance,semblance,词,NOUN,C1
-semicolon,semicolon,分号,PUNCT,B2
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
-seminary,seminary,词,NOUN,C1
-senate,senate,参议院,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-sending,sending,词,NOUN,B1
-senescence,senescence,词,NOUN,B2
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
-seniors,seniors,词,NOUN,C1
-sensation,sensation,感觉,NOUN,B2
-sense of duty,sense of duty,词,NOUN,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
-senseless,senseless,无意义的,ADJ,B2
-sensible,sensible,明智的,ADJ,B2
-sensibly,sensibly,词,ADV,B2
-sensitive,sensitive,敏感的,ADJ,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
-sensor donor,sensor donor,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensual,sensual,感官的,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
-sentence,to sentence,判决,VERB,B2
-sentence verdict,sentence verdict,词,NOUN,B2
-sentences,sentences,词,NOUN,B2
-sentencing,sentencing,词,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentient,sentient,词,ADJ,C1
-sentinel,sentinel,哨兵,NOUN,B2
-sentry,sentry,卫兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separate,separate,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
-separatist,separatist,词,NOUN,C1
-seraphic,seraphic,词,ADJ,C1
-serendipity,serendipity,词,NOUN,C1
-serene,serene,宁静的,ADJ,B2
-serenely,serenely,词,ADV,C1
-sergeant,sergeant,中士,NOUN,B2
-serial,serial,词,NOUN,B1
-serial killer,serial killer,连环杀手,NOUN,B2
-serialized drama,serialized drama,连续剧,NOUN,B2
-series of conversations,series of conversations,词,NOUN,B2
-seriously,seriously,认真地,ADV,B2
-serous,serous,词,ADJ,C1
-serpentine,serpentine,词,ADJ,C1
-serve,to serve,服务,VERB,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
-service,service,服务,NOUN,B2
-service favor,service favor,词,NOUN,A2
-service provider,service provider,服务商,NOUN,B2
-service road,service road,辅路,NOUN,B2
-service year,service year,,NOUN,B2
-services,services,词,NOUN,C1
-servile,servile,词,ADJ,C1
-servilely,servilely,奴性地,ADV,B2
-session,session,会议,NOUN,B2
-set,to set,设置,VERB,B2
-set a record,set a record,创造纪录,VERB,B2
-set of ideals,set of ideals,词,NOUN,B2
-set square,set square,词,NOUN,B2
-set up,to set up,建立,VERB,B2
-setting,setting,词,NOUN,B1
-setting sun,setting sun,夕阳,NOUN,B2
-settle,to settle,解决,VERB,B2
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seventeen,seventeen,十七,NUM,B2
-seventh,seventh,第七,ADJ,B2
-sever,sever,词,VERB,C1
-several,several,几个,ADJ,B2
-several (det),several,几个,DET,A2
-several (noun),several,若干,NOUN,B2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times,several times,几遍,NOUN,B2
-several times (adv),several times,词,ADV,C1
-severance,severance,词,NOUN,C1
-severely,severely,严厉地,ADV,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
-sewing,sewing,缝纫,NOUN,B2
-sewing needle,sewing needle,词,NOUN,C1
-sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexily,sexily,性感地,ADV,B2
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
-sexually,sexually,在性方面,ADV,B2
-sexy,sexy,性感的,ADJ,B2
-sh,sh,词,INTJ,C1
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shady,shady,阴凉的,ADJ,B2
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shaft,shaft,词,NOUN,B2
-shake hands,to shake hands,握手,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,词,AUX,B2
-shallow,shallow,浅的,ADJ,B2
-shambles,shambles,词,NOUN,C1
-shame,to shame,使羞愧,VERB,B2
-shame culture,shame culture,词,NOUN,B2
-shame pity,shame pity,词,NOUN,B2
-shameful,shameful,可耻的,ADJ,B2
-shameless person,shameless person,词,NOUN,B2
-shamelessness,shamelessness,无耻,NOUN,B2
-shape,to shape,塑造,VERB,B2
-shards,shards,词,NOUN,B2
-share,to share,分享,VERB,B2
-shared boundary ownership,shared boundary ownership,词,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shark,shark,鲨鱼,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-sharply,sharply,词,ADV,B2
-shatter,to shatter,粉碎,VERB,B2
-she,she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-sheaf,sheaf,捆,NOUN,B2
-shed,shed,棚屋,NOUN,B2
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet,sheet,床单,NOUN,B2
-sheet of paper,sheet of paper,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift,to shift,改变,VERB,B2
-shift rotation,shift rotation,倒班,NOUN,B2
-shift swap,shift swap,换班,NOUN,B2
-shift to an earlier date,to shift to an earlier date,提前,VERB,B2
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shine,to shine,照耀,VERB,B2
-shining,shining,词,ADJ,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship out,to ship out,出货,VERB,B2
-shipment,shipment,货物,NOUN,B2
-shipyard,shipyard,造船厂,NOUN,B2
-shirk,shirk,词,VERB,C1
-shit,shit,恐惧,NOUN,B2
-shit (adj),shit,该死的,ADJ,B2
-shit crap,shit crap,词,NOUN,B2
-shitty,shitty,词,ADJ,B2
-shiver,shiver,寒战,NOUN,B2
-shock,to shock,震惊,VERB,B2
-shocked,shocked,震惊的,ADJ,B2
-shocking,shocking,令人震惊的,ADJ,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoe,shoe,鞋,NOUN,B2
-shoe polish,shoe polish,词,NOUN,B2
-shoe removal,shoe removal,鞋脱,NOUN,B2
-shoelace,shoelace,词,NOUN,C1
-shoot,to shoot,射击,VERB,B2
-shoot at,shoot at,词,VERB,C1
-shoot down,to shoot down,击落,VERB,B2
-shooter,shooter,射手,NOUN,B2
-shooting,shooting,射击,NOUN,B2
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shootout,shootout,枪战,NOUN,B2
-shop,to shop,购物,VERB,B2
-shopkeeper,shopkeeper,词,NOUN,C1
-shopping,shopping,购物,NOUN,B2
-shopping center,shopping center,购物中心,NOUN,B2
-shopping mall,shopping mall,商场,NOUN,B2
-shore,shore,岸,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short film,short film,短片,NOUN,B2
-short news item,short news item,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-short-term,short-term,短期的,ADJ,B2
-shortage,shortage,短缺,NOUN,B2
-shortcoming,shortcoming,缺点,NOUN,B2
-shortcut,shortcut,捷径,NOUN,B2
-shorten,to shorten,缩短,VERB,B2
-shorter,shorter,词,ADJ,B2
-shortly,shortly,不久,ADV,B2
-shotgun,shotgun,猎枪,NOUN,B2
-should,should,应该,AUX,B2
-should (adv),should,你该,ADV,B2
-should not,should not,不该,AUX,B2
-should ought to,should ought to,应该,AUX,B2
-shout,shout,喊叫,NOUN,B2
-show,show,表演,NOUN,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-shower,to shower,淋浴,VERB,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-showy,showy,词,ADJ,B2
-shriek,shriek,词,VERB,C1
-shrill,shrill,尖锐的,ADJ,B2
-shrimp,shrimp,虾,NOUN,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrivel,shrivel,词,VERB,C1
-shrub,shrub,词,NOUN,C1
-shrug,shrug,词,VERB,C1
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shuttle,shuttle,穿梭巴士,NOUN,B2
-sibilant,sibilant,词,ADJ,C1
-sibling,sibling,兄弟姐妹,NOUN,B2
-sibyl,sibyl,词,NOUN,C1
-sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickly,sickly,词,ADJ,C1
-sickness,sickness,词,NOUN,B2
-side,side,骄傲的,ADJ,B2
-side door,side door,侧门,NOUN,B2
-side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-siege time,siege time,攻城时,NOUN,C1
-sifted,sifted,词,ADJ,C1
-sigh,sigh,叹息,NOUN,B2
-sigh with sorrow,to sigh with sorrow,感慨,VERB,B2
-sighing,sighing,叹息的,ADJ,B2
-sightseeing,sightseeing,词,NOUN,C1
-sign,to sign,签名,VERB,B2
-sign brand,sign brand,词,NOUN,C1
-sign for,to sign for,签收,VERB,B2
-signal,to signal,示意,VERB,B2
-signatory,signatory,词,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signed,signed,词,ADJ,B2
-significant,significant,重要的,ADJ,B2
-signify,to signify,意味着,VERB,B2
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silenced,silenced,词,ADJ,C1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-silly thing,silly thing,词,NOUN,C1
-silvery,silvery,词,ADJ,C1
-simian,simian,词,ADJ,C1
-similarly,similarly,词,ADV,B2
-simony,simony,词,NOUN,C1
-simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
-simulator,simulator,词,NOUN,C1
-simultaneously,simultaneously,同时地,ADV,B2
-since,since,以来,PART,B2
-since (sconj),since,既,SCONJ,A2
-since then,since then,从那以后,ADV,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerely,sincerely,真诚地,ADV,B2
-sinecure,sinecure,词,NOUN,C1
-sinew,sinew,词,NOUN,C1
-single,single,单曲,NOUN,B2
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-singular (adj),singular,词,ADJ,C1
-singularity,singularity,单一性,NOUN,B2
-sinister,sinister,不祥的,ADJ,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sinuous,sinuous,词,ADJ,C1
-sir,sir,郎,PART,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-site,site,词,NOUN,B1
-sitting stably,sitting stably,坐得,NOUN,C1
-six-line stanza,six-line stanza,词,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixteen,sixteen,十六,NUM,B2
-sixth,sixth,,NOUN,B2
-skate (noun),skate,词,NOUN,A2
-skater,skater,skater,NOUN,B2
-skating,skating,词,NOUN,B2
-skeletal,skeletal,词,ADJ,C1
-skeptic,skeptic,词,NOUN,C1
-ski (noun),ski,词,NOUN,C1
-ski resort,ski resort,滑雪场,NOUN,C1
-skid slip-up,skid slip-up,词,NOUN,C1
-skilful,skilful,熟练的,ADJ,B2
-skillful,skillful,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skin hide,skin hide,词,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-skirmish,skirmish,小规模战斗,NOUN,B2
-sky blue,sky blue,天蓝色,ADJ,B2
-skylight,skylight,天窗,NOUN,B2
-slack off,slack off,词,VERB,C1
-slackening dip,slackening dip,词,NOUN,C1
-slake,slake,词,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slammer jail,slammer jail,词,NOUN,C1
-slander (noun),slander,词,NOUN,B2
-slang,slang,俚语,NOUN,B2
-slanted,slanted,斜,ADJ,B2
-slaughter (noun),slaughter,屠,NOUN,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleek,sleek,词,ADJ,C1
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleeper,sleeper,词,NOUN,C1
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
-sleigh,sleigh,雪橇,NOUN,C1
-slender,slender,词,ADJ,B2
-slenderness,slenderness,词,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-slick,slick,词,ADJ,C1
-sliding,sliding,滑动的,ADJ,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
-slim,slim,苗条,ADJ,B2
-slimy,slimy,词,ADJ,B2
-sling,sling,词,NOUN,C1
-slip (noun),slip,词,NOUN,C1
-slit,slit,词,NOUN,C1
-slither,slither,词,VERB,C1
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slothful,slothful,懒惰的,ADJ,B2
-slovenly,slovenly,词,ADJ,C1
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
-slower,slower,更慢,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slum,slum,贫民窟,NOUN,B2
-slur,slur,词,VERB,C1
-slut,slut,荡妇,NOUN,B2
-slyly,slyly,词,ADV,C1
-small bag,small bag,词,NOUN,C1
-small basket,small basket,词,NOUN,C1
-small boat,small boat,词,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small step,small step,词,NOUN,C1
-small sword,small sword,词,NOUN,C1
-small things,small things,词,NOUN,B2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
-smear,smear,抹,NOUN,C1
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoker,smoker,词,NOUN,C1
-smoking (adj),smoking,词,ADJ,C1
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
-smugness,smugness,词,NOUN,C1
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snap (verb),snap,词,VERB,C1
-snare,snare,词,NOUN,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneaker,sneaker,词,NOUN,A1
-sneer,sneer,词,VERB,C1
-sneeze (noun),sneeze,词,NOUN,C1
-sniffle,sniffle,词,VERB,C1
-sniper,sniper,狙击手,NOUN,B2
-snippet,snippet,词,NOUN,C1
-snitch,snitch,告密者,NOUN,B2
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snooping,snooping,词,NOUN,C1
-snore,snore,打呼噜,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowdrift,snowdrift,词,NOUN,B1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so much,so much,那么多,DET,B2
-so much so many,so much so many,词,ADV,C1
-so thus,so thus,所以/如此,ADV,B2
-so to speak,so to speak,可以说,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-so-called,so-called,,NOUN,B2
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
-sobriquet,sobriquet,词,NOUN,C1
-soccer,soccer,足球,NOUN,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social problem,social problem,社会问题,NOUN,B2
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social standard,social standard,社会标准,NOUN,C1
-social status,social status,社会地位,NOUN,C1
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social turmoil,social turmoil,社会动荡,NOUN,C1
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialist,socialist,社会主义的,ADJ,B2
-socialist (noun),socialist,社会主义者,NOUN,B2
-socialize,to socialize,交往,VERB,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,词,ADV,C1
-societal,societal,词,ADJ,B2
-sociological,sociological,词,ADJ,C1
-sociologist,sociologist,社会学家,NOUN,B2
-socket,socket,词,NOUN,C1
-soda,soda,苏打,NOUN,B2
-softball,softball,垒球,NOUN,B2
-softness,softness,词,NOUN,B2
-software,software,软件,NOUN,B2
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-sojourn,sojourn,逗留,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-soldier,soldier,士兵,NOUN,B2
-soldiers,soldiers,官兵,NOUN,B2
-solecism,solecism,语法错误,NOUN,B2
-solely,solely,词,ADV,C1
-solemn,solemn,庄严的,ADJ,B2
-solemn (noun),solemn,solemn,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solemnly,solemnly,词,ADV,C1
-solicit,to solicit,恳求,VERB,B2
-solicit donations,to solicit donations,募捐,VERB,B2
-solicitation,solicitation,词,NOUN,C1
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solicitude,solicitude,词,NOUN,B2
-solid,solid,固体的,ADJ,B2
-solid substantial,solid substantial,词,ADJ,B2
-solid-state drive,solid-state drive,固态硬盘,NOUN,B2
-solidity,solidity,固,NOUN,C1
-solipsism,solipsism,唯我论,NOUN,B2
-solitary,solitary,孤独的,ADJ,B2
-solstice,solstice,词,NOUN,C1
-solve a case,solve a case,破案,VERB,B2
-somber,somber,词,ADJ,B2
-some,some,一些,DET,B2
-some (noun),some,词,NOUN,B2
-some (pron),some,词,PRON,B2
-some many a,some many a,词,DET,A2
-some out,some out,出些,NOUN,B2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-somebody,somebody,词,PRON,A1
-somehow,somehow,以某种方式,ADV,B2
-someone,someone,某人,PRON,B2
-someone stealing,someone stealing,有人偷,NOUN,C1
-someone's,someone's,某人的,PRON,B2
-something,something,某事,PRON,B2
-something better,something better,词,NOUN,C1
-something like that,something like that,词,PRON,B2
-sometime,sometime,在某个时候,ADV,B2
-somewhat,somewhat,词,ADV,C1
-somewhere,somewhere,某处,ADV,B2
-somewhere (noun),somewhere,somewhere,NOUN,B2
-somewhere else,somewhere else,词,ADV,B1
-somnolent,somnolent,词,ADJ,C1
-son of a bitch,son of a bitch,词,NOUN,B2
-son-in-law,son-in-law,词,NOUN,A2
-song,song,歌,PART,B2
-song festival,song festival,词,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sonorous,sonorous,词,ADJ,C1
-soon,soon,很快,ADV,B2
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soothing,soothing,词,ADJ,C1
-sophism,sophism,诡辩,NOUN,B2
-sophist,sophist,词,NOUN,B2
-sophisticated,sophisticated,复杂的,ADJ,B2
-sophomoric,sophomoric,词,ADJ,C1
-soporific,soporific,词,ADJ,C1
-sorcerer,sorcerer,巫师,NOUN,B2
-sordid,sordid,肮脏的,ADJ,B2
-sore,sore,疼痛的,ADJ,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry,sorry,抱歉,ADJ,B2
-sorry (intj),sorry,对不起,INTJ,B2
-sorry (noun),sorry,词,NOUN,A1
-sort,sort,种类,NOUN,B2
-sort,to sort,分类,VERB,B2
-sortie,sortie,词,NOUN,C1
-sought,sought,,NOUN,B2
-soul,soul,灵魂,NOUN,B2
-soulmate,soulmate,词,NOUN,C1
-sound,to sound,响起,VERB,B2
-sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,词,NOUN,B2
-sound of activity,sound of activity,动静,NOUN,B2
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundtrack,soundtrack,! 音轨,NOUN,B2
-sour cherry,sour cherry,词,NOUN,C1
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern,southern,南方的,ADJ,B2
-southern army,southern army,南军,NOUN,B2
-southern part,southern part,南部,NOUN,B2
-southward,southward,词,ADV,B2
-southwest,southwest,西南的,ADJ,B2
-sovereign,sovereign,君主,NOUN,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-sow,sow,母猪,NOUN,B2
-sow,to sow,播种,VERB,B2
-sow (noun),sow,母猪,NOUN,B2
-soy,soy,词,NOUN,C1
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space technology,space technology,航天技术,NOUN,C1
-spaceship,spaceship,宇宙飞船,NOUN,B2
-spacious,spacious,宽敞的,ADJ,B2
-spade,spade,铲子,NOUN,B2
-spam (noun),spam,词,NOUN,B1
-span cleaner,span cleaner,词,NOUN,B2
-spandex,spandex,氨纶,NOUN,C1
-spanish,spanish,西班牙的,ADJ,B2
-spanking,spanking,词,NOUN,B2
-spar,spar,词,VERB,C1
-spare,to spare,节省,VERB,B2
-spare (adj),spare,词,ADJ,B1
-spare (noun),spare,词,NOUN,C1
-spare time,spare time,业余,NOUN,B2
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
-sparrowhawk,sparrowhawk,词,NOUN,B2
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spate,spate,词,NOUN,C1
-spatial,spatial,空间的,ADJ,B2
-spatula,spatula,词,NOUN,B2
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specifically,specifically,具体地,ADV,B2
-specificity,specificity,词,NOUN,C1
-specious,specious,似是而非的,ADJ,B2
-specter,specter,词,NOUN,C1
-speculative,speculative,词,ADJ,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-spelling,spelling,拼写,NOUN,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-spent,spent,词,ADJ,B2
-sperm,sperm,精子,NOUN,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-spice,spice,香料,NOUN,B2
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spine,spine,脊柱,NOUN,B2
-spinning mill,spinning mill,纺纱厂,NOUN,B2
-spiral,spiral,词,NOUN,C1
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit world,spirit world,词,NOUN,B2
-spirited,spirited,词,ADJ,B2
-spiritual,spiritual,精神的,ADJ,B2
-spite,spite,恶意,NOUN,B2
-spittle,spittle,唾沫,NOUN,B2
-splash,splash,扑通,NOUN,B2
-splay,splay,词,VERB,C1
-splinter (noun),splinter,词,NOUN,B2
-split secession,split secession,分裂,NOUN,B2
-spoiled,spoiled,词,ADJ,B2
-spoiler,spoiler,词,NOUN,C1
-spoliation,spoliation,词,NOUN,C1
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
-sponsor (noun),sponsor,词,NOUN,B2
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-sporadic,sporadic,词,ADJ,C1
-sporadically,sporadically,词,ADV,B2
-sports,sports,体育,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,词,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot,spot,地点,NOUN,B2
-spot goods,spot goods,现货,NOUN,C1
-spree,spree,词,NOUN,C1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-spry,spry,词,ADJ,C1
-spurious,spurious,虚假的,ADJ,B2
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-squabble (noun),squabble,词,NOUN,B2
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squall,squall,骤雨,NOUN,B2
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak (noun),squeak,吱吱声,NOUN,B2
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squid,squid,词,NOUN,B2
-squire,squire,词,NOUN,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-stab (noun),stab,捅,NOUN,C1
-stabilization,stabilization,稳定化,NOUN,B2
-stably,stably,稳定地,ADV,B2
-stack (noun),stack,词,NOUN,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
-staging,staging,上演,NOUN,B2
-stagnant,stagnant,停滞的,ADJ,B2
-staid,staid,词,ADJ,C1
-staircase,staircase,词,NOUN,B1
-stairwell,stairwell,楼梯间,NOUN,C1
-stalemate,stalemate,词,NOUN,C1
-stalwart,stalwart,词,ADJ,C1
-stamina,stamina,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stampede,stampede,词,NOUN,B2
-stanch,stanch,词,VERB,C1
-stand,stand,摊位,NOUN,B2
-standby,standby,待机,VERB,C1
-standing,standing,就站,NOUN,B2
-standing (adv),standing,词,ADV,A1
-standpoint,standpoint,词,NOUN,B2
-standstill,standstill,停滞,NOUN,B2
-stanza,stanza,词,NOUN,B2
-staple,staple,词,NOUN,C1
-stapler,stapler,词,NOUN,A2
-star anise,star anise,八角,NOUN,B2
-star celebrity,star celebrity,词,NOUN,B1
-star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-stark,stark,词,ADJ,B2
-starry sky,starry sky,星空,NOUN,B2
-start,start,开始,NOUN,B2
-start of school year,start of school year,词,NOUN,B1
-starter,starter,词,NOUN,C1
-starting point,starting point,词,NOUN,B2
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-starve,to starve,挨饿,VERB,B2
-starved,starved,饥饿的,ADJ,B2
-state,to state,说明,VERB,B2
-state (adj),state,词,ADJ,B1
-state federal,state federal,词,NOUN,B2
-state of emergency,state of emergency,词,NOUN,C1
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-statics,statics,词,NOUN,C1
-stationery,stationery,文具,NOUN,B2
-stationery shop,stationery shop,词,NOUN,B2
-statism,statism,词,NOUN,C1
-statistic,statistic,统计数据,NOUN,B2
-statute,statute,词,NOUN,C1
-statutory rape,statutory rape,词,NOUN,C1
-staunch,staunch,坚定的,ADJ,B2
-stave,stave,词,NOUN,C1
-stay,to stay,停留,VERB,B2
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadily,steadily,词,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
-steady,steady,稳定的,ADJ,B2
-steak,steak,牛排,NOUN,B2
-steal sword,steal sword,盗剑,NOUN,B2
-stealth,stealth,秘密行动,NOUN,B2
-stealthy,stealthy,词,ADJ,C1
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steamed stuffed bun,steamed stuffed bun,包子,NOUN,B2
-steep,steep,陡峭的,ADJ,B2
-steer,to steer,引导,VERB,B2
-steering,steering,掌舵的,ADJ,B2
-steering (noun),steering,词,NOUN,C1
-steering control,steering control,词,NOUN,C1
-steering wheel,steering wheel,方向盘,NOUN,B2
-stem cell,stem cell,干细胞,NOUN,C1
-stemming,stemming,词,ADJ,B1
-stench,stench,恶臭,NOUN,B2
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-stepfather,stepfather,词,NOUN,A1
-stepmother,stepmother,后母,NOUN,B2
-steppe,steppe,词,NOUN,C1
-steps,steps,台阶,NOUN,B2
-stepson,stepson,词,NOUN,A2
-stereotype,stereotype,刻板印象,NOUN,B2
-stereotypical,stereotypical,词,ADJ,C1
-sterile,sterile,无菌的,ADJ,B2
-sterility,sterility,词,NOUN,C1
-stern (adj),stern,词,ADJ,C1
-stern (noun),stern,词,NOUN,C1
-stevedore,stevedore,词,NOUN,C1
-stew,stew,炖菜,NOUN,B2
-stew,to stew,炖,VERB,B2
-stick,stick,棍子,NOUN,B2
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiff,stiff,僵硬的,ADJ,B2
-stiff glove,stiff glove,词,NOUN,B2
-stifle,stifle,词,VERB,C1
-stigmatization,stigmatization,词,NOUN,B2
-stiletto,stiletto,词,NOUN,C1
-still,still,仍然,ADV,B2
-still also,still also,还,ADV,A1
-stillness,stillness,静中,NOUN,B2
-stilted,stilted,词,ADJ,C1
-stimulate,to stimulate,激发,VERB,B2
-stimulating,stimulating,词,ADJ,C1
-stimulus,stimulus,刺激,NOUN,B2
-sting,to sting,刺,VERB,B2
-stink (noun),stink,词,NOUN,B2
-stipend,stipend,津贴,NOUN,B2
-stipulation,stipulation,词,NOUN,C1
-stir,stir,搅拌,NOUN,B2
-stir-fry,stir-fry,炒,VERB,B1
-stitch,stitch,针脚,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
-stock,stock,库存,NOUN,B2
-stock market,stock market,股市,NOUN,B2
-stock-market,stock-market,词,ADJ,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stocking,stocking,词,NOUN,C1
-stockpile,stockpile,储备,NOUN,B2
-stodgy,stodgy,词,ADJ,C1
-stoic,stoic,坚忍的,ADJ,B2
-stoically,stoically,词,ADV,C1
-stoke,to stoke,添燃料,VERB,B2
-stolen,stolen,被偷的,ADJ,B2
-stolid,stolid,冷漠的,ADJ,C1
-stomach ache,stomach ache,词,NOUN,C1
-stomachache,stomachache,肚子痛,NOUN,B2
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stool,stool,词,NOUN,C1
-stop bleeding,stop bleeding,止血,VERB,B2
-stop me,to stop me,拦我,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-stopover,stopover,中途停留,NOUN,B2
-storage room,storage room,储藏室,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-story history,story history,词,NOUN,A1
-stout,stout,词,ADJ,C1
-stove,stove,炉灶,NOUN,B2
-stowage,stowage,词,NOUN,C1
-straight,straight,笔直的,ADJ,B2
-straight (adv),straight,直接地,ADV,B1
-straight (noun),straight,直的,NOUN,B2
-straight ahead,straight ahead,词,ADV,B2
-straighten,to straighten,弄直,VERB,B2
-straightforward,straightforward,直率的,ADJ,B2
-straitjacket,straitjacket,词,NOUN,C1
-strand,strand,词,NOUN,C1
-strange troops,strange troops,怪兵,NOUN,B2
-strangely,strangely,奇怪地,ADV,B2
-strangeness,strangeness,奇怪,NOUN,B2
-stranger,stranger,陌生人,NOUN,B2
-strangulation,strangulation,词,NOUN,C1
-strap,strap,带子,NOUN,B2
-strapping,strapping,词,ADJ,C1
-stratagem,stratagem,策略,NOUN,B2
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratification,stratification,词,NOUN,C1
-stratum,stratum,阶层,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-stream,stream,溪流,NOUN,B2
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-strength,strength,力量,NOUN,B2
-strengthening,strengthening,词,NOUN,C1
-strenuous,strenuous,费力的,ADJ,B2
-stressed,stressed,焦虑的,ADJ,B2
-stressful,stressful,有压力的,ADJ,B2
-stretch,stretch,伸展,NOUN,B2
-stretched,stretched,词,ADJ,C1
-strictly,strictly,词,ADV,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-stride (noun),stride,词,NOUN,C1
-strident,strident,刺耳的,ADJ,B2
-strife,strife,词,NOUN,B2
-strikebreaker,strikebreaker,词,NOUN,C1
-striker,striker,罢工者,NOUN,B2
-striking,striking,词,ADJ,B2
-string,string,细绳,NOUN,B2
-string music,string music,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-stripe,stripe,条纹,NOUN,B2
-striped,striped,词,ADJ,B2
-stripping,stripping,词,ADJ,B2
-striving,striving,词,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-stroke,stroke,中风,NOUN,B2
-stroll,stroll,闲逛,NOUN,B2
-stroller,stroller,婴儿车,NOUN,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structure,to structure,构建,VERB,B2
-structuredness,structuredness,结构性,NOUN,B2
-struggle,struggle,斗争,NOUN,B2
-struggle,to struggle,挣扎,VERB,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studies,studies,学业,NOUN,B2
-studious,studious,词,ADJ,C1
-study,to study,学习,VERB,B2
-study tour,study tour,游学,NOUN,C1
-stuff,stuff,东西,NOUN,B2
-stuff,to stuff,填塞,VERB,B2
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stunning,stunning,极好的,ADJ,B2
-stunt,stunt,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupefied,stupefied,词,ADJ,C1
-stupendous,stupendous,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
-stupor,stupor,昏迷,NOUN,B2
-stylish,stylish,雅致的,ADJ,B2
-stylist,stylist,词,NOUN,C1
-stymie,stymie,词,VERB,C1
-su sha,su sha,我夙砂,NOUN,B2
-suave,suave,词,ADJ,C1
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subconscious,subconscious,潜意识,NOUN,B2
-subdue,to subdue,制服,VERB,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject field,subject field,词,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,词,ADJ,B2
-subject topic,subject topic,主题/话题,NOUN,B2
-subjection,subjection,词,NOUN,B2
-sublime,sublime,崇高的,ADJ,B2
-subliminal,subliminal,词,ADJ,C1
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordinate,subordinate,下属,NOUN,B2
-subordination,subordination,隶属,NOUN,C1
-subpoena,subpoena,词,NOUN,B2
-subscribe,to subscribe,订阅,VERB,B2
-subsequently,subsequently,词,ADV,C1
-subservient,subservient,词,ADJ,C1
-subside,to subside,平息,VERB,B2
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,词,NOUN,B2
-subsidiary,subsidiary,子公司,NOUN,B2
-subsidize,to subsidize,资助,VERB,B2
-substance,substance,物质,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantial,substantial,大量的,ADJ,B2
-substantially,substantially,词,ADV,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subtitle,subtitle,字幕,NOUN,B2
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-subtle,subtle,微妙的,ADJ,B2
-subtlety,subtlety,微妙,NOUN,B2
-subtly,subtly,词,ADV,C1
-suburban,suburban,词,ADJ,C1
-suburbs,suburbs,词,NOUN,B2
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
-subway,subway,地铁,NOUN,B2
-successful,successful,成功的,ADJ,B2
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
-successor,successor,继任者,NOUN,B2
-succinctly,succinctly,词,ADV,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-such,such,如此,DET,B2
-such a,such a,这样的,DET,B2
-such a thing,such a thing,词,PRON,B1
-sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suffering (adj),suffering,词,ADJ,C1
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffocating,suffocating,词,ADJ,B2
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestibility,suggestibility,词,NOUN,C1
-suicidal,suicidal,词,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sully,sully,词,VERB,C1
-sultriness,sultriness,词,NOUN,B2
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-summarily,summarily,草率地,ADV,B2
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
-sumptuousness,sumptuousness,词,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower,sunflower,向日葵,NOUN,B2
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
-sunny day,sunny day,晴天,NOUN,C1
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super (adv),super,词,ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-proof,super-proof,超证,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-theory,super-theory,超论,NOUN,C1
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-superb,superb,极好的,ADJ,B2
-supercilious,supercilious,词,ADJ,C1
-superhero,superhero,词,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior,superior,上级,NOUN,B2
-superior upper,superior upper,词,ADJ,C1
-superiority,superiority,优越性/优势,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supernumerary,supernumerary,词,ADJ,C1
-supersede,supersede,词,VERB,C1
-superstitious,superstitious,迷信的,ADJ,B2
-supine,supine,词,ADJ,C1
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplies,supplies,词,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
-support medium,support medium,词,NOUN,C1
-supported,supported,词,ADJ,B2
-supporter advocate,supporter advocate,词,NOUN,B1
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,词,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-supposition,supposition,词,NOUN,C1
-suppression of us,suppression of us,压咱,NOUN,C1
-supremacy,supremacy,霸权,NOUN,B2
-supreme,supreme,最高的,ADJ,B2
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-surcharge,surcharge,附加费,NOUN,B2
-sure,sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-surety bond,surety bond,词,NOUN,C1
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surgical,surgical,外科的,ADJ,B2
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus (adj),surplus,词,ADJ,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
-surprised,surprised,惊讶的,ADJ,B2
-surprising,surprising,令人惊讶的,ADJ,B2
-surrender,to surrender,投降,VERB,B2
-surreptitious,surreptitious,秘密的,ADJ,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrogate,surrogate,词,NOUN,C1
-surround,to surround,包围,VERB,B2
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
-surroundings,surroundings,周围,NOUN,B2
-surveil,to surveil,监视,VERB,B2
-survival,survival,生存,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
-susha,susha,夙砂大,NOUN,B2
-suspect,to suspect,怀疑,VERB,B2
-suspend,to suspend,暂停,VERB,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-sustain,sustain,词,VERB,C1
-sustainability policy,sustainability policy,词,NOUN,C1
-suture,to suture,缝合,VERB,B2
-svelte,svelte,词,ADJ,C1
-swagger (noun),swagger,词,NOUN,B2
-swap,swap,词,VERB,B2
-swarm (noun),swarm,词,NOUN,C1
-swarthy,swarthy,词,ADJ,C1
-sweat,to sweat,出汗,VERB,B2
-sweater,sweater,毛衣,NOUN,B2
-sweatshirt,sweatshirt,词,NOUN,C1
-sweden,sweden,词,PROPN,B2
-swedish,swedish,瑞典语,NOUN,B2
-sweepings,sweepings,词,NOUN,B2
-sweet,sweet,糖果,NOUN,B2
-sweet dream,sweet dream,美梦,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweetheart,sweetheart,爱人,NOUN,B2
-sweetie,sweetie,亲爱的,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swiftness,swiftness,词,NOUN,C1
-swim,to swim,游泳,VERB,B2
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,词,NOUN,C1
-swimwear,swimwear,词,NOUN,B2
-swindler,swindler,骗子,NOUN,B2
-swine,swine,猪,NOUN,B2
-swirl,swirl,词,VERB,C1
-swiss,swiss,瑞士的,ADJ,B2
-switch room,switch room,配电室,NOUN,B2
-switchman,switchman,词,NOUN,C1
-sword,sword,剑,NOUN,B2
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordless,swordless,剑不,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsman,swordsman,剑客,NOUN,B2
-swordsmanship,swordsmanship,剑术,NOUN,B2
-sycophant,sycophant,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
-syllogism,syllogism,三段论,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbolic,symbolic,象征的,ADJ,B2
-symbolize,to symbolize,象征,VERB,B2
-symmetrical,symmetrical,对称的,ADJ,B2
-sympathetic,sympathetic,同情的,ADJ,B2
-sympathize,to sympathize,同情,VERB,B2
-sympathy,sympathy,同情,NOUN,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symphonic,symphonic,交响乐的,ADJ,B2
-symposium,symposium,研讨会,NOUN,B2
-symptom,symptom,症,PART,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-synaptic,synaptic,词,ADJ,C1
-sync,sync,同步,NOUN,B2
-syncopate,syncopate,词,VERB,C1
-syncretism,syncretism,词,NOUN,C1
-syndicate,syndicate,词,NOUN,C1
-syndrome,syndrome,综合征,NOUN,B2
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,词,NOUN,B2
-synonym,synonym,词,NOUN,C1
-synopsis,synopsis,词,NOUN,C1
-synoptic,synoptic,概要的,ADJ,B2
-synthesize,to synthesize,合成,VERB,B2
-synthetic,synthetic,合成的,ADJ,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-syrian,syrian,叙利亚的,ADJ,B2
-systematically,systematically,词,ADV,B2
-systemless,systemless,无系统的,ADJ,B2
-t-shirt,t-shirt,词,NOUN,B1
-tab,tab,词,NOUN,C1
-tabernacle,tabernacle,词,NOUN,C1
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tablecloth,tablecloth,词,NOUN,C1
-tablet,tablet,平板电脑,NOUN,B2
-taboo,taboo,禁忌,NOUN,B2
-taboo (adj),taboo,词,ADJ,C1
-tachometer,tachometer,转速表,NOUN,B2
-tacit,tacit,心照不宣的,ADJ,B2
-tacitly,tacitly,默不作声地,ADV,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-tackle,to tackle,处理,VERB,B2
-tackling,tackling,词,NOUN,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,词,NOUN,B2
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactics,tactics,战术,NOUN,B2
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,词,ADJ,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-tail,tail,尾巴,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a leave of absence,to take a leave of absence,休学,VERB,B2
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take along,to take along,带走,VERB,B2
-take an x-ray,take an x-ray,拍片,VERB,C1
-take away,to take away,拿走,VERB,B2
-take care of,to take care of,照顾,VERB,B2
-take cuttings,to take cuttings,扦插,VERB,B2
-take medicine,take medicine,服药,VERB,C1
-take office,to take office,就职,VERB,B2
-take over,to take over,接管,VERB,B2
-take place,to take place,举行,VERB,B2
-take refuge,take refuge,避难,VERB,C1
-take revenge,to take revenge,报复,VERB,B2
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
-takeover,takeover,词,NOUN,C1
-taking,taking,拍摄,NOUN,B2
-taking command,taking command,挂帅,NOUN,B2
-tale,tale,词,NOUN,A1
-talented,talented,有才华的,ADJ,B2
-talisman,talisman,词,NOUN,B2
-talk,talk,谈话,NOUN,B2
-talk nonsense,to talk nonsense,胡言乱语,VERB,B2
-talk show,talk show,脱口秀,NOUN,C1
-talkative,talkative,健谈的,ADJ,B2
-talkativeness,talkativeness,多嘴,NOUN,B2
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-tall,tall,高的,ADJ,B2
-tall and slender,tall and slender,词,ADJ,C1
-tally,tally,词,VERB,C1
-tamable,tamable,词,ADJ,C1
-tame,to tame,驯服,VERB,B2
-tame (adj),tame,词,ADJ,A1
-taming,taming,词,NOUN,C1
-tamper,tamper,词,VERB,C1
-tan,to tan,晒黑,VERB,B2
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tangle,tangle,混乱,NOUN,B2
-tank cistern,tank cistern,词,NOUN,C1
-tanned,tanned,词,ADJ,B2
-tantamount,tantamount,词,ADJ,C1
-tantrum,tantrum,词,NOUN,C1
-tap,tap,水龙头,NOUN,B2
-tape,tape,词,NOUN,A2
-tapestry,tapestry,词,NOUN,C1
-target,target,目标,NOUN,B2
-target,to target,针对,VERB,B2
-target group,target group,词,NOUN,C1
-targeted,targeted,有针对性的,ADJ,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
-taro,taro,芋头,NOUN,B2
-tarragon,tarragon,词,NOUN,B2
-tarry,tarry,词,VERB,C1
-tart pie,tart pie,词,NOUN,C1
-taste preference,taste preference,口味,NOUN,B2
-tasteless,tasteless,无味的,ADJ,B2
-tasting,tasting,词,NOUN,C1
-tasty,tasty,美味的,ADJ,B2
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tatter,tatter,词,NOUN,C1
-tattoo,tattoo,纹身,NOUN,B2
-tautology,tautology,词,NOUN,C1
-tavern,tavern,酒馆,NOUN,B2
-tawdry,tawdry,词,ADJ,C1
-tax,to tax,征税,VERB,B2
-tax authorities,tax authorities,税务机关,NOUN,B2
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax rate,tax rate,词,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax return,tax return,词,NOUN,B2
-tax revenue,tax revenue,税收,NOUN,B2
-tax-exempt,tax-exempt,免税,ADJ,B2
-taxable,taxable,应纳税的,ADJ,B2
-taxi,taxi,出租车,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-taxonomy,taxonomy,分类学,NOUN,B2
-taxpayer,taxpayer,纳税人,NOUN,B2
-tea,tea,茶,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-tea plantation,tea plantation,茶园,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching,teaching,教学的,ADJ,B2
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
-teammate,teammate,队友,NOUN,B2
-teapot,teapot,词,NOUN,C1
-tear,to tear,撕碎,VERB,B2
-tears,tears,眼泪,NOUN,B2
-tease,to tease,取笑,VERB,B2
-teasing playful,teasing playful,词,ADJ,C1
-technically,technically,技术上地,ADV,B2
-technique,technique,技巧,NOUN,B2
-technocratic,technocratic,技术官僚的,ADJ,B2
-tectonic,tectonic,词,ADJ,C1
-teddy bear,teddy bear,词,NOUN,B2
-tedious painful,tedious painful,词,ADJ,B2
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teetotal,teetotal,词,ADJ,C1
-teleological,teleological,词,ADJ,B2
-telepathy,telepathy,词,NOUN,C1
-telephone number,telephone number,电话号码,NOUN,B2
-telephone ringing,telephone ringing,词,NOUN,C1
-telephones,telephones,词,NOUN,B2
-telephony,telephony,电话学,NOUN,B2
-television set,television set,词,NOUN,B1
-telling-off,telling-off,词,NOUN,B1
-telltale,telltale,词,ADJ,C1
-temerity,temerity,鲁莽,NOUN,B2
-temper,temper,脾气,NOUN,B2
-temperament,temperament,气质,NOUN,B2
-temperamental,temperamental,词,ADJ,C1
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature,temperature,温度,NOUN,B2
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-template,template,词,NOUN,C1
-temple,temple,寺庙,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-tenable,tenable,词,ADJ,C1
-tenacity,tenacity,坚韧,NOUN,B2
-tend,tend,词,VERB,B2
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tenement,tenement,词,NOUN,C1
-tenet,tenet,词,NOUN,C1
-tenor,tenor,男高音,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
-tense (noun),tense,词,NOUN,B1
-tense excited,tense excited,词,ADJ,B2
-tensile,tensile,词,ADJ,C1
-tenth,tenth,第十,ADJ,B2
-tenuous,tenuous,词,ADJ,C1
-tepid,tepid,词,ADJ,C1
-teratogenic,teratogenic,词,ADJ,B2
-term transition,term transition,换届,NOUN,C1
-terminal,terminal,终末的,ADJ,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,词,NOUN,B2
-terrace,terrace,露台,NOUN,B2
-terribleness,terribleness,词,NOUN,B2
-terribly,terribly,可怕地/非常,ADV,B2
-terrified,terrified,极度恐惧的,ADJ,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
-territory expansion,territory expansion,开疆,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terse,terse,简练的,ADJ,B2
-tertiary,tertiary,第三的,ADJ,B2
-test drive,test drive,,NOUN,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-testator,testator,词,NOUN,C1
-testimony deposition,testimony deposition,词,NOUN,C1
-tether,tether,词,NOUN,C1
-than (adv),than,词,ADV,A1
-thank god,thank god,谢天谢地,INTJ,B2
-thanks,thanks,谢谢,NOUN,B2
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-that,that,那个,DET,B2
-that (noun),that,将那,NOUN,C1
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that little bit,that little bit,那点,NOUN,C1
-that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that one,that one,那个,PRON,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way (adv),that way,词,ADV,B2
-that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,词,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,词,NOUN,B2
-the chain,the chain,词,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,ADV,B2
-the day after tomorrow (noun),the day after tomorrow,词,NOUN,B2
-the day before yesterday,the day before yesterday,词,ADV,C1
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the emperor,the emperor,词,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masculine,the masculine,词,DET,A2
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the more,the more,越,ADV,B2
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
-the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,词,DET,B1
-the one (pron),the one,那个人,PRON,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,词,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the rich,the rich,词,NOUN,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,相同的,ADJ,B2
-the same (det),the same,词,DET,A2
-the same (pron),the same,词,PRON,C1
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unstellung,the unstellung,词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,词,NOUN,B2
-the urbewegung,the urbewegung,词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,词,NOUN,B2
-the urrechnung,the urrechnung,词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,词,NOUN,B2
-the verminderung,the verminderung,词,NOUN,B2
-the verstbindung,the verstbindung,词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,词,NOUN,B2
-the ververtiefung,the ververtiefung,词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the very,the very,正是,ADV,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,词,NOUN,B2
-the zerordnung,the zerordnung,词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-theatrical,theatrical,戏剧的,ADJ,B2
-their,their,他们的,DET,B2
-them dative,them dative,词,PRON,A2
-thematic,thematic,主题的,ADJ,B2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,词,ADJ,B2
-theologian,theologian,神学家,NOUN,B2
-theological,theological,神学的,ADJ,B2
-theorize,theorize,词,VERB,B2
-therapist,therapist,治疗师,NOUN,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-there's still time,to there's still time,来得及,VERB,B2
-thereafter,thereafter,此后,ADV,B2
-thereby,thereby,从而,ADV,B2
-therefore,therefore,所以,SCONJ,B2
-thermodynamics,thermodynamics,词,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-these,these,这些,DET,B2
-these three,these three,这三,NOUN,B2
-thespian,thespian,词,NOUN,C1
-thetic,thetic,正题的,ADJ,B2
-they,they,他们,PRON,B2
-they female,they female,她们,PRON,B2
-they things,they things,它们,PRON,B2
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thicket,thicket,灌木丛,NOUN,B2
-thief,thief,小偷,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thief presence,thief presence,有贼,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-think to want,to think to want,想,VERB,B2
-think up,to think up,构思,VERB,B2
-thinker,thinker,词,NOUN,C1
-thinner,thinner,词,ADJ,B2
-third,third,第三,ADJ,B2
-third (num),third,词,NUM,B1
-third bestowal,third bestowal,三授,NOUN,B2
-third place,third place,季军,NOUN,B2
-this,this,这个,DET,B2
-this (noun),this,你这,NOUN,B2
-this (pron),this,此,PRON,A1
-this afternoon,this afternoon,词,ADV,B2
-this battle,this battle,此战,NOUN,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this item,this item,这件,NOUN,B2
-this matter,this matter,这事,NOUN,B2
-this morning,this morning,今天早上,ADV,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
-this way,this way,这样,PRON,B2
-this way (adv),this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-this-camp,this-camp,这营,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
-thorny,thorny,词,ADJ,C1
-thorough,thorough,彻底的,ADJ,B2
-thoroughly,thoroughly,词,ADV,B2
-thoroughness,thoroughness,彻底,NOUN,B2
-those,those,那些,DET,B2
-thoughtful,thoughtful,体贴的,ADJ,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
-thousands,thousands,数千,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thrall,thrall,词,NOUN,C1
-thread (verb),thread,词,VERB,C1
-threadbare,threadbare,词,ADJ,C1
-threatened,threatened,词,ADJ,C1
-threatening,threatening,具有威胁性的,ADJ,B2
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
-three-d printing,three-d printing,3D打印,NOUN,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thrilling,thrilling,令人兴奋的,ADJ,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throng,throng,词,NOUN,C1
-through,through,通过,ADP,B2
-throw,throw,投掷,NOUN,B2
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-thrust toward,thrust toward,插向,NOUN,B2
-thug,thug,暴徒,NOUN,B2
-thumb,thumb,拇指,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thunderstorm,thunderstorm,雷阵雨,NOUN,B2
-thus,thus,因此,ADV,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thwart,to thwart,阻挠,VERB,B2
-tick,tick,滴答声,NOUN,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,词,NOUN,B2
-ticket window,ticket window,词,NOUN,B2
-tickle,tickle,词,NOUN,B2
-tidal,tidal,潮汐,ADJ,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
-tidy (adj),tidy,词,ADJ,B2
-tie,tie,领带,NOUN,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tie up,to tie up,绑,VERB,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tier,tier,分阶,NOUN,C1
-tight,tight,紧的,ADJ,B2
-tight grip,tight grip,手握紧,NOUN,B2
-tight narrow,tight narrow,词,ADJ,B1
-tight-fitting,tight-fitting,词,ADJ,B1
-tighten,to tighten,紧握/收紧,VERB,B2
-tightly,tightly,词,ADV,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-tights,tights,词,NOUN,C1
-tilt,tilt,倾斜,NOUN,B2
-timber,timber,词,NOUN,C1
-timbre,timbre,词,NOUN,C1
-time clock,time clock,词,NOUN,B2
-time limit,time limit,词,NOUN,B1
-time occasion,time occasion,次,NOUN,B2
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time out,time out,词,NOUN,B2
-time to go to bed,time to go to bed,词,ADV,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
-times,times,倍,NOUN,B2
-timidity,timidity,胆怯,NOUN,B2
-timorous,timorous,词,ADJ,C1
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (adj),tint,词,ADJ,C1
-tint (noun),tint,词,NOUN,C1
-tiny,tiny,微小的,ADJ,B2
-tiny minute,tiny minute,词,ADJ,C1
-tirade,tirade,长篇抨击,NOUN,B2
-tire,tire,轮胎,NOUN,B2
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tireless,tireless,不知疲倦的,ADJ,C1
-tirelessly,tirelessly,词,ADV,C1
-tiresome,tiresome,累人的,ADJ,B2
-tiring,tiring,词,ADJ,B2
-titanic,titanic,词,ADJ,C1
-titillate,titillate,词,VERB,C1
-tits,tits,词,NOUN,C1
-titular,titular,词,ADJ,C1
-to,to,去,PART,B2
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abort,to abort,流产,VERB,B2
-to abound,to abound,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,词,VERB,B2
-to absolve,to absolve,赦免,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abstract,to abstract,抽象,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abwandeln,to abwandeln,词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to accentuate,to accentuate,强调,VERB,B2
-to access,to access,进入,VERB,B2
-to acclaim,to acclaim,称赞,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to acknowledge,to acknowledge,承认,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to acquiesce,to acquiesce,默许,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act (verb),to act,行动,VERB,B2
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adduce,to adduce,引证,VERB,B2
-to adhere,to adhere,坚持,VERB,B2
-to adhere join,to adhere join,词,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to adore,to adore,爱慕,VERB,B2
-to afforest,to afforest,造林,VERB,B2
-to age,to age,变老,VERB,B2
-to aggravate,to aggravate,加重,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agitate,to agitate,鼓动,VERB,B2
-to agree with,to agree with,词,VERB,B2
-to ail,to ail,使苦恼,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alert,to alert,警告,VERB,B2
-to alienate,to alienate,使疏远,VERB,C1
-to align,to align,使一致,VERB,B2
-to allege,to allege,宣称,VERB,B2
-to alleviate,to alleviate,缓解,VERB,B2
-to allocate,to allocate,分配,VERB,B2
-to allude,to allude,暗指,VERB,B2
-to ally,to ally,结盟,VERB,B2
-to alter,to alter,改变,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to amalgamate,to amalgamate,合并,VERB,B2
-to amass,to amass,积聚,VERB,B2
-to amaze,to amaze,使吃惊,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to amplify,to amplify,放大,VERB,B2
-to anathematize,to anathematize,词,VERB,C1
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to anger,to anger,使生气,VERB,B2
-to animate,to animate,词,VERB,B2
-to annul,to annul,废除,VERB,B2
-to antagonize,to antagonize,词,VERB,C1
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,词,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appear in court,to appear in court,词,VERB,B2
-to apply be valid,to apply be valid,词,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to archive (verb),to archive,词,VERB,B2
-to arm,to arm,武装,VERB,B2
-to armor (verb),to armor,词,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,词,VERB,B2
-to ascribe,to ascribe,归因于,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to asphyxiate,to asphyxiate,使窒息,VERB,C1
-to assault,to assault,袭击,VERB,B2
-to assent,to assent,同意,VERB,B2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt,to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attenuate,to attenuate,减弱,VERB,B2
-to attest,to attest,证明,VERB,B2
-to attribute,to attribute,归因于,VERB,B2
-to augur,to augur,预言,VERB,B2
-to auscultate,to auscultate,听诊,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await orders,to await orders,待命,VERB,B2
-to back up,to back up,后退,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to bandage (verb),to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to bare,to bare,暴露,VERB,B2
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to barricade (verb),to barricade,词,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be able (aux),to be able,能够,AUX,B1
-to be added,to be added,加入,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be based on,to be based on,基于,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be content,to be content,词,VERB,C1
-to be correct,to be correct,正确,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be dissonant,to be dissonant,词,VERB,C1
-to be driven,to be driven,被驱动,VERB,B2
-to be equivalent,to be equivalent,词,VERB,C1
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be full of,to be full of,充满,VERB,B1
-to be good for,to be good for,词,VERB,B2
-to be happy,to be happy,词,VERB,A2
-to be here,to be here,在此,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be liable,to be liable,词,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be moved,to be moved,感动,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be needed,to be needed,被需要,VERB,B2
-to be noticeable,to be noticeable,词,VERB,C1
-to be noticed,to be noticed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,词,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be reckless,to be reckless,肆,VERB,B1
-to be related,to be related,词,VERB,C1
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be responsible,to be responsible,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be sleepy,to be sleepy,我困,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be struck,to be struck,词,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be valid,to be valid,词,VERB,B2
-to be visible,to be visible,词,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to bear to endure,to bear to endure,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to beatify,to beatify,宣福,VERB,C1
-to beautify,to beautify,美化,VERB,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become bold,to become bold,词,VERB,C1
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to beget,to beget,引起,VERB,B2
-to begin to cut into,to begin to cut into,词,VERB,C1
-to behave rudely,to behave rudely,词,VERB,C1
-to behead,to behead,斩首,VERB,B2
-to behold,to behold,注视,VERB,B2
-to benefit,to benefit,受益,VERB,B2
-to bequeath,to bequeath,遗赠,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to bet invest,to bet invest,词,VERB,B2
-to betroth,to betroth,词,VERB,C1
-to bevriezen,to bevriezen,词,VERB,C1
-to bewitch,to bewitch,迷住,VERB,B2
-to bicker,to bicker,争吵,VERB,B2
-to bide,to bide,等待,VERB,B2
-to bifurcate,to bifurcate,分叉,VERB,B2
-to bisect,to bisect,平分,VERB,B2
-to blaspheme,to blaspheme,亵渎,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to bleat,to bleat,哀叫,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to blink,to blink,眨眼,VERB,B2
-to block (verb),to block,堵塞,VERB,B2
-to blockade (verb),to blockade,词,VERB,B2
-to bloom,to bloom,开花,VERB,B2
-to blossom,to blossom,开花,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to blow up,to blow up,炸毁,VERB,B2
-to bluff,to bluff,虚张声势,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to blush,to blush,脸红,VERB,B2
-to board (verb),to board,词,VERB,C1
-to boil cook,to boil cook,词,VERB,B1
-to boost,to boost,促进,VERB,B2
-to border,to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to botch,to botch,搞砸,VERB,B2
-to bottle (verb),to bottle,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to box (verb),to box,词,VERB,B2
-to brake (verb),to brake,刹车,VERB,B2
-to brandish,to brandish,挥舞,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break in,to break in,词,VERB,B2
-to break into,to break into,撬开,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to breathe again,to breathe again,松口气,VERB,B2
-to bridle (verb),to bridle,词,VERB,C1
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring closer,to bring closer,靠近,VERB,B2
-to bring here,to bring here,词,VERB,C1
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to bristle,to bristle,使竖起,VERB,B2
-to brood,to brood,沉思,VERB,B2
-to build up,to build up,构建,VERB,B2
-to bullshit,to bullshit,胡扯,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump,to bump,碰撞,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to bungle,to bungle,搞砸,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to burnish,to burnish,擦亮,VERB,B2
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to calibrate,to calibrate,校准,VERB,B2
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call out,to call out,词,VERB,C1
-to call ring,to call ring,打电话,VERB,B2
-to camouflage,to camouflage,伪装,VERB,B2
-to camp,to camp,露营,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to caper,to caper,跳跃,VERB,B2
-to capitulate,to capitulate,投降,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to captivate,to captivate,迷住,VERB,B2
-to capture (verb),to capture,攻下,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carry on,to carry on,词,VERB,C1
-to carve,to carve,雕刻,VERB,B2
-to cash (verb),to cash,兑现,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to castigate,to castigate,严厉批评,VERB,B2
-to catalyze,to catalyze,催化,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,词,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to catechize,to catechize,词,VERB,B2
-to cause (verb),to cause,引起,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to cauterize,to cauterize,烧灼,VERB,B2
-to center,to center,居中,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to change clothes,to change clothes,更衣,VERB,B1
-to change trains,to change trains,词,VERB,A1
-to chastise,to chastise,严惩,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chill (verb),to chill,使冰冻,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,词,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clean out,to clean out,词,VERB,C1
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close eyes,to close eyes,闭眼,VERB,B2
-to cloy,to cloy,使厌烦,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to coax,to coax,词,VERB,C1
-to codify,to codify,词,VERB,C1
-to coerce,to coerce,强迫,VERB,B2
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to collate,to collate,核对,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to come true,to come true,词,VERB,B2
-to command (verb),to command,命令,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commercialize,to commercialize,商业化,VERB,B2
-to commission,to commission,委托,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,词,VERB,B2
-to commute,to commute,通勤,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to complement,to complement,补充,VERB,B2
-to complete finish,to complete finish,词,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to compose (noun),to compose,合成,NOUN,B2
-to compromise (verb),to compromise,妥协,VERB,B2
-to concede,to concede,承认,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to concoct,to concoct,编造,VERB,B2
-to concretize,to concretize,词,VERB,C1
-to condescend,to condescend,屈尊,VERB,B2
-to condone,to condone,宽恕,VERB,C1
-to confer,to confer,授予,VERB,B2
-to confine,to confine,限制,VERB,B2
-to conform,to conform,符合,VERB,B2
-to conjecture,to conjecture,猜测,VERB,B2
-to conjugate,to conjugate,变位,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to connote,to connote,暗示,VERB,B2
-to consent,to consent,同意,VERB,B2
-to conserve,to conserve,保存,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to consign,to consign,移交,VERB,C1
-to constipate,to constipate,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consummate,to consummate,完成,VERB,B2
-to contend,to contend,主张,VERB,B2
-to contest (verb),to contest,词,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to cook fix,to cook fix,做/修理,VERB,B2
-to cool (verb),to cool,冷却,VERB,B2
-to cope,to cope,应付,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to correspond (! verb),to correspond,词,! VERB,C1
-to corroborate,to corroborate,证实,VERB,B2
-to corrode,to corrode,腐蚀,VERB,C1
-to countersign,to countersign,副署,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,词,VERB,C1
-to covet,to covet,觊觎,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to cram,to cram,填鸭式学习,VERB,B2
-to crash,to crash,碰撞,VERB,B2
-to creak,to creak,嘎吱作响,VERB,B2
-to croak,to croak,呱呱叫,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,词,VERB,B2
-to crown (verb),to crown,加冠,VERB,B2
-to crumple,to crumple,弄皱,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to cuddle,to cuddle,拥抱,VERB,B2
-to culminate,to culminate,达到顶点,VERB,B2
-to curl,to curl,卷曲,VERB,B2
-to curtail,to curtail,削减,VERB,C1
-to curve (verb),to curve,词,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to cycle (verb),to cycle,循环,VERB,B2
-to dam up,to dam up,词,VERB,C1
-to damn (verb),to damn,词,VERB,B2
-to dampen,to dampen,使潮湿,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to date (verb),to date,词,VERB,B2
-to daunt,to daunt,使气馁,VERB,B2
-to dawdle,to dawdle,闲逛,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daze,to daze,使茫然,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deafen,to deafen,使聋,VERB,B2
-to deal,to deal,处理,VERB,B2
-to debase,to debase,贬低,VERB,B2
-to debut,to debut,首次亮相,VERB,B2
-to decant,to decant,倾析,VERB,B2
-to decentralize,to decentralize,去中心化,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,词,VERB,B2
-to declaim,to declaim,慷慨陈词,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declassify,to declassify,解密,VERB,C1
-to decode,to decode,解码,VERB,B2
-to decompress,to decompress,解压,VERB,C1
-to decontextualize,to decontextualize,词,VERB,C1
-to decouple,to decouple,分离,VERB,B2
-to decry,to decry,谴责,VERB,B2
-to defame,to defame,诽谤,VERB,C1
-to default (verb),to default,拖欠,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to defer,to defer,词,VERB,C1
-to deflate,to deflate,使泄气,VERB,B2
-to defray,to defray,支付,VERB,B2
-to defrost,to defrost,除霜,VERB,B2
-to defuse,to defuse,缓和,VERB,B2
-to deify,to deify,神化,VERB,B2
-to deign,to deign,屈尊,VERB,B2
-to dejta,to dejta,词,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delegitimize,to delegitimize,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to delight,to delight,使高兴,VERB,B2
-to delimit,to delimit,词,VERB,C1
-to delineate,to delineate,描绘,VERB,B2
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to demarcate,to demarcate,划定界限,VERB,B2
-to demilitarize,to demilitarize,非军事化,VERB,B2
-to democratize,to democratize,民主化,VERB,B2
-to demonize,to demonize,妖魔化,VERB,B2
-to denature,to denature,使变性,VERB,B2
-to denigrate,to denigrate,诋毁,VERB,B2
-to denominate,to denominate,命名,VERB,B2
-to denote,to denote,表示,VERB,B2
-to densify,to densify,词,VERB,C1
-to depersonalize,to depersonalize,词,VERB,C1
-to depilate,to depilate,脱毛,VERB,B2
-to deploy unfold,to deploy unfold,词,VERB,C1
-to depopulate,to depopulate,使人口减少,VERB,B2
-to deport,to deport,驱逐出境,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deprave,to deprave,使堕落,VERB,B2
-to depreciate,to depreciate,贬值,VERB,B2
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,词,VERB,B2
-to desert,to desert,擅离职守,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to destock,to destock,词,VERB,C1
-to detail,to detail,详述,VERB,B2
-to dethrone,to dethrone,废黜,VERB,B2
-to detract,to detract,贬低,VERB,C1
-to deviate,to deviate,偏离,VERB,B2
-to devour,to devour,吞食,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to digitize,to digitize,数字化,VERB,B2
-to dilute,to dilute,稀释,VERB,B2
-to dimension (verb),to dimension,词,VERB,C1
-to direct (verb),to direct,指挥,VERB,B2
-to dirty (verb),to dirty,词,VERB,C1
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disabuse,to disabuse,纠正错误想法,VERB,B2
-to disarrange,to disarrange,弄乱,VERB,B2
-to disarray (verb),to disarray,词,VERB,C1
-to discern,to discern,辨别,VERB,B2
-to disconcert,to disconcert,使惊慌,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disenchant,to disenchant,使清醒,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disentangle,to disentangle,词,VERB,C1
-to disfavor,to disfavor,不利于,VERB,B2
-to disfigure,to disfigure,毁容,VERB,B2
-to disguise (verb),to disguise,伪装,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to dishearten,to dishearten,使沮丧,VERB,B2
-to dishevel,to dishevel,弄乱,VERB,B2
-to dishonor,to dishonor,使蒙羞,VERB,B2
-to disinherit,to disinherit,剥夺继承权,VERB,B2
-to disintegrate,to disintegrate,瓦解,VERB,B2
-to disjoin,to disjoin,分离,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dislodge,to dislodge,逐出,VERB,B2
-to dismay,to dismay,使沮丧,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to disoblige,to disoblige,词,VERB,C1
-to dispel,to dispel,消除,VERB,B2
-to dispense,to dispense,分发,VERB,B2
-to disperse,to disperse,分散,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to dispose,to dispose,处理,VERB,B2
-to dispossess,to dispossess,词,VERB,C1
-to disproportion (verb),to disproportion,词,VERB,C1
-to disqualify,to disqualify,取消资格,VERB,B2
-to disrespect (verb),to disrespect,词,VERB,C1
-to disrupt,to disrupt,扰乱,VERB,B2
-to dissent (verb),to dissent,词,VERB,C1
-to dissipate,to dissipate,消散,VERB,B2
-to distance (verb),to distance,词,VERB,C1
-to distill,to distill,蒸馏,VERB,B2
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to disunite,to disunite,使分裂,VERB,C1
-to dither,to dither,犹豫不决,VERB,B2
-to diverge,to diverge,分歧,VERB,B2
-to divest,to divest,剥夺,VERB,B2
-to divulge,to divulge,泄露,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do hair,to do hair,词,VERB,C1
-to do harm,to do harm,伤害,VERB,B2
-to do make,to do make,词,VERB,A1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to dote,to dote,词,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape,to drape,悬挂,VERB,B2
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw support from,to draw support from,借助,VERB,B2
-to draw up,to draw up,起草,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to dream (verb),to dream,做梦,VERB,B1
-to dress (verb),to dress,词,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drip,to drip,滴,VERB,B2
-to drive herd,to drive herd,词,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,词,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun,to dry in the sun,晾晒,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry out,to dry out,词,VERB,C1
-to dry up,to dry up,词,VERB,B2
-to duck (verb),to duck,词,VERB,C1
-to dull (verb),to dull,词,VERB,C1
-to dump,to dump,抛弃,VERB,B2
-to dupe,to dupe,欺骗,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dust off,to dust off,词,VERB,C1
-to dye,to dye,染色,VERB,B2
-to each other (adv),to each other,词,ADV,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eclipse,to eclipse,使失色,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to edify,to edify,启发,VERB,B2
-to eject,to eject,弹出,VERB,B2
-to elaborate (verb),to elaborate,阐发,VERB,B2
-to elapse,to elapse,流逝,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to elevate,to elevate,词,VERB,C1
-to elide,to elide,省略,VERB,B2
-to elucidate,to elucidate,阐明,VERB,B2
-to elude,to elude,逃避,VERB,B2
-to email (verb),to email,词,VERB,B2
-to emasculate,to emasculate,使无力,VERB,B2
-to embark,to embark,上船,VERB,B2
-to embarrass,to embarrass,使尴尬,VERB,B2
-to embolden,to embolden,使大胆,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emigrate,to emigrate,移居国外,VERB,B2
-to empty,to empty,倒空,VERB,B2
-to encircle,to encircle,环绕,VERB,B2
-to encode,to encode,词,VERB,C1
-to encore (verb),to encore,词,VERB,C1
-to encroach,to encroach,侵蚀,VERB,B2
-to enervate,to enervate,使衰弱,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engrave,to engrave,雕刻,VERB,B2
-to engross,to engross,使全神贯注,VERB,B2
-to enhance,to enhance,增强,VERB,B2
-to enrage,to enrage,激怒,VERB,B2
-to enrapture,to enrapture,使狂喜,VERB,B2
-to enrol,to enrol,注册,VERB,B2
-to enslave,to enslave,奴役,VERB,B2
-to ensnare,to ensnare,诱捕,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthrall,to enthrall,迷住,VERB,B2
-to enthrone,to enthrone,立为王,VERB,B2
-to enunciate,to enunciate,阐明,VERB,B2
-to envy (verb),to envy,羡慕,VERB,B2
-to equal,to equal,无异,VERB,B2
-to equalize,to equalize,使相等,VERB,B2
-to equate,to equate,等同,VERB,B2
-to erect behave,to erect behave,词,VERB,B2
-to erode,to erode,侵蚀,VERB,B2
-to espy,to espy,词,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to estimate (verb),to estimate,估算,VERB,B2
-to eternalize,to eternalize,使永恒,VERB,B2
-to ever (verb),to ever,何尝,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to exalt,to exalt,颂扬,VERB,C1
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exclaim,to exclaim,呼喊,VERB,B2
-to exculpate,to exculpate,开脱,VERB,B2
-to excuse (verb),to excuse,原谅,VERB,B2
-to execrate,to execrate,痛恨,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exemplify,to exemplify,举例说明,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exfoliate,to exfoliate,去角质,VERB,C1
-to exist there is,to exist there is,存在/有,VERB,B2
-to exorcise,to exorcise,驱魔,VERB,B2
-to expatriate,to expatriate,使移居国外,VERB,B2
-to expectorate,to expectorate,吐痰,VERB,C1
-to experiment,to experiment,实验,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to expurgate,to expurgate,删节,VERB,B2
-to externalize,to externalize,使外在化,VERB,B2
-to extirpate,to extirpate,根除,VERB,B2
-to extol,to extol,赞美,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extricate,to extricate,使摆脱,VERB,B2
-to exude,to exude,散发,VERB,B2
-to fail to fulfill,to fail to fulfill,词,VERB,B2
-to fake,to fake,伪造,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall silent,to fall silent,沉默,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to familiarize,to familiarize,使熟悉,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fasten,to fasten,系紧,VERB,B2
-to fatten,to fatten,养肥,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign,to feign,假装,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to fell,to fell,砍倒,VERB,B2
-to ferret,to ferret,搜寻,VERB,B2
-to fertilize,to fertilize,施肥,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file a case,to file a case,立案,VERB,B2
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to film (verb),to film,拍摄,VERB,B2
-to finally,to finally,你可算,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fit suit,to fit suit,适合,VERB,B2
-to fix to set,to fix to set,词,VERB,B1
-to flame (verb),to flame,词,VERB,B2
-to flap,to flap,拍打,VERB,B2
-to flash,to flash,闪烁,VERB,B2
-to flatten,to flatten,使平坦,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flock,to flock,群集,VERB,B2
-to flog,to flog,鞭打,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flout,to flout,蔑视,VERB,B2
-to flow in,to flow in,词,VERB,C1
-to flow into,to flow into,词,VERB,C1
-to fluctuate,to fluctuate,词,VERB,C1
-to flush,to flush,冲洗,VERB,B2
-to flush out,to flush out,词,VERB,B2
-to fluster,to fluster,使慌乱,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to focus (verb),to focus,聚焦,VERB,B2
-to foist,to foist,强加,VERB,C1
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to forebode,to forebode,预兆,VERB,B2
-to form to train,to form to train,词,VERB,B1
-to fortify,to fortify,加强,VERB,B2
-to fossilize,to fossilize,石化,VERB,B2
-to fraction,to fraction,分割,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to fraternize,to fraternize,勾结,VERB,B2
-to freshen,to freshen,使清新,VERB,B2
-to frighten away,to frighten away,词,VERB,C1
-to frolic,to frolic,嬉戏,VERB,B2
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to fumigate,to fumigate,熏蒸,VERB,B2
-to function to work,to function to work,词,VERB,B1
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse (verb),to fuse,融合,VERB,B2
-to gain,to gain,获得,VERB,B2
-to gain weight,to gain weight,变胖,VERB,B2
-to galvanize,to galvanize,激励,VERB,B2
-to gape,to gape,目瞪口呆,VERB,B2
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gauge,to gauge,测量,VERB,B2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to germinate,to germinate,发芽,VERB,B2
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get along,to get along,词,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get by,to get by,过得去,VERB,B2
-to get fond of,to get fond of,词,VERB,C1
-to get into,to get into,陷入,VERB,B2
-to get into debt,to get into debt,词,VERB,C1
-to get off,to get off,词,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get stuck,to get stuck,词,VERB,B2
-to get to know,to get to know,词,VERB,B1
-to gift (verb),to gift,词,VERB,B1
-to giggle,to giggle,咯咯笑,VERB,B2
-to gird,to gird,词,VERB,C1
-to give a discount,to give a discount,打折,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give as a gift,to give as a gift,赠送,VERB,B2
-to give birth,to give birth,分娩,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glean,to glean,搜集,VERB,B2
-to globalize,to globalize,使全球化,VERB,B2
-to gloss,to gloss,注释,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go blind,to go blind,失明,VERB,B2
-to go deep into,to go deep into,词,VERB,B2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,词,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go there,to go there,词,VERB,B1
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up again,to go up again,词,VERB,B1
-to go up in smoke,to go up in smoke,词,VERB,B2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to goad,to goad,刺激,VERB,B2
-to gossip,to gossip,闲聊,VERB,B2
-to grant (verb),to grant,授予,VERB,B2
-to graspen,to graspen,词,VERB,B2
-to gratify,to gratify,使满足,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to gravitate,to gravitate,受吸引,VERB,B2
-to gray (verb),to gray,词,VERB,B2
-to group,to group,分组,VERB,B2
-to grow fond of,to grow fond of,词,VERB,C1
-to grow old,to grow old,词,VERB,A1
-to growl,to growl,咆哮,VERB,B2
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,词,VERB,B2
-to guillotine (verb),to guillotine,词,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to gurgle (verb),to gurgle,词,VERB,C1
-to gush (verb),to gush,词,VERB,C1
-to hail,to hail,下冰雹,VERB,B2
-to hail inspect,to hail inspect,盘查,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to handcuff (verb),to handcuff,词,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,词,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harangue (verb),to harangue,词,VERB,B2
-to harden,to harden,使经受锻炼,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,词,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have (aux),to have,词,AUX,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to have to,to have to,必须,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold up,to hold up,词,VERB,B2
-to hold up stop,to hold up stop,词,VERB,A2
-to hollow out,to hollow out,词,VERB,C1
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to hook (verb),to hook,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to humanize,to humanize,词,VERB,B2
-to hunt (verb),to hunt,狩猎,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idealize,to idealize,理想化,VERB,B2
-to idolize,to idolize,词,VERB,B2
-to ignite,to ignite,词,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to imbue,to imbue,词,VERB,C1
-to immobilize,to immobilize,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to implant,to implant,植入,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to imprint (verb),to imprint,词,VERB,C1
-to impute,to impute,归咎,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incarcerate,to incarcerate,词,VERB,B2
-to inconvenience,to inconvenience,使不便,VERB,B2
-to incriminate,to incriminate,归罪,VERB,B2
-to incur,to incur,招致,VERB,B2
-to indicate interpret,to indicate interpret,词,VERB,B2
-to indict,to indict,控告,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to indispose,to indispose,词,VERB,C1
-to indoctrinate,to indoctrinate,灌输,VERB,B2
-to induce to lead to,to induce to lead to,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to infest,to infest,滋生,VERB,B2
-to inflame,to inflame,使发炎,VERB,B2
-to inflict,to inflict,词,VERB,C1
-to inflict to impose,to inflict to impose,词,VERB,B2
-to infuse,to infuse,泡制,VERB,B2
-to innovate,to innovate,词,VERB,C1
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insinuate,to insinuate,暗示,VERB,B2
-to instill,to instill,灌输,VERB,B2
-to institute (verb),to institute,词,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to interact,to interact,词,VERB,C1
-to intercede,to intercede,调停,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to internalize,to internalize,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intoxicate,to intoxicate,使中毒,VERB,B2
-to intuit,to intuit,词,VERB,C1
-to invalidate,to invalidate,证明无效,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invoice,to invoice,开票,VERB,B2
-to invoke,to invoke,援引,VERB,B2
-to ironize,to ironize,讽刺,VERB,B2
-to irrigate,to irrigate,灌溉,VERB,B2
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to itch (verb),to itch,痒,VERB,B2
-to jam (verb),to jam,词,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,词,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to kneel,to kneel,词,VERB,B1
-to knit,to knit,编织,VERB,B2
-to knock down,to knock down,词,VERB,B2
-to knot (verb),to knot,词,VERB,C1
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack (verb),to lack,无凭,VERB,B2
-to lack basis,to lack basis,无据,VERB,B2
-to lament,to lament,哀叹,VERB,B2
-to land (verb),to land,降落,VERB,B1
-to languish,to languish,词,VERB,C1
-to laugh smile,to laugh smile,笑,VERB,A1
-to launder,to launder,洗钱,VERB,B2
-to lay down,to lay down,放下,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to lay put,to lay put,放,VERB,B2
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,词,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to leaf through,to leaf through,翻阅,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to lean out,to lean out,词,VERB,B2
-to leap,to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to,to leave to,词,VERB,B2
-to lengthen,to lengthen,延长,VERB,B2
-to lessen,to lessen,词,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to levy,to levy,征收,VERB,C1
-to license (verb),to license,词,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,词,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to light,to light,照亮,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,词,VERB,B2
-to lighten,to lighten,减轻,VERB,B2
-to like (aux),to like,词,AUX,A2
-to linger,to linger,徘徊,VERB,B2
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to list (verb),to list,列举,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to live in,to live in,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to load charge,to load charge,装载,VERB,B2
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lodge,to lodge,词,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to log in,to log in,登录,VERB,B2
-to long (verb),to long,词,VERB,B2
-to long for,to long for,渴望,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to loot (verb),to loot,词,VERB,C1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower,to lower,降低,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lunge,to lunge,词,VERB,C1
-to lure (verb),to lure,词,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to maim,to maim,词,VERB,C1
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make bland,to make bland,使乏味,VERB,B2
-to make drowsy,to make drowsy,词,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make heavier,to make heavier,加重,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,词,VERB,C1
-to make lasting,to make lasting,词,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make one's way,to make one's way,词,VERB,B2
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make proud,to make proud,使自豪,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to make up for substitute,to make up for substitute,词,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manifest,to manifest,表明,VERB,B2
-to manure (verb),to manure,词,VERB,C1
-to map out,to map out,摸清,VERB,B2
-to mark (verb),to mark,标记,VERB,B1
-to mark out,to mark out,词,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to massacre (verb),to massacre,词,VERB,C1
-to mast (verb),to mast,词,VERB,B2
-to matter (verb),to matter,要紧,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to maximize,to maximize,词,VERB,C1
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to think,to mean to think,词,VERB,C1
-to meant,to meant,意思是,VERB,B2
-to meddle,to meddle,词,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to mess about,to mess about,胡搞,VERB,B2
-to mess around,to mess around,胡闹,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mime (verb),to mime,词,VERB,C1
-to minimize,to minimize,最小化,VERB,B2
-to mirror,to mirror,反映,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to missed,to missed,错过,VERB,B2
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to moan (verb),to moan,词,VERB,B2
-to model (verb),to model,词,VERB,C1
-to modulate,to modulate,调节,VERB,B2
-to moor (verb),to moor,词,VERB,B2
-to mop (verb),to mop,词,VERB,A2
-to mortgage (verb),to mortgage,抵押,VERB,B2
-to mourn,to mourn,哀悼,VERB,B2
-to move away,to move away,移开,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move house,to move house,搬家,VERB,B2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to move touch,to move touch,使感动,VERB,B2
-to mud (verb),to mud,词,VERB,C1
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,词,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to mutiny (verb),to mutiny,词,VERB,B2
-to mystify,to mystify,神秘化,VERB,B2
-to nail,to nail,钉,VERB,B2
-to narrow,to narrow,使变窄,VERB,B2
-to navigate,to navigate,导航；航行,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to neutralize,to neutralize,中和,VERB,B2
-to nickname,to nickname,给...起绰号,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note (verb),to note,注意,VERB,B2
-to note down,to note down,词,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to nuance (verb),to nuance,使具有细微差别,VERB,B2
-to numb,to numb,使麻木,VERB,B2
-to number (verb),to number,词,VERB,C1
-to object,to object,反对,VERB,B2
-to objectify,to objectify,客观化,VERB,B2
-to oblige,to oblige,强迫,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to occur to,to occur to,词,VERB,B2
-to ogle,to ogle,词,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to order (verb),to order,下令,VERB,C1
-to orient,to orient,词,VERB,B2
-to orient to guide,to orient to guide,词,VERB,C1
-to ostracize,to ostracize,排斥,VERB,B2
-to oust,to oust,推翻,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to outline (verb),to outline,勾勒,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overestimate,to overestimate,词,VERB,C1
-to overflow,to overflow,溢出,VERB,B2
-to overlook,to overlook,忽视,VERB,B2
-to overshadow,to overshadow,使黯然失色,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to overstep,to overstep,越权,VERB,B2
-to overthrow,to overthrow,推翻,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,词,VERB,C1
-to package (verb),to package,词,VERB,C1
-to paint over,to paint over,重新粉刷,VERB,B2
-to pair (verb),to pair,词,VERB,C1
-to pamper,to pamper,纵容,VERB,B2
-to panic (verb),to panic,词,VERB,C1
-to parade,to parade,游行,VERB,B2
-to party,to party,狂欢,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pause (verb),to pause,……,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to pension off,to pension off,词,VERB,C1
-to perfect,to perfect,精修,VERB,B2
-to perforate,to perforate,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to perpetrate,to perpetrate,词,VERB,C1
-to perpetuate,to perpetuate,使永存,VERB,B2
-to persecute,to persecute,迫害,VERB,B2
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to persist,to persist,坚持,VERB,B2
-to personify,to personify,词,VERB,C1
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to photocopy (verb),to photocopy,复印,VERB,B2
-to pick out,to pick out,挑选,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to placate,to placate,安抚,VERB,B2
-to place put,to place put,放置,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to plot,to plot,密谋,VERB,B2
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plug in,to plug in,插入,VERB,B2
-to plunder (verb),to plunder,词,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to point to clock in,to point to clock in,词,VERB,B2
-to polarize,to polarize,使两极分化,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to polemicize,to polemicize,词,VERB,C1
-to pollute,to pollute,词,VERB,B2
-to portend,to portend,词,VERB,B2
-to position,to position,定位 / 安置,VERB,B2
-to post,to post,张贴,VERB,B2
-to postpone to carry over,to postpone to carry over,词,VERB,B2
-to postulate,to postulate,假定,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to powder (verb),to powder,词,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to preserve to protect,to preserve to protect,词,VERB,C1
-to preside,to preside,主持,VERB,B2
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to prick,to prick,扎,VERB,B2
-to prioritize,to prioritize,优先考虑,VERB,B2
-to privatize,to privatize,私有化,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to profile (verb),to profile,词,VERB,C1
-to program,to program,编程,VERB,B2
-to project,to project,投射,VERB,B2
-to prop up,to prop up,支撑,VERB,B2
-to propagate,to propagate,传播,VERB,B2
-to prosecute,to prosecute,起诉,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to pucker,to pucker,噘,VERB,B2
-to pull out hair,to pull out hair,词,VERB,C1
-to pull through,to pull through,词,VERB,B2
-to pump (verb),to pump,词,VERB,C1
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purge,to purge,清除,VERB,B2
-to purify,to purify,净化,VERB,B2
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push through,to push through,推动,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put away,to put away,词,VERB,B2
-to put back,to put back,放回,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,词,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to quiver,to quiver,颤抖,VERB,B2
-to race (verb),to race,词,VERB,B1
-to race down,to race down,词,VERB,C1
-to radiate,to radiate,辐射,VERB,B2
-to rage (verb),to rage,怒,VERB,B2
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to rant,to rant,咆哮,VERB,B2
-to ratify,to ratify,批准,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to ravage,to ravage,破坏,VERB,B2
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to rebel (verb),to rebel,造反,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record (verb),to record,备案,VERB,B1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recreate,to recreate,重建,VERB,B2
-to redden,to redden,变红,VERB,B2
-to redeem,to redeem,赎回,VERB,C1
-to rediscover,to rediscover,词,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to reflect on,to reflect on,思考,VERB,B2
-to refuel,to refuel,加油,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to regret (verb),to regret,后悔,VERB,A2
-to regret apologize,to regret apologize,词,VERB,B2
-to rehabilitate,to rehabilitate,使康复,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate,to relate,联系,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relativize,to relativize,词,VERB,C1
-to relaunch,to relaunch,重启,VERB,B2
-to relay,to relay,转达,VERB,B2
-to release from prison,to release from prison,词,VERB,B2
-to release let go,to release let go,词,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remunerate,to remunerate,词,VERB,C1
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,词,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repeal,to repeal,废除,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to repel,to repel,击退,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to replicate,to replicate,复制,VERB,B2
-to reply (verb),to reply,答辩,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resonate,to resonate,共鸣,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to result,to result,产生,VERB,B2
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retort,to retort,反驳,VERB,B2
-to retrace,to retrace,追溯,VERB,B2
-to retract,to retract,撤回,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return home,to return home,词,VERB,B1
-to return to restore,to return to restore,词,VERB,C1
-to revalue,to revalue,重新估值,VERB,B2
-to reverse,to reverse,反转,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to reward (verb),to reward,奖励,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to riddle,to riddle,使布满孔洞,VERB,B2
-to ride along,to ride along,词,VERB,B1
-to ridicule (verb),to ridicule,词,VERB,C1
-to rinse,to rinse,冲洗,VERB,B2
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll up,to roll up,卷,VERB,B1
-to roof (verb),to roof,房顶,VERB,B2
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to rough-hew,to rough-hew,粗加工,VERB,B2
-to ruffle,to ruffle,词,VERB,C1
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to sabotage,to sabotage,破坏,VERB,B2
-to sacrifice (verb),to sacrifice,词,VERB,B2
-to sadden,to sadden,使悲伤,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanctify,to sanctify,使神圣,VERB,B2
-to sanction,to sanction,认可,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to satiate,to satiate,使饱足,VERB,B2
-to saturate,to saturate,使饱和,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to savor,to savor,品味,VERB,B2
-to saw (verb),to saw,词,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scamper,to scamper,词,VERB,B2
-to scan,to scan,扫描,VERB,B2
-to scare away,to scare away,词,VERB,B2
-to scent,to scent,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scheme (verb),to scheme,词,VERB,C1
-to score (verb),to score,词,VERB,B2
-to scourge (verb),to scourge,词,VERB,C1
-to scout,to scout,侦察,VERB,B2
-to scram,to scram,词,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch (verb),to scratch,抓,VERB,B2
-to screw,to screw,拧,VERB,B2
-to scribble (verb),to scribble,词,VERB,C1
-to scrimp,to scrimp,词,VERB,C1
-to scrub,to scrub,擦洗,VERB,B2
-to sculpt,to sculpt,词,VERB,C1
-to search apply,to search apply,词,VERB,B2
-to seat,to seat,使坐下,VERB,B2
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to see emperor,to see emperor,面圣,VERB,C1
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segment (verb),to segment,词,VERB,B2
-to segregate,to segregate,隔离,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sequester,to sequester,隔离,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set aside,to set aside,移开,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sew in,to sew in,词,VERB,C1
-to sexualize,to sexualize,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to share divide,to share divide,分享,VERB,B2
-to sharpen,to sharpen,磨快,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shelter,to shelter,庇护,VERB,B2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shoe (verb),to shoe,词,VERB,C1
-to shoot dead,to shoot dead,词,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop be about,to shop be about,购物,VERB,B2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shroud,to shroud,覆盖,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shunt,to shunt,分流,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sidestep,to sidestep,词,VERB,C1
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to singe,to singe,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to situate,to situate,定位,VERB,B2
-to skein,to skein,词,VERB,B2
-to sketch,to sketch,勾勒,VERB,B2
-to skewer,to skewer,词,VERB,B2
-to skim,to skim,轻触,VERB,B2
-to skin,to skin,剥皮,VERB,B2
-to skip,to skip,词,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slash,to slash,猛砍,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slay,to slay,词,VERB,C1
-to slice (verb),to slice,词,VERB,C1
-to slide,to slide,滑动,VERB,B2
-to slight (verb),to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to snack (verb),to snack,词,VERB,C1
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to sneak away,to sneak away,溜走,VERB,B2
-to snoop,to snoop,窥探,VERB,B2
-to snort (verb),to snort,词,VERB,B2
-to snow,to snow,下雪,VERB,B2
-to snub,to snub,冷落,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solder,to solder,焊接,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort (verb),to sort,分类,VERB,B2
-to sort out,to sort out,词,VERB,B2
-to sour (verb),to sour,词,VERB,C1
-to spam,to spam,发垃圾信息,VERB,B2
-to sparkle,to sparkle,闪耀,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to spawn,to spawn,产卵,VERB,B2
-to specialize,to specialize,专攻,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spell,to spell,拼写,VERB,B2
-to spend time,to spend time,词,VERB,A2
-to spill,to spill,溢出,VERB,B2
-to spirit away,to spirit away,词,VERB,B2
-to splash,to splash,溅,VERB,B2
-to splint (verb),to splint,词,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to sponsor,to sponsor,赞助,VERB,B2
-to spot,to spot,看见,VERB,B2
-to spout,to spout,词,VERB,B2
-to spray (verb),to spray,词,VERB,B2
-to sprout,to sprout,发芽,VERB,B2
-to spy,to spy,监视,VERB,B2
-to spy on,to spy on,词,VERB,C1
-to squeak (verb),to squeak,词,VERB,B2
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stalk,to stalk,跟踪,VERB,B2
-to stammer,to stammer,结巴,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to standardize,to standardize,标准化,VERB,B2
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steep (verb),to steep,词,VERB,C1
-to steer control,to steer control,控制,VERB,B2
-to stem,to stem,起源于,VERB,B2
-to stem from,to stem from,词,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stew (verb),to stew,炖煮,VERB,B2
-to stick out,to stick out,伸出,VERB,B2
-to stiffen,to stiffen,词,VERB,C1
-to stifle smother,to stifle smother,词,VERB,B2
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop down,to stop down,词,VERB,C1
-to stratify,to stratify,分层,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to stride (verb),to stride,词,VERB,B2
-to strike down,to strike down,击倒,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip,to strip,裸露,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive for,to strive for,争取,VERB,B2
-to struggle (verb),to struggle,拼搏,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study to learn,to study to learn,学习,VERB,B2
-to stuff (verb),to stuff,塞,VERB,B2
-to stun,to stun,词,VERB,C1
-to stutter,to stutter,词,VERB,B2
-to stylize,to stylize,词,VERB,C1
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to subordinate,to subordinate,从属,VERB,B2
-to suborn,to suborn,教唆,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to substantiate,to substantiate,证实,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to suit (verb),to suit,适合,VERB,B2
-to suit agree,to suit agree,词,VERB,B2
-to sulk,to sulk,生闷气,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplement (verb),to supplement,补充,VERB,B2
-to supplicate,to supplicate,恳求,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surge (verb),to surge,词,VERB,B2
-to surname (verb),to surname,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to swagger (verb),to swagger,大摇大摆,VERB,C1
-to swallow up,to swallow up,词,VERB,B2
-to swarm,to swarm,分群,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to swell,to swell,使肿胀,VERB,B2
-to swing,to swing,荡秋千,VERB,B2
-to swipe,to swipe,词,VERB,C1
-to switch,to switch,切换,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to synchronize,to synchronize,词,VERB,C1
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to tag (verb),to tag,词,VERB,C1
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take amiss,to take amiss,词,VERB,C1
-to take back,to take back,拿回,VERB,B2
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,词,VERB,B2
-to take on,to take on,词,VERB,C1
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to talk chat,to talk chat,词,VERB,B2
-to tap to type,to tap to type,词,VERB,C1
-to target (verb),to target,针对,VERB,B2
-to tarnish,to tarnish,词,VERB,C1
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to teach reading,to teach reading,词,VERB,B2
-to tear down,to tear down,拆除,VERB,B2
-to tear out,to tear out,拔出,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to temper (verb),to temper,词,VERB,B2
-to temporize,to temporize,拖延,VERB,C1
-to tense (verb),to tense,词,VERB,B2
-to text,to text,发短信,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,词,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,词,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrill (verb),to thrill,词,VERB,B2
-to thrive,to thrive,茁壮成长,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrown,to thrown,词,VERB,B2
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy (verb),to tidy,整理,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
-to tinker,to tinker,词,VERB,B1
-to tip (verb),to tip,词,VERB,B2
-to tip over,to tip over,词,VERB,B2
-to tire get tired,to tire get tired,词,VERB,B2
-to title,to title,命名,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toast (verb),to toast,词,VERB,B2
-to toil (verb),to toil,词,VERB,C1
-to torment,to torment,折磨,VERB,B2
-to total (verb),to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to tow,to tow,词,VERB,C1
-to trace,to trace,描绘；标出,VERB,B2
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to transcribe,to transcribe,转录,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transgress,to transgress,违背,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to trigger (verb),to trigger,引发,VERB,B2
-to trivialize,to trivialize,使平庸,VERB,B2
-to tumble,to tumble,跌倒,VERB,B2
-to tune,to tune,调谐,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn off extinguish,to turn off extinguish,词,VERB,B2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to twinkle,to twinkle,词,VERB,B2
-to type,to type,打字,VERB,B2
-to unbalance,to unbalance,词,VERB,C1
-to unbend,to unbend,词,VERB,B2
-to unblind,to unblind,词,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to unbutton,to unbutton,词,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to underline,to underline,强调,VERB,B2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to undo,to undo,解开,VERB,B2
-to undress,to undress,脱衣,VERB,B2
-to unearth,to unearth,发掘,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unhook,to unhook,词,VERB,B2
-to unload,to unload,卸货,VERB,B2
-to unmask,to unmask,揭穿,VERB,B2
-to unplug,to unplug,词,VERB,C1
-to unravel,to unravel,解开,VERB,B2
-to unroll,to unroll,词,VERB,C1
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to untangle,to untangle,词,VERB,C1
-to unwrap,to unwrap,词,VERB,B1
-to uproot,to uproot,根除,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to use up,to use up,用完,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to vacuum (verb),to vacuum,词,VERB,A2
-to validate,to validate,验证,VERB,B2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vary,to vary,改变,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to venerate,to venerate,崇敬,VERB,B2
-to vent (verb),to vent,词,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to vibrate,to vibrate,振动,VERB,B2
-to view,to view,参观,VERB,B2
-to vilify,to vilify,诽谤,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to wane,to wane,减弱,VERB,B2
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to warp,to warp,弯曲,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch out,to watch out,小心,VERB,B2
-to watch tv,to watch tv,看电视,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to wear down,to wear down,词,VERB,B2
-to wear out,to wear out,磨损,VERB,B2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,词,VERB,B2
-to wed,to wed,词,VERB,C1
-to wedge,to wedge,卡住,VERB,B2
-to weed (verb),to weed,词,VERB,C1
-to weigh down,to weigh down,词,VERB,C1
-to whimper,to whimper,呜咽,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to wield,to wield,词,VERB,C1
-to wilt,to wilt,枯萎,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to wither,to wither,词,VERB,B2
-to woo,to woo,词,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to wound (verb),to wound,伤得,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wring,to wring,拧干,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn,to yearn,渴望,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-to zero out,to zero out,清零,VERB,B2
-toad,toad,蟾蜍,NOUN,B2
-toast,toast,你敬酒,NOUN,B2
-tobacco,tobacco,烟草,NOUN,B2
-today,today,今天,ADV,B2
-today's,today's,词,ADJ,C1
-toe,toe,脚趾,NOUN,B2
-tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-together,together,共同的,ADJ,B2
-toilet paper,toilet paper,卫生纸,NOUN,C1
-told instructed,told instructed,被告知的,ADJ,B2
-tolerance dependence,tolerance dependence,词,NOUN,C1
-tolerant,tolerant,宽容的,ADJ,B2
-tolerate,to tolerate,容忍,VERB,B2
-toll,toll,通行费,NOUN,B2
-tomb,tomb,坟墓,NOUN,B2
-tomb monument,tomb monument,词,NOUN,B2
-tombstone,tombstone,词,NOUN,C1
-tome,tome,词,NOUN,C1
-tomorrow night,tomorrow night,词,ADV,B2
-tonic (adj),tonic,词,ADJ,C1
-tonic (noun),tonic,词,NOUN,C1
-tonight,tonight,今晚,ADV,B2
-too,too,太,ADV,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
-too much,too much,太,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
-too soft,too soft,太软,NOUN,B2
-tool room,tool room,工具间,NOUN,B2
-tooling,tooling,词,NOUN,C1
-tooth,tooth,牙齿,NOUN,B2
-toothache,toothache,牙痛,NOUN,B2
-toothbrush,toothbrush,牙刷,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
-toothpaste,toothpaste,牙膏,NOUN,B2
-top,top,顶部,NOUN,B2
-top (adj),top,顶部的,ADJ,C1
-top dressing,top dressing,追肥,NOUN,B2
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-topographical,topographical,词,ADJ,C1
-torch,torch,手电筒,NOUN,B2
-torment (noun),torment,词,NOUN,C1
-torments,torments,词,NOUN,B2
-tornado,tornado,龙卷风,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torrid,torrid,词,ADJ,C1
-torso,torso,躯干,NOUN,B2
-tortuous,tortuous,词,ADJ,C1
-torture,to torture,折磨,VERB,B2
-torture ordeal,torture ordeal,词,NOUN,C1
-toss,toss,词,VERB,B2
-total,total,总数,NOUN,B2
-total (adj),total,完全的,ADJ,B2
-totalitarian,totalitarian,极权主义的,ADJ,B2
-totality,totality,词,NOUN,C1
-totally,totally,完全地,ADV,B2
-totem,totem,词,NOUN,C1
-touch,to touch,触摸,VERB,B2
-touchability,touchability,能触摸,NOUN,B2
-touching,touching,动人的,ADJ,B2
-touchstone,touchstone,词,NOUN,C1
-touchy,touchy,易怒的,ADJ,B2
-tough,tough,艰难的,ADJ,B2
-tough guy,tough guy,硬汉,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
-tourist,tourist,旅游的,ADJ,B2
-tournament,tournament,锦标赛,NOUN,B2
-tout,tout,词,VERB,C1
-toward,toward,朝向,ADP,B2
-towards,towards,迎向,ADV,B2
-town hall,town hall,市政厅,NOUN,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
-township head,township head,乡长,NOUN,B2
-township road,township road,乡道,NOUN,B2
-toxin,toxin,词,NOUN,C1
-toy,toy,玩具,NOUN,B2
-toys,toys,玩具,NOUN,B2
-trace,trace,痕迹,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
-track,track,轨道,NOUN,B2
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracksuit,tracksuit,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
-trade (verb),trade,词,VERB,A2
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
-trade unionist,trade unionist,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditionally,traditionally,传统地,ADV,B2
-traduce,traduce,词,VERB,C1
-traffic light,traffic light,红绿灯,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficker,trafficker,词,NOUN,C1
-tragically,tragically,词,ADV,B2
-trail,trail,词,NOUN,B1
-train ride,train ride,词,NOUN,A1
-train ticket,train ticket,词,NOUN,A1
-trained,trained,词,ADJ,C1
-trainer,trainer,词,NOUN,B2
-trainer bastard,trainer bastard,词,NOUN,B2
-training center,training center,培训中心,NOUN,C1
-trajectory,trajectory,轨迹,NOUN,B2
-tram,tram,有轨电车,NOUN,B2
-trance,trance,词,NOUN,C1
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transatlantic,transatlantic,词,ADJ,C1
-transcend,transcend,词,VERB,C1
-transcript,transcript,词,NOUN,C1
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transferee,transferee,词,NOUN,C1
-transferor,transferor,词,NOUN,C1
-transfix,transfix,词,VERB,C1
-transient,transient,词,ADJ,C1
-transition,transition,过渡,NOUN,B2
-transitory,transitory,词,ADJ,C1
-translucent,translucent,词,ADJ,C1
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport service,transport service,词,NOUN,C1
-transpose,transpose,词,VERB,C1
-transregional,transregional,词,ADJ,C1
-trapdoor,trapdoor,活板门,NOUN,B2
-trapped,trapped,词,ADJ,A2
-trash bag,trash bag,垃圾袋,NOUN,B2
-trash can,trash can,词,NOUN,A2
-trauma,trauma,创伤,NOUN,B2
-traumatic,traumatic,词,ADJ,B2
-travail,travail,词,NOUN,C1
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
-travesty,travesty,词,NOUN,C1
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
-treacherousness,treacherousness,阴险,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
-treat (noun),treat,盛宴,NOUN,B2
-treatise,treatise,词,NOUN,C1
-trek (noun),trek,词,NOUN,C1
-trembling,trembling,颤抖的,ADJ,B2
-tremendous,tremendous,词,ADJ,B2
-tremulous,tremulous,颤抖的,ADJ,B2
-trench coat,trench coat,词,NOUN,C1
-trenchant,trenchant,词,ADJ,C1
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-trial run,trial run,词,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tricky,tricky,词,ADJ,B2
-tricolor,tricolor,词,ADJ,C1
-trifling,trifling,微不足道的,ADJ,C1
-trigger (adj),trigger,词,ADJ,C1
-trigger imprint,trigger imprint,词,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-triggering,triggering,触发,NOUN,B2
-trilemma,trilemma,词,NOUN,B2
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trilogy,trilogy,词,NOUN,B2
-trim,trim,词,VERB,C1
-trinket,trinket,小饰品,NOUN,B2
-triumph,triumph,胜利,NOUN,B2
-trivia,trivia,词,NOUN,C1
-trivializable,trivializable,可轻描淡写的,ADJ,B2
-troglodyte,troglodyte,词,NOUN,C1
-troop dispatch,troop dispatch,出兵,NOUN,B2
-tropic,tropic,词,NOUN,C1
-tropical,tropical,热带的,ADJ,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
-troublesome,troublesome,麻烦的,ADJ,B2
-troubling,troubling,词,ADJ,B2
-trousers,trousers,裤子,NOUN,B2
-trout,trout,词,NOUN,C1
-truculent,truculent,词,ADJ,C1
-true,true,真实的,ADJ,B2
-true concession,true concession,真让,NOUN,B2
-true form,true form,原形,NOUN,B2
-true heart,true heart,本心,NOUN,B2
-true qi,true qi,真气,NOUN,C1
-truism,truism,自明之理,NOUN,B2
-truly,truly,词,ADV,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trunk,trunk,树干,NOUN,B2
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
-try hard to,to try hard to,力图,VERB,B2
-try out,try out,词,VERB,C1
-tsunami,tsunami,海啸,NOUN,C1
-tuberculosis,tuberculosis,词,NOUN,B2
-tug,tug,词,VERB,C1
-tumble (noun),tumble,词,NOUN,C1
-tumor,tumor,肿瘤,NOUN,B2
-tumult,tumult,词,NOUN,C1
-tumultuous,tumultuous,词,ADJ,C1
-turbid,turbid,词,ADJ,C1
-turbulence,turbulence,词,NOUN,C1
-turbulent,turbulent,动荡的,ADJ,B2
-turgid,turgid,词,ADJ,C1
-turkey,turkey,火鸡,NOUN,B2
-turkish,turkish,土耳其的,ADJ,B2
-turmoil,turmoil,混乱,NOUN,B2
-turn,turn,转弯,NOUN,B2
-turn around,to turn around,转身,VERB,B2
-turn of phrase,turn of phrase,词,NOUN,C1
-turn off,to turn off,关闭,VERB,B2
-turn on,to turn on,打开,VERB,B2
-turn out,to turn out,结果是,VERB,B2
-turn signal,turn signal,转向灯,NOUN,B2
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
-turnoff,turnoff,词,NOUN,B2
-turnover,turnover,营业额,NOUN,B2
-turntable,turntable,词,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
-tutelary,tutelary,词,ADJ,C1
-tutor,tutor,导师,NOUN,C1
-tutoring,tutoring,补习,NOUN,B2
-tv,tv,电视,NOUN,B2
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-twenty-five,twenty-five,词,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twice,twice,两次,ADV,B2
-twist (noun),twist,词,NOUN,C1
-twitching,twitching,抽搐的,ADJ,B2
-two animals,two animals,两只,NUM,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
-two-headed,two-headed,双头的,ADJ,B2
-two-way street,two-way street,双行道,NOUN,B2
-twofold,twofold,词,ADJ,B2
-tycoon,tycoon,词,NOUN,C1
-type like,type like,词,NOUN,B2
-typhoon,typhoon,台风,NOUN,B2
-typical,typical,典型的,ADJ,B2
-typically,typically,词,ADV,C1
-typographical,typographical,词,ADJ,B2
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-ubiquitous,ubiquitous,词,ADJ,C1
-ukrainian,ukrainian,乌克兰的,ADJ,B2
-ulterior,ulterior,词,ADJ,C1
-ultimate,ultimate,最终的,ADJ,B2
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimately,ultimately,最终,ADV,B2
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-um,um,嗯,INTJ,B2
-umbrage,umbrage,词,NOUN,C1
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unacceptable,unacceptable,不可接受的,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unambiguous,unambiguous,明确的,ADJ,B2
-unanimous,unanimous,一致的,ADJ,B2
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
-unattainable,unattainable,难以获得的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unbearable,unbearable,难以忍受的,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
-unbelievable,unbelievable,难以置信的,ADJ,B2
-unbelieving,unbelieving,词,ADJ,C1
-unbridled,unbridled,词,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
-uncertain,uncertain,不确定的,ADJ,B2
-uncertainty,uncertainty,不确定性,NOUN,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
-unclear,unclear,不清楚的,ADJ,B2
-uncomfortable,uncomfortable,不舒服的,ADJ,B2
-uncompromising,uncompromising,词,ADJ,B2
-unconditional,unconditional,无条件的,ADJ,B2
-unconquerable,unconquerable,词,ADJ,C1
-unconscious,unconscious,无意识的,ADJ,B2
-unconsciousness,unconsciousness,词,NOUN,C1
-uncontrollable,uncontrollable,无法控制的,ADJ,B2
-uncooled,uncooled,未寒,NOUN,B2
-uncountable,uncountable,词,ADJ,C1
-uncouth,uncouth,粗俗的,ADJ,B2
-uncover,to uncover,揭露,VERB,B2
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,词,ADJ,B2
-unctuous,unctuous,谄媚的,ADJ,B2
-uncultivated,uncultivated,词,ADJ,B2
-undaunted,undaunted,词,ADJ,C1
-undead,undead,词,NOUN,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
-undeniable,undeniable,不可否认的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under the,under the,词,ADP,B2
-underclass,underclass,底层,NOUN,B2
-undercover agent,undercover agent,卧底,NOUN,B2
-underestimate,to underestimate,低估,VERB,B2
-underestimation,underestimation,小看,NOUN,B2
-undergo,to undergo,经历,VERB,B2
-undergraduate,undergraduate,本科生,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
-underground,underground,地铁,NOUN,B2
-underground (adj),underground,地下的,ADJ,B1
-underground garage,underground garage,地下车库,NOUN,C1
-underling,underling,词,NOUN,C1
-underlying,underlying,词,ADJ,B2
-undermining authority,undermining authority,削弱权威,NOUN,B2
-underneath,underneath,在下面,ADV,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underpants,underpants,内裤,NOUN,B2
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-understandable,understandable,可理解的,ADJ,B2
-understanding,understanding,体贴的,ADJ,B2
-understood,understood,词,ADJ,A1
-undertake,to undertake,承担,VERB,B2
-undertaking,undertaking,事业,NOUN,B2
-underwater,underwater,词,ADJ,B2
-underwear,underwear,内衣,NOUN,B2
-underworld,underworld,地下世界,NOUN,B2
-underwrite,to underwrite,承保,VERB,B2
-undeserved,undeserved,词,ADJ,C1
-undisturbed,undisturbed,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undoubtedly,undoubtedly,无疑地,ADV,B2
-undulate,undulate,词,VERB,C1
-unearned,unearned,浪得,NOUN,C1
-uneasy,uneasy,不安的,ADJ,B2
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
-unequal,unequal,不平等的,ADJ,B2
-unequivocal,unequivocal,词,ADJ,C1
-unerring,unerring,词,ADJ,C1
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected,unexpected,意想不到的,ADJ,B2
-unexpected event,unexpected event,变故,NOUN,B2
-unexpectedly,unexpectedly,出乎意料地,ADV,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair,unfair,不公平的,ADJ,B2
-unfaithful,unfaithful,不忠的,ADJ,B2
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfettered,unfettered,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
-unfold,to unfold,展开,VERB,B2
-unfolding,unfolding,词,NOUN,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable,unforgivable,不可原谅的,ADJ,B2
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfortunate,unfortunate,不幸的,ADJ,B2
-unfortunately,unfortunately,不幸地,ADV,B2
-unfounded,unfounded,词,ADJ,C1
-unfriendly,unfriendly,不友好的,ADJ,B2
-ungabe,ungabe,词,NOUN,C1
-ungainly,ungainly,笨拙的,ADJ,C1
-ungestaltung,ungestaltung,词,NOUN,C1
-ungodliness,ungodliness,词,NOUN,C1
-ungrateful,ungrateful,忘恩负义的,ADJ,B2
-unhappy,unhappy,不快乐的,ADJ,B2
-unharmed,unharmed,未受伤的,ADJ,B2
-unhealthy,unhealthy,词,ADJ,C1
-unicorn,unicorn,词,NOUN,C1
-unification,unification,词,NOUN,B2
-unified examination,unified examination,统考,NOUN,B2
-uniform,uniform,制服,NOUN,B2
-uniformity,uniformity,词,NOUN,B2
-unify,to unify,统一,VERB,B2
-unilateral,unilateral,单方面的,ADJ,B2
-unimaginable,unimaginable,难以想象的,ADJ,B2
-unimpeachable,unimpeachable,词,ADJ,C1
-unimpeded,unimpeded,词,ADJ,C1
-unimportant,unimportant,不重要的,ADJ,B2
-uninhabited,uninhabited,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
-union (adj),union,词,ADJ,C1
-united,united,联合的,ADJ,B2
-universal,universal,普遍的,ADJ,B2
-universal applicability,universal applicability,普适性,NOUN,B2
-universe,universe,宇宙,NOUN,B2
-universities,universities,大学,NOUN,B2
-university of applied sciences,university of applied sciences,词,NOUN,B2
-university student,university student,大学生,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unknown,unknown,未知的,ADJ,B2
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
-unleash,to unleash,释放,VERB,B2
-unleashed,unleashed,词,ADJ,C1
-unless,unless,除非,SCONJ,B2
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlimited,unlimited,无限的,ADJ,B2
-unlocked,unlocked,词,NOUN,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unmitigated,unmitigated,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unnatural,unnatural,词,ADJ,B2
-unnecessary,unnecessary,不必要的,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unobtrusive,unobtrusive,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
-unpack,to unpack,拆包,VERB,B2
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
-unprecedented,unprecedented,史无前例的,ADJ,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpublished,unpublished,词,ADJ,B2
-unpunished,unpunished,词,ADJ,C1
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreality,unreality,虚幻,NOUN,B2
-unreasonable,unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unreflective,unreflective,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
-unrichtung,unrichtung,词,NOUN,C1
-unsafe,unsafe,词,ADJ,B1
-unscathed,unscathed,未受伤害的,ADJ,B2
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unsecured,unsecured,词,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unsetzung,unsetzung,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsociable,unsociable,词,ADJ,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsprache,unsprache,词,NOUN,C1
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsuccessful,unsuccessful,词,ADJ,C1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untenable,untenable,词,ADJ,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-unthinkable,unthinkable,不可想象的,ADJ,B2
-untidiness,untidiness,词,NOUN,B2
-untidy,untidy,词,ADJ,C1
-until to,until to,词,ADP,A2
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouchable,untouchable,不可触碰的,ADJ,B2
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untreibung,untreibung,词,NOUN,B2
-unviable,unviable,词,ADJ,C1
-unwandel,unwandel,词,NOUN,B2
-unwanted,unwanted,词,ADJ,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwise,unwise,词,ADJ,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
-upbraid,upbraid,词,VERB,C1
-upheaval,upheaval,剧变,NOUN,B2
-uphold,uphold,词,VERB,C1
-upper class,upper class,词,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-upright,upright,直立地,ADV,B2
-uprooted,uprooted,词,ADJ,C1
-ups and downs,ups and downs,词,NOUN,B2
-upset,upset,心烦的,ADJ,B2
-upshot,upshot,词,NOUN,C1
-upstart (adj),upstart,词,ADJ,C1
-upstart (noun),upstart,暴发户,NOUN,C1
-upward,upward,向上,ADV,B2
-upwards,upwards,向上,ADV,B2
-urban area,urban area,词,NOUN,C1
-urbane,urbane,词,ADJ,C1
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,C1
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
-usage,usage,还用,NOUN,C1
-usb flash drive,usb flash drive,U盘,NOUN,B2
-used,used,词,ADJ,C1
-useless zero,useless zero,词,ADJ,A2
-uselessly,uselessly,词,ADV,C1
-using this,using this,用这,NOUN,C1
-usual thing,usual thing,惯例,NOUN,B2
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-utensil,utensil,词,NOUN,C1
-utility,utility,效用,NOUN,B2
-utility room,utility room,杂物间,NOUN,C1
-utter,utter,词,ADJ,C1
-vacant lot,vacant lot,空地,NOUN,C1
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vacillate,vacillate,词,VERB,C1
-vacuous,vacuous,词,ADJ,C1
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum cleaner,vacuum cleaner,词,NOUN,B2
-vagabond,vagabond,词,NOUN,C1
-vagary,vagary,词,NOUN,C1
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vaguely,vaguely,词,ADV,C1
-vain,vain,徒劳的,ADJ,B2
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vale of tears,vale of tears,词,NOUN,C1
-valedictory,valedictory,词,ADJ,C1
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
-valid,valid,有效的,ADJ,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-vanilla,vanilla,词,NOUN,C1
-vanquish,vanquish,词,VERB,C1
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-variable (adj),variable,词,ADJ,C1
-variant,variant,变体,NOUN,B2
-variation,variation,变化,NOUN,B2
-variegate,variegate,词,VERB,C1
-various,various,各种各样的,ADJ,B2
-varnish,varnish,词,NOUN,B2
-vase,vase,花瓶,NOUN,B2
-vassal,vassal,之臣,NOUN,C1
-vat,vat,增值税,NOUN,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunt,vaunt,词,VERB,C1
-vaunted,vaunted,词,ADJ,B2
-veer,veer,词,VERB,C1
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehemence,vehemence,词,NOUN,C1
-vehement,vehement,激烈的,ADJ,C1
-veiled,veiled,隐晦的,ADJ,B2
-vending machine,vending machine,自动售货机,NOUN,B2
-veneer,veneer,词,NOUN,C1
-venereal disease,venereal disease,性病,NOUN,B2
-venial,venial,词,ADJ,C1
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-venture (noun),venture,词,NOUN,B2
-veracity,veracity,词,NOUN,C1
-verbal,verbal,词,ADJ,B2
-verbalize,verbalize,词,VERB,B2
-verbatim,verbatim,词,ADV,C1
-verbosely,verbosely,词,ADV,C1
-verdant,verdant,词,ADJ,C1
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-verge,verge,词,NOUN,C1
-vergestaltung,vergestaltung,词,NOUN,C1
-verifiable,verifiable,词,ADJ,C1
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkunft,verkunft,词,NOUN,C1
-vermilion,vermilion,词,NOUN,B2
-vernacular,vernacular,词,NOUN,C1
-vernahme,vernahme,词,NOUN,C1
-verpflegung,verpflegung,词,NOUN,C1
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
-versatile,versatile,多才多艺的,ADJ,B2
-versatility,versatility,词,NOUN,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verse,verse,词,NOUN,C1
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-versprache,versprache,词,NOUN,C1
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-versus,versus,对,ADP,B2
-verteilung,verteilung,词,NOUN,C1
-vertex,vertex,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
-vertigo,vertigo,词,NOUN,C1
-vertreibung,vertreibung,词,NOUN,C1
-verwandel,verwandel,词,NOUN,C1
-verweisung,verweisung,词,NOUN,C1
-verwirkung,verwirkung,词,NOUN,C1
-very best,very best,词,ADJ,B2
-very deep,very deep,很深,ADJ,B2
-very fine,very fine,词,ADJ,C1
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-vestige,vestige,词,NOUN,C1
-veterinarian,veterinarian,词,NOUN,C1
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-viable,viable,可行的,ADJ,B2
-vial,vial,词,NOUN,C1
-vibrant,vibrant,词,ADJ,C1
-vicarious,vicarious,词,ADJ,C1
-vice versa,vice versa,反之亦然,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
-vicious,vicious,词,ADJ,B2
-vicissitude,vicissitude,变迁,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-video clip,video clip,词,NOUN,C1
-video on demand,video on demand,点播,NOUN,C1
-videotape,videotape,词,NOUN,C1
-viewer,viewer,观众,NOUN,B2
-vigilant,vigilant,警惕的,ADJ,B2
-vignette,vignette,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
-vile (adv),vile,词,ADV,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vineyard,vineyard,葡萄园,NOUN,C1
-vintage,vintage,佳酿,NOUN,B2
-violate regulations,violate regulations,违规,VERB,C1
-violent act,violent act,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violet (adj),violet,词,ADJ,C1
-virginal,virginal,处女的,ADJ,B2
-virtual reality,virtual reality,虚拟现实,NOUN,B2
-virtuoso,virtuoso,词,NOUN,C1
-virtuous,virtuous,有德行的,ADJ,B2
-virulent,virulent,恶性的,ADJ,B2
-viscount,viscount,词,NOUN,C1
-visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
-visionary,visionary,词,NOUN,C1
-visiting ban,visiting ban,词,NOUN,B2
-visor,visor,词,NOUN,B2
-visualize,visualize,词,VERB,C1
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vitiate,vitiate,词,VERB,C1
-vitriolic,vitriolic,词,ADJ,C1
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
-vocabulary,vocabulary,词,NOUN,C1
-vocal range,vocal range,词,NOUN,C1
-vocation,vocation,词,NOUN,C1
-vociferous,vociferous,词,ADJ,C1
-vodka,vodka,词,NOUN,C1
-vogue,vogue,流行,NOUN,B2
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-void,void,最无,NOUN,B2
-volition,volition,词,NOUN,C1
-volleyball,volleyball,排球,NOUN,B2
-voluble,voluble,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-vomit (noun),vomit,词,NOUN,B2
-voracious,voracious,词,ADJ,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorkunft,vorkunft,词,NOUN,C1
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-votary,votary,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
-votive offering,votive offering,词,NOUN,C1
-vouch,vouch,词,VERB,C1
-vouchsafe,vouchsafe,词,VERB,C1
-vowel,vowel,词,NOUN,C1
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vs,vs,与...相对,ADP,B2
-vulnerable,vulnerable,易受伤害的,ADJ,B2
-vulture,vulture,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-waft,waft,词,VERB,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage murder unit,wage murder unit,词,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waive,waive,词,VERB,C1
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-walk,walk,行走,NOUN,B2
-walker,walker,词,NOUN,C1
-wall-mounted,wall-mounted,词,ADJ,C1
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-wan,wan,词,ADJ,B2
-wander,to wander,漫步,VERB,B2
-wanderer,wanderer,词,NOUN,C1
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
-want,want,想,AUX,B2
-want (adp),want,我要,ADP,A2
-want to lure,want to lure,想引,NOUN,B2
-want to need will,to want to need will,要,VERB,B2
-wanted,wanted,故意的,ADJ,B2
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warble (verb),warble,词,VERB,C1
-ward,ward,病房,NOUN,B2
-warden,warden,看守人,NOUN,B2
-wardrobe,wardrobe,衣柜,NOUN,B2
-warehouse store,warehouse store,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,词,ADJ,B2
-warmly,warmly,热情地,ADV,B2
-warmonger,warmonger,词,NOUN,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrior,warrior,战士,NOUN,B2
-warrior (part),warrior,士,PART,B2
-wary,wary,谨慎的,ADJ,B2
-wash (noun),wash,冲走,NOUN,C1
-washer,washer,词,NOUN,B2
-washing,washing,洗涤,NOUN,B2
-waste,to waste,浪费,VERB,B2
-waste disposal site,waste disposal site,词,NOUN,B1
-waste of time,waste of time,词,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wasteland,wasteland,荒地,NOUN,B2
-wastewater,wastewater,废水,NOUN,C1
-watch,watch,手表,NOUN,B2
-watch over,watch over,词,VERB,C1
-watched,watched,词,NOUN,B2
-watchmaking,watchmaking,词,NOUN,C1
-watchtower,watchtower,词,NOUN,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water falling,water falling,水落,NOUN,B2
-water garment,water garment,水衣,NOUN,C1
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-water spinach,water spinach,空心菜,NOUN,B2
-watercolor,watercolor,水彩画,NOUN,B2
-watermelon seed,watermelon seed,西瓜子,NOUN,B2
-waterproof,waterproof,防水的,ADJ,B2
-waterproof (verb),waterproof,词,VERB,C1
-watershed,watershed,词,NOUN,C1
-watertight,watertight,,NOUN,B2
-wave,to wave,挥手,VERB,B2
-waver,waver,动摇,VERB,C1
-wax,wax,蜡,NOUN,B2
-waxen,waxen,词,ADJ,C1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
-way out,way out,出路,NOUN,B2
-waylay,waylay,词,VERB,C1
-we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
-we two,we two,我俩,PRON,B2
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weaken,to weaken,削弱,VERB,B2
-weakened,weakened,词,ADJ,C1
-weakening,weakening,减弱,NOUN,B2
-weakly,weakly,词,ADV,C1
-weal,weal,词,NOUN,C1
-wealthy,wealthy,富有的,ADJ,B2
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
-wear,wear,磨损,NOUN,B2
-wear tear,wear tear,词,NOUN,C1
-wearily,wearily,词,ADV,C1
-wearisome,wearisome,词,ADJ,C1
-weary,weary,疲倦的,ADJ,B2
-weather forecast,weather forecast,词,NOUN,B1
-weather institute,weather institute,词,NOUN,B2
-weave,to weave,编织,VERB,B2
-weaving,weaving,编织,NOUN,B2
-webcam,webcam,网络摄像头,NOUN,B2
-wedding anniversary,wedding anniversary,结婚纪念日,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
-wedding photo,wedding photo,婚纱照,NOUN,B2
-week number,week number,周次,NOUN,B2
-weekday,weekday,工作日,NOUN,B2
-weekend,weekend,周末,NOUN,B2
-weekly,weekly,每周的,ADJ,B2
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weekly test,weekly test,周测,NOUN,B2
-weep,to weep,哭泣,VERB,B2
-weeping,weeping,痛哭,NOUN,C1
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
-welcome,welcome,欢迎,NOUN,B2
-welcome (adj),welcome,词,ADJ,B2
-welcome committee,welcome committee,,NOUN,B2
-welcoming,welcoming,舒适的,ADJ,B2
-weld,weld,词,VERB,C1
-welfare home,welfare home,福利院,NOUN,C1
-well,well,好吧,INTJ,B2
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
-well-disposed,well-disposed,词,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-liked,well-liked,词,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welter,welter,词,NOUN,C1
-wend,wend,词,VERB,C1
-werewolf,werewolf,狼人,NOUN,B2
-western,western,西方的,ADJ,B2
-westward,westward,往西,NOUN,B2
-westward (adv),westward,向西,ADV,B2
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wharf,wharf,词,NOUN,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
-when (adp),when,之时,ADP,B2
-when than,when than,词,SCONJ,A2
-when the time comes,when the time comes,到时候,ADV,B2
-where,where,哪里,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (sconj),whereas,词,SCONJ,C1
-whet,whet,词,VERB,C1
-whether,whether,是否,SCONJ,B2
-whey,whey,词,NOUN,B2
-which,which,哪一个,PRON,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
-whiny,whiny,词,ADJ,C1
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
-whirring,whirring,词,NOUN,C1
-whisk,whisk,打蛋器,NOUN,B2
-whisk whip,whisk whip,词,NOUN,B1
-whistleblower,whistleblower,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-wholehearted,wholehearted,词,ADJ,C1
-wholesome,wholesome,词,ADJ,C1
-whore,whore,妓女,NOUN,B2
-whose (det),whose,词,DET,B2
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
-wicked,wicked,邪恶的,ADJ,B2
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,词,NOUN,B2
-widower,widower,词,NOUN,C1
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wig,wig,假发,NOUN,B2
-wild beast,wild beast,词,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
-wilderness,wilderness,荒野,NOUN,B2
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will shall,will shall,将要/会,AUX,B2
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-willing,willing,肯,AUX,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-wimp,wimp,懦夫,NOUN,B2
-win,win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-windfall,windfall,意外之财,NOUN,B2
-winding,winding,词,ADJ,B2
-windless,windless,无风的,ADJ,B2
-window frame,window frame,窗框,NOUN,C1
-windowsill,windowsill,窗台,NOUN,C1
-windy,windy,有风的,ADJ,B2
-windy day,windy day,风天,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
-winsome,winsome,词,ADJ,C1
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wintry,wintry,冬天的,ADJ,B2
-wisely,wisely,明智地,ADV,B2
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wistful,wistful,词,ADJ,C1
-wit,wit,词,NOUN,C1
-witch hunt,witch hunt,词,NOUN,C1
-witchcraft,witchcraft,巫术,NOUN,B2
-with each other,with each other,词,ADV,A2
-with it,with it,在其中,ADV,B2
-with me,with me,词,PRON,A1
-with that,with that,以此,ADV,B2
-with this,with this,以此,ADV,B2
-with what,with what,用什么,ADV,B2
-with which,with which,词,PRON,A2
-with you,with you,词,PRON,A1
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawal fold,withdrawal fold,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without exception,without exception,无例外的,ADV,B2
-without further ado,without further ado,词,ADV,B2
-withstand,withstand,词,VERB,C1
-witness examination,witness examination,证人询问,NOUN,B2
-witness female,witness female,词,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,词,NOUN,C1
-witty saying,witty saying,词,NOUN,C1
-wizened,wizened,词,ADJ,C1
-woe (intj),woe,词,INTJ,B2
-woe (noun),woe,词,NOUN,C1
-woman-like,woman-like,妇似,NOUN,C1
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wonderful (adv),wonderful,词,ADV,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-wooded,wooded,树木茂盛的,ADJ,B2
-wooden,wooden,木制的,ADJ,B2
-woods,woods,林子,NOUN,B2
-word choice,word choice,措辞,NOUN,B2
-wording,wording,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-workday,workday,词,NOUN,C1
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working,working,词,ADJ,C1
-working class,working class,工人阶级,NOUN,B2
-working day,working day,词,NOUN,B2
-working method,working method,词,NOUN,B2
-workout,workout,词,NOUN,C1
-world champion,world champion,词,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldly,worldly,世俗的,ADJ,B2
-worn,worn,磨损的,ADJ,B2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worse (noun),worse,词,NOUN,B2
-worsening,worsening,词,NOUN,C1
-worst (adv),worst,词,ADV,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthless,worthless,无价值的,ADJ,B2
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would,would,将要,AUX,B2
-would like,would like,词,AUX,A2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-wow,wow,哇,INTJ,B2
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wrapper,wrapper,词,NOUN,C1
-wrathful,wrathful,词,ADJ,C1
-wreckage,wreckage,词,NOUN,C1
-wrench,wrench,词,NOUN,C1
-wretched,wretched,词,ADJ,C1
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-writ,writ,词,NOUN,C1
-writhe,writhe,词,VERB,C1
-written instruction,written instruction,批示,NOUN,C1
-wrongdoer,wrongdoer,罪犯,NOUN,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
-x-ray,x-ray,X光片,NOUN,B2
-xenophobia,xenophobia,排外心理,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
-yarn,yarn,纱线,NOUN,B2
-yeah,yeah,词,INTJ,A1
-yeah yeah,yeah yeah,是是是,INTJ,B2
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yeoman,yeoman,词,NOUN,C1
-yep,yep,词,INTJ,B2
-yes,yes,是的,PART,B2
-yes (adv),yes,词,ADV,A2
-yes (noun),yes,是啊,NOUN,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yes indeed (adv),yes indeed,词,ADV,B2
-yesterday (adv),yesterday,词,ADV,A1
-yesteryear,yesteryear,词,NOUN,C1
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yo,yo,哟,PART,B2
-yoga practice,yoga practice,词,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you dative,you dative,词,PRON,A2
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you formal,you formal,您,PRON,B2
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
-young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,词,ADJ,B2
-your,your,你的,PRON,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your pl,your pl,词,DET,B2
-your plural,your plural,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,词,PRON,B2
-yourself,yourself,你自己,PRON,B2
-youth culture,youth culture,词,NOUN,C1
-youth people,youth people,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful,youthful,词,ADJ,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
-yuck,yuck,呸,INTJ,B2
-zany,zany,词,ADJ,C1
-zeal,zeal,热情,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zen master,zen master,禅师,NOUN,B2
-zephyr,zephyr,词,NOUN,C1
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
-zero,zero,零,NOUN,B2
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
-zongzi,zongzi,粽子,NOUN,B2
-zoo,zoo,动物园,NOUN,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zukunft,zukunft,词,NOUN,C1
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
-zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
-zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
-آخر,other,其他的,DET,B2
-آخرون,others,他人,NOUN,B2
-آخِر,last,最后,ADV,B2
-آفة,vermin,害兽,NOUN,B2
-آلية مضادة,counter-mechanism,反机,NOUN,B2
-آلية مُغيَّرة,altered mechanism,改机,NOUN,B2
-آلَة ثَقِيلَة,heavy machine,重机,NOUN,B2
-آه,ouch,哎哟,INTJ,B2
-آيس كريم,ice cream,冰淇淋,NOUN,B2
-أب,father,父,PART,B2
-أباد,to exterminate,消灭,VERB,B2
-أبجدي,alphabetical,按字母顺序的,ADJ,B2
-أبداً,ever,曾经,ADV,B2
-أبداً,to ever,里何尝,VERB,B2
-أبدي,eternal,永恒的,ADJ,B2
-أبكم,dumb,愚蠢的,ADJ,B2
-أبلغ,to notify,通知,VERB,B2
-أبهر,to dazzle,使眼花,VERB,B2
-أتاح,to enable,使能够,VERB,B2
-أثار,to excite,使兴奋,VERB,B2
-أثار,to induce,引起,VERB,B2
-أثارَ,to arouse,引起,VERB,B2
-أثرى,to enrich,使丰富,VERB,B2
-أثّر,to influence,影响,VERB,B2
-أجبر,to compel,强迫,VERB,B2
-أجنبي,alien,外星人,NOUN,B2
-أحاط,to circumscribe,限制,VERB,B2
-أحاط,to enclose,围住,VERB,B2
-أحب,to fall in love,坠入爱河,VERB,B2
-أحمق,idiot,白痴,NOUN,B2
-أحياناً,occasionally,偶尔,ADV,B2
-أخبار سيئة,bad news,坏消息,NOUN,B2
-أخبر,to inform,通知,VERB,B2
-أخطأ,to err,犯错,VERB,B2
-أخطأ,to mistake,弄错,VERB,B2
-أخلاق,morality,道德,NOUN,B2
-أخلاق,morals,道德,NOUN,B2
-أخلاقي,ethical,道德的,ADJ,B2
-أخلّ,to derogate,贬损,VERB,B2
-أخْلَى,to evacuate,疏散,VERB,B2
-أدان,to denounce,谴责,VERB,B2
-أدرك,to perceive,察觉,VERB,B2
-أدنى,inferior,低等的,ADJ,B2
-أرثوذكسي,orthodox,正统的,ADJ,B2
-أرجوك,please,请,ADV,B2
-أرز مطبوخ,cooked rice,米饭,NOUN,B2
-أزال السموم,to detoxify,解毒,VERB,B2
-أزعج,to irritate,激怒,VERB,B2
-أزعجَ,to trouble,有劳,VERB,B2
-أزعَجَ,to upset,使生气,VERB,B2
-أساء فهم,to misunderstand,误解,VERB,B2
-أساساً,essentially,主要地,ADV,B2
-أساسي,essential,必要的,ADJ,B2
-أساسي,primary,主要的,ADJ,B2
-أسر,capture,捕获,NOUN,B2
-أسر,to capture,获取,VERB,B2
-أسفل النهر,downstream,下游,NOUN,B2
-أسوأ,worse,更糟的,ADJ,B2
-أشار,to indicate,表明,VERB,B2
-أصالة,originality,独创性,NOUN,B2
-أصلح,to mend,修补,VERB,B2
-أصلح,to reform,改革,VERB,B2
-أصلي,indigenous,本土的,ADJ,B2
-أصلي,native,本地的,ADJ,B2
-أصلي,original,最初的,ADJ,B2
-أصم,deaf,聋的,ADJ,B2
-أضعف,to demoralize,使士气低落,VERB,B2
-أضلّ,to mislead,误导,VERB,B2
-أطعم,to feed,喂养,VERB,B2
-أطلق,to emit,发出,VERB,B2
-أطلق,to release,释放,VERB,B2
-أعاد,to return first,先回,VERB,B2
-أعاد إصدار,to reissue,补办,VERB,B2
-أعاد النظر,to reconsider,重新考虑,VERB,B2
-أعاد بناء,to rebuild,重建,VERB,B2
-أعاد بناء,to reconstruct,重建,VERB,B2
-أعاد تدوير,to recycle,回收利用,VERB,B2
-أعاد رواية,to retell,转述,VERB,B2
-أعفى,to exempt,免除,VERB,B2
-أغرى,to entice,引诱,VERB,B2
-أغضب,to exasperate,激怒,VERB,B2
-أفق,prospect,前景,NOUN,B2
-أقام,to reside,居住,VERB,B2
-أكثر,more,更多,ADV,B2
-أكثر,more often,更频繁,ADV,B2
-أكثر,most,最,ADV,B2
-ألبوم,album,相册,NOUN,B2
-ألعاب نارية,fireworks,烟花,NOUN,B2
-ألغى,to revoke,撤销,VERB,B2
-ألف,to compose,组成,VERB,B2
-ألفية,millennium,千年,NOUN,B2
-ألم العضلات,muscle pain,肌肉痛,NOUN,B2
-ألماني,german,德国的,ADJ,B2
-ألوهية,divinity,神性,NOUN,B2
-أم,mom,妈妈,NOUN,B2
-أم,mother,娘,PART,B2
-أمة,nation,国家,NOUN,B2
-أمر,to order,命令,VERB,B2
-أمر عسكري,military order,军令,NOUN,B2
-أمس,yesterday,昨天,ADV,B2
-أمطر,to rain,下雨,VERB,B2
-أملى,to dictate,口述,VERB,B2
-أمير,prince,王子,NOUN,B2
-أنار,to enlighten,启发,VERB,B2
-أناناس,pineapple,菠萝,NOUN,B2
-أنت,you,你,PRON,B2
-أنثى,female,女性的,ADJ,B2
-أنعش,to refresh,使恢复精神,VERB,B2
-أنقذ,to rescue,拯救,VERB,B2
-أنهى,to finalize,完成,VERB,B2
-أو بالأحرى,or rather,或者,ADV,B2
-أودع,to deposit,存放,VERB,B2
-أوراق امتحان سابقة,past exam papers,真题,NOUN,B2
-أوركسترا,orchestra,管弦乐队,NOUN,B2
-أوصى,to recommend,推荐,VERB,B2
-أوفق,to reconcile,和解,VERB,B2
-أول ظهور,debut,初次登台,NOUN,B2
-أولا,first,首先,ADV,B2
-أولي,initial,最初的,ADJ,B2
-أي,namely,即,ADV,B2
-أيد,to endorse,支持,VERB,B2
-أيضًا,also,也,ADV,B2
-أيقونة,icon,偶像,NOUN,B2
-أينما,everywhere,到处,ADV,B2
-أَب,dad,爸爸,NOUN,B2
-أَبْعَد,further,进一步的,ADJ,B2
+ـاً,-ly,地,PART,B2
+بعض,a,一个,DET,B2
+قليلاً,a bit,一点,ADV,B2
+قليل,a little,一点,ADJ,B2
+زوجان,a married couple,夫妇,NOUN,B2
+زوج,a pair,一对,NUM,B2
+كومة,a pile,一堆,NUM,B2
+بئر,a well,井,NOUN,B2
+فترة,a while,一会儿,NOUN,B2
+هَجَرَ,to abandon,放弃,VERB,B2
+تَخَلَّى,to abdicate,退位,VERB,B2
 أَبْغَضَ,to abhor,憎恶,VERB,B2
-أَبْلَغَ,to impart,传授,VERB,B2
-أَبْهَرَ,to impress,使印象深刻,VERB,B2
-أَثَاث,furniture,家具,NOUN,B2
-أَثَثَ,to furnish,提供,VERB,B2
-أَثَر,effect,效果,NOUN,B2
-أَحْبَطَ,to frustrate,挫败,VERB,B2
-أَحْرَقَ,to incinerate,焚烧,VERB,B2
-أَخَافَ,to frighten,使害怕,VERB,B2
-أَدَّبَ,to discipline,管教,VERB,B2
-أَدْخَلَ,to insert,插入,VERB,B2
-أَرْبَعَةَ عَشَر,fourteen,十四,NUM,B2
-أَرْسَلَ,to transmit,传输,VERB,B2
-أَرْض,grounds,论据,NOUN,B2
-أَرْض,terrain,地形,NOUN,B2
-أَرْض,territory,领土,NOUN,B2
-أَرْض رَطْبَة,wetland,湿地,NOUN,B2
-أَزْعَجَ,to harass,骚扰,VERB,B2
-أَسَاءَ,to abuse,滥用,VERB,B2
-أَسَّسَ,to found,创立,VERB,B2
-أَسْتَضَفَ,to accommodate,容纳,VERB,B2
-أَصْلِي,fundamental,基本的,ADJ,B2
-أَضَرَّ,to damage,损坏,VERB,B2
-أَضَرَّ,to harm,损害,VERB,B2
-أَضْجَرَ,to make noise,闹得,VERB,B2
-أَطَّرَ,to frame,装框,VERB,B2
-أَعْدَى,to infect,感染,VERB,B2
-أَعْيا,to exhaust,耗尽,VERB,B2
-أَغْلَقَ,to lock up,关押,VERB,B2
-أَغْلَقَ,to lockdown,封城,VERB,B2
-أَغْوَى,to seduce,引诱,VERB,B2
-أَقَارِب الإِمَارة,imperial relatives,皇亲,NOUN,B2
-أَقْسَام مُخْتَلِفَة,various departments,各部,NOUN,B2
-أَكَادِيمِي,academic,学者,NOUN,B2
-أَكْمَلَ,supplement,补充,NOUN,B2
-أَكْمَلَ,to supplement,补充,VERB,B2
-أَلَحَّ,to insist,坚持,VERB,B2
-أَلْغَى,to eliminate,消除,VERB,B2
-أَلْقَى خِطَابًا,to make a speech,发言,VERB,B2
-أَلْهَمَ,to inspire,鼓舞,VERB,B2
-أَمَام,in front,在前面,ADV,B2
-أَمَام,front,前面,NOUN,B2
-أَمَّنَ,to insure,保证,VERB,B2
-أَمَّنَ,to secure,保护,VERB,B2
-أَمْر,edict,法令,NOUN,B2
-أَمْر عَابِر,trans-matter,超物,NOUN,B2
-أَمْرٌ,injunction,禁令,NOUN,B2
-أَمْسَكَ,grip,握法,NOUN,B2
-أَمْسَكَ,to apprehend,逮捕,VERB,B2
-أَمْسَكَ,to arrest,逮捕,VERB,B2
-أَمْسَكَ,to grasp,抓住,VERB,B2
-أَمْسَكَ,to grasp firmly,抓紧,VERB,B2
-أَمْسَكَ,to grip,紧握,VERB,B2
-أَمْسِ اللَّيْلَة,last night,昨晚,ADV,B2
-أَنْتَ,then you,那你,PRON,B2
-أَنْف,snout,口鼻,NOUN,B2
-أَنْفَقَ,to expend,花费,VERB,B2
-أَنْهَى,to terminate,终止,VERB,B2
-أَنْوَرَ,to illuminate,照亮,VERB,B2
-أَهْلَى,welcome,受欢迎的,ADJ,B2
-أَهْلَى,to welcome,欢迎,VERB,B2
-أَوضَحَ,to illustrate,说明,VERB,B2
-أَوْ,either,或者,CCONJ,B2
-أَوْحَى,to imply,暗示,VERB,B2
-أَوْصَى,to instruct,指导,VERB,B2
-أَوْفَى,to fulfill,履行,VERB,B2
-أَوْقَدَ,trigger,触发器,NOUN,B2
-أَوْقَدَ,to trigger,触发,VERB,B2
-أَوْقَفَ,to discontinue,停止,VERB,B2
-أَيّ,which,哪个,DET,B2
-أَيّ,which one,哪一个,PRON,B2
-أَيْ,that is,即,ADV,B2
-أُحْفُور,fossil,化石,NOUN,B2
-إبادة,extermination,灭绝,NOUN,B2
-إجازة تعويضية,compensatory leave,调休,NOUN,B2
-إحداثي,coordinate,坐标,NOUN,B2
-إحسان,great favor,大恩,NOUN,B2
-إخلاص,sincerity,真诚,NOUN,B2
-إرهو,erhu,二胡,NOUN,B2
-إسراع,to gallop,飞奔,VERB,B2
-إشارة,indication,指示,NOUN,B2
-إشارة مرور,road sign,路标,NOUN,B2
-إصبع,finger,手指,NOUN,B2
-إعادة,to give back,归还,VERB,B2
-إعادة استخدام,reuse,重用,NOUN,B2
-إعادة بناء,reconstruction,重建,NOUN,B2
-إعادة بيع,resale,转售,NOUN,B2
-إعادة تشكيل,reshaping,改形,NOUN,B2
-إعادة تعريف,redefinition,改界,NOUN,B2
-إعادة تقييم,revaluation,重新评估,NOUN,B2
-إعادة كتابة,retype,再型,NOUN,B2
-إعادة نظر,reconsideration,重思,NOUN,B2
-إعلان,declaration,宣言,NOUN,B2
-إقطاعي,feudal,封建,ADJ,B2
-إله,divine,神圣的,ADJ,B2
-إلى الأسفل,downwards,向下,ADV,B2
-إلى جانب,along with,随着,ADP,B2
-إمبراطور,emperor,皇帝,NOUN,B2
-إمبراطورة,empress,女皇,NOUN,B2
-إنجليزي,english,英国的,ADJ,B2
-إنجليزي,englishman,英国人,NOUN,B2
-إنذار,alarm,警报,NOUN,B2
-إنفاق,expenditure,支出,NOUN,B2
-إنقاذ,rescue a-fang,救阿方,NOUN,B2
-إنْذَارٌ مُبَكِّر,early warning,预警,NOUN,B2
-إيثيريوم,ethereum,以太坊,NOUN,B2
-إيجاز,brevity,简洁,NOUN,B2
-إيطالي,italian,意大利人,NOUN,B2
-إِحْصَاءَات مُجْتَمَعِيَّة,social statistics,社会统计,NOUN,B2
-إِسْتِضَافَة,accommodation,住宿,NOUN,B2
-إِعصار,cyclone,气旋,NOUN,B2
-إِلَه الحَرْب,god of war,战神,NOUN,B2
-إِلَهَة,goddess,女神,NOUN,B2
-إِلَى أَيِّ دَرَجَة,what extent,在何种程度上,ADV,B2
-إِلَى الأَمَام,forth,向前,ADV,B2
-إِلَى الأَمَام,forward,向前,ADV,B2
-إِلْغَاء,elimination,消除,NOUN,B2
-إِوَزّ,goose,鹅,NOUN,B2
-ابتز,to extort,敲诈,VERB,B2
-ابتزاز,extortion,勒索,NOUN,B2
-ابتكر,to devise,设计,VERB,B2
-ابتهج,to exult,狂喜,VERB,B2
-ابن عم,cousin,表亲,NOUN,B2
-اتجاه مضاد,counter-trend,反势,NOUN,B2
-اتحاد,federation,联邦,NOUN,B2
-اجتماع تجاري,business meeting,洽谈会,NOUN,B2
-اجتهد,to work hard for sth to strive for success,争气,VERB,B2
-احتج,to protest,抗议,VERB,B2
-احتجز,to detain,拘留,VERB,B2
-احترم,to respect,尊重,VERB,B2
-احتضن,to embrace,拥抱,VERB,B2
-احتفظ,to retain,保留,VERB,B2
-احتقر,to despise,鄙视,VERB,B2
-احتَفَلَ,to celebrate,庆祝,VERB,B2
-احْتِيَال,fraud,欺诈,NOUN,B2
-اختراق,penetration,渗透,NOUN,B2
-اخترق,to penetrate,穿透,VERB,B2
-اختلاس,misappropriation,挪用,NOUN,B2
-اختلف,to differ,不同,VERB,B2
-اختلق,to fabricate,捏造,VERB,B2
-اخيرا,recently,最近,ADV,B2
-اخْتَارَ,to select,选择,VERB,B2
-ادعى,to claim,声称,VERB,B2
-ارتداد,reversion,重归,NOUN,B2
-استأنف,resume,简历,NOUN,B2
-استأنف,to resume,重新开始,VERB,B2
-استبعد,to exclude,排除,VERB,B2
-استثناء,exception,例外,NOUN,B2
-استثنائي,exceptional,杰出的,ADJ,B2
-استجوب,to question,质疑,VERB,B2
-استحضر,to evoke,唤起,VERB,B2
-استحق,to be worth,值得,VERB,B2
-استحق,to deserve,值得,VERB,B2
-استحقاق,merit,功绩,NOUN,B2
-استحقاق أولي,first merit,首功,NOUN,B2
-استخراج,draw out,引出,NOUN,B2
-استخرج,to extract,提取,VERB,B2
-استراحة,break,休息,NOUN,B2
-استراحة ركوب,ride break,骑破,NOUN,B2
-استرجاع,retrieve qingming,拿回青冥,NOUN,B2
-استرخى,to relax,放松,VERB,B2
-استسلام,to give up,放弃,VERB,B2
-استشهد,to cite,引用,VERB,B2
-استطرد,to digress,离题,VERB,B2
-استعجال,hurry,匆忙,NOUN,B2
-استعداد,willingness,乐意,NOUN,B2
-استفاد,to draw on the experience of,借鉴,VERB,B2
-استفز,to provoke,激怒,VERB,B2
-استقرأ,to extrapolate,推断,VERB,B2
-استلزم,to require,需要,VERB,B2
-استلم الأوامر,to receive orders,受命,VERB,B2
-استلم البريد,to receive mail,收件,VERB,B2
-استمتاع,enjoyment,享受,NOUN,B2
-استمد,to derive,源于,VERB,B2
-استنشق,to inhale,吸入,VERB,B2
-استيقاظ,to get up,起床,VERB,B2
-اسْتَأْجَرَ,to hire,雇佣,VERB,B2
-اسْتَحَقَّ,to owe,欠,VERB,B2
-اسْتَخْدَمَ عَصَا,to use crutches,拄拐,VERB,B2
-اسْتَخْدَمَ عِصِيّ الأَكْل,to use chopsticks,动筷,VERB,B2
-اسْتَغَلَّ,to exploit,剥削,VERB,B2
-اسْتَغَلَّ,to utilize,利用,VERB,B2
-اسْتِراتيجِيَّة زائِدَة,over-strategy,超策,NOUN,B2
-اسْتِغْلَال,exploitation,利用,NOUN,B2
-اسْتِقْرَار مُجْتَمَعِيّ,social stability,社会稳定,NOUN,B2
-اشترى,to purchase,购买,VERB,B2
-اضطِراب,unrest,动荡,NOUN,B2
-اعتبر,to count as,算,VERB,B2
-اعتراف,recognition,认可,NOUN,B2
-اعترف,to recognize,认出,VERB,B2
-اعتمد,to depend,依赖,VERB,B2
-اعتمد,to depend on,依赖,VERB,B2
-افتتان,fascination,魅力,NOUN,B2
-افتراضي,hypothetical,假设的,ADJ,B2
-افترى,slander,诽谤,NOUN,B2
-افترى,to slander,诽谤,VERB,B2
-اقتبس,to quote,引用,VERB,B2
-اقتراح,proposal,提议,NOUN,B2
-اقتراح,proposition,主张,NOUN,B2
-اكتشف,to find out,找出,VERB,B2
-الأسوأ,worst,最坏的,ADJ,B2
-الأَسْمَاء الْكَامِلَة,full name,大名,NOUN,B2
-الإسكان,housing,住房,NOUN,B2
-الإصلاحية,reformism,改唯,NOUN,B2
-الإنسانية,humanity,人类,NOUN,B2
-الإِنْجِيل,bible,圣经,NOUN,B2
-الاستخبارات العسكرية,military intelligence,军情,NOUN,B2
-الاستخدام المفرط,hyper-use,超用,NOUN,B2
-البَاحَةُ الدَّاخِلِيَّةُ,inner court,朝内,NOUN,B2
-البِكْر,eldest son,长子,NOUN,B2
-البِيئَة,ecology,生态学,NOUN,B2
-التعرف على الوجه,face recognition,认人,NOUN,B2
-التغير المناخي,climate change,气候变化,NOUN,B2
-التكرار,recurrence,往复,NOUN,B2
-الجانب الآخر,other side,对面,NOUN,B2
-الجزء الخلفي,rear part,后部,NOUN,B2
-الجميع,everyone,每个人,PRON,B2
-الجيش,military,军队,NOUN,B2
-الحَرَّاس الإِمَاري,imperial guard,御林,NOUN,B2
-الدَّوْلَة الحاضِرَة,current dynasty,当朝,NOUN,B2
-الرغبة الحقيقية,really want,真要,NOUN,B2
-الرِّيح,in wind,临风,NOUN,B2
-السماح بالإخفاء,allow hiding,许躲,NOUN,B2
-السيد,mr.,先生,NOUN,B2
-السَّمَاء,in the sky,天上,NOUN,B2
-السَّنَة الْمَاضِيَة,last year,去年,NOUN,B2
-الطاقة المائية,hydro energy,水能,NOUN,B2
-الفَجْر,early morning,凌晨,NOUN,B2
-القدرة البشرية,human capacity,人会,NOUN,B2
-القِصَّةُ الدَّاخِلِيَّةُ,inside story,内幕,NOUN,B2
-المقصلة,guillotine,断头台,NOUN,B2
-المَدِينَةُ الدَّاخِلِيَّةُ,inside city,城内,NOUN,B2
-المَدْعُوّ,so-called,所谓的,ADJ,B2
-الَّذِي,whose,谁的,PRON,B2
-الْ,the,这,DET,B2
-الْبَاقِي,the rest,其余,NOUN,B2
-الْعَالَم كُلُّهُ,whole world,全世界,NOUN,B2
-الْمِنْطَقَات الْغَرْبِيَّة,western regions,西域,NOUN,B2
-امتثل,to comply with,遵守,VERB,B2
-امتحان شهري,monthly exam,月考,NOUN,B2
-انتبه,to mind,介意,VERB,B2
-انتظار,wait,等待,NOUN,B2
-انتظاري,wait for me,等我,NOUN,B2
-انتظر طويلا,to wait long,久等,VERB,B2
-انتقام,revenge,复仇,NOUN,B2
-انتقام,vengeance,报复,NOUN,B2
-انتقل للسكن,to move in,搬入,VERB,B2
-انتهاء,to get off work,下班,VERB,B2
-انتهى,to end up,最终到达,VERB,B2
-انجراف,drifting,漂泊,NOUN,B2
-انحطاط,decadence,衰落,NOUN,B2
-انخرط,to engage,从事,VERB,B2
-انخفاض حرارة الجسم,hypothermia,体温过低,NOUN,B2
-انخفض,to decline,下降,VERB,B2
-انسحاب,retreat,撤退,NOUN,B2
-انعكاس,reversal,突变,NOUN,B2
-انعكاس,reverse reflection,反影,NOUN,B2
-انعكس,to reflect,反映,VERB,B2
-انفَجَرَ,to explode,爆炸,VERB,B2
-انْبَثَق,to emanate,散发,VERB,B2
-انْتَهَى,to cease,停止,VERB,B2
-انْتَهَى,to expire,到期,VERB,B2
-انْتِفَاء,disinterest,公正;不感兴趣,NOUN,B2
-انْتِهَاء,cessation,终止,NOUN,B2
-انْزِعَاج,discomfort,不适,NOUN,B2
-انْغِمَاس,immersion,沉浸,NOUN,B2
-انْفَصَلَ,to disengage,脱离,VERB,B2
-انْفِجار,outburst,迸发,NOUN,B2
-اَلأَحَد,sunday,星期日,NOUN,B2
-اِتَّصَلَ بِالشَّبَكَة,to go online,上网,VERB,B2
-اِجْتَازَ,to go through,经历,VERB,B2
-اِحتَقَرَ,to look down upon,看不起,VERB,B2
-اِحْتِرار عَالَمِيّ,global warming,气候变暖,NOUN,B2
-اِرْتِفَاع,upturn,好转,NOUN,B2
-اِسْتَشَارَ,to consult reference,参考,VERB,B2
-اِسْتَهْلَكَ,to consume,消费,VERB,B2
-اِقْتَرَبَ,to approach,靠近,VERB,B2
+قَادِر,able,能够的,ADJ,B2
+شَاذّ,abnormal,异常的,ADJ,B2
+فَوْق,above,上面,ADV,B2
+خَدْش,abrasion,擦伤,NOUN,B2
+خَارِج,abroad,国外,NOUN,B2
+فَجْأِي,abrupt,突然的,ADJ,B2
+خُرَّاج,abscess,脓肿,NOUN,B2
+فَرَّ,to abscond,潜逃,VERB,B2
+غَائِب,absent,缺席的,ADJ,B2
+مُطْلَق,absolute,绝对的,ADJ,B2
+مُطْلَقاً,absolutely,绝对地,ADV,B2
 اِمْتَصَّ,to absorb,吸收,VERB,B2
-اِنتِحَار,suicide,自杀,NOUN,B2
+سَخِيف,absurd,荒谬的,ADJ,B2
+أَسَاءَ,to abuse,滥用,VERB,B2
+هُوَّة,abyss,深渊,NOUN,B2
+أَكَادِيمِي,academic,学者,NOUN,B2
+سَرَّعَ,to accelerate,加速,VERB,B2
+مُسَرِّع,accelerator,油门,NOUN,B2
+قَبِلَ,to accept,接受,VERB,B2
+بِالْخَطَأ,accidentally,意外地,ADV,B2
+أَسْتَضَفَ,to accommodate,容纳,VERB,B2
+إِسْتِضَافَة,accommodation,住宿,NOUN,B2
+شَرِيك,accomplice,同谋,NOUN,B2
+إنذار,alarm,警报,NOUN,B2
+ساعة منبّهة,alarm clock,闹钟,NOUN,B2
+مُقلِق,alarming,令人担忧的,ADJ,B2
+يا للأسف,alas,唉,INTJ,B2
+ألبوم,album,相册,NOUN,B2
+كحول,alcohol,酒精,NOUN,B2
+مُدمِن,alcoholic,酗酒者,NOUN,B2
+أجنبي,alien,外星人,NOUN,B2
+حيّ,alive,活着的,ADJ,B2
+كل,all,全部,ADV,B2
+طوال اليوم,all day long,一整天,NOUN,B2
+مُزعَم,alleged,所谓的,ADJ,B2
+زعمًا,allegedly,据称,ADV,B2
+مُحتَقِن,allergic,过敏的,ADJ,B2
+السماح بالإخفاء,allow hiding,许躲,NOUN,B2
+مُلْمِح,allusive,暗指的,ADJ,B2
+حليف,ally,盟友,NOUN,B2
+لوز,almond,杏仁,NOUN,B2
+تقريبًا,almost,几乎,ADV,B2
+وحده,alone,独自,ADV,B2
+على امتداد,along,沿着,ADP,B2
+إلى جانب,along with,随着,ADP,B2
+أبجدي,alphabetical,按字母顺序的,ADJ,B2
+حسنًا,alright,好的,ADV,B2
+أيضًا,also,也,ADV,B2
+كذلك,also too,也,ADV,B2
+معنى مُغيَّر,altered meaning,改义,NOUN,B2
+آلية مُغيَّرة,altered mechanism,改机,NOUN,B2
+يتناوب,to alternate,交替,VERB,B2
+بديل,alternative,替代方案,NOUN,B2
+رغم,although,虽然,SCONJ,B2
+مُذهِل,amazing,令人惊叹的,ADJ,B2
+مُتضاد المشاعر,ambivalent,矛盾的,ADJ,B2
+قَدَّرَ,to appreciate,感激,VERB,B2
+حَفْلَة تَقْدِير,appreciation banquet,答谢宴,NOUN,B2
+أَمْسَكَ,to apprehend,逮捕,VERB,B2
+مُتَدَرِّب,apprentice,学徒,NOUN,B2
+مُدْرِبَة,apprenticeship,学徒期,NOUN,B2
+اِقْتَرَبَ,to approach,靠近,VERB,B2
+مُنَاسِب,appropriate,适当的,ADJ,B2
+وَأَفَّقَ,to approve,批准,VERB,B2
+حَكَمَ,to arbitrate,仲裁,VERB,B2
+قَوْس,arc,弧,NOUN,B2
+عَتِيق,archaic,古老的,ADJ,B2
+عَتَاقَة,archaism,古语,NOUN,B2
+مِعْمَارِي,architect,建筑师,NOUN,B2
+شَغَف,ardor,热情,NOUN,B2
+حَلْقَة,arena,竞技场,NOUN,B2
+كُرْسِيّ مَيْسَم,armchair,扶手椅,NOUN,B2
+مُسَلَّح,armed,武装的,ADJ,B2
+دِرْع,armor,盔甲,NOUN,B2
+حَوْل,around,到处,ADV,B2
+أثارَ,to arouse,引起,VERB,B2
+رَتَّبَ,to arrange,安排,VERB,B2
+أَمْسَكَ,to arrest,逮捕,VERB,B2
+سَهْم,arrow,箭,NOUN,B2
+مَعْرَض فَنِّي,art gallery,美术馆,NOUN,B2
+مَقَالَة,article,文章,NOUN,B2
+صاغَ,to articulate,清晰表达,VERB,B2
+حِيلَة,artifice,诡计,NOUN,B2
+فَنِّي,artistic,艺术的,ADJ,B2
+صُورَة فَنِّيَة,artistic portrait,艺术照,NOUN,B2
+كَما,as,作为,SCONJ,B2
+كَأَنَّ,as if,仿佛,ADV,B2
+وَكَذَلِكَ,as well as,以及,CCONJ,B2
+صُعُود,ascension,升天,NOUN,B2
+مُسْتَحْيٍ,ashamed,羞愧的,ADJ,B2
+جَانِبًا,aside,在旁边,ADV,B2
+باب خلفي,back door,后门,NOUN,B2
+مقعد خلفي,back seat,后座,NOUN,B2
+عمود فقري,backbone,脊梁,NOUN,B2
+تدفق عكسي,backflow,倒流,NOUN,B2
+خلفية,background,背景,NOUN,B2
+حقيبة ظهر,backpack,背包,NOUN,B2
+طعنة في الظهر,backstab,背刺,NOUN,B2
+نسخة احتياطية,backup,备份,NOUN,B2
+ضوء الرجوع,backup light,倒车灯,NOUN,B2
+خلفاً,backwards,向后,ADV,B2
+لحم مقدد,bacon,培根,NOUN,B2
+بكتيريا,bacterium,细菌,NOUN,B2
+سيئ,bad,坏的,ADJ,B2
+فكرة سيئة,bad idea,坏水,NOUN,B2
+حظ سيئ,bad luck,倒霉,NOUN,B2
+أخبار سيئة,bad news,坏消息,NOUN,B2
+شيء سيئ,bad thing,坏事,NOUN,B2
+سيئاً,badly,坏地,ADV,B2
+تنس الريشة,badminton,羽毛球,NOUN,B2
+كفالة,bail,保释,NOUN,B2
+خبز,to bake,烘焙,VERB,B2
+وازن,to balance,平衡,VERB,B2
+كرة,ball,球,NOUN,B2
+قلم جاف,ballpoint pen,圆珠笔,NOUN,B2
+حظر,to ban,禁止,VERB,B2
+موز,banana,香蕉,NOUN,B2
+فرقة,band,乐队,NOUN,B2
+لص,bandit,强盗,NOUN,B2
+دوي,bang,巨响,NOUN,B2
+نفى,to banish,流放,VERB,B2
+مصرفي,banker,银行家,NOUN,B2
+ورقة نقدية,banknote,钞票,NOUN,B2
+مفلس,bankrupt,破产的,ADJ,B2
+لافتة,banner,横幅,NOUN,B2
+عمّد,to baptize,施洗,VERB,B2
+كفى,to be enough,足够,VERB,B2
+سحر,to be entranced,出神,VERB,B2
+برع,to be good at,擅长,VERB,B2
+شكر,to be grateful,感激,VERB,B2
+ضرب,to be hit,中箭,VERB,B2
+تبقى,to be left over,剩余,VERB,B2
+وقع,to be located,位于,VERB,B2
+فقد,to be missing,缺少,VERB,B2
+ناوب,to be on duty,值班,VERB,B2
+تحمل,to be responsible for,负责,VERB,B2
+صدق,to be right,正确,VERB,B2
+سلم,to be safe,安好,VERB,B2
+صمت,to be silent,沉默,VERB,B2
+كان,to be so,然,VERB,B2
+سرق,to be stolen,失窃,VERB,B2
+نفع,to be useful,有用,VERB,B2
+استحق,to be worth,值得,VERB,B2
+منارة,beacon,灯塔,NOUN,B2
+فاصوليا,bean,豆子,NOUN,B2
+محتمل,bearable,可忍受的,ADJ,B2
+ضرب,to beat,打败,VERB,B2
+ضرب,beating,跳动,NOUN,B2
+لأن,because,因为,CCONJ,B2
+بسبب,because of,因为,ADP,B2
+غرفة نوم,bedroom,卧室,NOUN,B2
+صفير,beep,吱吱声,NOUN,B2
+خنفساء,beetle,甲虫,NOUN,B2
+قبل,before,之前,ADV,B2
+مسبقا,beforehand,事先,ADV,B2
+تسول,to beg,乞求,VERB,B2
+بدأ,to begin to start,开始,VERB,B2
+مبتدئ,beginner,初学者,NOUN,B2
+تصرف,to behave,表现,VERB,B2
+خلف,behind,在后面,ADV,B2
+فُلْفُل حَلْو,bell pepper,甜椒,NOUN,B2
+عَدْوَانِيّ,bellicose,好战的,ADJ,B2
+زَأَرَ,to bellow,吼叫,VERB,B2
 اِنْتَمَى,to belong,属于,VERB,B2
 اِنْتَمَى إِلَى,to belong to,属于,VERB,B2
-اِنْزَلَقَ,to glide,滑行,VERB,B2
-بئر,a well,井,NOUN,B2
-بائد,obsolete,过时的,ADJ,B2
-بائس,miserable,痛苦的,ADJ,B2
-باب خلفي,back door,后门,NOUN,B2
-بارد كالجليد,ice-cold,冰冷的,ADJ,B2
-بارِز,outstanding,杰出的,ADJ,B2
-بالطبع,of course,理所当然的,ADJ,B2
-بالعكس,vice versa,反之亦然,ADV,B2
-بالغ,to exaggerate,夸大,VERB,B2
-بالكاد,only just,才,ADV,B2
-ببساطة,simply,简单地,ADV,B2
-بحث,to research,研究,VERB,B2
-بدأ,to begin to start,开始,VERB,B2
-بدأ,to initiate,发起,VERB,B2
-بديل,alternative,替代方案,NOUN,B2
-بذل قصارى الجهد,to do one's best,尽力,VERB,B2
-براءة اختراع,patent,专利,NOUN,B2
-برج,zodiac sign,属相,NOUN,B2
-برع,to be good at,擅长,VERB,B2
-برقوق,plum,李子,NOUN,B2
-برودة,coolness,凉爽,NOUN,B2
-برونز,bronze,青铜,NOUN,B2
-بريطاني,british,英国的,ADJ,B2
-بريطاني,briton,英国人,NOUN,B2
-برّد,cool,凉爽的,ADJ,B2
-برّد,to cool,冷却,VERB,B2
-بسبب,because of,因为,ADP,B2
-بسبب,due to,由于,ADP,B2
-بسيط,primitive,原始的,ADJ,B2
-بسّط,to simplify,简化,VERB,B2
-بشأن هذا,regarding this,对此,ADV,B2
-بشرة ناعمة,fine skin,细皮,NOUN,B2
-بشرط أن,provided that,只要,SCONJ,B2
-بطاقة ائتمان,credit card,信用卡,NOUN,B2
-بطاقة هوية,id card,身份证,NOUN,B2
-بطل,protagonist,主角,NOUN,B2
-بعد,yet,还,ADV,B2
-بعض,a,一个,DET,B2
-بعيد,far,远,ADV,B2
-بغيض,detestable,可恶的,ADJ,B2
-بكتيريا,bacterium,细菌,NOUN,B2
-بلاستيك,plastic,塑料,NOUN,B2
-بلدي,municipal,市政的,ADJ,B2
-بندقية,gun,枪,NOUN,B2
-بندقية,rifle,步枪,NOUN,B2
-بنوي,filial,孝顺,ADJ,B2
-بواب,doorman,门卫,NOUN,B2
-بوضوح,clearly,清楚地,ADV,B2
-بيت دعارة,brothel,妓院,NOUN,B2
-بيت شعر,couplet,对联,NOUN,B2
-بيّن,to demonstrate,证明,VERB,B2
-بَاب الأَمَام,front door,正门,NOUN,B2
-بَاهِر,splendid,极好的,ADJ,B2
-بَثَّ,to broadcast,播出,VERB,B2
-بَحَثَ,to look for,寻找,VERB,B2
-بَحَثَ,to look for to find,找,VERB,B2
-بَحَثَ,to search for,寻找,VERB,B2
-بَحْث,search,搜索,NOUN,B2
-بَدَا,to seem,似乎,VERB,B2
-بَدَعَ,to improvise,即兴创作,VERB,B2
-بَدَلًا,instead,代替,ADV,B2
-بَدَّلَ إِطَار,to change tire,换胎,VERB,B2
-بَرَاءَةٌ,innocence,无辜,NOUN,B2
-بَرَّأَ,to exonerate,使无罪,VERB,B2
-بَرُوتوكُول ثَقِيل,heavy etiquette,礼太重,NOUN,B2
-بَرِيء,harmless,无害的,ADJ,B2
-بَرِيءٌ,innocent,无辜的,ADJ,B2
-بَرِيد إِلِكْتُرُونِيّ,email,电子邮件,NOUN,B2
-بَرِّي,wild,野生的,ADJ,B2
-بَشَّر,to evangelize,传福音,VERB,B2
-بَصَرِيّ,graphic,图形的,ADJ,B2
-بَطَاتِيس مَقْلِيَة,fries,炸薯条,NOUN,B2
-بَطَل,champion,冠军,NOUN,B2
-بَطَلِي,heroic,英勇的,ADJ,B2
-بَعثة,expedition,探险,NOUN,B2
-بَعْضُ بَعْض,each other,互相,PRON,B2
-بَلْ عَلَى العَكْسِ,instead on the contrary,反而,ADV,B2
-بَنَى,to build,建造,VERB,B2
-بَنَى,to construct,建造,VERB,B2
-بَيْن,in between,在中间,ADV,B2
-بُعد,dimension,维度,NOUN,B2
-بُعد,grand distance,雄远,NOUN,B2
-بُقْعَة,stain,污渍,NOUN,B2
-بِالإِضَافَة,in addition,此外,ADV,B2
-بِالْخَطَأ,accidentally,意外地,ADV,B2
-بِذَلِكَ,hereby,特此,ADV,B2
-بِذَلِكَ,whereby,其中,ADV,B2
-بِذَلِكَ,that way,那样,PRON,B2
-بِسَبَب,thanks to,多亏,ADP,B2
-بِضَبْط,just right,恰到好处,ADV,B2
-بِلْيَارْدو,billiards,台球,NOUN,B2
-بِنَائِيّ,constructive,建设性的,ADJ,B2
-بِيانْتشونغ,bianzhong,编钟,NOUN,B2
-تأثير معدّل,modified effect,改效,NOUN,B2
-تأكيد,emphasis,强调,NOUN,B2
-تأمين سيارة,car insurance,车险,NOUN,B2
-تأمّل,to gaze,凝视,VERB,B2
-تأنق,to dress up,盛装打扮,VERB,B2
-تأوّه,moan,呻吟,NOUN,B2
-تأوّه,to moan,呻吟,VERB,B2
-تاجر,dealer,经销商,NOUN,B2
-تبرع,to donate,捐赠,VERB,B2
-تبريد,cooling,冷却,NOUN,B2
-تبقى,to be left over,剩余,VERB,B2
-تبول,to pee,小便,VERB,B2
-تتويج,coronation,加冕,NOUN,B2
-تتويج,enthronement,登基,NOUN,B2
-تجاري,business,商业的,ADJ,B2
-تجريبي,empirical,经验的,ADJ,B2
-تجزئة,retail,零售,NOUN,B2
-تجسيد,epitome,化身,NOUN,B2
-تجعد,wrinkle,皱纹,NOUN,B2
-تجمّع,to gather,聚集,VERB,B2
-تحالف أبدي,eternal alliance,永结,NOUN,B2
-تحت,down,顺...而下,ADP,B2
-تحدث,to converse,交谈,VERB,B2
-تحدي الخداع,deception dare,你敢骗我,NOUN,B2
-تحديد,to identify,识别,VERB,B2
-تحسين,to optimize,优化,VERB,B2
-تحمل,to be responsible for,负责,VERB,B2
-تحيز,prejudice,偏见,NOUN,B2
-تخلّص,to get rid of,摆脱,VERB,B2
-تخمر,to ferment,发酵,VERB,B2
-تخمين,guess,猜测,NOUN,B2
-تخيل,to envision,展望,VERB,B2
-تدرّب,to rehearse,排练,VERB,B2
-تدفق عكسي,backflow,倒流,NOUN,B2
-تدهور,to deteriorate,恶化,VERB,B2
-تذبذب,to oscillate,振荡,VERB,B2
-تذهيب,to gild,镀金,VERB,B2
-تراجع,to regress,倒退,VERB,B2
-ترقيم,punctuation,标点符号,NOUN,B2
-تزلج,to skate,滑冰,VERB,B2
-تزلج على الجليد,to ski,滑雪,VERB,B2
-تزيين,to garnish,装饰,VERB,B2
-تساهل,compromise,妥协,NOUN,B2
-تساهل,to compromise,危及,VERB,B2
-تسجيل,recording,录音,NOUN,B2
-تسجيل فيديو,video recording,录像,NOUN,B2
-تسجيل مركبة,vehicle registration,行驶证,NOUN,B2
-تسريحة شعر,hairstyle,发型,NOUN,B2
-تسليم,extradition,引渡,NOUN,B2
-تسليم,handover,拿给,NOUN,B2
-تسلّل,to infiltrate,渗透,VERB,B2
-تسمية,designation,指定,NOUN,B2
-تسول,to beg,乞求,VERB,B2
-تشابه,similarity,相似,NOUN,B2
-تشوانغ هي,zhuang he,庄郃,NOUN,B2
-تصحيحات,errata,勘误,NOUN,B2
-تصرف,to behave,表现,VERB,B2
-تصنيف,categorization,分类,NOUN,B2
-تصور,to conceive,构想,VERB,B2
-تضمين عكسي,reverse inclusion,反纳,NOUN,B2
-تطور,evolution,进化,NOUN,B2
-تطور,to evolve,进化,VERB,B2
-تعاطف,to empathize,共情,VERB,B2
-تعافى,to recover,恢复,VERB,B2
-تعافى,to recuperate,恢复,VERB,B2
-تعامل مع,to deal with,处理,VERB,B2
-تعاون,mutual aid,互助,NOUN,B2
-تعاون,to cooperate,合作,VERB,B2
-تعبير مجازي,idiom,习语,NOUN,B2
-تعجب,exclamation,感叹,NOUN,B2
-تعزيز,reinforcement,增援,NOUN,B2
-تغليف,wrapping,包装,NOUN,B2
-تفادي,to dodge,躲避,VERB,B2
-تفاصيله,its details,其详,NOUN,B2
-تفسير,exegesis,注释,NOUN,B2
-تفضيل,preference,偏好,NOUN,B2
-تفضيلاً,preferably,更愿意,ADV,B2
-تقارب,to converge,汇聚,VERB,B2
-تقاعد,to retire,退休,VERB,B2
-تقريبا,nearly,几乎,ADV,B2
-تقريبًا,almost,几乎,ADV,B2
-تقرير بيئي,environmental report,环境报告,NOUN,B2
-تقليدي,conventional,传统的,ADJ,B2
-تقنية النانو,nanotechnology,纳米技术,NOUN,B2
-تقنية مضادة,counter-technique,反术,NOUN,B2
-تقيح,to fester,溃烂,VERB,B2
-تقييد متبادل,mutual restriction,相克,NOUN,B2
-تلا,to recite,背诵,VERB,B2
-تلمس البطيخ,melon groping,摸瓜,NOUN,B2
-تلويح,to gesticulate,做手势,VERB,B2
-تمارين خط,handwriting practice,练字,NOUN,B2
-تماما,completely,完全地,ADV,B2
-تماماً,entirely,完全地,ADV,B2
-تماماً,quite,非常,ADV,B2
-تمايل,to wobble,摇晃,VERB,B2
-تمرد,rebel,反叛者,NOUN,B2
-تمرد,to rebel,反叛,VERB,B2
-تمرن,to work out,成功,VERB,B2
-تناول,to ingest,服用,VERB,B2
-تنبأ,to prophesy,预言,VERB,B2
-تنحى,to move aside,移开,VERB,B2
-تنس الريشة,badminton,羽毛球,NOUN,B2
-تنظيف,cleansing,清洗,NOUN,B2
-تنفيذ,execution,执行,NOUN,B2
-تنفيذي,executive,行政主管,NOUN,B2
-تنويع,to diversify,使多样化,VERB,B2
-تنين,dragon,龙,NOUN,B2
-تواصل,to communicate,交流,VERB,B2
-توافق,compatibility,兼容性,NOUN,B2
-توثيق,to document,记录,VERB,B2
-توزيعات أرباح,dividend,红利,NOUN,B2
-توصية,recommendation,推荐,NOUN,B2
-توصية من الآخرين,recommendation by others,他荐,NOUN,B2
-توظيف,employment,就业,NOUN,B2
-توظيف,placement,放置,NOUN,B2
-توفو مجفف,dried tofu,豆干,NOUN,B2
-توقف,pause,暂停,NOUN,B2
-توقف,to pause,暂停,VERB,B2
-توليد,to generate,产生,VERB,B2
-توليد متبادل,mutual generation,相生,NOUN,B2
-توهم,pretense,假装,NOUN,B2
-تيس,buck,美元,NOUN,B2
-تَأَقْلَمَ,to make do,做,VERB,B2
-تَأَلَّفَ,to consist,组成,VERB,B2
-تَأَمَّلَ,to contemplate,沉思,VERB,B2
-تَارِيخ,history,历史,NOUN,B2
-تَارِيخِي,historic,历史性的,ADJ,B2
-تَبَاعُد مُجْتَمَعِيّ,social distancing,社交距离,NOUN,B2
-تَبَخَّر,to evaporate,蒸发,VERB,B2
-تَبَسَّمَ,to grin,咧嘴笑,VERB,B2
-تَبْذِير,to squander,浪费,VERB,B2
-تَثْبِيت,to stabilize,使稳定,VERB,B2
-تَجاوَز,to overcome,克服,VERB,B2
-تَجْرِبَة,experiment,实验,NOUN,B2
-تَحَدَّثَ,to have an accident,遭遇意外,VERB,B2
-تَحَدَّى,to challenge,质疑,VERB,B2
-تَحَدَّى,to dare,敢于,VERB,B2
-تَحَرُّك مُجْتَمَعِيّ,social mobilization,社会动员,NOUN,B2
-تَحَكَّمَ,to control,控制,VERB,B2
-تَحَكُّم مُجْتَمَعِيّ,social arbitration,社会仲裁,NOUN,B2
+مَتَاع,belongings,所属物,NOUN,B2
 تَحْتَ,below,在...下面,ADP,B2
-تَحْرِير,emancipation,解放,NOUN,B2
-تَخَصُّص,major course,专业课,NOUN,B2
-تَخَصُّص,specialty,专业,NOUN,B2
-تَخَلَّى,to abdicate,退位,VERB,B2
-تَدْرِيب الرُّوح,spirit training,练神,NOUN,B2
-تَدْرِيجِيًّا,increasingly,越来越,ADV,B2
-تَدْوِير,to spin,旋转,VERB,B2
-تَدْوِيل دِمَاغِيّ,eeg,脑电图,NOUN,B2
-تَرَدَّدَ,frequent,频繁的,ADJ,B2
-تَرَدَّدَ,to frequent,常去,VERB,B2
-تَرَدَّدَ,to hesitate,犹豫,VERB,B2
-تَرَدُّد,unwillingness,不甘,NOUN,B2
-تَرِاث,heard beile,听说贝勒,NOUN,B2
-تَسَلَّلَ,to sneak,潜行,VERB,B2
-تَشَمَّمَ,to sniff,嗅,VERB,B2
-تَشْطِير,to split,分裂,VERB,B2
-تَصَالُح مُجْتَمَعِيّ,social reconciliation,社会和解,NOUN,B2
-تَضَادّ,inconsistency,不一致,NOUN,B2
-تَطَبُّق مُجْتَمَعِيّ,social stratification,社会分层,NOUN,B2
-تَعهيد,outsourcing,外包,NOUN,B2
-تَعَب السَّفَر,travel fatigue,车马劳顿,NOUN,B2
-تَعَرَّفَ,to know to recognize,认识,VERB,B2
-تَعَهَّدَ,to pledge,保证,VERB,B2
-تَعْيِين,to specify,具体说明,VERB,B2
-تَغَدَّى,to have lunch,吃午餐,VERB,B2
-تَفَاعُل مُجْتَمَعِيّ,social interaction,社会互动,NOUN,B2
-تَفْسِير,gloss,光泽,NOUN,B2
-تَقاطُع,overlap,重叠,NOUN,B2
-تَقَدَّمَ,to go first,先去,VERB,B2
-تَقَلُّبٌ,instability,不稳定,NOUN,B2
-تَقَلُّس,spasm,痉挛,NOUN,B2
-تَقْلِيد,tradition,传统,NOUN,B2
-تَقْلِيدِي,imitative,模仿性,ADJ,B2
-تَقْيِيد المَرُور,traffic restriction,限行,NOUN,B2
-تَقْيِيم العُروض,bid evaluation,评标,NOUN,B2
-تَمَلَّى,to plead,恳求,VERB,B2
-تَمَوَّطَ,to conspire,密谋,VERB,B2
-تَمَيُّز,to stand out,引人注目,VERB,B2
-تَمْجِيد,glorification,赞美,NOUN,B2
-تَنَحْنَحَ,to groan,呻吟,VERB,B2
-تَنَظِيم مُجْتَمَعِيّ,social organization,社会组织,NOUN,B2
-تَنَكَّرَ,disguise,伪装,NOUN,B2
-تَنَكَّرَ,to disguise,伪装,VERB,B2
-تَنَوُّع حَيَوِيّ,biodiversity,生物多样性,NOUN,B2
-تَهَدَّمَ,to crumble,粉碎,VERB,B2
-تَواطؤ المَزَايَدَة,bid collusion,串标,NOUN,B2
-تَوَاصُل,contact,联系,NOUN,B2
-تَوَاصُل مُجْتَمَعِيّ,social compromise,社会妥协,NOUN,B2
-تَوَافُق مُجْتَمَعِيّ,social harmony,社会和谐,NOUN,B2
-تَوَسَّلَ,to implore,恳求,VERB,B2
-تَوَقَّعَ,to expect,期待,VERB,B2
-تَوْجِيه,directive,指令,NOUN,B2
-تَوْقِيع,label,标签,NOUN,B2
-تَيَّار رَئِيسِي,mainstream,主流,NOUN,B2
-تِراث ثقافي,cultural relic,文物,NOUN,B2
-تِقْنِيَة,green technology,绿色技术,NOUN,B2
-تِلَال,hills,丘陵,NOUN,B2
-تِلْكَ السَّهْم,that arrow,那一箭,NOUN,B2
-ثبّط,to inhibit,抑制,VERB,B2
-ثقب,puncture,穿刺,NOUN,B2
-ثمين,precious,珍贵的,ADJ,B2
-ثوران,eruption,爆发,NOUN,B2
-ثوري,revolutionary,革命的,ADJ,B2
-ثَبَّتَ,to install,安装,VERB,B2
-ثَلَّاجَة,fridge,冰箱,NOUN,B2
-ثَمَانِيَة,eight,八,NUM,B2
-ثَمَرَة,chandelier,吊灯,NOUN,B2
-ثَوْرَةٌ,insurrection,起义,NOUN,B2
-ثِقَة,self-confidence,自信,NOUN,B2
-ثِقَة مُجْتَمَعِيَّة,social trust,社会信任,NOUN,B2
-جانب,facet,方面,NOUN,B2
-جبان,coward,懦夫,NOUN,B2
-جبن,cowardice,懦弱,NOUN,B2
-جدول,brook,小溪,NOUN,B2
-جدوى,feasibility,可行性,NOUN,B2
-جديد,brand new,崭新的,ADJ,B2
-جدير,worthy,值得的,ADJ,B2
-جرح,to wound,使受伤,VERB,B2
-جرس باب,doorbell,门铃,NOUN,B2
-جرعة,dosage,剂量,NOUN,B2
-جرف,cliff,悬崖,NOUN,B2
-جرو,puppy,小狗,NOUN,B2
-جريء,bold,大胆的,ADJ,B2
-جزر,carrot,胡萝卜,NOUN,B2
-جسد,to embody,体现,VERB,B2
-جسر مشاة,pedestrian bridge,天桥,NOUN,B2
-جسم,fuselage,机身,NOUN,B2
-جلاد,executioner,刽子手,NOUN,B2
-جلالتك,your majesty,陛下,NOUN,B2
-جلب,to fetch,取来,VERB,B2
-جلد,to excoriate,严厉批评,VERB,B2
-جلس,to sit down,坐下,VERB,B2
-جمع,to compile,编译,VERB,B2
-جمع التبرعات,to raise donations,募捐,VERB,B2
-جميل,pretty,漂亮的,ADJ,B2
-جناح,pavilion,亭子,NOUN,B2
-جند,to enlist,征募,VERB,B2
-جند,to recruit,招募,VERB,B2
-جنس,gender,性别,NOUN,B2
-جنية,fairy,仙女,NOUN,B2
-جهاز,gadget,小装置,NOUN,B2
-جهز,to equip,装备,VERB,B2
-جوار,nearby,附近的,ADJ,B2
-جوهرة,jewel,宝石,NOUN,B2
-جوّال,mobile,移动的,ADJ,B2
-جيانغهو,jianghu,江湖,NOUN,B2
-جياولونغ,jiaolong,娇龙,NOUN,B2
-جيد,fine,好的,ADJ,B2
-جين,jin,斤,NOUN,B2
-جَانِبًا,aside,在旁边,ADV,B2
-جَاهِل,ignorant,无知的,ADJ,B2
-جَحْد,disbelief,不信,NOUN,B2
-جَدَّة,grandma,奶奶,NOUN,B2
-جَرَحَ,to injure,使受伤,VERB,B2
-جَرِيء,impudent,无礼的,ADJ,B2
-جَرِيدَة يَوميَّة,daily newspaper,日报,NOUN,B2
-جَرِيمَة,great offense,冒犯大,NOUN,B2
-جَرِيًّا,certainly,当然,ADV,B2
-جَلَدَ,to whip,鞭打,VERB,B2
-جَلِيل,majestic,宏伟的,ADJ,B2
-جَنَازَة,funeral,葬礼,NOUN,B2
-جَوْلَة,cruise,巡航,NOUN,B2
-جُمْلَة,wholesale,批发,NOUN,B2
-جُنَّ,to go crazy,发疯,VERB,B2
-جُنُود,troops,部队,NOUN,B2
+مَقْعَد,bench,长凳,NOUN,B2
+مُعِين,benefactor,恩人,NOUN,B2
+كَرَم,benevolence,仁慈,NOUN,B2
+كَرِيم,benevolent,仁慈的,ADJ,B2
 جِوَار,beside next to,旁边,NOUN,B2
-حاج,pilgrim,朝圣者,NOUN,B2
-حادث سيارة,car accident,车祸,NOUN,B2
-حارس شخصي,bodyguard,保镖,NOUN,B2
-حارس مرافقة,escort guard,镖师,NOUN,B2
-حاسم,clear-cut,明确的,ADJ,B2
-حاسم,conclusive,决定性的,ADJ,B2
-حاسم,decisive,决定性的,ADJ,B2
-حاسِم,crucial,至关重要的,ADJ,B2
-حاضنة,preschool,幼儿园,NOUN,B2
-حاكى,to emulate,效仿,VERB,B2
-حاكى,to simulate,模拟,VERB,B2
-حالياً,nowadays,如今,ADV,B2
-حاليًّا,currently,目前,ADV,B2
-حامية,garrison,驻军,NOUN,B2
-حانة,pub,酒吧,NOUN,B2
-حبيب,boyfriend,男朋友,NOUN,B2
-حبيب,darling,亲爱的,NOUN,B2
-حتى,even,甚至,ADV,B2
-حجز,to reserve,预订,VERB,B2
-حجم,size,尺寸,NOUN,B2
-حد,boundary,边界,NOUN,B2
-حدث,to occur,发生,VERB,B2
-حدد,to determine,决定,VERB,B2
-حدود,border,边界,NOUN,B2
-حديد,iron,铁,NOUN,B2
-حديقة خضروات,vegetable garden,果园,NOUN,B2
-حذاء,boot,靴子,NOUN,B2
-حذر,careful,小心的,ADJ,B2
-حرب عالمية,world war,世界大战,NOUN,B2
-حركة,move,搬家,NOUN,B2
-حزين,melancholy,忧郁,ADJ,B2
-حساء صافٍ,clear soup,江瑶清羹,NOUN,B2
-حسب,to compute,计算,VERB,B2
-حسد,to envy,羡慕,VERB,B2
-حسنًا,alright,好的,ADV,B2
-حشرة,bug,虫子,NOUN,B2
-حصاة,pebble,卵石,NOUN,B2
-حصل,to obtain,获得,VERB,B2
-حصول,to get,得到,VERB,B2
-حضرتك,you polite,您,PRON,B2
-حطام,wreck,残骸,NOUN,B2
-حظ سيئ,bad luck,倒霉,NOUN,B2
-حظر,to ban,禁止,VERB,B2
-حظي باهتمام عالمي,to receive worldwide attention,举世瞩目,VERB,B2
-حفاضة,diaper,尿布,NOUN,B2
-حفر,to excavate,挖掘,VERB,B2
-حفرة,pit,坑,NOUN,B2
-حفز,to motivate,激励,VERB,B2
-حفلة موسيقية,concert,音乐会,NOUN,B2
-حق الدائن,creditor's right,债权,NOUN,B2
-حق المؤلف,copyright,版权,NOUN,B2
-حقا,really,真正地,ADV,B2
-حقيبة ظهر,backpack,背包,NOUN,B2
-حقيبة يد,handbag,手提包,NOUN,B2
-حقيقة,fact,事实,NOUN,B2
-حقيقي,genuine,真正的,ADJ,B2
-حك,itch,痒,NOUN,B2
-حك,to itch,发痒,VERB,B2
-حكاية خرافية,fairy tale,童话,NOUN,B2
-حكم,judgment,判断,NOUN,B2
-حكم,verdict,裁决,NOUN,B2
-حكم,to judge,判断,VERB,B2
-حكيم,wise,明智的,ADJ,B2
-حلبة التزلج,ice rink,溜冰场,NOUN,B2
-حلم,to dream,做梦,VERB,B2
-حليف,ally,盟友,NOUN,B2
-حم,father-in-law,岳父/公公,NOUN,B2
-حماس,excitement,兴奋,NOUN,B2
-حماية البيئة,environmental protection,环境保护,NOUN,B2
-حمل,pregnancy,怀孕,NOUN,B2
-حمى,to protect,保护,VERB,B2
-حمّس,to enthuse,使热情,VERB,B2
-حورية البحر,mermaid,美人鱼,NOUN,B2
-حوّل,to convert,转换,VERB,B2
-حي,vivid,生动的,ADJ,B2
-حياء,decency,体面,NOUN,B2
-حياء,modesty,谦虚,NOUN,B2
-حير,to puzzle,使困惑,VERB,B2
-حينئذ فقط,only then,才,ADV,B2
-حيوية,vigor,活力,NOUN,B2
-حيّ,alive,活着的,ADJ,B2
-حَاجِب,hip,臀部,NOUN,B2
-حَادِي عَشَرَة,eleven,十一,NUM,B2
-حَارِس,security guard,保安,NOUN,B2
+عِلّاوةً,besides,此外,ADV,B2
 حَاصَرَ,to besiege,包围,VERB,B2
-حَافلة البَعد البَعيد,long-distance bus,长途车,NOUN,B2
-حَافَة,fringe,边缘,NOUN,B2
-حَافَظَ,to maintain,维持,VERB,B2
-حَبِيب,lover,爱人,NOUN,B2
-حَبّ,grain,谷物,NOUN,B2
-حَبّ البرق,buckwheat,荞麦,NOUN,B2
-حَتَّى,until,直到,ADP,B2
-حَتَّى,up to,为止,ADP,B2
-حَتَّى الآن,so far,到目前为止,ADV,B2
-حَثَّ,to exhort,劝告,VERB,B2
-حَثَّ,to impel,推动,VERB,B2
-حَثّ,to spur,激励,VERB,B2
-حَدَّثَ,to discourse,论述,VERB,B2
-حَدَّثَ,to update,更新,VERB,B2
-حَدَّدَ,to locate,定位,VERB,B2
-حَذِر,cautious,小心的,ADJ,B2
-حَذِر,discreet,谨慎的,ADJ,B2
-حَذِر وَمُتَحَرٍّ,cautious and conscientious,兢兢业业,ADJ,B2
-حَرَقَ,burn,烧伤,NOUN,B2
-حَرَقَ,to burn,燃烧,VERB,B2
-حَرَّر,to edit,编辑,VERB,B2
-حَرَّر,to emancipate,解放,VERB,B2
-حَرَّرَ,to free,释放,VERB,B2
-حَرّك,to mobilize,动员,VERB,B2
-حَزَم,to pack,打包,VERB,B2
-حَسَن الْمَنْظَر,good-looking,好看的,ADJ,B2
-حَسَنًا,well,好,ADV,B2
-حَصَى,gravel,砾石,NOUN,B2
-حَطَّمَ,to smash,粉碎,VERB,B2
-حَطْم,smashing,砸过,NOUN,B2
-حَظّ,fortune,运气,NOUN,B2
-حَظّ سَعِيد,good luck,好运,NOUN,B2
-حَظّ سَعِيد,lucky chance,虽侥,NOUN,B2
-حَفيد,grandson,孙子,NOUN,B2
-حَفيدة,granddaughter,孙女,NOUN,B2
-حَفْل تَرْحِيب,welcome banquet,欢迎宴,NOUN,B2
-حَفْلَة تَقْدِير,appreciation banquet,答谢宴,NOUN,B2
-حَفْلُ كَشْف,unveiling ceremony,揭幕仪式,NOUN,B2
-حَقَارَة,unworthy,你不配,NOUN,B2
-حَقَنَ,to inject,注射,VERB,B2
-حَقِيبَة,suitcase,手提箱,NOUN,B2
-حَكَمَ,to arbitrate,仲裁,VERB,B2
-حَلْقَة,arena,竞技场,NOUN,B2
-حَمَلَ,to load,装载,VERB,B2
-حَمْل,lamb,羔羊,NOUN,B2
-حَوَّلَ,to transform,改变,VERB,B2
-حَوْل,around,到处,ADV,B2
-حَيَوِيّ,biological,生物的,ADJ,B2
-حُزَيْران,june,六月,NOUN,B2
-حُكم,reign,统治,NOUN,B2
-حِرفة,handicraft,工艺品,NOUN,B2
-حِصْن,fortress,堡垒,NOUN,B2
-حِيلَة,artifice,诡计,NOUN,B2
-خارِج,out,在外面,ADV,B2
-خارِج,outside,外部,NOUN,B2
-خاسِر,loser,失败者,NOUN,B2
-خاطر,to risk,冒险,VERB,B2
-خاطر بحياته,to risk life,拼命,VERB,B2
-خالف الانضباط,to violate discipline,违纪,VERB,B2
-خالق,creator,创造者,NOUN,B2
-خامل,sluggish,迟钝的,ADJ,B2
-خبز,to bake,烘焙,VERB,B2
-خدع,to deceive,欺骗,VERB,B2
-خرافة,fable,寓言,NOUN,B2
-خزان,reservoir,水库,NOUN,B2
-خشي,to dread,畏惧,VERB,B2
-خصب,fertile,肥沃的,ADJ,B2
-خضار,vegetable,蔬菜,NOUN,B2
-خطأ,error,错误,NOUN,B2
-خطأ,wrong,错误的事,NOUN,B2
-خطيئة,sin,罪,NOUN,B2
-خطير,risky,危险的,ADJ,B2
-خفض القيمة,to devalue,贬值,VERB,B2
-خفّف,to mitigate,减轻,VERB,B2
-خلاف,falling out,反目,NOUN,B2
-خلف,behind,在后面,ADV,B2
-خلفاً,backwards,向后,ADV,B2
-خلفي,rear,后面的,ADJ,B2
-خلفية,background,背景,NOUN,B2
-خلق,creation,创造,NOUN,B2
-خنفساء,beetle,甲虫,NOUN,B2
-خيار,option,选择,NOUN,B2
-خيارات,options,期权,NOUN,B2
-خيال,fantasy,幻想,NOUN,B2
-خيال,fiction,小说,NOUN,B2
-خَابَ,to disappoint,使失望,VERB,B2
-خَادِمَة,maid,女仆,NOUN,B2
-خَادِمَة,maidservant,女仆,NOUN,B2
-خَارِج,abroad,国外,NOUN,B2
-خَارِق,supernatural,超自然的,ADJ,B2
-خَاصّ,own,自己的,ADJ,B2
-خَاصّ,specific,具体的,ADJ,B2
-خَالَفَ,to contravene,违反,VERB,B2
-خَالِد,immortal,不朽的,ADJ,B2
-خَانَ,to betray,背叛,VERB,B2
-خَبَرَ,to experience,经历,VERB,B2
-خَبَرَ,to test,测试,VERB,B2
-خَبَرَة,smattering,少量,NOUN,B2
-خَبِيثٌ,insidious,潜伏的,ADJ,B2
-خَبِير,experienced,老练的,ADJ,B2
-خَتَمَ,to seal,密封,VERB,B2
-خَدَعَ,to trick,欺骗,VERB,B2
-خَدْش,abrasion,擦伤,NOUN,B2
-خَرَجَ,to go out,出去,VERB,B2
-خَزْنَة,vault,金库,NOUN,B2
-خَسارَة,lose,上丢,NOUN,B2
-خَضَعَ,to succumb,屈服,VERB,B2
-خَطَأ,make mistake,犯错,NOUN,B2
-خَطَفَ,to snatch,抢夺,VERB,B2
-خَطَّط,outline,大纲,NOUN,B2
-خَطَّط,to outline,勾勒,VERB,B2
-خَطَّطَ,to plan,计划,VERB,B2
-خَطْف,to kidnap,绑架,VERB,B2
-خَنَقَ,to suffocate,窒息,VERB,B2
-خَنْجَر,dagger,匕首,NOUN,B2
-خَيَالِي,imaginary,虚构的,ADJ,B2
-خُرَّاج,abscess,脓肿,NOUN,B2
-خِبْرَة,expertise,专业知识,NOUN,B2
-خِيار,cucumber,黄瓜,NOUN,B2
-خِيَانَة,treason,叛国罪,NOUN,B2
-دائخ,dizzy,头晕的,ADJ,B2
-داخل,within,在……之内,ADP,B2
-دار,to circulate,循环,VERB,B2
-دار البلدية,city hall,市政厅,NOUN,B2
-داعب,to caress,爱抚,VERB,B2
-دانْمَيْ,danmei,但没,NOUN,B2
-دبلوماسي,diplomatic,外交的,ADJ,B2
-دخل المدينة,to enter city,进城,VERB,B2
-دراجة نارية,motorcycle,摩托车,NOUN,B2
-دراماتيكي,dramatic,戏剧性的,ADJ,B2
-درج,drawer,抽屉,NOUN,B2
-دزينة,dozen,一打,NOUN,B2
-دفاية,radiator,暖气片,NOUN,B2
-دفع الحظ,push luck,太得寸,NOUN,B2
-دفع جوّال,mobile payment,移动支付,NOUN,B2
-دفع ضريبة,to pay tax,纳税,VERB,B2
-دفع مبتسماً,to pay smilingly,笑付,VERB,B2
-دفن,burial,埋葬,NOUN,B2
-دقيق,exact,精确的,ADJ,B2
-دقيق,meticulous,一丝不苟的,ADJ,B2
-دقيق,nuanced,细微差别的,ADJ,B2
-دقيق,punctual,准时的,ADJ,B2
-دمج,to merge,合并,VERB,B2
-دمر,to destroy,破坏,VERB,B2
-دمر,to devastate,摧毁,VERB,B2
-دمية,doll,玩偶,NOUN,B2
-دمية,puppet,木偶,NOUN,B2
-دمية قماشية,plush toy,毛绒玩具,NOUN,B2
-دناءة,inferiority,劣势,NOUN,B2
-دهن,fat,脂肪,NOUN,B2
-دوق,duke,公爵,NOUN,B2
-دولة عدوة,enemy state,敌国,NOUN,B2
-دوي,bang,巨响,NOUN,B2
-ديباج,brocade,锦绣,NOUN,B2
-ديسمبر,december,十二月,NOUN,B2
-ديمقراطية,democracy,民主,NOUN,B2
-ديناصور,dinosaur,恐龙,NOUN,B2
-ديناميت,dynamite,炸药,NOUN,B2
-ديناميكي,dynamic,动态的,ADJ,B2
-دَاء,malady,弊病,NOUN,B2
-دَائِم,constant,持续的,ADJ,B2
-دَائِمًا,constantly,不断地,ADV,B2
-دَاخِلٌ,inside,在里面,ADV,B2
-دَاخِلِيٌّ,insider,知情者,NOUN,B2
-دَار الإِمَارة,imperial court,朝廷,NOUN,B2
-دَارَ,cycle,循环,NOUN,B2
-دَارَ,to cycle,骑自行车,VERB,B2
-دَاسَ,to trample,踩踏,VERB,B2
-دَامَ,to last a period of time,为期,VERB,B2
-دَبَّسَ,to pin,别住,VERB,B2
-دَخَلَ,to go in,进去,VERB,B2
-دَخْل وَمَخْرَج,income and expense,收支,NOUN,B2
-دَرَجَة,grade,等级,NOUN,B2
-دَعَا,to sue,起诉,VERB,B2
-دَفْع إِلِكْتُرُونِيّ,electronic payment,电子支付,NOUN,B2
-دَفْعَة,impulse,冲动,NOUN,B2
-دَمَجَ,to consolidate,巩固,VERB,B2
-دَمَجَ,to incorporate,包含,VERB,B2
-دُهْنِيّ,greasy,油腻的,ADJ,B2
-دِرْع,armor,盔甲,NOUN,B2
-ذبح,slaughter,屠杀,NOUN,B2
-ذرة,corn,玉米,NOUN,B2
-ذروة,climax,高潮,NOUN,B2
-ذريعة,pretext,借口,NOUN,B2
-ذكر,mention,提及,NOUN,B2
-ذكر,to mention,提及,VERB,B2
-ذكي,witty,机智的,ADJ,B2
-ذو صلة,relevant,相关的,ADJ,B2
-ذو قيمة,worth,值得的,ADJ,B2
-ذَابَ,to thaw,解冻,VERB,B2
-ذَكَر,male,男性的,ADJ,B2
-ذَلِكَ,that,那个,PRON,B2
-ذَهَب,gold,金子,NOUN,B2
-رؤية للعالم,worldview,世界观,NOUN,B2
-رئيس,boss,老板,NOUN,B2
-رئيس الوزراء,premier,总理,NOUN,B2
-رئيس الوزراء,prime minister,总理,NOUN,B2
-رئيس قسم,department head,厅长,NOUN,B2
-رائد أعمال,entrepreneur,企业家,NOUN,B2
-رائع,fantastic,极好的,ADJ,B2
-راجل,pedestrian,行人,NOUN,B2
-راسخ,established,既定的,ADJ,B2
-رافَق,escort,护卫,NOUN,B2
-رافَق,to escort,护送,VERB,B2
-راهبة,nun,修女,NOUN,B2
-ربع سنة,quarter of a year,季度,NOUN,B2
-رتب,to put in order,收拾,VERB,B2
-رتشفة,sip,小口喝,NOUN,B2
-رجعي,regressive,退步的,ADJ,B2
-رجل,gentleman,绅士,NOUN,B2
-رجل,guy,家伙,NOUN,B2
-رجل أعمال,businessman,商人,NOUN,B2
-رجل وسيم,handsome guy,帅哥,NOUN,B2
-رحلة,ride,行程,NOUN,B2
-رخصة قيادة,driver's license,驾驶证,NOUN,B2
-رد,to respond,回应,VERB,B2
-رد على,to respond to,回应,VERB,B2
-رسم,fee,费用,NOUN,B2
-رسمل,to capitalize,利用,VERB,B2
-رشح,to filter,过滤,VERB,B2
-رصاصة,bullet,子弹,NOUN,B2
-رصيف,quay,码头,NOUN,B2
-رعاية,nurturing,养好,NOUN,B2
-رعى,to care for,照顾,VERB,B2
-رعى,to nurture,养育,VERB,B2
-رغبة في الموت,death wish,找死,NOUN,B2
-رغم,although,虽然,SCONJ,B2
-رفض,to reject,拒绝,VERB,B2
-رفض المحكمة,court dismissal,退朝,NOUN,B2
-رفض بأدب,to decline politely,婉拒,VERB,B2
-رفع,to raise,举起,VERB,B2
-رفيق,comrade,同志,NOUN,B2
-رفيق,playmate,玩伴,NOUN,B2
-رقبة,neck,脖子,NOUN,B2
-رقم اثنان,number two,二号,NOUN,B2
-رنين مغناطيسي,mri,核磁共振,NOUN,B2
-رهن,to mortgage,抵押,VERB,B2
-رَأَى,to see,看见,VERB,B2
-رَأَى,to see again,再见,VERB,B2
-رَأَى,to see corpse,见尸,VERB,B2
-رَئِيس,superior,更好的,ADJ,B2
-رَئِيس,chairman,主席,NOUN,B2
-رَئِيس,chairperson,主席,NOUN,B2
-رَئِيسِي,major,少校,NOUN,B2
-رَائِحَة,fragrance,香味,NOUN,B2
-رَائِع,gorgeous,华丽的,ADJ,B2
-رَابِطَة,binding,装订,NOUN,B2
-رَابِع,fourth,第四,ADJ,B2
-رَاعِي,herder,牧民,NOUN,B2
-رَاقٍ,exquisite,精致的,ADJ,B2
-رَاقَبَ,to supervise,监督,VERB,B2
+مَنّ,to bestow,授予,VERB,B2
+مَنّ,bestowal,授予,NOUN,B2
 رَاهَنَ,bet,打赌,NOUN,B2
 رَاهَنَ,to bet,打赌,VERB,B2
-رَتَّبَ,to arrange,安排,VERB,B2
-رَجَعَ,to go back,回去,VERB,B2
-رَدَّ,to bring back,带回,VERB,B2
-رَدِيء,lousy,糟糕的,ADJ,B2
-رَدِيء,terrible,可怕的,ADJ,B2
+خَانَ,to betray,背叛,VERB,B2
+مُحَسِّن,better,更好的,ADJ,B2
+مَا وَرَاء,beyond,在...之外,ADP,B2
+بِيانْتشونغ,bianzhong,编钟,NOUN,B2
+الإِنْجِيل,bible,圣经,NOUN,B2
+عَرْض,bid,出价,NOUN,B2
+تَواطؤ المَزَايَدَة,bid collusion,串标,NOUN,B2
+تَقْيِيم العُروض,bid evaluation,评标,NOUN,B2
+فَتْح العُروض,bid opening,开标,NOUN,B2
+فَاوِرة,bill,账单,NOUN,B2
+بِلْيَارْدو,billiards,台球,NOUN,B2
+مِلْيَار,billion,十亿,NUM,B2
+رَابِطَة,binding,装订,NOUN,B2
+تَنَوُّع حَيَوِيّ,biodiversity,生物多样性,NOUN,B2
+سِيَرَة,biography,传记,NOUN,B2
+حَيَوِيّ,biological,生物的,ADJ,B2
+حارس شخصي,bodyguard,保镖,NOUN,B2
+جريء,bold,大胆的,ADJ,B2
+قنبلة,bomb,炸弹,NOUN,B2
+يقصف,to bombard,轰炸,VERB,B2
+متعجرف,bombastic,夸大的,ADJ,B2
+عظمي,bony,瘦骨嶙峋的,ADJ,B2
+يحجز,to book,预订,VERB,B2
+كتيّب,booklet,小册子,NOUN,B2
+حذاء,boot,靴子,NOUN,B2
+كشك,booth,摊位,NOUN,B2
+حدود,border,边界,NOUN,B2
+يمل,to bore,使厌烦,VERB,B2
+رئيس,boss,老板,NOUN,B2
+كلا,both,两者都,CCONJ,B2
+كفتا,both hands,双手,NOUN,B2
+يزعج,bother,麻烦,NOUN,B2
+يزعج,to bother,打扰,VERB,B2
+صخرة,boulder,巨石,NOUN,B2
+حد,boundary,边界,NOUN,B2
+قوس,bow,蝴蝶结,NOUN,B2
+وعاء,bowl,碗,NOUN,B2
+حبيب,boyfriend,男朋友,NOUN,B2
+يفاخر,to brag,吹嘘,VERB,B2
+يفرمل,brake,刹车,NOUN,B2
+يفرمل,to brake,刹车,VERB,B2
+علامة,brand,品牌,NOUN,B2
+جديد,brand new,崭新的,ADJ,B2
+وقاحة,brazenness,厚颜无耻,NOUN,B2
+ينقض عقد,to breach contract,违约,VERB,B2
+استراحة,break,休息,NOUN,B2
+يتعطل,to break down,分解,VERB,B2
+يكسر,to break open,撬开,VERB,B2
+يتفكك,to break up,破裂,VERB,B2
+سلالة,breed,品种,NOUN,B2
+إيجاز,brevity,简洁,NOUN,B2
+مصنع بيرة,brewery,啤酒厂,NOUN,B2
 رَشَا,to bribe,贿赂,VERB,B2
-رَعَى,to graze,吃草,VERB,B2
-رَغْم,to in spite of,不顾,VERB,B2
-رَغْوَة,scum,渣滓,NOUN,B2
-رَفَاهِيَة,welfare,福利,NOUN,B2
-رَفَعَ,to upload,上传,VERB,B2
-رَفِيق,consort,福晋,NOUN,B2
-رَفْضٌ مُؤَقَّت,temporary refusal,暂不,NOUN,B2
-رَقَّبَ,to censor,审查,VERB,B2
-رَمَادِيّ,grey,灰色的,ADJ,B2
-رَمَى,to discard,丢弃,VERB,B2
-رَومانسِيَّة,idyll,田园诗,NOUN,B2
-رُكُود,to stagnate,停滞,VERB,B2
-رُوح,spirit,精神,NOUN,B2
-رِئَاسِيًّا,mainly,主要地,ADV,B2
-رِحْلَة,trip,旅行,NOUN,B2
-رِسَالَة نَصِّيَّة,text message,短信,NOUN,B2
-زئبق,mercury,汞,NOUN,B2
-زئير,growl,低吼,NOUN,B2
-زائر,visitor,访客,NOUN,B2
-زجاج النافذة,window glass,窗玻璃,NOUN,B2
-زعمًا,allegedly,据称,ADV,B2
-زلابية,dumpling,丸子,NOUN,B2
-زلق,slippery,滑的,ADJ,B2
-زميل,fellow,家伙,NOUN,B2
-زنك,zinc,锌,NOUN,B2
-زوج,couple,一对,NOUN,B2
-زوج,husband,丈夫,NOUN,B2
-زوج,a pair,一对,NUM,B2
-زوجان,a married couple,夫妇,NOUN,B2
-زوجة الأخ,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-زود,to provide,提供,VERB,B2
-زومبي,zombie,僵尸,NOUN,B2
-زوّر,to falsify,伪造,VERB,B2
-زي,costume,戏服,NOUN,B2
-زين,to decorate,装饰,VERB,B2
-زينة,decoration,装饰品,NOUN,B2
-زينة,ornament,装饰,NOUN,B2
-زَأَرَ,to bellow,吼叫,VERB,B2
-زَائِد,superfluous,多余的,ADJ,B2
-زَاحَ,to dislocate,使脱臼,VERB,B2
-زَادَ,to increase steadily,与日俱增,VERB,B2
-زَرَعَ,to cultivate,培养,VERB,B2
-زَرَعَ,to plant out,定植,VERB,B2
-زَرَقَة,lane,小巷,NOUN,B2
-زَفَرَ,to exhale,呼气,VERB,B2
-زَمَنِيّ,temporal,时间的,ADJ,B2
-زَوْج,spouse,配偶,NOUN,B2
-زَيَّن,to embellish,装饰,VERB,B2
-زِيادَة يَوميَّة,daily increase,日渐,NOUN,B2
-سؤال بلاغي,rhetorical question,宁非,NOUN,B2
-ساء,to worsen,恶化,VERB,B2
-سائق مخصّص,designated driver,代驾,NOUN,B2
-ساحر,fascinating,迷人的,ADJ,B2
-ساحر,wizard,巫师,NOUN,B2
-ساحرة,witch,女巫,NOUN,B2
-ساخر,ironic,讽刺的,ADJ,B2
-ساذج,gullible,易受骗的,ADJ,B2
-سار,pleasant,令人愉快的,ADJ,B2
-سارق,burglar,窃贼,NOUN,B2
+غرفة العرس,bridal chamber,洞房,NOUN,B2
+ملخص,brief,近点说,NOUN,B2
 ساطع,bright,明亮的,ADJ,B2
-ساعة منبّهة,alarm clock,闹钟,NOUN,B2
-ساكن,inhabitant,居民,NOUN,B2
+لامع,brilliant,杰出的,ADJ,B2
+رَدَّ,to bring back,带回,VERB,B2
+بريطاني,british,英国的,ADJ,B2
+بريطاني,briton,英国人,NOUN,B2
+بَثَّ,to broadcast,播出,VERB,B2
+ديباج,brocade,锦绣,NOUN,B2
+برونز,bronze,青铜,NOUN,B2
+جدول,brook,小溪,NOUN,B2
+بيت دعارة,brothel,妓院,NOUN,B2
+مَسَحَ,to brush,刷,VERB,B2
+قَسَا,to brutalize,使变得残忍,VERB,B2
+تيس,buck,美元,NOUN,B2
+حَبّ البرق,buckwheat,荞麦,NOUN,B2
+صديق,buddy,伙伴,NOUN,B2
+حشرة,bug,虫子,NOUN,B2
+بَنَى,to build,建造,VERB,B2
+رصاصة,bullet,子弹,NOUN,B2
+مُتَسَلِّط,bully,欺凌者,NOUN,B2
+مكتب,bureau,局,NOUN,B2
+سارق,burglar,窃贼,NOUN,B2
+سَرِقة,burglary,入室盗窃罪,NOUN,B2
+دفن,burial,埋葬,NOUN,B2
+حَرَقَ,burn,烧伤,NOUN,B2
+حَرَقَ,to burn,燃烧,VERB,B2
+شجيرة,bush,灌木,NOUN,B2
+تجاري,business,商业的,ADJ,B2
+اجتماع تجاري,business meeting,洽谈会,NOUN,B2
+رجل أعمال,businessman,商人,NOUN,B2
+ضجيج,bustle,喧闹,NOUN,B2
+وادٍ,canyon,峡谷,NOUN,B2
+قادر,capable,有能力的,ADJ,B2
+رسمل,to capitalize,利用,VERB,B2
+قائد,captain,队长,NOUN,B2
+أسر,capture,捕获,NOUN,B2
+أسر,to capture,获取,VERB,B2
+حادث سيارة,car accident,车祸,NOUN,B2
+تأمين سيارة,car insurance,车险,NOUN,B2
+قافلة,caravan,房车,NOUN,B2
+ضريبة الكربون,carbon tax,碳税,NOUN,B2
+رعى,to care for,照顾,VERB,B2
+مهنة,career,职业,NOUN,B2
+حذر,careful,小心的,ADJ,B2
+مقدم رعاية,caregiver,护理人员,NOUN,B2
+داعب,to caress,爱抚,VERB,B2
+قيم,caretaker,房屋管理员,NOUN,B2
+جزر,carrot,胡萝卜,NOUN,B2
+نقل,to carry forward,发扬,VERB,B2
+نفذ,to carry out,实施,VERB,B2
+صرف,cash,现金,ADJ,B2
+صرف,to cash,兑现,VERB,B2
+كشمير,cashmere,羊绒,NOUN,B2
+كسافا,cassava,木薯,NOUN,B2
+قلعة,castle,城堡,NOUN,B2
+عابر,casual,随意的,ADJ,B2
+فهرس,catalog,目录,NOUN,B2
+تصنيف,categorization,分类,NOUN,B2
+صنف,to categorize,分类,VERB,B2
+كاتدرائية,cathedral,大教堂,NOUN,B2
+كاثوليكية,catholicism,天主教,NOUN,B2
+ماشية,cattle,牛,NOUN,B2
 سبب,cause,原因,NOUN,B2
 سبب,to cause,引起,VERB,B2
 سبب الوفاة,cause of death,死因,NOUN,B2
-سترة,vest,背心,NOUN,B2
-سجل,record,记录,NOUN,B2
-سجل,to enroll,注册,VERB,B2
-سجل,to record,记录,VERB,B2
-سجن,jail,监狱,NOUN,B2
-سجّل,to register,注册,VERB,B2
-سحب,to drag,拖,VERB,B2
-سحب من الخدمة,decommissioning,退役,NOUN,B2
-سحر,to be entranced,出神,VERB,B2
-سحر,to enchant,使着迷,VERB,B2
-سخيف,ridiculous,荒谬的,ADJ,B2
-سرد,to recount,转述,VERB,B2
-سرد,to relate to narrate,叙述,VERB,B2
-سرق,to be stolen,失窃,VERB,B2
-سري,clandestine,秘密的,ADJ,B2
-سريع,quick,快的,ADJ,B2
-سريع,rapid,迅速的,ADJ,B2
-سريع الغضب,irascible,易怒的,ADJ,B2
-سعى,to pursue,追求,VERB,B2
-سعي,quest,探索,NOUN,B2
-سقوط,fall,瀑布,NOUN,B2
-سكران,drunk,醉酒的,ADJ,B2
-سكن,to inhabit,居住,VERB,B2
-سلاح الجريمة,murder weapon,凶器,NOUN,B2
-سلالة,breed,品种,NOUN,B2
-سلب,to despoil,掠夺,VERB,B2
-سلب,to rob,抢劫,VERB,B2
-سلسلة الصناعات,industry chain,产业链,NOUN,B2
-سلسلة جبال,mountain range,山脉,NOUN,B2
-سلك,plug,插头,NOUN,B2
-سلك,wire,电线,NOUN,B2
-سلم,to be safe,安好,VERB,B2
-سلى,to entertain,娱乐,VERB,B2
-سلّم,to extradite,引渡,VERB,B2
-سماد,compost,堆肥,NOUN,B2
-سمان,quail,鹌鹑,NOUN,B2
-سمة,feature,特征,NOUN,B2
-سنوات,years,数年,NOUN,B2
-سهّل,to facilitate,促进,VERB,B2
-سوء فهم,misunderstanding,误解,NOUN,B2
-سيء السمعة,notorious,臭名昭著的,ADJ,B2
-سيئ,bad,坏的,ADJ,B2
-سيئاً,badly,坏地,ADV,B2
-سيارة دفع رباعي,off-road vehicle,越野车,NOUN,B2
-سيد شاب,young master,少庄主,NOUN,B2
-سيدة شابة,young lady,小姐,NOUN,B2
-سيدي,sir,先生,NOUN,B2
-سيّدة,mistress,情妇,NOUN,B2
-سَائب,loose,松的,ADJ,B2
-سَابِق,former,以前的,ADJ,B2
-سَابِقًا,formerly,以前,ADV,B2
-سَاحَ,to hike,徒步旅行,VERB,B2
-سَاعَدَ,to help assistance,帮助,VERB,B2
-سَاهَمَ,to contribute,贡献,VERB,B2
-سَجَنَ,to imprison,监禁,VERB,B2
-سَحب,lottery,彩票,NOUN,B2
-سَحَب,to overdraw,透支,VERB,B2
-سَحّار,magician,魔术师,NOUN,B2
-سَخَط,outrage,愤怒,NOUN,B2
-سَخِيف,absurd,荒谬的,ADJ,B2
-سَرَّعَ,to accelerate,加速,VERB,B2
-سَرِقة,burglary,入室盗窃罪,NOUN,B2
-سَعِيد,glad,高兴的,ADJ,B2
-سَكِيت,sober,清醒的,ADJ,B2
-سَكْرَة,ecstasy,狂喜,NOUN,B2
-سَلَّمَ,to disarm,解除武装,VERB,B2
-سَلَّمَ,to greet,问候,VERB,B2
-سَلِسًا,smoothly,顺利,ADV,B2
-سَلِيمٌ,intact,完好无损的,ADJ,B2
-سَمَاء,heaven,天堂,NOUN,B2
-سَمِعَ,to hear a case,审理,VERB,B2
-سَهْم,arrow,箭,NOUN,B2
-سَهْم,stake,利害关系,NOUN,B2
-سَوَاء,whether,能否,NOUN,B2
-سَوَاء أَمْ,whether or not,是否,SCONJ,B2
-سَيَّارَة,sedan,轿车,NOUN,B2
-سَيَّارَة رِيَاضِيَّة,sports car,跑车,NOUN,B2
-سَيِّدَة,madam,夫人,NOUN,B2
-سَيْقَظَة مُجْتَمَعِيَّة,social awakening,社会觉醒,NOUN,B2
-سُلْطَة كَامِلَة,full power,全力,NOUN,B2
-سُمْعَة طَيِّبَة,good reputation,清誉,NOUN,B2
-سُنْبُكَة,snack,小吃,NOUN,B2
-سُهُولَة القَوْل,easy to say,好说,NOUN,B2
-سُوْق كَبِير,supermarket,超市,NOUN,B2
-سِجِلّ,log,日志,NOUN,B2
-سِحْر,spell,咒语,NOUN,B2
-سِرِّيَّة,secrecy,保密,NOUN,B2
-سِرّ,secret,秘密,NOUN,B2
-سِلْسِلَة,chain,链条,NOUN,B2
-سِلْسِلَة أَفْكَار,train of thought,思路,NOUN,B2
-سِمَة,characteristic,典型的,ADJ,B2
+حَذِر,cautious,小心的,ADJ,B2
+حَذِر وَمُتَحَرٍّ,cautious and conscientious,兢兢业业,ADJ,B2
+فُرْسَان,cavalry,骑兵,NOUN,B2
+انْتَهَى,to cease,停止,VERB,B2
+احتَفَلَ,to celebrate,庆祝,VERB,B2
+هَاتِف جَوَّال,cell phone,手机,NOUN,B2
+كَرْم,cellar,地窖,NOUN,B2
+رَقَّبَ,to censor,审查,VERB,B2
 سِنْت,cent,分,NOUN,B2
 سِنْتِيمِتْر,centimeter,厘米,NOUN,B2
-سِياج,hedge,树篱,NOUN,B2
-سِيَاحَة,hiking,徒步,NOUN,B2
+مَرْكَزَ,to centralize,集中,VERB,B2
+قُوَّة طَرْدِيَّة,centrifugal force,离心力,NOUN,B2
+قَلَنْسُوَة طَقْسِيَّة,ceremonial cap,爵弁,NOUN,B2
+مُعَيَّن,certain,某些,DET,B2
+جَرِيًّا,certainly,当然,ADV,B2
+شَهَادَة تَمِيْز,certificate of merit,奖状,NOUN,B2
+شَهَّدَ,to certify,证明,VERB,B2
+انْتِهَاء,cessation,终止,NOUN,B2
+سِلْسِلَة,chain,链条,NOUN,B2
+رَئِيس,chairman,主席,NOUN,B2
+رَئِيس,chairperson,主席,NOUN,B2
+تَحَدَّى,to challenge,质疑,VERB,B2
+بَطَل,champion,冠军,NOUN,B2
+كَانْسِلَر,chancellor,总理,NOUN,B2
+ثَمَرَة,chandelier,吊灯,NOUN,B2
+بَدَّلَ إِطَار,to change tire,换胎,VERB,B2
 سِيَاسَة مُتَغَيِّرَة,changed policy,改策,NOUN,B2
-سِيَرَة,biography,传记,NOUN,B2
-شاب,young,年轻的,ADJ,B2
-شاب,young man,年轻人,NOUN,B2
-شاب,young person,年轻人,NOUN,B2
-شابك,to entangle,使纠缠,VERB,B2
-شابه,to resemble,像,VERB,B2
-شاحِنَة,van,货车,NOUN,B2
-شاقّ,laborious,费力的,ADJ,B2
-شاهد عيان,eyewitness,目击,NOUN,B2
-شبه جزيرة,peninsula,半岛,NOUN,B2
-شتات عائلة,family ruin,家破,NOUN,B2
-شجار,quarreling,再吵,NOUN,B2
-شجع,to encourage,鼓励,VERB,B2
-شجيرة,bush,灌木,NOUN,B2
-شخص,to diagnose,诊断,VERB,B2
-شر,evil,邪,PART,B2
-شراب,drink,饮料,NOUN,B2
-شراسة,fierceness,凶猛,NOUN,B2
-شرس,fierce,凶猛的,ADJ,B2
-شرط سابق,prerequisite,前提,NOUN,B2
-شرطي,cop,警察,NOUN,B2
-شرف,to ennoble,使高贵,VERB,B2
-شركة,firm,坚固的,ADJ,B2
-شريحة,slice,薄片,NOUN,B2
-شعر,poetry,诗歌,NOUN,B2
-شفقة,pity,可惜,ADJ,B2
-شفقة,compassion,同情,NOUN,B2
-شقاء,misfortune,不幸,NOUN,B2
+وَجَّهَ,to channel,疏导,VERB,B2
+فَوْضَوِيّ,chaotic,混乱的,ADJ,B2
+صَوْمَعَة,chapel,小教堂,NOUN,B2
+فَصْل,chapter,章节,NOUN,B2
+شَخْصِيَّة,character,性格,NOUN,B2
+كَلِمَة شَخْصِيَّة,character word,字,NOUN,B2
+سِمَة,characteristic,典型的,ADJ,B2
+عيد الميلاد,christmas,圣诞节,NOUN,B2
+دار,to circulate,循环,VERB,B2
+أحاط,to circumscribe,限制,VERB,B2
+ظرف,circumstance,情况,NOUN,B2
+استشهد,to cite,引用,VERB,B2
+دار البلدية,city hall,市政厅,NOUN,B2
+موظف مدني,civil servant,公务员,NOUN,B2
+مدني,civilian,平民,NOUN,B2
+متمدن,civilized,文明的,ADJ,B2
+ادعى,to claim,声称,VERB,B2
+عشيرة,clan,家族,NOUN,B2
+سري,clandestine,秘密的,ADJ,B2
+صف,class,班级,NOUN,B2
+كلاسيكي,classic,经典的,ADJ,B2
+كلاسيكي,classical,古典的,ADJ,B2
+مُصنِّف للوحات والقماش إلخ,classifier for paintings cloth etc.,幅,NUM,B2
+مُصنِّف للأشجار,classifier for trees,棵,NUM,B2
+فصل دراسي,classroom,教室,NOUN,B2
+مخلب,claw,爪子,NOUN,B2
+نظيف,clean,干净的,ADJ,B2
+نظّف,to clean up,清理,VERB,B2
+تنظيف,cleansing,清洗,NOUN,B2
+صفّى,to clear,清理,VERB,B2
+معرفة واضحة,clear knowledge,明知,NOUN,B2
+حساء صافٍ,clear soup,江瑶清羹,NOUN,B2
+حاسم,clear-cut,明确的,ADJ,B2
+بوضوح,clearly,清楚地,ADV,B2
+محدد بوضوح,clearly demarcated,分明,ADJ,B2
 شقّ,to cleave,劈开,VERB,B2
-شكر,to be grateful,感激,VERB,B2
-شكل,figure,图形,NOUN,B2
+كاتب,clerk,职员,NOUN,B2
+كليشيه,cliche,陈词滥调,NOUN,B2
+عميل,client,客户,NOUN,B2
+جرف,cliff,悬崖,NOUN,B2
+التغير المناخي,climate change,气候变化,NOUN,B2
+ذروة,climax,高潮,NOUN,B2
+شيوع,commonality,共同点,NOUN,B2
+عامي,commoner,平民,NOUN,B2
+تواصل,to communicate,交流,VERB,B2
+مجتمع,community,社区,NOUN,B2
+مدمج,compact,紧凑的,ADJ,B2
+مقصورة,compartment,隔间,NOUN,B2
+شفقة,compassion,同情,NOUN,B2
+توافق,compatibility,兼容性,NOUN,B2
+مواطن,compatriot,同胞,NOUN,B2
+أجبر,to compel,强迫,VERB,B2
+إجازة تعويضية,compensatory leave,调休,NOUN,B2
+نافس,to compete,竞争,VERB,B2
+كفؤ,competent,胜任的,ADJ,B2
+منافس,competitor,竞争者,NOUN,B2
+جمع,to compile,编译,VERB,B2
+كامل,complete,完整的,ADJ,B2
+تماما,completely,完全地,ADV,B2
+متوافق,compliant,符合的,ADJ,B2
+عقد,to complicate,使复杂化,VERB,B2
+مجاملة,compliment,称赞,NOUN,B2
+امتثل,to comply with,遵守,VERB,B2
+مكون,component,组成部分,NOUN,B2
+ألف,to compose,组成,VERB,B2
+ملحن,composer,作曲家,NOUN,B2
+سماد,compost,堆肥,NOUN,B2
+مركب,compound,复合性,ADJ,B2
+ضغط,to compress,压缩,VERB,B2
+تساهل,compromise,妥协,NOUN,B2
+تساهل,to compromise,危及,VERB,B2
+حسب,to compute,计算,VERB,B2
+رفيق,comrade,同志,NOUN,B2
+تصور,to conceive,构想,VERB,B2
+يعني,to concern,涉及,VERB,B2
+حفلة موسيقية,concert,音乐会,NOUN,B2
+حاسم,conclusive,决定性的,ADJ,B2
+تَأَلَّفَ,to consist,组成,VERB,B2
+مُتَّسِق,consistent,一致的,ADJ,B2
+دَمَجَ,to consolidate,巩固,VERB,B2
+رَفِيق,consort,福晋,NOUN,B2
+ظَاهِر,conspicuous,显著的,ADJ,B2
+تَمَوَّطَ,to conspire,密谋,VERB,B2
+شُرْطِيّ,constable,警官,NOUN,B2
+دَائِم,constant,持续的,ADJ,B2
+دَائِمًا,constantly,不断地,ADV,B2
+كَوْسَد,constellation,星座,NOUN,B2
+شَكَّلَ,to constitute,构成,VERB,B2
+قَيَّدَ,to constrain,限制,VERB,B2
+قَيْد,constraint,约束,NOUN,B2
+بَنَى,to construct,建造,VERB,B2
+بِنَائِيّ,constructive,建设性的,ADJ,B2
+اِسْتَشَارَ,to consult reference,参考,VERB,B2
+مُسْتَشَار,consultant,顾问,NOUN,B2
+اِسْتَهْلَكَ,to consume,消费,VERB,B2
+تَوَاصُل,contact,联系,NOUN,B2
+لَوَّثَ,to contaminate,污染,VERB,B2
+تَأَمَّلَ,to contemplate,沉思,VERB,B2
+مُعَاصِر,contemporary,当代的,ADJ,B2
+مُنَافَسَة,contest,比赛,NOUN,B2
+طَارِئ,contingency,偶然性,NOUN,B2
+عَاقَدَ,to contract,收缩,VERB,B2
+نَاقَضَ,to contradict,反驳,VERB,B2
+مُتَنَاقِض,contradictory,矛盾的,ADJ,B2
+عَكْس,contrary,反而,NOUN,B2
+نِيَّة مُخَالِفَة,contrary intention,反意,NOUN,B2
+قَابَلَ,to contrast,对比,VERB,B2
+خَالَفَ,to contravene,违反,VERB,B2
+سَاهَمَ,to contribute,贡献,VERB,B2
+تَحَكَّمَ,to control,控制,VERB,B2
+غُرْفَة التَّحَكُّم,control room,控制室,NOUN,B2
+مُخْتَلَف,controversial,有争议的,ADJ,B2
+عقد,to convene,召集,VERB,B2
+مناسب,convenient,方便的,ADJ,B2
+تقليدي,conventional,传统的,ADJ,B2
+تقارب,to converge,汇聚,VERB,B2
+تحدث,to converse,交谈,VERB,B2
+حوّل,to convert,转换,VERB,B2
+نقل,to convey,传达,VERB,B2
+كفتة مطبوخة,cooked meatball,丸子熟,NOUN,B2
+أرز مطبوخ,cooked rice,米饭,NOUN,B2
+برّد,cool,凉爽的,ADJ,B2
+برّد,to cool,冷却,VERB,B2
+هدأ,to cool down,冷却,VERB,B2
+تبريد,cooling,冷却,NOUN,B2
+برودة,coolness,凉爽,NOUN,B2
+تعاون,to cooperate,合作,VERB,B2
+إحداثي,coordinate,坐标,NOUN,B2
+منسق,coordinator,协调员,NOUN,B2
+شرطي,cop,警察,NOUN,B2
+حق المؤلف,copyright,版权,NOUN,B2
+ذرة,corn,玉米,NOUN,B2
+تتويج,coronation,加冕,NOUN,B2
+مراسلة,correspondence,通信,NOUN,B2
+كلّف,to cost,花费,VERB,B2
+زي,costume,戏服,NOUN,B2
+كوخ,cottage,小屋,NOUN,B2
+اعتبر,to count as,算,VERB,B2
+عارض,to counter,反击,VERB,B2
 شكل مضاد,counter-form,反式,NOUN,B2
-شمر,fennel,茴香,NOUN,B2
-شمل,to encompass,包含,VERB,B2
-شن حرب,to wage war,作战,VERB,B2
-شهادة,witness testimony,人证,NOUN,B2
+منطق مضاد,counter-logic,反逻,NOUN,B2
+مادة مضادة,counter-matter,反物,NOUN,B2
+آلية مضادة,counter-mechanism,反机,NOUN,B2
+نموذج مضاد,counter-model,反模,NOUN,B2
+ملاحظة مضادة,counter-observation,反察,NOUN,B2
+صفة مضادة,counter-quality,反质,NOUN,B2
+مسار مضاد,counter-route,反途,NOUN,B2
+مهارة مضادة,counter-skill,反技,NOUN,B2
+نعل مضاد,counter-sole,反唯,NOUN,B2
+هيكل مضاد,counter-structure,反结,NOUN,B2
+نظام مضاد,counter-system,反系,NOUN,B2
+تقنية مضادة,counter-technique,反术,NOUN,B2
+اتجاه مضاد,counter-trend,反势,NOUN,B2
+نوع مضاد,counter-type,反型,NOUN,B2
+هجوم مضاد,counterattack,反击,NOUN,B2
+مزيف,counterfeit,假冒,ADJ,B2
+نظير,counterpart,对应的人或物,NOUN,B2
+كونتيسة,countess,女伯爵,NOUN,B2
+لا يحصى,countless,无数的,ADJ,B2
+مقاطعة,county,县,NOUN,B2
+زوج,couple,一对,NOUN,B2
+بيت شعر,couplet,对联,NOUN,B2
+رفض المحكمة,court dismissal,退朝,NOUN,B2
+ابن عم,cousin,表亲,NOUN,B2
+جبان,coward,懦夫,NOUN,B2
+جبن,cowardice,懦弱,NOUN,B2
+مريح,cozy,舒适的,ADJ,B2
+يتصدع,to crack,破裂,VERB,B2
+صندوق,crate,板条箱,NOUN,B2
+فوهة,crater,火山口,NOUN,B2
+يخلق,to create,创造,VERB,B2
+خلق,creation,创造,NOUN,B2
+مبدع,creative,有创造力的,ADJ,B2
+خالق,creator,创造者,NOUN,B2
+بطاقة ائتمان,credit card,信用卡,NOUN,B2
+حق الدائن,creditor's right,债权,NOUN,B2
+عقيدة,creed,信条,NOUN,B2
+قمة,crest,顶峰,NOUN,B2
+مسرح الجريمة,crime scene,犯罪现场,NOUN,B2
+يقرفص,to crouch,蹲下,VERB,B2
+يتوج,crown,王冠,NOUN,B2
+يتوج,to crown,加冕,VERB,B2
+حاسِم,crucial,至关重要的,ADJ,B2
+قاسِي,cruel,残忍的,ADJ,B2
+قَسْوَة,cruelty,残忍,NOUN,B2
+جَوْلَة,cruise,巡航,NOUN,B2
+تَهَدَّمَ,to crumble,粉碎,VERB,B2
+هَزِيمَة ساحِقَة,crushing defeat,惨败,NOUN,B2
+قِشْرَة,crust,外壳,NOUN,B2
+خِيار,cucumber,黄瓜,NOUN,B2
+زَرَعَ,to cultivate,培养,VERB,B2
+تِراث ثقافي,cultural relic,文物,NOUN,B2
+مَكار,cunning,狡猾的,ADJ,B2
+كَفَّ,to curb,抑制,VERB,B2
+الدَّوْلَة الحاضِرَة,current dynasty,当朝,NOUN,B2
+حاليًّا,currently,目前,ADV,B2
+لَعَنَ,to curse,诅咒,VERB,B2
+عَصَا السِّتار,curtain rod,窗帘杆,NOUN,B2
+مِخَدَّة,cushion,垫子,NOUN,B2
+قَطْع,cut,切口,NOUN,B2
+قَطَعَ,to cut off,切断,VERB,B2
+قَصَّرَ,to cut short,截断,VERB,B2
+دَارَ,cycle,循环,NOUN,B2
+دَارَ,to cycle,骑自行车,VERB,B2
+إِعصار,cyclone,气旋,NOUN,B2
+أَب,dad,爸爸,NOUN,B2
+خَنْجَر,dagger,匕首,NOUN,B2
+يَوميًّا,daily,每日的,ADJ,B2
+زِيادَة يَوميَّة,daily increase,日渐,NOUN,B2
+جَرِيدَة يَوميَّة,daily newspaper,日报,NOUN,B2
+أَضَرَّ,to damage,损坏,VERB,B2
+شَتَمَ,damn,该死的,ADJ,B2
+شَتَمَ,to damn,诅咒,VERB,B2
+دانْمَيْ,danmei,但没,NOUN,B2
+تَحَدَّى,to dare,敢于,VERB,B2
+حبيب,darling,亲爱的,NOUN,B2
+لوحة القيادة,dashboard,仪表盘,NOUN,B2
+قاعدة بيانات,database,数据库,NOUN,B2
+واعد,date,日期,NOUN,B2
+واعد,to date,注明日期,VERB,B2
+ليل ونهار,day and night,昼夜,NOUN,B2
+أبهر,to dazzle,使眼花,VERB,B2
+ميت,dead,死的,ADJ,B2
+مميت,deadly,致命的,ADJ,B2
+أصم,deaf,聋的,ADJ,B2
+تعامل مع,to deal with,处理,VERB,B2
+تاجر,dealer,经销商,NOUN,B2
+رغبة في الموت,death wish,找死,NOUN,B2
+قابل للنقاش,debatable,有争议的,ADJ,B2
+ناقش,to debate,辩论,VERB,B2
+أول ظهور,debut,初次登台,NOUN,B2
+عقد,decade,十年,NOUN,B2
+انحطاط,decadence,衰落,NOUN,B2
+منحط,decadent,颓废,ADJ,B2
+خدع,to deceive,欺骗,VERB,B2
+ديسمبر,december,十二月,NOUN,B2
+حياء,decency,体面,NOUN,B2
+لائق,decent,体面的,ADJ,B2
+تحدي الخداع,deception dare,你敢骗我,NOUN,B2
+فك شفرة,to decipher,破译,VERB,B2
+متخذ القرار,decision-maker,决策者,NOUN,B2
+حاسم,decisive,决定性的,ADJ,B2
+إعلان,declaration,宣言,NOUN,B2
+انخفض,to decline,下降,VERB,B2
+رفض بأدب,to decline politely,婉拒,VERB,B2
+سحب من الخدمة,decommissioning,退役,NOUN,B2
+فكك,to deconstruct,解构,VERB,B2
+زين,to decorate,装饰,VERB,B2
+زينة,decoration,装饰品,NOUN,B2
+نقص,decrease,减少,NOUN,B2
+ديمقراطية,democracy,民主,NOUN,B2
+هدم,to demolish,拆除,VERB,B2
+شيطان,demon,恶魔,NOUN,B2
+بيّن,to demonstrate,证明,VERB,B2
+أضعف,to demoralize,使士气低落,VERB,B2
+أدان,to denounce,谴责,VERB,B2
+طبيب أسنان,dentist,牙医,NOUN,B2
+رئيس قسم,department head,厅长,NOUN,B2
+متجر متعدد الأقسام,department store,百货商店,NOUN,B2
+اعتمد,to depend,依赖,VERB,B2
+اعتمد,to depend on,依赖,VERB,B2
+معتمد,dependent,依赖的,ADJ,B2
+صوّر,to depict,描绘,VERB,B2
+نشر,to deploy,部署,VERB,B2
+نشر,deployment,部署,NOUN,B2
+عزّل,to depose,废黜,VERB,B2
+أودع,to deposit,存放,VERB,B2
+كبت,to depress,使沮丧,VERB,B2
+مكتئب,depressed,沮丧的,ADJ,B2
+نائب,deputy,副的,ADJ,B2
+عطّل,to derail,使脱轨,VERB,B2
+استمد,to derive,源于,VERB,B2
+أخلّ,to derogate,贬损,VERB,B2
+نزول,descent,下降,NOUN,B2
+استحق,to deserve,值得,VERB,B2
+صمّم,to design,设计,VERB,B2
+عيّن,to designate,指定,VERB,B2
+سائق مخصّص,designated driver,代驾,NOUN,B2
+تسمية,designation,指定,NOUN,B2
+كفّ,to desist,停止,VERB,B2
+مكتب,desk,书桌,NOUN,B2
+يائس,desperate,绝望的,ADJ,B2
+احتقر,to despise,鄙视,VERB,B2
+سلب,to despoil,掠夺,VERB,B2
+مصير,destiny,命运,NOUN,B2
+دمر,to destroy,破坏,VERB,B2
+فصل,to detach,分离,VERB,B2
+مفصل,detailed,详细的,ADJ,B2
+احتجز,to detain,拘留,VERB,B2
+كشف,to detect,探测,VERB,B2
+كشف,detection,检测,NOUN,B2
+محقق,detective,侦探,NOUN,B2
+تدهور,to deteriorate,恶化,VERB,B2
+حدد,to determine,决定,VERB,B2
+مصمم,determined,下定决心的,ADJ,B2
+مقت,to detest,厌恶,VERB,B2
+بغيض,detestable,可恶的,ADJ,B2
+فجر,to detonate,引爆,VERB,B2
+أزال السموم,to detoxify,解毒,VERB,B2
+خفض القيمة,to devalue,贬值,VERB,B2
+دمر,to devastate,摧毁,VERB,B2
+متقدم,developed,发达的,ADJ,B2
+ابتكر,to devise,设计,VERB,B2
+مخلص,devoted,忠诚的,ADJ,B2
+شخص,to diagnose,诊断,VERB,B2
+مخطط,diagram,图表,NOUN,B2
+ماس,diamond,钻石,NOUN,B2
+حفاضة,diaper,尿布,NOUN,B2
+أملى,to dictate,口述,VERB,B2
+اختلف,to differ,不同,VERB,B2
+ميز,to differentiate,区分,VERB,B2
+هجوم صعب,difficult attack,难攻,NOUN,B2
+مشكلة صعبة,difficult problem,难题,NOUN,B2
+نشر,to diffuse,扩散,VERB,B2
+هضم,to digest,消化,VERB,B2
+استطرد,to digress,离题,VERB,B2
+وسع,to dilate,膨胀,VERB,B2
+بُعد,dimension,维度,NOUN,B2
+قلل,to diminish,减少,VERB,B2
+ديناصور,dinosaur,恐龙,NOUN,B2
+دبلوماسي,diplomatic,外交的,ADJ,B2
+وَجَّهَ,direct,直接的,ADJ,B2
+وَجَّهَ,to direct,对准,VERB,B2
+لَوْحَة اتِّجَاه,direction sign,指示牌,NOUN,B2
+تَوْجِيه,directive,指令,NOUN,B2
+مُتَّسِخ,dirty,脏的,ADJ,B2
+عَيْب,disadvantage,劣势,NOUN,B2
+خَابَ,to disappoint,使失望,VERB,B2
+مُسْتَخِيب,disappointed,失望的,ADJ,B2
+مُخِيب,disappointing,令人失望的,ADJ,B2
+عَابَ,to disapprove,不赞成,VERB,B2
+سَلَّمَ,to disarm,解除武装,VERB,B2
+مُدَمِّر,disastrous,灾难性的,ADJ,B2
+جَحْد,disbelief,不信,NOUN,B2
+رَمَى,to discard,丢弃,VERB,B2
+أَدَّبَ,to discipline,管教,VERB,B2
+فَصَحَ,to disclose,揭露,VERB,B2
+انْزِعَاج,discomfort,不适,NOUN,B2
+فَصَلَ,to disconnect,断开,VERB,B2
+أَوْقَفَ,to discontinue,停止,VERB,B2
+حَدَّثَ,to discourse,论述,VERB,B2
+نَقَصَ,to discredit,败坏名声,VERB,B2
+حَذِر,discreet,谨慎的,ADJ,B2
+فَرَّقَ,to discriminate,歧视,VERB,B2
+مَرَض,disease,疾病,NOUN,B2
+نَزَلَ,to disembark,下船,VERB,B2
+انْفَصَلَ,to disengage,脱离,VERB,B2
+تَنَكَّرَ,disguise,伪装,NOUN,B2
+تَنَكَّرَ,to disguise,伪装,VERB,B2
+غَاسِلَة أطْباق,dishwasher,洗碗机,NOUN,B2
+عَقَّمَ,to disinfect,消毒,VERB,B2
+انْتِفَاء,disinterest,公正;不感兴趣,NOUN,B2
+مُنْصِف,disinterested,公正的,ADJ,B2
+كَرِهَ,to dislike,不喜欢,VERB,B2
+زَاحَ,to dislocate,使脱臼,VERB,B2
+تنويع,to diversify,使多样化,VERB,B2
+صرف,to divert,转移,VERB,B2
+قسم,to divide,分开,VERB,B2
+توزيعات أرباح,dividend,红利,NOUN,B2
+عرافة,divination,占卜,NOUN,B2
+إله,divine,神圣的,ADJ,B2
+ألوهية,divinity,神性,NOUN,B2
+دائخ,dizzy,头晕的,ADJ,B2
+لا,do not,莫,ADV,B2
+عدم استخدام,do not use,别用,NOUN,B2
+بذل قصارى الجهد,to do one's best,尽力,VERB,B2
+فعل,to do to make,做,VERB,B2
+توثيق,to document,记录,VERB,B2
+فيلم وثائقي,documentary,纪录片,NOUN,B2
+تفادي,to dodge,躲避,VERB,B2
+عقيدة,dogma,教条,NOUN,B2
+دمية,doll,玩偶,NOUN,B2
+محلي,domestic,国内的,ADJ,B2
+تبرع,to donate,捐赠,VERB,B2
+منجز,done,事已,NOUN,B2
+مقبض باب,door handle,门把手,NOUN,B2
+جرس باب,doorbell,门铃,NOUN,B2
+بواب,doorman,门卫,NOUN,B2
+ممسحة أقدام,doormat,门垫,NOUN,B2
+مهجع,dormitory,宿舍,NOUN,B2
+جرعة,dosage,剂量,NOUN,B2
+مزدوج,double,两倍的,ADJ,B2
+تحت,down,顺...而下,ADP,B2
+أسفل النهر,downstream,下游,NOUN,B2
+إلى الأسفل,downwards,向下,ADV,B2
+دزينة,dozen,一打,NOUN,B2
+سحب,to drag,拖,VERB,B2
+تنين,dragon,龙,NOUN,B2
+دراماتيكي,dramatic,戏剧性的,ADJ,B2
+استفاد,to draw on the experience of,借鉴,VERB,B2
+استخراج,draw out,引出,NOUN,B2
+درج,drawer,抽屉,NOUN,B2
+خشي,to dread,畏惧,VERB,B2
+حلم,to dream,做梦,VERB,B2
+لبس,dress,连衣裙,NOUN,B2
+لبس,to dress,给...穿衣,VERB,B2
+تأنق,to dress up,盛装打扮,VERB,B2
+توفو مجفف,dried tofu,豆干,NOUN,B2
+انجراف,drifting,漂泊,NOUN,B2
+شراب,drink,饮料,NOUN,B2
+رخصة قيادة,driver's license,驾驶证,NOUN,B2
+ممر,driveway,车道,NOUN,B2
+طائرة بدون طيار,drone,无人机,NOUN,B2
+قطرة,drop,滴,NOUN,B2
+غرق,to drown,溺死,VERB,B2
+عقار,drug,药物,NOUN,B2
+سكران,drunk,醉酒的,ADJ,B2
+مستحق,due,到期的,ADJ,B2
+بسبب,due to,由于,ADP,B2
+دوق,duke,公爵,NOUN,B2
+ممل,dull,枯燥的,ADJ,B2
+أبكم,dumb,愚蠢的,ADJ,B2
+زلابية,dumpling,丸子,NOUN,B2
+كرر,to duplicate,复制,VERB,B2
+مدة,duration,持续时间,NOUN,B2
+نهاراً,during the day,在白天,ADV,B2
+هولندي,dutch,荷兰的,ADJ,B2
+واجب,duty,责任,NOUN,B2
+قزم,dwarf,侏儒,NOUN,B2
+مسكن,dwelling,住宅,NOUN,B2
+ديناميكي,dynamic,动态的,ADJ,B2
+ديناميت,dynamite,炸药,NOUN,B2
+كُلّ,each,每个,DET,B2
+بَعْضُ بَعْض,each other,互相,PRON,B2
+مُبَكِّرًا,earlier,刚才,ADV,B2
+الفَجْر,early morning,凌晨,NOUN,B2
+إنْذَارٌ مُبَكِّر,early warning,预警,NOUN,B2
+شَرْقِيّ,eastern,东方的,ADJ,B2
+سُهُولَة القَوْل,easy to say,好说,NOUN,B2
+غَرِيب,eccentric,古怪的,ADJ,B2
+البِيئَة,ecology,生态学,NOUN,B2
+مَنظومَة بِيئِيَّة,ecosystem,生态系统,NOUN,B2
+سَكْرَة,ecstasy,狂喜,NOUN,B2
+أَمْر,edict,法令,NOUN,B2
+حَرَّر,to edit,编辑,VERB,B2
+عَلَّمَ,to educate,教育,VERB,B2
+تَدْوِيل دِمَاغِيّ,eeg,脑电图,NOUN,B2
+أَثَر,effect,效果,NOUN,B2
+مُفْعِل,efficient,高效的,ADJ,B2
+ثَمَانِيَة,eight,八,NUM,B2
+أَوْ,either,或者,CCONJ,B2
+فَصَّل,elaborate,详尽的,ADJ,B2
+فَصَّل,to elaborate,制定,VERB,B2
+مُسِنّ,elderly,老年人,NOUN,B2
+البِكْر,eldest son,长子,NOUN,B2
+كَهْرَبَائِيّ,electric,电动的,ADJ,B2
+دَفْع إِلِكْتُرُونِيّ,electronic payment,电子支付,NOUN,B2
+حَادِي عَشَرَة,eleven,十一,NUM,B2
+أَلْغَى,to eliminate,消除,VERB,B2
+إِلْغَاء,elimination,消除,NOUN,B2
+بَرِيد إِلِكْتُرُونِيّ,email,电子邮件,NOUN,B2
+انْبَثَق,to emanate,散发,VERB,B2
+حَرَّر,to emancipate,解放,VERB,B2
+تَحْرِير,emancipation,解放,NOUN,B2
+مُحَاسِر,embarrassed,尴尬的,ADJ,B2
+غَرَس,to embed,嵌入,VERB,B2
+زَيَّن,to embellish,装饰,VERB,B2
+جسد,to embody,体现,VERB,B2
+احتضن,to embrace,拥抱,VERB,B2
+ظهر,to emerge,出现,VERB,B2
+ظهور,emergence,涌现,NOUN,B2
+أطلق,to emit,发出,VERB,B2
+عاطفي,emotional,情绪的,ADJ,B2
+تعاطف,to empathize,共情,VERB,B2
+إمبراطور,emperor,皇帝,NOUN,B2
+تأكيد,emphasis,强调,NOUN,B2
+تجريبي,empirical,经验的,ADJ,B2
+وظف,to employ,雇用,VERB,B2
+توظيف,employment,就业,NOUN,B2
+إمبراطورة,empress,女皇,NOUN,B2
+فارغ,empty,空的,ADJ,B2
 شهرة زائفة,empty fame,虚名,NOUN,B2
+حاكى,to emulate,效仿,VERB,B2
+أتاح,to enable,使能够,VERB,B2
+سحر,to enchant,使着迷,VERB,B2
+أحاط,to enclose,围住,VERB,B2
+شمل,to encompass,包含,VERB,B2
+واجه,to encounter,遭遇,VERB,B2
+شجع,to encourage,鼓励,VERB,B2
+نهاية,end,端,PART,B2
+انتهى,to end up,最终到达,VERB,B2
+هدد,to endanger,危及,VERB,B2
+مهدد بالانقراض,endangered,濒危的,ADJ,B2
+لا نهائي,endless,无尽的,ADJ,B2
+أيد,to endorse,支持,VERB,B2
+وهب,to endow,赋予,VERB,B2
+عدو,enemy,敌人,NOUN,B2
+عدو حتمي,enemy must,仇必,NOUN,B2
+دولة عدوة,enemy state,敌国,NOUN,B2
+طاقة,energy,能量,NOUN,B2
+فرض,to enforce,执行,VERB,B2
+انخرط,to engage,从事,VERB,B2
+مشغول,engaged,订婚的,ADJ,B2
+إنجليزي,english,英国的,ADJ,B2
+إنجليزي,englishman,英国人,NOUN,B2
+استمتاع,enjoyment,享受,NOUN,B2
+وسّع,to enlarge,扩大,VERB,B2
+أنار,to enlighten,启发,VERB,B2
+جند,to enlist,征募,VERB,B2
+عداوة,enmity,敌意,NOUN,B2
+شرف,to ennoble,使高贵,VERB,B2
+كافي,enough,足够的,ADJ,B2
+أثرى,to enrich,使丰富,VERB,B2
+سجل,to enroll,注册,VERB,B2
+ضمن,to ensure,确保,VERB,B2
+لزم,to entail,牵涉,VERB,B2
+شابك,to entangle,使纠缠,VERB,B2
+دخل المدينة,to enter city,进城,VERB,B2
+سلى,to entertain,娱乐,VERB,B2
+مركز ترفيهي,entertainment center,娱乐中心,NOUN,B2
+تتويج,enthronement,登基,NOUN,B2
+حمّس,to enthuse,使热情,VERB,B2
+أغرى,to entice,引诱,VERB,B2
+كامل,entire,整个的,ADJ,B2
+تماماً,entirely,完全地,ADV,B2
+كمال,entirety,全部,NOUN,B2
+كيان,entity,实体,NOUN,B2
+رائد أعمال,entrepreneur,企业家,NOUN,B2
+عدّ,to enumerate,列举,VERB,B2
+حماية البيئة,environmental protection,环境保护,NOUN,B2
+تقرير بيئي,environmental report,环境报告,NOUN,B2
+تخيل,to envision,展望,VERB,B2
+حسد,to envy,羡慕,VERB,B2
+تجسيد,epitome,化身,NOUN,B2
+جهز,to equip,装备,VERB,B2
+شيد,to erect,建立,VERB,B2
+إرهو,erhu,二胡,NOUN,B2
+أخطأ,to err,犯错,VERB,B2
+تصحيحات,errata,勘误,NOUN,B2
+خطأ,error,错误,NOUN,B2
+ثوران,eruption,爆发,NOUN,B2
+صَعَّد,to escalate,升级,VERB,B2
+مصعد,escalator,自动扶梯,NOUN,B2
+هَرَب,escape,逃跑,NOUN,B2
+هَرَب,to escape,逃跑,VERB,B2
+رافَق,escort,护卫,NOUN,B2
+رافَق,to escort,护送,VERB,B2
+حارس مرافقة,escort guard,镖师,NOUN,B2
+أساسي,essential,必要的,ADJ,B2
+معدات أساسية,essential equipment,要置,NOUN,B2
+أساساً,essentially,主要地,ADV,B2
+راسخ,established,既定的,ADJ,B2
+مؤسسة,establishment,机构,NOUN,B2
+قَدَّر,estimate,估计,NOUN,B2
+قَدَّر,to estimate,估计,VERB,B2
+أبدي,eternal,永恒的,ADJ,B2
+تحالف أبدي,eternal alliance,永结,NOUN,B2
+إيثيريوم,ethereum,以太坊,NOUN,B2
+أخلاقي,ethical,道德的,ADJ,B2
+عرقي,ethnic,种族的,ADJ,B2
+أخْلَى,to evacuate,疏散,VERB,B2
+بَشَّر,to evangelize,传福音,VERB,B2
+تَبَخَّر,to evaporate,蒸发,VERB,B2
+حتى,even,甚至,ADV,B2
+في النهاية,eventually,最终,ADV,B2
+أبداً,ever,曾经,ADV,B2
+أبداً,to ever,里何尝,VERB,B2
+كل,every,每个,DET,B2
+كل يوم,every day,天天,ADV,B2
+الجميع,everyone,每个人,PRON,B2
+كل شيء,everything,一切,PRON,B2
+أينما,everywhere,到处,ADV,B2
+طرد,to evict,驱逐,VERB,B2
+شر,evil,邪,PART,B2
+استحضر,to evoke,唤起,VERB,B2
+تطور,evolution,进化,NOUN,B2
+تطور,to evolve,进化,VERB,B2
+فاقم,to exacerbate,加剧,VERB,B2
+دقيق,exact,精确的,ADJ,B2
+بالغ,to exaggerate,夸大,VERB,B2
+مبالغ,exaggerated,夸张的,ADJ,B2
+فحص,to examine,检查,VERB,B2
+أغضب,to exasperate,激怒,VERB,B2
+حفر,to excavate,挖掘,VERB,B2
+ممتاز,excellent,优秀的,ADJ,B2
+عدا,except,除了,ADP,B2
+استثناء,exception,例外,NOUN,B2
+استثنائي,exceptional,杰出的,ADJ,B2
+مفرط,excessive,过度的,ADJ,B2
+أثار,to excite,使兴奋,VERB,B2
+متحمس,excited,兴奋的,ADJ,B2
+حماس,excitement,兴奋,NOUN,B2
+تعجب,exclamation,感叹,NOUN,B2
+استبعد,to exclude,排除,VERB,B2
+مستبعد,excluded,排除在外的,ADJ,B2
+كفّر,to excommunicate,开除教籍,VERB,B2
+جلد,to excoriate,严厉批评,VERB,B2
+عذر,to excuse,原谅,VERB,B2
+نفذ,to execute,执行,VERB,B2
+تنفيذ,execution,执行,NOUN,B2
+جلاد,executioner,刽子手,NOUN,B2
+تنفيذي,executive,行政主管,NOUN,B2
+منفذ,executor,遗嘱执行人,NOUN,B2
+تفسير,exegesis,注释,NOUN,B2
+أعفى,to exempt,免除,VERB,B2
+مارس,to exercise,锻炼,VERB,B2
+زَفَرَ,to exhale,呼气,VERB,B2
+أَعْيا,to exhaust,耗尽,VERB,B2
+عَرَضَ,to exhibit,展览,VERB,B2
+حَثَّ,to exhort,劝告,VERB,B2
+نَبَشَ,to exhume,掘出,VERB,B2
+نَفَى,exile,流亡,NOUN,B2
+نَفَى,to exile,流放,VERB,B2
+وُجِدَ,to exist,存在,VERB,B2
+بَرَّأَ,to exonerate,使无罪,VERB,B2
+وَسَّعَ,to expand,扩大,VERB,B2
+وَاسِع,expansive,扩张的,ADJ,B2
+تَوَقَّعَ,to expect,期待,VERB,B2
+بَعثة,expedition,探险,NOUN,B2
+طَرَدَ,to expel,开除,VERB,B2
+أَنْفَقَ,to expend,花费,VERB,B2
+إنفاق,expenditure,支出,NOUN,B2
+مَصْرُوف,expense,费用,NOUN,B2
+خَبَرَ,to experience,经历,VERB,B2
+خَبِير,experienced,老练的,ADJ,B2
+تَجْرِبَة,experiment,实验,NOUN,B2
+خِبْرَة,expertise,专业知识,NOUN,B2
+انْتَهَى,to expire,到期,VERB,B2
+صَرِيح,explicit,明确的,ADJ,B2
+انفَجَرَ,to explode,爆炸,VERB,B2
+اسْتَغَلَّ,to exploit,剥削,VERB,B2
+اسْتِغْلَال,exploitation,利用,NOUN,B2
+مُنْفَجِر,explosive,炸药,NOUN,B2
+صَدَّرَ,to export,出口,VERB,B2
+عَرَّضَ,to expose,暴露,VERB,B2
+مَعْرِض,exposition,阐述,NOUN,B2
+فَصَّلَ,to expound,阐述,VERB,B2
+عَبَّرَ,to express,表达,VERB,B2
+نَزَعَ,to expropriate,征用,VERB,B2
+رَاقٍ,exquisite,精致的,ADJ,B2
+شَامِل,extensive,广泛的,ADJ,B2
+مدى,extent,程度,NOUN,B2
+أباد,to exterminate,消灭,VERB,B2
+إبادة,extermination,灭绝,NOUN,B2
+ابتز,to extort,敲诈,VERB,B2
+ابتزاز,extortion,勒索,NOUN,B2
+استخرج,to extract,提取,VERB,B2
+سلّم,to extradite,引渡,VERB,B2
+تسليم,extradition,引渡,NOUN,B2
+استقرأ,to extrapolate,推断,VERB,B2
+متطرف,extreme,极端,ADJ,B2
+للغاية,extremely,极其,ADV,B2
+ابتهج,to exult,狂喜,VERB,B2
+شاهد عيان,eyewitness,目击,NOUN,B2
+خرافة,fable,寓言,NOUN,B2
+نسيج,fabric,织物,NOUN,B2
+اختلق,to fabricate,捏造,VERB,B2
+قراءة الوجه,face reading,面相,NOUN,B2
+التعرف على الوجه,face recognition,认人,NOUN,B2
+جانب,facet,方面,NOUN,B2
+سهّل,to facilitate,促进,VERB,B2
+نسخة طبق الأصل,facsimile,副本,NOUN,B2
+حقيقة,fact,事实,NOUN,B2
+فصيل,faction,派,NOUN,B2
+عامل,factor,因素,NOUN,B2
+محاولة فاشلة,failed bid,流标,NOUN,B2
+معرض,fair,交易会,NOUN,B2
+جنية,fairy,仙女,NOUN,B2
+حكاية خرافية,fairy tale,童话,NOUN,B2
+وفي,faithful,忠诚的,ADJ,B2
+سقوط,fall,瀑布,NOUN,B2
+نام,to fall asleep,入睡,VERB,B2
+أحب,to fall in love,坠入爱河,VERB,B2
+خلاف,falling out,反目,NOUN,B2
+فشل,falling though,虽坠,NOUN,B2
+زوّر,to falsify,伪造,VERB,B2
+مألوف,familiar,熟悉的,ADJ,B2
+فرد عائلة,family member,家庭成员,NOUN,B2
+شتات عائلة,family ruin,家破,NOUN,B2
+رائع,fantastic,极好的,ADJ,B2
+خيال,fantasy,幻想,NOUN,B2
+بعيد,far,远,ADV,B2
+مهزلة,farce,闹剧,NOUN,B2
+فتن,to fascinate,使着迷,VERB,B2
+ساحر,fascinating,迷人的,ADJ,B2
+افتتان,fascination,魅力,NOUN,B2
+دهن,fat,脂肪,NOUN,B2
+قاتل,fatal,致命的,ADJ,B2
+أب,father,父,PART,B2
+حم,father-in-law,岳父/公公,NOUN,B2
+ظروف مواتية,favorable circumstances,顺境,NOUN,B2
+مفضل,favorite,最喜欢的,ADJ,B2
+جدوى,feasibility,可行性,NOUN,B2
+ممكن,feasible,可行的,ADJ,B2
+مأثرة,feat,功绩,NOUN,B2
+سمة,feature,特征,NOUN,B2
+فبراير,february,二月,NOUN,B2
+اتحاد,federation,联邦,NOUN,B2
+رسم,fee,费用,NOUN,B2
+أطعم,to feed,喂养,VERB,B2
+زميل,fellow,家伙,NOUN,B2
+أنثى,female,女性的,ADJ,B2
+صديقة,female friend,女性朋友,NOUN,B2
+قريبات,female relatives,女眷,NOUN,B2
+نسوية,feminism,女权主义,NOUN,B2
+مبارزة,fencing,击剑,NOUN,B2
+شمر,fennel,茴香,NOUN,B2
+تخمر,to ferment,发酵,VERB,B2
+خصب,fertile,肥沃的,ADJ,B2
+تقيح,to fester,溃烂,VERB,B2
+جلب,to fetch,取来,VERB,B2
+إقطاعي,feudal,封建,ADJ,B2
+قلة,few,几下,NOUN,B2
+خيال,fiction,小说,NOUN,B2
+شرس,fierce,凶猛的,ADJ,B2
+شراسة,fierceness,凶猛,NOUN,B2
+قاتل,to fight,对抗,VERB,B2
+مقاتل,fighter,战士,NOUN,B2
+شكل,figure,图形,NOUN,B2
+بنوي,filial,孝顺,ADJ,B2
+عبأ,to fill in,填写,VERB,B2
+صور,film,电影,NOUN,B2
+صور,to film,拍摄,VERB,B2
+رشح,to filter,过滤,VERB,B2
+نهائي,final,最终的,ADJ,B2
+مرحلة نهائية,final stage,末期,NOUN,B2
+أنهى,to finalize,完成,VERB,B2
+مول,to finance,资助,VERB,B2
+مالية,finances,财政,NOUN,B2
+اكتشف,to find out,找出,VERB,B2
+جيد,fine,好的,ADJ,B2
+بشرة ناعمة,fine skin,细皮,NOUN,B2
+إصبع,finger,手指,NOUN,B2
+طرد,to fire,开火,VERB,B2
+مفرقع ناري,firecracker,鞭炮,NOUN,B2
+مدفأة,fireplace,壁炉,NOUN,B2
+مقاوم للنار,fireproof,防火的,ADJ,B2
+ألعاب نارية,fireworks,烟花,NOUN,B2
+شركة,firm,坚固的,ADJ,B2
+أولا,first,首先,ADV,B2
+غطاء أولي,first capping,首加缁布冠,NOUN,B2
+مسودة أولى,first draft,初稿,NOUN,B2
+استحقاق أولي,first merit,首功,NOUN,B2
+نَسِيّ,forgetful,健忘的,ADJ,B2
+شَوْكَة,fork,叉子,NOUN,B2
+شَكَّلَ,to form,形成,VERB,B2
+قَوْنَنَ,to formalize,使正式化,VERB,B2
+سَابِق,former,以前的,ADJ,B2
+سَابِقًا,formerly,以前,ADV,B2
+صِيغَة,formula,公式,NOUN,B2
+صَاغَ,to formulate,制定,VERB,B2
+إِلَى الأَمَام,forth,向前,ADV,B2
+حِصْن,fortress,堡垒,NOUN,B2
+مَحْظُوظ,fortunate,幸运的,ADJ,B2
+لِحُسْنِ الحَظّ,fortunately,幸运地,ADV,B2
+حَظّ,fortune,运气,NOUN,B2
+عِرَافَة,fortune telling,算命,NOUN,B2
+إِلَى الأَمَام,forward,向前,ADV,B2
+أُحْفُور,fossil,化石,NOUN,B2
+أَسَّسَ,to found,创立,VERB,B2
+مُؤَسِّس,founder,创始人,NOUN,B2
+مَسْبَك,foundry,铸造厂,NOUN,B2
+نَافُورَة,fountain,喷泉,NOUN,B2
+أَرْبَعَةَ عَشَر,fourteen,十四,NUM,B2
+رَابِع,fourth,第四,ADJ,B2
+كَسْر,fraction,分数,NOUN,B2
+عَلَامَةُ كَسْر,fraction marker,分之,PART,B2
+شَظِيَّة,fragment,碎片,NOUN,B2
+رَائِحَة,fragrance,香味,NOUN,B2
+عَطِر,fragrant,芬芳的,ADJ,B2
+أَطَّرَ,to frame,装框,VERB,B2
+احْتِيَال,fraud,欺诈,NOUN,B2
+غَرِيب الأَطْوَار,freak,怪人,NOUN,B2
+حَرَّرَ,to free,释放,VERB,B2
+وَقْت فَرَاغ,free time,业余时间,NOUN,B2
+مَطَر مُتَجَمِّد,freezing rain,冻雨,NOUN,B2
+فَرَنْسِيّ,french,法国的,ADJ,B2
+فَرَنْسِيّ,frenchman,法国人,NOUN,B2
+تَرَدَّدَ,frequent,频繁的,ADJ,B2
+تَرَدَّدَ,to frequent,常去,VERB,B2
+طَازَجِيَّة,freshness,新鲜,NOUN,B2
+ثَلَّاجَة,fridge,冰箱,NOUN,B2
+وَدُود,friendly,友好的,ADJ,B2
+بَطَاتِيس مَقْلِيَة,fries,炸薯条,NOUN,B2
+أَخَافَ,to frighten,使害怕,VERB,B2
+حَافَة,fringe,边缘,NOUN,B2
+مِنْ,from,来自,ADP,B2
+مُنْذُ الطُّفُولَة,from childhood,从小,ADV,B2
+مُنْذُ الآن,from now on,今后,ADV,B2
+أَمَام,front,前面,NOUN,B2
+بَاب الأَمَام,front door,正门,NOUN,B2
+أَحْبَطَ,to frustrate,挫败,VERB,B2
+مُحْبَط,frustrated,沮丧的,ADJ,B2
+مُحْبِط,frustrating,令人沮丧的,ADJ,B2
+أَوْفَى,to fulfill,履行,VERB,B2
+الأَسْمَاء الْكَامِلَة,full name,大名,NOUN,B2
+سُلْطَة كَامِلَة,full power,全力,NOUN,B2
+مَرِح,fun,有趣的,ADJ,B2
+يَعْمَل,to function,运作,VERB,B2
+وِظِيفِي,functional,功能的,ADJ,B2
+وِظِيفِيَّة,functionality,功能性,NOUN,B2
+صِنْدُوْق,fund,基金,NOUN,B2
+أَصْلِي,fundamental,基本的,ADJ,B2
+جَنَازَة,funeral,葬礼,NOUN,B2
+فَرْو,fur,毛皮,NOUN,B2
+غَضْبَان,furious,愤怒的,ADJ,B2
+أَثَثَ,to furnish,提供,VERB,B2
+أَثَاث,furniture,家具,NOUN,B2
+أَبْعَد,further,进一步的,ADJ,B2
+عِلَاء عَلَى ذَلِكَ,furthermore,此外,ADV,B2
+غَضَب,fury,狂怒,NOUN,B2
+جسم,fuselage,机身,NOUN,B2
+ضجيج,fuss,大惊小怪,NOUN,B2
+مستقبلي,future,未来的,ADJ,B2
+جهاز,gadget,小装置,NOUN,B2
+معرض,gallery,画廊,NOUN,B2
+إسراع,to gallop,飞奔,VERB,B2
+مقامرة,gamble,赌博,NOUN,B2
+تزيين,to garnish,装饰,VERB,B2
+حامية,garrison,驻军,NOUN,B2
+محطة,gas station,加油站,NOUN,B2
+تجمّع,to gather,聚集,VERB,B2
+تأمّل,to gaze,凝视,VERB,B2
+جنس,gender,性别,NOUN,B2
+توليد,to generate,产生,VERB,B2
+نشأة,genesis,起源,NOUN,B2
+وراثة,genetics,遗传学,NOUN,B2
+نوع,genre,类型,NOUN,B2
+رجل,gentleman,绅士,NOUN,B2
+حقيقي,genuine,真正的,ADJ,B2
+هندسة,geometry,几何学,NOUN,B2
+ألماني,german,德国的,ADJ,B2
+تلويح,to gesticulate,做手势,VERB,B2
+حصول,to get,得到,VERB,B2
+انتهاء,to get off work,下班,VERB,B2
+تخلّص,to get rid of,摆脱,VERB,B2
+استيقاظ,to get up,起床,VERB,B2
+عملاق,giant,巨人,NOUN,B2
+ضخم,gigantic,巨大的,ADJ,B2
+قواد,gigolo,面首,NOUN,B2
+تذهيب,to gild,镀金,VERB,B2
+صديقة,girlfriend,女朋友,NOUN,B2
+إعادة,to give back,归还,VERB,B2
+منح,to give to grant,予以,VERB,B2
+استسلام,to give up,放弃,VERB,B2
+معطى,given,给定,NOUN,B2
+نَهْر جَليديّ,glacier,冰川,NOUN,B2
+سَعِيد,glad,高兴的,ADJ,B2
+نَظَّارَة,glasses,眼镜,NOUN,B2
+اِنْزَلَقَ,to glide,滑行,VERB,B2
+اِحْتِرار عَالَمِيّ,global warming,气候变暖,NOUN,B2
+تَمْجِيد,glorification,赞美,NOUN,B2
+مَجَّدَ,to glorify,赞美,VERB,B2
+مَجِيد,glorious,辉煌的,ADJ,B2
+تَفْسِير,gloss,光泽,NOUN,B2
+قُفَّاز,glove,手套,NOUN,B2
+غِرَاء,glue,胶水,NOUN,B2
+قَضَمَ,to gnaw,啃,VERB,B2
+رَجَعَ,to go back,回去,VERB,B2
+جُنَّ,to go crazy,发疯,VERB,B2
+نَزَلَ,to go down,下去,VERB,B2
+تَقَدَّمَ,to go first,先去,VERB,B2
+مَسَاعَدَة,go help,去帮,NOUN,B2
+دَخَلَ,to go in,进去,VERB,B2
+اِتَّصَلَ بِالشَّبَكَة,to go online,上网,VERB,B2
+خَرَجَ,to go out,出去,VERB,B2
+اِجْتَازَ,to go through,经历,VERB,B2
+إِلَه الحَرْب,god of war,战神,NOUN,B2
+إِلَهَة,goddess,女神,NOUN,B2
+عَرِيب,godfather,教父,NOUN,B2
+ذَهَب,gold,金子,NOUN,B2
+حَظّ سَعِيد,good luck,好运,NOUN,B2
+سُمْعَة طَيِّبَة,good reputation,清誉,NOUN,B2
+حَسَن الْمَنْظَر,good-looking,好看的,ADJ,B2
+وَدَاعاً,goodbye,再见,INTJ,B2
+إِوَزّ,goose,鹅,NOUN,B2
+رَائِع,gorgeous,华丽的,ADJ,B2
+نِعْمَة,grace,优雅,NOUN,B2
+دَرَجَة,grade,等级,NOUN,B2
+حَبّ,grain,谷物,NOUN,B2
+عَظِيم,grand,宏伟的,ADJ,B2
+بُعد,grand distance,雄远,NOUN,B2
+حَفيدة,granddaughter,孙女,NOUN,B2
+مُبَاهِج,grandiose,浮夸的,ADJ,B2
+جَدَّة,grandma,奶奶,NOUN,B2
+حَفيد,grandson,孙子,NOUN,B2
+غرانيت,granite,花岗岩,NOUN,B2
+مَنَحَ,grant,拨款,NOUN,B2
+مَنَحَ,to grant,授予,VERB,B2
+عِنَب,grape,葡萄,NOUN,B2
+بَصَرِيّ,graphic,图形的,ADJ,B2
+أَمْسَكَ,to grasp,抓住,VERB,B2
+أَمْسَكَ,to grasp firmly,抓紧,VERB,B2
+مَرْعَى,grassland,草地,NOUN,B2
+حَصَى,gravel,砾石,NOUN,B2
+رَعَى,to graze,吃草,VERB,B2
+شَحَّمَ,to grease,涂油,VERB,B2
+دُهْنِيّ,greasy,油腻的,ADJ,B2
+إحسان,great favor,大恩,NOUN,B2
+جَرِيمَة,great offense,冒犯大,NOUN,B2
+قُوَّة,great power,大国,NOUN,B2
+عَيْن,green eye,碧眼,NOUN,B2
+عَيْن,green eyes,想碧眼,NOUN,B2
+تِقْنِيَة,green technology,绿色技术,NOUN,B2
+عَيْن,green-eyed,让碧眼,NOUN,B2
+سَلَّمَ,to greet,问候,VERB,B2
+قَنَبْلَة,grenade,手榴弹,NOUN,B2
+رَمَادِيّ,grey,灰色的,ADJ,B2
+قَاسِي,grim,严酷的,ADJ,B2
+وَسَخ,grime,污垢,NOUN,B2
+تَبَسَّمَ,to grin,咧嘴笑,VERB,B2
+أَمْسَكَ,grip,握法,NOUN,B2
+أَمْسَكَ,to grip,紧握,VERB,B2
+تَنَحْنَحَ,to groan,呻吟,VERB,B2
+أَرْض,grounds,论据,NOUN,B2
+نَشَأَ,to grow up,成长,VERB,B2
+زئير,growl,低吼,NOUN,B2
+يضمن,to guarantee,保证,VERB,B2
+يحرس,to guard,看守,VERB,B2
+تخمين,guess,猜测,NOUN,B2
+يوجّه,to guide,引导,VERB,B2
+المقصلة,guillotine,断头台,NOUN,B2
+مذنب,guilty,有罪的,ADJ,B2
+عازف جيتار,guitarist,吉他手,NOUN,B2
+ساذج,gullible,易受骗的,ADJ,B2
+بندقية,gun,枪,NOUN,B2
+هبّة,gust,阵风,NOUN,B2
+رجل,guy,家伙,NOUN,B2
+صالة رياضية,gymnasium,体育馆,NOUN,B2
+ها,ha,哈,INTJ,B2
+عادة,habit,习惯,NOUN,B2
+عادة ماضية,habitually in the past,往常,NOUN,B2
+يقطع,to hack,入侵；盗版,VERB,B2
+يفاوض,to haggle,讨价还价,VERB,B2
+مفاوَضة,haggling,计较,NOUN,B2
+تسريحة شعر,hairstyle,发型,NOUN,B2
+نصف,half,一半的,ADJ,B2
+قاعة,hall,殿,PART,B2
+ممر,hallway,走廊,NOUN,B2
+يتوقف,to halt,停止,VERB,B2
+لحم مقدد,ham,火腿,NOUN,B2
+يسلّم,to hand over,交付,VERB,B2
+حقيبة يد,handbag,手提包,NOUN,B2
+قيد,handcuff,手铐,NOUN,B2
+حِرفة,handicraft,工艺品,NOUN,B2
+يتعامل,handle,把手,NOUN,B2
+يتعامل,to handle,处理,VERB,B2
+تسليم,handover,拿给,NOUN,B2
+وسيم,handsome,帅气的,ADJ,B2
+رجل وسيم,handsome guy,帅哥,NOUN,B2
+تمارين خط,handwriting practice,练字,NOUN,B2
+عَلَّقَ,to hang up,挂断,VERB,B2
+أَزْعَجَ,to harass,骚扰,VERB,B2
+صَعْبُ الاختِيَار,hard to choose,难以抉择,ADJ,B2
+صَعْبُ التَّمْيِيز,hard to distinguish,难以区分,ADJ,B2
+صَعْبُ الصِّيَانَة,hard to maintain,难以维持,ADJ,B2
+صَعْبُ التَّكَلُّم,hard to speak of,难以启齿,ADJ,B2
+كَادَ,hardly,几乎不,ADV,B2
+أَضَرَّ,to harm,损害,VERB,B2
+ضَارّ,harmful,有害的,ADJ,B2
+بَرِيء,harmless,无害的,ADJ,B2
+قِيثَارَة,harp,竖琴,NOUN,B2
+عَجَلَة,haste,匆忙,NOUN,B2
+قُبَّعَة,hat,帽子,NOUN,B2
+كَرَاهَة,hate,仇恨,NOUN,B2
+مَلَكَ,have,有,AUX,B2
+مَلَكَ,to have,有,VERB,B2
+تَحَدَّثَ,to have an accident,遭遇意外,VERB,B2
+تَغَدَّى,to have lunch,吃午餐,VERB,B2
+مَلَكَ,to have only,唯有,VERB,B2
+وَاجِب,have to,还得,NOUN,B2
+عُنْوَان,heading,标题,NOUN,B2
+شَفَى,to heal,治愈,VERB,B2
+شِفَاء,healing,治愈,NOUN,B2
+صَحِيح,healthy,健康的,ADJ,B2
+سَمِعَ,to hear a case,审理,VERB,B2
+تَرِاث,heard beile,听说贝勒,NOUN,B2
+نَظَبَة قَلْب,heart attack,心脏病发作,NOUN,B2
+نَبْض,heartbeat,心跳,NOUN,B2
+مَوْجَة حَرّ,heat wave,热浪,NOUN,B2
+سَمَاء,heaven,天堂,NOUN,B2
+عَطْر سَمَاوِيّ,heavenly fragrance,天香,NOUN,B2
+بَرُوتوكُول ثَقِيل,heavy etiquette,礼太重,NOUN,B2
+عُقْدَة ثَقِيلَة,heavy knot,重结,NOUN,B2
+آلَة ثَقِيلَة,heavy machine,重机,NOUN,B2
+نَوْع ثَقِيل,heavy type,重型,NOUN,B2
+عَمَل شَاق,heavy work,重功,NOUN,B2
+سِياج,hedge,树篱,NOUN,B2
+هَهْهَهْ,hehe,嘿嘿,INTJ,B2
+مَرْحَبًا,hello,你好,INTJ,B2
+مَسَاعَدَة,help,帮助,NOUN,B2
+سَاعَدَ,to help assistance,帮助,VERB,B2
+مُسَاعِد,helpful,有帮助的,ADJ,B2
+عَاجِز,helpless,无助的,ADJ,B2
+عِشْب,herb,草药,NOUN,B2
+رَاعِي,herder,牧民,NOUN,B2
+هُنَا,here,此地,NOUN,B2
+بِذَلِكَ,hereby,特此,ADV,B2
+بَطَلِي,heroic,英勇的,ADJ,B2
+تَرَدَّدَ,to hesitate,犹豫,VERB,B2
+هَي,hey,嘿,INTJ,B2
+هَلْو,hi,嗨,INTJ,B2
+مَخْفِي,hidden,隐藏的,ADJ,B2
+عَظَمَة,highness,殿下,NOUN,B2
+طَرِيق سَرِيع,highway,公路,NOUN,B2
+سَاحَ,to hike,徒步旅行,VERB,B2
+سِيَاحَة,hiking,徒步,NOUN,B2
+مُضْحِك,hilarious,滑稽的,ADJ,B2
+تِلَال,hills,丘陵,NOUN,B2
+قَبْضَة,hilt,剑柄,NOUN,B2
+هُوَ,him,他吧,NOUN,B2
+مَنَعَ,to hinder,阻碍,VERB,B2
+عَقَبَة,hindrance,障碍,NOUN,B2
+حَاجِب,hip,臀部,NOUN,B2
+اسْتَأْجَرَ,to hire,雇佣,VERB,B2
+هُوَ,his,他的,DET,B2
+مَغَادَرَتُهُ,his departure,他走,NOUN,B2
+تَارِيخِي,historic,历史性的,ADJ,B2
+تَارِيخ,history,历史,NOUN,B2
+الإسكان,housing,住房,NOUN,B2
+كَيْف,how,又怎会,NOUN,B2
+كم,how many,多少,NUM,B2
+غير ذلك,however,然而,CCONJ,B2
+عناق,hug,拥抱,NOUN,B2
+ضخم,huge,巨大的,ADJ,B2
+هه,huh,哈,INTJ,B2
+القدرة البشرية,human capacity,人会,NOUN,B2
+الإنسانية,humanity,人类,NOUN,B2
+صيد,hunt,狩猎,NOUN,B2
+صيد,to hunt,打猎,VERB,B2
+صياد,hunter,猎人,NOUN,B2
+هورا,hurrah,万岁,INTJ,B2
+استعجال,hurry,匆忙,NOUN,B2
+زوج,husband,丈夫,NOUN,B2
+الطاقة المائية,hydro energy,水能,NOUN,B2
+الاستخدام المفرط,hyper-use,超用,NOUN,B2
+منافق,hypocrite,伪君子,NOUN,B2
+انخفاض حرارة الجسم,hypothermia,体温过低,NOUN,B2
+افتراضي,hypothetical,假设的,ADJ,B2
+هستيري,hysterical,歇斯底里的,ADJ,B2
+لا أستحق مدحك,i don't deserve your praise,不敢当,INTJ,B2
+آيس كريم,ice cream,冰淇淋,NOUN,B2
+هوكي الجليد,ice hockey,冰球,NOUN,B2
+حلبة التزلج,ice rink,溜冰场,NOUN,B2
+بارد كالجليد,ice-cold,冰冷的,ADJ,B2
+أيقونة,icon,偶像,NOUN,B2
+بطاقة هوية,id card,身份证,NOUN,B2
+صورة شخصية,id photo,证件照,NOUN,B2
+غاية,ideal,理想的,ADJ,B2
+مطابق,identical,完全相同的,ADJ,B2
+تحديد,to identify,识别,VERB,B2
+تعبير مجازي,idiom,习语,NOUN,B2
+أحمق,idiot,白痴,NOUN,B2
+صَنَم,idol,偶像,NOUN,B2
+رَومانسِيَّة,idyll,田园诗,NOUN,B2
+جَاهِل,ignorant,无知的,ADJ,B2
+مَرِيض,ill,生病的,ADJ,B2
+مُمَنَع,illegal,非法的,ADJ,B2
+مُمَنَعِيَّة,illegality,非法,NOUN,B2
+شِرْجِي,illegitimate,非法的,ADJ,B2
+مَرَض,illness,疾病,NOUN,B2
+أَنْوَرَ,to illuminate,照亮,VERB,B2
+أَوضَحَ,to illustrate,说明,VERB,B2
+صُورَة,image,形象,NOUN,B2
+خَيَالِي,imaginary,虚构的,ADJ,B2
+قَلَّدَ,to imitate,模仿,VERB,B2
+تَقْلِيدِي,imitative,模仿性,ADJ,B2
+غَيْرِ مُقَاس,immeasurable,不可估量的,ADJ,B2
+فَوْرِي,immediate,立即的,ADJ,B2
+انْغِمَاس,immersion,沉浸,NOUN,B2
+مُهَاجِر,immigrant,移民,NOUN,B2
+هَاجَرَ,to immigrate,移入,VERB,B2
+هِجْرَة,immigration,移民,NOUN,B2
+خَالِد,immortal,不朽的,ADJ,B2
+عِلاجٌ مُنَاعِي,immunotherapy,免疫治疗,NOUN,B2
+عَجْز,impairment,左手废,NOUN,B2
+أَبْلَغَ,to impart,传授,VERB,B2
+مُسْتَعْجِل,impatient,不耐烦的,ADJ,B2
+حَثَّ,to impel,推动,VERB,B2
+مُلْزِم,imperative,必要的,ADJ,B2
+دَار الإِمَارة,imperial court,朝廷,NOUN,B2
+وَصِيَّة الأَب الإِمَاري,imperial father's will,父皇要,NOUN,B2
+الحَرَّاس الإِمَاري,imperial guard,御林,NOUN,B2
+أَقَارِب الإِمَارة,imperial relatives,皇亲,NOUN,B2
+نَفَّذَ,to implement,实施,VERB,B2
+شَارَكَ,to implicate,连累,VERB,B2
+تَوَسَّلَ,to implore,恳求,VERB,B2
+أَوْحَى,to imply,暗示,VERB,B2
+لَئِيم,impolite,不礼貌的,ADJ,B2
+فَرَضَ,to impose,强加,VERB,B2
+أَبْهَرَ,to impress,使印象深刻,VERB,B2
+مُبْهِر,impressive,令人印象深刻的,ADJ,B2
+سَجَنَ,to imprison,监禁,VERB,B2
+غَيْر لَائِق,improper,不合适的,ADJ,B2
+بَدَعَ,to improvise,即兴创作,VERB,B2
+جَرِيء,impudent,无礼的,ADJ,B2
+دَفْعَة,impulse,冲动,NOUN,B2
+بِالإِضَافَة,in addition,此外,ADV,B2
+بَيْن,in between,在中间,ADV,B2
+فِي حَال,in case,如果,SCONJ,B2
+أَمَام,in front,在前面,ADV,B2
+فِيهِ,in it,在里面,ADV,B2
+مُحِبّ,in love,恋爱中的,ADJ,B2
+لِكَيْ,in order to,以期,SCONJ,B2
+رَغْم,to in spite of,不顾,VERB,B2
+السَّمَاء,in the sky,天上,NOUN,B2
+فِي وَقْت,in time,及时地,ADV,B2
+الرِّيح,in wind,临风,NOUN,B2
+كِتَابَة,in writing,书面,NOUN,B2
+عَجْز,inability,无能,NOUN,B2
+غَيْر لَائِق,inappropriate,不恰当的,ADJ,B2
+فَتَّحَ,to inaugurate,启用,VERB,B2
+عَرَضِيًّا,incidentally,顺便地,ADV,B2
+أَحْرَقَ,to incinerate,焚烧,VERB,B2
+مَالَ,to incline,使倾斜,VERB,B2
+دَخْل وَمَخْرَج,income and expense,收支,NOUN,B2
+غَيْر مُفْهَم,incomprehensible,不可理解的,ADJ,B2
+تَضَادّ,inconsistency,不一致,NOUN,B2
+مُتَضَادّ,inconsistent,不一致的,ADJ,B2
+دَمَجَ,to incorporate,包含,VERB,B2
+زَادَ,to increase steadily,与日俱增,VERB,B2
+تَدْرِيجِيًّا,increasingly,越来越,ADV,B2
+غَيْر حَاسِم,indecisive,犹豫不决的,ADJ,B2
+لا يُمحى,indelible,不可磨灭的,ADJ,B2
+مستقل,independent,独立的,ADJ,B2
+لا يوصف,indescribable,难以形容的,ADJ,B2
+أشار,to indicate,表明,VERB,B2
+إشارة,indication,指示,NOUN,B2
+لائحة اتهام,indictment,起诉,NOUN,B2
+غير مبالٍ,indifferent,冷漠的,ADJ,B2
+أصلي,indigenous,本土的,ADJ,B2
+مُسْتَهْجِن,indignant,愤慨的,ADJ,B2
+لا غنى عنه,indispensable,不可或缺的,ADJ,B2
+فردي,individual,单独的,ADJ,B2
+مهمة فردية,individual assignment,个人作业,NOUN,B2
+فردية,individuality,个性,NOUN,B2
+أثار,to induce,引起,VERB,B2
+سلسلة الصناعات,industry chain,产业链,NOUN,B2
+غير فعّال,inefficient,低效的,ADJ,B2
+أَعْدَى,to infect,感染,VERB,B2
+أدنى,inferior,低等的,ADJ,B2
+دناءة,inferiority,劣势,NOUN,B2
+تسلّل,to infiltrate,渗透,VERB,B2
+أثّر,to influence,影响,VERB,B2
+أخبر,to inform,通知,VERB,B2
+غير رسمي,informal,非正式的,ADJ,B2
+مبدع,ingenious,灵巧的,ADJ,B2
+تناول,to ingest,服用,VERB,B2
+مكوّن,ingredient,成分,NOUN,B2
+سكن,to inhabit,居住,VERB,B2
+ساكن,inhabitant,居民,NOUN,B2
+استنشق,to inhale,吸入,VERB,B2
+متأصل,inherent,固有的,ADJ,B2
+ورث,to inherit,继承,VERB,B2
+ثبّط,to inhibit,抑制,VERB,B2
+أولي,initial,最初的,ADJ,B2
+في البداية,initially,首先,ADV,B2
+بدأ,to initiate,发起,VERB,B2
+حَقَنَ,to inject,注射,VERB,B2
+أَمْرٌ,injunction,禁令,NOUN,B2
+جَرَحَ,to injure,使受伤,VERB,B2
+مُجَرَّحٌ,injured,受伤的,ADJ,B2
+نَزْلٌ,inn,小旅馆,NOUN,B2
+فِطْرِيٌّ,innate,天生的,ADJ,B2
+البَاحَةُ الدَّاخِلِيَّةُ,inner court,朝内,NOUN,B2
+بَرَاءَةٌ,innocence,无辜,NOUN,B2
+بَرِيءٌ,innocent,无辜的,ADJ,B2
+مُبْتَكِرٌ,innovative,创新的,ADJ,B2
+مَجْنُونٌ,insane,疯狂的,ADJ,B2
+مَقْتِلُ حَشَرَاتٍ,insecticide,杀虫剂,NOUN,B2
+غَيْرُ آمِنٍ,insecure,不安全的,ADJ,B2
+مُتَّصِلٌ,inseparable,不可分割的,ADJ,B2
+أَدْخَلَ,to insert,插入,VERB,B2
+دَاخِلٌ,inside,在里面,ADV,B2
+المَدِينَةُ الدَّاخِلِيَّةُ,inside city,城内,NOUN,B2
+القِصَّةُ الدَّاخِلِيَّةُ,inside story,内幕,NOUN,B2
+دَاخِلِيٌّ,insider,知情者,NOUN,B2
+خَبِيثٌ,insidious,潜伏的,ADJ,B2
+غَيْرُ مُهِمٍّ,insignificant,微不足道的,ADJ,B2
+أَلَحَّ,to insist,坚持,VERB,B2
+أَلْهَمَ,to inspire,鼓舞,VERB,B2
+تَقَلُّبٌ,instability,不稳定,NOUN,B2
+ثَبَّتَ,to install,安装,VERB,B2
+مَثَلٌ,instance,例子,NOUN,B2
+بَدَلًا,instead,代替,ADV,B2
+بَلْ عَلَى العَكْسِ,instead on the contrary,反而,ADV,B2
+أَوْصَى,to instruct,指导,VERB,B2
+غَيْرُ كَافٍ,insufficient,不足的,ADJ,B2
+أَمَّنَ,to insure,保证,VERB,B2
+غَيْرُ مُتَجَاوَزٍ,insurmountable,不可逾越的,ADJ,B2
+ثَوْرَةٌ,insurrection,起义,NOUN,B2
+سَلِيمٌ,intact,完好无损的,ADJ,B2
+سريع الغضب,irascible,易怒的,ADJ,B2
+حديد,iron,铁,NOUN,B2
+ساخر,ironic,讽刺的,ADJ,B2
+لا عقلانية,irrationality,非理性,NOUN,B2
+غير قابل للتوفيق,irreconcilable,不可调和的,ADJ,B2
+لا يقبل الجدل,irrefutable,无可辩驳的,ADJ,B2
+غير ذي صلة,irrelevant,不相关的,ADJ,B2
+لا يعوض,irreplaceable,不可替代的,ADJ,B2
+لا تشوبه شائبة,irreproachable,无可指责的,ADJ,B2
+لا يقاوم,irresistible,不可抗拒的,ADJ,B2
+غير مسؤول,irresponsible,不负责任的,ADJ,B2
+غير قابل للعكس,irreversible,不可逆转的,ADJ,B2
+أزعج,to irritate,激怒,VERB,B2
+عزل,to isolate,隔离,VERB,B2
+هو,it,它,PRON,B2
+إيطالي,italian,意大利人,NOUN,B2
+حك,itch,痒,NOUN,B2
+حك,to itch,发痒,VERB,B2
+تفاصيله,its details,其详,NOUN,B2
+يشم,jade,这玉,NOUN,B2
+مصنوعات اليشم,jade ware,玉器,NOUN,B2
+سجن,jail,监狱,NOUN,B2
+ياباني,japanese,日本人,NOUN,B2
+فك,jaw,下巴,NOUN,B2
+يهودي,jew,犹太人,NOUN,B2
+جوهرة,jewel,宝石,NOUN,B2
+جيانغهو,jianghu,江湖,NOUN,B2
+جياولونغ,jiaolong,娇龙,NOUN,B2
+جين,jin,斤,NOUN,B2
+مشترك,joint,平等的,ADJ,B2
+مزح,to joke,开玩笑,VERB,B2
+مبتهج,joyful,快乐的,ADJ,B2
+حكم,to judge,判断,VERB,B2
+حكم,judgment,判断,NOUN,B2
+يوليو,july,七月,NOUN,B2
+قَفْزَة,jump,跳跃,NOUN,B2
+حُزَيْران,june,六月,NOUN,B2
+غَابَة,jungle,丛林,NOUN,B2
+مَحْكَمَة,jurisdiction area,辖区,NOUN,B2
+كَمَا فِي الْمَاضِي,just as in the past,一如既往,ADV,B2
+بِضَبْط,just right,恰到好处,ADV,B2
+لَوْحَة مَفَاتِيح,keyboard,键盘,NOUN,B2
+صَبِيّ,kid,小孩,NOUN,B2
+خَطْف,to kidnap,绑架,VERB,B2
+قَتْل,to kill,杀死,VERB,B2
+قَتْلُ عَطْوَيْنِ بِحَجَرٍ وَاحِد,kill two birds with one stone,一举两得,ADJ,B2
+نَوْع,kind,仁慈的,ADJ,B2
+طَيْطَاء,kite,风筝,NOUN,B2
+فُرْسَان,knight,骑士,NOUN,B2
+طَرَق,to knock,敲,VERB,B2
+عُقْدَة,knot,结,NOUN,B2
+تَعَرَّفَ,to know to recognize,认识,VERB,B2
+مَعْرُوف,known,已知的,ADJ,B2
+تَوْقِيع,label,标签,NOUN,B2
+شاقّ,laborious,费力的,ADJ,B2
+عَدِمَ,lack,缺乏,NOUN,B2
+عَدِمَ,to lack,缺乏,VERB,B2
+لَقْنِيّ,laconic,简洁的,ADJ,B2
+حَمْل,lamb,羔羊,NOUN,B2
+عَجْز,lame,跛的,ADJ,B2
+هَبَطَ,land,土地,NOUN,B2
+هَبَطَ,to land,着陆,VERB,B2
+زَرَقَة,lane,小巷,NOUN,B2
+فَنَاس,lantern,灯笼,NOUN,B2
+وَاسِع,large-scale,大规模的,ADJ,B2
+آخِر,last,最后,ADV,B2
+دَامَ,to last a period of time,为期,VERB,B2
+أَمْسِ اللَّيْلَة,last night,昨晚,ADV,B2
+السَّنَة الْمَاضِيَة,last year,去年,NOUN,B2
+غُرفة المَعيشة,living room,客厅,NOUN,B2
+حَمَلَ,to load,装载,VERB,B2
+حَدَّدَ,to locate,定位,VERB,B2
+مَوضِع,location,地点,NOUN,B2
+قَفَلَ,to lock,锁上,VERB,B2
+أَغْلَقَ,to lock up,关押,VERB,B2
+أَغْلَقَ,to lockdown,封城,VERB,B2
+غُرفة التَّغيير,locker room,更衣室,NOUN,B2
+عالٍ,lofty,崇高的,ADJ,B2
+سِجِلّ,log,日志,NOUN,B2
+لُوجِسْتِيّات,logistics,后勤,NOUN,B2
+وَحْدَة,loneliness,孤独,NOUN,B2
+وَحيد,lonely,孤独的,ADJ,B2
+قَديمًا,long ago,早已,ADV,B2
+عِشْ,long live,万岁,INTJ,B2
+طَويلاً,long time,长时间,ADV,B2
+حَافلة البَعد البَعيد,long-distance bus,长途车,NOUN,B2
+عَنِيَ,to look after,照料,VERB,B2
+نَظَرَ,to look at,观看,VERB,B2
+نَظَر,look at you,你看你,NOUN,B2
+اِحتَقَرَ,to look down upon,看不起,VERB,B2
+بَحَثَ,to look for,寻找,VERB,B2
+بَحَثَ,to look for to find,找,VERB,B2
+نَظَرَ,to look up,查阅,VERB,B2
+مُراقِب,lookout,瞭望,NOUN,B2
+سَائب,loose,松的,ADJ,B2
+غَنيمَة,loot,战利品,NOUN,B2
+لُورد يُو,lord yu,玉大人,NOUN,B2
+كَلام السَّيِّد,lord's words,主说,NOUN,B2
+خَسارَة,lose,上丢,NOUN,B2
+نَقَصَ,to lose weight,减肥,VERB,B2
+خاسِر,loser,失败者,NOUN,B2
+ضائع,lost,迷失的,ADJ,B2
+كَثير,lot,许多,NOUN,B2
+سَحب,lottery,彩票,NOUN,B2
+صَاخِب,loud,大声的,ADJ,B2
+صَالَة,lounge,休息室,NOUN,B2
+قَمْلَة,louse,虱子,NOUN,B2
+رَدِيء,lousy,糟糕的,ADJ,B2
+حَبِيب,lover,爱人,NOUN,B2
+حَظّ سَعِيد,lucky chance,虽侥,NOUN,B2
+طُعْمَة,lure,诱惑,NOUN,B2
+سَيِّدَة,madam,夫人,NOUN,B2
+سَحّار,magician,魔术师,NOUN,B2
+مَجِيد,magnificent,壮丽的,ADJ,B2
+كَبَّرَ,to magnify,放大,VERB,B2
+خَادِمَة,maid,女仆,NOUN,B2
+عَذْرَاء,maiden,少女,NOUN,B2
+خَادِمَة,maidservant,女仆,NOUN,B2
+صُنْدُوق بَرِيد,mailbox,邮箱,NOUN,B2
+رِئَاسِيًّا,mainly,主要地,ADV,B2
+تَيَّار رَئِيسِي,mainstream,主流,NOUN,B2
+حَافَظَ,to maintain,维持,VERB,B2
+جَلِيل,majestic,宏伟的,ADJ,B2
+رَئِيسِي,major,少校,NOUN,B2
+تَخَصُّص,major course,专业课,NOUN,B2
+أَلْقَى خِطَابًا,to make a speech,发言,VERB,B2
+تَأَقْلَمَ,to make do,做,VERB,B2
+خَطَأ,make mistake,犯错,NOUN,B2
+أَضْجَرَ,to make noise,闹得,VERB,B2
+عَوَّضَ,to make up for,弥补,VERB,B2
+صَانِع,maker,制造者,NOUN,B2
+دَاء,malady,弊病,NOUN,B2
+ذَكَر,male,男性的,ADJ,B2
+مُدِير,manager,经理,NOUN,B2
+مَلَّصَ,to manipulate,操纵,VERB,B2
+مَنَازِل,manor,庄园,NOUN,B2
+قَصْر,mansion,豪宅,NOUN,B2
+صَنَعَ,to manufacture,制造,VERB,B2
+مُصَنِّع,manufacturer,制造商,NOUN,B2
+متوسط,mediocre,平庸的,ADJ,B2
+وسيط,medium,媒介,NOUN,B2
+كئيب,melancholic,忧郁的,ADJ,B2
+حزين,melancholy,忧郁,ADJ,B2
+تلمس البطيخ,melon groping,摸瓜,NOUN,B2
+عضو,member,成员,NOUN,B2
+مذكرة,memorandum,备忘录,NOUN,B2
+نصب تذكاري,memorial,纪念碑,NOUN,B2
+أصلح,to mend,修补,VERB,B2
+عقلي,mental,精神的,ADJ,B2
+ذكر,mention,提及,NOUN,B2
+ذكر,to mention,提及,VERB,B2
+قائمة,menu,菜单,NOUN,B2
+زئبق,mercury,汞,NOUN,B2
+فقط,merely,仅仅,ADV,B2
+دمج,to merge,合并,VERB,B2
+استحقاق,merit,功绩,NOUN,B2
+حورية البحر,mermaid,美人鱼,NOUN,B2
+فوضى,mess,混乱,NOUN,B2
+طريقة,method,方法,NOUN,B2
+دقيق,meticulous,一丝不苟的,ADJ,B2
+مكسيكي,mexican,墨西哥的,ADJ,B2
+منتصف الليل,midnight,午夜,NOUN,B2
+قوة,might,威力,NOUN,B2
+هاجر,to migrate,迁移,VERB,B2
+معتدل,mild,温和的,ADJ,B2
+ميل,mile,英里,NOUN,B2
+معلم,milestone,里程碑,NOUN,B2
+الجيش,military,军队,NOUN,B2
+الاستخبارات العسكرية,military intelligence,军情,NOUN,B2
+أمر عسكري,military order,军令,NOUN,B2
+قوة عسكرية,military power,兵权,NOUN,B2
+ألفية,millennium,千年,NOUN,B2
+انتبه,to mind,介意,VERB,B2
+وزير,minister,臣,PART,B2
+وزارة,ministry,部,NOUN,B2
+مقرر فرعي,minor course,辅修课,NOUN,B2
+اختلاس,misappropriation,挪用,NOUN,B2
+بائس,miserable,痛苦的,ADJ,B2
+شقاء,misfortune,不幸,NOUN,B2
+أضلّ,to mislead,误导,VERB,B2
+مفقود,missing,失踪的,ADJ,B2
+أخطأ,to mistake,弄错,VERB,B2
+سيّدة,mistress,情妇,NOUN,B2
+أساء فهم,to misunderstand,误解,VERB,B2
+سوء فهم,misunderstanding,误解,NOUN,B2
+خفّف,to mitigate,减轻,VERB,B2
+تأوّه,moan,呻吟,NOUN,B2
+تأوّه,to moan,呻吟,VERB,B2
+جوّال,mobile,移动的,ADJ,B2
+دفع جوّال,mobile payment,移动支付,NOUN,B2
+حَرّك,to mobilize,动员,VERB,B2
+نموذج,model,模型,NOUN,B2
+معتدل,moderate,适度的,ADJ,B2
+مطر معتدل,moderate rain,中雨,NOUN,B2
+حياء,modesty,谦虚,NOUN,B2
+تأثير معدّل,modified effect,改效,NOUN,B2
+نموذج معدّل,modified model,改模,NOUN,B2
+صوت معدّل,modified sound,改响,NOUN,B2
+نظام معدّل,modified system,改系,NOUN,B2
+عَدّل,to modify,修改,VERB,B2
+أم,mom,妈妈,NOUN,B2
+نقدي,monetary,金钱的,ADJ,B2
+مراقبة,monitoring,监控,NOUN,B2
+غرفة مراقبة,monitoring room,监控室,NOUN,B2
+مملّ,monotonous,单调的,ADJ,B2
+وحش,monster,怪物,NOUN,B2
+قمر الشهر,month moon,月,NOUN,B2
 شهريّا,monthly,每月的,ADJ,B2
+امتحان شهري,monthly exam,月考,NOUN,B2
+كعكة القمر,mooncake,月饼,NOUN,B2
+أخلاق,morality,道德,NOUN,B2
+أخلاق,morals,道德,NOUN,B2
+أكثر,more,更多,ADV,B2
+أكثر,more often,更频繁,ADV,B2
+علاوة على ذلك,moreover,此外,ADV,B2
+صحيفة الصباح,morning newspaper,晨报,NOUN,B2
+رهن,to mortgage,抵押,VERB,B2
+أكثر,most,最,ADV,B2
+في الغالب,mostly,主要地,ADV,B2
+أم,mother,娘,PART,B2
+طمأنة الأم,mother's reassurance,娘放心,NOUN,B2
+حفز,to motivate,激励,VERB,B2
+محرك,motor,发动机,NOUN,B2
+دراجة نارية,motorcycle,摩托车,NOUN,B2
+منزل متنقل,motorhome,露营车,NOUN,B2
+منحدر جبلي,mountain descent,下山,NOUN,B2
+سلسلة جبال,mountain range,山脉,NOUN,B2
+لقمة,mouthful,一口,NOUN,B2
+حركة,move,搬家,NOUN,B2
+تنحى,to move aside,移开,VERB,B2
+انتقل للسكن,to move in,搬入,VERB,B2
+السيد,mr.,先生,NOUN,B2
+رنين مغناطيسي,mri,核磁共振,NOUN,B2
+كثير,much,多,DET,B2
+مشوش,muddled,混乱的,ADJ,B2
+ضرب,to multiply,乘；增加,VERB,B2
+بلدي,municipal,市政的,ADJ,B2
+قتل,to murder,谋杀,VERB,B2
+سلاح الجريمة,murder weapon,凶器,NOUN,B2
+قاتل,murderer,凶手,NOUN,B2
+همس,murmur,低语,NOUN,B2
+ألم العضلات,muscle pain,肌肉痛,NOUN,B2
+فطر,mushroom,蘑菇,NOUN,B2
+نوتة,musical score,乐谱,NOUN,B2
+موسيقي,musician,音乐家,NOUN,B2
+يجب,must,必须,AUX,B2
+صامت,mute,沉默的；哑的,ADJ,B2
+لحم خروف,mutton,羊肉,NOUN,B2
+تعاون,mutual aid,互助,NOUN,B2
+توليد متبادل,mutual generation,相生,NOUN,B2
+تقييد متبادل,mutual restriction,相克,NOUN,B2
+متبادلا,mutually,相互地,ADV,B2
+ي,my,我的,DET,B2
+قضيب,my big one,我偌大,NOUN,B2
+مكان,my place,我处,NOUN,B2
+مسكن,my residence,我府,NOUN,B2
+نفسي,myself,我自,NOUN,B2
+غامض,mysterious,神秘的,ADJ,B2
+لغز,mystery,谜,NOUN,B2
+هَمَلَ,to nag,唠叨,VERB,B2
+عاري,naked,裸体的,ADJ,B2
+أي,namely,即,ADV,B2
+تقنية النانو,nanotechnology,纳米技术,NOUN,B2
+منديل,napkin,餐巾,NOUN,B2
+كريه,nasty,令人不快的,ADJ,B2
+أمة,nation,国家,NOUN,B2
+أصلي,native,本地的,ADJ,B2
+مشاغب,naughty,淘气的,ADJ,B2
+نازي,nazi,纳粹分子,NOUN,B2
+قريب,near,在附近,ADP,B2
+جوار,nearby,附近的,ADJ,B2
+تقريبا,nearly,几乎,ADV,B2
+مرتب,neat,整洁的,ADJ,B2
+رقبة,neck,脖子,NOUN,B2
+لا يسمح,not allow,不许,AUX,B2
+غير مسموح,not allowed,不准,ADJ,B2
+لا يأتي,to not come,不来,VERB,B2
+لا يملك,to not have,没,VERB,B2
+ليس فقط,not only,不光,CCONJ,B2
+لاحظ,note,笔记,NOUN,B2
+لاحظ,to note,记录,VERB,B2
+لا شيء,nothing,没有什么,PRON,B2
+لاحظ,to notice,注意到,VERB,B2
+أبلغ,to notify,通知,VERB,B2
+سيء السمعة,notorious,臭名昭著的,ADJ,B2
+حالياً,nowadays,如今,ADV,B2
+لا مكان,nowhere,无处,ADV,B2
+دقيق,nuanced,细微差别的,ADJ,B2
+رقم اثنان,number two,二号,NOUN,B2
+عديد,numerous,众多的,ADJ,B2
+راهبة,nun,修女,NOUN,B2
+رعى,to nurture,养育,VERB,B2
+رعاية,nurturing,养好,NOUN,B2
+طاعة,obedience,服从,NOUN,B2
+مطيع,obedient,顺从的,ADJ,B2
+غرض,object,物体,NOUN,B2
+موضوعي,objective,客观的,ADJ,B2
+مهووس,obsessed,着迷的,ADJ,B2
+بائد,obsolete,过时的,ADJ,B2
+حصل,to obtain,获得,VERB,B2
+واضح,obvious,明显的,ADJ,B2
+أحياناً,occasionally,偶尔,ADV,B2
+مشغول,occupied,被占用的,ADJ,B2
+حدث,to occur,发生,VERB,B2
+من,of,的,ADP,B2
+بالطبع,of course,理所当然的,ADJ,B2
+سيارة دفع رباعي,off-road vehicle,越野车,NOUN,B2
+نفس,oneself,自己,PRON,B2
+فقط,only,唯一的,ADJ,B2
+بالكاد,only just,才,ADV,B2
+حينئذ فقط,only then,才,ADV,B2
+نفسي,only-me,只我,NOUN,B2
+عمل,to operate,操作,VERB,B2
+مقابل,opposite,相反的,ADJ,B2
+تحسين,to optimize,优化,VERB,B2
+خيار,option,选择,NOUN,B2
+خيارات,options,期权,NOUN,B2
+أو بالأحرى,or rather,或者,ADV,B2
+مرسوم شفوي,oral decree,口谕,NOUN,B2
+أوركسترا,orchestra,管弦乐队,NOUN,B2
+أمر,to order,命令,VERB,B2
+منظم,orderly,有序的,ADJ,B2
+عادة,ordinarily,通常,ADV,B2
+عادي,ordinary,普通的,ADJ,B2
+يوم عادي,ordinary day,平日,NOUN,B2
+عامة الناس,ordinary people,老百姓,NOUN,B2
+نظم,to organize,组织,VERB,B2
+منظم,organizer,组织者,NOUN,B2
+أصلي,original,最初的,ADJ,B2
+مستند أصلي,original document,原件,NOUN,B2
+أصالة,originality,独创性,NOUN,B2
+في الأصل,originally,最初,ADV,B2
+نشأ,to originate,发源,VERB,B2
+زينة,ornament,装饰,NOUN,B2
+أرثوذكسي,orthodox,正统的,ADJ,B2
+تذبذب,to oscillate,振荡,VERB,B2
+آخر,other,其他的,DET,B2
+الجانب الآخر,other side,对面,NOUN,B2
+آخرون,others,他人,NOUN,B2
+وإلا,otherwise,否则,ADV,B2
+آه,ouch,哎哟,INTJ,B2
+مَنا,our,我们的,DET,B2
+خارِج,out,在外面,ADV,B2
+مِن,out of,从...出来,ADP,B2
+انْفِجار,outburst,迸发,NOUN,B2
+مُتَعالٍ,outdated,过时的,ADJ,B2
+مَرحاض,outhouse,茅房,NOUN,B2
+خَطَّط,outline,大纲,NOUN,B2
+خَطَّط,to outline,勾勒,VERB,B2
+نَظَرَة,outlook,前景,NOUN,B2
+سَخَط,outrage,愤怒,NOUN,B2
+خارِج,outside,外部,NOUN,B2
+تَعهيد,outsourcing,外包,NOUN,B2
+بارِز,outstanding,杰出的,ADJ,B2
+فَوْق,over,在...上方,ADP,B2
+هُناكَ,over there,在那边,ADV,B2
+مَجال زائِد,over-domain,超畴,NOUN,B2
+اسْتِراتيجِيَّة زائِدَة,over-strategy,超策,NOUN,B2
+ضَرْبَة زائِدَة,over-stroke,超程,NOUN,B2
+غائِم,overcast,阴天的,ADJ,B2
+تَجاوَز,to overcome,克服,VERB,B2
+سَحَب,to overdraw,透支,VERB,B2
+مُتَأَخِّر,overdue,逾期,ADJ,B2
+فَيْض,overflow,溢出,NOUN,B2
+تَقاطُع,overlap,重叠,NOUN,B2
+لَيْلًا,overnight,一夜之间,ADV,B2
+صِينِيّون مُهاجِرون,overseas chinese,华侨,NOUN,B2
+عَمَل زائِد,overtime,加班,NOUN,B2
+غَلَب,to overwhelm,使不知所措,VERB,B2
+اسْتَحَقَّ,to owe,欠,VERB,B2
+خَاصّ,own,自己的,ADJ,B2
+مُقَدِّم الوَظْع,pace-setter,标兵,NOUN,B2
+حَزَم,to pack,打包,VERB,B2
+مُكْتَنِز,packed,打包,ADJ,B2
+كلمة المرور,password,密码,NOUN,B2
+ماضٍ,past,过去的,ADJ,B2
+أوراق امتحان سابقة,past exam papers,真题,NOUN,B2
+قس,pastor,牧师,NOUN,B2
+براءة اختراع,patent,专利,NOUN,B2
+عمة,paternal aunt,姑母,NOUN,B2
+مثير للشفقة,pathetic,可悲的,ADJ,B2
+صبر,patience,耐心,NOUN,B2
+مريض,patient,病人,NOUN,B2
+وطني,patriotic,爱国的,ADJ,B2
+توقف,pause,暂停,NOUN,B2
+توقف,to pause,暂停,VERB,B2
+جناح,pavilion,亭子,NOUN,B2
+مخلب,paw,爪子,NOUN,B2
+قدم احتراماته,to pay respects,参见,VERB,B2
+دفع مبتسماً,to pay smilingly,笑付,VERB,B2
+دفع ضريبة,to pay tax,纳税,VERB,B2
+كامل الدفع,payment all,付都,NOUN,B2
+فول سوداني,peanut,花生,NOUN,B2
+كمثرى,pear,梨,NOUN,B2
+لؤلؤ,pearl,珍珠,NOUN,B2
+فلاح,peasant,农民,NOUN,B2
+حصاة,pebble,卵石,NOUN,B2
+غريب,peculiar,奇怪的,ADJ,B2
+راجل,pedestrian,行人,NOUN,B2
+جسر مشاة,pedestrian bridge,天桥,NOUN,B2
+تبول,to pee,小便,VERB,B2
+قلم رصاص,pencil,铅笔,NOUN,B2
+اخترق,to penetrate,穿透,VERB,B2
+اختراق,penetration,渗透,NOUN,B2
+شبه جزيرة,peninsula,半岛,NOUN,B2
+أدرك,to perceive,察觉,VERB,B2
+نسبة مئوية,percent,百分比,NOUN,B2
+مدرك,perceptive,敏锐的,ADJ,B2
+مَلَّحَ,to pickle,腌渍,VERB,B2
+نزهة,picnic,野餐,NOUN,B2
+معلومة,piece of information,信息,NOUN,B2
+كومة,pile,堆,NOUN,B2
+حاج,pilgrim,朝圣者,NOUN,B2
+دَبَّسَ,to pin,别住,VERB,B2
+أناناس,pineapple,菠萝,NOUN,B2
+قراصن,pirate,海盗,NOUN,B2
+حفرة,pit,坑,NOUN,B2
+مأساوي,pitiful,可怜的,ADJ,B2
+شفقة,pity,可惜,ADJ,B2
+وَضَعَ,to place,放置,VERB,B2
+توظيف,placement,放置,NOUN,B2
+طاعون,plague,瘟疫,NOUN,B2
+خَطَّطَ,to plan,计划,VERB,B2
+طائرة,plane,飞机,NOUN,B2
+زَرَعَ,to plant out,定植,VERB,B2
+مزرعة,plantation,人工林,NOUN,B2
+بلاستيك,plastic,塑料,NOUN,B2
+مسرحية,play,剧本,NOUN,B2
+رفيق,playmate,玩伴,NOUN,B2
+مناشدة,plea,辩护,NOUN,B2
+تَمَلَّى,to plead,恳求,VERB,B2
+سار,pleasant,令人愉快的,ADJ,B2
+أرجوك,please,请,ADV,B2
+تَعَهَّدَ,to pledge,保证,VERB,B2
+محنة,plight,处境,NOUN,B2
+سلك,plug,插头,NOUN,B2
+برقوق,plum,李子,NOUN,B2
+دمية قماشية,plush toy,毛绒玩具,NOUN,B2
+شعر,poetry,诗歌,NOUN,B2
+شَارَ,to point,指向,VERB,B2
+لحظة,point in time,时间点,NOUN,B2
+ثمين,precious,珍贵的,ADJ,B2
+مفترس,predator,捕食者,NOUN,B2
+مأزق,predicament,困境,NOUN,B2
+مقدمة,preface,序言,NOUN,B2
+تفضيلاً,preferably,更愿意,ADV,B2
+تفضيل,preference,偏好,NOUN,B2
+حمل,pregnancy,怀孕,NOUN,B2
+تحيز,prejudice,偏见,NOUN,B2
+رئيس الوزراء,premier,总理,NOUN,B2
+عرض أول,premiere,首演,NOUN,B2
+فرضية,premise,前提,NOUN,B2
+يجهز درساً,to prepare a lesson,预习,VERB,B2
+مخالف للعقل,preposterous,荒谬的,ADJ,B2
+شرط سابق,prerequisite,前提,NOUN,B2
+حاضنة,preschool,幼儿园,NOUN,B2
+يصف,to prescribe,开处方,VERB,B2
+يعرض,present,在场的,ADJ,B2
+يعرض,to present,呈现,VERB,B2
+عرض,presentation,展示,NOUN,B2
+صيانة,preservation,保护,NOUN,B2
+يحفظ,to preserve,保护,VERB,B2
+يضغط,to press,按,VERB,B2
+مؤتمر صحفي,press conference,新闻发布会,NOUN,B2
+يفترض,to presume,假定,VERB,B2
+يتوهم,to pretend,假装,VERB,B2
+يتوهم أنه,to pretend to be,冒充,VERB,B2
+توهم,pretense,假装,NOUN,B2
+ذريعة,pretext,借口,NOUN,B2
+جميل,pretty,漂亮的,ADJ,B2
+يسود,to prevail,盛行,VERB,B2
+منع,prevention,预防,NOUN,B2
+أساسي,primary,主要的,ADJ,B2
+رئيس الوزراء,prime minister,总理,NOUN,B2
+بسيط,primitive,原始的,ADJ,B2
+أمير,prince,王子,NOUN,B2
+تنبأ,to prophesy,预言,VERB,B2
+نسبة,proportion,比例,NOUN,B2
+اقتراح,proposal,提议,NOUN,B2
+اقتراح,proposition,主张,NOUN,B2
+لياقة,propriety,分寸,NOUN,B2
+مدع,prosecutor,检察官,NOUN,B2
+أفق,prospect,前景,NOUN,B2
+مزدهر,prosperous,繁荣的,ADJ,B2
+عاهرة,prostitute,妓女,NOUN,B2
+بطل,protagonist,主角,NOUN,B2
+حمى,to protect,保护,VERB,B2
+احتج,to protest,抗议,VERB,B2
+مثل,proverb,谚语,NOUN,B2
+زود,to provide,提供,VERB,B2
+قدم دليلا,to provide evidence,举证,VERB,B2
+قدم ملاحظات,to provide feedback,反馈,VERB,B2
+كفل,to provide for,供应,VERB,B2
+بشرط أن,provided that,只要,SCONJ,B2
+طريق إقليمي,provincial highway,省道,NOUN,B2
+استفز,to provoke,激怒,VERB,B2
+قرب,proximity,邻近,NOUN,B2
+وكيل,proxy,代理人,NOUN,B2
+طبيب نفسي,psychiatrist,精神科医生,NOUN,B2
+حانة,pub,酒吧,NOUN,B2
+عامة,public,公众,NOUN,B2
+نظام عام,public order,治安,NOUN,B2
+مصلحة عامة,public welfare,公益性,NOUN,B2
+نشر,publication,出版物,NOUN,B2
+نشر,to publish,出版,VERB,B2
+دقيق,punctual,准时的,ADJ,B2
+ترقيم,punctuation,标点符号,NOUN,B2
+ثقب,puncture,穿刺,NOUN,B2
+عاقب,to punish,惩罚,VERB,B2
+دمية,puppet,木偶,NOUN,B2
+جرو,puppy,小狗,NOUN,B2
+اشترى,to purchase,购买,VERB,B2
+نقي,pure,纯净的,ADJ,B2
+يين بنفسجي,purple yin,紫阴,NOUN,B2
+سعى,to pursue,追求,VERB,B2
+دفع الحظ,push luck,太得寸,NOUN,B2
+وضع,to put down,放下,VERB,B2
+رتب,to put in order,收拾,VERB,B2
+لبس,to put on,穿上,VERB,B2
+حير,to puzzle,使困惑,VERB,B2
+سمان,quail,鹌鹑,NOUN,B2
+شجار,quarreling,再吵,NOUN,B2
+ربع سنة,quarter of a year,季度,NOUN,B2
+مجلة فصلية,quarterly magazine,季刊,NOUN,B2
+رصيف,quay,码头,NOUN,B2
+ملكة,queen,女王,NOUN,B2
+سعي,quest,探索,NOUN,B2
+استجوب,to question,质疑,VERB,B2
+مشكوك فيه,questionable,可疑的,ADJ,B2
+سريع,quick,快的,ADJ,B2
+هادئ,quiet,安静的,ADJ,B2
+لحاف,quilt,被子,NOUN,B2
+تماماً,quite,非常,ADV,B2
+اقتبس,to quote,引用,VERB,B2
+دفاية,radiator,暖气片,NOUN,B2
+غضب,rage,愤怒,NOUN,B2
+غضب,to rage,狂怒,VERB,B2
+أمطر,to rain,下雨,VERB,B2
+قوس قزح,rainbow,彩虹,NOUN,B2
+معطف مطر,raincoat,雨衣,NOUN,B2
+غابة مطيرة,rainforest,雨林,NOUN,B2
+رفع,to raise,举起,VERB,B2
+جمع التبرعات,to raise donations,募捐,VERB,B2
+منحدر,ramp,坡道,NOUN,B2
+طغيان متفشي,rampant tyranny,横行,NOUN,B2
+سريع,rapid,迅速的,ADJ,B2
+واقعي,realistic,现实的,ADJ,B2
+حقا,really,真正地,ADV,B2
+الرغبة الحقيقية,really want,真要,NOUN,B2
+مملكة,realm,领域,NOUN,B2
+خلفي,rear,后面的,ADJ,B2
+الجزء الخلفي,rear part,后部,NOUN,B2
+تمرد,rebel,反叛者,NOUN,B2
+تمرد,to rebel,反叛,VERB,B2
+قلب متمرد,rebellious heart,反心,NOUN,B2
+أعاد بناء,to rebuild,重建,VERB,B2
+استلم البريد,to receive mail,收件,VERB,B2
+استلم الأوامر,to receive orders,受命,VERB,B2
+حظي باهتمام عالمي,to receive worldwide attention,举世瞩目,VERB,B2
+اخيرا,recently,最近,ADV,B2
+مستلم,recipient,接受者,NOUN,B2
+تلا,to recite,背诵,VERB,B2
+اعتراف,recognition,认可,NOUN,B2
+اعترف,to recognize,认出,VERB,B2
+أوصى,to recommend,推荐,VERB,B2
+توصية,recommendation,推荐,NOUN,B2
+توصية من الآخرين,recommendation by others,他荐,NOUN,B2
+أوفق,to reconcile,和解,VERB,B2
+أعاد النظر,to reconsider,重新考虑,VERB,B2
+إعادة نظر,reconsideration,重思,NOUN,B2
+أعاد بناء,to reconstruct,重建,VERB,B2
+إعادة بناء,reconstruction,重建,NOUN,B2
+سجل,record,记录,NOUN,B2
+سجل,to record,记录,VERB,B2
+مشغل أسطوانات,record player,唱机,NOUN,B2
+تسجيل,recording,录音,NOUN,B2
+سرد,to recount,转述,VERB,B2
+تعافى,to recover,恢复,VERB,B2
+جند,to recruit,招募,VERB,B2
+صحح,to rectify,纠正,VERB,B2
+تعافى,to recuperate,恢复,VERB,B2
+التكرار,recurrence,往复,NOUN,B2
+أعاد تدوير,to recycle,回收利用,VERB,B2
+إعادة تعريف,redefinition,改界,NOUN,B2
+صقّل,to refine,提炼,VERB,B2
+انعكس,to reflect,反映,VERB,B2
+أصلح,to reform,改革,VERB,B2
+الإصلاحية,reformism,改唯,NOUN,B2
+أنعش,to refresh,使恢复精神,VERB,B2
+بشأن هذا,regarding this,对此,ADV,B2
+نظام,regime,政权,NOUN,B2
+سجّل,to register,注册,VERB,B2
+تراجع,to regress,倒退,VERB,B2
+رجعي,regressive,退步的,ADJ,B2
+ندم,to regret,后悔,VERB,B2
+منتظم,regular,规律的,ADJ,B2
+تدرّب,to rehearse,排练,VERB,B2
+حُكم,reign,统治,NOUN,B2
+عوّض,to reimburse,偿还,VERB,B2
+عزّز,to reinforce,加强,VERB,B2
+تعزيز,reinforcement,增援,NOUN,B2
+أعاد إصدار,to reissue,补办,VERB,B2
+كرّر,to reiterate,重申,VERB,B2
+رفض,to reject,拒绝,VERB,B2
+سرد,to relate to narrate,叙述,VERB,B2
+مرتبط,related,相关的,ADJ,B2
+قريب,relative,亲属,NOUN,B2
+نسبياً,relatively,相对地,ADV,B2
+نسبياً,relatively speaking,相对而言,ADV,B2
+استرخى,to relax,放松,VERB,B2
+مرتاح,relaxed,放松的,ADJ,B2
+أطلق,to release,释放,VERB,B2
+هبط,to relegate,降级,VERB,B2
+صلة,relevance,相关性,NOUN,B2
+ذو صلة,relevant,相关的,ADJ,B2
+موثوق,reliable,可靠的,ADJ,B2
+صد,repulse,击退,NOUN,B2
+طلب,request,请求,NOUN,B2
+استلزم,to require,需要,VERB,B2
+مطلوب,required,必需的,ADJ,B2
+متطلب,requirement,要求,NOUN,B2
+إعادة بيع,resale,转售,NOUN,B2
+أنقذ,to rescue,拯救,VERB,B2
+إنقاذ,rescue a-fang,救阿方,NOUN,B2
+بحث,to research,研究,VERB,B2
+شابه,to resemble,像,VERB,B2
+حجز,to reserve,预订,VERB,B2
+خزان,reservoir,水库,NOUN,B2
+إعادة تشكيل,reshaping,改形,NOUN,B2
+أقام,to reside,居住,VERB,B2
+قرار,resolution,决心,NOUN,B2
+مورد,resource,资源,NOUN,B2
+احترم,to respect,尊重,VERB,B2
+موقر,respectful deferential,恭敬,ADJ,B2
+رد,to respond,回应,VERB,B2
+رد على,to respond to,回应,VERB,B2
+قيد,to restrict,限制,VERB,B2
+استأنف,resume,简历,NOUN,B2
+استأنف,to resume,重新开始,VERB,B2
+تجزئة,retail,零售,NOUN,B2
+احتفظ,to retain,保留,VERB,B2
+أعاد رواية,to retell,转述,VERB,B2
+تقاعد,to retire,退休,VERB,B2
+انسحاب,retreat,撤退,NOUN,B2
+استرجاع,retrieve qingming,拿回青冥,NOUN,B2
+أعاد,to return first,先回,VERB,B2
+إعادة كتابة,retype,再型,NOUN,B2
+لم شمل,reunion,重聚,NOUN,B2
+إعادة استخدام,reuse,重用,NOUN,B2
+إعادة تقييم,revaluation,重新评估,NOUN,B2
+كشف,to reveal,揭示,VERB,B2
+انتقام,revenge,复仇,NOUN,B2
+وقّر,to revere,尊敬,VERB,B2
+انعكاس,reversal,突变,NOUN,B2
+تضمين عكسي,reverse inclusion,反纳,NOUN,B2
+انعكاس,reverse reflection,反影,NOUN,B2
+ظهر,reverse side,反面,NOUN,B2
+ارتداد,reversion,重归,NOUN,B2
+ألغى,to revoke,撤销,VERB,B2
+ثوري,revolutionary,革命的,ADJ,B2
+كافأ,reward,奖励,NOUN,B2
+كافأ,to reward,奖励,VERB,B2
+سؤال بلاغي,rhetorical question,宁非,NOUN,B2
+موهوب,richly endowed by nature,得天独厚,ADJ,B2
+رحلة,ride,行程,NOUN,B2
+استراحة ركوب,ride break,骑破,NOUN,B2
+فارس,rider,骑手,NOUN,B2
+سخيف,ridiculous,荒谬的,ADJ,B2
+بندقية,rifle,步枪,NOUN,B2
+صالح,righteous,正直的,ADJ,B2
+غضب مقدس,righteous indignation,义愤,NOUN,B2
+صلاح,righteousness,亦正,NOUN,B2
+صلب,rigid,僵硬的,ADJ,B2
+طريق دائري,ring road,绕城,NOUN,B2
+ناضج,ripe,成熟的,ADJ,B2
+خاطر,to risk,冒险,VERB,B2
+خاطر بحياته,to risk life,拼命,VERB,B2
+مخاطرة بالموت,risking death,冒死,NOUN,B2
+خطير,risky,危险的,ADJ,B2
+طقس,ritual,仪式,NOUN,B2
+منافسة,rivalry,竞争,NOUN,B2
+إشارة مرور,road sign,路标,NOUN,B2
 شوى,roast,烤肉,NOUN,B2
 شوى,to roast,煎烤,VERB,B2
 شوى خروفا,to roast lamb,烤羊,VERB,B2
-شيء سيئ,bad thing,坏事,NOUN,B2
-شيد,to erect,建立,VERB,B2
-شيطان,demon,恶魔,NOUN,B2
-شيوع,commonality,共同点,NOUN,B2
-شَاذّ,abnormal,异常的,ADJ,B2
-شَارَ,to point,指向,VERB,B2
-شَارَكَ,to implicate,连累,VERB,B2
-شَاسِع,vast,巨大的,ADJ,B2
-شَامِل,extensive,广泛的,ADJ,B2
-شَتَمَ,damn,该死的,ADJ,B2
-شَتَمَ,to damn,诅咒,VERB,B2
-شَحَّمَ,to grease,涂油,VERB,B2
-شَخْصِيَّة,character,性格,NOUN,B2
-شَرِيك,accomplice,同谋,NOUN,B2
-شَرْقِيّ,eastern,东方的,ADJ,B2
-شَظِيَّة,fragment,碎片,NOUN,B2
-شَغَف,ardor,热情,NOUN,B2
-شَفَى,to heal,治愈,VERB,B2
-شَفَّاف,transparent,透明的,ADJ,B2
-شَكَّلَ,to constitute,构成,VERB,B2
-شَكَّلَ,to form,形成,VERB,B2
-شَهَادَة تَمِيْز,certificate of merit,奖状,NOUN,B2
-شَهَّدَ,to certify,证明,VERB,B2
-شَهِدَ,to testify,作证,VERB,B2
-شَوْكَة,fork,叉子,NOUN,B2
-شُرْطِيّ,constable,警官,NOUN,B2
-شُعَاع,sunshine,阳光,NOUN,B2
-شُكْر,thanks,谢谢,INTJ,B2
-شِرْجِي,illegitimate,非法的,ADJ,B2
-شِفَاء,healing,治愈,NOUN,B2
-صاغَ,to articulate,清晰表达,VERB,B2
-صالة رياضية,gymnasium,体育馆,NOUN,B2
-صالح,righteous,正直的,ADJ,B2
-صامت,mute,沉默的；哑的,ADJ,B2
-صبر,patience,耐心,NOUN,B2
-صحح,to rectify,纠正,VERB,B2
-صحيفة الصباح,morning newspaper,晨报,NOUN,B2
-صخرة,boulder,巨石,NOUN,B2
-صد,repulse,击退,NOUN,B2
-صدق,to be right,正确,VERB,B2
-صديق,buddy,伙伴,NOUN,B2
-صديقة,female friend,女性朋友,NOUN,B2
-صديقة,girlfriend,女朋友,NOUN,B2
-صرف,cash,现金,ADJ,B2
-صرف,to cash,兑现,VERB,B2
-صرف,to divert,转移,VERB,B2
-صف,class,班级,NOUN,B2
-صفارة إنذار,siren,汽笛,NOUN,B2
-صفة مضادة,counter-quality,反质,NOUN,B2
-صفر,zero,零,NUM,B2
-صفعة,slap,拍击,NOUN,B2
-صفير,beep,吱吱声,NOUN,B2
-صفّى,to clear,清理,VERB,B2
-صقّل,to refine,提炼,VERB,B2
-صلاح,righteousness,亦正,NOUN,B2
-صلب,rigid,僵硬的,ADJ,B2
-صلة,relevance,相关性,NOUN,B2
-صمت,to be silent,沉默,VERB,B2
-صمّم,to design,设计,VERB,B2
-صندوق,crate,板条箱,NOUN,B2
-صنف,to categorize,分类,VERB,B2
-صوت معدّل,modified sound,改响,NOUN,B2
-صور,film,电影,NOUN,B2
-صور,to film,拍摄,VERB,B2
-صورة شخصية,id photo,证件照,NOUN,B2
-صوّر,to depict,描绘,VERB,B2
-صياد,hunter,猎人,NOUN,B2
-صيانة,preservation,保护,NOUN,B2
-صيد,hunt,狩猎,NOUN,B2
-صيد,to hunt,打猎,VERB,B2
-صَاخِب,loud,大声的,ADJ,B2
-صَاغَ,to formulate,制定,VERB,B2
-صَالَة,lounge,休息室,NOUN,B2
-صَالِح,usable,可用的,ADJ,B2
-صَانِع,maker,制造者,NOUN,B2
-صَبِيّ,kid,小孩,NOUN,B2
-صَحِيح,healthy,健康的,ADJ,B2
-صَدَّرَ,to export,出口,VERB,B2
+سلب,to rob,抢劫,VERB,B2
 صَرَخَ,scream,尖叫,NOUN,B2
 صَرَخَ,to scream,尖叫,VERB,B2
-صَرِيح,explicit,明确的,ADJ,B2
-صَعَّد,to escalate,升级,VERB,B2
-صَعْبُ الاختِيَار,hard to choose,难以抉择,ADJ,B2
-صَعْبُ التَّكَلُّم,hard to speak of,难以启齿,ADJ,B2
-صَعْبُ التَّمْيِيز,hard to distinguish,难以区分,ADJ,B2
-صَعْبُ الصِّيَانَة,hard to maintain,难以维持,ADJ,B2
-صَفَّرَ,to whistle,吹口哨,VERB,B2
 صَفَّى,to screen,筛选,VERB,B2
-صَنَعَ,to manufacture,制造,VERB,B2
-صَنَم,idol,偶像,NOUN,B2
-صَوْمَعَة,chapel,小教堂,NOUN,B2
-صُعُود,ascension,升天,NOUN,B2
-صُنْدُوق بَرِيد,mailbox,邮箱,NOUN,B2
-صُورَة,image,形象,NOUN,B2
-صُورَة فَنِّيَة,artistic portrait,艺术照,NOUN,B2
-صِغَر,smallness,小小,NOUN,B2
-صِفَة,trait,特征,NOUN,B2
-صِنْدُوْق,fund,基金,NOUN,B2
-صِيغَة,formula,公式,NOUN,B2
-صِينِيّون مُهاجِرون,overseas chinese,华侨,NOUN,B2
-ضائع,lost,迷失的,ADJ,B2
-ضجيج,bustle,喧闹,NOUN,B2
-ضجيج,fuss,大惊小怪,NOUN,B2
-ضحكتك,your laugh,你笑,NOUN,B2
-ضخم,gigantic,巨大的,ADJ,B2
-ضخم,huge,巨大的,ADJ,B2
-ضرب,beating,跳动,NOUN,B2
-ضرب,to be hit,中箭,VERB,B2
-ضرب,to beat,打败,VERB,B2
-ضرب,to multiply,乘；增加,VERB,B2
-ضريبة الكربون,carbon tax,碳税,NOUN,B2
-ضغط,to compress,压缩,VERB,B2
-ضمن,to ensure,确保,VERB,B2
-ضوء الرجوع,backup light,倒车灯,NOUN,B2
-ضَارّ,harmful,有害的,ADJ,B2
-ضَافَ,to treat guests,请客,VERB,B2
-ضَرْبَة زائِدَة,over-stroke,超程,NOUN,B2
-ضَيْف عَابِر,trans-guest,超客,NOUN,B2
-طائرة,plane,飞机,NOUN,B2
-طائرة بدون طيار,drone,无人机,NOUN,B2
-طاعة,obedience,服从,NOUN,B2
-طاعون,plague,瘟疫,NOUN,B2
-طاقة,energy,能量,NOUN,B2
-طاقم,staff,全体员工,NOUN,B2
-طبيب أسنان,dentist,牙医,NOUN,B2
-طبيب نفسي,psychiatrist,精神科医生,NOUN,B2
-طرد,to evict,驱逐,VERB,B2
-طرد,to fire,开火,VERB,B2
-طريق إقليمي,provincial highway,省道,NOUN,B2
-طريق دائري,ring road,绕城,NOUN,B2
-طريقة,method,方法,NOUN,B2
-طعنة في الظهر,backstab,背刺,NOUN,B2
-طغيان متفشي,rampant tyranny,横行,NOUN,B2
-طقس,ritual,仪式,NOUN,B2
-طلب,request,请求,NOUN,B2
-طمأنة الأم,mother's reassurance,娘放心,NOUN,B2
-طوال اليوم,all day long,一整天,NOUN,B2
-طوعي,voluntary,自愿的,ADJ,B2
+مَسْرَحِيَّة,screenplay,剧本,NOUN,B2
+مَسْرَحِيَّة,script for play,剧本,NOUN,B2
+مَهْمَهَة,scruple,顾虑,NOUN,B2
+غَوَص,scuba diving,潜水,NOUN,B2
+رَغْوَة,scum,渣滓,NOUN,B2
+خَتَمَ,to seal,密封,VERB,B2
+بَحْث,search,搜索,NOUN,B2
+بَحَثَ,to search for,寻找,VERB,B2
+مَخْرَج,seclusion exit,出关,NOUN,B2
+مَرَّة,second time,再而,NOUN,B2
+سِرِّيَّة,secrecy,保密,NOUN,B2
+سِرّ,secret,秘密,NOUN,B2
+لِقَاء,secret meeting,密会,NOUN,B2
 طَائِفَة,sect,教派,NOUN,B2
-طَارِئ,contingency,偶然性,NOUN,B2
-طَازَجِيَّة,freshness,新鲜,NOUN,B2
-طَامِع,seeking instant benefit,急功近利,ADJ,B2
-طَرَدَ,to expel,开除,VERB,B2
-طَرَق,to knock,敲,VERB,B2
-طَرِيق سَرِيع,highway,公路,NOUN,B2
-طَرِيّ,tender,嫩的,ADJ,B2
-طَعَّمَ,to vaccinate,接种疫苗,VERB,B2
-طَعْن,to stab,刺,VERB,B2
-طَلَب,seeking,寻求,NOUN,B2
+أَمَّنَ,to secure,保护,VERB,B2
+حَارِس,security guard,保安,NOUN,B2
+سَيَّارَة,sedan,轿车,NOUN,B2
+أَغْوَى,to seduce,引诱,VERB,B2
+رَأَى,to see,看见,VERB,B2
+رَأَى,to see again,再见,VERB,B2
+رَأَى,to see corpse,见尸,VERB,B2
+مُوَاكَبَة,see off,送走,NOUN,B2
+فَطِنَ,to see through,看穿,VERB,B2
 طَلَبَ,to seek,寻找,VERB,B2
 طَلَبَ,to seek audience,求见,VERB,B2
 طَلَبَ,to seek truth from facts,实事求是,VERB,B2
-طَويلاً,long time,长时间,ADV,B2
-طَوَّرَ,to upgrade,升级,VERB,B2
-طَيْطَاء,kite,风筝,NOUN,B2
-طُعْمَة,lure,诱惑,NOUN,B2
-ظرف,circumstance,情况,NOUN,B2
-ظروف,situation circumstances,情形,NOUN,B2
-ظروف مواتية,favorable circumstances,顺境,NOUN,B2
-ظهر,reverse side,反面,NOUN,B2
-ظهر,to emerge,出现,VERB,B2
-ظهور,emergence,涌现,NOUN,B2
-ظَاهِر,conspicuous,显著的,ADJ,B2
+طَلَب,seeking,寻求,NOUN,B2
+طَامِع,seeking instant benefit,急功近利,ADJ,B2
+بَدَا,to seem,似乎,VERB,B2
 ظَاهِرِيًّا,seemingly,表面上,ADV,B2
-ظَنَّ,to suppose,假设,VERB,B2
-ظِلّ ثَلْج,snow shadow,雪影姐姐,NOUN,B2
-عابر,casual,随意的,ADJ,B2
-عادة,ordinarily,通常,ADV,B2
-عادة,habit,习惯,NOUN,B2
-عادة ماضية,habitually in the past,往常,NOUN,B2
-عادي,ordinary,普通的,ADJ,B2
-عارض,to counter,反击,VERB,B2
-عاري,naked,裸体的,ADJ,B2
-عازف جيتار,guitarist,吉他手,NOUN,B2
-عاطفي,emotional,情绪的,ADJ,B2
-عاقب,to punish,惩罚,VERB,B2
-عالمي,worldwide,全世界的,ADJ,B2
-عالٍ,lofty,崇高的,ADJ,B2
-عامة,public,公众,NOUN,B2
-عامة الناس,ordinary people,老百姓,NOUN,B2
-عامل,factor,因素,NOUN,B2
-عامي,commoner,平民,NOUN,B2
-عاهرة,prostitute,妓女,NOUN,B2
-عبأ,to fill in,填写,VERB,B2
-عبد,slave,奴隶,NOUN,B2
-عبد,to worship,崇拜,VERB,B2
-عدا,except,除了,ADP,B2
-عداوة,enmity,敌意,NOUN,B2
-عدم استخدام,do not use,别用,NOUN,B2
-عدو,enemy,敌人,NOUN,B2
-عدو حتمي,enemy must,仇必,NOUN,B2
-عديد,numerous,众多的,ADJ,B2
-عدّ,to enumerate,列举,VERB,B2
-عذر,to excuse,原谅,VERB,B2
-عذراء,virgin,处女,NOUN,B2
-عرافة,divination,占卜,NOUN,B2
-عرض,presentation,展示,NOUN,B2
-عرض أول,premiere,首演,NOUN,B2
-عرقي,ethnic,种族的,ADJ,B2
-عزل,to isolate,隔离,VERB,B2
-عزّز,to reinforce,加强,VERB,B2
-عزّل,to depose,废黜,VERB,B2
-عشيرة,clan,家族,NOUN,B2
-عضو,member,成员,NOUN,B2
-عطّل,to derail,使脱轨,VERB,B2
-عظمي,bony,瘦骨嶙峋的,ADJ,B2
-عقار,drug,药物,NOUN,B2
-عقد,decade,十年,NOUN,B2
-عقد,to complicate,使复杂化,VERB,B2
-عقد,to convene,召集,VERB,B2
-عقل,wits,心眼,NOUN,B2
-عقلي,mental,精神的,ADJ,B2
-عقيدة,creed,信条,NOUN,B2
-عقيدة,dogma,教条,NOUN,B2
-علامة,brand,品牌,NOUN,B2
-علاوة على ذلك,moreover,此外,ADV,B2
-على امتداد,along,沿着,ADP,B2
-عمة,paternal aunt,姑母,NOUN,B2
-عمدة القرية,village head,村长,NOUN,B2
-عمل,to operate,操作,VERB,B2
-عملاق,giant,巨人,NOUN,B2
-عمليا,virtually,几乎,ADV,B2
-عمود فقري,backbone,脊梁,NOUN,B2
-عميل,client,客户,NOUN,B2
-عمّد,to baptize,施洗,VERB,B2
-عناق,hug,拥抱,NOUN,B2
-عوّض,to reimburse,偿还,VERB,B2
-عيد الميلاد,christmas,圣诞节,NOUN,B2
-عيّن,to designate,指定,VERB,B2
-عَابَ,to disapprove,不赞成,VERB,B2
-عَاجِز,helpless,无助的,ADJ,B2
-عَادَةً,usually,通常,ADV,B2
-عَادِيّ,usual,通常的,ADJ,B2
-عَاقَدَ,to contract,收缩,VERB,B2
-عَانَى,to suffer from insomnia,失眠,VERB,B2
-عَبَّرَ,to express,表达,VERB,B2
-عَتَاقَة,archaism,古语,NOUN,B2
-عَتِيق,archaic,古老的,ADJ,B2
-عَجَلَة,haste,匆忙,NOUN,B2
-عَجْز,lame,跛的,ADJ,B2
-عَجْز,impairment,左手废,NOUN,B2
-عَجْز,inability,无能,NOUN,B2
-عَدِمَ,lack,缺乏,NOUN,B2
-عَدِمَ,to lack,缺乏,VERB,B2
-عَدّل,to modify,修改,VERB,B2
-عَدْوَانِيّ,bellicose,好战的,ADJ,B2
-عَذْرَاء,maiden,少女,NOUN,B2
-عَرَضَ,to exhibit,展览,VERB,B2
-عَرَضِيًّا,incidentally,顺便地,ADV,B2
-عَرَّضَ,to expose,暴露,VERB,B2
-عَرِيب,godfather,教父,NOUN,B2
-عَرْض,bid,出价,NOUN,B2
-عَرْض,width,宽度,NOUN,B2
-عَصَا السِّتار,curtain rod,窗帘杆,NOUN,B2
-عَطِر,fragrant,芬芳的,ADJ,B2
-عَطْر سَمَاوِيّ,heavenly fragrance,天香,NOUN,B2
-عَظَمَة,highness,殿下,NOUN,B2
-عَظِيم,grand,宏伟的,ADJ,B2
-عَقَبَة,hindrance,障碍,NOUN,B2
-عَقَّمَ,to disinfect,消毒,VERB,B2
-عَكْس,contrary,反而,NOUN,B2
-عَلَامَةُ كَسْر,fraction marker,分之,PART,B2
-عَلَّقَ,to hang up,挂断,VERB,B2
-عَلَّمَ,to educate,教育,VERB,B2
-عَمَل زائِد,overtime,加班,NOUN,B2
-عَمَل شَاق,heavy work,重功,NOUN,B2
-عَنِيَ,to look after,照料,VERB,B2
-عَوَّضَ,to make up for,弥补,VERB,B2
-عَيِّنَة,specimen,标本,NOUN,B2
-عَيْب,disadvantage,劣势,NOUN,B2
-عَيْن,green eye,碧眼,NOUN,B2
-عَيْن,green eyes,想碧眼,NOUN,B2
-عَيْن,green-eyed,让碧眼,NOUN,B2
-عُقْدَة,knot,结,NOUN,B2
-عُقْدَة ثَقِيلَة,heavy knot,重结,NOUN,B2
-عُنْوَان,heading,标题,NOUN,B2
-عِرَافَة,fortune telling,算命,NOUN,B2
-عِشْ,long live,万岁,INTJ,B2
-عِشْب,herb,草药,NOUN,B2
-عِلاج,therapy,治疗,NOUN,B2
-عِلاجٌ مُنَاعِي,immunotherapy,免疫治疗,NOUN,B2
-عِلَاء عَلَى ذَلِكَ,furthermore,此外,ADV,B2
-عِلّاوةً,besides,此外,ADV,B2
-عِنَب,grape,葡萄,NOUN,B2
-غائِم,overcast,阴天的,ADJ,B2
-غابة,woodland,林地,NOUN,B2
-غابة مطيرة,rainforest,雨林,NOUN,B2
-غامض,mysterious,神秘的,ADJ,B2
-غاية,ideal,理想的,ADJ,B2
-غرانيت,granite,花岗岩,NOUN,B2
-غرض,object,物体,NOUN,B2
-غرفة العرس,bridal chamber,洞房,NOUN,B2
-غرفة انتظار,waiting room,候诊室,NOUN,B2
-غرفة مراقبة,monitoring room,监控室,NOUN,B2
-غرفة نوم,bedroom,卧室,NOUN,B2
-غرق,to drown,溺死,VERB,B2
-غريب,peculiar,奇怪的,ADJ,B2
-غضب,rage,愤怒,NOUN,B2
-غضب,wrath,愤怒,NOUN,B2
-غضب,to rage,狂怒,VERB,B2
-غضب مقدس,righteous indignation,义愤,NOUN,B2
-غطاء أولي,first capping,首加缁布冠,NOUN,B2
-غير ذلك,however,然而,CCONJ,B2
-غير ذي صلة,irrelevant,不相关的,ADJ,B2
-غير رسمي,informal,非正式的,ADJ,B2
-غير فعّال,inefficient,低效的,ADJ,B2
-غير قابل للتوفيق,irreconcilable,不可调和的,ADJ,B2
-غير قابل للعكس,irreversible,不可逆转的,ADJ,B2
-غير مبالٍ,indifferent,冷漠的,ADJ,B2
-غير مسؤول,irresponsible,不负责任的,ADJ,B2
-غير مسموح,not allowed,不准,ADJ,B2
-غَائِب,absent,缺席的,ADJ,B2
-غَابَة,jungle,丛林,NOUN,B2
-غَاسِلَة أطْباق,dishwasher,洗碗机,NOUN,B2
-غَرَس,to embed,嵌入,VERB,B2
-غَرِيب,eccentric,古怪的,ADJ,B2
-غَرِيب,weird,奇怪的,ADJ,B2
-غَرِيب,weirdo,怪人,NOUN,B2
-غَرِيب الأَطْوَار,freak,怪人,NOUN,B2
-غَضَب,fury,狂怒,NOUN,B2
-غَضْبَان,furious,愤怒的,ADJ,B2
-غَلَب,to overwhelm,使不知所措,VERB,B2
-غَنيمَة,loot,战利品,NOUN,B2
-غَوَص,scuba diving,潜水,NOUN,B2
-غَيْر حَاسِم,indecisive,犹豫不决的,ADJ,B2
-غَيْر لَائِق,improper,不合适的,ADJ,B2
-غَيْر لَائِق,inappropriate,不恰当的,ADJ,B2
-غَيْر مُفْهَم,incomprehensible,不可理解的,ADJ,B2
-غَيْرُ آمِنٍ,insecure,不安全的,ADJ,B2
-غَيْرُ عَادِيّ,unusual,不寻常的,ADJ,B2
-غَيْرُ كَافٍ,insufficient,不足的,ADJ,B2
-غَيْرُ مُتَجَاوَزٍ,insurmountable,不可逾越的,ADJ,B2
-غَيْرُ مُتَوَقَّع,unpredictable,不可预测的,ADJ,B2
-غَيْرُ مُسْتَقِرّ,unstable,不稳定的,ADJ,B2
-غَيْرُ مُعْقُول,unreasonable,不合理的,ADJ,B2
-غَيْرُ مُفِيد,useless,无用的,ADJ,B2
-غَيْرُ مُهِمٍّ,insignificant,微不足道的,ADJ,B2
-غَيْرِ مُقَاس,immeasurable,不可估量的,ADJ,B2
-غُرفة التَّغيير,locker room,更衣室,NOUN,B2
-غُرفة المَعيشة,living room,客厅,NOUN,B2
-غُرُور,vanity,虚荣,NOUN,B2
-غُرْفَة التَّحَكُّم,control room,控制室,NOUN,B2
-غِرَاء,glue,胶水,NOUN,B2
-ـاً,-ly,地,PART,B2
-فائز,winner,获胜者,NOUN,B2
-فارس,rider,骑手,NOUN,B2
-فارغ,empty,空的,ADJ,B2
-فاصوليا,bean,豆子,NOUN,B2
-فاقم,to exacerbate,加剧,VERB,B2
-فبراير,february,二月,NOUN,B2
-فتاة حمقاء,silly girl,傻丫头,NOUN,B2
-فترة,a while,一会儿,NOUN,B2
-فتن,to fascinate,使着迷,VERB,B2
-فجر,to detonate,引爆,VERB,B2
-فحص,to examine,检查,VERB,B2
-فرد عائلة,family member,家庭成员,NOUN,B2
-فردي,individual,单独的,ADJ,B2
-فردية,individuality,个性,NOUN,B2
-فرض,to enforce,执行,VERB,B2
-فرضية,premise,前提,NOUN,B2
-فرقة,band,乐队,NOUN,B2
-فشل,falling though,虽坠,NOUN,B2
-فصل,to detach,分离,VERB,B2
-فصل دراسي,classroom,教室,NOUN,B2
-فصيل,faction,派,NOUN,B2
-فطر,mushroom,蘑菇,NOUN,B2
-فطر الأذن الخشبية,wood ear mushroom,木耳,NOUN,B2
-فعل,to do to make,做,VERB,B2
-فقد,to be missing,缺少,VERB,B2
-فقط,only,唯一的,ADJ,B2
-فقط,merely,仅仅,ADV,B2
-فك,jaw,下巴,NOUN,B2
-فك شفرة,to decipher,破译,VERB,B2
-فكرة سيئة,bad idea,坏水,NOUN,B2
-فكرة واحدة,single thought,一念,NOUN,B2
-فكك,to deconstruct,解构,VERB,B2
-فلاح,peasant,农民,NOUN,B2
-فهرس,catalog,目录,NOUN,B2
-فوضى,mess,混乱,NOUN,B2
-فول سوداني,peanut,花生,NOUN,B2
-فوهة,crater,火山口,NOUN,B2
-في الأصل,originally,最初,ADV,B2
-في البداية,initially,首先,ADV,B2
-في الغالب,mostly,主要地,ADV,B2
-في النهاية,eventually,最终,ADV,B2
-فيلم وثائقي,documentary,纪录片,NOUN,B2
-فَاجَأَ,to surprise,使惊讶,VERB,B2
-فَاوِرة,bill,账单,NOUN,B2
-فَتَّحَ,to inaugurate,启用,VERB,B2
-فَتْح العُروض,bid opening,开标,NOUN,B2
-فَجْأِي,abrupt,突然的,ADJ,B2
-فَخِيم,sumptuous,奢华的,ADJ,B2
-فَخّ,trap,陷阱,NOUN,B2
-فَرَضَ,to impose,强加,VERB,B2
-فَرَنْسِيّ,french,法国的,ADJ,B2
-فَرَنْسِيّ,frenchman,法国人,NOUN,B2
-فَرَّ,to abscond,潜逃,VERB,B2
-فَرَّقَ,to discriminate,歧视,VERB,B2
-فَرْو,fur,毛皮,NOUN,B2
-فَصَحَ,to disclose,揭露,VERB,B2
-فَصَلَ,to disconnect,断开,VERB,B2
-فَصَّل,elaborate,详尽的,ADJ,B2
-فَصَّل,to elaborate,制定,VERB,B2
-فَصَّلَ,to expound,阐述,VERB,B2
-فَصْل,chapter,章节,NOUN,B2
-فَطِنَ,to see through,看穿,VERB,B2
-فَكَّ,to untie,解开,VERB,B2
-فَنَاس,lantern,灯笼,NOUN,B2
-فَنِّي,artistic,艺术的,ADJ,B2
-فَوْرِي,immediate,立即的,ADJ,B2
-فَوْضَوِيّ,chaotic,混乱的,ADJ,B2
-فَوْق,over,在...上方,ADP,B2
-فَوْق,above,上面,ADV,B2
-فَوْق,up,向上,ADV,B2
-فَوْقَ الجَوَاء,super-quality,超质,NOUN,B2
-فَوْقَ الدَّرَجَة,super-grade,超级,NOUN,B2
-فَوْقَ الشُّمُول,super-comprehensive,超遍,NOUN,B2
-فَوْقَ الفِكْر,super-thought,超思,NOUN,B2
-فَوْقَ المَبْدَأ,super-principle,超则,NOUN,B2
-فَوْقَ النَّظَام,super-system,超制,NOUN,B2
-فَيْض,overflow,溢出,NOUN,B2
-فُرْسَان,cavalry,骑兵,NOUN,B2
-فُرْسَان,knight,骑士,NOUN,B2
-فُلْفُل حَلْو,bell pepper,甜椒,NOUN,B2
-فِرْقَة,squad,小队,NOUN,B2
-فِرْقَة,troop,部队,NOUN,B2
-فِطْرِيٌّ,innate,天生的,ADJ,B2
-فِي حَال,in case,如果,SCONJ,B2
-فِي وَقْت,in time,及时地,ADV,B2
-فِيهِ,in it,在里面,ADV,B2
-فْتَرَة,while,一会儿,NOUN,B2
-قائد,captain,队长,NOUN,B2
-قائمة,menu,菜单,NOUN,B2
-قابل للنقاش,debatable,有争议的,ADJ,B2
-قاتل,fatal,致命的,ADJ,B2
-قاتل,murderer,凶手,NOUN,B2
-قاتل,to fight,对抗,VERB,B2
-قادر,capable,有能力的,ADJ,B2
-قاسِي,cruel,残忍的,ADJ,B2
-قاعة,hall,殿,PART,B2
-قاعدة بيانات,database,数据库,NOUN,B2
-قافلة,caravan,房车,NOUN,B2
-قبل,before,之前,ADV,B2
-قتل,to murder,谋杀,VERB,B2
-قدم احتراماته,to pay respects,参见,VERB,B2
-قدم دليلا,to provide evidence,举证,VERB,B2
-قدم ملاحظات,to provide feedback,反馈,VERB,B2
-قراءة الوجه,face reading,面相,NOUN,B2
-قرار,resolution,决心,NOUN,B2
-قراصن,pirate,海盗,NOUN,B2
-قرب,proximity,邻近,NOUN,B2
-قرص فيديو,video disc,影碟,NOUN,B2
-قريب,near,在附近,ADP,B2
-قريب,relative,亲属,NOUN,B2
-قريبات,female relatives,女眷,NOUN,B2
-قزم,dwarf,侏儒,NOUN,B2
-قس,pastor,牧师,NOUN,B2
-قسم,to divide,分开,VERB,B2
-قسيمة,voucher,代金券,NOUN,B2
-قضيب,my big one,我偌大,NOUN,B2
-قطرة,drop,滴,NOUN,B2
-قلب متمرد,rebellious heart,反心,NOUN,B2
-قلة,few,几下,NOUN,B2
-قلعة,castle,城堡,NOUN,B2
-قلل,to diminish,减少,VERB,B2
-قلم جاف,ballpoint pen,圆珠笔,NOUN,B2
-قلم رصاص,pencil,铅笔,NOUN,B2
-قليل,a little,一点,ADJ,B2
-قليلاً,a bit,一点,ADV,B2
-قليلاً,slightly,轻微地,ADV,B2
+نَزْعَة,seizure,没收,NOUN,B2
+اخْتَارَ,to select,选择,VERB,B2
+ثِقَة,self-confidence,自信,NOUN,B2
 قماش حريري,silk cloth,丝绸,NOUN,B2
-قمة,crest,顶峰,NOUN,B2
-قمر الشهر,month moon,月,NOUN,B2
-قنبلة,bomb,炸弹,NOUN,B2
-قواد,gigolo,面首,NOUN,B2
-قوة,might,威力,NOUN,B2
-قوة عسكرية,military power,兵权,NOUN,B2
-قوس,bow,蝴蝶结,NOUN,B2
-قوس قزح,rainbow,彩虹,NOUN,B2
-قيد,handcuff,手铐,NOUN,B2
-قيد,to restrict,限制,VERB,B2
-قيم,caretaker,房屋管理员,NOUN,B2
-قَابَلَ,to contrast,对比,VERB,B2
-قَادِر,able,能够的,ADJ,B2
-قَاسِي,grim,严酷的,ADJ,B2
-قَبِلَ,to accept,接受,VERB,B2
-قَبْضَة,hilt,剑柄,NOUN,B2
-قَتْل,to kill,杀死,VERB,B2
-قَتْلُ عَطْوَيْنِ بِحَجَرٍ وَاحِد,kill two birds with one stone,一举两得,ADJ,B2
-قَديمًا,long ago,早已,ADV,B2
-قَدَّر,estimate,估计,NOUN,B2
-قَدَّر,to estimate,估计,VERB,B2
-قَدَّرَ,to appreciate,感激,VERB,B2
-قَرَار عَابِر,trans-decision,超断,NOUN,B2
-قَسَا,to brutalize,使变得残忍,VERB,B2
-قَسْوَة,cruelty,残忍,NOUN,B2
-قَصَّرَ,to cut short,截断,VERB,B2
-قَصْر,mansion,豪宅,NOUN,B2
-قَضَمَ,to gnaw,啃,VERB,B2
-قَطَعَ,to cut off,切断,VERB,B2
-قَطْع,cut,切口,NOUN,B2
-قَفَلَ,to lock,锁上,VERB,B2
-قَفْزَة,jump,跳跃,NOUN,B2
-قَلَنْسُوَة طَقْسِيَّة,ceremonial cap,爵弁,NOUN,B2
-قَلَّدَ,to imitate,模仿,VERB,B2
-قَمَامَة,trash,垃圾,NOUN,B2
-قَمَعَ,to suppress,压制,VERB,B2
-قَمْلَة,louse,虱子,NOUN,B2
-قَنَبْلَة,grenade,手榴弹,NOUN,B2
-قَوْس,arc,弧,NOUN,B2
-قَوْنَنَ,to formalize,使正式化,VERB,B2
-قَيَّدَ,to constrain,限制,VERB,B2
-قَيْد,constraint,约束,NOUN,B2
-قُبَّعَة,hat,帽子,NOUN,B2
-قُفَّاز,glove,手套,NOUN,B2
-قُوَّة,great power,大国,NOUN,B2
-قُوَّة طَرْدِيَّة,centrifugal force,离心力,NOUN,B2
-قِشْرَة,crust,外壳,NOUN,B2
-قِيثَارَة,harp,竖琴,NOUN,B2
-كأس خمر,wine cup,这酒盏,NOUN,B2
-كئيب,melancholic,忧郁的,ADJ,B2
-كاتب,clerk,职员,NOUN,B2
-كاتدرائية,cathedral,大教堂,NOUN,B2
-كاثوليكية,catholicism,天主教,NOUN,B2
-كافأ,reward,奖励,NOUN,B2
-كافأ,to reward,奖励,VERB,B2
-كافي,enough,足够的,ADJ,B2
-كامل,complete,完整的,ADJ,B2
-كامل,entire,整个的,ADJ,B2
-كامل الدفع,payment all,付都,NOUN,B2
-كان,to be so,然,VERB,B2
-كبت,to depress,使沮丧,VERB,B2
-كتيّب,booklet,小册子,NOUN,B2
-كثير,much,多,DET,B2
-كحول,alcohol,酒精,NOUN,B2
-كذلك,also too,也,ADV,B2
-كرة,ball,球,NOUN,B2
-كرر,to duplicate,复制,VERB,B2
-كرمة,vine,藤蔓,NOUN,B2
-كريه,nasty,令人不快的,ADJ,B2
-كرّر,to reiterate,重申,VERB,B2
-كسافا,cassava,木薯,NOUN,B2
-كشف,detection,检测,NOUN,B2
-كشف,to detect,探测,VERB,B2
-كشف,to reveal,揭示,VERB,B2
-كشك,booth,摊位,NOUN,B2
-كشمير,cashmere,羊绒,NOUN,B2
-كعكة القمر,mooncake,月饼,NOUN,B2
-كفؤ,competent,胜任的,ADJ,B2
-كفالة,bail,保释,NOUN,B2
-كفتا,both hands,双手,NOUN,B2
-كفتة مطبوخة,cooked meatball,丸子熟,NOUN,B2
-كفل,to provide for,供应,VERB,B2
-كفى,to be enough,足够,VERB,B2
-كفّ,to desist,停止,VERB,B2
-كفّر,to excommunicate,开除教籍,VERB,B2
-كل,all,全部,ADV,B2
-كل,every,每个,DET,B2
-كل شيء,everything,一切,PRON,B2
-كل يوم,every day,天天,ADV,B2
-كلا,both,两者都,CCONJ,B2
-كلاسيكي,classic,经典的,ADJ,B2
-كلاسيكي,classical,古典的,ADJ,B2
-كلمة المرور,password,密码,NOUN,B2
-كليشيه,cliche,陈词滥调,NOUN,B2
-كلّف,to cost,花费,VERB,B2
-كم,sleeve,袖子,NOUN,B2
-كم,how many,多少,NUM,B2
-كمال,entirety,全部,NOUN,B2
-كمثرى,pear,梨,NOUN,B2
-كوخ,cottage,小屋,NOUN,B2
-كومة,pile,堆,NOUN,B2
-كومة,a pile,一堆,NUM,B2
-كونتيسة,countess,女伯爵,NOUN,B2
-كيان,entity,实体,NOUN,B2
-كَأَنَّ,as if,仿佛,ADV,B2
-كَأْس,trophy,奖杯,NOUN,B2
-كَادَ,hardly,几乎不,ADV,B2
-كَانْسِلَر,chancellor,总理,NOUN,B2
-كَبَّرَ,to magnify,放大,VERB,B2
-كَثير,lot,许多,NOUN,B2
-كَثِير,so much,这么多,ADV,B2
-كَذَلِكَ,so,所以,ADV,B2
-كَرَاهَة,hate,仇恨,NOUN,B2
-كَرَم,benevolence,仁慈,NOUN,B2
-كَرِهَ,to dislike,不喜欢,VERB,B2
-كَرِيم,benevolent,仁慈的,ADJ,B2
-كَرْم,cellar,地窖,NOUN,B2
-كَسْر,fraction,分数,NOUN,B2
-كَفَّ,to curb,抑制,VERB,B2
-كَلام السَّيِّد,lord's words,主说,NOUN,B2
-كَلِمَة شَخْصِيَّة,character word,字,NOUN,B2
-كَما,as,作为,SCONJ,B2
-كَمَا فِي الْمَاضِي,just as in the past,一如既往,ADV,B2
-كَنْز,treasure,财宝,NOUN,B2
-كَهْرَبَائِيّ,electric,电动的,ADJ,B2
-كَوْسَد,constellation,星座,NOUN,B2
-كَيْف,how,又怎会,NOUN,B2
-كُرْسِيّ مَيْسَم,armchair,扶手椅,NOUN,B2
-كُرْسِيّ مُعَوِّق,wheelchair,轮椅,NOUN,B2
-كُلّ,each,每个,DET,B2
-كِتَاب دِرَاسِيّ,textbook,教科书,NOUN,B2
-كِتَابَة,in writing,书面,NOUN,B2
-لأن,because,因为,CCONJ,B2
-لؤلؤ,pearl,珍珠,NOUN,B2
-لا,do not,莫,ADV,B2
-لا أستحق مدحك,i don't deserve your praise,不敢当,INTJ,B2
-لا تشوبه شائبة,irreproachable,无可指责的,ADJ,B2
-لا شيء,nothing,没有什么,PRON,B2
-لا عقلانية,irrationality,非理性,NOUN,B2
-لا غنى عنه,indispensable,不可或缺的,ADJ,B2
-لا مكان,nowhere,无处,ADV,B2
-لا نهائي,endless,无尽的,ADJ,B2
-لا يأتي,to not come,不来,VERB,B2
-لا يحصى,countless,无数的,ADJ,B2
-لا يسمح,not allow,不许,AUX,B2
-لا يصلح,won't do,不行,ADJ,B2
-لا يصلح,to won't do,不成,VERB,B2
-لا يعوض,irreplaceable,不可替代的,ADJ,B2
-لا يقاوم,irresistible,不可抗拒的,ADJ,B2
-لا يقبل الجدل,irrefutable,无可辩驳的,ADJ,B2
-لا يمكنك العيش,you cannot live,你也活不,NOUN,B2
-لا يملك,to not have,没,VERB,B2
-لا يوصف,indescribable,难以形容的,ADJ,B2
-لا يُمحى,indelible,不可磨灭的,ADJ,B2
-لائحة اتهام,indictment,起诉,NOUN,B2
-لائق,decent,体面的,ADJ,B2
-لاحظ,note,笔记,NOUN,B2
-لاحظ,to note,记录,VERB,B2
-لاحظ,to notice,注意到,VERB,B2
-لافتة,banner,横幅,NOUN,B2
-لامع,brilliant,杰出的,ADJ,B2
-لبس,dress,连衣裙,NOUN,B2
-لبس,to dress,给...穿衣,VERB,B2
-لبس,to put on,穿上,VERB,B2
-لحاف,quilt,被子,NOUN,B2
-لحظة,point in time,时间点,NOUN,B2
-لحم خروف,mutton,羊肉,NOUN,B2
-لحم مقدد,bacon,培根,NOUN,B2
-لحم مقدد,ham,火腿,NOUN,B2
-لزم,to entail,牵涉,VERB,B2
-لص,bandit,强盗,NOUN,B2
-لغز,mystery,谜,NOUN,B2
-لف,to wind,缠绕,VERB,B2
-لف,to wrap,包裹,VERB,B2
-لقمة,mouthful,一口,NOUN,B2
-للغاية,extremely,极其,ADV,B2
-لم شمل,reunion,重聚,NOUN,B2
-لوحة القيادة,dashboard,仪表盘,NOUN,B2
-لوز,almond,杏仁,NOUN,B2
-لياقة,propriety,分寸,NOUN,B2
-ليس فقط,not only,不光,CCONJ,B2
-ليل ونهار,day and night,昼夜,NOUN,B2
-لَئِيم,impolite,不礼貌的,ADJ,B2
-لَحْمُ الفَخِذ,tenderloin,里脊,NOUN,B2
-لَعَنَ,to curse,诅咒,VERB,B2
-لَقَب,surname,姓氏,NOUN,B2
-لَقْنِيّ,laconic,简洁的,ADJ,B2
-لَهُمْ,their,他们的,PRON,B2
-لَوَّثَ,to contaminate,污染,VERB,B2
-لَوْحَة اتِّجَاه,direction sign,指示牌,NOUN,B2
-لَوْحَة مَفَاتِيح,keyboard,键盘,NOUN,B2
-لَيْلًا,overnight,一夜之间,ADV,B2
-لُوجِسْتِيّات,logistics,后勤,NOUN,B2
-لُورد يُو,lord yu,玉大人,NOUN,B2
-لِحُسْنِ الحَظّ,fortunately,幸运地,ADV,B2
-لِقَاء,secret meeting,密会,NOUN,B2
-لِكَيْ,in order to,以期,SCONJ,B2
-لِكَيْ,so that,以便,SCONJ,B2
-مأثرة,feat,功绩,NOUN,B2
-مأزق,predicament,困境,NOUN,B2
-مأساوي,pitiful,可怜的,ADJ,B2
-مألوف,familiar,熟悉的,ADJ,B2
-مؤتمر صحفي,press conference,新闻发布会,NOUN,B2
-مؤسسة,establishment,机构,NOUN,B2
-مادة مضادة,counter-matter,反物,NOUN,B2
-مارس,to exercise,锻炼,VERB,B2
-ماس,diamond,钻石,NOUN,B2
-ماشية,cattle,牛,NOUN,B2
-ماضٍ,past,过去的,ADJ,B2
-مالية,finances,财政,NOUN,B2
-مبارزة,fencing,击剑,NOUN,B2
-مبالغ,exaggerated,夸张的,ADJ,B2
-مبتدئ,beginner,初学者,NOUN,B2
-مبتذل,vulgar,粗俗的,ADJ,B2
-مبتهج,joyful,快乐的,ADJ,B2
-مبدع,creative,有创造力的,ADJ,B2
-مبدع,ingenious,灵巧的,ADJ,B2
-متأصل,inherent,固有的,ADJ,B2
-متبادلا,mutually,相互地,ADV,B2
-متجر متعدد الأقسام,department store,百货商店,NOUN,B2
-متحمس,excited,兴奋的,ADJ,B2
-متخذ القرار,decision-maker,决策者,NOUN,B2
+فتاة حمقاء,silly girl,傻丫头,NOUN,B2
+تشابه,similarity,相似,NOUN,B2
+بسّط,to simplify,简化,VERB,B2
+ببساطة,simply,简单地,ADV,B2
+حاكى,to simulate,模拟,VERB,B2
 متزامن,simultaneous,同时的,ADJ,B2
-متطرف,extreme,极端,ADJ,B2
-متطلب,requirement,要求,NOUN,B2
-متعجرف,bombastic,夸大的,ADJ,B2
-متقدم,developed,发达的,ADJ,B2
-متمدن,civilized,文明的,ADJ,B2
-متوافق,compliant,符合的,ADJ,B2
-متوسط,mediocre,平庸的,ADJ,B2
-مثل,proverb,谚语,NOUN,B2
-مثير للشفقة,pathetic,可悲的,ADJ,B2
-مجاملة,compliment,称赞,NOUN,B2
-مجتمع,community,社区,NOUN,B2
-مجلة فصلية,quarterly magazine,季刊,NOUN,B2
-محاولة فاشلة,failed bid,流标,NOUN,B2
-محتمل,bearable,可忍受的,ADJ,B2
-محدد بوضوح,clearly demarcated,分明,ADJ,B2
-محرك,motor,发动机,NOUN,B2
-محطة,gas station,加油站,NOUN,B2
-محقق,detective,侦探,NOUN,B2
-محلي,domestic,国内的,ADJ,B2
-محنة,plight,处境,NOUN,B2
-مخاطرة بالموت,risking death,冒死,NOUN,B2
-مخالف للعقل,preposterous,荒谬的,ADJ,B2
-مخضرم,veteran,老手,NOUN,B2
-مخطئ,wrong mistake,错误,ADJ,B2
-مخطط,diagram,图表,NOUN,B2
-مخلب,claw,爪子,NOUN,B2
-مخلب,paw,爪子,NOUN,B2
-مخلص,devoted,忠诚的,ADJ,B2
+خطيئة,sin,罪,NOUN,B2
 مخلص,sincere,真诚的,ADJ,B2
-مدة,duration,持续时间,NOUN,B2
-مدرك,perceptive,敏锐的,ADJ,B2
-مدع,prosecutor,检察官,NOUN,B2
-مدفأة,fireplace,壁炉,NOUN,B2
-مدمج,compact,紧凑的,ADJ,B2
-مدني,civilian,平民,NOUN,B2
-مدى,extent,程度,NOUN,B2
-مذكرة,memorandum,备忘录,NOUN,B2
-مذنب,guilty,有罪的,ADJ,B2
-مراسلة,correspondence,通信,NOUN,B2
-مراقبة,monitoring,监控,NOUN,B2
-مرتاح,relaxed,放松的,ADJ,B2
-مرتب,neat,整洁的,ADJ,B2
-مرتبط,related,相关的,ADJ,B2
-مرحلة نهائية,final stage,末期,NOUN,B2
-مرسوم شفوي,oral decree,口谕,NOUN,B2
-مركب,compound,复合性,ADJ,B2
-مركز ترفيهي,entertainment center,娱乐中心,NOUN,B2
-مريح,cozy,舒适的,ADJ,B2
-مريض,patient,病人,NOUN,B2
-مزح,to joke,开玩笑,VERB,B2
-مزدهر,prosperous,繁荣的,ADJ,B2
-مزدوج,double,两倍的,ADJ,B2
-مزرعة,plantation,人工林,NOUN,B2
-مزيف,counterfeit,假冒,ADJ,B2
-مسار مضاد,counter-route,反途,NOUN,B2
-مسبقا,beforehand,事先,ADV,B2
-مستبعد,excluded,排除在外的,ADJ,B2
-مستحق,due,到期的,ADJ,B2
-مستعد,willing,乐意的,ADJ,B2
-مستقبلي,future,未来的,ADJ,B2
-مستقل,independent,独立的,ADJ,B2
-مستلم,recipient,接受者,NOUN,B2
-مستند أصلي,original document,原件,NOUN,B2
-مسح,to wipe,擦,VERB,B2
-مسرح الجريمة,crime scene,犯罪现场,NOUN,B2
-مسرحية,play,剧本,NOUN,B2
-مسكن,dwelling,住宅,NOUN,B2
-مسكن,my residence,我府,NOUN,B2
-مسودة أولى,first draft,初稿,NOUN,B2
-مشاغب,naughty,淘气的,ADJ,B2
-مشترك,joint,平等的,ADJ,B2
-مشغل أسطوانات,record player,唱机,NOUN,B2
-مشغول,engaged,订婚的,ADJ,B2
-مشغول,occupied,被占用的,ADJ,B2
-مشكلة صعبة,difficult problem,难题,NOUN,B2
-مشكوك فيه,questionable,可疑的,ADJ,B2
-مشوش,muddled,混乱的,ADJ,B2
-مصرفي,banker,银行家,NOUN,B2
-مصعد,escalator,自动扶梯,NOUN,B2
-مصلحة عامة,public welfare,公益性,NOUN,B2
-مصمم,determined,下定决心的,ADJ,B2
-مصنع بيرة,brewery,啤酒厂,NOUN,B2
-مصنوعات اليشم,jade ware,玉器,NOUN,B2
-مصير,destiny,命运,NOUN,B2
-مطابق,identical,完全相同的,ADJ,B2
-مطر معتدل,moderate rain,中雨,NOUN,B2
-مطلوب,required,必需的,ADJ,B2
-مطنب,verbose,冗长的,ADJ,B2
-مطيع,obedient,顺从的,ADJ,B2
-معتدل,mild,温和的,ADJ,B2
-معتدل,moderate,适度的,ADJ,B2
-معتمد,dependent,依赖的,ADJ,B2
-معدات أساسية,essential equipment,要置,NOUN,B2
-معرض,fair,交易会,NOUN,B2
-معرض,gallery,画廊,NOUN,B2
-معرفة واضحة,clear knowledge,明知,NOUN,B2
-معطف مطر,raincoat,雨衣,NOUN,B2
-معطى,given,给定,NOUN,B2
-معلم,milestone,里程碑,NOUN,B2
-معلومة,piece of information,信息,NOUN,B2
-معنى مُغيَّر,altered meaning,改义,NOUN,B2
+إخلاص,sincerity,真诚,NOUN,B2
+فكرة واحدة,single thought,一念,NOUN,B2
 مغسلة,sink,水槽,NOUN,B2
-مفاوَضة,haggling,计较,NOUN,B2
-مفترس,predator,捕食者,NOUN,B2
-مفرط,excessive,过度的,ADJ,B2
-مفرقع ناري,firecracker,鞭炮,NOUN,B2
-مفصل,detailed,详细的,ADJ,B2
-مفضل,favorite,最喜欢的,ADJ,B2
-مفقود,missing,失踪的,ADJ,B2
-مفلس,bankrupt,破产的,ADJ,B2
-مقابل,opposite,相反的,ADJ,B2
-مقاتل,fighter,战士,NOUN,B2
-مقاطعة,county,县,NOUN,B2
-مقامرة,gamble,赌博,NOUN,B2
-مقاوم للتجعد,wrinkle-resistant,防皱,ADJ,B2
-مقاوم للرياح,windproof,挡风的,ADJ,B2
-مقاوم للنار,fireproof,防火的,ADJ,B2
-مقبض باب,door handle,门把手,NOUN,B2
-مقت,to detest,厌恶,VERB,B2
-مقدم رعاية,caregiver,护理人员,NOUN,B2
-مقدمة,preface,序言,NOUN,B2
-مقرر فرعي,minor course,辅修课,NOUN,B2
-مقصورة,compartment,隔间,NOUN,B2
-مقعد خلفي,back seat,后座,NOUN,B2
-مكان,my place,我处,NOUN,B2
-مكان,venue,场地,NOUN,B2
-مكان العمل,workplace,工作场所,NOUN,B2
-مكتئب,depressed,沮丧的,ADJ,B2
-مكتب,bureau,局,NOUN,B2
-مكتب,desk,书桌,NOUN,B2
-مكسيكي,mexican,墨西哥的,ADJ,B2
-مكون,component,组成部分,NOUN,B2
-مكوّن,ingredient,成分,NOUN,B2
-ملاحظة مضادة,counter-observation,反察,NOUN,B2
-ملحن,composer,作曲家,NOUN,B2
-ملخص,brief,近点说,NOUN,B2
-ملك,your,你的,DET,B2
-ملكة,queen,女王,NOUN,B2
-ممتاز,excellent,优秀的,ADJ,B2
-ممر,driveway,车道,NOUN,B2
-ممر,hallway,走廊,NOUN,B2
-ممسحة,wiper,雨刷,NOUN,B2
-ممسحة أقدام,doormat,门垫,NOUN,B2
-ممكن,feasible,可行的,ADJ,B2
-ممل,dull,枯燥的,ADJ,B2
-مملكة,realm,领域,NOUN,B2
-مملّ,monotonous,单调的,ADJ,B2
-مميت,deadly,致命的,ADJ,B2
-من,of,的,ADP,B2
-منارة,beacon,灯塔,NOUN,B2
-مناسب,convenient,方便的,ADJ,B2
-مناشدة,plea,辩护,NOUN,B2
-منافس,competitor,竞争者,NOUN,B2
-منافسة,rivalry,竞争,NOUN,B2
-منافق,hypocrite,伪君子,NOUN,B2
-منتصف الليل,midnight,午夜,NOUN,B2
-منتظم,regular,规律的,ADJ,B2
-منجز,done,事已,NOUN,B2
-منح,to give to grant,予以,VERB,B2
-منحدر,ramp,坡道,NOUN,B2
-منحدر جبلي,mountain descent,下山,NOUN,B2
-منحط,decadent,颓废,ADJ,B2
-منديل,napkin,餐巾,NOUN,B2
-منزل متنقل,motorhome,露营车,NOUN,B2
-منسق,coordinator,协调员,NOUN,B2
-منطق مضاد,counter-logic,反逻,NOUN,B2
-منطقة,zone,区域,NOUN,B2
-منظر,view,观点,NOUN,B2
-منظم,orderly,有序的,ADJ,B2
-منظم,organizer,组织者,NOUN,B2
-منع,prevention,预防,NOUN,B2
-منع,to withhold,扣留,VERB,B2
-منفذ,executor,遗嘱执行人,NOUN,B2
-مهارة مضادة,counter-skill,反技,NOUN,B2
-مهجع,dormitory,宿舍,NOUN,B2
-مهدد بالانقراض,endangered,濒危的,ADJ,B2
-مهزلة,farce,闹剧,NOUN,B2
-مهمة فردية,individual assignment,个人作业,NOUN,B2
-مهنة,career,职业,NOUN,B2
-مهووس,obsessed,着迷的,ADJ,B2
-مواطن,compatriot,同胞,NOUN,B2
-موثوق,reliable,可靠的,ADJ,B2
-مورد,resource,资源,NOUN,B2
-موز,banana,香蕉,NOUN,B2
-موسيقي,musician,音乐家,NOUN,B2
-موضوعي,objective,客观的,ADJ,B2
-موظف مدني,civil servant,公务员,NOUN,B2
-موقر,respectful deferential,恭敬,ADJ,B2
+رتشفة,sip,小口喝,NOUN,B2
+سيدي,sir,先生,NOUN,B2
+صفارة إنذار,siren,汽笛,NOUN,B2
+زوجة الأخ,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
+جلس,to sit down,坐下,VERB,B2
 موقف,situation,情况,NOUN,B2
-مول,to finance,资助,VERB,B2
-موهوب,richly endowed by nature,得天独厚,ADJ,B2
-ميت,dead,死的,ADJ,B2
-ميز,to differentiate,区分,VERB,B2
-ميل,mile,英里,NOUN,B2
-مَا,what,什么,ADV,B2
-مَا وَرَاء,beyond,在...之外,ADP,B2
-مَالَ,to incline,使倾斜,VERB,B2
-مَتَاع,belongings,所属物,NOUN,B2
-مَثَلٌ,instance,例子,NOUN,B2
-مَجال زائِد,over-domain,超畴,NOUN,B2
-مَجَّدَ,to glorify,赞美,VERB,B2
-مَجِيد,glorious,辉煌的,ADJ,B2
-مَجِيد,magnificent,壮丽的,ADJ,B2
-مَجْمُوع,sum,总和,NOUN,B2
-مَجْنُونٌ,insane,疯狂的,ADJ,B2
-مَحَطَّة القِطَار,train station,火车站,NOUN,B2
-مَحَلّ,whereabouts,行踪,NOUN,B2
-مَحْظُوظ,fortunate,幸运的,ADJ,B2
-مَحْكَمَة,jurisdiction area,辖区,NOUN,B2
-مَخْرَج,seclusion exit,出关,NOUN,B2
-مَخْفِي,hidden,隐藏的,ADJ,B2
-مَدْح,tribute,贡品,NOUN,B2
-مَرحاض,outhouse,茅房,NOUN,B2
-مَرَض,disease,疾病,NOUN,B2
-مَرَض,illness,疾病,NOUN,B2
-مَرَّة,second time,再而,NOUN,B2
-مَرُور,traffic,交通,NOUN,B2
-مَرِح,fun,有趣的,ADJ,B2
-مَرِيض,ill,生病的,ADJ,B2
-مَرْحَبًا,hello,你好,INTJ,B2
-مَرْعَى,grassland,草地,NOUN,B2
-مَرْكَزَ,to centralize,集中,VERB,B2
-مَسَاعَدَة,go help,去帮,NOUN,B2
-مَسَاعَدَة,help,帮助,NOUN,B2
-مَسَحَ,to brush,刷,VERB,B2
-مَسِيحِيّ,tragic,悲剧的,ADJ,B2
-مَسْبَك,foundry,铸造厂,NOUN,B2
-مَسْرَحِيَّة,screenplay,剧本,NOUN,B2
-مَسْرَحِيَّة,script for play,剧本,NOUN,B2
-مَشَى,to tread,踏上,VERB,B2
-مَصَّ,to suck,吸,VERB,B2
-مَصّاص دَم,vampire,吸血鬼,NOUN,B2
-مَصْرُوف,expense,费用,NOUN,B2
-مَطَر مُتَجَمِّد,freezing rain,冻雨,NOUN,B2
-مَعْرَض فَنِّي,art gallery,美术馆,NOUN,B2
-مَعْرُوف,known,已知的,ADJ,B2
-مَعْرِض,exposition,阐述,NOUN,B2
-مَعْيَار,standard,标准,NOUN,B2
-مَغَادَرَتُهُ,his departure,他走,NOUN,B2
-مَقَالَة,article,文章,NOUN,B2
-مَقْتِلُ حَشَرَاتٍ,insecticide,杀虫剂,NOUN,B2
-مَقْعَد,bench,长凳,NOUN,B2
-مَكار,cunning,狡猾的,ADJ,B2
-مَلَكَ,have,有,AUX,B2
-مَلَكَ,to have,有,VERB,B2
-مَلَكَ,to have only,唯有,VERB,B2
-مَلَّحَ,to pickle,腌渍,VERB,B2
-مَلَّصَ,to manipulate,操纵,VERB,B2
-مَنا,our,我们的,DET,B2
-مَنظومَة بِيئِيَّة,ecosystem,生态系统,NOUN,B2
-مَنَازِل,manor,庄园,NOUN,B2
-مَنَحَ,grant,拨款,NOUN,B2
-مَنَحَ,to grant,授予,VERB,B2
-مَنَعَ,to hinder,阻碍,VERB,B2
-مَنّ,bestowal,授予,NOUN,B2
-مَنّ,to bestow,授予,VERB,B2
-مَهْمَهَة,scruple,顾虑,NOUN,B2
-مَوضِع,location,地点,NOUN,B2
-مَوْجَة حَرّ,heat wave,热浪,NOUN,B2
-مَوْضُوع,theme,主题,NOUN,B2
-مَوْضُوع خَاصّ,special topic,专题,NOUN,B2
-مَيْل مُجْتَمَعِيّ,social trend,社会趋势,NOUN,B2
-مُؤَسِّس,founder,创始人,NOUN,B2
-مُؤَقَّت,tentative,暂定的,ADJ,B2
-مُؤَقَّتًا,temporarily,临时地,ADV,B2
-مُبَاهِج,grandiose,浮夸的,ADJ,B2
-مُبَكِّرًا,earlier,刚才,ADV,B2
-مُبْتَكِرٌ,innovative,创新的,ADJ,B2
-مُبْهِر,impressive,令人印象深刻的,ADJ,B2
-مُبْهِر,spectacular,壮观的,ADJ,B2
-مُتضاد المشاعر,ambivalent,矛盾的,ADJ,B2
-مُتَأَخِّر,overdue,逾期,ADJ,B2
-مُتَحَدِّث,spokesperson,发言人,NOUN,B2
-مُتَحَيِّز,tendentious,有偏见的,ADJ,B2
-مُتَخَصِّص,specialized,专业的,ADJ,B2
-مُتَدَرِّب,apprentice,学徒,NOUN,B2
-مُتَسَلِّط,bully,欺凌者,NOUN,B2
-مُتَضَادّ,inconsistent,不一致的,ADJ,B2
-مُتَعالٍ,outdated,过时的,ADJ,B2
-مُتَفَرِّج,spectator,观众,NOUN,B2
-مُتَمَسِّك,tenacious,顽强的,ADJ,B2
-مُتَنَاقِض,contradictory,矛盾的,ADJ,B2
-مُتَّسِخ,dirty,脏的,ADJ,B2
-مُتَّسِق,consistent,一致的,ADJ,B2
-مُتَّصِلٌ,inseparable,不可分割的,ADJ,B2
-مُجَرَّحٌ,injured,受伤的,ADJ,B2
-مُحتَقِن,allergic,过敏的,ADJ,B2
-مُحَاسِر,embarrassed,尴尬的,ADJ,B2
-مُحَسِّن,better,更好的,ADJ,B2
-مُحِبّ,in love,恋爱中的,ADJ,B2
-مُحْبَط,frustrated,沮丧的,ADJ,B2
-مُحْبِط,frustrating,令人沮丧的,ADJ,B2
-مُخِيب,disappointing,令人失望的,ADJ,B2
-مُخْتَلَف,controversial,有争议的,ADJ,B2
-مُدمِن,alcoholic,酗酒者,NOUN,B2
-مُدَمِّر,disastrous,灾难性的,ADJ,B2
-مُدِير,manager,经理,NOUN,B2
-مُدْرِبَة,apprenticeship,学徒期,NOUN,B2
-مُذهِل,amazing,令人惊叹的,ADJ,B2
-مُراقِب,lookout,瞭望,NOUN,B2
-مُرَبَّع,square,平方的,ADJ,B2
-مُرْعِب,terrifying,令人恐惧的,ADJ,B2
-مُزعَم,alleged,所谓的,ADJ,B2
-مُزْعِج,unpleasant,令人不快的,ADJ,B2
-مُسَاعِد,helpful,有帮助的,ADJ,B2
-مُسَرِّع,accelerator,油门,NOUN,B2
-مُسَلَّح,armed,武装的,ADJ,B2
-مُسِنّ,elderly,老年人,NOUN,B2
-مُسْتَحْيٍ,ashamed,羞愧的,ADJ,B2
-مُسْتَخِيب,disappointed,失望的,ADJ,B2
-مُسْتَشَار,consultant,顾问,NOUN,B2
-مُسْتَعْجِل,impatient,不耐烦的,ADJ,B2
-مُسْتَقِرّ,stable,稳定的,ADJ,B2
-مُسْتَهْجِن,indignant,愤慨的,ADJ,B2
-مُصنِّف للأشجار,classifier for trees,棵,NUM,B2
-مُصنِّف للوحات والقماش إلخ,classifier for paintings cloth etc.,幅,NUM,B2
-مُصَنِّع,manufacturer,制造商,NOUN,B2
-مُضْحِك,hilarious,滑稽的,ADJ,B2
-مُطْلَق,absolute,绝对的,ADJ,B2
-مُطْلَقاً,absolutely,绝对地,ADV,B2
-مُعَاصِر,contemporary,当代的,ADJ,B2
-مُعَانِد,willful,任性的,ADJ,B2
-مُعَيَّن,certain,某些,DET,B2
-مُعِين,benefactor,恩人,NOUN,B2
-مُفَاجَأ,sudden,突然的,ADJ,B2
-مُفِيد,useful,有用的,ADJ,B2
-مُفْعِل,efficient,高效的,ADJ,B2
-مُقلِق,alarming,令人担忧的,ADJ,B2
-مُقَدِّم الوَظْع,pace-setter,标兵,NOUN,B2
-مُكْتَنِز,packed,打包,ADJ,B2
-مُلْزِم,imperative,必要的,ADJ,B2
-مُلْمِح,allusive,暗指的,ADJ,B2
-مُمَارَسَة مُجْتَمَعِيَّة,social practice,社会实践,NOUN,B2
-مُمَنَع,illegal,非法的,ADJ,B2
-مُمَنَعِيَّة,illegality,非法,NOUN,B2
-مُنَاسِب,appropriate,适当的,ADJ,B2
-مُنَاسِب,suitable,合适的,ADJ,B2
-مُنَافَسَة,contest,比赛,NOUN,B2
-مُنْذُ الآن,from now on,今后,ADV,B2
-مُنْذُ الطُّفُولَة,from childhood,从小,ADV,B2
-مُنْصِف,disinterested,公正的,ADJ,B2
-مُنْفَجِر,explosive,炸药,NOUN,B2
-مُهَاجِر,immigrant,移民,NOUN,B2
-مُوَاكَبَة,see off,送走,NOUN,B2
-مِثْل,such,这样的,ADJ,B2
-مِخَدَّة,cushion,垫子,NOUN,B2
-مِعْمَارِي,architect,建筑师,NOUN,B2
-مِلْيَار,billion,十亿,NUM,B2
-مِن,out of,从...出来,ADP,B2
-مِنْ,from,来自,ADP,B2
-مِنْ,than,比,ADP,B2
-نائب,deputy,副的,ADJ,B2
-نادلة,waitress,女服务员,NOUN,B2
-نازي,nazi,纳粹分子,NOUN,B2
-ناضج,ripe,成熟的,ADJ,B2
-نافس,to compete,竞争,VERB,B2
-نافس,to vie,竞争,VERB,B2
-ناقش,to debate,辩论,VERB,B2
-نام,to fall asleep,入睡,VERB,B2
-ناوب,to be on duty,值班,VERB,B2
-ندم,to regret,后悔,VERB,B2
-نذر,vow,誓言,NOUN,B2
-نزهة,picnic,野餐,NOUN,B2
-نزول,descent,下降,NOUN,B2
-نسبة,proportion,比例,NOUN,B2
-نسبة مئوية,percent,百分比,NOUN,B2
-نسبياً,relatively,相对地,ADV,B2
-نسبياً,relatively speaking,相对而言,ADV,B2
-نسخة احتياطية,backup,备份,NOUN,B2
-نسخة طبق الأصل,facsimile,副本,NOUN,B2
-نسوية,feminism,女权主义,NOUN,B2
-نسيج,fabric,织物,NOUN,B2
-نشأ,to originate,发源,VERB,B2
-نشأة,genesis,起源,NOUN,B2
-نشر,deployment,部署,NOUN,B2
-نشر,publication,出版物,NOUN,B2
-نشر,to deploy,部署,VERB,B2
-نشر,to diffuse,扩散,VERB,B2
-نشر,to publish,出版,VERB,B2
-نصب تذكاري,memorial,纪念碑,NOUN,B2
-نصف,half,一半的,ADJ,B2
-نظام,regime,政权,NOUN,B2
-نظام عام,public order,治安,NOUN,B2
-نظام مضاد,counter-system,反系,NOUN,B2
-نظام معدّل,modified system,改系,NOUN,B2
-نظم,to organize,组织,VERB,B2
-نظير,counterpart,对应的人或物,NOUN,B2
-نظيف,clean,干净的,ADJ,B2
-نظّف,to clean up,清理,VERB,B2
+ظروف,situation circumstances,情形,NOUN,B2
+حجم,size,尺寸,NOUN,B2
+تزلج,to skate,滑冰,VERB,B2
+هيكل عظمي,skeleton,骨架,NOUN,B2
+تزلج على الجليد,to ski,滑雪,VERB,B2
+افترى,slander,诽谤,NOUN,B2
+افترى,to slander,诽谤,VERB,B2
+صفعة,slap,拍击,NOUN,B2
+ذبح,slaughter,屠杀,NOUN,B2
+عبد,slave,奴隶,NOUN,B2
+كم,sleeve,袖子,NOUN,B2
+شريحة,slice,薄片,NOUN,B2
+قليلاً,slightly,轻微地,ADV,B2
 نعال,slipper,拖鞋,NOUN,B2
-نعل مضاد,counter-sole,反唯,NOUN,B2
-نعم,yes,是啊,NOUN,B2
-نفذ,to carry out,实施,VERB,B2
-نفذ,to execute,执行,VERB,B2
-نفس,oneself,自己,PRON,B2
-نفسي,myself,我自,NOUN,B2
-نفسي,only-me,只我,NOUN,B2
-نفع,to be useful,有用,VERB,B2
-نفى,to banish,流放,VERB,B2
-نقدي,monetary,金钱的,ADJ,B2
-نقص,decrease,减少,NOUN,B2
-نقل,to carry forward,发扬,VERB,B2
-نقل,to convey,传达,VERB,B2
-نقي,pure,纯净的,ADJ,B2
-نموذج,model,模型,NOUN,B2
-نموذج مضاد,counter-model,反模,NOUN,B2
-نموذج معدّل,modified model,改模,NOUN,B2
-نهائي,final,最终的,ADJ,B2
-نهاراً,during the day,在白天,ADV,B2
-نهاية,end,端,PART,B2
-نوتة,musical score,乐谱,NOUN,B2
-نوع,genre,类型,NOUN,B2
-نوع مضاد,counter-type,反型,NOUN,B2
+زلق,slippery,滑的,ADJ,B2
+خامل,sluggish,迟钝的,ADJ,B2
+صِغَر,smallness,小小,NOUN,B2
+حَطَّمَ,to smash,粉碎,VERB,B2
+حَطْم,smashing,砸过,NOUN,B2
+خَبَرَة,smattering,少量,NOUN,B2
+سَلِسًا,smoothly,顺利,ADV,B2
+سُنْبُكَة,snack,小吃,NOUN,B2
+خَطَفَ,to snatch,抢夺,VERB,B2
+تَسَلَّلَ,to sneak,潜行,VERB,B2
+تَشَمَّمَ,to sniff,嗅,VERB,B2
+أَنْف,snout,口鼻,NOUN,B2
+ظِلّ ثَلْج,snow shadow,雪影姐姐,NOUN,B2
+نَخْلَة ثَلْج,snowflake,雪花,NOUN,B2
+كَذَلِكَ,so,所以,ADV,B2
+حَتَّى الآن,so far,到目前为止,ADV,B2
+كَثِير,so much,这么多,ADV,B2
+لِكَيْ,so that,以便,SCONJ,B2
+المَدْعُوّ,so-called,所谓的,ADJ,B2
+سَكِيت,sober,清醒的,ADJ,B2
+تَحَكُّم مُجْتَمَعِيّ,social arbitration,社会仲裁,NOUN,B2
+سَيْقَظَة مُجْتَمَعِيَّة,social awakening,社会觉醒,NOUN,B2
+تَوَاصُل مُجْتَمَعِيّ,social compromise,社会妥协,NOUN,B2
+تَبَاعُد مُجْتَمَعِيّ,social distancing,社交距离,NOUN,B2
+تَوَافُق مُجْتَمَعِيّ,social harmony,社会和谐,NOUN,B2
+هُوِيَّة مُجْتَمَعِيَّة,social identity,社会身份,NOUN,B2
+تَفَاعُل مُجْتَمَعِيّ,social interaction,社会互动,NOUN,B2
+تَحَرُّك مُجْتَمَعِيّ,social mobilization,社会动员,NOUN,B2
+تَنَظِيم مُجْتَمَعِيّ,social organization,社会组织,NOUN,B2
+مُمَارَسَة مُجْتَمَعِيَّة,social practice,社会实践,NOUN,B2
+تَصَالُح مُجْتَمَعِيّ,social reconciliation,社会和解,NOUN,B2
+اسْتِقْرَار مُجْتَمَعِيّ,social stability,社会稳定,NOUN,B2
+إِحْصَاءَات مُجْتَمَعِيَّة,social statistics,社会统计,NOUN,B2
+تَطَبُّق مُجْتَمَعِيّ,social stratification,社会分层,NOUN,B2
+مَيْل مُجْتَمَعِيّ,social trend,社会趋势,NOUN,B2
+ثِقَة مُجْتَمَعِيَّة,social trust,社会信任,NOUN,B2
+تَقَلُّس,spasm,痉挛,NOUN,B2
+مَوْضُوع خَاصّ,special topic,专题,NOUN,B2
+مُتَخَصِّص,specialized,专业的,ADJ,B2
+تَخَصُّص,specialty,专业,NOUN,B2
+نَوْع,species,物种,NOUN,B2
+خَاصّ,specific,具体的,ADJ,B2
+تَعْيِين,to specify,具体说明,VERB,B2
+عَيِّنَة,specimen,标本,NOUN,B2
+نَظَّارَة,spectacles,眼镜,NOUN,B2
+مُبْهِر,spectacular,壮观的,ADJ,B2
+مُتَفَرِّج,spectator,观众,NOUN,B2
+سِحْر,spell,咒语,NOUN,B2
+تَدْوِير,to spin,旋转,VERB,B2
+رُوح,spirit,精神,NOUN,B2
+تَدْرِيب الرُّوح,spirit training,练神,NOUN,B2
+بَاهِر,splendid,极好的,ADJ,B2
+تَشْطِير,to split,分裂,VERB,B2
+مُتَحَدِّث,spokesperson,发言人,NOUN,B2
+سَيَّارَة رِيَاضِيَّة,sports car,跑车,NOUN,B2
+زَوْج,spouse,配偶,NOUN,B2
+حَثّ,to spur,激励,VERB,B2
+فِرْقَة,squad,小队,NOUN,B2
+تَبْذِير,to squander,浪费,VERB,B2
+مُرَبَّع,square,平方的,ADJ,B2
+طَعْن,to stab,刺,VERB,B2
+تَثْبِيت,to stabilize,使稳定,VERB,B2
+مُسْتَقِرّ,stable,稳定的,ADJ,B2
+طاقم,staff,全体员工,NOUN,B2
+رُكُود,to stagnate,停滞,VERB,B2
+بُقْعَة,stain,污渍,NOUN,B2
+سَهْم,stake,利害关系,NOUN,B2
+وَقُوف,to stand,站立,VERB,B2
+تَمَيُّز,to stand out,引人注目,VERB,B2
+وَقُوف جَانِبًا بِجَانِب,to stand side by side,并列,VERB,B2
+مَعْيَار,standard,标准,NOUN,B2
+خَضَعَ,to succumb,屈服,VERB,B2
+مِثْل,such,这样的,ADJ,B2
+مَصَّ,to suck,吸,VERB,B2
+مُفَاجَأ,sudden,突然的,ADJ,B2
+دَعَا,to sue,起诉,VERB,B2
+عَانَى,to suffer from insomnia,失眠,VERB,B2
+خَنَقَ,to suffocate,窒息,VERB,B2
+اِنتِحَار,suicide,自杀,NOUN,B2
 نَاسَبَ,suit,西装,NOUN,B2
 نَاسَبَ,to suit,适合,VERB,B2
-نَافُورَة,fountain,喷泉,NOUN,B2
-نَاقَضَ,to contradict,反驳,VERB,B2
-نَبَشَ,to exhume,掘出,VERB,B2
-نَبْض,heartbeat,心跳,NOUN,B2
-نَجْوَى,whisper,低语,NOUN,B2
-نَحْنُ,us,我们,PRON,B2
-نَخْلَة ثَلْج,snowflake,雪花,NOUN,B2
-نَزَعَ,to expropriate,征用,VERB,B2
-نَزَلَ,to disembark,下船,VERB,B2
-نَزَلَ,to go down,下去,VERB,B2
-نَزْعَة,seizure,没收,NOUN,B2
-نَزْلٌ,inn,小旅馆,NOUN,B2
-نَسِيّ,forgetful,健忘的,ADJ,B2
-نَشَأَ,to grow up,成长,VERB,B2
-نَظَبَة قَلْب,heart attack,心脏病发作,NOUN,B2
-نَظَر,look at you,你看你,NOUN,B2
-نَظَرَ,to look at,观看,VERB,B2
-نَظَرَ,to look up,查阅,VERB,B2
-نَظَرَة,outlook,前景,NOUN,B2
-نَظَّارَة,glasses,眼镜,NOUN,B2
-نَظَّارَة,spectacles,眼镜,NOUN,B2
-نَظْرِيًّا,theoretically,理论上,ADV,B2
-نَعَى,to whine,哀叹,VERB,B2
-نَفَى,exile,流亡,NOUN,B2
-نَفَى,to exile,流放,VERB,B2
-نَفَّذَ,to implement,实施,VERB,B2
-نَقَصَ,to discredit,败坏名声,VERB,B2
-نَقَصَ,to lose weight,减肥,VERB,B2
-نَقَلَ,to transport,运输,VERB,B2
-نَقْل إِلَيْك,transmission to you,传你,NOUN,B2
-نَهْر جَليديّ,glacier,冰川,NOUN,B2
-نَوْع,kind,仁慈的,ADJ,B2
-نَوْع,species,物种,NOUN,B2
-نَوْع ثَقِيل,heavy type,重型,NOUN,B2
-نِعْمَة,grace,优雅,NOUN,B2
-نِيَّة مُخَالِفَة,contrary intention,反意,NOUN,B2
-ها,ha,哈,INTJ,B2
-هاجر,to migrate,迁移,VERB,B2
-هادئ,quiet,安静的,ADJ,B2
-هبط,to relegate,降级,VERB,B2
-هبّة,gust,阵风,NOUN,B2
-هجوم صعب,difficult attack,难攻,NOUN,B2
-هجوم مضاد,counterattack,反击,NOUN,B2
-هدأ,to cool down,冷却,VERB,B2
-هدد,to endanger,危及,VERB,B2
-هدم,to demolish,拆除,VERB,B2
-هستيري,hysterical,歇斯底里的,ADJ,B2
-هضم,to digest,消化,VERB,B2
-همس,murmur,低语,NOUN,B2
-هندسة,geometry,几何学,NOUN,B2
-هه,huh,哈,INTJ,B2
-هو,it,它,PRON,B2
-هورا,hurrah,万岁,INTJ,B2
-هوكي الجليد,ice hockey,冰球,NOUN,B2
-هولندي,dutch,荷兰的,ADJ,B2
-هيكل عظمي,skeleton,骨架,NOUN,B2
-هيكل مضاد,counter-structure,反结,NOUN,B2
-هَاتِف جَوَّال,cell phone,手机,NOUN,B2
-هَاجَرَ,to immigrate,移入,VERB,B2
-هَادِئ,tranquil,宁静的,ADJ,B2
-هَادِئ,unruffled,从容,ADJ,B2
-هَبَطَ,land,土地,NOUN,B2
-هَبَطَ,to land,着陆,VERB,B2
-هَجَرَ,to abandon,放弃,VERB,B2
-هَرَب,escape,逃跑,NOUN,B2
-هَرَب,to escape,逃跑,VERB,B2
-هَزِيمَة ساحِقَة,crushing defeat,惨败,NOUN,B2
-هَلْو,hi,嗨,INTJ,B2
-هَمَلَ,to nag,唠叨,VERB,B2
-هَهْهَهْ,hehe,嘿嘿,INTJ,B2
-هَوَس,whim,突发奇想,NOUN,B2
-هَي,hey,嘿,INTJ,B2
-هَيِّن,trivial,琐碎的,ADJ,B2
-هَيِّنَة,trifle,琐事,NOUN,B2
+مُنَاسِب,suitable,合适的,ADJ,B2
+حَقِيبَة,suitcase,手提箱,NOUN,B2
+مَجْمُوع,sum,总和,NOUN,B2
+فَخِيم,sumptuous,奢华的,ADJ,B2
+اَلأَحَد,sunday,星期日,NOUN,B2
+شُعَاع,sunshine,阳光,NOUN,B2
+فَوْقَ الشُّمُول,super-comprehensive,超遍,NOUN,B2
+فَوْقَ الدَّرَجَة,super-grade,超级,NOUN,B2
+فَوْقَ المَبْدَأ,super-principle,超则,NOUN,B2
+فَوْقَ الجَوَاء,super-quality,超质,NOUN,B2
+فَوْقَ النَّظَام,super-system,超制,NOUN,B2
+فَوْقَ الفِكْر,super-thought,超思,NOUN,B2
+زَائِد,superfluous,多余的,ADJ,B2
+رَئِيس,superior,更好的,ADJ,B2
+سُوْق كَبِير,supermarket,超市,NOUN,B2
+خَارِق,supernatural,超自然的,ADJ,B2
+رَاقَبَ,to supervise,监督,VERB,B2
+أَكْمَلَ,supplement,补充,NOUN,B2
+أَكْمَلَ,to supplement,补充,VERB,B2
+ظَنَّ,to suppose,假设,VERB,B2
+قَمَعَ,to suppress,压制,VERB,B2
+لَقَب,surname,姓氏,NOUN,B2
+فَاجَأَ,to surprise,使惊讶,VERB,B2
+زَمَنِيّ,temporal,时间的,ADJ,B2
+مُؤَقَّتًا,temporarily,临时地,ADV,B2
+رَفْضٌ مُؤَقَّت,temporary refusal,暂不,NOUN,B2
+مُتَمَسِّك,tenacious,顽强的,ADJ,B2
+مُتَحَيِّز,tendentious,有偏见的,ADJ,B2
+طَرِيّ,tender,嫩的,ADJ,B2
+لَحْمُ الفَخِذ,tenderloin,里脊,NOUN,B2
+مُؤَقَّت,tentative,暂定的,ADJ,B2
+أَنْهَى,to terminate,终止,VERB,B2
+أَرْض,terrain,地形,NOUN,B2
+رَدِيء,terrible,可怕的,ADJ,B2
+مُرْعِب,terrifying,令人恐惧的,ADJ,B2
+أَرْض,territory,领土,NOUN,B2
+خَبَرَ,to test,测试,VERB,B2
+شَهِدَ,to testify,作证,VERB,B2
+رِسَالَة نَصِّيَّة,text message,短信,NOUN,B2
+كِتَاب دِرَاسِيّ,textbook,教科书,NOUN,B2
+مِنْ,than,比,ADP,B2
+شُكْر,thanks,谢谢,INTJ,B2
+بِسَبَب,thanks to,多亏,ADP,B2
+ذَلِكَ,that,那个,PRON,B2
+تِلْكَ السَّهْم,that arrow,那一箭,NOUN,B2
+أَيْ,that is,即,ADV,B2
+بِذَلِكَ,that way,那样,PRON,B2
+ذَابَ,to thaw,解冻,VERB,B2
+الْ,the,这,DET,B2
+الْبَاقِي,the rest,其余,NOUN,B2
+لَهُمْ,their,他们的,PRON,B2
 هُمْ,them,他们,PRON,B2
-هُناكَ,over there,在那边,ADV,B2
-هُنَا,here,此地,NOUN,B2
+مَوْضُوع,theme,主题,NOUN,B2
+أَنْتَ,then you,那你,PRON,B2
+نَظْرِيًّا,theoretically,理论上,ADV,B2
+عِلاج,therapy,治疗,NOUN,B2
 هُنَاكَ,there,那儿,NOUN,B2
-هُوَ,his,他的,DET,B2
-هُوَ,him,他吧,NOUN,B2
-هُوَّة,abyss,深渊,NOUN,B2
-هُوِيَّة مُجْتَمَعِيَّة,social identity,社会身份,NOUN,B2
-هِجْرَة,immigration,移民,NOUN,B2
-وإلا,otherwise,否则,ADV,B2
-واجب,duty,责任,NOUN,B2
-واجه,to encounter,遭遇,VERB,B2
-وادٍ,canyon,峡谷,NOUN,B2
-وازن,to balance,平衡,VERB,B2
-واضح,obvious,明显的,ADJ,B2
-واعد,date,日期,NOUN,B2
-واعد,to date,注明日期,VERB,B2
-واقعي,realistic,现实的,ADJ,B2
-وجهة نظر,viewpoint,观点,NOUN,B2
-وحده,alone,独自,ADV,B2
-وحش,monster,怪物,NOUN,B2
-وراثة,genetics,遗传学,NOUN,B2
-ورث,to inherit,继承,VERB,B2
-ورقة نقدية,banknote,钞票,NOUN,B2
-وزارة,ministry,部,NOUN,B2
-وزير,minister,臣,PART,B2
-وسع,to dilate,膨胀,VERB,B2
-وسيط,medium,媒介,NOUN,B2
-وسيم,handsome,帅气的,ADJ,B2
-وسّع,to enlarge,扩大,VERB,B2
-وضع,to put down,放下,VERB,B2
-وطني,patriotic,爱国的,ADJ,B2
-وظف,to employ,雇用,VERB,B2
-وعاء,bowl,碗,NOUN,B2
+تَقْلِيد,tradition,传统,NOUN,B2
+مَرُور,traffic,交通,NOUN,B2
+تَقْيِيد المَرُور,traffic restriction,限行,NOUN,B2
+مَسِيحِيّ,tragic,悲剧的,ADJ,B2
+سِلْسِلَة أَفْكَار,train of thought,思路,NOUN,B2
+مَحَطَّة القِطَار,train station,火车站,NOUN,B2
+صِفَة,trait,特征,NOUN,B2
+دَاسَ,to trample,踩踏,VERB,B2
+هَادِئ,tranquil,宁静的,ADJ,B2
+قَرَار عَابِر,trans-decision,超断,NOUN,B2
+ضَيْف عَابِر,trans-guest,超客,NOUN,B2
+أَمْر عَابِر,trans-matter,超物,NOUN,B2
+حَوَّلَ,to transform,改变,VERB,B2
+نَقْل إِلَيْك,transmission to you,传你,NOUN,B2
+أَرْسَلَ,to transmit,传输,VERB,B2
+شَفَّاف,transparent,透明的,ADJ,B2
+نَقَلَ,to transport,运输,VERB,B2
+فَخّ,trap,陷阱,NOUN,B2
+قَمَامَة,trash,垃圾,NOUN,B2
+تَعَب السَّفَر,travel fatigue,车马劳顿,NOUN,B2
+مَشَى,to tread,踏上,VERB,B2
+خِيَانَة,treason,叛国罪,NOUN,B2
+كَنْز,treasure,财宝,NOUN,B2
+ضَافَ,to treat guests,请客,VERB,B2
+مَدْح,tribute,贡品,NOUN,B2
+خَدَعَ,to trick,欺骗,VERB,B2
+هَيِّنَة,trifle,琐事,NOUN,B2
+أَوْقَدَ,trigger,触发器,NOUN,B2
+أَوْقَدَ,to trigger,触发,VERB,B2
+رِحْلَة,trip,旅行,NOUN,B2
+هَيِّن,trivial,琐碎的,ADJ,B2
+فِرْقَة,troop,部队,NOUN,B2
+جُنُود,troops,部队,NOUN,B2
+كَأْس,trophy,奖杯,NOUN,B2
+أزعجَ,to trouble,有劳,VERB,B2
+مُزْعِج,unpleasant,令人不快的,ADJ,B2
+غَيْرُ مُتَوَقَّع,unpredictable,不可预测的,ADJ,B2
+غَيْرُ مُعْقُول,unreasonable,不合理的,ADJ,B2
+اضطِراب,unrest,动荡,NOUN,B2
+هَادِئ,unruffled,从容,ADJ,B2
+غَيْرُ مُسْتَقِرّ,unstable,不稳定的,ADJ,B2
+فَكَّ,to untie,解开,VERB,B2
+حَتَّى,until,直到,ADP,B2
+غَيْرُ عَادِيّ,unusual,不寻常的,ADJ,B2
+حَفْلُ كَشْف,unveiling ceremony,揭幕仪式,NOUN,B2
+تَرَدُّد,unwillingness,不甘,NOUN,B2
+حَقَارَة,unworthy,你不配,NOUN,B2
+فَوْق,up,向上,ADV,B2
+حَتَّى,up to,为止,ADP,B2
+حَدَّثَ,to update,更新,VERB,B2
+طَوَّرَ,to upgrade,升级,VERB,B2
+رَفَعَ,to upload,上传,VERB,B2
+أزعَجَ,to upset,使生气,VERB,B2
+اِرْتِفَاع,upturn,好转,NOUN,B2
+نَحْنُ,us,我们,PRON,B2
+صَالِح,usable,可用的,ADJ,B2
+اسْتَخْدَمَ عِصِيّ الأَكْل,to use chopsticks,动筷,VERB,B2
+اسْتَخْدَمَ عَصَا,to use crutches,拄拐,VERB,B2
+مُفِيد,useful,有用的,ADJ,B2
+غَيْرُ مُفِيد,useless,无用的,ADJ,B2
+عَادِيّ,usual,通常的,ADJ,B2
+عَادَةً,usually,通常,ADV,B2
+اسْتَغَلَّ,to utilize,利用,VERB,B2
+طَعَّمَ,to vaccinate,接种疫苗,VERB,B2
+مَصّاص دَم,vampire,吸血鬼,NOUN,B2
+شاحِنَة,van,货车,NOUN,B2
+غُرُور,vanity,虚荣,NOUN,B2
+أَقْسَام مُخْتَلِفَة,various departments,各部,NOUN,B2
+شَاسِع,vast,巨大的,ADJ,B2
+خَزْنَة,vault,金库,NOUN,B2
+خضار,vegetable,蔬菜,NOUN,B2
+حديقة خضروات,vegetable garden,果园,NOUN,B2
+تسجيل مركبة,vehicle registration,行驶证,NOUN,B2
+انتقام,vengeance,报复,NOUN,B2
+مكان,venue,场地,NOUN,B2
+مطنب,verbose,冗长的,ADJ,B2
+حكم,verdict,裁决,NOUN,B2
+آفة,vermin,害兽,NOUN,B2
 وعاء,vessel,船,NOUN,B2
-وفي,faithful,忠诚的,ADJ,B2
-وقاحة,brazenness,厚颜无耻,NOUN,B2
-وقع,to be located,位于,VERB,B2
-وقّر,to revere,尊敬,VERB,B2
-وكيل,proxy,代理人,NOUN,B2
-وهب,to endow,赋予,VERB,B2
-وودانغ,wudang,武当,NOUN,B2
-وَأَفَّقَ,to approve,批准,VERB,B2
-وَاجِب,have to,还得,NOUN,B2
-وَاسِع,expansive,扩张的,ADJ,B2
-وَاسِع,large-scale,大规模的,ADJ,B2
-وَجَّهَ,direct,直接的,ADJ,B2
-وَجَّهَ,to channel,疏导,VERB,B2
-وَجَّهَ,to direct,对准,VERB,B2
-وَحيد,lonely,孤独的,ADJ,B2
-وَحْدَة,loneliness,孤独,NOUN,B2
-وَدَاعاً,goodbye,再见,INTJ,B2
-وَدُود,friendly,友好的,ADJ,B2
-وَسَخ,grime,污垢,NOUN,B2
-وَسَّعَ,to expand,扩大,VERB,B2
+سترة,vest,背心,NOUN,B2
+مخضرم,veteran,老手,NOUN,B2
+بالعكس,vice versa,反之亦然,ADV,B2
+قرص فيديو,video disc,影碟,NOUN,B2
+تسجيل فيديو,video recording,录像,NOUN,B2
+نافس,to vie,竞争,VERB,B2
+منظر,view,观点,NOUN,B2
+وجهة نظر,viewpoint,观点,NOUN,B2
+حيوية,vigor,活力,NOUN,B2
+عمدة القرية,village head,村长,NOUN,B2
+كرمة,vine,藤蔓,NOUN,B2
+خالف الانضباط,to violate discipline,违纪,VERB,B2
+عذراء,virgin,处女,NOUN,B2
+عمليا,virtually,几乎,ADV,B2
+زائر,visitor,访客,NOUN,B2
+حي,vivid,生动的,ADJ,B2
+طوعي,voluntary,自愿的,ADJ,B2
+قسيمة,voucher,代金券,NOUN,B2
+نذر,vow,誓言,NOUN,B2
+مبتذل,vulgar,粗俗的,ADJ,B2
+شن حرب,to wage war,作战,VERB,B2
+انتظار,wait,等待,NOUN,B2
+انتظاري,wait for me,等我,NOUN,B2
+انتظر طويلا,to wait long,久等,VERB,B2
+غرفة انتظار,waiting room,候诊室,NOUN,B2
+نادلة,waitress,女服务员,NOUN,B2
+غَرِيب,weird,奇怪的,ADJ,B2
+غَرِيب,weirdo,怪人,NOUN,B2
+أَهْلَى,welcome,受欢迎的,ADJ,B2
+أَهْلَى,to welcome,欢迎,VERB,B2
+حَفْل تَرْحِيب,welcome banquet,欢迎宴,NOUN,B2
+رَفَاهِيَة,welfare,福利,NOUN,B2
+حَسَنًا,well,好,ADV,B2
+الْمِنْطَقَات الْغَرْبِيَّة,western regions,西域,NOUN,B2
+أَرْض رَطْبَة,wetland,湿地,NOUN,B2
+مَا,what,什么,ADV,B2
+إِلَى أَيِّ دَرَجَة,what extent,在何种程度上,ADV,B2
+كُرْسِيّ مُعَوِّق,wheelchair,轮椅,NOUN,B2
+مَحَلّ,whereabouts,行踪,NOUN,B2
+بِذَلِكَ,whereby,其中,ADV,B2
+سَوَاء,whether,能否,NOUN,B2
+سَوَاء أَمْ,whether or not,是否,SCONJ,B2
+أَيّ,which,哪个,DET,B2
+أَيّ,which one,哪一个,PRON,B2
+فْتَرَة,while,一会儿,NOUN,B2
+هَوَس,whim,突发奇想,NOUN,B2
+نَعَى,to whine,哀叹,VERB,B2
+جَلَدَ,to whip,鞭打,VERB,B2
+نَجْوَى,whisper,低语,NOUN,B2
+صَفَّرَ,to whistle,吹口哨,VERB,B2
+الْعَالَم كُلُّهُ,whole world,全世界,NOUN,B2
+جُمْلَة,wholesale,批发,NOUN,B2
+الَّذِي,whose,谁的,PRON,B2
 وَسَّعَ,to widen,加宽,VERB,B2
-وَصِيَّة الأَب الإِمَاري,imperial father's will,父皇要,NOUN,B2
-وَضَعَ,to place,放置,VERB,B2
-وَقُوف,to stand,站立,VERB,B2
-وَقُوف جَانِبًا بِجَانِب,to stand side by side,并列,VERB,B2
-وَقْت فَرَاغ,free time,业余时间,NOUN,B2
-وَكَذَلِكَ,as well as,以及,CCONJ,B2
-وُجِدَ,to exist,存在,VERB,B2
-وِظِيفِي,functional,功能的,ADJ,B2
-وِظِيفِيَّة,functionality,功能性,NOUN,B2
-ي,my,我的,DET,B2
-يا للأسف,alas,唉,INTJ,B2
-يائس,desperate,绝望的,ADJ,B2
-ياباني,japanese,日本人,NOUN,B2
+عَرْض,width,宽度,NOUN,B2
+بَرِّي,wild,野生的,ADJ,B2
+مُعَانِد,willful,任性的,ADJ,B2
+مستعد,willing,乐意的,ADJ,B2
+استعداد,willingness,乐意,NOUN,B2
+لف,to wind,缠绕,VERB,B2
+زجاج النافذة,window glass,窗玻璃,NOUN,B2
+مقاوم للرياح,windproof,挡风的,ADJ,B2
+كأس خمر,wine cup,这酒盏,NOUN,B2
+فائز,winner,获胜者,NOUN,B2
+مسح,to wipe,擦,VERB,B2
+ممسحة,wiper,雨刷,NOUN,B2
+سلك,wire,电线,NOUN,B2
+حكيم,wise,明智的,ADJ,B2
+ساحرة,witch,女巫,NOUN,B2
+منع,to withhold,扣留,VERB,B2
+داخل,within,在……之内,ADP,B2
+شهادة,witness testimony,人证,NOUN,B2
+عقل,wits,心眼,NOUN,B2
+ذكي,witty,机智的,ADJ,B2
+ساحر,wizard,巫师,NOUN,B2
+تمايل,to wobble,摇晃,VERB,B2
+لا يصلح,won't do,不行,ADJ,B2
+لا يصلح,to won't do,不成,VERB,B2
+فطر الأذن الخشبية,wood ear mushroom,木耳,NOUN,B2
+غابة,woodland,林地,NOUN,B2
+اجتهد,to work hard for sth to strive for success,争气,VERB,B2
+تمرن,to work out,成功,VERB,B2
+مكان العمل,workplace,工作场所,NOUN,B2
+حرب عالمية,world war,世界大战,NOUN,B2
+رؤية للعالم,worldview,世界观,NOUN,B2
+عالمي,worldwide,全世界的,ADJ,B2
+أسوأ,worse,更糟的,ADJ,B2
+ساء,to worsen,恶化,VERB,B2
+عبد,to worship,崇拜,VERB,B2
+الأسوأ,worst,最坏的,ADJ,B2
+ذو قيمة,worth,值得的,ADJ,B2
+جدير,worthy,值得的,ADJ,B2
+جرح,to wound,使受伤,VERB,B2
+لف,to wrap,包裹,VERB,B2
+تغليف,wrapping,包装,NOUN,B2
+غضب,wrath,愤怒,NOUN,B2
+حطام,wreck,残骸,NOUN,B2
+تجعد,wrinkle,皱纹,NOUN,B2
+مقاوم للتجعد,wrinkle-resistant,防皱,ADJ,B2
+خطأ,wrong,错误的事,NOUN,B2
+مخطئ,wrong mistake,错误,ADJ,B2
+وودانغ,wudang,武当,NOUN,B2
 ياردة,yard,院子,NOUN,B2
-يافع,youngster,年少者,NOUN,B2
-يتصدع,to crack,破裂,VERB,B2
-يتعامل,handle,把手,NOUN,B2
-يتعامل,to handle,处理,VERB,B2
-يتعطل,to break down,分解,VERB,B2
-يتفكك,to break up,破裂,VERB,B2
-يتناوب,to alternate,交替,VERB,B2
-يتوج,crown,王冠,NOUN,B2
-يتوج,to crown,加冕,VERB,B2
-يتوقف,to halt,停止,VERB,B2
-يتوهم,to pretend,假装,VERB,B2
-يتوهم أنه,to pretend to be,冒充,VERB,B2
-يجب,must,必须,AUX,B2
-يجهز درساً,to prepare a lesson,预习,VERB,B2
-يحجز,to book,预订,VERB,B2
-يحرس,to guard,看守,VERB,B2
-يحفظ,to preserve,保护,VERB,B2
-يخلق,to create,创造,VERB,B2
-يزعج,bother,麻烦,NOUN,B2
-يزعج,to bother,打扰,VERB,B2
-يسلّم,to hand over,交付,VERB,B2
-يسود,to prevail,盛行,VERB,B2
 يشتاق إلى,to yearn for,渴望,VERB,B2
-يشم,jade,这玉,NOUN,B2
+سنوات,years,数年,NOUN,B2
 يصرخ,to yell,大吼,VERB,B2
-يصف,to prescribe,开处方,VERB,B2
-يضغط,to press,按,VERB,B2
-يضمن,to guarantee,保证,VERB,B2
-يعرض,present,在场的,ADJ,B2
-يعرض,to present,呈现,VERB,B2
-يعني,to concern,涉及,VERB,B2
-يفاخر,to brag,吹嘘,VERB,B2
-يفاوض,to haggle,讨价还价,VERB,B2
-يفترض,to presume,假定,VERB,B2
-يفرمل,brake,刹车,NOUN,B2
-يفرمل,to brake,刹车,VERB,B2
-يقرفص,to crouch,蹲下,VERB,B2
-يقصف,to bombard,轰炸,VERB,B2
-يقطع,to hack,入侵；盗版,VERB,B2
-يكسر,to break open,撬开,VERB,B2
+نعم,yes,是啊,NOUN,B2
+أمس,yesterday,昨天,ADV,B2
+بعد,yet,还,ADV,B2
+أنت,you,你,PRON,B2
 يمكنك,you can,您能,NOUN,B2
-يمل,to bore,使厌烦,VERB,B2
-ينقض عقد,to breach contract,违约,VERB,B2
-يهودي,jew,犹太人,NOUN,B2
+لا يمكنك العيش,you cannot live,你也活不,NOUN,B2
+حضرتك,you polite,您,PRON,B2
+شاب,young,年轻的,ADJ,B2
+سيدة شابة,young lady,小姐,NOUN,B2
+شاب,young man,年轻人,NOUN,B2
+سيد شاب,young master,少庄主,NOUN,B2
+شاب,young person,年轻人,NOUN,B2
+يافع,youngster,年少者,NOUN,B2
+ملك,your,你的,DET,B2
+ضحكتك,your laugh,你笑,NOUN,B2
+جلالتك,your majesty,陛下,NOUN,B2
 يوان شياو,yuanxiao,元宵,NOUN,B2
-يوجّه,to guide,引导,VERB,B2
-يوليو,july,七月,NOUN,B2
-يوم عادي,ordinary day,平日,NOUN,B2
-يين بنفسجي,purple yin,紫阴,NOUN,B2
-يَعْمَل,to function,运作,VERB,B2
-يَوميًّا,daily,每日的,ADJ,B2
+صفر,zero,零,NUM,B2
+تشوانغ هي,zhuang he,庄郃,NOUN,B2
+زنك,zinc,锌,NOUN,B2
+برج,zodiac sign,属相,NOUN,B2
+زومبي,zombie,僵尸,NOUN,B2
+منطقة,zone,区域,NOUN,B2

--- a/build_contract_delivery.py
+++ b/build_contract_delivery.py
@@ -276,23 +276,18 @@ def build_delivery_rows(
             groups[(row.gloss, row.english_pos)].append(row)
         ranked[lang] = []
         for group in groups.values():
-            sorted_group = sorted(
-                group,
-                key=lambda r: (LEVELS.index(r.cefr), len(r.lemma), r.lemma),
-            )
-            # Emit rank 1 row representing the concept
-            best = sorted_group[0]
-            ranked[lang].append(
-                DeliveryRow(
-                    lemma=best.lemma,
-                    pos=best.pos,
-                    gloss=best.gloss,
-                    english_pos=best.english_pos,
-                    cefr=best.cefr,
-                    rank=1,
-                    concept_key=best.concept_key,
+            for position, item in enumerate(sorted(group, key=lambda r: r.lemma)):
+                ranked[lang].append(
+                    DeliveryRow(
+                        lemma=item.lemma,
+                        pos=item.pos,
+                        gloss=item.gloss,
+                        english_pos=item.english_pos,
+                        cefr=item.cefr,
+                        rank=position + 1,
+                        concept_key=item.concept_key,
+                    )
                 )
-            )
     return dict(ranked)
 
 

--- a/check_data_contract.py
+++ b/check_data_contract.py
@@ -41,6 +41,21 @@ CODE_TO_DIR = {code: name for name, code in LANG_DIRS.items()}
 GLOSS_ASCII = re.compile(r"^[A-Za-z '.-]+$")
 MIN_COVERAGE = 0.60
 
+ARABIC_SCRIPT = re.compile(r"[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF]")
+CHINESE_SCRIPT = re.compile(r"[\u4E00-\u9FFF\u3400-\u4DBF]")
+FORBIDDEN_JUNK_LEMMAS = {
+    "复合词",
+    "名词",
+    "动词",
+    "形容词",
+    "副词",
+    "介词",
+    "代词",
+    "连词",
+    "感叹词",
+    "X",
+}
+
 TSV_HEADER = [
     "lemma",
     "pos",
@@ -215,6 +230,26 @@ def check_ascii(rows: list[Row]) -> list[str]:
     return violations
 
 
+def check_script_and_substance(rows: list[Row]) -> list[str]:
+    """Criterion 6: valid target script, no junk placeholder tokens, no ungrounded gloss copies."""
+    violations = []
+    for row in rows:
+        lemma = row.lemma.strip()
+        if not lemma:
+            violations.append(f"{row.lang}:empty_lemma:'{row.english_gloss}'")
+            continue
+        if lemma in FORBIDDEN_JUNK_LEMMAS:
+            violations.append(f"{row.lang}:junk_lemma:'{lemma}'")
+            continue
+        if row.lang == "ar":
+            if any(c.isalpha() for c in lemma) and not ARABIC_SCRIPT.search(lemma):
+                violations.append(f"ar:non_arabic_script:'{lemma}'")
+        elif row.lang == "zh":
+            if any(c.isalpha() for c in lemma) and not CHINESE_SCRIPT.search(lemma):
+                violations.append(f"zh:non_chinese_script:'{lemma}'")
+    return violations
+
+
 def run_baseline(root: Path) -> int:
     rows = load_csv_rows(root)
     print(f"CSV baseline: {len(rows)} rows")
@@ -287,6 +322,12 @@ def run_delivery(delivery: Path, root: Path) -> int:
     for item in ascii_bad[:20]:
         print(f"  {item}")
     failed |= bool(ascii_bad)
+
+    script_bad = check_script_and_substance(rows)
+    print(f"criterion 6: {len(script_bad)} script or substance violations")
+    for item in script_bad[:20]:
+        print(f"  {item}")
+    failed |= bool(script_bad)
 
     print("RESULT: FAIL" if failed else "RESULT: PASS")
     return 1 if failed else 0

--- a/chinese/expansion.csv
+++ b/chinese/expansion.csv
@@ -1,18111 +1,6758 @@
 Chinese_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
-! 副本,duplicate,! 副本,NOUN,B2
-! 情感表达,emotional expression,! 情感表达,NOUN,B2
-! 权威地位,position of authority,! 权威地位,NOUN,B2
-! 表现欲,demonstrativeness,! 表现欲,NOUN,B2
-! 音轨,soundtrack,! 音轨,NOUN,B2
-African,African,African,ADJ,B1
-Alawi,Alawi,Alawi,NOUN,C1
-Alice,Alice,Alice,NOUN,B2
-Amazigh,Amazigh,Amazigh,NOUN,C1
-American (noun),American,American (noun),NOUN,B2
-Andalusian,Andalusian,Andalusian,ADJ,B2
-Arabic (noun),Arabic,Arabic (noun),NOUN,B1
-Arabic language,Arabic language,Arabic language,NOUN,A2
-Arabs,Arabs,Arabs,NOUN,B2
-Atlantic,Atlantic,Atlantic,ADJ,C1
-Balkanization,Balkanization,Balkanization,NOUN,C1
-Brussels,Brussels,Brussels,ADJ,C1
-Buddhism,Buddhism,Buddhism,NOUN,B2
-Buddhist,Buddhist,Buddhist,NOUN,B2
-Calvinism,Calvinism,Calvinism,NOUN,C1
-Caucasian,Caucasian,Caucasian,ADJ,B2
-Celtic,Celtic,Celtic,ADJ,B2
-Chinese person,Chinese person,Chinese person,NOUN,B2
-Christian (adj),Christian,Christian (adj),ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,Christmas Eve dinner,NOUN,C1
-Congo,Congo,Congo,NOUN,C1
-Cretaceous,Cretaceous,Cretaceous,ADJ,B2
-DIY,DIY,DIY,NOUN,C1
-DNA,DNA,DNA,NOUN,B2
-Ed,Ed,Ed,NOUN,B2
-Egyptian (noun),Egyptian,Egyptian (noun),NOUN,B2
-England,England,England,PROPN,B1
-English (noun),English,English (noun),NOUN,A2
-English language,English language,English language,NOUN,A2
-Etruscan,Etruscan,Etruscan,ADJ,C1
-Eucharist,Eucharist,Eucharist,NOUN,C1
-Eurasian,Eurasian,Eurasian,ADJ,C1
-Fauvism,Fauvism,Fauvism,NOUN,C1
-France,France,France,NOUN,B1
-Franciscan,Franciscan,Franciscan,ADJ,C1
-French (noun),French,French (noun),NOUN,B2
-French language,French language,French language,NOUN,A2
-French-speaking world,French-speaking world,French-speaking world,NOUN,B2
-Frenchification,Frenchification,Frenchification,NOUN,C1
-Friday evening,Friday evening,Friday evening,NOUN,C1
-Gallic,Gallic,Gallic,ADJ,C1
-German (noun),German,German (noun),NOUN,B2
-Gnawa,Gnawa,Gnawa,NOUN,B2
-Gothic,Gothic,Gothic,ADJ,C1
-Goyaesque,Goyaesque,Goyaesque,ADJ,C1
-Gypsy,Gypsy,Gypsy,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,Hassaniya Arabic,NOUN,C1
-Havana cigar,Havana cigar,Havana cigar,NOUN,C1
-Hebraic,Hebraic,Hebraic,ADJ,C1
-Hebrew,Hebrew,Hebrew,NOUN,C1
-Hellenism,Hellenism,Hellenism,NOUN,C1
-Hellenist,Hellenist,Hellenist,NOUN,C1
-Herculean,Herculean,Herculean,ADJ,C1
-Hindu,Hindu,Hindu,NOUN,C1
-Hinduism,Hinduism,Hinduism,NOUN,C1
-Hurufiyya,Hurufiyya,Hurufiyya,NOUN,C1
-IT-related,IT-related,IT-related,ADJ,C1
-Iberian,Iberian,Iberian,ADJ,C1
-Indian (noun),Indian,Indian (noun),NOUN,B1
-Indians,Indians,Indians,NOUN,C1
-Irish (noun),Irish,Irish (noun),NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,Islamic jurisprudence,NOUN,C1
-Islamic law,Islamic law,Islamic law,NOUN,B2
-Islamism,Islamism,Islamism,NOUN,C1
-Israeli,Israeli,Israeli,ADJ,B2
-January evening,January evening,January evening,NOUN,B2
-Japanese person,Japanese person,Japanese person,NOUN,C1
-Jesuit,Jesuit,Jesuit,NOUN,C1
-Jewish quarter,Jewish quarter,Jewish quarter,NOUN,C1
-Kufic,Kufic,Kufic,ADJ,C1
-Latin (noun),Latin,Latin (noun),NOUN,C1
-Limburgish,Limburgish,Limburgish,ADJ,C1
-Machiavellian,Machiavellian,Machiavellian,ADJ,C1
-Maghrebi,Maghrebi,Maghrebi,ADJ,C1
-Marxist,Marxist,Marxist,ADJ,C1
-Mary,Mary,Mary,NOUN,B2
-Mm,Mm,Mm,INTJ,C1
-Mon,Mon,Mon,NOUN,C1
-Moroccan,Moroccan,Moroccan,ADJ,B2
-Mrs.,Mrs.,Mrs.,NOUN,A1
-Ms.,Ms.,Ms.,NOUN,C1
-Muslim (adj),Muslim,Muslim (adj),ADJ,B1
-Natan,Natan,Natan,NOUN,B2
-New Year dress,New Year dress,New Year dress,NOUN,B2
-No.,No.,No.,NOUN,C1
-Nordic,Nordic,Nordic,ADJ,C1
-Olympics,Olympics,Olympics,NOUN,B1
-Parisian,Parisian,Parisian,ADJ,B1
-Parkinson's disease,Parkinson's disease,Parkinson's disease,NOUN,C1
-Philippic (adj),Philippic,Philippic (adj),ADJ,C1
-Prophet birthday,Prophet birthday,Prophet birthday,NOUN,B2
-Quran,Quran,Quran,NOUN,B2
-Rotterdam,Rotterdam,Rotterdam,ADJ,C1
-SIM card,SIM card,SIM card,NOUN,B1
-Salafism,Salafism,Salafism,NOUN,C1
-Saturday evening,Saturday evening,Saturday evening,NOUN,C1
-Serbian,Serbian,Serbian,ADJ,C1
-Shiism,Shiism,Shiism,NOUN,C1
-Spain,Spain,Spain,NOUN,B2
-Sufi,Sufi,Sufi,NOUN,C1
-Sufi order,Sufi order,Sufi order,NOUN,B2
-Sufism,Sufism,Sufism,NOUN,C1
-Sunday someone,Sunday someone,Sunday someone,NOUN,A2
-Surinamese,Surinamese,Surinamese,ADJ,C1
-TV ratings,TV ratings,TV ratings,NOUN,B1
-TV series,TV series,TV series,NOUN,B1
-Tajwid,Tajwid,Tajwid,NOUN,C1
-Thai,Thai,Thai,ADJ,C1
-Tifinagh script,Tifinagh script,Tifinagh script,NOUN,C1
-Whistles,Whistles,Whistles,NOUN,C1
-Wushk,Wushk,Wushk,NOUN,B1
-X光片,x-ray,X光片,NOUN,B2
-Yay,Yay,Yay,INTJ,C1
-YouTuber,YouTuber,YouTuber,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,Youth Welfare Office,NOUN,C1
-a an,a an,a an,DET,A2
-a little (adv),a little,a little (adv),ADV,B2
-a long time,a long time,a long time,ADV,A2
-a one,a one,a one,DET,A1
-a posteriori,a posteriori,a posteriori,ADJ,C1
-a priori,a priori,a priori,ADJ,C1
-abate,abate,abate,VERB,B2
-abbey,abbey,abbey,NOUN,B2
-abbot,abbot,abbot,NOUN,B2
-aberrant,aberrant,aberrant,ADJ,B2
-aberziehung,aberziehung,aberziehung,NOUN,B2
-abet,abet,abet,VERB,B2
-abfassung,abfassung,abfassung,NOUN,B2
-abforderung,abforderung,abforderung,NOUN,C1
-abgestaltung,abgestaltung,abgestaltung,NOUN,C1
-abhorrent,abhorrent,abhorrent,ADJ,B2
-abjure,abjure,abjure,VERB,B2
-abkunft,abkunft,abkunft,NOUN,C1
-ablution,ablution,ablution,NOUN,B2
-abominate,abominate,abominate,VERB,B2
-abomination,abomination,abomination,NOUN,B2
-about fifteen,about fifteen,about fifteen,NOUN,B2
-about fifty,about fifty,about fifty,NOUN,B2
-about ten,about ten,about ten,NOUN,B1
-about thirty,about thirty,about thirty,NOUN,B2
-about this,about this,about this,ADV,B2
-about what,about what,about what,ADV,B1
-about which,about which,about which,PRON,B2
-above all,above all,above all,NOUN,B2
-above average,above average,above average,ADJ,C1
-above over,above over,above over,ADP,A2
-above-mentioned,above-mentioned,above-mentioned,ADJ,B2
-abpflegung,abpflegung,abpflegung,NOUN,C1
-abrasive,abrasive,abrasive,ADJ,B2
-abregelung,abregelung,abregelung,NOUN,C1
-abrichtung,abrichtung,abrichtung,NOUN,C1
-abrogate,abrogate,abrogate,VERB,B2
-abschaft,abschaft,abschaft,NOUN,C1
-abschrift,abschrift,abschrift,NOUN,C1
-absent-minded,absent-minded,absent-minded,ADJ,B2
-absenteeism,absenteeism,absenteeism,NOUN,C1
-absetzung,absetzung,absetzung,NOUN,C1
-absinnung,absinnung,absinnung,NOUN,C1
-absolutely not,absolutely not,absolutely not,ADV,C1
-absolution,absolution,absolution,NOUN,C1
-absolutist,absolutist,absolutist,ADJ,C1
-absprache,absprache,absprache,NOUN,C1
-abstract (noun),abstract,abstract (noun),NOUN,C1
-abstractionism,abstractionism,abstractionism,NOUN,C1
-absucht,absucht,absucht,NOUN,C1
-absuchung,absuchung,absuchung,NOUN,C1
-absurdism,absurdism,absurdism,NOUN,C1
-abtheilung,abtheilung,abtheilung,NOUN,C1
-abundantly,abundantly,abundantly,ADV,C1
-abuse case,abuse case,abuse case,NOUN,C1
-abuse of power,abuse of power,abuse of power,NOUN,C1
-abuser,abuser,abuser,NOUN,B2
-abuses,abuses,abuses,NOUN,C1
-abwandel,abwandel,abwandel,NOUN,C1
-abwirkung,abwirkung,abwirkung,NOUN,C1
-abysmal,abysmal,abysmal,ADJ,B2
-accede,accede,accede,VERB,B2
-accessibility features,accessibility features,accessibility features,NOUN,B2
-accessory,accessory,accessory,NOUN,B2
-acclimatize,acclimatize,acclimatize,VERB,B2
-accommodating,accommodating,accommodating,ADJ,B2
-accompanying,accompanying,accompanying,ADJ,C1
-according to that,according to that,according to that,ADV,C1
-accordingly consequently,accordingly consequently,accordingly consequently,ADV,C1
-accordion,accordion,accordion,NOUN,B2
-accost,accost,accost,VERB,B2
-accounting (adj),accounting,accounting (adj),ADJ,C1
-accreditation,accreditation,accreditation,NOUN,C1
-accumulator,accumulator,accumulator,NOUN,C1
-accused,accused,accused,NOUN,B2
-accused person,accused person,accused person,NOUN,B2
-accusing of treason,accusing of treason,accusing of treason,NOUN,C1
-acedia spiritual sloth,acedia spiritual sloth,acedia spiritual sloth,NOUN,C1
-acerbate,acerbate,acerbate,VERB,B2
-achievable,achievable,achievable,ADJ,B2
-achieved,achieved,achieved,ADJ,B1
-acid (adj),acid,acid (adj),ADJ,B1
-acid sour,acid sour,acid sour,ADJ,B2
-acidic,acidic,acidic,ADJ,B2
-acolyte,acolyte,acolyte,NOUN,B2
-acorn,acorn,acorn,NOUN,B1
-acquired,acquired,acquired,ADJ,B2
-acquisition of ownership,acquisition of ownership,acquisition of ownership,NOUN,C1
-acrid,acrid,acrid,ADJ,B2
-acrimonious,acrimonious,acrimonious,ADJ,B2
-acronym,acronym,acronym,NOUN,B2
-acrostic,acrostic,acrostic,NOUN,C1
-act of kneeling,act of kneeling,act of kneeling,NOUN,C1
-action document,action document,action document,NOUN,B2
-activation,activation,activation,NOUN,B2
-active population,active population,active population,NOUN,C1
-activism,activism,activism,NOUN,B2
-activist,activist,activist,NOUN,C1
-activities,activities,activities,NOUN,B2
-acts of worship,acts of worship,acts of worship,NOUN,C1
-actuate,actuate,actuate,VERB,B2
-acumen,acumen,acumen,NOUN,C1
-acuteness sharpness,acuteness sharpness,acuteness sharpness,NOUN,C1
-adaptability,adaptability,adaptability,NOUN,C1
-adaptable,adaptable,adaptable,ADJ,B2
-adaptive,adaptive,adaptive,ADJ,C1
-add-on,add-on,add-on,NOUN,C1
-addictive,addictive,addictive,ADJ,B2
-additional extra,additional extra,additional extra,ADJ,C1
-adept,adept,adept,ADJ,B2
-adequate suitable,adequate suitable,adequate suitable,ADJ,C1
-adherence,adherence,adherence,NOUN,B2
-adhesive bandage,adhesive bandage,adhesive bandage,NOUN,B2
-adjoin,adjoin,adjoin,VERB,B2
-adjourn,adjourn,adjourn,VERB,B2
-adjournment,adjournment,adjournment,NOUN,C1
-adjudge,adjudge,adjudge,VERB,B2
-adjudication,adjudication,adjudication,NOUN,C1
-adjure,adjure,adjure,VERB,B2
-adjustability,adjustability,adjustability,NOUN,C1
-administrative offense,administrative offense,administrative offense,NOUN,C1
-admirable,admirable,admirable,ADJ,B2
-admiration,admiration,admiration,NOUN,B2
-admissibility acceptance,admissibility acceptance,admissibility acceptance,NOUN,C1
-admissible,admissible,admissible,ADJ,B2
-admissible eligible,admissible eligible,admissible eligible,ADJ,C1
-admission,admission,admission,NOUN,B1
-admitted,admitted,admitted,ADJ,B2
-adolescence,adolescence,adolescence,NOUN,B2
-adorable,adorable,adorable,ADJ,B2
-adoration worship,adoration worship,adoration worship,NOUN,C1
-adoul notaries,adoul notaries,adoul notaries,NOUN,C1
-adrenaline,adrenaline,adrenaline,NOUN,C1
-adroit,adroit,adroit,ADJ,B2
-adulation,adulation,adulation,NOUN,C1
-adultery,adultery,adultery,NOUN,C1
-advance notice,advance notice,advance notice,NOUN,B2
-adventurous,adventurous,adventurous,ADJ,B2
-adversarial,adversarial,adversarial,ADJ,B2
-advertiser,advertiser,advertiser,NOUN,B2
-advisability,advisability,advisability,NOUN,C1
-advisable,advisable,advisable,ADJ,B2
-advisor consultant,advisor consultant,advisor consultant,NOUN,B2
-advisory,advisory,advisory,ADJ,C1
-advocacy,advocacy,advocacy,NOUN,C1
-advocate (noun),advocate,advocate (noun),NOUN,B2
-aerodynamics,aerodynamics,aerodynamics,NOUN,C1
-aeronautical,aeronautical,aeronautical,ADJ,B2
-aesthetic taste,aesthetic taste,aesthetic taste,NOUN,C1
-affability,affability,affability,NOUN,C1
-affable,affable,和蔼可亲的,ADJ,B2
-affect,to affect,影响,VERB,B2
-affectation,affectation,做作,NOUN,B2
-affected eloquence,affected eloquence,affected eloquence,NOUN,C1
-affected speech,affected speech,affected speech,NOUN,C1
-affectedness,affectedness,affectedness,NOUN,C1
-affidavit,affidavit,affidavit,NOUN,B2
-affiliate,affiliate,附属机构,NOUN,B2
-affiliation,affiliation,隶属关系,NOUN,B2
-affinity,affinity,affinity,NOUN,C1
-affirmative,affirmative,affirmative,ADJ,B2
-affix,affix,affix,NOUN,B2
-afflict,to afflict,折磨,VERB,B2
-affluent,affluent,affluent,ADJ,B2
-afford,afford,afford,VERB,A2
-affordable,affordable,负担得起的,ADJ,B2
-afraid (noun),afraid,afraid (noun),NOUN,B2
-after,after,在...之后,SCONJ,B2
-after (adv),after,after (adv),ADV,A1
-after that,after that,此后,ADV,B2
-after the example of,after the example of,after the example of,NOUN,C1
-after this,after this,after this,ADV,B2
-after to,after to,after to,ADP,A2
-after which,after which,之后,ADV,B2
-aftertaste,aftertaste,aftertaste,NOUN,C1
-against,against,反对,ADP,B2
-against it,against it,against it,ADV,A2
-agate,agate,agate,NOUN,B1
-age lifetime,age lifetime,age lifetime,NOUN,A2
-agency,agency,代理机构,NOUN,B2
-agenda,agenda,agenda,NOUN,C1
-agglomerate,agglomerate,agglomerate,NOUN,B2
-aggrandizement,aggrandizement,aggrandizement,NOUN,C1
-aggravated,aggravated,aggravated,ADJ,C1
-aggravating,aggravating,aggravating,ADJ,B2
-aggravation,aggravation,aggravation,NOUN,C1
-aggregate (noun),aggregate,aggregate (noun),NOUN,B2
-aggregation,aggregation,aggregation,NOUN,C1
-aggression,aggression,侵略,NOUN,B2
-aggressive,aggressive,好斗的,ADJ,B2
-aggressiveness,aggressiveness,攻击性,NOUN,B2
-aggressor,aggressor,aggressor,NOUN,C1
-agitation,agitation,agitation,NOUN,B2
-agnatic inheritance,agnatic inheritance,agnatic inheritance,NOUN,C1
-agnostic (adj),agnostic,agnostic (adj),ADJ,B2
-agnostic (noun),agnostic,agnostic (noun),NOUN,B2
-agnosticism,agnosticism,agnosticism,NOUN,C1
-agonize,agonize,agonize,VERB,B2
-agony,agony,极度痛苦,NOUN,B2
-agreeable,agreeable,agreeable,ADJ,B2
-agricultural,agricultural,农业的,ADJ,B2
-ahead,ahead,在前面,ADV,B2
-aim,aim,目标,NOUN,B2
-aim,to aim,瞄准,VERB,B2
-aimless,aimless,aimless,ADJ,C1
-aims,aims,aims,NOUN,C1
-air conditioner,air conditioner,air conditioner,NOUN,B1
-airline,airline,airline,NOUN,C1
-aisle,aisle,aisle,NOUN,B1
-aita song,aita song,aita song,NOUN,C1
-alarm (verb),alarm,alarm (verb),VERB,B2
-alarm clock,alarm clock,闹钟,NOUN,B2
-alarm system,alarm system,alarm system,NOUN,C1
-alarming,alarming,令人担忧的,ADJ,B2
-alarmism,alarmism,alarmism,NOUN,C1
-alchemy,alchemy,alchemy,NOUN,C1
-alcohol,alcohol,酒精,NOUN,B2
-alcoholic,alcoholic,酗酒者,NOUN,B2
-alderman,alderman,alderman,NOUN,B2
-alert,alert,警觉的,ADJ,B2
-algae,algae,algae,NOUN,B2
-algebra,algebra,代数,NOUN,B2
-algebraic,algebraic,algebraic,ADJ,C1
-algorithm,algorithm,算法,NOUN,B2
-alien (adj),alien,alien (adj),ADJ,B1
-alienation,alienation,异化,NOUN,B2
-alignment,alignment,结盟,NOUN,B2
-alike,alike,alike,ADV,B1
-alimony,alimony,赡养费,NOUN,B2
-alive,alive,活着的,ADJ,B2
-alkalinity,alkalinity,alkalinity,NOUN,C1
-all entirely,all entirely,all entirely,DET,B2
-all saints' day,all saints' day,all saints' day,NOUN,B2
-all the more,all the more,all the more,ADV,B2
-all together,all together,all together,ADV,C1
-allay,allay,allay,VERB,C1
-allegation,allegation,allegation,NOUN,C1
-alleged,alleged,所谓的,ADJ,B2
-alleged presumed,alleged presumed,alleged presumed,ADJ,C1
-allegedly,allegedly,据称,ADV,B2
-allegiance,allegiance,allegiance,NOUN,B2
-allegorical,allegorical,allegorical,ADJ,C1
-allegory,allegory,allegory,NOUN,C1
-allergic,allergic,过敏的,ADJ,B2
-alleys,alleys,alleys,NOUN,B2
-alliteration,alliteration,alliteration,NOUN,C1
-allocation,allocation,allocation,NOUN,C1
-allot,allot,allot,VERB,C1
-allotment,allotment,allotment,NOUN,C1
-allure,allure,allure,NOUN,C1
-almonds,almonds,almonds,NOUN,A2
-alms,alms,alms,NOUN,B2
-alms zakat,alms zakat,alms zakat,NOUN,B2
-aloof,aloof,aloof,ADJ,C1
-already may particle,already may particle,already may particle,PART,A2
-also (noun),also,also (noun),NOUN,A2
-altar,altar,altar,NOUN,B2
-alteration,alteration,alteration,NOUN,B2
-alternating,alternating,alternating,ADJ,B2
-although (cconj),although,although (cconj),CCONJ,B2
-amalgam conflation,amalgam conflation,amalgam conflation,NOUN,B2
-ambient surrounding,ambient surrounding,ambient surrounding,ADJ,C1
-ambivalence,ambivalence,ambivalence,NOUN,B2
-ameliorate,ameliorate,ameliorate,VERB,C1
-amelioration,amelioration,amelioration,NOUN,C1
-amendments,amendments,amendments,NOUN,C1
-amends,amends,amends,NOUN,C1
-amicable out-of-court,amicable out-of-court,amicable out-of-court,ADJ,B2
-amoral,amoral,amoral,ADJ,C1
-amortization,amortization,amortization,NOUN,C1
-amphitheater lecture hall,amphitheater lecture hall,amphitheater lecture hall,NOUN,B2
-ample loose-fitting,ample loose-fitting,ample loose-fitting,ADJ,C1
-amplitude range,amplitude range,amplitude range,NOUN,C1
-amused,amused,amused,ADJ,B2
-an,an,an,DET,A1
-anacoluthon,anacoluthon,anacoluthon,NOUN,C1
-anadiplosis,anadiplosis,anadiplosis,NOUN,C1
-anagram,anagram,anagram,NOUN,B2
-analgesia,analgesia,analgesia,NOUN,C1
-analogize,analogize,analogize,VERB,B2
-analogous similar,analogous similar,analogous similar,ADJ,C1
-anamnesis case history,anamnesis case history,anamnesis case history,NOUN,C1
-anarchical,anarchical,anarchical,ADJ,C1
-anarchism,anarchism,anarchism,NOUN,C1
-anatomy dissection,anatomy dissection,anatomy dissection,NOUN,C1
-ancestral,ancestral,ancestral,ADJ,C1
-anchovy,anchovy,anchovy,NOUN,B2
-ancient rootedness,ancient rootedness,ancient rootedness,NOUN,C1
-androgynous,androgynous,androgynous,ADJ,C1
-anecdotal,anecdotal,anecdotal,ADJ,C1
-anemic,anemic,anemic,ADJ,C1
-anerziehung,anerziehung,anerziehung,NOUN,C1
-aneurysm,aneurysm,aneurysm,NOUN,C1
-anfahrt,anfahrt,anfahrt,NOUN,C1
-anfassung,anfassung,anfassung,NOUN,C1
-anforderung,anforderung,anforderung,NOUN,C1
-angabe,angabe,angabe,NOUN,C1
-angestaltung,angestaltung,angestaltung,NOUN,C1
-anguished,anguished,anguished,ADJ,C1
-animal pen,animal pen,animal pen,NOUN,B1
-animated,animated,animated,ADJ,C1
-annex (noun),annex,annex (noun),NOUN,B2
-annexes,annexes,annexes,NOUN,C1
-annotation,annotation,annotation,NOUN,C1
-annuity private income,annuity private income,annuity private income,NOUN,C1
-annulment,annulment,annulment,NOUN,C1
-anodyne,anodyne,anodyne,ADJ,C1
-anoint,anoint,anoint,VERB,C1
-anomalous,anomalous,anomalous,ADJ,C1
-anomie,anomie,anomie,NOUN,C1
-anonymity,anonymity,anonymity,NOUN,C1
-anonymization,anonymization,anonymization,NOUN,C1
-anonymously,anonymously,anonymously,ADV,B2
-anorexia,anorexia,anorexia,NOUN,C1
-another time,another time,another time,ADV,C1
-anpflegung,anpflegung,anpflegung,NOUN,C1
-anregelung,anregelung,anregelung,NOUN,C1
-anschaft,anschaft,anschaft,NOUN,C1
-anschrift,anschrift,anschrift,NOUN,B2
-ansetzung,ansetzung,ansetzung,NOUN,C1
-ansicht,ansicht,ansicht,NOUN,C1
-ansinnung,ansinnung,ansinnung,NOUN,C1
-ansprache,ansprache,ansprache,NOUN,C1
-ansucht,ansucht,ansucht,NOUN,C1
-ansuchung,ansuchung,ansuchung,NOUN,C1
-answers,answers,answers,NOUN,C1
-antagonistic,antagonistic,antagonistic,ADJ,C1
-antediluvian,antediluvian,antediluvian,ADJ,C1
-anteroom,anteroom,anteroom,NOUN,B2
-anthem,anthem,anthem,NOUN,B2
-anthem song,anthem song,anthem song,NOUN,A1
-anthill,anthill,anthill,NOUN,C1
-anthropological,anthropological,anthropological,ADJ,C1
-anti-Semitic,anti-Semitic,anti-Semitic,ADJ,C1
-anticipated,anticipated,anticipated,ADJ,C1
-anticipatory,anticipatory,anticipatory,ADJ,C1
-antinomy,antinomy,antinomy,NOUN,C1
-antiphrasis,antiphrasis,antiphrasis,NOUN,C1
-antiquities ruins,antiquities ruins,antiquities ruins,NOUN,B2
-antiquity,antiquity,antiquity,NOUN,B2
-antisemite,antisemite,antisemite,NOUN,C1
-antonomasia,antonomasia,antonomasia,NOUN,C1
-antonyms,antonyms,antonyms,NOUN,C1
-antreibung,antreibung,antreibung,NOUN,C1
-antsy,antsy,antsy,ADJ,C1
-anvil,anvil,anvil,NOUN,B2
-anwandel,anwandel,anwandel,NOUN,C1
-anweisung,anweisung,anweisung,NOUN,C1
-anwirkung,anwirkung,anwirkung,NOUN,C1
-anxious eager,anxious eager,anxious eager,ADJ,B1
-any (adj),any,any (adj),ADJ,B1
-any (adv),any,any (adv),ADV,B2
-any (det),any,any (det),DET,A1
-anybody,anybody,anybody,PRON,A1
-anymore,anymore,anymore,ADV,A1
-anywhere,anywhere,anywhere,ADV,A1
-apart from (verb),apart from,apart from (verb),VERB,C1
-apartheid,apartheid,apartheid,NOUN,C1
-apiary,apiary,apiary,NOUN,B2
-apnea,apnea,apnea,NOUN,C1
-apocalypse,apocalypse,apocalypse,NOUN,C1
-apogee,apogee,apogee,NOUN,C1
-apolitical,apolitical,apolitical,ADJ,B2
-apologies,apologies,apologies,NOUN,B1
-apophatic,apophatic,apophatic,ADJ,C1
-apophthegm,apophthegm,apophthegm,NOUN,C1
-apoplexy,apoplexy,apoplexy,NOUN,C1
-aporetic,aporetic,aporetic,ADJ,C1
-aporia,aporia,aporia,NOUN,B2
-apostille,apostille,apostille,NOUN,B2
-apostle,apostle,apostle,NOUN,C1
-apostrophize,apostrophize,apostrophize,VERB,C1
-apotheosis,apotheosis,apotheosis,NOUN,C1
-app,app,app,NOUN,B1
-appall,appall,appall,VERB,C1
-appalling,appalling,appalling,ADJ,C1
-apparel,apparel,apparel,NOUN,C1
-apparent,apparent,apparent,ADJ,C1
-appeals,appeals,appeals,NOUN,C1
-appellate,appellate,appellate,ADJ,C1
-append,append,append,VERB,C1
-appertain,appertain,appertain,VERB,C1
-appetizers,appetizers,appetizers,NOUN,B2
-appliance,appliance,appliance,NOUN,B1
-applicable,applicable,applicable,ADJ,B2
-appointments,appointments,appointments,NOUN,B2
-apportion,apportion,apportion,VERB,C1
-appreciable,appreciable,appreciable,ADJ,C1
-apprehend,to apprehend,逮捕,VERB,B2
-apprehension,apprehension,忧虑,NOUN,B2
-approachable,approachable,approachable,ADJ,C1
-appropriateness,appropriateness,appropriateness,NOUN,C1
-appropriation,appropriation,appropriation,NOUN,B2
-approval,approval,批准,NOUN,B2
-approval pleasure,approval pleasure,approval pleasure,NOUN,C1
-approved,approved,approved,ADJ,C1
-approx.,approx.,approx.,ADV,C1
-approximation,approximation,近似值,NOUN,B2
-apron,apron,围裙,NOUN,B2
-apt,apt,apt,ADJ,C1
-aquatic,aquatic,aquatic,ADJ,C1
-aqueduct,aqueduct,aqueduct,NOUN,C1
-aqueous,aqueous,aqueous,ADJ,B2
-arabesque,arabesque,阿拉伯式花纹,NOUN,B2
-arabized word,arabized word,arabized word,NOUN,C1
-arbitrage,arbitrage,arbitrage,NOUN,C1
-arbitral,arbitral,arbitral,ADJ,C1
-arbitrarily,arbitrarily,arbitrarily,ADV,C1
-arbitrariness,arbitrariness,arbitrariness,NOUN,C1
-arbitrary,arbitrary,任意的,ADJ,B2
-arbitration,arbitration,仲裁,NOUN,B2
-arch,arch,拱门,NOUN,B2
-archaeological,archaeological,考古的,ADJ,B2
-archaeologist,archaeologist,archaeologist,NOUN,C1
-archaeology,archaeology,考古学,NOUN,B2
-archaic,archaic,古老的,ADJ,B2
-archaism,archaism,古语,NOUN,B2
-archbishop,archbishop,archbishop,NOUN,B2
-archeology,archeology,archeology,NOUN,C1
-architectural,architectural,建筑的,ADJ,B2
-archival,archival,archival,ADJ,C1
-archived,archived,archived,ADJ,C1
-archives,archives,archives,NOUN,C1
-archiving,archiving,archiving,NOUN,B2
-ardent blazing,ardent blazing,ardent blazing,ADJ,C1
-ardent grief,ardent grief,ardent grief,NOUN,C1
-ardent longing,ardent longing,ardent longing,NOUN,C1
-arena,arena,竞技场,NOUN,B2
-argan,argan,argan,NOUN,B1
-argentinian,argentinian,argentinian,ADJ,B2
-arguable,arguable,arguable,ADJ,C1
-argumentative,argumentative,argumentative,ADJ,C1
-argumentativeness,argumentativeness,argumentativeness,NOUN,C1
-aridity,aridity,aridity,NOUN,C1
-arise,to arise,出现,VERB,B2
-aristocracy,aristocracy,贵族阶层,NOUN,B2
-aristocrat,aristocrat,贵族,NOUN,B2
-aristocratic,aristocratic,aristocratic,ADJ,C1
-arithmetic (adj),arithmetic,arithmetic (adj),ADJ,C1
-arithmetic (noun),arithmetic,arithmetic (noun),NOUN,C1
-armament,armament,armament,NOUN,B2
-armband,armband,armband,NOUN,C1
-armchair,armchair,扶手椅,NOUN,B2
-armed,armed,武装的,ADJ,B2
-armed force,armed force,armed force,NOUN,C1
-armored,armored,armored,ADJ,C1
-armorer,armorer,,NOUN,B2
-aromatic,aromatic,aromatic,ADJ,C1
-around,around,在周围,ADP,B2
-around at,around at,around at,ADP,A2
-around the,around the,around the,ADP,B1
-arousal,arousal,arousal,NOUN,C1
-arraign,arraign,arraign,VERB,C1
-arranged,arranged,arranged,ADJ,B2
-arrangement,arrangement,安排,NOUN,B2
-arrears,arrears,欠款,NOUN,B2
-arrest,arrest,逮捕,NOUN,B2
-arrest warrant,arrest warrant,arrest warrant,NOUN,C1
-arrhythmia,arrhythmia,arrhythmia,NOUN,C1
-arrogance,arrogance,傲慢,NOUN,B2
-arrogant,arrogant,傲慢的,ADJ,B2
-arrogate,arrogate,arrogate,VERB,C1
-arsenal,arsenal,军火库,NOUN,B2
-arterial,arterial,arterial,ADJ,C1
-artful,artful,artful,ADJ,C1
-artfully,artfully,artfully,ADV,C1
-artichoke,artichoke,artichoke,NOUN,B1
-articles,articles,articles,NOUN,C1
-articular,articular,articular,ADJ,C1
-articulate,to articulate,清晰表达,VERB,B2
-artifice,artifice,诡计,NOUN,B2
-artificially,artificially,artificially,ADV,B2
-artist,artist,艺术家,NOUN,B2
-artistry,artistry,,NOUN,B2
-artless,artless,artless,ADJ,C1
-artwork,artwork,artwork,NOUN,B2
-as (cconj),as,as (cconj),CCONJ,B1
-as (noun),as,as (noun),NOUN,B2
-as a precaution,as a precaution,as a precaution,ADV,C1
-as a result of which,as a result of which,as a result of which,ADV,B2
-as far as,as far as,as far as,ADV,B2
-as for (adv),as for,as for (adv),ADV,B1
-as for (part),as for,as for (part),PART,B1
-as if,as if,好像,SCONJ,B2
-as long as,as long as,只要,SCONJ,B2
-as many,as many,as many,NUM,B2
-as much,as much,as much,ADV,A1
-as possible,as possible,as possible,ADV,B2
-as soon as,as soon as,一...就,SCONJ,B2
-as soon as possible,as soon as possible,as soon as possible,ADV,C1
-as that who,as that who,as that who,PRON,A2
-as well as (sconj),as well as,as well as (sconj),SCONJ,B2
-as when,as when,as when,SCONJ,A1
-asbestos,asbestos,asbestos,NOUN,C1
-ascending,ascending,ascending,ADJ,C1
-ascent,ascent,上升,NOUN,B2
-ascertain,ascertain,ascertain,VERB,C1
-ascetic (noun),ascetic,ascetic (noun),NOUN,C1
-asharite school,asharite school,asharite school,NOUN,C1
-ashes,ashes,ashes,NOUN,B2
-ashore,ashore,ashore,ADV,C1
-aside (noun),aside,aside (noun),NOUN,C1
-asinine,asinine,asinine,ADJ,C1
-asleep,asleep,asleep,ADJ,A2
-aspersion,aspersion,aspersion,NOUN,C1
-aspirant,aspirant,aspirant,NOUN,C1
-assail,assail,assail,VERB,C1
-assailant,assailant,assailant,NOUN,C1
-assent (noun),assent,assent (noun),NOUN,B2
-asshole,asshole,asshole,NOUN,A2
-assiduity,assiduity,assiduity,NOUN,B2
-assiduous application,assiduous application,assiduous application,NOUN,C1
-assiduously,assiduously,assiduously,ADV,C1
-assiduousness,assiduousness,assiduousness,NOUN,C1
-associate (noun),associate,associate (noun),NOUN,B2
-assort,assort,assort,VERB,C1
-assortment,assortment,assortment,NOUN,C1
-assuage,assuage,assuage,VERB,C1
-asthenia,asthenia,asthenia,NOUN,C1
-astonishment amazement,astonishment amazement,astonishment amazement,NOUN,B2
-astound,astound,astound,VERB,C1
-astounding,astounding,astounding,ADJ,C1
-astride (adp),astride,astride (adp),ADP,C1
-astride (adv),astride,astride (adv),ADV,C1
-astringent (adj),astringent,astringent (adj),ADJ,C1
-astringent (noun),astringent,astringent (noun),NOUN,B2
-astronomer,astronomer,astronomer,NOUN,B1
-asylum shelter,asylum shelter,asylum shelter,NOUN,B2
-asymptomatic,asymptomatic,asymptomatic,ADJ,C1
-asyndeton,asyndeton,asyndeton,NOUN,B2
-at it,at it,at it,ADV,B2
-at length,at length,at length,ADV,B2
-at most,at most,at most,ADV,C1
-at night,at night,at night,ADV,B2
-at noon,at noon,at noon,ADV,A1
-at on,at on,at on,ADP,A1
-at the beginning,at the beginning,at the beginning,ADV,C1
-at the bottom,at the bottom,at the bottom,ADV,B2
-at the home of,at the home of,at the home of,ADP,A1
-at the latest,at the latest,at the latest,ADV,C1
-ataraxia,ataraxia,ataraxia,NOUN,C1
-athletics,athletics,athletics,NOUN,C1
-atmosphere environment,atmosphere environment,atmosphere environment,NOUN,B1
-atomic bomb,atomic bomb,atomic bomb,NOUN,B1
-atony,atony,atony,NOUN,C1
-atrocious,atrocious,atrocious,ADJ,C1
-atrocious terrible,atrocious terrible,atrocious terrible,ADJ,B2
-attache office,attache office,attache office,NOUN,C1
-attached,attached,attached,ADJ,B2
-attainment,attainment,attainment,NOUN,C1
-attempt at crime,attempt at crime,attempt at crime,NOUN,C1
-attention (intj),attention,attention (intj),INTJ,B2
-attentively,attentively,attentively,ADV,C1
-attestation,attestation,attestation,NOUN,C1
-attitude setting,attitude setting,attitude setting,NOUN,B2
-attributists,attributists,attributists,NOUN,C1
-audibility,audibility,audibility,NOUN,C1
-audio,audio,audio,NOUN,B2
-audition,audition,audition,NOUN,B1
-auditory,auditory,auditory,ADJ,C1
-auferziehung,auferziehung,auferziehung,NOUN,C1
-aufgabe,aufgabe,aufgabe,NOUN,C1
-aufgestaltung,aufgestaltung,aufgestaltung,NOUN,B2
-aufkunft,aufkunft,aufkunft,NOUN,C1
-aufnahme,aufnahme,aufnahme,NOUN,C1
-aufpflegung,aufpflegung,aufpflegung,NOUN,C1
-aufregelung,aufregelung,aufregelung,NOUN,C1
-aufschaft,aufschaft,aufschaft,NOUN,C1
-aufschrift,aufschrift,aufschrift,NOUN,C1
-aufsetzung,aufsetzung,aufsetzung,NOUN,C1
-aufsicht,aufsicht,aufsicht,NOUN,C1
-aufsinnung,aufsinnung,aufsinnung,NOUN,C1
-aufsprache,aufsprache,aufsprache,NOUN,C1
-aufsucht,aufsucht,aufsucht,NOUN,C1
-aufsuchung,aufsuchung,aufsuchung,NOUN,C1
-aufteilung,aufteilung,aufteilung,NOUN,C1
-auftheilung,auftheilung,auftheilung,NOUN,C1
-auftreibung,auftreibung,auftreibung,NOUN,C1
-aufwandel,aufwandel,aufwandel,NOUN,C1
-aufwirkung,aufwirkung,aufwirkung,NOUN,C1
-augment,augment,augment,VERB,C1
-augmentation,augmentation,augmentation,NOUN,C1
-augury,augury,augury,NOUN,C1
-auserziehung,auserziehung,auserziehung,NOUN,C1
-ausfassung,ausfassung,ausfassung,NOUN,C1
-ausgabe,ausgabe,ausgabe,NOUN,C1
-auskunft,auskunft,auskunft,NOUN,C1
-ausnahme,ausnahme,ausnahme,NOUN,C1
-auspflegung,auspflegung,auspflegung,NOUN,C1
-auspicious,auspicious,auspicious,ADJ,C1
-ausregelung,ausregelung,ausregelung,NOUN,C1
-ausrichtung,ausrichtung,ausrichtung,NOUN,C1
-ausschaft,ausschaft,ausschaft,NOUN,C1
-aussicht,aussicht,aussicht,NOUN,C1
-aussucht,aussucht,aussucht,NOUN,B2
-aussuchung,aussuchung,aussuchung,NOUN,B2
-austeilung,austeilung,austeilung,NOUN,C1
-austheilung,austheilung,austheilung,NOUN,C1
-austreibung,austreibung,austreibung,NOUN,C1
-autarchy,autarchy,autarchy,NOUN,C1
-autarky,autarky,autarky,NOUN,B2
-authenticated,authenticated,authenticated,ADJ,C1
-authoritarianism,authoritarianism,authoritarianism,NOUN,C1
-authority figure,authority figure,authority figure,NOUN,B2
-authority structure,authority structure,authority structure,NOUN,B2
-autistic (adj),autistic,autistic (adj),ADJ,C1
-autistic (noun),autistic,autistic (noun),NOUN,C1
-autobiographical,autobiographical,autobiographical,ADJ,C1
-autocracy,autocracy,autocracy,NOUN,C1
-autumnal,autumnal,autumnal,ADJ,C1
-auxiliary,auxiliary,auxiliary,ADJ,C1
-avail,avail,avail,NOUN,C1
-avarice,avarice,avarice,NOUN,C1
-avaricious,avaricious,avaricious,ADJ,C1
-aver,aver,aver,VERB,C1
-averageness,averageness,averageness,NOUN,B2
-avert,avert,avert,VERB,C1
-avow,avow,avow,VERB,C1
-award auction,award auction,award auction,NOUN,B2
-awarding,awarding,awarding,NOUN,C1
-awe-inspiring,awe-inspiring,awe-inspiring,ADJ,C1
-awesome,awesome,awesome,ADJ,A2
-awl,awl,awl,NOUN,B2
-awning,awning,awning,NOUN,B2
-axiological,axiological,axiological,ADJ,C1
-axiology,axiology,axiology,NOUN,C1
-axioms,axioms,axioms,NOUN,C1
-axis axle,axis axle,axis axle,NOUN,C1
-babble,babble,babble,NOUN,B2
-babble of voices,babble of voices,babble of voices,NOUN,B1
-baby diminutive,baby diminutive,baby diminutive,NOUN,B1
-baby walker,baby walker,baby walker,NOUN,B1
-baccalaureate,baccalaureate,baccalaureate,NOUN,B2
-bachelor (adj),bachelor,bachelor (adj),ADJ,A2
-back then,back then,back then,ADV,A1
-back way,back way,back way,NOUN,B1
-backfire,backfire,backfire,VERB,C1
-backpacker,backpacker,backpacker,NOUN,B1
-backside,backside,backside,NOUN,B2
-backslide,backslide,backslide,VERB,C1
-backward,backward,backward,ADV,B2
-backwards,backwards,向后,ADV,B2
-backyard,backyard,backyard,NOUN,B2
-bacon,bacon,培根,NOUN,B2
-bacon bit,bacon bit,bacon bit,NOUN,B1
-bacterium,bacterium,细菌,NOUN,B2
-bad (noun),bad,bad (noun),NOUN,B2
-bad luck,bad luck,倒霉,NOUN,B2
-badger,badger,badger,NOUN,C1
-badly,badly,坏地,ADV,B2
-baffle,baffle,baffle,VERB,C1
-bag,bag,包,NOUN,B2
-baker,baker,面包师,NOUN,B2
-bakery,bakery,bakery,NOUN,A2
-balance,to balance,平衡,VERB,B2
-balanced,balanced,平衡的,ADJ,B2
-bald,bald,秃头的,ADJ,B2
-baldness,baldness,baldness,NOUN,B2
-bale,bale,bale,NOUN,C1
-balk,balk,balk,VERB,C1
-ball,ball,球,NOUN,B2
-ballad,ballad,ballad,NOUN,C1
-ballast,ballast,ballast,NOUN,C1
-ballot boxes,ballot boxes,ballot boxes,NOUN,C1
-ballpoint pen,ballpoint pen,圆珠笔,NOUN,B2
-ban,ban,禁令,NOUN,B2
-banal,banal,陈腐的,ADJ,B2
-banality,banality,陈词滥调,NOUN,B2
-bananas,bananas,bananas,NOUN,A1
-band volume,band volume,band volume,NOUN,C1
-bandage,bandage,绷带,NOUN,B2
-bandaging,bandaging,bandaging,NOUN,C1
-bandwidth,bandwidth,bandwidth,ADJ,C1
-bang,bang,巨响,NOUN,B2
-banish,to banish,流放,VERB,B2
-banister,banister,banister,NOUN,C1
-banker,banker,银行家,NOUN,B2
-banking,banking,银行的,ADJ,B2
-bankrupt,bankrupt,破产的,ADJ,B2
-bankruptcy,bankruptcy,破产,NOUN,B2
-banner,banner,横幅,NOUN,B2
-banner headline,banner headline,banner headline,NOUN,C1
-banter,banter,戏谑,NOUN,B2
-baptism,baptism,baptism,NOUN,B2
-baptize,to baptize,施洗,VERB,B2
-bar of soap,bar of soap,bar of soap,NOUN,B2
-barbarian,barbarian,barbarian,NOUN,B2
-barbaric,barbaric,野蛮的,ADJ,B2
-barbarism,barbarism,野蛮,NOUN,B2
-barbarity,barbarity,残暴,NOUN,B2
-barbarization,barbarization,barbarization,NOUN,B2
-barber,barber,barber,NOUN,A2
-barefoot,barefoot,赤脚的,ADJ,B2
-bareheaded,bareheaded,bareheaded,ADJ,C1
-bargaining,bargaining,bargaining,NOUN,C1
-bark,to bark,吠叫,VERB,B2
-bark (noun),bark,bark (noun),NOUN,B2
-barking,barking,barking,NOUN,B2
-barley,barley,大麦,NOUN,B2
-barn,barn,谷仓,NOUN,B2
-baron,baron,baron,NOUN,B2
-barracks,barracks,barracks,NOUN,B2
-barrage,barrage,barrage,NOUN,C1
-barren,barren,barren,ADJ,C1
-barrenness,barrenness,barrenness,NOUN,C1
-barter (noun),barter,barter (noun),NOUN,C1
-barter (verb),barter,barter (verb),VERB,C1
-base,to base,基于,VERB,B2
-baseness,baseness,卑鄙,NOUN,B2
-bash,bash,bash,VERB,C1
-bashful,bashful,bashful,ADJ,B2
-bashfulness,bashfulness,bashfulness,NOUN,C1
-basic attitude,basic attitude,basic attitude,NOUN,C1
-basic essential,basic essential,basic essential,ADJ,B1
-basil,basil,罗勒,NOUN,B2
-basing,basing,basing,NOUN,C1
-bask,bask,bask,VERB,C1
-baste,baste,baste,VERB,C1
-basting,basting,basting,NOUN,C1
-bath attendant,bath attendant,bath attendant,NOUN,C1
-bath scrubber,bath scrubber,bath scrubber,NOUN,C1
-bathrobe,bathrobe,bathrobe,NOUN,A2
-batter,batter,batter,NOUN,C1
-bawdiness,bawdiness,bawdiness,NOUN,C1
-bawl,bawl,bawl,VERB,C1
-be crushed,be crushed,be crushed,VERB,C1
-be patient,be patient,be patient,VERB,A1
-be quiet,be quiet,be quiet,VERB,A1
-be rumored,be rumored,be rumored,VERB,C1
-be tender,be tender,be tender,ADJ,B2
-beak,beak,beak,NOUN,B2
-beanie,beanie,beanie,NOUN,A2
-beans,beans,beans,NOUN,A1
-beaten,beaten,beaten,ADJ,B2
-beatitude,beatitude,beatitude,NOUN,B2
-beautification,beautification,beautification,NOUN,C1
-beaver,beaver,beaver,NOUN,C1
-because (cconj),because,because (cconj),CCONJ,A2
-because of this,because of this,because of this,ADV,A2
-beckon,beckon,beckon,VERB,C1
-becoming,becoming,becoming,NOUN,C1
-bedsheet,bedsheet,bedsheet,NOUN,B2
-bedside,bedside,bedside,NOUN,C1
-beech grove,beech grove,beech grove,NOUN,C1
-beef,beef,beef,NOUN,A1
-beehive,beehive,beehive,NOUN,C1
-beeping,beeping,beeping,NOUN,C1
-beerziehung,beerziehung,beerziehung,NOUN,C1
-befahrt,befahrt,befahrt,NOUN,C1
-befall,befall,befall,VERB,C1
-befassung,befassung,befassung,NOUN,C1
-befit,befit,befit,VERB,C1
-beforderung,beforderung,beforderung,NOUN,C1
-before one's eyes,before one's eyes,before one's eyes,ADV,C1
-before that,before that,before that,ADV,B1
-befuddle,befuddle,befuddle,VERB,C1
-begabe,begabe,begabe,NOUN,C1
-begestaltung,begestaltung,begestaltung,NOUN,C1
-beginning primer,beginning primer,beginning primer,NOUN,C1
-begrudge,begrudge,begrudge,VERB,C1
-beguile,beguile,beguile,VERB,C1
-behavioral,behavioral,behavioral,ADJ,B2
-behavioral pattern,behavioral pattern,behavioral pattern,NOUN,C1
-behind (adv),behind,behind (adv),ADV,A1
-behind (noun),behind,behind (noun),NOUN,B2
-behoove,behoove,behoove,VERB,C1
-being lost,being lost,being lost,NOUN,C1
-being swept along,being swept along,being swept along,NOUN,C1
-bekunft,bekunft,bekunft,NOUN,C1
-belabor,belabor,belabor,VERB,C1
-belated,belated,belated,ADJ,C1
-belatedly,belatedly,belatedly,ADV,C1
-belch,belch,belch,VERB,C1
-beleaguer,beleaguer,beleaguer,VERB,C1
-belie,belie,belie,VERB,C1
-belief creed,belief creed,belief creed,NOUN,B2
-belief in the afterlife,belief in the afterlife,belief in the afterlife,NOUN,C1
-believability,believability,believability,NOUN,C1
-belittling,belittling,belittling,NOUN,C1
-bell tower,bell tower,bell tower,NOUN,A2
-bellows,bellows,bellows,NOUN,C1
-below (noun),below,below (noun),NOUN,B2
-bemoan,bemoan,bemoan,VERB,C1
-bemuse,bemuse,bemuse,VERB,C1
-bench seat,bench seat,bench seat,NOUN,C1
-beneath,beneath,beneath,ADP,B2
-beneficence,beneficence,beneficence,NOUN,C1
-beneficial,beneficial,beneficial,ADJ,B2
-bequest,bequest,bequest,NOUN,B2
-berate,berate,berate,VERB,C1
-bereave,bereave,bereave,VERB,C1
-bereaved,bereaved,bereaved,ADJ,C1
-beregelung,beregelung,beregelung,NOUN,C1
-berichtung,berichtung,berichtung,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berry,berry,berry,NOUN,A1
-beschaft,beschaft,beschaft,NOUN,C1
-beschrift,beschrift,beschrift,NOUN,C1
-beseech,beseech,beseech,VERB,C1
-beset,beset,beset,VERB,C1
-besetzung,besetzung,besetzung,NOUN,C1
-besicht,besicht,besicht,NOUN,C1
-besides (noun),besides,besides (noun),NOUN,B2
-besieged,besieged,besieged,ADJ,B2
-besieging,besieging,besieging,NOUN,C1
-besinnung,besinnung,besinnung,NOUN,C1
-besmirch,besmirch,besmirch,VERB,C1
-best possible,best possible,best possible,ADJ,C1
-bestial,bestial,bestial,ADJ,C1
-besucht,besucht,besucht,NOUN,C1
-betheilung,betheilung,betheilung,NOUN,C1
-betreibung,betreibung,betreibung,NOUN,C1
-better (adv),better,better (adv),ADV,A1
-between us,between us,between us,ADP,B1
-beverage,beverage,beverage,NOUN,B2
-bewail,bewail,bewail,VERB,C1
-bewandel,bewandel,bewandel,NOUN,C1
-beware,beware,beware,VERB,C1
-beweisung,beweisung,beweisung,NOUN,C1
-bewilder,bewilder,bewilder,VERB,C1
-bewirkung,bewirkung,bewirkung,NOUN,C1
-bibliomaniac,bibliomaniac,bibliomaniac,NOUN,C1
-bibliophily,bibliophily,bibliophily,NOUN,C1
-bickering,bickering,bickering,NOUN,C1
-bicycle kick,bicycle kick,bicycle kick,NOUN,B2
-bids,bids,bids,NOUN,C1
-biennial,biennial,biennial,NOUN,C1
-bifurcation,bifurcation,bifurcation,NOUN,C1
-big cat,big cat,big cat,NOUN,C1
-big lout,big lout,big lout,NOUN,C1
-bigness,bigness,bigness,NOUN,B2
-bigotry,bigotry,bigotry,NOUN,C1
-bilingual,bilingual,bilingual,ADJ,C1
-bilingualism,bilingualism,bilingualism,NOUN,C1
-bilk,bilk,bilk,VERB,C1
-bill of exchange,bill of exchange,bill of exchange,NOUN,C1
-billion (noun),billion,billion (noun),NOUN,B2
-billionaire,billionaire,billionaire,NOUN,C1
-billow,billow,billow,NOUN,C1
-bin,bin,bin,NOUN,B2
-binder,binder,binder,NOUN,A2
-binding (adj),binding,binding (adj),ADJ,C1
-bingo,bingo,bingo,NOUN,B2
-biographical,biographical,biographical,ADJ,C1
-biographies,biographies,biographies,NOUN,C1
-biologist,biologist,biologist,NOUN,B2
-bipartisan,bipartisan,bipartisan,ADJ,C1
-bipartisanship,bipartisanship,bipartisanship,NOUN,C1
-birds,birds,birds,NOUN,B1
-birds chirping,birds chirping,birds chirping,NOUN,C1
-birdsong,birdsong,birdsong,NOUN,C1
-birth rate,birth rate,birth rate,NOUN,C1
-births,births,births,NOUN,C1
-bitter quarrel,bitter quarrel,bitter quarrel,NOUN,C1
-blab,blab,blab,VERB,C1
-black pepper,black pepper,black pepper,NOUN,B2
-blackbird,blackbird,blackbird,NOUN,B2
-blackout,blackout,blackout,NOUN,C1
-blacksmith shop,blacksmith shop,blacksmith shop,NOUN,C1
-blacksmithing,blacksmithing,blacksmithing,NOUN,B2
-bladder,bladder,bladder,NOUN,B2
-blah,blah,blah,INTJ,C1
-blanch,blanch,blanch,VERB,C1
-blandish,blandish,blandish,VERB,C1
-blank,blank,blank,ADJ,B1
-blare,blare,blare,NOUN,C1
-blast,blast,blast,NOUN,B1
-blatant,blatant,blatant,ADJ,C1
-blazing,blazing,blazing,ADJ,C1
-blazing ardor,blazing ardor,blazing ardor,NOUN,C1
-blend,blend,blend,VERB,B2
-blender,blender,blender,NOUN,B2
-blending,blending,blending,NOUN,C1
-blight,blight,blight,NOUN,C1
-blind person,blind person,blind person,NOUN,B2
-blindfold,blindfold,blindfold,NOUN,C1
-blindside,blindside,blindside,VERB,C1
-blissful wellbeing,blissful wellbeing,blissful wellbeing,NOUN,C1
-blister,blister,blister,NOUN,C1
-bloat,bloat,bloat,VERB,C1
-blockage,blockage,blockage,NOUN,B2
-blocked,blocked,blocked,ADJ,A1
-blockhead,blockhead,blockhead,NOUN,B2
-blocking,blocking,blocking,NOUN,B2
-blog post,blog post,blog post,NOUN,C1
-blogger,blogger,blogger,NOUN,B2
-blood money,blood money,blood money,NOUN,C1
-blood-related,blood-related,blood-related,ADJ,C1
-bloody,bloody,血淋淋的,ADJ,B2
-bloom (noun),bloom,bloom (noun),NOUN,C1
-bloom of youth,bloom of youth,bloom of youth,NOUN,C1
-blooming,blooming,blooming,ADJ,C1
-blossoming ripening,blossoming ripening,blossoming ripening,NOUN,C1
-blot,blot,污点,NOUN,B2
-blouse,blouse,女衬衫,NOUN,B2
-blow beating,blow beating,blow beating,NOUN,B2
-blow of fate,blow of fate,blow of fate,NOUN,C1
-blubber,blubber,blubber,NOUN,C1
-blue (noun),blue,blue (noun),NOUN,C1
-blueprint,blueprint,blueprint,NOUN,C1
-blueprint diagram,blueprint diagram,blueprint diagram,NOUN,C1
-blunt,blunt,blunt,ADJ,B2
-bluntly,bluntly,直率地,ADV,B2
-blur,to blur,模糊,VERB,B2
-blurred,blurred,blurred,ADJ,C1
-blurriness,blurriness,blurriness,NOUN,C1
-blurry,blurry,blurry,ADJ,B2
-blurt,blurt,blurt,VERB,C1
-bluster,bluster,bluster,VERB,C1
-board,board,木板,NOUN,B2
-boarder,boarder,boarder,NOUN,B2
-boarding,boarding,boarding,NOUN,C1
-boarding school,boarding school,寄宿学校,NOUN,B2
-boast (noun),boast,boast (noun),NOUN,B2
-boastfulness,boastfulness,boastfulness,NOUN,B2
-boasting,boasting,夸耀,NOUN,B2
-bode,bode,bode,VERB,C1
-bodies,bodies,bodies,NOUN,C1
-bodily,bodily,身体上的,ADJ,B2
-boggle,boggle,boggle,VERB,C1
-boil (noun),boil,boil (noun),NOUN,C1
-boiled,boiled,boiled,ADJ,B1
-boiler,boiler,锅炉,NOUN,B2
-boiling,boiling,沸腾,NOUN,B2
-boiling (adj),boiling,boiling (adj),ADJ,C1
-boldness daring,boldness daring,boldness daring,NOUN,B2
-bolster (noun),bolster,bolster (noun),NOUN,C1
-bolster (verb),bolster,bolster (verb),VERB,C1
-bolstering,bolstering,bolstering,NOUN,C1
-bolt,bolt,bolt,NOUN,B2
-bolted,bolted,bolted,ADJ,C1
-bomb,bomb,炸弹,NOUN,B2
-bombard,to bombard,轰炸,VERB,B2
-bombast,bombast,bombast,NOUN,C1
-bombastic,bombastic,夸大的,ADJ,B2
-bomber,bomber,bomber,NOUN,C1
-bondholder,bondholder,bondholder,NOUN,C1
-bonds,bonds,bonds,NOUN,C1
-bonhomie,bonhomie,bonhomie,NOUN,C1
-bony,bony,瘦骨嶙峋的,ADJ,B2
-booking,booking,booking,NOUN,A2
-bookmark,bookmark,bookmark,NOUN,B2
-bookseller,bookseller,bookseller,NOUN,C1
-bookstore,bookstore,bookstore,NOUN,B2
-boom,boom,繁荣,NOUN,B2
-boorish,boorish,boorish,ADJ,C1
-boot,boot,靴子,NOUN,B2
-booth,booth,摊位,NOUN,B2
-border,border,边境的,ADJ,B2
-border area,border area,border area,NOUN,C1
-border check,border check,border check,NOUN,B2
-border control,border control,border control,NOUN,C1
-border frontier,border frontier,border frontier,NOUN,B1
-border guard,border guard,border guard,NOUN,C1
-border legislation,border legislation,border legislation,NOUN,B2
-border region,border region,border region,NOUN,B2
-bordering,bordering,bordering,ADJ,C1
-bore,to bore,使厌烦,VERB,B2
-boredom,boredom,无聊,NOUN,B2
-boring,boring,无聊的,ADJ,B2
-born (adj),born,born (adj),ADJ,B2
-born (noun),born,born (noun),NOUN,B2
-born (verb),born,born (verb),VERB,A1
-borrowed,borrowed,borrowed,ADJ,C1
-borrower,borrower,借款人,NOUN,B2
-bosom,bosom,bosom,NOUN,C1
-boss female,boss female,boss female,NOUN,B2
-boss manager,boss manager,boss manager,NOUN,A1
-botanical,botanical,botanical,ADJ,C1
-botany,botany,botany,NOUN,C1
-botched job,botched job,botched job,NOUN,B2
-both,both,两者都,CCONJ,B2
-both (noun),both,both (noun),NOUN,B2
-bother,to bother,打扰,VERB,B2
-bottle opener,bottle opener,bottle opener,NOUN,B1
-bottleneck,bottleneck,bottleneck,NOUN,C1
-bounce,bounce,bounce,VERB,B2
-bound,bound,一定的,ADJ,B2
-bounty,bounty,bounty,NOUN,C1
-bourgeoisie,bourgeoisie,资产阶级,NOUN,B2
-bovine,bovine,bovine,ADJ,C1
-bow (verb),bow,bow (verb),VERB,B1
-bow tie,bow tie,bow tie,NOUN,B2
-boyfriend,boyfriend,男朋友,NOUN,B2
-brabant,brabant,brabant,ADJ,B2
-brace,brace,brace,NOUN,C1
-bracelet,bracelet,手镯,NOUN,B2
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,brain damage,NOUN,B2
-brainstorming,brainstorming,brainstorming,NOUN,C1
-brainy,brainy,brainy,ADJ,B2
-brake,brake,刹车,NOUN,B2
-brakeman,brakeman,brakeman,NOUN,C1
-brakes,brakes,brakes,NOUN,C1
-braking,braking,braking,NOUN,C1
-bran,bran,bran,NOUN,B2
-branch,branch,分支,NOUN,B2
-branch of study,branch of study,branch of study,NOUN,B1
-branch office,branch office,branch office,NOUN,C1
-branched,branched,branched,ADJ,C1
-branching,branching,branching,NOUN,C1
-brass band,brass band,brass band,NOUN,B2
-brassware,brassware,brassware,NOUN,C1
-bravo,bravo,bravo,NOUN,B2
-bray,bray,bray,VERB,C1
-brazier,brazier,brazier,NOUN,B1
-breach,breach,违反,NOUN,B2
-breach of duty,breach of duty,breach of duty,NOUN,B2
-breach of promise,breach of promise,breach of promise,NOUN,C1
-breadth,breadth,breadth,NOUN,C1
-breadth crossing,breadth crossing,breadth crossing,NOUN,C1
-break,break,休息,NOUN,B2
-break fraction,break fraction,break fraction,NOUN,C1
-breakage,breakage,breakage,NOUN,C1
-breakdown of order,breakdown of order,breakdown of order,NOUN,C1
-breaker cutter,breaker cutter,breaker cutter,NOUN,C1
-breaststroke,breaststroke,breaststroke,NOUN,C1
-breathing,breathing,breathing,NOUN,B2
-breathing space,breathing space,breathing space,NOUN,C1
-breathlessness,breathlessness,breathlessness,NOUN,B1
-breeding,breeding,breeding,NOUN,C1
-breeding site,breeding site,breeding site,NOUN,C1
-breviary,breviary,breviary,NOUN,C1
-bribe-taker,bribe-taker,bribe-taker,NOUN,C1
-bribes,bribes,bribes,NOUN,C1
-bricks,bricks,bricks,NOUN,B1
-bridal trousseau,bridal trousseau,bridal trousseau,NOUN,C1
-bridegroom,bridegroom,bridegroom,NOUN,C1
-brief moment,brief moment,brief moment,NOUN,C1
-briefcase,briefcase,briefcase,NOUN,C1
-briefly,briefly,briefly,ADV,C1
-brigade,brigade,brigade,NOUN,C1
-brigand poet,brigand poet,brigand poet,NOUN,C1
-brighten,brighten,brighten,VERB,C1
-brightly,brightly,brightly,ADV,C1
-brightness,brightness,brightness,NOUN,C1
-brilliance of mind,brilliance of mind,brilliance of mind,NOUN,C1
-brilliantly keen,brilliantly keen,brilliantly keen,ADJ,C1
-brim,brim,brim,NOUN,C1
-bristle (noun),bristle,bristle (noun),NOUN,C1
-brittleness,brittleness,brittleness,NOUN,C1
-broach,broach,broach,VERB,C1
-broad,broad,broad,ADJ,B1
-broad bean,broad bean,broad bean,NOUN,C1
-broad beans,broad beans,broad beans,NOUN,B2
-broadcast (adj),broadcast,broadcast (adj),ADJ,C1
-broadcasting station,broadcasting station,broadcasting station,NOUN,C1
-broaden,broaden,broaden,VERB,C1
-broil,broil,broil,VERB,C1
-brokenness,brokenness,brokenness,NOUN,C1
-bronze-colored,bronze-colored,bronze-colored,ADJ,B2
-brooch,brooch,brooch,NOUN,C1
-brooding (adj),brooding,brooding (adj),ADJ,B2
-broom blow,broom blow,broom blow,NOUN,C1
-browbeat,browbeat,browbeat,VERB,C1
-bruises,bruises,bruises,NOUN,B2
-brutal,brutal,brutal,ADJ,B2
-brutalizing,brutalizing,brutalizing,ADJ,C1
-brutally,brutally,brutally,ADV,C1
-brute,brute,brute,ADJ,B2
-buckle,buckle,buckle,VERB,C1
-bucolic,bucolic,bucolic,ADJ,C1
-buddy pal,buddy pal,buddy pal,NOUN,B1
-budge,budge,budge,VERB,C1
-budgeting,budgeting,budgeting,NOUN,C1
-buff,buff,buff,NOUN,C1
-buffalo,buffalo,buffalo,NOUN,C1
-buffer,buffer,buffer,NOUN,C1
-building manager,building manager,building manager,NOUN,B1
-bulge,bulge,bulge,NOUN,C1
-bull,bull,bull,NOUN,B1
-bulldoze,bulldoze,bulldoze,VERB,C1
-bulldozer,bulldozer,bulldozer,NOUN,C1
-bulletproof,bulletproof,bulletproof,NOUN,B2
-bullying,bullying,bullying,NOUN,B2
-bumble,bumble,bumble,VERB,C1
-bumblebee,bumblebee,bumblebee,NOUN,C1
-bunch,bunch,bunch,NOUN,A2
-bundling,bundling,bundling,NOUN,C1
-bungler,bungler,bungler,NOUN,C1
-bunker,bunker,bunker,NOUN,B2
-buoy,buoy,buoy,NOUN,C1
-buoyancy,buoyancy,buoyancy,NOUN,C1
-bureaucrat,bureaucrat,bureaucrat,NOUN,C1
-bureaucratic,bureaucratic,bureaucratic,ADJ,C1
-burger stand,burger stand,,NOUN,B2
-burglarize,burglarize,burglarize,VERB,C1
-burgle,burgle,burgle,VERB,C1
-burlap,burlap,burlap,NOUN,B2
-burlesque (adj),burlesque,burlesque (adj),ADJ,B2
-burlesque (noun),burlesque,burlesque (noun),NOUN,C1
-burned,burned,burned,ADJ,B2
-burning (noun),burning,burning (noun),NOUN,A1
-burp (noun),burp,burp (noun),NOUN,C1
-burrow (noun),burrow,burrow (noun),NOUN,C1
-burrow (verb),burrow,burrow (verb),VERB,C1
-burst in,burst in,burst in,VERB,C1
-bursting forth,bursting forth,bursting forth,NOUN,C1
-bushy,bushy,bushy,ADJ,C1
-business sector,business sector,business sector,NOUN,B2
-business world,business world,business world,NOUN,C1
-bust,bust,bust,NOUN,B1
-but-for,but-for,but-for,NOUN,B2
-butcher shop,butcher shop,butcher shop,NOUN,A2
-butler,butler,butler,NOUN,C1
-buttermilk,buttermilk,buttermilk,NOUN,A2
-buyer purchaser,buyer purchaser,buyer purchaser,NOUN,B2
-buying and selling,buying and selling,buying and selling,NOUN,B2
-buzz (noun),buzz,buzz (noun),NOUN,B2
-buzzer,buzzer,buzzer,NOUN,C1
-buzzing,buzzing,buzzing,NOUN,C1
-by analogy with,by analogy with,by analogy with,ADV,C1
-by chance (adj),by chance,by chance (adj),ADJ,A2
-by doing,by doing,by doing,SCONJ,B1
-by force,by force,by force,ADV,B2
-by hearsay,by hearsay,by hearsay,ADV,C1
-by heart,by heart,by heart,ADV,B2
-by himself,by himself,by himself,ADV,B2
-by inference,by inference,by inference,ADV,C1
-by itself,by itself,by itself,ADV,B2
-by telephone,by telephone,by telephone,ADJ,C1
-by virtue of,by virtue of,by virtue of,ADP,C1
-by way of digression,by way of digression,by way of digression,ADV,C1
-by way of rectification,by way of rectification,by way of rectification,ADV,C1
-by-elections,by-elections,by-elections,NOUN,C1
-bypass (noun),bypass,bypass (noun),NOUN,C1
-bypassing,bypassing,bypassing,NOUN,C1
-cabin boy,cabin boy,cabin boy,NOUN,C1
-cache,cache,cache,NOUN,C1
-cachexia,cachexia,cachexia,NOUN,C1
-cackle,cackle,cackle,VERB,C1
-cactus,cactus,cactus,NOUN,B1
-cadence,cadence,cadence,NOUN,B2
-cadres,cadres,cadres,NOUN,C1
-caesura,caesura,caesura,NOUN,C1
-cafeteria,cafeteria,cafeteria,NOUN,B1
-caffeine,caffeine,caffeine,NOUN,C1
-caftan,caftan,caftan,NOUN,A1
-cage (verb),cage,cage (verb),VERB,C1
-caid local governor,caid local governor,caid local governor,NOUN,C1
-cajole,cajole,cajole,VERB,C1
-calcareous,calcareous,calcareous,ADJ,B2
-caliber,caliber,caliber,NOUN,C1
-calibrated,calibrated,calibrated,ADJ,C1
-calibrator,calibrator,calibrator,NOUN,C1
-caliph,caliph,caliph,NOUN,B2
-caliphate,caliphate,caliphate,NOUN,C1
-call to prayer,call to prayer,call to prayer,NOUN,B2
-caller,caller,caller,NOUN,A2
-calligrapher,calligrapher,calligrapher,NOUN,C1
-calming,calming,calming,ADJ,B2
-calorie,calorie,calorie,NOUN,C1
-calve,calve,calve,VERB,C1
-camouflage (noun),camouflage,camouflage (noun),NOUN,C1
-campfire,campfire,campfire,NOUN,C1
-campus,campus,campus,NOUN,B2
-campus-like,campus-like,campus-like,ADJ,B2
-can (noun),can,can (noun),NOUN,B2
-can jar,can jar,can jar,NOUN,B2
-canal belt,canal belt,canal belt,NOUN,C1
-cancerous,cancerous,cancerous,ADJ,C1
-candid,candid,candid,ADJ,C1
-candy shop,candy shop,candy shop,NOUN,B2
-cane,cane,cane,NOUN,B2
-canning,canning,canning,NOUN,C1
-canoe,canoe,canoe,NOUN,C1
-cantillation,cantillation,cantillation,NOUN,C1
-canvass,canvass,canvass,VERB,C1
-capacitate,capacitate,capacitate,VERB,C1
-capacitor condenser,capacitor condenser,capacitor condenser,NOUN,C1
-caper (noun),caper,caper (noun),NOUN,B2
-capillary,capillary,capillary,ADJ,C1
-capital flight,capital flight,capital flight,NOUN,B2
-capital letter,capital letter,capital letter,NOUN,C1
-capital loss,capital loss,capital loss,NOUN,C1
-capitalist,capitalist,capitalist,NOUN,C1
-capitalization,capitalization,capitalization,NOUN,C1
-capitulation,capitulation,capitulation,NOUN,C1
-capping,capping,capping,NOUN,B2
-capricious,capricious,capricious,ADJ,C1
-capsize,capsize,capsize,VERB,C1
-capsule,capsule,capsule,NOUN,B1
-captious,captious,captious,ADJ,B2
-captivated,captivated,captivated,ADJ,C1
-captive (adj),captive,captive (adj),ADJ,B2
-captive bond,captive bond,captive bond,NOUN,C1
-car door,car door,car door,NOUN,C1
-car hood,car hood,car hood,NOUN,C1
-car key,car key,car key,NOUN,C1
-carafe,carafe,carafe,NOUN,C1
-caramelize,caramelize,caramelize,VERB,C1
-caravanserai,caravanserai,caravanserai,NOUN,C1
-caraway,caraway,caraway,NOUN,B2
-carbohydrates,carbohydrates,carbohydrates,NOUN,C1
-carcinoma,carcinoma,carcinoma,NOUN,C1
-card map,card map,card map,NOUN,A1
-cardiac,cardiac,心脏的,ADJ,B2
-care,to care,照顾,VERB,B2
-care home,care home,,NOUN,B2
-care worker,care worker,care worker,NOUN,B2
-careen,careen,careen,VERB,C1
-career,career,职业,NOUN,B2
-career leap,career leap,career leap,NOUN,C1
-careerism,careerism,careerism,NOUN,C1
-careerist,careerist,careerist,ADJ,B2
-carelessness,carelessness,carelessness,NOUN,C1
-carer,carer,carer,NOUN,C1
-caress,to caress,爱抚,VERB,B2
-caress (noun),caress,caress (noun),NOUN,B2
-caretaker,caretaker,房屋管理员,NOUN,B2
-cargo,cargo,货物,NOUN,B2
-caricatural,caricatural,漫画的,ADJ,B2
-caricature,caricature,讽刺画,NOUN,B2
-caricature (verb),caricature,caricature (verb),VERB,B2
-carnation,carnation,carnation,NOUN,B2
-carnival,carnival,狂欢节,NOUN,B2
-carob,carob,carob,NOUN,B2
-carol,carol,carol,NOUN,B1
-carouse,carouse,carouse,VERB,C1
-carousel,carousel,carousel,NOUN,C1
-carp (noun),carp,carp (noun),NOUN,C1
-carp (verb),carp,carp (verb),VERB,C1
-carpenter,carpenter,木匠,NOUN,B2
-carpentry,carpentry,木工,NOUN,B2
-carpooling,carpooling,carpooling,NOUN,B1
-carrier,carrier,承运人,NOUN,B2
-carrot,carrot,胡萝卜,NOUN,B2
-carrying porterage,carrying porterage,carrying porterage,NOUN,C1
-cartel,cartel,cartel,NOUN,B2
-cartilage,cartilage,软骨,NOUN,B2
-cartography,cartography,cartography,NOUN,B2
-carton,carton,carton,NOUN,C1
-cartridge,cartridge,cartridge,NOUN,C1
-cascade,cascade,cascade,NOUN,C1
-case inflection,case inflection,case inflection,NOUN,C1
-cash,cash,现金,ADJ,B2
-cash register,cash register,收银机,NOUN,B2
-casino,casino,casino,NOUN,B2
-casket,casket,casket,NOUN,C1
-cassation,cassation,cassation,NOUN,B2
-cast (adj),cast,cast (adj),ADJ,C1
-cast iron,cast iron,cast iron,NOUN,B2
-castanets,castanets,castanets,NOUN,B1
-caste,caste,caste,NOUN,B2
-casting,casting,casting,NOUN,C1
-castrate,castrate,castrate,VERB,C1
-casual (adv),casual,casual (adv),ADV,B2
-catacomb,catacomb,catacomb,NOUN,B2
-catalepsy,catalepsy,catalepsy,NOUN,B2
-catalysis,catalysis,catalysis,NOUN,C1
-catalyst,catalyst,催化剂,NOUN,B2
-cataract,cataract,cataract,NOUN,B2
-catastrophe,catastrophe,大灾难,NOUN,B2
-catch,catch,捕捉,NOUN,B2
-catching up,catching up,catching up,NOUN,C1
-catechism,catechism,catechism,NOUN,C1
-categorically,categorically,categorically,ADV,C1
-categorization,categorization,分类,NOUN,B2
-categorize,to categorize,分类,VERB,B2
-cater,cater,cater,VERB,C1
-caterer,caterer,caterer,NOUN,C1
-catering,catering,catering,NOUN,B1
-catharsis,catharsis,宣泄,NOUN,B2
-cathedral,cathedral,大教堂,NOUN,B2
-catheter,catheter,catheter,NOUN,C1
-catheterize,catheterize,catheterize,VERB,C1
-catholicism,catholicism,天主教,NOUN,B2
-cattle,cattle,牛,NOUN,B2
-cattle rancher,cattle rancher,cattle rancher,NOUN,B2
-caudillism,caudillism,caudillism,NOUN,C1
-cauldron,cauldron,cauldron,NOUN,C1
-causal link,causal link,causal link,NOUN,B2
-causality,causality,因果关系,NOUN,B2
-causation,causation,因果关系,NOUN,B2
-cause of death,cause of death,死因,NOUN,B2
-caustic,caustic,caustic,ADJ,B2
-cave,cave,洞穴,NOUN,B2
-cavern,cavern,cavern,NOUN,B2
-cavil,cavil,cavil,VERB,C1
-cavort,cavort,cavort,VERB,C1
-caw,to caw,呱呱叫,VERB,B2
-caw (noun),caw,caw (noun),NOUN,C1
-cease,to cease,停止,VERB,B2
-cedar,cedar,cedar,NOUN,B1
-cede,cede,cede,VERB,C1
-ceiling,ceiling,天花板,NOUN,B2
-celebrant,celebrant,celebrant,NOUN,B2
-celebration,celebration,庆祝,NOUN,B2
-celebrity,celebrity,名人,NOUN,B2
-celerity,celerity,celerity,NOUN,B2
-celestial (adj),celestial,celestial (adj),ADJ,B2
-celestial (noun),celestial,celestial (noun),NOUN,B2
-celestial body,celestial body,celestial body,NOUN,B2
-celibacy,celibacy,独身,NOUN,B2
-celibate,celibate,celibate,ADJ,B2
-cell phone ringing,cell phone ringing,cell phone ringing,NOUN,C1
-cells,cells,cells,NOUN,C1
-cenotaph,cenotaph,cenotaph,NOUN,B2
-censure (noun),censure,censure (noun),NOUN,C1
-censure (verb),censure,censure (verb),VERB,C1
-centenary,centenary,centenary,NOUN,C1
-centennial,centennial,centennial,ADJ,B2
-centime,centime,centime,NOUN,B2
-centipede,centipede,centipede,NOUN,B2
-cento,cento,cento,NOUN,C1
-centrality,centrality,centrality,NOUN,C1
-centre,centre,centre,NOUN,B2
-century-old,century-old,century-old,ADJ,B2
-cereal,cereal,cereal,NOUN,B2
-ceremonial protocol,ceremonial protocol,ceremonial protocol,NOUN,C1
-ceremoniously,ceremoniously,ceremoniously,ADV,C1
-chain (adj),chain,chain (adj),ADJ,C1
-chain of transmission,chain of transmission,chain of transmission,NOUN,C1
-chalet,chalet,chalet,NOUN,B1
-chalice,chalice,chalice,NOUN,C1
-challenges,challenges,challenges,NOUN,C1
-challenging,challenging,challenging,ADJ,C1
-chamberlain,chamberlain,chamberlain,NOUN,C1
-chamois,chamois,chamois,NOUN,C1
-chance opportunity,chance opportunity,chance opportunity,NOUN,A2
-chancery,chancery,chancery,NOUN,C1
-chandelier sheen,chandelier sheen,chandelier sheen,NOUN,C1
-change of scenery,change of scenery,change of scenery,NOUN,B1
-chant,chant,chant,VERB,C1
-chants,chants,chants,NOUN,B2
-chaperon,chaperon,chaperon,NOUN,C1
-chaplain,chaplain,chaplain,NOUN,C1
-chapter of Quran,chapter of Quran,chapter of Quran,NOUN,B2
-character trait creation,character trait creation,character trait creation,NOUN,C1
-characterization,characterization,characterization,NOUN,C1
-characters,characters,characters,NOUN,C1
-charade,charade,charade,NOUN,B2
-charges,charges,charges,NOUN,C1
-charging,charging,charging,NOUN,C1
-charitable,charitable,charitable,ADJ,B2
-charmer,charmer,charmer,NOUN,B2
-charter-based,charter-based,charter-based,ADJ,C1
-chassis frame,chassis frame,chassis frame,NOUN,C1
-chasten,chasten,chasten,VERB,C1
-chastity probity,chastity probity,chastity probity,NOUN,C1
-chatter (noun),chatter,chatter (noun),NOUN,A2
-chauffeur,chauffeur,chauffeur,NOUN,C1
-chauvinism,chauvinism,chauvinism,NOUN,B2
-cheapen,cheapen,cheapen,VERB,C1
-check-in,check-in,check-in,NOUN,B1
-checked,checked,checked,ADJ,C1
-checkers,checkers,checkers,NOUN,A2
-checkmark,checkmark,checkmark,NOUN,C1
-checkmate,checkmate,checkmate,NOUN,C1
-cheekbone,cheekbone,cheekbone,NOUN,C1
-cheerful-faced,cheerful-faced,cheerful-faced,ADJ,C1
-cheerfulness,cheerfulness,cheerfulness,NOUN,C1
-chemical (noun),chemical,chemical (noun),NOUN,B2
-chemicals,chemicals,chemicals,NOUN,C1
-chemist,chemist,chemist,NOUN,C1
-cheque,cheque,cheque,NOUN,A2
-chermoula,chermoula,chermoula,NOUN,B2
-chermoula-marinated,chermoula-marinated,chermoula-marinated,ADJ,B2
-chest breast,chest breast,chest breast,NOUN,B2
-chest of drawers,chest of drawers,chest of drawers,NOUN,A2
-chiaroscuro,chiaroscuro,chiaroscuro,NOUN,B2
-chiasmus,chiasmus,chiasmus,NOUN,C1
-chic (adj),chic,chic (adj),ADJ,C1
-chic (noun),chic,chic (noun),NOUN,C1
-chickpeas,chickpeas,chickpeas,NOUN,A2
-chide,chide,chide,VERB,C1
-chiefly,chiefly,chiefly,ADV,B2
-child's play,child's play,child's play,NOUN,C1
-childcare,childcare,childcare,NOUN,C1
-childhood trauma,childhood trauma,childhood trauma,NOUN,C1
-childish infantile,childish infantile,childish infantile,ADJ,C1
-chill (noun),chill,chill (noun),NOUN,B1
-chilling,chilling,chilling,ADJ,C1
-chime,chime,chime,NOUN,C1
-chimera,chimera,chimera,NOUN,C1
-chimney sweep,chimney sweep,chimney sweep,NOUN,C1
-chimpanzee,chimpanzee,chimpanzee,NOUN,B2
-chirp (noun),chirp,chirp (noun),NOUN,C1
-chitchat,chitchat,chitchat,NOUN,B2
-chivalrous,chivalrous,chivalrous,ADJ,B2
-chives,chives,chives,NOUN,B1
-chocolate shop,chocolate shop,chocolate shop,NOUN,B2
-choirboy,choirboy,choirboy,NOUN,C1
-choke,choke,choke,VERB,B2
-cholera,cholera,cholera,NOUN,C1
-chomp,chomp,chomp,VERB,C1
-chorale,chorale,chorale,NOUN,C1
-choreograph,choreograph,choreograph,VERB,C1
-choreographic,choreographic,choreographic,ADJ,C1
-choreography,choreography,choreography,NOUN,C1
-chortle,chortle,chortle,VERB,C1
-christen,christen,christen,VERB,C1
-christianization,christianization,christianization,NOUN,C1
-christmas eve,christmas eve,christmas eve,NOUN,B2
-christmas porridge,christmas porridge,christmas porridge,NOUN,B2
-chromatic,chromatic,chromatic,ADJ,B2
-chromaticity,chromaticity,chromaticity,NOUN,C1
-chromosomal,chromosomal,chromosomal,ADJ,C1
-chronicler,chronicler,chronicler,NOUN,B2
-chronological,chronological,chronological,ADJ,C1
-chuck,chuck,chuck,VERB,B1
-chuckle,chuckle,chuckle,VERB,B2
-churchgoing,churchgoing,churchgoing,NOUN,C1
-churn,churn,churn,VERB,C1
-churn skin,churn skin,churn skin,NOUN,B2
-cider,cider,cider,NOUN,B2
-cinematic,cinematic,cinematic,ADJ,B1
-cinematographic,cinematographic,cinematographic,ADJ,B2
-circular (adj),circular,circular (adj),ADJ,C1
-circular (noun),circular,circular (noun),NOUN,B2
-circulating,circulating,circulating,ADJ,B2
-circumference,circumference,circumference,NOUN,C1
-circumscription,circumscription,circumscription,NOUN,C1
-circumspection,circumspection,circumspection,NOUN,B2
-circumstantial accusative,circumstantial accusative,circumstantial accusative,NOUN,C1
-circumvent,circumvent,circumvent,VERB,C1
-circus (adj),circus,circus (adj),ADJ,B2
-cirrhosis,cirrhosis,cirrhosis,NOUN,B2
-citadel,citadel,citadel,NOUN,C1
-city dweller,city dweller,city dweller,NOUN,C1
-civic,civic,civic,ADJ,C1
-civic-mindedness,civic-mindedness,civic-mindedness,NOUN,B2
-civil war,civil war,civil war,NOUN,B2
-civilize,civilize,civilize,VERB,C1
-clack,clack,clack,NOUN,C1
-clairvoyance,clairvoyance,clairvoyance,NOUN,B2
-clairvoyant,clairvoyant,clairvoyant,ADJ,B2
-clamber,clamber,clamber,VERB,C1
-clamorous,clamorous,clamorous,ADJ,B2
-clampdown,clampdown,clampdown,NOUN,C1
-clandestine migration,clandestine migration,clandestine migration,NOUN,B2
-clandestineness,clandestineness,clandestineness,NOUN,B2
-clandestinity,clandestinity,clandestinity,NOUN,B2
-clang,clang,clang,NOUN,C1
-clank,clank,clank,NOUN,C1
-clapping,clapping,clapping,NOUN,B2
-clarified butter,clarified butter,clarified butter,NOUN,A2
-clarity evidentness,clarity evidentness,clarity evidentness,NOUN,C1
-clash (noun),clash,clash (noun),NOUN,C1
-clasp,clasp,clasp,NOUN,C1
-class session,class session,class session,NOUN,B1
-class stratification,class stratification,class stratification,NOUN,C1
-class test,class test,class test,NOUN,B1
-classical poetry,classical poetry,classical poetry,NOUN,C1
-classicist,classicist,classicist,ADJ,B2
-clauses,clauses,clauses,NOUN,C1
-clay stove,clay stove,clay stove,NOUN,B1
-cleaner (adj),cleaner,cleaner (adj),ADJ,B2
-cleanliness cleanness,cleanliness cleanness,cleanliness cleanness,NOUN,C1
-cleanse,cleanse,cleanse,VERB,C1
-clear limpid,clear limpid,clear limpid,ADJ,C1
-clear the throat,clear the throat,clear the throat,VERB,B2
-clearance,clearance,clearance,NOUN,C1
-clearing,clearing,林中空地,NOUN,B2
-clearing of the throat,clearing of the throat,clearing of the throat,NOUN,C1
-cleave,to cleave,劈开,VERB,B2
-clench,clench,clench,VERB,C1
-clergy,clergy,神职人员,NOUN,B2
-clericalism,clericalism,clericalism,NOUN,B2
-clerk,clerk,职员,NOUN,B2
-clerk cleric,clerk cleric,clerk cleric,NOUN,C1
-click,to click,点击,VERB,B2
-click (noun),click,click (noun),NOUN,C1
-clickbait,clickbait,clickbait,NOUN,C1
-clientele,clientele,clientele,NOUN,B2
-clientelism,clientelism,庇护主义,NOUN,B2
-cliffhanger,cliffhanger,cliffhanger,NOUN,B1
-climatic,climatic,climatic,ADJ,C1
-climatology,climatology,climatology,NOUN,C1
-climax,climax,高潮,NOUN,B2
-climb,to climb,攀登,VERB,B2
-climbing,climbing,climbing,NOUN,B1
-clinch,clinch,clinch,VERB,C1
-cling,to cling,紧贴,VERB,B2
-clinic,clinic,诊所,NOUN,B2
-clink,clink,clink,NOUN,C1
-clinking,clinking,clinking,NOUN,C1
-clipping,clipping,clipping,NOUN,C1
-cloak,cloak,斗篷,NOUN,B2
-clobber,clobber,clobber,VERB,C1
-clog (noun),clog,clog (noun),NOUN,B2
-clog (verb),clog,clog (verb),VERB,C1
-cloned,cloned,cloned,ADJ,C1
-cloning,cloning,cloning,NOUN,C1
-close scrutiny,close scrutiny,close scrutiny,NOUN,C1
-closed,closed,关闭的,ADJ,B2
-closed disabled,closed disabled,closed disabled,ADJ,B2
-closely,closely,closely,ADV,B2
-closer (adv),closer,closer (adv),ADV,B2
-closet,closet,壁橱,NOUN,B2
-closing,closing,closing,NOUN,B2
-closure,closure,关闭,NOUN,B2
-clot,clot,凝块,NOUN,B2
-clothe,clothe,clothe,VERB,C1
-cloud (adj),cloud,cloud (adj),ADJ,C1
-cloud of smoke,cloud of smoke,cloud of smoke,NOUN,C1
-cloudy,cloudy,阴沉的,ADJ,B2
-clout,clout,clout,NOUN,C1
-clover,clover,clover,NOUN,C1
-cloying,cloying,cloying,ADJ,C1
-club blow,club blow,club blow,NOUN,C1
-cluck,cluck,cluck,NOUN,C1
-clueless,clueless,clueless,ADJ,C1
-clump,clump,clump,NOUN,C1
-clumsily,clumsily,clumsily,ADV,B2
-clumsy,clumsy,笨拙的,ADJ,B2
-clunky,clunky,clunky,ADJ,C1
-clutter,clutter,clutter,NOUN,C1
-co-,co-,co-,ADV,B2
-co-founder,co-founder,co-founder,NOUN,C1
-co-occurrence,co-occurrence,co-occurrence,NOUN,C1
-co-ownership,co-ownership,co-ownership,NOUN,B2
-coagulated,coagulated,coagulated,ADJ,C1
-coagulation,coagulation,coagulation,NOUN,B2
-coalesce,coalesce,coalesce,VERB,C1
-coalition,coalition,联盟,NOUN,B2
-coarse,coarse,粗糙的,ADJ,B2
-coarse rough,coarse rough,coarse rough,ADJ,C1
-coast road,coast road,coast road,NOUN,B2
-coastal (noun),coastal,coastal (noun),NOUN,B2
-coastline,coastline,coastline,NOUN,B2
-coating,coating,coating,NOUN,C1
-coating plaster,coating plaster,coating plaster,NOUN,C1
-cobble,cobble,cobble,VERB,C1
-cobbler,cobbler,cobbler,NOUN,B2
-cock,cock,cock,NOUN,B2
-cockroach,cockroach,cockroach,NOUN,A1
-cocktail,cocktail,鸡尾酒,NOUN,B2
-cocoa,cocoa,cocoa,NOUN,C1
-cod,cod,cod,NOUN,B1
-coddle,coddle,coddle,VERB,C1
-code of conduct,code of conduct,code of conduct,NOUN,C1
-codicil,codicil,codicil,NOUN,C1
-codicology,codicology,codicology,NOUN,C1
-codified,codified,codified,ADJ,C1
-coding,coding,coding,NOUN,B2
-coexistence,coexistence,共存,NOUN,B2
-coffee maker,coffee maker,coffee maker,NOUN,A2
-coffin,coffin,棺材,NOUN,B2
-cog,cog,cog,NOUN,C1
-cogency,cogency,cogency,NOUN,C1
-cogitate,cogitate,cogitate,VERB,C1
-cogito,cogito,cogito,NOUN,C1
-cognate,cognate,cognate,NOUN,B2
-cognizance,cognizance,cognizance,NOUN,C1
-cogwheel,cogwheel,cogwheel,NOUN,C1
-cohabitation,cohabitation,cohabitation,NOUN,C1
-cohere,cohere,cohere,VERB,C1
-coherence,coherence,连贯性,NOUN,B2
-coherent,coherent,连贯的,ADJ,B2
-coil (noun),coil,coil (noun),NOUN,C1
-coin purse,coin purse,coin purse,NOUN,B2
-coincidence of ideas,coincidence of ideas,coincidence of ideas,NOUN,C1
-coining,coining,coining,NOUN,B2
-coins,coins,coins,NOUN,C1
-coitus,coitus,coitus,NOUN,B2
-coke,coke,coke,NOUN,B2
-colander,colander,漏勺,NOUN,B2
-cold,cold,寒冷,NOUN,B2
-coldness,coldness,coldness,NOUN,B2
-colic,colic,colic,NOUN,C1
-coliseum,coliseum,coliseum,NOUN,B2
-collaborate,to collaborate,合作,VERB,B2
-collapse,collapse,倒塌,NOUN,B2
-collar,collar,衣领,NOUN,B2
-collarbone,collarbone,collarbone,NOUN,B2
-collateral,collateral,附属的,ADJ,B2
-collation,collation,collation,NOUN,B2
-colleague female,colleague female,colleague female,NOUN,B2
-collect,to collect,收集,VERB,B2
-collected,collected,collected,ADJ,B2
-collectie,collectie,collectie,NOUN,B2
-collections,collections,collections,NOUN,C1
-collective,collective,集体的,ADJ,B2
-collectivism,collectivism,collectivism,NOUN,C1
-collectivization,collectivization,collectivization,NOUN,B2
-collector,collector,收藏家,NOUN,B2
-collegiality,collegiality,collegiality,NOUN,C1
-collegiate,collegiate,collegiate,ADJ,B2
-collide,to collide,碰撞,VERB,B2
-collision,collision,碰撞,NOUN,B2
-collocation,collocation,collocation,NOUN,C1
-colloquial,colloquial,colloquial,ADJ,B2
-colloquial language,colloquial language,colloquial language,NOUN,C1
-colloquium,colloquium,colloquium,NOUN,B2
-collusion,collusion,collusion,NOUN,B2
-colon (punct),colon,colon (punct),PUNCT,A2
-colonial,colonial,colonial,ADJ,C1
-colonial settlers,colonial settlers,colonial settlers,NOUN,C1
-colonist,colonist,colonist,NOUN,B2
-colonizing,colonizing,colonizing,ADJ,C1
-colonnade,colonnade,colonnade,NOUN,C1
-colophon,colophon,colophon,NOUN,B2
-coloration,coloration,coloration,NOUN,B2
-colorblind,colorblind,colorblind,ADJ,B2
-coloring,coloring,coloring,NOUN,B2
-colorless,colorless,colorless,ADJ,C1
-colossal,colossal,colossal,ADJ,B2
-colossus,colossus,colossus,NOUN,B2
-columnar,columnar,columnar,ADJ,C1
-columnist,columnist,columnist,NOUN,C1
-combatant,combatant,combatant,NOUN,B2
-combative,combative,combative,ADJ,B2
-combinations,combinations,combinations,NOUN,C1
-combinatorial,combinatorial,combinatorial,ADJ,B2
-combinatorics,combinatorics,combinatorics,NOUN,C1
-combing,combing,combing,NOUN,C1
-combining,combining,combining,ADJ,B2
-combustibility,combustibility,combustibility,NOUN,C1
-combustion,combustion,combustion,NOUN,C1
-come on,come on,come on,INTJ,C1
-comer,comer,comer,NOUN,C1
-comfortable tranquility,comfortable tranquility,comfortable tranquility,NOUN,C1
-comfortably,comfortably,comfortably,ADV,C1
-comforting,comforting,comforting,ADJ,B2
-comic (noun),comic,comic (noun),NOUN,B2
-comicness,comicness,comicness,NOUN,C1
-comma (noun),comma,comma (noun),NOUN,B1
-commandeer,commandeer,commandeer,VERB,C1
-commandment,commandment,commandment,NOUN,C1
-commence,commence,commence,VERB,B2
-commend,commend,commend,VERB,C1
-commendable,commendable,commendable,ADJ,C1
-commendation,commendation,commendation,NOUN,C1
-commensalism,commensalism,commensalism,NOUN,B2
-commensurability,commensurability,commensurability,NOUN,C1
-commentaries,commentaries,commentaries,NOUN,C1
-commercial (noun),commercial,commercial (noun),NOUN,B2
-commercialization,commercialization,commercialization,NOUN,C1
-commiserate,commiserate,commiserate,VERB,C1
-commitments,commitments,commitments,NOUN,C1
-committees,committees,committees,NOUN,C1
-commodatum,commodatum,commodatum,NOUN,C1
-commodification,commodification,commodification,NOUN,C1
-common good,common good,common good,NOUN,B2
-common opinion,common opinion,common opinion,NOUN,C1
-common shared,common shared,common shared,ADJ,B1
-commonly,commonly,commonly,ADV,C1
-commonplace,commonplace,commonplace,ADJ,C1
-communal work,communal work,communal work,NOUN,C1
-communes,communes,communes,NOUN,C1
-communicativeness,communicativeness,communicativeness,NOUN,C1
-communion rail,communion rail,communion rail,NOUN,B2
-communitarian,communitarian,communitarian,ADJ,C1
-community-related,community-related,community-related,ADJ,B2
-commuter,commuter,commuter,NOUN,A2
-comorbidity,comorbidity,comorbidity,NOUN,B2
-compactness,compactness,compactness,NOUN,C1
-comparability,comparability,comparability,NOUN,C1
-comparative weighing,comparative weighing,comparative weighing,NOUN,C1
-compartmental,compartmental,compartmental,ADJ,C1
-compassion sympathy,compassion sympathy,compassion sympathy,NOUN,B2
-compatible,compatible,compatible,ADJ,C1
-compelling,compelling,compelling,ADJ,C1
-compendious,compendious,compendious,ADJ,B2
-compendium,compendium,compendium,NOUN,B2
-competencies,competencies,competencies,NOUN,B2
-competing,competing,competing,ADJ,C1
-competition bastard,competition bastard,competition bastard,NOUN,B2
-competitive exam,competitive exam,competitive exam,NOUN,B2
-complacency,complacency,complacency,NOUN,B2
-complaints,complaints,complaints,NOUN,C1
-complete idiot,complete idiot,complete idiot,NOUN,C1
-completeness,completeness,,NOUN,B2
-complications,complications,complications,NOUN,C1
-compliment,compliment,称赞,NOUN,B2
-component,component,组成部分,NOUN,B2
-composer,composer,作曲家,NOUN,B2
-composition,composition,作文,NOUN,B2
-compositional,compositional,compositional,ADJ,C1
-compostable,compostable,compostable,ADJ,B2
-composure,composure,镇定,NOUN,B2
-compound,compound,化合物,NOUN,B2
-comprehend,to comprehend,理解,VERB,B2
-comprehensibility,comprehensibility,comprehensibility,NOUN,C1
-compressed,compressed,compressed,ADJ,C1
-compressibility,compressibility,compressibility,NOUN,C1
-compressible,compressible,compressible,ADJ,C1
-compressor,compressor,压缩机,NOUN,B2
-comprise,comprise,comprise,VERB,C1
-compromise,compromise,妥协,NOUN,B2
-compulsion,compulsion,compulsion,NOUN,C1
-compulsive,compulsive,强迫性的,ADJ,B2
-compulsorily,compulsorily,compulsorily,ADV,C1
-compunction,compunction,compunction,NOUN,B2
-compurgation oath,compurgation oath,compurgation oath,NOUN,C1
-computability,computability,computability,NOUN,C1
-compute,to compute,计算,VERB,B2
-computer mouse,computer mouse,computer mouse,NOUN,B1
-computer science,computer science,computer science,NOUN,C1
-computer specialist,computer specialist,computer specialist,NOUN,B2
-computing,computing,计算机科学,NOUN,B2
-con artist,con artist,con artist,NOUN,B1
-concatenation,concatenation,concatenation,NOUN,B2
-concavity,concavity,concavity,NOUN,B2
-concealed,concealed,concealed,ADJ,C1
-conceit,conceit,conceit,NOUN,C1
-conceited,conceited,自负的,ADJ,B2
-concentration,concentration,专注,NOUN,B2
-concentric,concentric,concentric,ADJ,C1
-concepts,concepts,concepts,NOUN,C1
-conceptualize,conceptualize,conceptualize,VERB,C1
-concerning (adj),concerning,concerning (adj),ADJ,B2
-concerns,concerns,concerns,NOUN,C1
-concert,concert,音乐会,NOUN,B2
-concerto,concerto,concerto,NOUN,C1
-conch,conch,conch,NOUN,B2
-conciliation,conciliation,conciliation,NOUN,B2
-concise,concise,简洁的,ADJ,B2
-conclave,conclave,conclave,NOUN,B2
-concluding,concluding,concluding,ADJ,B2
-conclusion of contract,conclusion of contract,conclusion of contract,NOUN,C1
-concomitantly,concomitantly,concomitantly,ADV,B2
-concordance,concordance,concordance,NOUN,B2
-concordat,concordat,concordat,NOUN,B2
-concrete,concrete,混凝土,NOUN,B2
-concretization,concretization,concretization,NOUN,C1
-concupiscence,concupiscence,concupiscence,NOUN,B2
-concur,concur,concur,VERB,C1
-concurrence,concurrence,concurrence,NOUN,B2
-concurrently,concurrently,concurrently,ADV,C1
-condemned,condemned,condemned,ADJ,B2
-condensation,condensation,凝结,NOUN,B2
-condenser,condenser,condenser,NOUN,C1
-condescending,condescending,屈尊的,ADJ,B2
-condition,to condition,制约,VERB,B2
-conditional,conditional,条件的,ADJ,B2
-conditioning (adj),conditioning,conditioning (adj),ADJ,B2
-conditioning (noun),conditioning,conditioning (noun),NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,conditioning adaptation air conditioning,NOUN,C1
-condolence,condolence,哀悼,NOUN,B2
-condolences,condolences,哀悼,NOUN,B2
-conducive,conducive,conducive,ADJ,B2
-conduciveness,conduciveness,conduciveness,NOUN,C1
-conductor,conductor,conductor,NOUN,C1
-conduit,conduit,conduit,NOUN,B2
-cone,cone,圆锥体,NOUN,B2
-confederal,confederal,confederal,ADJ,C1
-conference,conference,会议,NOUN,B2
-conference talk,conference talk,conference talk,NOUN,C1
-confetti,confetti,confetti,NOUN,C1
-confidant,confidant,confidant,NOUN,B2
-confide,to confide,吐露,VERB,B2
-confident,confident,自信的,ADJ,B2
-confidential,confidential,机密的,ADJ,B2
-confidentiality,confidentiality,保密性,NOUN,B2
-confiding,confiding,confiding,NOUN,C1
-configuration,configuration,配置,NOUN,B2
-configure,configure,configure,VERB,C1
-configured,configured,configured,ADJ,C1
-confinement,confinement,confinement,NOUN,B2
-confines edges,confines edges,confines edges,NOUN,C1
-confirmation,confirmation,确认,NOUN,B2
-confiscate,to confiscate,没收,VERB,B2
-confiscation,confiscation,没收,NOUN,B2
-conflictual,conflictual,conflictual,ADJ,C1
-confluence,confluence,confluence,NOUN,B2
-conforming,conforming,conforming,ADJ,B2
-conformism,conformism,因循守旧,NOUN,B2
-conformist (adj),conformist,conformist (adj),ADJ,B2
-conformist (noun),conformist,conformist (noun),NOUN,B2
-conformity,conformity,conformity,NOUN,B2
-confound,confound,confound,VERB,C1
-confrontation,confrontation,对抗,NOUN,B2
-confronted,confronted,confronted,ADJ,B2
-confronting,confronting,confronting,ADJ,B2
-confused (adv),confused,confused (adv),ADV,B1
-confused embarrassed,confused embarrassed,confused embarrassed,ADJ,C1
-confused hesitant,confused hesitant,confused hesitant,ADJ,A2
-confusedly,confusedly,confusedly,ADV,C1
-congeal,congeal,congeal,VERB,C1
-conglomerate,conglomerate,conglomerate,NOUN,B2
-congregate,congregate,congregate,VERB,C1
-congressperson,congressperson,congressperson,NOUN,B2
-congruence,congruence,congruence,NOUN,B2
-conic,conic,conic,NOUN,B2
-conjoin,conjoin,conjoin,VERB,C1
-conjugal,conjugal,conjugal,ADJ,B2
-conjunctural,conjunctural,conjunctural,ADJ,C1
-connectedness,connectedness,connectedness,NOUN,C1
-connector,connector,connector,NOUN,B2
-connivance,connivance,connivance,NOUN,B2
-connive,connive,connive,VERB,C1
-conniving,conniving,conniving,ADJ,C1
-consanguineous,consanguineous,consanguineous,ADJ,B2
-conscientious objection,conscientious objection,conscientious objection,NOUN,B2
-conscientiously,conscientiously,conscientiously,ADV,C1
-consciously,consciously,consciously,ADV,B2
-conscript,conscript,conscript,NOUN,C1
-conscription,conscription,conscription,NOUN,C1
-consecration,consecration,consecration,NOUN,C1
-consensualism,consensualism,consensualism,NOUN,C1
-consequent,consequent,consequent,ADJ,B2
-conservatism,conservatism,conservatism,NOUN,C1
-considered,considered,considered,ADJ,B1
-console (noun),console,console (noun),NOUN,B2
-consolidable,consolidable,consolidable,ADJ,C1
-consolidation,consolidation,consolidation,NOUN,C1
-consonance,consonance,consonance,NOUN,B2
-consortium,consortium,consortium,NOUN,B2
-conspirator,conspirator,conspirator,NOUN,B2
-constants,constants,constants,NOUN,C1
-constative,constative,constative,ADJ,C1
-consternation,consternation,consternation,NOUN,B2
-constituencies,constituencies,constituencies,NOUN,C1
-constitutional amendment,constitutional amendment,constitutional amendment,NOUN,C1
-constitutional article,constitutional article,constitutional article,NOUN,C1
-constitutionalization,constitutionalization,constitutionalization,NOUN,B2
-constraints,constraints,constraints,NOUN,C1
-constrict,constrict,constrict,VERB,C1
-constructiveness,constructiveness,constructiveness,NOUN,C1
-construe,construe,construe,VERB,C1
-consumerist,consumerist,consumerist,ADJ,B2
-consummate (adj),consummate,consummate (adj),ADJ,B2
-consummation,consummation,consummation,NOUN,B2
-consumptive,consumptive,consumptive,ADJ,B2
-contact (noun),contact,contact (noun),NOUN,A2
-contactual,contactual,contactual,ADJ,B2
-contagion,contagion,contagion,NOUN,B2
-containment,containment,containment,NOUN,C1
-contemporaneity,contemporaneity,contemporaneity,NOUN,C1
-contemptuously,contemptuously,contemptuously,ADV,C1
-contender,contender,contender,NOUN,B2
-content (adj),content,content (adj),ADJ,B2
-contextualization,contextualization,contextualization,NOUN,C1
-contiguity,contiguity,contiguity,NOUN,B2
-contiguous,contiguous,contiguous,ADJ,B2
-continence,continence,continence,NOUN,B2
-continental,continental,continental,ADJ,B2
-continually,continually,continually,ADV,B2
-contort,contort,contort,VERB,C1
-contortion,contortion,contortion,NOUN,B2
-contour,contour,contour,NOUN,B2
-contracted,contracted,contracted,ADJ,B2
-contracting,contracting,contracting,NOUN,C1
-contractor,contractor,contractor,NOUN,B1
-contractual nature,contractual nature,contractual nature,NOUN,C1
-contractuality,contractuality,contractuality,NOUN,C1
-contradictoriness,contradictoriness,contradictoriness,NOUN,C1
-contraindicate,contraindicate,contraindicate,VERB,C1
-contraindication,contraindication,contraindication,NOUN,C1
-contrary (adj),contrary,contrary (adj),ADJ,C1
-contrast (noun),contrast,contrast (noun),NOUN,C1
-contrastive,contrastive,contrastive,ADJ,C1
-contributions,contributions,contributions,NOUN,C1
-contrite,contrite,contrite,ADJ,B2
-contrive,contrive,contrive,VERB,C1
-controllability,controllability,controllability,NOUN,C1
-controller,controller,controller,NOUN,C1
-controlling,controlling,controlling,ADJ,C1
-contumacy,contumacy,contumacy,NOUN,C1
-contusion,contusion,contusion,NOUN,B2
-convalesce,convalesce,convalesce,VERB,B2
-convalescence,convalescence,convalescence,NOUN,C1
-convalescent,convalescent,convalescent,ADJ,B2
-convenant,convenant,convenant,NOUN,C1
-convenience,convenience,convenience,NOUN,B2
-convent,convent,convent,NOUN,B2
-conventionality,conventionality,conventionality,NOUN,C1
-convergent,convergent,convergent,ADJ,C1
-conversation technique,conversation technique,conversation technique,NOUN,C1
-convert (noun),convert,convert (noun),NOUN,B2
-convex,convex,convex,ADJ,B2
-convexity,convexity,convexity,NOUN,B2
-conveyance,conveyance,conveyance,NOUN,C1
-conveyance routing,conveyance routing,conveyance routing,NOUN,B2
-convict (adj),convict,convict (adj),ADJ,B2
-convict (noun),convict,convict (noun),NOUN,C1
-convicted,convicted,convicted,ADJ,B2
-conviviality,conviviality,conviviality,NOUN,B2
-convoke,convoke,convoke,VERB,C1
-convoluted,convoluted,convoluted,ADJ,B2
-convolutional,convolutional,convolutional,ADJ,B2
-convoy,convoy,convoy,NOUN,B2
-convulse,convulse,convulse,VERB,C1
-convulsive,convulsive,convulsive,ADJ,B2
-cookbook,cookbook,cookbook,NOUN,C1
-cool-headed,cool-headed,cool-headed,ADJ,B2
-cooler,cooler,cooler,ADJ,C1
-coop,coop,coop,VERB,C1
-cooperative (adj),cooperative,cooperative (adj),ADJ,C1
-cooperative (noun),cooperative,cooperative (noun),NOUN,B1
-coordinated,coordinated,coordinated,ADJ,C1
-coordinates,coordinates,coordinates,NOUN,C1
-coordination,coordination,coordination,NOUN,B2
-copious,copious,copious,ADJ,B2
-coquettish,coquettish,coquettish,ADJ,C1
-coral (adj),coral,coral (adj),ADJ,C1
-cord,cord,cord,NOUN,B2
-cordial,cordial,cordial,ADJ,B2
-cordiality,cordiality,cordiality,NOUN,C1
-cordoning,cordoning,cordoning,NOUN,C1
-coriander,coriander,coriander,NOUN,B2
-corniche,corniche,corniche,NOUN,C1
-corporeal,corporeal,corporeal,ADJ,B2
-corpulent,corpulent,corpulent,ADJ,B2
-corpuscle,corpuscle,corpuscle,NOUN,C1
-correctional,correctional,correctional,ADJ,C1
-corrections,corrections,corrections,NOUN,B2
-correlate,correlate,correlate,VERB,C1
-correlative,correlative,correlative,ADJ,B2
-correlatively,correlatively,correlatively,ADV,B2
-correspondents,correspondents,correspondents,NOUN,C1
-corridors,corridors,corridors,NOUN,C1
-corrigible,corrigible,corrigible,ADJ,B2
-corrupted,corrupted,corrupted,NOUN,B2
-corruptibility,corruptibility,corruptibility,NOUN,C1
-cosmogony,cosmogony,cosmogony,NOUN,C1
-cosmology,cosmology,cosmology,NOUN,B2
-cosmopolitanism,cosmopolitanism,cosmopolitanism,NOUN,B2
-cosmos,cosmos,cosmos,NOUN,C1
-costumbrism,costumbrism,costumbrism,NOUN,B2
-costumes,costumes,costumes,NOUN,B2
-cosy,cosy,cosy,ADJ,B2
-couch,couch,couch,NOUN,B1
-cough (noun),cough,cough (noun),NOUN,B2
-could,could,could,AUX,A1
-council-related,council-related,council-related,ADJ,C1
-counsel,counsel,counsel,NOUN,B2
-counselor,counselor,counselor,NOUN,C1
-countenance,countenance,countenance,NOUN,B2
-counter clerk,counter clerk,counter clerk,NOUN,B1
-counteract,counteract,counteract,VERB,C1
-counterbalance,counterbalance,counterbalance,VERB,C1
-countercurrent,countercurrent,countercurrent,NOUN,B2
-countermand,countermand,countermand,VERB,C1
-counterweight,counterweight,counterweight,NOUN,B2
-country land,country land,country land,NOUN,A1
-courageously,courageously,courageously,ADV,C1
-court appearance,court appearance,court appearance,NOUN,C1
-court clerk,court clerk,court clerk,NOUN,C1
-court costs,court costs,court costs,NOUN,C1
-courtier,courtier,courtier,NOUN,B2
-courtly,courtly,courtly,ADJ,B2
-couscous,couscous,couscous,NOUN,A1
-cousin female,cousin female,cousin female,NOUN,B2
-cove,cove,cove,NOUN,B2
-cover-up,cover-up,cover-up,NOUN,C1
-coward (adj),coward,coward (adj),ADJ,A2
-cower,cower,cower,VERB,C1
-cowpeas,cowpeas,cowpeas,NOUN,B2
-crackdown,crackdown,crackdown,NOUN,C1
-cracker,cracker,cracker,NOUN,B2
-cracking,cracking,cracking,NOUN,B2
-cramped,cramped,cramped,ADJ,C1
-crank,crank,crank,NOUN,C1
-crash bang,crash bang,crash bang,NOUN,C1
-crass,crass,crass,ADJ,B2
-cravenly,cravenly,cravenly,ADV,C1
-crayon,crayon,crayon,NOUN,C1
-crazy nutcase,crazy nutcase,crazy nutcase,NOUN,C1
-creak (noun),creak,creak (noun),NOUN,B2
-creamy,creamy,creamy,ADJ,C1
-crease,crease,crease,NOUN,C1
-credible,credible,credible,ADJ,C1
-credulous,credulous,credulous,ADJ,B2
-creep (verb),creep,creep (verb),VERB,B2
-cremate,cremate,cremate,VERB,C1
-cremation,cremation,cremation,NOUN,B2
-crenelate,crenelate,crenelate,VERB,C1
-crescendo,crescendo,crescendo,NOUN,C1
-crescent,crescent,,NOUN,B2
-crib,crib,crib,NOUN,C1
-crick,crick,crick,NOUN,C1
-crime novel,crime novel,crime novel,NOUN,B1
-crime rate,crime rate,crime rate,NOUN,B2
-criminal lawyer,criminal lawyer,criminal lawyer,NOUN,B2
-criminal record,criminal record,criminal record,NOUN,B2
-criminalization,criminalization,criminalization,NOUN,C1
-crimson,crimson,crimson,ADJ,C1
-cringe,cringe,cringe,VERB,C1
-crinkle,crinkle,crinkle,VERB,C1
-cripple,cripple,cripple,VERB,C1
-crisis deepening,crisis deepening,crisis deepening,NOUN,C1
-crisis of conscience,crisis of conscience,crisis of conscience,NOUN,C1
-crisis-ridden,crisis-ridden,crisis-ridden,ADJ,C1
-crisp,crisp,crisp,ADJ,C1
-criticizable,criticizable,criticizable,ADJ,B2
-critique,critique,critique,NOUN,C1
-crochet,crochet,crochet,NOUN,C1
-crocodile,crocodile,crocodile,NOUN,A1
-cronyism,cronyism,cronyism,NOUN,C1
-cross-border,cross-border,cross-border,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,cross-cultural exchange,NOUN,C1
-cross-cutting,cross-cutting,cross-cutting,ADJ,C1
-crossing the border,crossing the border,crossing the border,NOUN,B2
-crosswise,crosswise,crosswise,ADJ,C1
-crouch (noun),crouch,crouch (noun),NOUN,B2
-croup,croup,croup,NOUN,C1
-crowbar,crowbar,crowbar,NOUN,B2
-crucible,crucible,crucible,NOUN,B2
-crucifixion,crucifixion,crucifixion,NOUN,C1
-crucify,crucify,crucify,VERB,C1
-cruelly,cruelly,cruelly,ADV,B2
-cruelty harshness,cruelty harshness,cruelty harshness,NOUN,B2
-cruise passenger,cruise passenger,cruise passenger,NOUN,B1
-crumb,crumb,crumb,NOUN,C1
-crumbs,crumbs,crumbs,NOUN,B2
-crunching,crunching,crunching,NOUN,C1
-crushing,crushing,crushing,NOUN,B2
-crusty,crusty,crusty,ADJ,B2
-cry weep,cry weep,cry weep,VERB,A1
-crying shouting,crying shouting,crying shouting,NOUN,B1
-cryptic,cryptic,cryptic,ADJ,C1
-crystal glass,crystal glass,crystal glass,NOUN,B1
-crystallization,crystallization,crystallization,NOUN,C1
-crystallize,crystallize,crystallize,VERB,C1
-cubit,cubit,cubit,NOUN,B2
-cuckold,cuckold,cuckold,VERB,C1
-cuddle (noun),cuddle,cuddle (noun),NOUN,C1
-cue,cue,cue,NOUN,B2
-cuff,cuff,cuff,NOUN,C1
-cuisine,cuisine,cuisine,NOUN,C1
-cull,cull,cull,VERB,C1
-culminating,culminating,culminating,ADJ,C1
-culmination,culmination,culmination,NOUN,B2
-culturalism,culturalism,culturalism,NOUN,C1
-cultured,cultured,cultured,ADJ,B2
-cumber,cumber,cumber,VERB,C1
-cumin,cumin,cumin,NOUN,B1
-cumulative,cumulative,cumulative,ADJ,B2
-cunning shrewdness,cunning shrewdness,cunning shrewdness,NOUN,B2
-cunningly,cunningly,cunningly,ADV,C1
-cupboard wardrobe,cupboard wardrobe,cupboard wardrobe,NOUN,A2
-cupola,cupola,cupola,NOUN,C1
-cupping,cupping,cupping,NOUN,B1
-curate,curate,curate,VERB,C1
-curator,curator,curator,NOUN,B2
-curatorship,curatorship,curatorship,NOUN,C1
-curd,curd,curd,NOUN,B2
-curdle,curdle,curdle,VERB,C1
-curdled milk,curdled milk,curdled milk,NOUN,A2
-curiously,curiously,curiously,ADV,C1
-currency exchange,currency exchange,currency exchange,NOUN,B2
-current events,current events,current events,NOUN,B2
-current times,current times,current times,NOUN,B2
-curriculum vitae,curriculum vitae,curriculum vitae,NOUN,B2
-curry,curry,curry,NOUN,B2
-curvature,curvature,curvature,NOUN,B2
-curved,curved,curved,ADJ,B2
-cusp,cusp,cusp,NOUN,B2
-custodian,custodian,custodian,NOUN,B2
-customary law,customary law,customary law,NOUN,C1
-customer orientation,customer orientation,customer orientation,NOUN,B2
-customization,customization,customization,NOUN,C1
-customs (adj),customs,customs (adj),ADJ,C1
-cutaneous,cutaneous,cutaneous,ADJ,C1
-cutlet,cutlet,cutlet,NOUN,B1
-cuttlefish,cuttlefish,cuttlefish,NOUN,B2
-cybernetics,cybernetics,cybernetics,NOUN,C1
-cyborg,cyborg,cyborg,NOUN,C1
-cycling,cycling,cycling,NOUN,C1
-cykel,cykel,cykel,NOUN,B2
-cyst,cyst,cyst,NOUN,B2
-czech,czech,czech,ADJ,B2
-dab,dab,dab,VERB,C1
-dabble,dabble,dabble,VERB,C1
-dachshund,dachshund,dachshund,NOUN,A1
-dadaism,dadaism,dadaism,NOUN,C1
-daglig,daglig,daglig,ADJ,C1
-daily (noun),daily,daily (noun),NOUN,B2
-daily wage,daily wage,daily wage,NOUN,C1
-dairy,dairy,dairy,ADJ,C1
-dally,dally,dally,VERB,C1
-damask,damask,damask,NOUN,B2
-damm,damm,damm,NOUN,B2
-damned,damned,damned,ADJ,B2
-damping,damping,damping,NOUN,C1
-dance floor,dance floor,dance floor,NOUN,B2
-dandelion,dandelion,dandelion,NOUN,B1
-dandle,dandle,dandle,VERB,C1
-dandruff,dandruff,dandruff,NOUN,B2
-dangle,dangle,dangle,VERB,C1
-darbuka,darbuka,darbuka,NOUN,C1
-daring,daring,daring,ADJ,B2
-daring bold,daring bold,daring bold,ADJ,B2
-dark blue,dark blue,dark blue,ADJ,A1
-dark depths,dark depths,dark depths,NOUN,C1
-dark-colored,dark-colored,dark-colored,ADJ,A2
-darkness of night,darkness of night,darkness of night,NOUN,C1
-darn (adj),darn,darn (adj),ADJ,B1
-darn (verb),darn,darn (verb),VERB,B2
-dart (noun),dart,dart (noun),NOUN,B2
-dart (verb),dart,dart (verb),VERB,C1
-dash (verb),dash,dash (verb),VERB,C1
-data leak,data leak,data leak,NOUN,C1
-data protection,data protection,data protection,NOUN,B2
-date history,date history,date history,NOUN,A2
-dates,dates,dates,NOUN,A2
-daub,daub,daub,VERB,C1
-day after tomorrow,day after tomorrow,day after tomorrow,NOUN,B2
-day off,day off,day off,NOUN,B2
-day out,day out,day out,NOUN,B2
-day school,day school,day school,NOUN,C1
-daydream (noun),daydream,daydream (noun),NOUN,C1
-daydreaming,daydreaming,daydreaming,NOUN,C1
-dazed,dazed,dazed,ADJ,C1
-dazed one,dazed one,dazed one,NOUN,B2
-dazzled,dazzled,dazzled,ADJ,C1
-de facto,de facto,de facto,ADJ,C1
-de-escalation,de-escalation,de-escalation,NOUN,C1
-deacon,deacon,deacon,NOUN,C1
-dead person,dead person,dead person,NOUN,B1
-deaden,deaden,deaden,VERB,C1
-deadlock,deadlock,deadlock,NOUN,C1
-deaf person,deaf person,deaf person,NOUN,B2
-deafening,deafening,deafening,ADJ,C1
-deals,deals,deals,NOUN,C1
-deanship,deanship,deanship,NOUN,C1
-dear,dear,,NOUN,B2
-dearest,dearest,dearest,NOUN,B2
-death rattle,death rattle,death rattle,NOUN,C1
-deaths,deaths,deaths,NOUN,C1
-debasement,debasement,debasement,NOUN,C1
-debauch,debauch,debauch,VERB,C1
-debilitate,debilitate,debilitate,VERB,C1
-debit,debit,debit,VERB,C1
-debrief,debrief,debrief,VERB,C1
-debris,debris,debris,NOUN,B2
-debris rubble,debris rubble,debris rubble,NOUN,C1
-debug,debug,debug,VERB,C1
-debunk,debunk,debunk,VERB,C1
-decalogue,decalogue,decalogue,NOUN,B2
-decamp,decamp,decamp,VERB,C1
-decapitate,decapitate,decapitate,VERB,C1
-decay,decay,decay,VERB,C1
-decease,decease,decease,NOUN,C1
-deceived,deceived,deceived,ADJ,A2
-decelerate,decelerate,decelerate,VERB,C1
-decentralized,decentralized,decentralized,ADJ,C1
-decimal (adj),decimal,decimal (adj),ADJ,C1
-deciphering,deciphering,deciphering,NOUN,C1
-deck,deck,deck,NOUN,B1
-declamatory style,declamatory style,declamatory style,NOUN,C1
-declarant,declarant,declarant,NOUN,B2
-declarative,declarative,declarative,ADJ,C1
-declension,declension,declension,NOUN,C1
-decline setting,decline setting,decline setting,NOUN,C1
-decoding,decoding,decoding,NOUN,B2
-decommission,decommission,decommission,VERB,C1
-decompensation,decompensation,decompensation,NOUN,C1
-decomposed,decomposed,decomposed,ADJ,C1
-decomposition,decomposition,decomposition,NOUN,C1
-deconcentration,deconcentration,deconcentration,NOUN,C1
-deconsecrate,deconsecrate,deconsecrate,VERB,C1
-deconstructionist,deconstructionist,deconstructionist,ADJ,C1
-decontaminate,decontaminate,decontaminate,VERB,C1
-decorated,decorated,decorated,ADJ,B1
-decorous,decorous,decorous,ADJ,B2
-decorous modesty,decorous modesty,decorous modesty,NOUN,C1
-decoy,decoy,decoy,NOUN,C1
-decreasing,decreasing,decreasing,ADJ,B2
-decrepit,decrepit,decrepit,ADJ,B2
-deductions,deductions,deductions,NOUN,C1
-deductive,deductive,deductive,ADJ,C1
-deem,deem,deem,VERB,C1
-deep darkness,deep darkness,deep darkness,NOUN,C1
-deep-rooted,deep-rooted,deep-rooted,ADJ,B2
-deeply profoundly,deeply profoundly,deeply profoundly,ADV,B2
-deface,deface,deface,VERB,C1
-defamatory,defamatory,defamatory,ADJ,C1
-defamiliarization,defamiliarization,defamiliarization,NOUN,C1
-defeatist,defeatist,defeatist,ADJ,C1
-defection,defection,defection,NOUN,B2
-defectiveness,defectiveness,defectiveness,NOUN,C1
-defense lawyer,defense lawyer,defense lawyer,NOUN,B2
-defenseless,defenseless,defenseless,ADJ,C1
-deferential,deferential,deferential,ADJ,C1
-deficitary,deficitary,deficitary,ADJ,C1
-defile,defile,defile,VERB,C1
-definable,definable,definable,ADJ,C1
-deflated,deflated,deflated,ADJ,B1
-deflationary,deflationary,deflationary,ADJ,C1
-deflect,deflect,deflect,VERB,C1
-deflower,deflower,deflower,VERB,C1
-defoliate,defoliate,defoliate,VERB,C1
-deforest,deforest,deforest,VERB,C1
-deformity,deformity,deformity,NOUN,C1
-defunct,defunct,defunct,ADJ,C1
-degenerative,degenerative,degenerative,ADJ,B2
-degrading,degrading,degrading,ADJ,C1
-degrease,degrease,degrease,VERB,C1
-degree graduation,degree graduation,degree graduation,NOUN,B2
-degrowth,degrowth,degrowth,NOUN,C1
-dehumanize,dehumanize,dehumanize,VERB,C1
-dehydrate,dehydrate,dehydrate,VERB,C1
-dehydration dryness,dehydration dryness,dehydration dryness,NOUN,C1
-deice,deice,deice,VERB,C1
-deification,deification,deification,NOUN,C1
-del,del,del,NOUN,B2
-delegate (noun),delegate,delegate (noun),NOUN,B2
-delegation of authority,delegation of authority,delegation of authority,NOUN,C1
-delegations,delegations,delegations,NOUN,C1
-deleterious,deleterious,deleterious,ADJ,B2
-deletion,deletion,deletion,NOUN,B2
-deli meats,deli meats,deli meats,NOUN,C1
-deliberateness,deliberateness,deliberateness,NOUN,C1
-deliberations,deliberations,deliberations,NOUN,C1
-deliberatively,deliberatively,deliberatively,ADV,C1
-delicious tasty,delicious tasty,delicious tasty,ADJ,A1
-deliciousness,deliciousness,deliciousness,NOUN,B2
-delimitation,delimitation,delimitation,NOUN,C1
-deliquesce,deliquesce,deliquesce,VERB,C1
-delirious,delirious,delirious,ADJ,B2
-deliverance issuance,deliverance issuance,deliverance issuance,NOUN,C1
-delivery person,delivery person,delivery person,NOUN,C1
-delouse,delouse,delouse,VERB,C1
-delta,delta,,NOUN,B2
-delude,delude,delude,VERB,C1
-deluge flood,deluge flood,deluge flood,NOUN,B2
-delve,delve,delve,VERB,C1
-demagogic,demagogic,demagogic,ADJ,C1
-demagogue,demagogue,demagogue,NOUN,C1
-demand-based activism,demand-based activism,demand-based activism,NOUN,C1
-demean,demean,demean,VERB,C1
-dement,dement,dement,VERB,C1
-demented,demented,demented,ADJ,C1
-demijohn,demijohn,demijohn,NOUN,B2
-demobilize,demobilize,demobilize,VERB,C1
-demonic,demonic,demonic,ADJ,C1
-demonization,demonization,demonization,NOUN,C1
-demons,demons,demons,NOUN,C1
-demonstrable,demonstrable,demonstrable,ADJ,C1
-demonstrator,demonstrator,demonstrator,NOUN,C1
-demoralization,demoralization,demoralization,NOUN,C1
-demote,demote,demote,VERB,C1
-demur,demur,demur,VERB,C1
-demystify,demystify,demystify,VERB,C1
-denationalize,denationalize,denationalize,VERB,C1
-denial contradiction,denial contradiction,denial contradiction,NOUN,C1
-denim jacket,denim jacket,denim jacket,NOUN,C1
-denomination,denomination,denomination,NOUN,C1
-denominator,denominator,denominator,NOUN,C1
-dental,dental,dental,ADJ,C1
-denude,denude,denude,VERB,C1
-deodorize,deodorize,deodorize,VERB,C1
-deontology,deontology,deontology,NOUN,C1
-departmental,departmental,departmental,ADJ,B2
-dependency,dependency,dependency,NOUN,B2
-dependent passivity,dependent passivity,dependent passivity,NOUN,C1
-deplete,deplete,deplete,VERB,C1
-depletion,depletion,depletion,NOUN,C1
-depone,depone,depone,VERB,C1
-depopulation,depopulation,depopulation,NOUN,B2
-deposed,deposed,deposed,ADJ,C1
-depositional,depositional,depositional,ADJ,C1
-deposits,deposits,deposits,NOUN,C1
-deprecate,deprecate,deprecate,VERB,C1
-deprecation,deprecation,deprecation,NOUN,C1
-depredate,depredate,depredate,VERB,C1
-depredation,depredation,depredation,NOUN,C1
-depressing,depressing,depressing,ADJ,B2
-deputation,deputation,deputation,NOUN,B2
-depute,depute,depute,VERB,C1
-deracinate,deracinate,deracinate,VERB,C1
-derailment,derailment,derailment,NOUN,C1
-derange,derange,derange,VERB,C1
-derby,derby,derby,NOUN,B2
-deregulate,deregulate,deregulate,VERB,C1
-deregulation,deregulation,deregulation,NOUN,B2
-dereliction,dereliction,dereliction,NOUN,C1
-deride,deride,deride,VERB,C1
-derision mockery,derision mockery,derision mockery,NOUN,C1
-derisory paltry,derisory paltry,derisory paltry,ADJ,B2
-derivation,derivation,derivation,NOUN,C1
-dermal,dermal,dermal,ADJ,C1
-derogation,derogation,derogation,NOUN,C1
-derogatory,derogatory,derogatory,ADJ,C1
-desalination,desalination,desalination,NOUN,C1
-descant,descant,descant,VERB,C1
-descend go down,descend go down,descend go down,VERB,A1
-descendants,descendants,descendants,NOUN,C1
-descending,descending,descending,ADJ,C1
-describable,describable,describable,ADJ,C1
-descriptiveness,descriptiveness,descriptiveness,NOUN,C1
-descry,descry,descry,VERB,C1
-desecrate,desecrate,desecrate,VERB,C1
-desecration,desecration,desecration,NOUN,C1
-desegregate,desegregate,desegregate,VERB,C1
-deserter,deserter,deserter,NOUN,C1
-deserved,deserved,deserved,ADJ,B2
-desiccate,desiccate,desiccate,VERB,C1
-desiccation,desiccation,desiccation,NOUN,C1
-desirous,desirous,desirous,ADJ,C1
-desk chest of drawers,desk chest of drawers,desk chest of drawers,NOUN,B2
-desolate loneliness,desolate loneliness,desolate loneliness,NOUN,C1
-despatch,despatch,despatch,VERB,C1
-despite (adv),despite,despite (adv),ADV,B2
-despoliation,despoliation,despoliation,NOUN,C1
-despond,despond,despond,VERB,C1
-despondency,despondency,despondency,NOUN,C1
-despotic,despotic,despotic,ADJ,C1
-desquamation,desquamation,desquamation,NOUN,C1
-destine,destine,destine,VERB,C1
-destined,destined,,NOUN,B2
-destitute,destitute,destitute,ADJ,C1
-destroyed,destroyed,destroyed,ADJ,B2
-destroyer,destroyer,destroyer,NOUN,C1
-detachable,detachable,detachable,ADJ,C1
-detector,detector,detector,NOUN,C1
-deter,deter,deter,VERB,C1
-deteriorated,deteriorated,deteriorated,ADJ,B2
-determinant,determinant,determinant,NOUN,C1
-determinist,determinist,determinist,ADJ,C1
-deterrence,deterrence,deterrence,NOUN,C1
-deterrent,deterrent,deterrent,NOUN,C1
-detractor,detractor,detractor,NOUN,C1
-detritus,detritus,detritus,NOUN,C1
-devastated,devastated,devastated,ADJ,B2
-development works,development works,development works,NOUN,B2
-developments,developments,developments,NOUN,B2
-deviance,deviance,deviance,NOUN,B2
-device system,device system,device system,NOUN,B1
-devil damn,devil damn,devil damn,NOUN,A1
-devious,devious,devious,ADJ,B2
-devoice,devoice,devoice,VERB,C1
-devoid,devoid,devoid,ADJ,C1
-devoid lacking,devoid lacking,devoid lacking,ADJ,C1
-devolution,devolution,devolution,NOUN,C1
-devolve,devolve,devolve,VERB,C1
-devotion to duty,devotion to duty,devotion to duty,NOUN,C1
-devotional humility,devotional humility,devotional humility,NOUN,C1
-devotional worship,devotional worship,devotional worship,NOUN,C1
-devourer,devourer,devourer,NOUN,B2
-devout,devout,devout,ADJ,B2
-devoutly,devoutly,devoutly,ADV,C1
-dexterous,dexterous,dexterous,ADJ,C1
-diabetic,diabetic,diabetic,ADJ,C1
-diachrony,diachrony,diachrony,NOUN,C1
-diaeresis,diaeresis,diaeresis,NOUN,C1
-dial (noun),dial,dial (noun),NOUN,C1
-dial (verb),dial,dial (verb),VERB,B2
-dialectic (adj),dialectic,dialectic (adj),ADJ,C1
-dialectician,dialectician,dialectician,NOUN,C1
-dialing code,dialing code,dialing code,NOUN,C1
-dialogism,dialogism,dialogism,NOUN,C1
-diameter,diameter,diameter,NOUN,C1
-diametrically,diametrically,diametrically,ADV,C1
-diapers,diapers,diapers,NOUN,B1
-diaphanous,diaphanous,diaphanous,ADJ,C1
-diaspora community,diaspora community,diaspora community,NOUN,C1
-diatribe,diatribe,diatribe,NOUN,C1
-dictation,dictation,,NOUN,B2
-didactics,didactics,didactics,NOUN,C1
-dietary,dietary,dietary,ADJ,C1
-different (adv),different,different (adv),ADV,B2
-differentiable,differentiable,differentiable,ADJ,C1
-differentiating,differentiating,differentiating,ADJ,C1
-difficult flirt,difficult flirt,,NOUN,B2
-diffusely,diffusely,diffusely,ADV,C1
-diffusion spread,diffusion spread,diffusion spread,NOUN,C1
-dig up,dig up,dig up,VERB,B2
-digestible,digestible,digestible,ADJ,C1
-digitized,digitized,digitized,ADJ,C1
-diglossia,diglossia,diglossia,NOUN,C1
-dignified,dignified,dignified,ADJ,C1
-dignifiedly,dignifiedly,dignifiedly,ADV,C1
-dignify,dignify,dignify,VERB,C1
-dignitaries,dignitaries,dignitaries,NOUN,C1
-digression,digression,digression,NOUN,C1
-dike,dike,dike,NOUN,B2
-dilated,dilated,dilated,ADJ,C1
-dilution,dilution,dilution,NOUN,C1
-dim,dim,dim,ADJ,C1
-dimmed,dimmed,dimmed,ADJ,C1
-dimple,dimple,dimple,NOUN,C1
-dine,dine,dine,VERB,C1
-dinghy,dinghy,dinghy,NOUN,C1
-dining hall,dining hall,dining hall,NOUN,C1
-dining room,dining room,dining room,NOUN,B1
-dining table,dining table,dining table,NOUN,B2
-diocesan,diocesan,diocesan,ADJ,C1
-diocese,diocese,diocese,NOUN,B2
-dioxide,dioxide,dioxide,NOUN,C1
-diplomat,diplomat,diplomat,NOUN,C1
-dipsomaniac,dipsomaniac,dipsomaniac,NOUN,C1
-direct hit,direct hit,direct hit,NOUN,C1
-directionality,directionality,directionality,NOUN,C1
-directive (adj),directive,directive (adj),ADJ,C1
-directness,directness,directness,NOUN,C1
-directory,directory,directory,NOUN,C1
-dirham,dirham,dirham,NOUN,A1
-dirt filth,dirt filth,dirt filth,NOUN,C1
-dirt soil,dirt soil,dirt soil,NOUN,A1
-dirtier,dirtier,dirtier,ADJ,B2
-dirty bastard,dirty bastard,dirty bastard,NOUN,C1
-dirty trick,dirty trick,dirty trick,NOUN,B2
-disable,disable,disable,VERB,C1
-disadvantaged,disadvantaged,disadvantaged,ADJ,C1
-disadvantageous,disadvantageous,disadvantageous,ADJ,B2
-disaffect,disaffect,disaffect,VERB,C1
-disaffected,disaffected,disaffected,ADJ,C1
-disaffection,disaffection,disaffection,NOUN,C1
-disallow,disallow,disallow,VERB,C1
-disapproval,disapproval,disapproval,NOUN,C1
-disarray (noun),disarray,disarray (noun),NOUN,C1
-disassembly,disassembly,disassembly,NOUN,C1
-disassociate,disassociate,disassociate,VERB,C1
-disband,disband,disband,VERB,C1
-disbar,disbar,disbar,VERB,C1
-disbelieve,disbelieve,disbelieve,VERB,C1
-disburden,disburden,disburden,VERB,C1
-disburse,disburse,disburse,VERB,C1
-disbursement,disbursement,disbursement,NOUN,C1
-discipleship,discipleship,discipleship,NOUN,C1
-disciplined,disciplined,disciplined,ADJ,C1
-disclaim,disclaim,disclaim,VERB,C1
-discolor,discolor,discolor,VERB,C1
-discomfit,discomfit,discomfit,VERB,C1
-discompose,discompose,discompose,VERB,C1
-disconnection,disconnection,disconnection,NOUN,C1
-disconsolation,disconsolation,disconsolation,NOUN,C1
-discontinuity,discontinuity,discontinuity,NOUN,B2
-discordant,discordant,discordant,ADJ,C1
-discouragement,discouragement,discouragement,NOUN,C1
-discourteous,discourteous,discourteous,ADJ,C1
-discredit (noun),discredit,discredit (noun),NOUN,B2
-discrediting,discrediting,discrediting,NOUN,C1
-discreetly,discreetly,discreetly,ADV,B2
-discrete,discrete,discrete,ADJ,C1
-discretionary,discretionary,discretionary,ADJ,C1
-discretionary punishment,discretionary punishment,discretionary punishment,NOUN,C1
-discursive,discursive,discursive,ADJ,C1
-disdainful,disdainful,disdainful,ADJ,C1
-disembarkation,disembarkation,disembarkation,NOUN,C1
-disembarrass,disembarrass,disembarrass,VERB,C1
-disembody,disembody,disembody,VERB,C1
-disembowel,disembowel,disembowel,VERB,C1
-disenchantment,disenchantment,disenchantment,NOUN,B2
-disenfranchise,disenfranchise,disenfranchise,VERB,C1
-disenfranchised,disenfranchised,disenfranchised,ADJ,C1
-disengagement,disengagement,disengagement,NOUN,B2
-disestablish,disestablish,disestablish,VERB,C1
-disesteem,disesteem,disesteem,VERB,C1
-disfavor (noun),disfavor,disfavor (noun),NOUN,C1
-disfranchise,disfranchise,disfranchise,VERB,C1
-disgorge,disgorge,disgorge,VERB,C1
-disgruntle,disgruntle,disgruntle,VERB,C1
-dish towel,dish towel,dish towel,NOUN,B2
-disharmony,disharmony,disharmony,NOUN,B2
-disheartened,disheartened,disheartened,ADJ,C1
-disheartening,disheartening,disheartening,ADJ,C1
-dishes,dishes,dishes,NOUN,C1
-disheveled,disheveled,disheveled,ADJ,B2
-dishonorable,dishonorable,dishonorable,ADJ,C1
-disillusion,disillusion,disillusion,VERB,C1
-disillusionment,disillusionment,disillusionment,NOUN,C1
-disincline,disincline,disincline,VERB,C1
-disinflation,disinflation,disinflation,NOUN,B2
-disinhibited,disinhibited,disinhibited,ADJ,C1
-disintegration,disintegration,disintegration,NOUN,B2
-disinter,disinter,disinter,VERB,C1
-disinterest,disinterest,公正;不感兴趣,NOUN,B2
-disinvestment,disinvestment,disinvestment,NOUN,C1
-disjointed,disjointed,disjointed,ADJ,C1
-disloyalty,disloyalty,disloyalty,NOUN,B2
-dismay (noun),dismay,dismay (noun),NOUN,C1
-dismember,dismember,dismember,VERB,C1
-dismissal of charges,dismissal of charges,dismissal of charges,NOUN,C1
-dismissal referral,dismissal referral,dismissal referral,NOUN,C1
-disorganization,disorganization,disorganization,NOUN,B2
-disorganize,disorganize,disorganize,VERB,C1
-disoriented,disoriented,disoriented,ADJ,C1
-disown,disown,disown,VERB,C1
-disparage,disparage,disparage,VERB,C1
-disparagement,disparagement,disparagement,NOUN,C1
-dispassionate,dispassionate,dispassionate,ADJ,C1
-dispensary,dispensary,dispensary,NOUN,C1
-dispersion,dispersion,dispersion,NOUN,C1
-dispirit,dispirit,dispirit,VERB,C1
-displace,displace,displace,VERB,C1
-displaced person,displaced person,displaced person,NOUN,C1
-displeased,displeased,displeased,ADJ,C1
-disport,disport,disport,VERB,C1
-disposed,disposed,disposed,ADJ,C1
-dispossessed,dispossessed,dispossessed,ADJ,C1
-disproportionate,disproportionate,disproportionate,ADJ,C1
-disprove,disprove,disprove,VERB,C1
-disputation,disputation,disputation,NOUN,C1
-dispute lawsuit,dispute lawsuit,dispute lawsuit,NOUN,C1
-disputed case,disputed case,disputed case,NOUN,C1
-disqualification,disqualification,disqualification,NOUN,C1
-disquiet,disquiet,disquiet,NOUN,C1
-disquisition,disquisition,disquisition,NOUN,B2
-disrepair,disrepair,disrepair,NOUN,C1
-disrobe,disrobe,disrobe,VERB,C1
-disruption,disruption,disruption,NOUN,C1
-dissatisfy,dissatisfy,dissatisfy,VERB,C1
-dissemble,dissemble,dissemble,VERB,C1
-dissembling,dissembling,dissembling,ADJ,C1
-dissemination,dissemination,dissemination,NOUN,C1
-dissert,dissert,dissert,VERB,C1
-disserve,disserve,disserve,VERB,C1
-dissever,dissever,dissever,VERB,C1
-dissimilar,dissimilar,dissimilar,ADJ,C1
-dissimulation,dissimulation,dissimulation,NOUN,C1
-dissociate,dissociate,dissociate,VERB,C1
-dissolute,dissolute,dissolute,ADJ,C1
-dissonant,dissonant,dissonant,ADJ,C1
-dissuasion,dissuasion,dissuasion,NOUN,C1
-dissuasive,dissuasive,dissuasive,ADJ,C1
-distaste,distaste,distaste,NOUN,C1
-distend,distend,distend,VERB,C1
-distich,distich,distich,NOUN,C1
-distil,distil,distil,VERB,C1
-distillation,distillation,distillation,NOUN,C1
-distinctive,distinctive,distinctive,ADJ,C1
-distinctly,distinctly,distinctly,ADV,B2
-distinguishable,distinguishable,distinguishable,ADJ,C1
-distrain,distrain,distrain,VERB,C1
-distressing,distressing,distressing,ADJ,B1
-distributed,distributed,distributed,ADJ,C1
-districting,districting,districting,NOUN,C1
-districts,districts,districts,NOUN,C1
-distrustful,distrustful,distrustful,ADJ,C1
-dithyramb,dithyramb,dithyramb,NOUN,C1
-dive (noun),dive,dive (noun),NOUN,B2
-dive appear,dive appear,dive appear,VERB,B2
-diver,diver,diver,NOUN,B2
-diverging,diverging,diverging,ADJ,C1
-divestment,divestment,divestment,NOUN,C1
-divide cleavage,divide cleavage,divide cleavage,NOUN,B2
-divider,divider,divider,NOUN,C1
-divinatory,divinatory,divinatory,ADJ,C1
-divine reward,divine reward,divine reward,NOUN,C1
-divine trial,divine trial,divine trial,NOUN,C1
-divisibility,divisibility,divisibility,NOUN,C1
-divisible,divisible,divisible,ADJ,B2
-divisive,divisive,divisive,ADJ,C1
-divisor,divisor,divisor,NOUN,C1
-divorce (noun),divorce,divorce (noun),NOUN,B1
-divorced,divorced,divorced,ADJ,B2
-divorced woman,divorced woman,divorced woman,NOUN,B2
-djellaba,djellaba,djellaba,NOUN,B2
-docilely,docilely,docilely,ADV,C1
-doctor visit,doctor visit,,NOUN,B2
-doctrinaire,doctrinaire,doctrinaire,ADJ,B2
-doctrine,doctrine,doctrine,NOUN,B2
-documented,documented,documented,ADJ,C1
-documents,documents,documents,NOUN,B2
-doff,doff,doff,VERB,C1
-doggedly,doggedly,doggedly,ADV,C1
-dollar,dollar,dollar,NOUN,C1
-domesticate,domesticate,domesticate,VERB,C1
-domineering,domineering,domineering,ADJ,C1
-domineeringness,domineeringness,domineeringness,NOUN,B2
-don,don,don,VERB,C1
-don't give a fuck,don't give a fuck,don't give a fuck,ADJ,C1
-donkey foal,donkey foal,donkey foal,NOUN,B2
-doom,doom,doom,VERB,C1
-doorbell button,doorbell button,doorbell button,NOUN,B2
-doorkeeper,doorkeeper,doorkeeper,NOUN,B1
-dope (noun),dope,dope (noun),NOUN,B2
-doping,doping,doping,NOUN,C1
-doping agents,doping agents,doping agents,NOUN,B2
-dorm,dorm,dorm,NOUN,B2
-dormant,dormant,dormant,ADJ,C1
-dotting,dotting,dotting,NOUN,C1
-double (noun),double,double (noun),NOUN,C1
-double entendre,double entendre,double entendre,NOUN,C1
-doubt (noun),doubt,doubt (noun),NOUN,A2
-doughy,doughy,doughy,ADJ,B2
-douse,douse,douse,VERB,C1
-down payment,down payment,down payment,NOUN,B1
-downgrade,downgrade,downgrade,VERB,C1
-download (noun),download,download (noun),NOUN,B2
-downplay,downplay,downplay,VERB,C1
-downplaying,downplaying,downplaying,NOUN,C1
-downright,downright,downright,ADV,B1
-downsize,downsize,downsize,VERB,C1
-downstairs,downstairs,downstairs,ADV,B1
-doze (noun),doze,doze (noun),NOUN,C1
-doze (verb),doze,doze (verb),VERB,C1
-doze off,doze off,doze off,VERB,B2
-draconian,draconian,draconian,ADJ,C1
-dragonfly,dragonfly,dragonfly,NOUN,C1
-dragoon,dragoon,dragoon,VERB,C1
-drainage,drainage,drainage,NOUN,C1
-drainage sewage,drainage sewage,drainage sewage,NOUN,C1
-dramatization,dramatization,dramatization,NOUN,C1
-drastic,drastic,drastic,ADJ,C1
-draught,draught,draught,NOUN,C1
-drawl,drawl,drawl,VERB,C1
-dreamer,dreamer,dreamer,NOUN,C1
-dreary,dreary,dreary,ADJ,B2
-dredge (noun),dredge,dredge (noun),NOUN,B2
-dredge (verb),dredge,dredge (verb),VERB,C1
-drench,drench,drench,VERB,C1
-dressing room,dressing room,dressing room,NOUN,B2
-dribble,dribble,dribble,VERB,C1
-dribbling,dribbling,dribbling,NOUN,B2
-dried,dried,dried,ADJ,B1
-dried curd,dried curd,dried curd,NOUN,B2
-dried cured,dried cured,dried cured,ADJ,B2
-dried meat,dried meat,dried meat,NOUN,B2
-drift (verb),drift,drift (verb),VERB,B2
-drift excess,drift excess,drift excess,NOUN,C1
-drinks,drinks,drinks,NOUN,C1
-dripping (adj),dripping,dripping (adj),ADJ,C1
-dripping (noun),dripping,dripping (noun),NOUN,C1
-drive mad,drive mad,drive mad,VERB,C1
-drivel,drivel,drivel,NOUN,C1
-drizzly,drizzly,drizzly,ADJ,C1
-droop,droop,droop,VERB,C1
-drop cap,drop cap,drop cap,NOUN,C1
-dropout,dropout,dropout,NOUN,B2
-dropper,dropper,dropper,NOUN,C1
-droppings,droppings,droppings,NOUN,B2
-drops,drops,drops,NOUN,B1
-drowning,drowning,drowning,NOUN,C1
-drub,drub,drub,VERB,C1
-drudge,drudge,drudge,NOUN,C1
-drug addict,drug addict,drug addict,NOUN,C1
-drug addiction,drug addiction,drug addiction,NOUN,C1
-drug medication,drug medication,drug medication,NOUN,C1
-drummer,drummer,drummer,NOUN,B1
-dry cleaner,dry cleaner,dry cleaner,NOUN,A2
-dry land,dry land,dry land,NOUN,B2
-dry sausage,dry sausage,dry sausage,NOUN,B2
-drying,drying,drying,NOUN,C1
-drying up,drying up,drying up,NOUN,C1
-dryness,dryness,dryness,NOUN,A1
-dual,dual,dual,ADJ,C1
-dual form,dual form,dual form,NOUN,C1
-dub,dub,dub,VERB,C1
-duct pipe,duct pipe,duct pipe,NOUN,B2
-ductile,ductile,ductile,ADJ,C1
-dude,dude,dude,NOUN,A2
-due date maturity,due date maturity,due date maturity,NOUN,B2
-duel,duel,duel,NOUN,C1
-duet,duet,duet,NOUN,B2
-dull-witted,dull-witted,dull-witted,ADJ,B2
-duly,duly,duly,ADV,C1
-dumbfound,dumbfound,dumbfound,VERB,C1
-dummy,dummy,dummy,NOUN,B2
-dump (noun),dump,dump (noun),NOUN,B1
-dump site,dump site,dump site,NOUN,B2
-dunes,dunes,dunes,NOUN,B2
-dung,dung,dung,NOUN,B2
-dunghill,dunghill,dunghill,NOUN,C1
-duo,duo,duo,NOUN,C1
-duplex,duplex,duplex,NOUN,C1
-duplication,duplication,duplication,NOUN,C1
-durable,durable,durable,ADJ,C1
-dust coat,dust coat,dust coat,NOUN,C1
-duster,duster,duster,NOUN,C1
-duty of care,duty of care,duty of care,NOUN,C1
-duty of confidentiality,duty of confidentiality,duty of confidentiality,NOUN,B2
-dwell,dwell,dwell,VERB,C1
-dwindle,dwindle,dwindle,VERB,C1
-dwindling,dwindling,dwindling,NOUN,C1
-dyed,dyed,dyed,ADJ,B1
-dying,dying,,NOUN,B2
-dynamics,dynamics,dynamics,NOUN,C1
-dynamism,dynamism,dynamism,NOUN,B2
-dysfunctional,dysfunctional,dysfunctional,ADJ,C1
-each one,each one,each one,PRON,B2
-eager anticipation,eager anticipation,eager anticipation,NOUN,C1
-eagerness,eagerness,eagerness,NOUN,B2
-early (noun),early,early (noun),NOUN,B2
-early morning (adv),early morning,early morning (adv),ADV,B2
-early sign,early sign,early sign,NOUN,C1
-earnest,earnest,earnest,ADJ,B1
-earnestly,earnestly,earnestly,ADV,C1
-earnings,earnings,earnings,NOUN,C1
-earrings,earrings,earrings,NOUN,B1
-ears of wheat,ears of wheat,ears of wheat,NOUN,B2
-ease affluence,ease affluence,ease affluence,NOUN,C1
-ease of circumstances,ease of circumstances,ease of circumstances,NOUN,C1
-easement,easement,easement,NOUN,C1
-easier,easier,easier,ADJ,B2
-easily,easily,easily,ADV,B2
-easing,easing,easing,NOUN,C1
-eastward,eastward,eastward,ADV,B2
-eating,eating,,NOUN,B2
-eating habit,eating habit,eating habit,NOUN,C1
-ebb,ebb,ebb,VERB,C1
-ebb tide,ebb tide,ebb tide,NOUN,B1
-eccentric person,eccentric person,eccentric person,NOUN,C1
-ecclesial,ecclesial,ecclesial,ADJ,C1
-echoes,echoes,echoes,NOUN,C1
-eclectic,eclectic,eclectic,ADJ,C1
-economic climate,economic climate,economic climate,NOUN,B2
-economic cycle,economic cycle,economic cycle,NOUN,B2
-economic forecaster,economic forecaster,economic forecaster,NOUN,C1
-economical,economical,economical,ADJ,A1
-economically,economically,economically,ADV,B1
-economize,economize,economize,VERB,C1
-ecstatic,ecstatic,ecstatic,ADJ,C1
-eddy,eddy,eddy,NOUN,B2
-edge border,edge border,edge border,NOUN,C1
-edible,edible,edible,ADJ,C1
-edifying,edifying,edifying,ADJ,C1
-editorial office,editorial office,editorial office,NOUN,B2
-efface,efface,efface,VERB,C1
-effect and traces,effect and traces,effect and traces,NOUN,C1
-effect-seeking,effect-seeking,effect-seeking,NOUN,C1
-effects,effects,effects,NOUN,B2
-effectuate,effectuate,effectuate,VERB,C1
-effervesce,effervesce,effervesce,VERB,C1
-effervescence,effervescence,effervescence,NOUN,C1
-effervescent,effervescent,effervescent,ADJ,C1
-effigy,effigy,effigy,NOUN,C1
-effuse,effuse,effuse,VERB,C1
-egalitarian,egalitarian,egalitarian,ADJ,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,egg carton,NOUN,C1
-egg-laying,egg-laying,egg-laying,NOUN,B2
-ego,ego,ego,NOUN,C1
-egoism,egoism,egoism,NOUN,C1
-egolatry,egolatry,egolatry,NOUN,C1
-egomaniac,egomaniac,egomaniac,NOUN,C1
-eh,eh,eh,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,eider track,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eight (noun),eight,eight (noun),NOUN,B2
-einfahrt,einfahrt,einfahrt,NOUN,C1
-einfassung,einfassung,einfassung,NOUN,C1
-einforderung,einforderung,einforderung,NOUN,C1
-eingestaltung,eingestaltung,eingestaltung,NOUN,C1
-einkunft,einkunft,einkunft,NOUN,C1
-einpflegung,einpflegung,einpflegung,NOUN,C1
-einregelung,einregelung,einregelung,NOUN,C1
-einrichtung,einrichtung,einrichtung,NOUN,C1
-einschrift,einschrift,einschrift,NOUN,C1
-einsetzung,einsetzung,einsetzung,NOUN,C1
-einsinnung,einsinnung,einsinnung,NOUN,C1
-einsucht,einsucht,einsucht,NOUN,C1
-einsuchung,einsuchung,einsuchung,NOUN,C1
-eintheilung,eintheilung,eintheilung,NOUN,C1
-eintreibung,eintreibung,eintreibung,NOUN,C1
-einwandel,einwandel,einwandel,NOUN,C1
-either (adv),either,either (adv),ADV,B2
-elaboration,elaboration,elaboration,NOUN,C1
-eldest,eldest,eldest,ADJ,A2
-elected officials,elected officials,elected officials,NOUN,C1
-elections,elections,elections,NOUN,B1
-elective,elective,elective,ADJ,C1
-electivity,electivity,electivity,NOUN,C1
-electoral,electoral,electoral,ADJ,C1
-electoralist,electoralist,electoralist,ADJ,C1
-electric (noun),electric,electric (noun),NOUN,B2
-electric guitar,electric guitar,electric guitar,NOUN,B2
-electric plug,electric plug,electric plug,NOUN,B1
-electrical engineering,electrical engineering,electrical engineering,NOUN,C1
-electrical theory,electrical theory,electrical theory,NOUN,B2
-electrification,electrification,electrification,NOUN,C1
-electrify,electrify,electrify,VERB,C1
-electrocute,electrocute,electrocute,VERB,C1
-electron,electron,electron,NOUN,B2
-electronic bracelet,electronic bracelet,electronic bracelet,NOUN,C1
-elegance,elegance,elegance,NOUN,C1
-elemental,elemental,elemental,ADJ,B2
-elements of an offense,elements of an offense,elements of an offense,NOUN,C1
-elevated,elevated,elevated,ADJ,C1
-eleven (noun),eleven,eleven (noun),NOUN,B2
-eleventh,eleventh,eleventh,NUM,B1
-elf,elf,elf,NOUN,C1
-elicit,elicit,elicit,VERB,C1
-eligible,eligible,eligible,ADJ,C1
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,elitism,NOUN,C1
-elongate,elongate,elongate,VERB,C1
-elope,elope,elope,VERB,C1
-else,else,else,ADV,A1
-elucidation,elucidation,elucidation,NOUN,C1
-emaciate,emaciate,emaciate,VERB,C1
-emaciated,emaciated,emaciated,ADJ,C1
-emaciation,emaciation,emaciation,NOUN,C1
-embalm,embalm,embalm,VERB,C1
-embattle,embattle,embattle,VERB,C1
-embers,embers,embers,NOUN,B1
-embitter,embitter,embitter,VERB,C1
-emblazon,emblazon,emblazon,VERB,C1
-embodiment,embodiment,embodiment,NOUN,B2
-emboss,emboss,emboss,VERB,C1
-embrace each other,embrace each other,embrace each other,VERB,B2
-embroil,embroil,embroil,VERB,C1
-embryonic,embryonic,embryonic,ADJ,C1
-emend,emend,emend,VERB,B2
-emergence emanation,emergence emanation,emergence emanation,NOUN,C1
-emerging,emerging,emerging,ADJ,C1
-eminence,eminence,eminence,NOUN,C1
-emirate,emirate,emirate,NOUN,C1
-emissions,emissions,emissions,NOUN,C1
-emitter,emitter,emitter,NOUN,C1
-emolument,emolument,emolument,NOUN,C1
-emote,emote,emote,VERB,C1
-emoticon,emoticon,emoticon,NOUN,C1
-emotional life,emotional life,emotional life,NOUN,B2
-emotionality lyricism,emotionality lyricism,emotionality lyricism,NOUN,C1
-empathetic,empathetic,empathetic,ADJ,B1
-emphatic,emphatic,emphatic,ADJ,C1
-emphatically,emphatically,emphatically,ADV,C1
-empirically,empirically,empirically,ADV,B2
-employability,employability,employability,NOUN,B2
-employers,employers,employers,NOUN,B1
-emporium,emporium,emporium,NOUN,C1
-empowerment,empowerment,empowerment,NOUN,C1
-emptying,emptying,emptying,NOUN,B2
-empyrean,empyrean,empyrean,ADJ,C1
-emulation,emulation,emulation,NOUN,B2
-emulator,emulator,emulator,NOUN,C1
-emulsify,emulsify,emulsify,VERB,C1
-emulsion,emulsion,emulsion,NOUN,C1
-enamel (verb),enamel,enamel (verb),VERB,C1
-enamor,enamor,enamor,VERB,C1
-encage,encage,encage,VERB,C1
-encamp,encamp,encamp,VERB,C1
-encampment,encampment,encampment,NOUN,C1
-encampments,encampments,encampments,NOUN,C1
-encapsulate,encapsulate,encapsulate,VERB,C1
-encase,encase,encase,VERB,C1
-encephalic,encephalic,encephalic,ADJ,C1
-enchain,enchain,enchain,VERB,C1
-enclosed,enclosed,enclosed,ADJ,B2
-enclosure pen,enclosure pen,enclosure pen,NOUN,C1
-encomium,encomium,encomium,NOUN,C1
-encore (noun),encore,encore (noun),NOUN,C1
-encouraging,encouraging,encouraging,ADJ,C1
-encroachment,encroachment,encroachment,NOUN,C1
-encrust,encrust,encrust,VERB,C1
-encrypt,encrypt,encrypt,VERB,C1
-encrypted,encrypted,encrypted,ADJ,B2
-encumber,encumber,encumber,VERB,C1
-end of the working day,end of the working day,end of the working day,NOUN,C1
-end of the year,end of the year,end of the year,NOUN,C1
-endear,endear,endear,VERB,C1
-endeavor (noun),endeavor,endeavor (noun),NOUN,B2
-endeavor (verb),endeavor,endeavor (verb),VERB,C1
-endemic disease,endemic disease,endemic disease,NOUN,B2
-endogamy,endogamy,endogamy,NOUN,C1
-endogenous,endogenous,endogenous,ADJ,C1
-endoscope,endoscope,endoscope,NOUN,C1
-endoscopy,endoscopy,endoscopy,NOUN,C1
-endue,endue,endue,VERB,C1
-enduring hardship,enduring hardship,enduring hardship,NOUN,C1
-enemy of the state,enemy of the state,enemy of the state,NOUN,C1
-energize,energize,energize,VERB,C1
-enfeeble,enfeeble,enfeeble,VERB,C1
-enfold,enfold,enfold,VERB,C1
-enforceability,enforceability,enforceability,NOUN,C1
-enfranchise,enfranchise,enfranchise,VERB,C1
-engender,engender,engender,VERB,C1
-engine motor,engine motor,engine motor,NOUN,C1
-english teacher,english teacher,,NOUN,B2
-engraft,engraft,engraft,VERB,C1
-engraver,engraver,engraver,NOUN,C1
-engrossing,engrossing,engrossing,ADJ,B2
-engulf,engulf,engulf,VERB,C1
-enigma,enigma,enigma,NOUN,C1
-enjambment,enjambment,enjambment,NOUN,C1
-enjoin,enjoin,enjoin,VERB,C1
-enjoyable,enjoyable,enjoyable,ADJ,B1
-enjoyed,enjoyed,enjoyed,ADJ,C1
-enkindle,enkindle,enkindle,VERB,C1
-enlargement,enlargement,enlargement,NOUN,C1
-enlightening,enlightening,enlightening,ADJ,C1
-enliven,enliven,enliven,VERB,C1
-enmesh,enmesh,enmesh,VERB,C1
-enough (adv),enough,enough (adv),ADV,B2
-enough okay,enough okay,enough okay,ADJ,A1
-enquire,enquire,enquire,VERB,C1
-enraged,enraged,enraged,ADJ,C1
-enriching,enriching,enriching,ADJ,C1
-enrolled,enrolled,enrolled,ADJ,B2
-ensconce,ensconce,ensconce,VERB,C1
-enshrine,enshrine,enshrine,VERB,C1
-enshrinement,enshrinement,enshrinement,NOUN,C1
-enshroud,enshroud,enshroud,VERB,C1
-ensign,ensign,ensign,NOUN,C1
-enslavement,enslavement,enslavement,NOUN,B2
-enslavement by love,enslavement by love,enslavement by love,NOUN,C1
-ensue,ensue,ensue,VERB,B2
-entelechy,entelechy,entelechy,NOUN,C1
-enterprising,enterprising,enterprising,ADJ,C1
-entertainer,entertainer,entertainer,NOUN,B2
-enticement,enticement,enticement,NOUN,C1
-entirely,entirely,完全地,ADV,B2
-entitle,entitle,entitle,VERB,C1
-entitled to exist,entitled to exist,entitled to exist,ADJ,C1
-entitlements,entitlements,entitlements,NOUN,B2
-entomb,entomb,entomb,VERB,C1
-entomology,entomology,entomology,NOUN,C1
-entourage,entourage,随从,NOUN,B2
-entrancing,entrancing,entrancing,ADJ,C1
-entrap,entrap,entrap,VERB,C1
-entreat,entreat,entreat,VERB,C1
-entrench,to entrench,巩固,VERB,B2
-entrenchment,entrenchment,entrenchment,NOUN,C1
-entrepreneur,entrepreneur,企业家,NOUN,B2
-entrepreneurship,entrepreneurship,entrepreneurship,NOUN,C1
-entwine,entwine,entwine,VERB,C1
-enumerate,to enumerate,列举,VERB,B2
-enunciation,enunciation,发音,NOUN,B2
-enunciative,enunciative,enunciative,ADJ,C1
-envelop,envelop,envelop,VERB,C1
-envenom,envenom,envenom,VERB,C1
-envious,envious,嫉妒的,ADJ,B2
-envious jealous,envious jealous,envious jealous,ADJ,B2
-environ,environ,environ,VERB,C1
-environmental,environmental,环境的,ADJ,B2
-envisage,envisage,envisage,VERB,C1
-envoy,envoy,envoy,NOUN,B2
-envy,envy,嫉妒,NOUN,B2
-enwetens,enwetens,enwetens,ADV,C1
-eon age,eon age,eon age,NOUN,C1
-epic,epic,史诗,NOUN,B2
-epic quality,epic quality,epic quality,NOUN,C1
-epicurean,epicurean,享乐主义的,ADJ,B2
-epidemic,epidemic,流行病,NOUN,B2
-epidermal,epidermal,epidermal,ADJ,C1
-epigram,epigram,epigram,NOUN,C1
-epilepsy,epilepsy,epilepsy,NOUN,C1
-epilogue,epilogue,epilogue,NOUN,C1
-episode,episode,集,NOUN,B2
-episodic,episodic,episodic,ADJ,C1
-epistemology,epistemology,认识论,NOUN,B2
-epistolary,epistolary,epistolary,ADJ,C1
-epitaph,epitaph,epitaph,NOUN,B2
-epithet,epithet,epithet,NOUN,B2
-epitome,epitome,化身,NOUN,B2
-epitomize,epitomize,epitomize,VERB,C1
-eponymous,eponymous,eponymous,ADJ,C1
-equal same,equal same,equal same,ADJ,A1
-equality,equality,平等,NOUN,B2
-equalization,equalization,equalization,NOUN,B2
-equally,equally,equally,ADV,B2
-equanimity,equanimity,equanimity,NOUN,C1
-equation,equation,方程,NOUN,B2
-equatorial,equatorial,equatorial,ADJ,C1
-equestrian,equestrian,equestrian,ADJ,B2
-equidistant,equidistant,equidistant,ADJ,C1
-equilateral,equilateral,equilateral,ADJ,C1
-equilibrate,equilibrate,equilibrate,VERB,C1
-equilibrium,equilibrium,平衡,NOUN,B2
-equip,to equip,装备,VERB,B2
-equipped,equipped,配备的,ADJ,B2
-equivalent,equivalent,等价物,NOUN,B2
-equivocal,equivocal,equivocal,ADJ,C1
-equivocate,equivocate,equivocate,VERB,C1
-eradicate,to eradicate,根除,VERB,B2
-erase,to erase,擦除,VERB,B2
-erect,to erect,建立,VERB,B2
-erection,erection,erection,NOUN,C1
-ererziehung,ererziehung,ererziehung,NOUN,C1
-erfassung,erfassung,erfassung,NOUN,C1
-ergabe,ergabe,ergabe,NOUN,C1
-ergestaltung,ergestaltung,ergestaltung,NOUN,C1
-ergonomics,ergonomics,ergonomics,NOUN,C1
-erkunft,erkunft,erkunft,NOUN,C1
-ernahme,ernahme,ernahme,NOUN,C1
-erpflegung,erpflegung,erpflegung,NOUN,C1
-errant,errant,errant,ADJ,C1
-erregelung,erregelung,erregelung,NOUN,C1
-erroneous,erroneous,erroneous,ADJ,C1
-error,error,错误,NOUN,B2
-erschrift,erschrift,erschrift,NOUN,C1
-ersetzung,ersetzung,ersetzung,NOUN,B2
-ersicht,ersicht,ersicht,NOUN,C1
-ersinnung,ersinnung,ersinnung,NOUN,C1
-ersprache,ersprache,ersprache,NOUN,C1
-ersucht,ersucht,ersucht,NOUN,C1
-ersuchung,ersuchung,ersuchung,NOUN,C1
-erteilung,erteilung,erteilung,NOUN,C1
-ertheilung,ertheilung,ertheilung,NOUN,C1
-ertreibung,ertreibung,ertreibung,NOUN,C1
-erupt,erupt,erupt,VERB,C1
-eruption,eruption,爆发,NOUN,B2
-erwandel,erwandel,erwandel,NOUN,C1
-erwirkung,erwirkung,erwirkung,NOUN,B2
-erzerziehung,erzerziehung,erzerziehung,NOUN,C1
-erzfahrt,erzfahrt,erzfahrt,NOUN,B2
-erzfassung,erzfassung,erzfassung,NOUN,C1
-erzforderung,erzforderung,erzforderung,NOUN,C1
-erzgabe,erzgabe,erzgabe,NOUN,C1
-erzgestaltung,erzgestaltung,erzgestaltung,NOUN,C1
-erzkunft,erzkunft,erzkunft,NOUN,C1
-erznahme,erznahme,erznahme,NOUN,C1
-erzpflegung,erzpflegung,erzpflegung,NOUN,C1
-erzrichtung,erzrichtung,erzrichtung,NOUN,C1
-erzschaft,erzschaft,erzschaft,NOUN,C1
-erzschrift,erzschrift,erzschrift,NOUN,C1
-erzsetzung,erzsetzung,erzsetzung,NOUN,C1
-erzsicht,erzsicht,erzsicht,NOUN,C1
-erzsinnung,erzsinnung,erzsinnung,NOUN,C1
-erzsprache,erzsprache,erzsprache,NOUN,C1
-erzsucht,erzsucht,erzsucht,NOUN,C1
-erzsuchung,erzsuchung,erzsuchung,NOUN,C1
-erzteilung,erzteilung,erzteilung,NOUN,C1
-erztheilung,erztheilung,erztheilung,NOUN,B2
-erztreibung,erztreibung,erztreibung,NOUN,C1
-erzwandel,erzwandel,erzwandel,NOUN,C1
-erzweisung,erzweisung,erzweisung,NOUN,C1
-erzwirkung,erzwirkung,erzwirkung,NOUN,C1
-escalate,to escalate,升级,VERB,B2
-escalation,escalation,升级,NOUN,B2
-escaping,escaping,escaping,NOUN,C1
-eschatological,eschatological,eschatological,ADJ,C1
-eschatology,eschatology,eschatology,NOUN,C1
-escheat,escheat,escheat,VERB,C1
-eschew,eschew,eschew,VERB,C1
-esophagus,esophagus,esophagus,NOUN,B2
-esoteric,esoteric,esoteric,ADJ,C1
-esotericism,esotericism,esotericism,NOUN,B2
-espionage,espionage,间谍活动,NOUN,B2
-espresso,espresso,espresso,NOUN,B2
-essayist,essayist,essayist,NOUN,C1
-essayistic,essayistic,essayistic,ADJ,C1
-essayistic quality,essayistic quality,essayistic quality,NOUN,C1
-essence core,essence core,essence core,NOUN,B2
-essential,essential,必要的,ADJ,B2
-essentiality,essentiality,essentiality,NOUN,C1
-establishment,establishment,机构,NOUN,B2
-estate,estate,地产,NOUN,B2
-esteem,esteem,尊重,NOUN,B2
-estimate,estimate,估计,NOUN,B2
-estimation,estimation,estimation,NOUN,C1
-estrange,estrange,estrange,VERB,C1
-estuary,estuary,河口,NOUN,B2
-etc.,etc.,etc.,ADV,C1
-etch,etch,etch,VERB,C1
-eternity without beginning,eternity without beginning,eternity without beginning,NOUN,C1
-eternity without end,eternity without end,eternity without end,NOUN,C1
-ethnic group,ethnic group,ethnic group,NOUN,C1
-eulogize,eulogize,eulogize,VERB,C1
-eunuch,eunuch,eunuch,NOUN,C1
-euphemistic,euphemistic,euphemistic,ADJ,B2
-euphonic,euphonic,euphonic,ADJ,C1
-euphoric,euphoric,euphoric,ADJ,C1
-europe,europe,europe,PROPN,B2
-euthanasia,euthanasia,euthanasia,NOUN,C1
-evanesce,evanesce,evanesce,VERB,C1
-evangelical,evangelical,evangelical,ADJ,C1
-evangelist,evangelist,evangelist,NOUN,C1
-evangelization,evangelization,evangelization,NOUN,C1
-evaporating,evaporating,evaporating,ADJ,C1
-evening gathering,evening gathering,evening gathering,NOUN,C1
-evening meal,evening meal,evening meal,NOUN,B2
-evening party,evening party,evening party,NOUN,B1
-eventual,eventual,eventual,ADJ,C1
-eventual outcome,eventual outcome,eventual outcome,NOUN,C1
-eventuate,eventuate,eventuate,VERB,C1
-ever,ever,,NOUN,B2
-everlasting,everlasting,everlasting,ADJ,C1
-everlastingness,everlastingness,everlastingness,NOUN,C1
-every other sunday,every other sunday,every other sunday,NOUN,B2
-everybody,everybody,everybody,PRON,A1
-everydayness,everydayness,everydayness,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evidentiary weight,evidentiary weight,evidentiary weight,NOUN,C1
-evil (adj),evil,evil (adj),ADJ,B1
-evince,evince,evince,VERB,C1
-eviscerate,eviscerate,eviscerate,VERB,C1
-evolutionary,evolutionary,evolutionary,ADJ,C1
-exact change,exact change,exact change,NOUN,C1
-exactitude,exactitude,exactitude,NOUN,C1
-exactly just,exactly just,exactly just,ADV,B2
-exaltation,exaltation,exaltation,NOUN,C1
-exalted,exalted,exalted,ADJ,B2
-exam evening,exam evening,exam evening,NOUN,B2
-excavated,excavated,excavated,ADJ,B1
-excavation,excavation,excavation,NOUN,B2
-excavator,excavator,excavator,NOUN,B2
-except unless,except unless,except unless,ADP,A2
-exceptionally,exceptionally,exceptionally,ADV,B2
-excess weight,excess weight,excess weight,NOUN,C1
-excessively,excessively,excessively,ADV,C1
-excessiveness,excessiveness,excessiveness,NOUN,C1
-exchange fee,exchange fee,exchange fee,NOUN,C1
-exchange money,exchange money,exchange money,NOUN,A1
-exchange of accusations,exchange of accusations,exchange of accusations,NOUN,C1
-exchange of verses,exchange of verses,exchange of verses,NOUN,C1
-exchanger,exchanger,exchanger,NOUN,C1
-exchanges,exchanges,exchanges,NOUN,C1
-excise (noun),excise,excise (noun),NOUN,C1
-excise (verb),excise,excise (verb),VERB,C1
-excision,excision,excision,NOUN,C1
-excitability,excitability,excitability,NOUN,B2
-exclamation (punct),exclamation,exclamation (punct),PUNCT,A2
-exclusive dedication,exclusive dedication,exclusive dedication,NOUN,C1
-exclusivism,exclusivism,exclusivism,NOUN,C1
-excrescence,excrescence,excrescence,NOUN,C1
-excrete,excrete,excrete,VERB,C1
-exculpation,exculpation,exculpation,NOUN,B2
-execution by firing squad,execution by firing squad,execution by firing squad,NOUN,C1
-executive board,executive board,executive board,NOUN,C1
-executory,executory,executory,ADJ,C1
-exercise book,exercise book,exercise book,NOUN,C1
-exercise equipment,exercise equipment,exercise equipment,NOUN,B2
-exercise of authority,exercise of authority,exercise of authority,NOUN,B2
-exercises,exercises,exercises,NOUN,B2
-exert,exert,exert,VERB,C1
-exhalation,exhalation,exhalation,NOUN,C1
-exhausting,exhausting,exhausting,ADJ,B2
-exhibitor,exhibitor,exhibitor,NOUN,C1
-exhilarate,exhilarate,exhilarate,VERB,C1
-exhortation,exhortation,exhortation,NOUN,C1
-exhumation,exhumation,exhumation,NOUN,C1
-exigent,exigent,exigent,ADJ,C1
-exile (noun),exile,exile (noun),NOUN,B2
-exiled,exiled,exiled,ADJ,C1
-exit (verb),exit,exit (verb),VERB,A1
-exodus,exodus,exodus,NOUN,C1
-exoneration,exoneration,exoneration,NOUN,C1
-exorbitant,exorbitant,exorbitant,ADJ,C1
-exorcism,exorcism,exorcism,NOUN,C1
-exordium,exordium,exordium,NOUN,C1
-exoteric,exoteric,exoteric,ADJ,B2
-exoticism,exoticism,exoticism,NOUN,B2
-expanse,expanse,expanse,NOUN,B2
-expatiate,expatiate,expatiate,VERB,C1
-expatriation,expatriation,expatriation,NOUN,C1
-expectant,expectant,expectant,ADJ,C1
-expectoration,expectoration,expectoration,NOUN,C1
-expedite,expedite,expedite,VERB,C1
-expeditionary,expeditionary,expeditionary,ADJ,C1
-expeditious,expeditious,expeditious,ADJ,B2
-expensiveness,expensiveness,expensiveness,NOUN,B2
-experimentation,experimentation,experimentation,NOUN,C1
-expert opinion,expert opinion,expert opinion,NOUN,B2
-expiate,expiate,expiate,VERB,C1
-expiration,expiration,expiration,NOUN,C1
-expletive,expletive,expletive,NOUN,C1
-explicate,explicate,explicate,VERB,C1
-exploit (noun),exploit,exploit (noun),NOUN,C1
-exploitable,exploitable,exploitable,ADJ,C1
-exploits,exploits,exploits,NOUN,C1
-exploratory,exploratory,exploratory,ADJ,C1
-explosive (noun),explosive,explosive (noun),NOUN,B2
-export (noun),export,export (noun),NOUN,B2
-exportation,exportation,exportation,NOUN,C1
-exports,exports,exports,NOUN,C1
-expostulate,expostulate,expostulate,VERB,C1
-expression of opinion,expression of opinion,expression of opinion,NOUN,B2
-expressionism,expressionism,expressionism,NOUN,C1
-expunge,expunge,expunge,VERB,C1
-exquisite,exquisite,精致的,ADJ,B2
-exquisiteness,exquisiteness,exquisiteness,NOUN,C1
-extemporize,extemporize,extemporize,VERB,C1
-extension cord,extension cord,extension cord,NOUN,C1
-extenuate,extenuate,extenuate,VERB,C1
-extenuating,extenuating,extenuating,ADJ,C1
-exterminate,to exterminate,消灭,VERB,B2
-external,external,外部的,ADJ,B2
-extinguish,to extinguish,熄灭,VERB,B2
-extinguishable,extinguishable,extinguishable,ADJ,C1
-extinguishing,extinguishing,extinguishing,NOUN,C1
-extirpation,extirpation,extirpation,NOUN,C1
-extolling,extolling,extolling,NOUN,C1
-extra,extra,额外的,ADJ,B2
-extra (adv),extra,extra (adv),ADV,A1
-extract,to extract,提取,VERB,B2
-extradite,to extradite,引渡,VERB,B2
-extradition,extradition,引渡,NOUN,B2
-extramarital,extramarital,extramarital,ADJ,C1
-extraordinary,extraordinary,非凡的,ADJ,B2
-extrapolate,to extrapolate,推断,VERB,B2
-extrapolation,extrapolation,extrapolation,NOUN,C1
-extravagance,extravagance,奢侈,NOUN,B2
-extraversion,extraversion,extraversion,NOUN,C1
-extreme,extreme,极端,ADJ,B2
-extreme unction,extreme unction,extreme unction,NOUN,C1
-extremism,extremism,extremism,NOUN,C1
-extrinsic,extrinsic,extrinsic,ADJ,C1
-extroversion,extroversion,外向,NOUN,B2
-extrovert,extrovert,extrovert,ADJ,C1
-extrude,extrude,extrude,VERB,C1
-exuberance,exuberance,exuberance,NOUN,C1
-exudation,exudation,exudation,NOUN,C1
-exult,to exult,狂喜,VERB,B2
-exultation,exultation,欢腾,NOUN,B2
-eyebrows,eyebrows,eyebrows,NOUN,A1
-eyelash,eyelash,睫毛,NOUN,B2
-fabric,fabric,织物,NOUN,B2
-fabricate,to fabricate,捏造,VERB,B2
-fabricated,fabricated,fabricated,ADJ,B2
-fabulist,fabulist,fabulist,NOUN,B2
-facade,facade,正面,NOUN,B2
-face veil,face veil,face veil,NOUN,B2
-facet,facet,方面,NOUN,B2
-facilitation,facilitation,facilitation,NOUN,C1
-facility,facility,设施,NOUN,B2
-facsimile,facsimile,副本,NOUN,B2
-facticity,facticity,facticity,NOUN,C1
-factious,factious,factious,ADJ,C1
-factotum,factotum,factotum,NOUN,C1
-faculty,faculty,学院,NOUN,B2
-fad,fad,fad,NOUN,C1
-fade,to fade,褪色,VERB,B2
-fade away,fade away,fade away,VERB,C1
-faded,faded,褪色的,ADJ,B2
-fading away,fading away,fading away,NOUN,C1
-fag,fag,fag,NOUN,C1
-faggot,faggot,faggot,NOUN,C1
-failing student,failing student,failing student,NOUN,B2
-failure to act,failure to act,failure to act,NOUN,C1
-faint (noun),faint,faint (noun),NOUN,C1
-fair,fair,交易会,NOUN,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,fair-haired,ADJ,B1
-fairly,fairly,fairly,ADV,C1
-fairness,fairness,fairness,NOUN,B2
-fairy,fairy,仙女,NOUN,B2
-faithfully,faithfully,faithfully,ADV,C1
-fake news,fake news,fake news,NOUN,B2
-falcon,falcon,猎鹰,NOUN,B2
-falconry,falconry,falconry,NOUN,B2
-fall back,to fall back,回落,VERB,B2
-fall collapse,fall collapse,fall collapse,NOUN,C1
-fall ill,to fall ill,患病,VERB,B2
-fall in love,to fall in love,坠入爱河,VERB,B2
-fallacious,fallacious,fallacious,ADJ,B2
-fallacy,fallacy,谬误,NOUN,B2
-fallible,fallible,fallible,ADJ,C1
-fallout,fallout,fallout,NOUN,C1
-fallow land,fallow land,fallow land,NOUN,B2
-false,false,错误的,ADJ,B2
-false oath,false oath,false oath,NOUN,C1
-falsehood,falsehood,谎言,NOUN,B2
-falsely,falsely,falsely,ADV,C1
-falseness,falseness,falseness,NOUN,C1
-falsifiability,falsifiability,falsifiability,NOUN,C1
-falsification,falsification,falsification,NOUN,C1
-falsity,falsity,虚假,NOUN,B2
-falter,falter,falter,VERB,C1
-faltering,faltering,faltering,ADJ,C1
-familial,familial,familial,ADJ,B2
-family (adj),family,family (adj),ADJ,B1
-family situation,family situation,family situation,NOUN,C1
-family therapy,family therapy,family therapy,NOUN,C1
-family tie,family tie,family tie,NOUN,B2
-famish,famish,famish,VERB,C1
-famished,famished,famished,ADJ,C1
-fanatic,fanatic,fanatic,ADJ,B2
-fanatical,fanatical,fanatical,ADJ,C1
-fancy,fancy,fancy,ADJ,B1
-fancy decoration,fancy decoration,fancy decoration,NOUN,C1
-fantasize,fantasize,fantasize,VERB,C1
-fantasizing,fantasizing,fantasizing,NOUN,C1
-far (adv),far,far (adv),ADV,A1
-farrow,farrow,farrow,VERB,C1
-farsighted,farsighted,farsighted,ADJ,C1
-fascist (adj),fascist,fascist (adj),ADJ,C1
-fascist (noun),fascist,fascist (noun),NOUN,C1
-fashion designer,fashion designer,fashion designer,NOUN,C1
-fashion plate,fashion plate,fashion plate,NOUN,C1
-fatalist (noun),fatalist,fatalist (noun),NOUN,C1
-fatally,fatally,fatally,ADV,C1
-fateful,fateful,fateful,ADJ,C1
-fathom,fathom,fathom,VERB,C1
-fatness,fatness,fatness,NOUN,C1
-fats,fats,fats,NOUN,C1
-fatty acid,fatty acid,fatty acid,NOUN,C1
-fatuous,fatuous,fatuous,ADJ,C1
-fatwa,fatwa,fatwa,NOUN,B2
-faucet,faucet,faucet,NOUN,C1
-faulty,faulty,faulty,ADJ,C1
-favorable,favorable,favorable,ADJ,C1
-favourite,favourite,favourite,ADJ,B1
-fawn,fawn,fawn,VERB,C1
-faze,faze,faze,VERB,B1
-fear of heights,fear of heights,fear of heights,NOUN,B2
-fearlessness,fearlessness,fearlessness,NOUN,C1
-febrile,febrile,febrile,ADJ,C1
-fecundate,fecundate,fecundate,VERB,C1
-fecundity,fecundity,fecundity,NOUN,C1
-fed up (adj),fed up,fed up (adj),ADJ,B1
-fed up (noun),fed up,fed up (noun),NOUN,B2
-federalize,federalize,federalize,VERB,C1
-feed (noun),feed,feed (noun),NOUN,B2
-feeding,feeding,feeding,NOUN,C1
-feigning ignorance,feigning ignorance,feigning ignorance,VERB,C1
-felicitate,felicitate,felicitate,VERB,C1
-felicity,felicity,felicity,NOUN,C1
-feline,feline,feline,ADJ,C1
-felt,felt,felt,NOUN,C1
-female judge,female judge,female judge,NOUN,C1
-female neighbor,female neighbor,female neighbor,NOUN,C1
-female prosecutor,female prosecutor,female prosecutor,NOUN,C1
-female student,female student,female student,NOUN,C1
-female teacher,female teacher,female teacher,NOUN,C1
-females,females,females,NOUN,B2
-feminization,feminization,feminization,NOUN,C1
-fend,fend,fend,VERB,C1
-fender,fender,fender,NOUN,C1
-fennec fox,fennec fox,fennec fox,NOUN,B2
-fenugreek,fenugreek,fenugreek,NOUN,B2
-feral,feral,feral,ADJ,C1
-fermata,fermata,fermata,NOUN,B2
-fernbildung,fernbildung,fernbildung,NOUN,C1
-fernerziehung,fernerziehung,fernerziehung,NOUN,C1
-fernfahrt,fernfahrt,fernfahrt,NOUN,C1
-fernfassung,fernfassung,fernfassung,NOUN,C1
-fernforderung,fernforderung,fernforderung,NOUN,C1
-ferngabe,ferngabe,ferngabe,NOUN,C1
-ferngestaltung,ferngestaltung,ferngestaltung,NOUN,C1
-fernkunft,fernkunft,fernkunft,NOUN,B2
-fernleitung,fernleitung,fernleitung,NOUN,C1
-fernmessung,fernmessung,fernmessung,NOUN,C1
-fernnahme,fernnahme,fernnahme,NOUN,C1
-fernordnung,fernordnung,fernordnung,NOUN,C1
-fernpflegung,fernpflegung,fernpflegung,NOUN,C1
-fernregelung,fernregelung,fernregelung,NOUN,C1
-fernrichtung,fernrichtung,fernrichtung,NOUN,C1
-fernschrift,fernschrift,fernschrift,NOUN,C1
-fernsetzung,fernsetzung,fernsetzung,NOUN,C1
-fernsicht,fernsicht,fernsicht,NOUN,C1
-fernsinnung,fernsinnung,fernsinnung,NOUN,C1
-fernsprache,fernsprache,fernsprache,NOUN,C1
-fernstellung,fernstellung,fernstellung,NOUN,C1
-fernsuchung,fernsuchung,fernsuchung,NOUN,C1
-fernteilung,fernteilung,fernteilung,NOUN,C1
-ferntreibung,ferntreibung,ferntreibung,NOUN,C1
-fernwandel,fernwandel,fernwandel,NOUN,C1
-fernwandlung,fernwandlung,fernwandlung,NOUN,C1
-fernweisung,fernweisung,fernweisung,NOUN,C1
-fernwendung,fernwendung,fernwendung,NOUN,C1
-fernwirkung,fernwirkung,fernwirkung,NOUN,C1
-ferociously,ferociously,ferociously,ADV,C1
-ferret (noun),ferret,ferret (noun),NOUN,B2
-ferrule,ferrule,ferrule,NOUN,C1
-fervent,fervent,fervent,ADJ,C1
-fervor,fervor,fervor,NOUN,C1
-festivals,festivals,festivals,NOUN,C1
-festivity,festivity,festivity,NOUN,C1
-fete,fete,fete,VERB,C1
-fetid,fetid,fetid,ADJ,C1
-fetishism,fetishism,fetishism,NOUN,B2
-fetter,fetter,fetter,VERB,C1
-feverish,feverish,feverish,ADJ,C1
-fez,fez,fez,NOUN,B2
-fib,fib,fib,VERB,C1
-fibrous,fibrous,fibrous,ADJ,C1
-fictionalization,fictionalization,fictionalization,NOUN,C1
-fictionalize,fictionalize,fictionalize,VERB,C1
-fiddle (noun),fiddle,fiddle (noun),NOUN,B2
-fiddle (verb),fiddle,fiddle (verb),VERB,C1
-fidget,fidget,fidget,VERB,C1
-fiduciary,fiduciary,fiduciary,ADJ,C1
-fief,fief,fief,NOUN,B2
-field (adj),field,field (adj),ADJ,C1
-fieldwork,fieldwork,fieldwork,NOUN,B1
-fiend,fiend,fiend,NOUN,C1
-fierce one,fierce one,fierce one,NOUN,B2
-fifth (num),fifth,fifth (num),NUM,B2
-fig,fig,fig,NOUN,C1
-fig tree,fig tree,fig tree,NOUN,C1
-fighting,fighting,fighting,NOUN,B2
-figuration,figuration,figuration,NOUN,B2
-figurative language,figurative language,figurative language,NOUN,C1
-figuratively,figuratively,figuratively,ADV,C1
-filament,filament,filament,NOUN,C1
-filch,filch,filch,VERB,C1
-filibuster,filibuster,filibuster,NOUN,C1
-filigree,filigree,filigree,NOUN,C1
-filings,filings,filings,NOUN,C1
-fillet (noun),fillet,fillet (noun),NOUN,C1
-fillet (verb),fillet,fillet (verb),VERB,C1
-filling,filling,filling,NOUN,B2
-film art,film art,film art,NOUN,C1
-film director,film director,film director,NOUN,B2
-film industry,film industry,film industry,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,film studio,NOUN,B2
-filmmaker,filmmaker,filmmaker,NOUN,C1
-filter (noun),filter,filter (noun),NOUN,B2
-filth garbage,filth garbage,filth garbage,NOUN,C1
-fin,fin,fin,NOUN,B2
-finality,finality,finality,NOUN,C1
-financial liability,financial liability,financial liability,NOUN,C1
-financially,financially,financially,ADV,B2
-fine (noun),fine,fine (noun),NOUN,B1
-fine print,fine print,fine print,NOUN,C1
-fine well,fine well,fine well,ADJ,A1
-finely,finely,finely,ADV,C1
-fingernail,fingernail,fingernail,NOUN,B2
-finial,finial,finial,NOUN,C1
-finish end,finish end,finish end,VERB,A1
-fir tree,fir tree,fir tree,NOUN,B2
-fire department,fire department,fire department,NOUN,B2
-fire extinguisher,fire extinguisher,fire extinguisher,NOUN,C1
-fire kick,fire kick,fire kick,VERB,A2
-fire station,fire station,fire station,NOUN,C1
-firedamp,firedamp,firedamp,NOUN,C1
-firework,firework,firework,NOUN,B2
-firm entrenchment,firm entrenchment,firm entrenchment,NOUN,C1
-firm fixed,firm fixed,firm fixed,ADJ,B1
-firmament,firmament,firmament,NOUN,C1
-firmly,firmly,firmly,ADV,C1
-first (num),first,first (num),NUM,A2
-first aid,first aid,first aid,NOUN,B2
-fiscal,fiscal,fiscal,ADJ,C1
-fiscal tax,fiscal tax,fiscal tax,ADJ,B1
-fish bone,fish bone,fish bone,NOUN,C1
-fish shop,fish shop,fish shop,NOUN,A2
-fisheries,fisheries,fisheries,NOUN,B2
-fishery,fishery,fishery,NOUN,B2
-fishhook,fishhook,fishhook,NOUN,B2
-fishing,fishing,fishing,NOUN,B2
-fishmonger,fishmonger,fishmonger,NOUN,B2
-fistula,fistula,fistula,NOUN,B2
-fit (noun),fit,fit (noun),NOUN,B2
-fitting out,fitting out,fitting out,NOUN,B2
-fittings,fittings,fittings,NOUN,C1
-five (adj),five,five (adj),ADJ,C1
-five-year term,five-year term,five-year term,NOUN,C1
-fixation,fixation,fixation,NOUN,C1
-fizz,fizz,fizz,VERB,C1
-fizzle,fizzle,fizzle,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,flabbergast,VERB,C1
-flabby,flabby,flabby,ADJ,B2
-flaccid,flaccid,flaccid,ADJ,B2
-flaccidity,flaccidity,flaccidity,NOUN,C1
-flagellation,flagellation,flagellation,NOUN,C1
-flagrant,flagrant,flagrant,ADJ,C1
-flagrante delicto,flagrante delicto,flagrante delicto,NOUN,C1
-flail,flail,flail,VERB,C1
-flair,flair,flair,NOUN,C1
-flake (noun),flake,flake (noun),NOUN,C1
-flake (verb),flake,flake (verb),VERB,C1
-flaming,flaming,flaming,ADJ,C1
-flange,flange,flange,NOUN,C1
-flank (verb),flank,flank (verb),VERB,C1
-flap (noun),flap,flap (noun),NOUN,C1
-flare,flare,flare,VERB,C1
-flash (noun),flash,flash (noun),NOUN,B2
-flashback,flashback,flashback,NOUN,C1
-flashlight,flashlight,flashlight,NOUN,B2
-flat (noun),flat,flat (noun),NOUN,B1
-flat rate,flat rate,flat rate,NOUN,B2
-flat-nosed,flat-nosed,flat-nosed,ADJ,B2
-flat-rate,flat-rate,flat-rate,ADJ,C1
-flatterer,flatterer,flatterer,NOUN,C1
-flattering,flattering,flattering,ADJ,C1
-flaunt,flaunt,flaunt,VERB,C1
-flawed,flawed,flawed,ADJ,C1
-flay,flay,flay,VERB,C1
-flea chip,flea chip,flea chip,NOUN,B2
-fleck,fleck,fleck,NOUN,C1
-fleece (noun),fleece,fleece (noun),NOUN,C1
-flex,flex,flex,VERB,C1
-flexion,flexion,flexion,NOUN,C1
-flick,flick,flick,VERB,C1
-flicker,flicker,flicker,VERB,C1
-flinch,flinch,flinch,VERB,C1
-fling (noun),fling,fling (noun),NOUN,C1
-fling (verb),fling,fling (verb),VERB,C1
-flip,flip,flip,VERB,B2
-flirt (noun),flirt,flirt (noun),NOUN,B2
-flirt (verb),flirt,flirt (verb),VERB,B2
-flirtation,flirtation,flirtation,NOUN,C1
-flirting,flirting,flirting,NOUN,C1
-flit,flit,flit,VERB,C1
-float (noun),float,float (noun),NOUN,B2
-floating (noun),floating,floating (noun),NOUN,C1
-flogging,flogging,flogging,NOUN,C1
-flooded,flooded,flooded,ADJ,B2
-floor projectile,floor projectile,floor projectile,NOUN,C1
-floor story,floor story,floor story,NOUN,A2
-floorboard,floorboard,floorboard,NOUN,C1
-flop,flop,flop,VERB,C1
-floral,floral,floral,ADJ,C1
-florist,florist,florist,NOUN,C1
-flotation,flotation,flotation,NOUN,C1
-flounce,flounce,flounce,VERB,C1
-flounder,flounder,flounder,VERB,C1
-floundering,floundering,floundering,NOUN,C1
-flourishing (noun),flourishing,flourishing (noun),NOUN,C1
-flowerbed stalls,flowerbed stalls,flowerbed stalls,NOUN,C1
-flowering,flowering,flowering,NOUN,B2
-fluently,fluently,fluently,ADV,C1
-fluff,fluff,fluff,NOUN,C1
-fluid (adj),fluid,fluid (adj),ADJ,B2
-fluidity,fluidity,fluidity,NOUN,C1
-fluidize,fluidize,fluidize,VERB,C1
-fluids,fluids,fluids,NOUN,C1
-fluke,fluke,fluke,NOUN,B2
-flunk,flunk,flunk,VERB,C1
-fluorescence,fluorescence,fluorescence,NOUN,C1
-fluorescent,fluorescent,fluorescent,ADJ,C1
-fluorine,fluorine,fluorine,NOUN,C1
-fluster (noun),fluster,fluster (noun),NOUN,C1
-flutist,flutist,flutist,NOUN,C1
-flutter (noun),flutter,flutter (noun),NOUN,B2
-flying,flying,flying,ADJ,B2
-flyover,flyover,flyover,NOUN,C1
-flyting poems,flyting poems,flyting poems,NOUN,C1
-fob,fob,fob,NOUN,C1
-focalization,focalization,focalization,NOUN,C1
-foggy,foggy,foggy,ADJ,C1
-foil (noun),foil,foil (noun),NOUN,C1
-fold over,fold over,fold over,VERB,C1
-foldable,foldable,foldable,ADJ,C1
-foliaceous,foliaceous,foliaceous,ADJ,C1
-foliage,foliage,foliage,NOUN,B2
-foliar,foliar,foliar,ADJ,C1
-folk oboe,folk oboe,folk oboe,NOUN,B2
-folk singer,folk singer,folk singer,NOUN,C1
-folkloric,folkloric,folkloric,ADJ,C1
-follower enthusiast,follower enthusiast,follower enthusiast,NOUN,C1
-followers,followers,followers,NOUN,C1
-following (adj),following,following (adj),ADJ,B2
-following (adp),following,following (adp),ADP,C1
-following next,following next,following next,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,following the example of,NOUN,C1
-foment,foment,foment,VERB,C1
-fond of food,fond of food,fond of food,ADJ,B1
-fondle,fondle,fondle,VERB,C1
-fondness,fondness,fondness,NOUN,B2
-foolhardiness,foolhardiness,foolhardiness,NOUN,C1
-foolishness,foolishness,foolishness,NOUN,B1
-footage,footage,footage,NOUN,B2
-football camp,football camp,football camp,NOUN,B2
-football player,football player,football player,NOUN,C1
-foothill,foothill,foothill,NOUN,B2
-footnote,footnote,footnote,NOUN,C1
-footstool,footstool,footstool,NOUN,C1
-for each other,for each other,for each other,ADV,B2
-for guidance orientation,for guidance orientation,for guidance orientation,ADV,C1
-for hours,for hours,for hours,ADJ,B2
-for my sake,for my sake,for my sake,ADV,C1
-for that,for that,for that,ADV,A2
-for that purpose,for that purpose,for that purpose,ADV,B2
-for the,for the,for the,ADP,A2
-for the sake of argument,for the sake of argument,for the sake of argument,ADV,C1
-for what purpose,for what purpose,for what purpose,ADV,B2
-for your sake,for your sake,for your sake,ADV,B2
-forage,forage,forage,VERB,C1
-foray,foray,foray,NOUN,C1
-forbear,forbear,forbear,VERB,C1
-forbearance,forbearance,forbearance,NOUN,C1
-forbearing,forbearing,forbearing,ADJ,C1
-forced labor,forced labor,forced labor,NOUN,C1
-forceful,forceful,forceful,ADJ,B2
-forcing submission,forcing submission,forcing submission,NOUN,C1
-ford,ford,ford,NOUN,B2
-forearm,forearm,forearm,NOUN,C1
-foreboding,foreboding,foreboding,NOUN,C1
-forecast (verb),forecast,forecast (verb),VERB,B2
-foreclose,foreclose,foreclose,VERB,C1
-foreclosure of rights,foreclosure of rights,foreclosure of rights,NOUN,B2
-forecourt,forecourt,forecourt,NOUN,C1
-foredoom,foredoom,foredoom,VERB,C1
-forego,forego,forego,VERB,C1
-foreground,foreground,foreground,NOUN,C1
-foreign strange,foreign strange,foreign strange,ADJ,B2
-foreknow,foreknow,foreknow,VERB,C1
-foreman,foreman,foreman,NOUN,B2
-forenoon,forenoon,forenoon,NOUN,A1
-forensic evidence collection,forensic evidence collection,forensic evidence collection,NOUN,C1
-foreshadow,foreshadow,foreshadow,VERB,C1
-foreshadowing,foreshadowing,foreshadowing,NOUN,C1
-foreshorten,foreshorten,foreshorten,VERB,C1
-forest (adj),forest,forest (adj),ADJ,C1
-forest ranger,forest ranger,forest ranger,NOUN,C1
-forest-related,forest-related,forest-related,ADJ,B2
-forestall,forestall,forestall,VERB,C1
-forestry,forestry,forestry,ADJ,C1
-foretell,foretell,foretell,VERB,C1
-forewarn,forewarn,forewarn,VERB,C1
-foreword,foreword,foreword,NOUN,C1
-forfeit,forfeit,forfeit,VERB,C1
-forfeiture,forfeiture,forfeiture,NOUN,B2
-forge (noun),forge,forge (noun),NOUN,C1
-forged,forged,forged,ADJ,C1
-forger,forger,forger,NOUN,C1
-forgetfulness,forgetfulness,forgetfulness,NOUN,B2
-forging,forging,forging,NOUN,C1
-forgiving,forgiving,forgiving,ADJ,C1
-forgo,forgo,forgo,VERB,C1
-formal notice,formal notice,formal notice,NOUN,C1
-formalist (adj),formalist,formalist (adj),ADJ,C1
-formalist (noun),formalist,formalist (noun),NOUN,C1
-fornicate,fornicate,fornicate,VERB,C1
-forsake,forsake,forsake,VERB,C1
-forswear,forswear,forswear,VERB,C1
-forthcoming,forthcoming,forthcoming,ADJ,C1
-fortification,fortification,fortification,NOUN,C1
-fortlet,fortlet,fortlet,NOUN,C1
-fortune teller,fortune teller,fortune teller,NOUN,B2
-forums,forums,forums,NOUN,C1
-forward (verb),forward,forward (verb),VERB,B2
-fossilization,fossilization,fossilization,NOUN,B2
-fossilized,fossilized,fossilized,ADJ,C1
-foster,foster,foster,VERB,B2
-foul,foul,foul,NOUN,B2
-foul-mouthed,foul-mouthed,foul-mouthed,ADJ,C1
-foundations,foundations,foundations,NOUN,C1
-four (adj),four,four (adj),ADJ,C1
-fourth (num),fourth,fourth (num),NUM,B1
-fowl,fowl,fowl,NOUN,C1
-foyer,foyer,foyer,NOUN,C1
-fractional,fractional,fractional,ADJ,B2
-fractured,fractured,fractured,ADJ,C1
-frame of reference,frame of reference,frame of reference,NOUN,C1
-framework-related,framework-related,framework-related,ADJ,C1
-framing,framing,framing,NOUN,C1
-fraternal,fraternal,fraternal,ADJ,C1
-fraternity,fraternity,fraternity,NOUN,C1
-fraud prevention,fraud prevention,fraud prevention,NOUN,C1
-fraudster,fraudster,fraudster,NOUN,C1
-fraudulent,fraudulent,fraudulent,ADJ,C1
-fraudulent concealment,fraudulent concealment,fraudulent concealment,NOUN,C1
-fray,fray,fray,VERB,C1
-frayed,frayed,frayed,ADJ,C1
-frazzle,frazzle,frazzle,VERB,C1
-freckles,freckles,freckles,NOUN,B2
-free association,free association,free association,NOUN,C1
-free of charge (adv),free of charge,free of charge (adv),ADV,B1
-free of charge (noun),free of charge,free of charge (noun),NOUN,B2
-free trade,free trade,free trade,NOUN,C1
-free will,free will,free will,NOUN,B2
-freedmen clients,freedmen clients,freedmen clients,NOUN,C1
-freedom of choice,freedom of choice,freedom of choice,NOUN,B2
-french fry,french fry,french fry,NOUN,B2
-frequencies,frequencies,frequencies,NOUN,B2
-frequency (adj),frequency,frequency (adj),ADJ,C1
-frequent (adj),frequent,frequent (adj),ADJ,B2
-fresco,fresco,fresco,NOUN,B2
-fresh,fresh,,NOUN,B2
-fresh soft,fresh soft,fresh soft,ADJ,A1
-fret,fret,fret,VERB,C1
-friar,friar,friar,NOUN,C1
-fried,fried,fried,ADJ,B1
-fried food,fried food,fried food,NOUN,C1
-friend female,friend female,friend female,NOUN,A1
-friend male,friend male,friend male,NOUN,A1
-friends,friends,friends,NOUN,B1
-friends with,friends with,friends with,ADJ,B2
-frightful,frightful,frightful,ADJ,B1
-frill,frill,frill,NOUN,C1
-frisian,frisian,frisian,ADJ,B2
-frisk,frisk,frisk,VERB,C1
-fritter,fritter,fritter,VERB,C1
-frivol,frivol,frivol,VERB,C1
-frizz,frizz,frizz,VERB,C1
-frock,frock,frock,NOUN,C1
-from Cadiz,from Cadiz,from Cadiz,ADJ,C1
-from Granada,from Granada,from Granada,ADJ,C1
-from Havana,from Havana,from Havana,ADJ,C1
-from Seville,from Seville,from Seville,ADJ,C1
-from as of,from as of,from as of,ADP,A2
-from each other,from each other,from each other,ADV,C1
-from here,from here,from here,ADV,B2
-from home,from home,from home,ADV,B2
-from onward,from onward,from onward,ADP,A1
-from the,from the,from the,ADP,C1
-from this,from this,from this,ADV,B2
-from what,from what,from what,ADV,B2
-frontiers,frontiers,frontiers,NOUN,C1
-frontispiece,frontispiece,frontispiece,NOUN,C1
-frontrunner,frontrunner,frontrunner,NOUN,C1
-frosted,frosted,frosted,ADJ,C1
-frosty,frosty,frosty,ADJ,A1
-frown,frown,,NOUN,B2
-frown (verb),frown,frown (verb),VERB,C1
-frowning,frowning,frowning,NOUN,C1
-frozen (noun),frozen,frozen (noun),NOUN,B2
-fructify,fructify,fructify,VERB,C1
-fruit tree,fruit tree,fruit tree,ADJ,B2
-fruitful,fruitful,fruitful,ADJ,C1
-fruitfully,fruitfully,fruitfully,ADV,C1
-fruiting,fruiting,fruiting,ADJ,C1
-fruitless,fruitless,fruitless,ADJ,C1
-fryer,fryer,fryer,NOUN,C1
-fuchsia,fuchsia,fuchsia,NOUN,C1
-fuddle,fuddle,fuddle,VERB,C1
-fudge,fudge,fudge,NOUN,C1
-fuels,fuels,fuels,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,fuels hydrocarbons,NOUN,C1
-fugitive (adj),fugitive,fugitive (adj),ADJ,B2
-fugitive (noun),fugitive,fugitive (noun),NOUN,B2
-fulcrum,fulcrum,fulcrum,NOUN,C1
-fulfil,fulfil,fulfil,VERB,C1
-full fed,full fed,full fed,ADJ,A1
-full fed up,full fed up,full fed up,ADJ,B1
-full satiated,full satiated,full satiated,ADJ,A2
-full stop,full stop,full stop,NOUN,B2
-full-fledged,full-fledged,full-fledged,ADJ,C1
-full-time,full-time,full-time,ADJ,B2
-fullness,fullness,fullness,NOUN,C1
-fully,fully,fully,ADV,C1
-fulminate,fulminate,fulminate,VERB,C1
-fumarole,fumarole,fumarole,NOUN,C1
-fumble,fumble,fumble,VERB,C1
-fume,fume,fume,NOUN,C1
-fumigation,fumigation,fumigation,NOUN,C1
-functioning operation,functioning operation,functioning operation,NOUN,B1
-fundamental rights,fundamental rights,fundamental rights,NOUN,C1
-fundamentally,fundamentally,fundamentally,ADV,C1
-funding,funding,funding,NOUN,B2
-fundraiser,fundraiser,fundraiser,NOUN,C1
-funeral (adj),funeral,funeral (adj),ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,funeral rites,NOUN,C1
-funerary,funerary,funerary,ADJ,B2
-fungal,fungal,fungal,ADJ,C1
-fungi,fungi,fungi,NOUN,B2
-fungibility,fungibility,fungibility,NOUN,C1
-funniness,funniness,,NOUN,B2
-furbish,furbish,furbish,VERB,C1
-furl,furl,furl,VERB,C1
-furlough (noun),furlough,furlough (noun),NOUN,C1
-furnished,furnished,furnished,ADJ,B2
-further (adv),further,further (adv),ADV,B2
-further additional,further additional,further additional,ADJ,B2
-further to in reference,further to in reference,further to in reference,ADV,C1
-furtive,furtive,furtive,ADJ,B2
-furtively,furtively,furtively,ADV,C1
-furuncle,furuncle,furuncle,NOUN,C1
-futile,futile,futile,ADJ,C1
-futurist,futurist,futurist,NOUN,C1
-futuristic,futuristic,futuristic,ADJ,C1
-fuzzy,fuzzy,fuzzy,ADJ,C1
-gad,gad,gad,VERB,C1
-gag,gag,gag,NOUN,C1
-gainsay,gainsay,gainsay,VERB,C1
-galactic,galactic,galactic,ADJ,C1
-galician,galician,galician,ADJ,B2
-gallbladder,gallbladder,gallbladder,NOUN,C1
-gallery owner,gallery owner,gallery owner,NOUN,C1
-galley,galley,galley,NOUN,C1
-gallon,gallon,gallon,NOUN,C1
-galloping,galloping,galloping,ADJ,C1
-gallows,gallows,gallows,NOUN,C1
-galvanization,galvanization,galvanization,NOUN,C1
-galvanized,galvanized,galvanized,ADJ,C1
-gambling,gambling,gambling,NOUN,C1
-gambol,gambol,gambol,VERB,C1
-game play,game play,game play,NOUN,B2
-gamete,gamete,gamete,NOUN,B2
-gantry portal,gantry portal,gantry portal,NOUN,C1
-gaol,gaol,gaol,NOUN,C1
-gaping,gaping,,NOUN,B2
-garb,garb,garb,NOUN,C1
-garbage,garbage,garbage,NOUN,B2
-garble,garble,garble,VERB,C1
-gargle (noun),gargle,gargle (noun),NOUN,C1
-gargle (verb),gargle,gargle (verb),VERB,C1
-garment making,garment making,garment making,NOUN,C1
-garner,garner,garner,VERB,C1
-garrison towns,garrison towns,garrison towns,NOUN,C1
-gas flame,gas flame,gas flame,NOUN,B2
-gas meter,gas meter,gas meter,NOUN,B2
-gas pipeline,gas pipeline,gas pipeline,NOUN,C1
-gash,gash,gash,NOUN,C1
-gasket,gasket,gasket,NOUN,B1
-gasp (noun),gasp,gasp (noun),NOUN,B2
-gasp (verb),gasp,gasp (verb),VERB,B2
-gastronome,gastronome,gastronome,NOUN,C1
-gatekeeper,gatekeeper,gatekeeper,NOUN,B2
-gateway,gateway,gateway,NOUN,C1
-gather (noun),gather,gather (noun),NOUN,C1
-gauge (noun),gauge,gauge (noun),NOUN,C1
-gauge meter,gauge meter,gauge meter,NOUN,C1
-gaunt,gaunt,gaunt,ADJ,C1
-gazelle,gazelle,gazelle,NOUN,B1
-gazette,gazette,gazette,NOUN,C1
-geerziehung,geerziehung,geerziehung,NOUN,C1
-gefahrt,gefahrt,gefahrt,NOUN,B2
-gefassung,gefassung,gefassung,NOUN,C1
-gegabe,gegabe,gegabe,NOUN,C1
-gegestaltung,gegestaltung,gegestaltung,NOUN,C1
-gekunft,gekunft,gekunft,NOUN,C1
-gel,gel,gel,NOUN,C1
-gelatin,gelatin,gelatin,NOUN,C1
-geld,geld,geld,VERB,C1
-gemstone,gemstone,gemstone,NOUN,C1
-genahme,genahme,genahme,NOUN,C1
-gendarme,gendarme,gendarme,NOUN,B1
-gendarmerie,gendarmerie,gendarmerie,NOUN,C1
-gender parity,gender parity,gender parity,NOUN,C1
-genealogical,genealogical,genealogical,ADJ,C1
-genealogist,genealogist,genealogist,NOUN,C1
-general assembly,general assembly,general assembly,NOUN,C1
-generations,generations,generations,NOUN,B2
-generatrix,generatrix,generatrix,NOUN,B2
-genesis emergence,genesis emergence,genesis emergence,NOUN,C1
-genetic modification,genetic modification,genetic modification,NOUN,B2
-genetically,genetically,genetically,ADV,B2
-genial,genial,genial,ADJ,C1
-genocide,genocide,genocide,NOUN,B2
-genre classification,genre classification,genre classification,NOUN,C1
-gentle reproach,gentle reproach,gentle reproach,NOUN,C1
-gentlemen,gentlemen,gentlemen,NOUN,C1
-gentleness,gentleness,gentleness,NOUN,C1
-gentrification,gentrification,gentrification,NOUN,C1
-genuflect,genuflect,genuflect,VERB,C1
-genuflection,genuflection,genuflection,NOUN,C1
-genus,genus,genus,NOUN,C1
-geocentric,geocentric,geocentric,ADJ,C1
-geographer,geographer,geographer,NOUN,C1
-geographically,geographically,geographically,ADV,C1
-geolocation,geolocation,geolocation,NOUN,C1
-geometer,geometer,geometer,NOUN,C1
-geophysics,geophysics,geophysics,NOUN,C1
-geostrategic,geostrategic,geostrategic,ADJ,C1
-gepflegung,gepflegung,gepflegung,NOUN,C1
-geregelung,geregelung,geregelung,NOUN,C1
-geriatric,geriatric,geriatric,ADJ,C1
-geriatrics,geriatrics,geriatrics,NOUN,B2
-german person,german person,german person,NOUN,B2
-germanic,germanic,germanic,ADJ,C1
-germicidal,germicidal,germicidal,ADJ,C1
-geschaft,geschaft,geschaft,NOUN,C1
-geschrift,geschrift,geschrift,NOUN,C1
-gesetzung,gesetzung,gesetzung,NOUN,C1
-gesicht,gesicht,gesicht,NOUN,C1
-gesprache,gesprache,gesprache,NOUN,C1
-gestation,gestation,gestation,NOUN,C1
-gestural,gestural,gestural,ADJ,C1
-gesuchung,gesuchung,gesuchung,NOUN,C1
-get out,get out,get out,VERB,C1
-getaway,getaway,getaway,NOUN,C1
-getting rich,getting rich,getting rich,NOUN,C1
-gewandel,gewandel,gewandel,NOUN,C1
-geweisung,geweisung,geweisung,NOUN,C1
-gewirkung,gewirkung,gewirkung,NOUN,C1
-ghaita,ghaita,ghaita,NOUN,B2
-gharar,gharar,gharar,NOUN,C1
-gherkin,gherkin,gherkin,NOUN,B1
-ghoriba cookie,ghoriba cookie,ghoriba cookie,NOUN,B2
-ghostly,ghostly,ghostly,ADJ,C1
-gibber,gibber,gibber,VERB,C1
-gibberish,gibberish,gibberish,NOUN,C1
-gibe,gibe,gibe,VERB,C1
-giddy,giddy,giddy,ADJ,B2
-giftedness,giftedness,giftedness,NOUN,C1
-gilding,gilding,gilding,NOUN,C1
-gills,gills,gills,NOUN,B2
-girdle,girdle,girdle,NOUN,C1
-girl daughter,girl daughter,girl daughter,NOUN,A1
-given datum,given datum,given datum,NOUN,C1
-giving of oneself,giving of oneself,giving of oneself,NOUN,C1
-glacial,glacial,glacial,ADJ,C1
-gladden,gladden,gladden,VERB,C1
-gladiator,gladiator,gladiator,NOUN,C1
-glamour,glamour,glamour,NOUN,C1
-glare,glare,glare,VERB,C1
-glass bottle,glass bottle,glass bottle,NOUN,B1
-glasses spectacles,glasses spectacles,glasses spectacles,NOUN,A1
-glaze,glaze,glaze,VERB,C1
-gleam,gleam,gleam,NOUN,C1
-glebe,glebe,glebe,NOUN,C1
-gleeful,gleeful,gleeful,ADJ,C1
-glimmer,glimmer,glimmer,NOUN,C1
-glint,glint,glint,NOUN,C1
-glisten,glisten,glisten,VERB,C1
-glitter (noun),glitter,glitter (noun),NOUN,B2
-glitter (verb),glitter,glitter (verb),VERB,C1
-gloat,gloat,gloat,VERB,C1
-gloating,gloating,gloating,NOUN,C1
-glomerulus,glomerulus,glomerulus,NOUN,C1
-gloriously,gloriously,gloriously,ADV,C1
-glossator,glossator,glossator,NOUN,C1
-gloves,gloves,gloves,NOUN,B2
-glow (verb),glow,glow (verb),VERB,B2
-glow glimmer,glow glimmer,glow glimmer,NOUN,C1
-glower,glower,glower,VERB,C1
-glucose,glucose,glucose,NOUN,C1
-glut,glut,glut,NOUN,C1
-gluteal,gluteal,gluteal,ADJ,C1
-glutton,glutton,glutton,NOUN,C1
-glyph,glyph,glyph,NOUN,C1
-gnash,gnash,gnash,VERB,C1
-go away,go away,go away,VERB,C1
-go wrong,go wrong,go wrong,VERB,C1
-goalkeeper,goalkeeper,goalkeeper,NOUN,B2
-gobble,gobble,gobble,VERB,C1
-goblin,goblin,goblin,NOUN,C1
-godliness,godliness,godliness,NOUN,C1
-godmother,godmother,godmother,NOUN,C1
-godson,godson,godson,NOUN,A2
-goggle,goggle,goggle,VERB,C1
-going,going,going,NOUN,B2
-gondolier,gondolier,gondolier,NOUN,C1
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,good cooked,ADJ,A1
-good evening,good evening,good evening,INTJ,A1
-good lord,good lord,good lord,INTJ,B2
-good nature,good nature,good nature,NOUN,B2
-good offices,good offices,good offices,NOUN,C1
-good-natured,good-natured,good-natured,ADJ,B2
-good-naturedness,good-naturedness,good-naturedness,NOUN,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-gorge,gorge,gorge,NOUN,C1
-gospel,gospel,gospel,NOUN,C1
-gossipmonger,gossipmonger,gossipmonger,NOUN,B2
-gossipy,gossipy,gossipy,ADJ,B2
-gouge,gouge,gouge,VERB,C1
-governability,governability,governability,NOUN,B2
-governable,governable,governable,ADJ,B2
-governess,governess,governess,NOUN,C1
-governorate,governorate,governorate,NOUN,C1
-gracefulness,gracefulness,gracefulness,NOUN,C1
-grail,grail,grail,NOUN,B2
-grammatical,grammatical,grammatical,ADJ,C1
-gramophone,gramophone,gramophone,NOUN,C1
-granary,granary,granary,NOUN,C1
-grand master,grand master,grand master,NOUN,B2
-grandiloquence,grandiloquence,grandiloquence,NOUN,C1
-grandiloquent,grandiloquent,grandiloquent,ADJ,B2
-grandiloquently,grandiloquently,grandiloquently,ADV,C1
-grandparent,grandparent,grandparent,NOUN,B2
-granitic,granitic,granitic,ADJ,C1
-granting of respite,granting of respite,granting of respite,NOUN,C1
-grants,grants,grants,NOUN,C1
-granular,granular,granular,ADJ,C1
-granule,granule,granule,NOUN,C1
-grapefruit,grapefruit,grapefruit,NOUN,A2
-grapes,grapes,grapes,NOUN,A1
-graph,graph,graph,NOUN,C1
-graphic artist,graphic artist,graphic artist,NOUN,C1
-graphic design,graphic design,graphic design,NOUN,C1
-graphic designer,graphic designer,graphic designer,NOUN,B2
-grapple,grapple,grapple,VERB,C1
-grasp understand,grasp understand,grasp understand,VERB,B1
-grasshopper,grasshopper,grasshopper,NOUN,B1
-grassroots,grassroots,grassroots,ADJ,C1
-grate,grate,grate,VERB,C1
-grater,grater,grater,NOUN,B2
-gratification,gratification,gratification,NOUN,C1
-gravid,gravid,gravid,ADJ,B2
-gravitas,gravitas,gravitas,NOUN,C1
-gravity of loss,gravity of loss,gravity of loss,NOUN,C1
-gray hair,gray hair,gray hair,NOUN,B2
-grayish,grayish,grayish,ADJ,C1
-grease (noun),grease,grease (noun),NOUN,C1
-great (adv),great,great (adv),ADV,B1
-great-grandfather,great-grandfather,great-grandfather,NOUN,B2
-greaten,greaten,greaten,VERB,C1
-greatest,greatest,greatest,NOUN,B2
-green-clad,green-clad,,NOUN,B2
-greetings,greetings,,NOUN,B2
-grenadier,grenadier,grenadier,NOUN,C1
-grey area,grey area,grey area,NOUN,B2
-griddle flatbread,griddle flatbread,griddle flatbread,NOUN,B2
-grieve,grieve,grieve,VERB,C1
-grieved,grieved,grieved,ADJ,B2
-grievously unjust,grievously unjust,grievously unjust,ADJ,C1
-grill (noun),grill,grill (noun),NOUN,B2
-grilled,grilled,grilled,ADJ,B1
-grimace,grimace,grimace,NOUN,C1
-grimness,grimness,grimness,NOUN,C1
-grinder,grinder,grinder,NOUN,C1
-grip adhesion,grip adhesion,grip adhesion,NOUN,C1
-gripe,gripe,gripe,VERB,C1
-grit,grit,grit,NOUN,C1
-groan (noun),groan,groan (noun),NOUN,B2
-grocer,grocer,grocer,NOUN,A2
-grocery,grocery,grocery,NOUN,B2
-grooming,grooming,grooming,NOUN,C1
-grooved,grooved,grooved,ADJ,C1
-grope,grope,grope,VERB,C1
-grotesque,grotesque,grotesque,ADJ,B2
-grounds of judgment,grounds of judgment,grounds of judgment,NOUN,C1
-groundwater pollution,groundwater pollution,groundwater pollution,NOUN,B2
-group cohesion,group cohesion,group cohesion,NOUN,C1
-group dynamics,group dynamics,group dynamics,NOUN,C1
-group harmony,group harmony,group harmony,NOUN,C1
-group identity,group identity,group identity,NOUN,C1
-group weakness,group weakness,group weakness,NOUN,C1
-group work,group work,group work,NOUN,B2
-grouping,grouping,grouping,NOUN,B2
-grouse,grouse,grouse,VERB,C1
-grovel,grovel,grovel,VERB,C1
-growing,growing,growing,ADJ,B2
-growl (noun),growl,growl (noun),NOUN,B2
-growth rate,growth rate,growth rate,NOUN,C1
-grub,grub,grub,NOUN,C1
-grueling,grueling,grueling,ADJ,C1
-grunt,grunt,grunt,VERB,B2
-guarantee (noun),guarantee,guarantee (noun),NOUN,B1
-guarantees,guarantees,guarantees,NOUN,C1
-guardrail,guardrail,guardrail,NOUN,C1
-guerrilla,guerrilla,guerrilla,NOUN,C1
-guerrilla fighter,guerrilla fighter,guerrilla fighter,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guidebook,guidebook,guidebook,NOUN,B1
-guiding light,guiding light,guiding light,NOUN,C1
-guild (adj),guild,guild (adj),ADJ,C1
-guitar music,guitar music,guitar music,NOUN,C1
-gurgle (noun),gurgle,gurgle (noun),NOUN,C1
-gush (noun),gush,gush (noun),NOUN,B2
-gustatory,gustatory,gustatory,ADJ,C1
-guttural,guttural,guttural,ADJ,C1
-guzzle,guzzle,guzzle,VERB,C1
-gymnastic,gymnastic,gymnastic,ADJ,C1
-gynecologist,gynecologist,gynecologist,NOUN,C1
-gyroscope,gyroscope,gyroscope,NOUN,C1
-habit formation,habit formation,habit formation,NOUN,C1
-habitability,habitability,habitability,NOUN,C1
-habitus,habitus,habitus,NOUN,C1
-habous endowments,habous endowments,habous endowments,NOUN,C1
-hackneyed,hackneyed,hackneyed,ADJ,C1
-hadra,hadra,hadra,NOUN,B2
-hair dryer,hair dryer,hair dryer,NOUN,C1
-hair-raising,hair-raising,hair-raising,ADJ,B2
-haircut,haircut,haircut,NOUN,C1
-hairy,hairy,hairy,ADJ,C1
-hakawati,hakawati,hakawati,NOUN,B2
-half (adj),half,half (adj),ADJ,A1
-half board,half board,half board,NOUN,B1
-hallowed,hallowed,hallowed,ADJ,C1
-halo,halo,halo,NOUN,B2
-handful,handful,handful,NOUN,B2
-handicap,handicap,handicap,NOUN,C1
-handlebars,handlebars,handlebars,NOUN,C1
-handy,handy,handy,ADJ,B1
-hanged man,hanged man,hanged man,NOUN,C1
-hanger,hanger,hanger,NOUN,A2
-hangover,hangover,hangover,NOUN,B2
-haphazard,haphazard,haphazard,ADJ,C1
-hapless,hapless,hapless,ADJ,C1
-happen to,happen to,happen to,VERB,C1
-happy cheerful,happy cheerful,happy cheerful,ADJ,B1
-harangue (noun),harangue,harangue (noun),NOUN,B2
-harassed,harassed,harassed,ADJ,C1
-harassments,harassments,harassments,NOUN,C1
-harbinger,harbinger,harbinger,NOUN,C1
-harbour,harbour,harbour,NOUN,B2
-hard to please,hard to please,hard to please,ADJ,C1
-hardening,hardening,hardening,NOUN,C1
-harder,harder,harder,ADJ,A2
-hardship of circumstances,hardship of circumstances,hardship of circumstances,NOUN,C1
-hardship of life,hardship of life,hardship of life,NOUN,C1
-hardware (adj),hardware,hardware (adj),ADJ,C1
-hardware store,hardware store,hardware store,NOUN,C1
-harm strength might,harm strength might,harm strength might,NOUN,C1
-harried,harried,harried,ADJ,C1
-harshly,harshly,harshly,ADV,C1
-harshness,harshness,harshness,NOUN,B2
-harvest crop,harvest crop,harvest crop,NOUN,B2
-hashtag,hashtag,hashtag,NOUN,B2
-hatching,hatching,hatching,NOUN,C1
-haughtily,haughtily,haughtily,ADV,C1
-haul,haul,haul,VERB,B2
-haunt,haunt,haunt,VERB,C1
-have back,have back,have back,VERB,C1
-have time,have time,have time,VERB,B2
-having a cold,having a cold,having a cold,ADJ,B2
-head cold,head cold,head cold,NOUN,B1
-head office,head office,head office,NOUN,C1
-headband,headband,headband,NOUN,C1
-headdress,headdress,headdress,NOUN,C1
-headlines,headlines,headlines,NOUN,B2
-headstrong,headstrong,headstrong,ADJ,C1
-healer,healer,healer,NOUN,B2
-health care,health care,health care,NOUN,B2
-healthcare,healthcare,healthcare,NOUN,B2
-healthy correct strong,healthy correct strong,healthy correct strong,ADJ,A1
-heap cluster,heap cluster,heap cluster,NOUN,C1
-hearing aid,hearing aid,hearing aid,NOUN,B2
-hearsay,hearsay,hearsay,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,heart-to-heart disclosure,NOUN,C1
-heartbreaking,heartbreaking,heartbreaking,ADJ,C1
-heartbroken,heartbroken,heartbroken,ADJ,C1
-heartburn,heartburn,heartburn,NOUN,B1
-heartfelt (noun),heartfelt,heartfelt (noun),NOUN,B2
-heartless,heartless,heartless,ADJ,C1
-heartlessness,heartlessness,heartlessness,NOUN,B2
-heartrending,heartrending,heartrending,ADJ,C1
-heavenly body,heavenly body,heavenly body,NOUN,B2
-heavenly kingdom,heavenly kingdom,heavenly kingdom,NOUN,C1
-hectare,hectare,hectare,NOUN,C1
-hectic (adj),hectic,hectic (adj),ADJ,C1
-hedonist,hedonist,hedonist,NOUN,C1
-heedlessness,heedlessness,heedlessness,NOUN,C1
-heinous,heinous,heinous,ADJ,C1
-hello (adv),hello,hello (adv),ADV,B1
-hello (part),hello,hello (part),PART,A2
-hello bye,hello bye,hello bye,INTJ,B2
-hello peace,hello peace,hello peace,NOUN,A1
-hem,hem,hem,NOUN,B2
-hematoma,hematoma,hematoma,NOUN,B2
-hemicycle,hemicycle,hemicycle,NOUN,C1
-hemiplegia,hemiplegia,hemiplegia,NOUN,C1
-hemistich,hemistich,hemistich,NOUN,C1
-hemorrhoid,hemorrhoid,hemorrhoid,NOUN,C1
-hemostasis,hemostasis,hemostasis,NOUN,C1
-hemostat,hemostat,hemostat,NOUN,C1
-henchman,henchman,henchman,NOUN,C1
-henhouse,henhouse,henhouse,NOUN,C1
-hepatitis,hepatitis,hepatitis,NOUN,C1
-her (pron),her,her (pron),PRON,A1
-her their,her their,her their,DET,A1
-herald,herald,herald,NOUN,C1
-heraldry,heraldry,heraldry,NOUN,C1
-herbaceous,herbaceous,herbaceous,ADJ,B2
-herbal tea,herbal tea,herbal tea,NOUN,B2
-herbalism,herbalism,herbalism,NOUN,C1
-herbalist,herbalist,herbalist,NOUN,B1
-herbarium,herbarium,herbarium,NOUN,C1
-herbs,herbs,herbs,NOUN,B2
-here is,here is,here is,ADV,A1
-here you go,here you go,here you go,INTJ,B2
-hereafter,hereafter,hereafter,NOUN,C1
-herein,herein,herein,ADV,B1
-heresiarch,heresiarch,heresiarch,NOUN,C1
-heretical,heretical,heretical,ADJ,C1
-heretical innovation,heretical innovation,heretical innovation,NOUN,C1
-hermeneutics,hermeneutics,hermeneutics,NOUN,C1
-hermetic,hermetic,hermetic,ADJ,C1
-hermitage,hermitage,hermitage,NOUN,B2
-hernia,hernia,hernia,NOUN,C1
-heroic deeds,heroic deeds,heroic deeds,NOUN,C1
-heroic poetry,heroic poetry,heroic poetry,NOUN,C1
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,heroine,NOUN,B1
-heron,heron,heron,NOUN,C1
-heterodox,heterodox,heterodox,ADJ,C1
-heterodoxy,heterodoxy,heterodoxy,NOUN,C1
-heterosexual,heterosexual,heterosexual,ADJ,C1
-heuristic,heuristic,heuristic,ADJ,C1
-hexadecimal,hexadecimal,hexadecimal,ADJ,C1
-hexagon,hexagon,hexagon,NOUN,C1
-heyday,heyday,heyday,NOUN,C1
-hidden intentions,hidden intentions,hidden intentions,NOUN,C1
-hidden matters,hidden matters,hidden matters,NOUN,C1
-hide-and-seek,hide-and-seek,hide-and-seek,NOUN,B2
-hider,hider,hider,NOUN,B2
-hiding ambush,hiding ambush,hiding ambush,NOUN,B2
-hieratic,hieratic,hieratic,ADJ,C1
-hieroglyphic,hieroglyphic,hieroglyphic,NOUN,C1
-high cost of living,high cost of living,high cost of living,NOUN,B2
-high school diploma,high school diploma,high school diploma,NOUN,C1
-high school graduate,high school graduate,high school graduate,NOUN,B2
-high school student,high school student,high school student,NOUN,B2
-highlands,highlands,highlands,NOUN,B2
-highlighter,highlighter,highlighter,NOUN,C1
-hijack,hijack,hijack,VERB,C1
-hijacking,hijacking,hijacking,NOUN,C1
-him dative,him dative,him dative,PRON,A2
-himself herself,himself herself,himself herself,PRON,A1
-hinterbildung,hinterbildung,hinterbildung,NOUN,C1
-hintererziehung,hintererziehung,hintererziehung,NOUN,C1
-hinterfahrt,hinterfahrt,hinterfahrt,NOUN,C1
-hinterforderung,hinterforderung,hinterforderung,NOUN,C1
-hintergabe,hintergabe,hintergabe,NOUN,C1
-hintergestaltung,hintergestaltung,hintergestaltung,NOUN,C1
-hinterkunft,hinterkunft,hinterkunft,NOUN,C1
-hintermessung,hintermessung,hintermessung,NOUN,C1
-hinternahme,hinternahme,hinternahme,NOUN,C1
-hinterordnung,hinterordnung,hinterordnung,NOUN,C1
-hinterpflegung,hinterpflegung,hinterpflegung,NOUN,C1
-hinterschaft,hinterschaft,hinterschaft,NOUN,C1
-hinterschrift,hinterschrift,hinterschrift,NOUN,C1
-hintersetzung,hintersetzung,hintersetzung,NOUN,C1
-hintersinnung,hintersinnung,hintersinnung,NOUN,C1
-hintersprache,hintersprache,hintersprache,NOUN,C1
-hinterstellung,hinterstellung,hinterstellung,NOUN,C1
-hinterteilung,hinterteilung,hinterteilung,NOUN,C1
-hintertreibung,hintertreibung,hintertreibung,NOUN,C1
-hinterwandlung,hinterwandlung,hinterwandlung,NOUN,C1
-hinterweisung,hinterweisung,hinterweisung,NOUN,B2
-hinterwirkung,hinterwirkung,hinterwirkung,NOUN,C1
-hirsute,hirsute,hirsute,ADJ,C1
-his (pron),his,his (pron),PRON,A1
-his her own,his her own,his her own,DET,B2
-his hers theirs,his hers theirs,his hers theirs,PRON,A2
-hispanic,hispanic,hispanic,ADJ,C1
-historicist,historicist,historicist,NOUN,C1
-historicization,historicization,historicization,NOUN,C1
-history education,history education,history education,NOUN,C1
-histrionic,histrionic,histrionic,ADJ,C1
-hit beat,hit beat,hit beat,VERB,A2
-hitch,hitch,hitch,NOUN,B2
-hoarding,hoarding,hoarding,NOUN,C1
-hoax,hoax,hoax,NOUN,C1
-hoax deception,hoax deception,hoax deception,NOUN,C1
-hocherziehung,hocherziehung,hocherziehung,NOUN,C1
-hochfahrt,hochfahrt,hochfahrt,NOUN,C1
-hochfassung,hochfassung,hochfassung,NOUN,C1
-hochforderung,hochforderung,hochforderung,NOUN,B2
-hochgabe,hochgabe,hochgabe,NOUN,B2
-hochgestaltung,hochgestaltung,hochgestaltung,NOUN,C1
-hochnahme,hochnahme,hochnahme,NOUN,C1
-hochpflegung,hochpflegung,hochpflegung,NOUN,C1
-hochregelung,hochregelung,hochregelung,NOUN,C1
-hochrichtung,hochrichtung,hochrichtung,NOUN,C1
-hochschaft,hochschaft,hochschaft,NOUN,C1
-hochschrift,hochschrift,hochschrift,NOUN,C1
-hochsetzung,hochsetzung,hochsetzung,NOUN,C1
-hochsicht,hochsicht,hochsicht,NOUN,C1
-hochsinnung,hochsinnung,hochsinnung,NOUN,C1
-hochsprache,hochsprache,hochsprache,NOUN,C1
-hochsucht,hochsucht,hochsucht,NOUN,C1
-hochsuchung,hochsuchung,hochsuchung,NOUN,C1
-hochteilung,hochteilung,hochteilung,NOUN,C1
-hochtheilung,hochtheilung,hochtheilung,NOUN,C1
-hochtreibung,hochtreibung,hochtreibung,NOUN,C1
-hochwandel,hochwandel,hochwandel,NOUN,C1
-hochwirkung,hochwirkung,hochwirkung,NOUN,C1
-hock,hock,hock,NOUN,C1
-hold catch,hold catch,hold catch,VERB,A1
-hold together,hold together,hold together,VERB,C1
-holding company,holding company,holding company,NOUN,C1
-holdup,holdup,holdup,NOUN,B2
-holiday feast,holiday feast,holiday feast,NOUN,A2
-holidaymaker,holidaymaker,holidaymaker,NOUN,C1
-holm oak,holm oak,holm oak,NOUN,C1
-hologram,hologram,hologram,NOUN,C1
-homage,homage,homage,NOUN,C1
-home (adv),home,home (adv),ADV,B1
-home automation,home automation,home automation,NOUN,B1
-home hearth,home hearth,home hearth,NOUN,B1
-home-based,home-based,home-based,ADJ,C1
-home-loving,home-loving,home-loving,ADJ,B2
-homelessness,homelessness,homelessness,NOUN,B2
-homemade,homemade,homemade,ADJ,B2
-homeopathy,homeopathy,homeopathy,NOUN,C1
-homeward,homeward,homeward,NOUN,B2
-homework duty,homework duty,homework duty,NOUN,A2
-homiletic,homiletic,homiletic,ADJ,C1
-hominization,hominization,hominization,NOUN,C1
-homonym,homonym,homonym,NOUN,C1
-honor culture,honor culture,honor culture,NOUN,B2
-honorability,honorability,honorability,NOUN,C1
-honoree,honoree,honoree,NOUN,C1
-honorific,honorific,honorific,ADJ,C1
-hooligan,hooligan,hooligan,NOUN,B2
-hoped-for,hoped-for,hoped-for,ADJ,C1
-hopeful,hopeful,hopeful,ADJ,C1
-hopelessly,hopelessly,hopelessly,ADV,B2
-hopelessness,hopelessness,hopelessness,NOUN,C1
-horde,horde,horde,NOUN,B2
-horoscope,horoscope,horoscope,NOUN,B2
-horrified,horrified,horrified,ADJ,B2
-hors d'oeuvre,hors d'oeuvre,hors d'oeuvre,NOUN,C1
-horseshoe,horseshoe,horseshoe,NOUN,C1
-hospice,hospice,hospice,NOUN,C1
-hospital-acquired,hospital-acquired,hospital-acquired,ADJ,C1
-hospitality industry,hospitality industry,hospitality industry,NOUN,B2
-hospitalization,hospitalization,hospitalization,NOUN,C1
-hostel,hostel,hostel,NOUN,C1
-hot dry wind,hot dry wind,hot dry wind,NOUN,B2
-hotbed,hotbed,hotbed,NOUN,C1
-hotel industry,hotel industry,hotel industry,NOUN,C1
-house call,house call,house call,NOUN,C1
-house search,house search,house search,NOUN,B2
-household (adj),household,household (adj),ADJ,B2
-household income,household income,household income,NOUN,B2
-housekeeper,housekeeper,housekeeper,NOUN,C1
-how much (adv),how much,how much (adv),ADV,B2
-howl (noun),howl,howl (noun),NOUN,B2
-hubbub,hubbub,hubbub,NOUN,C1
-hubris,hubris,hubris,NOUN,C1
-hudud punishments,hudud punishments,hudud punishments,NOUN,C1
-human (noun),human,human (noun),NOUN,A1
-human being,human being,human being,NOUN,B1
-human rights (adj),human rights,human rights (adj),ADJ,C1
-human rights work,human rights work,human rights work,NOUN,C1
-humanism,humanism,人文主义,NOUN,B2
-humanization,humanization,人性化,NOUN,B2
-humbly,humbly,humbly,ADV,C1
-humility,humility,谦逊,NOUN,B2
-humming,humming,humming,NOUN,B2
-hummingbird,hummingbird,hummingbird,NOUN,B2
-humorist,humorist,humorist,NOUN,C1
-hump,hump,hump,NOUN,C1
-hunch,hunch,hunch,NOUN,B2
-hunchbacked,hunchbacked,驼背的,ADJ,B2
-hundreds (noun),hundreds,hundreds (noun),NOUN,B2
-hundreds (num),hundreds,hundreds (num),NUM,B2
-hunt,hunt,狩猎,NOUN,B2
-hunter,hunter,猎人,NOUN,B2
-hut,hut,小屋,NOUN,B2
-hyaline,hyaline,hyaline,ADJ,C1
-hybrid,hybrid,杂交的,ADJ,B2
-hybridism,hybridism,hybridism,NOUN,C1
-hybridity,hybridity,hybridity,NOUN,C1
-hybridization,hybridization,杂交,NOUN,B2
-hydrant,hydrant,hydrant,NOUN,C1
-hydration,hydration,hydration,NOUN,C1
-hydrogen,hydrogen,氢,NOUN,B2
-hydrography,hydrography,hydrography,NOUN,C1
-hydrology,hydrology,hydrology,NOUN,C1
-hydrophobia,hydrophobia,hydrophobia,NOUN,C1
-hydropic,hydropic,hydropic,ADJ,C1
-hydrosphere,hydrosphere,hydrosphere,NOUN,C1
-hydrotherapy,hydrotherapy,hydrotherapy,NOUN,C1
-hygiene,hygiene,卫生,NOUN,B2
-hygienic,hygienic,hygienic,ADJ,B2
-hymn,hymn,赞美诗,NOUN,B2
-hymnal,hymnal,hymnal,NOUN,C1
-hyperbaton,hyperbaton,hyperbaton,NOUN,C1
-hyperbolic,hyperbolic,hyperbolic,ADJ,C1
-hypertension,hypertension,hypertension,NOUN,C1
-hypertensive,hypertensive,hypertensive,ADJ,C1
-hyperthermia,hyperthermia,hyperthermia,NOUN,B2
-hypnosis,hypnosis,催眠,NOUN,B2
-hypochondria,hypochondria,hypochondria,NOUN,C1
-hypochondriac,hypochondriac,hypochondriac,NOUN,C1
-hypotension,hypotension,hypotension,NOUN,C1
-hypotensive,hypotensive,hypotensive,ADJ,C1
-hypothermia,hypothermia,体温过低,NOUN,B2
-hypothesize,hypothesize,hypothesize,VERB,B2
-hypothetical,hypothetical,假设的,ADJ,B2
-hypothetically,hypothetically,hypothetically,ADV,C1
-hysterectomy,hysterectomy,hysterectomy,NOUN,C1
-hysteria,hysteria,hysteria,NOUN,C1
-hysterical,hysterical,歇斯底里的,ADJ,B2
-ice cube,ice cube,ice cube,NOUN,A2
-ice pick,ice pick,ice pick,NOUN,B2
-ice-cold,ice-cold,冰冷的,ADJ,B2
-icicle,icicle,icicle,NOUN,B2
-icon,icon,偶像,NOUN,B2
-iconic,iconic,iconic,ADJ,C1
-iconicity,iconicity,iconicity,NOUN,C1
-iconoclastic,iconoclastic,iconoclastic,ADJ,C1
-iconographic,iconographic,iconographic,ADJ,C1
-icy,icy,冰冷的,ADJ,B2
-id,id,证件,NOUN,B2
-id card,id card,身份证,NOUN,B2
-ideal,ideal,理想的,ADJ,B2
-idealist,idealist,理想主义者,NOUN,B2
-idealization,idealization,idealization,NOUN,B2
-ideational,ideational,ideational,ADJ,C1
-identifier,identifier,identifier,NOUN,C1
-identitarianism,identitarianism,identitarianism,NOUN,C1
-identity-related,identity-related,identity-related,ADJ,C1
-ideological,ideological,意识形态的,ADJ,B2
-ideologization,ideologization,ideologization,NOUN,C1
-ideology,ideology,意识形态,NOUN,B2
-idiocy,idiocy,愚蠢,NOUN,B2
-idiomatic,idiomatic,idiomatic,ADJ,C1
-idiopathic,idiopathic,idiopathic,ADJ,C1
-idiosyncratic,idiosyncratic,idiosyncratic,ADJ,C1
-idiot,idiot,白痴,NOUN,B2
-idiot (adj),idiot,idiot (adj),ADJ,A2
-idle,idle,懒惰的,ADJ,B2
-idolatry,idolatry,idolatry,NOUN,B2
-idyll,idyll,田园诗,NOUN,B2
-idyllic,idyllic,idyllic,ADJ,C1
-if counterfactual,if counterfactual,if counterfactual,SCONJ,A2
-if necessary,if necessary,if necessary,ADV,C1
-if when,if when,如果,SCONJ,B2
-ignition,ignition,点火,NOUN,B2
-ignoble malice,ignoble malice,ignoble malice,NOUN,C1
-ignominious,ignominious,ignominious,ADJ,C1
-ignominy,ignominy,ignominy,NOUN,B2
-ignore,to ignore,忽视,VERB,B2
-iliac,iliac,iliac,ADJ,C1
-ill,ill,生病的,ADJ,B2
-illegally,illegally,illegally,ADV,C1
-illegitimate,illegitimate,非法的,ADJ,B2
-illiteracy,illiteracy,illiteracy,NOUN,C1
-illiterate,illiterate,illiterate,ADJ,B2
-illogical,illogical,illogical,ADJ,B2
-illuminate,to illuminate,照亮,VERB,B2
-illuminator,illuminator,illuminator,NOUN,B2
-illusory,illusory,illusory,ADJ,C1
-illustrative,illustrative,illustrative,ADJ,C1
-image formation,image formation,image formation,NOUN,B2
-imaginary (noun),imaginary,imaginary (noun),NOUN,C1
-imaging,imaging,imaging,NOUN,C1
-imamate,imamate,imamate,NOUN,C1
-imbecile,imbecile,imbecile,NOUN,C1
-imbecility,imbecility,imbecility,NOUN,C1
-immaculate,immaculate,immaculate,ADJ,C1
-immanent,immanent,immanent,ADJ,C1
-immediacy,immediacy,immediacy,NOUN,C1
-immemorial,immemorial,immemorial,ADJ,C1
-immensely,immensely,immensely,ADV,B2
-immensity,immensity,immensity,NOUN,C1
-immerse,immerse,immerse,VERB,C1
-immersed,immersed,immersed,ADJ,C1
-immoderate,immoderate,immoderate,ADJ,C1
-immoderation,immoderation,immoderation,NOUN,C1
-immorality,immorality,immorality,NOUN,C1
-impartial,impartial,impartial,ADJ,C1
-impasse,impasse,impasse,NOUN,C1
-impassive,impassive,impassive,ADJ,C1
-impassively,impassively,impassively,ADV,B2
-impatience,impatience,impatience,NOUN,C1
-imperatively,imperatively,imperatively,ADV,C1
-imperceptible,imperceptible,imperceptible,ADJ,C1
-imperceptibly,imperceptibly,imperceptibly,ADV,C1
-imperfection,imperfection,imperfection,NOUN,C1
-imperialist,imperialist,imperialist,ADJ,C1
-imperious,imperious,imperious,ADJ,C1
-impersonal,impersonal,impersonal,ADJ,C1
-impersonation,impersonation,impersonation,NOUN,B2
-impertinence,impertinence,impertinence,NOUN,C1
-impertinent,impertinent,impertinent,ADJ,C1
-imperturbability,imperturbability,imperturbability,NOUN,C1
-imperturbably,imperturbably,imperturbably,ADV,C1
-impetuosity,impetuosity,impetuosity,NOUN,C1
-impetuous,impetuous,impetuous,ADJ,B2
-impetus,impetus,impetus,NOUN,C1
-impiety,impiety,impiety,NOUN,C1
-impious,impious,impious,ADJ,B2
-implantation,implantation,implantation,NOUN,C1
-implausible,implausible,implausible,ADJ,C1
-impoliteness,impoliteness,impoliteness,NOUN,C1
-import (noun),import,import (noun),NOUN,B2
-important thing,important thing,important thing,NOUN,C1
-imports,imports,imports,NOUN,C1
-imposition,imposition,imposition,NOUN,C1
-impostor,impostor,impostor,NOUN,B2
-imposture,imposture,imposture,NOUN,C1
-impotent,impotent,impotent,ADJ,C1
-impound lot,impound lot,impound lot,NOUN,B1
-impoverished,impoverished,impoverished,ADJ,B2
-impoverishment,impoverishment,impoverishment,NOUN,C1
-imprecation,imprecation,imprecation,NOUN,C1
-imprecise,imprecise,imprecise,ADJ,C1
-impregnation,impregnation,impregnation,NOUN,C1
-imprisoned,imprisoned,imprisoned,ADJ,B2
-improvidence,improvidence,improvidence,NOUN,C1
-imprudence,imprudence,imprudence,NOUN,C1
-imprudent,imprudent,imprudent,ADJ,C1
-impulsivity,impulsivity,impulsivity,NOUN,C1
-impure,impure,impure,ADJ,C1
-imputation,imputation,imputation,NOUN,C1
-in a hurry (adj),in a hurry,in a hurry (adj),ADJ,B1
-in a hurry (adv),in a hurry,in a hurry (adv),ADV,A2
-in absentia (adj),in absentia,in absentia (adj),ADJ,C1
-in absentia (adv),in absentia,in absentia (adv),ADV,B2
-in accordance (adj),in accordance,in accordance (adj),ADJ,B2
-in addition to,in addition to,in addition to,ADP,B2
-in agreement,in agreement,in agreement,ADV,C1
-in anticipation of,in anticipation of,in anticipation of,ADV,C1
-in cash,in cash,in cash,ADV,B2
-in conclusion,in conclusion,in conclusion,ADV,C1
-in continuous succession,in continuous succession,in continuous succession,ADV,C1
-in deficit,in deficit,in deficit,ADJ,C1
-in every detail,in every detail,in every detail,ADV,C1
-in exchange for,in exchange for,in exchange for,ADP,C1
-in its entirety,in its entirety,in its entirety,ADV,C1
-in mind,in mind,in mind,ADV,B2
-in need,in need,in need,ADJ,A2
-in no way,in no way,in no way,ADV,C1
-in parallel,in parallel,in parallel,ADV,B2
-in parallel with,in parallel with,in parallel with,ADV,C1
-in particular,in particular,in particular,ADV,B2
-in presence of parties,in presence of parties,in presence of parties,ADJ,C1
-in private,in private,in private,ADV,B2
-in question,in question,in question,ADV,C1
-in return,in return,in return,NOUN,B2
-in the back,in the back,in the back,ADV,B2
-in the evening,in the evening,in the evening,ADV,B2
-in the future,in the future,in the future,ADV,B2
-in the middle,in the middle,in the middle,ADV,B1
-in the morning,in the morning,in the morning,ADV,C1
-in the past (adv),in the past,in the past (adv),ADV,B2
-in there,in there,in there,ADV,B2
-in time (adj),in time,in time (adj),ADJ,B1
-in unison,in unison,in unison,ADV,B2
-in vain (noun),in vain,in vain (noun),NOUN,B2
-in writing (adv),in writing,in writing (adv),ADV,B2
-in-law,in-law,in-law,NOUN,A2
-inaccessible,inaccessible,inaccessible,ADJ,C1
-inaccurate,inaccurate,inaccurate,ADJ,C1
-inaction,inaction,inaction,NOUN,C1
-inactive,inactive,inactive,ADJ,C1
-inactivity,inactivity,inactivity,NOUN,B2
-inadmissibility,inadmissibility,inadmissibility,NOUN,C1
-inadvertent,inadvertent,inadvertent,ADJ,C1
-inadvertently,inadvertently,inadvertently,ADV,B2
-inalienable,inalienable,inalienable,ADJ,C1
-inane,inane,inane,ADJ,C1
-inanimate,inanimate,inanimate,ADJ,C1
-inappreciable,inappreciable,inappreciable,ADJ,C1
-inattentive,inattentive,inattentive,ADJ,C1
-inaudible,inaudible,inaudible,ADJ,B2
-inborn nature,inborn nature,inborn nature,NOUN,C1
-incandescence,incandescence,incandescence,NOUN,C1
-incapable,incapable,incapable,ADJ,B1
-incapacity,incapacity,incapacity,NOUN,C1
-incarceration,incarceration,incarceration,NOUN,C1
-incarnation,incarnation,incarnation,NOUN,C1
-incendiary,incendiary,incendiary,ADJ,C1
-incentivization,incentivization,incentivization,NOUN,C1
-inceptive,inceptive,inceptive,ADJ,C1
-incest,incest,incest,NOUN,C1
-inchoative,inchoative,inchoative,ADJ,C1
-incidental,incidental,incidental,ADJ,B2
-incineration,incineration,incineration,NOUN,C1
-incinerator,incinerator,incinerator,NOUN,C1
-incipient,incipient,incipient,ADJ,C1
-inciting,inciting,inciting,ADJ,C1
-inclemency,inclemency,inclemency,NOUN,C1
-inclement,inclement,inclement,ADJ,B2
-inclined prone,inclined prone,inclined prone,ADJ,C1
-including (adv),including,including (adv),ADV,A2
-incognito,incognito,incognito,ADJ,C1
-incommunicado,incommunicado,incommunicado,ADJ,C1
-incompatible,incompatible,incompatible,ADJ,C1
-incompetence,incompetence,incompetence,NOUN,C1
-incompleteness,incompleteness,incompleteness,NOUN,B2
-incomprehension,incomprehension,incomprehension,NOUN,C1
-incongruity,incongruity,incongruity,NOUN,B2
-inconsiderate,inconsiderate,inconsiderate,ADJ,C1
-inconsolable,inconsolable,inconsolable,ADJ,C1
-inconspicuous,inconspicuous,inconspicuous,ADJ,C1
-inconstant,inconstant,inconstant,ADJ,C1
-incontestably,incontestably,incontestably,ADV,B2
-inconvenience (noun),inconvenience,inconvenience (noun),NOUN,C1
-inconvenient,inconvenient,inconvenient,ADJ,C1
-incorrectness,incorrectness,incorrectness,NOUN,C1
-increase excess,increase excess,increase excess,NOUN,C1
-increase growth,increase growth,increase growth,NOUN,C1
-incredible amazing,incredible amazing,incredible amazing,ADJ,A1
-incredulous,incredulous,incredulous,ADJ,C1
-inculcate,inculcate,inculcate,VERB,C1
-incumbent,incumbent,incumbent,ADJ,C1
-incursion,incursion,incursion,NOUN,C1
-indebted,indebted,indebted,ADJ,B2
-indecent,indecent,indecent,ADJ,C1
-indecipherable,indecipherable,indecipherable,ADJ,C1
-indecision,indecision,indecision,NOUN,C1
-indefinite,indefinite,indefinite,ADJ,C1
-indeterminate,indeterminate,indeterminate,ADJ,C1
-indexed,indexed,indexed,ADJ,C1
-indexes,indexes,indexes,NOUN,C1
-indian (adj),indian,indian (adj),ADJ,B2
-indigent,indigent,indigent,ADJ,C1
-indignity,indignity,indignity,NOUN,C1
-indirect,indirect,indirect,ADJ,C1
-indiscreet,indiscreet,indiscreet,ADJ,C1
-indisputable,indisputable,indisputable,ADJ,C1
-indisputably,indisputably,indisputably,ADV,C1
-indistinct,indistinct,indistinct,ADJ,B2
-indistinguishable,indistinguishable,indistinguishable,ADJ,C1
-individualization,individualization,individualization,NOUN,C1
-individually,individually,individually,ADV,C1
-indolent,indolent,indolent,ADJ,C1
-indomitable,indomitable,indomitable,ADJ,C1
-indonesian,indonesian,indonesian,ADJ,B2
-induction,induction,induction,NOUN,C1
-inductive,inductive,inductive,ADJ,C1
-indulge,indulge,indulge,VERB,C1
-indulgence,indulgence,indulgence,NOUN,C1
-indulgent,indulgent,indulgent,ADJ,C1
-industrious,industrious,industrious,ADJ,C1
-inedible,inedible,inedible,ADJ,C1
-ineffable,ineffable,ineffable,ADJ,C1
-ineffective,ineffective,ineffective,ADJ,C1
-ineffectiveness,ineffectiveness,ineffectiveness,NOUN,B2
-inept,inept,inept,ADJ,C1
-ineptitude,ineptitude,ineptitude,NOUN,C1
-inequity,inequity,inequity,NOUN,C1
-inertness,inertness,inertness,NOUN,B2
-inescapable,inescapable,inescapable,ADJ,C1
-inevitable (noun),inevitable,inevitable (noun),NOUN,B2
-inexact,inexact,inexact,ADJ,C1
-inexhaustible,inexhaustible,inexhaustible,ADJ,C1
-inexpressible,inexpressible,inexpressible,ADJ,C1
-inexpressive,inexpressive,inexpressive,ADJ,C1
-infallible,infallible,infallible,ADJ,C1
-infantilism,infantilism,infantilism,NOUN,C1
-infatuated,infatuated,infatuated,ADJ,B2
-inferential,inferential,inferential,ADJ,C1
-infertility,infertility,infertility,NOUN,C1
-infiltrator,infiltrator,infiltrator,NOUN,C1
-infinitely,infinitely,infinitely,ADV,B2
-infinity,infinity,infinity,NOUN,C1
-inflamed,inflamed,inflamed,ADJ,B2
-inflammatory,inflammatory,inflammatory,ADJ,C1
-inflationary,inflationary,inflationary,ADJ,C1
-inflection,inflection,inflection,NOUN,B2
-influential,influential,influential,ADJ,C1
-influential person,influential person,influential person,NOUN,C1
-infographic computer graphics,infographic computer graphics,infographic computer graphics,NOUN,C1
-informatics,informatics,informatics,NOUN,B2
-information desk,information desk,information desk,NOUN,B1
-information exchange,information exchange,information exchange,NOUN,B2
-informative,informative,informative,ADJ,B2
-informer,informer,informer,NOUN,C1
-informers,informers,informers,NOUN,C1
-infraction,infraction,infraction,NOUN,C1
-infractions,infractions,infractions,NOUN,C1
-infrared,infrared,infrared,ADJ,C1
-infrastructural,infrastructural,infrastructural,ADJ,C1
-ingratitude,ingratitude,ingratitude,NOUN,C1
-ingredients,ingredients,ingredients,NOUN,B1
-inhabited,inhabited,inhabited,ADJ,C1
-inharmonious,inharmonious,inharmonious,ADJ,C1
-inherence,inherence,inherence,NOUN,B2
-inherit,to inherit,继承,VERB,B2
-inheritance,inheritance,遗产,NOUN,B2
-inherited,inherited,inherited,ADJ,C1
-inhibit,to inhibit,抑制,VERB,B2
-inhibited,inhibited,inhibited,ADJ,B2
-inhospitable,inhospitable,inhospitable,ADJ,C1
-inhumanity,inhumanity,inhumanity,NOUN,C1
-inimitability,inimitability,inimitability,NOUN,C1
-initial (noun),initial,initial (noun),NOUN,B2
-initialization,initialization,initialization,NOUN,C1
-initiation,initiation,initiation,NOUN,C1
-initiative,initiative,主动权,NOUN,B2
-inject,to inject,注射,VERB,B2
-injection,injection,注射,NOUN,B2
-injure,to injure,使受伤,VERB,B2
-injured,injured,受伤的,ADJ,B2
-inkwell,inkwell,inkwell,NOUN,C1
-inmate,inmate,inmate,NOUN,C1
-innate disposition,innate disposition,innate disposition,NOUN,C1
-innate nature,innate nature,innate nature,NOUN,B2
-innate qualities,innate qualities,innate qualities,NOUN,C1
-inner,inner,内部的,ADJ,B2
-inner self,inner self,inner self,NOUN,C1
-inner workings,inner workings,inner workings,NOUN,C1
-innocence,innocence,无辜,NOUN,B2
-innocent person,innocent person,innocent person,NOUN,C1
-innuendo,innuendo,innuendo,NOUN,C1
-inopportune,inopportune,inopportune,ADJ,C1
-inorganic,inorganic,inorganic,ADJ,C1
-inputs,inputs,inputs,NOUN,C1
-inscrutable,inscrutable,inscrutable,ADJ,C1
-insect,insect,昆虫,NOUN,B2
-insecure,insecure,不安全的,ADJ,B2
-insemination,insemination,insemination,NOUN,C1
-insensitivity,insensitivity,insensitivity,NOUN,C1
-insertion,insertion,insertion,NOUN,B2
-inside,inside,在内部,ADP,B2
-inside of,inside of,inside of,ADP,B2
-insidious,insidious,潜伏的,ADJ,B2
-insidiously,insidiously,insidiously,ADV,B2
-insignificant,insignificant,微不足道的,ADJ,B2
-insincere,insincere,insincere,ADJ,C1
-insinuation,insinuation,insinuation,NOUN,B2
-insipid,insipid,insipid,ADJ,C1
-insist,to insist,坚持,VERB,B2
-insistence,insistence,坚持,NOUN,B2
-insistence persistence,insistence persistence,insistence persistence,NOUN,B2
-insolence,insolence,无礼,NOUN,B2
-insolence rudeness,insolence rudeness,insolence rudeness,NOUN,B2
-insolent,insolent,傲慢的,ADJ,B2
-insolent conceit,insolent conceit,insolent conceit,NOUN,C1
-insolvency,insolvency,无偿付能力,NOUN,B2
-inspection,inspection,检查,NOUN,B2
-inspector,inspector,检查员,NOUN,B2
-inspectorate,inspectorate,inspectorate,NOUN,C1
-inspiration,inspiration,灵感,NOUN,B2
-instability,instability,不稳定,NOUN,B2
-installation,installation,安装,NOUN,B2
-installation assembly,installation assembly,installation assembly,NOUN,C1
-installed,installed,installed,ADJ,C1
-installment plan,installment plan,installment plan,NOUN,B2
-installments,installments,installments,NOUN,B2
-instantly,instantly,instantly,ADV,C1
-instead,instead,代替,ADV,B2
-instead (adp),instead,instead (adp),ADP,C1
-instead of,instead of,instead of,ADP,A2
-instigator,instigator,instigator,NOUN,C1
-instinct,instinct,本能,NOUN,B2
-instinctively,instinctively,instinctively,ADV,C1
-instinctuality,instinctuality,instinctuality,NOUN,C1
-institute,institute,机构,NOUN,B2
-institutionalization,institutionalization,制度化,NOUN,B2
-institutionalized,institutionalized,institutionalized,ADJ,C1
-instruction deposit,instruction deposit,instruction deposit,NOUN,C1
-instruction leaflet,instruction leaflet,instruction leaflet,NOUN,B2
-instrumental piece,instrumental piece,instrumental piece,NOUN,C1
-instrumentalist (adj),instrumentalist,instrumentalist (adj),ADJ,C1
-instrumentalist (noun),instrumentalist,instrumentalist (noun),NOUN,B2
-insufferable,insufferable,insufferable,ADJ,C1
-insulation,insulation,绝缘,NOUN,B2
-insulator,insulator,insulator,NOUN,B2
-insult,insult,辱骂,NOUN,B2
-insurances,insurances,insurances,NOUN,C1
-insured,insured,insured,NOUN,B2
-insurer,insurer,insurer,NOUN,C1
-insurgency,insurgency,insurgency,NOUN,C1
-intact,intact,完好无损的,ADJ,B2
-intake,intake,intake,NOUN,C1
-integer,integer,integer,NOUN,C1
-integration,integration,融合,NOUN,B2
-intellectual (noun),intellectual,intellectual (noun),NOUN,B2
-intellectual life,intellectual life,intellectual life,NOUN,B2
-intelligence,intelligence,智力,NOUN,B2
-intelligence-related,intelligence-related,intelligence-related,ADJ,C1
-intelligently,intelligently,intelligently,ADV,C1
-intelligible,intelligible,intelligible,ADJ,C1
-intemperate,intemperate,intemperate,ADJ,C1
-intended,intended,,NOUN,B2
-intended meaning,intended meaning,intended meaning,NOUN,C1
-intensification,intensification,intensification,NOUN,C1
-intentionality,intentionality,intentionality,NOUN,C1
-intentions,intentions,intentions,NOUN,C1
-interactivity,interactivity,interactivity,NOUN,C1
-intercession,intercession,intercession,NOUN,C1
-intercity bus,intercity bus,intercity bus,NOUN,B2
-interconnection,interconnection,interconnection,NOUN,C1
-interdicted person,interdicted person,interdicted person,NOUN,C1
-interdiction,interdiction,interdiction,NOUN,C1
-interesting things,interesting things,interesting things,NOUN,C1
-interim (adj),interim,interim (adj),ADJ,C1
-interim (noun),interim,interim (noun),NOUN,B2
-interjection,interjection,interjection,NOUN,C1
-interlaced,interlaced,interlaced,ADJ,C1
-interlocked,interlocked,interlocked,ADJ,C1
-intermediate,intermediate,intermediate,ADJ,C1
-intermission,intermission,intermission,NOUN,C1
-intern,intern,intern,NOUN,C1
-internal rhyme,internal rhyme,internal rhyme,NOUN,C1
-internationalization,internationalization,internationalization,NOUN,C1
-interpellation,interpellation,interpellation,NOUN,C1
-interpretive,interpretive,interpretive,ADJ,C1
-interrupted,interrupted,interrupted,ADJ,B2
-intertextuality,intertextuality,intertextuality,NOUN,C1
-intertwined,intertwined,intertwined,ADJ,C1
-interval,interval,interval,NOUN,C1
-interviewer,interviewer,interviewer,NOUN,C1
-intestines,intestines,intestines,NOUN,B2
-intimate (noun),intimate,intimate (noun),NOUN,B2
-intimate friendship,intimate friendship,intimate friendship,NOUN,C1
-intimately,intimately,intimately,ADV,C1
-into (adp),into,into (adp),ADP,A1
-into (adv),into,into (adv),ADV,B1
-intolerable,intolerable,intolerable,ADJ,C1
-intolerant,intolerant,intolerant,ADJ,B2
-intonational quality,intonational quality,intonational quality,NOUN,C1
-intoxication,intoxication,intoxication,NOUN,C1
-intransigence,intransigence,intransigence,NOUN,C1
-intrepidity,intrepidity,intrepidity,NOUN,C1
-intricacy,intricacy,intricacy,NOUN,C1
-intrigue (noun),intrigue,intrigue (noun),NOUN,C1
-intriguing,intriguing,intriguing,ADJ,C1
-intrinsically,intrinsically,intrinsically,ADV,C1
-introductory,introductory,introductory,ADJ,C1
-introversion,introversion,introversion,NOUN,B2
-intrusive,intrusive,intrusive,ADJ,C1
-intuitionist,intuitionist,intuitionist,ADJ,C1
-intuitive,intuitive,intuitive,ADJ,C1
-inure,inure,inure,VERB,C1
-invalidated,invalidated,invalidated,ADJ,C1
-invalidity,invalidity,invalidity,NOUN,C1
-invariable,invariable,invariable,ADJ,C1
-inverse,inverse,inverse,NOUN,C1
-inverted,inverted,inverted,ADJ,C1
-investigative,investigative,investigative,ADJ,C1
-investment (adj),investment,investment (adj),ADJ,C1
-inviolate,inviolate,inviolate,ADJ,C1
-invite offer,invite offer,invite offer,VERB,A2
-invited,invited,invited,ADJ,C1
-invocation,invocation,invocation,NOUN,C1
-invocations,invocations,invocations,NOUN,C1
-invoicing,invoicing,invoicing,NOUN,B2
-involuntarily,involuntarily,involuntarily,ADV,C1
-involuntary,involuntary,involuntary,ADJ,B2
-involved party,involved party,involved party,NOUN,C1
-invulnerability,invulnerability,invulnerability,NOUN,C1
-inward,inward,inward,ADJ,C1
-iodine deficiency,iodine deficiency,iodine deficiency,NOUN,C1
-ion,ion,ion,NOUN,C1
-iris,iris,iris,NOUN,B2
-irksome,irksome,irksome,ADJ,C1
-ironically,ironically,ironically,ADV,C1
-ironing,ironing,ironing,NOUN,B1
-irrefutably,irrefutably,irrefutably,ADV,C1
-irreligious,irreligious,irreligious,ADJ,C1
-irremediably,irremediably,irremediably,ADV,B2
-irretrievable,irretrievable,irretrievable,ADJ,C1
-irreversibility,irreversibility,irreversibility,NOUN,C1
-irrigation,irrigation,irrigation,NOUN,B2
-irritability,irritability,irritability,NOUN,C1
-irritable boredom,irritable boredom,irritable boredom,NOUN,C1
-islamization,islamization,islamization,NOUN,C1
-islander,islander,islander,NOUN,C1
-isolated reports,isolated reports,isolated reports,NOUN,C1
-isthmus,isthmus,isthmus,NOUN,C1
-itch (noun),itch,itch (noun),NOUN,C1
-iterative,iterative,iterative,ADJ,C1
-jack plug,jack plug,jack plug,NOUN,C1
-jackal,jackal,jackal,NOUN,B2
-jailer,jailer,jailer,NOUN,B2
-janitor,janitor,janitor,NOUN,B2
-jargon-heavy,jargon-heavy,jargon-heavy,ADJ,C1
-jarring,jarring,jarring,ADJ,C1
-jasmine,jasmine,jasmine,NOUN,C1
-jasmine tea,jasmine tea,jasmine tea,NOUN,C1
-jaws,jaws,jaws,NOUN,C1
-jersey,jersey,jersey,NOUN,B1
-jest,jest,jest,NOUN,C1
-jewel robbery,jewel robbery,jewel robbery,NOUN,C1
-jeweler,jeweler,jeweler,NOUN,B2
-jewelry making,jewelry making,jewelry making,NOUN,B2
-jewelry set,jewelry set,jewelry set,NOUN,C1
-jinn,jinn,jinn,NOUN,B2
-jizya tax,jizya tax,jizya tax,NOUN,C1
-job interview,job interview,job interview,NOUN,B2
-job position,job position,job position,NOUN,A1
-jocular,jocular,jocular,ADJ,C1
-jocularity,jocularity,jocularity,NOUN,B2
-jog,jog,jog,VERB,A1
-jogging,jogging,jogging,NOUN,C1
-joie de vivre,joie de vivre,joie de vivre,NOUN,B2
-joint liability,joint liability,joint liability,NOUN,C1
-jointness,jointness,jointness,NOUN,C1
-joker,joker,joker,NOUN,C1
-joking,joking,joking,NOUN,B2
-journal,journal,journal,NOUN,C1
-journalistic,journalistic,journalistic,ADJ,C1
-journeying,journeying,journeying,NOUN,C1
-joust,joust,joust,NOUN,B1
-jubilant,jubilant,jubilant,ADJ,C1
-judge sentence,judge sentence,judge sentence,VERB,B2
-judgeable,judgeable,judgeable,ADJ,C1
-judicious,judicious,judicious,ADJ,C1
-judiciously,judiciously,judiciously,ADV,B2
-jumble,jumble,jumble,NOUN,B2
-junction,junction,junction,NOUN,C1
-juncture,juncture,juncture,NOUN,B2
-jungles,jungles,jungles,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,juniper,NOUN,B2
-junkie,junkie,junkie,NOUN,C1
-junta,junta,junta,NOUN,C1
-juristic preference,juristic preference,juristic preference,NOUN,C1
-just as,just as,just as,ADV,A2
-just like that,just like that,just like that,ADV,B2
-justifiable,justifiable,justifiable,ADJ,C1
-justified,justified,justified,ADJ,B2
-justness,justness,justness,NOUN,B2
-juvenile delinquency,juvenile delinquency,juvenile delinquency,NOUN,B2
-juxtapose,juxtapose,juxtapose,VERB,C1
-kaleidoscope,kaleidoscope,kaleidoscope,NOUN,B2
-kasbah,kasbah,kasbah,NOUN,B1
-keenly,keenly,keenly,ADV,C1
-keenness,keenness,keenness,NOUN,B2
-keep away,keep away,keep away,VERB,C1
-keeping up with,keeping up with,keeping up with,NOUN,B2
-kept,kept,kept,ADJ,B2
-kick (noun),kick,kick (noun),NOUN,B1
-kids,kids,kids,NOUN,B2
-killed,killed,killed,NOUN,B2
-killing,killing,killing,NOUN,B2
-kin,kin,kin,NOUN,B2
-kind type,kind type,kind type,NOUN,A1
-kindheartedness,kindheartedness,kindheartedness,NOUN,B2
-kindness gentleness,kindness gentleness,kindness gentleness,NOUN,B2
-kiss (noun),kiss,kiss (noun),NOUN,A2
-kit,kit,kit,NOUN,B2
-kitchen annex,kitchen annex,kitchen annex,NOUN,B1
-kitten,kitten,kitten,NOUN,B2
-kneader,kneader,kneader,NOUN,C1
-kneeling (adj),kneeling,kneeling (adj),ADJ,C1
-knife wound,knife wound,knife wound,NOUN,B2
-knocking,knocking,knocking,NOUN,B1
-knowingly,knowingly,knowingly,ADV,C1
-knowledge of human nature,knowledge of human nature,knowledge of human nature,NOUN,C1
-knowledgeably,knowledgeably,knowledgeably,ADV,C1
-kohl,kohl,kohl,NOUN,A1
-laazima,laazima,laazima,NOUN,B2
-labile,labile,labile,ADJ,B2
-labor-related,labor-related,labor-related,ADJ,C1
-laboratory (adj),laboratory,laboratory (adj),ADJ,C1
-laborer,laborer,laborer,NOUN,B2
-laborious striving,laborious striving,laborious striving,NOUN,C1
-laboriously,laboriously,laboriously,ADV,C1
-labour market,labour market,labour market,NOUN,B1
-labyrinth,labyrinth,labyrinth,NOUN,C1
-labyrinthine,labyrinthine,labyrinthine,ADJ,C1
-lace,lace,lace,NOUN,C1
-lack of affection,lack of affection,lack of affection,NOUN,C1
-lack of appetite,lack of appetite,lack of appetite,NOUN,C1
-lack of awareness,lack of awareness,lack of awareness,NOUN,C1
-lack of knowledge,lack of knowledge,lack of knowledge,NOUN,C1
-laconically,laconically,laconically,ADV,C1
-laconism,laconism,laconism,NOUN,B2
-lacquer,lacquer,lacquer,NOUN,C1
-ladies and gentlemen,ladies and gentlemen,ladies and gentlemen,NOUN,C1
-ladle,ladle,ladle,NOUN,A2
-lagoon,lagoon,lagoon,NOUN,C1
-lair,lair,lair,NOUN,C1
-lair den,lair den,lair den,NOUN,C1
-lame person,lame person,lame person,NOUN,B2
-lament (noun),lament,lament (noun),NOUN,C1
-lamentable,lamentable,lamentable,ADJ,C1
-lamp niche,lamp niche,lamp niche,NOUN,C1
-lampoon,lampoon,lampoon,NOUN,C1
-land ownership,land ownership,land ownership,NOUN,C1
-land policy,land policy,land policy,NOUN,B2
-land register,land register,land register,NOUN,B2
-land tax,land tax,land tax,NOUN,C1
-land titling,land titling,land titling,NOUN,B2
-land use,land use,land use,NOUN,B2
-land-related,land-related,land-related,ADJ,C1
-landmark (noun),landmark,landmark (noun),NOUN,C1
-landmine,landmine,landmine,NOUN,C1
-landowner,landowner,landowner,NOUN,C1
-languid,languid,languid,ADJ,C1
-lapidary,lapidary,lapidary,ADJ,B2
-lapse of time,lapse of time,lapse of time,NOUN,C1
-large,large,large,ADJ,A2
-large clay jar,large clay jar,large clay jar,NOUN,B1
-large estate,large estate,large estate,NOUN,C1
-large landowner,large landowner,large landowner,NOUN,C1
-large serving bowl,large serving bowl,large serving bowl,NOUN,B1
-lascivious,lascivious,lascivious,ADJ,C1
-lasciviousness,lasciviousness,lasciviousness,NOUN,C1
-lassitude,lassitude,lassitude,NOUN,C1
-last (adv),last,last (adv),ADV,B2
-last (num),last,last (num),NUM,A2
-last evening,last evening,,NOUN,B2
-lasting,lasting,lasting,ADJ,C1
-late afternoon,late afternoon,late afternoon,NOUN,C1
-late behind,late behind,late behind,ADJ,B2
-late belated,late belated,late belated,ADJ,C1
-lately,lately,lately,ADV,A2
-later (adj),later,later (adj),ADJ,C1
-later earlier,later earlier,later earlier,ADV,C1
-lateral side,lateral side,lateral side,ADJ,C1
-lathe,lathe,lathe,NOUN,C1
-lathing turning,lathing turning,lathing turning,NOUN,C1
-latitude,latitude,latitude,NOUN,C1
-latitude leeway,latitude leeway,latitude leeway,NOUN,C1
-laudable,laudable,laudable,ADJ,C1
-laugh (noun),laugh,laugh (noun),NOUN,B2
-laughing,laughing,laughing,ADJ,C1
-launch (noun),launch,launch (noun),NOUN,B1
-launcher,launcher,launcher,NOUN,C1
-laundering,laundering,laundering,NOUN,B2
-laundromat,laundromat,laundromat,NOUN,A2
-laundry detergent,laundry detergent,laundry detergent,NOUN,B2
-laureate winner,laureate winner,laureate winner,NOUN,C1
-laurel,laurel,laurel,NOUN,C1
-lavish,lavish,lavish,ADJ,C1
-lawless,lawless,lawless,ADJ,B2
-lawlessness,lawlessness,lawlessness,NOUN,C1
-lawsuit demand,lawsuit demand,lawsuit demand,NOUN,B1
-lawyer female,lawyer female,lawyer female,NOUN,B2
-laxative,laxative,laxative,NOUN,C1
-lay (adj),lay,lay (adj),ADJ,C1
-layer shift,layer shift,layer shift,NOUN,B2
-lazybones,lazybones,lazybones,NOUN,C1
-leader female,leader female,leader female,NOUN,C1
-leader ladder,leader ladder,leader ladder,NOUN,B1
-leaf litter,leaf litter,leaf litter,NOUN,C1
-leafiness,leafiness,leafiness,NOUN,C1
-leafy,leafy,leafy,ADJ,B2
-leak escape,leak escape,leak escape,NOUN,B1
-lean (adj),lean,lean (adj),ADJ,B2
-learned,learned,learned,ADJ,C1
-learnedly,learnedly,learnedly,ADV,C1
-learner,learner,learner,NOUN,C1
-leash,leash,leash,NOUN,B2
-leasing,leasing,leasing,NOUN,C1
-least (adj),least,least (adj),ADJ,A1
-leather goods,leather goods,leather goods,NOUN,C1
-leather jacket,leather jacket,leather jacket,NOUN,C1
-leathery,leathery,leathery,ADJ,B2
-led astray,led astray,led astray,ADJ,C1
-leek,leek,leek,NOUN,A2
-left over,left over,left over,ADJ,A2
-left-handed,left-handed,left-handed,ADJ,C1
-leftism,leftism,leftism,NOUN,C1
-leftist,leftist,leftist,ADJ,C1
-leftovers,leftovers,leftovers,NOUN,B2
-leg of lamb,leg of lamb,leg of lamb,NOUN,B1
-legal capacity,legal capacity,legal capacity,NOUN,C1
-legal challenge,legal challenge,legal challenge,NOUN,B2
-legal consideration,legal consideration,legal consideration,NOUN,C1
-legal expert,legal expert,legal expert,NOUN,C1
-legal fees,legal fees,legal fees,NOUN,C1
-legal guardian,legal guardian,legal guardian,NOUN,C1
-legal representative,legal representative,legal representative,NOUN,C1
-legalization,legalization,legalization,NOUN,C1
-legible,legible,legible,ADJ,C1
-legible readable,legible readable,legible readable,ADJ,C1
-legion,legion,legion,NOUN,B2
-legion unit,legion unit,,NOUN,B2
-legislative elections,legislative elections,legislative elections,NOUN,C1
-legislator,legislator,legislator,NOUN,C1
-legislature,legislature,legislature,NOUN,B2
-legitimization,legitimization,legitimization,NOUN,B2
-leisurely,leisurely,leisurely,ADJ,C1
-lemon verbena,lemon verbena,lemon verbena,NOUN,B2
-lemonade,lemonade,lemonade,NOUN,A2
-lender,lender,lender,NOUN,B2
-lending,lending,lending,NOUN,C1
-lengthy,lengthy,lengthy,ADJ,C1
-lens,lens,lens,NOUN,C1
-lentil lens,lentil lens,lentil lens,NOUN,C1
-lentils,lentils,lentils,NOUN,A2
-lessor,lessor,lessor,NOUN,C1
-lethality,lethality,lethality,NOUN,C1
-lethargy,lethargy,lethargy,NOUN,C1
-lever,lever,lever,NOUN,B2
-lever crane,lever crane,lever crane,NOUN,C1
-leverage,leverage,leverage,NOUN,B2
-levity,levity,levity,NOUN,C1
-levy sample,levy sample,levy sample,NOUN,B2
-lexical,lexical,lexical,ADJ,C1
-liabilities,liabilities,liabilities,NOUN,C1
-libel,libel,libel,NOUN,C1
-liberty,liberty,liberty,NOUN,B2
-licenses,licenses,licenses,NOUN,C1
-licensor,licensor,licensor,NOUN,C1
-lichen,lichen,lichen,NOUN,B2
-life sentence,life sentence,life sentence,NOUN,B2
-lifeguard,lifeguard,lifeguard,NOUN,B2
-lifelong,lifelong,lifelong,ADJ,B2
-light blue,light blue,light blue,ADJ,A1
-light bulb,light bulb,light bulb,NOUN,B2
-light bulb blister,light bulb blister,light bulb blister,NOUN,C1
-light grey,light grey,light grey,ADJ,B2
-light sleep,light sleep,light sleep,NOUN,C1
-light up turn on,light up turn on,light up turn on,VERB,A1
-light-colored,light-colored,light-colored,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,lightbulb,NOUN,A1
-lighting,lighting,lighting,NOUN,B2
-lightning flash,lightning flash,lightning flash,NOUN,B1
-like as,like as,like as,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,like this (adv),ADV,B1
-likeable,likeable,likeable,ADJ,C1
-likely (adj),likely,likely (adj),ADJ,A1
-likely (adv),likely,likely (adv),ADV,A1
-likely source,likely source,likely source,NOUN,C1
-lily,lily,lily,NOUN,B2
-limbo,limbo,,NOUN,B2
-limbs faculties,limbs faculties,limbs faculties,NOUN,C1
-liminal,liminal,liminal,ADJ,B2
-limited liability company,limited liability company,limited liability company,NOUN,C1
-limits,limits,limits,NOUN,B2
-limpidity,limpidity,limpidity,NOUN,C1
-line queue,line queue,line queue,NOUN,B1
-lineages,lineages,lineages,NOUN,C1
-liner,liner,liner,NOUN,C1
-lingual,lingual,lingual,ADJ,B2
-linguist,linguist,linguist,NOUN,C1
-linguistic intuition,linguistic intuition,linguistic intuition,NOUN,C1
-lining understudy,lining understudy,lining understudy,NOUN,B1
-link (adj),link,link (adj),ADJ,C1
-link connector,link connector,link connector,NOUN,C1
-linkage (noun),linkage,linkage (noun),NOUN,C1
-linking,linking,linking,NOUN,C1
-lip service,lip service,lip service,NOUN,C1
-lipless,lipless,lipless,ADJ,C1
-lisp (noun),lisp,lisp (noun),NOUN,C1
-listen (intj),listen,listen (intj),INTJ,B2
-listing,listing,listing,NOUN,C1
-listless,listless,listless,ADJ,C1
-litanies,litanies,litanies,NOUN,C1
-literalism,literalism,literalism,NOUN,C1
-literariness,literariness,literariness,NOUN,C1
-literary thefts,literary thefts,literary thefts,NOUN,C1
-lithe,lithe,lithe,ADJ,C1
-lithography,lithography,lithography,NOUN,C1
-litigation against a judge,litigation against a judge,litigation against a judge,NOUN,C1
-litotes understatement,litotes understatement,litotes understatement,NOUN,C1
-litterateur,litterateur,litterateur,NOUN,C1
-little (adj),little,little (adj),ADJ,A1
-little (adv),little,little (adv),ADV,A2
-little boy,little boy,little boy,NOUN,B2
-little finger,little finger,little finger,NOUN,B2
-little girl,little girl,little girl,NOUN,B2
-little heart,little heart,little heart,NOUN,B2
-little thing,little thing,little thing,NOUN,B2
-little town,little town,little town,NOUN,C1
-liturgical,liturgical,liturgical,ADJ,C1
-liturgy,liturgy,liturgy,NOUN,C1
-live (adj),live,live (adj),ADJ,B1
-live stream,live stream,live stream,NOUN,B2
-livelihood,livelihood,livelihood,NOUN,C1
-liveliness,liveliness,liveliness,NOUN,B1
-livestock farming,livestock farming,livestock farming,NOUN,C1
-living being,living being,living being,NOUN,C1
-loaded,loaded,loaded,ADJ,C1
-loading,loading,loading,NOUN,B2
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,loathsome,ADJ,C1
-lobby,lobby,lobby,NOUN,C1
-lobe,lobe,lobe,NOUN,A2
-localism,localism,localism,NOUN,C1
-locally,locally,locally,ADV,C1
-lockdown confinement,lockdown confinement,lockdown confinement,NOUN,C1
-locker,locker,locker,NOUN,C1
-locksmith,locksmith,locksmith,NOUN,C1
-locomotive,locomotive,locomotive,NOUN,C1
-loft,loft,loft,NOUN,C1
-logarithm,logarithm,logarithm,NOUN,C1
-logically,logically,logically,ADV,B2
-logistical,logistical,logistical,ADJ,C1
-logistics (adj),logistics,logistics (adj),ADJ,C1
-logomachy,logomachy,logomachy,NOUN,C1
-logorrhea,logorrhea,logorrhea,NOUN,C1
-long,long,,NOUN,B2
-long lease,long lease,long lease,NOUN,C1
-long pipe,long pipe,long pipe,NOUN,B2
-long poem,long poem,long poem,NOUN,C1
-long stretch of time,long stretch of time,long stretch of time,NOUN,C1
-long-distance runner,long-distance runner,long-distance runner,NOUN,B2
-long-established,long-established,long-established,ADJ,C1
-long-running,long-running,long-running,ADJ,C1
-longevity,longevity,longevity,NOUN,C1
-look around,look around,look around,VERB,C1
-loom,loom,loom,NOUN,B2
-looming,looming,looming,ADJ,C1
-loopholes,loopholes,loopholes,NOUN,C1
-loose thread,loose thread,loose thread,NOUN,C1
-looseness,looseness,looseness,NOUN,C1
-loquacious,loquacious,loquacious,ADJ,C1
-lord god,lord god,lord god,NOUN,B2
-lordship,lordship,lordship,NOUN,C1
-losses,losses,losses,NOUN,B1
-lotar,lotar,lotar,NOUN,C1
-love at first sight,love at first sight,love at first sight,NOUN,C1
-lovely,lovely,lovely,ADJ,B2
-lovesickness,lovesickness,lovesickness,NOUN,C1
-lovestruck,lovestruck,lovestruck,ADJ,C1
-low blow,low blow,low blow,NOUN,C1
-low point,low point,low point,NOUN,C1
-lower (noun),lower,lower (noun),NOUN,B2
-lowering,lowering,lowering,NOUN,C1
-lowly,lowly,lowly,ADJ,B2
-loyalism,loyalism,loyalism,NOUN,C1
-loyalty fidelity,loyalty fidelity,loyalty fidelity,NOUN,B2
-lubrication,lubrication,lubrication,NOUN,C1
-lucid,lucid,lucid,ADJ,C1
-luck turn,luck turn,luck turn,NOUN,A2
-lucky find,lucky find,lucky find,NOUN,B2
-lucky one,lucky one,lucky one,NOUN,B2
-lucubrate,lucubrate,lucubrate,VERB,C1
-lucubration,lucubration,lucubration,NOUN,C1
-lukewarmness,lukewarmness,lukewarmness,NOUN,C1
-lullaby,lullaby,lullaby,NOUN,C1
-luminosity,luminosity,luminosity,NOUN,C1
-lump in throat,lump in throat,lump in throat,NOUN,C1
-lunar,lunar,lunar,ADJ,C1
-lupini beans,lupini beans,lupini beans,NOUN,B2
-lure decoy,lure decoy,lure decoy,NOUN,C1
-lurid,lurid,lurid,ADJ,C1
-lute,lute,lute,NOUN,C1
-lyre,lyre,lyre,NOUN,B2
-lyricism,lyricism,lyricism,NOUN,C1
-macabre,macabre,macabre,ADJ,C1
-macaw,macaw,macaw,NOUN,C1
-macerate,macerate,macerate,VERB,C1
-machination,machination,machination,NOUN,C1
-machine (adj),machine,machine (adj),ADJ,B2
-machinery,machinery,machinery,NOUN,C1
-mad,mad,mad,ADJ,A1
-made,made,made,ADJ,B2
-maelstrom,maelstrom,maelstrom,NOUN,C1
-magnanimous pardon,magnanimous pardon,magnanimous pardon,NOUN,C1
-magnetic,magnetic,magnetic,ADJ,B2
-magnetism,magnetism,magnetism,NOUN,C1
-magnifying glass,magnifying glass,magnifying glass,NOUN,C1
-magnitude,magnitude,magnitude,NOUN,C1
-magus,magus,magus,NOUN,C1
-maieutic,maieutic,maieutic,ADJ,C1
-main text,main text,main text,NOUN,C1
-main thing,main thing,main thing,NOUN,B2
-majority (adj),majority,majority (adj),ADJ,B2
-make amends,make amends,make amends,VERB,C1
-make flexible,make flexible,make flexible,VERB,C1
-makeshift solution,makeshift solution,makeshift solution,NOUN,B2
-makhzen-related,makhzen-related,makhzen-related,ADJ,C1
-making,making,making,NOUN,B2
-maladjusted,maladjusted,maladjusted,ADJ,C1
-maladjustment,maladjustment,maladjustment,NOUN,C1
-malaria,malaria,malaria,NOUN,B2
-male goat,male goat,male goat,NOUN,B2
-malefic,malefic,malefic,ADJ,B2
-malevolent,malevolent,malevolent,ADJ,C1
-malhun,malhun,malhun,NOUN,B2
-malignancy,malignancy,malignancy,NOUN,C1
-malignity,malignity,malignity,NOUN,C1
-maliki school,maliki school,maliki school,NOUN,C1
-mall,mall,mall,NOUN,B2
-malleability,malleability,malleability,NOUN,C1
-malleable,malleable,malleable,ADJ,C1
-mallow greens,mallow greens,mallow greens,NOUN,B2
-mammalian,mammalian,mammalian,ADJ,C1
-managed,managed,,NOUN,B2
-management pipe,management pipe,management pipe,NOUN,B2
-managing director,managing director,managing director,NOUN,B2
-mandatory compulsory,mandatory compulsory,mandatory compulsory,ADJ,B1
-mane,mane,mane,NOUN,C1
-manifestation,manifestation,manifestation,NOUN,C1
-manifold,manifold,manifold,ADJ,B2
-manipulator,manipulator,manipulator,NOUN,C1
-manliness,manliness,manliness,NOUN,C1
-manly deed,manly deed,manly deed,NOUN,C1
-manly virtue,manly virtue,manly virtue,NOUN,C1
-manners,manners,manners,NOUN,B2
-mannish,mannish,mannish,ADJ,C1
-manslaughter,manslaughter,manslaughter,NOUN,C1
-manual (noun),manual,manual (noun),NOUN,B1
-manufacture (noun),manufacture,manufacture (noun),NOUN,C1
-manufacturing,manufacturing,manufacturing,NOUN,B1
-manumission,manumission,manumission,NOUN,C1
-manure (noun),manure,manure (noun),NOUN,C1
-many (det),many,many (det),DET,B2
-many (pron),many,many (pron),PRON,B1
-many a,many a,many a,ADJ,C1
-maple,maple,maple,NOUN,B2
-maqam,maqam,maqam,NOUN,B2
-maqama,maqama,maqama,NOUN,C1
-marbly,marbly,marbly,ADJ,B2
-mare,mare,mare,NOUN,B2
-marginally,marginally,marginally,ADV,B2
-marinade,marinade,marinade,NOUN,B2
-marital conjugal,marital conjugal,marital conjugal,ADJ,C1
-mark (noun),mark,mark (noun),NOUN,A2
-marker,marker,marker,NOUN,B2
-market (adj),market,market (adj),ADJ,C1
-market inspection,market inspection,market inspection,NOUN,C1
-market inspector,market inspector,market inspector,NOUN,C1
-markets,markets,markets,NOUN,C1
-maroon,maroon,maroon,ADJ,C1
-marsh,marsh,marsh,NOUN,C1
-marshy,marshy,marshy,ADJ,B2
-martial (adj),martial,martial (adj),ADJ,B2
-martyr,martyr,martyr,NOUN,C1
-marvel (noun),marvel,marvel (noun),NOUN,B2
-masculine,masculine,,NOUN,B2
-masculine (adj),masculine,masculine (adj),ADJ,B2
-masculinity,masculinity,masculinity,NOUN,C1
-masculinization,masculinization,masculinization,NOUN,C1
-mask (verb),mask,mask (verb),VERB,C1
-masochism,masochism,masochism,NOUN,C1
-mason,mason,mason,NOUN,C1
-masquerade,masquerade,masquerade,NOUN,C1
-mass (adj),mass,mass (adj),ADJ,C1
-mass appeal,mass appeal,mass appeal,NOUN,C1
-mass media,mass media,mass media,NOUN,B2
-mass-transmitted,mass-transmitted,mass-transmitted,ADJ,C1
-massage (noun),massage,massage (noun),NOUN,B2
-massage (verb),massage,massage (verb),VERB,B2
-masseur,masseur,masseur,NOUN,B2
-mast (noun),mast,mast (noun),NOUN,C1
-masterly,masterly,masterly,ADJ,B2
-mastermind,mastermind,mastermind,NOUN,C1
-mat,mat,mat,NOUN,B2
-matches,matches,matches,NOUN,C1
-mate,mate,mate,NOUN,A2
-material (adj),material,material (adj),ADJ,C1
-maternal,maternal,maternal,ADJ,C1
-mathematician,mathematician,mathematician,NOUN,C1
-matriarchy,matriarchy,matriarchy,NOUN,C1
-mausoleum,mausoleum,mausoleum,NOUN,B1
-maverick,maverick,maverick,NOUN,C1
-mawkish,mawkish,mawkish,ADJ,C1
-mawkishness,mawkishness,mawkishness,NOUN,C1
-mawwal,mawwal,mawwal,NOUN,B2
-maximization,maximization,maximization,NOUN,C1
-maximum (noun),maximum,maximum (noun),NOUN,B2
-may (aux),may,may (aux),AUX,A1
-may be allowed,may be allowed,may be allowed,AUX,A2
-may subjunctive,may subjunctive,may subjunctive,AUX,C1
-maze,maze,maze,NOUN,C1
-maze labyrinth,maze labyrinth,maze labyrinth,NOUN,C1
-me accusative,me accusative,me accusative,PRON,A2
-me dative,me dative,me dative,PRON,A2
-mead,mead,mead,NOUN,C1
-meager,meager,meager,ADJ,C1
-mean (noun),mean,mean (noun),NOUN,C1
-meander,meander,meander,NOUN,C1
-meandering,meandering,meandering,ADJ,B2
-meanness,meanness,meanness,NOUN,C1
-measurable,measurable,measurable,ADJ,C1
-measured,measured,measured,ADJ,B2
-measurements,measurements,measurements,NOUN,C1
-mechanically,mechanically,mechanically,ADV,C1
-mechanics,mechanics,mechanics,NOUN,C1
-mechanization,mechanization,mechanization,NOUN,C1
-mechanized,mechanized,mechanized,ADJ,C1
-medallion,medallion,medallion,NOUN,C1
-meddlesome (adj),meddlesome,meddlesome (adj),ADJ,C1
-media (adj),media,media (adj),ADJ,C1
-media professionals,media professionals,media professionals,NOUN,C1
-media-related,media-related,media-related,ADJ,B2
-median (adj),median,median (adj),ADJ,C1
-medical checkup,medical checkup,medical checkup,NOUN,A2
-medical examiner,medical examiner,medical examiner,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,medical practitioner,NOUN,C1
-medical test,medical test,medical test,NOUN,B1
-medical tests,medical tests,medical tests,NOUN,B2
-medium-sized,medium-sized,medium-sized,ADJ,C1
-meekness,meekness,meekness,NOUN,B2
-meeting point,meeting point,meeting point,NOUN,C1
-megabyte,megabyte,megabyte,NOUN,C1
-megalomania,megalomania,megalomania,NOUN,B2
-megalomaniac,megalomaniac,megalomaniac,ADJ,C1
-melancholy (adj),melancholy,melancholy (adj),ADJ,B2
-mellifluous,mellifluous,mellifluous,ADJ,C1
-mellifluousness,mellifluousness,mellifluousness,NOUN,C1
-melodious,melodious,melodious,ADJ,C1
-melodiousness,melodiousness,melodiousness,NOUN,C1
-melodrama,melodrama,melodrama,NOUN,C1
-melted,melted,melted,ADJ,C1
-melting,melting,melting,NOUN,B2
-membrane,membrane,membrane,NOUN,C1
-memorial (adj),memorial,memorial (adj),ADJ,C1
-memorizer,memorizer,memorizer,NOUN,C1
-memory loss,memory loss,memory loss,NOUN,C1
-men,men,men,NOUN,C1
-menace,menace,menace,NOUN,C1
-mendacious,mendacious,mendacious,ADJ,C1
-meninx,meninx,meninx,NOUN,C1
-menses,menses,menses,NOUN,B2
-mentioned,mentioned,mentioned,ADJ,B2
-mentoring,mentoring,mentoring,NOUN,B2
-mercantile,mercantile,mercantile,ADJ,C1
-mercenaries,mercenaries,mercenaries,NOUN,C1
-mercenary (adj),mercenary,mercenary (adj),ADJ,C1
-merciful,merciful,merciful,ADJ,B2
-mercilessly,mercilessly,mercilessly,ADV,C1
-mercurial,mercurial,mercurial,ADJ,C1
-mercy blow,mercy blow,mercy blow,NOUN,B2
-merged,merged,merged,ADJ,C1
-merger fusion,merger fusion,merger fusion,NOUN,B1
-merits,merits,merits,NOUN,C1
-merriment,merriment,merriment,NOUN,C1
-mesh,mesh,mesh,NOUN,C1
-mesmerizing,mesmerizing,mesmerizing,ADJ,C1
-message errand,message errand,message errand,NOUN,B2
-messaging,messaging,messaging,NOUN,C1
-metalepsis,metalepsis,metalepsis,NOUN,C1
-metalinguistic,metalinguistic,metalinguistic,ADJ,C1
-metallurgy,metallurgy,metallurgy,NOUN,C1
-metamorphosis,metamorphosis,metamorphosis,NOUN,C1
-metaphysical,metaphysical,metaphysical,ADJ,C1
-metastasis,metastasis,metastasis,NOUN,C1
-metempsychosis,metempsychosis,metempsychosis,NOUN,C1
-meteor,meteor,meteor,NOUN,B2
-meteorite,meteorite,meteorite,NOUN,C1
-meteorological observations,meteorological observations,meteorological observations,NOUN,C1
-metering,metering,metering,ADJ,C1
-methane,methane,methane,NOUN,C1
-methodical,methodical,methodical,ADJ,C1
-metrical foot,metrical foot,metrical foot,NOUN,C1
-metropolises,metropolises,metropolises,NOUN,C1
-metropolitan,metropolitan,metropolitan,ADJ,C1
-mettle,mettle,mettle,NOUN,C1
-microbe,microbe,microbe,NOUN,C1
-microchip,microchip,microchip,NOUN,C1
-microeconomic,microeconomic,microeconomic,ADJ,B2
-mid-morning,mid-morning,mid-morning,NOUN,C1
-midday heat,midday heat,midday heat,NOUN,B1
-middle (adj),middle,middle (adj),ADJ,B2
-middle (adv),middle,middle (adv),ADV,B2
-middle school,middle school,middle school,NOUN,B1
-middle-school student,middle-school student,middle-school student,NOUN,C1
-midpoint,midpoint,midpoint,NOUN,B2
-midwife,midwife,midwife,NOUN,C1
-mightily,mightily,mightily,ADV,C1
-mighty,mighty,mighty,ADJ,B1
-mighty man,mighty man,mighty man,NOUN,B2
-migrant,migrant,migrant,NOUN,B2
-migratory,migratory,migratory,ADJ,C1
-mildew,mildew,mildew,VERB,C1
-militant,militant,militant,ADJ,C1
-militaristic,militaristic,militaristic,ADJ,C1
-militarization,militarization,militarization,NOUN,C1
-military (noun),military,military (noun),NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,milking,NOUN,C1
-milkman,milkman,milkman,NOUN,C1
-millenary,millenary,millenary,ADJ,C1
-miller,miller,miller,NOUN,B2
-millimeter,millimeter,millimeter,NOUN,C1
-million (num),million,million (num),NUM,A1
-millionaire,millionaire,millionaire,NOUN,B2
-mime (noun),mime,mime (noun),NOUN,C1
-mimicry,mimicry,mimicry,NOUN,B2
-minaret,minaret,minaret,NOUN,B1
-minatory,minatory,minatory,ADJ,C1
-minced meat,minced meat,minced meat,NOUN,A2
-mind-blowing,mind-blowing,mind-blowing,ADJ,C1
-mindset,mindset,mindset,NOUN,B2
-mine (pron),mine,mine (pron),PRON,C1
-mineral (adj),mineral,mineral (adj),ADJ,C1
-mineral metal,mineral metal,mineral metal,NOUN,C1
-miniature painting,miniature painting,miniature painting,NOUN,C1
-minimalist,minimalist,minimalist,NOUN,C1
-minimization,minimization,minimization,NOUN,C1
-minimum,minimum,minimum,NOUN,B2
-minimum-wage earner,minimum-wage earner,minimum-wage earner,NOUN,B2
-mining,mining,mining,ADJ,C1
-minivan,minivan,minivan,NOUN,B2
-minutes,minutes,minutes,NOUN,B2
-miraculous,miraculous,miraculous,ADJ,C1
-mirage,mirage,mirage,NOUN,C1
-mirthful,mirthful,mirthful,ADJ,C1
-misanthropic,misanthropic,misanthropic,ADJ,C1
-mischief,mischief,mischief,NOUN,C1
-misconception,misconception,misconception,NOUN,B2
-misdeed,misdeed,misdeed,NOUN,C1
-misdemeanor,misdemeanor,misdemeanor,NOUN,B2
-miserliness,miserliness,miserliness,NOUN,C1
-mishap,mishap,mishap,NOUN,C1
-misjudge,misjudge,misjudge,VERB,C1
-mismatch,mismatch,mismatch,NOUN,C1
-miss teacher,miss teacher,miss teacher,NOUN,B2
-misserziehung,misserziehung,misserziehung,NOUN,C1
-missfahrt,missfahrt,missfahrt,NOUN,C1
-missfassung,missfassung,missfassung,NOUN,B2
-missforderung,missforderung,missforderung,NOUN,C1
-missgabe,missgabe,missgabe,NOUN,C1
-missgestaltung,missgestaltung,missgestaltung,NOUN,C1
-missionary,missionary,missionary,NOUN,C1
-missionizing,missionizing,missionizing,ADJ,C1
-missions,missions,missions,NOUN,C1
-missive,missive,missive,NOUN,C1
-misskunft,misskunft,misskunft,NOUN,C1
-missnahme,missnahme,missnahme,NOUN,C1
-misspflegung,misspflegung,misspflegung,NOUN,C1
-missregelung,missregelung,missregelung,NOUN,C1
-missrichtung,missrichtung,missrichtung,NOUN,C1
-misssetzung,misssetzung,misssetzung,NOUN,C1
-misssicht,misssicht,misssicht,NOUN,B2
-misssinnung,misssinnung,misssinnung,NOUN,C1
-misssprache,misssprache,misssprache,NOUN,C1
-misssucht,misssucht,misssucht,NOUN,C1
-misssuchung,misssuchung,misssuchung,NOUN,C1
-missteilung,missteilung,missteilung,NOUN,C1
-misswandel,misswandel,misswandel,NOUN,C1
-missweisung,missweisung,missweisung,NOUN,C1
-misswirkung,misswirkung,misswirkung,NOUN,C1
-misunderstood,misunderstood,misunderstood,ADJ,C1
-miterziehung,miterziehung,miterziehung,NOUN,C1
-mitfassung,mitfassung,mitfassung,NOUN,C1
-mitforderung,mitforderung,mitforderung,NOUN,C1
-mitgabe,mitgabe,mitgabe,NOUN,C1
-mitgestaltung,mitgestaltung,mitgestaltung,NOUN,C1
-mitigating,mitigating,mitigating,ADJ,C1
-mitigating factor,mitigating factor,mitigating factor,NOUN,B2
-mitigation,mitigation,mitigation,NOUN,C1
-mitkunft,mitkunft,mitkunft,NOUN,C1
-mitnahme,mitnahme,mitnahme,NOUN,C1
-mitpflegung,mitpflegung,mitpflegung,NOUN,B2
-mitregelung,mitregelung,mitregelung,NOUN,C1
-mitrichtung,mitrichtung,mitrichtung,NOUN,C1
-mitschaft,mitschaft,mitschaft,NOUN,C1
-mitschrift,mitschrift,mitschrift,NOUN,C1
-mitsicht,mitsicht,mitsicht,NOUN,B2
-mitsinnung,mitsinnung,mitsinnung,NOUN,C1
-mitsprache,mitsprache,mitsprache,NOUN,C1
-mitsucht,mitsucht,mitsucht,NOUN,C1
-mitsuchung,mitsuchung,mitsuchung,NOUN,C1
-mitteilung,mitteilung,mitteilung,NOUN,C1
-mittheilung,mittheilung,mittheilung,NOUN,B2
-mittreibung,mittreibung,mittreibung,NOUN,C1
-mitwandel,mitwandel,mitwandel,NOUN,C1
-mitweisung,mitweisung,mitweisung,NOUN,C1
-mitwirkung,mitwirkung,mitwirkung,NOUN,C1
-mixed-race,mixed-race,mixed-race,ADJ,C1
-mixer,mixer,mixer,NOUN,C1
-mixing,mixing,mixing,NOUN,B2
-mob,mob,mob,NOUN,B2
-mobile (noun),mobile,mobile (noun),NOUN,B2
-mocker,mocker,mocker,NOUN,B2
-mockery,mockery,mockery,NOUN,C1
-modality,modality,modality,NOUN,B2
-model prototype,model prototype,model prototype,NOUN,C1
-modem,modem,modem,NOUN,C1
-moderator,moderator,moderator,NOUN,C1
-modernist,modernist,modernist,ADJ,C1
-modernity,modernity,modernity,NOUN,C1
-modestly,modestly,modestly,ADV,C1
-modesty bashfulness,modesty bashfulness,modesty bashfulness,NOUN,B2
-modulation,modulation,modulation,NOUN,C1
-module,module,module,NOUN,C1
-moisten,moisten,moisten,VERB,C1
-moisture,moisture,moisture,NOUN,B2
-moisturizer,moisturizer,moisturizer,NOUN,B2
-molar,molar,molar,NOUN,A2
-molding,molding,molding,NOUN,C1
-molecular,molecular,molecular,ADJ,C1
-mollify,mollify,mollify,VERB,C1
-molten,molten,molten,ADJ,C1
-molting,molting,molting,NOUN,C1
-momentarily,momentarily,momentarily,ADV,B2
-momentous,momentous,momentous,ADJ,C1
-mommy,mommy,mommy,NOUN,B1
-monastic community,monastic community,monastic community,NOUN,C1
-monasticism,monasticism,monasticism,NOUN,C1
-monetization,monetization,monetization,NOUN,C1
-money transfer,money transfer,money transfer,NOUN,B1
-mongoose,mongoose,mongoose,NOUN,B2
-monism,monism,monism,NOUN,C1
-monologue,monologue,monologue,NOUN,B2
-monotheism,monotheism,monotheism,NOUN,C1
-monotonic,monotonic,monotonic,ADJ,C1
-monotony,monotony,monotony,NOUN,C1
-monumental,monumental,monumental,ADJ,C1
-moodiness,moodiness,moodiness,NOUN,B2
-mooring,mooring,mooring,NOUN,C1
-mop (noun),mop,mop (noun),NOUN,B2
-moral defect,moral defect,moral defect,NOUN,C1
-moral fable,moral fable,moral fable,NOUN,C1
-moral portrait,moral portrait,moral portrait,NOUN,C1
-moral restraint,moral restraint,moral restraint,NOUN,C1
-moralization,moralization,moralization,NOUN,C1
-moralizing (noun),moralizing,moralizing (noun),NOUN,C1
-morally,morally,morally,ADV,C1
-morass,morass,morass,NOUN,C1
-morbid,morbid,morbid,ADJ,C1
-morbidity,morbidity,morbidity,NOUN,C1
-more expensive,more expensive,more expensive,ADJ,B2
-more personal,more personal,more personal,ADJ,C1
-morgue,morgue,morgue,NOUN,B1
-morning (adj),morning,morning (adj),ADJ,C1
-moroccanization,moroccanization,moroccanization,NOUN,C1
-morocco leather,morocco leather,morocco leather,NOUN,C1
-moron,moron,moron,NOUN,C1
-morose,morose,morose,ADJ,C1
-mortal (adj),mortal,mortal (adj),ADJ,B2
-mortal (noun),mortal,mortal (noun),NOUN,B2
-mortar,mortar,mortar,NOUN,C1
-mortuary,mortuary,mortuary,NOUN,B2
-moslem,moslem,moslem,NOUN,C1
-most (det),most,most (det),DET,B2
-most (pron),most,most (pron),PRON,C1
-most famous,most famous,most famous,ADJ,B2
-moth,moth,moth,NOUN,B2
-motion picture,motion picture,motion picture,NOUN,C1
-motive for murder,motive for murder,motive for murder,NOUN,C1
-motley,motley,motley,ADJ,B2
-motorist,motorist,motorist,NOUN,C1
-motorway,motorway,motorway,NOUN,B2
-mount,mount,mount,NOUN,A1
-mountaineer,mountaineer,mountaineer,NOUN,C1
-mourning,mourning,mourning,NOUN,B2
-mouth animal,mouth animal,mouth animal,NOUN,B1
-mow,mow,mow,VERB,B2
-mrouzia,mrouzia,mrouzia,NOUN,B2
-much (adj),much,much (adj),ADJ,A1
-much (adv),much,much (adv),ADV,B2
-mucous,mucous,mucous,ADJ,C1
-muddied,muddied,muddied,ADJ,C1
-muddy (adj),muddy,muddy (adj),ADJ,C1
-mudslinging,mudslinging,mudslinging,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,mudslinging exchanges,NOUN,C1
-muezzin,muezzin,muezzin,NOUN,B2
-muffin,muffin,muffin,NOUN,B2
-mufti,mufti,mufti,NOUN,C1
-mug (noun),mug,mug (noun),NOUN,B2
-mulch,mulch,mulch,NOUN,C1
-multiple,multiple,multiple,ADJ,B2
-multiplicity,multiplicity,multiplicity,NOUN,C1
-multiplier,multiplier,multiplier,NOUN,C1
-mum,mum,mum,NOUN,A2
-mundane,mundane,mundane,ADJ,C1
-munificent,munificent,munificent,ADJ,C1
-muqarnas,muqarnas,muqarnas,NOUN,C1
-mural,mural,mural,NOUN,C1
-murder (noun),murder,murder (noun),NOUN,B1
-murder case,murder case,murder case,NOUN,B2
-murder scene,murder scene,murder scene,NOUN,C1
-murder victim,murder victim,murder victim,NOUN,C1
-murderer female,murderer female,murderer female,NOUN,B2
-murk of dawn,murk of dawn,murk of dawn,NOUN,C1
-murky,murky,murky,ADJ,C1
-murmuring,murmuring,murmuring,NOUN,C1
-muscular,muscular,muscular,ADJ,C1
-muse,muse,muse,VERB,B2
-mushroom fungus,mushroom fungus,mushroom fungus,NOUN,C1
-musical composition,musical composition,musical composition,NOUN,C1
-musical note,musical note,musical note,NOUN,C1
-musicality,musicality,musicality,NOUN,C1
-musk,musk,musk,NOUN,B2
-must (verb),must,must (verb),VERB,A1
-mustard,mustard,mustard,NOUN,A1
-mutable,mutable,mutable,ADJ,C1
-mutagenic,mutagenic,mutagenic,ADJ,C1
-mutazilites,mutazilites,mutazilites,NOUN,C1
-mute person,mute person,mute person,NOUN,B2
-mutilate,mutilate,mutilate,VERB,C1
-mutual affection,mutual affection,mutual affection,NOUN,C1
-mutual consent,mutual consent,mutual consent,NOUN,C1
-mutual forgiveness,mutual forgiveness,mutual forgiveness,NOUN,C1
-mutual pulling,mutual pulling,mutual pulling,NOUN,C1
-mutual understanding,mutual understanding,mutual understanding,NOUN,B1
-muwashshah,muwashshah,muwashshah,NOUN,B2
-muzzling,muzzling,muzzling,NOUN,C1
-my (pron),my,my (pron),PRON,A1
-myelin,myelin,myelin,NOUN,C1
-myriad,myriad,myriad,ADJ,C1
-nacherziehung,nacherziehung,nacherziehung,NOUN,C1
-nachfahrt,nachfahrt,nachfahrt,NOUN,C1
-nachfassung,nachfassung,nachfassung,NOUN,B2
-nachforderung,nachforderung,nachforderung,NOUN,C1
-nachgabe,nachgabe,nachgabe,NOUN,C1
-nachgestaltung,nachgestaltung,nachgestaltung,NOUN,C1
-nachkunft,nachkunft,nachkunft,NOUN,C1
-nachnahme,nachnahme,nachnahme,NOUN,C1
-nachpflegung,nachpflegung,nachpflegung,NOUN,C1
-nachregelung,nachregelung,nachregelung,NOUN,C1
-nachschaft,nachschaft,nachschaft,NOUN,B2
-nachschrift,nachschrift,nachschrift,NOUN,C1
-nachsetzung,nachsetzung,nachsetzung,NOUN,C1
-nachsicht,nachsicht,nachsicht,NOUN,C1
-nachsprache,nachsprache,nachsprache,NOUN,C1
-nachsucht,nachsucht,nachsucht,NOUN,B2
-nachteilung,nachteilung,nachteilung,NOUN,C1
-nachtreibung,nachtreibung,nachtreibung,NOUN,C1
-nachwandel,nachwandel,nachwandel,NOUN,B2
-nahbildung,nahbildung,nahbildung,NOUN,C1
-nahforderung,nahforderung,nahforderung,NOUN,C1
-nahgabe,nahgabe,nahgabe,NOUN,C1
-nahgestaltung,nahgestaltung,nahgestaltung,NOUN,C1
-nahkunft,nahkunft,nahkunft,NOUN,C1
-nahleitung,nahleitung,nahleitung,NOUN,C1
-nahmessung,nahmessung,nahmessung,NOUN,C1
-nahnahme,nahnahme,nahnahme,NOUN,C1
-nahordnung,nahordnung,nahordnung,NOUN,C1
-nahpflegung,nahpflegung,nahpflegung,NOUN,C1
-nahrechnung,nahrechnung,nahrechnung,NOUN,C1
-nahregelung,nahregelung,nahregelung,NOUN,C1
-nahrichtung,nahrichtung,nahrichtung,NOUN,C1
-nahschaft,nahschaft,nahschaft,NOUN,C1
-nahschrift,nahschrift,nahschrift,NOUN,C1
-nahsetzung,nahsetzung,nahsetzung,NOUN,C1
-nahsicht,nahsicht,nahsicht,NOUN,C1
-nahsinnung,nahsinnung,nahsinnung,NOUN,C1
-nahsprache,nahsprache,nahsprache,NOUN,C1
-nahstellung,nahstellung,nahstellung,NOUN,C1
-nahsucht,nahsucht,nahsucht,NOUN,C1
-nahsuchung,nahsuchung,nahsuchung,NOUN,C1
-nahteilung,nahteilung,nahteilung,NOUN,C1
-nahtheilung,nahtheilung,nahtheilung,NOUN,C1
-nahtreibung,nahtreibung,nahtreibung,NOUN,C1
-nahwandel,nahwandel,nahwandel,NOUN,C1
-nahwandlung,nahwandlung,nahwandlung,NOUN,C1
-nahweisung,nahweisung,nahweisung,NOUN,C1
-nahwendung,nahwendung,nahwendung,NOUN,C1
-nahwirkung,nahwirkung,nahwirkung,NOUN,C1
-name-calling,name-calling,name-calling,NOUN,C1
-named,named,named,ADP,C1
-narcotics,narcotics,narcotics,NOUN,C1
-narrated,narrated,narrated,ADJ,C1
-narration,narration,narration,NOUN,B2
-narrative (adj),narrative,narrative (adj),ADJ,C1
-narratives,narratives,narratives,NOUN,C1
-narrativity,narrativity,narrativity,NOUN,C1
-narrators,narrators,narrators,NOUN,C1
-narrowing,narrowing,narrowing,NOUN,B2
-nascent,nascent,nascent,ADJ,C1
-national citizen,national citizen,national citizen,NOUN,C1
-national team,national team,national team,NOUN,B1
-native (noun),native,native (noun),NOUN,C1
-naturalism,naturalism,naturalism,NOUN,C1
-naturalization,naturalization,naturalization,NOUN,B2
-nautical,nautical,nautical,ADJ,C1
-naval,naval,naval,ADJ,C1
-navigational,navigational,navigational,ADJ,C1
-near (adv),near,near (adv),ADV,A1
-nearest (noun),nearest,nearest (noun),NOUN,B2
-nearness,nearness,nearness,NOUN,B2
-neatly,neatly,neatly,ADV,B2
-nebulous,nebulous,nebulous,ADJ,C1
-necessarily incumbent,necessarily incumbent,necessarily incumbent,ADV,C1
-necklace chain,necklace chain,necklace chain,NOUN,A1
-neckline,neckline,neckline,NOUN,C1
-necrosis,necrosis,necrosis,NOUN,C1
-nectar,nectar,nectar,NOUN,C1
-needlessly,needlessly,needlessly,ADV,C1
-nefarious,nefarious,nefarious,ADJ,C1
-neglect (noun),neglect,neglect (noun),NOUN,C1
-negotiator,negotiator,negotiator,NOUN,C1
-neigh (noun),neigh,neigh (noun),NOUN,C1
-neighbor female,neighbor female,neighbor female,NOUN,B2
-neighbors,neighbors,neighbors,NOUN,B1
-neighbourhood,neighbourhood,neighbourhood,NOUN,B2
-neither (adv),neither,neither (adv),ADV,A1
-neither (det),neither,neither (det),DET,A2
-neither nor,neither nor,neither nor,CCONJ,A2
-nemesis,nemesis,nemesis,NOUN,C1
-neologism,neologism,neologism,NOUN,C1
-nepotism,nepotism,nepotism,NOUN,B2
-nerve impulse,nerve impulse,nerve impulse,NOUN,C1
-nesting box,nesting box,nesting box,NOUN,B1
-nettle,nettle,nettle,NOUN,C1
-networking,networking,networking,NOUN,C1
-neural,neural,neural,ADJ,C1
-neuralgia,neuralgia,neuralgia,NOUN,C1
-neurasthenia,neurasthenia,neurasthenia,NOUN,C1
-neurological,neurological,neurological,ADJ,C1
-neuron,neuron,neuron,NOUN,B2
-neuroscience,neuroscience,neuroscience,NOUN,C1
-neuroticism,neuroticism,neuroticism,NOUN,C1
-neutron,neutron,neutron,NOUN,C1
-new beginning,new beginning,new beginning,NOUN,C1
-new development,new development,new development,NOUN,C1
-newly,newly,newly,ADV,C1
-newly acquired,newly acquired,newly acquired,ADJ,C1
-newly introduced,newly introduced,newly introduced,ADJ,C1
-news bulletin,news bulletin,news bulletin,NOUN,B2
-news report,news report,news report,NOUN,B1
-next day,next day,next day,NOUN,A2
-next following,next following,next following,ADJ,C1
-next to (adv),next to,next to (adv),ADV,B2
-ney,ney,ney,NOUN,B2
-niceness,niceness,niceness,NOUN,B2
-niche,niche,niche,NOUN,C1
-nigella seeds,nigella seeds,nigella seeds,NOUN,B2
-nihilistic,nihilistic,nihilistic,ADJ,C1
-nine (noun),nine,nine (noun),NOUN,B2
-ninth (noun),ninth,ninth (noun),NOUN,B2
-nitrogen,nitrogen,nitrogen,NOUN,B2
-no (intj),no,no (intj),INTJ,A1
-no (part),no,no (part),PART,B2
-no matter (adj),no matter,no matter (adj),ADJ,C1
-no one (pron),no one,no one (pron),PRON,A1
-nobility of character,nobility of character,nobility of character,NOUN,C1
-noble qualities,noble qualities,noble qualities,NOUN,C1
-noble trait,noble trait,noble trait,NOUN,C1
-node,node,node,NOUN,C1
-noise row,noise row,noise row,NOUN,C1
-noisome,noisome,noisome,ADJ,C1
-nomads,nomads,nomads,NOUN,B2
-nominal,nominal,nominal,ADJ,C1
-nominee,nominee,nominee,NOUN,C1
-non-compliance,non-compliance,non-compliance,NOUN,C1
-non-extendable,non-extendable,non-extendable,ADJ,C1
-nonchalant,nonchalant,nonchalant,ADJ,C1
-nonconformist,nonconformist,nonconformist,NOUN,C1
-nonexistent,nonexistent,nonexistent,ADJ,C1
-nonlinear,nonlinear,nonlinear,ADJ,C1
-nonmetal,nonmetal,nonmetal,NOUN,C1
-nonviolence,nonviolence,nonviolence,NOUN,B2
-normal ordinary,normal ordinary,normal ordinary,ADJ,A2
-normalization,normalization,normalization,NOUN,C1
-normativity,normativity,normativity,NOUN,C1
-northeast,northeast,northeast,NOUN,C1
-northward,northward,northward,ADV,B2
-nosology,nosology,nosology,NOUN,C1
-nostalgic,nostalgic,nostalgic,ADJ,C1
-nostril,nostril,nostril,NOUN,C1
-not at all,not at all,not at all,ADV,C1
-not care,not care,not care,VERB,C1
-notables,notables,notables,NOUN,B2
-note mark,note mark,note mark,NOUN,A2
-note patch,note patch,note patch,NOUN,C1
-noteworthy,noteworthy,noteworthy,ADJ,C1
-nothingness,nothingness,nothingness,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,nothingness nonexistence,NOUN,C1
-notifications,notifications,notifications,NOUN,C1
-notion,notion,notion,NOUN,B2
-notoriously,notoriously,notoriously,ADV,C1
-notwithstanding,notwithstanding,notwithstanding,ADP,C1
-novice,novice,novice,NOUN,C1
-noxious,noxious,noxious,ADJ,C1
-nuclear (noun),nuclear,nuclear (noun),NOUN,B2
-nuclear power,nuclear power,nuclear power,NOUN,B2
-nucleus,nucleus,nucleus,NOUN,B2
-nudge,nudge,nudge,NOUN,B2
-nudity,nudity,nudity,NOUN,C1
-nugget,nugget,nugget,NOUN,C1
-nullify,nullify,nullify,VERB,C1
-numbering,numbering,numbering,NOUN,C1
-numeral,numeral,numeral,NOUN,C1
-numerical,numerical,numerical,ADJ,C1
-nunation,nunation,nunation,NOUN,C1
-nutritional,nutritional,nutritional,ADJ,C1
-o,o,o,PART,B1
-o'clock (adv),o'clock,o'clock (adv),ADV,B2
-oak,oak,oak,NOUN,B1
-oath of allegiance,oath of allegiance,oath of allegiance,NOUN,C1
-obdurate,obdurate,obdurate,ADJ,C1
-obelisk,obelisk,obelisk,NOUN,C1
-oberfahrt,oberfahrt,oberfahrt,NOUN,C1
-oberfassung,oberfassung,oberfassung,NOUN,C1
-oberforderung,oberforderung,oberforderung,NOUN,C1
-obergabe,obergabe,obergabe,NOUN,C1
-obergestaltung,obergestaltung,obergestaltung,NOUN,C1
-oberkunft,oberkunft,oberkunft,NOUN,C1
-obermessung,obermessung,obermessung,NOUN,C1
-obernahme,obernahme,obernahme,NOUN,C1
-oberordnung,oberordnung,oberordnung,NOUN,C1
-oberpflegung,oberpflegung,oberpflegung,NOUN,C1
-oberrechnung,oberrechnung,oberrechnung,NOUN,C1
-oberregelung,oberregelung,oberregelung,NOUN,C1
-oberrichtung,oberrichtung,oberrichtung,NOUN,C1
-oberschaft,oberschaft,oberschaft,NOUN,C1
-oberschrift,oberschrift,oberschrift,NOUN,C1
-obersetzung,obersetzung,obersetzung,NOUN,C1
-obersicht,obersicht,obersicht,NOUN,C1
-obersinnung,obersinnung,obersinnung,NOUN,C1
-obersprache,obersprache,obersprache,NOUN,C1
-oberstellung,oberstellung,oberstellung,NOUN,C1
-obersucht,obersucht,obersucht,NOUN,C1
-oberteilung,oberteilung,oberteilung,NOUN,C1
-obertheilung,obertheilung,obertheilung,NOUN,C1
-obertreibung,obertreibung,obertreibung,NOUN,C1
-oberwandel,oberwandel,oberwandel,NOUN,C1
-oberweisung,oberweisung,oberweisung,NOUN,C1
-oberwendung,oberwendung,oberwendung,NOUN,C1
-oberwirkung,oberwirkung,oberwirkung,NOUN,C1
-obese,obese,obese,ADJ,B2
-obfuscate,obfuscate,obfuscate,VERB,C1
-obituary notice,obituary notice,obituary notice,NOUN,C1
-objective goal,objective goal,objective goal,NOUN,A2
-objectively,objectively,objectively,ADV,C1
-objectivism,objectivism,objectivism,NOUN,C1
-obligatory,obligatory,obligatory,ADJ,C1
-obliging,obliging,obliging,ADJ,B2
-obliterate,obliterate,obliterate,VERB,C1
-obliteration,obliteration,obliteration,NOUN,C1
-oblivion,oblivion,oblivion,NOUN,C1
-oblivious,oblivious,oblivious,ADJ,C1
-obscenity,obscenity,obscenity,NOUN,C1
-obscurantist,obscurantist,obscurantist,ADJ,C1
-obscure (adj),obscure,obscure (adj),ADJ,C1
-obsequious,obsequious,obsequious,ADJ,C1
-observable,observable,observable,ADJ,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,observational,ADJ,C1
-observers,observers,observers,NOUN,C1
-obsess,obsess,obsess,VERB,B2
-obsession with youth,obsession with youth,obsession with youth,NOUN,C1
-obstacle hindrance,obstacle hindrance,obstacle hindrance,NOUN,C1
-obstinately,obstinately,obstinately,ADV,C1
-obstreperous,obstreperous,obstreperous,ADJ,C1
-obtrusive,obtrusive,obtrusive,ADJ,C1
-obtuse,obtuse,obtuse,ADJ,C1
-obviate,obviate,obviate,VERB,C1
-occasional,occasional,occasional,ADJ,C1
-occultism,occultism,occultism,NOUN,B2
-octave,octave,octave,NOUN,C1
-octopus,octopus,octopus,NOUN,B2
-ocular,ocular,ocular,ADJ,C1
-oddly,oddly,oddly,ADV,B2
-odious,odious,odious,ADJ,C1
-odor,odor,odor,NOUN,C1
-odorlessness,odorlessness,odorlessness,NOUN,C1
-odyssey,odyssey,odyssey,NOUN,C1
-of course (adj),of course,of course (adj),ADJ,B2
-of course (intj),of course,of course (intj),INTJ,C1
-of first instance,of first instance,of first instance,ADJ,C1
-of it,of it,of it,ADV,B2
-of old,of old,of old,ADV,C1
-of the,of the,of the,ADP,A1
-of the noose,of the noose,of the noose,ADJ,C1
-of this,of this,of this,ADV,B1
-of utrecht,of utrecht,of utrecht,ADJ,B2
-off (adv),off,off (adv),ADV,B2
-off-center,off-center,off-center,ADJ,C1
-off-track,off-track,off-track,ADJ,C1
-offcuts,offcuts,offcuts,NOUN,C1
-offence,offence,offence,NOUN,B2
-offensive (noun),offensive,offensive (noun),NOUN,C1
-official approval,official approval,official approval,NOUN,C1
-official report,official report,official report,NOUN,B1
-official statement,official statement,official statement,NOUN,B2
-officious,officious,officious,ADJ,C1
-offshoring,offshoring,offshoring,NOUN,B2
-oh I see,oh I see,oh I see,INTJ,A1
-oil lamp,oil lamp,oil lamp,NOUN,C1
-oil petroleum,oil petroleum,oil petroleum,NOUN,C1
-oil tanker,oil tanker,oil tanker,NOUN,C1
-oilfield,oilfield,oilfield,NOUN,C1
-ok,ok,ok,INTJ,B2
-okay (adj),okay,okay (adj),ADJ,A1
-old people,old people,old people,ADJ,A1
-oldest,oldest,oldest,ADJ,C1
-oleander,oleander,oleander,NOUN,B2
-olfactory,olfactory,olfactory,ADJ,C1
-oligopoly,oligopoly,oligopoly,NOUN,B2
-olives,olives,olives,NOUN,A2
-omnipotent,omnipotent,omnipotent,ADJ,C1
-omniscient,omniscient,omniscient,ADJ,C1
-on,on,,NOUN,B2
-on condition,on condition,on condition,SCONJ,C1
-on that,on that,on that,ADV,B1
-on that day,on that day,on that day,ADV,C1
-on the one hand,on the one hand,on the one hand,ADV,B2
-on this,on this,on this,ADV,C1
-on upon,on upon,on upon,ADP,B2
-oncology,oncology,oncology,NOUN,C1
-one,one,,NOUN,B2
-one (adj),one,one (adj),ADJ,A2
-one (det),one,one (det),DET,C1
-one (pron),one,one (pron),PRON,B2
-one impersonal,one impersonal,one impersonal,PRON,A2
-one-sidedness,one-sidedness,one-sidedness,NOUN,B2
-one-upmanship,one-upmanship,one-upmanship,NOUN,C1
-onerous,onerous,onerous,ADJ,C1
-oneself (adv),oneself,oneself (adv),ADV,A1
-oneself reflexive,oneself reflexive,oneself reflexive,PRON,A2
-ongoing (noun),ongoing,ongoing (noun),NOUN,B2
-online,online,online,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,online store,NOUN,C1
-only (det),only,only (det),DET,B2
-oops,oops,oops,INTJ,C1
-oozing,oozing,oozing,NOUN,B2
-opaque,opaque,opaque,ADJ,C1
-open air,open air,open air,NOUN,C1
-open ground,open ground,open ground,NOUN,C1
-open-mindedness,open-mindedness,open-mindedness,NOUN,C1
-operation business,operation business,operation business,NOUN,B2
-operational,operational,operational,ADJ,C1
-operationalization,operationalization,operationalization,NOUN,B2
-operative part,operative part,operative part,NOUN,C1
-operetta,operetta,operetta,NOUN,C1
-opium den,opium den,opium den,NOUN,B2
-opportune,opportune,opportune,ADJ,C1
-opportunism,opportunism,opportunism,NOUN,C1
-opportunist,opportunist,opportunist,NOUN,C1
-opportunistic,opportunistic,opportunistic,ADJ,B2
-opportunity used,opportunity used,opportunity used,NOUN,B2
-opposing,opposing,opposing,ADJ,C1
-oppressed,oppressed,oppressed,ADJ,B1
-oppressive weight,oppressive weight,oppressive weight,NOUN,C1
-opprobrium,opprobrium,opprobrium,NOUN,C1
-opt,opt,opt,VERB,C1
-optical illusion,optical illusion,optical illusion,NOUN,C1
-optician,optician,optician,NOUN,C1
-optics perspective,optics perspective,optics perspective,NOUN,C1
-optimum,optimum,optimum,NOUN,C1
-opulence,opulence,opulence,NOUN,C1
-or something,or something,or something,ADV,C1
-oracular,oracular,oracular,ADJ,C1
-oral narratives,oral narratives,oral narratives,NOUN,C1
-oral transmission,oral transmission,oral transmission,NOUN,C1
-orality,orality,orality,NOUN,C1
-orally,orally,orally,ADV,B2
-orange color,orange color,orange color,ADJ,A1
-orator speaker,orator speaker,orator speaker,NOUN,C1
-oratory,oratory,oratory,NOUN,C1
-orbital,orbital,orbital,ADJ,C1
-orchestrate,orchestrate,orchestrate,VERB,C1
-orchestration,orchestration,orchestration,NOUN,C1
-ordain,ordain,ordain,VERB,C1
-order mission,order mission,order mission,NOUN,A2
-ore,ore,ore,NOUN,B2
-organism,organism,organism,NOUN,C1
-organization body,organization body,organization body,NOUN,B1
-orientalism,orientalism,orientalism,NOUN,C1
-orientalist,orientalist,orientalist,NOUN,C1
-orientation direction,orientation direction,orientation direction,NOUN,B1
-originating,originating,originating,ADJ,B1
-originator,originator,originator,NOUN,C1
-orison prayer,orison prayer,orison prayer,NOUN,C1
-ornamental,ornamental,ornamental,ADJ,C1
-ornamentation,ornamentation,ornamentation,NOUN,C1
-ornate,ornate,ornate,ADJ,C1
-orphaned,orphaned,orphaned,ADJ,B2
-orthogonality,orthogonality,orthogonality,NOUN,C1
-orthographic,orthographic,orthographic,ADJ,C1
-oscillating,oscillating,oscillating,ADJ,C1
-oscillation,oscillation,oscillation,NOUN,C1
-osseous,osseous,osseous,ADJ,C1
-ostensible,ostensible,ostensible,ADJ,C1
-ostensibly,ostensibly,ostensibly,ADV,B2
-ostentation,ostentation,ostentation,NOUN,C1
-ostentatious,ostentatious,ostentatious,ADJ,C1
-ostracism,ostracism,ostracism,NOUN,C1
-ostrich,ostrich,ostrich,NOUN,B2
-other (det),other,other (det),DET,B2
-others (pron),others,others (pron),PRON,B2
-otherworldly,otherworldly,otherworldly,ADJ,C1
-ought to,ought to,ought to,AUX,A2
-ounce,ounce,ounce,NOUN,C1
-our (pron),our,our (pron),PRON,A1
-out (adp),out,out (adp),ADP,B2
-out of place,out of place,out of place,ADJ,B2
-out there,out there,out there,ADV,B2
-outdoor,outdoor,outdoor,ADJ,C1
-outdoor pool,outdoor pool,outdoor pool,NOUN,C1
-outer,outer,outer,ADJ,B2
-outermost,outermost,outermost,ADJ,C1
-outlast,outlast,outlast,VERB,B2
-output,output,output,NOUN,B2
-outputs,outputs,outputs,NOUN,C1
-outrageous,outrageous,outrageous,ADJ,B2
-outright,outright,outright,ADV,C1
-outset,outset,outset,NOUN,C1
-outside (adp),outside,outside (adp),ADP,B2
-outside of,outside of,outside of,ADP,B2
-outside world,outside world,outside world,NOUN,B2
-outskirts,outskirts,outskirts,NOUN,B1
-outward (adj),outward,outward (adj),ADJ,C1
-outward (adv),outward,outward (adv),ADV,B2
-outward journey,outward journey,outward journey,NOUN,C1
-ovarian,ovarian,ovarian,ADJ,C1
-over it,over it,over it,ADV,B1
-over-indebtedness,over-indebtedness,over-indebtedness,NOUN,C1
-overabundant,overabundant,overabundant,ADJ,B2
-overbearing arrogance,overbearing arrogance,overbearing arrogance,NOUN,C1
-overbidding,overbidding,overbidding,NOUN,C1
-overconsumption,overconsumption,overconsumption,NOUN,C1
-overcrowding,overcrowding,overcrowding,NOUN,C1
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,overflowing exuberant,ADJ,C1
-overhead,overhead,overhead,NOUN,C1
-overheating,overheating,overheating,NOUN,C1
-overload surcharge,overload surcharge,overload surcharge,NOUN,C1
-overly familiar,overly familiar,overly familiar,ADJ,B2
-overreach,overreach,overreach,NOUN,C1
-overrule,overrule,overrule,VERB,C1
-overseas,overseas,overseas,ADV,B2
-overt,overt,overt,ADJ,C1
-overtaking exceeding,overtaking exceeding,overtaking exceeding,NOUN,B2
-overthrow projection,overthrow projection,overthrow projection,NOUN,C1
-overthrow reversal,overthrow reversal,overthrow reversal,NOUN,C1
-overweight,overweight,overweight,ADJ,C1
-overwork,overwork,overwork,NOUN,C1
-ow,ow,ow,INTJ,C1
-own clean,own clean,own clean,ADJ,B1
-ox,ox,ox,NOUN,C1
-oxidation,oxidation,oxidation,NOUN,C1
-oxidized,oxidized,oxidized,ADJ,C1
-oxygen-rich,oxygen-rich,oxygen-rich,ADJ,C1
-oysters,oysters,oysters,NOUN,B2
-ozone,ozone,ozone,NOUN,B2
-pacific,pacific,pacific,ADJ,B2
-pack (noun),pack,pack (noun),NOUN,C1
-package packet,package packet,package packet,NOUN,B1
-pacts,pacts,pacts,NOUN,C1
-padding,padding,padding,NOUN,C1
-paddle,paddle,paddle,VERB,C1
-padlock,padlock,padlock,NOUN,B2
-paid,paid,paid,ADJ,B2
-pain hurt,pain hurt,pain hurt,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,pained,ADJ,C1
-painless,painless,,NOUN,B2
-painstaking,painstaking,painstaking,ADJ,C1
-paint dye,paint dye,paint dye,VERB,A1
-paintbrush,paintbrush,paintbrush,NOUN,B2
-palanquin,palanquin,palanquin,NOUN,B1
-palatable,palatable,palatable,ADJ,C1
-paleography,paleography,paleography,NOUN,C1
-palimpsest,palimpsest,palimpsest,NOUN,C1
-palisade,palisade,palisade,NOUN,C1
-pallid,pallid,pallid,ADJ,C1
-palm grove,palm grove,palm grove,NOUN,B2
-palpable,palpable,palpable,ADJ,C1
-paltriness,paltriness,paltriness,NOUN,C1
-paltry,paltry,paltry,ADJ,C1
-pamphlet,pamphlet,pamphlet,NOUN,C1
-panacea,panacea,panacea,NOUN,C1
-pancreas,pancreas,胰腺,NOUN,B2
-pandemic,pandemic,大流行病,NOUN,B2
-panegyric,panegyric,颂词,NOUN,B2
-panel,panel,小组,NOUN,B2
-panel of judges,panel of judges,panel of judges,NOUN,B2
-panoramic,panoramic,panoramic,ADJ,C1
-pantheism,pantheism,泛神论,NOUN,B2
-panties,panties,panties,NOUN,C1
-pants trousers,pants trousers,pants trousers,NOUN,A1
-papal bull,papal bull,papal bull,NOUN,B2
-paper-based,paper-based,paper-based,ADJ,C1
-paperless,paperless,paperless,ADJ,C1
-paperwork,paperwork,文书工作,NOUN,B2
-parable,parable,parable,NOUN,B2
-parade (noun),parade,parade (noun),NOUN,B2
-paradise,paradise,天堂,NOUN,B2
-paradise heaven,paradise heaven,paradise heaven,NOUN,B1
-paradox,paradox,悖论,NOUN,B2
-paradoxically,paradoxically,paradoxically,ADV,C1
-paragon,paragon,典范,NOUN,B2
-paragraph heel,paragraph heel,paragraph heel,NOUN,C1
-paralipsis,paralipsis,paralipsis,NOUN,C1
-parallelism,parallelism,parallelism,NOUN,C1
-paralogism,paralogism,paralogism,NOUN,B2
-paralyze,to paralyze,使瘫痪,VERB,B2
-paramedic,paramedic,急救人员,NOUN,B2
-paramount,paramount,paramount,ADJ,C1
-paranoia,paranoia,paranoia,NOUN,C1
-paranoid,paranoid,paranoid,ADJ,B2
-parapet,parapet,parapet,NOUN,C1
-paraphrase,paraphrase,paraphrase,VERB,B2
-parasol,parasol,parasol,NOUN,B1
-parch,parch,parch,VERB,C1
-parchment,parchment,parchment,NOUN,C1
-pardoning,pardoning,pardoning,NOUN,C1
-parent-friendly,parent-friendly,,NOUN,B2
-parenthesis,parenthesis,parenthesis,NOUN,C1
-paresis,paresis,paresis,NOUN,C1
-pariah,pariah,pariah,NOUN,C1
-parish,parish,parish,NOUN,B2
-parishioner,parishioner,parishioner,NOUN,C1
-parishioners,parishioners,parishioners,NOUN,C1
-parking,parking,停车,NOUN,B2
-parking meter,parking meter,parking meter,NOUN,B1
-parley,parley,parley,NOUN,C1
-parlor,parlor,parlor,NOUN,C1
-parody,parody,戏仿,NOUN,B2
-paronomasia,paronomasia,近音词双关,NOUN,B2
-paronym,paronym,paronym,NOUN,C1
-parquet,parquet,parquet,NOUN,C1
-parrot,parrot,鹦鹉,NOUN,B2
-parsley,parsley,欧芹,NOUN,B2
-part-time,part-time,part-time,NOUN,B1
-participation,participation,参与,NOUN,B2
-participatory,participatory,参与式的,ADJ,B2
-particle,particle,颗粒,NOUN,B2
-particular,particular,特定的,ADJ,B2
-particularize,particularize,particularize,VERB,B2
-partisan (adj),partisan,partisan (adj),ADJ,C1
-partisan (noun),partisan,partisan (noun),NOUN,C1
-partition,partition,partition,NOUN,C1
-partitioning,partitioning,partitioning,NOUN,C1
-partly,partly,部分地,ADV,B2
-partner female,partner female,partner female,NOUN,B2
-partnership,partnership,伙伴关系,NOUN,B2
-partridge,partridge,partridge,NOUN,B2
-party concert,party concert,party concert,NOUN,B1
-party to the contract,party to the contract,party to the contract,NOUN,B2
-pashalik,pashalik,pashalik,NOUN,C1
-passable,passable,passable,ADJ,C1
-passage,passage,段落,NOUN,B2
-passed,passed,passed,ADJ,B2
-passerby,passerby,passerby,NOUN,C1
-passion,passion,激情,NOUN,B2
-passionate love,passionate love,passionate love,NOUN,C1
-passive reliance on others,passive reliance on others,passive reliance on others,NOUN,C1
-past,past,过去的,ADJ,B2
-past (adp),past,past (adp),ADP,B2
-pasta,pasta,意大利面,NOUN,B2
-pastor,pastor,牧师,NOUN,B2
-pastoral (adj),pastoral,pastoral (adj),ADJ,C1
-pastoral (noun),pastoral,pastoral (noun),NOUN,C1
-pastry chef,pastry chef,pastry chef,NOUN,C1
-patch,patch,补丁,NOUN,B2
-patently,patently,patently,ADV,B2
-pathological,pathological,病态的,ADJ,B2
-patient,patient,耐心的,ADJ,B2
-patient female,patient female,patient female,NOUN,B2
-patiently,patiently,patiently,ADV,C1
-patriarch,patriarch,patriarch,NOUN,C1
-patriarchy,patriarchy,父权制,NOUN,B2
-patricide,patricide,patricide,NOUN,B2
-patriot,patriot,patriot,NOUN,B2
-patrol duty,patrol duty,patrol duty,NOUN,B2
-patron,patron,赞助人,NOUN,B2
-patronage,patronage,patronage,NOUN,B2
-paucity,paucity,paucity,NOUN,C1
-pauper,pauper,pauper,NOUN,B2
-pave,pave,pave,VERB,C1
-pave with bricks,pave with bricks,pave with bricks,VERB,C1
-pave with flags,pave with flags,pave with flags,VERB,C1
-paving,paving,paving,NOUN,B2
-paving stone,paving stone,paving stone,NOUN,A2
-paw,paw,爪子,NOUN,B2
-pawn (noun),pawn,pawn (noun),NOUN,C1
-pay attention,to pay attention,注意,VERB,B2
-payments,payments,payments,NOUN,C1
-pea,pea,pea,NOUN,C1
-peacefully,peacefully,peacefully,ADV,C1
-peach tree,peach tree,peach tree,NOUN,C1
-peak,peak,顶峰,NOUN,B2
-peanut field,peanut field,peanut field,NOUN,B2
-peccadillo,peccadillo,peccadillo,NOUN,C1
-peculiarity,peculiarity,peculiarity,NOUN,B2
-pecuniary,pecuniary,pecuniary,ADJ,C1
-pedal,pedal,pedal,NOUN,B1
-pedantic,pedantic,pedantic,ADJ,C1
-pedantically,pedantically,pedantically,ADV,C1
-pediatrics,pediatrics,pediatrics,NOUN,C1
-pediment,pediment,pediment,NOUN,C1
-peek,peek,peek,VERB,C1
-peel (noun),peel,peel (noun),NOUN,B2
-peer review,peer review,peer review,NOUN,C1
-peerless,peerless,peerless,ADJ,C1
-peg,peg,peg,NOUN,C1
-pejorative,pejorative,pejorative,ADJ,C1
-pellucid,pellucid,pellucid,ADJ,C1
-pelvis,pelvis,pelvis,NOUN,B2
-pelvis basin,pelvis basin,pelvis basin,NOUN,B2
-penalty payment,penalty payment,penalty payment,NOUN,C1
-penchant,penchant,penchant,NOUN,C1
-pencil case,pencil case,pencil case,NOUN,C1
-pending,pending,pending,ADJ,B1
-penguin,penguin,penguin,NOUN,A1
-penis,penis,penis,NOUN,B2
-penitence,penitence,penitence,NOUN,C1
-penitent,penitent,penitent,ADJ,C1
-penitentiary,penitentiary,penitentiary,ADJ,C1
-pennant,pennant,pennant,NOUN,C1
-penniless,penniless,penniless,ADJ,B1
-penury,penury,penury,NOUN,C1
-people (pron),people,people (pron),PRON,B2
-peppermint,peppermint,peppermint,NOUN,C1
-perception opinion,perception opinion,perception opinion,NOUN,B2
-perceptual,perceptual,perceptual,ADJ,B2
-percussion instruments,percussion instruments,percussion instruments,NOUN,C1
-peremptorily,peremptorily,peremptorily,ADV,C1
-perfectly,perfectly,perfectly,ADV,A2
-perfidious,perfidious,perfidious,ADJ,C1
-perfidiously,perfidiously,perfidiously,ADV,C1
-performative,performative,performative,ADJ,C1
-performativity,performativity,performativity,NOUN,C1
-performer,performer,performer,NOUN,C1
-perfunctory,perfunctory,perfunctory,ADJ,C1
-perhaps (part),perhaps,perhaps (part),PART,C1
-perhaps maybe,perhaps maybe,perhaps maybe,SCONJ,A2
-peri-urban,peri-urban,peri-urban,ADJ,B2
-period (punct),period,period (punct),PUNCT,B2
-period epoch,period epoch,period epoch,NOUN,B2
-periodic,periodic,periodic,ADJ,C1
-periodical,periodical,periodical,NOUN,C1
-periphrasis,periphrasis,periphrasis,NOUN,C1
-perishing,perishing,perishing,NOUN,B2
-perks,perks,perks,NOUN,C1
-permanently,permanently,permanently,ADV,C1
-permeability,permeability,permeability,NOUN,C1
-permissible,permissible,permissible,ADJ,C1
-permutations,permutations,permutations,NOUN,C1
-perplex,perplex,perplex,VERB,C1
-person of independent means,person of independent means,person of independent means,NOUN,C1
-personable,personable,personable,ADJ,C1
-personal best,personal best,personal best,NOUN,B2
-personalization,personalization,personalization,NOUN,C1
-personification,personification,personification,NOUN,C1
-perspectives,perspectives,perspectives,NOUN,C1
-perspectivism,perspectivism,perspectivism,NOUN,C1
-perspicacious,perspicacious,perspicacious,ADJ,C1
-perspicacity,perspicacity,perspicacity,NOUN,B2
-pertinent,pertinent,pertinent,ADJ,C1
-pertinently,pertinently,pertinently,ADV,B2
-pervasive,pervasive,pervasive,ADJ,C1
-perversity,perversity,perversity,NOUN,C1
-pest,pest,pest,NOUN,C1
-pesticides,pesticides,pesticides,NOUN,C1
-pestilent,pestilent,pestilent,ADJ,C1
-petal,petal,petal,NOUN,C1
-petition for review,petition for review,petition for review,NOUN,C1
-petitioner claimant,petitioner claimant,petitioner claimant,NOUN,C1
-petrochemicals,petrochemicals,petrochemicals,NOUN,C1
-pettiness,pettiness,pettiness,NOUN,C1
-petty,petty,petty,ADJ,B2
-petulant,petulant,petulant,ADJ,C1
-phantasmagorical,phantasmagorical,phantasmagorical,ADJ,C1
-phantom,phantom,phantom,NOUN,C1
-pharisee,pharisee,pharisee,NOUN,B2
-pharynx,pharynx,pharynx,NOUN,B2
-phased (adv),phased,phased (adv),ADV,B1
-phased nature,phased nature,phased nature,NOUN,C1
-phasic,phasic,phasic,ADJ,C1
-pheasant,pheasant,pheasant,NOUN,C1
-phenomenological,phenomenological,phenomenological,ADJ,C1
-phew,phew,phew,INTJ,C1
-philanthropic,philanthropic,philanthropic,ADJ,C1
-philatelist,philatelist,philatelist,NOUN,C1
-philately,philately,philately,NOUN,C1
-philharmonic,philharmonic,philharmonic,NOUN,C1
-philology,philology,philology,NOUN,C1
-philosophizing,philosophizing,philosophizing,NOUN,C1
-philosophy of life,philosophy of life,philosophy of life,NOUN,B2
-phishing,phishing,phishing,NOUN,B2
-phlebitis,phlebitis,phlebitis,NOUN,C1
-phloem,phloem,phloem,ADJ,C1
-phone credit,phone credit,phone credit,NOUN,B1
-phoneme,phoneme,phoneme,NOUN,C1
-phosphate,phosphate,phosphate,NOUN,B2
-phosphorescence,phosphorescence,phosphorescence,NOUN,C1
-phosphorescent,phosphorescent,phosphorescent,ADJ,C1
-phosphorus,phosphorus,phosphorus,NOUN,C1
-photo model,photo model,photo model,NOUN,B2
-photogenic,photogenic,photogenic,ADJ,C1
-photographic,photographic,photographic,ADJ,C1
-photogravure,photogravure,photogravure,NOUN,C1
-photophobia,photophobia,photophobia,NOUN,C1
-phototypy,phototypy,phototypy,NOUN,C1
-phraseology,phraseology,phraseology,NOUN,C1
-physicist,physicist,physicist,NOUN,C1
-physiotherapist,physiotherapist,physiotherapist,NOUN,B1
-pianist,pianist,pianist,NOUN,C1
-piano music,piano music,piano music,NOUN,B2
-picaresque,picaresque,picaresque,ADJ,C1
-pickle (noun),pickle,pickle (noun),NOUN,C1
-pickles,pickles,pickles,NOUN,B2
-pictogram,pictogram,pictogram,NOUN,C1
-picture photo,picture photo,picture photo,NOUN,A2
-pidgin,pidgin,pidgin,NOUN,C1
-piece of bread,piece of bread,piece of bread,NOUN,B2
-piecework,piecework,piecework,NOUN,C1
-piety pity,piety pity,piety pity,NOUN,B2
-pile heap,pile heap,pile heap,NOUN,C1
-pillowcase,pillowcase,pillowcase,NOUN,C1
-pills,pills,pills,NOUN,B2
-pimp,pimp,pimp,NOUN,C1
-pimple,pimple,pimple,NOUN,B2
-pinch (noun),pinch,pinch (noun),NOUN,C1
-pink (noun),pink,pink (noun),NOUN,B1
-piously,piously,piously,ADV,C1
-pipe dream,pipe dream,pipe dream,NOUN,C1
-piquant,piquant,piquant,ADJ,C1
-piracy,piracy,piracy,NOUN,B2
-pirated,pirated,pirated,ADJ,B2
-piston,piston,piston,NOUN,C1
-pitch,pitch,pitch,NOUN,B1
-pitch darkness,pitch darkness,pitch darkness,NOUN,C1
-piteous,piteous,piteous,ADJ,C1
-pithy,pithy,pithy,ADJ,C1
-pitiable,pitiable,pitiable,ADJ,C1
-pittance,pittance,pittance,NOUN,C1
-pity compassion,pity compassion,pity compassion,NOUN,B2
-pivot,pivot,pivot,NOUN,B2
-pivotal,pivotal,pivotal,ADJ,C1
-pizza,pizza,pizza,NOUN,B1
-placed before,placed before,placed before,ADJ,B2
-placenta,placenta,placenta,NOUN,B2
-placental,placental,placental,ADJ,C1
-placid,placid,placid,ADJ,C1
-placidity,placidity,placidity,NOUN,C1
-plain (adj),plain,plain (adj),ADJ,B1
-plaintive sorrow,plaintive sorrow,plaintive sorrow,NOUN,C1
-plastic (noun),plastic,plastic (noun),NOUN,B1
-plastic arts,plastic arts,plastic arts,NOUN,C1
-platforms,platforms,platforms,NOUN,C1
-platinum,platinum,platinum,NOUN,B2
-platitude,platitude,platitude,NOUN,C1
-plausibility,plausibility,plausibility,NOUN,B2
-playable,playable,playable,ADJ,B2
-playful,playful,playful,ADJ,C1
-playfulness,playfulness,playfulness,NOUN,B2
-playing,playing,playing,NOUN,B2
-plays,plays,plays,NOUN,C1
-pleading,pleading,pleading,NOUN,B2
-pleasant,pleasant,令人愉快的,ADJ,B2
-pleasantly,pleasantly,pleasantly,ADV,C1
-please,please,请,ADV,B2
-please you're welcome,please you're welcome,please you're welcome,INTJ,A2
-pleased,pleased,pleased,ADJ,B1
-pleasure,pleasure,快乐,NOUN,B2
-plebeian,plebeian,plebeian,ADJ,C1
-plebiscite,plebiscite,plebiscite,NOUN,B2
-pledge (noun),pledge,pledge (noun),NOUN,B2
-plenary,plenary,plenary,ADJ,C1
-plentiful,plentiful,plentiful,ADJ,B2
-plenty (adv),plenty,plenty (adv),ADV,B2
-pleonasm,pleonasm,pleonasm,NOUN,B2
-pliable,pliable,pliable,ADJ,C1
-pliant,pliant,pliant,ADJ,C1
-pliers,pliers,钳子,NOUN,B2
-plot,plot,情节,NOUN,B2
-plot of land,plot of land,plot of land,NOUN,B2
-plot twist,plot twist,plot twist,NOUN,C1
-plow,plow,plow,NOUN,B2
-plow handle,plow handle,plow handle,NOUN,C1
-plowing,plowing,犁地,NOUN,B2
-plug,plug,插头,NOUN,B2
-plumb,plumb,plumb,NOUN,C1
-plumber,plumber,水管工,NOUN,B2
-plumbing,plumbing,管道工程,NOUN,B2
-plump,plump,plump,ADJ,C1
-plunder,plunder,掠夺,NOUN,B2
-plunge,plunge,plunge,VERB,C1
-plural (noun),plural,plural (noun),NOUN,C1
-plurality,plurality,plurality,NOUN,C1
-plutocracy,plutocracy,财阀政治,NOUN,B2
-pneumonia,pneumonia,pneumonia,NOUN,C1
-poach,poach,poach,VERB,C1
-podcast,podcast,播客,NOUN,B2
-podcasting,podcasting,podcasting,NOUN,B1
-poet,poet,诗人,NOUN,B2
-poetic,poetic,poetic,ADJ,C1
-poetic imitations,poetic imitations,poetic imitations,NOUN,C1
-poetic mastery,poetic mastery,poetic mastery,NOUN,C1
-poetic talent,poetic talent,poetic talent,NOUN,C1
-poetics,poetics,poetics,NOUN,C1
-poignant,poignant,poignant,ADJ,C1
-point grade,point grade,point grade,NOUN,A2
-point in time,point in time,时间点,NOUN,B2
-point of view,point of view,point of view,NOUN,C1
-pointed specialized,pointed specialized,pointed specialized,ADJ,C1
-pointless,pointless,pointless,ADJ,C1
-pointlessly,pointlessly,pointlessly,ADV,B2
-pointwise,pointwise,pointwise,ADJ,C1
-poisoned,poisoned,poisoned,NOUN,B2
-poisonous,poisonous,有毒的,ADJ,B2
-poke,poke,poke,VERB,B2
-polarization,polarization,两极分化 / 极化,NOUN,B2
-pole,pole,极,NOUN,B2
-polemic,polemic,polemic,NOUN,C1
-polemical,polemical,论战的,ADJ,B2
-polemicist,polemicist,polemicist,NOUN,C1
-police officer female,police officer female,police officer female,NOUN,B2
-police questioning,police questioning,police questioning,NOUN,C1
-police report,police report,police report,NOUN,B2
-police search,police search,police search,NOUN,C1
-police station,police station,警察局,NOUN,B2
-policeman,policeman,警察,NOUN,B2
-policy-related,policy-related,policy-related,ADJ,C1
-polish,to polish,擦亮,VERB,B2
-polished,polished,polished,ADJ,C1
-polishing,polishing,polishing,NOUN,B2
-politeness,politeness,politeness,NOUN,C1
-politic,politic,politic,ADJ,C1
-political,political,政治的,ADJ,B2
-politician,politician,政治家,NOUN,B2
-politicization,politicization,politicization,NOUN,C1
-poll,poll,民意调查,NOUN,B2
-pollination,pollination,授粉,NOUN,B2
-pollinic,pollinic,pollinic,ADJ,C1
-pollster,pollster,pollster,NOUN,C1
-pollutant,pollutant,污染物,NOUN,B2
-polluted,polluted,受污染的,ADJ,B2
-polyphony,polyphony,polyphony,NOUN,B2
-polyptoton,polyptoton,polyptoton,NOUN,C1
-polysemy,polysemy,polysemy,NOUN,C1
-polysyndeton,polysyndeton,polysyndeton,NOUN,B2
-pomp,pomp,pomp,NOUN,C1
-pompous,pompous,pompous,ADJ,C1
-pompously,pompously,pompously,ADV,C1
-ponderous,ponderous,ponderous,ADJ,C1
-pool,pool,水池,NOUN,B2
-pooled,pooled,pooled,ADJ,C1
-poor person,poor person,poor person,NOUN,B2
-poor style,poor style,poor style,NOUN,C1
-poorest,poorest,poorest,ADJ,B2
-pop,pop,pop,NOUN,B1
-popcorn,popcorn,popcorn,ADJ,C1
-pope,pope,教皇,NOUN,B2
-poppy,poppy,poppy,NOUN,B1
-pops,pops,pops,NOUN,C1
-popularity,popularity,流行,NOUN,B2
-populate,to populate,居住,VERB,B2
-populous,populous,populous,ADJ,C1
-porch,porch,门廊,NOUN,B2
-pork,pork,pork,NOUN,B2
-porn,porn,色情,NOUN,B2
-pornographic,pornographic,色情的,ADJ,B2
-porosity,porosity,porosity,NOUN,C1
-porous,porous,porous,ADJ,C1
-port harbor,port harbor,port harbor,NOUN,A1
-portable,portable,portable,ADJ,C1
-portentous,portentous,portentous,ADJ,C1
-portfolios,portfolios,portfolios,NOUN,C1
-portico,portico,portico,NOUN,C1
-portion serving,portion serving,portion serving,NOUN,B2
-portrait subject,portrait subject,portrait subject,NOUN,C1
-portrayal,portrayal,portrayal,NOUN,B2
-posit,posit,posit,VERB,B2
-positions,positions,positions,NOUN,C1
-positivism,positivism,positivism,NOUN,C1
-positivist,positivist,positivist,ADJ,C1
-positivity,positivity,positivity,NOUN,B2
-possessive,possessive,possessive,ADJ,C1
-possible future,possible future,possible future,ADJ,C1
-postal,postal,postal,ADJ,C1
-posterity,posterity,posterity,NOUN,C1
-postman,postman,postman,NOUN,B2
-postscript,postscript,postscript,NOUN,C1
-potent,potent,potent,ADJ,C1
-potion,potion,potion,NOUN,B2
-potter,potter,potter,NOUN,B2
-pouch,pouch,pouch,NOUN,C1
-poultice,poultice,poultice,NOUN,B2
-power struggle,power struggle,power struggle,NOUN,C1
-powers,powers,powers,NOUN,C1
-practicing,practicing,practicing,ADJ,C1
-pragmatics,pragmatics,pragmatics,NOUN,C1
-pragmatist,pragmatist,pragmatist,NOUN,C1
-prairie,prairie,prairie,NOUN,C1
-praise singer,praise singer,praise singer,NOUN,C1
-praiseworthy,praiseworthy,praiseworthy,ADJ,C1
-prawn,prawn,prawn,NOUN,C1
-prayer beads,prayer beads,prayer beads,NOUN,C1
-prayer niche,prayer niche,prayer niche,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,pre-Islamic era,NOUN,C1
-pre-dawn meal,pre-dawn meal,pre-dawn meal,NOUN,B1
-pre-eternity,pre-eternity,pre-eternity,NOUN,C1
-preacher,preacher,preacher,NOUN,B2
-precautionary,precautionary,precautionary,ADJ,C1
-precipice,precipice,precipice,NOUN,C1
-precipitate,precipitate,precipitate,VERB,C1
-precipitous,precipitous,precipitous,ADJ,C1
-preclude,preclude,preclude,VERB,C1
-precocious talent,precocious talent,precocious talent,NOUN,C1
-preconception,preconception,preconception,NOUN,B2
-predilection,predilection,predilection,NOUN,C1
-predisposition,predisposition,predisposition,NOUN,B2
-predominant,predominant,predominant,ADJ,B2
-predominantly,predominantly,predominantly,ADV,C1
-preeminence,preeminence,preeminence,NOUN,B2
-preeminent,preeminent,preeminent,ADJ,C1
-preemption right,preemption right,preemption right,NOUN,C1
-preemptively,preemptively,preemptively,ADV,C1
-prefect,prefect,prefect,NOUN,B1
-prefectures,prefectures,prefectures,NOUN,C1
-prejudiced,prejudiced,prejudiced,ADJ,B2
-prejudicial,prejudicial,prejudicial,ADJ,C1
-prelate,prelate,prelate,NOUN,C1
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,premature,ADJ,C1
-premature baby,premature baby,premature baby,NOUN,B2
-prematurely,prematurely,prematurely,ADV,C1
-prematurity,prematurity,prematurity,NOUN,C1
-premeditate,premeditate,premeditate,VERB,C1
-preoccupation,preoccupation,,NOUN,B2
-preparations,preparations,preparations,NOUN,C1
-preparatory (adj),preparatory,preparatory (adj),ADJ,C1
-preparatory (noun),preparatory,preparatory (noun),NOUN,B2
-preparedness,preparedness,preparedness,NOUN,B1
-preponderance,preponderance,preponderance,NOUN,C1
-prescient,prescient,prescient,ADJ,C1
-presidential elections,presidential elections,presidential elections,NOUN,C1
-presidentialism,presidentialism,presidentialism,NOUN,C1
-presumed,presumed,presumed,ADJ,B2
-presumption of continuity,presumption of continuity,presumption of continuity,NOUN,C1
-presumptuous,presumptuous,presumptuous,ADJ,C1
-pretender,pretender,pretender,NOUN,C1
-pretending to forget,pretending to forget,pretending to forget,VERB,C1
-pretension,pretension,pretension,NOUN,C1
-preterition,preterition,preterition,NOUN,B2
-prevailing,prevailing,prevailing,ADJ,C1
-prevalence,prevalence,prevalence,NOUN,C1
-prevalent,prevalent,prevalent,ADJ,C1
-prevaricate,prevaricate,prevaricate,VERB,C1
-preventive,preventive,preventive,ADJ,B2
-preview,preview,preview,NOUN,C1
-previous (noun),previous,previous (noun),NOUN,B2
-price capping,price capping,price capping,NOUN,C1
-price increase,price increase,price increase,NOUN,C1
-prices,prices,prices,NOUN,C1
-prickly,prickly,prickly,ADJ,C1
-pride arrogance,pride arrogance,pride arrogance,NOUN,C1
-priesthood,priesthood,priesthood,NOUN,C1
-primal,primal,primal,ADJ,C1
-primarily,primarily,primarily,ADV,C1
-primary school,primary school,primary school,NOUN,B2
-primary school teacher,primary school teacher,primary school teacher,NOUN,C1
-primate,primate,primate,NOUN,C1
-prime matter,prime matter,prime matter,NOUN,C1
-primordial chaos,primordial chaos,primordial chaos,NOUN,C1
-principal (adj),principal,principal (adj),ADJ,B2
-principality,principality,principality,NOUN,C1
-printed,printed,printed,ADJ,C1
-printed form,printed form,printed form,NOUN,B1
-printing,printing,printing,NOUN,C1
-printing house,printing house,printing house,NOUN,B2
-printing press,printing press,printing press,NOUN,C1
-priority (adj),priority,priority (adj),ADJ,B2
-pristine,pristine,pristine,ADJ,C1
-private accessory prosecution,private accessory prosecution,private accessory prosecution,NOUN,C1
-privatization,privatization,privatization,NOUN,B2
-privileged,privileged,privileged,ADJ,B2
-pro-natalist,pro-natalist,pro-natalist,ADJ,B2
-probable,probable,probable,ADJ,B2
-probationary,probationary,probationary,ADJ,B2
-probative,probative,probative,ADJ,C1
-probing the depths,probing the depths,probing the depths,NOUN,C1
-problematic,problematic,problematic,ADJ,B2
-problematic issue,problematic issue,problematic issue,NOUN,C1
-procedures,procedures,procedures,NOUN,C1
-process technique,process technique,process technique,NOUN,B1
-processable,processable,processable,ADJ,C1
-processing (adj),processing,processing (adj),ADJ,C1
-processing (noun),processing,processing (noun),NOUN,B2
-proclivity,proclivity,proclivity,NOUN,C1
-prodigal,prodigal,prodigal,ADJ,C1
-prodigious,prodigious,prodigious,ADJ,C1
-profane,profane,profane,ADJ,C1
-profess,profess,profess,VERB,B2
-professional (noun),professional,professional (noun),NOUN,B2
-professional ethics,professional ethics,professional ethics,NOUN,C1
-professional formation,professional formation,professional formation,NOUN,B2
-professionalism,professionalism,professionalism,NOUN,B2
-professorship,professorship,professorship,NOUN,C1
-proffer,proffer,proffer,VERB,C1
-proficiency,proficiency,proficiency,NOUN,C1
-profitable,profitable,profitable,ADJ,B2
-profits,profits,profits,NOUN,B2
-profligate,profligate,profligate,ADJ,C1
-profuse,profuse,profuse,ADJ,C1
-profusion,profusion,profusion,NOUN,C1
-program schedule,program schedule,program schedule,NOUN,A2
-programmed,programmed,programmed,ADJ,C1
-progression,progression,progression,NOUN,C1
-prohibited,prohibited,prohibited,ADJ,C1
-prohibited items,prohibited items,prohibited items,NOUN,B2
-prohibitive,prohibitive,prohibitive,ADJ,C1
-projectile,projectile,projectile,NOUN,C1
-projection,projection,projection,NOUN,C1
-projections,projections,projections,NOUN,C1
-prolapse,prolapse,prolapse,NOUN,C1
-prolegomena,prolegomena,prolegomena,NOUN,C1
-prolific,prolific,prolific,ADJ,C1
-prominence,prominence,prominence,NOUN,B2
-promoted,promoted,promoted,ADJ,B1
-prompt,prompt,prompt,ADJ,C1
-promptness,promptness,promptness,NOUN,C1
-prone,prone,prone,ADJ,C1
-pronoun,pronoun,pronoun,NOUN,B1
-proofreader,proofreader,proofreader,NOUN,C1
-propaedeutic,propaedeutic,propaedeutic,ADJ,C1
-propellant,propellant,propellant,NOUN,C1
-prophethood,prophethood,prophethood,NOUN,C1
-prophylactic,prophylactic,prophylactic,ADJ,C1
-propitious,propitious,propitious,ADJ,C1
-proponent,proponent,proponent,NOUN,C1
-proportionality,proportionality,proportionality,NOUN,C1
-proportionally,proportionally,proportionally,ADV,C1
-proprietor,proprietor,proprietor,NOUN,C1
-propulsion,propulsion,propulsion,NOUN,C1
-prose writer,prose writer,prose writer,NOUN,C1
-prosecutions,prosecutions,prosecutions,NOUN,C1
-prosecutor's office,prosecutor's office,prosecutor's office,NOUN,B2
-proselyte,proselyte,proselyte,NOUN,C1
-prosopopoeia,prosopopoeia,prosopopoeia,NOUN,C1
-prospecting,prospecting,prospecting,NOUN,C1
-prospecting drilling,prospecting drilling,prospecting drilling,NOUN,C1
-prosthesis,prosthesis,prosthesis,NOUN,C1
-prostitution,prostitution,prostitution,NOUN,B2
-protective cover,protective cover,protective cover,NOUN,C1
-protector,protector,protector,NOUN,B2
-protest (noun),protest,protest (noun),NOUN,B2
-protest movement,protest movement,protest movement,NOUN,C1
-proton,proton,proton,NOUN,C1
-prototype,prototype,prototype,NOUN,C1
-protract,protract,protract,VERB,C1
-protracted,protracted,protracted,ADJ,C1
-proud refusal,proud refusal,proud refusal,NOUN,C1
-proudly,proudly,proudly,ADV,C1
-proverbs,proverbs,proverbs,NOUN,C1
-providential,providential,providential,ADJ,C1
-provinces,provinces,provinces,NOUN,C1
-provision,provision,provision,NOUN,C1
-provisionally,provisionally,provisionally,ADV,C1
-prow,prow,prow,NOUN,C1
-prowess,prowess,prowess,NOUN,C1
-prowl,prowl,prowl,VERB,C1
-prudently,prudently,prudently,ADV,C1
-prudishness,prudishness,prudishness,NOUN,C1
-pruning,pruning,pruning,NOUN,C1
-psalm,psalm,psalm,NOUN,B2
-psalter,psalter,psalter,NOUN,C1
-pseudonym,pseudonym,pseudonym,NOUN,C1
-psoriasis,psoriasis,psoriasis,NOUN,C1
-psst,psst,psst,INTJ,C1
-psychic,psychic,psychic,ADJ,C1
-psychoanalyst,psychoanalyst,psychoanalyst,NOUN,C1
-psychologically,psychologically,psychologically,ADV,C1
-psychopathy,psychopathy,psychopathy,NOUN,C1
-public holiday (noun),public holiday,public holiday (noun),NOUN,C1
-puerile,puerile,puerile,ADJ,C1
-puerperal,puerperal,puerperal,ADJ,C1
-puff pastry,puff pastry,puff pastry,NOUN,C1
-pugnacious,pugnacious,pugnacious,ADJ,C1
-pugnacity,pugnacity,pugnacity,NOUN,C1
-puissant,puissant,puissant,ADJ,C1
-pulley,pulley,pulley,NOUN,C1
-pummel,pummel,pummel,VERB,C1
-pumping,pumping,pumping,NOUN,C1
-pun,pun,pun,NOUN,C1
-punch (verb),punch,punch (verb),VERB,B2
-punch drink,punch drink,punch drink,NOUN,C1
-punctilious,punctilious,punctilious,ADJ,C1
-punctuality,punctuality,punctuality,NOUN,B2
-puncture tap,puncture tap,puncture tap,NOUN,C1
-pundit,pundit,pundit,NOUN,C1
-pungent,pungent,pungent,ADJ,C1
-punishable,punishable,punishable,ADJ,B2
-puny,puny,puny,ADJ,C1
-pupil female,pupil female,pupil female,NOUN,C1
-puppets,puppets,puppets,NOUN,B2
-purchase price,purchase price,purchase price,NOUN,B2
-puritanical,puritanical,puritanical,ADJ,C1
-purple (noun),purple,purple (noun),NOUN,A2
-purpose design,purpose design,purpose design,NOUN,C1
-purse,purse,purse,NOUN,B1
-pursuant to (adp),pursuant to,pursuant to (adp),ADP,C1
-purveyor,purveyor,purveyor,NOUN,C1
-pus,pus,pus,NOUN,C1
-push (noun),push,push (noun),NOUN,C1
-pusillanimity,pusillanimity,pusillanimity,NOUN,C1
-putative,putative,putative,ADJ,C1
-putrid,putrid,putrid,ADJ,C1
-qasida form,qasida form,qasida form,NOUN,C1
-quackery,quackery,quackery,NOUN,B2
-quaint,quaint,quaint,ADJ,C1
-qualifiers,qualifiers,qualifiers,NOUN,B2
-qualifying,qualifying,qualifying,ADJ,C1
-quandary,quandary,quandary,NOUN,B2
-quantifiable,quantifiable,quantifiable,ADJ,B2
-quantum,quantum,quantum,ADJ,B2
-quarantine (noun),quarantine,quarantine (noun),NOUN,C1
-quarrelsome,quarrelsome,quarrelsome,ADJ,C1
-quarry,quarry,quarry,NOUN,B1
-quarter of an hour,quarter of an hour,quarter of an hour,NOUN,C1
-quartz,quartz,quartz,NOUN,C1
-quasi,quasi,quasi,ADV,B2
-quaternary,quaternary,quaternary,ADJ,B2
-queer,queer,queer,ADJ,C1
-quench,quench,quench,VERB,C1
-querulous,querulous,querulous,ADJ,C1
-question mark,question mark,question mark,PUNCT,A2
-questioning (adj),questioning,questioning (adj),ADJ,C1
-questionnaire,questionnaire,questionnaire,NOUN,C1
-questions,questions,questions,NOUN,C1
-quibble,quibble,quibble,NOUN,C1
-quibbling,quibbling,quibbling,NOUN,C1
-quick-witted,quick-witted,quick-witted,ADJ,C1
-quiescent,quiescent,quiescent,ADJ,C1
-quiet (noun),quiet,quiet (noun),NOUN,A1
-quietude,quietude,quietude,NOUN,C1
-quill,quill,quill,NOUN,C1
-quint,quint,quint,NOUN,C1
-quintessential,quintessential,quintessential,ADJ,C1
-quip,quip,quip,NOUN,C1
-quirk,quirk,quirk,NOUN,C1
-quirky,quirky,quirky,ADJ,C1
-quit,quit,quit,VERB,A2
-quits,quits,quits,ADJ,C1
-quixotic,quixotic,quixotic,ADJ,C1
-quotable,quotable,quotable,ADJ,B2
-quotidian,quotidian,quotidian,ADJ,C1
-quotient,quotient,quotient,NOUN,B2
-rabble,rabble,rabble,NOUN,C1
-racketeering,racketeering,racketeering,NOUN,B2
-radar,radar,radar,NOUN,B2
-radicalism,radicalism,radicalism,NOUN,C1
-radically,radically,radically,ADV,B2
-radio silence,radio silence,radio silence,NOUN,C1
-radioactivity,radioactivity,radioactivity,NOUN,C1
-radiography rays,radiography rays,radiography rays,NOUN,C1
-radiology,radiology,radiology,NOUN,C1
-rags,rags,rags,NOUN,B2
-ragtag,ragtag,ragtag,ADJ,C1
-rai,rai,rai,NOUN,B2
-raider,raider,raider,NOUN,C1
-raids,raids,raids,NOUN,C1
-railroad,railroad,railroad,NOUN,B2
-rails,rails,rails,NOUN,C1
-rain clouds,rain clouds,rain clouds,NOUN,C1
-raise (noun),raise,raise (noun),NOUN,B1
-raisin,raisin,raisin,NOUN,A1
-raisins,raisins,raisins,NOUN,A2
-rajaz poem,rajaz poem,rajaz poem,NOUN,C1
-rally (noun),rally,rally (noun),NOUN,B2
-rallying,rallying,rallying,NOUN,C1
-rambunctious,rambunctious,rambunctious,ADJ,C1
-rampart,rampart,rampart,NOUN,C1
-ramshackle,ramshackle,ramshackle,ADJ,C1
-ranch,ranch,ranch,NOUN,B2
-rancher,rancher,rancher,NOUN,C1
-rancorous,rancorous,rancorous,ADJ,C1
-randomly,randomly,randomly,ADV,B2
-range zone,range zone,range zone,NOUN,C1
-ranger,ranger,ranger,NOUN,B2
-ranking classification,ranking classification,ranking classification,NOUN,C1
-rapacious,rapacious,rapacious,ADJ,C1
-rapacity,rapacity,rapacity,NOUN,C1
-rapidly,rapidly,rapidly,ADV,B2
-rapier,rapier,rapier,NOUN,C1
-rapporteur,rapporteur,rapporteur,NOUN,C1
-rapturous,rapturous,rapturous,ADJ,C1
-rarefaction,rarefaction,rarefaction,NOUN,C1
-rash (noun),rash,rash (noun),NOUN,B2
-raspy,raspy,raspy,ADJ,C1
-rate percentage,rate percentage,rate percentage,NOUN,B2
-rate price,rate price,rate price,NOUN,C1
-rather but,rather but,rather but,CCONJ,A2
-rather more precisely,rather more precisely,rather more precisely,ADV,C1
-rather on the contrary,rather on the contrary,rather on the contrary,CCONJ,B2
-rational,rational,rational,ADJ,B2
-rationalist,rationalist,rationalist,NOUN,B2
-rationalization conservation,rationalization conservation,rationalization conservation,NOUN,C1
-rattling,rattling,rattling,NOUN,C1
-raucous,raucous,raucous,ADJ,C1
-ravage (noun),ravage,ravage (noun),NOUN,C1
-ravenous,ravenous,ravenous,ADJ,C1
-ravine,ravine,ravine,NOUN,B2
-raw material scarcity,raw material scarcity,raw material scarcity,NOUN,C1
-raw ore,raw ore,raw ore,ADJ,C1
-rays,rays,rays,NOUN,B2
-raze,raze,raze,VERB,C1
-razor blade,razor blade,razor blade,NOUN,B1
-reach suffice,reach suffice,reach suffice,VERB,B2
-readability,readability,readability,NOUN,C1
-readiness to help,readiness to help,readiness to help,NOUN,C1
-reaffirm,reaffirm,reaffirm,VERB,B2
-real estate agent,real estate agent,real estate agent,NOUN,C1
-realist,realist,realist,NOUN,C1
-reality TV,reality TV,reality TV,NOUN,C1
-reaper,reaper,reaper,NOUN,C1
-rear (noun),rear,rear (noun),NOUN,B2
-rearmament,rearmament,rearmament,NOUN,C1
-reasonably,reasonably,reasonably,ADV,C1
-reasoned,reasoned,reasoned,ADJ,B2
-reassuring,reassuring,reassuring,ADJ,B1
-rebirth,rebirth,rebirth,NOUN,B2
-reboot,reboot,reboot,VERB,C1
-rebound (noun),rebound,rebound (noun),NOUN,C1
-rebound (verb),rebound,rebound (verb),VERB,C1
-rebuff,rebuff,rebuff,VERB,C1
-recalcitrant,recalcitrant,recalcitrant,ADJ,C1
-recalibrate,recalibrate,recalibrate,VERB,B2
-recall (noun),recall,recall (noun),NOUN,B2
-recant,recant,recant,VERB,C1
-recapitulate,recapitulate,recapitulate,VERB,C1
-recede,recede,recede,VERB,C1
-receipt discharge,receipt discharge,receipt discharge,NOUN,C1
-receipts,receipts,receipts,NOUN,C1
-receivables,receivables,receivables,NOUN,C1
-receiving stolen goods,receiving stolen goods,receiving stolen goods,NOUN,B2
-recent,recent,recent,ADJ,B2
-recess,recess,recess,NOUN,C1
-recharge (noun),recharge,recharge (noun),NOUN,B2
-recidivism,recidivism,recidivism,NOUN,B2
-reciprocally,reciprocally,reciprocally,ADV,B2
-reciprocate,reciprocate,reciprocate,VERB,C1
-recitation,recitation,recitation,NOUN,C1
-reclamation,reclamation,reclamation,NOUN,B2
-recline,recline,recline,VERB,C1
-reclusive,reclusive,reclusive,ADJ,C1
-recognized,recognized,recognized,NOUN,B2
-recommended,recommended,recommended,ADJ,C1
-recompense,recompense,recompense,VERB,C1
-recondite,recondite,recondite,ADJ,C1
-reconnoiter,reconnoiter,reconnoiter,VERB,C1
-reconquest,reconquest,reconquest,NOUN,C1
-recoup,recoup,recoup,VERB,C1
-recourse,recourse,recourse,NOUN,B2
-recruit (noun),recruit,recruit (noun),NOUN,B2
-recruitment-related,recruitment-related,recruitment-related,ADJ,C1
-rectangular,rectangular,rectangular,ADJ,C1
-rectifier,rectifier,rectifier,NOUN,C1
-rector,rector,rector,NOUN,C1
-recur,recur,recur,VERB,B2
-recurring,recurring,recurring,ADJ,C1
-recursive,recursive,recursive,ADJ,C1
-red-haired,red-haired,red-haired,ADJ,B2
-redact,redact,redact,VERB,C1
-redesign,redesign,redesign,NOUN,C1
-redevelopment,redevelopment,redevelopment,NOUN,C1
-redolent,redolent,redolent,ADJ,C1
-redoubtable,redoubtable,redoubtable,ADJ,C1
-redress,redress,redress,VERB,B2
-reductionism,reductionism,reductionism,NOUN,C1
-reed bed,reed bed,reed bed,NOUN,B2
-reed pen,reed pen,reed pen,NOUN,C1
-reef,reef,reef,NOUN,B2
-reefs,reefs,reefs,NOUN,B2
-reel,reel,reel,NOUN,C1
-refereed,refereed,refereed,ADJ,C1
-reference framework,reference framework,reference framework,NOUN,C1
-references,references,references,NOUN,C1
-referendum-related,referendum-related,referendum-related,ADJ,B2
-referral,referral,referral,NOUN,C1
-refinement elevation,refinement elevation,refinement elevation,NOUN,C1
-refinery,refinery,refinery,NOUN,C1
-reflective,reflective,reflective,ADJ,C1
-reflex,reflex,reflex,NOUN,C1
-reformatory,reformatory,reformatory,NOUN,C1
-reforms,reforms,reforms,NOUN,C1
-refractory,refractory,refractory,ADJ,C1
-refrigeration,refrigeration,refrigeration,NOUN,C1
-refulgent,refulgent,refulgent,ADJ,C1
-refurbish,refurbish,refurbish,VERB,C1
-refusal to take oath,refusal to take oath,refusal to take oath,NOUN,C1
-refutable,refutable,refutable,ADJ,B2
-refutation,refutation,refutation,NOUN,C1
-regal,regal,regal,ADJ,C1
-regard (verb),regard,regard (verb),VERB,B2
-regardless (adp),regardless,regardless (adp),ADP,B2
-regeneration,regeneration,regeneration,NOUN,B2
-regent,regent,regent,NOUN,C1
-regimen,regimen,regimen,NOUN,C1
-regiment,regiment,regiment,NOUN,B2
-regionalization,regionalization,regionalization,NOUN,C1
-register (noun),register,register (noun),NOUN,B1
-registration number,registration number,registration number,NOUN,C1
-regrettable,regrettable,regrettable,ADJ,B2
-regularization,regularization,regularization,NOUN,C1
-regulated,regulated,regulated,ADJ,C1
-regulator,regulator,regulator,NOUN,C1
-rehabilitative,rehabilitative,rehabilitative,ADJ,B2
-reification,reification,reification,NOUN,C1
-rein,rein,rein,NOUN,C1
-reinforced,reinforced,reinforced,ADJ,C1
-reins,reins,reins,NOUN,B2
-reintegration,reintegration,reintegration,NOUN,C1
-reissue (noun),reissue,reissue (noun),NOUN,C1
-relapse (verb),relapse,relapse (verb),VERB,B2
-relating to birth,relating to birth,relating to birth,ADJ,C1
-relation,relation,relation,NOUN,B1
-relational,relational,relational,ADJ,B2
-relativist,relativist,relativist,ADJ,C1
-relativity,relativity,relativity,NOUN,C1
-relaxed comfortable,relaxed comfortable,relaxed comfortable,ADJ,A2
-relaxed loose,relaxed loose,relaxed loose,ADJ,B2
-released,released,released,ADJ,B2
-religious chanter,religious chanter,religious chanter,NOUN,C1
-religious chanting,religious chanting,religious chanting,NOUN,C1
-religious scholar,religious scholar,religious scholar,NOUN,B1
-religiously,religiously,religiously,ADV,C1
-relinquish,relinquish,relinquish,VERB,C1
-relinquishment,relinquishment,relinquishment,NOUN,C1
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,remaining (adj),ADJ,C1
-remains spoils,remains spoils,remains spoils,NOUN,B2
-remand,remand,remand,NOUN,B2
-remark (verb),remark,remark (verb),VERB,B2
-remedial,remedial,remedial,ADJ,C1
-remediation,remediation,remediation,NOUN,B2
-reminisce,reminisce,reminisce,VERB,C1
-reminiscence,reminiscence,reminiscence,NOUN,C1
-reminiscent,reminiscent,reminiscent,ADJ,C1
-remiss,remiss,remiss,ADJ,C1
-remission,remission,remission,NOUN,C1
-remit,remit,remit,VERB,C1
-remnant,remnant,remnant,NOUN,C1
-removal deforestation,removal deforestation,removal deforestation,NOUN,C1
-removal deletion,removal deletion,removal deletion,NOUN,C1
-removed,removed,removed,ADJ,B2
-renascent,renascent,renascent,ADJ,C1
-rend,rend,rend,VERB,C1
-render,render,render,VERB,C1
-rendition,rendition,rendition,NOUN,C1
-renegade,renegade,renegade,NOUN,C1
-renewer,renewer,renewer,NOUN,C1
-renounce,renounce,renounce,VERB,C1
-rental,rental,rental,ADJ,C1
-rentierism,rentierism,rentierism,NOUN,C1
-reopening,reopening,reopening,NOUN,C1
-reparable,reparable,reparable,ADJ,C1
-repast,repast,repast,NOUN,C1
-repatriate,repatriate,repatriate,VERB,C1
-repatriation,repatriation,repatriation,NOUN,C1
-repeal (noun),repeal,repeal (noun),NOUN,C1
-repeat offender,repeat offender,repeat offender,NOUN,B2
-repelling,repelling,repelling,VERB,C1
-repetitive,repetitive,repetitive,ADJ,C1
-replenish,replenish,replenish,VERB,C1
-replica,replica,replica,NOUN,C1
-report denunciation,report denunciation,report denunciation,NOUN,B1
-reportage,reportage,reportage,NOUN,C1
-representational,representational,representational,ADJ,C1
-repressed,repressed,repressed,ADJ,C1
-reprint,reprint,reprint,NOUN,C1
-reprisal,reprisal,reprisal,NOUN,C1
-reprisals,reprisals,reprisals,NOUN,C1
-reprobate,reprobate,reprobate,NOUN,C1
-reproductive,reproductive,reproductive,ADJ,C1
-reptiles,reptiles,reptiles,NOUN,B2
-republicanism,republicanism,republicanism,NOUN,C1
-repudiate,repudiate,repudiate,VERB,C1
-repudiation,repudiation,repudiation,NOUN,C1
-repugnant,repugnant,repugnant,ADJ,C1
-reputable,reputable,reputable,ADJ,C1
-repute,repute,repute,NOUN,C1
-requirements,requirements,requirements,NOUN,C1
-requisite,requisite,requisite,NOUN,C1
-requisition,requisition,requisition,NOUN,C1
-rerun,rerun,rerun,NOUN,B2
-rescheduling,rescheduling,rescheduling,NOUN,C1
-rescind,rescind,rescind,VERB,C1
-resection,resection,resection,NOUN,B2
-resent,resent,resent,VERB,C1
-reserve protected area,reserve protected area,reserve protected area,NOUN,C1
-reshoring,reshoring,reshoring,NOUN,B2
-reshuffle,reshuffle,reshuffle,NOUN,C1
-residence housing,residence housing,residence housing,NOUN,A2
-residential,residential,residential,ADJ,B2
-residue,residue,residue,NOUN,C1
-resigned submission,resigned submission,resigned submission,NOUN,C1
-resilience,resilience,resilience,NOUN,C1
-resilient,resilient,resilient,ADJ,C1
-resin,resin,resin,NOUN,C1
-resistant,resistant,resistant,ADJ,C1
-resistor,resistor,resistor,NOUN,C1
-reskilling,reskilling,reskilling,NOUN,B2
-resocialization,resocialization,resocialization,NOUN,B2
-respect (noun),respect,respect (noun),NOUN,A1
-respectfully,respectfully,respectfully,ADV,C1
-respectively,respectively,respectively,ADV,C1
-resplendent,resplendent,resplendent,ADJ,C1
-rest stop,rest stop,rest stop,NOUN,B1
-restate,restate,restate,VERB,B2
-restitution,restitution,restitution,NOUN,C1
-restive,restive,restive,ADJ,C1
-restless,restless,restless,ADJ,B2
-restrain,restrain,restrain,VERB,C1
-results,results,results,NOUN,C1
-resurgent,resurgent,resurgent,ADJ,C1
-resuscitate,resuscitate,resuscitate,VERB,C1
-retaliate,retaliate,retaliate,VERB,C1
-retaliation,retaliation,retaliation,NOUN,C1
-retarded,retarded,retarded,ADJ,C1
-retina,retina,retina,NOUN,B2
-retinue,retinue,retinue,NOUN,B2
-retirement pension,retirement pension,retirement pension,NOUN,B2
-retort (noun),retort,retort (noun),NOUN,C1
-retraining,retraining,retraining,NOUN,C1
-retroactive,retroactive,retroactive,ADJ,C1
-retrospect,retrospect,retrospect,NOUN,C1
-retrospective (adj),retrospective,retrospective (adj),ADJ,C1
-retrospective (noun),retrospective,retrospective (noun),NOUN,C1
-revealing (adj),revealing,revealing (adj),ADJ,C1
-revel,revel,revel,VERB,C1
-revelry,revelry,revelry,NOUN,B2
-revenues,revenues,revenues,NOUN,C1
-reverberation,reverberation,reverberation,NOUN,C1
-reverentially,reverentially,reverentially,ADV,C1
-reverie,reverie,reverie,NOUN,C1
-reverse (noun),reverse,reverse (noun),NOUN,C1
-revile,revile,revile,VERB,C1
-revivalism,revivalism,revivalism,NOUN,C1
-revocation,revocation,revocation,NOUN,C1
-revolver,revolver,revolver,NOUN,C1
-revulsion,revulsion,revulsion,NOUN,C1
-rhetorical clarity,rhetorical clarity,rhetorical clarity,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,rhetorical embellishment,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,rhetorical shift of person,NOUN,C1
-rhetorician,rhetorician,rhetorician,NOUN,C1
-rheumatism,rheumatism,rheumatism,NOUN,C1
-rhymed prose,rhymed prose,rhymed prose,NOUN,C1
-rhythmic,rhythmic,rhythmic,ADJ,C1
-riad,riad,riad,NOUN,B1
-rial,rial,rial,NOUN,A2
-ribald,ribald,ribald,ADJ,C1
-ribald joke,ribald joke,ribald joke,NOUN,C1
-ribaldry,ribaldry,ribaldry,NOUN,C1
-ribat fortified convent,ribat fortified convent,ribat fortified convent,NOUN,C1
-rich man,rich man,rich man,NOUN,C1
-richer,richer,richer,ADJ,B2
-rickety,rickety,rickety,ADJ,C1
-ricochet,ricochet,ricochet,NOUN,C1
-ridicule (noun),ridicule,ridicule (noun),NOUN,C1
-ridiculing,ridiculing,ridiculing,NOUN,C1
-riding,riding,riding,NOUN,B2
-rife,rife,rife,ADJ,C1
-riffraff,riffraff,riffraff,NOUN,C1
-right (intj),right,right (intj),INTJ,C1
-rightism,rightism,rightism,NOUN,C1
-rightist,rightist,rightist,ADJ,C1
-rightly,rightly,rightly,ADV,B2
-rigidly moral,rigidly moral,rigidly moral,ADJ,C1
-rigor,rigor,rigor,NOUN,B2
-rigorously,rigorously,rigorously,ADV,C1
-rile,rile,rile,VERB,C1
-rim,rim,rim,NOUN,C1
-rings,rings,rings,NOUN,B2
-ringtone,ringtone,ringtone,NOUN,C1
-rioter,rioter,rioter,NOUN,C1
-ripple,ripple,ripple,NOUN,C1
-rise (noun),rise,rise (noun),NOUN,B2
-rising (adj),rising,rising (adj),ADJ,C1
-rising (noun),rising,rising (noun),NOUN,B2
-rising above pettiness,rising above pettiness,rising above pettiness,NOUN,C1
-risks,risks,risks,NOUN,C1
-rite,rite,rite,NOUN,C1
-rites,rites,rites,NOUN,C1
-ritual impurity,ritual impurity,ritual impurity,NOUN,C1
-ritualism,ritualism,ritualism,NOUN,C1
-river mouth,river mouth,river mouth,NOUN,C1
-river-gauging,river-gauging,river-gauging,ADJ,C1
-riverbed,riverbed,riverbed,NOUN,B2
-road (adj),road,road (adj),ADJ,B2
-roadblock,roadblock,,NOUN,B2
-roaming,roaming,roaming,NOUN,C1
-roar (noun),roar,roar (noun),NOUN,B2
-roasted,roasted,roasted,ADJ,B2
-robe,robe,robe,NOUN,B2
-robotic,robotic,robotic,ADJ,C1
-robotics,robotics,robotics,NOUN,C1
-robotization,robotization,robotization,NOUN,C1
-robustness,robustness,robustness,NOUN,C1
-rock cliff,rock cliff,rock cliff,NOUN,A1
-rock music,rock music,rock music,NOUN,B2
-rocket (adj),rocket,rocket (adj),ADJ,C1
-rocky,rocky,rocky,ADJ,C1
-rococo,rococo,rococo,ADJ,C1
-rod,rod,rod,NOUN,B1
-rogatory,rogatory,rogatory,ADJ,C1
-rogue,rogue,rogue,NOUN,B2
-rolled,rolled,rolled,ADJ,C1
-roller skate,roller skate,roller skate,NOUN,B1
-rolling,rolling,rolling,NOUN,C1
-romanticism,romanticism,romanticism,NOUN,C1
-roof terrace,roof terrace,roof terrace,NOUN,A2
-roof tiles,roof tiles,roof tiles,NOUN,B1
-roominess,roominess,roominess,NOUN,C1
-roots,roots,roots,NOUN,C1
-rose bush,rose bush,rose bush,NOUN,B1
-roster,roster,roster,NOUN,C1
-rot decomposition,rot decomposition,rot decomposition,NOUN,C1
-rotating,rotating,rotating,ADJ,C1
-rotation,rotation,rotation,NOUN,C1
-rote learning,rote learning,rote learning,NOUN,B2
-rote teaching,rote teaching,rote teaching,NOUN,C1
-rotund,rotund,rotund,ADJ,C1
-rotunda,rotunda,rotunda,NOUN,C1
-round trip,round trip,round trip,NOUN,B1
-routing,routing,routing,NOUN,C1
-rove,rove,rove,VERB,C1
-row series,row series,row series,NOUN,B1
-rowboat,rowboat,rowboat,NOUN,B2
-royal court,royal court,royal court,NOUN,C1
-rubicund,rubicund,rubicund,ADJ,C1
-ruby,ruby,ruby,NOUN,C1
-ruckus,ruckus,ruckus,NOUN,C1
-rudely,rudely,rudely,ADV,C1
-rudimentary,rudimentary,rudimentary,ADJ,C1
-rueful,rueful,rueful,ADJ,C1
-ruin (noun),ruin,ruin (noun),NOUN,B2
-ruin relic,ruin relic,ruin relic,NOUN,B2
-ruined,ruined,ruined,ADJ,B2
-rulebook,rulebook,rulebook,NOUN,B2
-ruling (adj),ruling,ruling (adj),ADJ,C1
-rumbling,rumbling,rumbling,NOUN,C1
-ruminant,ruminant,ruminant,NOUN,C1
-ruminate,ruminate,ruminate,VERB,C1
-rumination,rumination,rumination,NOUN,C1
-ruminative,ruminative,ruminative,ADJ,C1
-rummage,rummage,rummage,VERB,C1
-rumors,rumors,rumors,NOUN,B2
-run away fled,run away fled,run away fled,VERB,A1
-run over (adj),run over,run over (adj),ADJ,B2
-run-down,run-down,run-down,ADJ,C1
-runaway,runaway,runaway,NOUN,B2
-rung,rung,rung,NOUN,C1
-running over,running over,running over,NOUN,C1
-runway,runway,runway,NOUN,C1
-rural (noun),rural,rural (noun),NOUN,B2
-rurality,rurality,rurality,NOUN,C1
-ruralization,ruralization,ruralization,NOUN,C1
-ruse,ruse,ruse,NOUN,C1
-rusk,rusk,rusk,NOUN,A2
-rusty,rusty,rusty,ADJ,C1
-sabbatical,sabbatical,sabbatical,NOUN,C1
-saber,saber,saber,NOUN,C1
-sabotage (adj),sabotage,sabotage (adj),ADJ,C1
-saboteur,saboteur,saboteur,NOUN,B2
-saccharine,saccharine,saccharine,ADJ,C1
-sacrilegious,sacrilegious,sacrilegious,ADJ,B2
-sacrosanct,sacrosanct,sacrosanct,ADJ,C1
-saddening,saddening,saddening,ADJ,C1
-saddle,saddle,saddle,NOUN,B2
-saddle pad,saddle pad,saddle pad,NOUN,B2
-saddlebags,saddlebags,saddlebags,NOUN,B2
-sadism,sadism,sadism,NOUN,C1
-sadly,sadly,sadly,ADV,B2
-safe container,safe container,safe container,NOUN,C1
-saffron,saffron,saffron,NOUN,A2
-sagacity,sagacity,sagacity,NOUN,B2
-sage,sage,sage,NOUN,C1
-sailboat,sailboat,,NOUN,B2
-sailors,sailors,sailors,NOUN,B2
-saints,saints,saints,NOUN,C1
-salacious,salacious,salacious,ADJ,C1
-salaried,salaried,salaried,ADJ,B2
-salesman,salesman,salesman,NOUN,B2
-salient,salient,salient,ADJ,C1
-salinity,salinity,salinity,NOUN,B2
-saliva,saliva,saliva,NOUN,B2
-salt flat,salt flat,salt flat,NOUN,B2
-salt shaker,salt shaker,salt shaker,NOUN,B2
-salted,salted,salted,ADJ,B2
-salubrious,salubrious,salubrious,ADJ,C1
-salutary,salutary,salutary,ADJ,C1
-salvage,salvage,salvage,NOUN,C1
-salve,salve,salve,NOUN,C1
-sama,sama,sama,NOUN,B2
-same (det),same,same (det),DET,A1
-sanctification,sanctification,sanctification,NOUN,C1
-sanctimoniousness,sanctimoniousness,sanctimoniousness,NOUN,C1
-sanctity,sanctity,sanctity,NOUN,C1
-sands,sands,sands,NOUN,B2
-sandy,sandy,sandy,ADJ,B2
-sanguinary,sanguinary,sanguinary,ADJ,C1
-sanguine,sanguine,sanguine,ADJ,C1
-sanitary,sanitary,sanitary,ADJ,B2
-santur,santur,santur,NOUN,C1
-sap,sap,sap,NOUN,C1
-saplings,saplings,saplings,NOUN,C1
-sarcasm,sarcasm,sarcasm,NOUN,C1
-sarcastic,sarcastic,sarcastic,ADJ,C1
-sardonic,sardonic,sardonic,ADJ,C1
-sat,sat,sat,NOUN,B1
-satchel,satchel,satchel,NOUN,C1
-sated,sated,sated,ADJ,B2
-saucepan,saucepan,saucepan,NOUN,B2
-saucy,saucy,saucy,ADJ,B2
-sauna,sauna,sauna,NOUN,B2
-saunter,saunter,saunter,VERB,C1
-savage,savage,,NOUN,B2
-savant,savant,savant,NOUN,C1
-saver,saver,saver,NOUN,C1
-savory,savory,savory,ADJ,C1
-savvy,savvy,savvy,ADJ,C1
-sawdust,sawdust,sawdust,NOUN,C1
-sayings,sayings,sayings,NOUN,C1
-sayings and traditions,sayings and traditions,sayings and traditions,NOUN,C1
-scaffolding,scaffolding,scaffolding,NOUN,C1
-scalar,scalar,scalar,ADJ,C1
-scale model,scale model,scale model,NOUN,C1
-scales,scales,scales,NOUN,B2
-scallion,scallion,scallion,NOUN,B2
-scaly,scaly,scaly,ADJ,C1
-scammer,scammer,scammer,NOUN,B2
-scandinavian,scandinavian,scandinavian,ADJ,B2
-scanning,scanning,scanning,NOUN,C1
-scant,scant,scant,ADJ,C1
-scantily,scantily,scantily,ADV,C1
-scapegoat,scapegoat,scapegoat,NOUN,C1
-scarecrow,scarecrow,scarecrow,NOUN,C1
-scarf shawl,scarf shawl,scarf shawl,NOUN,A1
-scathing,scathing,scathing,ADJ,C1
-scatterbrained,scatterbrained,scatterbrained,ADJ,B2
-scattering,scattering,scattering,NOUN,B2
-scenography,scenography,scenography,NOUN,C1
-sceptical,sceptical,sceptical,ADJ,C1
-schema,schema,schema,NOUN,B2
-schizophrenic,schizophrenic,schizophrenic,ADJ,C1
-scholar learned,scholar learned,scholar learned,NOUN,C1
-scholing,scholing,scholing,NOUN,B2
-scholium,scholium,scholium,NOUN,C1
-school bag,school bag,school bag,NOUN,A2
-school bench,school bench,school bench,NOUN,A1
-school leaving exam,school leaving exam,school leaving exam,NOUN,B1
-school principal,school principal,school principal,NOUN,C1
-schoolbag,schoolbag,schoolbag,NOUN,A1
-schooling,schooling,schooling,NOUN,C1
-schoolyard,schoolyard,schoolyard,NOUN,A1
-scintillate,scintillate,scintillate,VERB,C1
-scoff (noun),scoff,scoff (noun),NOUN,C1
-scoff (verb),scoff,scoff (verb),VERB,C1
-scoop,scoop,scoop,NOUN,B2
-scornful,scornful,scornful,ADJ,C1
-scorpion,scorpion,scorpion,NOUN,A1
-scottish,scottish,scottish,ADJ,B2
-scour,scour,scour,VERB,C1
-scouting locating,scouting locating,scouting locating,NOUN,B2
-scrappy,scrappy,scrappy,ADJ,C1
-screaming,screaming,screaming,NOUN,B2
-screening,screening,screening,NOUN,B1
-screw (noun),screw,screw (noun),NOUN,C1
-screw up,screw up,screw up,VERB,C1
-scribal misreading,scribal misreading,scribal misreading,NOUN,C1
-scribble (noun),scribble,scribble (noun),NOUN,C1
-scribe,scribe,scribe,NOUN,C1
-scrubland,scrubland,scrubland,NOUN,C1
-scrupulosity,scrupulosity,scrupulosity,NOUN,C1
-scrupulousness,scrupulousness,scrupulousness,NOUN,C1
-sculptural,sculptural,sculptural,ADJ,C1
-scumbag,scumbag,scumbag,NOUN,C1
-scurrilous,scurrilous,scurrilous,ADJ,C1
-scurry,scurry,scurry,VERB,C1
-scurvy,scurvy,scurvy,NOUN,C1
-scuttle,scuttle,scuttle,VERB,C1
-scythe,scythe,scythe,NOUN,B2
-seam,seam,seam,NOUN,C1
-seaplane,seaplane,seaplane,NOUN,B2
-search engine optimization,search engine optimization,search engine optimization,NOUN,C1
-search warrant,search warrant,search warrant,NOUN,C1
-searing,searing,searing,NOUN,B2
-seashell,seashell,seashell,NOUN,B2
-seasonal pasture camp,seasonal pasture camp,seasonal pasture camp,NOUN,B2
-seasoned,seasoned,seasoned,ADJ,B2
-seasoned experience,seasoned experience,seasoned experience,NOUN,C1
-seasoning,seasoning,seasoning,NOUN,C1
-seats,seats,seats,NOUN,C1
-seaweed,seaweed,seaweed,NOUN,C1
-secession,secession,secession,NOUN,C1
-second (noun),second,second (noun),NOUN,B2
-second (num),second,second (num),NUM,A1
-second again,second again,second again,ADJ,A1
-second chance dredging,second chance dredging,second chance dredging,NOUN,C1
-second-hand,second-hand,second-hand,ADJ,C1
-secondment,secondment,secondment,NOUN,C1
-secret confidence,secret confidence,secret confidence,NOUN,C1
-secret service,secret service,secret service,NOUN,B2
-secrets,secrets,secrets,NOUN,C1
-sect taifa,sect taifa,sect taifa,NOUN,C1
-sectarianism,sectarianism,sectarianism,NOUN,C1
-sectoral,sectoral,sectoral,ADJ,C1
-secular,secular,secular,ADJ,C1
-secular layperson,secular layperson,secular layperson,ADJ,C1
-secure (adj),secure,secure (adj),ADJ,B1
-security matter,security matter,security matter,NOUN,C1
-security service,security service,security service,NOUN,C1
-securocratic,securocratic,securocratic,ADJ,C1
-sedate,sedate,sedate,ADJ,C1
-sedative,sedative,sedative,NOUN,C1
-sedentary lifestyle,sedentary lifestyle,sedentary lifestyle,NOUN,B2
-sediment,sediment,sediment,NOUN,C1
-sedimentation,sedimentation,sedimentation,NOUN,C1
-sediments deposits,sediments deposits,sediments deposits,NOUN,C1
-seditious,seditious,seditious,ADJ,C1
-sedulous,sedulous,sedulous,ADJ,C1
-see you,see you,see you,VERB,A2
-seedling,seedling,seedling,NOUN,B2
-seeds,seeds,seeds,NOUN,B2
-seedy,seedy,seedy,ADJ,C1
-seeking blessing,seeking blessing,seeking blessing,NOUN,C1
-seeking foreign backing,seeking foreign backing,seeking foreign backing,NOUN,C1
-seeking forgiveness,seeking forgiveness,seeking forgiveness,NOUN,C1
-seeking intercession,seeking intercession,seeking intercession,NOUN,C1
-seemly,seemly,seemly,ADJ,C1
-seethe,seethe,seethe,VERB,C1
-segment (noun),segment,segment (noun),NOUN,B2
-selectively,selectively,selectively,ADV,B2
-selector,selector,selector,NOUN,C1
-self (adv),self,self (adv),ADV,B2
-self-abasement,self-abasement,self-abasement,NOUN,C1
-self-deception,self-deception,self-deception,NOUN,C1
-self-defense,self-defense,self-defense,NOUN,B2
-self-diminishment,self-diminishment,self-diminishment,NOUN,C1
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,self-evident (adj),ADJ,C1
-self-interest,self-interest,self-interest,NOUN,B2
-self-made,self-made,self-made,ADJ,C1
-self-respect,self-respect,self-respect,NOUN,B2
-self-satisfaction,self-satisfaction,self-satisfaction,NOUN,C1
-self-worth,self-worth,self-worth,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfless,selfless,selfless,ADJ,B2
-selfless devotion,selfless devotion,selfless devotion,NOUN,C1
-semantic,semantic,semantic,ADJ,C1
-semblance,semblance,semblance,NOUN,C1
-seminal,seminal,seminal,ADJ,C1
-seminary,seminary,seminary,NOUN,C1
-sending,sending,sending,NOUN,B1
-senescence,senescence,senescence,NOUN,B2
-senile,senile,senile,ADJ,C1
-seniors,seniors,seniors,NOUN,C1
-sensationalism,sensationalism,sensationalism,NOUN,C1
-sense of duty,sense of duty,sense of duty,NOUN,B2
-sense of humor,sense of humor,sense of humor,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sensibly,sensibly,sensibly,ADV,B2
-sensitive to cold,sensitive to cold,sensitive to cold,ADJ,C1
-sensitization,sensitization,sensitization,NOUN,B2
-sensor donor,sensor donor,sensor donor,NOUN,B2
-sensors,sensors,sensors,NOUN,B2
-sensory,sensory,sensory,ADJ,B2
-sensuality,sensuality,sensuality,NOUN,C1
-sentence verdict,sentence verdict,sentence verdict,NOUN,B2
-sentences,sentences,sentences,NOUN,B2
-sentencing,sentencing,sentencing,NOUN,B2
-sententiously,sententiously,sententiously,ADV,C1
-sentient,sentient,sentient,ADJ,C1
-separatism,separatism,separatism,NOUN,C1
-separatist,separatist,separatist,NOUN,C1
-sequential,sequential,sequential,ADJ,C1
-seraphic,seraphic,seraphic,ADJ,C1
-serendipity,serendipity,serendipity,NOUN,C1
-serenely,serenely,serenely,ADV,C1
-serial,serial,serial,NOUN,B1
-series of conversations,series of conversations,series of conversations,NOUN,B2
-serous,serous,serous,ADJ,C1
-serpentine,serpentine,serpentine,ADJ,C1
-serum,serum,serum,NOUN,B2
-service counter,service counter,service counter,NOUN,B1
-service favor,service favor,service favor,NOUN,A2
-service of process,service of process,service of process,NOUN,C1
-service user,service user,service user,NOUN,C1
-service users,service users,service users,NOUN,C1
-service year,service year,,NOUN,B2
-services,services,services,NOUN,C1
-servile,servile,servile,ADJ,C1
-serving,serving,serving,NOUN,B2
-set of ideals,set of ideals,set of ideals,NOUN,B2
-set square,set square,set square,NOUN,B2
-set-off,set-off,set-off,NOUN,C1
-setting,setting,setting,NOUN,B1
-setting splinting,setting splinting,setting splinting,NOUN,C1
-settings,settings,settings,NOUN,C1
-settlement deal,settlement deal,settlement deal,NOUN,C1
-seven (adj),seven,seven (adj),ADJ,B2
-sever,sever,sever,VERB,C1
-several (adj),several,several (adj),ADJ,A2
-several (pron),several,several (pron),PRON,A2
-several times (adv),several times,several times (adv),ADV,C1
-severance,severance,severance,NOUN,C1
-sewage,sewage,sewage,NOUN,C1
-sewer,sewer,sewer,NOUN,C1
-sewing needle,sewing needle,sewing needle,NOUN,C1
-sex gender,sex gender,sex gender,NOUN,B2
-sexagesimal,sexagesimal,sexagesimal,ADJ,C1
-sexist,sexist,sexist,ADJ,C1
-sfouf,sfouf,sfouf,NOUN,B2
-sh,sh,sh,INTJ,C1
-shabby,shabby,shabby,ADJ,B2
-shadow shade,shadow shade,shadow shade,NOUN,B1
-shadows,shadows,shadows,NOUN,C1
-shafii school,shafii school,shafii school,NOUN,C1
-shaft,shaft,shaft,NOUN,B2
-shake off,shake off,shake off,VERB,B2
-shall will,shall will,shall will,AUX,B2
-shambles,shambles,shambles,NOUN,C1
-shame culture,shame culture,shame culture,NOUN,B2
-shame disgrace,shame disgrace,shame disgrace,NOUN,B2
-shame pity,shame pity,shame pity,NOUN,B2
-shameless person,shameless person,shameless person,NOUN,B2
-shantytown,shantytown,shantytown,NOUN,B2
-shards,shards,shards,NOUN,B2
-shared boundary ownership,shared boundary ownership,shared boundary ownership,NOUN,B2
-shareholding,shareholding,shareholding,NOUN,B2
-shares,shares,shares,NOUN,C1
-sharifs,sharifs,sharifs,NOUN,C1
-sharp acute,sharp acute,sharp acute,ADJ,C1
-sharp-witted,sharp-witted,sharp-witted,ADJ,C1
-sharply,sharply,sharply,ADV,B2
-shear,shear,shear,NOUN,C1
-shearing,shearing,shearing,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,sheepskin,NOUN,B2
-sheet of paper,sheet of paper,sheet of paper,NOUN,B2
-sheikh,sheikh,sheikh,NOUN,C1
-sheikhdom,sheikhdom,sheikhdom,NOUN,C1
-sheltered one,sheltered one,sheltered one,NOUN,B2
-shenanigan,shenanigan,shenanigan,NOUN,C1
-sheriff,sheriff,sheriff,NOUN,B1
-shibboleth,shibboleth,shibboleth,NOUN,C1
-shimmer,shimmer,shimmer,VERB,C1
-shine (noun),shine,shine (noun),NOUN,B1
-shining,shining,shining,ADJ,C1
-shiny,shiny,shiny,ADJ,B2
-ship captain,ship captain,ship captain,NOUN,C1
-shirk,shirk,shirk,VERB,C1
-shit crap,shit crap,shit crap,NOUN,B2
-shitty,shitty,shitty,ADJ,B2
-shivers,shivers,shivers,NOUN,B2
-shoddy,shoddy,shoddy,ADJ,C1
-shoe polish,shoe polish,shoe polish,NOUN,B2
-shoelace,shoelace,shoelace,NOUN,C1
-shoot at,shoot at,shoot at,VERB,C1
-shopkeeper,shopkeeper,shopkeeper,NOUN,C1
-short circuit,short circuit,short circuit,NOUN,B2
-short news item,short news item,short news item,NOUN,C1
-short piece,short piece,short piece,NOUN,C1
-short story,short story,short story,NOUN,C1
-short while,short while,short while,NOUN,C1
-short work,short work,short work,NOUN,C1
-shortcomings,shortcomings,shortcomings,NOUN,C1
-shorter,shorter,shorter,ADJ,B2
-shortest,shortest,shortest,NOUN,B2
-should must,should must,should must,AUX,A2
-showing off,showing off,showing off,NOUN,C1
-showy,showy,showy,ADJ,B2
-shred,shred,shred,NOUN,B2
-shriek,shriek,shriek,VERB,C1
-shrinkage,shrinkage,shrinkage,NOUN,C1
-shrivel,shrivel,shrivel,VERB,C1
-shrub,shrub,shrub,NOUN,C1
-shrug,shrug,shrug,VERB,C1
-shrunken,shrunken,shrunken,ADJ,B2
-shun,shun,shun,VERB,C1
-shut,shut,shut,VERB,A1
-shutdown,shutdown,shutdown,NOUN,C1
-sibilant,sibilant,sibilant,ADJ,C1
-sibyl,sibyl,sibyl,NOUN,C1
-sickle,sickle,sickle,NOUN,B2
-sickly,sickly,sickly,ADJ,C1
-sickness,sickness,sickness,NOUN,B2
-sideboard,sideboard,sideboard,NOUN,C1
-sideburn,sideburn,sideburn,NOUN,B1
-sifted,sifted,sifted,ADJ,C1
-sightseeing,sightseeing,sightseeing,NOUN,C1
-sign brand,sign brand,sign brand,NOUN,C1
-signatory,signatory,signatory,NOUN,B2
-signed,signed,signed,ADJ,B2
-signified,signified,signified,NOUN,C1
-signifier,signifier,signifier,NOUN,C1
-silenced,silenced,silenced,ADJ,C1
-silencing,silencing,silencing,NOUN,C1
-silent quiet,silent quiet,silent quiet,ADJ,A1
-silently,silently,silently,ADV,C1
-silly thing,silly thing,silly thing,NOUN,C1
-silos,silos,silos,NOUN,C1
-silt,silt,silt,NOUN,C1
-silvery,silvery,silvery,ADJ,C1
-simian,simian,simian,ADJ,C1
-similarly,similarly,similarly,ADV,B2
-simony,simony,simony,NOUN,C1
-simple-minded,simple-minded,simple-minded,ADJ,C1
-simplified,simplified,simplified,ADJ,B2
-simulator,simulator,simulator,NOUN,C1
-simultaneously with,simultaneously with,simultaneously with,ADV,C1
-since then (sconj),since then,since then (sconj),SCONJ,A2
-sincerity devotion,sincerity devotion,sincerity devotion,NOUN,B2
-sinecure,sinecure,sinecure,NOUN,C1
-sinew,sinew,sinew,NOUN,C1
-single person,single person,single person,NOUN,B2
-singular (adj),singular,singular (adj),ADJ,C1
-singular (noun),singular,singular (noun),NOUN,B2
-sinuous,sinuous,sinuous,ADJ,C1
-sit cross-legged,sit cross-legged,sit cross-legged,VERB,B2
-sit-in,sit-in,sit-in,NOUN,B2
-sit-in participant,sit-in participant,sit-in participant,NOUN,C1
-site,site,site,NOUN,B1
-sitter,sitter,sitter,NOUN,B1
-sitting,sitting,sitting,NOUN,B2
-six-line stanza,six-line stanza,six-line stanza,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixth,sixth,,NOUN,B2
-skate (noun),skate,skate (noun),NOUN,A2
-skater,skater,,NOUN,B2
-skating,skating,skating,NOUN,B2
-skeletal,skeletal,skeletal,ADJ,C1
-skeptic,skeptic,skeptic,NOUN,C1
-sketchiness,sketchiness,sketchiness,NOUN,C1
-ski (noun),ski,ski (noun),NOUN,C1
-skid slip-up,skid slip-up,skid slip-up,NOUN,C1
-skiff,skiff,skiff,NOUN,C1
-skillfully,skillfully,skillfully,ADV,B2
-skillfulness,skillfulness,skillfulness,NOUN,B2
-skin hide,skin hide,skin hide,NOUN,B2
-skinny,skinny,skinny,ADJ,B2
-slack,slack,slack,ADJ,B2
-slack off,slack off,slack off,VERB,C1
-slackening dip,slackening dip,slackening dip,NOUN,C1
-slackness,slackness,slackness,NOUN,C1
-slake,slake,slake,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,slam (verb),VERB,B2
-slammer jail,slammer jail,slammer jail,NOUN,C1
-slander (noun),slander,slander (noun),NOUN,B2
-slaughterhouse,slaughterhouse,slaughterhouse,NOUN,C1
-slavery bondage,slavery bondage,slavery bondage,NOUN,C1
-sleek,sleek,sleek,ADJ,C1
-sleep sleepiness,sleep sleepiness,sleep sleepiness,NOUN,A2
-sleeper,sleeper,sleeper,NOUN,C1
-slender,slender,slender,ADJ,B2
-slenderness,slenderness,slenderness,NOUN,B2
-slice of bread,slice of bread,slice of bread,NOUN,C1
-slick,slick,slick,ADJ,C1
-slight (adj),slight,slight (adj),ADJ,B2
-slimy,slimy,slimy,ADJ,B2
-sling,sling,sling,NOUN,C1
-slip (noun),slip,slip (noun),NOUN,C1
-slit,slit,slit,NOUN,C1
-slither,slither,slither,VERB,C1
-sloppy,sloppy,sloppy,ADJ,B1
-slot,slot,slot,NOUN,C1
-slovenly,slovenly,slovenly,ADJ,C1
-slur,slur,slur,VERB,C1
-slyly,slyly,slyly,ADV,C1
-small bag,small bag,small bag,NOUN,C1
-small basket,small basket,small basket,NOUN,C1
-small boat,small boat,small boat,NOUN,B2
-small box casket,small box casket,small box casket,NOUN,C1
-small cave,small cave,small cave,NOUN,B2
-small dog,small dog,small dog,NOUN,C1
-small forge,small forge,small forge,NOUN,C1
-small loaf,small loaf,small loaf,NOUN,B2
-small room,small room,small room,NOUN,B1
-small step,small step,small step,NOUN,C1
-small sword,small sword,small sword,NOUN,C1
-small things,small things,small things,NOUN,B2
-small window,small window,small window,NOUN,A2
-smarting,smarting,smarting,NOUN,C1
-smelt,smelt,smelt,VERB,C1
-smelting,smelting,smelting,NOUN,C1
-smirk,smirk,smirk,VERB,C1
-smitten,smitten,smitten,ADJ,C1
-smock,smock,smock,NOUN,B2
-smoked,smoked,smoked,ADJ,C1
-smoker,smoker,smoker,NOUN,C1
-smoking (adj),smoking,smoking (adj),ADJ,C1
-smoothness,smoothness,smoothness,NOUN,C1
-smuggle,smuggle,smuggle,VERB,C1
-smugness,smugness,smugness,NOUN,C1
-snaffle,snaffle,snaffle,NOUN,B2
-snap (noun),snap,snap (noun),NOUN,B2
-snap (verb),snap,snap (verb),VERB,C1
-snare,snare,snare,NOUN,C1
-sneaker,sneaker,sneaker,NOUN,A1
-sneakers,sneakers,sneakers,NOUN,B2
-sneaking,sneaking,sneaking,NOUN,B2
-sneer,sneer,sneer,VERB,C1
-sneeze (noun),sneeze,sneeze (noun),NOUN,C1
-sneezing,sneezing,sneezing,NOUN,C1
-sniffle,sniffle,sniffle,VERB,C1
-snippet,snippet,snippet,NOUN,C1
-snob,snob,snob,NOUN,C1
-snobbery,snobbery,snobbery,NOUN,C1
-snooping,snooping,snooping,NOUN,C1
-snoring,snoring,snoring,NOUN,B2
-snort (noun),snort,snort (noun),NOUN,B2
-snow-white,snow-white,snow-white,ADJ,C1
-snowdrift,snowdrift,snowdrift,NOUN,B1
-snowy,snowy,snowy,ADJ,C1
-snub (noun),snub,snub (noun),NOUN,C1
-so much so many,so much so many,so much so many,ADV,C1
-so-and-so,so-and-so,so-and-so,PRON,C1
-so-called,so-called,,NOUN,B2
-soap (verb),soap,soap (verb),VERB,C1
-sobriquet,sobriquet,sobriquet,NOUN,C1
-social tension,social tension,social tension,NOUN,C1
-socialism,socialism,socialism,NOUN,C1
-socially,socially,socially,ADV,C1
-societal,societal,societal,ADJ,B2
-sociological,sociological,sociological,ADJ,C1
-socket,socket,socket,NOUN,C1
-softness,softness,softness,NOUN,B2
-softness pliancy,softness pliancy,softness pliancy,NOUN,C1
-software (adj),software,software (adj),ADJ,C1
-soil investigation,soil investigation,soil investigation,NOUN,C1
-solar (adj),solar,solar (adj),ADJ,B1
-solar (noun),solar,solar (noun),NOUN,B2
-solar physics,solar physics,solar physics,NOUN,C1
-solely,solely,solely,ADV,C1
-solemn,solemn,,NOUN,B2
-solemnity,solemnity,solemnity,NOUN,C1
-solemnly,solemnly,solemnly,ADV,C1
-solfege,solfege,solfege,NOUN,C1
-solicitation,solicitation,solicitation,NOUN,C1
-solicitor,solicitor,solicitor,NOUN,C1
-solicitous,solicitous,solicitous,ADJ,C1
-solicitude,solicitude,solicitude,NOUN,B2
-solid substantial,solid substantial,solid substantial,ADJ,B2
-solidifying,solidifying,solidifying,ADJ,C1
-soloist,soloist,soloist,NOUN,C1
-solstice,solstice,solstice,NOUN,C1
-solute,solute,solute,NOUN,C1
-somber,somber,somber,ADJ,B2
-some (noun),some,some (noun),NOUN,B2
-some (pron),some,some (pron),PRON,B2
-some many a,some many a,some many a,DET,A2
-somebody,somebody,somebody,PRON,A1
-something better,something better,something better,NOUN,C1
-something like that,something like that,something like that,PRON,B2
-somewhat,somewhat,somewhat,ADV,C1
-somewhere,somewhere,,NOUN,B2
-somewhere else,somewhere else,somewhere else,ADV,B1
-somnolent,somnolent,somnolent,ADJ,C1
-son of a bitch,son of a bitch,son of a bitch,NOUN,B2
-son-in-law,son-in-law,son-in-law,NOUN,A2
-sonata,sonata,sonata,NOUN,C1
-song festival,song festival,song festival,NOUN,B2
-sonorous,sonorous,sonorous,ADJ,C1
-soothing,soothing,soothing,ADJ,C1
-soothsayer,soothsayer,soothsayer,NOUN,B2
-sophist,sophist,sophist,NOUN,B2
-sophistic,sophistic,sophistic,ADJ,C1
-sophomoric,sophomoric,sophomoric,ADJ,C1
-soporific,soporific,soporific,ADJ,C1
-sore (adv),sore,sore (adv),ADV,A2
-sorry (noun),sorry,sorry (noun),NOUN,A1
-sortie,sortie,sortie,NOUN,C1
-sought,sought,,NOUN,B2
-sought-after,sought-after,sought-after,ADJ,C1
-soul spirit,soul spirit,soul spirit,NOUN,B2
-soulmate,soulmate,soulmate,NOUN,C1
-sound clip,sound clip,sound clip,NOUN,B2
-sound judgment,sound judgment,sound judgment,NOUN,C1
-soundness of judgment,soundness of judgment,soundness of judgment,NOUN,C1
-sour cherry,sour cherry,sour cherry,NOUN,C1
-sources,sources,sources,NOUN,C1
-sourdough,sourdough,sourdough,NOUN,C1
-southeast (adj),southeast,southeast (adj),ADJ,C1
-southerner,southerner,southerner,NOUN,B2
-southward,southward,southward,ADV,B2
-soy,soy,soy,NOUN,C1
-space (adj),space,space (adj),ADJ,C1
-spaciousness,spaciousness,spaciousness,NOUN,C1
-spadix,spadix,spadix,NOUN,C1
-spam (noun),spam,spam (noun),NOUN,B1
-span cleaner,span cleaner,span cleaner,NOUN,B2
-span duration,span duration,span duration,NOUN,C1
-spanish (noun),spanish,spanish (noun),NOUN,B2
-spanking,spanking,spanking,NOUN,B2
-spar,spar,spar,VERB,C1
-spare (adj),spare,spare (adj),ADJ,B1
-spare (noun),spare,spare (noun),NOUN,C1
-sparkle (noun),sparkle,sparkle (noun),NOUN,C1
-sparkling,sparkling,sparkling,ADJ,B2
-sparrowhawk,sparrowhawk,sparrowhawk,NOUN,B2
-sparse,sparse,sparse,ADJ,C1
-spasm convulsion,spasm convulsion,spasm convulsion,NOUN,C1
-spasmodic,spasmodic,spasmodic,ADJ,C1
-spate,spate,spate,NOUN,C1
-spatula,spatula,spatula,NOUN,B2
-speaking of which,speaking of which,speaking of which,ADV,C1
-special window,special window,special window,NOUN,B2
-specifications,specifications,specifications,NOUN,C1
-specificity,specificity,specificity,NOUN,C1
-spectacle,spectacle,spectacle,NOUN,B2
-specter,specter,specter,NOUN,C1
-spectrometer,spectrometer,spectrometer,NOUN,C1
-speculative,speculative,speculative,ADJ,B2
-speed bumps,speed bumps,speed bumps,NOUN,C1
-speed radar,speed radar,speed radar,NOUN,B1
-spend the night,spend the night,spend the night,VERB,B2
-spendthrift,spendthrift,spendthrift,NOUN,C1
-spent,spent,spent,ADJ,B2
-spherical,spherical,spherical,ADJ,C1
-sphincter,sphincter,sphincter,NOUN,C1
-spices,spices,spices,NOUN,B1
-spike,spike,spike,NOUN,B2
-spill (noun),spill,spill (noun),NOUN,C1
-spilling,spilling,spilling,NOUN,C1
-spin (noun),spin,spin (noun),NOUN,C1
-spinsterhood,spinsterhood,spinsterhood,NOUN,B2
-spiral,spiral,spiral,NOUN,C1
-spirit world,spirit world,spirit world,NOUN,B2
-spirited,spirited,spirited,ADJ,B2
-spiritual retreat,spiritual retreat,spiritual retreat,NOUN,C1
-splay,splay,splay,VERB,C1
-spleen,spleen,spleen,NOUN,B2
-splinter (noun),splinter,splinter (noun),NOUN,B2
-split (noun),split,split (noun),NOUN,C1
-splitter,splitter,splitter,NOUN,C1
-spoiled,spoiled,spoiled,ADJ,B2
-spoiled child,spoiled child,spoiled child,NOUN,B1
-spoiler,spoiler,spoiler,NOUN,C1
-spoils,spoils,spoils,NOUN,C1
-spoils of war,spoils of war,spoils of war,NOUN,C1
-spoliation,spoliation,spoliation,NOUN,C1
-sponge,sponge,sponge,NOUN,B2
-sponger,sponger,sponger,NOUN,C1
-spongy,spongy,spongy,ADJ,C1
-sponsor (noun),sponsor,sponsor (noun),NOUN,B2
-spontaneity,spontaneity,spontaneity,NOUN,C1
-spontaneously,spontaneously,spontaneously,ADV,C1
-spoonerism,spoonerism,spoonerism,NOUN,C1
-spoonful,spoonful,spoonful,NOUN,B2
-sporadic,sporadic,sporadic,ADJ,C1
-sporadically,sporadically,sporadically,ADV,B2
-sports park,sports park,sports park,NOUN,B2
-sprayer sprinkler,sprayer sprinkler,sprayer sprinkler,NOUN,C1
-spreading,spreading,spreading,NOUN,C1
-spree,spree,spree,NOUN,C1
-springboard,springboard,springboard,NOUN,C1
-sprinkling,sprinkling,sprinkling,NOUN,B2
-sprite,sprite,sprite,NOUN,C1
-spry,spry,spry,ADJ,C1
-spurn,spurn,spurn,VERB,C1
-spurt,spurt,spurt,VERB,C1
-sputum,sputum,sputum,NOUN,C1
-squabble (noun),squabble,squabble (noun),NOUN,B2
-squabble (verb),squabble,squabble (verb),VERB,C1
-squadron,squadron,squadron,NOUN,B1
-squander (noun),squander,squander (noun),NOUN,C1
-squanderer,squanderer,squanderer,NOUN,C1
-squeal,squeal,squeal,VERB,C1
-squelch,squelch,squelch,VERB,C1
-squid,squid,squid,NOUN,B2
-squire,squire,squire,NOUN,C1
-stack (noun),stack,stack (noun),NOUN,B2
-staff (verb),staff,staff (verb),VERB,B1
-stage design,stage design,stage design,NOUN,B2
-staid,staid,staid,ADJ,C1
-staircase,staircase,staircase,NOUN,B1
-stakes,stakes,stakes,NOUN,B2
-stalemate,stalemate,stalemate,NOUN,C1
-stalking,stalking,stalking,NOUN,C1
-stalling,stalling,stalling,NOUN,B2
-stalwart,stalwart,stalwart,ADJ,C1
-stamina,stamina,stamina,NOUN,C1
-stammering,stammering,stammering,NOUN,C1
-stamp buffer,stamp buffer,stamp buffer,NOUN,C1
-stampede,stampede,stampede,NOUN,B2
-stanch,stanch,stanch,VERB,C1
-standard (adj),standard,standard (adj),ADJ,C1
-standard criterion,standard criterion,standard criterion,NOUN,C1
-standing (adv),standing,standing (adv),ADV,A1
-standoffish,standoffish,standoffish,ADJ,B2
-standpoint,standpoint,standpoint,NOUN,B2
-stands,stands,stands,NOUN,B2
-stanza,stanza,stanza,NOUN,B2
-staple,staple,staple,NOUN,C1
-stapler,stapler,stapler,NOUN,A2
-star celebrity,star celebrity,star celebrity,NOUN,B1
-starboard,starboard,starboard,NOUN,C1
-stark,stark,stark,ADJ,B2
-starling,starling,starling,NOUN,B2
-start of school year,start of school year,start of school year,NOUN,B1
-starter,starter,starter,NOUN,C1
-starting point,starting point,starting point,NOUN,B2
-starting premise,starting premise,starting premise,NOUN,C1
-startling,startling,startling,ADJ,C1
-starvation,starvation,starvation,NOUN,C1
-state (adj),state,state (adj),ADJ,B1
-state federal,state federal,state federal,NOUN,B2
-state of emergency,state of emergency,state of emergency,NOUN,C1
-stateless person,stateless person,stateless person,NOUN,C1
-statement of the obvious,statement of the obvious,statement of the obvious,NOUN,C1
-statements,statements,statements,NOUN,C1
-static (noun),static,static (noun),NOUN,B2
-statics,statics,statics,NOUN,C1
-stationery shop,stationery shop,stationery shop,NOUN,B2
-statism,statism,statism,NOUN,C1
-statization,statization,statization,NOUN,C1
-statute,statute,statute,NOUN,C1
-statute of limitations,statute of limitations,statute of limitations,NOUN,B2
-statutory rape,statutory rape,statutory rape,NOUN,C1
-stave,stave,stave,NOUN,C1
-stay remain,stay remain,stay remain,VERB,A1
-steadfast,steadfast,steadfast,ADJ,C1
-steadfastness,steadfastness,steadfastness,NOUN,B2
-steadily,steadily,steadily,ADV,B2
-stealthily,stealthily,stealthily,ADV,B2
-stealthy,stealthy,stealthy,ADJ,C1
-steamed,steamed,steamed,ADJ,B2
-steering (noun),steering,steering (noun),NOUN,C1
-steering control,steering control,steering control,NOUN,C1
-stem (adj),stem,stem (adj),ADJ,C1
-stemming,stemming,stemming,ADJ,B1
-stentorian,stentorian,stentorian,ADJ,C1
-stepfather,stepfather,stepfather,NOUN,A1
-steppe,steppe,steppe,NOUN,C1
-stepson,stepson,stepson,NOUN,A2
-stereotypical,stereotypical,stereotypical,ADJ,C1
-stereotyping,stereotyping,stereotyping,NOUN,C1
-stereotypy routineness,stereotypy routineness,stereotypy routineness,NOUN,C1
-sterility,sterility,sterility,NOUN,C1
-sterilization,sterilization,sterilization,NOUN,B2
-sterilizer,sterilizer,sterilizer,NOUN,C1
-stern (adj),stern,stern (adj),ADJ,C1
-stern (noun),stern,stern (noun),NOUN,C1
-stevedore,stevedore,stevedore,NOUN,C1
-sticking point,sticking point,sticking point,NOUN,C1
-stickler,stickler,stickler,NOUN,C1
-stiff glove,stiff glove,stiff glove,NOUN,B2
-stifle,stifle,stifle,VERB,C1
-stifling,stifling,stifling,ADJ,B2
-stigmatization,stigmatization,stigmatization,NOUN,B2
-stiletto,stiletto,stiletto,NOUN,C1
-stilted,stilted,stilted,ADJ,C1
-stimulating,stimulating,stimulating,ADJ,C1
-stink (noun),stink,stink (noun),NOUN,B2
-stipulation,stipulation,stipulation,NOUN,C1
-stitches,stitches,stitches,NOUN,B1
-stochastic,stochastic,stochastic,ADJ,B2
-stock-market,stock-market,stock-market,ADJ,B2
-stocking,stocking,stocking,NOUN,C1
-stodgy,stodgy,stodgy,ADJ,C1
-stoically,stoically,stoically,ADV,C1
-stolen one,stolen one,stolen one,NOUN,B2
-stomach ache,stomach ache,stomach ache,NOUN,C1
-stool,stool,stool,NOUN,C1
-stop (noun),stop,stop (noun),NOUN,B2
-stork,stork,stork,NOUN,B1
-storming,storming,storming,NOUN,C1
-story history,story history,story history,NOUN,A1
-stout,stout,stout,ADJ,C1
-stowage,stowage,stowage,NOUN,C1
-strabismus,strabismus,strabismus,NOUN,B2
-straight ahead,straight ahead,straight ahead,ADV,B2
-straight direct,straight direct,straight direct,ADJ,A1
-straight line,straight line,straight line,NOUN,C1
-straitened circumstances,straitened circumstances,straitened circumstances,NOUN,C1
-straitjacket,straitjacket,straitjacket,NOUN,C1
-strand,strand,strand,NOUN,C1
-strangest,strangest,strangest,NOUN,C1
-strangulation,strangulation,strangulation,NOUN,C1
-strapping,strapping,strapping,ADJ,C1
-strategist,strategist,strategist,NOUN,C1
-stratification,stratification,stratification,NOUN,C1
-stratigraphic,stratigraphic,stratigraphic,ADJ,C1
-street kid,street kid,street kid,NOUN,B2
-street lamp,street lamp,street lamp,NOUN,B1
-street lighting,street lighting,street lighting,NOUN,B1
-strengthening,strengthening,strengthening,NOUN,C1
-stretch out,stretch out,stretch out,VERB,B2
-stretched,stretched,stretched,ADJ,C1
-strictly,strictly,strictly,ADV,B2
-strictness,strictness,strictness,NOUN,B2
-stride (noun),stride,stride (noun),NOUN,C1
-strife,strife,strife,NOUN,B2
-strike-related,strike-related,strike-related,ADJ,C1
-strikebreaker,strikebreaker,strikebreaker,NOUN,C1
-striking,striking,striking,ADJ,B2
-string instruments,string instruments,string instruments,NOUN,C1
-string music,string music,string music,NOUN,C1
-stringent,stringent,stringent,ADJ,C1
-striped,striped,striped,ADJ,B2
-stripping,stripping,stripping,ADJ,B2
-striving,striving,striving,NOUN,B2
-strongest,strongest,strongest,NOUN,B2
-structuralism,structuralism,structuralism,NOUN,C1
-structuralist,structuralist,structuralist,ADJ,C1
-structured,structured,structured,ADJ,C1
-structures,structures,structures,NOUN,C1
-studious,studious,studious,ADJ,C1
-stuffed,stuffed,stuffed,ADJ,B1
-stumble (noun),stumble,stumble (noun),NOUN,C1
-stunner,stunner,stunner,NOUN,B2
-stunt,stunt,stunt,NOUN,B2
-stupefaction,stupefaction,stupefaction,NOUN,C1
-stupefied,stupefied,stupefied,ADJ,C1
-stupendous,stupendous,stupendous,ADJ,C1
-stuttering,stuttering,stuttering,NOUN,C1
-stylist,stylist,stylist,NOUN,C1
-stylistics,stylistics,stylistics,NOUN,C1
-stymie,stymie,stymie,VERB,C1
-suave,suave,suave,ADJ,C1
-subaltern,subaltern,subaltern,NOUN,C1
-subdivision,subdivision,subdivision,NOUN,B2
-subject field,subject field,subject field,NOUN,B2
-subject to the law,subject to the law,subject to the law,ADJ,B2
-subjection,subjection,subjection,NOUN,B2
-subjectivism,subjectivism,subjectivism,NOUN,C1
-subjectivity,subjectivity,subjectivity,NOUN,B2
-sublimation,sublimation,sublimation,NOUN,C1
-subliminal,subliminal,subliminal,ADJ,C1
-subliming,subliming,subliming,ADJ,C1
-sublimity,sublimity,sublimity,NOUN,C1
-submissive,submissive,submissive,ADJ,C1
-subpoena,subpoena,subpoena,NOUN,B2
-subsequently,subsequently,subsequently,ADV,C1
-subservient,subservient,subservient,ADJ,C1
-subsidiarily,subsidiarily,subsidiarily,ADV,C1
-subsidiarity,subsidiarity,subsidiarity,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantially,substantially,substantially,ADV,B2
-substitute deputy,substitute deputy,substitute deputy,NOUN,C1
-substitutes,substitutes,substitutes,NOUN,C1
-substitution,substitution,substitution,NOUN,C1
-subterfuge,subterfuge,subterfuge,NOUN,C1
-subterranean,subterranean,subterranean,ADJ,C1
-subtitles,subtitles,subtitles,NOUN,A2
-subtitling,subtitling,subtitling,NOUN,C1
-subtly,subtly,subtly,ADV,C1
-suburban,suburban,suburban,ADJ,C1
-suburbs,suburbs,suburbs,NOUN,B2
-subversion,subversion,subversion,NOUN,C1
-subversive,subversive,subversive,ADJ,C1
-subvert,subvert,subvert,VERB,C1
-successive,successive,successive,ADJ,C1
-succinctly,succinctly,succinctly,ADV,B2
-succor,succor,succor,NOUN,C1
-succulent,succulent,succulent,ADJ,C1
-such a thing,such a thing,such a thing,PRON,B1
-sudden braking,sudden braking,sudden braking,NOUN,C1
-sudden shower,sudden shower,sudden shower,NOUN,B1
-suffering (adj),suffering,suffering (adj),ADJ,C1
-sufficiently,sufficiently,sufficiently,ADV,C1
-suffocating,suffocating,suffocating,ADJ,B2
-suffrage,suffrage,suffrage,NOUN,C1
-suffuse,suffuse,suffuse,VERB,C1
-sugarcane juice,sugarcane juice,sugarcane juice,NOUN,C1
-suggestibility,suggestibility,suggestibility,NOUN,C1
-suggestiveness,suggestiveness,suggestiveness,NOUN,C1
-suicidal,suicidal,suicidal,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-sukuk,sukuk,sukuk,NOUN,C1
-sukuk issuance,sukuk issuance,sukuk issuance,NOUN,C1
-sulfide,sulfide,sulfide,NOUN,C1
-sulfuric,sulfuric,sulfuric,NOUN,B2
-sullen,sullen,sullen,ADJ,C1
-sullenness,sullenness,sullenness,NOUN,C1
-sully,sully,sully,VERB,C1
-sultanic,sultanic,sultanic,ADJ,C1
-sultriness,sultriness,sultriness,NOUN,B2
-sultry,sultry,sultry,ADJ,C1
-summarization,summarization,summarization,NOUN,B2
-summarizing,summarizing,summarizing,NOUN,C1
-summer vacationers,summer vacationers,summer vacationers,NOUN,B2
-summery,summery,summery,ADJ,C1
-sumptuousness,sumptuousness,sumptuousness,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sundae,sundae,sundae,NOUN,C1
-sunder,sunder,sunder,VERB,C1
-sundry,sundry,sundry,ADJ,C1
-super (adj),super,super (adj),ADJ,A2
-super (adv),super,super (adv),ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-superannuated,superannuated,superannuated,ADJ,C1
-supercilious,supercilious,supercilious,ADJ,C1
-superficiality,superficiality,superficiality,NOUN,C1
-superhero,superhero,superhero,NOUN,B2
-superintendent,superintendent,superintendent,NOUN,C1
-superior upper,superior upper,superior upper,ADJ,C1
-superlative,superlative,superlative,ADJ,C1
-supernumerary,supernumerary,supernumerary,ADJ,C1
-supersede,supersede,supersede,VERB,C1
-supine,supine,supine,ADJ,C1
-supplant,supplant,supplant,VERB,C1
-supple,supple,supple,ADJ,C1
-supplement extra charge,supplement extra charge,supplement extra charge,NOUN,C1
-supplies,supplies,supplies,NOUN,B2
-supplying,supplying,supplying,NOUN,C1
-support medium,support medium,support medium,NOUN,C1
-support pillar,support pillar,support pillar,NOUN,C1
-supported,supported,supported,ADJ,B2
-supporter advocate,supporter advocate,supporter advocate,NOUN,B1
-supporters,supporters,supporters,NOUN,B2
-supportive,supportive,supportive,ADJ,B2
-supposed to,supposed to,supposed to,ADJ,B1
-supposition,supposition,supposition,NOUN,C1
-suppository,suppository,suppository,NOUN,C1
-suppuration,suppuration,suppuration,NOUN,C1
-surety bond,surety bond,surety bond,NOUN,C1
-surfeit,surfeit,surfeit,NOUN,C1
-surging effusive,surging effusive,surging effusive,ADJ,C1
-surly,surly,surly,ADJ,C1
-surmise,surmise,surmise,VERB,C1
-surmount,surmount,surmount,VERB,C1
-surplus (adj),surplus,surplus (adj),ADJ,B2
-surreptitiously,surreptitiously,surreptitiously,ADV,B2
-surrogate,surrogate,surrogate,NOUN,C1
-surrounding,surrounding,surrounding,ADJ,C1
-susceptible,susceptible,susceptible,ADJ,C1
-suspicions,suspicions,suspicions,NOUN,C1
-sustain,sustain,sustain,VERB,C1
-sustainability policy,sustainability policy,sustainability policy,NOUN,C1
-svelte,svelte,svelte,ADJ,C1
-swab,swab,swab,NOUN,B2
-swagger (noun),swagger,swagger (noun),NOUN,B2
-swap,swap,swap,VERB,B2
-swarm (noun),swarm,swarm (noun),NOUN,C1
-swarthy,swarthy,swarthy,ADJ,C1
-sweater knitwear,sweater knitwear,sweater knitwear,NOUN,A1
-sweatshirt,sweatshirt,sweatshirt,NOUN,C1
-sweden,sweden,sweden,PROPN,B2
-sweep (noun),sweep,sweep (noun),NOUN,B2
-sweepings,sweepings,sweepings,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-swelling,swelling,swelling,NOUN,B2
-swelter,swelter,swelter,VERB,C1
-swift,swift,swift,ADJ,C1
-swiftness,swiftness,swiftness,NOUN,C1
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,swimmer,NOUN,C1
-swimwear,swimwear,swimwear,NOUN,B2
-swinging,swinging,,NOUN,B2
-swirl,swirl,swirl,VERB,C1
-switch key,switch key,switch key,NOUN,C1
-switchman,switchman,switchman,NOUN,C1
-sycophant,sycophant,sycophant,NOUN,C1
-sycophantic,sycophantic,sycophantic,ADJ,B2
-syllabification,syllabification,syllabification,NOUN,C1
-symbiosis,symbiosis,symbiosis,NOUN,C1
-symbolization,symbolization,symbolization,NOUN,C1
-symmetric,symmetric,symmetric,ADJ,C1
-symptoms,symptoms,symptoms,NOUN,B1
-synaptic,synaptic,synaptic,ADJ,C1
-synchronized,synchronized,synchronized,ADJ,C1
-synchrony,synchrony,synchrony,NOUN,C1
-syncopate,syncopate,syncopate,VERB,C1
-syncretism,syncretism,syncretism,NOUN,C1
-syndicate,syndicate,syndicate,NOUN,C1
-synecdoche,synecdoche,synecdoche,NOUN,C1
-syneresis,syneresis,syneresis,NOUN,B2
-synonym,synonym,synonym,NOUN,C1
-synopsis,synopsis,synopsis,NOUN,C1
-syntactic,syntactic,syntactic,ADJ,C1
-systematically,systematically,systematically,ADV,B2
-t-shirt,t-shirt,t-shirt,NOUN,B1
-tab,tab,tab,NOUN,C1
-tabernacle,tabernacle,tabernacle,NOUN,C1
-tableau,tableau,tableau,NOUN,C1
-tablecloth,tablecloth,tablecloth,NOUN,C1
-taboo (adj),taboo,taboo (adj),ADJ,C1
-tackling,tackling,tackling,NOUN,B2
-tacky,tacky,tacky,ADJ,B2
-tacky thing,tacky thing,tacky thing,NOUN,B2
-tact,tact,tact,NOUN,C1
-tactful appeasement,tactful appeasement,tactful appeasement,NOUN,C1
-tactical,tactical,tactical,ADJ,C1
-tactician,tactician,tactician,NOUN,C1
-tactile,tactile,tactile,ADJ,C1
-tactless,tactless,tactless,ADJ,B2
-tag (noun),tag,tag (noun),NOUN,B2
-taken,taken,taken,ADJ,C1
-takeover,takeover,takeover,NOUN,C1
-tale,tale,tale,NOUN,A1
-talisman,talisman,talisman,NOUN,B2
-talked,talked,talked,ADJ,C1
-tall and slender,tall and slender,tall and slender,ADJ,C1
-tally,tally,tally,VERB,C1
-tamable,tamable,tamable,ADJ,C1
-tambourine,tambourine,tambourine,NOUN,B2
-tame (adj),tame,tame (adj),ADJ,A1
-taming,taming,taming,NOUN,C1
-tamper,tamper,tamper,VERB,C1
-tangential,tangential,tangential,ADJ,C1
-tangibility,tangibility,tangibility,NOUN,C1
-tank cistern,tank cistern,tank cistern,NOUN,C1
-tanned,tanned,tanned,ADJ,B2
-tannery,tannery,tannery,NOUN,B2
-tantamount,tantamount,tantamount,ADJ,C1
-tantrum,tantrum,tantrum,NOUN,C1
-tape,tape,tape,NOUN,A2
-tapestry,tapestry,tapestry,NOUN,C1
-tarab,tarab,tarab,NOUN,B2
-target group,target group,target group,NOUN,C1
-tarragon,tarragon,tarragon,NOUN,B2
-tarry,tarry,tarry,VERB,C1
-tart pie,tart pie,tart pie,NOUN,C1
-tasting,tasting,tasting,NOUN,C1
-tasty delightful,tasty delightful,tasty delightful,ADJ,C1
-tatter,tatter,tatter,NOUN,C1
-tautology,tautology,tautology,NOUN,C1
-tawdry,tawdry,tawdry,ADJ,C1
-tax (adj),tax,tax (adj),ADJ,C1
-tax duty,tax duty,tax duty,NOUN,C1
-tax rate,tax rate,tax rate,NOUN,B2
-tax relief,tax relief,tax relief,NOUN,C1
-tax return,tax return,tax return,NOUN,B2
-taxi driver,taxi driver,taxi driver,NOUN,C1
-taxi ride,taxi ride,taxi ride,NOUN,A2
-teacher female,teacher female,teacher female,NOUN,B2
-teapot,teapot,teapot,NOUN,C1
-tearing,tearing,,NOUN,B2
-teasing playful,teasing playful,teasing playful,ADJ,C1
-technocrat,technocrat,technocrat,NOUN,C1
-tectonic,tectonic,tectonic,ADJ,C1
-teddy bear,teddy bear,teddy bear,NOUN,B2
-tedious painful,tedious painful,tedious painful,ADJ,B2
-tedium,tedium,tedium,NOUN,C1
-teem,teem,teem,VERB,C1
-teeter,teeter,teeter,VERB,C1
-teeth,teeth,teeth,NOUN,A1
-teething,teething,teething,NOUN,B1
-teetotal,teetotal,teetotal,ADJ,C1
-telecommunications,telecommunications,telecommunications,NOUN,C1
-telegraph lightning,telegraph lightning,telegraph lightning,NOUN,C1
-teleological,teleological,teleological,ADJ,B2
-telepathy,telepathy,telepathy,NOUN,C1
-telephone ringing,telephone ringing,telephone ringing,NOUN,C1
-telephones,telephones,telephones,NOUN,B2
-television set,television set,television set,NOUN,B1
-teller,teller,teller,NOUN,B2
-telling-off,telling-off,telling-off,NOUN,B1
-telltale,telltale,telltale,ADJ,C1
-temperament dispositions,temperament dispositions,temperament dispositions,NOUN,C1
-temperamental,temperamental,temperamental,ADJ,C1
-temperance,temperance,temperance,NOUN,C1
-temperate,temperate,temperate,ADJ,C1
-tempest,tempest,tempest,NOUN,C1
-tempestuous,tempestuous,tempestuous,ADJ,C1
-template,template,template,NOUN,C1
-temporal (noun),temporal,temporal (noun),NOUN,B2
-temptation,temptation,temptation,NOUN,B2
-ten (noun),ten,ten (noun),NOUN,B2
-tenable,tenable,tenable,ADJ,C1
-tend,tend,tend,VERB,B2
-tender (noun),tender,tender (noun),NOUN,C1
-tender affection,tender affection,tender affection,NOUN,C1
-tender mercy,tender mercy,tender mercy,NOUN,C1
-tender-hearted,tender-hearted,tender-hearted,ADJ,C1
-tenement,tenement,tenement,NOUN,C1
-tenet,tenet,tenet,NOUN,C1
-tens,tens,tens,NOUN,B2
-tense (noun),tense,tense (noun),NOUN,B1
-tense angry,tense angry,tense angry,ADJ,A2
-tense excited,tense excited,tense excited,ADJ,B2
-tensile,tensile,tensile,ADJ,C1
-tenth (noun),tenth,tenth (noun),NOUN,B2
-tenuous,tenuous,tenuous,ADJ,C1
-tenure,tenure,tenure,NOUN,B2
-tepid,tepid,tepid,ADJ,C1
-teratogenic,teratogenic,teratogenic,ADJ,B2
-term of office,term of office,term of office,NOUN,C1
-terminus,terminus,,NOUN,B2
-tern path,tern path,tern path,NOUN,B2
-terribleness,terribleness,terribleness,NOUN,B2
-territoriality,territoriality,territoriality,NOUN,C1
-terrorist (adj),terrorist,terrorist (adj),ADJ,C1
-terseness,terseness,terseness,NOUN,C1
-test drive,test drive,,NOUN,B2
-test tube,test tube,test tube,NOUN,C1
-testamentary substitution,testamentary substitution,testamentary substitution,NOUN,C1
-testator,testator,testator,NOUN,C1
-testicular,testicular,testicular,ADJ,C1
-testimony deposition,testimony deposition,testimony deposition,NOUN,C1
-tether,tether,tether,NOUN,C1
-textuality,textuality,textuality,NOUN,C1
-texture,texture,texture,NOUN,C1
-than (adv),than,than (adv),ADV,A1
-tharid,tharid,tharid,NOUN,B2
-that (sconj),that,that (sconj),SCONJ,A1
-that conjunction,that conjunction,that conjunction,SCONJ,A2
-that feminine,that feminine,that feminine,DET,A1
-that masculine,that masculine,that masculine,DET,A1
-that neutral over there,that neutral over there,that neutral over there,PRON,B1
-that way (adv),that way,that way (adv),ADV,B2
-the Abbewegung,the Abbewegung,the Abbewegung,NOUN,C1
-the Abbildung,the Abbildung,the Abbildung,NOUN,C1
-the Abbruch,the Abbruch,the Abbruch,NOUN,C1
-the Abend,the Abend,the Abend,NOUN,C1
-the Abendessen,the Abendessen,the Abendessen,NOUN,C1
-the Abendrot,the Abendrot,the Abendrot,NOUN,C1
-the Abenteuer,the Abenteuer,the Abenteuer,NOUN,C1
-the Aber,the Aber,the Aber,NOUN,C1
-the Aberweiterung,the Aberweiterung,the Aberweiterung,NOUN,C1
-the Abfahrt,the Abfahrt,the Abfahrt,NOUN,C1
-the Abfall,the Abfall,the Abfall,NOUN,C1
-the Abflug,the Abflug,the Abflug,NOUN,C1
-the Abform,the Abform,the Abform,NOUN,C1
-the Abgabe,the Abgabe,the Abgabe,NOUN,C1
-the Abhalt,the Abhalt,the Abhalt,NOUN,C1
-the Abkehr,the Abkehr,the Abkehr,NOUN,C1
-the Abkopplung,the Abkopplung,the Abkopplung,NOUN,C1
-the Ablauf,the Ablauf,the Ablauf,NOUN,C1
-the Ablehnung,the Ablehnung,the Ablehnung,NOUN,C1
-the Ableitung,the Ableitung,the Ableitung,NOUN,C1
-the Ablesung,the Ablesung,the Ablesung,NOUN,C1
-the Abmacht,the Abmacht,the Abmacht,NOUN,C1
-the Abmachung,the Abmachung,the Abmachung,NOUN,C1
-the Abminderung,the Abminderung,the Abminderung,NOUN,C1
-the Abmischung,the Abmischung,the Abmischung,NOUN,C1
-the Abnahme,the Abnahme,the Abnahme,NOUN,C1
-the Abneigung,the Abneigung,the Abneigung,NOUN,C1
-the Abrechnung,the Abrechnung,the Abrechnung,NOUN,C1
-the Absammlung,the Absammlung,the Absammlung,NOUN,C1
-the Abschied,the Abschied,the Abschied,NOUN,C1
-the Abschluss,the Abschluss,the Abschluss,NOUN,C1
-the Absicht,the Absicht,the Absicht,NOUN,C1
-the Absolvent,the Absolvent,the Absolvent,NOUN,C1
-the Abstammung,the Abstammung,the Abstammung,NOUN,C1
-the Abstand,the Abstand,the Abstand,NOUN,C1
-the Abstellung,the Abstellung,the Abstellung,NOUN,C1
-the Abstieg,the Abstieg,the Abstieg,NOUN,C1
-the Abstrich,the Abstrich,the Abstrich,NOUN,C1
-the Absturz,the Absturz,the Absturz,NOUN,C1
-the Abteilung,the Abteilung,the Abteilung,NOUN,C1
-the Abtreibung,the Abtreibung,the Abtreibung,NOUN,C1
-the Abverbesserung,the Abverbesserung,the Abverbesserung,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,the Abvereinfachung,NOUN,C1
-the Abvertiefung,the Abvertiefung,the Abvertiefung,NOUN,C1
-the Abwanderung,the Abwanderung,the Abwanderung,NOUN,C1
-the Abwandlung,the Abwandlung,the Abwandlung,NOUN,C1
-the Abwehr,the Abwehr,the Abwehr,NOUN,C1
-the Abwendung,the Abwendung,the Abwendung,NOUN,C1
-the Abwerk,the Abwerk,the Abwerk,NOUN,C1
-the Abwertung,the Abwertung,the Abwertung,NOUN,C1
-the Abzahlung,the Abzahlung,the Abzahlung,NOUN,C1
-the Abzweigung,the Abzweigung,the Abzweigung,NOUN,C1
-the Achtung,the Achtung,the Achtung,NOUN,C1
-the Acker,the Acker,the Acker,NOUN,C1
-the Adel,the Adel,the Adel,NOUN,C1
-the Adelsitz,the Adelsitz,the Adelsitz,NOUN,C1
-the Adelstitel,the Adelstitel,the Adelstitel,NOUN,C1
-the Adern,the Adern,the Adern,NOUN,C1
-the Adler,the Adler,the Adler,NOUN,C1
-the Admiral,the Admiral,the Admiral,NOUN,C1
-the Adresse,the Adresse,the Adresse,NOUN,C1
-the Advokat,the Advokat,the Advokat,NOUN,C1
-the Affe,the Affe,the Affe,NOUN,C1
-the Affekt,the Affekt,the Affekt,NOUN,C1
-the Aggression,the Aggression,the Aggression,NOUN,C1
-the Agrar,the Agrar,the Agrar,NOUN,C1
-the Ahne,the Ahne,the Ahne,NOUN,C1
-the Ahnen,the Ahnen,the Ahnen,NOUN,C1
-the Akrobat,the Akrobat,the Akrobat,NOUN,C1
-the Akt,the Akt,the Akt,NOUN,C1
-the Akteur,the Akteur,the Akteur,NOUN,C1
-the Aktie,the Aktie,the Aktie,NOUN,C1
-the Akzent,the Akzent,the Akzent,NOUN,C1
-the Alchimie,the Alchimie,the Alchimie,NOUN,C1
-the Algebra,the Algebra,the Algebra,NOUN,C1
-the Algorithmus,the Algorithmus,the Algorithmus,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,the Alleinherrschaft,NOUN,C1
-the Allergie,the Allergie,the Allergie,NOUN,C1
-the Allmende,the Allmende,the Allmende,NOUN,C1
-the Almanach,the Almanach,the Almanach,NOUN,C1
-the Almosen,the Almosen,the Almosen,NOUN,C1
-the Alp,the Alp,the Alp,NOUN,C1
-the Alpdruck,the Alpdruck,the Alpdruck,NOUN,C1
-the Alter,the Alter,the Alter,NOUN,C1
-the Altmetall,the Altmetall,the Altmetall,NOUN,C1
-the Altpapier,the Altpapier,the Altpapier,NOUN,C1
-the Aluminium,the Aluminium,the Aluminium,NOUN,C1
-the Amateur,the Amateur,the Amateur,NOUN,C1
-the Ameise,the Ameise,the Ameise,NOUN,C1
-the Amme,the Amme,the Amme,NOUN,C1
-the Amtes,the Amtes,the Amtes,NOUN,C1
-the Amtszeit,the Amtszeit,the Amtszeit,NOUN,C1
-the Anbau,the Anbau,the Anbau,NOUN,C1
-the Anbewegung,the Anbewegung,the Anbewegung,NOUN,C1
-the Anbiederung,the Anbiederung,the Anbiederung,NOUN,C1
-the Anbildung,the Anbildung,the Anbildung,NOUN,C1
-the Anbindng,the Anbindng,the Anbindng,NOUN,C1
-the Anbohrung,the Anbohrung,the Anbohrung,NOUN,C1
-the Anerweiterung,the Anerweiterung,the Anerweiterung,NOUN,C1
-the Anfall,the Anfall,the Anfall,NOUN,C1
-the Anfang,the Anfang,the Anfang,NOUN,C1
-the Anflug,the Anflug,the Anflug,NOUN,C1
-the Anfrage,the Anfrage,the Anfrage,NOUN,C1
-the Angebot,the Angebot,the Angebot,NOUN,C1
-the Angeklagte,the Angeklagte,the Angeklagte,NOUN,C1
-the Angelpunkt,the Angelpunkt,the Angelpunkt,NOUN,C1
-the Angestellte,the Angestellte,the Angestellte,NOUN,C1
-the Angleichung,the Angleichung,the Angleichung,NOUN,C1
-the Anhalt,the Anhalt,the Anhalt,NOUN,C1
-the Anhandlung,the Anhandlung,the Anhandlung,NOUN,C1
-the Ankraft,the Ankraft,the Ankraft,NOUN,C1
-the Ankunft,the Ankunft,the Ankunft,NOUN,C1
-the Anlage,the Anlage,the Anlage,NOUN,C1
-the Anleitung,the Anleitung,the Anleitung,NOUN,C1
-the Anliegen,the Anliegen,the Anliegen,NOUN,C1
-the Anmacht,the Anmacht,the Anmacht,NOUN,C1
-the Anmerkung,the Anmerkung,the Anmerkung,NOUN,C1
-the Anmessung,the Anmessung,the Anmessung,NOUN,C1
-the Anminderung,the Anminderung,the Anminderung,NOUN,C1
-the Anmischung,the Anmischung,the Anmischung,NOUN,C1
-the Anrechnung,the Anrechnung,the Anrechnung,NOUN,C1
-the Anruf,the Anruf,the Anruf,NOUN,C1
-the Ansammlung,the Ansammlung,the Ansammlung,NOUN,C1
-the Anschein,the Anschein,the Anschein,NOUN,C1
-the Anspruch,the Anspruch,the Anspruch,NOUN,C1
-the Anstalt,the Anstalt,the Anstalt,NOUN,C1
-the Ansteigerung,the Ansteigerung,the Ansteigerung,NOUN,C1
-the Anstieg,the Anstieg,the Anstieg,NOUN,C1
-the Anstoff,the Anstoff,the Anstoff,NOUN,C1
-the Antenne,the Antenne,the Antenne,NOUN,C1
-the Anthropologie,the Anthropologie,the Anthropologie,NOUN,C1
-the Antibiotikum,the Antibiotikum,the Antibiotikum,NOUN,C1
-the Anverbesserung,the Anverbesserung,the Anverbesserung,NOUN,C1
-the Anvertiefung,the Anvertiefung,the Anvertiefung,NOUN,C1
-the Anverwandte,the Anverwandte,the Anverwandte,NOUN,C1
-the Anwandlung,the Anwandlung,the Anwandlung,NOUN,C1
-the Anwendung,the Anwendung,the Anwendung,NOUN,C1
-the Anwert,the Anwert,the Anwert,NOUN,C1
-the Aufbildung,the Aufbildung,the Aufbildung,NOUN,C1
-the Aufbindung,the Aufbindung,the Aufbindung,NOUN,C1
-the Auferweiterung,the Auferweiterung,the Auferweiterung,NOUN,C1
-the Aufform,the Aufform,the Aufform,NOUN,C1
-the Aufhandlung,the Aufhandlung,the Aufhandlung,NOUN,C1
-the Aufkraft,the Aufkraft,the Aufkraft,NOUN,C1
-the Aufmacht,the Aufmacht,the Aufmacht,NOUN,C1
-the Aufmessung,the Aufmessung,the Aufmessung,NOUN,C1
-the Aufminderung,the Aufminderung,the Aufminderung,NOUN,C1
-the Aufmischung,the Aufmischung,the Aufmischung,NOUN,C1
-the Aufrechnung,the Aufrechnung,the Aufrechnung,NOUN,C1
-the Aufsammlung,the Aufsammlung,the Aufsammlung,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,the Aufsteigerung,NOUN,C1
-the Aufstellung,the Aufstellung,the Aufstellung,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,the Aufverbesserung,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,the Aufvereinfachung,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,the Aufvertiefung,NOUN,C1
-the Aufwerk,the Aufwerk,the Aufwerk,NOUN,C1
-the Ausbewegung,the Ausbewegung,the Ausbewegung,NOUN,C1
-the Ausbindung,the Ausbindung,the Ausbindung,NOUN,C1
-the Ausform,the Ausform,the Ausform,NOUN,C1
-the Ausheilung,the Ausheilung,the Ausheilung,NOUN,C1
-the Auskraft,the Auskraft,the Auskraft,NOUN,C1
-the Ausmacht,the Ausmacht,the Ausmacht,NOUN,C1
-the Ausmessung,the Ausmessung,the Ausmessung,NOUN,C1
-the Ausminderung,the Ausminderung,the Ausminderung,NOUN,C1
-the Ausmischung,the Ausmischung,the Ausmischung,NOUN,C1
-the Ausordnung,the Ausordnung,the Ausordnung,NOUN,C1
-the Ausrechnung,the Ausrechnung,the Ausrechnung,NOUN,C1
-the Aussammlung,the Aussammlung,the Aussammlung,NOUN,C1
-the Aussteigerung,the Aussteigerung,the Aussteigerung,NOUN,C1
-the Ausstoff,the Ausstoff,the Ausstoff,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,the Ausverbesserung,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,the Ausvereinfachung,NOUN,C1
-the Auswandlung,the Auswandlung,the Auswandlung,NOUN,C1
-the Auswerk,the Auswerk,the Auswerk,NOUN,C1
-the Auswert,the Auswert,the Auswert,NOUN,C1
-the Bebewegung,the Bebewegung,the Bebewegung,NOUN,C1
-the Bebildung,the Bebildung,the Bebildung,NOUN,C1
-the Bebindung,the Bebindung,the Bebindung,NOUN,C1
-the Beform,the Beform,the Beform,NOUN,C1
-the Behandlung,the Behandlung,the Behandlung,NOUN,C1
-the Beheilung,the Beheilung,the Beheilung,NOUN,C1
-the Bemacht,the Bemacht,the Bemacht,NOUN,C1
-the Bemischung,the Bemischung,the Bemischung,NOUN,C1
-the Besammlung,the Besammlung,the Besammlung,NOUN,C1
-the Besteigerung,the Besteigerung,the Besteigerung,NOUN,C1
-the Bestoff,the Bestoff,the Bestoff,NOUN,C1
-the Beverbesserung,the Beverbesserung,the Beverbesserung,NOUN,C1
-the Bewandlung,the Bewandlung,the Bewandlung,NOUN,C1
-the Bewerk,the Bewerk,the Bewerk,NOUN,C1
-the Bewert,the Bewert,the Bewert,NOUN,C1
-the Einbewegung,the Einbewegung,the Einbewegung,NOUN,C1
-the Einbildung,the Einbildung,the Einbildung,NOUN,C1
-the Einbindung,the Einbindung,the Einbindung,NOUN,C1
-the Einerweiterung,the Einerweiterung,the Einerweiterung,NOUN,C1
-the Einform,the Einform,the Einform,NOUN,C1
-the Einhandlung,the Einhandlung,the Einhandlung,NOUN,C1
-the Einheilung,the Einheilung,the Einheilung,NOUN,C1
-the Einkraft,the Einkraft,the Einkraft,NOUN,C1
-the Einmacht,the Einmacht,the Einmacht,NOUN,C1
-the Einminderung,the Einminderung,the Einminderung,NOUN,C1
-the Einmischung,the Einmischung,the Einmischung,NOUN,C1
-the Einordnung,the Einordnung,the Einordnung,NOUN,C1
-the Einrechnung,the Einrechnung,the Einrechnung,NOUN,C1
-the Einsammlung,the Einsammlung,the Einsammlung,NOUN,C1
-the Einsteigerung,the Einsteigerung,the Einsteigerung,NOUN,C1
-the Einstellung,the Einstellung,the Einstellung,NOUN,C1
-the Einstoff,the Einstoff,the Einstoff,NOUN,C1
-the Einverbesserung,the Einverbesserung,the Einverbesserung,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,the Einvereinfachung,NOUN,C1
-the Einvertiefung,the Einvertiefung,the Einvertiefung,NOUN,C1
-the Einwandlung,the Einwandlung,the Einwandlung,NOUN,C1
-the Einwendung,the Einwendung,the Einwendung,NOUN,C1
-the Einwert,the Einwert,the Einwert,NOUN,C1
-the Erbewegung,the Erbewegung,the Erbewegung,NOUN,C1
-the Erbildung,the Erbildung,the Erbildung,NOUN,C1
-the Erbindung,the Erbindung,the Erbindung,NOUN,C1
-the Erform,the Erform,the Erform,NOUN,C1
-the Erhandlung,the Erhandlung,the Erhandlung,NOUN,C1
-the Erheilung,the Erheilung,the Erheilung,NOUN,C1
-the Erkraft,the Erkraft,the Erkraft,NOUN,C1
-the Ermacht,the Ermacht,the Ermacht,NOUN,C1
-the Ermessung,the Ermessung,the Ermessung,NOUN,C1
-the Erminderung,the Erminderung,the Erminderung,NOUN,C1
-the Ermischung,the Ermischung,the Ermischung,NOUN,C1
-the Erordnung,the Erordnung,the Erordnung,NOUN,C1
-the Errechnung,the Errechnung,the Errechnung,NOUN,C1
-the Ersammlung,the Ersammlung,the Ersammlung,NOUN,C1
-the Ersteigerung,the Ersteigerung,the Ersteigerung,NOUN,C1
-the Erstellung,the Erstellung,the Erstellung,NOUN,C1
-the Erstoff,the Erstoff,the Erstoff,NOUN,C1
-the Erverbesserung,the Erverbesserung,the Erverbesserung,NOUN,C1
-the Ervertiefung,the Ervertiefung,the Ervertiefung,NOUN,C1
-the Erwandlung,the Erwandlung,the Erwandlung,NOUN,C1
-the Erwerk,the Erwerk,the Erwerk,NOUN,C1
-the Erwert,the Erwert,the Erwert,NOUN,C1
-the Erzbewegung,the Erzbewegung,the Erzbewegung,NOUN,C1
-the Erzbildung,the Erzbildung,the Erzbildung,NOUN,C1
-the Erzbindung,the Erzbindung,the Erzbindung,NOUN,C1
-the Erzform,the Erzform,the Erzform,NOUN,C1
-the Erzhandlung,the Erzhandlung,the Erzhandlung,NOUN,C1
-the Erzleitung,the Erzleitung,the Erzleitung,NOUN,C1
-the Erzmacht,the Erzmacht,the Erzmacht,NOUN,C1
-the Erzmessung,the Erzmessung,the Erzmessung,NOUN,C1
-the Erzminderung,the Erzminderung,the Erzminderung,NOUN,C1
-the Erzordnung,the Erzordnung,the Erzordnung,NOUN,C1
-the Erzrechnung,the Erzrechnung,the Erzrechnung,NOUN,C1
-the Erzsammlung,the Erzsammlung,the Erzsammlung,NOUN,C1
-the Erzstellung,the Erzstellung,the Erzstellung,NOUN,C1
-the Erzstoff,the Erzstoff,the Erzstoff,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,the Erzverbesserung,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,the Erzvereinfachung,NOUN,C1
-the Erzwandlung,the Erzwandlung,the Erzwandlung,NOUN,C1
-the Erzwert,the Erzwert,the Erzwert,NOUN,C1
-the Gebewegung,the Gebewegung,the Gebewegung,NOUN,C1
-the Geerweiterung,the Geerweiterung,the Geerweiterung,NOUN,C1
-the Gehandlung,the Gehandlung,the Gehandlung,NOUN,C1
-the Geheilung,the Geheilung,the Geheilung,NOUN,C1
-the Gekraft,the Gekraft,the Gekraft,NOUN,C1
-the Geleitung,the Geleitung,the Geleitung,NOUN,C1
-the Gemacht,the Gemacht,the Gemacht,NOUN,C1
-the Gemessung,the Gemessung,the Gemessung,NOUN,C1
-the Geminderung,the Geminderung,the Geminderung,NOUN,C1
-the Geordnung,the Geordnung,the Geordnung,NOUN,C1
-the Gerechnung,the Gerechnung,the Gerechnung,NOUN,C1
-the Gesammlung,the Gesammlung,the Gesammlung,NOUN,C1
-the Gesteigerung,the Gesteigerung,the Gesteigerung,NOUN,C1
-the Gestellung,the Gestellung,the Gestellung,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,the Gevereinfachung,NOUN,C1
-the Gevertiefung,the Gevertiefung,the Gevertiefung,NOUN,C1
-the Gewandlung,the Gewandlung,the Gewandlung,NOUN,C1
-the Gewerk,the Gewerk,the Gewerk,NOUN,C1
-the Gewert,the Gewert,the Gewert,NOUN,C1
-the Grundbewegung,the Grundbewegung,the Grundbewegung,NOUN,C1
-the Grundbindung,the Grundbindung,the Grundbindung,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,the Grunderweiterung,NOUN,C1
-the Grundform,the Grundform,the Grundform,NOUN,C1
-the Grundhandlung,the Grundhandlung,the Grundhandlung,NOUN,C1
-the Grundheilung,the Grundheilung,the Grundheilung,NOUN,C1
-the Grundkraft,the Grundkraft,the Grundkraft,NOUN,C1
-the Grundleitung,the Grundleitung,the Grundleitung,NOUN,C1
-the Grundmacht,the Grundmacht,the Grundmacht,NOUN,C1
-the Grundmessung,the Grundmessung,the Grundmessung,NOUN,C1
-the Grundminderung,the Grundminderung,the Grundminderung,NOUN,C1
-the Grundmischung,the Grundmischung,the Grundmischung,NOUN,C1
-the Grundordnung,the Grundordnung,the Grundordnung,NOUN,C1
-the Grundrechnung,the Grundrechnung,the Grundrechnung,NOUN,C1
-the Grundsammlung,the Grundsammlung,the Grundsammlung,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,the Grundsteigerung,NOUN,C1
-the Grundstellung,the Grundstellung,the Grundstellung,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,the Grundvereinfachung,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,the Grundvertiefung,NOUN,C1
-the Grundwandlung,the Grundwandlung,the Grundwandlung,NOUN,C1
-the Grundwendung,the Grundwendung,the Grundwendung,NOUN,C1
-the Grundwerk,the Grundwerk,the Grundwerk,NOUN,C1
-the Grundwert,the Grundwert,the Grundwert,NOUN,C1
-the Hochbewegung,the Hochbewegung,the Hochbewegung,NOUN,C1
-the Hochbildung,the Hochbildung,the Hochbildung,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,the Hocherweiterung,NOUN,C1
-the Hochform,the Hochform,the Hochform,NOUN,C1
-the Hochhandlung,the Hochhandlung,the Hochhandlung,NOUN,C1
-the Hochheilung,the Hochheilung,the Hochheilung,NOUN,C1
-the Hochkraft,the Hochkraft,the Hochkraft,NOUN,C1
-the Hochmacht,the Hochmacht,the Hochmacht,NOUN,C1
-the Hochmessung,the Hochmessung,the Hochmessung,NOUN,C1
-the Hochmischung,the Hochmischung,the Hochmischung,NOUN,C1
-the Hochrechnung,the Hochrechnung,the Hochrechnung,NOUN,C1
-the Hochstellung,the Hochstellung,the Hochstellung,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,the Hochverbesserung,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,the Hochvereinfachung,NOUN,C1
-the Hochwandlung,the Hochwandlung,the Hochwandlung,NOUN,C1
-the Hochwendung,the Hochwendung,the Hochwendung,NOUN,C1
-the Hochwerk,the Hochwerk,the Hochwerk,NOUN,C1
-the Hochwert,the Hochwert,the Hochwert,NOUN,C1
-the Missbindung,the Missbindung,the Missbindung,NOUN,C1
-the Misserweiterung,the Misserweiterung,the Misserweiterung,NOUN,C1
-the Missform,the Missform,the Missform,NOUN,C1
-the Misshandlung,the Misshandlung,the Misshandlung,NOUN,C1
-the Missheilung,the Missheilung,the Missheilung,NOUN,C1
-the Missleitung,the Missleitung,the Missleitung,NOUN,C1
-the Missmacht,the Missmacht,the Missmacht,NOUN,C1
-the Missmessung,the Missmessung,the Missmessung,NOUN,C1
-the Missminderung,the Missminderung,the Missminderung,NOUN,C1
-the Missmischung,the Missmischung,the Missmischung,NOUN,C1
-the Misssammlung,the Misssammlung,the Misssammlung,NOUN,C1
-the Misssteigerung,the Misssteigerung,the Misssteigerung,NOUN,C1
-the Missstellung,the Missstellung,the Missstellung,NOUN,C1
-the Missverbesserung,the Missverbesserung,the Missverbesserung,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,the Missvereinfachung,NOUN,C1
-the Misswandlung,the Misswandlung,the Misswandlung,NOUN,C1
-the Misswendung,the Misswendung,the Misswendung,NOUN,C1
-the Misswerk,the Misswerk,the Misswerk,NOUN,C1
-the Misswert,the Misswert,the Misswert,NOUN,C1
-the Mitbewegung,the Mitbewegung,the Mitbewegung,NOUN,C1
-the Mitbindung,the Mitbindung,the Mitbindung,NOUN,C1
-the Miterweiterung,the Miterweiterung,the Miterweiterung,NOUN,C1
-the Mitform,the Mitform,the Mitform,NOUN,C1
-the Mithandlung,the Mithandlung,the Mithandlung,NOUN,C1
-the Mitleitung,the Mitleitung,the Mitleitung,NOUN,C1
-the Mitmacht,the Mitmacht,the Mitmacht,NOUN,C1
-the Mitmessung,the Mitmessung,the Mitmessung,NOUN,C1
-the Mitminderung,the Mitminderung,the Mitminderung,NOUN,C1
-the Mitmischung,the Mitmischung,the Mitmischung,NOUN,C1
-the Mitrechnung,the Mitrechnung,the Mitrechnung,NOUN,C1
-the Mitsammlung,the Mitsammlung,the Mitsammlung,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,the Mitsteigerung,NOUN,C1
-the Mitstoff,the Mitstoff,the Mitstoff,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,the Mitvereinfachung,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,the Mitvertiefung,NOUN,C1
-the Mitwandlung,the Mitwandlung,the Mitwandlung,NOUN,C1
-the Mitwendung,the Mitwendung,the Mitwendung,NOUN,C1
-the Mitwerk,the Mitwerk,the Mitwerk,NOUN,C1
-the Mitwert,the Mitwert,the Mitwert,NOUN,C1
-the Nachbewegung,the Nachbewegung,the Nachbewegung,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,the Nacherweiterung,NOUN,C1
-the Nachform,the Nachform,the Nachform,NOUN,C1
-the Nachhandlung,the Nachhandlung,the Nachhandlung,NOUN,C1
-the Nachkraft,the Nachkraft,the Nachkraft,NOUN,C1
-the Nachmacht,the Nachmacht,the Nachmacht,NOUN,C1
-the Nachminderung,the Nachminderung,the Nachminderung,NOUN,C1
-the Nachmischung,the Nachmischung,the Nachmischung,NOUN,C1
-the Nachordnung,the Nachordnung,the Nachordnung,NOUN,C1
-the Nachrechnung,the Nachrechnung,the Nachrechnung,NOUN,C1
-the Nachsammlung,the Nachsammlung,the Nachsammlung,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,the Nachsteigerung,NOUN,C1
-the Nachstellung,the Nachstellung,the Nachstellung,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,the Nachverbesserung,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,the Nachvereinfachung,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,the Nachvertiefung,NOUN,C1
-the Nachwandlung,the Nachwandlung,the Nachwandlung,NOUN,C1
-the Nachwendung,the Nachwendung,the Nachwendung,NOUN,C1
-the Nachwerk,the Nachwerk,the Nachwerk,NOUN,C1
-the Nachwert,the Nachwert,the Nachwert,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,the Tiefbewegung,NOUN,C1
-the Tiefbildung,the Tiefbildung,the Tiefbildung,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,the Tieferweiterung,NOUN,C1
-the Tiefform,the Tiefform,the Tiefform,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,the Tiefhandlung,NOUN,C1
-the Tiefheilung,the Tiefheilung,the Tiefheilung,NOUN,C1
-the Tiefkraft,the Tiefkraft,the Tiefkraft,NOUN,C1
-the Tiefmacht,the Tiefmacht,the Tiefmacht,NOUN,C1
-the Tiefmessung,the Tiefmessung,the Tiefmessung,NOUN,C1
-the Tiefminderung,the Tiefminderung,the Tiefminderung,NOUN,C1
-the Tiefmischung,the Tiefmischung,the Tiefmischung,NOUN,C1
-the Tiefordnung,the Tiefordnung,the Tiefordnung,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,the Tiefsammlung,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,the Tiefsteigerung,NOUN,C1
-the Tiefstellung,the Tiefstellung,the Tiefstellung,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,the Tiefvereinfachung,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,the Tiefvertiefung,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,the Tiefwandlung,NOUN,C1
-the Tiefwendung,the Tiefwendung,the Tiefwendung,NOUN,C1
-the Tiefwerk,the Tiefwerk,the Tiefwerk,NOUN,C1
-the Tiefwert,the Tiefwert,the Tiefwert,NOUN,C1
-the Unbewegung,the Unbewegung,the Unbewegung,NOUN,C1
-the Unbindung,the Unbindung,the Unbindung,NOUN,C1
-the Unerweiterung,the Unerweiterung,the Unerweiterung,NOUN,C1
-the Unform,the Unform,the Unform,NOUN,C1
-the Unhandlung,the Unhandlung,the Unhandlung,NOUN,C1
-the Unheilung,the Unheilung,the Unheilung,NOUN,C1
-the Unkraft,the Unkraft,the Unkraft,NOUN,C1
-the Unmacht,the Unmacht,the Unmacht,NOUN,C1
-the Unmessung,the Unmessung,the Unmessung,NOUN,C1
-the Unordnung,the Unordnung,the Unordnung,NOUN,C1
-the Unrechnung,the Unrechnung,the Unrechnung,NOUN,C1
-the Unsammlung,the Unsammlung,the Unsammlung,NOUN,C1
-the Unsteigerung,the Unsteigerung,the Unsteigerung,NOUN,C1
-the Unstoff,the Unstoff,the Unstoff,NOUN,C1
-the Unterbewegung,the Unterbewegung,the Unterbewegung,NOUN,C1
-the Unterbildung,the Unterbildung,the Unterbildung,NOUN,C1
-the Unterbindung,the Unterbindung,the Unterbindung,NOUN,C1
-the Unterform,the Unterform,the Unterform,NOUN,C1
-the Unterhandlung,the Unterhandlung,the Unterhandlung,NOUN,C1
-the Unterkraft,the Unterkraft,the Unterkraft,NOUN,C1
-the Untermacht,the Untermacht,the Untermacht,NOUN,C1
-the Untermessung,the Untermessung,the Untermessung,NOUN,C1
-the Unterminderung,the Unterminderung,the Unterminderung,NOUN,C1
-the Untermischung,the Untermischung,the Untermischung,NOUN,C1
-the Unterrechnung,the Unterrechnung,the Unterrechnung,NOUN,C1
-the Untersammlung,the Untersammlung,the Untersammlung,NOUN,C1
-the Untersteigerung,the Untersteigerung,the Untersteigerung,NOUN,C1
-the Unterstellung,the Unterstellung,the Unterstellung,NOUN,C1
-the Unterstoff,the Unterstoff,the Unterstoff,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,the Unterverbesserung,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,the Untervereinfachung,NOUN,C1
-the Untervertiefung,the Untervertiefung,the Untervertiefung,NOUN,C1
-the Unterwandlung,the Unterwandlung,the Unterwandlung,NOUN,C1
-the Unterwendung,the Unterwendung,the Unterwendung,NOUN,C1
-the Unterwerk,the Unterwerk,the Unterwerk,NOUN,C1
-the Unterwert,the Unterwert,the Unterwert,NOUN,C1
-the Unverbesserung,the Unverbesserung,the Unverbesserung,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,the Unvereinfachung,NOUN,C1
-the Unvertiefung,the Unvertiefung,the Unvertiefung,NOUN,C1
-the Unwerk,the Unwerk,the Unwerk,NOUN,C1
-the Unwert,the Unwert,the Unwert,NOUN,C1
-the Urbildung,the Urbildung,the Urbildung,NOUN,C1
-the Urbindung,the Urbindung,the Urbindung,NOUN,C1
-the Urerweiterung,the Urerweiterung,the Urerweiterung,NOUN,C1
-the Urform,the Urform,the Urform,NOUN,C1
-the Urhandlung,the Urhandlung,the Urhandlung,NOUN,C1
-the Urkraft,the Urkraft,the Urkraft,NOUN,C1
-the Urleitung,the Urleitung,the Urleitung,NOUN,C1
-the Urmacht,the Urmacht,the Urmacht,NOUN,C1
-the Urmessung,the Urmessung,the Urmessung,NOUN,C1
-the Urminderung,the Urminderung,the Urminderung,NOUN,C1
-the Urordnung,the Urordnung,the Urordnung,NOUN,C1
-the Ursteigerung,the Ursteigerung,the Ursteigerung,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,the Urvereinfachung,NOUN,C1
-the Urwandlung,the Urwandlung,the Urwandlung,NOUN,C1
-the Urwendung,the Urwendung,the Urwendung,NOUN,C1
-the Urwerk,the Urwerk,the Urwerk,NOUN,C1
-the Urwert,the Urwert,the Urwert,NOUN,C1
-the Verbewegung,the Verbewegung,the Verbewegung,NOUN,C1
-the Verbildung,the Verbildung,the Verbildung,NOUN,C1
-the Verbindung,the Verbindung,the Verbindung,NOUN,C1
-the Vererweiterung,the Vererweiterung,the Vererweiterung,NOUN,C1
-the Verheilung,the Verheilung,the Verheilung,NOUN,C1
-the Verkraft,the Verkraft,the Verkraft,NOUN,C1
-the Verleitung,the Verleitung,the Verleitung,NOUN,C1
-the Vermessung,the Vermessung,the Vermessung,NOUN,C1
-the Vermischung,the Vermischung,the Vermischung,NOUN,C1
-the Verordnung,the Verordnung,the Verordnung,NOUN,C1
-the Verrechnung,the Verrechnung,the Verrechnung,NOUN,C1
-the Verstbewegung,the Verstbewegung,the Verstbewegung,NOUN,C1
-the Verstbildung,the Verstbildung,the Verstbildung,NOUN,C1
-the Versteigerung,the Versteigerung,the Versteigerung,NOUN,C1
-the Versterweiterung,the Versterweiterung,the Versterweiterung,NOUN,C1
-the Verstform,the Verstform,the Verstform,NOUN,C1
-the Verstheilung,the Verstheilung,the Verstheilung,NOUN,C1
-the Verstkraft,the Verstkraft,the Verstkraft,NOUN,C1
-the Verstmacht,the Verstmacht,the Verstmacht,NOUN,C1
-the Verstmessung,the Verstmessung,the Verstmessung,NOUN,C1
-the Verstminderung,the Verstminderung,the Verstminderung,NOUN,C1
-the Verstmischung,the Verstmischung,the Verstmischung,NOUN,C1
-the Verstoff,the Verstoff,the Verstoff,NOUN,C1
-the Verstordnung,the Verstordnung,the Verstordnung,NOUN,C1
-the Verstrechnung,the Verstrechnung,the Verstrechnung,NOUN,C1
-the Verstsammlung,the Verstsammlung,the Verstsammlung,NOUN,C1
-the Verststeigerung,the Verststeigerung,the Verststeigerung,NOUN,C1
-the Verststellung,the Verststellung,the Verststellung,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,the Verstverbesserung,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,the Verstvertiefung,NOUN,C1
-the Verstwandlung,the Verstwandlung,the Verstwandlung,NOUN,C1
-the Verstwendung,the Verstwendung,the Verstwendung,NOUN,C1
-the Verstwert,the Verstwert,the Verstwert,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,the Ververeinfachung,NOUN,C1
-the Verwendung,the Verwendung,the Verwendung,NOUN,C1
-the Verwerk,the Verwerk,the Verwerk,NOUN,C1
-the Verwert,the Verwert,the Verwert,NOUN,C1
-the Vorbewegung,the Vorbewegung,the Vorbewegung,NOUN,C1
-the Vorbildung,the Vorbildung,the Vorbildung,NOUN,C1
-the Vorform,the Vorform,the Vorform,NOUN,C1
-the Vorhandlung,the Vorhandlung,the Vorhandlung,NOUN,C1
-the Vorheilung,the Vorheilung,the Vorheilung,NOUN,C1
-the Vorleitung,the Vorleitung,the Vorleitung,NOUN,C1
-the Vormacht,the Vormacht,the Vormacht,NOUN,C1
-the Vormessung,the Vormessung,the Vormessung,NOUN,C1
-the Vorminderung,the Vorminderung,the Vorminderung,NOUN,C1
-the Vormischung,the Vormischung,the Vormischung,NOUN,C1
-the Vorsammlung,the Vorsammlung,the Vorsammlung,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,the Vorsteigerung,NOUN,C1
-the Vorstoff,the Vorstoff,the Vorstoff,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,the Vorvereinfachung,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,the Vorvertiefung,NOUN,C1
-the Vorwandlung,the Vorwandlung,the Vorwandlung,NOUN,C1
-the Vorwendung,the Vorwendung,the Vorwendung,NOUN,C1
-the Vorwerk,the Vorwerk,the Vorwerk,NOUN,C1
-the Weitbewegung,the Weitbewegung,the Weitbewegung,NOUN,C1
-the Weitbildung,the Weitbildung,the Weitbildung,NOUN,C1
-the Weitbindung,the Weitbindung,the Weitbindung,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,the Weiterweiterung,NOUN,C1
-the Weitform,the Weitform,the Weitform,NOUN,C1
-the Weithandlung,the Weithandlung,the Weithandlung,NOUN,C1
-the Weitkraft,the Weitkraft,the Weitkraft,NOUN,C1
-the Weitleitung,the Weitleitung,the Weitleitung,NOUN,C1
-the Weitmacht,the Weitmacht,the Weitmacht,NOUN,C1
-the Weitmessung,the Weitmessung,the Weitmessung,NOUN,C1
-the Weitrechnung,the Weitrechnung,the Weitrechnung,NOUN,C1
-the Weitsammlung,the Weitsammlung,the Weitsammlung,NOUN,C1
-the Weitstellung,the Weitstellung,the Weitstellung,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,the Weitvereinfachung,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,the Weitvertiefung,NOUN,C1
-the Weitwandlung,the Weitwandlung,the Weitwandlung,NOUN,C1
-the Weitwerk,the Weitwerk,the Weitwerk,NOUN,C1
-the Weitwert,the Weitwert,the Weitwert,NOUN,C1
-the Zerbewegung,the Zerbewegung,the Zerbewegung,NOUN,C1
-the Zerbindung,the Zerbindung,the Zerbindung,NOUN,C1
-the Zerform,the Zerform,the Zerform,NOUN,C1
-the Zerheilung,the Zerheilung,the Zerheilung,NOUN,C1
-the Zerleitung,the Zerleitung,the Zerleitung,NOUN,C1
-the Zermacht,the Zermacht,the Zermacht,NOUN,C1
-the Zermessung,the Zermessung,the Zermessung,NOUN,C1
-the Zerminderung,the Zerminderung,the Zerminderung,NOUN,C1
-the Zermischung,the Zermischung,the Zermischung,NOUN,C1
-the Zersammlung,the Zersammlung,the Zersammlung,NOUN,C1
-the Zersteigerung,the Zersteigerung,the Zersteigerung,NOUN,C1
-the Zerstellung,the Zerstellung,the Zerstellung,NOUN,C1
-the Zerstoff,the Zerstoff,the Zerstoff,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,the Zerverbesserung,NOUN,C1
-the Zervertiefung,the Zervertiefung,the Zervertiefung,NOUN,C1
-the Zerwandlung,the Zerwandlung,the Zerwandlung,NOUN,C1
-the Zerwendung,the Zerwendung,the Zerwendung,NOUN,C1
-the Zerwerk,the Zerwerk,the Zerwerk,NOUN,C1
-the Zerwert,the Zerwert,the Zerwert,NOUN,C1
-the Zubewegung,the Zubewegung,the Zubewegung,NOUN,C1
-the Zubildung,the Zubildung,the Zubildung,NOUN,C1
-the Zubindung,the Zubindung,the Zubindung,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,the Zuerweiterung,NOUN,C1
-the Zuform,the Zuform,the Zuform,NOUN,C1
-the Zuheilung,the Zuheilung,the Zuheilung,NOUN,C1
-the Zukraft,the Zukraft,the Zukraft,NOUN,C1
-the Zuleitung,the Zuleitung,the Zuleitung,NOUN,C1
-the Zumacht,the Zumacht,the Zumacht,NOUN,C1
-the Zumessung,the Zumessung,the Zumessung,NOUN,C1
-the Zuminderung,the Zuminderung,the Zuminderung,NOUN,C1
-the Zumischung,the Zumischung,the Zumischung,NOUN,C1
-the Zuordnung,the Zuordnung,the Zuordnung,NOUN,C1
-the Zusammlung,the Zusammlung,the Zusammlung,NOUN,C1
-the Zusteigerung,the Zusteigerung,the Zusteigerung,NOUN,C1
-the Zustellung,the Zustellung,the Zustellung,NOUN,C1
-the Zustoff,the Zustoff,the Zustoff,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,the Zuverbesserung,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,the Zuvereinfachung,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,the Zuvertiefung,NOUN,C1
-the Zuwendung,the Zuwendung,the Zuwendung,NOUN,C1
-the Zuwerk,the Zuwerk,the Zuwerk,NOUN,C1
-the Zuwert,the Zuwert,the Zuwert,NOUN,C1
-the abbindung,the abbindung,the abbindung,NOUN,B2
-the abhandlung,the abhandlung,the abhandlung,NOUN,B2
-the abordnung,the abordnung,the abordnung,NOUN,B2
-the alias,the alias,the alias,NOUN,B2
-the altertum,the altertum,the altertum,NOUN,B2
-the anbettlung,the anbettlung,the anbettlung,NOUN,B2
-the angriff,the angriff,the angriff,NOUN,B2
-the anordnung,the anordnung,the anordnung,NOUN,B2
-the anvereinfachung,the anvereinfachung,the anvereinfachung,NOUN,B2
-the ausleitung,the ausleitung,the ausleitung,NOUN,B2
-the auswendung,the auswendung,the auswendung,NOUN,B2
-the beordnung,the beordnung,the beordnung,NOUN,B2
-the best,the best,the best,NOUN,C1
-the cash register,the cash register,the cash register,NOUN,B2
-the cavalry,the cavalry,the cavalry,NOUN,B2
-the chain,the chain,the chain,NOUN,B2
-the day after tomorrow (noun),the day after tomorrow,the day after tomorrow (noun),NOUN,B2
-the day before yesterday,the day before yesterday,the day before yesterday,ADV,C1
-the emperor,the emperor,the emperor,NOUN,B2
-the erzerweiterung,the erzerweiterung,the erzerweiterung,NOUN,B2
-the following,the following,the following,PRON,C1
-the geform,the geform,the geform,NOUN,B2
-the grundbildung,the grundbildung,the grundbildung,NOUN,B2
-the hochminderung,the hochminderung,the hochminderung,NOUN,B2
-the hochsteigerung,the hochsteigerung,the hochsteigerung,NOUN,B2
-the masculine,the masculine,the masculine,DET,A2
-the missrechnung,the missrechnung,the missrechnung,NOUN,B2
-the morning after,the morning after,the morning after,NOUN,C1
-the morning of,the morning of,the morning of,NOUN,C1
-the nachheilung,the nachheilung,the nachheilung,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,the one (det),DET,B1
-the other evening,the other evening,the other evening,ADV,B2
-the rich,the rich,the rich,NOUN,B2
-the same (det),the same,the same (det),DET,A2
-the same (pron),the same,the same (pron),PRON,C1
-the unseen,the unseen,the unseen,NOUN,C1
-the unstellung,the unstellung,the unstellung,NOUN,B2
-the unwendung,the unwendung,the unwendung,NOUN,B2
-the urbewegung,the urbewegung,the urbewegung,NOUN,B2
-the urmischung,the urmischung,the urmischung,NOUN,B2
-the urrechnung,the urrechnung,the urrechnung,NOUN,B2
-the urstellung,the urstellung,the urstellung,NOUN,B2
-the vermacht,the vermacht,the vermacht,NOUN,B2
-the verminderung,the verminderung,the verminderung,NOUN,B2
-the verstbindung,the verstbindung,the verstbindung,NOUN,B2
-the versthandlung,the versthandlung,the versthandlung,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,the verstvereinfachung,NOUN,B2
-the ververbesserung,the ververbesserung,the ververbesserung,NOUN,B2
-the ververtiefung,the ververtiefung,the ververtiefung,NOUN,B2
-the vorkraft,the vorkraft,the vorkraft,NOUN,B2
-the zerkraft,the zerkraft,the zerkraft,NOUN,B2
-the zerordnung,the zerordnung,the zerordnung,NOUN,B2
-their (det),their,their (det),DET,B2
-them dative,them dative,them dative,PRON,A2
-then-current,then-current,then-current,ADJ,C1
-theocratic,theocratic,theocratic,ADJ,B2
-theodicy,theodicy,theodicy,NOUN,C1
-theorize,theorize,theorize,VERB,B2
-there direction,there direction,there direction,ADV,B1
-there is there are,there is there are,there is there are,VERB,A1
-thermal (noun),thermal,thermal (noun),NOUN,B2
-thermodynamics,thermodynamics,thermodynamics,NOUN,B2
-thermometer,thermometer,thermometer,NOUN,C1
-thesaurus,thesaurus,thesaurus,NOUN,C1
-these (pron),these,these (pron),PRON,A1
-thespian,thespian,thespian,NOUN,C1
-they two,they two,they two,PRON,A1
-thickets,thickets,thickets,NOUN,B2
-think about,think about,think about,VERB,B1
-thinker,thinker,thinker,NOUN,C1
-thinner,thinner,thinner,ADJ,B2
-third (num),third,third (num),NUM,B1
-this afternoon,this afternoon,this afternoon,ADV,B2
-this feminine,this feminine,this feminine,DET,A1
-this masculine,this masculine,this masculine,DET,A1
-this neutral,this neutral,this neutral,PRON,A1
-this time,this time,this time,ADV,B1
-thoracic,thoracic,thoracic,ADJ,C1
-thorny,thorny,thorny,ADJ,C1
-thoroughly,thoroughly,thoroughly,ADV,B2
-those (pron),those,those (pron),PRON,A1
-thoughtfulness,thoughtfulness,thoughtfulness,NOUN,C1
-thousand (noun),thousand,thousand (noun),NOUN,B2
-thousands (num),thousands,thousands (num),NUM,B1
-thrall,thrall,thrall,NOUN,C1
-thread (verb),thread,thread (verb),VERB,C1
-threadbare,threadbare,threadbare,ADJ,C1
-threads,threads,threads,NOUN,B2
-threatened,threatened,threatened,ADJ,C1
-threats,threats,threats,NOUN,C1
-three times,three times,three times,ADV,B2
-threnody,threnody,threnody,NOUN,C1
-threshing floor,threshing floor,threshing floor,NOUN,B2
-thrill (noun),thrill,thrill (noun),NOUN,B2
-thrilled,thrilled,thrilled,ADJ,B2
-thriving one,thriving one,thriving one,NOUN,B2
-throes,throes,throes,NOUN,C1
-thrombosis,thrombosis,thrombosis,NOUN,C1
-throng,throng,throng,NOUN,C1
-throughout,throughout,throughout,ADP,B1
-throw away,throw away,throw away,VERB,C1
-throw out,throw out,throw out,VERB,C1
-throwing,throwing,throwing,NOUN,B2
-thunderous,thunderous,thunderous,ADJ,B2
-thyme,thyme,thyme,NOUN,B2
-thyroid,thyroid,thyroid,ADJ,B2
-ticket office,ticket office,ticket office,NOUN,C1
-ticket validation,ticket validation,ticket validation,NOUN,B2
-ticket window,ticket window,ticket window,NOUN,B2
-tickle,tickle,tickle,NOUN,B2
-tidy (adj),tidy,tidy (adj),ADJ,B2
-tiebreaker,tiebreaker,tiebreaker,NOUN,C1
-tieferziehung,tieferziehung,tieferziehung,NOUN,C1
-tieffahrt,tieffahrt,tieffahrt,NOUN,C1
-tieffassung,tieffassung,tieffassung,NOUN,C1
-tiefforderung,tiefforderung,tiefforderung,NOUN,C1
-tiefgabe,tiefgabe,tiefgabe,NOUN,C1
-tiefgestaltung,tiefgestaltung,tiefgestaltung,NOUN,C1
-tiefkunft,tiefkunft,tiefkunft,NOUN,C1
-tiefnahme,tiefnahme,tiefnahme,NOUN,C1
-tiefpflegung,tiefpflegung,tiefpflegung,NOUN,C1
-tiefregelung,tiefregelung,tiefregelung,NOUN,C1
-tiefrichtung,tiefrichtung,tiefrichtung,NOUN,C1
-tiefschaft,tiefschaft,tiefschaft,NOUN,C1
-tiefschrift,tiefschrift,tiefschrift,NOUN,C1
-tiefsetzung,tiefsetzung,tiefsetzung,NOUN,C1
-tiefsicht,tiefsicht,tiefsicht,NOUN,C1
-tiefsinnung,tiefsinnung,tiefsinnung,NOUN,C1
-tiefsprache,tiefsprache,tiefsprache,NOUN,C1
-tiefsucht,tiefsucht,tiefsucht,NOUN,C1
-tiefteilung,tiefteilung,tiefteilung,NOUN,C1
-tieftheilung,tieftheilung,tieftheilung,NOUN,C1
-tieftreibung,tieftreibung,tieftreibung,NOUN,C1
-tiefwandel,tiefwandel,tiefwandel,NOUN,C1
-tiefweisung,tiefweisung,tiefweisung,NOUN,C1
-tiefwirkung,tiefwirkung,tiefwirkung,NOUN,C1
-tight narrow,tight narrow,tight narrow,ADJ,B1
-tight-fitting,tight-fitting,tight-fitting,ADJ,B1
-tight-lipped,tight-lipped,tight-lipped,ADJ,B2
-tightfisted,tightfisted,tightfisted,ADJ,C1
-tightly,tightly,tightly,ADV,C1
-tightrope walker,tightrope walker,tightrope walker,NOUN,C1
-tights,tights,tights,NOUN,C1
-timber,timber,timber,NOUN,C1
-timbre,timbre,timbre,NOUN,C1
-time clock,time clock,time clock,NOUN,B2
-time era,time era,time era,NOUN,A2
-time limit,time limit,time limit,NOUN,B1
-time once,time once,time once,NOUN,A2
-time out,time out,time out,NOUN,B2
-time to go to bed,time to go to bed,time to go to bed,ADV,B2
-timely opportune,timely opportune,timely opportune,ADJ,C1
-timid,timid,timid,ADJ,B2
-timorous,timorous,timorous,ADJ,C1
-tingling (adj),tingling,tingling (adj),ADJ,C1
-tinplate,tinplate,tinplate,NOUN,C1
-tinsmith,tinsmith,tinsmith,NOUN,C1
-tint (adj),tint,tint (adj),ADJ,C1
-tint (noun),tint,tint (noun),NOUN,C1
-tiny minute,tiny minute,tiny minute,ADJ,C1
-tips,tips,tips,NOUN,C1
-tire (noun),tire,tire (noun),NOUN,B1
-tired of,tired of,,NOUN,B2
-tirelessly,tirelessly,tirelessly,ADV,C1
-tiring,tiring,tiring,ADJ,B2
-tissue (adj),tissue,tissue (adj),ADJ,C1
-titanic,titanic,titanic,ADJ,C1
-titillate,titillate,titillate,VERB,C1
-titling,titling,titling,NOUN,C1
-tits,tits,tits,NOUN,C1
-titular,titular,titular,ADJ,C1
-to abbauen,to abbauen,to abbauen,VERB,C1
-to abbilden,to abbilden,to abbilden,VERB,C1
-to abbinden,to abbinden,to abbinden,VERB,C1
-to abbrechen,to abbrechen,to abbrechen,VERB,C1
-to abdichten,to abdichten,to abdichten,VERB,C1
-to abfallen,to abfallen,to abfallen,VERB,C1
-to abfassen,to abfassen,to abfassen,VERB,C1
-to abfedern,to abfedern,to abfedern,VERB,C1
-to abfinden,to abfinden,to abfinden,VERB,C1
-to abflachen,to abflachen,to abflachen,VERB,C1
-to abfragen,to abfragen,to abfragen,VERB,C1
-to abgelten,to abgelten,to abgelten,VERB,C1
-to abgrenzen,to abgrenzen,to abgrenzen,VERB,C1
-to abhalten,to abhalten,to abhalten,VERB,C1
-to abhandeln,to abhandeln,to abhandeln,VERB,C1
-to abheben,to abheben,to abheben,VERB,C1
-to abkapseln,to abkapseln,to abkapseln,VERB,C1
-to abklingen,to abklingen,to abklingen,VERB,C1
-to abkoppeln,to abkoppeln,to abkoppeln,VERB,C1
-to ablehnen,to ablehnen,to ablehnen,VERB,C1
-to ableiten,to ableiten,to ableiten,VERB,C1
-to abliefern,to abliefern,to abliefern,VERB,C1
-to abmildern,to abmildern,to abmildern,VERB,C1
-to abnehmen,to abnehmen,to abnehmen,VERB,C1
-to abnicken,to abnicken,to abnicken,VERB,C1
-to abound,to abound,to abound,VERB,C1
-to abrangieren,to abrangieren,to abrangieren,VERB,C1
-to absaufen,to absaufen,to absaufen,VERB,C1
-to absaugen,to absaugen,to absaugen,VERB,C1
-to abschaffen,to abschaffen,to abschaffen,VERB,C1
-to abschatten,to abschatten,to abschatten,VERB,C1
-to abschauen,to abschauen,to abschauen,VERB,C1
-to abschieben,to abschieben,to abschieben,VERB,C1
-to abschirmen,to abschirmen,to abschirmen,VERB,C1
-to abschlagen,to abschlagen,to abschlagen,VERB,C1
-to abschleifen,to abschleifen,to abschleifen,VERB,C1
-to abschrecken,to abschrecken,to abschrecken,VERB,C1
-to abschreiben,to abschreiben,to abschreiben,VERB,C1
-to abschwenken,to abschwenken,to abschwenken,VERB,C1
-to absenden,to absenden,to absenden,VERB,C1
-to absichern,to absichern,to absichern,VERB,B2
-to absolvieren,to absolvieren,to absolvieren,VERB,C1
-to absondern,to absondern,to absondern,VERB,C1
-to absorbieren,to absorbieren,to absorbieren,VERB,C1
-to abspannen,to abspannen,to abspannen,VERB,C1
-to abspeisen,to abspeisen,to abspeisen,VERB,C1
-to absprechen,to absprechen,to absprechen,VERB,C1
-to abstatten,to abstatten,to abstatten,VERB,C1
-to abstehen,to abstehen,to abstehen,VERB,C1
-to absteigen,to absteigen,to absteigen,VERB,C1
-to abstellen,to abstellen,to abstellen,VERB,C1
-to abstract (verb),to abstract,to abstract (verb),VERB,B2
-to abtasten,to abtasten,to abtasten,VERB,C1
-to abtauchen,to abtauchen,to abtauchen,VERB,C1
-to abtippen,to abtippen,to abtippen,VERB,C1
-to abtragen,to abtragen,to abtragen,VERB,C1
-to abtrainieren,to abtrainieren,to abtrainieren,VERB,C1
-to abtreiben,to abtreiben,to abtreiben,VERB,C1
-to abtrennen,to abtrennen,to abtrennen,VERB,C1
-to abtun,to abtun,to abtun,VERB,B2
-to abturnen,to abturnen,to abturnen,VERB,C1
-to abuse (verb),to abuse,to abuse (verb),VERB,B2
-to abwandeln,to abwandeln,to abwandeln,VERB,B2
-to abwarten,to abwarten,to abwarten,VERB,C1
-to abwaschen,to abwaschen,to abwaschen,VERB,C1
-to abwechseln,to abwechseln,to abwechseln,VERB,C1
-to abwehren,to abwehren,to abwehren,VERB,C1
-to abweisen,to abweisen,to abweisen,VERB,C1
-to abwenden,to abwenden,to abwenden,VERB,C1
-to abwerfen,to abwerfen,to abwerfen,VERB,C1
-to abwickeln,to abwickeln,to abwickeln,VERB,C1
-to abwiegen,to abwiegen,to abwiegen,VERB,C1
-to abwinken,to abwinken,to abwinken,VERB,C1
-to abwirken,to abwirken,to abwirken,VERB,C1
-to abwischen,to abwischen,to abwischen,VERB,C1
-to abzahlen,to abzahlen,to abzahlen,VERB,C1
-to abzeichnen,to abzeichnen,to abzeichnen,VERB,C1
-to abzocken,to abzocken,to abzocken,VERB,C1
-to abzweigen,to abzweigen,to abzweigen,VERB,C1
-to accommodate to prepare,to accommodate to prepare,to accommodate to prepare,VERB,C1
-to acquit to settle,to acquit to settle,to acquit to settle,VERB,C1
-to act despotically,to act despotically,to act despotically,VERB,C1
-to act on,to act on,to act on,VERB,B2
-to act pitiful,to act pitiful,to act pitiful,VERB,B1
-to address informally,to address informally,to address informally,VERB,C1
-to adhere join,to adhere join,to adhere join,VERB,B2
-to administer an oath,to administer an oath,to administer an oath,VERB,C1
-to admit to confess,to admit to confess,to admit to confess,VERB,A2
-to aggregate (verb),to aggregate,to aggregate (verb),VERB,B2
-to agree to approve,to agree to approve,to agree to approve,VERB,A2
-to agree with,to agree with,to agree with,VERB,B2
-to aim (verb),to aim,to aim (verb),VERB,B2
-to aim steer,to aim steer,to aim steer,VERB,B2
-to almost (verb),to almost,to almost (verb),VERB,B2
-to alter to spoil,to alter to spoil,to alter to spoil,VERB,C1
-to amnesty (verb),to amnesty,to amnesty (verb),VERB,C1
-to anathematize,to anathematize,to anathematize,VERB,C1
-to animate,to animate,to animate,VERB,B2
-to answer to reply,to answer to reply,to answer to reply,VERB,A2
-to antagonize,to antagonize,to antagonize,VERB,C1
-to antedate,to antedate,to antedate,VERB,B2
-to apostatize,to apostatize,to apostatize,VERB,B2
-to appeal to,to appeal to,to appeal to,VERB,C1
-to appear in court,to appear in court,to appear in court,VERB,B2
-to apply be valid,to apply be valid,to apply be valid,VERB,B2
-to apply for,to apply for,to apply for,VERB,B1
-to appoint add,to appoint add,to appoint add,VERB,B2
-to archive (verb),to archive,to archive (verb),VERB,B2
-to armor (verb),to armor,to armor (verb),VERB,B2
-to arrange a meeting,to arrange a meeting,to arrange a meeting,VERB,B1
-to arrange develop,to arrange develop,to arrange develop,VERB,B2
-to ascend to promote,to ascend to promote,to ascend to promote,VERB,B2
-to ask for,to ask for,to ask for,VERB,A1
-to assume to think,to assume to think,to assume to think,VERB,A2
-to atrophy (verb),to atrophy,to atrophy (verb),VERB,B2
-to attend to prepare,to attend to prepare,to attend to prepare,VERB,A2
-to avenge oneself,to avenge oneself,to avenge oneself,VERB,C1
-to award (verb),to award,to award (verb),VERB,B2
-to badmouth,to badmouth,to badmouth,VERB,C1
-to bang (verb),to bang,to bang (verb),VERB,C1
-to bargain (verb),to bargain,to bargain (verb),VERB,C1
-to barricade (verb),to barricade,to barricade (verb),VERB,B2
-to be (aux),to be,to be (aux),AUX,B2
-to be able (verb),to be able,to be able (verb),VERB,B2
-to be able to (verb),to be able to,to be able to (verb),VERB,B2
-to be absent-minded,to be absent-minded,to be absent-minded,VERB,B2
-to be accused,to be accused,to be accused,VERB,B2
-to be acknowledged,to be acknowledged,to be acknowledged,VERB,B2
-to be addressed,to be addressed,to be addressed,VERB,B2
-to be admitted,to be admitted,to be admitted,VERB,B2
-to be adopted,to be adopted,to be adopted,VERB,B2
-to be allowed (verb),to be allowed,to be allowed (verb),VERB,B2
-to be allowed to,to be allowed to,to be allowed to,AUX,B1
-to be allowed to may,to be allowed to may,to be allowed to may,AUX,A1
-to be analyzed,to be analyzed,to be analyzed,VERB,B2
-to be approved,to be approved,to be approved,VERB,B2
-to be arrested,to be arrested,to be arrested,VERB,B2
-to be ascribed,to be ascribed,to be ascribed,VERB,B2
-to be assumed,to be assumed,to be assumed,VERB,B2
-to be astonished,to be astonished,to be astonished,VERB,B2
-to be attempted,to be attempted,to be attempted,VERB,B2
-to be attributed,to be attributed,to be attributed,VERB,B2
-to be banned,to be banned,to be banned,VERB,B2
-to be believed,to be believed,to be believed,VERB,B2
-to be broadcast,to be broadcast,to be broadcast,VERB,B2
-to be calculated,to be calculated,to be calculated,VERB,B2
-to be cancelled,to be cancelled,to be cancelled,VERB,B2
-to be classified,to be classified,to be classified,VERB,B2
-to be concluded,to be concluded,to be concluded,VERB,B2
-to be considered,to be considered,to be considered,VERB,B2
-to be content,to be content,to be content,VERB,C1
-to be contradicted,to be contradicted,to be contradicted,VERB,B2
-to be dazzled,to be dazzled,to be dazzled,VERB,B2
-to be deduced,to be deduced,to be deduced,VERB,B2
-to be deemed bad,to be deemed bad,to be deemed bad,VERB,B2
-to be deemed likely,to be deemed likely,to be deemed likely,VERB,B2
-to be defined,to be defined,to be defined,VERB,B2
-to be demanded,to be demanded,to be demanded,VERB,B2
-to be denied,to be denied,to be denied,VERB,B2
-to be derived,to be derived,to be derived,VERB,B2
-to be described,to be described,to be described,VERB,B2
-to be detained,to be detained,to be detained,VERB,B2
-to be discovered,to be discovered,to be discovered,VERB,C1
-to be discussed,to be discussed,to be discussed,VERB,B2
-to be disillusioned,to be disillusioned,to be disillusioned,VERB,C1
-to be dissonant,to be dissonant,to be dissonant,VERB,C1
-to be equivalent,to be equivalent,to be equivalent,VERB,C1
-to be estimated,to be estimated,to be estimated,VERB,B2
-to be evaluated,to be evaluated,to be evaluated,VERB,B2
-to be expected,to be expected,to be expected,VERB,B2
-to be fooled,to be fooled,to be fooled,VERB,C1
-to be forbidden,to be forbidden,to be forbidden,VERB,B2
-to be fortunate,to be fortunate,to be fortunate,VERB,B1
-to be good for,to be good for,to be good for,VERB,B2
-to be grandiloquent,to be grandiloquent,to be grandiloquent,VERB,C1
-to be happy,to be happy,to be happy,VERB,A2
-to be heedless,to be heedless,to be heedless,VERB,B2
-to be held,to be held,to be held,VERB,B2
-to be imagined,to be imagined,to be imagined,VERB,B2
-to be infatuated,to be infatuated,to be infatuated,VERB,B2
-to be inferred,to be inferred,to be inferred,VERB,B2
-to be inspected,to be inspected,to be inspected,VERB,B2
-to be judged,to be judged,to be judged,VERB,B2
-to be justified,to be justified,to be justified,VERB,B2
-to be kidnapped,to be kidnapped,to be kidnapped,VERB,B2
-to be known,to be known,to be known,VERB,B2
-to be liable,to be liable,to be liable,VERB,B2
-to be location,to be location,to be location,VERB,A1
-to be lost,to be lost,to be lost,VERB,B1
-to be made available,to be made available,to be made available,VERB,B2
-to be measured,to be measured,to be measured,VERB,B2
-to be mentioned,to be mentioned,to be mentioned,VERB,B2
-to be named,to be named,to be named,VERB,B2
-to be necessary,to be necessary,to be necessary,VERB,A1
-to be necessary must,to be necessary must,to be necessary must,VERB,A2
-to be nicknamed,to be nicknamed,to be nicknamed,VERB,B2
-to be not,to be not,to be not,VERB,A1
-to be noticeable,to be noticeable,to be noticeable,VERB,C1
-to be noticed,to be noticed,to be noticed,VERB,B2
-to be observed,to be observed,to be observed,VERB,B2
-to be ongoing,to be ongoing,to be ongoing,VERB,B2
-to be out of tune,to be out of tune,to be out of tune,VERB,C1
-to be pardoned,to be pardoned,to be pardoned,VERB,B2
-to be pedantic,to be pedantic,to be pedantic,VERB,C1
-to be possible,to be possible,to be possible,VERB,A1
-to be predicted,to be predicted,to be predicted,VERB,B2
-to be preoccupied,to be preoccupied,to be preoccupied,VERB,B2
-to be presented,to be presented,to be presented,VERB,B2
-to be prosecuted,to be prosecuted,to be prosecuted,VERB,B2
-to be published,to be published,to be published,VERB,B2
-to be reborn,to be reborn,to be reborn,VERB,C1
-to be received,to be received,to be received,VERB,B2
-to be refuted,to be refuted,to be refuted,VERB,B2
-to be related,to be related,to be related,VERB,C1
-to be released,to be released,to be released,VERB,B2
-to be relentless,to be relentless,to be relentless,VERB,C1
-to be renowned,to be renowned,to be renowned,VERB,B2
-to be requested,to be requested,to be requested,VERB,B2
-to be researched,to be researched,to be researched,VERB,B2
-to be responsible,to be responsible,to be responsible,VERB,B2
-to be said,to be said,to be said,VERB,B2
-to be scarce,to be scarce,to be scarce,VERB,C1
-to be seen,to be seen,to be seen,VERB,B2
-to be shy,to be shy,to be shy,VERB,A2
-to be sought,to be sought,to be sought,VERB,B2
-to be startled,to be startled,to be startled,VERB,C1
-to be struck,to be struck,to be struck,VERB,B2
-to be studied,to be studied,to be studied,VERB,B2
-to be subject to,to be subject to,to be subject to,VERB,B2
-to be suited,to be suited,to be suited,VERB,B2
-to be summoned,to be summoned,to be summoned,VERB,B2
-to be tested,to be tested,to be tested,VERB,B2
-to be transferred,to be transferred,to be transferred,VERB,B2
-to be translated,to be translated,to be translated,VERB,B2
-to be treated,to be treated,to be treated,VERB,B2
-to be tried,to be tried,to be tried,VERB,B2
-to be unaware,to be unaware,to be unaware,VERB,B2
-to be understood,to be understood,to be understood,VERB,B2
-to be unnecessary,to be unnecessary,to be unnecessary,VERB,C1
-to be unworthy,to be unworthy,to be unworthy,VERB,C1
-to be valid,to be valid,to be valid,VERB,B2
-to be vigilant,to be vigilant,to be vigilant,VERB,B2
-to be visible,to be visible,to be visible,VERB,B2
-to be widowed,to be widowed,to be widowed,VERB,C1
-to be worthy,to be worthy,to be worthy,VERB,B2
-to bear fruit,to bear fruit,to bear fruit,VERB,C1
-to bear to endure,to bear to endure,to bear to endure,VERB,C1
-to beat up,to beat up,to beat up,VERB,C1
-to become (aux),to become,to become (aux),AUX,B2
-to become absorbed,to become absorbed,to become absorbed,VERB,C1
-to become again,to become again,to become again,VERB,B1
-to become alert,to become alert,to become alert,VERB,B2
-to become bold,to become bold,to become bold,VERB,C1
-to become certain,to become certain,to become certain,VERB,B2
-to become gangrenous,to become gangrenous,to become gangrenous,VERB,C1
-to become independent,to become independent,to become independent,VERB,C1
-to become minister,to become minister,to become minister,VERB,C1
-to become poor,to become poor,to become poor,VERB,B2
-to beep (verb),to beep,to beep (verb),VERB,C1
-to begin to cut into,to begin to cut into,to begin to cut into,VERB,C1
-to behave rudely,to behave rudely,to behave rudely,VERB,C1
-to beschieten,to beschieten,to beschieten,VERB,C1
-to bet invest,to bet invest,to bet invest,VERB,B2
-to betroth,to betroth,to betroth,VERB,C1
-to bevriezen,to bevriezen,to bevriezen,VERB,C1
-to bid farewell,to bid farewell,to bid farewell,VERB,B1
-to blaze (verb),to blaze,to blaze (verb),VERB,B2
-to blazon,to blazon,to blazon,VERB,C1
-to blind (verb),to blind,to blind (verb),VERB,B2
-to blockade (verb),to blockade,to blockade (verb),VERB,B2
-to blow one's nose,to blow one's nose,to blow one's nose,VERB,B1
-to board (verb),to board,to board (verb),VERB,C1
-to boil cook,to boil cook,to boil cook,VERB,B1
-to border on,to border on,to border on,VERB,C1
-to bottle (verb),to bottle,to bottle (verb),VERB,C1
-to bound (verb),to bound,to bound (verb),VERB,C1
-to bound leap,to bound leap,to bound leap,VERB,B2
-to box (verb),to box,to box (verb),VERB,B2
-to brawl (verb),to brawl,to brawl (verb),VERB,B1
-to breach (verb),to breach,to breach (verb),VERB,C1
-to break a pledge,to break a pledge,to break a pledge,VERB,C1
-to break away,to break away,to break away,VERB,C1
-to break in,to break in,to break in,VERB,B2
-to break the back,to break the back,to break the back,VERB,C1
-to bridle (verb),to bridle,to bridle (verb),VERB,C1
-to bring along,to bring along,to bring along,VERB,B1
-to bring here,to bring here,to bring here,VERB,C1
-to broadcast (verb),to broadcast,to broadcast (verb),VERB,B2
-to burden (verb),to burden,to burden (verb),VERB,B2
-to burn food,to burn food,to burn food,VERB,C1
-to buzz (verb),to buzz,to buzz (verb),VERB,C1
-to bypass (verb),to bypass,to bypass (verb),VERB,C1
-to cadge,to cadge,to cadge,VERB,C1
-to calcify,to calcify,to calcify,VERB,C1
-to call back,to call back,to call back,VERB,B2
-to call name,to call name,to call name,VERB,A2
-to call out,to call out,to call out,VERB,C1
-to call to contact,to call to contact,to call to contact,VERB,A2
-to canonize,to canonize,to canonize,VERB,B2
-to captain (verb),to captain,to captain (verb),VERB,B2
-to carry on,to carry on,to carry on,VERB,C1
-to cash to take a blow,to cash to take a blow,to cash to take a blow,VERB,C1
-to cast (verb),to cast,to cast (verb),VERB,B2
-to catch sight of,to catch sight of,to catch sight of,VERB,B2
-to catch up with,to catch up with,to catch up with,VERB,B2
-to catechize,to catechize,to catechize,VERB,B2
-to cause remorse,to cause remorse,to cause remorse,VERB,B2
-to cement (verb),to cement,to cement (verb),VERB,B2
-to chain (verb),to chain,to chain (verb),VERB,C1
-to chair (verb),to chair,to chair (verb),VERB,C1
-to change trains,to change trains,to change trains,VERB,A1
-to chisel (verb),to chisel,to chisel (verb),VERB,B2
-to circle (verb),to circle,to circle (verb),VERB,B2
-to circumcise,to circumcise,to circumcise,VERB,B2
-to clash (verb),to clash,to clash (verb),VERB,C1
-to clean out,to clean out,to clean out,VERB,C1
-to clear customs,to clear customs,to clear customs,VERB,C1
-to clear land,to clear land,to clear land,VERB,C1
-to clear one's throat,to clear one's throat,to clear one's throat,VERB,C1
-to clear up,to clear up,to clear up,VERB,C1
-to climb rise,to climb rise,to climb rise,VERB,C1
-to cling to,to cling to,to cling to,VERB,B2
-to cloister (verb),to cloister,to cloister (verb),VERB,C1
-to clone (verb),to clone,to clone (verb),VERB,C1
-to cluster (verb),to cluster,to cluster (verb),VERB,B2
-to coagulate,to coagulate,to coagulate,VERB,B2
-to coat (verb),to coat,to coat (verb),VERB,C1
-to coax,to coax,to coax,VERB,C1
-to codify,to codify,to codify,VERB,C1
-to cohabit,to cohabit,to cohabit,VERB,B2
-to coil (verb),to coil,to coil (verb),VERB,C1
-to coin (verb),to coin,to coin (verb),VERB,B2
-to come true,to come true,to come true,VERB,B2
-to comment (verb),to comment,to comment (verb),VERB,B2
-to comment on,to comment on,to comment on,VERB,C1
-to commune,to commune,to commune,VERB,B2
-to compact (verb),to compact,to compact (verb),VERB,C1
-to complete finish,to complete finish,to complete finish,VERB,B2
-to compliment (verb),to compliment,to compliment (verb),VERB,C1
-to computerize,to computerize,to computerize,VERB,C1
-to conclude an agreement,to conclude an agreement,to conclude an agreement,VERB,C1
-to concretize,to concretize,to concretize,VERB,C1
-to conjure away,to conjure away,to conjure away,VERB,B2
-to constipate,to constipate,to constipate,VERB,C1
-to constitutionalize,to constitutionalize,to constitutionalize,VERB,C1
-to contest (verb),to contest,to contest (verb),VERB,B2
-to corner (verb),to corner,to corner (verb),VERB,C1
-to correspond (! verb),to correspond,to correspond (! verb),! VERB,C1
-to corrupt (verb),to corrupt,to corrupt (verb),VERB,B2
-to couple pair (verb),to couple pair,to couple pair (verb),VERB,B2
-to court (verb),to court,to court (verb),VERB,B2
-to cover up,to cover up,to cover up,VERB,C1
-to crack (verb),to crack,to crack (verb),VERB,B2
-to crash (verb),to crash,to crash (verb),VERB,B2
-to cross out,to cross out,to cross out,VERB,C1
-to cross-check,to cross-check,to cross-check,VERB,B2
-to crow (verb),to crow,to crow (verb),VERB,C1
-to crowd together,to crowd together,to crowd together,VERB,B2
-to cry out,to cry out,to cry out,VERB,B2
-to curse (verb),to curse,to curse (verb),VERB,B2
-to curve (verb),to curve,to curve (verb),VERB,B2
-to cushion (verb),to cushion,to cushion (verb),VERB,B2
-to cut up,to cut up,to cut up,VERB,C1
-to dam up,to dam up,to dam up,VERB,C1
-to damn (verb),to damn,to damn (verb),VERB,B2
-to date (verb),to date,to date (verb),VERB,B2
-to dawn (verb),to dawn,to dawn (verb),VERB,C1
-to deactivate,to deactivate,to deactivate,VERB,C1
-to decimate,to decimate,to decimate,VERB,B2
-to declare oneself,to declare oneself,to declare oneself,VERB,B2
-to decontextualize,to decontextualize,to decontextualize,VERB,C1
-to defend oneself,to defend oneself,to defend oneself,VERB,B2
-to defer,to defer,to defer,VERB,C1
-to dejta,to dejta,to dejta,VERB,B2
-to delay to take long,to delay to take long,to delay to take long,VERB,C1
-to delegitimize,to delegitimize,to delegitimize,VERB,C1
-to delete to remove,to delete to remove,to delete to remove,VERB,C1
-to delimit,to delimit,to delimit,VERB,C1
-to deliver to issue,to deliver to issue,to deliver to issue,VERB,C1
-to delude oneself,to delude oneself,to delude oneself,VERB,B2
-to densify,to densify,to densify,VERB,C1
-to depersonalize,to depersonalize,to depersonalize,VERB,C1
-to deploy unfold,to deploy unfold,to deploy unfold,VERB,C1
-to deputize,to deputize,to deputize,VERB,C1
-to descend from,to descend from,to descend from,VERB,B2
-to desertify,to desertify,to desertify,VERB,C1
-to design (verb),to design,to design (verb),VERB,B2
-to desolate (verb),to desolate,to desolate (verb),VERB,C1
-to despair (verb),to despair,to despair (verb),VERB,C1
-to destock,to destock,to destock,VERB,C1
-to dialogue (verb),to dialogue,to dialogue (verb),VERB,B2
-to dialyze,to dialyze,to dialyze,VERB,C1
-to digitalize,to digitalize,to digitalize,VERB,C1
-to dimension (verb),to dimension,to dimension (verb),VERB,C1
-to dirty (verb),to dirty,to dirty (verb),VERB,C1
-to disappear to vanish,to disappear to vanish,to disappear to vanish,VERB,A2
-to disarray (verb),to disarray,to disarray (verb),VERB,C1
-to disconsole,to disconsole,to disconsole,VERB,C1
-to disdain (verb),to disdain,to disdain (verb),VERB,C1
-to disentail,to disentail,to disentail,VERB,C1
-to disentangle,to disentangle,to disentangle,VERB,C1
-to disgust (verb),to disgust,to disgust (verb),VERB,B2
-to disjoint (verb),to disjoint,to disjoint (verb),VERB,C1
-to dismiss from office,to dismiss from office,to dismiss from office,VERB,C1
-to disoblige,to disoblige,to disoblige,VERB,C1
-to dispossess,to dispossess,to dispossess,VERB,C1
-to disproportion (verb),to disproportion,to disproportion (verb),VERB,C1
-to disrespect (verb),to disrespect,to disrespect (verb),VERB,C1
-to dissent (verb),to dissent,to dissent (verb),VERB,C1
-to distance (verb),to distance,to distance (verb),VERB,C1
-to distress (verb),to distress,to distress (verb),VERB,B2
-to distrust (verb),to distrust,to distrust (verb),VERB,C1
-to do crafts,to do crafts,to do crafts,VERB,B1
-to do hair,to do hair,to do hair,VERB,C1
-to do justice to,to do justice to,to do justice to,VERB,C1
-to do make,to do make,to do make,VERB,A1
-to do wrong,to do wrong,to do wrong,VERB,B2
-to domicile,to domicile,to domicile,VERB,C1
-to dope (verb),to dope,to dope (verb),VERB,B2
-to dote,to dote,to dote,VERB,B2
-to double (verb),to double,to double (verb),VERB,B2
-to drain (verb),to drain,to drain (verb),VERB,C1
-to draw back,to draw back,to draw back,VERB,C1
-to dress (verb),to dress,to dress (verb),VERB,B2
-to drill (verb),to drill,to drill (verb),VERB,B2
-to drive herd,to drive herd,to drive herd,VERB,B2
-to drive in to break down,to drive in to break down,to drive in to break down,VERB,C1
-to drive lead,to drive lead,to drive lead,VERB,B2
-to drive there,to drive there,to drive there,VERB,B2
-to drown to sink,to drown to sink,to drown to sink,VERB,A2
-to dry out,to dry out,to dry out,VERB,C1
-to dry up,to dry up,to dry up,VERB,B2
-to duck (verb),to duck,to duck (verb),VERB,C1
-to dull (verb),to dull,to dull (verb),VERB,C1
-to dust (verb),to dust,to dust (verb),VERB,C1
-to dust off,to dust off,to dust off,VERB,C1
-to each other (adv),to each other,to each other (adv),ADV,C1
-to earmark,to earmark,to earmark,VERB,C1
-to eat animals,to eat animals,to eat animals,VERB,A2
-to edge (verb),to edge,to edge (verb),VERB,C1
-to elbow (verb),to elbow,to elbow (verb),VERB,B2
-to elevate,to elevate,to elevate,VERB,C1
-to email (verb),to email,to email (verb),VERB,B2
-to encode,to encode,to encode,VERB,C1
-to encore (verb),to encore,to encore (verb),VERB,C1
-to encounter (verb),to encounter,to encounter (verb),VERB,B2
-to enter into,to enter into,to enter into,VERB,B2
-to erect behave,to erect behave,to erect behave,VERB,B2
-to espy,to espy,to espy,VERB,B2
-to evidence (verb),to evidence,to evidence (verb),VERB,C1
-to exchange to replace,to exchange to replace,to exchange to replace,VERB,A2
-to execute by firing squad,to execute by firing squad,to execute by firing squad,VERB,C1
-to experiment (verb),to experiment,to experiment (verb),VERB,B2
-to fail to fulfill,to fail to fulfill,to fail to fulfill,VERB,B2
-to federate,to federate,to federate,VERB,C1
-to feel dizzy,to feel dizzy,to feel dizzy,VERB,A2
-to feign ignorance,to feign ignorance,to feign ignorance,VERB,C1
-to festoon,to festoon,to festoon,VERB,C1
-to figure (verb),to figure,to figure (verb),VERB,C1
-to file (verb),to file,to file (verb),VERB,C1
-to finance to fund,to finance to fund,to finance to fund,VERB,B1
-to fit out to develop,to fit out to develop,to fit out to develop,VERB,C1
-to fix to prepare,to fix to prepare,to fix to prepare,VERB,A2
-to fix to set,to fix to set,to fix to set,VERB,B1
-to flame (verb),to flame,to flame (verb),VERB,B2
-to fleece (verb),to fleece,to fleece (verb),VERB,C1
-to flood (verb),to flood,to flood (verb),VERB,C1
-to flow (verb),to flow,to flow (verb),VERB,B2
-to flow in,to flow in,to flow in,VERB,C1
-to flow into,to flow into,to flow into,VERB,C1
-to fluctuate,to fluctuate,to fluctuate,VERB,C1
-to flush out,to flush out,to flush out,VERB,B2
-to foam (verb),to foam,to foam (verb),VERB,B2
-to foil (verb),to foil,to foil (verb),VERB,C1
-to fold back to withdraw,to fold back to withdraw,to fold back to withdraw,VERB,C1
-to force-feed,to force-feed,to force-feed,VERB,C1
-to form a coalition,to form a coalition,to form a coalition,VERB,C1
-to form to train,to form to train,to form to train,VERB,B1
-to fractionate,to fractionate,to fractionate,VERB,C1
-to fracture (verb),to fracture,to fracture (verb),VERB,C1
-to fragment (verb),to fragment,to fragment (verb),VERB,C1
-to free (verb),to free,to free (verb),VERB,B1
-to frighten away,to frighten away,to frighten away,VERB,C1
-to fuck,to fuck,to fuck,VERB,B2
-to fuck off,to fuck off,to fuck off,VERB,C1
-to function to work,to function to work,to function to work,VERB,B1
-to gasify,to gasify,to gasify,VERB,C1
-to gather to collect,to gather to collect,to gather to collect,VERB,A2
-to gather to meet,to gather to meet,to gather to meet,VERB,A2
-to generate to beget,to generate to beget,to generate to beget,VERB,C1
-to gestate,to gestate,to gestate,VERB,C1
-to get along,to get along,to get along,VERB,B2
-to get better,to get better,to get better,VERB,A2
-to get bored,to get bored,to get bored,VERB,B1
-to get cheaper,to get cheaper,to get cheaper,VERB,A2
-to get engaged,to get engaged,to get engaged,VERB,B1
-to get expensive,to get expensive,to get expensive,VERB,A2
-to get fond of,to get fond of,to get fond of,VERB,C1
-to get into debt,to get into debt,to get into debt,VERB,C1
-to get off,to get off,to get off,VERB,B2
-to get on,to get on,to get on,VERB,B2
-to get started,to get started,to get started,VERB,C1
-to get stoned,to get stoned,to get stoned,VERB,C1
-to get stuck,to get stuck,to get stuck,VERB,B2
-to get to know,to get to know,to get to know,VERB,B1
-to gift (verb),to gift,to gift (verb),VERB,B1
-to gird,to gird,to gird,VERB,C1
-to give a gift,to give a gift,to give a gift,VERB,A2
-to give in,to give in,to give in,VERB,B2
-to gloss over,to gloss over,to gloss over,VERB,B2
-to glue (verb),to glue,to glue (verb),VERB,C1
-to go along,to go along,to go along,VERB,C1
-to go bald,to go bald,to go bald,VERB,C1
-to go deep into,to go deep into,to go deep into,VERB,B2
-to go down to descend,to go down to descend,to go down to descend,VERB,A2
-to go numb,to go numb,to go numb,VERB,B2
-to go there,to go there,to go there,VERB,B1
-to go travel,to go travel,to go travel,VERB,A1
-to go up again,to go up again,to go up again,VERB,B1
-to go up in smoke,to go up in smoke,to go up in smoke,VERB,B2
-to go up to climb,to go up to climb,to go up to climb,VERB,A2
-to graspen,to graspen,to graspen,VERB,B2
-to gray (verb),to gray,to gray (verb),VERB,B2
-to grill (verb),to grill,to grill (verb),VERB,A2
-to grow fond of,to grow fond of,to grow fond of,VERB,C1
-to grow old,to grow old,to grow old,VERB,A1
-to guess divine,to guess divine,to guess divine,VERB,B2
-to guess right,to guess right,to guess right,VERB,B2
-to guillotine (verb),to guillotine,to guillotine (verb),VERB,B2
-to gulp down,to gulp down,to gulp down,VERB,C1
-to gurgle (verb),to gurgle,to gurgle (verb),VERB,C1
-to gush (verb),to gush,to gush (verb),VERB,C1
-to half-close,to half-close,to half-close,VERB,C1
-to half-hear,to half-hear,to half-hear,VERB,C1
-to half-open,to half-open,to half-open,VERB,C1
-to hallucinate,to hallucinate,to hallucinate,VERB,B2
-to hand in,to hand in,to hand in,VERB,B2
-to handcuff (verb),to handcuff,to handcuff (verb),VERB,B2
-to hang hook,to hang hook,to hang hook,VERB,B2
-to harangue (verb),to harangue,to harangue (verb),VERB,B2
-to harmonize,to harmonize,to harmonize,VERB,B2
-to hasten,to hasten,to hasten,VERB,C1
-to hatch bloom,to hatch bloom,to hatch bloom,VERB,B2
-to have (aux),to have,to have (aux),AUX,B2
-to have auxiliary,to have auxiliary,to have auxiliary,AUX,A1
-to have supper,to have supper,to have supper,VERB,C1
-to have to (verb),to have to,to have to (verb),VERB,B2
-to head (verb),to head,to head (verb),VERB,B2
-to hear of,to hear of,to hear of,VERB,B1
-to help out repair,to help out repair,to help out repair,VERB,B2
-to herniate,to herniate,to herniate,VERB,C1
-to hide to disappear,to hide to disappear,to hide to disappear,VERB,A2
-to hit the mark,to hit the mark,to hit the mark,VERB,B2
-to hoard,to hoard,to hoard,VERB,C1
-to hoist,to hoist,to hoist,VERB,C1
-to hold keep,to hold keep,to hold keep,VERB,B2
-to hold talks,to hold talks,to hold talks,VERB,C1
-to hold up,to hold up,to hold up,VERB,B2
-to hold up stop,to hold up stop,to hold up stop,VERB,A2
-to hollow out,to hollow out,to hollow out,VERB,C1
-to homogenize,to homogenize,to homogenize,VERB,C1
-to homologate,to homologate,to homologate,VERB,C1
-to hook (verb),to hook,to hook (verb),VERB,C1
-to hop,to hop,to hop,VERB,A1
-to house (verb),to house,to house (verb),VERB,B2
-to huddle,to huddle,to huddle,VERB,C1
-to hug (verb),to hug,to hug (verb),VERB,B2
-to humanize,to humanize,to humanize,VERB,B2
-to hypnotize,to hypnotize,to hypnotize,VERB,C1
-to idolize,to idolize,to idolize,VERB,B2
-to ignite,to ignite,to ignite,VERB,B2
-to ignite to inflame,to ignite to inflame,to ignite to inflame,VERB,C1
-to imbue,to imbue,to imbue,VERB,C1
-to immobilize,to immobilize,to immobilize,VERB,C1
-to impoverish,to impoverish,to impoverish,VERB,C1
-to imprecate,to imprecate,to imprecate,VERB,C1
-to impregnate,to impregnate,to impregnate,VERB,C1
-to imprint (verb),to imprint,to imprint (verb),VERB,C1
-to incapacitate,to incapacitate,to incapacitate,VERB,C1
-to incarcerate,to incarcerate,to incarcerate,VERB,B2
-to incentivize,to incentivize,to incentivize,VERB,C1
-to indicate interpret,to indicate interpret,to indicate interpret,VERB,B2
-to indignate,to indignate,to indignate,VERB,C1
-to indispose,to indispose,to indispose,VERB,C1
-to induce to lead to,to induce to lead to,to induce to lead to,VERB,C1
-to inflate to blow,to inflate to blow,to inflate to blow,VERB,A2
-to inflict,to inflict,to inflict,VERB,C1
-to inflict to impose,to inflict to impose,to inflict to impose,VERB,B2
-to inform to reach,to inform to reach,to inform to reach,VERB,A2
-to innovate,to innovate,to innovate,VERB,C1
-to inoculate,to inoculate,to inoculate,VERB,C1
-to insist to design,to insist to design,to insist to design,VERB,A2
-to institute (verb),to institute,to institute (verb),VERB,C1
-to interact,to interact,to interact,VERB,C1
-to interlace,to interlace,to interlace,VERB,C1
-to interleave,to interleave,to interleave,VERB,C1
-to interlock,to interlock,to interlock,VERB,C1
-to intermix,to intermix,to intermix,VERB,C1
-to internalize,to internalize,to internalize,VERB,C1
-to interpolate,to interpolate,to interpolate,VERB,C1
-to interweave,to interweave,to interweave,VERB,C1
-to intone,to intone,to intone,VERB,C1
-to intuit,to intuit,to intuit,VERB,C1
-to invite to bless,to invite to bless,to invite to bless,VERB,A2
-to issue a fatwa,to issue a fatwa,to issue a fatwa,VERB,C1
-to issue exhibit,to issue exhibit,to issue exhibit,VERB,C1
-to jam (verb),to jam,to jam (verb),VERB,B2
-to jest ironically,to jest ironically,to jest ironically,VERB,C1
-to join to adhere,to join to adhere,to join to adhere,VERB,B2
-to jostle,to jostle,to jostle,VERB,C1
-to jostle shove,to jostle shove,to jostle shove,VERB,B2
-to juggle,to juggle,to juggle,VERB,C1
-to keep pace with,to keep pace with,to keep pace with,VERB,C1
-to knead,to knead,to knead,VERB,A1
-to kneel,to kneel,to kneel,VERB,B1
-to knock down,to knock down,to knock down,VERB,B2
-to knock to pound,to knock to pound,to knock to pound,VERB,A2
-to knot (verb),to knot,to knot (verb),VERB,C1
-to know a fact,to know a fact,to know a fact,VERB,A2
-to know be acquainted,to know be acquainted,to know be acquainted,VERB,A2
-to label (verb),to label,to label (verb),VERB,C1
-to languish,to languish,to languish,VERB,C1
-to lay eggs,to lay eggs,to lay eggs,VERB,C1
-to lay off to dismiss,to lay off to dismiss,to lay off to dismiss,VERB,C1
-to laze,to laze,to laze,VERB,C1
-to lead astray,to lead astray,to lead astray,VERB,B2
-to lead to succeed,to lead to succeed,to lead to succeed,VERB,B2
-to lean against,to lean against,to lean against,VERB,B2
-to lean out,to lean out,to lean out,VERB,B2
-to learn a lesson,to learn a lesson,to learn a lesson,VERB,C1
-to leave to,to leave to,to leave to,VERB,B2
-to leave to abandon,to leave to abandon,to leave to abandon,VERB,A2
-to legislate,to legislate,to legislate,VERB,C1
-to lend to borrow,to lend to borrow,to lend to borrow,VERB,A2
-to lessen,to lessen,to lessen,VERB,B2
-to let in,to let in,to let in,VERB,C1
-to let out,to let out,to let out,VERB,B1
-to lethargize,to lethargize,to lethargize,VERB,C1
-to license (verb),to license,to license (verb),VERB,B2
-to lie tell untruth,to lie tell untruth,to lie tell untruth,VERB,A2
-to lie to,to lie to,to lie to,VERB,B2
-to lift oneself up,to lift oneself up,to lift oneself up,VERB,B2
-to light ignite,to light ignite,to light ignite,VERB,B2
-to like (aux),to like,to like (aux),AUX,A2
-to link (verb),to link,to link (verb),VERB,C1
-to liquefy,to liquefy,to liquefy,VERB,C1
-to lisp (verb),to lisp,to lisp (verb),VERB,B2
-to listen to,to listen to,to listen to,VERB,B2
-to litigate,to litigate,to litigate,VERB,C1
-to live in,to live in,to live in,VERB,C1
-to live on,to live on,to live on,VERB,C1
-to load (verb),to load,to load (verb),VERB,B2
-to lock (verb),to lock,to lock (verb),VERB,B2
-to lock conclude,to lock conclude,to lock conclude,VERB,B2
-to lock in,to lock in,to lock in,VERB,B2
-to lodge,to lodge,to lodge,VERB,B2
-to lodge in,to lodge in,to lodge in,VERB,C1
-to loiter,to loiter,to loiter,VERB,C1
-to long (verb),to long,to long (verb),VERB,B2
-to look like,to look like,to look like,VERB,A2
-to loot (verb),to loot,to loot (verb),VERB,C1
-to lower the price of,to lower the price of,to lower the price of,VERB,B2
-to lukewarm (verb),to lukewarm,to lukewarm (verb),VERB,C1
-to lull,to lull,to lull,VERB,B2
-to lunge,to lunge,to lunge,VERB,C1
-to lure (verb),to lure,to lure (verb),VERB,B2
-to lurk,to lurk,to lurk,VERB,B2
-to magnetize,to magnetize,to magnetize,VERB,C1
-to maim,to maim,to maim,VERB,C1
-to maintain oneself,to maintain oneself,to maintain oneself,VERB,B1
-to make drowsy,to make drowsy,to make drowsy,VERB,B2
-to make excuses,to make excuses,to make excuses,VERB,B2
-to make explicit,to make explicit,to make explicit,VERB,B2
-to make fail,to make fail,to make fail,VERB,C1
-to make fall in love,to make fall in love,to make fall in love,VERB,C1
-to make happy,to make happy,to make happy,VERB,B2
-to make impossible,to make impossible,to make impossible,VERB,C1
-to make independent,to make independent,to make independent,VERB,C1
-to make lasting,to make lasting,to make lasting,VERB,B2
-to make more expensive,to make more expensive,to make more expensive,VERB,C1
-to make one's way,to make one's way,to make one's way,VERB,B2
-to make uneasy,to make uneasy,to make uneasy,VERB,C1
-to make up for substitute,to make up for substitute,to make up for substitute,VERB,B2
-to mandate (verb),to mandate,to mandate (verb),VERB,B2
-to maneuver (verb),to maneuver,to maneuver (verb),VERB,C1
-to manure (verb),to manure,to manure (verb),VERB,C1
-to mark out,to mark out,to mark out,VERB,B2
-to mash (verb),to mash,to mash (verb),VERB,A2
-to massacre (verb),to massacre,to massacre (verb),VERB,C1
-to mast (verb),to mast,to mast (verb),VERB,B2
-to mature (verb),to mature,to mature (verb),VERB,B2
-to maximize,to maximize,to maximize,VERB,C1
-to mean to head to,to mean to head to,to mean to head to,VERB,A2
-to mean to think,to mean to think,to mean to think,VERB,C1
-to meddle,to meddle,to meddle,VERB,B2
-to medicalize,to medicalize,to medicalize,VERB,C1
-to memorize,to memorize,to memorize,VERB,A2
-to mention to remember,to mention to remember,to mention to remember,VERB,A2
-to merge (noun),to merge,to merge (noun),NOUN,B2
-to militarize,to militarize,to militarize,VERB,C1
-to mime (verb),to mime,to mime (verb),VERB,C1
-to mince,to mince,to mince,VERB,B1
-to misplace,to misplace,to misplace,VERB,C1
-to mix in,to mix in,to mix in,VERB,B2
-to mix up,to mix up,to mix up,VERB,C1
-to moan (verb),to moan,to moan (verb),VERB,B2
-to model (verb),to model,to model (verb),VERB,C1
-to modernize,to modernize,to modernize,VERB,C1
-to moon (verb),to moon,to moon (verb),VERB,A2
-to moor (verb),to moor,to moor (verb),VERB,B2
-to mop (verb),to mop,to mop (verb),VERB,A2
-to mop to rinse,to mop to rinse,to mop to rinse,VERB,A2
-to move forward,to move forward,to move forward,VERB,A2
-to move on,to move on,to move on,VERB,C1
-to mud (verb),to mud,to mud (verb),VERB,C1
-to muddle,to muddle,to muddle,VERB,C1
-to muddy (verb),to muddy,to muddy (verb),VERB,C1
-to muffle,to muffle,to muffle,VERB,C1
-to mug (verb),to mug,to mug (verb),VERB,C1
-to multiply tenfold,to multiply tenfold,to multiply tenfold,VERB,B2
-to mumble,to mumble,to mumble,VERB,C1
-to mutiny (verb),to mutiny,to mutiny (verb),VERB,B2
-to need must,to need must,to need must,VERB,A2
-to note down,to note down,to note down,VERB,B2
-to nourish,to nourish,to nourish,VERB,C1
-to number (verb),to number,to number (verb),VERB,C1
-to obscure (verb),to obscure,to obscure (verb),VERB,B2
-to observe to watch,to observe to watch,to observe to watch,VERB,B1
-to obtain issuance,to obtain issuance,to obtain issuance,VERB,C1
-to occur to,to occur to,to occur to,VERB,B2
-to ogle,to ogle,to ogle,VERB,B2
-to operationalize,to operationalize,to operationalize,VERB,C1
-to opt to choose,to opt to choose,to opt to choose,VERB,C1
-to orient,to orient,to orient,VERB,B2
-to orient to guide,to orient to guide,to orient to guide,VERB,C1
-to outdistance,to outdistance,to outdistance,VERB,C1
-to outrage (verb),to outrage,to outrage (verb),VERB,C1
-to overcast (verb),to overcast,to overcast (verb),VERB,C1
-to overestimate,to overestimate,to overestimate,VERB,C1
-to overflow (verb),to overflow,to overflow (verb),VERB,B2
-to own (verb),to own,to own (verb),VERB,B2
-to pacify,to pacify,to pacify,VERB,C1
-to package (verb),to package,to package (verb),VERB,C1
-to paint (verb),to paint,to paint (verb),VERB,B2
-to pair (verb),to pair,to pair (verb),VERB,C1
-to panic (verb),to panic,to panic (verb),VERB,C1
-to patch (verb),to patch,to patch (verb),VERB,A2
-to patrol (verb),to patrol,to patrol (verb),VERB,B2
-to pawn (verb),to pawn,to pawn (verb),VERB,C1
-to pay homage to,to pay homage to,to pay homage to,VERB,C1
-to pay out,to pay out,to pay out,VERB,C1
-to peddle,to peddle,to peddle,VERB,C1
-to pension off,to pension off,to pension off,VERB,C1
-to perforate,to perforate,to perforate,VERB,C1
-to perform umrah,to perform umrah,to perform umrah,VERB,C1
-to perfume (verb),to perfume,to perfume (verb),VERB,B1
-to perjure,to perjure,to perjure,VERB,B2
-to perpetrate,to perpetrate,to perpetrate,VERB,C1
-to personify,to personify,to personify,VERB,C1
-to pester,to pester,to pester,VERB,C1
-to phagocytize,to phagocytize,to phagocytize,VERB,C1
-to philosophize,to philosophize,to philosophize,VERB,C1
-to phone (verb),to phone,to phone (verb),VERB,B2
-to pierce,to pierce,to pierce,VERB,B2
-to pigeonhole,to pigeonhole,to pigeonhole,VERB,C1
-to pilgrimage (verb),to pilgrimage,to pilgrimage (verb),VERB,B2
-to pipe (verb),to pipe,to pipe (verb),VERB,A2
-to pity (verb),to pity,to pity (verb),VERB,B2
-to plant beans,to plant beans,to plant beans,VERB,C1
-to plaster (verb),to plaster,to plaster (verb),VERB,C1
-to pledge mutually,to pledge mutually,to pledge mutually,VERB,C1
-to pluck,to pluck,to pluck,VERB,C1
-to plunder (verb),to plunder,to plunder (verb),VERB,B2
-to point a gun,to point a gun,to point a gun,VERB,C1
-to point to clock in,to point to clock in,to point to clock in,VERB,B2
-to pole (verb),to pole,to pole (verb),VERB,C1
-to polemicize,to polemicize,to polemicize,VERB,C1
-to pollute,to pollute,to pollute,VERB,B2
-to portend,to portend,to portend,VERB,B2
-to postpone to carry over,to postpone to carry over,to postpone to carry over,VERB,B2
-to pound (verb),to pound,to pound (verb),VERB,B2
-to powder (verb),to powder,to powder (verb),VERB,B2
-to prejudge,to prejudge,to prejudge,VERB,B2
-to premiere (verb),to premiere,to premiere (verb),VERB,C1
-to preserve to protect,to preserve to protect,to preserve to protect,VERB,C1
-to presuppose,to presuppose,to presuppose,VERB,B2
-to profile (verb),to profile,to profile (verb),VERB,C1
-to protect to defend,to protect to defend,to protect to defend,VERB,A2
-to provide to supply,to provide to supply,to provide to supply,VERB,B1
-to publish edit,to publish edit,to publish edit,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,to publish to spread to hang laundry,VERB,A2
-to pull out hair,to pull out hair,to pull out hair,VERB,C1
-to pull through,to pull through,to pull through,VERB,B2
-to pump (verb),to pump,to pump (verb),VERB,C1
-to purchase (verb),to purchase,to purchase (verb),VERB,B2
-to purify certify,to purify certify,to purify certify,VERB,C1
-to pursue to continue,to pursue to continue,to pursue to continue,VERB,B1
-to push back,to push back,to push back,VERB,B2
-to put away,to put away,to put away,VERB,B2
-to put on track,to put on track,to put on track,VERB,B2
-to put standing,to put standing,to put standing,VERB,A2
-to put to bed,to put to bed,to put to bed,VERB,A1
-to put to sleep,to put to sleep,to put to sleep,VERB,B2
-to quantify,to quantify,to quantify,VERB,B2
-to question officially,to question officially,to question officially,VERB,C1
-to race (verb),to race,to race (verb),VERB,B1
-to race down,to race down,to race down,VERB,C1
-to ram (verb),to ram,to ram (verb),VERB,C1
-to rape (verb),to rape,to rape (verb),VERB,B2
-to ratify to approve,to ratify to approve,to ratify to approve,VERB,C1
-to rave,to rave,to rave,VERB,C1
-to reach achieve,to reach achieve,to reach achieve,VERB,B1
-to read aloud,to read aloud,to read aloud,VERB,B2
-to read to be,to read to be,to read to be,VERB,B1
-to receive payment,to receive payment,to receive payment,VERB,B1
-to reconquer,to reconquer,to reconquer,VERB,C1
-to record save,to record save,to record save,VERB,B2
-to recover to retrieve,to recover to retrieve,to recover to retrieve,VERB,A2
-to recover to wake up,to recover to wake up,to recover to wake up,VERB,A2
-to rediscover,to rediscover,to rediscover,VERB,B2
-to redo,to redo,to redo,VERB,B1
-to reelect,to reelect,to reelect,VERB,C1
-to reflect deeply,to reflect deeply,to reflect deeply,VERB,B2
-to register to record,to register to record,to register to record,VERB,A2
-to regret apologize,to regret apologize,to regret apologize,VERB,B2
-to reign (verb),to reign,to reign (verb),VERB,B2
-to rein in,to rein in,to rein in,VERB,C1
-to reinvent,to reinvent,to reinvent,VERB,C1
-to relapse into crime,to relapse into crime,to relapse into crime,VERB,B2
-to relativize,to relativize,to relativize,VERB,C1
-to release from prison,to release from prison,to release from prison,VERB,B2
-to release let go,to release let go,to release let go,VERB,B2
-to remain to stay,to remain to stay,to remain to stay,VERB,A2
-to remove makeup,to remove makeup,to remove makeup,VERB,C1
-to remove to pull out,to remove to pull out,to remove to pull out,VERB,A2
-to remunerate,to remunerate,to remunerate,VERB,C1
-to reoffend,to reoffend,to reoffend,VERB,B2
-to reproach (verb),to reproach,to reproach (verb),VERB,B2
-to research (verb),to research,to research (verb),VERB,B2
-to restructure,to restructure,to restructure,VERB,C1
-to resurrect to revive,to resurrect to revive,to resurrect to revive,VERB,C1
-to return home,to return home,to return home,VERB,B1
-to return something,to return something,to return something,VERB,A2
-to return to restore,to return to restore,to return to restore,VERB,C1
-to rewrite,to rewrite,to rewrite,VERB,C1
-to ride along,to ride along,to ride along,VERB,B1
-to ridicule (verb),to ridicule,to ridicule (verb),VERB,C1
-to rock (verb),to rock,to rock (verb),VERB,C1
-to roll up sleeves,to roll up sleeves,to roll up sleeves,VERB,B1
-to root out,to root out,to root out,VERB,C1
-to round (verb),to round,to round (verb),VERB,A2
-to row (verb),to row,to row (verb),VERB,B2
-to ruffle,to ruffle,to ruffle,VERB,C1
-to rule out,to rule out,to rule out,VERB,C1
-to sacrifice (verb),to sacrifice,to sacrifice (verb),VERB,B2
-to sanction to punish,to sanction to punish,to sanction to punish,VERB,C1
-to saw (verb),to saw,to saw (verb),VERB,B2
-to say goodbye fire,to say goodbye fire,to say goodbye fire,VERB,B1
-to scamper,to scamper,to scamper,VERB,B2
-to scare away,to scare away,to scare away,VERB,B2
-to scent,to scent,to scent,VERB,B2
-to schematize,to schematize,to schematize,VERB,C1
-to scheme (verb),to scheme,to scheme (verb),VERB,C1
-to score (verb),to score,to score (verb),VERB,B2
-to scourge (verb),to scourge,to scourge (verb),VERB,C1
-to scram,to scram,to scram,VERB,B2
-to scrape,to scrape,to scrape,VERB,B2
-to scratch to rub,to scratch to rub,to scratch to rub,VERB,A2
-to scream (verb),to scream,to scream (verb),VERB,A2
-to scribble (verb),to scribble,to scribble (verb),VERB,C1
-to scrimp,to scrimp,to scrimp,VERB,C1
-to sculpt,to sculpt,to sculpt,VERB,C1
-to search apply,to search apply,to search apply,VERB,B2
-to second (verb),to second,to second (verb),VERB,C1
-to secularize,to secularize,to secularize,VERB,C1
-to seek clarification,to seek clarification,to seek clarification,VERB,B2
-to seep,to seep,to seep,VERB,B2
-to segment (verb),to segment,to segment (verb),VERB,B2
-to sell dispose,to sell dispose,to sell dispose,VERB,B2
-to sense (verb),to sense,to sense (verb),VERB,B2
-to sermonize,to sermonize,to sermonize,VERB,B2
-to set off again,to set off again,to set off again,VERB,B2
-to set on fire,to set on fire,to set on fire,VERB,C1
-to sew again,to sew again,to sew again,VERB,B1
-to sew in,to sew in,to sew in,VERB,C1
-to sexualize,to sexualize,to sexualize,VERB,C1
-to shade,to shade,to shade,VERB,C1
-to shell (verb),to shell,to shell (verb),VERB,C1
-to shelter house,to shelter house,to shelter house,VERB,B2
-to shiver (verb),to shiver,to shiver (verb),VERB,B1
-to shoe (verb),to shoe,to shoe (verb),VERB,C1
-to shoot dead,to shoot dead,to shoot dead,VERB,B2
-to shop for groceries,to shop for groceries,to shop for groceries,VERB,A2
-to shout oneself hoarse,to shout oneself hoarse,to shout oneself hoarse,VERB,C1
-to show off,to show off,to show off,VERB,C1
-to shuffle,to shuffle,to shuffle,VERB,B2
-to sicken,to sicken,to sicken,VERB,C1
-to sidestep,to sidestep,to sidestep,VERB,C1
-to sigh (verb),to sigh,to sigh (verb),VERB,B2
-to sight (verb),to sight,to sight (verb),VERB,C1
-to simmer,to simmer,to simmer,VERB,B1
-to simper,to simper,to simper,VERB,C1
-to singe,to singe,to singe,VERB,B2
-to sip (verb),to sip,to sip (verb),VERB,B2
-to skein,to skein,to skein,VERB,B2
-to skewer,to skewer,to skewer,VERB,B2
-to skip,to skip,to skip,VERB,B2
-to slam to snap,to slam to snap,to slam to snap,VERB,C1
-to slap (verb),to slap,to slap (verb),VERB,B2
-to slay,to slay,to slay,VERB,C1
-to slice (verb),to slice,to slice (verb),VERB,C1
-to slip away,to slip away,to slip away,VERB,C1
-to slope down,to slope down,to slope down,VERB,B2
-to snack (verb),to snack,to snack (verb),VERB,C1
-to snack eat sweets,to snack eat sweets,to snack eat sweets,VERB,A1
-to snort (verb),to snort,to snort (verb),VERB,B2
-to soil (verb),to soil,to soil (verb),VERB,C1
-to sort out,to sort out,to sort out,VERB,B2
-to sour (verb),to sour,to sour (verb),VERB,C1
-to spectacularize,to spectacularize,to spectacularize,VERB,C1
-to spend time,to spend time,to spend time,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,to spend time to judge to fulfill,VERB,B1
-to spend to exchange,to spend to exchange,to spend to exchange,VERB,A2
-to spirit away,to spirit away,to spirit away,VERB,B2
-to splint (verb),to splint,to splint (verb),VERB,B2
-to splinter (verb),to splinter,to splinter (verb),VERB,C1
-to split one's sides,to split one's sides,to split one's sides,VERB,C1
-to spout,to spout,to spout,VERB,B2
-to spray (verb),to spray,to spray (verb),VERB,B2
-to spread to make a bed,to spread to make a bed,to spread to make a bed,VERB,A2
-to spy on,to spy on,to spy on,VERB,C1
-to squeak (verb),to squeak,to squeak (verb),VERB,B2
-to stack (verb),to stack,to stack (verb),VERB,B2
-to stage (verb),to stage,to stage (verb),VERB,C1
-to stamp (verb),to stamp,to stamp (verb),VERB,B2
-to stand by,to stand by,to stand by,VERB,B2
-to stand out to differentiate,to stand out to differentiate,to stand out to differentiate,VERB,C1
-to stay overnight,to stay overnight,to stay overnight,VERB,B2
-to steep (verb),to steep,to steep (verb),VERB,C1
-to stem from,to stem from,to stem from,VERB,B2
-to sterilize,to sterilize,to sterilize,VERB,C1
-to stiffen,to stiffen,to stiffen,VERB,C1
-to stifle smother,to stifle smother,to stifle smother,VERB,B2
-to stone (verb),to stone,to stone (verb),VERB,C1
-to stop down,to stop down,to stop down,VERB,C1
-to store (verb),to store,to store (verb),VERB,B2
-to straighten up,to straighten up,to straighten up,VERB,B2
-to strain (verb),to strain,to strain (verb),VERB,B2
-to stress (verb),to stress,to stress (verb),VERB,C1
-to stride (verb),to stride,to stride (verb),VERB,B2
-to string (verb),to string,to string (verb),VERB,C1
-to strip of leaves,to strip of leaves,to strip of leaves,VERB,C1
-to study at university,to study at university,to study at university,VERB,A2
-to stun,to stun,to stun,VERB,C1
-to stutter,to stutter,to stutter,VERB,B2
-to stylize,to stylize,to stylize,VERB,C1
-to subject (verb),to subject,to subject (verb),VERB,C1
-to subtract,to subtract,to subtract,VERB,C1
-to succeed to pass,to succeed to pass,to succeed to pass,VERB,A2
-to suck up,to suck up,to suck up,VERB,C1
-to suffer from,to suffer from,to suffer from,VERB,B2
-to suffice to reach,to suffice to reach,to suffice to reach,VERB,B1
-to suit agree,to suit agree,to suit agree,VERB,B2
-to sunbathe,to sunbathe,to sunbathe,VERB,B2
-to support lean,to support lean,to support lean,VERB,B1
-to surf,to surf,to surf,VERB,C1
-to surge (verb),to surge,to surge (verb),VERB,B2
-to surname (verb),to surname,to surname (verb),VERB,B2
-to swallow up,to swallow up,to swallow up,VERB,B2
-to sway hips,to sway hips,to sway hips,VERB,C1
-to swipe,to swipe,to swipe,VERB,C1
-to synchronize,to synchronize,to synchronize,VERB,C1
-to tack,to tack,to tack,VERB,C1
-to tackle approach,to tackle approach,to tackle approach,VERB,B2
-to tag (verb),to tag,to tag (verb),VERB,C1
-to take a course,to take a course,to take a course,VERB,B2
-to take a shower,to take a shower,to take a shower,VERB,A2
-to take advantage of,to take advantage of,to take advantage of,VERB,B1
-to take amiss,to take amiss,to take amiss,VERB,C1
-to take bribes,to take bribes,to take bribes,VERB,C1
-to take communion,to take communion,to take communion,VERB,B2
-to take down,to take down,to take down,VERB,C1
-to take minutes,to take minutes,to take minutes,VERB,B2
-to take off to remove,to take off to remove,to take off to remove,VERB,A2
-to take on,to take on,to take on,VERB,C1
-to take one's time,to take one's time,to take one's time,VERB,B2
-to take possession of,to take possession of,to take possession of,VERB,B2
-to take root,to take root,to take root,VERB,B2
-to take time,to take time,to take time,VERB,B1
-to take to bed,to take to bed,to take to bed,VERB,C1
-to talk chat,to talk chat,to talk chat,VERB,B2
-to tap to type,to tap to type,to tap to type,VERB,C1
-to tarnish,to tarnish,to tarnish,VERB,C1
-to task (verb),to task,to task (verb),VERB,C1
-to tax to accuse of,to tax to accuse of,to tax to accuse of,VERB,C1
-to teach reading,to teach reading,to teach reading,VERB,B2
-to tear to pieces,to tear to pieces,to tear to pieces,VERB,C1
-to tell to narrate,to tell to narrate,to tell to narrate,VERB,A2
-to temper (verb),to temper,to temper (verb),VERB,B2
-to tense (verb),to tense,to tense (verb),VERB,B2
-to there (adv),to there,to there (adv),ADV,A1
-to thicken,to thicken,to thicken,VERB,C1
-to thin (verb),to thin,to thin (verb),VERB,C1
-to think it over,to think it over,to think it over,VERB,B2
-to think opine,to think opine,to think opine,VERB,B2
-to thrill (verb),to thrill,to thrill (verb),VERB,B2
-to throw in,to throw in,to throw in,VERB,B2
-to throw oneself at,to throw oneself at,to throw oneself at,VERB,C1
-to thrown,to thrown,to thrown,VERB,B2
-to thrust (verb),to thrust,to thrust (verb),VERB,C1
-to thunder (verb),to thunder,to thunder (verb),VERB,B2
-to tidy to order,to tidy to order,to tidy to order,VERB,B1
-to tinker,to tinker,to tinker,VERB,B1
-to tip (verb),to tip,to tip (verb),VERB,B2
-to tip over,to tip over,to tip over,VERB,B2
-to tire get tired,to tire get tired,to tire get tired,VERB,B2
-to title to be titled,to title to be titled,to title to be titled,VERB,B1
-to toast (verb),to toast,to toast (verb),VERB,B2
-to toil (verb),to toil,to toil (verb),VERB,C1
-to topple,to topple,to topple,VERB,C1
-to totalize,to totalize,to totalize,VERB,C1
-to tow,to tow,to tow,VERB,C1
-to trap (verb),to trap,to trap (verb),VERB,C1
-to traumatize,to traumatize,to traumatize,VERB,C1
-to treasure (verb),to treasure,to treasure (verb),VERB,B2
-to trek (verb),to trek,to trek (verb),VERB,C1
-to turn back,to turn back,to turn back,VERB,B2
-to turn off extinguish,to turn off extinguish,to turn off extinguish,VERB,B2
-to turn on to employ,to turn on to employ,to turn on to employ,VERB,A2
-to turn out to be,to turn out to be,to turn out to be,VERB,C1
-to twinkle,to twinkle,to twinkle,VERB,B2
-to tyrannize,to tyrannize,to tyrannize,VERB,C1
-to unbalance,to unbalance,to unbalance,VERB,C1
-to unbend,to unbend,to unbend,VERB,B2
-to unblind,to unblind,to unblind,VERB,B2
-to unblock,to unblock,to unblock,VERB,C1
-to unbutton,to unbutton,to unbutton,VERB,B2
-to uncage,to uncage,to uncage,VERB,C1
-to uncouple,to uncouple,to uncouple,VERB,C1
-to uncover to reveal,to uncover to reveal,to uncover to reveal,VERB,A2
-to unhinge,to unhinge,to unhinge,VERB,C1
-to unhook,to unhook,to unhook,VERB,B2
-to unplug,to unplug,to unplug,VERB,C1
-to unroll,to unroll,to unroll,VERB,C1
-to unscrew,to unscrew,to unscrew,VERB,B2
-to unseat,to unseat,to unseat,VERB,C1
-to unshackle,to unshackle,to unshackle,VERB,C1
-to unsheathe,to unsheathe,to unsheathe,VERB,C1
-to unstitch,to unstitch,to unstitch,VERB,B2
-to untangle,to untangle,to untangle,VERB,C1
-to unwrap,to unwrap,to unwrap,VERB,B1
-to usually do,to usually do,to usually do,VERB,C1
-to vacuum (verb),to vacuum,to vacuum (verb),VERB,A2
-to valorize,to valorize,to valorize,VERB,C1
-to vent (verb),to vent,to vent (verb),VERB,B2
-to venture (verb),to venture,to venture (verb),VERB,B2
-to vouch for,to vouch for,to vouch for,VERB,B2
-to wall up,to wall up,to wall up,VERB,C1
-to warm up,to warm up,to warm up,VERB,B2
-to wash up,to wash up,to wash up,VERB,A2
-to watch for,to watch for,to watch for,VERB,C1
-to water give drink,to water give drink,to water give drink,VERB,B2
-to wax (verb),to wax,to wax (verb),VERB,A1
-to wear down,to wear down,to wear down,VERB,B2
-to wear to get dressed,to wear to get dressed,to wear to get dressed,VERB,A2
-to weary to tire,to weary to tire,to weary to tire,VERB,B2
-to wed,to wed,to wed,VERB,C1
-to weed (verb),to weed,to weed (verb),VERB,C1
-to weigh down,to weigh down,to weigh down,VERB,C1
-to weigh options,to weigh options,to weigh options,VERB,B2
-to whiten,to whiten,to whiten,VERB,B2
-to wield,to wield,to wield,VERB,C1
-to wipe to clean,to wipe to clean,to wipe to clean,VERB,A2
-to withdraw to sample,to withdraw to sample,to withdraw to sample,VERB,C1
-to wither,to wither,to wither,VERB,B2
-to woo,to woo,to woo,VERB,B2
-to word (verb),to word,to word (verb),VERB,C1
-to worry anxiety,to worry anxiety,to worry anxiety,VERB,A2
-to wrap up,to wrap up,to wrap up,VERB,B2
-to wrestle,to wrestle,to wrestle,VERB,B2
-to wriggle,to wriggle,to wriggle,VERB,B2
-to wrinkle (verb),to wrinkle,to wrinkle (verb),VERB,C1
-to write down,to write down,to write down,VERB,B2
-to yell at,to yell at,to yell at,VERB,B1
-to yelp,to yelp,to yelp,VERB,C1
-today (adv),today,today (adv),ADV,A1
-today's,today's,today's,ADJ,C1
-togetherness,togetherness,togetherness,NOUN,C1
-toiling,toiling,toiling,ADJ,C1
-tolerance dependence,tolerance dependence,tolerance dependence,NOUN,C1
-tomb monument,tomb monument,tomb monument,NOUN,B2
-tombstone,tombstone,tombstone,NOUN,C1
-tome,tome,tome,NOUN,C1
-tomorrow (adv),tomorrow,tomorrow (adv),ADV,A1
-tomorrow night,tomorrow night,tomorrow night,ADV,B2
-tonality,tonality,tonality,NOUN,C1
-tonic (adj),tonic,tonic (adj),ADJ,C1
-tonic (noun),tonic,tonic (noun),NOUN,C1
-tonight (noun),tonight,tonight (noun),NOUN,B2
-tonsil,tonsil,tonsil,NOUN,B2
-tooling,tooling,tooling,NOUN,C1
-top scorer,top scorer,top scorer,NOUN,B2
-topographical,topographical,topographical,ADJ,C1
-torment (noun),torment,torment (noun),NOUN,C1
-tormentor,tormentor,tormentor,NOUN,B2
-torments,torments,torments,NOUN,B2
-torpid,torpid,torpid,ADJ,C1
-torpor,torpor,torpor,NOUN,C1
-torque,torque,torque,NOUN,C1
-torrid,torrid,torrid,ADJ,C1
-tortious,tortious,tortious,ADJ,C1
-tortoise,tortoise,tortoise,NOUN,B1
-tortuous,tortuous,tortuous,ADJ,C1
-torture ordeal,torture ordeal,torture ordeal,NOUN,C1
-toss,toss,toss,VERB,B2
-totalitarianism,totalitarianism,totalitarianism,NOUN,C1
-totality,totality,totality,NOUN,C1
-totem,totem,totem,NOUN,C1
-totemism,totemism,totemism,NOUN,C1
-touchstone,touchstone,touchstone,NOUN,C1
-tout,tout,tout,VERB,C1
-towering,towering,towering,ADJ,B2
-toxicity,toxicity,toxicity,NOUN,C1
-toxin,toxin,toxin,NOUN,C1
-tracking,tracking,tracking,NOUN,C1
-tracksuit,tracksuit,tracksuit,NOUN,C1
-tractable,tractable,tractable,ADJ,C1
-trade (verb),trade,trade (verb),VERB,A2
-trade unionist,trade unionist,trade unionist,NOUN,C1
-trade-off,trade-off,trade-off,NOUN,C1
-trading practice,trading practice,trading practice,NOUN,C1
-traditional female singers,traditional female singers,traditional female singers,NOUN,B1
-traditionalism,traditionalism,traditionalism,NOUN,C1
-traditions,traditions,traditions,NOUN,B1
-traduce,traduce,traduce,VERB,C1
-traffic ticket,traffic ticket,traffic ticket,NOUN,C1
-trafficker,trafficker,trafficker,NOUN,C1
-trafficking,trafficking,trafficking,NOUN,C1
-tragically,tragically,tragically,ADV,B2
-tragicness,tragicness,tragicness,NOUN,C1
-trail,trail,trail,NOUN,B1
-train ride,train ride,train ride,NOUN,A1
-train ticket,train ticket,train ticket,NOUN,A1
-trained,trained,trained,ADJ,C1
-trainer,trainer,trainer,NOUN,B2
-trainer bastard,trainer bastard,trainer bastard,NOUN,B2
-traits qualities,traits qualities,traits qualities,NOUN,C1
-trance,trance,trance,NOUN,C1
-tranquility,tranquility,tranquility,NOUN,B1
-transatlantic,transatlantic,transatlantic,ADJ,C1
-transcend,transcend,transcend,VERB,C1
-transcript,transcript,transcript,NOUN,C1
-transfer window,transfer window,transfer window,NOUN,B2
-transferee,transferee,transferee,NOUN,C1
-transferor,transferor,transferor,NOUN,C1
-transferred,transferred,transferred,ADJ,C1
-transfix,transfix,transfix,VERB,C1
-transformer converter,transformer converter,transformer converter,NOUN,C1
-transhumance,transhumance,transhumance,NOUN,B2
-transient,transient,transient,ADJ,C1
-transistor,transistor,transistor,NOUN,C1
-transitory,transitory,transitory,ADJ,C1
-translatology,translatology,translatology,NOUN,C1
-translucent,translucent,translucent,ADJ,C1
-transmute,transmute,transmute,VERB,C1
-transpire,transpire,transpire,VERB,C1
-transport (adj),transport,transport (adj),ADJ,C1
-transport service,transport service,transport service,NOUN,C1
-transportation,transportation,transportation,NOUN,C1
-transporter,transporter,transporter,NOUN,C1
-transpose,transpose,transpose,VERB,C1
-transregional,transregional,transregional,ADJ,C1
-trapped,trapped,trapped,ADJ,A2
-trapping,trapping,trapping,NOUN,C1
-trash can,trash can,trash can,NOUN,A2
-traumatic,traumatic,traumatic,ADJ,B2
-travail,travail,travail,NOUN,C1
-travel (noun),travel,travel (noun),NOUN,B2
-travel guide,travel guide,travel guide,NOUN,A1
-traveled,traveled,traveled,ADJ,C1
-travesty,travesty,travesty,NOUN,C1
-treacherously,treacherously,treacherously,ADV,C1
-treasure room,treasure room,treasure room,NOUN,C1
-treatise,treatise,treatise,NOUN,C1
-trek (noun),trek,trek (noun),NOUN,C1
-tremendous,tremendous,tremendous,ADJ,B2
-trench coat,trench coat,trench coat,NOUN,C1
-trenchant,trenchant,trenchant,ADJ,C1
-trending,trending,trending,ADJ,C1
-trepidation,trepidation,trepidation,NOUN,C1
-trespass (verb),trespass,trespass (verb),VERB,C1
-trial run,trial run,trial run,NOUN,B2
-tribalism (adj),tribalism,tribalism (adj),ADJ,C1
-tribalism (noun),tribalism,tribalism (noun),NOUN,C1
-tribulation,tribulation,tribulation,NOUN,C1
-tribunal,tribunal,tribunal,NOUN,C1
-tribune,tribune,tribune,NOUN,C1
-tricky,tricky,tricky,ADJ,B2
-tricolor,tricolor,tricolor,ADJ,C1
-trigger (adj),trigger,trigger (adj),ADJ,C1
-trigger imprint,trigger imprint,trigger imprint,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-trigonometry,trigonometry,trigonometry,NOUN,C1
-trilemma,trilemma,trilemma,NOUN,B2
-trill,trill,trill,NOUN,C1
-trillion,trillion,trillion,NUM,B2
-trilogy,trilogy,trilogy,NOUN,B2
-trim,trim,trim,VERB,C1
-trivia,trivia,trivia,NOUN,C1
-trocar,trocar,trocar,NOUN,C1
-troglodyte,troglodyte,troglodyte,NOUN,C1
-tropic,tropic,tropic,NOUN,C1
-trouble spot,trouble spot,trouble spot,NOUN,C1
-troublemaker,troublemaker,troublemaker,NOUN,B2
-troubling,troubling,troubling,ADJ,B2
-trout,trout,trout,NOUN,C1
-trowel,trowel,trowel,NOUN,B2
-truculent,truculent,truculent,ADJ,C1
-truly,truly,truly,ADV,B2
-truncate,truncate,truncate,VERB,C1
-truncheon,truncheon,truncheon,NOUN,C1
-trust in God,trust in God,trust in God,NOUN,C1
-try out,try out,try out,VERB,C1
-tuberculosis,tuberculosis,tuberculosis,NOUN,B2
-tug,tug,tug,VERB,C1
-tumble (noun),tumble,tumble (noun),NOUN,C1
-tumoral,tumoral,tumoral,ADJ,C1
-tumult,tumult,tumult,NOUN,C1
-tumultuous,tumultuous,tumultuous,ADJ,C1
-tuning,tuning,tuning,NOUN,C1
-turban,turban,turban,NOUN,B2
-turbid,turbid,turbid,ADJ,C1
-turbine,turbine,turbine,NOUN,C1
-turbulence,turbulence,turbulence,NOUN,C1
-turgid,turgid,turgid,ADJ,C1
-turmeric,turmeric,turmeric,NOUN,B2
-turn of phrase,turn of phrase,turn of phrase,NOUN,C1
-turncoat,turncoat,turncoat,NOUN,C1
-turnoff,turnoff,turnoff,NOUN,B2
-turntable,turntable,turntable,NOUN,B2
-turpitude,turpitude,turpitude,NOUN,C1
-tutelary,tutelary,tutelary,ADJ,C1
-tweezers,tweezers,tweezers,NOUN,C1
-twenty-five,twenty-five,twenty-five,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twinning,twinning,twinning,NOUN,B2
-twist (noun),twist,twist (noun),NOUN,C1
-twofold,twofold,twofold,ADJ,B2
-tycoon,tycoon,tycoon,NOUN,C1
-type like,type like,type like,NOUN,B2
-typically,typically,typically,ADV,C1
-typographical,typographical,typographical,ADJ,B2
-typography,typography,typography,NOUN,C1
-tyrannical might,tyrannical might,tyrannical might,NOUN,C1
-tyrannically haughty,tyrannically haughty,tyrannically haughty,ADJ,C1
-ubiquitous,ubiquitous,ubiquitous,ADJ,C1
-ulterior,ulterior,ulterior,ADJ,C1
-ultimate outcome,ultimate outcome,ultimate outcome,NOUN,C1
-ultimatum,ultimatum,ultimatum,NOUN,C1
-ululate,ululate,ululate,VERB,B2
-ululation,ululation,ululation,NOUN,C1
-umbrage,umbrage,umbrage,NOUN,C1
-unabated,unabated,unabated,ADJ,C1
-unable,unable,unable,ADJ,B2
-unaccustomed,unaccustomed,unaccustomed,ADJ,C1
-unaffected,unaffected,unaffected,ADJ,C1
-unaffectionate,unaffectionate,unaffectionate,ADJ,C1
-unalterable,unalterable,unalterable,ADJ,C1
-unanimity,unanimity,unanimity,NOUN,C1
-unappealable,unappealable,unappealable,ADJ,C1
-unapproachable,unapproachable,unapproachable,ADJ,C1
-unaware,unaware,unaware,ADJ,B2
-unbeatable,unbeatable,unbeatable,ADJ,C1
-unbelieving,unbelieving,unbelieving,ADJ,C1
-unbridled,unbridled,unbridled,ADJ,B2
-uncanny,uncanny,uncanny,ADJ,C1
-unchanging,unchanging,unchanging,ADJ,C1
-uncivil,uncivil,uncivil,ADJ,C1
-unclassifiable,unclassifiable,unclassifiable,ADJ,C1
-uncompromising,uncompromising,uncompromising,ADJ,B2
-unconquerable,unconquerable,unconquerable,ADJ,C1
-unconscious (noun),unconscious,unconscious (noun),NOUN,C1
-unconsciousness,unconsciousness,unconsciousness,NOUN,C1
-uncountable,uncountable,uncountable,ADJ,C1
-uncovered,uncovered,uncovered,ADJ,A2
-uncritical,uncritical,uncritical,ADJ,B2
-uncultivated,uncultivated,uncultivated,ADJ,B2
-undaunted,undaunted,undaunted,ADJ,C1
-undead,undead,undead,NOUN,C1
-undeniably,undeniably,undeniably,ADV,B2
-under the,under the,under the,ADP,B2
-underground canal,underground canal,underground canal,NOUN,B2
-underling,underling,underling,NOUN,C1
-underlying,underlying,underlying,ADJ,B2
-underneath (adp),underneath,underneath (adp),ADP,B1
-underpin,underpin,underpin,VERB,C1
-underscore,underscore,underscore,VERB,C1
-understood,understood,understood,ADJ,A1
-undervaluing,undervaluing,undervaluing,NOUN,C1
-underwater,underwater,underwater,ADJ,B2
-undeserved,undeserved,undeserved,ADJ,C1
-undisturbed,undisturbed,undisturbed,ADJ,C1
-undo (adj),undo,undo (adj),ADJ,C1
-undoubted,undoubted,undoubted,ADJ,C1
-undulate,undulate,undulate,VERB,C1
-unemployed person,unemployed person,unemployed person,NOUN,B2
-unequivocal,unequivocal,unequivocal,ADJ,C1
-unerring,unerring,unerring,ADJ,C1
-unevenness,unevenness,unevenness,NOUN,C1
-unfair prejudice,unfair prejudice,unfair prejudice,NOUN,C1
-unfairness,unfairness,unfairness,NOUN,C1
-unfaithful infidel,unfaithful infidel,unfaithful infidel,ADJ,C1
-unfathomable,unfathomable,unfathomable,ADJ,C1
-unfavorable,unfavorable,unfavorable,ADJ,C1
-unfettered,unfettered,unfettered,ADJ,C1
-unfinished,unfinished,unfinished,ADJ,C1
-unfolding,unfolding,unfolding,NOUN,C1
-unforderung,unforderung,unforderung,NOUN,C1
-unforeseeable,unforeseeable,unforeseeable,ADJ,C1
-unforgettable,unforgettable,unforgettable,ADJ,C1
-unforgivable (noun),unforgivable,unforgivable (noun),NOUN,B2
-unfounded,unfounded,unfounded,ADJ,C1
-ungabe,ungabe,ungabe,NOUN,C1
-ungestaltung,ungestaltung,ungestaltung,NOUN,C1
-ungodliness,ungodliness,ungodliness,NOUN,C1
-unhappiness,unhappiness,unhappiness,NOUN,C1
-unhealthy,unhealthy,unhealthy,ADJ,C1
-unhurried patience,unhurried patience,unhurried patience,NOUN,C1
-unicorn,unicorn,unicorn,NOUN,C1
-unification,unification,unification,NOUN,B2
-uniformity,uniformity,uniformity,NOUN,B2
-unilateralism,unilateralism,unilateralism,NOUN,C1
-unimpeachable,unimpeachable,unimpeachable,ADJ,C1
-unimpeded,unimpeded,unimpeded,ADJ,C1
-uninhabited,uninhabited,uninhabited,ADJ,C1
-uninhibited,uninhibited,uninhibited,ADJ,C1
-unintelligible,unintelligible,unintelligible,ADJ,C1
-uninterrupted,uninterrupted,uninterrupted,ADJ,C1
-union (adj),union,union (adj),ADJ,C1
-unionist,unionist,unionist,ADJ,B2
-unique (noun),unique,unique (noun),NOUN,B2
-universal total,universal total,universal total,ADJ,C1
-university (adj),university,university (adj),ADJ,C1
-university of applied sciences,university of applied sciences,university of applied sciences,NOUN,B2
-unkempt,unkempt,unkempt,ADJ,C1
-unkunft,unkunft,unkunft,NOUN,C1
-unleashed,unleashed,unleashed,ADJ,C1
-unlike (adp),unlike,unlike (adp),ADP,B2
-unlocked,unlocked,unlocked,NOUN,B2
-unmentionable,unmentionable,unmentionable,ADJ,C1
-unmissable,unmissable,unmissable,ADJ,C1
-unmistakable,unmistakable,unmistakable,ADJ,C1
-unmitigated,unmitigated,unmitigated,ADJ,C1
-unnatural,unnatural,unnatural,ADJ,B2
-unnoticed,unnoticed,unnoticed,ADJ,C1
-unobtrusive,unobtrusive,unobtrusive,ADJ,C1
-unoccupied,unoccupied,unoccupied,ADJ,C1
-unparalleled (adj),unparalleled,unparalleled (adj),ADJ,C1
-unpopular,unpopular,unpopular,ADJ,C1
-unpostponable,unpostponable,unpostponable,ADJ,C1
-unpredictable (noun),unpredictable,unpredictable (noun),NOUN,B2
-unprepared,unprepared,unprepared,ADJ,C1
-unproductive,unproductive,unproductive,ADJ,C1
-unpublished,unpublished,unpublished,ADJ,B2
-unpunished,unpunished,unpunished,ADJ,C1
-unreachable,unreachable,unreachable,ADJ,C1
-unreal,unreal,unreal,ADJ,C1
-unrecognized,unrecognized,unrecognized,ADJ,C1
-unreflective,unreflective,unreflective,ADJ,C1
-unregelung,unregelung,unregelung,NOUN,C1
-unrelated,unrelated,unrelated,ADJ,C1
-unreliable,unreliable,unreliable,ADJ,C1
-unremitting,unremitting,unremitting,ADJ,C1
-unrepeatable,unrepeatable,unrepeatable,ADJ,C1
-unrepentant,unrepentant,unrepentant,ADJ,C1
-unrequited,unrequited,unrequited,ADJ,C1
-unrichtung,unrichtung,unrichtung,NOUN,C1
-unsafe,unsafe,unsafe,ADJ,B1
-unschaft,unschaft,unschaft,NOUN,B2
-unschrift,unschrift,unschrift,NOUN,C1
-unsecured,unsecured,unsecured,NOUN,B2
-unseemly,unseemly,unseemly,ADJ,C1
-unseen realities,unseen realities,unseen realities,NOUN,C1
-unsetzung,unsetzung,unsetzung,NOUN,C1
-unshakable,unshakable,unshakable,ADJ,C1
-unsicht,unsicht,unsicht,NOUN,C1
-unsinnung,unsinnung,unsinnung,NOUN,C1
-unsociable,unsociable,unsociable,ADJ,C1
-unspeakable,unspeakable,unspeakable,ADJ,C1
-unsprache,unsprache,unsprache,NOUN,C1
-unsteady,unsteady,unsteady,ADJ,C1
-unstinting,unstinting,unstinting,ADJ,C1
-unsubscription,unsubscription,unsubscription,NOUN,B1
-unsuccessful,unsuccessful,unsuccessful,ADJ,C1
-unsucht,unsucht,unsucht,NOUN,C1
-unsuchung,unsuchung,unsuchung,NOUN,C1
-unteilung,unteilung,unteilung,NOUN,C1
-untenable,untenable,untenable,ADJ,C1
-untererziehung,untererziehung,untererziehung,NOUN,C1
-unterfahrt,unterfahrt,unterfahrt,NOUN,C1
-unterfassung,unterfassung,unterfassung,NOUN,C1
-unterforderung,unterforderung,unterforderung,NOUN,C1
-untergabe,untergabe,untergabe,NOUN,C1
-untergestaltung,untergestaltung,untergestaltung,NOUN,C1
-unternahme,unternahme,unternahme,NOUN,C1
-unterregelung,unterregelung,unterregelung,NOUN,C1
-unterrichtung,unterrichtung,unterrichtung,NOUN,C1
-unterschaft,unterschaft,unterschaft,NOUN,C1
-unterschrift,unterschrift,unterschrift,NOUN,C1
-untersetzung,untersetzung,untersetzung,NOUN,B2
-untersicht,untersicht,untersicht,NOUN,C1
-untersprache,untersprache,untersprache,NOUN,C1
-untersucht,untersucht,untersucht,NOUN,C1
-untersuchung,untersuchung,untersuchung,NOUN,C1
-unterteilung,unterteilung,unterteilung,NOUN,C1
-untertheilung,untertheilung,untertheilung,NOUN,C1
-unterwandel,unterwandel,unterwandel,NOUN,C1
-unterweisung,unterweisung,unterweisung,NOUN,C1
-unterwirkung,unterwirkung,unterwirkung,NOUN,C1
-untheilung,untheilung,untheilung,NOUN,C1
-untidiness,untidiness,untidiness,NOUN,B2
-untidy,untidy,untidy,ADJ,C1
-until to,until to,until to,ADP,A2
-until up to,until up to,until up to,ADP,A1
-untimely (adj),untimely,untimely (adj),ADJ,C1
-untimely (noun),untimely,untimely (noun),NOUN,C1
-untouched,untouched,untouched,ADJ,C1
-untoward,untoward,untoward,ADJ,C1
-unviable,unviable,unviable,ADJ,C1
-unwanted,unwanted,unwanted,ADJ,B2
-unwarranted,unwarranted,unwarranted,ADJ,C1
-unwell,unwell,unwell,ADJ,C1
-unwieldy,unwieldy,unwieldy,ADJ,C1
-unwirkung,unwirkung,unwirkung,NOUN,C1
-unwise,unwise,unwise,ADJ,C1
-unwitting,unwitting,unwitting,ADJ,C1
-unwonted,unwonted,unwonted,ADJ,C1
-upbraid,upbraid,upbraid,VERB,C1
-update (noun),update,update (noun),NOUN,B1
-updated,updated,updated,ADJ,C1
-upgrade (noun),upgrade,upgrade (noun),NOUN,C1
-upgraded,upgraded,upgraded,ADJ,C1
-uphold,uphold,uphold,VERB,C1
-upholding of rights,upholding of rights,upholding of rights,NOUN,C1
-upload (noun),upload,upload (noun),NOUN,C1
-upper class,upper class,upper class,NOUN,B2
-upper voice,upper voice,upper voice,NOUN,C1
-uprightness,uprightness,uprightness,NOUN,B2
-uprooted,uprooted,uprooted,ADJ,C1
-ups and downs,ups and downs,ups and downs,NOUN,B2
-upshot,upshot,upshot,NOUN,C1
-upstart (adj),upstart,upstart (adj),ADJ,C1
-urban area,urban area,urban area,NOUN,C1
-urbane,urbane,urbane,ADJ,C1
-urbanism,urbanism,urbanism,NOUN,B2
-urerziehung,urerziehung,urerziehung,NOUN,C1
-urfahrt,urfahrt,urfahrt,NOUN,C1
-urfassung,urfassung,urfassung,NOUN,C1
-urforderung,urforderung,urforderung,NOUN,C1
-urkunft,urkunft,urkunft,NOUN,C1
-urpflegung,urpflegung,urpflegung,NOUN,C1
-urregelung,urregelung,urregelung,NOUN,C1
-urrichtung,urrichtung,urrichtung,NOUN,C1
-urschaft,urschaft,urschaft,NOUN,C1
-ursinnung,ursinnung,ursinnung,NOUN,C1
-ursprache,ursprache,ursprache,NOUN,C1
-ursucht,ursucht,ursucht,NOUN,C1
-ursuchung,ursuchung,ursuchung,NOUN,C1
-urtheilung,urtheilung,urtheilung,NOUN,C1
-urtreibung,urtreibung,urtreibung,NOUN,C1
-urweisung,urweisung,urweisung,NOUN,C1
-urwirkung,urwirkung,urwirkung,NOUN,C1
-usage-based,usage-based,usage-based,ADJ,C1
-used,used,used,ADJ,C1
-useless zero,useless zero,useless zero,ADJ,A2
-uselessly,uselessly,uselessly,ADV,C1
-usufructuary,usufructuary,usufructuary,NOUN,C1
-usurer,usurer,usurer,NOUN,C1
-usurpation,usurpation,usurpation,NOUN,C1
-usury,usury,usury,NOUN,C1
-utensil,utensil,utensil,NOUN,C1
-uterine,uterine,uterine,ADJ,C1
-utmost extreme end,utmost extreme end,utmost extreme end,NOUN,C1
-utter,utter,utter,ADJ,C1
-utterance-related,utterance-related,utterance-related,ADJ,C1
-vacate,vacate,vacate,VERB,C1
-vaccinal,vaccinal,vaccinal,ADJ,C1
-vacillate,vacillate,vacillate,VERB,C1
-vacuous,vacuous,vacuous,ADJ,C1
-vacuum (noun),vacuum,vacuum (noun),NOUN,B2
-vacuum cleaner,vacuum cleaner,vacuum cleaner,NOUN,B2
-vacuum pump,vacuum pump,vacuum pump,NOUN,C1
-vagabond,vagabond,vagabond,NOUN,C1
-vagabond-poet life,vagabond-poet life,vagabond-poet life,NOUN,C1
-vagary,vagary,vagary,NOUN,C1
-vagrancy,vagrancy,vagrancy,NOUN,C1
-vagrant,vagrant,vagrant,NOUN,C1
-vaguely,vaguely,vaguely,ADV,C1
-vainglorious,vainglorious,vainglorious,ADJ,C1
-vainglory,vainglory,vainglory,NOUN,C1
-vale of tears,vale of tears,vale of tears,NOUN,C1
-valedictory,valedictory,valedictory,ADJ,C1
-valiantly,valiantly,valiantly,ADV,C1
-valued,valued,valued,ADJ,C1
-valve,valve,valve,NOUN,C1
-vanilla,vanilla,vanilla,NOUN,C1
-vanishing,vanishing,vanishing,NOUN,C1
-vanquish,vanquish,vanquish,VERB,C1
-vapid,vapid,vapid,ADJ,C1
-vapor,vapor,vapor,NOUN,C1
-vaporizer,vaporizer,vaporizer,NOUN,C1
-variable (adj),variable,variable (adj),ADJ,C1
-variables,variables,variables,NOUN,C1
-variegate,variegate,variegate,VERB,C1
-varnish,varnish,varnish,NOUN,B2
-varying,varying,varying,ADJ,B2
-vastness,vastness,vastness,NOUN,B2
-vaulting pole,vaulting pole,vaulting pole,NOUN,C1
-vaunt,vaunt,vaunt,VERB,C1
-vaunted,vaunted,vaunted,ADJ,B2
-vector,vector,vector,NOUN,C1
-veer,veer,veer,VERB,C1
-vegetarian (adj),vegetarian,vegetarian (adj),ADJ,A1
-vehemence,vehemence,vehemence,NOUN,C1
-vehicular,vehicular,vehicular,ADJ,C1
-veil,veil,veil,NOUN,C1
-velarization,velarization,velarization,NOUN,C1
-veneer,veneer,veneer,NOUN,C1
-venial,venial,venial,ADJ,C1
-venom,venom,venom,NOUN,C1
-venomous,venomous,venomous,ADJ,C1
-vent (noun),vent,vent (noun),NOUN,B2
-venture (noun),venture,venture (noun),NOUN,B2
-veracity,veracity,veracity,NOUN,C1
-verbal,verbal,verbal,ADJ,B2
-verbal sparring,verbal sparring,verbal sparring,NOUN,C1
-verbalize,verbalize,verbalize,VERB,B2
-verbatim,verbatim,verbatim,ADV,C1
-verbosely,verbosely,verbosely,ADV,C1
-verdant,verdant,verdant,ADJ,C1
-vererziehung,vererziehung,vererziehung,NOUN,C1
-verfahrt,verfahrt,verfahrt,NOUN,C1
-verforderung,verforderung,verforderung,NOUN,C1
-vergabe,vergabe,vergabe,NOUN,C1
-verge,verge,verge,NOUN,C1
-vergestaltung,vergestaltung,vergestaltung,NOUN,C1
-verifiable,verifiable,verifiable,ADJ,C1
-verification,verification,verification,NOUN,C1
-veritable,veritable,veritable,ADJ,C1
-verity,verity,verity,NOUN,C1
-verkunft,verkunft,verkunft,NOUN,C1
-vermilion,vermilion,vermilion,NOUN,B2
-vernacular,vernacular,vernacular,NOUN,C1
-vernahme,vernahme,vernahme,NOUN,C1
-vernier,vernier,vernier,NOUN,C1
-verpflegung,verpflegung,verpflegung,NOUN,C1
-verregelung,verregelung,verregelung,NOUN,C1
-verrichtung,verrichtung,verrichtung,NOUN,C1
-versatility,versatility,versatility,NOUN,B2
-verschrift,verschrift,verschrift,NOUN,C1
-verse,verse,verse,NOUN,C1
-verse of Quran,verse of Quran,verse of Quran,NOUN,B2
-versetzung,versetzung,versetzung,NOUN,C1
-versicht,versicht,versicht,NOUN,C1
-versification,versification,versification,NOUN,C1
-versinnung,versinnung,versinnung,NOUN,B2
-versprache,versprache,versprache,NOUN,C1
-versucht,versucht,versucht,NOUN,C1
-versuchung,versuchung,versuchung,NOUN,C1
-vertebra,vertebra,vertebra,NOUN,B2
-verteilung,verteilung,verteilung,NOUN,C1
-vertex,vertex,vertex,NOUN,C1
-vertheilung,vertheilung,vertheilung,NOUN,C1
-vertigo,vertigo,vertigo,NOUN,C1
-vertigo dizziness,vertigo dizziness,vertigo dizziness,NOUN,C1
-vertreibung,vertreibung,vertreibung,NOUN,C1
-verwandel,verwandel,verwandel,NOUN,C1
-verweisung,verweisung,verweisung,NOUN,C1
-verwirkung,verwirkung,verwirkung,NOUN,C1
-very best,very best,very best,ADJ,B2
-very fine,very fine,very fine,ADJ,C1
-very well,very well,very well,ADV,B2
-vestige,vestige,vestige,NOUN,C1
-veterinarian,veterinarian,veterinarian,NOUN,C1
-vex,vex,vex,VERB,C1
-vexation,vexation,vexation,NOUN,C1
-vial,vial,vial,NOUN,C1
-vibrant,vibrant,vibrant,ADJ,C1
-vicarious,vicarious,vicarious,ADJ,C1
-vice versa (adj),vice versa,vice versa (adj),ADJ,B2
-vicious,vicious,vicious,ADJ,B2
-video clip,video clip,video clip,NOUN,C1
-videotape,videotape,videotape,NOUN,C1
-viewing,viewing,viewing,NOUN,B1
-vignette,vignette,vignette,NOUN,C1
-vigor of prime,vigor of prime,vigor of prime,NOUN,C1
-vigorous,vigorous,vigorous,ADJ,C1
-vile (adv),vile,vile (adv),ADV,B2
-vindicate,vindicate,vindicate,VERB,C1
-vindictive,vindictive,vindictive,ADJ,C1
-violations,violations,violations,NOUN,C1
-violent act,violent act,violent act,NOUN,C1
-violet (adj),violet,violet (adj),ADJ,C1
-violet (noun),violet,violet (noun),NOUN,B2
-viper,viper,viper,NOUN,B2
-virtuoso,virtuoso,virtuoso,NOUN,C1
-viscosity,viscosity,viscosity,NOUN,C1
-viscount,viscount,viscount,NOUN,C1
-visionary,visionary,visionary,NOUN,C1
-visiting ban,visiting ban,visiting ban,NOUN,B2
-visor,visor,visor,NOUN,B2
-visualize,visualize,visualize,VERB,C1
-vital,vital,vital,ADJ,B2
-vitality,vitality,vitality,NOUN,B2
-vitiate,vitiate,vitiate,VERB,C1
-vitriolic,vitriolic,vitriolic,ADJ,C1
-vituperate,vituperate,vituperate,VERB,C1
-vivacious,vivacious,vivacious,ADJ,C1
-vocabulary,vocabulary,vocabulary,NOUN,C1
-vocal range,vocal range,vocal range,NOUN,C1
-vocalization,vocalization,vocalization,NOUN,C1
-vocation,vocation,vocation,NOUN,C1
-vocationalization,vocationalization,vocationalization,NOUN,C1
-vociferous,vociferous,vociferous,ADJ,C1
-vodka,vodka,vodka,NOUN,C1
-voiceover,voiceover,voiceover,NOUN,C1
-voicing,voicing,voicing,NOUN,C1
-volatility,volatility,volatility,NOUN,C1
-volcanic,volcanic,volcanic,ADJ,C1
-volition,volition,volition,NOUN,C1
-voltage,voltage,voltage,NOUN,C1
-voluble,voluble,voluble,ADJ,C1
-volume measure,volume measure,volume measure,NOUN,B2
-volumetric,volumetric,volumetric,ADJ,C1
-voluminous,voluminous,voluminous,ADJ,C1
-voluntariness,voluntariness,voluntariness,NOUN,C1
-voluntarist,voluntarist,voluntarist,ADJ,C1
-voluptuous,voluptuous,voluptuous,ADJ,C1
-vomit (noun),vomit,vomit (noun),NOUN,B2
-vomiting,vomiting,vomiting,NOUN,C1
-voracious,voracious,voracious,ADJ,C1
-voracity,voracity,voracity,NOUN,C1
-vorderbildung,vorderbildung,vorderbildung,NOUN,C1
-vordererziehung,vordererziehung,vordererziehung,NOUN,C1
-vorderfahrt,vorderfahrt,vorderfahrt,NOUN,C1
-vorderforderung,vorderforderung,vorderforderung,NOUN,C1
-vordergabe,vordergabe,vordergabe,NOUN,C1
-vordergestaltung,vordergestaltung,vordergestaltung,NOUN,C1
-vorderkunft,vorderkunft,vorderkunft,NOUN,C1
-vordermessung,vordermessung,vordermessung,NOUN,C1
-vordernahme,vordernahme,vordernahme,NOUN,C1
-vorderordnung,vorderordnung,vorderordnung,NOUN,C1
-vorderpflegung,vorderpflegung,vorderpflegung,NOUN,C1
-vorderrechnung,vorderrechnung,vorderrechnung,NOUN,C1
-vorderregelung,vorderregelung,vorderregelung,NOUN,C1
-vorderschaft,vorderschaft,vorderschaft,NOUN,C1
-vorderschrift,vorderschrift,vorderschrift,NOUN,C1
-vordersicht,vordersicht,vordersicht,NOUN,C1
-vordersprache,vordersprache,vordersprache,NOUN,C1
-vorderstellung,vorderstellung,vorderstellung,NOUN,C1
-vordersucht,vordersucht,vordersucht,NOUN,C1
-vordersuchung,vordersuchung,vordersuchung,NOUN,C1
-vorderteilung,vorderteilung,vorderteilung,NOUN,C1
-vordertheilung,vordertheilung,vordertheilung,NOUN,C1
-vordertreibung,vordertreibung,vordertreibung,NOUN,C1
-vorderwandel,vorderwandel,vorderwandel,NOUN,B2
-vorderwandlung,vorderwandlung,vorderwandlung,NOUN,C1
-vorderwendung,vorderwendung,vorderwendung,NOUN,C1
-vorderwirkung,vorderwirkung,vorderwirkung,NOUN,C1
-vorerziehung,vorerziehung,vorerziehung,NOUN,B2
-vorfahrt,vorfahrt,vorfahrt,NOUN,C1
-vorfassung,vorfassung,vorfassung,NOUN,C1
-vorforderung,vorforderung,vorforderung,NOUN,C1
-vorgabe,vorgabe,vorgabe,NOUN,C1
-vorgestaltung,vorgestaltung,vorgestaltung,NOUN,C1
-vorkunft,vorkunft,vorkunft,NOUN,C1
-vornahme,vornahme,vornahme,NOUN,C1
-vorpflegung,vorpflegung,vorpflegung,NOUN,C1
-vorregelung,vorregelung,vorregelung,NOUN,C1
-vorrichtung,vorrichtung,vorrichtung,NOUN,C1
-vorschaft,vorschaft,vorschaft,NOUN,C1
-vorsetzung,vorsetzung,vorsetzung,NOUN,C1
-vorsicht,vorsicht,vorsicht,NOUN,C1
-vorsinnung,vorsinnung,vorsinnung,NOUN,C1
-vorsprache,vorsprache,vorsprache,NOUN,C1
-vorsucht,vorsucht,vorsucht,NOUN,C1
-vorsuchung,vorsuchung,vorsuchung,NOUN,C1
-vortreibung,vortreibung,vortreibung,NOUN,C1
-vorweisung,vorweisung,vorweisung,NOUN,C1
-vorwirkung,vorwirkung,vorwirkung,NOUN,C1
-votary,votary,votary,NOUN,C1
-vote counting austerity,vote counting austerity,vote counting austerity,NOUN,C1
-votive offering,votive offering,votive offering,NOUN,C1
-vouch,vouch,vouch,VERB,C1
-vouchsafe,vouchsafe,vouchsafe,VERB,C1
-vowel,vowel,vowel,NOUN,C1
-vowel inclination,vowel inclination,vowel inclination,NOUN,C1
-voyage,voyage,voyage,NOUN,B2
-voyeur,voyeur,voyeur,NOUN,C1
-vulture,vulture,vulture,NOUN,B2
-wading,wading,wading,NOUN,B2
-waffle,waffle,waffle,NOUN,A2
-waft,waft,waft,VERB,C1
-wage earner,wage earner,wage earner,NOUN,C1
-wage murder unit,wage murder unit,wage murder unit,NOUN,B2
-wage-related,wage-related,wage-related,ADJ,C1
-wager,wager,wager,NOUN,C1
-waggish,waggish,waggish,ADJ,C1
-wagon,wagon,wagon,NOUN,B2
-wahhabism,wahhabism,wahhabism,NOUN,C1
-wailing,wailing,wailing,NOUN,B2
-waive,waive,waive,VERB,C1
-wake (noun),wake,wake (noun),NOUN,C1
-waken,waken,waken,VERB,B2
-walker,walker,walker,NOUN,C1
-walking,walking,walking,NOUN,B1
-wall fence,wall fence,wall fence,NOUN,A2
-wall-mounted,wall-mounted,wall-mounted,ADJ,C1
-wallow,wallow,wallow,VERB,C1
-walnuts,walnuts,walnuts,NOUN,B2
-wan,wan,wan,ADJ,B2
-wanderer,wanderer,wanderer,NOUN,C1
-wandering (adj),wandering,wandering (adj),ADJ,C1
-wanted one,wanted one,wanted one,NOUN,B2
-wanted person,wanted person,wanted person,NOUN,C1
-wanton,wanton,wanton,ADJ,C1
-war-related,war-related,war-related,ADJ,B2
-warble (noun),warble,warble (noun),NOUN,C1
-warble (verb),warble,warble (verb),VERB,C1
-warehouse store,warehouse store,warehouse store,NOUN,B1
-warm-up,warm-up,warm-up,NOUN,B1
-warmer,warmer,warmer,ADJ,B2
-warmonger,warmonger,warmonger,NOUN,C1
-warning (adj),warning,warning (adj),ADJ,C1
-warship,warship,warship,NOUN,C1
-wash clothes,wash clothes,wash clothes,VERB,A1
-washer,washer,washer,NOUN,B2
-waste disposal site,waste disposal site,waste disposal site,NOUN,B1
-waste of time,waste of time,waste of time,NOUN,B2
-watch of the night,watch of the night,watch of the night,NOUN,C1
-watch over,watch over,watch over,VERB,C1
-watched,watched,watched,NOUN,B2
-watchmaking,watchmaking,watchmaking,NOUN,C1
-watchtower,watchtower,watchtower,NOUN,B2
-water jug,water jug,water jug,NOUN,B2
-watering,watering,watering,NOUN,B2
-waterproof (verb),waterproof,waterproof (verb),VERB,C1
-watershed,watershed,watershed,NOUN,C1
-waterskin,waterskin,waterskin,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,waterwheel,NOUN,C1
-wave (adj),wave,wave (adj),ADJ,C1
-waves,waves,waves,NOUN,B1
-waxen,waxen,waxen,ADJ,C1
-way home,way home,way home,NOUN,C1
-way of thinking,way of thinking,way of thinking,NOUN,B2
-waylay,waylay,waylay,VERB,C1
-we us,we us,we us,PRON,A2
-weakened,weakened,weakened,ADJ,C1
-weakly,weakly,weakly,ADV,C1
-weal,weal,weal,NOUN,C1
-wealthy easy,wealthy easy,wealthy easy,ADJ,C1
-weapon arms,weapon arms,weapon arms,NOUN,A1
-wear tear,wear tear,wear tear,NOUN,C1
-wearily,wearily,wearily,ADV,C1
-wearisome,wearisome,wearisome,ADJ,C1
-weather forecast,weather forecast,weather forecast,NOUN,B1
-weather institute,weather institute,weather institute,NOUN,B2
-weathering,weathering,weathering,NOUN,C1
-weaver,weaver,weaver,NOUN,B1
-weeding,weeding,weeding,NOUN,C1
-weeds,weeds,weeds,NOUN,C1
-weighing,weighing,weighing,NOUN,B2
-weight training,weight training,weight training,NOUN,C1
-weiterziehung,weiterziehung,weiterziehung,NOUN,C1
-weitfahrt,weitfahrt,weitfahrt,NOUN,C1
-weitfassung,weitfassung,weitfassung,NOUN,C1
-weitforderung,weitforderung,weitforderung,NOUN,C1
-weitgabe,weitgabe,weitgabe,NOUN,C1
-weitgestaltung,weitgestaltung,weitgestaltung,NOUN,C1
-weitkunft,weitkunft,weitkunft,NOUN,C1
-weitnahme,weitnahme,weitnahme,NOUN,C1
-weitpflegung,weitpflegung,weitpflegung,NOUN,C1
-weitrichtung,weitrichtung,weitrichtung,NOUN,C1
-weitschaft,weitschaft,weitschaft,NOUN,C1
-weitschrift,weitschrift,weitschrift,NOUN,C1
-weitsetzung,weitsetzung,weitsetzung,NOUN,C1
-weitsinnung,weitsinnung,weitsinnung,NOUN,C1
-weitsprache,weitsprache,weitsprache,NOUN,C1
-weitsucht,weitsucht,weitsucht,NOUN,C1
-weitteilung,weitteilung,weitteilung,NOUN,B2
-weittheilung,weittheilung,weittheilung,NOUN,C1
-weittreibung,weittreibung,weittreibung,NOUN,C1
-weitwirkung,weitwirkung,weitwirkung,NOUN,C1
-welcome (adj),welcome,welcome (adj),ADJ,B2
-welcome (intj),welcome,welcome (intj),INTJ,A1
-welcome (noun),welcome,welcome (noun),NOUN,A2
-welcome committee,welcome committee,,NOUN,B2
-weld,weld,weld,VERB,C1
-welder,welder,welder,NOUN,C1
-well-behaved,well-behaved,well-behaved,ADJ,B2
-well-crafted,well-crafted,well-crafted,ADJ,B2
-well-disposed,well-disposed,well-disposed,ADJ,B2
-well-liked,well-liked,well-liked,ADJ,B2
-well-read,well-read,well-read,ADJ,C1
-welter,welter,welter,NOUN,C1
-wend,wend,wend,VERB,C1
-westerner,westerner,westerner,NOUN,B2
-wet nurse,wet nurse,wet nurse,NOUN,B1
-wharf,wharf,wharf,NOUN,B2
-what (adv),what,what (adv),ADV,B2
-what for,what for,what for,ADV,A2
-whatsoever,whatsoever,whatsoever,DET,B2
-wheedle,wheedle,wheedle,VERB,C1
-when than,when than,when than,SCONJ,A2
-whenever,whenever,whenever,NOUN,B2
-where i,where i,,NOUN,B2
-where to,where to,where to,ADV,A2
-whereas (cconj),whereas,whereas (cconj),CCONJ,B2
-whereas (sconj),whereas,whereas (sconj),SCONJ,C1
-whereas since,whereas since,whereas since,SCONJ,A2
-wherever (adv),wherever,wherever (adv),ADV,B1
-wherever (cconj),wherever,wherever (cconj),CCONJ,C1
-whet,whet,whet,VERB,C1
-whether (part),whether,whether (part),PART,A1
-whey,whey,whey,NOUN,B2
-whimsical,whimsical,whimsical,ADJ,C1
-whimsy,whimsy,whimsy,NOUN,C1
-whiny,whiny,whiny,ADJ,C1
-whirl,whirl,whirl,VERB,C1
-whirring,whirring,whirring,NOUN,C1
-whisk whip,whisk whip,whisk whip,NOUN,B1
-whistleblower,whistleblower,whistleblower,NOUN,C1
-whistling,whistling,whistling,NOUN,C1
-whitewash,whitewash,whitewash,VERB,C1
-whiting,whiting,whiting,NOUN,B2
-whittle,whittle,whittle,VERB,C1
-whoever,whoever,whoever,PRON,B2
-wholehearted,wholehearted,wholehearted,ADJ,C1
-wholesale (adv),wholesale,wholesale (adv),ADV,B1
-wholesome,wholesome,wholesome,ADJ,C1
-whose (det),whose,whose (det),DET,B2
-wick,wick,wick,NOUN,C1
-wide-awake,wide-awake,wide-awake,ADJ,C1
-widening,widening,widening,NOUN,B2
-widower,widower,widower,NOUN,C1
-widowhood,widowhood,widowhood,NOUN,C1
-wiederbildung,wiederbildung,wiederbildung,NOUN,C1
-wiederfahrt,wiederfahrt,wiederfahrt,NOUN,B2
-wiederfassung,wiederfassung,wiederfassung,NOUN,C1
-wiederforderung,wiederforderung,wiederforderung,NOUN,C1
-wiedergabe,wiedergabe,wiedergabe,NOUN,C1
-wiedergestaltung,wiedergestaltung,wiedergestaltung,NOUN,C1
-wiederleitung,wiederleitung,wiederleitung,NOUN,B2
-wiedermessung,wiedermessung,wiedermessung,NOUN,C1
-wiedernahme,wiedernahme,wiedernahme,NOUN,C1
-wiederpflegung,wiederpflegung,wiederpflegung,NOUN,C1
-wiederrechnung,wiederrechnung,wiederrechnung,NOUN,C1
-wiederregelung,wiederregelung,wiederregelung,NOUN,C1
-wiederrichtung,wiederrichtung,wiederrichtung,NOUN,C1
-wiederschaft,wiederschaft,wiederschaft,NOUN,C1
-wiederschrift,wiederschrift,wiederschrift,NOUN,C1
-wiedersetzung,wiedersetzung,wiedersetzung,NOUN,C1
-wiederstellung,wiederstellung,wiederstellung,NOUN,C1
-wiederteilung,wiederteilung,wiederteilung,NOUN,C1
-wiedertheilung,wiedertheilung,wiedertheilung,NOUN,C1
-wiederwandel,wiederwandel,wiederwandel,NOUN,C1
-wiederwandlung,wiederwandlung,wiederwandlung,NOUN,C1
-wiederweisung,wiederweisung,wiederweisung,NOUN,C1
-wiederwendung,wiederwendung,wiederwendung,NOUN,C1
-wiederwirkung,wiederwirkung,wiederwirkung,NOUN,C1
-wild beast,wild beast,wild beast,NOUN,B2
-wild boar,wild boar,wild boar,NOUN,C1
-wild ones,wild ones,wild ones,NOUN,C1
-wildlife,wildlife,wildlife,NOUN,C1
-wile,wile,wile,NOUN,C1
-will not (part),will not,will not (part),PART,A1
-will willpower,will willpower,will willpower,NOUN,B2
-willow,willow,willow,NOUN,B2
-willowy,willowy,willowy,ADJ,C1
-wily,wily,wily,ADJ,C1
-wince,wince,wince,VERB,C1
-wind (adj),wind,wind (adj),ADJ,C1
-winding,winding,winding,ADJ,B2
-windmill,windmill,windmill,NOUN,B2
-winning,winning,winning,ADJ,C1
-winsome,winsome,winsome,ADJ,C1
-wired,wired,wired,ADJ,C1
-wistful,wistful,wistful,ADJ,C1
-wit,wit,wit,NOUN,C1
-witch hunt,witch hunt,witch hunt,NOUN,C1
-with each other,with each other,with each other,ADV,A2
-with me,with me,with me,PRON,A1
-with the aim of,with the aim of,with the aim of,ADP,C1
-with which,with which,with which,PRON,A2
-with you,with you,with you,PRON,A1
-withdrawal fold,withdrawal fold,withdrawal fold,NOUN,C1
-withdrawn,withdrawn,withdrawn,ADJ,B2
-withering,withering,withering,NOUN,C1
-without (sconj),without,without (sconj),SCONJ,B1
-without further ado,without further ado,without further ado,ADV,B2
-withstand,withstand,withstand,VERB,C1
-witness female,witness female,witness female,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,witticism,NOUN,C1
-witty saying,witty saying,witty saying,NOUN,C1
-wizened,wizened,wizened,ADJ,C1
-woe (intj),woe,woe (intj),INTJ,B2
-woe (noun),woe,woe (noun),NOUN,C1
-women,women,women,NOUN,B2
-women's quarters,women's quarters,women's quarters,NOUN,C1
-wonderful (adv),wonderful,wonderful (adv),ADV,B2
-wont,wont,wont,NOUN,C1
-woody,woody,woody,ADJ,C1
-work book,work book,work book,NOUN,B1
-workday,workday,workday,NOUN,C1
-worker laborer,worker laborer,worker laborer,NOUN,B1
-workforce,workforce,workforce,NOUN,B2
-working,working,working,ADJ,C1
-working day,working day,working day,NOUN,B2
-working method,working method,working method,NOUN,B2
-workout,workout,workout,NOUN,C1
-works,works,works,NOUN,B2
-workshops,workshops,workshops,NOUN,B2
-world champion,world champion,world champion,NOUN,B2
-world-famous,world-famous,world-famous,ADJ,C1
-worldliness,worldliness,worldliness,NOUN,C1
-wormwood,wormwood,wormwood,NOUN,A2
-worn out,worn out,worn out,ADJ,C1
-worse (noun),worse,worse (noun),NOUN,B2
-worsening,worsening,worsening,NOUN,C1
-worst (adv),worst,worst (adv),ADV,C1
-worst (noun),worst,worst (noun),NOUN,C1
-worth seeing,worth seeing,worth seeing,ADJ,C1
-worthwhile (adj),worthwhile,worthwhile (adj),ADJ,C1
-would like,would like,would like,AUX,A2
-woven rug,woven rug,woven rug,NOUN,C1
-wraith,wraith,wraith,NOUN,C1
-wrangle,wrangle,wrangle,VERB,C1
-wrapper,wrapper,wrapper,NOUN,C1
-wrathful,wrathful,wrathful,ADJ,C1
-wreckage,wreckage,wreckage,NOUN,C1
-wrench,wrench,wrench,NOUN,C1
-wretched,wretched,wretched,ADJ,C1
-wrinkled crumpled,wrinkled crumpled,wrinkled crumpled,ADJ,B1
-wrinkles,wrinkles,wrinkles,NOUN,B2
-writ,writ,writ,NOUN,C1
-writhe,writhe,writhe,VERB,C1
-written claim,written claim,written claim,NOUN,C1
-wry,wry,wry,ADJ,C1
-xerography,xerography,xerography,NOUN,C1
-yacht,yacht,yacht,NOUN,B2
-yeah,yeah,yeah,INTJ,A1
-year-old,year-old,year-old,ADJ,A1
-yearling sheep,yearling sheep,yearling sheep,NOUN,B2
-yeoman,yeoman,yeoman,NOUN,C1
-yep,yep,yep,INTJ,B2
-yes (adv),yes,yes (adv),ADV,A2
-yes indeed (adv),yes indeed,yes indeed (adv),ADV,B2
-yesterday (adv),yesterday,yesterday (adv),ADV,A1
-yesteryear,yesteryear,yesteryear,NOUN,C1
-yoga practice,yoga practice,yoga practice,NOUN,B2
-yore,yore,yore,NOUN,C1
-you accusative,you accusative,you accusative,PRON,A2
-you dative,you dative,you dative,PRON,A2
-you feminine,you feminine,you feminine,PRON,A1
-you masculine,you masculine,you masculine,PRON,A1
-younger sibling,younger sibling,younger sibling,NOUN,C1
-youngest,youngest,youngest,ADJ,B2
-your (pron),your,your (pron),PRON,A1
-your pl,your pl,your pl,DET,B2
-your plural (pron),your plural,your plural (pron),PRON,A2
-yours,yours,yours,PRON,B2
-youth culture,youth culture,youth culture,NOUN,C1
-youth people,youth people,youth people,NOUN,C1
-youthful,youthful,youthful,ADJ,C1
-youthful vigor,youthful vigor,youthful vigor,NOUN,C1
-zajal,zajal,zajal,NOUN,B2
-zany,zany,zany,ADJ,C1
-zealot,zealot,zealot,NOUN,C1
-zealous,zealous,zealous,ADJ,C1
-zellige tiles,zellige tiles,zellige tiles,NOUN,A2
-zephyr,zephyr,zephyr,NOUN,C1
-zererziehung,zererziehung,zererziehung,NOUN,C1
-zerfahrt,zerfahrt,zerfahrt,NOUN,C1
-zerfassung,zerfassung,zerfassung,NOUN,C1
-zerforderung,zerforderung,zerforderung,NOUN,C1
-zergabe,zergabe,zergabe,NOUN,C1
-zergestaltung,zergestaltung,zergestaltung,NOUN,C1
-zerkunft,zerkunft,zerkunft,NOUN,C1
-zero (noun),zero,zero (noun),NOUN,B1
-zeroing,zeroing,zeroing,NOUN,C1
-zerpflegung,zerpflegung,zerpflegung,NOUN,C1
-zerregelung,zerregelung,zerregelung,NOUN,B2
-zerrichtung,zerrichtung,zerrichtung,NOUN,C1
-zerschaft,zerschaft,zerschaft,NOUN,C1
-zerschrift,zerschrift,zerschrift,NOUN,C1
-zersetzung,zersetzung,zersetzung,NOUN,C1
-zersinnung,zersinnung,zersinnung,NOUN,C1
-zersprache,zersprache,zersprache,NOUN,C1
-zertheilung,zertheilung,zertheilung,NOUN,C1
-zertreibung,zertreibung,zertreibung,NOUN,C1
-zerwandel,zerwandel,zerwandel,NOUN,C1
-zerweisung,zerweisung,zerweisung,NOUN,C1
-zerwirkung,zerwirkung,zerwirkung,NOUN,C1
-zest,zest,zest,NOUN,C1
-zesty,zesty,zesty,ADJ,C1
-zuerziehung,zuerziehung,zuerziehung,NOUN,C1
-zufassung,zufassung,zufassung,NOUN,C1
-zuforderung,zuforderung,zuforderung,NOUN,C1
-zugabe,zugabe,zugabe,NOUN,C1
-zugestaltung,zugestaltung,zugestaltung,NOUN,C1
-zukunft,zukunft,zukunft,NOUN,C1
-zunahme,zunahme,zunahme,NOUN,C1
-zupflegung,zupflegung,zupflegung,NOUN,C1
-zuregelung,zuregelung,zuregelung,NOUN,C1
-zuschrift,zuschrift,zuschrift,NOUN,C1
-zusetzung,zusetzung,zusetzung,NOUN,C1
-zusinnung,zusinnung,zusinnung,NOUN,C1
-zusucht,zusucht,zusucht,NOUN,C1
-zusuchung,zusuchung,zusuchung,NOUN,C1
-zuteilung,zuteilung,zuteilung,NOUN,C1
-zutheilung,zutheilung,zutheilung,NOUN,C1
-zutreibung,zutreibung,zutreibung,NOUN,C1
-zuwandel,zuwandel,zuwandel,NOUN,C1
-zuweisung,zuweisung,zuweisung,NOUN,C1
-zuwirkung,zuwirkung,zuwirkung,NOUN,C1
-أسود,black,أسود,NOUN,B2
-أطلانطي,atlantean,أطلانطي,ADJ,B2
-أطول,longest,أطول,NOUN,B2
-بري,land,بري,ADJ,B2
-بضع,a few,بضع,NOUN,B2
-ثلاث,three,ثلاث,ADJ,B2
-شي,something,شي,NOUN,B2
-مدفون,buried,مدفون,ADJ,B2
-مسلم,muslim,مسلم,NOUN,B2
 一,a,一个,DET,B2
-一,one,人们,PRON,B2
-一...就,as soon as,一...就,ADV,B2
-一丝不苟地,meticulously,一丝不苟地,ADV,B2
-一丝不苟地,scrupulously,一丝不苟地,ADV,B2
-一丝不苟的,scrupulous,一丝不苟的,ADJ,B2
-一个半,one and a half,一个半,NUM,B2
-一些,some,一些,PRON,B2
-一些事情,some things,一些事情,PRON,B2
-一口烟,puff,一口烟,NOUN,B2
-一对,couple pair,一对,NOUN,B2
-一打,dozen,一打,NOUN,B2
-一批,batch,一批,NOUN,B2
-一月,january,一月,NOUN,B2
-一次性的,disposable,一次性的,ADJ,B2
-一清二楚的,clear as day,一清二楚的,ADJ,B2
 一点,a little,一点儿,ADV,B2
-一点,bit,一点,NOUN,B2
-一百,hundred,一百,NOUN,B2
-一百,one hundred,一百,NUM,B2
-一瞥,glance,一瞥,NOUN,B2
-一瞥,glimpse,一瞥,NOUN,B2
-一致,agree,一致,ADJ,B2
-一致的,agreed,一致的,ADJ,B2
-一致的,congruent,一致的,ADJ,B2
-一般,general,一般的,ADJ,B2
-一起来,to come along,一起来,VERB,B2
-七十,seventy,七十,NUM,B2
-七月,july,七月,NOUN,B2
-万岁,hooray,万岁,INTJ,B2
-万岁,hurrah,万岁,INTJ,B2
-三分之一,third,三分之一,NOUN,B2
-三十,thirty,三十,NUM,B2
-三段论,syllogism,三段论,NOUN,B2
-三角形的,triangular,三角形的,ADJ,B2
-三重的,triple,三倍的,ADJ,B2
-上传,upload,上传,NOUN,B2
-上传,to upload,上传,VERB,B2
-上升,rise,上涨,NOUN,B2
-上流的,posh,上流的,ADJ,B2
-上瘾,addicted,上瘾的,ADJ,B2
-上翻,upturn,好转,NOUN,B2
-上船,to embark,上船,VERB,B2
-上诉人,appellant,上诉人,NOUN,B2
-上述的,aforementioned,上述的,ADJ,B2
-上面,above,上面,ADV,B2
-上面的,upper,上面的,ADJ,B2
-下一个,next,下一个,ADJ,B2
-下冰雹,to hail,下冰雹,VERB,B2
-下士,corporal,下士,NOUN,B2
-下巴,chin,下巴,NOUN,B2
-下巴,jaw,下巴,NOUN,B2
-下水道,drain,排水沟,NOUN,B2
-下载,download,下载,NOUN,B2
-下降,decline,衰退,NOUN,B2
-下雪,to snow,下雪,VERB,B2
-下面,below,下面,ADV,B2
-下面,underneath,在下面,ADV,B2
-下面的,below,下面的,ADJ,B2
-下马,to dismount,下马,VERB,B2
-不,no,不,ADV,B2
-不,nah,不,INTJ,B2
-不,nope,不,INTJ,B2
-不,not,不,PART,B2
-不一致,discordance,不一致,NOUN,B2
-不一致,inconsistency,不一致,NOUN,B2
-不久,shortly,不久,ADV,B2
-不人道的,inhuman,不人道的,ADJ,B2
-不信任,distrust,不信任,NOUN,B2
-不公平,unfair,不公平的,ADJ,B2
-不公正,unjust,不公正的,ADJ,B2
-不兼容,incompatibility,不兼容,NOUN,B2
-不利于,to disfavor,不利于,VERB,B2
-不利的,adverse,不利的,ADJ,B2
-不加区别地,indiscriminately,不加区别地,ADV,B2
-不动产,real estate,不动产,NOUN,B2
-不协调的,incongruous,不协调的,ADJ,B2
-不及格,failing an exam,不及格,NOUN,B2
-不友好的,unfriendly,不友好的,ADJ,B2
-不受打扰地,in peace,不受打扰地,ADV,B2
-不受时效限制的,not subject to limitation,不受时效限制的,ADJ,B2
-不变地,invariably,不变地,ADV,B2
-不可原谅的,unforgivable,不可原谅的,ADJ,B2
-不可想象的,inconceivable,不可想象的,ADJ,B2
-不可想象的,unthinkable,不可想象的,ADJ,B2
-不可或缺的,integral,不可或缺的,ADJ,B2
-不可接受的,inadmissible,不可接受的,ADJ,B2
-不可渗透的,impenetrable,不可穿透的,ADJ,B2
-不可移动的,immovable,不可移动的,ADJ,B2
-不可触碰的,untouchable,不可触碰的,ADJ,B2
-不可阻挡地,inexorably,不可阻挡地,ADV,B2
-不合时宜的,misplaced,不合时宜的,ADJ,B2
-不同,to differ,不同,VERB,B2
-不同意,to disagree,不同意,VERB,B2
-不同意的,disagreeing,不同意的,ADJ,B2
-不和,discord,不和,NOUN,B2
-不和谐,dissonance,不和谐,NOUN,B2
-不在/离开,away gone,不在/离开,ADV,B2
-不在场证明,alibi,不在场证明,NOUN,B2
-不太可能的,unlikely,不太可能的,ADJ,B2
-不妥协的,intransigent,不妥协的,ADJ,B2
-不安,unease,不安,NOUN,B2
-不安全感,insecurity,不安全感,NOUN,B2
-不安的,disturbed,不安的,ADJ,B2
-不完美的,imperfect,不完美的,ADJ,B2
-不容忍,intolerance,不容忍,NOUN,B2
-不平等,inequality,不平等,NOUN,B2
-不幸,unfortunately,不幸地,ADV,B2
-不幸,misfortune,不幸,NOUN,B2
-不必要的,unnecessary,不必要的,ADJ,B2
-不忠,infidelity,不忠,NOUN,B2
-不忠的,disloyal,不忠的,ADJ,B2
-不忠的,unfaithful,不忠的,ADJ,B2
-不悦,displeasure,不悦,NOUN,B2
-不情愿,reluctance,不情愿,NOUN,B2
-不情愿的,reluctant,不情愿的,ADJ,B2
-不愉快的,unpleasant,令人不快的,ADJ,B2
-不懈 / 猛烈,relentlessness,不懈 / 猛烈,NOUN,B2
-不成比例,disproportion,不成比例,NOUN,B2
-不成熟的,immature,不成熟的,ADJ,B2
-不敬,disrespect,不敬,NOUN,B2
-不断地,constantly,不断地,ADV,B2
-不服从,disobedience,不服从,NOUN,B2
-不服从的,disobedient,不服从的,ADJ,B2
-不朽,immortality,不朽,NOUN,B2
-不朽的,immortal,不朽的,ADJ,B2
-不果断的,indecisive,犹豫不决的,ADJ,B2
-不正确的,incorrect,不正确的,ADJ,B2
-不流血的,bloodless,不流血的,ADJ,B2
-不满,discontent,不满,NOUN,B2
-不满,dissatisfaction,不满,NOUN,B2
-不满的,dissatisfied,不满的,ADJ,B2
-不相交的,disjoint,不相交的,ADJ,B2
-不知怎么,somehow,以某种方式,ADV,B2
-不知疲倦的,tireless,不知疲倦的,ADJ,B2
-不知足的,insatiable,不知足的,ADJ,B2
-不确定,uncertain,不确定的,ADJ,B2
-不确定,uncertainty,不确定性,NOUN,B2
-不礼貌的,impolite,不礼貌的,ADJ,B2
-不祥的,sinister,不祥的,ADJ,B2
-不稳定化,precarization,不稳定化,NOUN,B2
-不稳定性,precariousness,不稳定性,NOUN,B2
-不稳定的,erratic,不稳定的,ADJ,B2
-不稳定的,precarious,不稳定的,ADJ,B2
-不稳定的,unstable,不稳定的,ADJ,B2
-不管,regardless,不管,ADV,B2
-不纯,impurity,不纯,NOUN,B2
-不舒服,uncomfortable,不舒服的,ADJ,B2
-不良少年,delinquent,罪犯,NOUN,B2
-不规则,irregularity,不规则,NOUN,B2
-不规则的,irregular,不规则的,ADJ,B2
-不诚实的,dishonest,不诚实的,ADJ,B2
-不贞,immodesty,不贞,NOUN,B2
-不负责任的,irresponsible,不负责任的,ADJ,B2
-不费力的,effortless,不费力的,ADJ,B2
-不赞成,to disapprove,不赞成,VERB,B2
-不足,deficiency,缺乏,NOUN,B2
-不足,insufficiency,不足,NOUN,B2
-不足的,deficient,有缺陷的,ADJ,B2
-不足的,inadequate,不足的,ADJ,B2
-不连贯,incoherence,不连贯,NOUN,B2
-不连贯的,incoherent,不连贯的,ADJ,B2
-不透明性,opacity,不透明性,NOUN,B2
-不道德的,immoral,不道德的,ADJ,B2
-与...交朋友,to befriend,与...交朋友,VERB,B2
-与...相对,vs,与...相对,ADP,B2
-丑闻,scandal,丑闻,NOUN,B2
-丑陋,ugliness,丑陋,NOUN,B2
-丑陋的,hideous,丑陋的,ADJ,B2
-专业中心,expertise center,专业中心,NOUN,B2
-专业人士,professional,专业的,ADJ,B2
-专业化,specialization,专业化,NOUN,B2
-专业知识,expertise,专业知识,NOUN,B2
-专制,authoritarian,独裁的,ADJ,B2
-专制,despotism,专制,NOUN,B2
-专制的,autocratic,专制的,ADJ,B2
-专员,commissioner,专员,NOUN,B2
-专家,specialist,专家,NOUN,B2
-专攻,to specialize,专攻,VERB,B2
-专横的,peremptory,专横的,ADJ,B2
-专横的,tyrannical,专横的,ADJ,B2
-专注,attentive,专心的,ADJ,B2
-专注倾听,attentive listening,专注倾听,NOUN,B2
-专注的,focused,专注的,ADJ,B2
-世俗主义,secularism,世俗主义,NOUN,B2
-世俗化,secularization,世俗化,NOUN,B2
-世俗的,worldly,世俗的,ADJ,B2
-世界主义的,cosmopolitan,世界主义的,ADJ,B2
-世界大战,world war,世界大战,NOUN,B2
-业余爱好者,amateur,业余爱好者,NOUN,B2
-东南,southeast,东南,NOUN,B2
-东方的,eastern,东方的,ADJ,B2
-东西,stuff,东西,NOUN,B2
-丝带,ribbon,丝带,NOUN,B2
-丢失的,lost,迷失的,ADJ,B2
-两者,both,两者,PRON,B2
-两者的,both,两者的,ADJ,B2
-两者都,both,两者都,DET,B2
-两院制的,bicameral,两院制的,ADJ,B2
-严厉地,severely,严厉地,ADV,B2
-严厉批评,to castigate,严厉批评,VERB,B2
-严厉的,harsh,严厉的,ADJ,B2
-严惩,to chastise,严惩,VERB,B2
-严格的,rigorous,严格的,ADJ,B2
-严重地,gravely,严重地,ADV,B2
-丧葬的,funereal,丧葬的,ADJ,B2
-个人主义,individualism,个人主义,NOUN,B2
-个人的,individual,单独的,ADJ,B2
-个人的,personal,个人的,ADJ,B2
-个人隐私,personal integrity,个人隐私,NOUN,B2
-个体经营者,self-employed person,个体经营者,NOUN,B2
-个性化的,personalized,个性化的,ADJ,B2
-中世纪的,medieval,中世纪的,ADJ,B2
-中产阶层,middle class,中产阶层,NOUN,B2
-中位数,median,中位数,NOUN,B2
-中和,to neutralize,中和,VERB,B2
-中国人,the chinese,中国人,NOUN,B2
-中国的,chinese,中国的,ADJ,B2
-中场球员,midfielder,中场球员,NOUN,B2
-中央车站,central station,中央车站,NOUN,B2
-中断,to break off,中断,VERB,B2
-中止,to discontinue,停止,VERB,B2
-中立,neutrality,中立,NOUN,B2
-中途停留,stopover,中途停留,NOUN,B2
-中间,midst,中间,NOUN,B2
-中间派的,centrist,中间派的,ADJ,B2
-中风,stroke,中风,NOUN,B2
-临时的,provisional,临时的,ADJ,B2
-临时解雇,to furlough,临时解雇,VERB,B2
-丹麦的,danish,丹麦的,ADJ,B2
-为,for,为了,ADP,B2
-为...提供交通服务,to serve a route,为...提供交通服务,VERB,B2
-为了,for the sake of,为了,ADP,B2
-为了什么,for what,为了什么,ADV,B2
-为了它,for it,为此,ADV,B2
-为此,for this,为此,ADV,B2
-为此,for this purpose,为此,ADV,B2
-主任医师,chief physician,主任医师,NOUN,B2
-主办,to host,接待,VERB,B2
-主导地位,predominance,主导地位,NOUN,B2
-主导的,dominant,占主导地位的,ADJ,B2
-主张,to contend,主张,VERB,B2
-主持,to preside,主持,VERB,B2
-主持人,presenter,主持人,NOUN,B2
-主权,sovereign,主权的,ADJ,B2
-主权主义者,sovereigntist,主权主义者,NOUN,B2
-主流的,mainstream,主流的,ADJ,B2
-主管,executive,行政主管,NOUN,B2
-主管/经理,director manager,主管/经理,NOUN,B2
-主编,editor-in-chief,主编,NOUN,B2
-主要原因,main reason,主要原因,NOUN,B2
-主要地,largely,主要地,ADV,B2
-主要地,mainly,主要地,ADV,B2
-主要的,major,主要的,ADJ,B2
-主角,leading role,主角,NOUN,B2
-主题,motif,主题,NOUN,B2
-主题/话题,subject topic,主题/话题,NOUN,B2
-主题曲,theme music,主题曲,NOUN,B2
-主题的,thematic,主题的,ADJ,B2
-举例说明,to exemplify,举例说明,VERB,B2
-久坐的,sedentary,久坐的,ADJ,B2
-义务,obligation,义务,NOUN,B2
-乌克兰的,ukrainian,乌克兰的,ADJ,B2
-乌托邦,utopia,乌托邦,NOUN,B2
-乌托邦的,utopian,乌托邦式的,ADJ,B2
-乌鸦,crow,乌鸦,NOUN,B2
-乌龟,turtle,海龟,NOUN,B2
-乏味的,tedious,乏味的,ADJ,B2
-乐意地,gladly,乐意地,ADV,B2
-乐意地/宁愿,gladly willingly,乐意地/宁愿,ADV,B2
-乐观,optimism,乐观,NOUN,B2
-乐趣,fun,乐趣,NOUN,B2
-乐趣/玩笑,fun joke,乐趣/玩笑,NOUN,B2
-九十,ninety,九十,NUM,B2
-也不,neither,也不,CCONJ,B2
-也不,nor,也不,CCONJ,B2
-也许,maybe,也许,ADV,B2
-习惯,to get used to,习惯于,VERB,B2
-习惯化,habituation,习惯化,NOUN,B2
-习惯的,accustomed,习惯的,ADJ,B2
-习惯的,customary,习惯的,ADJ,B2
-习惯行为,habitual behavior,习惯行为,NOUN,B2
-乡土的,folksy,乡土的,ADJ,B2
-乡村的,rustic,乡村的,ADJ,B2
-书呆子,nerd,书呆子,NOUN,B2
-书柜,bookcase,书柜,NOUN,B2
-书桌,desk,书桌,NOUN,B2
-书目,bibliography,参考书目,NOUN,B2
-书面,written,书面的,ADJ,B2
-乳房,breast,乳房,NOUN,B2
-乳白色的,milky,乳白色的,ADJ,B2
-争吵,quarrel,争吵,NOUN,B2
-争吵,to bicker,争吵,VERB,B2
-争执,altercation,争执,NOUN,B2
-事件,events,事件,NOUN,B2
-事件,incident,事件,NOUN,B2
-事实的,factual,事实的,ADJ,B2
-二元性,duality,二元性,NOUN,B2
-二元论,dualism,二元论,NOUN,B2
-二分法,dichotomy,二分法,NOUN,B2
-二月,february,二月,NOUN,B2
-二维的,two-dimensional,二维的,ADJ,B2
-二进制的,binary,二进制的,ADJ,B2
-云,clouds,云,NOUN,B2
-互动,interaction,互动,NOUN,B2
-互助,mutual support,互助,NOUN,B2
-互助保险,mutual insurance,互助保险,NOUN,B2
-互悯,mutual compassion,互悯,NOUN,B2
-互联网,internet,互联网,NOUN,B2
-互补性,complementarity,互补性,NOUN,B2
-互补的,complementary,互补的,ADJ,B2
-五十,fifty,五十,NUM,B2
-五联诗,quintain,五联诗,NOUN,B2
-亚洲的,asian,亚洲的,ADJ,B2
-交互的,interactive,交互式的,ADJ,B2
-交响乐,symphony,交响乐,NOUN,B2
-交响乐的,symphonic,交响乐的,ADJ,B2
-交易,deal,交易,NOUN,B2
-交替,alternation,轮流,NOUN,B2
-交替地,alternatively,交替地,ADV,B2
-产卵,to spawn,产卵,VERB,B2
-产生,to generate engender,产生,VERB,B2
-产生,to result,产生,VERB,B2
-产科学,obstetrics,产科学,NOUN,B2
-享乐主义,hedonism,享乐主义,NOUN,B2
-享乐主义的,hedonistic,享乐主义的,ADJ,B2
-享受,enjoyment,享受,NOUN,B2
-亭子,kiosk,亭子,NOUN,B2
-亮点,highlight,亮点,NOUN,B2
-亲切地,cordially,亲切地,ADV,B2
-亲切地,kindly,亲切地,ADV,B2
-亲切的,gracious,亲切的,ADJ,B2
-亲属,family relatives,亲属,NOUN,B2
-亲属关系,kinship,亲属关系,NOUN,B2
-亲爱的,darling,亲爱的,NOUN,B2
-亲笔签名,autograph,亲笔签名,NOUN,B2
-亵渎,blasphemy,亵渎,NOUN,B2
-亵渎,sacrilege,亵渎,NOUN,B2
-亵渎,to blaspheme,亵渎,VERB,B2
-亵渎坟墓,grave desecration,亵渎坟墓,NOUN,B2
-人们,one you,人们,PRON,B2
-人们,people,人们,PRON,B2
-人口学,demography,人口学,NOUN,B2
-人口普查,census,人口普查,NOUN,B2
-人口统计的,demographic,人口统计的,ADJ,B2
-人文主义者,humanist,人文主义者,NOUN,B2
-人文学科,humanities,人文学科,NOUN,B2
-人格谋杀,character assassination,人格谋杀,NOUN,B2
-人民 / 民族,people nation,人民 / 民族,NOUN,B2
-人类,human,人类的,ADJ,B2
-人类学,anthropology,人类学,NOUN,B2
-人脉,contacts,人脉,NOUN,B2
-人行天桥,footbridge,人行天桥,NOUN,B2
-人行道,pavement,人行道,NOUN,B2
-人身伤害,bodily harm,人身伤害,NOUN,B2
-人道主义的,humanitarian,人道主义的,ADJ,B2
-人道的,humane,人道的,ADJ,B2
-人际的,interpersonal,人际的,ADJ,B2
-什一税,tithe,什一税,NOUN,B2
-什么,what,什么,ADV,B2
-什么样的,what kind of,什么样的,PRON,B2
-仁慈,clemency,仁慈,NOUN,B2
-仁慈,kindness,仁慈,NOUN,B2
-今天,today,今天,ADV,B2
-今天早上,this morning,今天早上,ADV,B2
-今晚,this evening,今晚,ADV,B2
-今晚,tonight,今晚,ADV,B2
-介入,to step in,介入,VERB,B2
-介绍,introduction,介绍,NOUN,B2
-从上方,from above,从上方,ADV,B2
-从业者,practitioner,从业者,NOUN,B2
-从中,from it,从中,ADV,B2
-从中,from which,从中,ADV,B2
-从事,to occupy oneself,从事,VERB,B2
-从众心理,herd mentality,从众心理,NOUN,B2
-从内部,from within,从内部,ADV,B2
-从后面,from behind,从后面,ADV,B2
-从哪里,from where,从哪里,ADV,B2
-从属,to subordinate,从属,VERB,B2
-从此以后,henceforth,从此以后,ADV,B2
-从那以后,since then,从那以后,ADV,B2
-从那里,from there,从那里,ADV,B2
-仓库,depot,仓库,NOUN,B2
-仓鼠轮,squirrel wheel,仓鼠轮,NOUN,B2
-仔细地,carefully,仔细地,ADV,B2
-仔细检查,to scrutinize,仔细检查,VERB,B2
-他,him,他,PRON,B2
-他/她,him her,他/她,PRON,B2
-他/这位,he this one,他/这位,PRON,B2
-他们,them,他们,PRON,B2
-他们的,their,他们的,PRON,B2
-他的,his,他的,DET,B2
-他的/她的/它的/他们的,his her its their,他的/她的/它的/他们的,DET,B2
-代表,on behalf of,代表,ADP,B2
-代表,to represent,代表,VERB,B2
-代表团,delegation,代表团,NOUN,B2
-代表性,representativeness,代表性,NOUN,B2
-代表性的,representative,有代表性的,ADJ,B2
-代谢的,metabolic,代谢的,ADJ,B2
-代际的,generational,代际的,ADJ,B2
-令人不安的,disturbing,令人不安的,ADJ,B2
-令人不快的,nasty,令人不快的,ADJ,B2
-令人信服的,convincing,令人信服的,ADJ,B2
-令人兴奋的,exciting,令人兴奋的,ADJ,B2
-令人兴奋的,thrilling,令人兴奋的,ADJ,B2
-令人印象深刻的,impressive,令人印象深刻的,ADJ,B2
-令人厌恶的,disgusting,令人厌恶的,ADJ,B2
-令人厌恶的,repulsive,令人反感的,ADJ,B2
-令人厌恶的人,creep,令人厌恶的人,NOUN,B2
-令人困惑的,confusing,令人困惑的,ADJ,B2
-令人失望的,disappointing,令人失望的,ADJ,B2
-令人失望的,dismal,令人失望的,ADJ,B2
-令人尴尬,embarrassing,令人尴尬的,ADJ,B2
-令人恐惧的,frightening,令人恐惧的,ADJ,B2
-令人恐惧的,horrifying,令人毛骨悚然的,ADJ,B2
-令人恼火的,irritating,令人恼火的,ADJ,B2
-令人惊讶的,surprising,令人惊讶的,ADJ,B2
-令人愉快的,delightful,令人愉快的,ADJ,B2
-令人感动的,deeply moving,令人感动的,ADJ,B2
-令人担忧的,worrying,令人担忧的,ADJ,B2
-令人毛骨悚然的,creepy,令人毛骨悚然的,ADJ,B2
-令人沮丧的,frustrating,令人沮丧的,ADJ,B2
-令人清爽的,refreshing,令人清爽的,ADJ,B2
-令人满意的,satisfying,令人满意的,ADJ,B2
-令人羞辱的,humiliating,令人羞辱的,ADJ,B2
-令人羡慕的,enviable,令人羡慕的,ADJ,B2
-令人震惊的,shocking,令人震惊的,ADJ,B2
-令人震惊的,stunning,极好的,ADJ,B2
-令人高兴的,heartening,令人高兴的,ADJ,B2
-令状,warrant,令状,NOUN,B2
-以便,in order to so that,以便,SCONJ,B2
-以免,lest,唯恐,SCONJ,B2
-以前,ago,以前,ADV,B2
-以前,before previously,以前,ADV,B2
-以此,with that,以此,ADV,B2
-以此,with this,以此,ADV,B2
-仪式,rituals,仪式,NOUN,B2
-仪式的,ceremonial,仪式的,ADJ,B2
-仰慕者,admirer,仰慕者,NOUN,B2
-价值基础,values base,价值基础,NOUN,B2
-价值观,values,价值观,NOUN,B2
-任何,any,任何,DET,B2
-任何事,anything,任何事,PRON,B2
-任务,assignment,任务,NOUN,B2
-任性的,perverse,任性的,ADJ,B2
-份额,share,股份,NOUN,B2
-伊斯兰的,islamic,伊斯兰的,ADJ,B2
-伊朗的,iranian,伊朗的,ADJ,B2
-伊玛目,imam,伊玛目,NOUN,B2
-休战,truce,休战,NOUN,B2
-众多的,numerous,众多的,ADJ,B2
-优先考虑,to prioritize,优先考虑,VERB,B2
-优化,optimization,优化,NOUN,B2
-优越性/优势,superiority,优越性/优势,NOUN,B2
-优雅,elegant,优雅的,ADJ,B2
-优雅,grace,优雅,NOUN,B2
-会众,congregation,集会,NOUN,B2
-会员资格,membership,会员资格,NOUN,B2
-会计,accounting,会计,NOUN,B2
-会议的,conference-based,会议的,ADJ,B2
-会面/击中,meeting hit,会面/击中,NOUN,B2
-传入的,incoming,进来的,ADJ,B2
-传感器,sensor,传感器,NOUN,B2
-传播,diffusion,传播,NOUN,B2
-传播,to propagate,传播,VERB,B2
-传教,proselytism,传教,NOUN,B2
-传教,to evangelize,传福音,VERB,B2
-传染性的,contagious,传染性的,ADJ,B2
-传统地,traditionally,传统地,ADV,B2
-传统服饰,traditional costume,传统服饰,NOUN,B2
-传统的,conventional,传统的,ADJ,B2
-传统的,traditional,传统的,ADJ,B2
-传说的,legendary,传奇的,ADJ,B2
-伤害,causing harm,伤害,NOUN,B2
-伤害,to do harm,伤害,VERB,B2
-伦理学,ethics,伦理学,NOUN,B2
-伦理的,ethical,道德的,ADJ,B2
-伪君子,hypocrite,伪君子,NOUN,B2
-伪善的,sanctimonious,伪善的,ADJ,B2
-伪装,to camouflage,伪装,VERB,B2
-伪装,to disguise,伪装,VERB,B2
-伪证,perjury,伪证,NOUN,B2
-伪造,counterfeiting,伪造,NOUN,B2
-伪造,forgery,伪造品,NOUN,B2
-伪造,to fake,伪造,VERB,B2
-伯爵夫人,countess,女伯爵,NOUN,B2
-伶牙俐齿的,glib,伶牙俐齿的,ADJ,B2
-伸出,to stick out,伸出,VERB,B2
-似是而非的,plausible,似是而非的,ADJ,B2
-似是而非的,specious,似是而非的,ADJ,B2
-但愿,hopefully,希望,ADV,B2
-位于,located,位于,ADJ,B2
-位于,to be located,位于,VERB,B2
-位似,homothety,位似,NOUN,B2
-位值,place value,位值,NOUN,B2
-位移,displacement,位移,NOUN,B2
-低估,to underestimate,低估,VERB,B2
-低地,lowland,低地,NOUN,B2
-低效,inefficiency,低效,NOUN,B2
-低语,to whisper,低语,VERB,B2
-住宿,accommodation,住宿,NOUN,B2
-住房,housing,住房,NOUN,B2
-住所,dwelling,住宅,NOUN,B2
-住院,to hospitalize,使住院,VERB,B2
-体操运动员,gymnast,体操运动员,NOUN,B2
-体检,checkup,体检,NOUN,B2
-体积,bulk,主体,NOUN,B2
-体裁,genre,类型,NOUN,B2
-体贴地,thoughtfully,体贴地,ADV,B2
-体贴的,understanding,体贴的,ADJ,B2
-体面,decent,体面的,ADJ,B2
-体面,decency,体面,NOUN,B2
-体面的,fatsoenlijk,体面的,ADJ,B2
-何种程度,what extent,在何种程度上,ADV,B2
-佛兰芒的,flemish,佛兰芒的,ADJ,B2
-你们的,your plural,你们的,DET,B2
-你好,good day,你好,INTJ,B2
-你的,your,你的,DET,B2
-你自己,yourself,你自己,PRON,B2
-佳酿,vintage,佳酿,NOUN,B2
-使一致,to align,使一致,VERB,B2
-使不便,to inconvenience,使不便,VERB,B2
-使不悦,to displease,使不快,VERB,B2
-使不稳定,to destabilize,使不稳定,VERB,B2
-使两极分化,to polarize,使两极分化,VERB,B2
-使中毒,to intoxicate,使中毒,VERB,B2
-使丰富,to enrich,使丰富,VERB,B2
-使乏味,to make bland,使乏味,VERB,B2
-使习惯,to accustom,使习惯,VERB,B2
-使人口减少,to depopulate,使人口减少,VERB,B2
-使人疏远的,alienating,使人疏远的,ADJ,B2
-使全球化,to globalize,使全球化,VERB,B2
-使全神贯注,to engross,使全神贯注,VERB,B2
-使兴奋,to excite,使兴奋,VERB,B2
-使具有细微差别,to nuance,使具有细微差别,VERB,B2
-使冰冻,to chill,使冰冻,VERB,B2
-使分裂,to disunite,使分裂,VERB,B2
-使厌烦,to cloy,使厌烦,VERB,B2
-使发炎,to inflame,使发炎,VERB,B2
-使变形,to deform,使变形,VERB,B2
-使变性,to denature,使变性,VERB,B2
-使变甜,to sweeten,使变甜,VERB,B2
-使变窄,to narrow,使变窄,VERB,B2
-使吃惊,to amaze,使吃惊,VERB,B2
-使合法化,to legitimize,使合法,VERB,B2
-使坐下,to seat,使坐下,VERB,B2
-使堕落,to deprave,使堕落,VERB,B2
-使复杂化,to complicate,使复杂化,VERB,B2
-使复苏,to revitalize,使复苏,VERB,B2
-使外在化,to externalize,使外在化,VERB,B2
-使大胆,to embolden,使大胆,VERB,B2
-使失望,to disappoint,使失望,VERB,B2
-使失色,to eclipse,使失色,VERB,B2
-使娱乐,to amuse,逗乐,VERB,B2
-使安心,to reassure,使安心,VERB,B2
-使尴尬,to embarrass,使尴尬,VERB,B2
-使布满孔洞,to riddle,使布满孔洞,VERB,B2
-使平坦,to flatten,使平坦,VERB,B2
-使平庸,to trivialize,使平庸,VERB,B2
-使平静,to calm down,使平静,VERB,B2
-使康复,to rehabilitate,使康复,VERB,B2
-使怜悯,to move to pity,使怜悯,VERB,B2
-使恐惧,to horrify,使惊骇,VERB,B2
-使恐惧,to terrify,使恐惧,VERB,B2
-使恢复精神,to refresh,使恢复精神,VERB,B2
-使悲伤,to sadden,使悲伤,VERB,B2
-使惊恐,to appal,使惊恐,VERB,B2
-使惊慌,to disconcert,使惊慌,VERB,B2
-使惊讶,to surprise,使惊讶,VERB,B2
-使愚蠢,to make stupid,使愚蠢,VERB,B2
-使感兴趣,to interest,使感兴趣,VERB,B2
-使感动,to move touch,使感动,VERB,B2
-使慌乱,to fluster,使慌乱,VERB,B2
-使担心,to worry to preoccupy,使担心,VERB,B2
-使摆脱,to extricate,使摆脱,VERB,B2
-使断奶,to wean,断奶,VERB,B2
-使无力,to emasculate,使无力,VERB,B2
-使残暴,to brutalize,使变得残忍,VERB,B2
-使气馁,to daunt,使气馁,VERB,B2
-使气馁,to discourage,使气馁,VERB,B2
-使永存,to perpetuate,使永存,VERB,B2
-使永恒,to eternalize,使永恒,VERB,B2
-使沮丧,to depress,使沮丧,VERB,B2
-使沮丧,to dishearten,使沮丧,VERB,B2
-使沮丧,to dismay,使沮丧,VERB,B2
-使泄气,to deflate,使泄气,VERB,B2
-使泄气,to demoralize,使士气低落,VERB,B2
-使清新,to freshen,使清新,VERB,B2
-使清醒,to disenchant,使清醒,VERB,B2
-使满足,to gratify,使满足,VERB,B2
-使潮湿,to dampen,使潮湿,VERB,B2
-使灵活,to soften,使灵活,VERB,B2
-使热情,to enthuse,使热情,VERB,B2
-使熟悉,to acquaint,使熟悉,VERB,B2
-使熟悉,to familiarize,使熟悉,VERB,B2
-使狂喜,to enrapture,使狂喜,VERB,B2
-使生气,to anger,使生气,VERB,B2
-使疏远,to alienate,使疏远,VERB,B2
-使疲倦,tire,轮胎,NOUN,B2
-使疲倦,to tire,使疲倦,VERB,B2
-使相等,to equalize,使相等,VERB,B2
-使神圣,to sanctify,使神圣,VERB,B2
-使移居国外,to expatriate,使移居国外,VERB,B2
-使窒息,to asphyxiate,使窒息,VERB,B2
-使竖起,to bristle,使竖起,VERB,B2
-使经受锻炼,to harden,使经受锻炼,VERB,B2
-使聋,to deafen,使聋,VERB,B2
-使肿胀,to swell,使肿胀,VERB,B2
-使能够,to enable,使能够,VERB,B2
-使自豪,to make proud,使自豪,VERB,B2
-使苦恼,to ail,使苦恼,VERB,B2
-使茫然,to daze,使茫然,VERB,B2
-使蒙羞,to dishonor,使蒙羞,VERB,B2
-使衰弱,to enervate,使衰弱,VERB,B2
-使贫困,to pauperize,使贫困,VERB,B2
-使边缘化,to marginalize,使边缘化,VERB,B2
-使迷失方向,to disorient,使迷失方向,VERB,B2
-使饱和,to saturate,使饱和,VERB,B2
-使饱足,to satiate,使饱足,VERB,B2
-使高兴,to delight,使高兴,VERB,B2
-使麻木,to numb,使麻木,VERB,B2
-使黯然失色,to overshadow,使黯然失色,VERB,B2
-侄女,niece,侄女,NOUN,B2
-例子,instance,例子,NOUN,B2
-侍者,waiter,服务员,NOUN,B2
-供养,to provide for,供应,VERB,B2
-供应,supply,供应,NOUN,B2
-供应,to furnish,提供,VERB,B2
-供暖,heating,供暖,NOUN,B2
-依照/根据,pursuant to,依照/根据,ADV,B2
-依赖,dependence,依赖,NOUN,B2
-依赖,to depend,依赖,VERB,B2
-依赖,to rely,依赖,VERB,B2
-依赖的,dependent,依赖的,ADJ,B2
-侦察,reconnaissance,侦察,NOUN,B2
-侦察,to scout,侦察,VERB,B2
-侧翼,flank,侧翼,NOUN,B2
-侧面/页,side page,侧面/页,NOUN,B2
-侧面的,lateral,侧面的,ADJ,B2
-侵入,intrusion,闯入,NOUN,B2
-侵犯,infringement,侵犯,NOUN,B2
-侵蚀,to encroach,侵蚀,VERB,B2
-侵蚀,to erode,侵蚀,VERB,B2
-便宜货,bargain,便宜货,NOUN,B2
-促进,to boost,促进,VERB,B2
-俄罗斯的,russian,俄罗斯的,ADJ,B2
-俚语,slang,俚语,NOUN,B2
-保加利亚的,bulgarian,保加利亚的,ADJ,B2
-保姆,babysitter,保姆,NOUN,B2
-保存,to conserve,保存,VERB,B2
-保存,to preserve,保护,VERB,B2
-保护,protective,保护的,ADJ,B2
-保护主义,protectionism,保护主义,NOUN,B2
-保持沉默,to keep silent,保持沉默,VERB,B2
-保理,factoring,保理,NOUN,B2
-保证,assurance,保证,NOUN,B2
-保证,suretyship,保证,NOUN,B2
-保证,to assure,保证,VERB,B2
-保险丝,fuse,保险丝,NOUN,B2
-保险箱,the safe,保险箱,NOUN,B2
-信,letter mail,信,NOUN,B2
-信任的,trusting,信任的,ADJ,B2
-信使,messenger,信使,NOUN,B2
-信徒,believer,信徒,NOUN,B2
-信徒,practicing believer,信徒,NOUN,B2
-信息,piece of information,信息,NOUN,B2
-信息技术,it,信息技术,NOUN,B2
-修理,to fix,修理,VERB,B2
-修车匠,bicycle repairer,修车匠,NOUN,B2
-修辞的,rhetorical,修辞的,ADJ,B2
-修道院,monastery,修道院,NOUN,B2
-倒空,to empty,倒空,VERB,B2
-候选资格,candidacy,候选资格,NOUN,B2
-借代,metonymy,转喻,NOUN,B2
-借出,to lend,借出,VERB,B2
-倦怠,languor,倦怠,NOUN,B2
-债务,debts,债务,NOUN,B2
-债务,indebtedness,负债,NOUN,B2
-值得,worth,值得的,ADJ,B2
-值得,worthy,值得的,ADJ,B2
-值得一提的,worth mentioning,值得一提的,ADJ,B2
-倾向,inclination,倾向,NOUN,B2
-倾向,propensity,倾向,NOUN,B2
-倾斜,lean,瘦的,ADJ,B2
-倾斜,tilt,倾斜,NOUN,B2
-倾斜,to lean,倾斜,VERB,B2
-倾斜的 / 古怪的,oblique weird,倾斜的 / 古怪的,ADJ,B2
-倾析,to decant,倾析,VERB,B2
-倾盆大雨,downpour,倾盆大雨,NOUN,B2
-倾诉,to pour out,倾诉,VERB,B2
-倾销,dumping,倾销,NOUN,B2
-假发,wig,假发,NOUN,B2
-假定,to postulate,假定,VERB,B2
-假期,holidays,假期,NOUN,B2
-假的,phony,假的,ADJ,B2
-假装,to feign,假装,VERB,B2
-偏偏,of all things,偏偏,ADV,B2
-偏头痛,migraine,偏头痛,NOUN,B2
-偏离,to deviate,偏离,VERB,B2
-偏袒,favoritism,偏袒,NOUN,B2
-做/修理,to cook fix,做/修理,VERB,B2
-做运动,to play sports,做运动,VERB,B2
-停止,stop,停止,NOUN,B2
-停止,to desist,停止,VERB,B2
-停泊,anchoring,停泊,NOUN,B2
-停滞,stagnation,停滞,NOUN,B2
-停滞,to stall,拖延,VERB,B2
-停滞的,stagnant,停滞的,ADJ,B2
-健康政策,health policy,健康政策,NOUN,B2
-健康的,healthy,健康的,ADJ,B2
-健忘症,amnesia,健忘症,NOUN,B2
-健谈,garrulous,喋喋不休的,ADJ,B2
-健谈的,talkative,健谈的,ADJ,B2
-健身,fitness,健康,NOUN,B2
-偶像破坏者,iconoclast,偶像破坏者,NOUN,B2
-偶然地,by chance,偶然地,ADV,B2
-偶然的,contingent,偶然的,ADJ,B2
-偶然的,fortuitous,偶然的,ADJ,B2
-偷听,to eavesdrop,偷听,VERB,B2
-偿付能力,solvency,偿付能力,NOUN,B2
-储存,store,商店,NOUN,B2
-储存,to store,储存,VERB,B2
-储蓄,saving,储蓄,NOUN,B2
-储蓄,savings,存款,NOUN,B2
-催化,to catalyze,催化,VERB,B2
-傲慢,haughtiness,傲慢,NOUN,B2
-傲慢/虚荣,arrogance vanity,傲慢/虚荣,NOUN,B2
-傲慢的,cocky,傲慢的,ADJ,B2
-傲慢的,haughty,傲慢的,ADJ,B2
-傻的,daft,傻的,ADJ,B2
-像那样,like that,像那样,ADV,B2
-僵化,inflexibility,僵化,NOUN,B2
-僵硬,stiffness,僵硬,NOUN,B2
-僵硬的,rigid,僵硬的,ADJ,B2
-儿童权利,children's rights,儿童权利,NOUN,B2
-允许,be allowed,允许,AUX,B2
-允许的,allowed,被允许的,ADJ,B2
-元帅,marshal,元帅,NOUN,B2
-兄弟姐妹,sibling,兄弟姐妹,NOUN,B2
-兄弟姐妹,siblings,兄弟姐妹,NOUN,B2
-充满活力的,full of life,充满活力的,ADJ,B2
-充满的,filled,充满的,ADJ,B2
-充电,to recharge,充电,VERB,B2
-充足,plenitude,充足,NOUN,B2
-先于,to precede,在...之前,VERB,B2
-先前,previously,以前,ADV,B2
-先前的,previous,先前的,ADJ,B2
-先前的,prior,先前的,ADJ,B2
-先发制人,preemption,先发制人,NOUN,B2
-先天的,congenital,先天的,ADJ,B2
-先生,mr.,先生,NOUN,B2
-先生,sir,先生,NOUN,B2
-先生/主人,mr master,先生/主人,NOUN,B2
-先知,prophet,先知,NOUN,B2
-先行词,antecedent,先行词,NOUN,B2
-先贤祠,pantheon,先贤祠,NOUN,B2
-先驱,pioneer,先驱,NOUN,B2
-先驱,precursor,先驱,NOUN,B2
-先验的,transcendental,先验的,ADJ,B2
-光子,photon,光子,NOUN,B2
-光学的,optical,光学的,ADJ,B2
-光泽,gloss,光泽,NOUN,B2
-光盘,disc,光盘,NOUN,B2
-光荣,gloriousness,光荣,NOUN,B2
-光谱,spectrum,光谱,NOUN,B2
-光谱的,spectral,幽灵般的,ADJ,B2
-光辉,glow,光芒,NOUN,B2
-克拉克斯布,qraqeb,克拉克斯布,NOUN,B2
-免疫,immunization,免疫,NOUN,B2
-免疫,to immunize,免疫,VERB,B2
-免疫的,immune,免疫的,ADJ,B2
-免税,tax exemption,免税,NOUN,B2
-免费,for free,免费,ADV,B2
-免费,free of charge,免费,NOUN,B2
-免除,to exempt,免除,VERB,B2
-党派性,partisanship,党派性,NOUN,B2
-兜帽,hood,兜帽,NOUN,B2
-入侵,invasion,入侵,NOUN,B2
-入侵者,invader,入侵者,NOUN,B2
-入室盗窃,burglary,入室盗窃罪,NOUN,B2
-全体船员,crew,全体船员,NOUN,B2
-全球化,globalization,全球化,NOUN,B2
-全球化进程,globalization process,全球化进程,NOUN,B2
-全神贯注的,absorbed,全神贯注的,ADJ,B2
-全科医生,general practitioner,全科医生,NOUN,B2
-全部,all of it,全部,PRON,B2
-全部曲目,repertoire,全部曲目,NOUN,B2
-全面的,all-round,全面的,ADJ,B2
-八十,eighty,八十,NUM,B2
-八行诗,eight-line stanza,八行诗,NOUN,B2
-公使馆,legation,公使馆,NOUN,B2
-公共假日,public holiday,公共假日,ADJ,B2
-公共喷泉,public fountain,公共喷泉,NOUN,B2
-公共浴室,public bath,公共浴室,NOUN,B2
-公制的,metric,公制的,ADJ,B2
-公务员,civil servant,公务员,NOUN,B2
-公司,corporation,公司,NOUN,B2
-公司,firm,公司,NOUN,B2
-公司的,corporate,公司的,ADJ,B2
-公平,equity,公平,NOUN,B2
-公平的/正派的,fair decent,公平的/正派的,ADJ,B2
-公开,publicly,公开地,ADV,B2
-公投,referendum,公民投票,NOUN,B2
-公报,communique,公报,NOUN,B2
-公报,press release,公报,NOUN,B2
-公正,impartiality,公正,NOUN,B2
-公民权,citizenship right,公民权,NOUN,B2
-公民的,civil,民事的,ADJ,B2
-公民身份,citizenship,公民身份,NOUN,B2
-公爵夫人,duchess,公爵夫人,NOUN,B2
-公理,axiom,公理,NOUN,B2
-公理的,axiomatic,公理的,ADJ,B2
-公用事业表,utility meter,公用事业表,NOUN,B2
-公羊,ram,公羊,NOUN,B2
-公鸡,rooster,公鸡,NOUN,B2
-六十,sixty,六十,NUM,B2
-六十来个,about sixty,六十来个,NOUN,B2
-六月,june,六月,NOUN,B2
-共产主义,communism,共产主义,NOUN,B2
-共产主义的,communist,شيوعي,ADJ,B2
-共产主义者,communist,共产主义者,NOUN,B2
-共同决定权,co-determination,共同决定权,NOUN,B2
-共同地,jointly,共同地,ADV,B2
-共同的,together,共同的,ADJ,B2
-共同研究,to study jointly,共同研究,VERB,B2
-共和的,republican,共和的,ADJ,B2
-共有人,co-owner,共有人,NOUN,B2
-共有权,joint ownership,共有,NOUN,B2
-共济失调,ataxia,共济失调,NOUN,B2
-共谋,complicity,共犯,NOUN,B2
-共谋的,complicit,共谋的,ADJ,B2
-共鸣,to resonate,共鸣,VERB,B2
-共鸣的,resonant,共鸣的,ADJ,B2
-关,off,关,ADP,B2
-关于,concerning,关于,ADP,B2
-关于哪个,of which,关于哪个,PRON,B2
-关于它,about it,关于它,ADV,B2
-关于那个,about that,关于那个,ADV,B2
-关怀的,caring,关怀的,ADJ,B2
-关掉,to switch off,关掉,VERB,B2
-关节,joint,关节,NOUN,B2
-关键性,criticality,临界性,NOUN,B2
-兴奋,excitement,兴奋,NOUN,B2
-兴奋剂,stimulant,兴奋剂,NOUN,B2
-兴高采烈,elated,兴高采烈的,ADJ,B2
-兴高采烈,elation,兴高采烈,NOUN,B2
-其他,other,其他的,DET,B2
-其他,other others,其他,DET,B2
-其次,secondly,其次,ADV,B2
-其间,meantime,同时,NOUN,B2
-具体地,specifically,具体地,ADV,B2
-具体的,specific,具体的,ADJ,B2
-养老金,pension,养老金,NOUN,B2
-养肥,to fatten,养肥,VERB,B2
-兼职工,part-time worker,兼职工,NOUN,B2
-兽穴,den,兽穴,NOUN,B2
-兽群,herd,兽群,NOUN,B2
-内在地,inwardly,内在地,ADV,B2
-内在性,immanence,内在性,NOUN,B2
-内接,to circumscribe,限制,VERB,B2
-内涵的,connotative,内涵的,ADJ,B2
-内疚,guilt,内疚,NOUN,B2
-内疚的,guilt-ridden,内疚的,ADJ,B2
-内脏,entrails,内脏,NOUN,B2
-内部的,internal,内部的,ADJ,B2
-内阁,cabinet,内阁,NOUN,B2
-再次,once again,再次,ADV,B2
-再见,bye,再见,INTJ,B2
-再见（电话用语）,goodbye phone,再见（电话用语）,NOUN,B2
-冒号,colon,冒号,NOUN,B2
-冒泡的,bubbling,冒泡的,ADJ,B2
-冒犯,affront,冒犯,NOUN,B2
-冒犯,offense,冒犯,NOUN,B2
-冒犯的,offensive,冒犯的,ADJ,B2
-冒险,adventure,冒险,NOUN,B2
-冒险家,adventurer,冒险家,NOUN,B2
-冒险的,risky,危险的,ADJ,B2
-冗余,redundancy,冗余,NOUN,B2
-冗长,prolixity,冗长,NOUN,B2
-冗长,verbosity,冗长,NOUN,B2
-冗长的,prolix,冗长的,ADJ,B2
-冗长的,verbose,冗长的,ADJ,B2
-军队,military,军事的,ADJ,B2
-农业,farming,农业,NOUN,B2
-农作物,crop,庄稼,NOUN,B2
-农场,farm yard,农场,NOUN,B2
-农庄,farmstead,农庄,NOUN,B2
-农村的,rural,乡村的,ADJ,B2
-农民,farmer,农民,NOUN,B2
-冬天的,wintry,冬天的,ADJ,B2
-冰冷的,ice cold,冰冷的,ADJ,B2
-冰川,glacier,冰川,NOUN,B2
-冰箱,fridge,冰箱,NOUN,B2
-冲动,impulsiveness,冲动,NOUN,B2
-冲动,whim,突发奇想,NOUN,B2
-冲动的,impulsive,冲动的,ADJ,B2
-冲洗,to flush,冲洗,VERB,B2
-冲洗,to rinse,冲洗,VERB,B2
-决定/确定,to decide determine,决定/确定,VERB,B2
-决定性的,definitive,决定性的,ADJ,B2
-决定论,determinism,决定论,NOUN,B2
-决定论的,deterministic,决定论的,ADJ,B2
-决断,decisiveness,决断,NOUN,B2
-决疑法,casuistry,决疑法,NOUN,B2
-决赛,final,决赛,NOUN,B2
-冷冻,freezing,冻结,NOUN,B2
-冷冻柜,freezer,冰柜,NOUN,B2
-冷却,cooling,冷却,NOUN,B2
-冷却,to cool,冷却,VERB,B2
-冷却器 / 冷却液,cooler coolant,冷却器 / 冷却液,NOUN,B2
-冷漠,aloofness,冷漠,NOUN,B2
-冷漠,apathy,冷漠,NOUN,B2
-冷漠的,apathetic,冷漠的,ADJ,B2
-冷漠的,stolid,冷漠的,ADJ,B2
-冷落,to snub,冷落,VERB,B2
-冷静的,phlegmatic,冷静的,ADJ,B2
-冻僵的,frozen,冻僵的,ADJ,B2
-净化,purification,净化,NOUN,B2
-净化,to purify,净化,VERB,B2
-净化的,purifying,净化的,ADJ,B2
-准备好的,prepared,准备好的,ADJ,B2
-准备好的,ready,准备好的,ADJ,B2
-准备好的/完成的,ready finished,准备好的/完成的,ADJ,B2
-准备就绪,readiness,准备就绪,NOUN,B2
-准时,punctual,准时的,ADJ,B2
-准时地 / 偶尔地,punctually occasionally,准时地 / 偶尔地,ADV,B2
-准确性,accuracy,准确性,NOUN,B2
-凉亭,bower,凉亭,NOUN,B2
-凉鞋,sandal,凉鞋,NOUN,B2
-减,minus,减,NOUN,B2
-减少,reduction,减少,NOUN,B2
-减少,to decrease,减少,VERB,B2
-减少,to diminish,减少,VERB,B2
-减弱,weakening,减弱,NOUN,B2
-减弱,to attenuate,减弱,VERB,B2
-减弱,to wane,减弱,VERB,B2
-减肥,to diet,减肥,VERB,B2
-减轻,to lighten,减轻,VERB,B2
-减速,slowdown,减速,NOUN,B2
-减速,to slow down,放慢,VERB,B2
-几个,several,几个,DET,B2
-几乎,virtually,几乎,ADV,B2
-几乎不,barely,几乎不,ADV,B2
-几乎不,hardly,几乎不,ADV,B2
-几乎不,scarcely,几乎不,ADV,B2
-几何,geometric,几何的,ADJ,B2
-几何学,geometry,几何学,NOUN,B2
-凭借,whereby,其中,ADV,B2
-凹凸不平的,bumpy,凹凸不平的,ADJ,B2
-凹痕,dent,凹痕,NOUN,B2
-凹的,concave,凹的,ADJ,B2
-出价,bid,出价,NOUN,B2
-出去,to exit to go out,出去,VERB,B2
-出口,export,出口,NOUN,B2
-出口,outlet,出口,NOUN,B2
-出口,to export,出口,VERB,B2
-出声地,aloud,出声地,ADV,B2
-出处注明,source citation,出处注明,NOUN,B2
-出席,turnout,出席率,NOUN,B2
-出版商,publisher,出版商,NOUN,B2
-出版社,publishing house,出版社,NOUN,B2
-出版自由,freedom of the press,出版自由,NOUN,B2
-出现,to emerge,出现,VERB,B2
-出现/显得,to appear to seem,出现/显得,VERB,B2
-出租,to rent out,出租,VERB,B2
-出纳员,cashier,出纳员,NOUN,B2
-出血,hemorrhage,出血,NOUN,B2
-击倒,to strike down,击倒,VERB,B2
-击退,to repel,击退,VERB,B2
-凿子,chisel,凿子,NOUN,B2
-分,cent,分,NOUN,B2
-分享,sharing,分享,NOUN,B2
-分享,to share divide,分享,VERB,B2
-分割,to fraction,分割,VERB,B2
-分包,subcontracting,分包,NOUN,B2
-分化,differentiation,区分,NOUN,B2
-分叉,to bifurcate,分叉,VERB,B2
-分发,to dispense,分发,VERB,B2
-分号,semicolon,分号,PUNCT,B2
-分娩,childbirth,分娩,NOUN,B2
-分娩,to give birth,分娩,VERB,B2
-分层,to stratify,分层,VERB,B2
-分开,apart,分开,ADV,B2
-分开地，单独地,separately,分开地，单独地,ADV,B2
-分开的,separate,分开的,ADJ,B2
-分开的,separated,分开的,ADJ,B2
-分心,distraction,分心,NOUN,B2
-分心,to distract,分心,VERB,B2
-分手,breakup,分手,NOUN,B2
-分散,to disperse,分散,VERB,B2
-分期,periodization,分期,NOUN,B2
-分期付款,in installments,分期付款,ADV,B2
-分析,analysis,分析,NOUN,B2
-分析的,analytical,分析的,ADJ,B2
-分歧,divergence,分歧,NOUN,B2
-分歧,to diverge,分歧,VERB,B2
-分歧的,divergent,分歧的,ADJ,B2
-分流,to shunt,分流,VERB,B2
-分离,detachment,脱落,NOUN,B2
-分离,to decouple,分离,VERB,B2
-分离,to detach,分离,VERB,B2
-分离,to disjoin,分离,VERB,B2
-分离/离婚,to separate divorce,分离/离婚,VERB,B2
-分类,classification,分类,NOUN,B2
-分类,sorting,分类,NOUN,B2
-分类,to sort,分类,VERB,B2
-分类学,taxonomy,分类学,NOUN,B2
-分组,to group,分组,VERB,B2
-分群,to swarm,分群,VERB,B2
-分裂,schism,分裂,NOUN,B2
-分裂,split,分裂,NOUN,B2
-分裂,split secession,分裂,NOUN,B2
-分解 / 降解,decomposition degradation,分解 / 降解,NOUN,B2
-分贝,decibel,分贝,NOUN,B2
-分配,to allocate,分配,VERB,B2
-分销商,distributor,分销商,NOUN,B2
-切入点,angle of approach,切入点,NOUN,B2
-切割,cutting,切割,NOUN,B2
-切口,incision,切口,NOUN,B2
-切换,to switch,切换,VERB,B2
-切线,tangent,切线,NOUN,B2
-刑事的,penal,刑事的,ADJ,B2
-刑法,criminal law,刑法,NOUN,B2
-刑警,detective force,刑警,NOUN,B2
-划定界限,to demarcate,划定界限,VERB,B2
-划界,demarcation,划界,NOUN,B2
-划船,row,行,NOUN,B2
-划船,to row,划船,VERB,B2
-列举,enumeration,列举,NOUN,B2
-列巴布琴,rebab,列巴布琴,NOUN,B2
-刘海,fringe,边缘,NOUN,B2
-刚刚,only just,才,ADV,B2
-创伤,trauma,创伤,NOUN,B2
-创造,creation,创造,NOUN,B2
-初学者,beginner,初学者,NOUN,B2
-初次登台,debut,初次登台,NOUN,B2
-初步的,preliminary,初步的,ADJ,B2
-初熟果实,first fruit,初熟果实,NOUN,B2
-删节,to expurgate,删节,VERB,B2
-判例法,case law,判例法,NOUN,B2
-判决,verdict,裁决,NOUN,B2
-判决执行,sentence enforcement,判决执行,NOUN,B2
-刨,to plane,刨,VERB,B2
-刨花,shavings,刨花,NOUN,B2
-利他主义,altruism,利他主义,NOUN,B2
-利他的,altruistic,利他的,ADJ,B2
-利用,utilization,利用,NOUN,B2
-别处,elsewhere,别处,ADV,B2
-刮,to shave,剃,VERB,B2
-到了,arrived present,到了,ADV,B2
-到处,around,到处,ADV,B2
-到期,expiry,失效,NOUN,B2
-到来,advent,到来,NOUN,B2
-到这里,hither,到这里,ADV,B2
-制定,to enact,颁布,VERB,B2
-制度化,to institutionalize,制度化,VERB,B2
-制服,uniform,制服,NOUN,B2
-制裁,sanction,制裁,NOUN,B2
-制造,manufacture,制造,NOUN,B2
-制造商,manufacturer,制造商,NOUN,B2
-刺,sting,刺,NOUN,B2
-刺,to stab,刺,VERB,B2
-刺,to stick,插入,VERB,B2
-刺激,stimulus,刺激,NOUN,B2
-刺激,to goad,刺激,VERB,B2
-刺激,to spur,激励,VERB,B2
-刺猬,hedgehog,刺猬,NOUN,B2
-刺痛,tingling,麻木感,NOUN,B2
-刺破,to puncture deflate,刺破,VERB,B2
-刺绣,to embroider,刺绣,VERB,B2
-刺耳的,strident,刺耳的,ADJ,B2
-刺耳的声音,cacophony,刺耳的声音,NOUN,B2
-刺骨的,biting,尖刻的,ADJ,B2
-刻板印象,stereotype,刻板印象,NOUN,B2
-刻痕,notch,刻痕,NOUN,B2
-刻薄的,mean,刻薄的,ADJ,B2
-刽子手,executioner,刽子手,NOUN,B2
-剂量,dose,剂量,NOUN,B2
-剃刀,razor,剃刀,NOUN,B2
-削减,to curtail,削减,VERB,B2
-削弱权威,undermining authority,削弱权威,NOUN,B2
-前任,predecessor,前任,NOUN,B2
-前几天,the other day,前几天,ADV,B2
-前线,front line,前线,NOUN,B2
-剥,to peel,削皮,VERB,B2
-剥削,exploitation,利用,NOUN,B2
-剥夺,deprivation,剥夺,NOUN,B2
-剥夺,to deprive,剥夺,VERB,B2
-剥夺,to divest,剥夺,VERB,B2
-剥夺继承权,to disinherit,剥夺继承权,VERB,B2
-剥皮,to skin,剥皮,VERB,B2
-剧作家,playwright,剧作家,NOUN,B2
-剧变,upheaval,剧变,NOUN,B2
-剧团,troupe,剧团,NOUN,B2
-剧本,screenplay,剧本,NOUN,B2
-剪辑,editing,剪辑,NOUN,B2
-副手,deputy,议员,NOUN,B2
-副朝,minor pilgrimage,副朝,NOUN,B2
-副署,to countersign,副署,VERB,B2
-割礼,circumcision,割礼,NOUN,B2
-割草机,lawnmower,割草机,NOUN,B2
-剽窃,plagiarism,剽窃,NOUN,B2
-剽窃,to plagiarize,剽窃,VERB,B2
-劝勉,to exhort,劝告,VERB,B2
-劝阻,to dissuade,劝阻,VERB,B2
-办公室工作,office work,办公室工作,NOUN,B2
-功利主义,utilitarianism,功利主义,NOUN,B2
-功利主义的,utilitarian,功利的,ADJ,B2
-功绩,feat,功绩,NOUN,B2
-功能主义,functionalism,功能主义,NOUN,B2
-功能性,functionality,功能性,NOUN,B2
-功能的,functional,功能的,ADJ,B2
-功能障碍,dysfunction,功能障碍,NOUN,B2
-加倍,double,两倍的,ADJ,B2
-加倍,doubling,加倍,NOUN,B2
-加倍,to double,加倍,VERB,B2
-加入,to be added,加入,VERB,B2
-加剧,exacerbation,加剧,NOUN,B2
-加剧,to exacerbate,加剧,VERB,B2
-加宽,to widen,加宽,VERB,B2
-加密,encryption,加密,NOUN,B2
-加强,to fortify,加强,VERB,B2
-加强,to reinforce,加强,VERB,B2
-加强,to strengthen,加强,VERB,B2
-加拿大的,canadian,加拿大的,ADJ,B2
-加油,to refuel,加油,VERB,B2
-加深,to deepen,加深,VERB,B2
-加热,to warm,加热,VERB,B2
-加班,overtime,加班,NOUN,B2
-加速,acceleration,加速,NOUN,B2
-加重,to aggravate,加重,VERB,B2
-加重,to make heavier,加重,VERB,B2
-劣势,inferiority,劣势,NOUN,B2
-动人的,touching,动人的,ADJ,B2
-动力,drive,动力,NOUN,B2
-动力学的,kinetic,运动的,ADJ,B2
-动态的,dynamic,动态的,ADJ,B2
-动机,motivation,动机,NOUN,B2
-动物园,zoo,动物园,NOUN,B2
-动物群,fauna,动物群,NOUN,B2
-动画,animation,动画,NOUN,B2
-动荡的,turbulent,动荡的,ADJ,B2
-动词,to abdanken,动词,VERB,B2
-动词,to absagen,动词,VERB,B2
-动词,to abschlafen,动词,VERB,B2
-动词,to abschweifen,动词,VERB,B2
-动词,to abstimmen,动词,VERB,B2
-动词,to abteilen,动词,VERB,B2
-动词,to abtrocken,动词,VERB,B2
-动词,to abzwecken,动词,VERB,B2
-助学贷款,student loan,助学贷款,NOUN,B2
-助手,helper,助手,NOUN,B2
-助跑,run-up,助跑,NOUN,B2
-努力/赌注,effort bet,努力/赌注,NOUN,B2
-努力地,hard,努力地,ADV,B2
-劳动力市场,labor market,劳动力市场,NOUN,B2
-勇敢的,courageous,勇敢的,ADJ,B2
-勇敢的,plucky,勇敢的,ADJ,B2
-勇气,valor,勇气,NOUN,B2
-勇气测试,test of courage,勇气测试,NOUN,B2
-勤勉,assiduous,勤勉的,ADJ,B2
-勾勒,to sketch,勾勒,VERB,B2
-勾结,to fraternize,勾结,VERB,B2
-包,bags,包,NOUN,B2
-包厢座位,stall,包厢座位,NOUN,B2
-包含,inclusion,包含,NOUN,B2
-包含,to be included,包含,VERB,B2
-包含,to encompass,包含,VERB,B2
-包括,including,包括,ADP,B2
-包装,packaging,包装,NOUN,B2
-包裹,parcel,包裹,NOUN,B2
-匈牙利的,hungarian,匈牙利的,ADJ,B2
-化妆,to apply makeup,化妆,VERB,B2
-化妆品,cosmetics,化妆品,NOUN,B2
-化妆品,makeup,化妆品,NOUN,B2
-化妆品的,cosmetic,化妆品的,ADJ,B2
-化学品,chemical,化学的,ADJ,B2
-化石,fossils,化石,NOUN,B2
-化石燃料,fossil fuel,化石燃料,NOUN,B2
-北方的,northern,北方的,ADJ,B2
-区分,to differentiate,区分,VERB,B2
-区别,distinction,区别,NOUN,B2
-区域,zone,区域,NOUN,B2
-区域主义,regionalism,区域主义,NOUN,B2
-区域化,to regionalize,区域化,VERB,B2
-医务室,infirmary,医务室,NOUN,B2
-医学的,medical,医疗的,ADJ,B2
-医护人员,healthcare worker,医护人员,NOUN,B2
-医源性的,iatrogenic,医源性的,ADJ,B2
-匿名的,anonymous,匿名的,ADJ,B2
-十一,eleven,十一,NUM,B2
-十一月,november,十一月,NOUN,B2
-十七,seventeen,十七,NUM,B2
-十三,thirteen,十三,NUM,B2
-十九,nineteen,十九,NUM,B2
-十二,twelve,十二,NUM,B2
-十二月,december,十二月,NOUN,B2
-十五,fifteen,十五,NUM,B2
-十亿,billion,十亿,NUM,B2
-十八,eighteen,十八,NUM,B2
-十六,sixteen,十六,NUM,B2
-十四,fourteen,十四,NUM,B2
-十字路口,crossroads,十字路口,NOUN,B2
-十年,decade,十年,NOUN,B2
-十月,october,十月,NOUN,B2
-升,litre,升,NOUN,B2
-升华,to sublimate,升华,VERB,B2
-午休,lunch break,午休,NOUN,B2
-半,half,一半的,ADJ,B2
-半场,half of a match,半场,NOUN,B2
-半小时,half hour,半小时,NOUN,B2
-半年,half-year,半年,NOUN,B2
-半开的,ajar,半开的,ADJ,B2
-半径,radius,半径,NOUN,B2
-半球,hemisphere,半球,NOUN,B2
-半途,halfway,半途,ADV,B2
-华丽的,flowery,华丽的,ADJ,B2
-协会性质的,associative,协会性质的,ADJ,B2
-协议,protocol,协议,NOUN,B2
-协调,harmonization,协调,NOUN,B2
-单一的,monolithic,单一的,ADJ,B2
-单向的,one-way,单向的,ADJ,B2
-单向通行,one-way traffic,单向通行,NOUN,B2
-单方面的,unilateral,单方面的,ADJ,B2
-单曲,single,单曲,NOUN,B2
-单独的,alone,单独的,ADJ,B2
-南方的,southern,南方的,ADJ,B2
-南非的,south african,南非的,ADJ,B2
-博士学位,doctorate,博士学位,NOUN,B2
-博学,erudition,博学,NOUN,B2
-博学的,erudite,博学的,ADJ,B2
-博物馆藏品,museum piece,博物馆藏品,NOUN,B2
-占优势的,preponderant,占优势的,ADJ,B2
-占星术,astrology,占星术,NOUN,B2
-卡住,to wedge,卡住,VERB,B2
-卡住的,stuck,卡住的,ADJ,B2
-卫生,sanitation,卫生,NOUN,B2
-印第安人,native american,印第安人,NOUN,B2
-印记,imprint,印记,NOUN,B2
-印象派,impressionism,印象主义,NOUN,B2
-印象深刻的,impressed,印象深刻的,ADJ,B2
-危害,to endanger,危及,VERB,B2
-危机局势,crisis situation,危机局势,NOUN,B2
-危险,dangerous,危险的,ADJ,B2
-危险性,dangerousness,危险性,NOUN,B2
-危险报告,hazard report,危险报告,NOUN,B2
-危险的,perilous,危险的,ADJ,B2
-即,namely,即,ADV,B2
-即,that is to say,即,CCONJ,B2
-即兴创作,improvisation,即兴创作,NOUN,B2
-即兴创作,to improvise,即兴创作,VERB,B2
-即兴的,impromptu,即兴的,ADJ,B2
-即兴的,improvised,即兴的,ADJ,B2
-即将到来的,coming,即将到来的,ADJ,B2
-即将到来的,upcoming,مقبل,ADJ,B2
-卵石,pebble,卵石,NOUN,B2
-卷曲,to curl,卷曲,VERB,B2
-卷曲的,curly,卷曲的,ADJ,B2
-卸货,to unload,卸货,VERB,B2
-历史,historical,历史的,ADJ,B2
-历史/故事,history story,历史/故事,NOUN,B2
-历史上,historically,历史上,ADV,B2
-历史主义,historicism,历史主义,NOUN,B2
-历史学家,historian,历史学家,NOUN,B2
-历史性,historicity,历史性,NOUN,B2
-压倒,to overwhelm,使不知所措,VERB,B2
-压倒性的,overwhelming,压倒性的,ADJ,B2
-压制的,repressive,压制的,ADJ,B2
-压力,stress,压力,NOUN,B2
-压抑的悲伤,suppressed grief,压抑的悲伤,NOUN,B2
-压碎,to crush,压碎,VERB,B2
-压迫,oppression,压迫,NOUN,B2
-压迫的,oppressive,压迫的,ADJ,B2
-厌世者,misanthrope,厌世者,NOUN,B2
-厌倦的,jaded,厌倦的,ADJ,B2
-厌恶,aversion,厌恶,NOUN,B2
-厌恶,disgust,厌恶,NOUN,B2
-厌恶,dislike,厌恶,NOUN,B2
-厌恶,to detest,厌恶,VERB,B2
-厌恶的,averse,厌恶的,ADJ,B2
-厚度,thickness,厚度,NOUN,B2
-厚颜无耻的,brazen,厚颜无耻的,ADJ,B2
-厚颜无耻的,cheeky,厚颜无耻的,ADJ,B2
-原住民,indigenous people,原住民,NOUN,B2
-原型,archetype,原型,NOUN,B2
-原子,atomic,原子的,ADJ,B2
-原子,atom,原子,NOUN,B2
-原子核,atomic nucleus,原子核,NOUN,B2
-原教旨主义,fundamentalism,原教旨主义,NOUN,B2
-原谅,to excuse,原谅,VERB,B2
-厢式送货车,delivery van,厢式送货车,NOUN,B2
-厨师,cook,厨师,NOUN,B2
-去,infinitive marker,去,PART,B2
-去,to,去,PART,B2
-去中心化,to decentralize,去中心化,VERB,B2
-去杠杆化,deleveraging,去杠杆化,NOUN,B2
-去污,decontamination,去污,NOUN,B2
-去角质,to exfoliate,去角质,VERB,B2
-参与,involvement,参与,NOUN,B2
-参与,to engage,从事,VERB,B2
-参与的,involved,涉及的,ADJ,B2
-参考,reference,参考,NOUN,B2
-参考,to refer,参考,VERB,B2
-参观,to view,参观,VERB,B2
-参议院,senate,参议院,NOUN,B2
-叉子,pitchfork,叉子,NOUN,B2
-及物性,transitivity,及物性,NOUN,B2
-友好的,amicable,友好的,ADJ,B2
-双人自行车 / 搭档,tandem duo,双人自行车 / 搭档,NOUN,B2
-双周的,biweekly,双周的,ADJ,B2
-双头的,two-headed,双头的,ADJ,B2
-双性恋的,bisexual,双性恋的,ADJ,B2
-双手灵巧的,ambidextrous,双手灵巧的,ADJ,B2
-双筒望远镜,binoculars,双筒望远镜,NOUN,B2
-双胞胎,twins,双胞胎,NOUN,B2
-双边的,bilateral,双边的,ADJ,B2
-反义关系,antonymy,反义关系,NOUN,B2
-反之亦然,vice versa,反之亦然,ADJ,B2
-反乌托邦,dystopia,反乌托邦,NOUN,B2
-反叛者,rebel,反叛者,NOUN,B2
-反复无常,fickleness,反复无常,NOUN,B2
-反对,objection,异议,NOUN,B2
-反对,opposition,对立,NOUN,B2
-反对,to advise against,劝阻,VERB,B2
-反对,to object,反对,VERB,B2
-反应,reaction,反应,NOUN,B2
-反应,to react,反应,VERB,B2
-反应堆,reactor,反应堆,NOUN,B2
-反应的,reactive,反应的,ADJ,B2
-反映,to mirror,反映,VERB,B2
-反犹太主义,antisemitism,反犹太主义,NOUN,B2
-反社会的,antisocial,反社会的,ADJ,B2
-反论点,counterargument,反论点,NOUN,B2
-反转,to reverse,反转,VERB,B2
-反馈,feedback,反馈,NOUN,B2
-反驳,to contradict,反驳,VERB,B2
-反驳,to retort,反驳,VERB,B2
-发作,paroxysm,发作,NOUN,B2
-发光的,luminous,发光的,ADJ,B2
-发出爆裂声,to crackle,噼啪作响,VERB,B2
-发垃圾信息,to spam,发垃圾信息,VERB,B2
-发射,launch,发射,NOUN,B2
-发掘,to unearth,发掘,VERB,B2
-发推文,to tweet,发推文,VERB,B2
-发明,invention,发明,NOUN,B2
-发现物,find,发现物,NOUN,B2
-发球/加价,serve markup,发球/加价,NOUN,B2
-发生,to occur,发生,VERB,B2
-发生,to take place,举行,VERB,B2
-发生率,incidence,发生率,NOUN,B2
-发电厂,power plant,发电厂,NOUN,B2
-发电厂,power station,发电厂,NOUN,B2
-发电机,generator,发电机,NOUN,B2
-发短信,to text,发短信,VERB,B2
-发绀,cyanosis,发绀,NOUN,B2
-发臭,to stink,发臭,VERB,B2
-发芽,to germinate,发芽,VERB,B2
-发芽,to sprout,发芽,VERB,B2
-发言人,spokesperson,发言人,NOUN,B2
-发酵,fermentation,发酵,NOUN,B2
-发酵,to ferment,发酵,VERB,B2
-发霉的,moldy,发霉的,ADJ,B2
-发音,pronunciation,发音,NOUN,B2
-发髻,hair bun,发髻,NOUN,B2
-取得资格,to qualify,使合格,VERB,B2
-取来,to fetch,取来,VERB,B2
-取消的/设定的,cancelled set,取消的/设定的,ADJ,B2
-取消资格,to disqualify,取消资格,VERB,B2
-受伤,wounded,受伤的,ADJ,B2
-受启发的,inspired,受启发的,ADJ,B2
-受吸引,to gravitate,受吸引,VERB,B2
-受围困的,beleaguered,受围困的,ADJ,B2
-受影响的,affected,受影响的,ADJ,B2
-受污染的,contaminated,受污染的,ADJ,B2
-受洗的,baptized,受洗的,ADJ,B2
-受益,to benefit,受益,VERB,B2
-受祝福的,blessed,受祝福的,ADJ,B2
-受精,fertilization,施肥,NOUN,B2
-受罚,to be punished,受罚,VERB,B2
-受训者,trainee,实习生,NOUN,B2
-受辱,to be humiliated,受辱,VERB,B2
-受过培训者,schooled person,受过培训者,NOUN,B2
-受过教育的,educated,受过教育的,ADJ,B2
-受遗赠人,legatee,受遗赠人,NOUN,B2
-变位,conjugation,变位,NOUN,B2
-变位,to conjugate,变位,VERB,B2
-变体,variant,变体,NOUN,B2
-变化,variation,变化,NOUN,B2
-变形,deformation,变形,NOUN,B2
-变暗,to darken,变暗,VERB,B2
-变红,to redden,变红,VERB,B2
-变老,to age,变老,VERB,B2
-变胖,to gain weight,变胖,VERB,B2
-变质的,metamorphic,变质的,ADJ,B2
-变迁,vicissitude,变迁,NOUN,B2
-变魔术,to conjure,变魔术,VERB,B2
-变黑,to blacken,变黑,VERB,B2
-叙事,narrative,叙述；故事,NOUN,B2
-叙事短诗,lay,叙事短诗,NOUN,B2
-叙利亚的,syrian,叙利亚的,ADJ,B2
-叙述者,narrator,叙述者,NOUN,B2
-叛乱,revolt,叛乱,NOUN,B2
-叛教,apostasy,叛教,NOUN,B2
-叛教者,apostate,叛教者,NOUN,B2
-叛逆的,rebellious,叛逆的,ADJ,B2
-叠句,refrain,副歌,NOUN,B2
-口号,slogan,口号,NOUN,B2
-口套,muzzle,口套,NOUN,B2
-口是心非,duplicity,口是心非,NOUN,B2
-口水,drool,口水,NOUN,B2
-口渴,thirst,口渴,NOUN,B2
-口红,lipstick,口红,NOUN,B2
-口译员,interpreter,口译员,NOUN,B2
-口述,to dictate,口述,VERB,B2
-口香糖,chewing gum,口香糖,NOUN,B2
-口香糖,gum,牙龈,NOUN,B2
-口鼻,snout,口鼻,NOUN,B2
-古典主义,classicism,古典主义,NOUN,B2
-古怪,eccentricity,古怪,NOUN,B2
-古怪的,outlandish,古怪的,ADJ,B2
-古斯古斯蒸锅,couscous steamer,古斯古斯蒸锅,NOUN,B2
-古旧的,antique,古老的,ADJ,B2
-句法,syntax,句法,NOUN,B2
-召集,convening,召集,NOUN,B2
-可乐,cola,可乐,NOUN,B2
-可争辩,debatable,有争议的,ADJ,B2
-可以说,so to speak,可以说,ADV,B2
-可信度,credibility,可信度,NOUN,B2
-可修正的,amendable,可修正的,ADJ,B2
-可兑换性,convertibility,可兑换性,NOUN,B2
-可兑换的,convertible,可兑换的,ADJ,B2
-可加工的,workable,可加工的,ADJ,B2
-可取性,desirability,可取性,NOUN,B2
-可取的,desirable,可取的,ADJ,B2
-可变格的,declinable,可变格的,ADJ,B2
-可命名的,nameable,可命名的,ADJ,B2
-可忍受的,bearable,可忍受的,ADJ,B2
-可怕地/非常,terribly,可怕地/非常,ADV,B2
-可怕的,horrible,可怕的,ADJ,B2
-可怕的,terrifying,令人恐惧的,ADJ,B2
-可怜的,poor wretched,可怜的,ADJ,B2
-可怜虫,poor devil,可怜虫,NOUN,B2
-可怜虫,wretch,令人厌恶的人,NOUN,B2
-可悲的,deplorable,可悲的,ADJ,B2
-可憎的,abominable,可憎的,ADJ,B2
-可接受的,acceptable,可接受的,ADJ,B2
-可控制的,controllable,可控制的,ADJ,B2
-可操纵的,manipulable,可操纵的,ADJ,B2
-可敬,venerable,值得尊敬的,ADJ,B2
-可敬的,honorable,可敬的,ADJ,B2
-可比较的,comparable,可比较的,ADJ,B2
-可渗透的,permeable,可渗透的,ADJ,B2
-可理解,understandable,可理解的,ADJ,B2
-可用,available,可获得的,ADJ,B2
-可用性,availability,可用性,NOUN,B2
-可用的,usable,可用的,ADJ,B2
-可疑的,doubtful,可疑的,ADJ,B2
-可疑的,questionable,可疑的,ADJ,B2
-可疑的,shady suspicious,可疑的,ADJ,B2
-可组合的,composable,可组合的,ADJ,B2
-可耻的,scandalous,可耻的,ADJ,B2
-可能,probably,大概,ADV,B2
-可能地,possibly,可能地,ADV,B2
-可能的,possible,可能的,ADJ,B2
-可能的,probable likely,可能的,ADJ,B2
-可获得的,attainable,可获得的,ADJ,B2
-可行的,viable,可行的,ADJ,B2
-可见的,visible,可见的,ADJ,B2
-可解释的,explicable,可解释的,ADJ,B2
-可设想的,conceivable,可设想的,ADJ,B2
-可证明的,provable,可证明的,ADJ,B2
-可质疑的,contestable,可质疑的,ADJ,B2
-可转让的,alienable,可转让的,ADJ,B2
-可轻描淡写的,trivializable,可轻描淡写的,ADJ,B2
-可辨认的,recognizable,可辨认的,ADJ,B2
-可达性,accessibility,可达性,NOUN,B2
-可达的,reachable,可到达的,ADJ,B2
-可选的,optional,可选的,ADJ,B2
-可避免的,avoidable,可避免的,ADJ,B2
-可重复性,reproducibility,可重复性,NOUN,B2
-可靠性,reliability,可靠性,NOUN,B2
-可靠的,trustworthy,值得信赖的,ADJ,B2
-可预测的,predictable,可预测的,ADJ,B2
-可预算的,budgetable,可预算的,ADJ,B2
-史学,historiography,史学,NOUN,B2
-史无前例的,unprecedented,史无前例的,ADJ,B2
-史诗的,epic,史诗的,ADJ,B2
-右边,right,右边,ADV,B2
-叶子,leaf page,叶子,NOUN,B2
-司法的,judicial,司法的,ADJ,B2
-司法系统,judiciary,司法官,NOUN,B2
-叹息的,sighing,叹息的,ADJ,B2
-叹气,to sigh,叹气,VERB,B2
-吃午餐,to have lunch,吃午餐,VERB,B2
-吃早餐,to have breakfast,吃早餐,VERB,B2
-吃晚餐,to have dinner,吃晚餐,VERB,B2
-各种各样的,various,各种各样的,ADJ,B2
-各种各样的,all kinds,各种各样的,DET,B2
-各自的,respective,各自的,ADJ,B2
-合作,cooperation,合作,NOUN,B2
-合同的,contractual,合同的,ADJ,B2
-合唱团,choir,合唱团,NOUN,B2
-合宪性,constitutionality,合宪性,NOUN,B2
-合并,merger,合并,NOUN,B2
-合并,to amalgamate,合并,VERB,B2
-合并,to incorporate,包含,VERB,B2
-合并,to merge,合并,VERB,B2
-合成,synthesis,综合,NOUN,B2
-合成的,synthetic,合成的,ADJ,B2
-合法地,legally,合法地,ADV,B2
-合法性,legality,合法性,NOUN,B2
-合法的,legitimate,合法的,ADJ,B2
-合理化,rationalization,合理化,NOUN,B2
-合理化,to rationalize,合理化,VERB,B2
-合规,compliance,合规,NOUN,B2
-合语法性,grammaticality,合语法性,NOUN,B2
-合适的,fitting,合适的,ADJ,B2
-合金,alloy,合金,NOUN,B2
-合页,hinge,合页,NOUN,B2
-吉他手,guitarist,吉他手,NOUN,B2
-吉祥物,mascot,吉祥物,NOUN,B2
-吊灯,chandelier,吊灯,NOUN,B2
-同义,synonymy,同义关系,NOUN,B2
-同事,coworker,同事,NOUN,B2
-同事的,collegial,同事的,ADJ,B2
-同位素,isotope,同位素,NOUN,B2
-同化,assimilation,同化,NOUN,B2
-同化,to assimilate,同化,VERB,B2
-同性恋的,homosexual,同性恋的,ADJ,B2
-同性恋者,gay,同性恋者,NOUN,B2
-同情,commiseration,同情,NOUN,B2
-同情,sympathy,同情,NOUN,B2
-同情/共情,sympathy empathy,同情/共情,NOUN,B2
-同情的,sympathetic,同情的,ADJ,B2
-同意,to assent,同意,VERB,B2
-同意,to consent,同意,VERB,B2
-同时地,simultaneously,同时地,ADV,B2
-同时的,simultaneous,同时的,ADJ,B2
-同样地,likewise,同样地,ADV,B2
-同步,sync,同步,NOUN,B2
-同步,synchronization,同步,NOUN,B2
-同步的,synchronous,同步的,ADJ,B2
-同盟者,confederate,同盟者,NOUN,B2
-同胞,fellow citizen,同胞,NOUN,B2
-同质性,homogeneity,同质性,NOUN,B2
-同质的,homogeneous,同质的,ADJ,B2
-同音异义,homonymy,同音异义,NOUN,B2
-名声,fame,名声,NOUN,B2
-名字,first name,名字,NOUN,B2
-名誉的,honorary,名誉的,ADJ,B2
-名词,the abgrund,名词,NOUN,B2
-名词,the abhang,名词,NOUN,B2
-名词,the abholung,名词,NOUN,B2
-名词,the abweisung,名词,NOUN,B2
-名词,the abwurf,名词,NOUN,B2
-名词,the ackerbau,名词,NOUN,B2
-名词,the adoption,名词,NOUN,B2
-名词,the adressat,名词,NOUN,B2
-名词,the akademie,名词,NOUN,B2
-名词,the akkord,名词,NOUN,B2
-名词,the akkumulator,名词,NOUN,B2
-名词,the aktion,名词,NOUN,B2
-名词,the aktivist,名词,NOUN,B2
-名词,the aktnadel,名词,NOUN,B2
-名词,the aktpunkt,名词,NOUN,B2
-名词,the aktuar,名词,NOUN,B2
-名词,the albatros,名词,NOUN,B2
-名词,the allianz,名词,NOUN,B2
-名词,the alpen,名词,NOUN,B2
-名词,the alphabet,名词,NOUN,B2
-名词,the alpinismus,名词,NOUN,B2
-名词,the altruismus,名词,NOUN,B2
-名词,the amboss,名词,NOUN,B2
-名词,the anbeginn,名词,NOUN,B2
-名词,the anbieter,名词,NOUN,B2
-名词,the anbruch,名词,NOUN,B2
-名词,the andrang,名词,NOUN,B2
-名词,the anreiz,名词,NOUN,B2
-名词,the ansage,名词,NOUN,B2
-名词,the anschlag,名词,NOUN,B2
-名词,the anteil,名词,NOUN,B2
-名词,the antrag,名词,NOUN,B2
-后天,the day after tomorrow,后天,ADV,B2
-后座,back seat,后座,NOUN,B2
-后来,later,后来,ADV,B2
-后果,consequence,后果,NOUN,B2
-后果,repercussion,反响,NOUN,B2
-后续,follow-up,跟进,NOUN,B2
-后退,to back up,后退,VERB,B2
-后部,rear,后面的,ADJ,B2
-后颈,nape,后颈,NOUN,B2
-吐,to spit,吐,VERB,B2
-吐痰,to expectorate,吐痰,VERB,B2
-向,towards,朝向,ADP,B2
-向上,up,向上,ADV,B2
-向上,upward,向上,ADV,B2
-向上,upwards,向上,ADV,B2
-向下,down,向下,ADV,B2
-向下,downwards,向下,ADV,B2
-向前,forth,向前,ADV,B2
-向左,left,左边的,ADJ,B2
-向日葵,sunflower,向日葵,NOUN,B2
-向西,westward,向西,ADV,B2
-吓唬,to scare,惊吓,VERB,B2
-吗啡,morphine,吗啡,NOUN,B2
-君主,monarch,君主,NOUN,B2
-君主制,monarchy,君主制,NOUN,B2
-吝啬,parsimony,吝啬,NOUN,B2
-吝啬,stinginess,吝啬；小气,NOUN,B2
-吝啬,to stint,吝啬,VERB,B2
-吝啬的,miserly,吝啬的,ADJ,B2
-吝啬的,parsimonious,吝啬的,ADJ,B2
-吞并,annex,附件,NOUN,B2
-吞并,annexation,吞并,NOUN,B2
-吞并,to annex,兼并,VERB,B2
-吞食,to devour,吞食,VERB,B2
-吟游诗人,bard,吟游诗人,NOUN,B2
-吠/责骂,to bark scold,吠/责骂,VERB,B2
-否决,veto,否决,NOUN,B2
-否认,to disavow,否认,VERB,B2
-否认 / 抛弃,to renounce to disown,否认 / 抛弃,VERB,B2
-含蓄地,implicitly,含蓄地,ADV,B2
-含蓄的,implicit,含蓄的,ADJ,B2
-听众,listener,听众,NOUN,B2
-听得见的,audible,听得见的,ADJ,B2
-听着,listen up,听着,INTJ,B2
-听诊,to auscultate,听诊,VERB,B2
-启发,to edify,启发,VERB,B2
-启示,revelation,启示,NOUN,B2
-启示录的,apocalyptic,启示录的,ADJ,B2
-吱吱声,squeak,吱吱声,NOUN,B2
-吸,to suck,吸,VERB,B2
-吸引力,attractiveness,吸引力,NOUN,B2
-吸烟,smoking,吸烟,NOUN,B2
-吸血,to vampirize,吸血,VERB,B2
-吹嘘,bragging,吹嘘,NOUN,B2
-吹牛,braggadocio,吹牛,NOUN,B2
-吻,kiss,吻,NOUN,B2
-吼叫,to bellow,吼叫,VERB,B2
-告密者,snitch,告密者,NOUN,B2
-告诫,to admonish,告诫,VERB,B2
-员工,staff,全体员工,NOUN,B2
-呜咽,to whimper,呜咽,VERB,B2
-周年纪念,jubilee,禧年,NOUN,B2
-呱呱叫,to croak,呱呱叫,VERB,B2
-呸,yuck,呸,INTJ,B2
-呻吟,groan,呻吟,NOUN,B2
-呻吟,moan,呻吟,NOUN,B2
-呻吟,to groan,呻吟,VERB,B2
-呼吸的,respiratory,呼吸的,ADJ,B2
-呼喊,to exclaim,呼喊,VERB,B2
-命令,to command,命令,VERB,B2
-命名,to denominate,命名,VERB,B2
-命名,to title,命名,VERB,B2
-命运,destiny,命运,NOUN,B2
-咆哮,growl,低吼,NOUN,B2
-咆哮,to growl,咆哮,VERB,B2
-咆哮,to rant,咆哮,VERB,B2
-和尚,monk,僧侣,NOUN,B2
-和解,rapprochement,和解,NOUN,B2
-和解,reconciliation,和解,NOUN,B2
-和谐,concord,和谐,NOUN,B2
-和谐,harmony,和谐,NOUN,B2
-咒语,incantation,咒语,NOUN,B2
-咕哝,to mutter,嘟囔,VERB,B2
-咨询,counseling,咨询,NOUN,B2
-咨询的,consultative,咨询的,ADJ,B2
-咯咯笑,to giggle,咯咯笑,VERB,B2
-咳嗽,cough,咳嗽,NOUN,B2
-哀伤的,plaintive,哀伤的,ADJ,B2
-哀叫,to bleat,哀叫,VERB,B2
-哀号,to wail,哀号,VERB,B2
-哀叹,to lament,哀叹,VERB,B2
-哀悼,to mourn,哀悼,VERB,B2
-品味,to savor,品味,VERB,B2
-品性,character trait,品性,NOUN,B2
-哄婴儿,to lull a baby,哄婴儿,VERB,B2
-哄笑,guffaw,哄笑,NOUN,B2
-哇,wow,哇,INTJ,B2
-哈利路亚,hallelujah,哈利路亚,INTJ,B2
-响,to ring,鸣响,VERB,B2
-响应性,responsiveness,反应性,NOUN,B2
-哎呀,darn,哎呀,INTJ,B2
-哎呀,yikes,哎呀,INTJ,B2
-哑的,dumb,愚蠢的,ADJ,B2
-哑的,mute,沉默的；哑的,ADJ,B2
-哔声,beep,吱吱声,NOUN,B2
-哗啦声,clatter,哗啦声,NOUN,B2
-哥们,bro,哥们,NOUN,B2
-哥哥,big brother,哥哥,NOUN,B2
-哥德堡,gothenburg,哥德堡,PROPN,B2
-哨兵,sentinel,哨兵,NOUN,B2
-哪个,which,哪个,DET,B2
-哭泣,crying,,NOUN,B2
-哮喘,asthma,哮喘,NOUN,B2
-哮喘的,asthmatic,哮喘的,ADJ,B2
-哲学家,philosopher,哲学家,NOUN,B2
-哲学的,philosophical,哲学的,ADJ,B2
-哺乳,breastfeeding,母乳喂养,NOUN,B2
-哺乳动物,mammal,哺乳动物,NOUN,B2
-唐突,brusqueness,唐突,NOUN,B2
-唤起,evocation,唤起,NOUN,B2
-唤起,to evoke,唤起,VERB,B2
-唤醒,to awaken,唤醒,VERB,B2
-唤醒,to rouse,唤醒,VERB,B2
-唯我论,solipsism,唯我论,NOUN,B2
-唯物主义,materialism,唯物主义,NOUN,B2
-唱歌,singing,歌唱,NOUN,B2
-啁啾,to chirp,啁啾,VERB,B2
-啃,to nibble,啃,VERB,B2
-商业化,to commercialize,商业化,VERB,B2
-商业的,business,商业的,ADJ,B2
-商人,businessman,商人,NOUN,B2
-商品,merchandise,商品,NOUN,B2
-商队,caravan,房车,NOUN,B2
-啜饮,sip,小口喝,NOUN,B2
-啜饮,to sip,小口喝,VERB,B2
-啮齿动物,rodent,啮齿动物,NOUN,B2
-喂养,feed,饲料,NOUN,B2
-喂养,to feed,喂养,VERB,B2
-喉,larynx,喉,NOUN,B2
-喊叫,shout,喊叫,NOUN,B2
-喘息,respite,喘息,NOUN,B2
-喜剧,comedy,喜剧,NOUN,B2
-喜剧演员,comedian,喜剧演员,NOUN,B2
-喜剧的,comic,喜剧的,ADJ,B2
-喧嚣,clamor,喧嚣,NOUN,B2
-喧嚣,din,喧嚣,NOUN,B2
-喧闹的,boisterous,喧闹的,ADJ,B2
-喷射,ejection,喷射,NOUN,B2
-喷气式飞机,jet,喷气式飞机,NOUN,B2
-嗅,to sniff,嗅,VERB,B2
-嗜血的,bloodthirsty,嗜血的,ADJ,B2
-嗯,well,好,ADV,B2
-嘎吱作响,to creak,嘎吱作响,VERB,B2
-嘎吱作响,to crunch,嘎吱作响,VERB,B2
-嘶嘶声,hiss,嘶嘶声,NOUN,B2
-嘶鸣,to neigh,嘶鸣,VERB,B2
-噘,to pucker,噘,VERB,B2
-器乐即兴演奏,instrumental improvisation,器乐即兴演奏,NOUN,B2
-噪音,noises,噪音,NOUN,B2
-噪音扰民,noise nuisance,噪音扰民,NOUN,B2
-嚎叫,to howl,嚎叫,VERB,B2
-囚禁,captivity,囚禁,NOUN,B2
-四十,forty,四十,NUM,B2
-四处走动,to walk around,四处走动,VERB,B2
-四月,april,四月,NOUN,B2
-回,back,回来,ADV,B2
-回复,reply,回复,NOUN,B2
-回应,response,回应,NOUN,B2
-回廊,cloister,回廊,NOUN,B2
-回归,regression,倒退,NOUN,B2
-回形针,paper clip,回形针,NOUN,B2
-回忆,recall,回忆,NOUN,B2
-回避,recusal,回避,NOUN,B2
-回避的,evasive,回避的,ADJ,B2
-因为,because,因为,CCONJ,B2
-因为,for because,因为,CCONJ,B2
-因果的,causal,因果的,ADJ,B2
-因此,consequently,因此,ADV,B2
-因此,hence,因此,ADV,B2
-团结,solidarity,团结,NOUN,B2
-团结,unity,团结,NOUN,B2
-团结,to rally,团结,VERB,B2
-团聚,reunion,重聚,NOUN,B2
-园丁,gardener,园丁,NOUN,B2
-园艺,gardening,园艺,NOUN,B2
-困住/砍倒,to trap fell,困住/砍倒,VERB,B2
-困境,dilemma,困境,NOUN,B2
-困惑,bewilderment,困惑,NOUN,B2
-困惑,to be puzzled,困惑,VERB,B2
-困惑的,perplexed,困惑的,ADJ,B2
-困难,difficulty,困难,NOUN,B2
-困难地,with difficulty,困难地,ADV,B2
-围住,to enclose,围住,VERB,B2
-围攻,to besiege,包围,VERB,B2
-固定,cement,水泥,NOUN,B2
-固定,to cement,巩固,VERB,B2
-固执,stubbornness,固执,NOUN,B2
-固执的,obstinate,固执的,ADJ,B2
-国会,congress,国会,NOUN,B2
-国会议员,mp,国会议员,NOUN,B2
-国内,domestic,国内,NOUN,B2
-国内的,domestic,国内的,ADJ,B2
-国务秘书,state secretary,国务秘书,NOUN,B2
-国外,abroad,国外,NOUN,B2
-国家的,national,国家的,ADJ,B2
-国家队教练,national coach,国家队教练,NOUN,B2
-国库,treasury,国库,NOUN,B2
-国有化,nationalization,国有化,NOUN,B2
-国有化,to nationalize,国有化,VERB,B2
-国歌,national anthem,国歌,NOUN,B2
-国际象棋,chess,国际象棋,NOUN,B2
-图书管理员,librarian,图书管理员,NOUN,B2
-图形,graphic,图形的,ADJ,B2
-图画,drawing,图画,NOUN,B2
-图表,chart,图表,NOUN,B2
-圆柱体,cylinder,圆柱体,NOUN,B2
-圆柱形的,cylindrical,圆柱形的,ADJ,B2
-土堆,mound,土堆,NOUN,B2
-土耳其的,turkish,土耳其的,ADJ,B2
-圣人,saint,圣人,NOUN,B2
-圣徒奇迹,saintly miracles,圣徒奇迹,NOUN,B2
-圣经,bible,圣经,NOUN,B2
-圣训,hadith prophetic saying,圣训,NOUN,B2
-圣诞树,christmas tree,圣诞树,NOUN,B2
-圣诞礼物,christmas present,圣诞礼物,NOUN,B2
-圣诞老人,santa claus,圣诞老人,NOUN,B2
-在,under,在...下面,ADP,B2
-在...上方,over about,在...上方,ADP,B2
-在...上面,on top of,在...上面,ADP,B2
-在...下方,under below,在...下方,ADP,B2
-在...前,in front of before,在...前,ADP,B2
-在...前面,in front of,在……前面,ADP,B2
-在...处,at with,在...处,ADP,B2
-在...旁边,beside,在...旁边,ADP,B2
-在...时,at the,在...时,ADP,B2
-在……之前,before,在...之前,SCONJ,B2
-在……之外,beyond,在...之外,ADP,B2
-在上面,on it,在上面,ADV,B2
-在上面,on top,在上面,ADV,B2
-在中间,in between,在中间,ADV,B2
-在什么上面,on what,在什么上面,ADV,B2
-在其上,on which,在其上,PRON,B2
-在其中,among them,在其中,ADV,B2
-在其中,in it,在里面,ADV,B2
-在其中,with it,在其中,ADV,B2
-在其中,in which,在其中,PRON,B2
-在前面,in front,在前面,ADV,B2
-在后面,behind,在...后面,ADP,B2
-在后面,at the back,在后面,ADV,B2
-在后面,behind it,在后面,ADV,B2
-在国外,abroad,在国外,ADV,B2
-在外面,outside,在外面,ADV,B2
-在室内,indoors,在室内,ADV,B2
-在家,at home,在家,ADV,B2
-在性方面,sexually,在性方面,ADV,B2
-在政治上,politically,在政治上,ADV,B2
-在旁边,aside,在旁边,ADV,B2
-在最上面,at the top,在最上面,ADV,B2
-在期间,during,在...期间,ADP,B2
-在职,professionally active,在职,NOUN,B2
-在船上,on board,在船上,ADV,B2
-在路上,on the way,在路上,ADV,B2
-在这里面,in here,在这里面,ADV,B2
-在那上面,up there,在那上面,ADV,B2
-在那下面,down there,在那下面,ADV,B2
-在那些日子/当时,in those days,在那些日子/当时,ADV,B2
-在那边,over there,在那边,ADV,B2
-在里面,inside,在里面,ADV,B2
-在附近,near,在附近,ADP,B2
-在隔壁,next door,在隔壁,ADV,B2
-地下世界,underworld,地下世界,NOUN,B2
-地下的,underground,地下的,ADJ,B2
-地中海的,mediterranean,地中海的,ADJ,B2
-地区,regions,地区,NOUN,B2
-地壳,crust,外壳,NOUN,B2
-地形,topography,地形,NOUN,B2
-地方性的,endemic,地方性的,ADJ,B2
-地方的,provincial,地方的,ADJ,B2
-地方选举,local elections,地方选举,NOUN,B2
-地毯,carpet rug,地毯,NOUN,B2
-地毯,rug,地毯,NOUN,B2
-地点,locality,地点,NOUN,B2
-地点,spot,地点,NOUN,B2
-地牢,dungeon,地牢,NOUN,B2
-地理,geographical,地理的,ADJ,B2
-地窖,cellar,地窖,NOUN,B2
-地缘政治,geopolitical,地缘政治的,ADJ,B2
-地缘政治,geopolitics,地缘政治,NOUN,B2
-地质,geological,地质的,ADJ,B2
-地震的,seismic,地震的,ADJ,B2
-场景/舞台,scene stage,场景/舞台,NOUN,B2
-均势,balance of power,均势,NOUN,B2
-均匀地,evenly,均匀地,ADV,B2
-坏,worse,更糟的,ADJ,B2
-坏名声,disrepute,坏名声,NOUN,B2
-坏疽,gangrene,坏疽,NOUN,B2
-坐标,coordinate,坐标,NOUN,B2
-坐着的,seated,坐着的,ADJ,B2
-坚决地,decidedly,坚决地,ADV,B2
-坚决的,determined,下定决心的,ADJ,B2
-坚定的,committed,投入的,ADJ,B2
-坚定的,staunch,坚定的,ADJ,B2
-坚忍的,stoic,坚忍的,ADJ,B2
-坚持,persistence,坚持,NOUN,B2
-坚持,to adhere,坚持,VERB,B2
-坚持,to hold on,抓住,VERB,B2
-坚持,to persevere,坚持,VERB,B2
-坚持,to persist,坚持,VERB,B2
-坚果,nut,坚果,NOUN,B2
-坚硬,rigidity,僵硬,NOUN,B2
-坚韧,tenacity,坚韧,NOUN,B2
-坚韧的,tenacious,顽强的,ADJ,B2
-坟墓,grave,坟墓,NOUN,B2
-坠落/猛冲,to fall crash,坠落/猛冲,VERB,B2
-坦率地,frankly,坦率地,ADV,B2
-垂死的,dying,垂死的,ADJ,B2
-垂直,vertical,垂直的,ADJ,B2
-垃圾,rubbish,垃圾,NOUN,B2
-垃圾袋,trash bag,垃圾袋,NOUN,B2
-垄断,to monopolize,垄断,VERB,B2
-垄断的,monopolistic,垄断的,ADJ,B2
-垫子,cushion,垫子,NOUN,B2
-垫草 / 猫砂,litter bedding,垫草 / 猫砂,NOUN,B2
-埃及的,egyptian,埃及的,ADJ,B2
-埃米尔的,emiri,埃米尔的,ADJ,B2
-城垛,battlement,城垛,NOUN,B2
-城市化,urbanization,城市化,NOUN,B2
-城市地图,city map,城市地图,NOUN,B2
-城市的,urban,城市的,ADJ,B2
-城镇,town,城镇,NOUN,B2
-培养,cultivation,培养,NOUN,B2
-基于,based,基于,ADJ,B2
-基于,to be based on,基于,VERB,B2
-基于/以此为基础,building upon,基于/以此为基础,ADV,B2
-基因,genetic,基因的,ADJ,B2
-基因组,genome,基因组,NOUN,B2
-基本收入,basic income,基本收入,NOUN,B2
-基本的,basal,基本的,ADJ,B2
-基本的,elementary,基本的,ADJ,B2
-基督徒,christian,基督徒,NOUN,B2
-基督教,christianity,基督教,NOUN,B2
-基础/理由,ground basis,基础/理由,NOUN,B2
-基础设施,infrastructure,基础设施,NOUN,B2
-堂兄弟,cousin,表亲,NOUN,B2
-堆,heap,堆,NOUN,B2
-堆,pile,堆,NOUN,B2
+能,able,能够的,ADJ,B2
 堕胎,abortion,流产,NOUN,B2
-堕落,decadence,衰落,NOUN,B2
-堕落,depravity,堕落,NOUN,B2
-堡垒,bastion,堡垒,NOUN,B2
-堡垒,fort,堡垒,NOUN,B2
-堡垒,fortress,堡垒,NOUN,B2
-塑料,plastic,塑料的,ADJ,B2
-塔,tower,塔,NOUN,B2
-塞入,to slip in,塞入,VERB,B2
-塞卢能量膏,sellou,塞卢能量膏,NOUN,B2
-填满,to fill,填满,VERB,B2
-填鸭式学习,to cram,填鸭式学习,VERB,B2
-墓地,graveyard,墓地,NOUN,B2
-增值,capital gain,增值,NOUN,B2
-增值税,vat,增值税,NOUN,B2
-增加,increases,增加,NOUN,B2
-增加的,increased,增加的,ADJ,B2
-增加的,increasing,增加的,ADJ,B2
-增大,magnification,增大,NOUN,B2
-增强,to enhance,增强,VERB,B2
-增援,reinforcement,增援,NOUN,B2
-增殖,proliferation,增殖,NOUN,B2
-增长,growth,增长,NOUN,B2
-墨西哥的,mexican,墨西哥的,ADJ,B2
-壁垒,bulwark,壁垒,NOUN,B2
-壁炉,fireplace,壁炉,NOUN,B2
-壁炉,hearth,壁炉,NOUN,B2
-声名狼藉的,infamous,声名狼藉的,ADJ,B2
-声学,acoustics,声学,NOUN,B2
-声学的,acoustic,声学的,ADJ,B2
-声音,vocal,直言的,ADJ,B2
-壳,shell,壳,NOUN,B2
-处于,to find oneself,处于,VERB,B2
-处女的,virginal,处女的,ADJ,B2
-处理,disposal,处理,NOUN,B2
-处理,to address,解决,VERB,B2
-处理,to deal,处理,VERB,B2
-处理,to dispose,处理,VERB,B2
-处理,to tackle,处理,VERB,B2
-处罚,penalties,处罚,NOUN,B2
-复兴,revival,复兴,NOUN,B2
-复制,to replicate,复制,VERB,B2
-复发,relapse,再犯,NOUN,B2
-复合词,the abheilung,复合词,NOUN,B2
-复合词,the abkraft,复合词,NOUN,B2
-复合词,the abmessung,复合词,NOUN,B2
-复合词,the absteigerung,复合词,NOUN,B2
-复合词,the abstoff,复合词,NOUN,B2
-复合词,the abwert,复合词,NOUN,B2
-复合词,the anbindung,复合词,NOUN,B2
-复合词,the anform,复合词,NOUN,B2
-复合词,the anheilung,复合词,NOUN,B2
-复合词,the anwerk,复合词,NOUN,B2
-复合词,the aufbewegung,复合词,NOUN,B2
-复合词,the aufheilung,复合词,NOUN,B2
-复合词,the aufleitung,复合词,NOUN,B2
-复合词,the aufordnung,复合词,NOUN,B2
-复合词,the aufstoff,复合词,NOUN,B2
-复合词,the aufwandlung,复合词,NOUN,B2
-复合词,the aufwendung,复合词,NOUN,B2
-复合词,the aufwert,复合词,NOUN,B2
-复合词,the ausbildung,复合词,NOUN,B2
-复合词,the auserweiterung,复合词,NOUN,B2
-复合词,the aushandlung,复合词,NOUN,B2
-复合词,the ausstellung,复合词,NOUN,B2
-复合词,the ausvertiefung,复合词,NOUN,B2
-复合词,the beerweiterung,复合词,NOUN,B2
-复合词,the bekraft,复合词,NOUN,B2
-复合词,the beleitung,复合词,NOUN,B2
-复合词,the bemessung,复合词,NOUN,B2
-复合词,the beminderung,复合词,NOUN,B2
-复合词,the berechnung,复合词,NOUN,B2
-复合词,the bevereinfachung,复合词,NOUN,B2
-复合词,the bevertiefung,复合词,NOUN,B2
-复合词,the bewendung,复合词,NOUN,B2
-复合词,the einmessung,复合词,NOUN,B2
-复合词,the einwerk,复合词,NOUN,B2
-复合词,the ererweiterung,复合词,NOUN,B2
-复合词,the erleitung,复合词,NOUN,B2
-复合词,the ervereinfachung,复合词,NOUN,B2
-复合词,the erwendung,复合词,NOUN,B2
-复合词,the erzheilung,复合词,NOUN,B2
-复合词,the erzkraft,复合词,NOUN,B2
-复合词,the erzmischung,复合词,NOUN,B2
-复合词,the erzsteigerung,复合词,NOUN,B2
-复合词,the erzvertiefung,复合词,NOUN,B2
-复合词,the erzwendung,复合词,NOUN,B2
-复合词,the erzwerk,复合词,NOUN,B2
-复合词,the gebildung,复合词,NOUN,B2
-复合词,the gebindung,复合词,NOUN,B2
-复合词,the gemischung,复合词,NOUN,B2
-复合词,the gestoff,复合词,NOUN,B2
-复合词,the geverbesserung,复合词,NOUN,B2
-复合词,the gewendung,复合词,NOUN,B2
-复合词,the grundstoff,复合词,NOUN,B2
-复合词,the grundverbesserung,复合词,NOUN,B2
-复合词,the hochbindung,复合词,NOUN,B2
-复合词,the hochleitung,复合词,NOUN,B2
-复合词,the hochordnung,复合词,NOUN,B2
-复合词,the hochsammlung,复合词,NOUN,B2
-复合词,the hochstoff,复合词,NOUN,B2
-复合词,the hochvertiefung,复合词,NOUN,B2
-复合词,the missbewegung,复合词,NOUN,B2
-复合词,the missbildung,复合词,NOUN,B2
-复合词,the misskraft,复合词,NOUN,B2
-复合词,the missordnung,复合词,NOUN,B2
-复合词,the missstoff,复合词,NOUN,B2
-复合词,the missvertiefung,复合词,NOUN,B2
-复合词,the mitbildung,复合词,NOUN,B2
-复合词,the mitheilung,复合词,NOUN,B2
-复合词,the mitkraft,复合词,NOUN,B2
-复合词,the mitordnung,复合词,NOUN,B2
-复合词,the mitstellung,复合词,NOUN,B2
-复合词,the mitverbesserung,复合词,NOUN,B2
-复合词,the nachbildung,复合词,NOUN,B2
-复合词,the nachbindung,复合词,NOUN,B2
-复合词,the nachleitung,复合词,NOUN,B2
-复合词,the nachmessung,复合词,NOUN,B2
-复合词,the nachstoff,复合词,NOUN,B2
-复合词,the tiefbindung,复合词,NOUN,B2
-复合词,the tiefleitung,复合词,NOUN,B2
-复合词,the tiefrechnung,复合词,NOUN,B2
-复合词,the tiefstoff,复合词,NOUN,B2
-复合词,the tiefverbesserung,复合词,NOUN,B2
-复合词,the unbildung,复合词,NOUN,B2
-复合词,the unleitung,复合词,NOUN,B2
-复合词,the unminderung,复合词,NOUN,B2
-复合词,the unmischung,复合词,NOUN,B2
-复合词,the untererweiterung,复合词,NOUN,B2
-复合词,the unterheilung,复合词,NOUN,B2
-复合词,the unterleitung,复合词,NOUN,B2
-复合词,the unterordnung,复合词,NOUN,B2
-复合词,the unwandlung,复合词,NOUN,B2
-复合词,the urheilung,复合词,NOUN,B2
-复合词,the ursammlung,复合词,NOUN,B2
-复合词,the urstoff,复合词,NOUN,B2
-复合词,the urverbesserung,复合词,NOUN,B2
-复合词,the urvertiefung,复合词,NOUN,B2
-复合词,the verform,复合词,NOUN,B2
-复合词,the verhandlung,复合词,NOUN,B2
-复合词,the verstellung,复合词,NOUN,B2
-复合词,the verstleitung,复合词,NOUN,B2
-复合词,the verststoff,复合词,NOUN,B2
-复合词,the verstwerk,复合词,NOUN,B2
-复合词,the verwandlung,复合词,NOUN,B2
-复合词,the vorbindung,复合词,NOUN,B2
-复合词,the vorerweiterung,复合词,NOUN,B2
-复合词,the vorordnung,复合词,NOUN,B2
-复合词,the vorrechnung,复合词,NOUN,B2
-复合词,the vorstellung,复合词,NOUN,B2
-复合词,the vorverbesserung,复合词,NOUN,B2
-复合词,the vorwert,复合词,NOUN,B2
-复合词,the weitheilung,复合词,NOUN,B2
-复合词,the weitminderung,复合词,NOUN,B2
-复合词,the weitmischung,复合词,NOUN,B2
-复合词,the weitordnung,复合词,NOUN,B2
-复合词,the weitsteigerung,复合词,NOUN,B2
-复合词,the weitstoff,复合词,NOUN,B2
-复合词,the weitverbesserung,复合词,NOUN,B2
-复合词,the weitwendung,复合词,NOUN,B2
-复合词,the zerbildung,复合词,NOUN,B2
-复合词,the zererweiterung,复合词,NOUN,B2
-复合词,the zerhandlung,复合词,NOUN,B2
-复合词,the zerrechnung,复合词,NOUN,B2
-复合词,the zervereinfachung,复合词,NOUN,B2
-复合词,the zuhandlung,复合词,NOUN,B2
-复合词,the zurechnung,复合词,NOUN,B2
-复合词,the zuwandlung,复合词,NOUN,B2
-复杂的,complex,复杂的,ADJ,B2
-复杂的,sophisticated,复杂的,ADJ,B2
-复活,resurrection,复活,NOUN,B2
-复苏,resuscitation,复苏,NOUN,B2
-夕阳,setting sun,夕阳,NOUN,B2
-外交关系,diplomatic relations,外交关系,NOUN,B2
-外交的,diplomatic,外交的,ADJ,B2
-外出,away,外出,ADJ,B2
-外向的,outgoing,外向的,ADJ,B2
-外围的,peripheral,外围的,ADJ,B2
-外国,foreign,外国的,ADJ,B2
-外国人,foreigner,外国人,NOUN,B2
-外星的,extraterrestrial,外星的,ADJ,B2
-外来词,loanword,外来词,NOUN,B2
-外科医生,surgeon,外科医生,NOUN,B2
-外科的,surgical,外科的,ADJ,B2
-外行,layperson,外行,NOUN,B2
-外面,out,在外面,ADV,B2
-多久,how long,多久,ADV,B2
-多产的,productive,多产的,ADJ,B2
-多余的,redundant,多余的,ADJ,B2
-多媒体图书馆,media library,多媒体图书馆,NOUN,B2
-多少,how much,多少,PRON,B2
-多年来,for years,多年,ADV,B2
-多彩的,colorful,五颜六色的,ADJ,B2
-多才多艺的,versatile,多才多艺的,ADJ,B2
-多样化,to diversify,使多样化,VERB,B2
-多样的,diverse,多样的,ADJ,B2
-多边形,polygon,多边形,NOUN,B2
-多部分的,multipart,多部分的,ADJ,B2
-多雨的,rainy,多雨的,ADJ,B2
-夜总会,nightclub,夜总会,NOUN,B2
-夜莺,nightingale,夜莺,NOUN,B2
-夜间的,nocturnal,夜间的,ADJ,B2
-大人物,bigwig,大人物,NOUN,B2
-大众,the masses,大众,NOUN,B2
-大公,grand duke,大公,NOUN,B2
-大公国,grand duchy,大公国,NOUN,B2
-大写,to capitalize,利用,VERB,B2
-大声地,loudly,大声地,ADV,B2
-大多数,most,大多数,ADJ,B2
-大学,universities,大学,NOUN,B2
-大学生,university student,大学生,NOUN,B2
-大官,grand officer,大官,NOUN,B2
-大家,all of them,大家,PRON,B2
-大摇大摆,to swagger,大摇大摆,VERB,B2
-大教堂,basilica,大教堂,NOUN,B2
-大斋期,lent,大斋期,NOUN,B2
-大气的,atmospheric,大气的,ADJ,B2
-大流散,diaspora,流散,NOUN,B2
-大炮,cannon,大炮,NOUN,B2
-大理石,marble,大理石,NOUN,B2
-大约,about,大约,ADV,B2
-大肆吹捧,to praise lavishly,大肆吹捧,VERB,B2
-大胆的,audacious,大胆的,ADJ,B2
-大脑的,cerebral,大脑的,ADJ,B2
-大腿,thigh,大腿,NOUN,B2
-大蒜,garlic,大蒜,NOUN,B2
-大都市,metropolis,大都市,NOUN,B2
-大量,lots,大量,NOUN,B2
-大量,plenty,大量,NOUN,B2
-大量地,massively,大量地,ADV,B2
-大量的,substantial,大量的,ADJ,B2
-大错,blunder,大错,NOUN,B2
-大陆,continent,大陆,NOUN,B2
-大麻,hemp,大麻,NOUN,B2
-天主教徒,catholic,天主教徒,NOUN,B2
-天主教的,catholic,天主教的,ADJ,B2
-天使群,host of angels,天使群,NOUN,B2
-天使般的,angelic,天使般的,ADJ,B2
-天哪,good heavens,天哪,INTJ,B2
-天哪,gosh,天哪,INTJ,B2
-天文,astronomical,天文学的,ADJ,B2
-天文台,observatory,天文台,NOUN,B2
-天真,naivety,天真,NOUN,B2
-天窗,skylight,天窗,NOUN,B2
-天线,antenna,天线,NOUN,B2
-天蓝色,sky blue,天蓝色,ADJ,B2
-天资,aptitude,天资,NOUN,B2
-天鹅,swan,天鹅,NOUN,B2
-太多,too much,太,ADV,B2
-太迟,too late,太迟,ADV,B2
-太阳能电池板,solar panel,太阳能电池板,NOUN,B2
-太阳镜,sunglasses,太阳镜,NOUN,B2
-失业,unemployed,失业的,ADJ,B2
-失业,unemployment,失业,NOUN,B2
-失明,to go blind,失明,VERB,B2
-失望,disappointment,失望,NOUN,B2
-失语症,aphasia,失语症,NOUN,B2
-失败主义,defeatism,失败主义,NOUN,B2
-失败的,failed,失败的,ADJ,B2
-失败者,loser,失败者,NOUN,B2
-失踪的,missing,失踪的,ADJ,B2
-头巾,headscarf,头巾,NOUN,B2
-头版,front page,头版,NOUN,B2
-头球,header,头球,NOUN,B2
-头盔,helmet,头盔,NOUN,B2
-头骨,skull,头骨,NOUN,B2
-夷平,to level,夷平,VERB,B2
-夸张,hyperbole,夸张,NOUN,B2
-夸张的,exaggerated,夸张的,ADJ,B2
-夹克,jacket,夹克,NOUN,B2
-夹子,clamp,夹钳,NOUN,B2
-夹层,mezzanine,夹层,NOUN,B2
-夺取,to wrest,强行夺取,VERB,B2
-奇怪地,strangely,奇怪地,ADV,B2
-奇怪的,odd,奇怪的,ADJ,B2
-奉承,flattery,奉承,NOUN,B2
-奉献,dedication,奉献,NOUN,B2
-奉献,to devote,奉献,VERB,B2
-契约,covenant,契约,NOUN,B2
-契约,pact,协定,NOUN,B2
-契约化,contractualization,契约化,NOUN,B2
-奔跑,to gallop,飞奔,VERB,B2
-奖品,prize,奖品,NOUN,B2
-奖学金,scholarship,奖学金,NOUN,B2
-奖学金生,scholarship holder,奖学金生,NOUN,B2
-套房,suite,套房,NOUN,B2
-套装,suit,西装,NOUN,B2
-奢侈品,luxury,奢侈,NOUN,B2
-奢侈的,extravagant,奢侈的,ADJ,B2
-奥地利的,austrian,奥地利的,ADJ,B2
-奥林匹克的,olympic,奥林匹克的,ADJ,B2
-女侍者,waitress,女服务员,NOUN,B2
-女同性恋的,lesbian,女同性恋的,ADJ,B2
-女孩/女朋友,girl girlfriend,女孩/女朋友,NOUN,B2
-女家长,matriarch,女家长,NOUN,B2
-女性朋友,female friend,女性朋友,NOUN,B2
-女性特质,femininity,女性气质,NOUN,B2
-女性的,female,女性的,ADJ,B2
-女性的,feminine,女性的,ADJ,B2
-女总统,president female,女总统,NOUN,B2
-女方离婚,khul',女方离婚,NOUN,B2
-女服务员,hostess,女服务员,NOUN,B2
-女权主义,feminism,女权主义,NOUN,B2
-女权主义者,feminist,女权主义者,NOUN,B2
-女演员,actress,女演员,NOUN,B2
-女男爵,baroness,女男爵,NOUN,B2
-奴役,servitude,奴役,NOUN,B2
-奴役,to enslave,奴役,VERB,B2
-奴性地,servilely,奴性地,ADV,B2
-奴隶制,slavery,奴隶制,NOUN,B2
-奶奶,granny,奶奶,NOUN,B2
-她,she they,她,PRON,B2
-她的,her,她的,DET,B2
-好,alright,好的,ADV,B2
-好/很好,good well,好/很好,ADJ,B2
-好吧,well,好吧,INTJ,B2
-好奇心,curiosity,好奇心,NOUN,B2
-好奇的,inquisitive,好奇的,ADJ,B2
-好客,hospitality,好客,NOUN,B2
-好战的,bellicose,好战的,ADJ,B2
-好战的,belligerent,好战的,ADJ,B2
-好斗性,combativeness,好斗性,NOUN,B2
-好的,okay,好的,INTJ,B2
-好色 / 淫荡,lubricity,好色 / 淫荡,NOUN,B2
-如画的；别致的,picturesque,如画的；别致的,ADJ,B2
-妇科,gynaecology,妇科,NOUN,B2
-妈妈,mom,妈妈,NOUN,B2
-妓女,whore,妓女,NOUN,B2
-妖魔化,to demonize,妖魔化,VERB,B2
-妹妹,little sister,妹妹,NOUN,B2
-妻子/夫人,wife mrs,妻子/夫人,NOUN,B2
-姐夫,brother-in-law,姐夫/妹夫,NOUN,B2
-姓,last name,姓,NOUN,B2
-委员会,councils,委员会,NOUN,B2
-委婉语,euphemism,委婉语,NOUN,B2
-委托,to commission,委托,VERB,B2
-委派,delegate,代表,NOUN,B2
-委派,to delegate,委派,VERB,B2
-姨妈,maternal aunt,姨母,NOUN,B2
-威严,commanding presence,威严,NOUN,B2
-威权,dominance,威权,NOUN,B2
-威胁,threat,威胁,NOUN,B2
-威胁的,threatening,具有威胁性的,ADJ,B2
-娱乐,amusement,娱乐,NOUN,B2
-娱乐,recreation,娱乐,NOUN,B2
-婚约,engagement,订婚,NOUN,B2
-婴儿,infant,婴儿,NOUN,B2
-婴儿车,stroller,婴儿车,NOUN,B2
-嫁妆,dowry,嫁妆,NOUN,B2
-嫁接,graft,嫁接,NOUN,B2
-嫉妒,jealousy,嫉妒,NOUN,B2
-嫉妒的,jealous,嫉妒的,ADJ,B2
-嬉戏,to frolic,嬉戏,VERB,B2
-子公司,subsidiary,子公司,NOUN,B2
-孕妇,pregnant woman,孕妇,NOUN,B2
-字母的,alphabetical,按字母顺序的,ADJ,B2
-字母表,alphabet,字母表,NOUN,B2
-字面上地,literally,字面上地,ADV,B2
-字面的,literal,字面的,ADJ,B2
-存在,to subsist,存在,VERB,B2
-存在/有,to exist there is,存在/有,VERB,B2
-存在主义,existentialism,存在主义,NOUN,B2
-存在主义的,existential,存在主义的,ADJ,B2
-存在的 / 可获得的,present available,存在的 / 可获得的,ADJ,B2
-存放,to deposit,存放,VERB,B2
-孙女,granddaughter,孙女,NOUN,B2
-孙辈,grandchild,孙辈,NOUN,B2
-孤独,loneliness,孤独,NOUN,B2
-孤独,solitude,孤独,NOUN,B2
-孤独的,solitary,孤独的,ADJ,B2
-孤立的,isolated,孤立的,ADJ,B2
-学习,to study,学习,VERB,B2
-学习曲线,learning curve,学习曲线,NOUN,B2
-学位/考试,degree exam,学位/考试,NOUN,B2
-学年,school year,学年,NOUN,B2
-学术的,scholastic,经院哲学的,ADJ,B2
-学校的,school,学校的,ADJ,B2
-学生,pupil,学生,NOUN,B2
-学生,schoolboy,学生,NOUN,B2
-学生宿舍,student residence,学生宿舍,NOUN,B2
-学者,academic,学者,NOUN,B2
-学识渊博的,deeply learned,学识渊博的,ADJ,B2
-学院,college,学院,NOUN,B2
-孵化,incubation,孵化,NOUN,B2
-宁静,serenity,宁静,NOUN,B2
-它 (中性),it neuter,它 (中性),PRON,B2
-它 (通性),it common,它 (通性),PRON,B2
-它的,its,它的,PRON,B2
-它自己,itself,它自己,PRON,B2
-宇宙的,cosmic,宇宙的,ADJ,B2
-宇航员,astronaut,宇航员,NOUN,B2
-守夜,to stay awake,守夜,VERB,B2
-守望,lookout,瞭望,NOUN,B2
-安全,security,安全,NOUN,B2
-安全的/可靠的,safe secure,安全的/可靠的,ADJ,B2
-安全的，安保的,security-related,安全的，安保的,ADJ,B2
-安息日,sabbath,安息日,NOUN,B2
-安慰,consolation,安慰,NOUN,B2
-安慰,to console,安慰,VERB,B2
-安抚,to appease,安抚,VERB,B2
-安抚,to placate,安抚,VERB,B2
-安眠药,sleeping pill,安眠药,NOUN,B2
-完全地,totally,完全地,ADV,B2
-完全的,total,完全的,ADJ,B2
-完成,to accomplish,完成,VERB,B2
-完成,to be done,被做,VERB,B2
-完成,to consummate,完成,VERB,B2
-完美,perfection,完美,NOUN,B2
-宏伟,grandiose,浮夸的,ADJ,B2
-宏伟,grandeur,宏伟,NOUN,B2
-宏伟,grandiosity,宏伟,NOUN,B2
-宏伟的,imposing,宏伟的,ADJ,B2
-宏观的,macroscopic,宏观的,ADJ,B2
-宏观经济学的,macroeconomic,宏观经济学的,ADJ,B2
-宗教战争,religious war,宗教战争,NOUN,B2
-宗教的,religious,宗教的,ADJ,B2
-宗教纷争,religious strife,宗教纷争,NOUN,B2
-宗教自由,freedom of religion,宗教自由,NOUN,B2
-宗教裁判所,inquisition,宗教裁判所,NOUN,B2
-宗派的,confessional,宗派的,ADJ,B2
-宗派的,sectarian,宗派的,ADJ,B2
-官僚机构,bureaucracy,官僚主义,NOUN,B2
-定义,to define,定义,VERB,B2
-定价,pricing,定价 / 收费,NOUN,B2
-定价,to set rates,定价,VERB,B2
-定位,to locate,定位,VERB,B2
-定位,to situate,定位,VERB,B2
-定位 / 安置,to position,定位 / 安置,VERB,B2
-定居点,settlement,解决,NOUN,B2
-定居的,resident,定居的,ADJ,B2
-定性的,qualitative,定性的,ADJ,B2
-定期地,periodically,定期地,ADV,B2
-定期地,regularly,定期地,ADV,B2
-定稿,to finalize,完成,VERB,B2
-定罪,to criminalize,定罪,VERB,B2
-定语的,attributive,定语的,ADJ,B2
-定量的,quantitative,定量的,ADJ,B2
-宝石,gem,宝石,NOUN,B2
-宝石,jewel,宝石,NOUN,B2
-实施,enforcement,执行,NOUN,B2
-实施,implementation,实施,NOUN,B2
-实用主义,pragmatism,实用主义,NOUN,B2
-实质性的,substantive,实质性的,ADJ,B2
-实验,experimental,实验的,ADJ,B2
-实验,to experiment,实验,VERB,B2
-实验室,lab,实验室,NOUN,B2
-审查,censorship,审查制度,NOUN,B2
-审查,to censor,审查,VERB,B2
-审美,aesthetic,审美的,ADJ,B2
-审计员,auditor,审计员,NOUN,B2
-审讯室,interrogation room,审讯室,NOUN,B2
-审问,interrogation,审问,NOUN,B2
-客户服务,customer service,客户服务,NOUN,B2
-客房,hotel room,酒店房间,NOUN,B2
-客观化,to objectify,客观化,VERB,B2
-客观性,objectivity,客观性,NOUN,B2
-宣传,propaganda,宣传,NOUN,B2
-宣传,publicity,宣传,NOUN,B2
-宣传,to advertise,做广告,VERB,B2
-宣告无罪,to acquit,宣告无罪,VERB,B2
-宣福,to beatify,宣福,VERB,B2
-宣称,to allege,宣称,VERB,B2
-宣言,manifesto,宣言,NOUN,B2
-室,chamber,房间,NOUN,B2
-室内布置,furnishing,室内布置,NOUN,B2
-宪法的,constitutional,宪法的,ADJ,B2
-害怕的,afraid,害怕的,ADJ,B2
-害怕的,scared,害怕的,ADJ,B2
-宵禁,curfew,宵禁,NOUN,B2
-家务,chore,家务,NOUN,B2
-家庭,household,家庭,NOUN,B2
-家庭团聚,family reunification,家庭团聚,NOUN,B2
-家庭圈子,family circle,家庭圈子,NOUN,B2
-家庭构成,family composition,家庭构成,NOUN,B2
-家庭生活,family life,家庭生活,NOUN,B2
-家庭紧张,family tension,家庭紧张,NOUN,B2
-家谱,genealogies,家谱,NOUN,B2
-家谱,genealogy,家谱学,NOUN,B2
-容光焕发的,radiant,容光焕发的,ADJ,B2
-容器,vessel,船,NOUN,B2
-容纳,to accommodate,容纳,VERB,B2
-宽大,leniency,宽厚,NOUN,B2
-宽大的,lenient,宽大的,ADJ,B2
-宽宏大量,magnanimity,宽宏大量,NOUN,B2
-宽宏大量的,magnanimous,宽宏大量的,ADJ,B2
-宽容的,tolerant,宽容的,ADJ,B2
-宽恕,to condone,宽恕,VERB,B2
-宽慰的,relieved,宽慰的,ADJ,B2
-宿命论,fatalism,宿命论,NOUN,B2
-宿命论的,fatalist,宿命论的,ADJ,B2
-密封的,airtight,密封的,ADJ,B2
-密谋,to conspire,密谋,VERB,B2
-密谋,to plot,密谋,VERB,B2
-富有想象力的,imaginative,富有想象力的,ADJ,B2
-富有的,wealthy,富有的,ADJ,B2
-富集,enrichment,丰富,NOUN,B2
-寒冷的,frigid,寒冷的,ADJ,B2
-寒战,shiver,寒战,NOUN,B2
-察觉,to perceive,察觉,VERB,B2
-寡头政治,oligarchy,寡头政治,NOUN,B2
-寡妇,widow,寡妇,NOUN,B2
-对,versus,对,ADP,B2
-对手,rival,对手,NOUN,B2
-对抗,antagonism,对抗,NOUN,B2
-对此,it,对此,ADV,B2
-对此,this,对此,ADV,B2
-对比,contrast,对比,NOUN,B2
-对称的,symmetrical,对称的,ADJ,B2
-对角地,diagonally,对角地,ADV,B2
-对角线,diagonal,对角线,NOUN,B2
-对话,conversation,对话,NOUN,B2
-对话,to dialogue,对话,VERB,B2
-对话者,interlocutor,对话者,NOUN,B2
-对跖点,antipode,对跖点,NOUN,B2
-对面,opposite,对面,ADP,B2
-寻得陪伴,finding comfort in company,寻得陪伴,NOUN,B2
-寻找,to look for,寻找,VERB,B2
-寻求庇护者,asylum seeker,寻求庇护者,NOUN,B2
-寻求者,seeker,寻求者,NOUN,B2
-寻觅，找到,to unearth to track down,寻觅，找到,VERB,B2
-导游,guided tour,导游,NOUN,B2
-导演,directing,导演,NOUN,B2
-导电性,conductivity,导电性,NOUN,B2
-导航；航行,to navigate,导航；航行,VERB,B2
-封建主义,feudalism,封建主义,NOUN,B2
-封爵,to ennoble,使高贵,VERB,B2
-封锁,blockade,封锁,NOUN,B2
-封闭,closedness,封闭,NOUN,B2
-射手,shooter,射手,NOUN,B2
-射手座,sagittarius,射手座,NOUN,B2
-射线,ray,光线,NOUN,B2
-将要,would,将要,AUX,B2
-将要/会,will shall,将要/会,AUX,B2
-尊重,respect,尊重,NOUN,B2
-小丑,buffoon,小丑,NOUN,B2
-小便,to pee,小便,VERB,B2
-小儿子,little son,小儿子,NOUN,B2
-小册子,brochure,小册子,NOUN,B2
-小册子作者,pamphleteer,小册子作者,NOUN,B2
-小包,packet,小包裹,NOUN,B2
-小号,trumpet,小号,NOUN,B2
-小吃摊,hot dog stand,小吃摊,NOUN,B2
-小圆面包,bread roll,小圆面包,NOUN,B2
-小太阳,little sun,小太阳,NOUN,B2
-小姐,young lady,小姐,NOUN,B2
-小孩,kid,小孩,NOUN,B2
-小家伙,little one,小家伙,NOUN,B2
-小屋,cottage,小屋,NOUN,B2
-小工具,gadget,小装置,NOUN,B2
-小弟弟,little brother,小弟弟,NOUN,B2
-小心,to watch out,小心,VERB,B2
-小手,little hand,小手,NOUN,B2
-小教堂,chapel,小教堂,NOUN,B2
-小数,decimal,小数,NOUN,B2
-小溪,brook,小溪,NOUN,B2
-小牛,calf,小腿,NOUN,B2
-小狗,puppy,小狗,NOUN,B2
-小睡,nap,午睡,NOUN,B2
-小礼物,small gift,小礼物,NOUN,B2
-小行星,asteroid,小行星,NOUN,B2
-小规模战斗,skirmish,小规模战斗,NOUN,B2
-小说,fiction,小说,NOUN,B2
-小说的,novelistic,小说般的,ADJ,B2
-小贩,peddler,小贩,NOUN,B2
-小酒馆,bistro,小酒馆,NOUN,B2
-小饰品,trinket,小饰品,NOUN,B2
-小鸡,chick,小鸡,NOUN,B2
-少,little,少,DET,B2
-少数,minority,少数,NOUN,B2
-少数派的,minority,少数派的,ADJ,B2
-少数群体,minority group,少数群体,NOUN,B2
-尖刻,acrimony,尖刻,NOUN,B2
-尖刻的,acerbic,尖刻的,ADJ,B2
-尖叫,scream,尖叫,NOUN,B2
-尖锐,acute,剧烈的,ADJ,B2
-尖锐的,shrill,尖锐的,ADJ,B2
-尝试 / 试穿,to try to try on,尝试 / 试穿,VERB,B2
-就业,employment,就业,NOUN,B2
-就职,to assume office,就任,VERB,B2
-就职,to inaugurate,启用,VERB,B2
-尴尬,awkwardness,尴尬,NOUN,B2
-尸体,corpse,尸体,NOUN,B2
-尸体/相似的,corpse alike,尸体/相似的,NOUN,B2
-尸检,autopsy,尸检,NOUN,B2
-尺寸 / 测量,size measure,尺寸 / 测量,NOUN,B2
-尽管,despite,尽管,ADP,B2
-尽管,although,尽管,CCONJ,B2
-尽管如此,nevertheless,尽管如此,ADV,B2
-局,directorate,局,NOUN,B2
-层/仓库,layer storage,层/仓库,NOUN,B2
-居中,to center,居中,VERB,B2
-居住地,place of residence,居住地,NOUN,B2
-居民,inhabitant,居民,NOUN,B2
-屈尊,condescension,屈尊,NOUN,B2
-屈尊,to condescend,屈尊,VERB,B2
-屈尊,to deign,屈尊,VERB,B2
-屈服,to succumb,屈服,VERB,B2
-屎,crap,屎,NOUN,B2
-屏幕,screen,屏幕,NOUN,B2
-属于,to belong,属于,VERB,B2
-属性,attribute,属性,NOUN,B2
-屠夫,butcher,屠夫,NOUN,B2
-屠宰/击落,to slaughter shoot down,屠宰/击落,VERB,B2
-山丘,hill,小山,NOUN,B2
-山羊,goat,山羊,NOUN,B2
-山谷,dal,山谷,NOUN,B2
-山谷,valley,山谷,NOUN,B2
-山顶,crest,顶峰,NOUN,B2
-岩板,rock slab,岩板,NOUN,B2
-岳母,mother-in-law,岳母,NOUN,B2
-峰会,summit,顶峰,NOUN,B2
-崇敬,reverence,尊敬,NOUN,B2
-崇敬,veneration,崇敬,NOUN,B2
-崇敬,to venerate,崇敬,VERB,B2
-崇高的,sublime,崇高的,ADJ,B2
-崩溃,breakdown,故障,NOUN,B2
-嵌入,to embed,嵌入,VERB,B2
-巡回的,itinerant,巡回的,ADJ,B2
-巡航,cruise,巡航,NOUN,B2
-巡逻,patrol,巡逻,NOUN,B2
-巢,nest,巢,NOUN,B2
-工业化,industrialization,工业化,NOUN,B2
-工业化,to industrialize,工业化,VERB,B2
-工业的,industrial,工业的,ADJ,B2
-工人阶级,working class,工人阶级,NOUN,B2
-工会,trade union,工会,NOUN,B2
-工会,union,工会,NOUN,B2
-工会主义,unionism,工会主义,NOUN,B2
-工作,job,工作,NOUN,B2
-工作任务,work task,工作任务,NOUN,B2
-工作场所,workplace,工作场所,NOUN,B2
-工作日,weekday,工作日,NOUN,B2
-工作环境,work environment,工作环境,NOUN,B2
-工具化,to instrumentalize,工具化,VERB,B2
-工匠,handyman,工匠,NOUN,B2
-工艺,craft,工艺,NOUN,B2
-工资,wage,工资,NOUN,B2
-左边,left,左边,ADV,B2
-巧妙地,delicately,巧妙地,ADV,B2
-巨大,enormity,极恶,NOUN,B2
-巨大地,enormously,巨大地,ADV,B2
-巨大的,giant,巨大的,ADJ,B2
-巨大的,immense,巨大的,ADJ,B2
-巨大的,massive,巨大的,ADJ,B2
-巩固的,consolidating,巩固的,ADJ,B2
-巫师,sorcerer,巫师,NOUN,B2
-巫师,wizard,巫师,NOUN,B2
-巫术,sorcery,巫术,NOUN,B2
-巫术,witchcraft,巫术,NOUN,B2
-差异,discrepancy,差异,NOUN,B2
-差异,disparity,差异,NOUN,B2
-差异,variance,方差,NOUN,B2
-已婚的,married,已婚的,ADJ,B2
-已故的,deceased,已故的,ADJ,B2
-已知的,known,已知的,ADJ,B2
-巴勒斯坦的,palestinian,巴勒斯坦的,ADJ,B2
-巴西的,brazilian,巴西的,ADJ,B2
-市中心,city centre,市中心,NOUN,B2
-市政,municipality,市镇,NOUN,B2
-市政厅,city hall,市政厅,NOUN,B2
-市政厅,town hall,市政厅,NOUN,B2
-市政的,municipal,市政的,ADJ,B2
-市议会,city council,市议会,NOUN,B2
-市议员,councilor,市议员,NOUN,B2
-市长的,mayoral,市长的,ADJ,B2
-布景,decor,布景,NOUN,B2
-布道,homily,布道,NOUN,B2
-布道,preaching,劝诫,NOUN,B2
-布道,sermon,布道,NOUN,B2
-布道,to preach,布道,VERB,B2
-帅哥/美女,good-looking person,帅哥/美女,NOUN,B2
-帆,sail,帆,NOUN,B2
-帆布,canvas,帆布,NOUN,B2
-希望,to hope,希望,VERB,B2
-希腊的,greek,希腊的,ADJ,B2
-希腊语,greek,希腊语,NOUN,B2
-帝国主义,imperialism,帝国主义,NOUN,B2
-帝国的,imperial,帝国的,ADJ,B2
-带子,band tape,带子,NOUN,B2
-带子,strap,带子,NOUN,B2
-带来/引导,to bring lead,带来/引导,VERB,B2
-帮派,gang,帮派,NOUN,B2
-常去,frequent,频繁的,ADJ,B2
-常去,to frequent,常去,VERB,B2
-常规,routine,常规,NOUN,B2
-帽子,cap,帽子,NOUN,B2
-干净地,cleanly,干净地,ADV,B2
-干旱的,arid,干旱的,ADJ,B2
-干杯,cheers,干杯,INTJ,B2
-干涉,interference,干扰,NOUN,B2
-干草,hay,干草,NOUN,B2
-干邑,cognac,干邑,NOUN,B2
-干预,intervention,干预,NOUN,B2
-平分,to bisect,平分,VERB,B2
-平均数,average,平均数,NOUN,B2
-平局,draw,平局,NOUN,B2
-平底锅,frying pan,平底锅,NOUN,B2
-平底锅,pan,平底锅,NOUN,B2
-平息,appeasement,平息,NOUN,B2
-平息,to subside,平息,VERB,B2
-平板电脑,tablet,平板电脑,NOUN,B2
-平民的,civilian,平民的,ADJ,B2
-平淡,prosaic,平淡无奇的,ADJ,B2
-平等待遇,equal treatment,平等待遇,NOUN,B2
-平衡的,balancing,平衡的,ADJ,B2
-平静,calmness,平静,NOUN,B2
-平静,to calm,使平静,VERB,B2
-平静地,calmly,平静地,ADV,B2
-年度的,annual,年度的,ADJ,B2
-年老,elderly,年长的,ADJ,B2
-年老的,aged,年老的,ADJ,B2
-年薪,annual wage,年薪,NOUN,B2
-年表,chronology,年表,NOUN,B2
-年轻人,youngster,年少者,NOUN,B2
-年长的,older,年长的,ADJ,B2
-幸运的,lucky,幸运的,ADJ,B2
-幻想,fantasy,幻想,NOUN,B2
-幻想,to daydream,幻想,VERB,B2
-幼儿园,preschool,幼儿园,NOUN,B2
-幼兽,cub,幼兽,NOUN,B2
-幼崽,offspring,幼崽,NOUN,B2
-幼虫,larva,幼虫,NOUN,B2
-幽默的,humorous,幽默的,ADJ,B2
-广口瓶,jar,广口瓶,NOUN,B2
-广告,advertising,广告业,NOUN,B2
-广告的,advertising,广告的,ADJ,B2
-广播,broadcasting,广播,NOUN,B2
-广播,to broadcast,播出,VERB,B2
-广播公司,broadcaster,广播公司,NOUN,B2
-广泛的,extended,广泛的,ADJ,B2
-广阔,expansive,扩张的,ADJ,B2
-庇护,asylum,庇护,NOUN,B2
-庇护,to shelter,庇护,VERB,B2
-床单,sheet,床单,NOUN,B2
-床垫,mattress,床垫,NOUN,B2
-序言,preamble,序言,NOUN,B2
-应付,to cope,应付,VERB,B2
-应受谴责的,reprehensible,应受谴责的,ADJ,B2
-应受责备的,reproachable,应受责备的,ADJ,B2
-应纳税的,taxable,应纳税的,ADJ,B2
-应该,ought,应该,AUX,B2
-应该,should ought to,应该,AUX,B2
-底层,underclass,底层,NOUN,B2
-庞大的,enormous,巨大的,ADJ,B2
-庞大的,gigantic,巨大的,ADJ,B2
-废弃,disuse,废弃,NOUN,B2
-废料,scrap,碎屑,NOUN,B2
-废除,abolition,废除,NOUN,B2
-废除,to annul,废除,VERB,B2
-废除,to repeal,废除,VERB,B2
-废黜,to dethrone,废黜,VERB,B2
-度假胜地,resort,度假胜地,NOUN,B2
-康复,rehabilitation,康复,NOUN,B2
-廉价,cheapness,廉价,NOUN,B2
-延期,postponement,延期,NOUN,B2
-延续,continuation,延续,NOUN,B2
-延误的,delayed,延误的,ADJ,B2
-延迟,delay,延迟,NOUN,B2
-延长,to lengthen,延长,VERB,B2
-建构主义,constructivism,建构主义,NOUN,B2
-建模,modeling,造型,NOUN,B2
-建筑群,complex,建筑群,NOUN,B2
-建议,advice,建议,NOUN,B2
-建议,proposal suggestion,建议,NOUN,B2
-建议,suggestion,建议,NOUN,B2
-建设,construction,建造,NOUN,B2
-开发者,developer,开发商,NOUN,B2
-开口,opening,开口,NOUN,B2
-开启,on,在...上,ADP,B2
-开启,to switch on,开启,VERB,B2
-开处方,to prescribe,开处方,VERB,B2
-开始,commencement,开始,NOUN,B2
-开始,to begin,开始,VERB,B2
-开放,openness,开放,NOUN,B2
-开放地,open,开放地,ADV,B2
-开火,to fire,开火,VERB,B2
-开玩笑,to joke,开玩笑,VERB,B2
-开票,to invoice,开票,VERB,B2
-开脱,to exculpate,开脱,VERB,B2
-开花,to bloom,开花,VERB,B2
-开花,to blossom,开花,VERB,B2
-开释,to exonerate,使无罪,VERB,B2
-开除教籍,excommunication,绝罚,NOUN,B2
-开除教籍,to excommunicate,开除教籍,VERB,B2
-异国情调的,exotic,异国情调的,ADJ,B2
-异常,anomaly,异常,NOUN,B2
-异步,asynchronous,异步的,ADJ,B2
-异端,heresy,异端,NOUN,B2
-异端,heretic,异端,NOUN,B2
-异见者,dissident,异见者,NOUN,B2
-异质,heterogeneous,异质的,ADJ,B2
-异质性,heterogeneity,异质性,NOUN,B2
-弃儿,foundling,弃婴,NOUN,B2
-弃儿,outcast,被遗弃者,NOUN,B2
-弃权,to abstain,克制,VERB,B2
-弄乱,to disarrange,弄乱,VERB,B2
-弄乱,to dishevel,弄乱,VERB,B2
-弄皱,to crumple,弄皱,VERB,B2
-弄直,to straighten,弄直,VERB,B2
-弄脏,to dirty to tarnish,弄脏,VERB,B2
-弄错,to mistake,弄错,VERB,B2
-引力,gravitation,引力,NOUN,B2
-引力的,gravitational,引力的,ADJ,B2
-引导,to channel,疏导,VERB,B2
-引用,citation,引用,NOUN,B2
-引证,to adduce,引证,VERB,B2
-引诱,to entice,引诱,VERB,B2
-引起,to beget,引起,VERB,B2
-引起回忆的,evocative,引起回忆的,ADJ,B2
-张贴,to post,张贴,VERB,B2
-弦,chord,弦,NOUN,B2
-弯曲,bending,弯曲,NOUN,B2
-弯曲,to bend,弯曲,VERB,B2
-弯曲,to warp,弯曲,VERB,B2
-弯的,bent,弯的,ADJ,B2
-弱智的,feeble-minded,弱智的,ADJ,B2
-弹出,to eject,弹出,VERB,B2
-弹性,elasticity,弹性,NOUN,B2
-弹药,ammunition,弹药,NOUN,B2
-强制,forced,强迫的,ADJ,B2
-强制的,mandatory,强制的,ADJ,B2
-强加,to foist,强加,VERB,B2
-强加,to impose,强加,VERB,B2
-强化的,intensive,强化的,ADJ,B2
-强奸,rape,强奸,NOUN,B2
-强行,forcibly,强制地,ADV,B2
-强调,to accentuate,强调,VERB,B2
-强调,to underline,强调,VERB,B2
-强迫,to coerce,强迫,VERB,B2
-强迫,to force,强迫,VERB,B2
-强迫,to oblige,强迫,VERB,B2
-强迫性,compulsiveness,强迫性,NOUN,B2
-归咎,to impute,归咎,VERB,B2
-归因,attribution,归因,NOUN,B2
-归因于,to ascribe,归因于,VERB,B2
-归因于,to attribute,归因于,VERB,B2
-归罪,to incriminate,归罪,VERB,B2
-归还,to give back,归还,VERB,B2
-当,when,当...时,SCONJ,B2
-当,while,当...时,SCONJ,B2
-当地人,natives inhabitants,当地人,NOUN,B2
-当然,of course,理所当然的,ADJ,B2
-当然,clear,当然,ADV,B2
-当然,sure,当然,ADV,B2
-当然,certainly,当然,INTJ,B2
-彗星,comet,彗星,NOUN,B2
-形容词,adjective,形容词,NOUN,B2
-形式,formality,礼节,NOUN,B2
-形式主义,formalism,形式主义,NOUN,B2
-形式化,to formalize,使正式化,VERB,B2
-形态学,morphology,形态学,NOUN,B2
-形态学的,morphological,形态的,ADJ,B2
-形成,formation,组建,NOUN,B2
-形而上学,metaphysics,形而上学,NOUN,B2
-彩票,lottery,彩票,NOUN,B2
-影响,impact,影响,NOUN,B2
-影响者,influencer,网红,NOUN,B2
-征募,to enlist,征募,VERB,B2
-征服,conquest,征服,NOUN,B2
-征服,conquests,征服,NOUN,B2
-征服,to subjugate,征服,VERB,B2
-征服者,conqueror,征服者,NOUN,B2
-征用,expropriation,征用,NOUN,B2
-征用,to expropriate,征用,VERB,B2
-征税,to tax,征税,VERB,B2
-征税,to tax to burden,征税,VERB,B2
-待售,for sale,待售,ADJ,B2
-很多,a lot,很多,ADV,B2
-很少,seldom,很少,ADV,B2
-律师,attorney,律师,NOUN,B2
-律师事务所,law firm,律师事务所,NOUN,B2
-徒劳地,in vain,徒劳,ADV,B2
-徒劳的,vain,徒劳的,ADJ,B2
-徒步旅行,hike,徒步旅行,NOUN,B2
-得体的,tactful,圆滑的,ADJ,B2
-徘徊,to linger,徘徊,VERB,B2
-循环,circulation,循环,NOUN,B2
-循环,loop,循环,NOUN,B2
-微不足道的,trifling,微不足道的,ADJ,B2
-微妙,subtlety,微妙,NOUN,B2
-微妙的,subtle,微妙的,ADJ,B2
-微小的,minimal,微小的,ADJ,B2
-微小的,tiny,微小的,ADJ,B2
-微弱的,faint,微弱的,ADJ,B2
-微波炉,microwave,微波炉,NOUN,B2
-微温的,lukewarm,微温的,ADJ,B2
-微观的,microscopic,微观的,ADJ,B2
-微风,breeze,微风,NOUN,B2
-德国人,german,德国的,ADJ,B2
-德语课,german class,德语课,NOUN,B2
-徽章,badge,徽章,NOUN,B2
-徽章,emblem,徽章,NOUN,B2
-心,heart,心,ADV,B2
-心,hearts,心,NOUN,B2
+上面,above,上面,ADV,B2
+国外,abroad,国外,NOUN,B2
+突然,abrupt,突然的,ADJ,B2
+缺席,absent,缺席的,ADJ,B2
 心不在焉,absent-mindedness,心不在焉,NOUN,B2
-心态,mentality,心态,NOUN,B2
-心烦的,upset,心烦的,ADJ,B2
-心照不宣地,tacitly,默不作声地,ADV,B2
-心照不宣的,tacit,心照不宣的,ADJ,B2
-心爱的,beloved,心爱的,ADJ,B2
-心爱的人,sweetheart,爱人,NOUN,B2
-心理学家,psychologist,心理学家,NOUN,B2
-心理的,psychological,心理的,ADJ,B2
-心脏病发作,heart attack,心脏病发作,NOUN,B2
-必然,necessarily,必然地,ADV,B2
-必要的,imperative,必要的,ADJ,B2
-必需的,required,必需的,ADJ,B2
-必须,have to,必须,AUX,B2
-必须,to have to,必须,VERB,B2
-忏悔,penance,忏悔,NOUN,B2
-忏悔,to repent,悔改,VERB,B2
-志同道合者,kindred spirit,志同道合者,NOUN,B2
-志愿工作,volunteer work,志愿工作,NOUN,B2
-志愿服务,volunteering,志愿服务,NOUN,B2
-忘恩负义的,ungrateful,忘恩负义的,ADJ,B2
-忙乱,hectic,忙乱,NOUN,B2
-忙碌,bustle,喧闹,NOUN,B2
-忙碌的,engaged,订婚的,ADJ,B2
-忠于事实的,truthful,忠于事实的,ADJ,B2
-忠诚,fidelity,忠诚,NOUN,B2
-忠诚的,devoted,忠诚的,ADJ,B2
-忠诚的,faithful loyal,忠诚的,ADJ,B2
-忧思,brooding,忧思,NOUN,B2
-忧虑的,apprehensive,忧虑的,ADJ,B2
-忧郁,melancholy,忧郁,NOUN,B2
-忧郁,the blues,忧郁,NOUN,B2
-忧郁的,melancholic,忧郁的,ADJ,B2
-快乐地,happily,快乐地,ADV,B2
-快乐的,gay,快乐的,ADJ,B2
-快乐的,joyful,快乐的,ADJ,B2
-快地,fast,快地,ADV,B2
-快的,quick,快的,ADJ,B2
-忽视,to disregard,忽视,VERB,B2
-忽视,to overlook,忽视,VERB,B2
-怀孕,pregnancy,怀孕,NOUN,B2
-怀孕的,pregnant,怀孕的,ADJ,B2
-怀旧,nostalgia,怀旧,NOUN,B2
-怀有,to harbor,怀有,VERB,B2
-怀疑,doubt,怀疑,NOUN,B2
-怀疑,skepticism,怀疑主义,NOUN,B2
-怀疑,to be skeptical,怀疑,VERB,B2
-怀疑,to suspect,怀疑,VERB,B2
-怀疑的,skeptical,怀疑的,ADJ,B2
-怎么会,how come,怎么会,INTJ,B2
-怜悯,pity,可惜,ADJ,B2
-怜悯,to pity,同情,VERB,B2
-思想开明的,open-minded,思想开明的,ADJ,B2
-急性子的人,hothead,急性子的人,NOUN,B2
-急诊医生,emergency doctor,急诊医生,NOUN,B2
-急诊室,emergency room,急诊室,NOUN,B2
-性别平等,gender equality,性别平等,NOUN,B2
-性别歧视,sexism,性别歧视,NOUN,B2
-性情,disposition,性情,NOUN,B2
-性感地,sexily,性感地,ADV,B2
-性感的,sexy,性感的,ADJ,B2
-性欲的,horny,性欲的,ADJ,B2
-性病,venereal disease,性病,NOUN,B2
-性的,sexual,性的,ADJ,B2
-怨恨,rancor,怨恨,NOUN,B2
-怪人,oddball,怪人,NOUN,B2
-怪异的,monstrous,怪异的,ADJ,B2
-怪诞的,bizarre,奇异的,ADJ,B2
-怯场,stage fright,怯场,NOUN,B2
-怯懦的,pusillanimous,怯懦的,ADJ,B2
-总,gross,总的,ADJ,B2
-总的来说,overall,总体上,ADV,B2
-总统,president,总统,NOUN,B2
-总统的,presidential,总统的,ADJ,B2
-总统职位,presidency,总统任期,NOUN,B2
-总统选举,presidential election,总统选举,NOUN,B2
-总计,to amount to,总计,VERB,B2
-恋爱的,in love,恋爱中的,ADJ,B2
-恋物,fetish,恋物,NOUN,B2
-恐吓,intimidation,恐吓,NOUN,B2
-恐吓,to intimidate,恐吓,VERB,B2
-恐怖,horror,恐怖,NOUN,B2
-恐怖,terror,恐怖,NOUN,B2
-恐怖主义,terrorism,恐怖主义,NOUN,B2
-恐怖分子们,terrorists,恐怖分子们,NOUN,B2
-恐惧,shit,恐惧,NOUN,B2
-恐惧症,phobia,恐惧症,NOUN,B2
-恐龙,dinosaur,恐龙,NOUN,B2
-恒定,constancy,恒定,NOUN,B2
-恒定的,constant,持续的,ADJ,B2
-恒星的,stellar,杰出的,ADJ,B2
-恢复,resumption,恢复,NOUN,B2
-恢复,to regain,恢复,VERB,B2
-恩人,benefactor,恩人,NOUN,B2
-恭喜,congratulations,恭喜,INTJ,B2
-恭敬的,respectful,恭敬的,ADJ,B2
-恰好,just precis,恰好,ADV,B2
-恳求,supplication,恳求,NOUN,B2
-恳求,to supplicate,恳求,VERB,B2
-恶习,vice,恶习,NOUN,B2
-恶作剧,prank,恶作剧,NOUN,B2
-恶化,deterioration,恶化,NOUN,B2
-恶化,to worsen,恶化,VERB,B2
-恶名,infamy,恶名,NOUN,B2
-恶心,nausea,恶心,NOUN,B2
-恶心的,nauseous,恶心的,ADJ,B2
-恶心的,sick nauseous,恶心的,ADJ,B2
-恶性的,malignant,恶性的,ADJ,B2
-恶性的,virulent,恶性的,ADJ,B2
-恶意,malevolence,恶意,NOUN,B2
-恶意,malice,恶意,NOUN,B2
-恶意,spite,恶意,NOUN,B2
-恶意的,malicious,恶意的,ADJ,B2
-恶意的,spiteful,怀恨的,ADJ,B2
-恶棍,scoundrel,恶棍,NOUN,B2
-恶棍,thug,暴徒,NOUN,B2
-恶棍的,villainous,恶棍的,ADJ,B2
-恶臭,stench,恶臭,NOUN,B2
-恶魔般的,devilish,恶魔般的,ADJ,B2
-恶魔般的,diabolical,恶魔般的,ADJ,B2
-悔恨的,remorseful,悔恨的,ADJ,B2
-悔罪,contrition,悔罪,NOUN,B2
-您,you formal,您,PRON,B2
-悬挂,to drape,悬挂,VERB,B2
-悬浮的,suspended,悬浮的,ADJ,B2
-悲伤,grief,悲伤,NOUN,B2
-悲伤,sadness,悲伤,NOUN,B2
-悲伤,sorrow,悲伤,NOUN,B2
-悲剧的,tragic,悲剧的,ADJ,B2
-悲惨,wretchedness,悲惨,NOUN,B2
-悲惨的,abject,悲惨的,ADJ,B2
-悲痛,distress,痛苦,NOUN,B2
-悲痛欲绝的,disconsolate,悲痛欲绝的,ADJ,B2
-悲观主义,pessimism,悲观主义,NOUN,B2
-悼词,eulogy,赞辞,NOUN,B2
-情人,lover,爱人,NOUN,B2
-情况,circumstance,情况,NOUN,B2
-情妇,mistress,情妇,NOUN,B2
-情感,emotional,情绪的,ADJ,B2
-情感上,emotionally,情感上,ADV,B2
-情感体验,emotional experience,情感体验,NOUN,B2
-情报机构,intelligence service,情报机构,NOUN,B2
-情绪,emotion,情感,NOUN,B2
-情绪性,emotionality,感性/情绪化,NOUN,B2
-惊人,astonishing,令人惊讶的,ADJ,B2
-惊叹,to marvel,使惊奇,VERB,B2
-惊讶,amazement,惊愕,NOUN,B2
-惊讶的,astonished,惊讶的,ADJ,B2
-惊讶的,surprised,惊讶的,ADJ,B2
-惊骇的,aghast,惊骇的,ADJ,B2
-惧怕,to dread,畏惧,VERB,B2
-惩罚,penalty,惩罚,NOUN,B2
-惩罚性的,punitive,惩罚性的,ADJ,B2
-惯例,usual thing,惯例,NOUN,B2
-惯性,inertia,惯性,NOUN,B2
-惰性的,inert,惰性的,ADJ,B2
-想出,to think up,构思,VERB,B2
-想知道,to wonder,觉得奇怪,VERB,B2
-想象的,imaginary,虚构的,ADJ,B2
-想象的,imagined,想象的,ADJ,B2
-意合,parataxis,意合,NOUN,B2
-意味着,to mean entail,意味着,VERB,B2
-意外,unexpected,意想不到的,ADJ,B2
-意外之财,windfall,意外之财,NOUN,B2
-意外的,unforeseen,意外的,ADJ,B2
-意大利人,italian,意大利人,NOUN,B2
-意大利的,italian,意大利的,ADJ,B2
-意思是,to meant,意思是,VERB,B2
-意见自由,freedom of opinion,意见自由,NOUN,B2
-意识,awareness,意识,NOUN,B2
-意识到,aware,意识到的,ADJ,B2
-意象,imagery,意象,NOUN,B2
-愚妄,folly,愚妄,NOUN,B2
-愚昧,fatuity,愚昧,NOUN,B2
-愚蠢,stupidity,愚蠢,NOUN,B2
-愚蠢的,idiotic,愚蠢的,ADJ,B2
-感人的,moving,感人的,ADJ,B2
-感动,to be moved,感动,VERB,B2
-感官的,sensual,感官的,ADJ,B2
-感激,grateful,感激的,ADJ,B2
-感觉,sensation,感觉,NOUN,B2
-感觉到,sense,感觉,NOUN,B2
-感觉到,to sense,隐约感到,VERB,B2
-愤世嫉俗的,cynical,愤世嫉俗的,ADJ,B2
-愤怒,outrage,愤怒,NOUN,B2
-愤怒,wrath,愤怒,NOUN,B2
-愤慨,indignation,愤慨,NOUN,B2
-慈善,philanthropy,慈善,NOUN,B2
-慈善家,philanthropist,慈善家,NOUN,B2
-慷慨,generosity,慷慨,NOUN,B2
-慷慨,munificence,慷慨,NOUN,B2
-慷慨地,generously,慷慨地,ADV,B2
-慷慨陈词,to declaim,慷慨陈词,VERB,B2
-懊悔,remorse,悔恨,NOUN,B2
-懒惰,laziness,懒惰,NOUN,B2
-懒惰的,slothful,懒惰的,ADJ,B2
-懦夫,wimp,懦夫,NOUN,B2
-懦弱的,cowardly,懦弱的,ADJ,B2
-戏剧作法,dramaturgy,戏剧艺术,NOUN,B2
-戏剧化,to dramatize,戏剧化,VERB,B2
-戏剧化,to theatricalize,戏剧化,VERB,B2
-戏剧性的,dramatic,戏剧性的,ADJ,B2
-戏剧的,theatrical,戏剧的,ADJ,B2
-成两半,in two,成两半,ADV,B2
-成为,become,成为,AUX,B2
-成分,constituent,成分,NOUN,B2
-成功,to succeed,成功,VERB,B2
-成功的,successful,成功的,ADJ,B2
-成员国,member state,成员国,NOUN,B2
-成对的 / 伴随的,paired accompanied,成对的 / 伴随的,ADJ,B2
-成年,adult,成年的,ADJ,B2
-成本加成销售,murabaha,成本加成销售,NOUN,B2
-成比例的,proportional,成比例的,ADJ,B2
-成熟,maturity,成熟,NOUN,B2
-成熟的,ripe,成熟的,ADJ,B2
-成瘾,addiction,上瘾,NOUN,B2
-成立,founding,成立,NOUN,B2
-成绩单,report card,成绩单,NOUN,B2
-我们,us,我们,PRON,B2
-我们的,our,我们的,DET,B2
-我们自己,ourselves,我们自己,PRON,B2
-我的,my,我的,DET,B2
-我自己,myself,我自己,PRON,B2
-或者,or rather,或者,ADV,B2
-战利品,loot,战利品,NOUN,B2
-战地医生,field medic,战地医生,NOUN,B2
-战壕,trench,沟渠,NOUN,B2
-战士,fighter,战士,NOUN,B2
-战斗,combating,打击,NOUN,B2
-战斗,to combat,对抗,VERB,B2
-战术,tactic,策略,NOUN,B2
-战栗,shudder,战栗,NOUN,B2
-截然不同的,disparate,截然不同的,ADJ,B2
-截肢,amputation,截肢,NOUN,B2
-截肢,to amputate,截肢,VERB,B2
-户外,outdoors,户外,ADV,B2
-房主,property owner,房主,NOUN,B2
-房地产,real estate,房地产,ADJ,B2
-所以/如此,so thus,所以/如此,ADV,B2
-所得税,income tax,所得税,NOUN,B2
-所有/大家,all everyone,所有/大家,PRON,B2
-所有权,ownership,,NOUN,B2
-所有权,property right,所有权,NOUN,B2
-所有者,owner,所有者,NOUN,B2
-手动地,manually,手动地,ADV,B2
-手工的,manual,手工的,ADJ,B2
-手指/脚趾,finger toe,手指/脚趾,NOUN,B2
-手提包,handbag,手提包,NOUN,B2
-手无寸铁的,unarmed,手无寸铁的,ADJ,B2
-手术,surgery,手术,NOUN,B2
-手术刀,scalpel,手术刀,NOUN,B2
-手机,mobile phone,手机,NOUN,B2
-手榴弹,grenade,手榴弹,NOUN,B2
-手稿,manuscript,手稿,NOUN,B2
-手铐,handcuff,手铐,NOUN,B2
-扎根,grounding,扎根,NOUN,B2
-扑通,splash,扑通,NOUN,B2
-打,to beat,打败,VERB,B2
-打字,to type,打字,VERB,B2
-打开,to turn on,打开,VERB,B2
-打手势,to gesticulate,做手势,VERB,B2
-打断,to interrupt,打断,VERB,B2
-打水,to draw water,打水,VERB,B2
-打火机,lighter,打火机,NOUN,B2
-打电话,phone,电话,NOUN,B2
-打电话,to call ring,打电话,VERB,B2
-打电话,to phone,打电话,VERB,B2
-打碎,to shatter,粉碎,VERB,B2
-打算,to intend,打算,VERB,B2
-打翻,to upset,使生气,VERB,B2
-打蛋器,whisk,打蛋器,NOUN,B2
-打鼾,to snore,打鼾,VERB,B2
-托儿所,daycare,托儿所,NOUN,B2
-托盘,tray,托盘,NOUN,B2
-托管,hosting,托管,NOUN,B2
-扣留,to withhold,扣留,VERB,B2
-扣除,to deduct,扣除,VERB,B2
-执法政策,enforcement policy,执法政策,NOUN,B2
-扩张,dilation,扩张,NOUN,B2
-扩张,expansion,扩张,NOUN,B2
-扩张,to dilate,膨胀,VERB,B2
-扩张主义,expansionism,扩张主义,NOUN,B2
-扩散,proliferate,扩散,! VERB,B2
-扫,to sweep,打扫,VERB,B2
-扫帚,broom,扫帚,NOUN,B2
-扫描,to scan,扫描,VERB,B2
-扬声器,loudspeaker,扬声器,NOUN,B2
-扭曲,twisted,扭曲的,ADJ,B2
-扭曲,distortion,扭曲,NOUN,B2
-扭曲,to distort,扭曲,VERB,B2
-扭曲的形象,distorted image,扭曲的形象,NOUN,B2
-扭转,torsion,扭转,NOUN,B2
-扭转,to twist,扭曲,VERB,B2
-扰乱,to disrupt,扰乱,VERB,B2
-扳机,trigger,触发器,NOUN,B2
-扶壁,buttress,扶壁,NOUN,B2
-批准,to ratify,批准,VERB,B2
-批评,criticism,批评,NOUN,B2
-扼住,to strangle,扼杀,VERB,B2
-承认,to acknowledge,承认,VERB,B2
-承认,to concede,承认,VERB,B2
-承诺,promise,承诺,NOUN,B2
-技工,mechanic,技工,NOUN,B2
-技术上地,technically,技术上地,ADV,B2
-技术化,to technologize,技术化,VERB,B2
-技术员,technician,技术员,NOUN,B2
-技术官僚制,technocracy,技术官僚主义,NOUN,B2
-技术官僚的,technocratic,技术官僚的,ADJ,B2
-技术的,technical,技术的,ADJ,B2
-技术的,technological,技术的,ADJ,B2
-抄写员,copyist,抄写员,NOUN,B2
-把手,handle,把手,NOUN,B2
-抑制,inhibition,抑制,NOUN,B2
-抑郁的，压抑的,depressive,抑郁的，压抑的,ADJ,B2
-抒情的,lyrical,抒情的,ADJ,B2
-抓,to scratch,抓,VERB,B2
-抓住,to seize,抓住,VERB,B2
-抓痕,scratch,抓痕,NOUN,B2
-投射,to project,投射,VERB,B2
-投掷,throw,投掷,NOUN,B2
-投机者,speculator,投机者,NOUN,B2
-投石机,catapult,投石机,NOUN,B2
-投票,vote,投票,NOUN,B2
-投票,voting,投票,NOUN,B2
-投资,investment,投资,NOUN,B2
-投降,to capitulate,投降,VERB,B2
-抗生素,antibiotic,抗生素,NOUN,B2
-抗生素,antibiotics,抗生素,NOUN,B2
-抗议,protest,抗议,NOUN,B2
-抗议者,protester,示威者,NOUN,B2
-折叠,to fold,折叠,VERB,B2
-折扣,discounts,折扣,NOUN,B2
-折痕,fold,折痕,NOUN,B2
-折磨,to torment,折磨,VERB,B2
-折衷主义,eclecticism,折衷主义,NOUN,B2
-抚养,to raise bring up,抚养,VERB,B2
-抚养孩子,to raise a child,抚养孩子,VERB,B2
-抚平,to smooth,使光滑,VERB,B2
-抛弃,to dump,抛弃,VERB,B2
-抢劫,robbery,抢劫案,NOUN,B2
-护卫舰,frigate,护卫舰,NOUN,B2
-护身符,amulet,护身符,NOUN,B2
-报价单,quote,报价单,NOUN,B2
-报警中心,alarm center,报警中心,NOUN,B2
-报道,reporting,报道,NOUN,B2
-抱怨,grumbling,抱怨,NOUN,B2
-抱怨,to grumble,抱怨,VERB,B2
-抱怨,to whine,哀叹,VERB,B2
-抱歉,sorry,抱歉,ADJ,B2
-抱负,aspiration,抱负,NOUN,B2
-抵抗运动,resistance movement,抵抗运动,NOUN,B2
-押韵,rhyme,韵脚,NOUN,B2
-抽搐的,twitching,抽搐的,ADJ,B2
-抽泣,sobbing,抽泣,NOUN,B2
-抽泣,to sob,啜泣,VERB,B2
-抽筋,cramp,抽筋,NOUN,B2
+弃权,to abstain,克制,VERB,B2
 抽象,abstraction,抽象,NOUN,B2
-抽象,to abstract,抽象,VERB,B2
-担保,warranty,保修单,NOUN,B2
-担忧的,concerned,担忧的,ADJ,B2
-担架,stretcher,担架,NOUN,B2
-拆包,to unpack,拆包,VERB,B2
-拆卸,to disassemble,拆卸,VERB,B2
-拆毁,demolition,拆除,NOUN,B2
-拆除,to demolish,拆除,VERB,B2
-拆除,to tear down,拆除,VERB,B2
-拇指,thumb,拇指,NOUN,B2
-拉丁的,latin,拉丁的,ADJ,B2
-拉比,rabbi,拉比,NOUN,B2
-拉紧,strain,压力,NOUN,B2
-拉紧,to strain,努力,VERB,B2
-拍打,to flap,拍打,VERB,B2
-拍摄,filming,拍摄,NOUN,B2
-拍摄,to film,拍摄,VERB,B2
-拍照,to photograph,拍照,VERB,B2
-拐杖,crutch,拐杖,NOUN,B2
-拒绝,rejection,拒绝,NOUN,B2
-拓宽,broadening,拓宽,NOUN,B2
-拔出,to tear out,拔出,VERB,B2
-拖,to drag,拖,VERB,B2
-拖延,procrastination,拖延,NOUN,B2
-拖延,to procrastinate,拖延,VERB,B2
-拖延,to temporize,拖延,VERB,B2
-拖延的,dilatory,拖延的,ADJ,B2
-拖拉机,tractor,拖拉机,NOUN,B2
-拖曳,drag,拖曳,NOUN,B2
-拖车,trailer,预告片,NOUN,B2
-拖鞋,slipper,拖鞋,NOUN,B2
-拘留所,detention center,拘留所,NOUN,B2
-招聘人员,recruiter,招聘人员,NOUN,B2
-招致,to incur,招致,VERB,B2
-拟人化,anthropomorphism,拟人化,NOUN,B2
-拟声词,onomatopoeia,拟声词,NOUN,B2
-拥堵,congestion,拥堵,NOUN,B2
-拥抱,hug,拥抱,NOUN,B2
-拥抱,to cuddle,拥抱,VERB,B2
-拥抱,to hug,拥抱,VERB,B2
-拥挤的,packed,打包,ADJ,B2
-拥有,own,自己的,ADJ,B2
-拥有,to own,拥有,VERB,B2
-拥有/处置,to have at one's disposal,拥有/处置,VERB,B2
-拦截,to intercept,拦截,VERB,B2
-拧,to screw,拧,VERB,B2
-拧干,to wring,拧干,VERB,B2
-括号,bracket,括号,NOUN,B2
-拯救,salvation,拯救,NOUN,B2
-拳击手,boxer,拳击手,NOUN,B2
-拳头,fist,拳头,NOUN,B2
-拼写,spelling,拼写,NOUN,B2
-拼写,to spell,拼写,VERB,B2
-拾音器,pickup,拾音器,NOUN,B2
-拿出,to take out,拿出,VERB,B2
-持久的,long-lasting,持久的,ADJ,B2
-持久的,standing,站立的,ADJ,B2
-持有者,holder,持有者,NOUN,B2
-持续的,continual,持续的,ADJ,B2
-持续的,continued,持续的,ADJ,B2
-持续的,incessant,持续的,ADJ,B2
-挂号信,registered mail,挂号信,NOUN,B2
-挂断,to hang up,挂断,VERB,B2
-指南针,compass,指南针,NOUN,B2
-指定,to specify,具体说明,VERB,B2
-指导,guidance,指导,NOUN,B2
-指导,tutelage,监护,NOUN,B2
-指导方针,guideline,指导方针,NOUN,B2
-指小词,diminutive,指小词,NOUN,B2
-指挥,to direct,对准,VERB,B2
-指控,accusation,指控,NOUN,B2
-指数,exponent,指数,NOUN,B2
-指数化,indexing,指数化,NOUN,B2
-指数的,exponential,指数的,ADJ,B2
-指标,indicator,指标,NOUN,B2
-指示,indication,指示,NOUN,B2
-指纹,fingerprint,指纹,NOUN,B2
-指责,rebuke,责备,NOUN,B2
-挑剔的,fussy,挑剔的,ADJ,B2
-挑衅的,provocative,挑衅的,ADJ,B2
-挑选,to pick out,挑选,VERB,B2
-挖掘,to excavate,挖掘,VERB,B2
-挥舞,to brandish,挥舞,VERB,B2
-挥霍,prodigality,挥霍,NOUN,B2
-挨饿,to starve,挨饿,VERB,B2
-挪威的,norwegian,挪威的,ADJ,B2
-挪用,misappropriation,挪用,NOUN,B2
-挫伤 / 外伤,contusion trauma,挫伤 / 外伤,NOUN,B2
-挫折,setback,挫折,NOUN,B2
-挫败,to frustrate,挫败,VERB,B2
-振动,to vibrate,振动,VERB,B2
-振荡,to oscillate,振荡,VERB,B2
-振荡器,oscillator,振荡器,NOUN,B2
-挽歌,elegy,挽歌,NOUN,B2
-捆,sheaf,捆,NOUN,B2
-捆绑,to tie up,绑,VERB,B2
-捏,pinch,捏,NOUN,B2
-捏,to pinch,捏,VERB,B2
-捐赠者,donor,捐赠者,NOUN,B2
-捕食者,predator,捕食者,NOUN,B2
-损坏,to damage,损坏,VERB,B2
-损害,detriment,损害,NOUN,B2
-损害赔偿,damages,损害赔偿,NOUN,B2
-据推测,presumably,据推测,ADV,B2
-捷径,shortcut,捷径,NOUN,B2
-授予,award,奖项,NOUN,B2
-授予,to award,分配,VERB,B2
-授予,to confer,授予,VERB,B2
-授予,to grant,授予,VERB,B2
-授权,authorization,授权,NOUN,B2
-授权,to empower,授权,VERB,B2
-授权书,power of attorney,委托书,NOUN,B2
-掉落,to drop,掉落,VERB,B2
-掌声,applause,掌声,NOUN,B2
-掌舵的,steering,掌舵的,ADJ,B2
-掏空的,hollowed,掏空的,ADJ,B2
-排他地,exclusively,专门地,ADV,B2
-排他性,exclusivity,排他性,NOUN,B2
-排他性的,exclusionary,排他性的,ADJ,B2
-排他的,exclusive,独有的,ADJ,B2
-排列,array,排列,NOUN,B2
-排外心理,xenophobia,排外心理,NOUN,B2
-排放,emission,排放,NOUN,B2
-排斥,to ostracize,排斥,VERB,B2
-排泄物,excrement,排泄物,NOUN,B2
-排练,rehearsal,排练,NOUN,B2
-排练,to rehearse,排练,VERB,B2
-排队,to queue,排队,VERB,B2
-排除,exclusion,排除,NOUN,B2
-掘出,to exhume,掘出,VERB,B2
-掠夺,looting,掠夺,NOUN,B2
-掠夺,plundering,掠夺,NOUN,B2
-掠夺,to despoil,掠夺,VERB,B2
-掠夺性的,predatory,掠夺的,ADJ,B2
-探测器,probe,探测器,NOUN,B2
-探索,exploration,探索,NOUN,B2
-接受者,recipient,接受者,NOUN,B2
-接吻,to make out,接吻,VERB,B2
-接壤,to border,接壤,VERB,B2
-接种,to vaccinate,接种疫苗,VERB,B2
-接管,to take over,接管,VERB,B2
-接触,contact,联系,NOUN,B2
-控制,hold,控制,NOUN,B2
-控制,to steer control,控制,VERB,B2
-控告,to indict,控告,VERB,B2
-推/生长,to push to grow,推/生长,VERB,B2
-推/碰撞,to bump push,推/碰撞,VERB,B2
-推力,thrust,猛推,NOUN,B2
-推动,to push through,推动,VERB,B2
-推广者,promoter,推动者,NOUN,B2
-推测,conjecture,推测,NOUN,B2
-推测,speculation,推测,NOUN,B2
-推测,to speculate,推测,VERB,B2
-推理,to reason,推理,VERB,B2
-推翻,to oust,推翻,VERB,B2
-推翻,to overthrow,推翻,VERB,B2
-推翻,to overturn,打翻,VERB,B2
-推荐,recommendation,推荐,NOUN,B2
-推论,corollary,推论,NOUN,B2
-措辞,diction,措辞,NOUN,B2
-措辞,phrasing,措辞,NOUN,B2
-措辞,word choice,措辞,NOUN,B2
-措辞,wording,措辞,NOUN,B2
-掴,slap,拍击,NOUN,B2
-掴,to slap,打耳光,VERB,B2
-描绘,to delineate,描绘,VERB,B2
-描绘的,depicted,描绘的,ADJ,B2
-描绘的,depicting,描绘的,ADJ,B2
-描绘；标出,to trace,描绘；标出,VERB,B2
-描述,description,描述,NOUN,B2
-描述性的,descriptive,描述性的,ADJ,B2
-提供,to provide,提供,VERB,B2
-提供者,provider,提供者,NOUN,B2
-提出上诉,to lodge an appeal,提出上诉,VERB,B2
-提名,nomination,提名,NOUN,B2
-提名,to nominate,提名,VERB,B2
-提炼,to refine,提炼,VERB,B2
-提议,offer,报价,NOUN,B2
-提醒物,reminder,提醒物,NOUN,B2
-提高意识,awareness raising,提高意识,NOUN,B2
-提高意识,to raise awareness,提高意识,VERB,B2
-提高意识,to sensitize,提高意识,VERB,B2
-插入,to plug in,插入,VERB,B2
-插图,illustration,插图,NOUN,B2
-插座,power outlet,插座,NOUN,B2
-揭穿,to unmask,揭穿,VERB,B2
-援引,to invoke,援引,VERB,B2
-搅拌,to stir,搅拌,VERB,B2
-搜寻,to ferret,搜寻,VERB,B2
-搜捕,manhunt,搜捕,NOUN,B2
-搜索引擎,search engine,搜索引擎,NOUN,B2
-搜集,to glean,搜集,VERB,B2
-搞砸,to botch,搞砸,VERB,B2
-搞砸,to bungle,搞砸,VERB,B2
-搬入,to move in,搬入,VERB,B2
-搬出,to move out,搬出,VERB,B2
-搬家,relocation,搬家,NOUN,B2
-搬家,to move house,搬家,VERB,B2
-搬运,to lug,搬运,VERB,B2
-搭车,ride lift,搭车,NOUN,B2
-携带,to take along,带走,VERB,B2
-摄入,to ingest,服用,VERB,B2
-摄影师,photographer,摄影师,NOUN,B2
-摆架子,airs,摆架子,NOUN,B2
-摆脱,to get rid of,摆脱,VERB,B2
-摇摆,to sway,摇摆,VERB,B2
-摇晃,to stagger,蹒跚,VERB,B2
-摇晃,to wobble,摇晃,VERB,B2
-摇篮,cradle,摇篮,NOUN,B2
-摊位,stand,摊位,NOUN,B2
-摊销,to amortize,摊销,VERB,B2
-摘录,excerpt,摘录,NOUN,B2
-摘录,extract,摘录,NOUN,B2
-摘要,summary,摘要,NOUN,B2
-摩擦,to rub,摩擦,VERB,B2
-摸清,to map out,摸清,VERB,B2
-撒酒疯,rowdiness,撒酒疯,NOUN,B2
-撞击,to crash into,撞击,VERB,B2
-撞击 / 冒犯,to strike to offend,撞击 / 冒犯,VERB,B2
-撤回,to retract,撤回,VERB,B2
-撤销,quashing,撤销,NOUN,B2
-撬开,to break into,撬开,VERB,B2
-播种,sowing,播种,NOUN,B2
-擅离职守,to desert,擅离职守,VERB,B2
-擅长,to excel,擅长,VERB,B2
-操作员,operator,经营者,NOUN,B2
-擦亮,to burnish,擦亮,VERB,B2
-擦洗,to scrub,擦洗,VERB,B2
-支付,to defray,支付,VERB,B2
-支出,expenditures,支出,NOUN,B2
-支撑,to prop up,支撑,VERB,B2
-支流,tributary,支流,NOUN,B2
-支票簿,checkbook,支票簿,NOUN,B2
-支配,to dominate,支配,VERB,B2
-收入,revenue,收入,NOUN,B2
-收回,to reclaim,收回,VERB,B2
-收缩,contraction,收缩,NOUN,B2
-收藏癖,collectomania,收藏癖,NOUN,B2
-收音机,radio,收音机,NOUN,B2
-改变,to alter,改变,VERB,B2
-改变,to vary,改变,VERB,B2
-改变/交换,change exchange,改变/交换,NOUN,B2
-攻击者,attacker,攻击者,NOUN,B2
-放,to lay put,放,VERB,B2
-放下,to drop off,放下,VERB,B2
-放下,to lay down,放下,VERB,B2
-放回,to put back,放回,VERB,B2
-放回 / 重新定位,to put back to reposition,放回 / 重新定位,VERB,B2
-放大,amplification,放大,NOUN,B2
-放大,to amplify,放大,VERB,B2
-放射性的,radioactive,放射性的,ADJ,B2
-放弃,renunciation,放弃,NOUN,B2
-放心的,rest assured,放心的,ADJ,B2
-放松,chill,放松,ADJ,B2
-放松,relaxation,缓和,NOUN,B2
-放牧,grazing,放牧,NOUN,B2
-放纵,binge,放纵,NOUN,B2
-放置,to lay,放置,VERB,B2
-放置,to place put,放置,VERB,B2
-放置,to put set,放置,VERB,B2
-放荡,debauchery,放荡,NOUN,B2
-放荡,libertinism,放荡,NOUN,B2
-放荡,licentiousness,放荡,NOUN,B2
-放荡不羁的,bohemian,放荡不羁的,ADJ,B2
-放荡的,licentious,放荡的,ADJ,B2
-政党,political party,政党,NOUN,B2
-政府的,governmental,政府的,ADJ,B2
-故事片,feature film,故事片,NOUN,B2
-故意地,intentionally,故意地,ADV,B2
-故意地,on purpose,故意地,ADV,B2
-故意的,deliberate,深思熟虑的,ADJ,B2
-故意的/恶意的,deliberate malicious,故意的/恶意的,ADJ,B2
-故障,glitch,故障,NOUN,B2
-故障,malfunction,故障,NOUN,B2
-效用,usefulness avail,效用,NOUN,B2
-效用,utility,效用,NOUN,B2
-敌意,animosity,敌意,NOUN,B2
-敏感性,sensitivity,敏感性,NOUN,B2
-敏感的,sensitive,敏感的,ADJ,B2
-敏捷的,nimble,敏捷的,ADJ,B2
-敏锐的,perceptive,敏锐的,ADJ,B2
-救世主,savior,救星,NOUN,B2
-救赎,redemption,救赎,NOUN,B2
-教会,church community,教会,NOUN,B2
-教会的,ecclesiastical,教会的,ADJ,B2
-教养,upbringing,教养,NOUN,B2
-教唆,to suborn,教唆,VERB,B2
-教堂,church,教堂,NOUN,B2
-教学,teaching,教学,NOUN,B2
-教学大纲,syllabus,教学大纲,NOUN,B2
-教学的,didactic,教学的,ADJ,B2
-教学的,teaching,教学的,ADJ,B2
-教条主义,dogmatism,教条主义,NOUN,B2
-教条的,dogmatic,教条的,ADJ,B2
-教科书,textbook,教科书,NOUN,B2
-教育,to educate,教育,VERB,B2
-教育学,pedagogy,教育学,NOUN,B2
-教育学的,pedagogical,教学的,ADJ,B2
-教育的,educational,教育的,ADJ,B2
-散发,emanation,散发物,NOUN,B2
-散发,to emanate,散发,VERB,B2
-散发,to exude,散发,VERB,B2
-散热器,radiator,暖气片,NOUN,B2
-敬意,deference,敬意,NOUN,B2
-数万,tens of thousands,数万,NUM,B2
-数十个,dozens,数十个,NOUN,B2
-数千,thousands,数千,NOUN,B2
-数字,digit,数字,NOUN,B2
-数字化,digitization,数字化,NOUN,B2
-数字化,to digitize,数字化,VERB,B2
-数学,math,数学,NOUN,B2
-数学的,mathematical,数学的,ADJ,B2
-数据处理,data processing,数据处理,NOUN,B2
-数据库,databas,数据库,NOUN,B2
-数百万的,millions of,数百万的,NUM,B2
-敲击,knock,敲击,NOUN,B2
-整个的,entire,整个的,ADJ,B2
-整体的,holistic,整体的,ADJ,B2
-整体论,holism,整体论,NOUN,B2
-整洁的,dapper,整洁的,ADJ,B2
-整洁的,neat,整洁的,ADJ,B2
-整洁的,well-groomed,整洁的,ADJ,B2
-整理,to tidy,整理,VERB,B2
-整理,to tidy up,整理,VERB,B2
-文件夹,folder,文件夹,NOUN,B2
-文凭,diploma,文凭,NOUN,B2
-文化交汇,cultural encounter,文化交汇,NOUN,B2
-文化涵化,acculturation,文化涵化,NOUN,B2
-文化的,cultural,文化的,ADJ,B2
-文化遗产,cultural heritage,文化遗产,NOUN,B2
-文学的,literary,文学的,ADJ,B2
-文明,civilisation,文明,NOUN,B2
-文明的,civilized,文明的,ADJ,B2
-文本,text,文本,NOUN,B2
-文本的,textual,文本的,ADJ,B2
-文献,documentation,文献,NOUN,B2
-文艺复兴,renaissance,复兴,NOUN,B2
-斗殴,brawl,斗殴,NOUN,B2
-斗牛犬,bulldog,斗牛犬,NOUN,B2
-斜的,oblique,斜的,ADJ,B2
-斥责,to rebuke,斥责,VERB,B2
-斧头,axe,斧头,NOUN,B2
-斩首,to behead,斩首,VERB,B2
-断头台,guillotine,断头台,NOUN,B2
-断奶,weaning,断奶,NOUN,B2
-断言,assertion,断言,NOUN,B2
-斯多葛主义,stoicism,斯多葛主义,NOUN,B2
-斯德哥尔摩,stockholm,斯德哥尔摩,PROPN,B2
-新奇事物,novelty,新奇事物,NOUN,B2
-新娘,bride,新娘,NOUN,B2
-新建建筑,new construction,新建建筑,NOUN,B2
-新手；初学者,neophyte,新手；初学者,NOUN,B2
-新月,new moon,新月,NOUN,B2
-新来者,newcomer,新来者,NOUN,B2
-新生儿的,neonatal,新生儿的,ADJ,B2
-新郎,groom,新郎,NOUN,B2
-新闻业,journalism,新闻业,NOUN,B2
-新闻报道,news reporting,新闻报道,NOUN,B2
-新闻界,press,新闻界,NOUN,B2
-新闻自由,press freedom,新闻自由,NOUN,B2
-新鲜,freshness,新鲜,NOUN,B2
-新鲜地,freshly,新鲜地,ADV,B2
-方向,orientation,取向,NOUN,B2
-方法论,methodology,方法论,NOUN,B2
-方法论的,methodological,方法论的,ADJ,B2
-方言,dialect,方言,NOUN,B2
-施肥,to fertilize,施肥,VERB,B2
-施虐的,sadistic,施虐的,ADJ,B2
-施魔法,to enchant,使着迷,VERB,B2
-旁边,next to,在...旁边,ADP,B2
-旅游,tourism,旅游业,NOUN,B2
-旅游的,tourist,旅游的,ADJ,B2
-旅游的,touristic,旅游的,ADJ,B2
-旅行,tour,旅行,NOUN,B2
-旅行,travel,出行,NOUN,B2
-旅行,trip,旅行,NOUN,B2
-旅行,to travel,旅行,VERB,B2
-旅行者,traveler,旅行家,NOUN,B2
-旅馆老板,hotelier,旅馆老板,NOUN,B2
-旋律,melody,旋律,NOUN,B2
-旋转,to spin,旋转,VERB,B2
-旋风,whirlwind,旋风；漩涡,NOUN,B2
-旗帜,flag,旗帜,NOUN,B2
-无,without,没有,ADP,B2
-无习惯,habitlessness,无习惯,NOUN,B2
-无产阶级,proletariat,无产阶级,NOUN,B2
-无人机,drone,无人机,NOUN,B2
-无价值的,worthless,无价值的,ADJ,B2
-无例外的,without exception,无例外的,ADV,B2
-无偿还能力的,insolvent,无偿还能力的,ADJ,B2
-无关,irrelevance,无关,NOUN,B2
-无力,impotence,无力,NOUN,B2
-无可指责的,irreproachable,无可指责的,ADJ,B2
-无味的,tasteless,无味的,ADJ,B2
-无处,nowhere,无处,ADV,B2
-无定形的,amorphous,无定形的,ADJ,B2
-无害的,innocuous,无害的,ADJ,B2
-无家可归的,homeless,无家可归的,ADJ,B2
-无形的,intangible,无形的,ADJ,B2
-无忧无虑的,carefree,无忧无虑的,ADJ,B2
-无性,asexual,无性的,ADJ,B2
-无情的,relentless,无情的,ADJ,B2
-无情的,ruthless,无情的,ADJ,B2
-无意义的,senseless,无意义的,ADJ,B2
-无意识,unconscious,无意识的,ADJ,B2
-无所不在的,omnipresent,无所不在的,ADJ,B2
-无摩擦的,frictionless,无摩擦的,ADJ,B2
-无政府主义者,anarchist,无政府主义者,NOUN,B2
-无政府状态,anarchy,无政府状态,NOUN,B2
-无效,nullity,无效；无能,NOUN,B2
-无效的,null and void,无效的,ADJ,B2
-无敌的,invincible,无敌的,ADJ,B2
-无望的,bleak,无望的,ADJ,B2
-无条件的,unconditional,无条件的,ADJ,B2
-无法抗拒的,irresistible,不可抗拒的,ADJ,B2
-无瑕疵的,impeccable,无瑕疵的,ADJ,B2
-无生命的,lifeless,无生命的,ADJ,B2
-无用的,useless,无用的,ADJ,B2
-无畏的,intrepid,无畏的,ADJ,B2
-无疑地,undoubtedly,无疑地,ADV,B2
-无礼的,disrespectful,无礼的,ADJ,B2
-无神论,atheism,无神论,NOUN,B2
-无神论的,atheistic,无神论的,ADJ,B2
-无神论者,atheist,无神论者,NOUN,B2
-无私的,disinterested,公正的,ADJ,B2
-无系统的,systemless,无系统的,ADJ,B2
-无线,wireless,无线的,ADJ,B2
-无经验的,inexperienced,生疏的,ADJ,B2
-无缝的,seamless,无缝的,ADJ,B2
-无罪释放,acquittal,无罪释放,NOUN,B2
-无耻,shamelessness,无耻,NOUN,B2
-无耻的,shameless,无耻的,ADJ,B2
-无能的,incompetent,无能的,ADJ,B2
-无菌的,sterile,无菌的,ADJ,B2
-无辜地,innocent,无辜地,ADV,B2
-无限的,endless,无尽的,ADJ,B2
-无限的,infinite,无限的,ADJ,B2
-无限的,unlimited,无限的,ADJ,B2
-无风的,windless,无风的,ADJ,B2
-无齿的,toothless,无齿的,ADJ,B2
-日光,daylight,日光,NOUN,B2
-日工,day laborer,日工,NOUN,B2
-日常生活,everyday life,日常生活,NOUN,B2
-日期,datum,日期,NOUN,B2
-日本人,japanese,日本人,NOUN,B2
-日本的,japanese,日本的,ADJ,B2
-日食,eclipse,日食,NOUN,B2
-早上好,good morning,早上好,INTJ,B2
-早熟的,precocious,早熟的,ADJ,B2
-早的,early,早的,ADJ,B2
-早餐,breakfast,早餐,NOUN,B2
-时代,epoch,时代,NOUN,B2
-时代错误,anachronism,时代错误,NOUN,B2
-时代错误的,anachronistic,时代错误的,ADJ,B2
-时刻表,timetable,时刻表,NOUN,B2
-时间性,temporality,时间性,NOUN,B2
-时间的,temporal,时间的,ADJ,B2
-时间线,timeline,时间线,NOUN,B2
-时间问题,matter of time,时间问题,NOUN,B2
-时髦的,snazzy,时髦的,ADJ,B2
-时髦的,stylish,雅致的,ADJ,B2
-昂贵的,costly,昂贵的,ADJ,B2
-明喻,simile,明喻,NOUN,B2
-明天,tomorrow,明天,ADV,B2
-明显地,manifestly,明显地,ADV,B2
-明显地,perceptibly,明显地,ADV,B2
-明显的,evident,明显的,ADJ,B2
-明智,wise,明智的,ADJ,B2
-明智地,wisely,明智地,ADV,B2
-明智的,sensible,明智的,ADJ,B2
-明确,explicit,明确的,ADJ,B2
-明确地,explicitly,明确地,ADV,B2
-明确地,expressly,明确地,ADV,B2
-明确的,definite,明确的,ADJ,B2
-明确的,express,明确的,ADJ,B2
-明确的,unambiguous,明确的,ADJ,B2
-昏睡的,lethargic,昏睡的,ADJ,B2
-昏迷,coma,昏迷,NOUN,B2
-昏迷,stupor,昏迷,NOUN,B2
-易受伤害的,vulnerable,易受伤害的,ADJ,B2
-易变,volatile,易变的,ADJ,B2
-易怒,irascibility,易怒,NOUN,B2
-易怒的,bilious,易怒的,ADJ,B2
-易怒的,choleric,易怒的,ADJ,B2
-易怒的,irascible,易怒的,ADJ,B2
-易怒的,touchy,易怒的,ADJ,B2
-易损的,damageable,易损的,ADJ,B2
-易接近的,accessible,易接近的,ADJ,B2
-易燃的,flammable,易燃的,ADJ,B2
-易燃的,inflammable,易燃的,ADJ,B2
-易碎的,brittle,易碎的,ADJ,B2
-易错性,fallibility,易错性,NOUN,B2
-星云,nebula,星云,NOUN,B2
-星期三,wednesday,星期三,NOUN,B2
-星期二,tuesday,星期二,NOUN,B2
-星期四,thursday,星期四,NOUN,B2
-星系,galaxy,星系,NOUN,B2
-春,vernal,春季的,ADJ,B2
-昨天,yesterday,昨天,ADV,B2
-昨晚,last night,昨晚,ADV,B2
-是,be,是,AUX,B2
-是,yes,是的,INTJ,B2
-是,to was,是,VERB,B2
-是否,whether,是否,SCONJ,B2
-是是是,yeah yeah,是是是,INTJ,B2
-是的,yes,是的,PART,B2
-昵称,nickname,绰号,NOUN,B2
-显微镜,microscope,显微镜,NOUN,B2
-显著地,notably,显著地,ADV,B2
-显著地,remarkably,显著地,ADV,B2
-显著的,pronounced,显著的,ADJ,B2
-晋升,advancement,晋升,NOUN,B2
-晒黑,to tan,晒黑,VERB,B2
-晚安,good night,晚安,INTJ,B2
-晚间闲谈,evening chat,晚间闲谈,NOUN,B2
-普遍性,generality,普遍性,NOUN,B2
-普遍的,universal,普遍的,ADJ,B2
-晴朗的,sunny,晴朗的,ADJ,B2
-智力,intellect,智力,NOUN,B2
-暂停,moratorium,暂停,NOUN,B2
-暂停,suspension,暂停,NOUN,B2
-暂时,for now,暂时,ADV,B2
-暂缓执行,reprieve,暂缓执行,NOUN,B2
-暑期游客,summer visitor,暑期游客,NOUN,B2
-暗指,to allude,暗指,VERB,B2
-暗示,hint,暗示,NOUN,B2
-暗示,to connote,暗示,VERB,B2
-暗示,to imply,暗示,VERB,B2
-暗示,to insinuate,暗示,VERB,B2
-暗示的,allusive,暗指的,ADJ,B2
-暴力,violence,暴力,NOUN,B2
-暴力地,violently,暴力地,ADV,B2
-暴发户,upstart,暴发户,NOUN,B2
-暴君,despot,暴君,NOUN,B2
-暴君,tyrant,暴君,NOUN,B2
-暴政,tyranny,暴政,NOUN,B2
-暴行,atrocity,暴行,NOUN,B2
-暴露,to bare,暴露,VERB,B2
-暴风雨的,stormy,有暴风雨的,ADJ,B2
-暴食,gluttony,暴食,NOUN,B2
-曲线,curve,曲线,NOUN,B2
-更便宜的,cheaper,更便宜的,ADJ,B2
-更冷的,colder,更冷的,ADJ,B2
-更厚的,thicker,更厚的,ADJ,B2
-更可取的,preferable,更可取的,ADJ,B2
-更喜欢,to prefer,更喜欢,VERB,B2
-更多,more pl,更多,ADJ,B2
-更大的,bigger,更大的,ADJ,B2
-更快的,faster,更快的,ADJ,B2
-更慢,slower,更慢,ADJ,B2
-更新,renewal,更新,NOUN,B2
-更新,to renew,更新,VERB,B2
-更早,earlier,刚才,ADV,B2
-更早的,earlier,更早的,ADJ,B2
-更有趣的,more fun,更有趣的,ADJ,B2
-更穷的,poorer,更穷的,ADJ,B2
-更经常,more often,更频繁,ADV,B2
-更美的,more beautiful,更美的,ADJ,B2
-更近的,closer,更近的,ADJ,B2
-更远处,further on,更远处,ADV,B2
-更重要的,more important,更重要的,ADJ,B2
-更长的,longer,更长的,ADJ,B2
-更高,higher,更高的,ADJ,B2
-替代,alternative,替代方案,NOUN,B2
-替代的,alternative,替代的,ADJ,B2
-最低点,nadir,最低点,NOUN,B2
-最低的,lowest,最低的,ADJ,B2
-最佳的,optimal,最佳的,ADJ,B2
-最后,last,最后的,ADJ,B2
-最喜欢的,favorite,最喜欢的,ADJ,B2
-最坏的,worst,最坏的,ADJ,B2
-最坏的事,worst thing,最坏的事,NOUN,B2
-最大的,biggest,最大,ADJ,B2
-最大的,maximal,最大的,ADJ,B2
-最大的,maximum,最大,ADJ,B2
-最好,preferably,更愿意,ADV,B2
-最好的,best,最好的,ADJ,B2
-最好的朋友,best friend,最好的朋友,NOUN,B2
-最小化,to minimize,最小化,VERB,B2
-最小的,smallest,最小的,ADJ,B2
-最少,least,最少,ADV,B2
-最新的,latest,最新的,ADJ,B2
-最爱,favorite,最爱,NOUN,B2
-最终,ultimately,最终,ADV,B2
-最终比分,final score,最终比分,NOUN,B2
-最终的,ultimate,最终的,ADJ,B2
-最近的,nearest,最近的,ADJ,B2
-最远,furthest,最远,ADV,B2
-最迟/最近,latest,最迟/最近,ADV,B2
-最里面的,innermost,最里面的,ADV,B2
-最重要的事,most important thing,最重要的事,NOUN,B2
-最高的,highest,最高的,ADJ,B2
-最高的,supreme,最高的,ADJ,B2
-有,have,有,AUX,B2
-有争议的,contentious,有争议的,ADJ,B2
-有争议的,contested,有争议的,ADJ,B2
-有争议的,controversial,有争议的,ADJ,B2
-有争议的,disputed,有争议的,ADJ,B2
-有伤风化的,risque,有伤风化的,ADJ,B2
-有倾向性的,tendentious,有偏见的,ADJ,B2
-有利可图的,lucrative,有利可图的,ADJ,B2
-有前途的,promising,有前途的,ADJ,B2
-有力气,to have strength,有力气,VERB,B2
-有压力的,stressed,焦虑的,ADJ,B2
-有压力的,stressful,有压力的,ADJ,B2
-有同情心的,compassionate,有同情心的,ADJ,B2
-有吸引力,attractive,有吸引力的,ADJ,B2
-有声望的,prestigious,有声望的,ADJ,B2
-有天赋的,endowed,有天赋的,ADJ,B2
-有天赋的,gifted,有天赋的,ADJ,B2
-有害的,damaging,有害的,ADJ,B2
-有害的,detrimental,有害的,ADJ,B2
-有害的,harmful,有害的,ADJ,B2
-有害的,pernicious,有害的,ADJ,B2
-有序性,orderliness,有序性,NOUN,B2
-有形的,tangible,有形的,ADJ,B2
-有德行的,virtuous,有德行的,ADJ,B2
-有意义的,meaningful,有意义的,ADJ,B2
-有才华的,talented,有才华的,ADJ,B2
-有效地,effectively,有效地,ADV,B2
-有效性,validity,有效期,NOUN,B2
-有效的,effective,有效的,ADJ,B2
-有效的,valid,有效的,ADJ,B2
-有教育意义的,instructive,有教育意义的,ADJ,B2
-有机地,organically,有机地,ADV,B2
-有机的,organic,有机的,ADJ,B2
-有毒的,toxic,有毒的,ADJ,B2
-有浮力的,buoyant,有浮力的,ADJ,B2
-有用,helpful,有帮助的,ADJ,B2
-有用的,useful,有用的,ADJ,B2
-有疗效的,curative,有疗效的,ADJ,B2
-有症状的,symptomatic,症状的,ADJ,B2
-有礼貌的,courteous,有礼貌的,ADJ,B2
-有礼貌的,mannerly,有礼貌的,ADJ,B2
-有组织的,organized,有组织的,ADJ,B2
-有经验,experienced,老练的,ADJ,B2
-有缺陷的,defective,有缺陷的,ADJ,B2
-有罪的/欠钱的,guilty owes,有罪的/欠钱的,ADJ,B2
-有能力的,competent,胜任的,ADJ,B2
-有色性,coloredness,有色性,NOUN,B2
-有色的,colored,有色的,ADJ,B2
-有节制的,abstemious,有节制的,ADJ,B2
-有角的,angular,有角的,ADJ,B2
-有责任的,liable,有责任的,ADJ,B2
-有趣的,amusing,有趣的,ADJ,B2
-有趣的,entertaining,有趣的,ADJ,B2
-有轨电车,tram,有轨电车,NOUN,B2
-有针对性的,targeted,有针对性的,ADJ,B2
-有限的,finite,有限的,ADJ,B2
-有限的,limited,有限的,ADJ,B2
-有雄心的,ambitious,有雄心的,ADJ,B2
-有风的,windy,有风的,ADJ,B2
-有魅力的,charismatic,有魅力的,ADJ,B2
-服从权威,loyalty to authority,服从权威,NOUN,B2
-服装,garment,服装,NOUN,B2
-服装,outfit,服装,NOUN,B2
-望远镜,telescope,望远镜,NOUN,B2
-朝圣,pilgrimage,朝圣,NOUN,B2
-朝圣者,pilgrim,朝圣者,NOUN,B2
-期待,anticipation,预期,NOUN,B2
-期望的目标,desired aim,期望的目标,NOUN,B2
-木偶,puppet,木偶,NOUN,B2
-木制的,wooden,木制的,ADJ,B2
-木炭,charcoal,木炭,NOUN,B2
-未受伤害的,unscathed,未受伤害的,ADJ,B2
-未受伤的,unharmed,未受伤的,ADJ,B2
-未婚夫,fiance,未婚夫,NOUN,B2
-未婚妻,fiancee,未婚妻,NOUN,B2
-未成年人,minor,未成年人,NOUN,B2
-未来主义,futurism,未来主义,NOUN,B2
-未来的,future,未来的,ADJ,B2
-未知数,unknown,未知数,NOUN,B2
-未知的,unknown,未知的,ADJ,B2
-未确定的,indeterminate unspecified,未确定的,ADJ,B2
-末日集合,final gathering,末日集合,NOUN,B2
-本体,noumenon,本体,NOUN,B2
-本土的,indigenous,本土的,ADJ,B2
-本地化,to localize,本地化,VERB,B2
-本地的,native,本地的,ADJ,B2
-本堂神父,parish priest,本堂神父,NOUN,B2
-本质,quiddity,本质,NOUN,B2
-术语,term,学期,NOUN,B2
-术语,terminology,术语,NOUN,B2
-术语的,terminological,术语的,ADJ,B2
-机会,chance,机会,NOUN,B2
-机器人,robot,机器人,NOUN,B2
-机敏,alertness,机敏,NOUN,B2
-机智,witty,机智的,ADJ,B2
-机智,quick wit,机智,NOUN,B2
-机械的,mechanical,机械的,ADJ,B2
-机灵的,resourceful,机灵的,ADJ,B2
-机身,fuselage,机身,NOUN,B2
-杀兄弟,fratricide,杀兄弟,NOUN,B2
-杂技演员,acrobat,杂技演员,NOUN,B2
-杂草,weed,杂草,NOUN,B2
-权利,entitlement,权利,NOUN,B2
-权利,rights,权利,NOUN,B2
-权威的,authoritative,权威的,ADJ,B2
-村庄,village,村庄,NOUN,B2
-杜撰的,apocryphal,杜撰的,ADJ,B2
-条例,ordinance,条例,NOUN,B2
-条纹,stripe,条纹,NOUN,B2
-杰作,masterpiece,杰作,NOUN,B2
-杰出的,eminent,杰出的,ADJ,B2
-松口气,to breathe again,松口气,VERB,B2
-松开,to loosen,放松,VERB,B2
-松弛,laxity,松弛,NOUN,B2
-松懈的,lax,松懈的,ADJ,B2
-松散的,loose,松的,ADJ,B2
-松树,pine,松树,NOUN,B2
-松脱,to come loose,松脱,VERB,B2
-松鼠,squirrel,松鼠,NOUN,B2
-板条箱,crate,板条箱,NOUN,B2
-板球,cricket,板球,NOUN,B2
-极乐,bliss,极乐,NOUN,B2
-极冷的,freezing,极冷的,ADJ,B2
-极地的,polar,极地的,ADJ,B2
-极好的,fabulous,极好的,ADJ,B2
-极好的,marvelous,极好的,ADJ,B2
-极好的,superb,极好的,ADJ,B2
-极小的,minuscule,极小的,ADJ,B2
-极度恐惧,mortal fear,极度恐惧,NOUN,B2
-极度恐惧的,terrified,极度恐惧的,ADJ,B2
-极度渴望,burning eagerness,极度渴望,NOUN,B2
-极性,polarity,极性,NOUN,B2
-极权主义的,totalitarian,极权主义的,ADJ,B2
-极硬的,very hard,极硬的,ADJ,B2
-极端主义者,extremist,极端主义者,NOUN,B2
-极简主义,minimalism,极简主义,NOUN,B2
-构建,to build up,构建,VERB,B2
-构建,to structure,构建,VERB,B2
-构成的,constitutive,构成的,ADJ,B2
-果断,assertiveness,果断,NOUN,B2
-果汁,juice,果汁,NOUN,B2
-果酱,jam,果酱,NOUN,B2
-枢机主教,cardinal,枢机主教,NOUN,B2
-枪声,gunshot,枪声,NOUN,B2
-枪战,shootout,枪战,NOUN,B2
-枪支,firearms,枪支,NOUN,B2
-枯萎,to wilt,枯萎,VERB,B2
-架子,shelf,架子,NOUN,B2
-枷锁,yoke,枷锁,NOUN,B2
-柏林的,berlijns,柏林的,ADJ,B2
-某些,some,某些,ADJ,B2
-某人,someone,某人,PRON,B2
-某人的,someone's,某人的,PRON,B2
-某处,somewhere,某处,ADV,B2
-某时,sometime,在某个时候,ADV,B2
-某物,something,某事,PRON,B2
-柑橘,citrus,柑橘,NOUN,B2
-染色,to dye,染色,VERB,B2
-柱子,pillar,柱子,NOUN,B2
-柳叶刀 / 刺血针,lancet,柳叶刀 / 刺血针,NOUN,B2
-柴火,firewood,木柴,NOUN,B2
-标准,criterion,标准,NOUN,B2
-标准化,standardization,标准化,NOUN,B2
-标准化,to standardize,标准化,VERB,B2
-标准阿拉伯语,standard arabic,标准阿拉伯语,NOUN,B2
-标本,specimen,标本,NOUN,B2
-标记,to mark,标记,VERB,B2
-标记 / 参考点,landmark reference point,标记 / 参考点,NOUN,B2
-标题,heading,标题,NOUN,B2
-标题,headline,标题,NOUN,B2
-栏杆,balustrade,栏杆,NOUN,B2
-栏杆,railing,栏杆,NOUN,B2
-树干,trunk,树干,NOUN,B2
-树木茂盛的,wooded,树木茂盛的,ADJ,B2
-树篱,hedge,树篱,NOUN,B2
-栓塞,embolism,栓塞,NOUN,B2
-校准,calibration,校准,NOUN,B2
-校准,to calibrate,校准,VERB,B2
-校对,proofreading,校对,NOUN,B2
-样品,sample,样本,NOUN,B2
-样品 / 排练,sample rehearsal,样品 / 排练,NOUN,B2
-核对,to collate,核对,VERB,B2
-核战争,nuclear war,核战争,NOUN,B2
-核武器,nuclear weapon,核武器,NOUN,B2
-核的,nuclear,核的,ADJ,B2
-根本,at all,根本,ADV,B2
-根本/绝对,at all absolutely,根本/绝对,ADV,B2
-根除,to extirpate,根除,VERB,B2
-根除,to uproot,根除,VERB,B2
-格式,format,格式,NOUN,B2
-格栅,grille,格栅,NOUN,B2
-框架,frame,框架,NOUN,B2
-档案,dossier,档案,NOUN,B2
-桤木,alder,桤木,NOUN,B2
-桨,oar,桨,NOUN,B2
-桶,barrel,桶,NOUN,B2
-梳理,mapping,梳理,NOUN,B2
-检察院,prosecution service,检察院,NOUN,B2
-检测,detection,检测,NOUN,B2
-检索,retrieval,检索,NOUN,B2
-检索,to retrieve,取回,VERB,B2
-棍棒,cudgel,棍棒,NOUN,B2
-棕榈树,palm tree,棕榈树,NOUN,B2
-棕色的,brown,棕色,ADJ,B2
-棘手的,intractable,难处理的,ADJ,B2
-棚屋,shack,棚屋,NOUN,B2
-棚屋,shed,棚屋,NOUN,B2
-棱镜,prism,棱镜,NOUN,B2
-植入,to implant,植入,VERB,B2
-植物群,flora,植物群,NOUN,B2
-椰枣,date fruit,椰枣,NOUN,B2
-楼上,upper floor,楼上,NOUN,B2
-概念,conception,概念,NOUN,B2
-概念的,conceptual,概念的,ADJ,B2
-概括,generalization,概括,NOUN,B2
-概括,to generalize,概括,VERB,B2
-概率,probability,概率,NOUN,B2
-概率的,probabilistic,概率的,ADJ,B2
-概要的,schematic,概要的,ADJ,B2
-概要的,synoptic,概要的,ADJ,B2
-概览,overview,概览,NOUN,B2
-榜样,role model,榜样,NOUN,B2
-榨油机,oil press,榨油机,NOUN,B2
-模仿,imitation,模仿,NOUN,B2
-模具,mold,鞋楦,NOUN,B2
-模块化的,modular,模块化的,ADJ,B2
-模式,mode,方式,NOUN,B2
-模拟,simulation,模拟,NOUN,B2
-模拟,to simulate,模拟,VERB,B2
-模拟的,analog,模拟的,ADJ,B2
-模棱两可的,ambiguous,模棱两可的,ADJ,B2
-模糊,vagueness,模糊,NOUN,B2
-模糊的,diffuse,模糊的,ADJ,B2
-模范国家,exemplary country,模范国家,NOUN,B2
-横梁,beam,光束,NOUN,B2
-横渡,crossing,交叉口,NOUN,B2
-横膈膜,diaphragm,横膈膜,NOUN,B2
-橙汁,orange juice,橙汁,NOUN,B2
-橙色的,orange,橙色的,ADJ,B2
-橡胶,rubber,橡胶,NOUN,B2
-橱柜,cupboard,橱柜,NOUN,B2
-檐口,cornice,檐口,NOUN,B2
-檐壁,frieze,檐壁,NOUN,B2
-欠下的,owed,欠下的,ADJ,B2
-次,time occasion,次,NOUN,B2
-欢呼,cheering,欢呼,NOUN,B2
-欢呼,cheers,欢呼,NOUN,B2
-欢呼,to cheer,欢呼,VERB,B2
-欢呼声,ululations,欢呼声,NOUN,B2
-欢喜,gladness,欢喜,NOUN,B2
-欢欣,jubilation,欢欣,NOUN,B2
-欢迎,welcome,受欢迎的,ADJ,B2
-欣快感,euphoria,欣快感,NOUN,B2
-欧洲的,european,欧洲的,ADJ,B2
-欲望,lust,欲望,NOUN,B2
-欺凌,to bully,欺凌,VERB,B2
-欺诈,to defraud,诈骗,VERB,B2
-欺骗,deceit,欺骗,NOUN,B2
-欺骗,to dupe,欺骗,VERB,B2
-欺骗,to trick,欺骗,VERB,B2
-欺骗性的,deceptive,欺骗性的,ADJ,B2
-止痛药,painkiller,止痛药,NOUN,B2
-正义,justice,正义,NOUN,B2
-正式地,formally,正式地,ADV,B2
-正式地,officially,正式地,ADV,B2
-正方形,square,广场,NOUN,B2
-正是,the very,正是,ADV,B2
-正是,yes indeed,正是,INTJ,B2
-正直,probity,正直,NOUN,B2
-正确,to be correct,正确,VERB,B2
-正确性,correctness,正确性,NOUN,B2
-正确的,right,正确的,ADJ,B2
-正统的,orthodox,正统的,ADJ,B2
-正题的,thetic,正题的,ADJ,B2
-此后,thereafter,此后,ADV,B2
-此时,by now,此时,ADV,B2
-步伐,pace,速度,NOUN,B2
-步兵,infantry,步兵,NOUN,B2
-步枪,rifle,步枪,NOUN,B2
-武装,to arm,武装,VERB,B2
-歧义,ambiguity,歧义,NOUN,B2
-歧视,discrimination,歧视,NOUN,B2
-歧视,to discriminate,歧视,VERB,B2
-歪曲的,distorted,歪曲的,ADJ,B2
-歹徒,outlaw,歹徒,NOUN,B2
-死,dead,死的,ADJ,B2
-死亡率,mortality,死亡率,NOUN,B2
-死后的,posthumous,死后的,ADJ,B2
-歼灭,to annihilate,消灭,VERB,B2
-残奥会的,paralympic,残奥会的,ADJ,B2
-残忍的,cruel,残忍的,ADJ,B2
-残暴,brutality,残暴,NOUN,B2
-残留物 / 废弃物,residues waste,残留物 / 废弃物,NOUN,B2
-残留的,residual,残留的,ADJ,B2
-残疾的,disabled,残疾的,ADJ,B2
-残缺的,lacunary,残缺的,ADJ,B2
-残骸,wreck,残骸,NOUN,B2
-殖民主义,colonialism,殖民主义,NOUN,B2
-殖民化,colonization,殖民化,NOUN,B2
-殖民地,colony,殖民地,NOUN,B2
-毁坏,devastation,破坏,NOUN,B2
-毁坏,to devastate,摧毁,VERB,B2
-毁坏财物,destruction of property,毁坏财物,NOUN,B2
-毁容,to disfigure,毁容,VERB,B2
-毁灭,downfall,毁灭,NOUN,B2
-毁灭,ruin,废墟,NOUN,B2
-毁灭,to perish,死亡,VERB,B2
-毁灭,to ruin,毁灭,VERB,B2
-毁灭性的,devastating,毁灭性的,ADJ,B2
-毅力,perseverance,毅力,NOUN,B2
-毅力,strong will,毅力,NOUN,B2
-母狗,bitch,母狗,NOUN,B2
-母猪,sow,母猪,NOUN,B2
-母鸡,hen,母鸡,NOUN,B2
-每,per,每,ADP,B2
-每个,every,每个,PRON,B2
-每周的,weekly,每周的,ADJ,B2
-每月的,monthly,每月的,ADJ,B2
-每隔一个,every other,每隔一个,DET,B2
-毒品,drugs,毒品,NOUN,B2
-毒气,poison gas,毒气,NOUN,B2
-毒贩,drug dealer,毒贩,NOUN,B2
-比,than,比,ADP,B2
-比利时人,belgian,比利时人,NOUN,B2
-比利时的,belgian,比利时的,ADJ,B2
-比喻的,figurative,比喻的,ADJ,B2
-比率,rate,比率,NOUN,B2
-比率,ratio,比率,NOUN,B2
-比赛,race,比赛,NOUN,B2
-比较的,comparative,比较的,ADJ,B2
-毕业,graduation,毕业,NOUN,B2
-毕生事业,life's work,毕生事业,NOUN,B2
-毛毛虫,caterpillar,毛毛虫,NOUN,B2
-毛皮,fur,毛皮,NOUN,B2
-毛衣,sweater,毛衣,NOUN,B2
-毫不留情地,implacably,毫不留情地,ADV,B2
-毫无,no,毫无,DET,B2
-毫无,none,没有一个,DET,B2
-毫无意义的,meaningless,毫无意义的,ADJ,B2
-毫无良知,unscrupulousness,毫无良知,NOUN,B2
-毯子,blanket,毯子,NOUN,B2
-民主主义者,democrat,民主主义者,NOUN,B2
-民主化,democratization,民主化,NOUN,B2
-民主化,to democratize,民主化,VERB,B2
-民主的,democratic,民主的,ADJ,B2
-民俗,folklore,民俗,NOUN,B2
-民族,ethnicity,种族,NOUN,B2
-民族主义,nationalism,民族主义,NOUN,B2
-民族主义者,nationalist,民族主义者,NOUN,B2
-民族学,ethnology,民族学,NOUN,B2
-民族志,ethnography,人种学,NOUN,B2
-民族的,ethnic,种族的,ADJ,B2
-民粹主义,populism,民粹主义,NOUN,B2
-民粹主义者,populist,民粹主义者,NOUN,B2
-气体,gas,气体,NOUN,B2
-气候否认,climate denial,气候否认,NOUN,B2
-气态的,gaseous,气态的,ADJ,B2
-气泡,bubble,气泡,NOUN,B2
-气球,balloon,气球,NOUN,B2
-气象的,meteorological,气象的,ADJ,B2
-氧化物,oxide,氧化物,NOUN,B2
-氧气,oxygen,氧气,NOUN,B2
-水力发电的,hydroelectric,水力发电的,ADJ,B2
-水坑,puddle,水坑,NOUN,B2
-水壶,kettle,水壶,NOUN,B2
-水手,sailor,水手,NOUN,B2
-水晶般的,crystalline,水晶般的,ADJ,B2
-水杯,drinking glass,水杯,NOUN,B2
-水桶,bucket,桶,NOUN,B2
-水槽,sink,水槽,NOUN,B2
-水龙头,tap,水龙头,NOUN,B2
-永久的,permanent,永久的,ADJ,B2
-永久的,perpetual,永久的,ADJ,B2
-永恒的,eternal,永恒的,ADJ,B2
-永远,ever,曾经,ADV,B2
-汇编,compilation,汇编,NOUN,B2
-汇聚,convergence,汇聚,NOUN,B2
-汉堡包,hamburger,汉堡包,NOUN,B2
-江湖骗子,charlatan,江湖骗子,NOUN,B2
-污名化,to stigmatize,污名化,VERB,B2
-污垢,grime,污垢,NOUN,B2
-污染,to contaminate,污染,VERB,B2
-污染的,contaminating,污染的,ADJ,B2
-汽油,petrol,汽油,NOUN,B2
-汽车,car,汽车,NOUN,B2
-汽车旅馆,motel,汽车旅馆,NOUN,B2
-沉思,contemplation,沉思,NOUN,B2
-沉思,to brood,沉思,VERB,B2
-沉思,to contemplate,沉思,VERB,B2
-沉思,to meditate,沉思,VERB,B2
-沉思的,contemplative,沉思的,ADJ,B2
-沉思的,pensive,沉思的,ADJ,B2
-沉积的,sedimentary,沉积的,ADJ,B2
-沉重地,heavily,沉重地,ADV,B2
-沉默,to be silent,沉默,VERB,B2
-沉默,to fall silent,沉默,VERB,B2
-沉默寡言的,reticent,沉默寡言的,ADJ,B2
-沉默寡言的,taciturn,沉默寡言的,ADJ,B2
-沙丘,dune,沙丘,NOUN,B2
-沙拉,salad,沙拉,NOUN,B2
-沙拉/生菜,salad lettuce,沙拉/生菜,NOUN,B2
-沙文主义的,chauvinistic,沙文主义的,ADJ,B2
-沙龙,salon,沙龙,NOUN,B2
-沟渠,ditch,沟渠,NOUN,B2
-没有,no not any,没有,DET,B2
-没有一个,none,没有一个,PRON,B2
-没有东西,nothing,没有什么,PRON,B2
-没有人,nobody,没有人,PRON,B2
-沥青,asphalt,沥青,NOUN,B2
-沮丧,dejection,沮丧,NOUN,B2
-沮丧,frustration,挫折,NOUN,B2
-沮丧的,depressed,沮丧的,ADJ,B2
-沮丧的,dispirited,沮丧的,ADJ,B2
-沮丧的,frustrated,沮丧的,ADJ,B2
-河道,watercourse,河道,NOUN,B2
-油,oil,油,NOUN,B2
-油腻,greasy,油腻的,ADJ,B2
-治理,governance,治理,NOUN,B2
-治疗师,therapist,治疗师,NOUN,B2
-治疗的,therapeutic,治疗的,ADJ,B2
-沼泽,bog,沼泽,NOUN,B2
-沿海的,coastal,沿海的,ADJ,B2
-沿着,along,沿着,ADP,B2
-泄漏,leak,泄漏,NOUN,B2
-泄露,disclosure,泄露,NOUN,B2
-泄露,to divulge,泄露,VERB,B2
-泉,spring eye,泉,NOUN,B2
-法典化,codification,法典化,NOUN,B2
-法医的,forensic,法医的,ADJ,B2
-法团主义,corporatism,法团主义,NOUN,B2
-法国人,frenchman,法国人,NOUN,B2
-法学专家,jurisconsult,法学专家,NOUN,B2
-法学家,jurist,法学家,NOUN,B2
-法官,magistrate,法官,NOUN,B2
-法律/团队,law team,法律/团队,NOUN,B2
-法律职业,legal profession,律师业,NOUN,B2
-法理学,jurisprudence,法理学,NOUN,B2
-法老,pharaoh,法老,NOUN,B2
-法西斯主义,fascism,法西斯主义,NOUN,B2
-法警,bailiff,法警,NOUN,B2
-法语,french,法国的,ADJ,B2
-泡制,to infuse,泡制,VERB,B2
-泡沫,foam,泡沫,NOUN,B2
-泡沫,froth,泡沫,NOUN,B2
-泡沫的,foamy,多泡沫的,ADJ,B2
-波兰的,polish,波兰的,ADJ,B2
-波动的,fluctuating,波动的,ADJ,B2
-波浪,wave,波浪,NOUN,B2
-泥,mud,泥,NOUN,B2
-泥土,dirt,污垢,NOUN,B2
-泥炭,peat,泥炭,NOUN,B2
-泥状食物,mash,泥状食物,NOUN,B2
-注册,registration,注册,NOUN,B2
-注册,to enrol,注册,VERB,B2
-注册的,registered,注册的,ADJ,B2
-注射器,syringe,注射器,NOUN,B2
-注意,to note,记录,VERB,B2
-注意到,to notice,注意到,VERB,B2
-注视,to behold,注视,VERB,B2
-注释,to annotate,注释,VERB,B2
-注释,to gloss,注释,VERB,B2
-注释家,exegete,注释家,NOUN,B2
-注销,to deregister,注销,VERB,B2
-泵,pump,泵,NOUN,B2
-洋葱,onion,洋葱,NOUN,B2
-洗劫,to strip bare,洗劫,VERB,B2
-洗发水,shampoo,洗发水,NOUN,B2
-洗涤剂,detergent,洗涤剂,NOUN,B2
-洗澡,to bathe,洗澡,VERB,B2
-洗碗机,dishwasher,洗碗机,NOUN,B2
-洗脑者,brainwasher,洗脑者,NOUN,B2
-洗衣店,laundry,洗衣,NOUN,B2
-洗衣房,laundry room,洗衣房,NOUN,B2
-洗钱,money laundering,洗钱,NOUN,B2
-洗钱,to launder,洗钱,VERB,B2
-洞,hollow,洼地,NOUN,B2
-洞察,insightfulness,洞察,NOUN,B2
-洞察力,discernment,洞察力,NOUN,B2
-洞穴,grotto,洞穴,NOUN,B2
-津贴,stipend,津贴,NOUN,B2
-洪水,deluge,洪水,NOUN,B2
-活板门,trapdoor,活板门,NOUN,B2
-活着的,alive living,活着的,ADJ,B2
-派,pie,派,NOUN,B2
-派生物,derivative,衍生物,NOUN,B2
-派系主义,factionalism,派系主义,NOUN,B2
-派遣,to dispatch,派遣,VERB,B2
-流产,to abort,流产,VERB,B2
-流利,fluency,流利,NOUN,B2
-流动,flow,流动,NOUN,B2
-流动,to flow,流动,VERB,B2
-流动性,liquidity,流动性,NOUN,B2
-流动性,mobility,流动性,NOUN,B2
-流感,flu,流感,NOUN,B2
-流放,exile,流亡,NOUN,B2
-流放,to exile,流放,VERB,B2
-流氓,rascal,无赖,NOUN,B2
-流浪汉,bum,流浪汉,NOUN,B2
-流血的,bleeding,流血的,ADJ,B2
-流行,vogue,流行,NOUN,B2
-流行音乐,pop music,流行音乐,NOUN,B2
-流通,to circulate,循环,VERB,B2
-流逝,to elapse,流逝,VERB,B2
-流量,flow rate,流量,NOUN,B2
-浅棕色的,light brown,浅棕色的,ADJ,B2
-测量,to gauge,测量,VERB,B2
-测量员,surveyor,测量员,NOUN,B2
-浩劫,holocaust,浩劫,NOUN,B2
-浪漫,romance,浪漫,NOUN,B2
-浪费,squandering,挥霍,NOUN,B2
-浪费的,wasteful,浪费的,ADJ,B2
-浴缸,bathtub,浴缸,NOUN,B2
-海上的,maritime,海事的,ADJ,B2
-海关官员,customs officer,海关官员,NOUN,B2
-海军,navy,海军,NOUN,B2
-海军陆战队,marine corps,海军陆战队,NOUN,B2
-海军陆战队员,marine,海军陆战队员,NOUN,B2
-海报,poster,海报,NOUN,B2
-海拔,altitude,海拔,NOUN,B2
-海洋的,marine,海洋的,ADJ,B2
-海湾,bay,海湾,NOUN,B2
-海盗,buccaneer,海盗,NOUN,B2
-海盗,pirate,海盗,NOUN,B2
-海豚,dolphin,海豚,NOUN,B2
-海豹,seal,海豹,NOUN,B2
-海鸥,seagull,海鸥,NOUN,B2
-浸,to dip,蘸,VERB,B2
-浸泡,to soak,浸透,VERB,B2
-涂油,to grease,涂油,VERB,B2
-涂鸦,graffiti,涂鸦,NOUN,B2
-消亡,cessation passing,消亡,NOUN,B2
-消化,digestion,消化,NOUN,B2
-消化不良,indigestion,消化不良,NOUN,B2
-消化的,digestive,消化的,ADJ,B2
-消失,disappearance,消失,NOUN,B2
-消散,to dissipate,消散,VERB,B2
-消极,negativity,消极,NOUN,B2
-消毒剂,antiseptic,防腐剂,NOUN,B2
-消灭,to wipe out,消灭,VERB,B2
-消耗的,emaciating,消耗的,ADJ,B2
-消费,consumption,消费,NOUN,B2
-消防员,firefighter,消防员,NOUN,B2
-消防队,fire brigade,消防队,NOUN,B2
-消除,to dispel,消除,VERB,B2
-涌入,influx,涌入,NOUN,B2
-液体,fluid,液体,NOUN,B2
-液压的,hydraulic,液压的,ADJ,B2
-液态的,liquid,液态的,ADJ,B2
-淋巴的,lymphatic,淋巴的,ADJ,B2
-淋巴结,lymph node,淋巴结,NOUN,B2
-淋浴,to shower,淋浴,VERB,B2
-淡化,to play down,淡化,VERB,B2
-淫秽的,obscene,淫秽的,ADJ,B2
-深刻的,incisive,深刻的,ADJ,B2
 深奥,abstruse,深奥的,ADJ,B2
-深思熟虑,well-considered,深思熟虑的,ADJ,B2
-深恶痛绝之物,anathema,深恶痛绝之物,NOUN,B2
-深深地,deeply,深深地,ADV,B2
-深渊,abyss,深渊,NOUN,B2
-混乱,disorder,混乱,NOUN,B2
-混乱,tangle,混乱,NOUN,B2
-混合物,mixture,混合物,NOUN,B2
-混合的,mixed,混合的,ADJ,B2
-混淆,to confuse,混淆,VERB,B2
-混蛋,devil bastard,混蛋,NOUN,B2
-混蛋,motherfucker,混蛋,NOUN,B2
-混蛋,the devil bastard,混蛋,NOUN,B2
-淹没,to submerge,淹没,VERB,B2
-添燃料,to stoke,添燃料,VERB,B2
-清新/鲜艳,freshness bloom,清新/鲜艳,NOUN,B2
-清晰,clarity,清晰,NOUN,B2
-清晰表达,articulation,清晰表达,NOUN,B2
-清洁,cleaning,清洁,NOUN,B2
-清澈的,crystal clear,清澈的,ADJ,B2
-清点,inventorying,清点,NOUN,B2
-清理,to clean up,清理,VERB,B2
-清真寺,mosque,清真寺,NOUN,B2
-清算,liquidation,清算,NOUN,B2
-清醒,sober,清醒的,ADJ,B2
-清醒,sobriety,清醒,NOUN,B2
-清醒 / 明晰,lucidity,清醒 / 明晰,NOUN,B2
-清除,to purge,清除,VERB,B2
-清零,to zero out,清零,VERB,B2
-渎职,malfeasance,渎职,NOUN,B2
-渐变,gradation,渐变,NOUN,B2
-渗透,to infiltrate,渗透,VERB,B2
-渡轮,ferry,渡轮,NOUN,B2
-渡鸦,raven,乌鸦,NOUN,B2
-温和的,mild,温和的,ADJ,B2
-温暖,warmth,温暖,NOUN,B2
-温柔,tenderness,柔情,NOUN,B2
-温顺的,docile,温顺的,ADJ,B2
-温顺的,meek,温顺的,ADJ,B2
-港口,harbor,港口,NOUN,B2
-渴望,yearning,向往,NOUN,B2
-渴望,to desire,渴望,VERB,B2
-渴望,to long for,渴望,VERB,B2
-渴望,to yearn,渴望,VERB,B2
-渴望的,keen eager,渴望的,ADJ,B2
-渴求,craving,渴求,NOUN,B2
-游客,tourist,游客,NOUN,B2
-游戏/玩耍,play game,游戏/玩耍,NOUN,B2
-游戏规则,game rule,游戏规则,NOUN,B2
-游泳,swimming,游泳,NOUN,B2
-游牧,nomadism,游牧生活,NOUN,B2
-游牧者,nomad,游牧者,NOUN,B2
-游行,to parade,游行,VERB,B2
-湿,wet,湿的,ADJ,B2
-湿疹,eczema,湿疹,NOUN,B2
-溃疡,ulcer,溃疡,NOUN,B2
-溃败,rout,溃败,NOUN,B2
-溅,to splash,溅,VERB,B2
-溜,to sneak,潜行,VERB,B2
-溜走,to sneak away,溜走,VERB,B2
-溢价,premium,溢价,NOUN,B2
-溢出,overflow,溢出,NOUN,B2
-溢出,to overflow,溢出,VERB,B2
-溢出,to spill,溢出,VERB,B2
-溶剂,solvent,溶剂,NOUN,B2
-溶解,to dissolve,溶解,VERB,B2
-溺水,to drown,溺死,VERB,B2
-滋生,to infest,滋生,VERB,B2
-滑倒,to slip,滑倒,VERB,B2
-滑动,to slide,滑动,VERB,B2
-滑动的,sliding,滑动的,ADJ,B2
-滑梯,slide,滑动,NOUN,B2
-滑的,slippery,滑的,ADJ,B2
-滑稽,hilarious,滑稽的,ADJ,B2
-滑行,to glide,滑行,VERB,B2
-滑雪,to ski,滑雪,VERB,B2
-滚动,to roll,滚动,VERB,B2
-满意,satisfaction,满意,NOUN,B2
-满月,full moon,满月,NOUN,B2
-满的/醉的,full drunk,满的/醉的,ADJ,B2
-满足,fulfillment,满足,NOUN,B2
-满足的,fulfilled,满足的,ADJ,B2
-滥交的,promiscuous,滥交的,ADJ,B2
+荒谬,absurd,荒谬的,ADJ,B2
 滥用,abuse,滥用,NOUN,B2
 滥用,to abuse,滥用,VERB,B2
-滥用的,abusive,滥用的,ADJ,B2
-滴,to drip,滴,VERB,B2
-滴水嘴兽,gargoyle,滴水嘴兽,NOUN,B2
-滴答声,tick,滴答声,NOUN,B2
-漂流,drift,漂移,NOUN,B2
-漂浮的,floating,漂浮的,ADJ,B2
-漂白剂,bleach,漂白剂,NOUN,B2
-漏斗,funnel,漏斗,NOUN,B2
-漏洞,loophole,漏洞,NOUN,B2
-漏洞,vulnerability,漏洞,NOUN,B2
-演员,actor,男演员,NOUN,B2
-演员阵容,cast,演员阵容,NOUN,B2
-演示,presentation,展示,NOUN,B2
-演示的,demonstrative,演示的,ADJ,B2
-演讲,speech,演讲,NOUN,B2
-演讲术,elocution,演讲术,NOUN,B2
-漩涡,vortex,漩涡,NOUN,B2
-漫步,to wander,漫步,VERB,B2
-漫游,to roam,漫游,VERB,B2
-潜在地,potentially,潜在地,ADV,B2
-潜在的,latent,潜在的,ADJ,B2
-潜在的,potential,潜在的,ADJ,B2
-潜意识,subconscious,潜意识,NOUN,B2
-潜水,dive,跳水,NOUN,B2
-潜水,to dive,潜水,VERB,B2
-潜艇,submarine,潜水艇,NOUN,B2
-潮汐,tide,潮汐,NOUN,B2
-潮汐运动,tidal movement,潮汐运动,NOUN,B2
-潮湿,damp,潮湿,ADJ,B2
-潮湿的,humid,潮湿的,ADJ,B2
-潮红,flushing,潮红,NOUN,B2
-澳大利亚的,australian,澳大利亚的,ADJ,B2
-激励,incentive,激励,NOUN,B2
-激励,to galvanize,激励,VERB,B2
-激励,to motivate,激励,VERB,B2
-激增,surge,激增,NOUN,B2
-激怒,to enrage,激怒,VERB,B2
-激怒,to exasperate,激怒,VERB,B2
-激怒,to irritate,激怒,VERB,B2
-激昂的,heated,激昂的,ADJ,B2
-激活,to activate,激活,VERB,B2
-激流,torrent,激流,NOUN,B2
-激烈的,vehement,激烈的,ADJ,B2
-激起兴趣,to intrigue,激起兴趣,VERB,B2
-灌木,bush,灌木,NOUN,B2
-灌木丛,thicket,灌木丛,NOUN,B2
-灌溉,to irrigate,灌溉,VERB,B2
-灌输,indoctrination,灌输,NOUN,B2
-灌输,to indoctrinate,灌输,VERB,B2
-灌输,to instill,灌输,VERB,B2
-火山口,crater,火山口,NOUN,B2
-火成的,igneous,火成的,ADJ,B2
-火炬,torch,手电筒,NOUN,B2
-火焰,blaze,火焰,NOUN,B2
-火焰,flame,火焰,NOUN,B2
-火箭,rocket,火箭,NOUN,B2
-火腿,ham,火腿,NOUN,B2
-火花,spark,火花,NOUN,B2
-火鸡,turkey,火鸡,NOUN,B2
-灭绝的,extinct,灭绝的,ADJ,B2
-灯笼,lantern,灯笼,NOUN,B2
-灰白的,ashen,灰白的,ADJ,B2
-灰色,gray,灰色的,ADJ,B2
-灰色,grey,灰色的,ADJ,B2
-灵巧,dexterity,灵巧,NOUN,B2
-灵性,spirituality,灵性,NOUN,B2
-灵知,gnosis,灵知,NOUN,B2
-灵知主义,gnosticism,灵知主义,NOUN,B2
-灼热的,scorching,灼热的,ADJ,B2
-灾难,affliction,灾难,NOUN,B2
-灾难,calamity,灾难,NOUN,B2
-灾难性的,calamitous,灾难性的,ADJ,B2
-灾难性的,catastrophic,灾难性的,ADJ,B2
-灾难性的,disastrous,灾难性的,ADJ,B2
-炉子,stove,炉灶,NOUN,B2
-炎症,inflammation,炎症,NOUN,B2
-炖菜,stew,炖菜,NOUN,B2
-炮兵,artillery,炮兵,NOUN,B2
-炸毁,to blow up,炸毁,VERB,B2
-炸药,explosive,爆炸性的,ADJ,B2
-炸药,dynamite,炸药,NOUN,B2
-炸药,explosives,炸药,NOUN,B2
-点,dot,点,NOUN,B2
-点缀,to garnish,装饰,VERB,B2
-点赞,like,点赞,NOUN,B2
-烈酒,liquor,烈酒,NOUN,B2
-烟,smoke,烟,NOUN,B2
-烟囱,chimney,烟囱,NOUN,B2
-烟头,cigarette butt,烟头,NOUN,B2
-烟灰,soot,烟灰,NOUN,B2
-烟灰缸,ashtray,烟灰缸,NOUN,B2
-烟花,fireworks,烟花,NOUN,B2
-烟草,tobacco,烟草,NOUN,B2
-烤成焦皮,to gratinate,烤成焦皮,VERB,B2
-烤箱,oven,烤箱,NOUN,B2
-烦扰,to annoy,使恼怒,VERB,B2
-烧伤,burns,烧伤,NOUN,B2
-烧灼,to cauterize,烧灼,VERB,B2
-烧烤,grilling,烧烤,NOUN,B2
-烧焦,to scorch,烧焦,VERB,B2
-烧焦的,burnt,烧焦的,ADJ,B2
-烧瓶,flask,小瓶,NOUN,B2
-热,heat,热,NOUN,B2
-热切的,avid,热切的,ADJ,B2
-热带的,tropical,热带的,ADJ,B2
-热情,ardor,热情,NOUN,B2
-热情,zeal,热情,NOUN,B2
-热情地,warmly,热情地,ADV,B2
-热情的,ardent,热情的,ADJ,B2
-热情的,passionate,热情的,ADJ,B2
-热水器,water heater,热水器,NOUN,B2
-热浪,heatwave,热浪,NOUN,B2
-热烈的,fiery,热烈的,ADJ,B2
-热的,thermal,热的,ADJ,B2
-烹饪,cooking,烹饪,NOUN,B2
-焊接,welding,焊接,NOUN,B2
-焊接,to solder,焊接,VERB,B2
-焦躁的,agitated,焦躁的,ADJ,B2
-煎,to fry,油炸,VERB,B2
-煎蛋卷,omelet,欧姆蛋,NOUN,B2
-煎蛋卷,omelette,煎蛋卷,NOUN,B2
-煎饼,pancake,煎饼,NOUN,B2
-照亮,to light,照亮,VERB,B2
-照明,illumination,照明,NOUN,B2
-照明主义,illuminationism,照明主义,NOUN,B2
-照片,photo,照片,NOUN,B2
-照耀,shine,光泽,NOUN,B2
-照耀,to shine,照耀,VERB,B2
-煽动,incitement,煽动,NOUN,B2
-煽动,to incite,煽动,VERB,B2
-煽动叛乱,sedition,煽动叛乱,NOUN,B2
-煽动性,demagoguery,煽动性,NOUN,B2
-熄灭的/无精打采的,extinguished listless,熄灭的/无精打采的,ADJ,B2
-熊,bear,熊,NOUN,B2
-熏蒸,to fumigate,熏蒸,VERB,B2
-熔岩,lava,熔岩,NOUN,B2
-熟悉的,familiar,熟悉的,ADJ,B2
-熟的,cooked,熟的,ADJ,B2
-熟练的,proficient,熟练的,ADJ,B2
-熟练的,skilful,熟练的,ADJ,B2
-熟练的,skillful,熟练的,ADJ,B2
-熵,entropy,熵,NOUN,B2
-燃料,fuel,燃料,NOUN,B2
-燃烧器,burner,燃烧器,NOUN,B2
-燃烧的,burning,灼热的,ADJ,B2
-燃烧的/敏锐的,ablaze keen,燃烧的/敏锐的,ADJ,B2
-燧石,flint,燧石,NOUN,B2
-爆发,outbreak,爆发,NOUN,B2
-爆发,to break out,爆发,VERB,B2
-爆炸,detonation,爆炸,NOUN,B2
-爆炸,to explode,爆炸,VERB,B2
-爆裂,to burst,爆发,VERB,B2
-爬行,to crawl,爬行,VERB,B2
-爱做梦的/空想家,dreamy dreamer,爱做梦的/空想家,ADJ,B2
-爱好,pastime,爱好,NOUN,B2
-爱好者,enthusiast,爱好者,NOUN,B2
-爱尔兰人,irish person,爱尔兰人,NOUN,B2
-爱尔兰的,irish,爱尔兰的,ADJ,B2
-爱慕,to adore,爱慕,VERB,B2
-爱打听的,nosy,爱打听的,ADJ,B2
-爱抱怨的人,grumbler,爱抱怨的人,NOUN,B2
-爱社交的,gregarious,爱社交的,ADJ,B2
-父亲的,paternal,父亲的,ADJ,B2
-爷爷,grandpa,爷爷,NOUN,B2
-爸爸,dad,爸爸,NOUN,B2
-爸爸,daddy,爸爸,NOUN,B2
-片刻,for a moment,片刻,ADV,B2
-版本,edition,版本,NOUN,B2
-版本,version,版本,NOUN,B2
-版权,copyright,版权,NOUN,B2
-版画,engraving,版画,NOUN,B2
-牙刷,toothbrush,牙刷,NOUN,B2
-牙医,dentist,牙医,NOUN,B2
-牙齿,dentition,牙齿,NOUN,B2
-牙齿,tooth,牙齿,NOUN,B2
-牛,cow,奶牛,NOUN,B2
-牛排,steak,牛排,NOUN,B2
-牡蛎,oyster,牡蛎,NOUN,B2
-牧师,priest,牧师,NOUN,B2
-牧羊人,shepherd,牧羊人,NOUN,B2
-物理治疗,physiotherapy,物理治疗,NOUN,B2
-物理的,physical,身体的,ADJ,B2
-牲畜,livestock,家畜,NOUN,B2
-牵涉,to entail,牵涉,VERB,B2
-牵连的,implicated,牵连的,ADJ,B2
-特价,special offer,特价,NOUN,B2
-特别地,particularly,特别地,ADV,B2
-特工,special agent,特工,NOUN,B2
-特有的,peculiar,奇怪的,ADJ,B2
-特权,prerogative,特权,NOUN,B2
-特权,privilege,特权,NOUN,B2
-特此,hereby,特此,ADV,B2
-特殊性,exceptionality,特殊性,NOUN,B2
-特许,to charter,租船,VERB,B2
-特许经营,franchise,特许经营权,NOUN,B2
-特质,idiosyncrasy,特质,NOUN,B2
-牺牲,sacrificed,牺牲,ADJ,B2
-牺牲,sacrifice,牺牲,NOUN,B2
-犁沟,furrow,犁沟,NOUN,B2
-犬儒主义,cynicism,犬儒主义,NOUN,B2
-犬齿,fang,犬齿,NOUN,B2
-犯大错,to blunder,犯大错,VERB,B2
-犯罪,crime,犯罪,NOUN,B2
-犯罪,criminality,犯罪,NOUN,B2
-犯罪现场,crime scene,犯罪现场,NOUN,B2
-犯罪者,perpetrator,肇事者,NOUN,B2
-犯错,to make a mistake,弄错,VERB,B2
-犹太人,jew,犹太人,NOUN,B2
-犹太人,jews,犹太人,NOUN,B2
-犹太的,jewish,犹太的,ADJ,B2
-犹豫,hesitation,犹豫,NOUN,B2
-犹豫不决,to dither,犹豫不决,VERB,B2
-犹豫不决的,undecided indecisive,犹豫不决的,ADJ,B2
-犹豫的,hesitant,犹豫的,ADJ,B2
-狂乱的,frantic,狂乱的,ADJ,B2
-狂喜,ecstasy,狂喜,NOUN,B2
-狂喜,rapture,狂喜,NOUN,B2
-狂妄自大的,megalomanic,狂妄自大的,ADJ,B2
-狂怒,fury,狂怒,NOUN,B2
-狂怒,rage,愤怒,NOUN,B2
-狂怒的,furious,愤怒的,ADJ,B2
-狂欢,bacchanal,狂欢,NOUN,B2
-狂欢,to party,狂欢,VERB,B2
-狂欢节式的,carnivalesque,狂欢节式的,ADJ,B2
-狂热,craze,狂热,NOUN,B2
-狂热,fanaticism,狂热,NOUN,B2
-狂热,frenzy,疯狂,NOUN,B2
-狂躁症,mania,狂躁症,NOUN,B2
-狂饮,to drink binge,狂饮,VERB,B2
-狙击手,sniper,狙击手,NOUN,B2
-狡猾,cunning,狡猾的,ADJ,B2
-狡猾,slyness,狡猾,NOUN,B2
-狡猾的,sly,狡猾的,ADJ,B2
-狡诈,deceitful,欺诈的,ADJ,B2
-独栋房屋,detached house,独栋房屋,NOUN,B2
-独白,soliloquy,独白,NOUN,B2
-独立,independence,独立,NOUN,B2
-独立地,independently,独立地,ADV,B2
-独裁,dictatorship,独裁统治,NOUN,B2
-独裁者,dictator,独裁者,NOUN,B2
-狭窄,stenosis,狭窄,NOUN,B2
-狭隘的,narrow-minded,狭隘的,ADJ,B2
-狼人,werewolf,狼人,NOUN,B2
-猎枪,shotgun,猎枪,NOUN,B2
-猎物,prey,猎物,NOUN,B2
-猛喝,to gulp,吞咽,VERB,B2
-猛扑,to pounce,猛扑,VERB,B2
-猛烈的抨击,philippic,猛烈的抨击,NOUN,B2
-猛砍,to slash,猛砍,VERB,B2
-猜测,to conjecture,猜测,VERB,B2
-猪,swine,猪,NOUN,B2
-猫,cats,猫,NOUN,B2
-猫头鹰,owl,猫头鹰,NOUN,B2
-猿/猴,monkey ape,猿/猴,NOUN,B2
-率领 / 提出,to lead to put forward,率领 / 提出,VERB,B2
-王室,royalty,王室,NOUN,B2
-王牌,ace,王牌,NOUN,B2
-王牌/尸体,ace carcass,王牌/尸体,NOUN,B2
-玩具,toys,玩具,NOUN,B2
-玩家,player,运动员,NOUN,B2
-环绕,to encircle,环绕,VERB,B2
-现代化,modernization,现代化,NOUN,B2
-现代的,modern,现代的,ADJ,B2
-现在,present time,现在,NOUN,B2
-现实的,realistic,现实的,ADJ,B2
-现有的,existing,现有的,ADJ,B2
-现行,flagrancy,现行,NOUN,B2
-现象学,phenomenology,现象学,NOUN,B2
-玷污,to taint,玷污,VERB,B2
-珐琅,enamel,珐琅,NOUN,B2
-珠宝,jewelry,珠宝,NOUN,B2
-珠宝店,jewelry store,珠宝店,NOUN,B2
-球体,sphere,领域,NOUN,B2
-球拍,racket,球拍,NOUN,B2
-理事会,council,委员会,NOUN,B2
-理发师,hairdresser,理发师,NOUN,B2
-理性主义,rationalism,理性主义,NOUN,B2
-理想化,to idealize,理想化,VERB,B2
-理想地,ideally,理想地,ADV,B2
-理智,sanity,理智,NOUN,B2
-理解,understanding,理解,NOUN,B2
-理论的,theoretical,理论的,ADJ,B2
-琐碎化,trivialization,浅薄化,NOUN,B2
-琐碎的,trivial,琐碎的,ADJ,B2
-瑕疵,blemish,瑕疵,NOUN,B2
-瑞典的,swedish,瑞典的,ADJ,B2
-瑞典语,swedish,瑞典语,NOUN,B2
-瑞士的,swiss,瑞士的,ADJ,B2
-瓦砾,rubble,瓦砾,NOUN,B2
-瓦解,to disintegrate,瓦解,VERB,B2
-瓷砖,tile,瓦片,NOUN,B2
-甜心,sweetie,亲爱的,NOUN,B2
-甜点,dessert,甜点,NOUN,B2
-生产,production,生产,NOUN,B2
-生产力,productivity,生产力,NOUN,B2
-生产至上主义的,productivist,生产至上主义的,ADJ,B2
-生姜,ginger,姜,NOUN,B2
-生态学,ecology,生态学,NOUN,B2
-生态的,ecological,生态的,ADJ,B2
-生成语法,generative grammar,生成语法,NOUN,B2
-生殖器,genital,生殖器,NOUN,B2
-生活方式,lifestyle,生活方式,NOUN,B2
-生火,to light a fire,生火,VERB,B2
-生物,creature,生物,NOUN,B2
-生物学,biology,生物学,NOUN,B2
-生物的,biological,生物的,ADJ,B2
-生理学,physiology,生理学,NOUN,B2
-生理的,physiological,生理的,ADJ,B2
-生病的,sick,生病的,ADJ,B2
-生的,raw,生的,ADJ,B2
-生育力,fertility,肥沃,NOUN,B2
-生计,subsistence,生计,NOUN,B2
-生闷气,to sulk,生闷气,VERB,B2
-用什么,with what,用什么,ADV,B2
-用完,to use up,用完,VERB,B2
-用户,user,用户,NOUN,B2
-用益权,usufruct,用益权,NOUN,B2
-用链条锁住；连贯,to chain to link together,用链条锁住；连贯,VERB,B2
-甲壳类动物,crustacean,甲壳类动物,NOUN,B2
-甲板/轮胎,deck tire,甲板/轮胎,NOUN,B2
-甲虫,beetle,甲虫,NOUN,B2
-申请,application,申请,NOUN,B2
-申请人,applicant,申请人,NOUN,B2
-电,electric,电动的,ADJ,B2
-电,electricity,电,NOUN,B2
-电力,electric power,电力,NOUN,B2
-电动机,electric motor,电动机,NOUN,B2
-电子学,electronics,电子学,NOUN,B2
-电子邮件,email,电子邮件,NOUN,B2
-电子邮件地址,email address,电子邮件地址,NOUN,B2
-电子阅读器,e-reader,电子阅读器,NOUN,B2
-电工,electrician,电工,NOUN,B2
-电影,film movie,电影,NOUN,B2
-电影院,cinema,电影院,NOUN,B2
-电报,telegram,电报,NOUN,B2
-电流,current,电流,NOUN,B2
-电线,wire,电线,NOUN,B2
-电缆,cable,电缆,NOUN,B2
-电网,power grid,电网,NOUN,B2
-电脑,dator,电脑,NOUN,B2
-电脑程序,computer program,电脑程序,NOUN,B2
-电视,tv,电视,NOUN,B2
-电视播出的,televised,电视播出的,ADJ,B2
-电视电影,tv movie,电视电影,NOUN,B2
-电视观众,tv viewer,电视观众,NOUN,B2
-电话,phone call,通话,NOUN,B2
-电话,telephone,电话,NOUN,B2
-电话号码,phone number,电话号码,NOUN,B2
-电话号码,telephone number,电话号码,NOUN,B2
-电话学,telephony,电话学,NOUN,B2
-电话总机,switchboard,总机,NOUN,B2
-电路,circuit,电路,NOUN,B2
-男同性恋者,gay man,男同性恋者,NOUN,B2
-男性,male,男性,NOUN,B2
-男性的,male,男性的,ADJ,B2
-男高音,tenor,男高音,NOUN,B2
-画家,painter,画家,NOUN,B2
-画廊,gallery,画廊,NOUN,B2
-界限,limit border,界限,NOUN,B2
-界面,interface,接口,NOUN,B2
-留在这里,to stay here,留在这里,VERB,B2
-畸形的,deformed,畸形的,ADJ,B2
-疏忽,lapse,疏忽,NOUN,B2
-疏忽,oversight,疏忽,NOUN,B2
-疏忽的,negligent,疏忽的,ADJ,B2
-疏散,evacuation,疏散,NOUN,B2
-疗效,healing power,疗效,NOUN,B2
-疗法,therapy,治疗,NOUN,B2
-疫苗,vaccination,疫苗接种,NOUN,B2
-疫苗的,vaccine-related,疫苗的,ADJ,B2
-疯子,lunatic,疯子,NOUN,B2
-疯子,madman,疯子,NOUN,B2
-疯狂地,insanely,疯狂地,ADV,B2
-疯狂的,insane,疯狂的,ADJ,B2
-疯狂的,nuts,疯狂的,ADJ,B2
-疲倦,tiredness,疲劳,NOUN,B2
-疲倦,weariness,疲倦,NOUN,B2
-疲倦的,weary,疲倦的,ADJ,B2
-疲劳,to get tired,疲劳,VERB,B2
-疼痛的,sore,疼痛的,ADJ,B2
-疾病,disease,疾病,NOUN,B2
-疾驰,gallop,疾驰,NOUN,B2
-病人,the sick,病人,NOUN,B2
-病变,lesion,病变,NOUN,B2
-病毒性的,viral,病毒性的,ADJ,B2
-病理学,pathology,病理学,NOUN,B2
-症状,symptom,症状,NOUN,B2
-症状学,symptomatology,症状学,NOUN,B2
-痒,itch,痒,NOUN,B2
-痒痒粉,itching powder,痒痒粉,NOUN,B2
-痕迹/轨道,track trace,痕迹/轨道,NOUN,B2
-痛恨,to execrate,痛恨,VERB,B2
-痛苦,anguish,痛苦,NOUN,B2
-痛苦,misery,痛苦,NOUN,B2
-痛苦的,painful,疼痛的,ADJ,B2
-痰,phlegm,痰,NOUN,B2
-痴呆,dementia,痴呆,NOUN,B2
-痴呆，疯狂,dementia madness,痴呆，疯狂,NOUN,B2
-痴迷的,entranced,痴迷的,ADJ,B2
-瘙痒,itching,瘙痒,NOUN,B2
-瘦骨嶙峋的,cadaverous,瘦骨嶙峋的,ADJ,B2
-瘫痪的,paralysed,瘫痪的,ADJ,B2
-瘫痪的,paralyzed,瘫痪的,ADJ,B2
-瘾君子,addict,上瘾者,NOUN,B2
-癌症,cancer,癌症,NOUN,B2
-癫痫,seizure,没收,NOUN,B2
-登岸,to disembark,下船,VERB,B2
-登录,to log in,登录,VERB,B2
-登记,enrollment,注册,NOUN,B2
-白天,during the day,在白天,ADV,B2
-白炽的,incandescent,白炽的,ADJ,B2
-百万,million,百万,NOUN,B2
-百分比,percent,百分比,NOUN,B2
-百分率,percentage,百分比,NOUN,B2
-百科全书,encyclopedia,百科全书,NOUN,B2
-百科全书式的,encyclopedic,百科全书式的,ADJ,B2
-的,of,的,ADP,B2
-的,the,这,DET,B2
-的/被,of by,的/被,ADP,B2
-皇家的,royal,皇家的,ADJ,B2
-皮层的,cortical,皮层的,ADJ,B2
-皮疹,rash,轻率的,ADJ,B2
-皱纹,wrinkle,皱纹,NOUN,B2
-盈利能力,profitability,盈利能力,NOUN,B2
-监护,guardianship,监护,NOUN,B2
-监护人,guardian,守卫,NOUN,B2
-监护权,custody,监护,NOUN,B2
-监控,monitoring,监控,NOUN,B2
-监狱,jail,监狱,NOUN,B2
-监狱,prison,监狱,NOUN,B2
-监督,supervision,监督,NOUN,B2
-监禁,imprisonment,监禁,NOUN,B2
-监禁,to lock up,关押,VERB,B2
-监管的,regulatory,监管的,ADJ,B2
-监视,surveillance,监视,NOUN,B2
-监视,to spy,监视,VERB,B2
-盒子 / 罐,box can,盒子 / 罐,NOUN,B2
-盔甲,armor,盔甲,NOUN,B2
-盘旋,to hover,盘旋,VERB,B2
-盘查,to hail inspect,盘查,VERB,B2
-盛宴,feast,盛宴,NOUN,B2
-盛宴,treat,盛宴,NOUN,B2
-盛行,to prevail,盛行,VERB,B2
-盟友,allies,盟友,NOUN,B2
-盟友,ally,盟友,NOUN,B2
-目击,to witness,目击,VERB,B2
-目前,currently,目前,ADV,B2
-目录,catalogue,目录,NOUN,B2
-目标,goal,目标,NOUN,B2
-目的/目的地,aim destination,目的/目的地,NOUN,B2
-目的论,teleology,目的论,NOUN,B2
-目瞪口呆,to gape,目瞪口呆,VERB,B2
-盲人,blind,百叶窗,NOUN,B2
-直到,until,直到,SCONJ,B2
-直升机,helicopter,直升机,NOUN,B2
-直接地,directly,直接地,ADV,B2
-直接地,straight,径直地,ADV,B2
-直的,straight,直的,NOUN,B2
-直立地,upright,直立地,ADV,B2
-直立的,upright,正直的,ADJ,B2
-相互的,reciprocal,互惠的,ADJ,B2
-相似的,akin,相似的,ADJ,B2
-相似的,similar,相似的,ADJ,B2
-相关性,correlation,相关性,NOUN,B2
-相关的,associated,相关的,ADJ,B2
-相关的,related,相关的,ADJ,B2
-相关的,relevant,相关的,ADJ,B2
-相反,on the contrary,相反,ADV,B2
-相反地,conversely,相反地,ADV,B2
-相同的,the same,相同的,ADJ,B2
-相对主义,relativism,相对主义,NOUN,B2
-相对的,relative,相对的,ADJ,B2
-相异性,otherness,相异性,NOUN,B2
-相当地,considerably,相当地,ADV,B2
-相等的,equivalent,相等的,ADJ,B2
-相邻,adjacent,邻近的,ADJ,B2
-盾,guilder,盾,NOUN,B2
-盾牌,shield,盾牌,NOUN,B2
-省,province,省,NOUN,B2
-省略,ellipsis,省略,NOUN,B2
-省略,to elide,省略,VERB,B2
-省略,to omit,省略,VERB,B2
-眉毛,brow,眉毛,NOUN,B2
-看,look,看,NOUN,B2
-看不见的,invisible,看不见的,ADJ,B2
-看守人,warden,看守人,NOUN,B2
-看电视,to watch tv,看电视,VERB,B2
-看见,to spot,看见,VERB,B2
-真人大小的,life-size,真人大小的,ADJ,B2
-真实性,authenticity,真实性,NOUN,B2
-真实的,real,真实的,ADJ,B2
-真的吗,oh really,真的吗,INTJ,B2
-真空的,vacuum,真空的,ADJ,B2
-真诚地,sincerely,真诚地,ADV,B2
-眨眼,to blink,眨眼,VERB,B2
-眨眼,to wink,眨眼,VERB,B2
-眩目,to dazzle,使眼花,VERB,B2
-眼泪,tear,眼泪,NOUN,B2
-眼镜,glasses,眼镜,NOUN,B2
-着色,to color,着色,VERB,B2
-着迷的,fascinated,着迷的,ADJ,B2
-着迷的,obsessed,着迷的,ADJ,B2
-着陆,landing,着陆,NOUN,B2
-睡衣,pajamas,睡衣,NOUN,B2
-睡过头,to oversleep,睡过头,VERB,B2
-睾丸,testicle,睾丸,NOUN,B2
-睿智的,sagacious,睿智的,ADJ,B2
-瞄准,targeting,定位,NOUN,B2
-瞥,to glance,瞥,VERB,B2
-瞥见,to glimpse,瞥见,VERB,B2
-瞬间地,instantaneously,瞬间地,ADV,B2
-瞬间的,instantaneous,瞬间的,ADJ,B2
-矛,spear,长矛,NOUN,B2
-矛盾修辞法,oxymoron,矛盾修辞法,NOUN,B2
-矛盾的,ambivalent,矛盾的,ADJ,B2
-矛盾的,contradictory,矛盾的,ADJ,B2
-矛盾的,paradoxical,矛盾的,ADJ,B2
-知情度,informedness,知情度,NOUN,B2
-知识交流,knowledge exchange,知识交流,NOUN,B2
-知识传授,knowledge transfer,知识传授,NOUN,B2
-知识的,intellectual,知识的,ADJ,B2
-矩阵,matrix,矩阵,NOUN,B2
-短暂的,ephemeral,短暂的,ADJ,B2
-短暂的,fleeting,短暂的,ADJ,B2
-短片,short film,短片,NOUN,B2
-短语,phrase,短语,NOUN,B2
-矮人,dwarf,侏儒,NOUN,B2
-石刑,stoning,石刑,NOUN,B2
-石化,to fossilize,石化,VERB,B2
-石楠荒原,heath,石楠荒原,NOUN,B2
-石膏,plaster,石膏,NOUN,B2
-矿,mine,矿井,NOUN,B2
-码头,pier,码头,NOUN,B2
-码头,quay,码头,NOUN,B2
-砌体,masonry,砌体,NOUN,B2
-砍倒,to fell,砍倒,VERB,B2
-研磨,to grind,磨碎,VERB,B2
-研究,research,研究,NOUN,B2
-研究,studies,学业,NOUN,B2
-砖,brick,砖,NOUN,B2
-砰,bang,砰,INTJ,B2
-破产的,broke,破产的,ADJ,B2
-破坏,to ravage,破坏,VERB,B2
-破坏,to sabotage,破坏,VERB,B2
-破坏,to spoil,损坏,VERB,B2
-破坏,to undermine,破坏,VERB,B2
-破坏稳定,destabilization,动摇,NOUN,B2
-破布,rag,破布,NOUN,B2
-破晓,dawning,破晓,NOUN,B2
-破烂的,ragged,破烂的,ADJ,B2
-破烂货,junk,破烂货,NOUN,B2
-破碎的,broken,破碎的,ADV,B2
-破裂,crack,裂缝,NOUN,B2
-破裂,to crack,破裂,VERB,B2
-破译,to decipher,破译,VERB,B2
-砾石,gravel,砾石,NOUN,B2
-硫,sulfur,硫,NOUN,B2
-硬度,hardness,硬度,NOUN,B2
-硬汉,tough guy,硬汉,NOUN,B2
-硬纸板,cardboard,硬纸板,NOUN,B2
-确保,to make sure,确保,VERB,B2
-确信的,convinced,确信的,ADJ,B2
-确切地; 正好,precisely,确切地; 正好,ADV,B2
-确定,determine,确定,VER! B,B2
-确定地,definitely,肯定地,ADV,B2
-确定的,determined definite,确定的,ADJ,B2
-确定的,sure,确定的,ADJ,B2
-确定的,sure safe,确定的,ADJ,B2
-确证的,apodictic,确证的,ADJ,B2
-碎片,fragment,碎片,NOUN,B2
-碎片化,fragmentation,碎片化,NOUN,B2
-碎裂,to crumble,粉碎,VERB,B2
-碰撞,crash,碰撞,NOUN,B2
-碰撞,to bump,碰撞,VERB,B2
-碰撞,to crash,碰撞,VERB,B2
-碰撞/震惊,bump shock,碰撞/震惊,NOUN,B2
-碳,carbon,碳,NOUN,B2
-碳氢化合物,hydrocarbon,碳氢化合物,NOUN,B2
-碳水化合物,carbohydrate,碳水化合物,NOUN,B2
-碾过,to run over,碾过,VERB,B2
-磁盘,disk,唱片,NOUN,B2
-磁铁,magnet,磁铁,NOUN,B2
-磋商,consultations,磋商,NOUN,B2
-磨坊,mill,磨坊,NOUN,B2
-磨快,to sharpen,磨快,VERB,B2
-磨损,wear,磨损,NOUN,B2
-磨损,to wear out,磨损,VERB,B2
-磨损的,worn,磨损的,ADJ,B2
-磨碎的,ground,磨碎的,ADJ,B2
-示威,demonstration,演示,NOUN,B2
-礼仪,decorum,礼仪,NOUN,B2
-礼貌,civility,礼貌,NOUN,B2
-礼貌地,politely,礼貌地,ADV,B2
-社会,social,社会的,ADJ,B2
-社会主义的,socialist,社会主义的,ADJ,B2
-社会主义者,socialist,社会主义者,NOUN,B2
-社会化,socialization,社会化,NOUN,B2
-社会声望,social prestige,社会声望,NOUN,B2
-社会学,sociology,社会学,NOUN,B2
-社会问题,social problem,社会问题,NOUN,B2
-社群主义,communitarianism,社群主义,NOUN,B2
-社群化,communautarization,社群化,NOUN,B2
-祈祷,prayer,祈祷,NOUN,B2
-祈祷,to pray,祈祷,VERB,B2
-祈祷室,prayer room,祈祷室,NOUN,B2
-祖先,ancestry,血统,NOUN,B2
-祖母,grandmother,祖母,NOUN,B2
-祖母,paternal grandmother,祖母,NOUN,B2
-祖母绿,emerald,祖母绿,NOUN,B2
-祖父母,grandparents,祖父母,NOUN,B2
-祖父母身份,grandparenthood,祖父母身份,NOUN,B2
-祝圣,to consecrate,奉献,VERB,B2
-祝贺,congratulations,祝贺,NOUN,B2
-神化,to deify,神化,VERB,B2
-神化的,apotheotic,神化的,ADJ,B2
-神圣,holiness,神圣,NOUN,B2
-神圣的,divine,神圣的,ADJ,B2
-神圣的,holy,神圣的,ADJ,B2
-神圣的,sacred,神圣的,ADJ,B2
-神学,theology,神学,NOUN,B2
-神学家,theologian,神学家,NOUN,B2
-神学的,theological,神学的,ADJ,B2
-神志正常的,sane,神志正常的,ADJ,B2
-神性,divinity,神性,NOUN,B2
-神权政治,theocracy,神权政治,NOUN,B2
-神殿,shrine,مشعر,NOUN,B2
-神秘主义,mysticism,神秘主义,NOUN,B2
-神秘化,to mystify,神秘化,VERB,B2
-神秘的,arcane,神秘的,ADJ,B2
-神秘的,enigmatic,神秘的,ADJ,B2
-神秘的,occult,神秘的,ADJ,B2
-神童,prodigy,神童,NOUN,B2
-神经症,neurosis,神经症,NOUN,B2
-神话,mythology,神话学,NOUN,B2
-神话化,mythologization,神话化,NOUN,B2
-神话性,mythicality,神话性,NOUN,B2
-神话般的,mythical,神话般的,ADJ,B2
-神谕,oracle,神谕,NOUN,B2
-祸害,scourge,灾祸,NOUN,B2
-禁令,injunction,禁令,NOUN,B2
-禁止,to forbid,禁止,VERB,B2
-禁止的,forbidden,被禁止的,ADJ,B2
-禁运,embargo,禁运,NOUN,B2
-禁食,fasting,禁食,NOUN,B2
-禁食,to fast,禁食,VERB,B2
-离婚,divorce,离婚,NOUN,B2
-离开,away,离开,ADV,B2
-离开/刺,to leave stick,离开/刺,VERB,B2
-离心机,centrifuge,离心机,NOUN,B2
-离题,to digress,离题,VERB,B2
-私事,personal,私事,NOUN,B2
-私有化,to privatize,私有化,VERB,B2
-私生子,bastard,混蛋,NOUN,B2
-私生活,private life,私生活,NOUN,B2
-秋千,swing,秋千,NOUN,B2
-种子,seed,种子,NOUN,B2
-种族主义,racism,种族主义,NOUN,B2
-种族主义的,racist,种族主义的,ADJ,B2
-种族主义者,racist,种族主义者,NOUN,B2
-种植,planting,种植,NOUN,B2
-种类,kind sort,种类,NOUN,B2
-种类,sort,种类,NOUN,B2
-种类/物种,kind species,种类/物种,NOUN,B2
-科学地,scientifically,科学地,ADV,B2
-科学家,scientists,科学家,NOUN,B2
-科学的,scientific,科学的,ADJ,B2
-秒,second,第二,ADJ,B2
-秘书处,secretariat,秘书处,NOUN,B2
-秘密的,clandestine,秘密的,ADJ,B2
-秘密的,secret,秘密的,ADJ,B2
-秘密的,surreptitious,秘密的,ADJ,B2
-秘密行动,stealth,秘密行动,NOUN,B2
-积极主动的,proactive,积极主动的,ADJ,B2
-积累,accumulation,积累,NOUN,B2
-积聚,to amass,积聚,VERB,B2
-称赞,to acclaim,称赞,VERB,B2
-移交,to consign,移交,VERB,B2
-移居国外,to emigrate,移居国外,VERB,B2
-移居国外者,expatriate,移居国外者,NOUN,B2
-移开,to move away,移开,VERB,B2
-移开,to set aside,移开,VERB,B2
-移民,emigration,移民,NOUN,B2
-移民,immigrant,移民,NOUN,B2
-移民,immigration,移民,NOUN,B2
-移除,to remove,移除,VERB,B2
-稀缺的,scarce,稀少的,ADJ,B2
-稀释,to dilute,稀释,VERB,B2
-程序的,procedural,程序的,ADJ,B2
-稍微超过,just over,稍微超过,ADV,B2
-税务机关,tax authorities,税务机关,NOUN,B2
-税收,taxation,征税,NOUN,B2
-稳定,to stabilize,使稳定,VERB,B2
-稳定化,stabilization,稳定化,NOUN,B2
-稳定地,stably,稳定地,ADV,B2
-稻草,straw,稻草,NOUN,B2
-穹顶,dome,圆顶,NOUN,B2
-空,empty,空的,ADJ,B2
-空中,aerial,航空的,ADJ,B2
-空军,air force,空军,NOUN,B2
-空缺,vacancy,空缺,NOUN,B2
-空缺的,vacant,空缺的,ADJ,B2
-空虚,emptiness,空虚,NOUN,B2
-空闲的/休假,free off,空闲的/休假,ADJ,B2
-空间的,spatial,空间的,ADJ,B2
-穿上,to put on,穿上,VERB,B2
-穿梭巴士,shuttle,穿梭巴士,NOUN,B2
-穿着的,dressed,穿着的,ADJ,B2
-穿衣,dress,连衣裙,NOUN,B2
-穿衣,to dress,给...穿衣,VERB,B2
-穿过,across,穿过,ADP,B2
-穿透,to penetrate,穿透,VERB,B2
-突出,to highlight,强调,VERB,B2
-突出的,prominent,突出的,ADJ,B2
-突然,abrupt,突然的,ADJ,B2
-窃贼,burglar,窃贼,NOUN,B2
-窒息,asphyxia,窒息,NOUN,B2
-窒息,to suffocate,窒息,VERB,B2
-窥探,to snoop,窥探,VERB,B2
-立为王,to enthrone,立为王,VERB,B2
-立体主义,cubism,立体主义,NOUN,B2
-立刻,at once,立刻,ADV,B2
-立即的,immediate,立即的,ADJ,B2
-立法的,legislative,立法的,ADJ,B2
-竖琴,harp,竖琴,NOUN,B2
-站立,to stand,站立,VERB,B2
-竞争的,competitive,竞争的,ADJ,B2
-章,chapter,章节,NOUN,B2
-童年创伤,youth trauma,童年创伤,NOUN,B2
-笃信宗教,religiosity,笃信宗教,NOUN,B2
-笑声,laughter,笑声,NOUN,B2
-笔记本电脑,laptop,笔记本电脑,NOUN,B2
-笔迹学,graphology,笔迹学,NOUN,B2
-符号,symbol,象征,NOUN,B2
-符号学,semiology,符号学，症状学,NOUN,B2
-符号学,semiotics,符号学,NOUN,B2
-符合,to conform,符合,VERB,B2
-笨拙,clumsiness,笨拙,NOUN,B2
-笨拙的,ungainly,笨拙的,ADJ,B2
-笨重的,cumbersome,笨重的,ADJ,B2
-第一名,number one,第一名,NOUN,B2
-第七,seventh,第七,ADJ,B2
-第三,third,第三,ADJ,B2
-第三的,tertiary,第三的,ADJ,B2
-第九,ninth,第九,ADJ,B2
-第五,fifth,خامس,ADJ,B2
-第八,eighth,第八,ADJ,B2
-第六,sixth,第六,ADJ,B2
-第十,tenth,第十,ADJ,B2
-第四,fourth,第四,ADJ,B2
-笼子,cage,笼子,NOUN,B2
-等同,to equate,等同,VERB,B2
-等待,to bide,等待,VERB,B2
-等待观望,to wait and see,等待观望,VERB,B2
-等等,and so forth,依此类推,ADV,B2
-等级,rank,等级,NOUN,B2
-等级制度,hierarchy,等级制度,NOUN,B2
-答录机,answering machine,邮箱,NOUN,B2
-策略,maneuver,策略,NOUN,B2
-策略,stratagem,策略,NOUN,B2
-筛,to sift,筛选,VERB,B2
-筛子,sieve,筛子,NOUN,B2
-签,lot,许多,NOUN,B2
-签名,signature,签名,NOUN,B2
-简介,profile,简介,NOUN,B2
-简化,simplification,简化,NOUN,B2
-简化,to simplify,简化,VERB,B2
-简单化,simplism,简单化,NOUN,B2
-简报,newsletter,简报,NOUN,B2
-简明的,succinct,简明的,ADJ,B2
-简朴,austere,严厉的,ADJ,B2
-简洁,conciseness,简洁,NOUN,B2
-简洁,concision,简洁,NOUN,B2
-简洁的,laconic,简洁的,ADJ,B2
-简短的,brief,简短的,ADJ,B2
-简练的,terse,简练的,ADJ,B2
-算了,oh well,算了,INTJ,B2
-管子,pipe,管子,NOUN,B2
-管弦乐队,orchestra,管弦乐队,NOUN,B2
-管理,administration,管理,NOUN,B2
-管理,to administer,管理,VERB,B2
-管理员,administrator,管理员,NOUN,B2
-管辖权,jurisdiction,管辖权,NOUN,B2
-篝火,bonfire,篝火,NOUN,B2
-篡夺,to usurp,篡夺,VERB,B2
-篮子,basket,篮子,NOUN,B2
-簸,to winnow,筛选,VERB,B2
-米,meter,米,NOUN,B2
-类似的,analogous,类似的,ADJ,B2
-类型学,typology,类型学,NOUN,B2
-类比,analogy,类比,NOUN,B2
-粉末,powder,粉末,NOUN,B2
-粉笔,chalk,粉笔,NOUN,B2
-粉红色的,pink,粉色的,ADJ,B2
-粗俗,vulgarity,粗俗,NOUN,B2
-粗俗的,uncouth,粗俗的,ADJ,B2
-粗加工,to rough-hew,粗加工,VERB,B2
-粗糙,roughness,粗糙,NOUN,B2
-粗面粉,semolina,粗面粉,NOUN,B2
-粗鲁的,rude,粗鲁的,ADJ,B2
-粘液,mucus,黏液,NOUN,B2
-粘稠,viscous,黏稠的,ADJ,B2
-精修,to perfect,精修,VERB,B2
-精力充沛的,energetic,精力充沛的,ADJ,B2
-精子,sperm,精子,NOUN,B2
-精明,astute,精明的,ADJ,B2
-精明的,shrewd,精明的,ADJ,B2
-精炼,polish,精炼,NOUN,B2
-精炼,refinement,修养,NOUN,B2
-精炼的,refined,精炼的,ADJ,B2
-精确,exactness,精确,NOUN,B2
-精确,precision,精确,NOUN,B2
-精神上地,mentally,精神上地,ADV,B2
-精神分析,psychoanalysis,精神分析,NOUN,B2
-精神分裂症,schizophrenia,精神分裂症,NOUN,B2
-精神变态者,psychopath,精神变态者,NOUN,B2
-精神奋斗,spiritual striving,精神奋斗,NOUN,B2
-精神导师,guru,精神导师,NOUN,B2
-精神状态,state of mind,精神状态,NOUN,B2
-精神病,psychosis,精神病,NOUN,B2
-精神病的,psychiatric,精神病的,ADJ,B2
-精神病院,mental hospital,精神病院,NOUN,B2
-精神的,mental,精神的,ADJ,B2
-精神的,spiritual,精神的,ADJ,B2
-精神科医生,psychiatrist,精神科医生,NOUN,B2
-精英,elite,精英,NOUN,B2
-精英政治,meritocracy,精英管理,NOUN,B2
-精选的,chosen,精选的,ADJ,B2
-精通,versed,精通的,ADJ,B2
-糖尿病,diabetes,糖尿病,NOUN,B2
-糖果,candy,糖果,NOUN,B2
-糖果,sweet,糖果,NOUN,B2
-糖果,sweets,甜食,NOUN,B2
-糖浆,syrup,糖浆,NOUN,B2
-糟糕的,awful,糟糕的,ADJ,B2
-系列,series,系列,NOUN,B2
-系紧,to fasten,系紧,VERB,B2
-系统的,systemic,全身性的,ADJ,B2
-素食者,vegetarian,素食者,NOUN,B2
-紧凑的,compact,紧凑的,ADJ,B2
-紧张,nervousness,紧张,NOUN,B2
-紧张,tension,紧张,NOUN,B2
-紧张的,tense,紧张的,ADJ,B2
-紧急呼叫,emergency call,紧急呼叫,NOUN,B2
-紧缩,austerity,紧缩,NOUN,B2
-紧缺商品,scarce commodity,紧缺商品,NOUN,B2
-紧迫,urgency,紧急,NOUN,B2
-紧迫的,pressing,紧迫的,ADJ,B2
-累人的,tiresome,累人的,ADJ,B2
-累积,to accrue,积累,VERB,B2
-繁殖,to reproduce,繁殖,VERB,B2
-繁茂的,exuberant,繁茂的,ADJ,B2
-繁荣,prosperity,繁荣,NOUN,B2
-繁荣,to flourish,繁荣,VERB,B2
-繁荣,to prosper,繁荣,VERB,B2
-繁荣的,flourishing,繁荣的,ADJ,B2
-繁重的,burdensome,繁重的,ADJ,B2
-纠正错误想法,to disabuse,纠正错误想法,VERB,B2
-纤维,fiber,纤维,NOUN,B2
-纤维化,fibrosis,纤维化,NOUN,B2
-纤维素,cellulose,纤维素,NOUN,B2
-约会,dating,年代测定,NOUN,B2
-约会,dejt,约会,NOUN,B2
-约会,to date,注明日期,VERB,B2
-约束,constraint,约束,NOUN,B2
-约束,to constrain,限制,VERB,B2
-纪录片,documentary,纪录片,NOUN,B2
-纪录的,documentary,纪录片的,ADJ,B2
-纪律的,disciplinary,纪律的,ADJ,B2
-纪念,commemoration,纪念,NOUN,B2
-纪念,remembrance,纪念,NOUN,B2
-纪念品,souvenir,纪念品,NOUN,B2
-纪念碑,monument,纪念碑,NOUN,B2
-纯,pure,纯净的,ADJ,B2
-纯净,purity,纯洁,NOUN,B2
-纯净的,clean pure,纯净的,ADJ,B2
-纯粹地,purely,纯粹地,ADV,B2
-纱线,yarn,纱线,NOUN,B2
-纳入,incorporation,纳入,NOUN,B2
-纳税人,taxpayer,纳税人,NOUN,B2
-纳粹,nazi,纳粹分子,NOUN,B2
-纵容,to pamper,纵容,VERB,B2
-纵火,arson,纵火,NOUN,B2
-纹章,coat of arms,纹章,NOUN,B2
-纹身,tattoo,纹身,NOUN,B2
-纺纱,spinning,纺纱,NOUN,B2
-纺纱厂,spinning mill,纺纱厂,NOUN,B2
-纽扣,button,按钮,NOUN,B2
-线,line,线,NOUN,B2
-线,thread,线,NOUN,B2
-线性的,linear,线性的,ADJ,B2
-组合,combination,结合,NOUN,B2
-组成,to consist,组成,VERB,B2
-细微差别,nuance,细微差别,NOUN,B2
-细微差别的,nuanced,细微差别的,ADJ,B2
-细木工匠,cabinetmaker,细木工匠,NOUN,B2
-细胞,cell,细胞,NOUN,B2
-细胞的,cellular,细胞的,ADJ,B2
-细致地,painstakingly,细致地,ADV,B2
-细菌,germ,病菌,NOUN,B2
-终末的,terminal,终末的,ADJ,B2
-终止,termination,解除,NOUN,B2
-终端,terminal,终点站,NOUN,B2
-绊倒,to stumble,绊倒,VERB,B2
-经公证的,notarized,经公证的,ADJ,B2
-经典的,classic,经典的,ADJ,B2
-经历,to go through,经历,VERB,B2
-经历,to undergo,经历,VERB,B2
-经常,frequently,经常,ADV,B2
-经济的,economic,经济的,ADJ,B2
-经过,past,经过,ADV,B2
-经销商,dealer,经销商,NOUN,B2
-经验,experiences,经验,NOUN,B2
-经验主义,empiricism,经验主义,NOUN,B2
-经验交流,experience exchange,经验交流,NOUN,B2
-经验的,empirical,经验的,ADJ,B2
-绑架,kidnapping,绑架,NOUN,B2
-绑架,to kidnap,绑架,VERB,B2
-绑架,to kidnapped,绑架,VERB,B2
-绑架者,kidnapper,绑架者,NOUN,B2
-结,knot,结,NOUN,B2
-结婚纪念日,wedding anniversary,结婚纪念日,NOUN,B2
-结局，解决,outcome ending,结局，解决,NOUN,B2
-结巴,to stammer,结巴,VERB,B2
-结构性,structuredness,结构性,NOUN,B2
-结果,to turn out,结果是,VERB,B2
-结盟,to ally,结盟,VERB,B2
-结识,to get acquainted,相互认识,VERB,B2
-结语,peroration,结语,NOUN,B2
-结账,checkout,收银台,NOUN,B2
-结账,to settle up,结账,VERB,B2
-绕道,detour,绕道,NOUN,B2
-绘图员,draftsman,绘图员,NOUN,B2
-绘画,paint,油漆,NOUN,B2
-绘画,to paint,粉刷,VERB,B2
-绘画的,pictorial,绘画的,ADJ,B2
-给...留下印象,to impress,使印象深刻,VERB,B2
-给...起绰号,to nickname,给...起绰号,VERB,B2
-给定的,given,给定的,ADJ,B2
-绝对的,categorical,绝对的,ADJ,B2
-绝望的,desperate,绝望的,ADJ,B2
-绝望的,hopeless,绝望的,ADJ,B2
-绞刑,hanging,绞刑,NOUN,B2
-绞刑架幽默,gallows humor,绞刑架幽默,NOUN,B2
-统治,reign,统治,NOUN,B2
-统计学,statistics,统计学,NOUN,B2
-统计数据,statistic,统计数据,NOUN,B2
-统计的,statistical,统计的,ADJ,B2
-继承,succession,连续,NOUN,B2
-继承人,heir,继承人,NOUN,B2
-继承法,inheritance law,继承法,NOUN,B2
-继续,to proceed,继续进行,VERB,B2
-维护,maintenance,维护,NOUN,B2
-绷紧的,taut,绷紧的,ADJ,B2
-综合征,syndrome,综合征,NOUN,B2
-缄默的,reserved,保留的,ADJ,B2
-缆车,cable car,缆车,NOUN,B2
-缓刑,probation,缓刑,NOUN,B2
-缓和,detente,缓和,NOUN,B2
-缓和,to defuse,缓和,VERB,B2
-缓和的,palliative,缓和的,ADJ,B2
-缓解,to alleviate,缓解,VERB,B2
-编剧,screenwriter,编剧,NOUN,B2
-编年史,annals,编年史,NOUN,B2
-编年史,chronicle,编年史,NOUN,B2
-编码,encoding,编码,NOUN,B2
-编程,programming,编程,NOUN,B2
-编程,to program,编程,VERB,B2
-编织,to knit,编织,VERB,B2
-编织,to weave,编织,VERB,B2
-编舞者,choreographer,编舞者,NOUN,B2
-编译,to compile,编译,VERB,B2
-编辑,editor,编辑,NOUN,B2
-编造,to concoct,编造,VERB,B2
-缝,to sew,缝纫,VERB,B2
-缝,to stitch,缝,VERB,B2
-缝合,stitching,缝合,NOUN,B2
-缠住,to entangle,使纠缠,VERB,B2
-缺席,absent,缺席的,ADJ,B2
-缺点,drawback,缺点,NOUN,B2
-缺陷,flaw,缺陷,NOUN,B2
-网格,grid,网格,NOUN,B2
-网络,network,网络,NOUN,B2
-网络安全,cybersecurity,网络安全,NOUN,B2
-网络的,cyber,网络的,ADJ,B2
-罗马人,roman,罗马人,NOUN,B2
-罗马尼亚人,romanian,罗马尼亚人,NOUN,B2
-罗马的,roman,罗马的,ADJ,B2
-罚款,fine,罚款,NOUN,B2
-罢工者,striker,罢工者,NOUN,B2
-罪人,sinner,罪人,NOUN,B2
-罪犯,wrongdoer,罪犯,NOUN,B2
-置于语境,to contextualize,置于语境,VERB,B2
-羊羔,lamb,羔羊,NOUN,B2
-美丽地,beautifully,美丽地,ADV,B2
-美丽的,fine pretty,美丽的,ADJ,B2
-美化,to beautify,美化,VERB,B2
-美味的,tasty,美味的,ADJ,B2
-美国人,american,美国的,ADJ,B2
-美好地,nicely nice,美好地,ADV,B2
-美好的,nice,好的,ADJ,B2
-美食学,gastronomy,美食学,NOUN,B2
-美食家,gourmet,美食家,NOUN,B2
-美食的,gastronomic,美食的,ADJ,B2
-羞怯,shyness,羞怯,NOUN,B2
-羞愧,to be ashamed,感到羞愧,VERB,B2
-羞辱,to shame,使羞愧,VERB,B2
-群,flock,兽群,NOUN,B2
-群众演员,extra,群众演员,NOUN,B2
-群体个体,group individual,群体个体,NOUN,B2
-群体团结,group solidarity,群体团结,NOUN,B2
-群体心态,group mentality,群体心态,NOUN,B2
-群体成员,group member,群体成员,NOUN,B2
-群体文化,group culture,群体文化,NOUN,B2
-群体规范,group norm,群体规范,NOUN,B2
-群岛,archipelago,群岛,NOUN,B2
-群集,to flock,群集,VERB,B2
-羽毛,feather,羽毛,NOUN,B2
-羽绒被,duvet,羽绒被,NOUN,B2
-翻新,renovation,翻新,NOUN,B2
-翻新,to renovate,翻新,VERB,B2
-翻译,translation,翻译,NOUN,B2
-翻译者,translator,译者,NOUN,B2
-翻阅,to leaf through,翻阅,VERB,B2
-耀眼,dazzling,耀眼的,ADJ,B2
-老人,old person,老人,NOUN,B2
-老人政治,gerontocracy,老人政治,NOUN,B2
-老化,aging,老化,NOUN,B2
-老妇,hag,老妇,NOUN,B2
-老妇人,older woman,老妇人,NOUN,B2
-老式的,old-fashioned,老式的,ADJ,B2
-老板主义,bossism,老板主义,NOUN,B2
-考虑/思考,to consider think,考虑/思考,VERB,B2
-考试,exam,考试,NOUN,B2
-考试,examination,考试,NOUN,B2
-考验,ordeal,苦难,NOUN,B2
-而是,but rather,而是,CCONJ,B2
-耐久性,durability,耐用性,NOUN,B2
-耙子,rake,耙子,NOUN,B2
-耳朵,ears,耳朵,NOUN,B2
-耻辱,disgrace,耻辱,NOUN,B2
-耻辱,dishonor,耻辱,NOUN,B2
-耻辱,stigma,耻辱,NOUN,B2
-聋,deaf,聋的,ADJ,B2
-职业,calling,使命,NOUN,B2
-职业,profession,职业,NOUN,B2
-职业养老金,occupational pension,职业养老金,NOUN,B2
-职业生涯,the career,职业生涯,NOUN,B2
-联合,united,联合的,ADJ,B2
-联合制作,coproduction,联合制作,NOUN,B2
-联系,to relate,联系,VERB,B2
-联系人,contact person,联系人,NOUN,B2
-联网的,networked,联网的,ADJ,B2
-联邦制,federalism,联邦主义,NOUN,B2
-联邦化,federalization,联邦化,NOUN,B2
-联邦的,federal,联邦的,ADJ,B2
-聚焦,to focus,聚焦,VERB,B2
-聪明的,intelligent,聪明的,ADJ,B2
-聪明的,smart clever,聪明的,ADJ,B2
-肆无忌惮的,unscrupulous,肆无忌惮的,ADJ,B2
-肉,flesh,肉,NOUN,B2
-肉,meat,肉,NOUN,B2
-肉丸,meatballs,肉丸,NOUN,B2
-肉汤,broth,肉汤,NOUN,B2
-肋骨,ribs,肋骨,NOUN,B2
-肌肉酸痛,muscle ache,肌肉酸痛,NOUN,B2
-肘,elbow,手肘,NOUN,B2
-肚脐,navel,肚脐,NOUN,B2
-肝脏,liver,肝脏,NOUN,B2
-肝脏的,hepatic,肝脏的,ADJ,B2
-肢体,limb,肢体,NOUN,B2
-肤色,complexion,肤色,NOUN,B2
-肥大,hypertrophy,肥大,NOUN,B2
-肥沃的,fertile,肥沃的,ADJ,B2
-肥胖,obesity,肥胖,NOUN,B2
-肮脏的,filthy,肮脏的,ADJ,B2
-肮脏的,sordid,肮脏的,ADJ,B2
-肯定地,surely safe,肯定地,ADV,B2
-肺,pulmonary,肺的,ADJ,B2
-肾的,renal,肾脏的,ADJ,B2
-肾脏,kidney,肾脏,NOUN,B2
-肿块,bump,肿块,NOUN,B2
-肿块,lump,块,NOUN,B2
-肿瘤,tumor,肿瘤,NOUN,B2
-肿胀的,swollen,肿胀的,ADJ,B2
-胆汁,bile,胆汁,NOUN,B2
-背信弃义,perfidy,背信弃义,NOUN,B2
-背包,backpack,背包,NOUN,B2
-背心,vest,背心,NOUN,B2
-背景,backdrop,背景,NOUN,B2
-背面,back side,背面,NOUN,B2
-胎儿,fetus,胎儿,NOUN,B2
-胖子,chubby,胖子,NOUN,B2
-胚胎,embryo,胚胎,NOUN,B2
-胜利,triumph,胜利,NOUN,B2
-胜利,win,胜利,NOUN,B2
-胡子,mustache,胡子,NOUN,B2
-胡扯,to bullshit,胡扯,VERB,B2
-胡搞,to mess about,胡搞,VERB,B2
-胡椒,pepper,胡椒,NOUN,B2
-胡闹,to mess around,胡闹,VERB,B2
-胰岛素,insulin,胰岛素,NOUN,B2
-胶体的,colloidal,胶体的,ADJ,B2
-胶状的,gelatinous,胶状的,ADJ,B2
-胸膜,pleura,胸膜,NOUN,B2
-能,able,能够的,ADJ,B2
-能,can,能够,AUX,B2
-能力,competence,能力,NOUN,B2
-能够,be able to,能,AUX,B2
-能够,to be able,能,VERB,B2
-能够,to be able to,能够,VERB,B2
-能干的/优秀的,capable good,能干的/优秀的,ADJ,B2
-能源危机,energy crisis,能源危机,NOUN,B2
-脂肪,fat,脂肪,NOUN,B2
-脂肪的,fatty,脂肪的,ADJ,B2
-脆弱,fragility,脆弱,NOUN,B2
-脆弱的,flimsy,脆弱的,ADJ,B2
-脆的,crunchy,脆的,ADJ,B2
-脊柱,backbone,脊梁,NOUN,B2
-脊柱,spine,脊柱,NOUN,B2
-脊髓,spinal cord,脊髓,NOUN,B2
-脑震荡,concussion,脑震荡,NOUN,B2
-脓肿,abscess,脓肿,NOUN,B2
-脚手架,scaffold,脚手架,NOUN,B2
-脚踝,ankle,脚踝,NOUN,B2
-脱毛,to depilate,脱毛,VERB,B2
-脱离,to disengage,脱离,VERB,B2
-脱离,to secede,脱离,VERB,B2
-脱臼,to dislocate,使脱臼,VERB,B2
-脱衣,to undress,脱衣,VERB,B2
-脱轨,to derail,使脱轨,VERB,B2
-脸红,to blush,脸红,VERB,B2
-脸颊,cheek,脸颊,NOUN,B2
-脾气坏的,grumpy,脾气坏的,ADJ,B2
-腌制,to marinate,腌制,VERB,B2
-腐烂,to rot,腐烂,VERB,B2
-腐蚀,corrupt,腐败的,ADJ,B2
-腐蚀,corrosion,腐蚀,NOUN,B2
-腐蚀,to corrode,腐蚀,VERB,B2
-腐蚀,to corrupt,腐败,VERB,B2
-腐蚀性的,corrosive,腐蚀性的,ADJ,B2
-腔,cavity,腔,NOUN,B2
-腹膜,peritoneum,腹膜,NOUN,B2
-腺,gland,腺体,NOUN,B2
-膝盖,knee,膝盖,NOUN,B2
-膝部,lap,大腿部,NOUN,B2
-膨胀的,inflated,膨胀的,ADJ,B2
-臀部,butt,臀部,NOUN,B2
-臀部,hip,臀部,NOUN,B2
-自信,self-confidence,自信,NOUN,B2
-自动,automated,自动化的,ADJ,B2
-自动化,automation,自动化,NOUN,B2
-自动化,to automate,使自动化,VERB,B2
-自动取款机,atm,自动取款机,NOUN,B2
-自动售货机,vending machine,自动售货机,NOUN,B2
-自动地,automatically,自动地,ADV,B2
-自发的,spontaneous,自发的,ADJ,B2
-自命不凡的,pretentious,自命不凡的,ADJ,B2
-自夸的,boastful,自夸的,ADJ,B2
-自学的,self-taught,自学的,ADJ,B2
-自尊,self-esteem,自尊,NOUN,B2
-自己,self,自己,PRON,B2
-自己的,own,自己的,DET,B2
-自恋,narcissism,自恋,NOUN,B2
-自恋的,narcissistic,自恋的,ADJ,B2
-自愿,voluntarily,自愿地,ADV,B2
-自我中心,egocentrism,自我中心,NOUN,B2
-自我形象,self-image,自我形象,NOUN,B2
-自我护理,self-care,自我护理,NOUN,B2
-自我牺牲,self-denial,自我牺牲,NOUN,B2
-自明之理,truism,自明之理,NOUN,B2
-自治,autonomy,自治,NOUN,B2
-自治的,autonomous,自治的,ADJ,B2
-自然保护区,nature reserve,自然保护区,NOUN,B2
-自然地,naturally,自然地,ADV,B2
-自然法则,natural law,自然法则,NOUN,B2
-自然的,natural,自然的,ADJ,B2
-自然神论,deism,自然神论,NOUN,B2
-自由主义,liberalism,自由主义,NOUN,B2
-自由化,liberalize,自由化,! VERB,B2
-自由化,liberalization,自由化,NOUN,B2
-自由地,freely,自由地,ADV,B2
-自由的,liberal,自由的,ADJ,B2
-自私,selfishness,自私,NOUN,B2
-自行车头盔,bike helmet,自行车头盔,NOUN,B2
-自行车道,cycle path,自行车道,NOUN,B2
-自闭症,autism,自闭症,NOUN,B2
-臭名昭著的,notorious,臭名昭著的,ADJ,B2
-臭的,stinking,发臭的,ADJ,B2
-致命,deadly,致命的,ADJ,B2
-致命地,deadly,致命地,ADV,B2
-致命性,fatality,致命性,NOUN,B2
-致命的,fatal,致命的,ADJ,B2
-致命的,lethal,致命的,ADJ,B2
-致死,death,致死,ADV,B2
-致病的,pathogenic,致病的,ADJ,B2
-舒适,comfort,安慰,NOUN,B2
-舒适的,cozy,舒适的,ADJ,B2
-舒适的,welcoming,舒适的,ADJ,B2
-舔,to lick,舔,VERB,B2
-舞者,dancer,舞者,NOUN,B2
-舞蹈,dance,舞蹈,NOUN,B2
-舞蹈,dans,舞蹈,NOUN,B2
-航行,to sail,航行,VERB,B2
-舰队,fleet,舰队,NOUN,B2
-舱口,hatch,舱口,NOUN,B2
-船内的,inboard,船内的,ADV,B2
-良心问题,matter of conscience,良心问题,NOUN,B2
-良性,benignity,良性,NOUN,B2
-良性的,benign,良性的,ADJ,B2
-艰难,hardship,艰难,NOUN,B2
-色情,eroticism,色情,NOUN,B2
-色情,pornography,色情,NOUN,B2
-色情的,erotic,色情的,ADJ,B2
-艺术的,artistic,艺术的,ADJ,B2
-节俭,frugality,节俭,NOUN,B2
-节制,abstinence,节制,NOUN,B2
-节奏,rhythm,节奏,NOUN,B2
-节奏性,rhythmicity,节奏性,NOUN,B2
-节日的,festive,节日的,ADJ,B2
-芜菁,turnip,芜菁,NOUN,B2
-芦笋,asparagus,芦笋,NOUN,B2
-芬兰的,finnish,芬兰的,ADJ,B2
-花岗岩,granite,花岗岩,NOUN,B2
-花环,garland,花环,NOUN,B2
-花瓶,vase,花瓶,NOUN,B2
-花费,to expend,花费,VERB,B2
-花费,to spend,花费,VERB,B2
-芽,bud,芽,NOUN,B2
-苍白,pallor,苍白,NOUN,B2
-苍白的,pale,苍白的,ADJ,B2
-苍蝇,fly,苍蝇,NOUN,B2
-苏丹,sultan,苏丹,NOUN,B2
-苏丹国,sultanate,苏丹国,NOUN,B2
-苏打,soda,苏打,NOUN,B2
-苔藓,moss,苔藓,NOUN,B2
-苟活,to vegetate,苟活,VERB,B2
-苦涩,bitterness,苦涩,NOUN,B2
-苦行,asceticism,苦行主义,NOUN,B2
-苦行的,ascetic,苦行的,ADJ,B2
-英勇,valiant,英勇的,ADJ,B2
-英勇,gallantry,英勇,NOUN,B2
-英勇地,heroically,英勇地,ADV,B2
-英勇的,gallant,英勇的,ADJ,B2
-英国人,briton,英国人,NOUN,B2
-英国人,englishman,英国人,NOUN,B2
-英国的,british,英国的,ADJ,B2
-英语,english,英国的,ADJ,B2
-英里,mile,英里,NOUN,B2
-英镑,pound,磅,NOUN,B2
-茁壮成长,to thrive,茁壮成长,VERB,B2
-范围,reach,范围,NOUN,B2
-范围,scope,范围,NOUN,B2
-茎,stem,茎,NOUN,B2
-茴香,anise,茴香,NOUN,B2
-草原,steppes,草原,NOUN,B2
-草地,meadow,草地,NOUN,B2
-草率地,summarily,草率地,ADV,B2
-荒凉,desolation,荒凉,NOUN,B2
-荒谬,absurd,荒谬的,ADJ,B2
-荒野,moor,荒野,NOUN,B2
-荒野,wilderness,荒野,NOUN,B2
-荡妇,slut,荡妇,NOUN,B2
-荡秋千,to swing,荡秋千,VERB,B2
-药剂师,pharmacist,药剂师,NOUN,B2
-药物,drug,药物,NOUN,B2
-药物的,pharmaceutical,制药的,ADJ,B2
-药膏,ointment,药膏,NOUN,B2
-荷兰人,dutchman,荷兰人,NOUN,B2
-荷兰的,dutch,荷兰的,ADJ,B2
-荷兰语,dutch,荷兰语,NOUN,B2
-获得,obtaining,获得,NOUN,B2
-获得,to acquire,获得,VERB,B2
-获得,to gain,获得,VERB,B2
-获得,to secure,保护,VERB,B2
-获得/弄到,to get acquire,获得/弄到,VERB,B2
-获授权,authorized,有资格的,ADJ,B2
-获救,to be saved,获救,VERB,B2
-获胜者,winner,获胜者,NOUN,B2
-菲律宾的,filipino,菲律宾的,ADJ,B2
-萎缩,atrophy,萎缩,NOUN,B2
-萝卜,radish,小萝卜,NOUN,B2
-营,battalion,营,NOUN,B2
-营养,nourishment,营养,NOUN,B2
-营养,sustenance,食物,NOUN,B2
-营养不良,malnutrition,营养不良,NOUN,B2
-营救,to rescue,拯救,VERB,B2
-营销,marketing,营销,NOUN,B2
-落到...身上,to fall to,落到...身上,VERB,B2
-著名,well-known,众所周知的,ADJ,B2
-著名的,illustrious,著名的,ADJ,B2
-著名的,renowned,著名的,ADJ,B2
-著名的/熟悉的,known famous,著名的/熟悉的,ADJ,B2
-葡萄牙语,portuguese,葡萄牙语,NOUN,B2
-董事职位,directorship,董事职位,NOUN,B2
-蒙昧主义,obscurantism,蒙昧主义,NOUN,B2
-蒸发,evaporation,蒸发,NOUN,B2
-蒸发,to evaporate,蒸发,VERB,B2
-蒸汽,steam,蒸汽,NOUN,B2
-蒸馏,to distill,蒸馏,VERB,B2
-蓄水池,cistern,蓄水池,NOUN,B2
-蔑视,contempt,轻视,NOUN,B2
-蔑视,to flout,蔑视,VERB,B2
-蔓延,proliferation of evil,蔓延,NOUN,B2
-蕨类植物,fern,蕨类植物,NOUN,B2
-薄,thinness,瘦,NOUN,B2
-薯条,fries,炸薯条,NOUN,B2
-薯片,chips,薯片,NOUN,B2
-藏书票,bookplate,藏书票,NOUN,B2
-藏身处,hideout,藏身处,NOUN,B2
-藏身处,hiding place,藏身处,NOUN,B2
-虐待,mistreatment,虐待,NOUN,B2
-虐待,to maltreat,虐待,VERB,B2
-虐待,to mistreat,أساء,VERB,B2
-虔诚,piety,虔诚,NOUN,B2
-虔诚,religiousness,虔诚,NOUN,B2
-虔诚的,pious,虔诚的,ADJ,B2
-虔诚的,reverent,虔诚的,ADJ,B2
-虚假信息,disinformation,虚假信息,NOUN,B2
-虚假的,spurious,虚假的,ADJ,B2
-虚幻,unreality,虚幻,NOUN,B2
-虚张声势,to bluff,虚张声势,VERB,B2
-虚弱,debility,虚弱,NOUN,B2
-虚弱的,feeble,虚弱的,ADJ,B2
-虚拟,virtual,虚拟的,ADJ,B2
-虚无主义,nihilism,虚无主义,NOUN,B2
-虚有权,bare ownership,虚有权,NOUN,B2
-虚构的,fictional,虚构的,ADJ,B2
-虚构的,fictitious,虚构的,ADJ,B2
-虚构角色,fictional character,虚构角色,NOUN,B2
-虫,worm,虫,NOUN,B2
-虫子,bug,虫子,NOUN,B2
-虾,shrimp,虾,NOUN,B2
-蚂蚁,ant,蚂蚁,NOUN,B2
-蚊子,mosquito,蚊子,NOUN,B2
-蚊帐,mosquito net,蚊帐,NOUN,B2
-蛊惑,demagogy,蛊惑,NOUN,B2
-蜂蜜,honey,蜂蜜,NOUN,B2
-蜇,to sting,刺,VERB,B2
-蜗牛,snail,蜗牛,NOUN,B2
-蜜月,honeymoon,蜜月,NOUN,B2
-蜡,wax,蜡,NOUN,B2
-蜥蜴,lizard,蜥蜴,NOUN,B2
-蝙蝠,bat,蝙蝠,NOUN,B2
-螃蟹,crab,螃蟹,NOUN,B2
-融合,fusion,融合,NOUN,B2
-融资,financing funding,融资,NOUN,B2
-融资,to finance,资助,VERB,B2
-螺丝刀,screwdriver,螺丝刀,NOUN,B2
-螺旋桨,propeller,螺旋桨,NOUN,B2
-蟾蜍,toad,蟾蜍,NOUN,B2
-蠢事,stupid things,蠢事,NOUN,B2
-血型,blood type,血型,NOUN,B2
-血统,lineage,血统,NOUN,B2
-血缘,consanguinity,血缘,NOUN,B2
-行为主义者,behaviorist,行为主义者,NOUN,B2
-行为方针,line of conduct,行为方针,NOUN,B2
-行会,guild,行会,NOUN,B2
-行动,to act,行动,VERB,B2
-行动方案,action plan,行动方案,NOUN,B2
-行政,administrative,行政的,ADJ,B2
-行星,planet,行星,NOUN,B2
-行李,baggage,行李,NOUN,B2
-行李,luggage,行李,NOUN,B2
-行程,itinerary,行程,NOUN,B2
-行话,jargon,行话,NOUN,B2
-街头采访,street interview,街头采访,NOUN,B2
-衣柜,wardrobe,衣柜,NOUN,B2
-补充,to complement,补充,VERB,B2
-补充物,complement,补充物,NOUN,B2
-补遗,addendum,补遗,NOUN,B2
-表征,to characterize,描绘,VERB,B2
-表明,to manifest,表明,VERB,B2
-表演,acting,行为,NOUN,B2
-表演,show,表演,NOUN,B2
-表现,showing,表现,NOUN,B2
-表现力,expressiveness,表现力,NOUN,B2
-表示,to denote,表示,VERB,B2
-表面的,superficial,表面的,ADJ,B2
-衰减,attenuation,衰减,NOUN,B2
-衰退/退潮,receding ebbing,衰退/退潮,NOUN,B2
-衷心的,heartfelt,衷心的,ADJ,B2
-袖子,sleeve,袖子,NOUN,B2
-被上诉人,respondent,被上诉人,NOUN,B2
-被偷的,stolen,被偷的,ADJ,B2
-被关在里面的,locked in,被关在里面的,ADJ,B2
-被创造,to be created,被创造,VERB,B2
-被判刑的,sentenced,被判刑的,ADJ,B2
-被占用的,occupied,被占用的,ADJ,B2
-被告,defendant,被告,NOUN,B2
-被告知的,told instructed,被告知的,ADJ,B2
-被声称,to be alleged,被声称,VERB,B2
-被愚弄的,bullshitted,被愚弄的,ADJ,B2
-被感染的,infected,被感染的,ADJ,B2
-被拘留者,detainee,被拘留者,NOUN,B2
-被拥有的,owned,被拥有的,ADJ,B2
-被拿走,to be taken,被拿走,VERB,B2
-被捕获的,caught,被捕获的,ADJ,B2
-被排除的,excluded,排除在外的,ADJ,B2
-被攻击的,attacked,被攻击的,ADJ,B2
-被欺骗,to be tricked,被欺骗,VERB,B2
-被淘汰的,knocked out,被淘汰的,ADJ,B2
-被爱的,loved,被爱的,ADJ,B2
-被看见,seen,被看见,ADJ,B2
-被砍倒,to be felled,被砍倒,VERB,B2
-被算作,to be counted,被算作,VERB,B2
-被绑架的,kidnapped,被绑架的,ADJ,B2
-被绞死的,hanged,被绞死的,ADJ,B2
-被解雇的,fired,被解雇的,ADJ,B2
-被证实,to be confirmed,被证实,VERB,B2
-被证明,to be proven,被证明,VERB,B2
-被诅咒的,cursed,被诅咒的,ADJ,B2
-被调查的,investigated,被调查的,ADJ,B2
-被迫,to be forced,被迫,VERB,B2
-被迫的,obliged,被迫的,ADJ,B2
-被通缉的,wanted,故意的,ADJ,B2
-被逮捕的,arrested,被逮捕的,ADJ,B2
-被需要,to be needed,被需要,VERB,B2
-被驱动,to be driven,被驱动,VERB,B2
-被驾驶的,driven,被驾驶的,ADJ,B2
-袭击,to assault,袭击,VERB,B2
-裁军,disarmament,裁军,NOUN,B2
-裁员,layoff,解雇,NOUN,B2
-裂变,fission,裂变,NOUN,B2
-裂痕,rift,裂痕,NOUN,B2
-裂缝,fissure,裂缝,NOUN,B2
-装嫩,to feigning youthfulness,装嫩,VERB,B2
-装满,to fill pack,装满,VERB,B2
-装置,apparatus,仪器,NOUN,B2
-装载,load,负载,NOUN,B2
-装载,to load,装载,VERB,B2
-装载,to load charge,装载,VERB,B2
-装饰,adornment,装饰品,NOUN,B2
-装饰,ornament,装饰,NOUN,B2
-装饰,to adorn,装饰,VERB,B2
-装饰,to decorate,装饰,VERB,B2
-装饰,to embellish,装饰,VERB,B2
-装饰性的,decorative,装饰性的,ADJ,B2
-裤子,pants,裤子,NOUN,B2
-裸体的,naked,裸体的,ADJ,B2
-裸露,to strip,裸露,VERB,B2
-西南的,southwest,西南的,ADJ,B2
-西方的,western,西方的,ADJ,B2
-西班牙语,spanish,西班牙的,ADJ,B2
-西葫芦,zucchini,西葫芦,NOUN,B2
-要么,either,或者,CCONJ,B2
-要求,requirement,要求,NOUN,B2
-要求,to demand,要求,VERB,B2
-要求高的,demanding,要求高的,ADJ,B2
-要紧,to matter,重要,VERB,B2
-覆盖,to shroud,覆盖,VERB,B2
-覆盖物,cover blanket,覆盖物,NOUN,B2
-覆盖范围,coverage,报道,NOUN,B2
-见多识广的,informed,见多识广的,ADJ,B2
-观众,spectator,观众,NOUN,B2
-观众,viewer,观众,NOUN,B2
-观察,to observe,观察,VERB,B2
-观望的,wait-and-see,观望的,ADJ,B2
-观看,to watch,观看,VERB,B2
-观看次数,views,观看次数,NOUN,B2
-规划,planning,规划,NOUN,B2
-规定,to stipulate,规定,VERB,B2
-规律性,regularity,规律性,NOUN,B2
-规格,specification,规格,NOUN,B2
-规章,regulations,法规,NOUN,B2
-规范的,canonical,规范的,ADJ,B2
-视力,eyesight,视力,NOUN,B2
-视听,audiovisual,视听的,ADJ,B2
-视觉,visual,视觉的,ADJ,B2
-视觉,vision,远见,NOUN,B2
-觊觎,to covet,觊觎,VERB,B2
-角膜,cornea,角膜,NOUN,B2
-角落,corner,角落,NOUN,B2
-角蝰,asp,角蝰,NOUN,B2
-解决,to resolve,解决,VERB,B2
-解剖学,anatomy,解剖学,NOUN,B2
-解压,to decompress,解压,VERB,B2
-解密,decryption,解密,NOUN,B2
-解密,to declassify,解密,VERB,B2
-解开,to unbridle,解开,VERB,B2
-解开,to undo,解开,VERB,B2
-解开,to unravel,解开,VERB,B2
-解放,emancipation,解放,NOUN,B2
-解放,to emancipate,解放,VERB,B2
-解放,to liberate,解放,VERB,B2
-解放的,liberating,解放的,ADJ,B2
-解散,dissolution,溶解,NOUN,B2
-解毒剂,antidote,解毒剂,NOUN,B2
-解码,to decode,解码,VERB,B2
-解离,dissociation,解离,NOUN,B2
-解释,explanation,解释,NOUN,B2
-解释,interpretation,解释,NOUN,B2
-解释,to interpret,解释,VERB,B2
-解释的,explanatory,解释的,ADJ,B2
-解除扣押,release of lien,解除扣押,NOUN,B2
-解雇,dismissal,解雇,NOUN,B2
-解雇,to dismiss fire,解雇,VERB,B2
-触发,triggering,触发,NOUN,B2
-言论自由,freedom of speech,言论自由,NOUN,B2
-誓言,oath,誓言,NOUN,B2
-警卫,guards,警卫,NOUN,B2
-警告,warning,警告,NOUN,B2
-警告,to alert,警告,VERB,B2
-警察,cop,警察,NOUN,B2
-警察,police officer,警察,NOUN,B2
-警察局长,police chief,警察局长,NOUN,B2
-警惕,vigilance,警惕,NOUN,B2
-警惕的,vigilant,警惕的,ADJ,B2
-警报,alert,警报,NOUN,B2
-警报器,siren,汽笛,NOUN,B2
-警棍,baton,警棍,NOUN,B2
-计算,to calculate,计算,VERB,B2
-计算,to count,重要,VERB,B2
-计算器,calculator,计算器,NOUN,B2
-订婚,betrothal,订婚,NOUN,B2
-订阅,subscription,订阅,NOUN,B2
-订阅,to subscribe,订阅,VERB,B2
-订阅者,subscriber,订阅者,NOUN,B2
-认可,endorsement,背书,NOUN,B2
-认可,to sanction,认可,VERB,B2
-认可的,accredited,认可的,ADJ,B2
-认真地,seriously,认真地,ADV,B2
-认知,cognition,认知,NOUN,B2
-认知的,cognitive,认知的,ADJ,B2
-认证,authentication,认证,NOUN,B2
-认证,certification,认证,NOUN,B2
-认证,to accredit,认可,VERB,B2
-认识/感觉,to know feel,认识/感觉,VERB,B2
-讨价还价,to haggle,讨价还价,VERB,B2
-让,to let,让,VERB,B2
-让步的,concessionary,让步的,ADJ,B2
-训斥,reprimand,训斥,NOUN,B2
-训练/锻炼,to train exercise,训练/锻炼,VERB,B2
-议会制,parliamentarism,议会制,NOUN,B2
-议会的/议员,parliamentary,议会的/议员,ADJ,B2
-议会选举,parliamentary elections,议会选举,NOUN,B2
-议员,member of parliament,议员,NOUN,B2
-记录,recording,录音,NOUN,B2
-记录,to document,记录,VERB,B2
-记忆,memorization,记忆,NOUN,B2
-记者,correspondent,记者,NOUN,B2
-记者,journalist,记者,NOUN,B2
-记者招待会,press conference,新闻发布会,NOUN,B2
-讲坛,pulpit,讲坛,NOUN,B2
-讲师,instructor,讲师,NOUN,B2
-讲得通,to make sense,讲得通,VERB,B2
-讲法语的,french-speaking,讲法语的,ADJ,B2
-讲英语的,english-speaking,讲英语的,ADJ,B2
-许可,permission,许可,NOUN,B2
-许可信号,all-clear,许可信号,NOUN,B2
-许多,much many,许多,ADJ,B2
-许多,many,许多,DET,B2
-许多,much,多,DET,B2
-许多事物,many things,许多事物,PRON,B2
-论坛,forum,论坛,NOUN,B2
-讽刺,irony,讽刺,NOUN,B2
-讽刺,to ironize,讽刺,VERB,B2
-讽刺的,ironic,讽刺的,ADJ,B2
-讽刺的,satirical,讽刺的,ADJ,B2
-设备,devices,设备,NOUN,B2
-设计,to design,设计,VERB,B2
-设计,to devise,设计,VERB,B2
+深渊,abyss,深渊,NOUN,B2
+学者,academic,学者,NOUN,B2
+加速,acceleration,加速,NOUN,B2
 访问,access,进入权,NOUN,B2
-诀窍,know-how,诀窍,NOUN,B2
-证人询问,witness examination,证人询问,NOUN,B2
-证券交易所,stock exchange,证券交易所,NOUN,B2
-证券化,securitization,证券化,NOUN,B2
-证实,corroboration,证实,NOUN,B2
-证实,to corroborate,证实,VERB,B2
-证实,to substantiate,证实,VERB,B2
-证明,to attest,证明,VERB,B2
-证明文件,supporting document,证明文件,NOUN,B2
-证明无效,to invalidate,证明无效,VERB,B2
-证词,deposition,证词,NOUN,B2
-评估,judgement,评估,NOUN,B2
-评分,grading,评分；记号,NOUN,B2
-评论,to commentate,评论,VERB,B2
-评论家,critic,评论家,NOUN,B2
-诅咒,damn,该死的,ADJ,B2
-诅咒,curse,诅咒,NOUN,B2
-诅咒,to curse,诅咒,VERB,B2
-诅咒,to damn,诅咒,VERB,B2
-诈骗,to swindle,诈骗,VERB,B2
-诉讼,court case,诉讼,NOUN,B2
-诉讼,lawsuit,诉讼,NOUN,B2
-诉讼当事人,litigant,诉讼当事人,NOUN,B2
-诉讼费,court fee,诉讼费,NOUN,B2
-诊断,to diagnose,诊断,VERB,B2
-诋毁,to denigrate,诋毁,VERB,B2
-词,anrichtung,词,NOUN,B2
-词,anteilung,词,NOUN,B2
-词,antheilung,词,NOUN,B2
-词,aufforderung,词,NOUN,B2
-词,aufrichtung,词,NOUN,B2
-词,aufweisung,词,NOUN,B2
-词,ausfahrt,词,NOUN,B2
-词,ausforderung,词,NOUN,B2
-词,ausgestaltung,词,NOUN,B2
-词,ausschrift,词,NOUN,B2
-词,aussetzung,词,NOUN,B2
-词,aussinnung,词,NOUN,B2
-词,auswandel,词,NOUN,B2
-词,ausweisung,词,NOUN,B2
-词,benahme,词,NOUN,B2
-词,bepflegung,词,NOUN,B2
-词,besprache,词,NOUN,B2
-词,besuchung,词,NOUN,B2
-词,beteilung,词,NOUN,B2
-词,einerziehung,词,NOUN,B2
-词,eingabe,词,NOUN,B2
-词,einnahme,词,NOUN,B2
-词,einschaft,词,NOUN,B2
-词,einsprache,词,NOUN,B2
-词,einteilung,词,NOUN,B2
-词,einweisung,词,NOUN,B2
-词,einwirkung,词,NOUN,B2
-词,erfahrt,词,NOUN,B2
-词,erforderung,词,NOUN,B2
-词,erschaft,词,NOUN,B2
-词,erweisung,词,NOUN,B2
-词,erzregelung,词,NOUN,B2
-词,fernrechnung,词,NOUN,B2
-词,fernschaft,词,NOUN,B2
-词,fernsucht,词,NOUN,B2
-词,ferntheilung,词,NOUN,B2
-词,geforderung,词,NOUN,B2
-词,gerichtung,词,NOUN,B2
-词,gesinnung,词,NOUN,B2
-词,gesucht,词,NOUN,B2
-词,geteilung,词,NOUN,B2
-词,getheilung,词,NOUN,B2
-词,getreibung,词,NOUN,B2
-词,hinterfassung,词,NOUN,B2
-词,hinterleitung,词,NOUN,B2
-词,hinterrechnung,词,NOUN,B2
-词,hinterregelung,词,NOUN,B2
-词,hinterrichtung,词,NOUN,B2
-词,hintersicht,词,NOUN,B2
-词,hintersucht,词,NOUN,B2
-词,hintersuchung,词,NOUN,B2
-词,hintertheilung,词,NOUN,B2
-词,hinterwandel,词,NOUN,B2
-词,hinterwendung,词,NOUN,B2
-词,hochkunft,词,NOUN,B2
-词,hochweisung,词,NOUN,B2
-词,missschaft,词,NOUN,B2
-词,missschrift,词,NOUN,B2
-词,misstheilung,词,NOUN,B2
-词,misstreibung,词,NOUN,B2
-词,mitfahrt,词,NOUN,B2
-词,mitsetzung,词,NOUN,B2
-词,nachrichtung,词,NOUN,B2
-词,nachsinnung,词,NOUN,B2
-词,nachsuchung,词,NOUN,B2
-词,nachtheilung,词,NOUN,B2
-词,nachweisung,词,NOUN,B2
-词,nachwirkung,词,NOUN,B2
-词,naherziehung,词,NOUN,B2
-词,nahfahrt,词,NOUN,B2
-词,nahfassung,词,NOUN,B2
-词,oberbildung,词,NOUN,B2
-词,obererziehung,词,NOUN,B2
-词,oberleitung,词,NOUN,B2
-词,obersuchung,词,NOUN,B2
-词,oberwandlung,词,NOUN,B2
-词,tiefsuchung,词,NOUN,B2
-词,unerziehung,词,NOUN,B2
-词,unfahrt,词,NOUN,B2
-词,unfassung,词,NOUN,B2
-词,unnahme,词,NOUN,B2
-词,unpflegung,词,NOUN,B2
-词,unterpflegung,词,NOUN,B2
-词,untersinnung,词,NOUN,B2
-词,untertreibung,词,NOUN,B2
-词,untreibung,词,NOUN,B2
-词,unwandel,词,NOUN,B2
-词,unweisung,词,NOUN,B2
-词,urgabe,词,NOUN,B2
-词,urgestaltung,词,NOUN,B2
-词,urnahme,词,NOUN,B2
-词,urschrift,词,NOUN,B2
-词,ursetzung,词,NOUN,B2
-词,ursicht,词,NOUN,B2
-词,urteilung,词,NOUN,B2
-词,urwandel,词,NOUN,B2
-词,verschaft,词,NOUN,B2
-词,vorderfassung,词,NOUN,B2
-词,vorderleitung,词,NOUN,B2
-词,vorderrichtung,词,NOUN,B2
-词,vordersetzung,词,NOUN,B2
-词,vordersinnung,词,NOUN,B2
-词,vorderweisung,词,NOUN,B2
-词,vorteilung,词,NOUN,B2
-词,vortheilung,词,NOUN,B2
-词,vorwandel,词,NOUN,B2
-词,weitregelung,词,NOUN,B2
-词,weitsicht,词,NOUN,B2
-词,weitsuchung,词,NOUN,B2
-词,weitwandel,词,NOUN,B2
-词,weitweisung,词,NOUN,B2
-词,wiedererziehung,词,NOUN,B2
-词,wiederkunft,词,NOUN,B2
-词,wiederordnung,词,NOUN,B2
-词,wiedersicht,词,NOUN,B2
-词,wiedersinnung,词,NOUN,B2
-词,wiedersprache,词,NOUN,B2
-词,wiedersucht,词,NOUN,B2
-词,wiedersuchung,词,NOUN,B2
-词,wiedertreibung,词,NOUN,B2
-词,zernahme,词,NOUN,B2
-词,zersicht,词,NOUN,B2
-词,zersucht,词,NOUN,B2
-词,zersuchung,词,NOUN,B2
-词,zerteilung,词,NOUN,B2
-词,zufahrt,词,NOUN,B2
-词,zurichtung,词,NOUN,B2
-词,zuschaft,词,NOUN,B2
-词,zusicht,词,NOUN,B2
-词,zusprache,词,NOUN,B2
-词汇学,lexicology,词汇学,NOUN,B2
-词汇表,glossary,词汇表,NOUN,B2
-词源学,etymology,词源学,NOUN,B2
-词语误用,catachresis,词语误用,NOUN,B2
-诗意,poetic quality,诗意,NOUN,B2
-诚实,honesty,诚实,NOUN,B2
-诚实,to be honest,诚实,VERB,B2
-诚实/正直,integrity trustworthiness,诚实/正直,NOUN,B2
-诚实地,honestly,诚实地,ADV,B2
-诠释学,hermeneutic,诠释学的,ADJ,B2
-诡计,cunning,诡计,NOUN,B2
-诡辩,sophism,诡辩,NOUN,B2
-该死,damn,该死,INTJ,B2
-该死的,confounded,该死的,ADJ,B2
-该死的,shit,该死的,ADJ,B2
-该死的,damn,该死的,ADV,B2
-详尽,exhaustive,详尽的,ADJ,B2
-详尽的,elaborate,详尽的,ADJ,B2
-详细地,in detail,详细地,ADV,B2
-详述,to detail,详述,VERB,B2
-语义内容,meaning content,语义内容,NOUN,B2
-语义学,semantics,语义学,NOUN,B2
-语境,context,上下文,NOUN,B2
-语境性,contextuality,语境性,NOUN,B2
-语境的,contextual,语境的,ADJ,B2
-语法错误,solecism,语法错误,NOUN,B2
-语素,morpheme,语素,NOUN,B2
-语言使用,language use,语言使用,NOUN,B2
-语言学,linguistics,语言学,NOUN,B2
-语言学家,philologist,语言学家,NOUN,B2
-语言的,linguistic,语言的,ADJ,B2
-语调,intonation,语调,NOUN,B2
-语音学,phonetics,语音学,NOUN,B2
-误导的,misleading,诡辩的,ADJ,B2
-诱人的,alluring,诱人的,ADJ,B2
-诱惑,to seduce,引诱,VERB,B2
-诱捕,to ensnare,诱捕,VERB,B2
-说唱歌手,rapper,说唱歌手,NOUN,B2
-说教的,moralizing,说教的,ADJ,B2
-说明,to account for,说明,VERB,B2
-说明,to illustrate,说明,VERB,B2
-说服,persuasion,说服,NOUN,B2
-说服,to convince,说服,VERB,B2
-说谎者,liar,骗子,NOUN,B2
-请,please,请,INTJ,B2
-读者,reader,读者,NOUN,B2
-诽谤,defamation,诽谤,NOUN,B2
-诽谤,slander,诽谤,NOUN,B2
-诽谤,to defame,诽谤,VERB,B2
-诽谤,to slander,诽谤,VERB,B2
-诽谤,to vilify,诽谤,VERB,B2
-课程,curriculum,课程,NOUN,B2
-谁,whom,谁,PRON,B2
-谁的,whose,谁的,PRON,B2
-调停,to intercede,调停,VERB,B2
-调和的,conciliatory,调和的,ADJ,B2
-调度；排序,scheduling,调度；排序,NOUN,B2
-调查,survey,调查,NOUN,B2
-调查员,investigator,调查员,NOUN,B2
-调节,adjustment,调节,NOUN,B2
-调节,to modulate,调节,VERB,B2
-调解,mediation,调解,NOUN,B2
-调谐,to tune,调谐,VERB,B2
-谄媚,obsequiousness,谄媚,NOUN,B2
-谄媚,servility,奴性,NOUN,B2
-谄媚,sycophancy,阿谀奉承,NOUN,B2
-谄媚地,obsequiously,谄媚地,ADV,B2
-谄媚的,unctuous,谄媚的,ADJ,B2
-谈判,negotiation,谈判；协商,NOUN,B2
-谈判,negotiations,谈判,NOUN,B2
-谋杀,to murder,谋杀,VERB,B2
-谋杀未遂,attempted murder,谋杀未遂,NOUN,B2
-谢天谢地,thank god,谢天谢地,INTJ,B2
-谢谢,thanks,谢谢,INTJ,B2
-谣言,rumor,谣言,NOUN,B2
-谦虚,modesty,谦虚,NOUN,B2
-谦逊的,humble,谦逊的,ADJ,B2
-谨慎,discretion,谨慎,NOUN,B2
-谨慎,prudence,谨慎,NOUN,B2
-谨慎的,circumspect,谨慎的,ADJ,B2
-谨慎的,discreet,谨慎的,ADJ,B2
-谨慎的,prudent,谨慎的,ADJ,B2
-谨慎的,wary,谨慎的,ADJ,B2
-谴责,to decry,谴责,VERB,B2
-谴责,to denounce,谴责,VERB,B2
-谴责,to deplore,谴责,VERB,B2
-谵妄,delirium,精神错乱,NOUN,B2
-豁免,exemption,豁免,NOUN,B2
+容纳,to accommodate,容纳,VERB,B2
+住宿,accommodation,住宿,NOUN,B2
+完成,to accomplish,完成,VERB,B2
+问责,accountability,问责制,NOUN,B2
+会计,accounting,会计,NOUN,B2
+认证,to accredit,认可,VERB,B2
+认可的,accredited,认可的,ADJ,B2
+累积,to accrue,积累,VERB,B2
+积累,accumulation,积累,NOUN,B2
+指控,accusation,指控,NOUN,B2
+使习惯,to accustom,使习惯,VERB,B2
+习惯的,accustomed,习惯的,ADJ,B2
+酸,acid,酸,NOUN,B2
+酸性,acidity,酸度,NOUN,B2
+声学,acoustics,声学,NOUN,B2
+获得,to acquire,获得,VERB,B2
+宣告无罪,to acquit,宣告无罪,VERB,B2
+无罪释放,acquittal,无罪释放,NOUN,B2
+尖刻,acrimony,尖刻,NOUN,B2
+杂技演员,acrobat,杂技演员,NOUN,B2
+穿过,across,穿过,ADP,B2
+行动,to act,行动,VERB,B2
+表演,acting,行为,NOUN,B2
+激活,to activate,激活,VERB,B2
+演员,actor,男演员,NOUN,B2
+女演员,actress,女演员,NOUN,B2
+尖锐,acute,剧烈的,ADJ,B2
+适应,adaptation,适应,NOUN,B2
+瘾君子,addict,上瘾者,NOUN,B2
+上瘾,addicted,上瘾的,ADJ,B2
+成瘾,addiction,上瘾,NOUN,B2
+额外,additional,额外的,ADJ,B2
+处理,to address,解决,VERB,B2
+相邻,adjacent,邻近的,ADJ,B2
+管理,to administer,管理,VERB,B2
+管理,administration,管理,NOUN,B2
+行政,administrative,行政的,ADJ,B2
+告诫,to admonish,告诫,VERB,B2
+装饰,to adorn,装饰,VERB,B2
+装饰,adornment,装饰品,NOUN,B2
+成年,adult,成年的,ADJ,B2
+预付款,advance payment,预付款,NOUN,B2
+冒险,adventure,冒险,NOUN,B2
+冒险家,adventurer,冒险家,NOUN,B2
+宣传,to advertise,做广告,VERB,B2
+广告,advertising,广告业,NOUN,B2
+建议,advice,建议,NOUN,B2
+反对,to advise against,劝阻,VERB,B2
+空中,aerial,航空的,ADJ,B2
+审美,aesthetic,审美的,ADJ,B2
+过敏,allergy,过敏,NOUN,B2
+允许的,allowed,被允许的,ADJ,B2
+合金,alloy,合金,NOUN,B2
+暗示的,allusive,暗指的,ADJ,B2
+盟友,ally,盟友,NOUN,B2
+沿着,along,沿着,ADP,B2
+字母的,alphabetical,按字母顺序的,ADJ,B2
+好,alright,好的,ADV,B2
+交替,alternation,轮流,NOUN,B2
+替代,alternative,替代方案,NOUN,B2
+利他主义,altruism,利他主义,NOUN,B2
+业余爱好者,amateur,业余爱好者,NOUN,B2
+惊讶,amazement,惊愕,NOUN,B2
+歧义,ambiguity,歧义,NOUN,B2
+模棱两可的,ambiguous,模棱两可的,ADJ,B2
+有雄心的,ambitious,有雄心的,ADJ,B2
+美国人,american,美国的,ADJ,B2
+弹药,ammunition,弹药,NOUN,B2
+摊销,to amortize,摊销,VERB,B2
+总计,to amount to,总计,VERB,B2
+截肢,to amputate,截肢,VERB,B2
+截肢,amputation,截肢,NOUN,B2
+护身符,amulet,护身符,NOUN,B2
+使娱乐,to amuse,逗乐,VERB,B2
+有趣的,amusing,有趣的,ADJ,B2
+模拟的,analog,模拟的,ADJ,B2
+类似的,analogous,类似的,ADJ,B2
+类比,analogy,类比,NOUN,B2
+分析,analysis,分析,NOUN,B2
+祖先,ancestry,血统,NOUN,B2
+锚,anchor,锚,NOUN,B2
+等等,and so forth,依此类推,ADV,B2
+轶事,anecdote,轶事,NOUN,B2
+麻醉,anesthesia,麻醉,NOUN,B2
+痛苦,anguish,痛苦,NOUN,B2
+动画,animation,动画,NOUN,B2
+敌意,animosity,敌意,NOUN,B2
+脚踝,ankle,脚踝,NOUN,B2
+吞并,annex,附件,NOUN,B2
+吞并,to annex,兼并,VERB,B2
+歼灭,to annihilate,消灭,VERB,B2
+注释,to annotate,注释,VERB,B2
+烦扰,to annoy,使恼怒,VERB,B2
+年度的,annual,年度的,ADJ,B2
+异常,anomaly,异常,NOUN,B2
+匿名的,anonymous,匿名的,ADJ,B2
+答录机,answering machine,邮箱,NOUN,B2
+蚂蚁,ant,蚂蚁,NOUN,B2
+天线,antenna,天线,NOUN,B2
+人类学,anthropology,人类学,NOUN,B2
+拟人化,anthropomorphism,拟人化,NOUN,B2
+抗生素,antibiotics,抗生素,NOUN,B2
+期待,anticipation,预期,NOUN,B2
+古旧的,antique,古老的,ADJ,B2
+消毒剂,antiseptic,防腐剂,NOUN,B2
+任何,any,任何,DET,B2
+分开,apart,分开,ADV,B2
+道歉,apology,道歉,NOUN,B2
+叛教,apostasy,叛教,NOUN,B2
+装置,apparatus,仪器,NOUN,B2
+安抚,to appease,安抚,VERB,B2
+上诉人,appellant,上诉人,NOUN,B2
+附录,appendix,附录,NOUN,B2
+食欲,appetite,食欲,NOUN,B2
+掌声,applause,掌声,NOUN,B2
+申请人,applicant,申请人,NOUN,B2
+申请,application,申请,NOUN,B2
+化妆,to apply makeup,化妆,VERB,B2
+预约,appointment,预约,NOUN,B2
+苦行,asceticism,苦行主义,NOUN,B2
+无性,asexual,无性的,ADJ,B2
+在旁边,aside,在旁边,ADV,B2
+抱负,aspiration,抱负,NOUN,B2
+追求,to aspire,渴望,VERB,B2
+驴,ass,驴,NOUN,B2
+集合,to assemble,集合,VERB,B2
+集会,assembly,集会,NOUN,B2
+资产,assets,资产,NOUN,B2
+勤勉,assiduous,勤勉的,ADJ,B2
+任务,assignment,任务,NOUN,B2
+同化,to assimilate,同化,VERB,B2
+同化,assimilation,同化,NOUN,B2
+就职,to assume office,就任,VERB,B2
+保证,to assure,保证,VERB,B2
+小行星,asteroid,小行星,NOUN,B2
+哮喘,asthma,哮喘,NOUN,B2
+震惊,to astonish,使惊讶,VERB,B2
+惊人,astonishing,令人惊讶的,ADJ,B2
+震惊,astonishment,惊讶,NOUN,B2
+占星术,astrology,占星术,NOUN,B2
+宇航员,astronaut,宇航员,NOUN,B2
+天文,astronomical,天文学的,ADJ,B2
+精明,astute,精明的,ADJ,B2
+庇护,asylum,庇护,NOUN,B2
+异步,asynchronous,异步的,ADJ,B2
+根本,at all,根本,ADV,B2
+在家,at home,在家,ADV,B2
+原子,atom,原子,NOUN,B2
+原子,atomic,原子的,ADJ,B2
+赎罪,to atone,赎罪,VERB,B2
+附上,to attach,附加,VERB,B2
+攻击者,attacker,攻击者,NOUN,B2
+达到,to attain,达到,VERB,B2
+专注,attentive,专心的,ADJ,B2
+律师,attorney,律师,NOUN,B2
+有吸引力,attractive,有吸引力的,ADJ,B2
+属性,attribute,属性,NOUN,B2
+视听,audiovisual,视听的,ADJ,B2
+审计员,auditor,审计员,NOUN,B2
+简朴,austere,严厉的,ADJ,B2
+紧缩,austerity,紧缩,NOUN,B2
+验证,to authenticate,认证,VERB,B2
+认证,authentication,认证,NOUN,B2
+真实性,authenticity,真实性,NOUN,B2
+专制,authoritarian,独裁的,ADJ,B2
+授权,authorization,授权,NOUN,B2
+获授权,authorized,有资格的,ADJ,B2
+亲笔签名,autograph,亲笔签名,NOUN,B2
+自动化,to automate,使自动化,VERB,B2
+自动,automated,自动化的,ADJ,B2
+自动地,automatically,自动地,ADV,B2
+自动化,automation,自动化,NOUN,B2
+尸检,autopsy,尸检,NOUN,B2
+可用,available,可获得的,ADJ,B2
+厌恶,aversion,厌恶,NOUN,B2
+醒,awake,醒着的,ADJ,B2
+唤醒,to awaken,唤醒,VERB,B2
+授予,award,奖项,NOUN,B2
+授予,to award,分配,VERB,B2
+意识到,aware,意识到的,ADJ,B2
+意识,awareness,意识,NOUN,B2
+离开,away,离开,ADV,B2
+斧头,axe,斧头,NOUN,B2
+公理,axiom,公理,NOUN,B2
+轴,axis,轴,NOUN,B2
+回,back,回来,ADV,B2
+后座,back seat,后座,NOUN,B2
+脊柱,backbone,脊梁,NOUN,B2
+背包,backpack,背包,NOUN,B2
+大教堂,basilica,大教堂,NOUN,B2
+篮子,basket,篮子,NOUN,B2
+私生子,bastard,混蛋,NOUN,B2
+蝙蝠,bat,蝙蝠,NOUN,B2
+一批,batch,一批,NOUN,B2
+洗澡,to bathe,洗澡,VERB,B2
+浴缸,bathtub,浴缸,NOUN,B2
+营,battalion,营,NOUN,B2
+海湾,bay,海湾,NOUN,B2
+集市,bazaar,集市,NOUN,B2
+是,be,是,AUX,B2
+能够,to be able,能,VERB,B2
+能够,be able to,能,AUX,B2
+能够,to be able to,能够,VERB,B2
+羞愧,to be ashamed,感到羞愧,VERB,B2
+完成,to be done,被做,VERB,B2
+被迫,to be forced,被迫,VERB,B2
+位于,to be located,位于,VERB,B2
+需要,to be required,被要求,VERB,B2
+沉默,to be silent,沉默,VERB,B2
+横梁,beam,光束,NOUN,B2
 豆,bean,豆子,NOUN,B2
-象征主义,symbolism,象征主义,NOUN,B2
-象征性的,emblematic,象征性的,ADJ,B2
-象征的,symbolic,象征的,ADJ,B2
-豪华的,opulent,豪华的,ADJ,B2
-豹,panther,豹,NOUN,B2
-贞洁,chastity,贞洁,NOUN,B2
-负担重的,burdened,负担重的,ADJ,B2
-负责任的,accountable,负责任的,ADJ,B2
-负责任的,responsible,负责的,ADJ,B2
-财务,finances,财政,NOUN,B2
-财富,wealth,财富,NOUN,B2
-责任,liability,责任,NOUN,B2
-责备,reproach,责备,NOUN,B2
-责备,to reproach,责备,VERB,B2
-败坏名誉,to discredit,败坏名声,VERB,B2
-货币的,monetary,金钱的,ADJ,B2
-货物,freight,货物,NOUN,B2
-货物,goods,商品,NOUN,B2
-货物,shipment,货物,NOUN,B2
-货物/负荷,load cargo,货物/负荷,NOUN,B2
-质量,mass,大量,NOUN,B2
-贪婪,greedy,贪婪的,ADJ,B2
-贪婪,covetousness,贪欲,NOUN,B2
-贪得无厌文化,culture of greed,贪得无厌文化,NOUN,B2
-贪欲,greedy ambition,贪欲,NOUN,B2
-贪污,embezzlement,贪污,NOUN,B2
-贫困,destitution,贫困,NOUN,B2
-贫困,poverty,贫困,NOUN,B2
-贫民窟,slum,贫民窟,NOUN,B2
+熊,bear,熊,NOUN,B2
+可忍受的,bearable,可忍受的,ADJ,B2
+野兽,beast,野兽,NOUN,B2
+打,to beat,打败,VERB,B2
+因为,because,因为,CCONJ,B2
+哔声,beep,吱吱声,NOUN,B2
+甲虫,beetle,甲虫,NOUN,B2
+在……之前,before,在...之前,SCONJ,B2
+开始,to begin,开始,VERB,B2
+初学者,beginner,初学者,NOUN,B2
+在后面,behind,在...后面,ADP,B2
+信徒,believer,信徒,NOUN,B2
 贬低,to belittle,轻视,VERB,B2
-贬低,to debase,贬低,VERB,B2
-贬低,to derogate,贬损,VERB,B2
-贬低,to detract,贬低,VERB,B2
-贬值,depreciation,贬值,NOUN,B2
-贬值,devaluation,贬值,NOUN,B2
-贬值,to depreciate,贬值,VERB,B2
-贬值,to devalue,贬值,VERB,B2
-贬谪,to relegate,降级,VERB,B2
-购买,purchase,购买,NOUN,B2
-购物,to shop,购物,VERB,B2
-购物,to shop be about,购物,VERB,B2
-贴花,decal,贴花,NOUN,B2
-贵族,nobleman,贵族,NOUN,B2
-贸易壁垒,trade barrier,贸易壁垒,NOUN,B2
-费力的,strenuous,费力的,ADJ,B2
-费用,charge,收费,NOUN,B2
-费用,costs,费用,NOUN,B2
-费用,expense,费用,NOUN,B2
-费用,expenses,费用,NOUN,B2
-费用,fee,费用,NOUN,B2
-费用,fees,酬金,NOUN,B2
+好战的,bellicose,好战的,ADJ,B2
+吼叫,to bellow,吼叫,VERB,B2
+属于,to belong,属于,VERB,B2
+长凳,bench,长凳,NOUN,B2
+弯曲,to bend,弯曲,VERB,B2
+恩人,benefactor,恩人,NOUN,B2
+良性的,benign,良性的,ADJ,B2
+围攻,to besiege,包围,VERB,B2
+最好的,best,最好的,ADJ,B2
+赌注,bet,打赌,NOUN,B2
+困惑,bewilderment,困惑,NOUN,B2
+在……之外,beyond,在...之外,ADP,B2
+圣经,bible,圣经,NOUN,B2
+书目,bibliography,参考书目,NOUN,B2
+最大的,biggest,最大,ADJ,B2
+胆汁,bile,胆汁,NOUN,B2
+十亿,billion,十亿,NUM,B2
+二进制的,binary,二进制的,ADJ,B2
+生物的,biological,生物的,ADJ,B2
+生物学,biology,生物学,NOUN,B2
+刺骨的,biting,尖刻的,ADJ,B2
+苦涩,bitterness,苦涩,NOUN,B2
+怪诞的,bizarre,奇异的,ADJ,B2
+黑市,black market,黑市,NOUN,B2
+铁匠,blacksmith,铁匠,NOUN,B2
+毯子,blanket,毯子,NOUN,B2
+亵渎,blasphemy,亵渎,NOUN,B2
+火焰,blaze,火焰,NOUN,B2
+漂白剂,bleach,漂白剂,NOUN,B2
+瑕疵,blemish,瑕疵,NOUN,B2
+盲人,blind,百叶窗,NOUN,B2
+极乐,bliss,极乐,NOUN,B2
+集团,bloc,阵营,NOUN,B2
+封锁,blockade,封锁,NOUN,B2
+崩溃,breakdown,故障,NOUN,B2
+早餐,breakfast,早餐,NOUN,B2
+哺乳,breastfeeding,母乳喂养,NOUN,B2
+微风,breeze,微风,NOUN,B2
+酿酒厂,brewery,啤酒厂,NOUN,B2
 贿赂,bribe,贿赂,NOUN,B2
 贿赂,bribery,贿赂,NOUN,B2
-资产,assets,资产,NOUN,B2
-资产负债表,balance sheet,资产负债表,NOUN,B2
-资产阶级的,bourgeois,资产阶级的,ADJ,B2
-资助,to subsidize,资助,VERB,B2
-资助者,financier,资助者,NOUN,B2
-资历,seniority,资历,NOUN,B2
-资本主义,capitalism,资本主义,NOUN,B2
-资源短缺,resource shortage,资源短缺,NOUN,B2
-赋予,to endow,赋予,VERB,B2
-赌博,to gamble,赌博,VERB,B2
-赌场,the casinos,赌场,NOUN,B2
-赌注,bet,打赌,NOUN,B2
-赎回,to buy back,赎回,VERB,B2
-赎回,to redeem,赎回,VERB,B2
-赎罪,atonement,赎罪,NOUN,B2
-赎罪,to atone,赎罪,VERB,B2
-赎金,ransom,赎金,NOUN,B2
-赔率,odds,赔率,NOUN,B2
-赞助,auspice,赞助,NOUN,B2
-赞助,to sponsor,赞助,VERB,B2
-赞歌,song of praise,赞歌,NOUN,B2
-赞美,to extol,赞美,VERB,B2
-赞美,to glorify,赞美,VERB,B2
-赠送,to give as a gift,赠送,VERB,B2
-赤裸的,bare,赤裸的,ADJ,B2
-赦免,to absolve,赦免,VERB,B2
-走廊,hallway,走廊,NOUN,B2
-走私,smuggling,走私,NOUN,B2
-走私犯,smuggler,走私者,NOUN,B2
-起作用,to function,运作,VERB,B2
-起源,genesis,起源,NOUN,B2
-起源于,to stem,起源于,VERB,B2
-起皱,wrinkling,起皱,NOUN,B2
-起草,to draw up,起草,VERB,B2
-起诉,indictment,起诉,NOUN,B2
-起诉,prosecution,起诉,NOUN,B2
-起诉,to prosecute,起诉,VERB,B2
-起飞,takeoff,起飞,NOUN,B2
-超现实主义,surrealism,超现实主义,NOUN,B2
-超自然的,supernatural,超自然的,ADJ,B2
-超越的,transcendent,卓越的,ADJ,B2
-超过,to overtake,超过,VERB,B2
-越,the more,越,ADV,B2
-越权,to overstep,越权,VERB,B2
-越轨,transgression,违犯,NOUN,B2
-越过,over,在...上方,ADP,B2
-越过,across,越过,ADV,B2
-足够,enough,足够的,ADJ,B2
-足球,soccer,足球,NOUN,B2
-足迹,footprint,足迹,NOUN,B2
-跌倒,to tumble,跌倒,VERB,B2
-跑,ran,跑,ADJ,B2
-跑步,running,进行中的,NOUN,B2
-跑步者,runner,跑步者,NOUN,B2
-跛的,lame,跛的,ADJ,B2
-跛行,to limp,跛行,VERB,B2
-跟踪,to stalk,跟踪,VERB,B2
-跨国公司,multinational,跨国公司,NOUN,B2
-路沟,gutter,路沟,NOUN,B2
-路障,barricade,路障,NOUN,B2
-路面,roadway,路面,NOUN,B2
-跳跃,jump,跳跃,NOUN,B2
-跳跃,to caper,跳跃,VERB,B2
-踏,to tread,踏上,VERB,B2
-踏板摩托车,scooter,踏板摩托车,NOUN,B2
-踢,kick,踢,NOUN,B2
-踢足球,to play football,踢足球,VERB,B2
-蹲,to squat,蹲,VERB,B2
-身体上地,physically,身体上地,ADV,B2
-躯干,torso,躯干,NOUN,B2
-躲避,to dodge,躲避,VERB,B2
-躺,to lie,撒谎,VERB,B2
-车祸,car accident,车祸,NOUN,B2
-车筐,bike basket,车筐,NOUN,B2
-车费,fare,车费,NOUN,B2
-车身,bodywork,车身,NOUN,B2
-车辆,vehicle,车辆,NOUN,B2
-车道,driveway,车道,NOUN,B2
-车间,workshop,研讨会,NOUN,B2
-轨迹,trajectory,轨迹,NOUN,B2
-轨道,orbit,轨道,NOUN,B2
-转会,transfers,转会,NOUN,B2
-转售,to resell,转售,VERB,B2
-转开,to turn away,转开,VERB,B2
-转录,to transcribe,转录,VERB,B2
-转折点,turning point,转折点,NOUN,B2
-转换,conversion,转换,NOUN,B2
-转换的,conversional,转换的,ADJ,B2
-转移,to divert,转移,VERB,B2
-转达,to relay,转达,VERB,B2
-轮子,wheel,轮子,NOUN,B2
-轮椅,wheelchair,轮椅,NOUN,B2
-轮班,shift,轮班,NOUN,B2
-软木塞,cork,软木塞,NOUN,B2
-软管,hose,软管,NOUN,B2
-轰炸,bombardment,轰炸,NOUN,B2
-轴,axis,轴,NOUN,B2
-轶事,anecdote,轶事,NOUN,B2
-轻信,gullible,易受骗的,ADJ,B2
-轻信,credulity,轻信,NOUN,B2
-轻快的,upbeat,轻快的,ADJ,B2
-轻浮的,frivolous,轻浮的,ADJ,B2
-轻率,indiscretion,轻率,NOUN,B2
-轻蔑,scorn,轻蔑,NOUN,B2
-轻蔑地,disdainfully,轻蔑地,ADV,B2
-轻触,to skim,轻触,VERB,B2
-轻轻地,gently,轻轻地,ADV,B2
-载送一程,to give a ride,载送一程,VERB,B2
-较低的,lower,较低的,ADJ,B2
-较小的,minor,较小的,ADJ,B2
-较少,less,更少,ADV,B2
-较少的,fewer,较少的,ADJ,B2
-较少的,less,较少的,ADJ,B2
-较年轻的,younger,较年轻的,ADJ,B2
-辅助的,ancillary,辅助的,ADJ,B2
+砖,brick,砖,NOUN,B2
+新娘,bride,新娘,NOUN,B2
+简短的,brief,简短的,ADJ,B2
 辉煌,brilliance,辉煌,NOUN,B2
-辉煌,splendor,辉煌,NOUN,B2
-辉煌的,splendid,极好的,ADJ,B2
-辐射,radiation,辐射,NOUN,B2
-辐射,to radiate,辐射,VERB,B2
-辖区,precinct,辖区,NOUN,B2
-辛苦,toil,苦工,NOUN,B2
-辞职,to step down,辞职,VERB,B2
-辞藻华丽的,florid,辞藻华丽的,ADJ,B2
-辣椒,chili,辣椒,NOUN,B2
-辨别,to discern,辨别,VERB,B2
-辩护,justification,理由,NOUN,B2
-辩护人,defender,防守者,NOUN,B2
-辩护人,pleader,辩护人,NOUN,B2
-辩护者,apologist,辩护者,NOUN,B2
-辩护词,closing argument,辩护词,NOUN,B2
-辩证法,dialectic,辩证法,NOUN,B2
-辫子,braid,辫子,NOUN,B2
-边境安排,border arrangement,边境安排,NOUN,B2
-边境社区,border community,边境社区,NOUN,B2
-边界,borders,边界,NOUN,B2
-边缘,margin,边缘,NOUN,B2
-边缘,periphery,边缘,NOUN,B2
-边缘化,marginalization,边缘化,NOUN,B2
-边缘的,marginal,边缘的,ADJ,B2
-边防哨所,border post,边防哨所,NOUN,B2
-达到,to attain,达到,VERB,B2
-达到顶点,to culminate,达到顶点,VERB,B2
-迁移,migration,移民,NOUN,B2
-迂回说法,circumlocution,迂回说法,NOUN,B2
-迂腐,pedantry,迂腐,NOUN,B2
-过去,past,过去,ADP,B2
-过去,over,过去,ADV,B2
-过去的,bygone,过去的,ADJ,B2
-过失,delinquency,违法行为,NOUN,B2
-过得去,to get by,过得去,VERB,B2
-过敏,allergy,过敏,NOUN,B2
-过时的,antiquated,过时的,ADJ,B2
-过时的,obsolete,过时的,ADJ,B2
-过来,to come here,来到这里,VERB,B2
-过渡,transition,过渡,NOUN,B2
-过渡的,transitional,过渡的,ADJ,B2
-过滤,filter,过滤器,NOUN,B2
-过滤,to filter,过滤,VERB,B2
-过生日的,having a birthday,过生日的,ADJ,B2
-过量,overdose,过量,NOUN,B2
-迎向,towards,迎向,ADV,B2
-运作/起作用,to function work,运作/起作用,VERB,B2
-运动,crusade,运动,NOUN,B2
-运动,sport,运动,NOUN,B2
-运动,to do sports,运动,VERB,B2
-运动的,athletic,运动的,ADJ,B2
-运动的,motor,运动的,ADJ,B2
-运动的,sporty,运动的,ADJ,B2
-运输,transit,运输,NOUN,B2
-运输,transport,运输,NOUN,B2
-近,near,靠近,ADV,B2
-近似的,approximate,近似的,ADJ,B2
-还,yet,还,ADV,B2
-这么,so much,这么多,ADV,B2
-这些,these,这些,PRON,B2
-这样的,such,如此,DET,B2
-这样的,such a,这样的,DET,B2
-这边,this way,这边,ADV,B2
-这里/到这里,here hither,这里/到这里,ADV,B2
-这里外面,out here,这里外面,ADV,B2
-进一步,further,进一步的,ADJ,B2
-进入,to access,进入,VERB,B2
-进入,to enter,进入,VERB,B2
-进口,import,进口,NOUN,B2
-进口,importation,进口,NOUN,B2
-进来,in,进来,ADV,B2
-进步人士,progressive,进步人士,NOUN,B2
-进行中,on,进行中,ADV,B2
-进行中的,ongoing,进行中的,ADJ,B2
-远,far,远,ADV,B2
-远征,expedition,探险,NOUN,B2
-远程办公,remote work,远程办公,NOUN,B2
-远程办公,to telework,远程办公,VERB,B2
-远足,to hike,徒步旅行,VERB,B2
-违反,to contravene,违反,VERB,B2
-违抗,to defy,违抗,VERB,B2
-违法者，不良分子,delinquent offender,违法者，不良分子,NOUN,B2
-违禁品,contraband,违禁品,NOUN,B2
-违禁的,illicit,违禁的,ADJ,B2
-违约,breach of contract,违约,NOUN,B2
-违约,default,违约,NOUN,B2
-违背,to transgress,违背,VERB,B2
-连指手套,mitten,连指手套,NOUN,B2
-连接,link,链接,NOUN,B2
-连接,to link,连接,VERB,B2
-连接的,connected,连接的,ADJ,B2
-连接的,connecting,连接的,ADJ,B2
-连接的,connective,连接的,ADJ,B2
-连根拔起,uprooting,背井离乡,NOUN,B2
-连环杀手,serial killer,连环杀手,NOUN,B2
-连环画,comic strip,连环画,NOUN,B2
-连续地,consecutively,连续地,ADV,B2
-连续的,consecutive,连续的,ADJ,B2
-连续的,continuous,连续的,ADJ,B2
-连词,conjunction,连词,NOUN,B2
-迟到,to be delayed,迟到,VERB,B2
-迪厅,disco,迪厅,NOUN,B2
-迫害,persecution,迫害,NOUN,B2
-迫害,to persecute,迫害,VERB,B2
-迫近的,imminent,即将来临的,ADJ,B2
-迷人的,captivating,迷人的,ADJ,B2
-迷人的,charming,迷人的,ADJ,B2
-迷人的,enchanting,迷人的,ADJ,B2
-迷人的,fascinating,迷人的,ADJ,B2
-迷住,to bewitch,迷住,VERB,B2
-迷住,to captivate,迷住,VERB,B2
-迷住,to enthrall,迷住,VERB,B2
-迷住,to fascinate,使着迷,VERB,B2
-迷信的,superstitious,迷信的,ADJ,B2
-迷失方向,disorientation,迷失方向,NOUN,B2
-迷恋,infatuation,迷恋,NOUN,B2
-迷惑,to puzzle,使困惑,VERB,B2
-迷路,astray,迷路,ADJ,B2
-迷路,to get lost,迷路,VERB,B2
-追求,to aspire,渴望,VERB,B2
-追求/诉讼,pursuit lawsuit,追求/诉讼,NOUN,B2
-追溯,to retrace,追溯,VERB,B2
-追踪,to track,追踪,VERB,B2
-退休,retirement,退休,NOUN,B2
-退休人员,retiree,退休人员,NOUN,B2
-退休的,retired,退休的,ADJ,B2
-退位,to abdicate,退位,VERB,B2
-退化,degeneration,退化,NOUN,B2
-适合,to fit suit,适合,VERB,B2
-适合的,fit,适合的,ADJ,B2
-适应,adaptation,适应,NOUN,B2
-适应环境,acclimatization,适应环境,NOUN,B2
-适度,moderation,克制,NOUN,B2
-适度的,moderate,适度的,ADJ,B2
-适得其反,counterproductivity,适得其反,NOUN,B2
-适得其反的,counterproductive,适得其反的,ADJ,B2
-逃亡,desertion,逃亡,NOUN,B2
-逃跑,to flee escape,逃跑,VERB,B2
-逃跑,to run away,逃跑,VERB,B2
-逃避,evasion,逃避,NOUN,B2
-逃避,to elude,逃避,VERB,B2
-选中的,selected,选中的,ADJ,B2
-选举,election,选举,NOUN,B2
-选区,constituency,选区,NOUN,B2
-选择性的,selective,选择的，挑选的,ADJ,B2
-选民,electorate,选民,NOUN,B2
-选民,voter,选民,NOUN,B2
-选票,ballot,选票,NOUN,B2
-选项,option,选择,NOUN,B2
-逍遥法外,impunity,逍遥法外,NOUN,B2
-透支,overdraft,透支,NOUN,B2
-逐出,to dislodge,逐出,VERB,B2
-逗号,comma,逗号,PUNCT,B2
-通信,correspondence,通信,NOUN,B2
-通勤,to commute,通勤,VERB,B2
-通常,normally,通常地,ADV,B2
-通常/习惯于,to use to usually,通常/习惯于,VERB,B2
-通常的,usual,通常的,ADJ,B2
-通用的,generic,通用的,ADJ,B2
-通知,notification,通知,NOUN,B2
-通行费,toll,通行费,NOUN,B2
-通过,through,通过,ADP,B2
-通量,flux,变迁,NOUN,B2
-通风,ventilation,通风,NOUN,B2
-造林,to afforest,造林,VERB,B2
-逻辑的,logical,合乎逻辑的,ADJ,B2
-逼迫,to pressurize,逼迫,VERB,B2
-遏制,curbing,遏制,NOUN,B2
-道堂,lodges,道堂,NOUN,B2
-道德,moral,道德,NOUN,B2
-道德,morals,道德,NOUN,B2
-道德主义,moralism,道德主义,NOUN,B2
-道德的,moral,道德的,ADJ,B2
-道歉,apology,道歉,NOUN,B2
-道歉的,apologetic,道歉的,ADJ,B2
-遗传,hereditary,遗传的,ADJ,B2
-遗传学,genetics,遗传学,NOUN,B2
-遗赠,to bequeath,遗赠,VERB,B2
-遥控器,remote control,遥控器,NOUN,B2
-遭遇,to encounter,遭遇,VERB,B2
-避孕套,condom,避孕套,NOUN,B2
-避开,away,避开,ADP,B2
-避难所,sanctuary,避难所,NOUN,B2
-那,the it,那,DET,B2
-那,that,（引导从句）,SCONJ,B2
-那/去,that to,那/去,PART,B2
-那个,that,那个,DET,B2
-那个,that yonder,那个,DET,B2
-那个,that one,那个,PRON,B2
-那个人,the one,那个人,PRON,B2
-那个男人,the guy,那个男人,NOUN,B2
-那个男人的,the guy's,那个男人的,NOUN,B2
-那么多,so much,那么多,DET,B2
-那些,those,那些,PRON,B2
-那里,there,那里,ADV,B2
-邪恶,villainy,邪恶,NOUN,B2
-邪恶的,wicked,邪恶的,ADJ,B2
-邪教,cult,邪教,NOUN,B2
-邮件,mail,邮件,NOUN,B2
-邮政编码,postal code,邮政编码,NOUN,B2
-邮票,stamp,邮票,NOUN,B2
-邮资,postage,邮资,NOUN,B2
-邻居,neighbour,邻居,NOUN,B2
-邻近的,neighboring,邻近的,ADJ,B2
-邻里,neighborhood,社区,NOUN,B2
-郊游,excursion,郊游,NOUN,B2
-部,ministry,部,NOUN,B2
-部分地,partially,部分地,ADV,B2
-部分的,partial,部分的,ADJ,B2
-部署,deployment,部署,NOUN,B2
-部落,tribe,部落,NOUN,B2
-部长的,ministerial,部长的,ADJ,B2
-部门,sector,部门,NOUN,B2
-都市化,urbanity,都市风度,NOUN,B2
-酋长,chieftain,酋长,NOUN,B2
-配偶,spouse,配偶,NOUN,B2
-配合,to play along,配合,VERB,B2
-配备,endowment,配备,NOUN,B2
-配方,formulation,配方,NOUN,B2
-配方,recipe,食谱,NOUN,B2
-配音,dubbing,配音,NOUN,B2
-配额分享,quota sharing,配额分享,NOUN,B2
-酒吧,pub,酒吧,NOUN,B2
-酒精的,alcoholic,酒精的,ADJ,B2
-酬金,gratuity,酬金,NOUN,B2
-酱汁,sauce,酱汁,NOUN,B2
-酵母,yeast,酵母,NOUN,B2
-酸,acid,酸,NOUN,B2
-酸奶,yogurt,酸奶,NOUN,B2
-酸性,acidity,酸度,NOUN,B2
-酿酒厂,brewery,啤酒厂,NOUN,B2
-醉酒,drunkenness,醉酒,NOUN,B2
-醋栗,currant,醋栗,NOUN,B2
-醒,awake,醒着的,ADJ,B2
-醒来,to wake,唤醒,VERB,B2
-采摘,picking,采摘,NOUN,B2
-采购,to procure,获取,VERB,B2
-释放,free,免费的,ADJ,B2
-释放,to free,释放,VERB,B2
-释放,to unleash,释放,VERB,B2
-释经,exegesis,注释,NOUN,B2
-里程碑,milestone,里程碑,NOUN,B2
-重力,gravity,重力,NOUN,B2
-重叠的,overlapping,重叠的,ADJ,B2
-重启,to relaunch,重启,VERB,B2
-重复的,repeated,反复的,ADJ,B2
-重建,to recreate,重建,VERB,B2
-重新估值,to revalue,重新估值,VERB,B2
-重新安置,resettlement,重新安置,NOUN,B2
-重新开始,to start again,重新开始,VERB,B2
-重新开放,to reopen,重新开放,VERB,B2
-重新粉刷,to paint over,重新粉刷,VERB,B2
-重新绘制,redrawing,重新绘制,NOUN,B2
-重新统一,reunification,重新统一,NOUN,B2
-重新考虑,to reconsider,重新考虑,VERB,B2
-重新表述,reformulation,重新表述,NOUN,B2
-重新造林,reforestation,重新造林,NOUN,B2
-重罪,felony,重罪,NOUN,B2
-重要性,importance,重要性,NOUN,B2
-重要的,significant,重要的,ADJ,B2
-重见,to see again,再见,VERB,B2
-重译,retranslation,重译,NOUN,B2
-野兔,hare,野兔,NOUN,B2
-野兽,beast,野兽,NOUN,B2
-野生,wild,野生的,ADJ,B2
-量角器,protractor,量角器,NOUN,B2
-金字塔,pyramid,金字塔,NOUN,B2
-金属的,metallic,金属的,ADJ,B2
-金库,vault,金库,NOUN,B2
-金枪鱼,tuna,金枪鱼,NOUN,B2
-金色的,golden,金色的,ADJ,B2
-金融,finance,金融,NOUN,B2
-金融的,financial,财务的,ADJ,B2
-金酒,gin,金酒,NOUN,B2
-鉴于,in view of,鉴于,ADP,B2
-鉴赏家,connoisseur,行家,NOUN,B2
-针叶,pine needle,针叶,NOUN,B2
-针叶树,conifer,针叶树,NOUN,B2
-钉,to nail,钉,VERB,B2
-钉住,to pin,别住,VERB,B2
-钉子,nail,指甲,NOUN,B2
-钓竿,fishing rod,钓竿,NOUN,B2
-钝的,dull,枯燥的,ADJ,B2
-钟表,clock watch,钟表,NOUN,B2
-钢笔,pen,钢笔,NOUN,B2
-钱包,wallet,钱包,NOUN,B2
-钱币学的,numismatic,钱币学的,ADJ,B2
-铁匠,blacksmith,铁匠,NOUN,B2
-铁的,iron,铁的,ADJ,B2
-铁路的,railway,铁路的,ADJ,B2
-铃声,ringing,铃声,NOUN,B2
-铲子,shovel,铲子,NOUN,B2
-铲子,spade,铲子,NOUN,B2
-银色的,silver,银色,ADJ,B2
-银行卡,bank card,银行卡,NOUN,B2
-铸造厂,foundry,铸造厂,NOUN,B2
-铺沥青,to asphalt,铺沥青,VERB,B2
-铺砖,tiling,铺瓷砖,NOUN,B2
-链条,chain,链条,NOUN,B2
-锁,to lock,锁上,VERB,B2
-锁子甲,chain mail,锁子甲,NOUN,B2
-锁定的,locked,锁定的,ADJ,B2
-锅,cooking pot,炖锅,NOUN,B2
-锈,rust,铁锈,NOUN,B2
-错综复杂的,byzantine,错综复杂的,ADJ,B2
-错综复杂的,intricate,错综复杂的,ADJ,B2
-错误,wrong,错误的,ADJ,B2
-错误的,mistaken,错误的,ADJ,B2
-错误的事,wrong,错误的事,NOUN,B2
-错过,to missed,错过,VERB,B2
-锚,anchor,锚,NOUN,B2
-锤子,hammer,锤子,NOUN,B2
-锦标赛,championship,锦标赛,NOUN,B2
-锯,saw,锯子,NOUN,B2
-镀的,plated,镀层的,ADJ,B2
-镀金,to gild,镀金,VERB,B2
-镁,magnesium,镁,NOUN,B2
-镇压,repression,镇压,NOUN,B2
-镐；锄,pickaxe,镐；锄,NOUN,B2
-镣铐,shackle,镣铐,NOUN,B2
-镶满宝石的,bejeweled,镶满宝石的,ADJ,B2
-镶边,edging,镶边,NOUN,B2
-长凳,bench,长凳,NOUN,B2
-长大的,grown,长大的,ADJ,B2
-长期的,perennial,长期的,ADJ,B2
-长篇抨击,tirade,长篇抨击,NOUN,B2
-长袍,tunic,束腰外衣,NOUN,B2
-长颈鹿,giraffe,长颈鹿,NOUN,B2
-门槛,threshold,门槛,NOUN,B2
-门票,entrance ticket,门票,NOUN,B2
-闪烁,to flash,闪烁,VERB,B2
-闪耀,to sparkle,闪耀,VERB,B2
-闭眼,to close eyes,闭眼,VERB,B2
-问责,accountability,问责制,NOUN,B2
-问责,to hold accountable,问责,VERB,B2
-问题,issue,问题,NOUN,B2
-问题,problem,问题,NOUN,B2
-闯入者,intruder,入侵者,NOUN,B2
-闲聊,to chatter,喋喋不休,VERB,B2
-闲聊,to gossip,闲聊,VERB,B2
-闲话,gossip,八卦,NOUN,B2
-闲逛,to dawdle,闲逛,VERB,B2
-间接地,indirectly,间接地,ADV,B2
-间歇的,intermittent,间歇的,ADJ,B2
-闹剧,farce,闹剧,NOUN,B2
-阐明,to elucidate,阐明,VERB,B2
-阐明,to enunciate,阐明,VERB,B2
-队伍,procession,行列,NOUN,B2
-队列,cohort,队列,NOUN,B2
-队列,queue,队列,NOUN,B2
-队列的,cohort-based,队列的,ADJ,B2
-防御的,defensive,防御的,ADJ,B2
-阴凉的,shady,阴凉的,ADJ,B2
-阴影,shading,阴影,NOUN,B2
-阴暗,gloominess,忧郁,NOUN,B2
-阴暗的,gloomy,阴郁的,ADJ,B2
-阴沉的,gruff,阴沉的,ADJ,B2
-阴谋,conspiracy,阴谋,NOUN,B2
-阴谋的,conspiratorial,阴谋的,ADJ,B2
-阴险的,treacherous,背叛的,ADJ,B2
-阵容,line-up,阵容,NOUN,B2
-阵雨,rain shower,阵雨,NOUN,B2
-阵风,gust,阵风,NOUN,B2
-阶层,stratum,阶层,NOUN,B2
-阶段,phase,阶段,NOUN,B2
-阶级斗争,class struggle,阶级斗争,NOUN,B2
-阻挠,to thwart,阻挠,VERB,B2
-阿尔法,alpha,阿尔法,NOUN,B2
-阿尔茨海默病,alzheimer's disease,阿尔茨海默病,NOUN,B2
-阿拉伯化,arabization,阿拉伯化,NOUN,B2
-阿拉伯的,arabic,阿拉伯的,ADJ,B2
-阿谀奉承,fawning flattery,阿谀奉承,NOUN,B2
-附上,to attach,附加,VERB,B2
-附加费,surcharge,附加费,NOUN,B2
-附录,appendix,附录,NOUN,B2
-附近,vicinity,附近,NOUN,B2
-附近的,nearby,附近的,ADJ,B2
-陆地的,terrestrial,地球的,ADJ,B2
-陈腐的,trite,陈腐的,ADJ,B2
-陌生人,stranger,陌生人,NOUN,B2
-降低,to lower,降低,VERB,B2
-降级,degradation,降级,NOUN,B2
-降职,demotion,降职,NOUN,B2
-限制,restriction,限制,NOUN,B2
-限制,to confine,限制,VERB,B2
-陡峭的,steep,陡峭的,ADJ,B2
-院子,yard,院子,NOUN,B2
-院长,dean,院长,NOUN,B2
-除了,apart from,除了,ADP,B2
-除了,except for,除了,ADP,B2
-除霜,to defrost,除霜,VERB,B2
-陪审员,juror,陪审员,NOUN,B2
-陪审团,jury,陪审团,NOUN,B2
-陶瓷,ceramics,陶瓷,NOUN,B2
-陷入,to get into,陷入,VERB,B2
-随即,thereupon,随后,ADV,B2
-随后的,subsequent,随后的,ADJ,B2
-随机的,random,随机的,ADJ,B2
-隐喻的,metaphorical,隐喻的,ADJ,B2
-隐士,hermit,隐士,NOUN,B2
-隐晦的,veiled,隐晦的,ADJ,B2
-隐瞒,to keep secret,隐瞒,VERB,B2
-隐藏,hidden,隐藏的,ADJ,B2
-隔离,isolation,隔绝,NOUN,B2
-隔离,to segregate,隔离,VERB,B2
-隔离,to sequester,隔离,VERB,B2
-隔离，分离,segregation,隔离，分离,NOUN,B2
-隔间,compartment,隔间,NOUN,B2
-隔音差的,thin-walled,隔音差的,ADJ,B2
-障碍,impediment,障碍,NOUN,B2
-难以捉摸的,elusive,难以捉摸的,ADJ,B2
-难以置信的,incredible,难以置信的,ADJ,B2
-难忘的,memorable,难忘的,ADJ,B2
-难民,refugee,难民,NOUN,B2
-雄辩,eloquent,雄辩的,ADJ,B2
-雄辩,eloquence,口才,NOUN,B2
-雄鹿,buck,美元,NOUN,B2
-集中,to centralize,集中,VERB,B2
-集中化,centralization,集中化,NOUN,B2
-集会,assembly,集会,NOUN,B2
-集会自由,freedom of assembly,集会自由,NOUN,B2
-集体劳动协议,collective labor agreement,集体劳动协议,NOUN,B2
-集合,set,一套,NOUN,B2
-集合,to assemble,集合,VERB,B2
-集团,bloc,阵营,NOUN,B2
-集市,bazaar,集市,NOUN,B2
-雇佣兵,mercenary,雇佣兵,NOUN,B2
-雇佣劳动,wage labor,雇佣劳动,NOUN,B2
-雇用,hiring,招聘,NOUN,B2
-雇用,to hire,雇佣,VERB,B2
-雌鹿,doe,雌鹿,NOUN,B2
-雕像,statue,雕像,NOUN,B2
-雕刻,to carve,雕刻,VERB,B2
-雕刻,to engrave,雕刻,VERB,B2
-雕塑家,sculptor,雕塑家,NOUN,B2
-雨,rain,雨,NOUN,B2
-雨衣,raincoat,雨衣,NOUN,B2
-雪茄,cigar,雪茄,NOUN,B2
-零,zero,零,NOUN,B2
-零售商,retailer,零售商,NOUN,B2
-零碎的,fragmentary,零碎的,ADJ,B2
-雷阵雨,thunderstorm,雷阵雨,NOUN,B2
-需要,to be required,被要求,VERB,B2
-震惊,astonishment,惊讶,NOUN,B2
-震惊,shock,震惊,NOUN,B2
-震惊,to astonish,使惊讶,VERB,B2
-震惊的,shocked,震惊的,ADJ,B2
-霜,frost,霜,NOUN,B2
-露台,terrace,露台,NOUN,B2
-露营,to camp,露营,VERB,B2
-露营地,campsite,露营地,NOUN,B2
-霸权,hegemony,霸权,NOUN,B2
-霸权,supremacy,霸权,NOUN,B2
-青少年的,juvenile,青少年的,ADJ,B2
-青春期,puberty,青春期,NOUN,B2
-青蛙,frog,青蛙,NOUN,B2
+英国的,british,英国的,ADJ,B2
+英国人,briton,英国人,NOUN,B2
+广播,to broadcast,播出,VERB,B2
+广播,broadcasting,广播,NOUN,B2
 青铜,bronze,青铜,NOUN,B2
-静止的,motionless,静止的,ADJ,B2
-非军事化,to demilitarize,非军事化,VERB,B2
-非凡的,phenomenal,非凡的,ADJ,B2
-非凡的,remarkable,非凡的,ADJ,B2
-非常,mighty very,非常,ADJ,B2
-非正式地,unofficially,非正式地,ADV,B2
-非法侵入,break-in,非法侵入,NOUN,B2
-非法的,unlawful,非法的,ADJ,B2
-非理性的,irrational,非理性的,ADJ,B2
-非营利的,nonprofit,非营利的,ADJ,B2
-靠近,to bring closer,靠近,VERB,B2
-面具,mask,面具,NOUN,B2
-面包,loaf,一条面包,NOUN,B2
-面团,dough,面团,NOUN,B2
-面条,noodle,面条,NOUN,B2
-面粉,flour,面粉,NOUN,B2
-面试,interview,面试,NOUN,B2
-面貌,facies,面貌,NOUN,B2
-革命化,to revolutionize,革命化,VERB,B2
-革新主义,renewalism,革新主义,NOUN,B2
-鞋,shoes,鞋子,NOUN,B2
-鞣制,tanning,晒黑,NOUN,B2
-鞣革工,tanner,制革工,NOUN,B2
-鞭打,to flog,鞭打,VERB,B2
-鞭打,to whip,鞭打,VERB,B2
-鞭笞,to excoriate,严厉批评,VERB,B2
-音乐学院,conservatory,音乐学院,NOUN,B2
-音乐家,musician,音乐家,NOUN,B2
-音乐的,musical,موسيقي,ADJ,B2
-音系学,phonology,音系学,NOUN,B2
-音节,syllable,音节,NOUN,B2
-韵律学,prosody,韵律学,NOUN,B2
-顶点,apex,顶点,NOUN,B2
-顶点,zenith,顶点,NOUN,B2
-顶部/极好,top great,顶部/极好,NOUN,B2
-顶部的,top,顶部的,ADJ,B2
-顶针,thimble,顶针,NOUN,B2
-顺便,by the way,顺便说一下,ADV,B2
-顺便,incidentally,顺便地,ADV,B2
-顽固,obstinacy,顽固,NOUN,B2
-顾忌,scruple,顾虑,NOUN,B2
-颂扬,glorification,赞美,NOUN,B2
-颂扬,to exalt,颂扬,VERB,B2
-预付款,advance payment,预付款,NOUN,B2
-预兆,to forebode,预兆,VERB,B2
-预后,prognosis,预后,NOUN,B2
-预定的,intended,预定的,ADJ,B2
-预感,inkling,预感,NOUN,B2
-预感,premonition,预感,NOUN,B2
-预留,to reserve,预订,VERB,B2
+小溪,brook,小溪,NOUN,B2
+扫帚,broom,扫帚,NOUN,B2
+肉汤,broth,肉汤,NOUN,B2
+姐夫,brother-in-law,姐夫/妹夫,NOUN,B2
+棕色的,brown,棕色,ADJ,B2
+使残暴,to brutalize,使变得残忍,VERB,B2
+气泡,bubble,气泡,NOUN,B2
+雄鹿,buck,美元,NOUN,B2
+水桶,bucket,桶,NOUN,B2
 预算的,budgetary,预算的,ADJ,B2
-预约,appointment,预约,NOUN,B2
-预言,prophecy,预言,NOUN,B2
-预言,to augur,预言,VERB,B2
-预订,reservation,预订,NOUN,B2
-预谋,premeditation,预谋,NOUN,B2
-预防,prevention,预防,NOUN,B2
-预防,prophylaxis,预防,NOUN,B2
+虫子,bug,虫子,NOUN,B2
+体积,bulk,主体,NOUN,B2
+官僚机构,bureaucracy,官僚主义,NOUN,B2
+窃贼,burglar,窃贼,NOUN,B2
+入室盗窃,burglary,入室盗窃罪,NOUN,B2
+燃烧的,burning,灼热的,ADJ,B2
+烧焦的,burnt,烧焦的,ADJ,B2
+爆裂,to burst,爆发,VERB,B2
+灌木,bush,灌木,NOUN,B2
+商业的,business,商业的,ADJ,B2
+商人,businessman,商人,NOUN,B2
+忙碌,bustle,喧闹,NOUN,B2
+屠夫,butcher,屠夫,NOUN,B2
+黄油,butter,黄油,NOUN,B2
+纽扣,button,按钮,NOUN,B2
+顺便,by the way,顺便说一下,ADV,B2
+再见,bye,再见,INTJ,B2
+过去的,bygone,过去的,ADJ,B2
+内阁,cabinet,内阁,NOUN,B2
+电缆,cable,电缆,NOUN,B2
+笼子,cage,笼子,NOUN,B2
+灾难,calamity,灾难,NOUN,B2
+计算,to calculate,计算,VERB,B2
+计算器,calculator,计算器,NOUN,B2
+小牛,calf,小腿,NOUN,B2
+校准,calibration,校准,NOUN,B2
+职业,calling,使命,NOUN,B2
+平静,to calm,使平静,VERB,B2
+平静,calmness,平静,NOUN,B2
+骆驼,camel,骆驼,NOUN,B2
+能,can,能够,AUX,B2
+癌症,cancer,癌症,NOUN,B2
+候选资格,candidacy,候选资格,NOUN,B2
+糖果,candy,糖果,NOUN,B2
+大炮,cannon,大炮,NOUN,B2
+帽子,cap,帽子,NOUN,B2
+资本主义,capitalism,资本主义,NOUN,B2
+大写,to capitalize,利用,VERB,B2
+迷人的,captivating,迷人的,ADJ,B2
+囚禁,captivity,囚禁,NOUN,B2
+汽车,car,汽车,NOUN,B2
+车祸,car accident,车祸,NOUN,B2
+商队,caravan,房车,NOUN,B2
+碳,carbon,碳,NOUN,B2
+细胞,cell,细胞,NOUN,B2
+地窖,cellar,地窖,NOUN,B2
+细胞的,cellular,细胞的,ADJ,B2
+固定,cement,水泥,NOUN,B2
+固定,to cement,巩固,VERB,B2
+审查,censorship,审查制度,NOUN,B2
+分,cent,分,NOUN,B2
+集中化,centralization,集中化,NOUN,B2
+集中,to centralize,集中,VERB,B2
+离心机,centrifuge,离心机,NOUN,B2
+陶瓷,ceramics,陶瓷,NOUN,B2
+链条,chain,链条,NOUN,B2
+粉笔,chalk,粉笔,NOUN,B2
+室,chamber,房间,NOUN,B2
+香槟,champagne,香槟,NOUN,B2
+锦标赛,championship,锦标赛,NOUN,B2
+机会,chance,机会,NOUN,B2
+引导,to channel,疏导,VERB,B2
+小教堂,chapel,小教堂,NOUN,B2
+章,chapter,章节,NOUN,B2
+表征,to characterize,描绘,VERB,B2
+木炭,charcoal,木炭,NOUN,B2
+费用,charge,收费,NOUN,B2
+魅力,charisma,个人魅力,NOUN,B2
+江湖骗子,charlatan,江湖骗子,NOUN,B2
+迷人的,charming,迷人的,ADJ,B2
+图表,chart,图表,NOUN,B2
+特许,to charter,租船,VERB,B2
+贞洁,chastity,贞洁,NOUN,B2
+闲聊,to chatter,喋喋不休,VERB,B2
+结账,checkout,收银台,NOUN,B2
+脸颊,cheek,脸颊,NOUN,B2
+厚颜无耻的,cheeky,厚颜无耻的,ADJ,B2
+欢呼,to cheer,欢呼,VERB,B2
+干杯,cheers,干杯,INTJ,B2
+化学品,chemical,化学的,ADJ,B2
+国际象棋,chess,国际象棋,NOUN,B2
+口香糖,chewing gum,口香糖,NOUN,B2
+小鸡,chick,小鸡,NOUN,B2
+烟囱,chimney,烟囱,NOUN,B2
+下巴,chin,下巴,NOUN,B2
+中国的,chinese,中国的,ADJ,B2
+凿子,chisel,凿子,NOUN,B2
+合唱团,choir,合唱团,NOUN,B2
+基督徒,christian,基督徒,NOUN,B2
+教堂,church,教堂,NOUN,B2
+香烟,cigarette,香烟,NOUN,B2
+电影院,cinema,电影院,NOUN,B2
+电路,circuit,电路,NOUN,B2
+流通,to circulate,循环,VERB,B2
+循环,circulation,循环,NOUN,B2
+割礼,circumcision,割礼,NOUN,B2
+内接,to circumscribe,限制,VERB,B2
+情况,circumstance,情况,NOUN,B2
+引用,citation,引用,NOUN,B2
+公民身份,citizenship,公民身份,NOUN,B2
+市政厅,city hall,市政厅,NOUN,B2
+公民的,civil,民事的,ADJ,B2
+公务员,civil servant,公务员,NOUN,B2
+文明的,civilized,文明的,ADJ,B2
+喧嚣,clamor,喧嚣,NOUN,B2
+夹子,clamp,夹钳,NOUN,B2
+鼓掌,to clap,拍手,VERB,B2
+清晰,clarity,清晰,NOUN,B2
+经典的,classic,经典的,ADJ,B2
+古典主义,classicism,古典主义,NOUN,B2
+分类,classification,分类,NOUN,B2
+黏土,clay,黏土,NOUN,B2
+清理,to clean up,清理,VERB,B2
+殖民主义,colonialism,殖民主义,NOUN,B2
+殖民化,colonization,殖民化,NOUN,B2
+着色,to color,着色,VERB,B2
+多彩的,colorful,五颜六色的,ADJ,B2
+昏迷,coma,昏迷,NOUN,B2
+战斗,to combat,对抗,VERB,B2
+战斗,combating,打击,NOUN,B2
+组合,combination,结合,NOUN,B2
+一起来,to come along,一起来,VERB,B2
+过来,to come here,来到这里,VERB,B2
+喜剧演员,comedian,喜剧演员,NOUN,B2
+喜剧,comedy,喜剧,NOUN,B2
+彗星,comet,彗星,NOUN,B2
+舒适,comfort,安慰,NOUN,B2
+喜剧的,comic,喜剧的,ADJ,B2
+命令,to command,命令,VERB,B2
+专员,commissioner,专员,NOUN,B2
+坚定的,committed,投入的,ADJ,B2
+公报,communique,公报,NOUN,B2
+共产主义,communism,共产主义,NOUN,B2
+共产主义的,communist,شيوعي,ADJ,B2
+社群主义,communitarianism,社群主义,NOUN,B2
+紧凑的,compact,紧凑的,ADJ,B2
+隔间,compartment,隔间,NOUN,B2
+指南针,compass,指南针,NOUN,B2
+有同情心的,compassionate,有同情心的,ADJ,B2
+能力,competence,能力,NOUN,B2
+有能力的,competent,胜任的,ADJ,B2
+汇编,compilation,汇编,NOUN,B2
+编译,to compile,编译,VERB,B2
+互补的,complementary,互补的,ADJ,B2
+复杂的,complex,复杂的,ADJ,B2
+合规,compliance,合规,NOUN,B2
+共谋的,complicit,共谋的,ADJ,B2
+共谋,complicity,共犯,NOUN,B2
+混淆,to confuse,混淆,VERB,B2
+拥堵,congestion,拥堵,NOUN,B2
+恭喜,congratulations,恭喜,INTJ,B2
+会众,congregation,集会,NOUN,B2
+国会,congress,国会,NOUN,B2
+推测,conjecture,推测,NOUN,B2
+变位,conjugation,变位,NOUN,B2
+变魔术,to conjure,变魔术,VERB,B2
+连接的,connected,连接的,ADJ,B2
+鉴赏家,connoisseur,行家,NOUN,B2
+征服者,conqueror,征服者,NOUN,B2
+祝圣,to consecrate,奉献,VERB,B2
+后果,consequence,后果,NOUN,B2
+因此,consequently,因此,ADV,B2
+组成,to consist,组成,VERB,B2
+安慰,consolation,安慰,NOUN,B2
+安慰,to console,安慰,VERB,B2
+阴谋,conspiracy,阴谋,NOUN,B2
+密谋,to conspire,密谋,VERB,B2
+恒定的,constant,持续的,ADJ,B2
+不断地,constantly,不断地,ADV,B2
+选区,constituency,选区,NOUN,B2
+宪法的,constitutional,宪法的,ADJ,B2
+合宪性,constitutionality,合宪性,NOUN,B2
+约束,to constrain,限制,VERB,B2
+约束,constraint,约束,NOUN,B2
+建设,construction,建造,NOUN,B2
 领事,consul,领事,NOUN,B2
 领事的,consular,领事的,ADJ,B2
 领事馆,consulate,领事馆,NOUN,B2
-领先的,leading,领先的,ADJ,B2
-领土的,territorial,领土的,ADJ,B2
-领域,domain,领域,NOUN,B2
-领带,tie,领带,NOUN,B2
-频率,frequency,频率,NOUN,B2
-题词,epigraph,题词,NOUN,B2
-颜色,colour,颜色,NOUN,B2
-额外,additional,额外的,ADJ,B2
-额头,forehead,前额,NOUN,B2
-颤抖,to quiver,颤抖,VERB,B2
-颤抖的,quivering,颤抖的,ADJ,B2
-颤抖的,trembling,颤抖的,ADJ,B2
-颤抖的,tremulous,颤抖的,ADJ,B2
-风,wind,风,NOUN,B2
-风景,landscape,风景,NOUN,B2
-风笛手,bagpiper,风笛手,NOUN,B2
-风筝,kite,风筝,NOUN,B2
-风趣,wittiness,风趣,NOUN,B2
-飘动,to flutter,飘动,VERB,B2
-飘渺的,ethereal,飘渺的,ADJ,B2
-飞机场,airfield,飞机场,NOUN,B2
-飞船,spaceship,宇宙飞船,NOUN,B2
-飞行员,pilot,飞行员,NOUN,B2
-食品加工的,food-processing,食品加工的,ADJ,B2
-食品的,food,食品的,ADJ,B2
-食堂,canteen,食堂,NOUN,B2
-食欲,appetite,食欲,NOUN,B2
-食物/生育,to food give birth,食物/生育,VERB,B2
-食言,to renege,食言,VERB,B2
-饥荒,famine,饥荒,NOUN,B2
-饥饿的,starved,饥饿的,ADJ,B2
-饮用水,drinking water,饮用水,NOUN,B2
-饮食,diet,饮食,NOUN,B2
-饲料,fodder,饲料,NOUN,B2
+消费,consumption,消费,NOUN,B2
+接触,contact,联系,NOUN,B2
+传染性的,contagious,传染性的,ADJ,B2
+污染,to contaminate,污染,VERB,B2
+沉思,to contemplate,沉思,VERB,B2
+沉思的,contemplative,沉思的,ADJ,B2
+蔑视,contempt,轻视,NOUN,B2
+语境,context,上下文,NOUN,B2
+语境的,contextual,语境的,ADJ,B2
+大陆,continent,大陆,NOUN,B2
+延续,continuation,延续,NOUN,B2
+连续的,continuous,连续的,ADJ,B2
+反驳,to contradict,反驳,VERB,B2
+矛盾的,contradictory,矛盾的,ADJ,B2
+违反,to contravene,违反,VERB,B2
+有争议的,controversial,有争议的,ADJ,B2
+传统的,conventional,传统的,ADJ,B2
+汇聚,convergence,汇聚,NOUN,B2
+对话,conversation,对话,NOUN,B2
+相反地,conversely,相反地,ADV,B2
+说服,to convince,说服,VERB,B2
+确信的,convinced,确信的,ADJ,B2
+令人信服的,convincing,令人信服的,ADJ,B2
+厨师,cook,厨师,NOUN,B2
 饼干,cookie,饼干,NOUN,B2
-首先,firstly,首先,ADV,B2
-首席执行官,ceo,首席执行官,NOUN,B2
-首映,premiere,首演,NOUN,B2
-首次亮相,to debut,首次亮相,VERB,B2
-首相,prime minister,总理,NOUN,B2
-首要的,prime,首要的,ADJ,B2
-首语重复修辞,anaphora,首语重复修辞,NOUN,B2
-香味,fragrance,香味,NOUN,B2
-香料,spice,香料,NOUN,B2
-香槟,champagne,香槟,NOUN,B2
-香水,perfume,香水,NOUN,B2
-香烟,cigarette,香烟,NOUN,B2
-香肠,sausage,香肠,NOUN,B2
-香脂,balm,香脂,NOUN,B2
-香脂,balsam,香脂,NOUN,B2
-马勒,bridle,马勒,NOUN,B2
-马厩,stable,畜舍,NOUN,B2
-马尔默,malmo,马尔默,PROPN,B2
-马赛克,mosaic,马赛克,NOUN,B2
-马赫曾,makhzen,马赫曾,NOUN,B2
-马驹,foal,马驹,NOUN,B2
-驯化,domestication,驯化,NOUN,B2
-驯服,to tame,驯服,VERB,B2
-驱逐,eviction,驱逐,NOUN,B2
-驱逐,expulsion,驱逐,NOUN,B2
-驱逐,to evict,驱逐,VERB,B2
-驱逐出境,deportation,驱逐出境,NOUN,B2
-驱逐出境,to deport,驱逐出境,VERB,B2
-驱魔,to exorcise,驱魔,VERB,B2
-驳船,barge,驳船,NOUN,B2
-驴,ass,驴,NOUN,B2
-驴,donkey,驴,NOUN,B2
-驼鹿,moose,驼鹿,NOUN,B2
-驾驶,to steer,引导,VERB,B2
-骄傲,pride,骄傲,NOUN,B2
-骄傲的,side,骄傲的,ADJ,B2
-骆驼,camel,骆驼,NOUN,B2
-验血,blood test,验血,NOUN,B2
-验证,to authenticate,认证,VERB,B2
-验证,to validate,验证,VERB,B2
-骑士,knight,骑士,NOUN,B2
-骑手,rider,骑手,NOUN,B2
-骑自行车的人,cyclist,骑自行车的人,NOUN,B2
-骗子,crook,骗子,NOUN,B2
-骗子,swindler,骗子,NOUN,B2
-骗局,scam,骗局,NOUN,B2
-骗局,sham,假冒,NOUN,B2
-骚动,uproar,骚动,NOUN,B2
-骚扰,harassment,骚扰,NOUN,B2
-骚扰,to harass,骚扰,VERB,B2
-骤雨,squall,骤雨,NOUN,B2
-骨架,carcass,骨架,NOUN,B2
-骨骼,skeleton,骨架,NOUN,B2
-骨髓,marrow,骨髓,NOUN,B2
+锅,cooking pot,炖锅,NOUN,B2
+冷却,cooling,冷却,NOUN,B2
+合作,cooperation,合作,NOUN,B2
+坐标,coordinate,坐标,NOUN,B2
+警察,cop,警察,NOUN,B2
+抄写员,copyist,抄写员,NOUN,B2
+版权,copyright,版权,NOUN,B2
+软木塞,cork,软木塞,NOUN,B2
+角落,corner,角落,NOUN,B2
+尸体,corpse,尸体,NOUN,B2
+相关性,correlation,相关性,NOUN,B2
+通信,correspondence,通信,NOUN,B2
+记者,correspondent,记者,NOUN,B2
+腐蚀,corrosion,腐蚀,NOUN,B2
+腐蚀,corrupt,腐败的,ADJ,B2
+腐蚀,to corrupt,腐败,VERB,B2
+咳嗽,cough,咳嗽,NOUN,B2
+理事会,council,委员会,NOUN,B2
+咨询,counseling,咨询,NOUN,B2
+计算,to count,重要,VERB,B2
+伯爵夫人,countess,女伯爵,NOUN,B2
+堂兄弟,cousin,表亲,NOUN,B2
+契约,covenant,契约,NOUN,B2
+覆盖范围,coverage,报道,NOUN,B2
+贪婪,covetousness,贪欲,NOUN,B2
+牛,cow,奶牛,NOUN,B2
+懦弱的,cowardly,懦弱的,ADJ,B2
+舒适的,cozy,舒适的,ADJ,B2
+螃蟹,crab,螃蟹,NOUN,B2
+破裂,crack,裂缝,NOUN,B2
+破裂,to crack,破裂,VERB,B2
+发出爆裂声,to crackle,噼啪作响,VERB,B2
+工艺,craft,工艺,NOUN,B2
+鹤,crane,起重机,NOUN,B2
+碰撞,crash,碰撞,NOUN,B2
+板条箱,crate,板条箱,NOUN,B2
+火山口,crater,火山口,NOUN,B2
+爬行,to crawl,爬行,VERB,B2
+创造,creation,创造,NOUN,B2
+生物,creature,生物,NOUN,B2
+可信度,credibility,可信度,NOUN,B2
+山顶,crest,顶峰,NOUN,B2
+全体船员,crew,全体船员,NOUN,B2
+犯罪,crime,犯罪,NOUN,B2
+犯罪现场,crime scene,犯罪现场,NOUN,B2
+犯罪,criminality,犯罪,NOUN,B2
+定罪,to criminalize,定罪,VERB,B2
+标准,criterion,标准,NOUN,B2
+评论家,critic,评论家,NOUN,B2
+关键性,criticality,临界性,NOUN,B2
+批评,criticism,批评,NOUN,B2
+农作物,crop,庄稼,NOUN,B2
+横渡,crossing,交叉口,NOUN,B2
+十字路口,crossroads,十字路口,NOUN,B2
+乌鸦,crow,乌鸦,NOUN,B2
+残忍的,cruel,残忍的,ADJ,B2
+碎裂,to crumble,粉碎,VERB,B2
+嘎吱作响,to crunch,嘎吱作响,VERB,B2
+压碎,to crush,压碎,VERB,B2
+地壳,crust,外壳,NOUN,B2
+甲壳类动物,crustacean,甲壳类动物,NOUN,B2
+拐杖,crutch,拐杖,NOUN,B2
+哭泣,crying,,NOUN,B2
+幼兽,cub,幼兽,NOUN,B2
+立体主义,cubism,立体主义,NOUN,B2
+文化的,cultural,文化的,ADJ,B2
+狡猾,cunning,狡猾的,ADJ,B2
+好奇心,curiosity,好奇心,NOUN,B2
+电流,current,电流,NOUN,B2
+目前,currently,目前,ADV,B2
+课程,curriculum,课程,NOUN,B2
+诅咒,curse,诅咒,NOUN,B2
+诅咒,to curse,诅咒,VERB,B2
+被诅咒的,cursed,被诅咒的,ADJ,B2
+曲线,curve,曲线,NOUN,B2
+监护权,custody,监护,NOUN,B2
+习惯的,customary,习惯的,ADJ,B2
+发绀,cyanosis,发绀,NOUN,B2
+网络的,cyber,网络的,ADJ,B2
+网络安全,cybersecurity,网络安全,NOUN,B2
+圆柱体,cylinder,圆柱体,NOUN,B2
+愤世嫉俗的,cynical,愤世嫉俗的,ADJ,B2
+爸爸,dad,爸爸,NOUN,B2
+损坏,to damage,损坏,VERB,B2
+诅咒,damn,该死的,ADJ,B2
+诅咒,to damn,诅咒,VERB,B2
+潮湿,damp,潮湿,ADJ,B2
+舞蹈,dance,舞蹈,NOUN,B2
+舞者,dancer,舞者,NOUN,B2
+危险,dangerous,危险的,ADJ,B2
+变暗,to darken,变暗,VERB,B2
+亲爱的,darling,亲爱的,NOUN,B2
+约会,to date,注明日期,VERB,B2
+约会,dating,年代测定,NOUN,B2
+日工,day laborer,日工,NOUN,B2
+眩目,to dazzle,使眼花,VERB,B2
+耀眼,dazzling,耀眼的,ADJ,B2
+死,dead,死的,ADJ,B2
+致命,deadly,致命的,ADJ,B2
+聋,deaf,聋的,ADJ,B2
+交易,deal,交易,NOUN,B2
+经销商,dealer,经销商,NOUN,B2
+院长,dean,院长,NOUN,B2
+可争辩,debatable,有争议的,ADJ,B2
+放荡,debauchery,放荡,NOUN,B2
+债务,debts,债务,NOUN,B2
+十年,decade,十年,NOUN,B2
+堕落,decadence,衰落,NOUN,B2
+狡诈,deceitful,欺诈的,ADJ,B2
+十二月,december,十二月,NOUN,B2
+体面,decency,体面,NOUN,B2
+体面,decent,体面的,ADJ,B2
+破译,to decipher,破译,VERB,B2
+下降,decline,衰退,NOUN,B2
+装饰,to decorate,装饰,VERB,B2
+减少,to decrease,减少,VERB,B2
+解密,decryption,解密,NOUN,B2
+奉献,dedication,奉献,NOUN,B2
+扣除,to deduct,扣除,VERB,B2
+加深,to deepen,加深,VERB,B2
+鹿,deer,鹿,NOUN,B2
+诽谤,defamation,诽谤,NOUN,B2
+违约,default,违约,NOUN,B2
+失败主义,defeatism,失败主义,NOUN,B2
+被告,defendant,被告,NOUN,B2
+辩护人,defender,防守者,NOUN,B2
+不足,deficiency,缺乏,NOUN,B2
+不足的,deficient,有缺陷的,ADJ,B2
+定义,to define,定义,VERB,B2
+确定地,definitely,肯定地,ADV,B2
+决定性的,definitive,决定性的,ADJ,B2
+使变形,to deform,使变形,VERB,B2
+变形,deformation,变形,NOUN,B2
+畸形的,deformed,畸形的,ADJ,B2
+欺诈,to defraud,诈骗,VERB,B2
+违抗,to defy,违抗,VERB,B2
+退化,degeneration,退化,NOUN,B2
+降级,degradation,降级,NOUN,B2
+自然神论,deism,自然神论,NOUN,B2
+沮丧,dejection,沮丧,NOUN,B2
+延迟,delay,延迟,NOUN,B2
+委派,delegate,代表,NOUN,B2
+委派,to delegate,委派,VERB,B2
+代表团,delegation,代表团,NOUN,B2
+故意的,deliberate,深思熟虑的,ADJ,B2
+令人愉快的,delightful,令人愉快的,ADJ,B2
+过失,delinquency,违法行为,NOUN,B2
+不良少年,delinquent,罪犯,NOUN,B2
+谵妄,delirium,精神错乱,NOUN,B2
+洪水,deluge,洪水,NOUN,B2
+要求,to demand,要求,VERB,B2
+要求高的,demanding,要求高的,ADJ,B2
+痴呆,dementia,痴呆,NOUN,B2
+民主的,democratic,民主的,ADJ,B2
+民主化,democratization,民主化,NOUN,B2
+人口学,demography,人口学,NOUN,B2
+拆除,to demolish,拆除,VERB,B2
+拆毁,demolition,拆除,NOUN,B2
+示威,demonstration,演示,NOUN,B2
+使泄气,to demoralize,使士气低落,VERB,B2
+谴责,to denounce,谴责,VERB,B2
+牙医,dentist,牙医,NOUN,B2
+依赖,to depend,依赖,VERB,B2
+依赖的,dependent,依赖的,ADJ,B2
+谴责,to deplore,谴责,VERB,B2
+部署,deployment,部署,NOUN,B2
+贬值,depreciation,贬值,NOUN,B2
+沮丧的,depressed,沮丧的,ADJ,B2
+剥夺,deprivation,剥夺,NOUN,B2
+剥夺,to deprive,剥夺,VERB,B2
+副手,deputy,议员,NOUN,B2
+脱轨,to derail,使脱轨,VERB,B2
+派生物,derivative,衍生物,NOUN,B2
+贬低,to derogate,贬损,VERB,B2
+描述,description,描述,NOUN,B2
+设计,to design,设计,VERB,B2
+渴望,to desire,渴望,VERB,B2
+书桌,desk,书桌,NOUN,B2
+绝望的,desperate,绝望的,ADJ,B2
+尽管,despite,尽管,ADP,B2
+暴君,despot,暴君,NOUN,B2
+专制,despotism,专制,NOUN,B2
+甜点,dessert,甜点,NOUN,B2
+破坏稳定,destabilization,动摇,NOUN,B2
+使不稳定,to destabilize,使不稳定,VERB,B2
+命运,destiny,命运,NOUN,B2
+贫困,destitution,贫困,NOUN,B2
+分离,to detach,分离,VERB,B2
+分离,detachment,脱落,NOUN,B2
+缓和,detente,缓和,NOUN,B2
+坚决的,determined,下定决心的,ADJ,B2
+决定论,determinism,决定论,NOUN,B2
+决定论的,deterministic,决定论的,ADJ,B2
+厌恶,to detest,厌恶,VERB,B2
+爆炸,detonation,爆炸,NOUN,B2
+绕道,detour,绕道,NOUN,B2
+贬值,to devalue,贬值,VERB,B2
+毁坏,to devastate,摧毁,VERB,B2
+毁坏,devastation,破坏,NOUN,B2
+开发者,developer,开发商,NOUN,B2
+魔鬼,devil,魔鬼,NOUN,B2
+设计,to devise,设计,VERB,B2
+奉献,to devote,奉献,VERB,B2
+忠诚的,devoted,忠诚的,ADJ,B2
+诊断,to diagnose,诊断,VERB,B2
+方言,dialect,方言,NOUN,B2
+对话,to dialogue,对话,VERB,B2
+大流散,diaspora,流散,NOUN,B2
 骰子,dice,骰子,NOUN,B2
-骰子,die,骰子,NOUN,B2
-髓质的,pulpy,髓质的,ADJ,B2
+口述,to dictate,口述,VERB,B2
+独裁,dictatorship,独裁统治,NOUN,B2
+饮食,diet,饮食,NOUN,B2
+区分,to differentiate,区分,VERB,B2
+分化,differentiation,区分,NOUN,B2
+困难,difficulty,困难,NOUN,B2
+消化,digestion,消化,NOUN,B2
+消化的,digestive,消化的,ADJ,B2
+数字化,digitization,数字化,NOUN,B2
+扩张,to dilate,膨胀,VERB,B2
+扩张,dilation,扩张,NOUN,B2
+困境,dilemma,困境,NOUN,B2
+减少,to diminish,减少,VERB,B2
+恐龙,dinosaur,恐龙,NOUN,B2
+浸,to dip,蘸,VERB,B2
+外交的,diplomatic,外交的,ADJ,B2
+指挥,to direct,对准,VERB,B2
+直接地,directly,直接地,ADV,B2
+泥土,dirt,污垢,NOUN,B2
+残疾的,disabled,残疾的,ADJ,B2
+不同意,to disagree,不同意,VERB,B2
+消失,disappearance,消失,NOUN,B2
+使失望,to disappoint,使失望,VERB,B2
+令人失望的,disappointing,令人失望的,ADJ,B2
+失望,disappointment,失望,NOUN,B2
+不赞成,to disapprove,不赞成,VERB,B2
+拆卸,to disassemble,拆卸,VERB,B2
+灾难性的,disastrous,灾难性的,ADJ,B2
+否认,to disavow,否认,VERB,B2
+中止,to discontinue,停止,VERB,B2
+不和,discord,不和,NOUN,B2
+不一致,discordance,不一致,NOUN,B2
+使气馁,to discourage,使气馁,VERB,B2
+败坏名誉,to discredit,败坏名声,VERB,B2
+谨慎的,discreet,谨慎的,ADJ,B2
+谨慎,discretion,谨慎,NOUN,B2
+歧视,to discriminate,歧视,VERB,B2
+歧视,discrimination,歧视,NOUN,B2
+疾病,disease,疾病,NOUN,B2
+登岸,to disembark,下船,VERB,B2
+脱离,to disengage,脱离,VERB,B2
+耻辱,disgrace,耻辱,NOUN,B2
+伪装,to disguise,伪装,VERB,B2
+厌恶,disgust,厌恶,NOUN,B2
+令人厌恶的,disgusting,令人厌恶的,ADJ,B2
+洗碗机,dishwasher,洗碗机,NOUN,B2
+虚假信息,disinformation,虚假信息,NOUN,B2
+无私的,disinterested,公正的,ADJ,B2
+磁盘,disk,唱片,NOUN,B2
+脱臼,to dislocate,使脱臼,VERB,B2
+解雇,dismissal,解雇,NOUN,B2
+下马,to dismount,下马,VERB,B2
+不服从,disobedience,不服从,NOUN,B2
+混乱,disorder,混乱,NOUN,B2
+使迷失方向,to disorient,使迷失方向,VERB,B2
+迷失方向,disorientation,迷失方向,NOUN,B2
+差异,disparity,差异,NOUN,B2
+派遣,to dispatch,派遣,VERB,B2
+使不悦,to displease,使不快,VERB,B2
+不悦,displeasure,不悦,NOUN,B2
+处理,disposal,处理,NOUN,B2
+忽视,to disregard,忽视,VERB,B2
+不满的,dissatisfied,不满的,ADJ,B2
+解散,dissolution,溶解,NOUN,B2
+溶解,to dissolve,溶解,VERB,B2
+不和谐,dissonance,不和谐,NOUN,B2
+劝阻,to dissuade,劝阻,VERB,B2
+区别,distinction,区别,NOUN,B2
+扭曲,to distort,扭曲,VERB,B2
+扭曲,distortion,扭曲,NOUN,B2
+分心,to distract,分心,VERB,B2
+分心,distraction,分心,NOUN,B2
+悲痛,distress,痛苦,NOUN,B2
+不信任,distrust,不信任,NOUN,B2
+令人不安的,disturbing,令人不安的,ADJ,B2
+潜水,dive,跳水,NOUN,B2
+潜水,to dive,潜水,VERB,B2
+分歧的,divergent,分歧的,ADJ,B2
+多样化,to diversify,使多样化,VERB,B2
+转移,to divert,转移,VERB,B2
+神圣的,divine,神圣的,ADJ,B2
+离婚,divorce,离婚,NOUN,B2
+博士学位,doctorate,博士学位,NOUN,B2
+记录,to document,记录,VERB,B2
+纪录的,documentary,纪录片的,ADJ,B2
+教条的,dogmatic,教条的,ADJ,B2
+教条主义,dogmatism,教条主义,NOUN,B2
+海豚,dolphin,海豚,NOUN,B2
+穹顶,dome,圆顶,NOUN,B2
+国内的,domestic,国内的,ADJ,B2
+驯化,domestication,驯化,NOUN,B2
+主导的,dominant,占主导地位的,ADJ,B2
+支配,to dominate,支配,VERB,B2
+驴,donkey,驴,NOUN,B2
+捐赠者,donor,捐赠者,NOUN,B2
+剂量,dose,剂量,NOUN,B2
+加倍,double,两倍的,ADJ,B2
+加倍,to double,加倍,VERB,B2
+怀疑,doubt,怀疑,NOUN,B2
+面团,dough,面团,NOUN,B2
+向下,down,向下,ADV,B2
+下载,download,下载,NOUN,B2
+倾盆大雨,downpour,倾盆大雨,NOUN,B2
+向下,downwards,向下,ADV,B2
+嫁妆,dowry,嫁妆,NOUN,B2
+一打,dozen,一打,NOUN,B2
+拖,to drag,拖,VERB,B2
+下水道,drain,排水沟,NOUN,B2
+戏剧性的,dramatic,戏剧性的,ADJ,B2
+戏剧化,to dramatize,戏剧化,VERB,B2
+戏剧作法,dramaturgy,戏剧艺术,NOUN,B2
+图画,drawing,图画,NOUN,B2
+惧怕,to dread,畏惧,VERB,B2
+穿衣,dress,连衣裙,NOUN,B2
+穿衣,to dress,给...穿衣,VERB,B2
+漂流,drift,漂移,NOUN,B2
+车道,driveway,车道,NOUN,B2
+无人机,drone,无人机,NOUN,B2
+掉落,to drop,掉落,VERB,B2
+溺水,to drown,溺死,VERB,B2
+药物,drug,药物,NOUN,B2
+二元论,dualism,二元论,NOUN,B2
+二元性,duality,二元性,NOUN,B2
+配音,dubbing,配音,NOUN,B2
+鸭子,duck,鸭子,NOUN,B2
+钝的,dull,枯燥的,ADJ,B2
+哑的,dumb,愚蠢的,ADJ,B2
+沙丘,dune,沙丘,NOUN,B2
+耐久性,durability,耐用性,NOUN,B2
+在期间,during,在...期间,ADP,B2
+白天,during the day,在白天,ADV,B2
+荷兰的,dutch,荷兰的,ADJ,B2
+矮人,dwarf,侏儒,NOUN,B2
+住所,dwelling,住宅,NOUN,B2
+动态的,dynamic,动态的,ADJ,B2
+功能障碍,dysfunction,功能障碍,NOUN,B2
+反乌托邦,dystopia,反乌托邦,NOUN,B2
+更早,earlier,刚才,ADV,B2
+早的,early,早的,ADJ,B2
+东方的,eastern,东方的,ADJ,B2
+教会的,ecclesiastical,教会的,ADJ,B2
+日食,eclipse,日食,NOUN,B2
+生态的,ecological,生态的,ADJ,B2
+经济的,economic,经济的,ADJ,B2
+狂喜,ecstasy,狂喜,NOUN,B2
+版本,edition,版本,NOUN,B2
+编辑,editor,编辑,NOUN,B2
+教育,to educate,教育,VERB,B2
+受过教育的,educated,受过教育的,ADJ,B2
+有效的,effective,有效的,ADJ,B2
+要么,either,或者,CCONJ,B2
+弹性,elasticity,弹性,NOUN,B2
+兴高采烈,elated,兴高采烈的,ADJ,B2
+肘,elbow,手肘,NOUN,B2
+年老,elderly,年长的,ADJ,B2
+选举,election,选举,NOUN,B2
+选民,electorate,选民,NOUN,B2
+电,electric,电动的,ADJ,B2
+电工,electrician,电工,NOUN,B2
+电,electricity,电,NOUN,B2
+优雅,elegant,优雅的,ADJ,B2
+挽歌,elegy,挽歌,NOUN,B2
+十一,eleven,十一,NUM,B2
+精英,elite,精英,NOUN,B2
+雄辩,eloquence,口才,NOUN,B2
+雄辩,eloquent,雄辩的,ADJ,B2
+电子邮件,email,电子邮件,NOUN,B2
+散发,to emanate,散发,VERB,B2
+散发,emanation,散发物,NOUN,B2
+解放,to emancipate,解放,VERB,B2
+解放,emancipation,解放,NOUN,B2
+令人尴尬,embarrassing,令人尴尬的,ADJ,B2
+嵌入,to embed,嵌入,VERB,B2
+装饰,to embellish,装饰,VERB,B2
+贪污,embezzlement,贪污,NOUN,B2
+刺绣,to embroider,刺绣,VERB,B2
+急诊室,emergency room,急诊室,NOUN,B2
+排放,emission,排放,NOUN,B2
+情绪,emotion,情感,NOUN,B2
+情感,emotional,情绪的,ADJ,B2
+情绪性,emotionality,感性/情绪化,NOUN,B2
+经验主义,empiricism,经验主义,NOUN,B2
+就业,employment,就业,NOUN,B2
+授权,to empower,授权,VERB,B2
+空虚,emptiness,空虚,NOUN,B2
+空,empty,空的,ADJ,B2
+使能够,to enable,使能够,VERB,B2
+制定,to enact,颁布,VERB,B2
+施魔法,to enchant,使着迷,VERB,B2
+围住,to enclose,围住,VERB,B2
+遭遇,to encounter,遭遇,VERB,B2
+加密,encryption,加密,NOUN,B2
+百科全书,encyclopedia,百科全书,NOUN,B2
+百科全书式的,encyclopedic,百科全书式的,ADJ,B2
+危害,to endanger,危及,VERB,B2
+无限的,endless,无尽的,ADJ,B2
+认可,endorsement,背书,NOUN,B2
+精力充沛的,energetic,精力充沛的,ADJ,B2
+实施,enforcement,执行,NOUN,B2
+参与,to engage,从事,VERB,B2
+忙碌的,engaged,订婚的,ADJ,B2
+婚约,engagement,订婚,NOUN,B2
+英语,english,英国的,ADJ,B2
+英国人,englishman,英国人,NOUN,B2
+版画,engraving,版画,NOUN,B2
+享受,enjoyment,享受,NOUN,B2
+征募,to enlist,征募,VERB,B2
+封爵,to ennoble,使高贵,VERB,B2
+巨大,enormity,极恶,NOUN,B2
+庞大的,enormous,巨大的,ADJ,B2
+足够,enough,足够的,ADJ,B2
+使丰富,to enrich,使丰富,VERB,B2
+富集,enrichment,丰富,NOUN,B2
+登记,enrollment,注册,NOUN,B2
+牵涉,to entail,牵涉,VERB,B2
+缠住,to entangle,使纠缠,VERB,B2
+进入,to enter,进入,VERB,B2
+爱好者,enthusiast,爱好者,NOUN,B2
+引诱,to entice,引诱,VERB,B2
+整个的,entire,整个的,ADJ,B2
+永恒的,eternal,永恒的,ADJ,B2
+伦理的,ethical,道德的,ADJ,B2
+伦理学,ethics,伦理学,NOUN,B2
+民族的,ethnic,种族的,ADJ,B2
+民族,ethnicity,种族,NOUN,B2
+民族志,ethnography,人种学,NOUN,B2
+民族学,ethnology,民族学,NOUN,B2
+悼词,eulogy,赞辞,NOUN,B2
+委婉语,euphemism,委婉语,NOUN,B2
+欣快感,euphoria,欣快感,NOUN,B2
+欧洲的,european,欧洲的,ADJ,B2
+疏散,evacuation,疏散,NOUN,B2
+传教,to evangelize,传福音,VERB,B2
+蒸发,to evaporate,蒸发,VERB,B2
+蒸发,evaporation,蒸发,NOUN,B2
+回避的,evasive,回避的,ADJ,B2
+永远,ever,曾经,ADV,B2
+驱逐,eviction,驱逐,NOUN,B2
+明显的,evident,明显的,ADJ,B2
+加剧,to exacerbate,加剧,VERB,B2
+加剧,exacerbation,加剧,NOUN,B2
+夸张的,exaggerated,夸张的,ADJ,B2
+考试,exam,考试,NOUN,B2
+考试,examination,考试,NOUN,B2
+挖掘,to excavate,挖掘,VERB,B2
+擅长,to excel,擅长,VERB,B2
+摘录,excerpt,摘录,NOUN,B2
+使兴奋,to excite,使兴奋,VERB,B2
+兴奋,excitement,兴奋,NOUN,B2
+令人兴奋的,exciting,令人兴奋的,ADJ,B2
+被排除的,excluded,排除在外的,ADJ,B2
+排除,exclusion,排除,NOUN,B2
+排他的,exclusive,独有的,ADJ,B2
+排他地,exclusively,专门地,ADV,B2
+排他性,exclusivity,排他性,NOUN,B2
+开除教籍,to excommunicate,开除教籍,VERB,B2
+开除教籍,excommunication,绝罚,NOUN,B2
+鞭笞,to excoriate,严厉批评,VERB,B2
+原谅,to excuse,原谅,VERB,B2
+刽子手,executioner,刽子手,NOUN,B2
+主管,executive,行政主管,NOUN,B2
+释经,exegesis,注释,NOUN,B2
+豁免,exemption,豁免,NOUN,B2
+详尽,exhaustive,详尽的,ADJ,B2
+劝勉,to exhort,劝告,VERB,B2
+流放,exile,流亡,NOUN,B2
+流放,to exile,流放,VERB,B2
+开释,to exonerate,使无罪,VERB,B2
+扩张,expansion,扩张,NOUN,B2
+广阔,expansive,扩张的,ADJ,B2
+远征,expedition,探险,NOUN,B2
+花费,to expend,花费,VERB,B2
+费用,expense,费用,NOUN,B2
+费用,expenses,费用,NOUN,B2
+有经验,experienced,老练的,ADJ,B2
+实验,experimental,实验的,ADJ,B2
+专业知识,expertise,专业知识,NOUN,B2
+到期,expiry,失效,NOUN,B2
+解释,explanation,解释,NOUN,B2
+明确,explicit,明确的,ADJ,B2
+爆炸,to explode,爆炸,VERB,B2
+剥削,exploitation,利用,NOUN,B2
+炸药,explosive,爆炸性的,ADJ,B2
+出口,export,出口,NOUN,B2
+出口,to export,出口,VERB,B2
+明确地,expressly,明确地,ADV,B2
+征用,to expropriate,征用,VERB,B2
+征用,expropriation,征用,NOUN,B2
+驱逐,expulsion,驱逐,NOUN,B2
+名声,fame,名声,NOUN,B2
+熟悉的,familiar,熟悉的,ADJ,B2
+狂热,fanaticism,狂热,NOUN,B2
+幻想,fantasy,幻想,NOUN,B2
+远,far,远,ADV,B2
+闹剧,farce,闹剧,NOUN,B2
+农民,farmer,农民,NOUN,B2
+农业,farming,农业,NOUN,B2
+迷住,to fascinate,使着迷,VERB,B2
+迷人的,fascinating,迷人的,ADJ,B2
+魅力,fascination,魅力,NOUN,B2
+禁食,to fast,禁食,VERB,B2
+禁食,fasting,禁食,NOUN,B2
+脂肪,fat,脂肪,NOUN,B2
+致命的,fatal,致命的,ADJ,B2
+最喜欢的,favorite,最喜欢的,ADJ,B2
+羽毛,feather,羽毛,NOUN,B2
+二月,february,二月,NOUN,B2
+联邦的,federal,联邦的,ADJ,B2
+联邦制,federalism,联邦主义,NOUN,B2
+喂养,feed,饲料,NOUN,B2
+喂养,to feed,喂养,VERB,B2
+反馈,feedback,反馈,NOUN,B2
+费用,fees,酬金,NOUN,B2
+重罪,felony,重罪,NOUN,B2
+女性的,female,女性的,ADJ,B2
+女性朋友,female friend,女性朋友,NOUN,B2
+女性特质,femininity,女性气质,NOUN,B2
+女权主义,feminism,女权主义,NOUN,B2
+发酵,to ferment,发酵,VERB,B2
+发酵,fermentation,发酵,NOUN,B2
+肥沃的,fertile,肥沃的,ADJ,B2
+生育力,fertility,肥沃,NOUN,B2
+受精,fertilization,施肥,NOUN,B2
+取来,to fetch,取来,VERB,B2
+胎儿,fetus,胎儿,NOUN,B2
+封建主义,feudalism,封建主义,NOUN,B2
+未婚夫,fiance,未婚夫,NOUN,B2
+纤维,fiber,纤维,NOUN,B2
+纤维化,fibrosis,纤维化,NOUN,B2
+小说,fiction,小说,NOUN,B2
+虚构的,fictional,虚构的,ADJ,B2
+第五,fifth,خامس,ADJ,B2
+五十,fifty,五十,NUM,B2
+战士,fighter,战士,NOUN,B2
+填满,to fill,填满,VERB,B2
+拍摄,to film,拍摄,VERB,B2
+过滤,filter,过滤器,NOUN,B2
+过滤,to filter,过滤,VERB,B2
+决赛,final,决赛,NOUN,B2
+定稿,to finalize,完成,VERB,B2
+融资,to finance,资助,VERB,B2
+财务,finances,财政,NOUN,B2
+金融的,financial,财务的,ADJ,B2
+罚款,fine,罚款,NOUN,B2
+指纹,fingerprint,指纹,NOUN,B2
+有限的,finite,有限的,ADJ,B2
+开火,to fire,开火,VERB,B2
+消防员,firefighter,消防员,NOUN,B2
+壁炉,fireplace,壁炉,NOUN,B2
+柴火,firewood,木柴,NOUN,B2
+烟花,fireworks,烟花,NOUN,B2
+公司,firm,公司,NOUN,B2
+名字,first name,名字,NOUN,B2
+裂变,fission,裂变,NOUN,B2
+拳头,fist,拳头,NOUN,B2
+健身,fitness,健康,NOUN,B2
+合适的,fitting,合适的,ADJ,B2
+修理,to fix,修理,VERB,B2
+旗帜,flag,旗帜,NOUN,B2
+火焰,flame,火焰,NOUN,B2
+侧翼,flank,侧翼,NOUN,B2
+烧瓶,flask,小瓶,NOUN,B2
+奉承,flattery,奉承,NOUN,B2
+缺陷,flaw,缺陷,NOUN,B2
+舰队,fleet,舰队,NOUN,B2
+短暂的,fleeting,短暂的,ADJ,B2
+脆弱的,flimsy,脆弱的,ADJ,B2
+群,flock,兽群,NOUN,B2
+面粉,flour,面粉,NOUN,B2
+繁荣,to flourish,繁荣,VERB,B2
+流动,flow,流动,NOUN,B2
+流动,to flow,流动,VERB,B2
+流感,flu,流感,NOUN,B2
+飘动,to flutter,飘动,VERB,B2
+通量,flux,变迁,NOUN,B2
+苍蝇,fly,苍蝇,NOUN,B2
+泡沫,foam,泡沫,NOUN,B2
+泡沫的,foamy,多泡沫的,ADJ,B2
+聚焦,to focus,聚焦,VERB,B2
+饲料,fodder,饲料,NOUN,B2
+折叠,to fold,折叠,VERB,B2
+文件夹,folder,文件夹,NOUN,B2
+民俗,folklore,民俗,NOUN,B2
+后续,follow-up,跟进,NOUN,B2
+人行天桥,footbridge,人行天桥,NOUN,B2
+为,for,为了,ADP,B2
+免费,for free,免费,ADV,B2
+为了它,for it,为此,ADV,B2
+暂时,for now,暂时,ADV,B2
+为了,for the sake of,为了,ADP,B2
+为了什么,for what,为了什么,ADV,B2
+多年来,for years,多年,ADV,B2
+禁止,to forbid,禁止,VERB,B2
+禁止的,forbidden,被禁止的,ADJ,B2
+强迫,to force,强迫,VERB,B2
+强制,forced,强迫的,ADJ,B2
+强行,forcibly,强制地,ADV,B2
+额头,forehead,前额,NOUN,B2
+外国,foreign,外国的,ADJ,B2
+外国人,foreigner,外国人,NOUN,B2
+伪造,forgery,伪造品,NOUN,B2
+形式主义,formalism,形式主义,NOUN,B2
+形式,formality,礼节,NOUN,B2
+形式化,to formalize,使正式化,VERB,B2
+形成,formation,组建,NOUN,B2
+向前,forth,向前,ADV,B2
+堡垒,fortress,堡垒,NOUN,B2
+四十,forty,四十,NUM,B2
+论坛,forum,论坛,NOUN,B2
+弃儿,foundling,弃婴,NOUN,B2
+铸造厂,foundry,铸造厂,NOUN,B2
+十四,fourteen,十四,NUM,B2
+第四,fourth,第四,ADJ,B2
+碎片,fragment,碎片,NOUN,B2
+碎片化,fragmentation,碎片化,NOUN,B2
+香味,fragrance,香味,NOUN,B2
+框架,frame,框架,NOUN,B2
+特许经营,franchise,特许经营权,NOUN,B2
+释放,free,免费的,ADJ,B2
+释放,to free,释放,VERB,B2
+冷冻柜,freezer,冰柜,NOUN,B2
+冷冻,freezing,冻结,NOUN,B2
+法语,french,法国的,ADJ,B2
+法国人,frenchman,法国人,NOUN,B2
+狂热,frenzy,疯狂,NOUN,B2
+频率,frequency,频率,NOUN,B2
+常去,frequent,频繁的,ADJ,B2
+常去,to frequent,常去,VERB,B2
+新鲜,freshness,新鲜,NOUN,B2
+冰箱,fridge,冰箱,NOUN,B2
+薯条,fries,炸薯条,NOUN,B2
+刘海,fringe,边缘,NOUN,B2
+青蛙,frog,青蛙,NOUN,B2
+霜,frost,霜,NOUN,B2
+挫败,to frustrate,挫败,VERB,B2
+沮丧的,frustrated,沮丧的,ADJ,B2
+令人沮丧的,frustrating,令人沮丧的,ADJ,B2
+沮丧,frustration,挫折,NOUN,B2
+煎,to fry,油炸,VERB,B2
+平底锅,frying pan,平底锅,NOUN,B2
+燃料,fuel,燃料,NOUN,B2
+满月,full moon,满月,NOUN,B2
+乐趣,fun,乐趣,NOUN,B2
+起作用,to function,运作,VERB,B2
+功能的,functional,功能的,ADJ,B2
+功能主义,functionalism,功能主义,NOUN,B2
+功能性,functionality,功能性,NOUN,B2
+原教旨主义,fundamentalism,原教旨主义,NOUN,B2
+毛皮,fur,毛皮,NOUN,B2
+狂怒的,furious,愤怒的,ADJ,B2
+供应,to furnish,提供,VERB,B2
+进一步,further,进一步的,ADJ,B2
+狂怒,fury,狂怒,NOUN,B2
+保险丝,fuse,保险丝,NOUN,B2
+机身,fuselage,机身,NOUN,B2
+融合,fusion,融合,NOUN,B2
+未来的,future,未来的,ADJ,B2
+未来主义,futurism,未来主义,NOUN,B2
+小工具,gadget,小装置,NOUN,B2
+星系,galaxy,星系,NOUN,B2
+英勇,gallantry,英勇,NOUN,B2
+画廊,gallery,画廊,NOUN,B2
+奔跑,to gallop,飞奔,VERB,B2
+赌博,to gamble,赌博,VERB,B2
+帮派,gang,帮派,NOUN,B2
+园丁,gardener,园丁,NOUN,B2
+大蒜,garlic,大蒜,NOUN,B2
+服装,garment,服装,NOUN,B2
+点缀,to garnish,装饰,VERB,B2
+健谈,garrulous,喋喋不休的,ADJ,B2
+气体,gas,气体,NOUN,B2
+齿轮,gear,齿轮,NOUN,B2
+家谱,genealogy,家谱学,NOUN,B2
+一般,general,一般的,ADJ,B2
+概括,generalization,概括,NOUN,B2
+概括,to generalize,概括,VERB,B2
+发电机,generator,发电机,NOUN,B2
+慷慨,generosity,慷慨,NOUN,B2
+起源,genesis,起源,NOUN,B2
+基因,genetic,基因的,ADJ,B2
+遗传学,genetics,遗传学,NOUN,B2
+基因组,genome,基因组,NOUN,B2
+体裁,genre,类型,NOUN,B2
+地理,geographical,地理的,ADJ,B2
+地质,geological,地质的,ADJ,B2
+几何,geometric,几何的,ADJ,B2
+几何学,geometry,几何学,NOUN,B2
+地缘政治,geopolitical,地缘政治的,ADJ,B2
+地缘政治,geopolitics,地缘政治,NOUN,B2
+细菌,germ,病菌,NOUN,B2
+德国人,german,德国的,ADJ,B2
+打手势,to gesticulate,做手势,VERB,B2
+结识,to get acquainted,相互认识,VERB,B2
+迷路,to get lost,迷路,VERB,B2
+摆脱,to get rid of,摆脱,VERB,B2
+习惯,to get used to,习惯于,VERB,B2
+巨大的,giant,巨大的,ADJ,B2
+庞大的,gigantic,巨大的,ADJ,B2
+镀金,to gild,镀金,VERB,B2
+生姜,ginger,姜,NOUN,B2
+长颈鹿,giraffe,长颈鹿,NOUN,B2
+归还,to give back,归还,VERB,B2
+冰川,glacier,冰川,NOUN,B2
+高兴的,glad,高兴的,ADJ,B2
+瞥,to glance,瞥,VERB,B2
+腺,gland,腺体,NOUN,B2
+眼镜,glasses,眼镜,NOUN,B2
+滑行,to glide,滑行,VERB,B2
+瞥见,to glimpse,瞥见,VERB,B2
+全球化,globalization,全球化,NOUN,B2
+阴暗,gloominess,忧郁,NOUN,B2
+阴暗的,gloomy,阴郁的,ADJ,B2
+颂扬,glorification,赞美,NOUN,B2
+赞美,to glorify,赞美,VERB,B2
+光泽,gloss,光泽,NOUN,B2
+光辉,glow,光芒,NOUN,B2
+暴食,gluttony,暴食,NOUN,B2
+灵知,gnosis,灵知,NOUN,B2
+经历,to go through,经历,VERB,B2
+目标,goal,目标,NOUN,B2
+山羊,goat,山羊,NOUN,B2
+金色的,golden,金色的,ADJ,B2
+货物,goods,商品,NOUN,B2
+鹅,goose,鹅,NOUN,B2
+闲话,gossip,八卦,NOUN,B2
+美食家,gourmet,美食家,NOUN,B2
+治理,governance,治理,NOUN,B2
+政府的,governmental,政府的,ADJ,B2
+优雅,grace,优雅,NOUN,B2
+渐变,gradation,渐变,NOUN,B2
+评分,grading,评分；记号,NOUN,B2
+嫁接,graft,嫁接,NOUN,B2
+孙辈,grandchild,孙辈,NOUN,B2
+孙女,granddaughter,孙女,NOUN,B2
+宏伟,grandeur,宏伟,NOUN,B2
+宏伟,grandiose,浮夸的,ADJ,B2
+祖母,grandmother,祖母,NOUN,B2
+花岗岩,granite,花岗岩,NOUN,B2
+授予,to grant,授予,VERB,B2
+图形,graphic,图形的,ADJ,B2
+感激,grateful,感激的,ADJ,B2
+坟墓,grave,坟墓,NOUN,B2
+砾石,gravel,砾石,NOUN,B2
+重力,gravity,重力,NOUN,B2
+灰色,gray,灰色的,ADJ,B2
+放牧,grazing,放牧,NOUN,B2
+涂油,to grease,涂油,VERB,B2
+油腻,greasy,油腻的,ADJ,B2
+贪婪,greedy,贪婪的,ADJ,B2
+手榴弹,grenade,手榴弹,NOUN,B2
+灰色,grey,灰色的,ADJ,B2
+悲伤,grief,悲伤,NOUN,B2
+污垢,grime,污垢,NOUN,B2
+研磨,to grind,磨碎,VERB,B2
+呻吟,to groan,呻吟,VERB,B2
+新郎,groom,新郎,NOUN,B2
+总,gross,总的,ADJ,B2
+咆哮,growl,低吼,NOUN,B2
+增长,growth,增长,NOUN,B2
+抱怨,to grumble,抱怨,VERB,B2
+抱怨,grumbling,抱怨,NOUN,B2
+监护人,guardian,守卫,NOUN,B2
+断头台,guillotine,断头台,NOUN,B2
+内疚,guilt,内疚,NOUN,B2
+吉他手,guitarist,吉他手,NOUN,B2
+轻信,gullible,易受骗的,ADJ,B2
+猛喝,to gulp,吞咽,VERB,B2
+口香糖,gum,牙龈,NOUN,B2
+阵风,gust,阵风,NOUN,B2
+习惯化,habituation,习惯化,NOUN,B2
+讨价还价,to haggle,讨价还价,VERB,B2
+理发师,hairdresser,理发师,NOUN,B2
+半,half,一半的,ADJ,B2
+走廊,hallway,走廊,NOUN,B2
+火腿,ham,火腿,NOUN,B2
+锤子,hammer,锤子,NOUN,B2
+手提包,handbag,手提包,NOUN,B2
+手铐,handcuff,手铐,NOUN,B2
+把手,handle,把手,NOUN,B2
+挂断,to hang up,挂断,VERB,B2
+骚扰,to harass,骚扰,VERB,B2
+骚扰,harassment,骚扰,NOUN,B2
+港口,harbor,港口,NOUN,B2
+几乎不,hardly,几乎不,ADV,B2
+硬度,hardness,硬度,NOUN,B2
+有害的,harmful,有害的,ADJ,B2
+协调,harmonization,协调,NOUN,B2
+和谐,harmony,和谐,NOUN,B2
+竖琴,harp,竖琴,NOUN,B2
+傲慢,haughtiness,傲慢,NOUN,B2
+有,have,有,AUX,B2
+吃早餐,to have breakfast,吃早餐,VERB,B2
+吃晚餐,to have dinner,吃晚餐,VERB,B2
+吃午餐,to have lunch,吃午餐,VERB,B2
+干草,hay,干草,NOUN,B2
+标题,heading,标题,NOUN,B2
+健康的,healthy,健康的,ADJ,B2
+堆,heap,堆,NOUN,B2
+心脏病发作,heart attack,心脏病发作,NOUN,B2
+热,heat,热,NOUN,B2
+供暖,heating,供暖,NOUN,B2
+刺猬,hedgehog,刺猬,NOUN,B2
+霸权,hegemony,霸权,NOUN,B2
+继承人,heir,继承人,NOUN,B2
+直升机,helicopter,直升机,NOUN,B2
+头盔,helmet,头盔,NOUN,B2
+有用,helpful,有帮助的,ADJ,B2
+出血,hemorrhage,出血,NOUN,B2
+母鸡,hen,母鸡,NOUN,B2
+兽群,herd,兽群,NOUN,B2
+特此,hereby,特此,ADV,B2
+遗传,hereditary,遗传的,ADJ,B2
+异端,heresy,异端,NOUN,B2
+异端,heretic,异端,NOUN,B2
+诠释学,hermeneutic,诠释学的,ADJ,B2
+犹豫,hesitation,犹豫,NOUN,B2
+异质,heterogeneous,异质的,ADJ,B2
+隐藏,hidden,隐藏的,ADJ,B2
+藏身处,hideout,藏身处,NOUN,B2
+等级制度,hierarchy,等级制度,NOUN,B2
 高,high,高的,ADJ,B2
 高中,high school,高中,NOUN,B2
-高兴,to rejoice,欢欣,VERB,B2
-高兴的,delighted,高兴的,ADJ,B2
-高兴的,glad,高兴的,ADJ,B2
-高官,dignitary,高官,NOUN,B2
-高尚,loftiness,高尚,NOUN,B2
-高山的,alpine,高山的,ADJ,B2
-高的,high tall,高的,ADJ,B2
-高等专业教育,higher professional education,高等专业教育,NOUN,B2
-高级的,advanced,高级的,ADJ,B2
+更高,higher,更高的,ADJ,B2
+突出,to highlight,强调,VERB,B2
 高贵,highness,殿下,NOUN,B2
-高贵的,noble,高尚的,ADJ,B2
-鬣狗,hyena,鬣狗,NOUN,B2
-魅力,charisma,个人魅力,NOUN,B2
-魅力,fascination,魅力,NOUN,B2
-魔术师,magician,魔术师,NOUN,B2
-魔法地,magically,魔法地,ADV,B2
-魔法的,magical,魔法的,ADJ,B2
-魔鬼,devil,魔鬼,NOUN,B2
-鲁莽,temerity,鲁莽,NOUN,B2
-鲑鱼,salmon,三文鱼,NOUN,B2
-鲨鱼,shark,鲨鱼,NOUN,B2
-鲸鱼,whale,鲸鱼,NOUN,B2
+远足,to hike,徒步旅行,VERB,B2
+滑稽,hilarious,滑稽的,ADJ,B2
+山丘,hill,小山,NOUN,B2
+臀部,hip,臀部,NOUN,B2
+雇用,to hire,雇佣,VERB,B2
+雇用,hiring,招聘,NOUN,B2
+他的,his,他的,DET,B2
+嘶嘶声,hiss,嘶嘶声,NOUN,B2
+历史学家,historian,历史学家,NOUN,B2
+历史,historical,历史的,ADJ,B2
+史学,historiography,史学,NOUN,B2
+坚持,to hold on,抓住,VERB,B2
+神圣,holiness,神圣,NOUN,B2
+整体的,holistic,整体的,ADJ,B2
+洞,hollow,洼地,NOUN,B2
+神圣的,holy,神圣的,ADJ,B2
+无家可归的,homeless,无家可归的,ADJ,B2
+同质的,homogeneous,同质的,ADJ,B2
+同性恋的,homosexual,同性恋的,ADJ,B2
+诚实地,honestly,诚实地,ADV,B2
+诚实,honesty,诚实,NOUN,B2
+蜂蜜,honey,蜂蜜,NOUN,B2
+蜜月,honeymoon,蜜月,NOUN,B2
 鸣笛,to honk,按喇叭,VERB,B2
-鸭子,duck,鸭子,NOUN,B2
-鹅,goose,鹅,NOUN,B2
-鹤,crane,起重机,NOUN,B2
-鹿,deer,鹿,NOUN,B2
-麻木的,insensitive,麻木的,ADJ,B2
-麻木的,numb,麻木的,ADJ,B2
-麻烦,hassle,麻烦,NOUN,B2
-麻袋,sack,麻袋,NOUN,B2
-麻醉,anesthesia,麻醉,NOUN,B2
-麻醉,to anesthetize,麻醉,VERB,B2
-麻雀,sparrow,麻雀,NOUN,B2
-黄昏,twilight,暮光,NOUN,B2
-黄油,butter,黄油,NOUN,B2
+名誉的,honorary,名誉的,ADJ,B2
+希望,to hope,希望,VERB,B2
+但愿,hopefully,希望,ADV,B2
+绝望的,hopeless,绝望的,ADJ,B2
+可怕的,horrible,可怕的,ADJ,B2
+使恐惧,to horrify,使惊骇,VERB,B2
+令人恐惧的,horrifying,令人毛骨悚然的,ADJ,B2
+恐怖,horror,恐怖,NOUN,B2
+好客,hospitality,好客,NOUN,B2
+住院,to hospitalize,使住院,VERB,B2
+主办,to host,接待,VERB,B2
+客房,hotel room,酒店房间,NOUN,B2
+家庭,household,家庭,NOUN,B2
+住房,housing,住房,NOUN,B2
+盘旋,to hover,盘旋,VERB,B2
+多少,how much,多少,PRON,B2
+嚎叫,to howl,嚎叫,VERB,B2
+拥抱,hug,拥抱,NOUN,B2
+拥抱,to hug,拥抱,VERB,B2
+人类,human,人类的,ADJ,B2
+说明,to illustrate,说明,VERB,B2
+意象,imagery,意象,NOUN,B2
+想象的,imaginary,虚构的,ADJ,B2
+伊玛目,imam,伊玛目,NOUN,B2
+模仿,imitation,模仿,NOUN,B2
+立即的,immediate,立即的,ADJ,B2
+移民,immigrant,移民,NOUN,B2
+移民,immigration,移民,NOUN,B2
+迫近的,imminent,即将来临的,ADJ,B2
+不朽,immortality,不朽,NOUN,B2
+免疫的,immune,免疫的,ADJ,B2
+免疫,immunization,免疫,NOUN,B2
+影响,impact,影响,NOUN,B2
+障碍,impediment,障碍,NOUN,B2
+不可渗透的,impenetrable,不可穿透的,ADJ,B2
+必要的,imperative,必要的,ADJ,B2
+帝国的,imperial,帝国的,ADJ,B2
+帝国主义,imperialism,帝国主义,NOUN,B2
+实施,implementation,实施,NOUN,B2
+含蓄的,implicit,含蓄的,ADJ,B2
+暗示,to imply,暗示,VERB,B2
+不礼貌的,impolite,不礼貌的,ADJ,B2
+重要性,importance,重要性,NOUN,B2
+进口,importation,进口,NOUN,B2
+强加,to impose,强加,VERB,B2
+给...留下印象,to impress,使印象深刻,VERB,B2
+印象派,impressionism,印象主义,NOUN,B2
+令人印象深刻的,impressive,令人印象深刻的,ADJ,B2
+监禁,imprisonment,监禁,NOUN,B2
+即兴创作,improvisation,即兴创作,NOUN,B2
+即兴创作,to improvise,即兴创作,VERB,B2
+冲动的,impulsive,冲动的,ADJ,B2
+详细地,in detail,详细地,ADV,B2
+在前面,in front,在前面,ADV,B2
+在...前面,in front of,在……前面,ADP,B2
+在其中,in it,在里面,ADV,B2
+恋爱的,in love,恋爱中的,ADJ,B2
+徒劳地,in vain,徒劳,ADV,B2
+就职,to inaugurate,启用,VERB,B2
+激励,incentive,激励,NOUN,B2
+事件,incident,事件,NOUN,B2
+顺便,incidentally,顺便地,ADV,B2
+煽动,to incite,煽动,VERB,B2
+煽动,incitement,煽动,NOUN,B2
+倾向,inclination,倾向,NOUN,B2
+传入的,incoming,进来的,ADJ,B2
+不兼容,incompatibility,不兼容,NOUN,B2
+不一致,inconsistency,不一致,NOUN,B2
+合并,to incorporate,包含,VERB,B2
+孵化,incubation,孵化,NOUN,B2
+债务,indebtedness,负债,NOUN,B2
+不果断的,indecisive,犹豫不决的,ADJ,B2
+独立,independence,独立,NOUN,B2
+指示,indication,指示,NOUN,B2
+指标,indicator,指标,NOUN,B2
+本土的,indigenous,本土的,ADJ,B2
+消化不良,indigestion,消化不良,NOUN,B2
+愤慨,indignation,愤慨,NOUN,B2
+个人的,individual,单独的,ADJ,B2
+个人主义,individualism,个人主义,NOUN,B2
+工业的,industrial,工业的,ADJ,B2
+不平等,inequality,不平等,NOUN,B2
+惯性,inertia,惯性,NOUN,B2
+无经验的,inexperienced,生疏的,ADJ,B2
+迷恋,infatuation,迷恋,NOUN,B2
+渗透,to infiltrate,渗透,VERB,B2
+无限的,infinite,无限的,ADJ,B2
+影响者,influencer,网红,NOUN,B2
+摄入,to ingest,服用,VERB,B2
+居民,inhabitant,居民,NOUN,B2
+聪明的,intelligent,聪明的,ADJ,B2
+打算,to intend,打算,VERB,B2
+互动,interaction,互动,NOUN,B2
+交互的,interactive,交互式的,ADJ,B2
+拦截,to intercept,拦截,VERB,B2
+使感兴趣,to interest,使感兴趣,VERB,B2
+界面,interface,接口,NOUN,B2
+干涉,interference,干扰,NOUN,B2
+对话者,interlocutor,对话者,NOUN,B2
+间歇的,intermittent,间歇的,ADJ,B2
+内部的,internal,内部的,ADJ,B2
+互联网,internet,互联网,NOUN,B2
+解释,to interpret,解释,VERB,B2
+解释,interpretation,解释,NOUN,B2
+口译员,interpreter,口译员,NOUN,B2
+审问,interrogation,审问,NOUN,B2
+打断,to interrupt,打断,VERB,B2
+干预,intervention,干预,NOUN,B2
+面试,interview,面试,NOUN,B2
+恐吓,to intimidate,恐吓,VERB,B2
+恐吓,intimidation,恐吓,NOUN,B2
+语调,intonation,语调,NOUN,B2
+棘手的,intractable,难处理的,ADJ,B2
+无畏的,intrepid,无畏的,ADJ,B2
+介绍,introduction,介绍,NOUN,B2
+闯入者,intruder,入侵者,NOUN,B2
+侵入,intrusion,闯入,NOUN,B2
+入侵,invasion,入侵,NOUN,B2
+发明,invention,发明,NOUN,B2
+调查员,investigator,调查员,NOUN,B2
+投资,investment,投资,NOUN,B2
+看不见的,invisible,看不见的,ADJ,B2
+参与的,involved,涉及的,ADJ,B2
+参与,involvement,参与,NOUN,B2
+易怒,irascibility,易怒,NOUN,B2
+易怒的,irascible,易怒的,ADJ,B2
+铁的,iron,铁的,ADJ,B2
+讽刺的,ironic,讽刺的,ADJ,B2
+讽刺,irony,讽刺,NOUN,B2
+无可指责的,irreproachable,无可指责的,ADJ,B2
+无法抗拒的,irresistible,不可抗拒的,ADJ,B2
+不负责任的,irresponsible,不负责任的,ADJ,B2
+激怒,to irritate,激怒,VERB,B2
+孤立的,isolated,孤立的,ADJ,B2
+隔离,isolation,隔绝,NOUN,B2
+同位素,isotope,同位素,NOUN,B2
+问题,issue,问题,NOUN,B2
+意大利人,italian,意大利人,NOUN,B2
+痒,itch,痒,NOUN,B2
+瘙痒,itching,瘙痒,NOUN,B2
+夹克,jacket,夹克,NOUN,B2
+果酱,jam,果酱,NOUN,B2
+日本人,japanese,日本人,NOUN,B2
+行话,jargon,行话,NOUN,B2
 黄疸,jaundice,黄疸,NOUN,B2
-黏土,clay,黏土,NOUN,B2
-黑客行为,hacking,黑客行为,NOUN,B2
-黑市,black market,黑市,NOUN,B2
-黑帮成员,gangster,黑帮成员,NOUN,B2
-黑手党,mafia,黑手党,NOUN,B2
-默许,to acquiesce,默许,VERB,B2
-鼓动,to agitate,鼓动,VERB,B2
-鼓掌,to clap,拍手,VERB,B2
-鼓舞人心的,inspiring,鼓舞人心的,ADJ,B2
-鼻涕,snot,鼻涕,NOUN,B2
-齿轮,gear,齿轮,NOUN,B2
+下巴,jaw,下巴,NOUN,B2
+嫉妒的,jealous,嫉妒的,ADJ,B2
+嫉妒,jealousy,嫉妒,NOUN,B2
+犹太人,jew,犹太人,NOUN,B2
+宝石,jewel,宝石,NOUN,B2
+珠宝,jewelry,珠宝,NOUN,B2
+工作,job,工作,NOUN,B2
+关节,joint,关节,NOUN,B2
+共有权,joint ownership,共有,NOUN,B2
+开玩笑,to joke,开玩笑,VERB,B2
+记者,journalist,记者,NOUN,B2
+快乐的,joyful,快乐的,ADJ,B2
+周年纪念,jubilee,禧年,NOUN,B2
+司法的,judicial,司法的,ADJ,B2
+司法系统,judiciary,司法官,NOUN,B2
+果汁,juice,果汁,NOUN,B2
+七月,july,七月,NOUN,B2
+跳跃,jump,跳跃,NOUN,B2
+六月,june,六月,NOUN,B2
+管辖权,jurisdiction,管辖权,NOUN,B2
+陪审员,juror,陪审员,NOUN,B2
+正义,justice,正义,NOUN,B2
+辩护,justification,理由,NOUN,B2
+水壶,kettle,水壶,NOUN,B2
+踢,kick,踢,NOUN,B2
+小孩,kid,小孩,NOUN,B2
+绑架,to kidnap,绑架,VERB,B2
+绑架,kidnapping,绑架,NOUN,B2
+肾脏,kidney,肾脏,NOUN,B2
+仁慈,kindness,仁慈,NOUN,B2
+动力学的,kinetic,运动的,ADJ,B2
+亲属关系,kinship,亲属关系,NOUN,B2
+吻,kiss,吻,NOUN,B2
+风筝,kite,风筝,NOUN,B2
+膝盖,knee,膝盖,NOUN,B2
+骑士,knight,骑士,NOUN,B2
+结,knot,结,NOUN,B2
+已知的,known,已知的,ADJ,B2
+简洁的,laconic,简洁的,ADJ,B2
+羊羔,lamb,羔羊,NOUN,B2
+跛的,lame,跛的,ADJ,B2
+着陆,landing,着陆,NOUN,B2
+风景,landscape,风景,NOUN,B2
+灯笼,lantern,灯笼,NOUN,B2
+膝部,lap,大腿部,NOUN,B2
+喉,larynx,喉,NOUN,B2
+最后,last,最后的,ADJ,B2
+昨晚,last night,昨晚,ADV,B2
+后来,later,后来,ADV,B2
+侧面的,lateral,侧面的,ADJ,B2
+笑声,laughter,笑声,NOUN,B2
+发射,launch,发射,NOUN,B2
+洗衣店,laundry,洗衣,NOUN,B2
+洗衣房,laundry room,洗衣房,NOUN,B2
+熔岩,lava,熔岩,NOUN,B2
+诉讼,lawsuit,诉讼,NOUN,B2
+松懈的,lax,松懈的,ADJ,B2
+放置,to lay,放置,VERB,B2
+裁员,layoff,解雇,NOUN,B2
+懒惰,laziness,懒惰,NOUN,B2
+领先的,leading,领先的,ADJ,B2
+泄漏,leak,泄漏,NOUN,B2
+倾斜,lean,瘦的,ADJ,B2
+倾斜,to lean,倾斜,VERB,B2
+向左,left,左边的,ADJ,B2
+法律职业,legal profession,律师业,NOUN,B2
+合法性,legality,合法性,NOUN,B2
+合法地,legally,合法地,ADV,B2
+传说的,legendary,传奇的,ADJ,B2
+立法的,legislative,立法的,ADJ,B2
+合法的,legitimate,合法的,ADJ,B2
+使合法化,to legitimize,使合法,VERB,B2
+借出,to lend,借出,VERB,B2
+宽大,leniency,宽厚,NOUN,B2
+宽大的,lenient,宽大的,ADJ,B2
+较少,less,更少,ADV,B2
+以免,lest,唯恐,SCONJ,B2
+让,to let,让,VERB,B2
+词汇学,lexicology,词汇学,NOUN,B2
+责任,liability,责任,NOUN,B2
+说谎者,liar,骗子,NOUN,B2
+自由主义,liberalism,自由主义,NOUN,B2
+自由化,liberalization,自由化,NOUN,B2
+解放,to liberate,解放,VERB,B2
+放荡,licentiousness,放荡,NOUN,B2
+舔,to lick,舔,VERB,B2
+躺,to lie,撒谎,VERB,B2
+打火机,lighter,打火机,NOUN,B2
+同样地,likewise,同样地,ADV,B2
+有限的,limited,有限的,ADJ,B2
+跛行,to limp,跛行,VERB,B2
+线,line,线,NOUN,B2
+血统,lineage,血统,NOUN,B2
+线性的,linear,线性的,ADJ,B2
+语言学,linguistics,语言学,NOUN,B2
+连接,link,链接,NOUN,B2
+连接,to link,连接,VERB,B2
+口红,lipstick,口红,NOUN,B2
+清算,liquidation,清算,NOUN,B2
+流动性,liquidity,流动性,NOUN,B2
+烈酒,liquor,烈酒,NOUN,B2
+诉讼当事人,litigant,诉讼当事人,NOUN,B2
+升,litre,升,NOUN,B2
+肝脏,liver,肝脏,NOUN,B2
+牲畜,livestock,家畜,NOUN,B2
+装载,load,负载,NOUN,B2
+装载,to load,装载,VERB,B2
+面包,loaf,一条面包,NOUN,B2
 龙虾,lobster,龙虾,NOUN,B2
+定位,to locate,定位,VERB,B2
+锁,to lock,锁上,VERB,B2
+监禁,to lock up,关押,VERB,B2
+逻辑的,logical,合乎逻辑的,ADJ,B2
+孤独,loneliness,孤独,NOUN,B2
+看,look,看,NOUN,B2
+寻找,to look for,寻找,VERB,B2
+守望,lookout,瞭望,NOUN,B2
+漏洞,loophole,漏洞,NOUN,B2
+松散的,loose,松的,ADJ,B2
+松开,to loosen,放松,VERB,B2
+战利品,loot,战利品,NOUN,B2
+失败者,loser,失败者,NOUN,B2
+丢失的,lost,迷失的,ADJ,B2
+签,lot,许多,NOUN,B2
+彩票,lottery,彩票,NOUN,B2
+情人,lover,爱人,NOUN,B2
+幸运的,lucky,幸运的,ADJ,B2
+行李,luggage,行李,NOUN,B2
+肿块,lump,块,NOUN,B2
+奢侈品,luxury,奢侈,NOUN,B2
+宏观的,macroscopic,宏观的,ADJ,B2
+疯子,madman,疯子,NOUN,B2
+魔法的,magical,魔法的,ADJ,B2
+魔术师,magician,魔术师,NOUN,B2
+宽宏大量,magnanimity,宽宏大量,NOUN,B2
+磁铁,magnet,磁铁,NOUN,B2
+邮件,mail,邮件,NOUN,B2
+主要地,mainly,主要地,ADV,B2
+维护,maintenance,维护,NOUN,B2
+犯错,to make a mistake,弄错,VERB,B2
+确保,to make sure,确保,VERB,B2
+化妆品,makeup,化妆品,NOUN,B2
+男性的,male,男性的,ADJ,B2
+故障,malfunction,故障,NOUN,B2
+恶意,malice,恶意,NOUN,B2
+恶性的,malignant,恶性的,ADJ,B2
+强制的,mandatory,强制的,ADJ,B2
+策略,maneuver,策略,NOUN,B2
+制造商,manufacturer,制造商,NOUN,B2
+手稿,manuscript,手稿,NOUN,B2
+边缘,margin,边缘,NOUN,B2
+边缘化,marginalization,边缘化,NOUN,B2
+海上的,maritime,海事的,ADJ,B2
+标记,to mark,标记,VERB,B2
+营销,marketing,营销,NOUN,B2
+已婚的,married,已婚的,ADJ,B2
+惊叹,to marvel,使惊奇,VERB,B2
+面具,mask,面具,NOUN,B2
+质量,mass,大量,NOUN,B2
+巨大的,massive,巨大的,ADJ,B2
+杰作,masterpiece,杰作,NOUN,B2
+唯物主义,materialism,唯物主义,NOUN,B2
+姨妈,maternal aunt,姨母,NOUN,B2
+数学,math,数学,NOUN,B2
+数学的,mathematical,数学的,ADJ,B2
+矩阵,matrix,矩阵,NOUN,B2
+要紧,to matter,重要,VERB,B2
+床垫,mattress,床垫,NOUN,B2
+成熟,maturity,成熟,NOUN,B2
+最大的,maximum,最大,ADJ,B2
+也许,maybe,也许,ADV,B2
+草地,meadow,草地,NOUN,B2
+刻薄的,mean,刻薄的,ADJ,B2
+其间,meantime,同时,NOUN,B2
+肉,meat,肉,NOUN,B2
+技工,mechanic,技工,NOUN,B2
+中位数,median,中位数,NOUN,B2
+调解,mediation,调解,NOUN,B2
+医学的,medical,医疗的,ADJ,B2
+地中海的,mediterranean,地中海的,ADJ,B2
+忧郁的,melancholic,忧郁的,ADJ,B2
+忧郁,melancholy,忧郁,NOUN,B2
+旋律,melody,旋律,NOUN,B2
+会员资格,membership,会员资格,NOUN,B2
+记忆,memorization,记忆,NOUN,B2
+精神的,mental,精神的,ADJ,B2
+心态,mentality,心态,NOUN,B2
+合并,to merge,合并,VERB,B2
+精英政治,meritocracy,精英管理,NOUN,B2
+信使,messenger,信使,NOUN,B2
+形而上学,metaphysics,形而上学,NOUN,B2
+米,meter,米,NOUN,B2
+方法论,methodology,方法论,NOUN,B2
+借代,metonymy,转喻,NOUN,B2
+墨西哥的,mexican,墨西哥的,ADJ,B2
+显微镜,microscope,显微镜,NOUN,B2
+中间,midst,中间,NOUN,B2
+偏头痛,migraine,偏头痛,NOUN,B2
+迁移,migration,移民,NOUN,B2
+温和的,mild,温和的,ADJ,B2
+英里,mile,英里,NOUN,B2
+里程碑,milestone,里程碑,NOUN,B2
+军队,military,军事的,ADJ,B2
+磨坊,mill,磨坊,NOUN,B2
+百万,million,百万,NOUN,B2
+矿,mine,矿井,NOUN,B2
+部长的,ministerial,部长的,ADJ,B2
+部,ministry,部,NOUN,B2
+未成年人,minor,未成年人,NOUN,B2
+少数,minority,少数,NOUN,B2
+挪用,misappropriation,挪用,NOUN,B2
+痛苦,misery,痛苦,NOUN,B2
+不幸,misfortune,不幸,NOUN,B2
+误导的,misleading,诡辩的,ADJ,B2
+失踪的,missing,失踪的,ADJ,B2
+弄错,to mistake,弄错,VERB,B2
+虐待,to mistreat,أساء,VERB,B2
+情妇,mistress,情妇,NOUN,B2
+混合的,mixed,混合的,ADJ,B2
+混合物,mixture,混合物,NOUN,B2
+呻吟,moan,呻吟,NOUN,B2
+手机,mobile phone,手机,NOUN,B2
+模式,mode,方式,NOUN,B2
+建模,modeling,造型,NOUN,B2
+适度的,moderate,适度的,ADJ,B2
+适度,moderation,克制,NOUN,B2
+现代的,modern,现代的,ADJ,B2
+现代化,modernization,现代化,NOUN,B2
+模块化的,modular,模块化的,ADJ,B2
+模具,mold,鞋楦,NOUN,B2
+妈妈,mom,妈妈,NOUN,B2
+修道院,monastery,修道院,NOUN,B2
+货币的,monetary,金钱的,ADJ,B2
+监控,monitoring,监控,NOUN,B2
+和尚,monk,僧侣,NOUN,B2
+垄断的,monopolistic,垄断的,ADJ,B2
+垄断,to monopolize,垄断,VERB,B2
+每月的,monthly,每月的,ADJ,B2
+纪念碑,monument,纪念碑,NOUN,B2
+道德,moral,道德,NOUN,B2
+道德,morals,道德,NOUN,B2
+更经常,more often,更频繁,ADV,B2
+形态学的,morphological,形态的,ADJ,B2
+形态学,morphology,形态学,NOUN,B2
+马赛克,mosaic,马赛克,NOUN,B2
+清真寺,mosque,清真寺,NOUN,B2
+蚊子,mosquito,蚊子,NOUN,B2
+苔藓,moss,苔藓,NOUN,B2
+大多数,most,大多数,ADJ,B2
+岳母,mother-in-law,岳母,NOUN,B2
+激励,to motivate,激励,VERB,B2
+动机,motivation,动机,NOUN,B2
+搬入,to move in,搬入,VERB,B2
+先生,mr.,先生,NOUN,B2
+许多,much,多,DET,B2
+粘液,mucus,黏液,NOUN,B2
+泥,mud,泥,NOUN,B2
+市政的,municipal,市政的,ADJ,B2
+市政,municipality,市镇,NOUN,B2
+慷慨,munificence,慷慨,NOUN,B2
+谋杀,to murder,谋杀,VERB,B2
+音乐的,musical,موسيقي,ADJ,B2
+音乐家,musician,音乐家,NOUN,B2
+哑的,mute,沉默的；哑的,ADJ,B2
+咕哝,to mutter,嘟囔,VERB,B2
+互助保险,mutual insurance,互助保险,NOUN,B2
+我的,my,我的,DET,B2
+神话,mythology,神话学,NOUN,B2
+钉子,nail,指甲,NOUN,B2
+天真,naivety,天真,NOUN,B2
+裸体的,naked,裸体的,ADJ,B2
+即,namely,即,ADV,B2
+小睡,nap,午睡,NOUN,B2
+自恋,narcissism,自恋,NOUN,B2
+叙事,narrative,叙述；故事,NOUN,B2
+叙述者,narrator,叙述者,NOUN,B2
+令人不快的,nasty,令人不快的,ADJ,B2
+国家的,national,国家的,ADJ,B2
+民族主义,nationalism,民族主义,NOUN,B2
+国有化,nationalization,国有化,NOUN,B2
+国有化,to nationalize,国有化,VERB,B2
+本地的,native,本地的,ADJ,B2
+自然的,natural,自然的,ADJ,B2
+自然保护区,nature reserve,自然保护区,NOUN,B2
+恶心,nausea,恶心,NOUN,B2
+海军,navy,海军,NOUN,B2
+纳粹,nazi,纳粹分子,NOUN,B2
+近,near,靠近,ADV,B2
+附近的,nearby,附近的,ADJ,B2
+整洁的,neat,整洁的,ADJ,B2
+星云,nebula,星云,NOUN,B2
+必然,necessarily,必然地,ADV,B2
+疏忽的,negligent,疏忽的,ADJ,B2
+谈判,negotiation,谈判；协商,NOUN,B2
+谈判,negotiations,谈判,NOUN,B2
+嘶鸣,to neigh,嘶鸣,VERB,B2
+邻里,neighborhood,社区,NOUN,B2
+邻近的,neighboring,邻近的,ADJ,B2
+也不,neither,也不,CCONJ,B2
+紧张,nervousness,紧张,NOUN,B2
+巢,nest,巢,NOUN,B2
+网络,network,网络,NOUN,B2
+神经症,neurosis,神经症,NOUN,B2
+中立,neutrality,中立,NOUN,B2
+下一个,next,下一个,ADJ,B2
+旁边,next to,在...旁边,ADP,B2
+啃,to nibble,啃,VERB,B2
+美好的,nice,好的,ADJ,B2
+昵称,nickname,绰号,NOUN,B2
+侄女,niece,侄女,NOUN,B2
+夜总会,nightclub,夜总会,NOUN,B2
+夜莺,nightingale,夜莺,NOUN,B2
+虚无主义,nihilism,虚无主义,NOUN,B2
+九十,ninety,九十,NUM,B2
+不,no,不,ADV,B2
+高贵的,noble,高尚的,ADJ,B2
+贵族,nobleman,贵族,NOUN,B2
+没有人,nobody,没有人,PRON,B2
+夜间的,nocturnal,夜间的,ADJ,B2
+游牧,nomadism,游牧生活,NOUN,B2
+提名,to nominate,提名,VERB,B2
+提名,nomination,提名,NOUN,B2
+毫无,none,没有一个,DET,B2
+不,nope,不,INTJ,B2
+通常,normally,通常地,ADV,B2
+北方的,northern,北方的,ADJ,B2
+不,not,不,PART,B2
+注意,to note,记录,VERB,B2
+没有东西,nothing,没有什么,PRON,B2
+注意到,to notice,注意到,VERB,B2
+通知,notification,通知,NOUN,B2
+臭名昭著的,notorious,臭名昭著的,ADJ,B2
+本体,noumenon,本体,NOUN,B2
+小说的,novelistic,小说般的,ADJ,B2
+十一月,november,十一月,NOUN,B2
+无处,nowhere,无处,ADV,B2
+核的,nuclear,核的,ADJ,B2
+无效,nullity,无效；无能,NOUN,B2
+众多的,numerous,众多的,ADJ,B2
+坚果,nut,坚果,NOUN,B2
+桨,oar,桨,NOUN,B2
+誓言,oath,誓言,NOUN,B2
+肥胖,obesity,肥胖,NOUN,B2
+反对,objection,异议,NOUN,B2
+客观性,objectivity,客观性,NOUN,B2
+义务,obligation,义务,NOUN,B2
+淫秽的,obscene,淫秽的,ADJ,B2
+蒙昧主义,obscurantism,蒙昧主义,NOUN,B2
+天文台,observatory,天文台,NOUN,B2
+观察,to observe,观察,VERB,B2
+着迷的,obsessed,着迷的,ADJ,B2
+过时的,obsolete,过时的,ADJ,B2
+固执的,obstinate,固执的,ADJ,B2
+被占用的,occupied,被占用的,ADJ,B2
+发生,to occur,发生,VERB,B2
+奇怪的,odd,奇怪的,ADJ,B2
+的,of,的,ADP,B2
+当然,of course,理所当然的,ADJ,B2
+提议,offer,报价,NOUN,B2
+正式地,officially,正式地,ADV,B2
+油,oil,油,NOUN,B2
+药膏,ointment,药膏,NOUN,B2
+好的,okay,好的,INTJ,B2
+老人,old person,老人,NOUN,B2
+煎蛋卷,omelet,欧姆蛋,NOUN,B2
+省略,to omit,省略,VERB,B2
+开启,on,在...上,ADP,B2
+在上面,on it,在上面,ADV,B2
+相反,on the contrary,相反,ADV,B2
+在路上,on the way,在路上,ADV,B2
+一,one,人们,PRON,B2
+洋葱,onion,洋葱,NOUN,B2
+刚刚,only just,才,ADV,B2
+开口,opening,开口,NOUN,B2
+操作员,operator,经营者,NOUN,B2
+反对,opposition,对立,NOUN,B2
+压迫,oppression,压迫,NOUN,B2
+光学的,optical,光学的,ADJ,B2
+乐观,optimism,乐观,NOUN,B2
+选项,option,选择,NOUN,B2
+可选的,optional,可选的,ADJ,B2
+轨道,orbit,轨道,NOUN,B2
+管弦乐队,orchestra,管弦乐队,NOUN,B2
+考验,ordeal,苦难,NOUN,B2
+有机的,organic,有机的,ADJ,B2
+有组织的,organized,有组织的,ADJ,B2
+方向,orientation,取向,NOUN,B2
+正统的,orthodox,正统的,ADJ,B2
+振荡,to oscillate,振荡,VERB,B2
+其他,other,其他的,DET,B2
+我们的,our,我们的,DET,B2
+外面,out,在外面,ADV,B2
+弃儿,outcast,被遗弃者,NOUN,B2
+出口,outlet,出口,NOUN,B2
+愤怒,outrage,愤怒,NOUN,B2
+在外面,outside,在外面,ADV,B2
+烤箱,oven,烤箱,NOUN,B2
+越过,over,在...上方,ADP,B2
+在那边,over there,在那边,ADV,B2
+总的来说,overall,总体上,ADV,B2
+溢出,overflow,溢出,NOUN,B2
+超过,to overtake,超过,VERB,B2
+加班,overtime,加班,NOUN,B2
+推翻,to overturn,打翻,VERB,B2
+压倒,to overwhelm,使不知所措,VERB,B2
+猫头鹰,owl,猫头鹰,NOUN,B2
+拥有,own,自己的,ADJ,B2
+拥有,to own,拥有,VERB,B2
+所有者,owner,所有者,NOUN,B2
+所有权,ownership,,NOUN,B2
+氧化物,oxide,氧化物,NOUN,B2
+氧气,oxygen,氧气,NOUN,B2
+步伐,pace,速度,NOUN,B2
+包装,packaging,包装,NOUN,B2
+拥挤的,packed,打包,ADJ,B2
+小包,packet,小包裹,NOUN,B2
+契约,pact,协定,NOUN,B2
+痛苦的,painful,疼痛的,ADJ,B2
+止痛药,painkiller,止痛药,NOUN,B2
+绘画,paint,油漆,NOUN,B2
+绘画,to paint,粉刷,VERB,B2
+画家,painter,画家,NOUN,B2
+苍白的,pale,苍白的,ADJ,B2
+棕榈树,palm tree,棕榈树,NOUN,B2
+平底锅,pan,平底锅,NOUN,B2
+煎饼,pancake,煎饼,NOUN,B2
+卵石,pebble,卵石,NOUN,B2
+特有的,peculiar,奇怪的,ADJ,B2
+教育学的,pedagogical,教学的,ADJ,B2
+教育学,pedagogy,教育学,NOUN,B2
+小便,to pee,小便,VERB,B2
+剥,to peel,削皮,VERB,B2
+钢笔,pen,钢笔,NOUN,B2
+穿透,to penetrate,穿透,VERB,B2
+养老金,pension,养老金,NOUN,B2
+胡椒,pepper,胡椒,NOUN,B2
+百分比,percent,百分比,NOUN,B2
+百分率,percentage,百分比,NOUN,B2
+敏锐的,perceptive,敏锐的,ADJ,B2
+完美,perfection,完美,NOUN,B2
+香水,perfume,香水,NOUN,B2
+定期地,periodically,定期地,ADV,B2
+外围的,peripheral,外围的,ADJ,B2
+毁灭,to perish,死亡,VERB,B2
+伪证,perjury,伪证,NOUN,B2
+永久的,permanent,永久的,ADJ,B2
+可渗透的,permeable,可渗透的,ADJ,B2
+许可,permission,许可,NOUN,B2
+犯罪者,perpetrator,肇事者,NOUN,B2
+迫害,persecution,迫害,NOUN,B2
+毅力,perseverance,毅力,NOUN,B2
+个人的,personal,个人的,ADJ,B2
+说服,persuasion,说服,NOUN,B2
+悲观主义,pessimism,悲观主义,NOUN,B2
+药物的,pharmaceutical,制药的,ADJ,B2
+药剂师,pharmacist,药剂师,NOUN,B2
+现象学,phenomenology,现象学,NOUN,B2
+慈善家,philanthropist,慈善家,NOUN,B2
+慈善,philanthropy,慈善,NOUN,B2
+哲学家,philosopher,哲学家,NOUN,B2
+痰,phlegm,痰,NOUN,B2
+恐惧症,phobia,恐惧症,NOUN,B2
+打电话,phone,电话,NOUN,B2
+打电话,to phone,打电话,VERB,B2
+电话,phone call,通话,NOUN,B2
+语音学,phonetics,语音学,NOUN,B2
+音系学,phonology,音系学,NOUN,B2
+照片,photo,照片,NOUN,B2
+拍照,to photograph,拍照,VERB,B2
+摄影师,photographer,摄影师,NOUN,B2
+物理的,physical,身体的,ADJ,B2
+生理学,physiology,生理学,NOUN,B2
+信息,piece of information,信息,NOUN,B2
+虔诚,piety,虔诚,NOUN,B2
+堆,pile,堆,NOUN,B2
+朝圣者,pilgrim,朝圣者,NOUN,B2
+朝圣,pilgrimage,朝圣,NOUN,B2
+柱子,pillar,柱子,NOUN,B2
+飞行员,pilot,飞行员,NOUN,B2
+钉住,to pin,别住,VERB,B2
+捏,pinch,捏,NOUN,B2
+捏,to pinch,捏,VERB,B2
+松树,pine,松树,NOUN,B2
+粉红色的,pink,粉色的,ADJ,B2
+管子,pipe,管子,NOUN,B2
+海盗,pirate,海盗,NOUN,B2
+怜悯,pity,可惜,ADJ,B2
+怜悯,to pity,同情,VERB,B2
+剽窃,plagiarism,剽窃,NOUN,B2
+行星,planet,行星,NOUN,B2
+种植,planting,种植,NOUN,B2
+石膏,plaster,石膏,NOUN,B2
+塑料,plastic,塑料的,ADJ,B2
+镀的,plated,镀层的,ADJ,B2
+玩家,player,运动员,NOUN,B2
+可能的,possible,可能的,ADJ,B2
+可能地,possibly,可能地,ADV,B2
+海报,poster,海报,NOUN,B2
+猛扑,to pounce,猛扑,VERB,B2
+英镑,pound,磅,NOUN,B2
+贫困,poverty,贫困,NOUN,B2
+粉末,powder,粉末,NOUN,B2
+授权书,power of attorney,委托书,NOUN,B2
+从业者,practitioner,从业者,NOUN,B2
+实用主义,pragmatism,实用主义,NOUN,B2
+祈祷,to pray,祈祷,VERB,B2
+祈祷,prayer,祈祷,NOUN,B2
+布道,to preach,布道,VERB,B2
+布道,preaching,劝诫,NOUN,B2
+序言,preamble,序言,NOUN,B2
+不稳定性,precariousness,不稳定性,NOUN,B2
+先于,to precede,在...之前,VERB,B2
+先驱,precursor,先驱,NOUN,B2
+捕食者,predator,捕食者,NOUN,B2
+掠夺性的,predatory,掠夺的,ADJ,B2
+前任,predecessor,前任,NOUN,B2
+更喜欢,to prefer,更喜欢,VERB,B2
+最好,preferably,更愿意,ADV,B2
+怀孕,pregnancy,怀孕,NOUN,B2
+怀孕的,pregnant,怀孕的,ADJ,B2
+首映,premiere,首演,NOUN,B2
+幼儿园,preschool,幼儿园,NOUN,B2
+开处方,to prescribe,开处方,VERB,B2
+演示,presentation,展示,NOUN,B2
+主持人,presenter,主持人,NOUN,B2
+保存,to preserve,保护,VERB,B2
+总统职位,presidency,总统任期,NOUN,B2
+总统,president,总统,NOUN,B2
+总统的,presidential,总统的,ADJ,B2
+新闻界,press,新闻界,NOUN,B2
+记者招待会,press conference,新闻发布会,NOUN,B2
+紧迫的,pressing,紧迫的,ADJ,B2
+盛行,to prevail,盛行,VERB,B2
+先前的,previous,先前的,ADJ,B2
+先前,previously,以前,ADV,B2
+定价,pricing,定价 / 收费,NOUN,B2
+骄傲,pride,骄傲,NOUN,B2
+牧师,priest,牧师,NOUN,B2
+首相,prime minister,总理,NOUN,B2
+棱镜,prism,棱镜,NOUN,B2
+监狱,prison,监狱,NOUN,B2
+特权,privilege,特权,NOUN,B2
+概率的,probabilistic,概率的,ADJ,B2
+概率,probability,概率,NOUN,B2
+可能,probably,大概,ADV,B2
+问题,problem,问题,NOUN,B2
+继续,to proceed,继续进行,VERB,B2
+队伍,procession,行列,NOUN,B2
+拖延,to procrastinate,拖延,VERB,B2
+拖延,procrastination,拖延,NOUN,B2
+采购,to procure,获取,VERB,B2
+生产,production,生产,NOUN,B2
+生产力,productivity,生产力,NOUN,B2
+职业,profession,职业,NOUN,B2
+专业人士,professional,专业的,ADJ,B2
+熟练的,proficient,熟练的,ADJ,B2
+简介,profile,简介,NOUN,B2
+编程,programming,编程,NOUN,B2
+无产阶级,proletariat,无产阶级,NOUN,B2
+冗长的,prolix,冗长的,ADJ,B2
+冗长,prolixity,冗长,NOUN,B2
+突出的,prominent,突出的,ADJ,B2
+承诺,promise,承诺,NOUN,B2
+有前途的,promising,有前途的,ADJ,B2
+推广者,promoter,推动者,NOUN,B2
+发音,pronunciation,发音,NOUN,B2
+校对,proofreading,校对,NOUN,B2
+宣传,propaganda,宣传,NOUN,B2
+倾向,propensity,倾向,NOUN,B2
+平淡,prosaic,平淡无奇的,ADJ,B2
+起诉,prosecution,起诉,NOUN,B2
+繁荣,prosperity,繁荣,NOUN,B2
+保护主义,protectionism,保护主义,NOUN,B2
+保护,protective,保护的,ADJ,B2
+抗议,protest,抗议,NOUN,B2
+抗议者,protester,示威者,NOUN,B2
+协议,protocol,协议,NOUN,B2
+提供,to provide,提供,VERB,B2
+供养,to provide for,供应,VERB,B2
+提供者,provider,提供者,NOUN,B2
+省,province,省,NOUN,B2
+谨慎,prudence,谨慎,NOUN,B2
+精神科医生,psychiatrist,精神科医生,NOUN,B2
+心理学家,psychologist,心理学家,NOUN,B2
+精神病,psychosis,精神病,NOUN,B2
+酒吧,pub,酒吧,NOUN,B2
+青春期,puberty,青春期,NOUN,B2
+公开,publicly,公开地,ADV,B2
+出版商,publisher,出版商,NOUN,B2
+出版社,publishing house,出版社,NOUN,B2
+肺,pulmonary,肺的,ADJ,B2
+泵,pump,泵,NOUN,B2
+准时,punctual,准时的,ADJ,B2
+学生,pupil,学生,NOUN,B2
+木偶,puppet,木偶,NOUN,B2
+小狗,puppy,小狗,NOUN,B2
+购买,purchase,购买,NOUN,B2
+纯,pure,纯净的,ADJ,B2
+纯净,purity,纯洁,NOUN,B2
+穿上,to put on,穿上,VERB,B2
+迷惑,to puzzle,使困惑,VERB,B2
+金字塔,pyramid,金字塔,NOUN,B2
+取得资格,to qualify,使合格,VERB,B2
+定性的,qualitative,定性的,ADJ,B2
+定量的,quantitative,定量的,ADJ,B2
+争吵,quarrel,争吵,NOUN,B2
+码头,quay,码头,NOUN,B2
+可疑的,questionable,可疑的,ADJ,B2
+队列,queue,队列,NOUN,B2
+快的,quick,快的,ADJ,B2
+拉比,rabbi,拉比,NOUN,B2
+比赛,race,比赛,NOUN,B2
+种族主义,racism,种族主义,NOUN,B2
+球拍,racket,球拍,NOUN,B2
+辐射,radiation,辐射,NOUN,B2
+散热器,radiator,暖气片,NOUN,B2
+收音机,radio,收音机,NOUN,B2
+放射性的,radioactive,放射性的,ADJ,B2
+萝卜,radish,小萝卜,NOUN,B2
+狂怒,rage,愤怒,NOUN,B2
+破烂的,ragged,破烂的,ADJ,B2
+栏杆,railing,栏杆,NOUN,B2
+雨,rain,雨,NOUN,B2
+雨衣,raincoat,雨衣,NOUN,B2
+公羊,ram,公羊,NOUN,B2
+怨恨,rancor,怨恨,NOUN,B2
+随机的,random,随机的,ADJ,B2
+等级,rank,等级,NOUN,B2
+赎金,ransom,赎金,NOUN,B2
+强奸,rape,强奸,NOUN,B2
+和解,rapprochement,和解,NOUN,B2
+流氓,rascal,无赖,NOUN,B2
+皮疹,rash,轻率的,ADJ,B2
+理性主义,rationalism,理性主义,NOUN,B2
+合理化,rationalization,合理化,NOUN,B2
+渡鸦,raven,乌鸦,NOUN,B2
+生的,raw,生的,ADJ,B2
+射线,ray,光线,NOUN,B2
+剃刀,razor,剃刀,NOUN,B2
+可达的,reachable,可到达的,ADJ,B2
+反应,to react,反应,VERB,B2
+反应,reaction,反应,NOUN,B2
+反应的,reactive,反应的,ADJ,B2
+反应堆,reactor,反应堆,NOUN,B2
+读者,reader,读者,NOUN,B2
+准备就绪,readiness,准备就绪,NOUN,B2
+准备好的,ready,准备好的,ADJ,B2
+真实的,real,真实的,ADJ,B2
+房地产,real estate,房地产,ADJ,B2
+后部,rear,后面的,ADJ,B2
+推理,to reason,推理,VERB,B2
+使安心,to reassure,使安心,VERB,B2
+反叛者,rebel,反叛者,NOUN,B2
+指责,rebuke,责备,NOUN,B2
+配方,recipe,食谱,NOUN,B2
+接受者,recipient,接受者,NOUN,B2
+相互的,reciprocal,互惠的,ADJ,B2
+收回,to reclaim,收回,VERB,B2
+推荐,recommendation,推荐,NOUN,B2
+和解,reconciliation,和解,NOUN,B2
+侦察,reconnaissance,侦察,NOUN,B2
+重新考虑,to reconsider,重新考虑,VERB,B2
+记录,recording,录音,NOUN,B2
+回避,recusal,回避,NOUN,B2
+参考,to refer,参考,VERB,B2
+参考,reference,参考,NOUN,B2
+公投,referendum,公民投票,NOUN,B2
+精炼的,refined,精炼的,ADJ,B2
+精炼,refinement,修养,NOUN,B2
+重新造林,reforestation,重新造林,NOUN,B2
+叠句,refrain,副歌,NOUN,B2
+难民,refugee,难民,NOUN,B2
+注册,registration,注册,NOUN,B2
+回归,regression,倒退,NOUN,B2
+规章,regulations,法规,NOUN,B2
+排练,to rehearse,排练,VERB,B2
+加强,to reinforce,加强,VERB,B2
+增援,reinforcement,增援,NOUN,B2
+拒绝,rejection,拒绝,NOUN,B2
+高兴,to rejoice,欢欣,VERB,B2
+复发,relapse,再犯,NOUN,B2
+相关的,related,相关的,ADJ,B2
+相对的,relative,相对的,ADJ,B2
+相对主义,relativism,相对主义,NOUN,B2
+放松,relaxation,缓和,NOUN,B2
+贬谪,to relegate,降级,VERB,B2
+相关的,relevant,相关的,ADJ,B2
+可靠性,reliability,可靠性,NOUN,B2
+宗教的,religious,宗教的,ADJ,B2
+依赖,to rely,依赖,VERB,B2
+纪念,remembrance,纪念,NOUN,B2
+懊悔,remorse,悔恨,NOUN,B2
+移除,to remove,移除,VERB,B2
+文艺复兴,renaissance,复兴,NOUN,B2
+肾的,renal,肾脏的,ADJ,B2
+食言,to renege,食言,VERB,B2
+更新,to renew,更新,VERB,B2
+更新,renewal,更新,NOUN,B2
+翻新,to renovate,翻新,VERB,B2
+翻新,renovation,翻新,NOUN,B2
+重复的,repeated,反复的,ADJ,B2
+忏悔,to repent,悔改,VERB,B2
+后果,repercussion,反响,NOUN,B2
+应受谴责的,reprehensible,应受谴责的,ADJ,B2
+代表,to represent,代表,VERB,B2
+代表性的,representative,有代表性的,ADJ,B2
+代表性,representativeness,代表性,NOUN,B2
+镇压,repression,镇压,NOUN,B2
+压制的,repressive,压制的,ADJ,B2
+训斥,reprimand,训斥,NOUN,B2
+责备,reproach,责备,NOUN,B2
+繁殖,to reproduce,繁殖,VERB,B2
+共和的,republican,共和的,ADJ,B2
+令人厌恶的,repulsive,令人反感的,ADJ,B2
+必需的,required,必需的,ADJ,B2
+要求,requirement,要求,NOUN,B2
+营救,to rescue,拯救,VERB,B2
+研究,research,研究,NOUN,B2
+预订,reservation,预订,NOUN,B2
+预留,to reserve,预订,VERB,B2
+缄默的,reserved,保留的,ADJ,B2
+解决,to resolve,解决,VERB,B2
+度假胜地,resort,度假胜地,NOUN,B2
+尊重,respect,尊重,NOUN,B2
+呼吸的,respiratory,呼吸的,ADJ,B2
+回应,response,回应,NOUN,B2
+负责任的,responsible,负责的,ADJ,B2
+响应性,responsiveness,反应性,NOUN,B2
+复活,resurrection,复活,NOUN,B2
+退休的,retired,退休的,ADJ,B2
+退休,retirement,退休,NOUN,B2
+检索,retrieval,检索,NOUN,B2
+检索,to retrieve,取回,VERB,B2
+团聚,reunion,重聚,NOUN,B2
+启示,revelation,启示,NOUN,B2
+崇敬,reverence,尊敬,NOUN,B2
+修辞的,rhetorical,修辞的,ADJ,B2
+押韵,rhyme,韵脚,NOUN,B2
+节奏,rhythm,节奏,NOUN,B2
+骑手,rider,骑手,NOUN,B2
+步枪,rifle,步枪,NOUN,B2
+裂痕,rift,裂痕,NOUN,B2
+正确的,right,正确的,ADJ,B2
+权利,rights,权利,NOUN,B2
+僵硬的,rigid,僵硬的,ADJ,B2
+坚硬,rigidity,僵硬,NOUN,B2
+严格的,rigorous,严格的,ADJ,B2
+响,to ring,鸣响,VERB,B2
+铃声,ringing,铃声,NOUN,B2
+成熟的,ripe,成熟的,ADJ,B2
+上升,rise,上涨,NOUN,B2
+冒险的,risky,危险的,ADJ,B2
+漫游,to roam,漫游,VERB,B2
+抢劫,robbery,抢劫案,NOUN,B2
+机器人,robot,机器人,NOUN,B2
+火箭,rocket,火箭,NOUN,B2
+榜样,role model,榜样,NOUN,B2
+滚动,to roll,滚动,VERB,B2
+罗马人,roman,罗马人,NOUN,B2
+浪漫,romance,浪漫,NOUN,B2
+公鸡,rooster,公鸡,NOUN,B2
+粗糙,roughness,粗糙,NOUN,B2
+唤醒,to rouse,唤醒,VERB,B2
+常规,routine,常规,NOUN,B2
+划船,row,行,NOUN,B2
+划船,to row,划船,VERB,B2
+皇家的,royal,皇家的,ADJ,B2
+摩擦,to rub,摩擦,VERB,B2
+粗鲁的,rude,粗鲁的,ADJ,B2
+毁灭,ruin,废墟,NOUN,B2
+毁灭,to ruin,毁灭,VERB,B2
+谣言,rumor,谣言,NOUN,B2
+碾过,to run over,碾过,VERB,B2
+跑步者,runner,跑步者,NOUN,B2
+跑步,running,进行中的,NOUN,B2
+农村的,rural,乡村的,ADJ,B2
+俄罗斯的,russian,俄罗斯的,ADJ,B2
+锈,rust,铁锈,NOUN,B2
+麻袋,sack,麻袋,NOUN,B2
+悲伤,sadness,悲伤,NOUN,B2
+睿智的,sagacious,睿智的,ADJ,B2
+航行,to sail,航行,VERB,B2
+圣人,saint,圣人,NOUN,B2
+沙拉,salad,沙拉,NOUN,B2
+鲑鱼,salmon,三文鱼,NOUN,B2
+拯救,salvation,拯救,NOUN,B2
+样品,sample,样本,NOUN,B2
+制裁,sanction,制裁,NOUN,B2
+避难所,sanctuary,避难所,NOUN,B2
+凉鞋,sandal,凉鞋,NOUN,B2
+理智,sanity,理智,NOUN,B2
+圣诞老人,santa claus,圣诞老人,NOUN,B2
+讽刺的,satirical,讽刺的,ADJ,B2
+满意,satisfaction,满意,NOUN,B2
+酱汁,sauce,酱汁,NOUN,B2
+香肠,sausage,香肠,NOUN,B2
+储蓄,savings,存款,NOUN,B2
+救世主,savior,救星,NOUN,B2
+锯,saw,锯子,NOUN,B2
+脚手架,scaffold,脚手架,NOUN,B2
+手术刀,scalpel,手术刀,NOUN,B2
+骗局,scam,骗局,NOUN,B2
+丑闻,scandal,丑闻,NOUN,B2
+稀缺的,scarce,稀少的,ADJ,B2
+吓唬,to scare,惊吓,VERB,B2
+害怕的,scared,害怕的,ADJ,B2
+精神分裂症,schizophrenia,精神分裂症,NOUN,B2
+奖学金,scholarship,奖学金,NOUN,B2
+学术的,scholastic,经院哲学的,ADJ,B2
+科学的,scientific,科学的,ADJ,B2
+范围,scope,范围,NOUN,B2
+烧焦,to scorch,烧焦,VERB,B2
+灼热的,scorching,灼热的,ADJ,B2
+恶棍,scoundrel,恶棍,NOUN,B2
+祸害,scourge,灾祸,NOUN,B2
+废料,scrap,碎屑,NOUN,B2
+抓,to scratch,抓,VERB,B2
+尖叫,scream,尖叫,NOUN,B2
+屏幕,screen,屏幕,NOUN,B2
+剧本,screenplay,剧本,NOUN,B2
+螺丝刀,screwdriver,螺丝刀,NOUN,B2
+顾忌,scruple,顾虑,NOUN,B2
+仔细检查,to scrutinize,仔细检查,VERB,B2
+雕塑家,sculptor,雕塑家,NOUN,B2
+海鸥,seagull,海鸥,NOUN,B2
+脱离,to secede,脱离,VERB,B2
+秒,second,第二,ADJ,B2
+其次,secondly,其次,ADV,B2
+秘密的,secret,秘密的,ADJ,B2
+秘书处,secretariat,秘书处,NOUN,B2
+宗派的,sectarian,宗派的,ADJ,B2
+部门,sector,部门,NOUN,B2
+世俗主义,secularism,世俗主义,NOUN,B2
+获得,to secure,保护,VERB,B2
+安全,security,安全,NOUN,B2
+诱惑,to seduce,引诱,VERB,B2
+重见,to see again,再见,VERB,B2
+种子,seed,种子,NOUN,B2
+地震的,seismic,地震的,ADJ,B2
+抓住,to seize,抓住,VERB,B2
+癫痫,seizure,没收,NOUN,B2
+选择性的,selective,选择的，挑选的,ADJ,B2
+自信,self-confidence,自信,NOUN,B2
+自私,selfishness,自私,NOUN,B2
+符号学,semiology,符号学，症状学,NOUN,B2
+符号学,semiotics,符号学,NOUN,B2
+资历,seniority,资历,NOUN,B2
+感觉,sensation,感觉,NOUN,B2
+感觉到,sense,感觉,NOUN,B2
+感觉到,to sense,隐约感到,VERB,B2
+无意义的,senseless,无意义的,ADJ,B2
+明智的,sensible,明智的,ADJ,B2
+敏感的,sensitive,敏感的,ADJ,B2
+敏感性,sensitivity,敏感性,NOUN,B2
+传感器,sensor,传感器,NOUN,B2
+宁静,serenity,宁静,NOUN,B2
+连环杀手,serial killer,连环杀手,NOUN,B2
+系列,series,系列,NOUN,B2
+布道,sermon,布道,NOUN,B2
+谄媚,servility,奴性,NOUN,B2
+集合,set,一套,NOUN,B2
+挫折,setback,挫折,NOUN,B2
+定居点,settlement,解决,NOUN,B2
+七十,seventy,七十,NUM,B2
+几个,several,几个,DET,B2
+缝,to sew,缝纫,VERB,B2
+性的,sexual,性的,ADJ,B2
+棚屋,shack,棚屋,NOUN,B2
+镣铐,shackle,镣铐,NOUN,B2
+骗局,sham,假冒,NOUN,B2
+羞辱,to shame,使羞愧,VERB,B2
+无耻的,shameless,无耻的,ADJ,B2
+洗发水,shampoo,洗发水,NOUN,B2
+份额,share,股份,NOUN,B2
+鲨鱼,shark,鲨鱼,NOUN,B2
+打碎,to shatter,粉碎,VERB,B2
+刮,to shave,剃,VERB,B2
+棚屋,shed,棚屋,NOUN,B2
+床单,sheet,床单,NOUN,B2
+架子,shelf,架子,NOUN,B2
+壳,shell,壳,NOUN,B2
+牧羊人,shepherd,牧羊人,NOUN,B2
+盾牌,shield,盾牌,NOUN,B2
+轮班,shift,轮班,NOUN,B2
+照耀,shine,光泽,NOUN,B2
+照耀,to shine,照耀,VERB,B2
+震惊,shock,震惊,NOUN,B2
+令人震惊的,shocking,令人震惊的,ADJ,B2
+鞋,shoes,鞋子,NOUN,B2
+枪战,shootout,枪战,NOUN,B2
+购物,to shop,购物,VERB,B2
+捷径,shortcut,捷径,NOUN,B2
+喊叫,shout,喊叫,NOUN,B2
+铲子,shovel,铲子,NOUN,B2
+淋浴,to shower,淋浴,VERB,B2
+精明的,shrewd,精明的,ADJ,B2
+神殿,shrine,مشعر,NOUN,B2
+战栗,shudder,战栗,NOUN,B2
+兄弟姐妹,siblings,兄弟姐妹,NOUN,B2
+生病的,sick,生病的,ADJ,B2
+筛子,sieve,筛子,NOUN,B2
+筛,to sift,筛选,VERB,B2
+叹气,to sigh,叹气,VERB,B2
+签名,signature,签名,NOUN,B2
+重要的,significant,重要的,ADJ,B2
+银色的,silver,银色,ADJ,B2
+相似的,similar,相似的,ADJ,B2
+明喻,simile,明喻,NOUN,B2
+简化,to simplify,简化,VERB,B2
+模拟,simulation,模拟,NOUN,B2
+同时的,simultaneous,同时的,ADJ,B2
+唱歌,singing,歌唱,NOUN,B2
+水槽,sink,水槽,NOUN,B2
+啜饮,sip,小口喝,NOUN,B2
+啜饮,to sip,小口喝,VERB,B2
+警报器,siren,汽笛,NOUN,B2
+第六,sixth,第六,ADJ,B2
+六十,sixty,六十,NUM,B2
+骨骼,skeleton,骨架,NOUN,B2
+怀疑的,skeptical,怀疑的,ADJ,B2
+怀疑,skepticism,怀疑主义,NOUN,B2
+滑雪,to ski,滑雪,VERB,B2
+头骨,skull,头骨,NOUN,B2
+诽谤,slander,诽谤,NOUN,B2
+诽谤,to slander,诽谤,VERB,B2
+掴,slap,拍击,NOUN,B2
+掴,to slap,打耳光,VERB,B2
+奴隶制,slavery,奴隶制,NOUN,B2
+安眠药,sleeping pill,安眠药,NOUN,B2
+袖子,sleeve,袖子,NOUN,B2
+滑梯,slide,滑动,NOUN,B2
+滑倒,to slip,滑倒,VERB,B2
+拖鞋,slipper,拖鞋,NOUN,B2
+滑的,slippery,滑的,ADJ,B2
+口号,slogan,口号,NOUN,B2
+减速,to slow down,放慢,VERB,B2
+狡猾的,sly,狡猾的,ADJ,B2
+狡猾,slyness,狡猾,NOUN,B2
+最小的,smallest,最小的,ADJ,B2
+烟,smoke,烟,NOUN,B2
+吸烟,smoking,吸烟,NOUN,B2
+抚平,to smooth,使光滑,VERB,B2
+走私犯,smuggler,走私者,NOUN,B2
+走私,smuggling,走私,NOUN,B2
+蜗牛,snail,蜗牛,NOUN,B2
+溜,to sneak,潜行,VERB,B2
+嗅,to sniff,嗅,VERB,B2
+打鼾,to snore,打鼾,VERB,B2
+口鼻,snout,口鼻,NOUN,B2
+这么,so much,这么多,ADV,B2
+浸泡,to soak,浸透,VERB,B2
+抽泣,to sob,啜泣,VERB,B2
+抽泣,sobbing,抽泣,NOUN,B2
+清醒,sober,清醒的,ADJ,B2
+清醒,sobriety,清醒,NOUN,B2
+社会,social,社会的,ADJ,B2
+社会学,sociology,社会学,NOUN,B2
+团结,solidarity,团结,NOUN,B2
+独白,soliloquy,独白,NOUN,B2
+孤独,solitude,孤独,NOUN,B2
+偿付能力,solvency,偿付能力,NOUN,B2
+溶剂,solvent,溶剂,NOUN,B2
+不知怎么,somehow,以某种方式,ADV,B2
+某人,someone,某人,PRON,B2
+某物,something,某事,PRON,B2
+某时,sometime,在某个时候,ADV,B2
+某处,somewhere,某处,ADV,B2
+烟灰,soot,烟灰,NOUN,B2
+诡辩,sophism,诡辩,NOUN,B2
+悲伤,sorrow,悲伤,NOUN,B2
+抱歉,sorry,抱歉,ADJ,B2
+分类,to sort,分类,VERB,B2
+纪念品,souvenir,纪念品,NOUN,B2
+主权,sovereign,主权的,ADJ,B2
+播种,sowing,播种,NOUN,B2
+飞船,spaceship,宇宙飞船,NOUN,B2
+西班牙语,spanish,西班牙的,ADJ,B2
+火花,spark,火花,NOUN,B2
+麻雀,sparrow,麻雀,NOUN,B2
+矛,spear,长矛,NOUN,B2
+专家,specialist,专家,NOUN,B2
+专业化,specialization,专业化,NOUN,B2
+具体的,specific,具体的,ADJ,B2
+规格,specification,规格,NOUN,B2
+指定,to specify,具体说明,VERB,B2
+观众,spectator,观众,NOUN,B2
+光谱的,spectral,幽灵般的,ADJ,B2
+光谱,spectrum,光谱,NOUN,B2
+推测,to speculate,推测,VERB,B2
+推测,speculation,推测,NOUN,B2
+演讲,speech,演讲,NOUN,B2
+花费,to spend,花费,VERB,B2
+球体,sphere,领域,NOUN,B2
+旋转,to spin,旋转,VERB,B2
+灵性,spirituality,灵性,NOUN,B2
+吐,to spit,吐,VERB,B2
+恶意的,spiteful,怀恨的,ADJ,B2
+辉煌的,splendid,极好的,ADJ,B2
+辉煌,splendor,辉煌,NOUN,B2
+分裂,split,分裂,NOUN,B2
+破坏,to spoil,损坏,VERB,B2
+发言人,spokesperson,发言人,NOUN,B2
+自发的,spontaneous,自发的,ADJ,B2
+运动,sport,运动,NOUN,B2
+配偶,spouse,配偶,NOUN,B2
+刺激,to spur,激励,VERB,B2
+浪费,squandering,挥霍,NOUN,B2
+正方形,square,广场,NOUN,B2
+蹲,to squat,蹲,VERB,B2
+松鼠,squirrel,松鼠,NOUN,B2
+刺,to stab,刺,VERB,B2
+稳定,to stabilize,使稳定,VERB,B2
+马厩,stable,畜舍,NOUN,B2
+员工,staff,全体员工,NOUN,B2
+摇晃,to stagger,蹒跚,VERB,B2
+停滞,stagnation,停滞,NOUN,B2
+停滞,to stall,拖延,VERB,B2
+邮票,stamp,邮票,NOUN,B2
+站立,to stand,站立,VERB,B2
+标准化,standardization,标准化,NOUN,B2
+持久的,standing,站立的,ADJ,B2
+挨饿,to starve,挨饿,VERB,B2
+统计学,statistics,统计学,NOUN,B2
+雕像,statue,雕像,NOUN,B2
+蒸汽,steam,蒸汽,NOUN,B2
+驾驶,to steer,引导,VERB,B2
+恒星的,stellar,杰出的,ADJ,B2
+茎,stem,茎,NOUN,B2
+恶臭,stench,恶臭,NOUN,B2
+狭窄,stenosis,狭窄,NOUN,B2
+刻板印象,stereotype,刻板印象,NOUN,B2
+无菌的,sterile,无菌的,ADJ,B2
+刺,to stick,插入,VERB,B2
+僵硬,stiffness,僵硬,NOUN,B2
+耻辱,stigma,耻辱,NOUN,B2
+污名化,to stigmatize,污名化,VERB,B2
+兴奋剂,stimulant,兴奋剂,NOUN,B2
+蜇,to sting,刺,VERB,B2
+吝啬,stinginess,吝啬；小气,NOUN,B2
+发臭,to stink,发臭,VERB,B2
+臭的,stinking,发臭的,ADJ,B2
+规定,to stipulate,规定,VERB,B2
+搅拌,to stir,搅拌,VERB,B2
+证券交易所,stock exchange,证券交易所,NOUN,B2
+斯多葛主义,stoicism,斯多葛主义,NOUN,B2
+停止,stop,停止,NOUN,B2
+储存,store,商店,NOUN,B2
+储存,to store,储存,VERB,B2
+暴风雨的,stormy,有暴风雨的,ADJ,B2
+炉子,stove,炉灶,NOUN,B2
+直接地,straight,径直地,ADV,B2
+弄直,to straighten,弄直,VERB,B2
+拉紧,strain,压力,NOUN,B2
+拉紧,to strain,努力,VERB,B2
+陌生人,stranger,陌生人,NOUN,B2
+扼住,to strangle,扼杀,VERB,B2
+带子,strap,带子,NOUN,B2
+加强,to strengthen,加强,VERB,B2
+有压力的,stressed,焦虑的,ADJ,B2
+担架,stretcher,担架,NOUN,B2
+中风,stroke,中风,NOUN,B2
+构建,to structure,构建,VERB,B2
+卡住的,stuck,卡住的,ADJ,B2
+研究,studies,学业,NOUN,B2
+学习,to study,学习,VERB,B2
+东西,stuff,东西,NOUN,B2
+绊倒,to stumble,绊倒,VERB,B2
+令人震惊的,stunning,极好的,ADJ,B2
+愚蠢,stupidity,愚蠢,NOUN,B2
+时髦的,stylish,雅致的,ADJ,B2
+征服,to subjugate,征服,VERB,B2
+潜艇,submarine,潜水艇,NOUN,B2
+淹没,to submerge,淹没,VERB,B2
+订阅,to subscribe,订阅,VERB,B2
+订阅者,subscriber,订阅者,NOUN,B2
+订阅,subscription,订阅,NOUN,B2
+随后的,subsequent,随后的,ADJ,B2
+平息,to subside,平息,VERB,B2
+子公司,subsidiary,子公司,NOUN,B2
+生计,subsistence,生计,NOUN,B2
+大量的,substantial,大量的,ADJ,B2
+成功,to succeed,成功,VERB,B2
+成功的,successful,成功的,ADJ,B2
+继承,succession,连续,NOUN,B2
+屈服,to succumb,屈服,VERB,B2
+这样的,such,如此,DET,B2
+吸,to suck,吸,VERB,B2
+窒息,to suffocate,窒息,VERB,B2
+建议,suggestion,建议,NOUN,B2
+套装,suit,西装,NOUN,B2
+摘要,summary,摘要,NOUN,B2
+峰会,summit,顶峰,NOUN,B2
+晴朗的,sunny,晴朗的,ADJ,B2
+表面的,superficial,表面的,ADJ,B2
+超自然的,supernatural,超自然的,ADJ,B2
+监督,supervision,监督,NOUN,B2
+供应,supply,供应,NOUN,B2
+确定的,sure,确定的,ADJ,B2
+激增,surge,激增,NOUN,B2
+外科医生,surgeon,外科医生,NOUN,B2
+手术,surgery,手术,NOUN,B2
+使惊讶,to surprise,使惊讶,VERB,B2
+令人惊讶的,surprising,令人惊讶的,ADJ,B2
+超现实主义,surrealism,超现实主义,NOUN,B2
+监视,surveillance,监视,NOUN,B2
+调查,survey,调查,NOUN,B2
+测量员,surveyor,测量员,NOUN,B2
+怀疑,to suspect,怀疑,VERB,B2
+暂停,suspension,暂停,NOUN,B2
+营养,sustenance,食物,NOUN,B2
+天鹅,swan,天鹅,NOUN,B2
+摇摆,to sway,摇摆,VERB,B2
+毛衣,sweater,毛衣,NOUN,B2
+扫,to sweep,打扫,VERB,B2
+糖果,sweet,糖果,NOUN,B2
+使变甜,to sweeten,使变甜,VERB,B2
+心爱的人,sweetheart,爱人,NOUN,B2
+甜心,sweetie,亲爱的,NOUN,B2
+糖果,sweets,甜食,NOUN,B2
+诈骗,to swindle,诈骗,VERB,B2
+骗子,swindler,骗子,NOUN,B2
+秋千,swing,秋千,NOUN,B2
+电话总机,switchboard,总机,NOUN,B2
+谄媚,sycophancy,阿谀奉承,NOUN,B2
+教学大纲,syllabus,教学大纲,NOUN,B2
+符号,symbol,象征,NOUN,B2
+同情,sympathy,同情,NOUN,B2
+交响乐,symphony,交响乐,NOUN,B2
+症状,symptom,症状,NOUN,B2
+有症状的,symptomatic,症状的,ADJ,B2
+同步,synchronization,同步,NOUN,B2
+同步的,synchronous,同步的,ADJ,B2
+同义,synonymy,同义关系,NOUN,B2
+句法,syntax,句法,NOUN,B2
+合成,synthesis,综合,NOUN,B2
+注射器,syringe,注射器,NOUN,B2
+糖浆,syrup,糖浆,NOUN,B2
+系统的,systemic,全身性的,ADJ,B2
+心照不宣的,tacit,心照不宣的,ADJ,B2
+心照不宣地,tacitly,默不作声地,ADV,B2
+沉默寡言的,taciturn,沉默寡言的,ADJ,B2
+处理,to tackle,处理,VERB,B2
+得体的,tactful,圆滑的,ADJ,B2
+战术,tactic,策略,NOUN,B2
+携带,to take along,带走,VERB,B2
+接管,to take over,接管,VERB,B2
+发生,to take place,举行,VERB,B2
+起飞,takeoff,起飞,NOUN,B2
+健谈的,talkative,健谈的,ADJ,B2
+驯服,to tame,驯服,VERB,B2
+晒黑,to tan,晒黑,VERB,B2
+切线,tangent,切线,NOUN,B2
+有形的,tangible,有形的,ADJ,B2
+鞣革工,tanner,制革工,NOUN,B2
+鞣制,tanning,晒黑,NOUN,B2
+瞄准,targeting,定位,NOUN,B2
+绷紧的,taut,绷紧的,ADJ,B2
+征税,to tax,征税,VERB,B2
+税收,taxation,征税,NOUN,B2
+教学,teaching,教学,NOUN,B2
+眼泪,tear,眼泪,NOUN,B2
+技术的,technical,技术的,ADJ,B2
+技术员,technician,技术员,NOUN,B2
+技术官僚制,technocracy,技术官僚主义,NOUN,B2
+技术的,technological,技术的,ADJ,B2
+目的论,teleology,目的论,NOUN,B2
+电话,telephone,电话,NOUN,B2
+望远镜,telescope,望远镜,NOUN,B2
+时间的,temporal,时间的,ADJ,B2
+坚韧的,tenacious,顽强的,ADJ,B2
+有倾向性的,tendentious,有偏见的,ADJ,B2
+温柔,tenderness,柔情,NOUN,B2
+紧张的,tense,紧张的,ADJ,B2
+紧张,tension,紧张,NOUN,B2
+术语,term,学期,NOUN,B2
+终端,terminal,终点站,NOUN,B2
+终止,termination,解除,NOUN,B2
+术语的,terminological,术语的,ADJ,B2
+术语,terminology,术语,NOUN,B2
+陆地的,terrestrial,地球的,ADJ,B2
+使恐惧,to terrify,使恐惧,VERB,B2
+可怕的,terrifying,令人恐惧的,ADJ,B2
+领土的,territorial,领土的,ADJ,B2
+恐怖,terror,恐怖,NOUN,B2
+恐怖主义,terrorism,恐怖主义,NOUN,B2
+睾丸,testicle,睾丸,NOUN,B2
+文本,text,文本,NOUN,B2
+教科书,textbook,教科书,NOUN,B2
+文本的,textual,文本的,ADJ,B2
+比,than,比,ADP,B2
+谢谢,thanks,谢谢,INTJ,B2
+那,that,（引导从句）,SCONJ,B2
+的,the,这,DET,B2
+他们,them,他们,PRON,B2
+神权政治,theocracy,神权政治,NOUN,B2
+神学,theology,神学,NOUN,B2
+理论的,theoretical,理论的,ADJ,B2
+治疗的,therapeutic,治疗的,ADJ,B2
+疗法,therapy,治疗,NOUN,B2
+那里,there,那里,ADV,B2
+随即,thereupon,随后,ADV,B2
+热的,thermal,热的,ADJ,B2
+这些,these,这些,PRON,B2
+厚度,thickness,厚度,NOUN,B2
+大腿,thigh,大腿,NOUN,B2
+想出,to think up,构思,VERB,B2
+薄,thinness,瘦,NOUN,B2
+第三,third,第三,ADJ,B2
+口渴,thirst,口渴,NOUN,B2
+十三,thirteen,十三,NUM,B2
+三十,thirty,三十,NUM,B2
+那些,those,那些,PRON,B2
+线,thread,线,NOUN,B2
+威胁,threat,威胁,NOUN,B2
+威胁的,threatening,具有威胁性的,ADJ,B2
+门槛,threshold,门槛,NOUN,B2
+通过,through,通过,ADP,B2
+投掷,throw,投掷,NOUN,B2
+推力,thrust,猛推,NOUN,B2
+恶棍,thug,暴徒,NOUN,B2
+拇指,thumb,拇指,NOUN,B2
+星期四,thursday,星期四,NOUN,B2
+阻挠,to thwart,阻挠,VERB,B2
+潮汐,tide,潮汐,NOUN,B2
+整理,to tidy up,整理,VERB,B2
+领带,tie,领带,NOUN,B2
+捆绑,to tie up,绑,VERB,B2
+瓷砖,tile,瓦片,NOUN,B2
+铺砖,tiling,铺瓷砖,NOUN,B2
+刺痛,tingling,麻木感,NOUN,B2
+微小的,tiny,微小的,ADJ,B2
+使疲倦,tire,轮胎,NOUN,B2
+使疲倦,to tire,使疲倦,VERB,B2
+疲倦,tiredness,疲劳,NOUN,B2
+什一税,tithe,什一税,NOUN,B2
+今天,today,今天,ADV,B2
+辛苦,toil,苦工,NOUN,B2
+明天,tomorrow,明天,ADV,B2
+太多,too much,太,ADV,B2
+牙齿,tooth,牙齿,NOUN,B2
+地形,topography,地形,NOUN,B2
+火炬,torch,手电筒,NOUN,B2
+激流,torrent,激流,NOUN,B2
+扭转,torsion,扭转,NOUN,B2
+完全地,totally,完全地,ADV,B2
+旅行,tour,旅行,NOUN,B2
+旅游,tourism,旅游业,NOUN,B2
+游客,tourist,游客,NOUN,B2
+旅游的,touristic,旅游的,ADJ,B2
+向,towards,朝向,ADP,B2
+塔,tower,塔,NOUN,B2
+城镇,town,城镇,NOUN,B2
+有毒的,toxic,有毒的,ADJ,B2
+追踪,to track,追踪,VERB,B2
+拖拉机,tractor,拖拉机,NOUN,B2
+工会,trade union,工会,NOUN,B2
+传统的,traditional,传统的,ADJ,B2
+悲剧的,tragic,悲剧的,ADJ,B2
+拖车,trailer,预告片,NOUN,B2
+受训者,trainee,实习生,NOUN,B2
+超越的,transcendent,卓越的,ADJ,B2
+先验的,transcendental,先验的,ADJ,B2
+越轨,transgression,违犯,NOUN,B2
+过渡的,transitional,过渡的,ADJ,B2
+翻译,translation,翻译,NOUN,B2
+翻译者,translator,译者,NOUN,B2
+运输,transport,运输,NOUN,B2
+旅行,travel,出行,NOUN,B2
+旅行,to travel,旅行,VERB,B2
+旅行者,traveler,旅行家,NOUN,B2
+托盘,tray,托盘,NOUN,B2
+阴险的,treacherous,背叛的,ADJ,B2
+踏,to tread,踏上,VERB,B2
+国库,treasury,国库,NOUN,B2
+战壕,trench,沟渠,NOUN,B2
+部落,tribe,部落,NOUN,B2
+支流,tributary,支流,NOUN,B2
+欺骗,to trick,欺骗,VERB,B2
+扳机,trigger,触发器,NOUN,B2
+旅行,trip,旅行,NOUN,B2
+三重的,triple,三倍的,ADJ,B2
+琐碎的,trivial,琐碎的,ADJ,B2
+琐碎化,trivialization,浅薄化,NOUN,B2
+剧团,troupe,剧团,NOUN,B2
+休战,truce,休战,NOUN,B2
+小号,trumpet,小号,NOUN,B2
+树干,trunk,树干,NOUN,B2
+可靠的,trustworthy,值得信赖的,ADJ,B2
+星期二,tuesday,星期二,NOUN,B2
+金枪鱼,tuna,金枪鱼,NOUN,B2
+长袍,tunic,束腰外衣,NOUN,B2
+打开,to turn on,打开,VERB,B2
+结果,to turn out,结果是,VERB,B2
+转折点,turning point,转折点,NOUN,B2
+出席,turnout,出席率,NOUN,B2
+乌龟,turtle,海龟,NOUN,B2
+指导,tutelage,监护,NOUN,B2
+十二,twelve,十二,NUM,B2
+黄昏,twilight,暮光,NOUN,B2
+扭转,to twist,扭曲,VERB,B2
+扭曲,twisted,扭曲的,ADJ,B2
+暴政,tyranny,暴政,NOUN,B2
+暴君,tyrant,暴君,NOUN,B2
+丑陋,ugliness,丑陋,NOUN,B2
+溃疡,ulcer,溃疡,NOUN,B2
+最终,ultimately,最终,ADV,B2
+不确定,uncertain,不确定的,ADJ,B2
+不确定,uncertainty,不确定性,NOUN,B2
+不舒服,uncomfortable,不舒服的,ADJ,B2
+无意识,unconscious,无意识的,ADJ,B2
+在,under,在...下面,ADP,B2
+低估,to underestimate,低估,VERB,B2
+破坏,to undermine,破坏,VERB,B2
+下面,underneath,在下面,ADV,B2
+可理解,understandable,可理解的,ADJ,B2
+理解,understanding,理解,NOUN,B2
+不安,unease,不安,NOUN,B2
+失业,unemployed,失业的,ADJ,B2
+失业,unemployment,失业,NOUN,B2
+意外,unexpected,意想不到的,ADJ,B2
+不公平,unfair,不公平的,ADJ,B2
+不幸,unfortunately,不幸地,ADV,B2
+工会,union,工会,NOUN,B2
+工会主义,unionism,工会主义,NOUN,B2
+联合,united,联合的,ADJ,B2
+团结,unity,团结,NOUN,B2
+不公正,unjust,不公正的,ADJ,B2
+未知的,unknown,未知的,ADJ,B2
+释放,to unleash,释放,VERB,B2
+不太可能的,unlikely,不太可能的,ADJ,B2
+不必要的,unnecessary,不必要的,ADJ,B2
+拆包,to unpack,拆包,VERB,B2
+不愉快的,unpleasant,令人不快的,ADJ,B2
+不稳定的,unstable,不稳定的,ADJ,B2
+直到,until,直到,SCONJ,B2
+向上,up,向上,ADV,B2
+教养,upbringing,教养,NOUN,B2
+即将到来的,upcoming,مقبل,ADJ,B2
+上传,to upload,上传,VERB,B2
+上面的,upper,上面的,ADJ,B2
+直立的,upright,正直的,ADJ,B2
+骚动,uproar,骚动,NOUN,B2
+连根拔起,uprooting,背井离乡,NOUN,B2
+打翻,to upset,使生气,VERB,B2
+上翻,upturn,好转,NOUN,B2
+城市的,urban,城市的,ADJ,B2
+都市化,urbanity,都市风度,NOUN,B2
+紧迫,urgency,紧急,NOUN,B2
+我们,us,我们,PRON,B2
+有用的,useful,有用的,ADJ,B2
+无用的,useless,无用的,ADJ,B2
+用户,user,用户,NOUN,B2
+通常的,usual,通常的,ADJ,B2
+用益权,usufruct,用益权,NOUN,B2
+篡夺,to usurp,篡夺,VERB,B2
+功利主义的,utilitarian,功利的,ADJ,B2
+功利主义,utilitarianism,功利主义,NOUN,B2
+利用,utilization,利用,NOUN,B2
+乌托邦,utopia,乌托邦,NOUN,B2
+乌托邦的,utopian,乌托邦式的,ADJ,B2
+空缺,vacancy,空缺,NOUN,B2
+空缺的,vacant,空缺的,ADJ,B2
+接种,to vaccinate,接种疫苗,VERB,B2
+疫苗,vaccination,疫苗接种,NOUN,B2
+英勇,valiant,英勇的,ADJ,B2
+有效性,validity,有效期,NOUN,B2
+山谷,valley,山谷,NOUN,B2
+勇气,valor,勇气,NOUN,B2
+差异,variance,方差,NOUN,B2
+车辆,vehicle,车辆,NOUN,B2
+可敬,venerable,值得尊敬的,ADJ,B2
+崇敬,veneration,崇敬,NOUN,B2
+通风,ventilation,通风,NOUN,B2
+冗长,verbosity,冗长,NOUN,B2
+判决,verdict,裁决,NOUN,B2
+春,vernal,春季的,ADJ,B2
+精通,versed,精通的,ADJ,B2
+版本,version,版本,NOUN,B2
+垂直,vertical,垂直的,ADJ,B2
+容器,vessel,船,NOUN,B2
+背心,vest,背心,NOUN,B2
+否决,veto,否决,NOUN,B2
+恶习,vice,恶习,NOUN,B2
+附近,vicinity,附近,NOUN,B2
+警惕,vigilance,警惕,NOUN,B2
+村庄,village,村庄,NOUN,B2
+暴力,violence,暴力,NOUN,B2
+虚拟,virtual,虚拟的,ADJ,B2
+几乎,virtually,几乎,ADV,B2
+粘稠,viscous,黏稠的,ADJ,B2
+视觉,vision,远见,NOUN,B2
+视觉,visual,视觉的,ADJ,B2
+声音,vocal,直言的,ADJ,B2
+易变,volatile,易变的,ADJ,B2
+自愿,voluntarily,自愿地,ADV,B2
+漩涡,vortex,漩涡,NOUN,B2
+投票,vote,投票,NOUN,B2
+选民,voter,选民,NOUN,B2
+投票,voting,投票,NOUN,B2
+粗俗,vulgarity,粗俗,NOUN,B2
+工资,wage,工资,NOUN,B2
+哀号,to wail,哀号,VERB,B2
+侍者,waiter,服务员,NOUN,B2
+女侍者,waitress,女服务员,NOUN,B2
+醒来,to wake,唤醒,VERB,B2
+钱包,wallet,钱包,NOUN,B2
+漫步,to wander,漫步,VERB,B2
+被通缉的,wanted,故意的,ADJ,B2
+看守人,warden,看守人,NOUN,B2
+衣柜,wardrobe,衣柜,NOUN,B2
+温暖,warmth,温暖,NOUN,B2
+警告,warning,警告,NOUN,B2
+担保,warranty,保修单,NOUN,B2
+是,to was,是,VERB,B2
+浪费的,wasteful,浪费的,ADJ,B2
+观看,to watch,观看,VERB,B2
+波浪,wave,波浪,NOUN,B2
+财富,wealth,财富,NOUN,B2
+使断奶,to wean,断奶,VERB,B2
+断奶,weaning,断奶,NOUN,B2
+疲倦,weariness,疲倦,NOUN,B2
+编织,to weave,编织,VERB,B2
+结婚纪念日,wedding anniversary,结婚纪念日,NOUN,B2
+星期三,wednesday,星期三,NOUN,B2
+杂草,weed,杂草,NOUN,B2
+工作日,weekday,工作日,NOUN,B2
+每周的,weekly,每周的,ADJ,B2
+欢迎,welcome,受欢迎的,ADJ,B2
+焊接,welding,焊接,NOUN,B2
+嗯,well,好,ADV,B2
+深思熟虑,well-considered,深思熟虑的,ADJ,B2
+著名,well-known,众所周知的,ADJ,B2
+湿,wet,湿的,ADJ,B2
+鲸鱼,whale,鲸鱼,NOUN,B2
+什么,what,什么,ADV,B2
+何种程度,what extent,在何种程度上,ADV,B2
+轮子,wheel,轮子,NOUN,B2
+轮椅,wheelchair,轮椅,NOUN,B2
+当,when,当...时,SCONJ,B2
+凭借,whereby,其中,ADV,B2
+是否,whether,是否,SCONJ,B2
+哪个,which,哪个,DET,B2
+当,while,当...时,SCONJ,B2
+冲动,whim,突发奇想,NOUN,B2
+抱怨,to whine,哀叹,VERB,B2
+鞭打,to whip,鞭打,VERB,B2
+旋风,whirlwind,旋风；漩涡,NOUN,B2
+低语,to whisper,低语,VERB,B2
+谁,whom,谁,PRON,B2
+谁的,whose,谁的,PRON,B2
+加宽,to widen,加宽,VERB,B2
+寡妇,widow,寡妇,NOUN,B2
+野生,wild,野生的,ADJ,B2
+风,wind,风,NOUN,B2
+眨眼,to wink,眨眼,VERB,B2
+获胜者,winner,获胜者,NOUN,B2
+簸,to winnow,筛选,VERB,B2
+电线,wire,电线,NOUN,B2
+无线,wireless,无线的,ADJ,B2
+明智,wise,明智的,ADJ,B2
+困难地,with difficulty,困难地,ADV,B2
+无,without,没有,ADP,B2
+目击,to witness,目击,VERB,B2
+机智,witty,机智的,ADJ,B2
+巫师,wizard,巫师,NOUN,B2
+摇晃,to wobble,摇晃,VERB,B2
+想知道,to wonder,觉得奇怪,VERB,B2
+工作场所,workplace,工作场所,NOUN,B2
+车间,workshop,研讨会,NOUN,B2
+世界大战,world war,世界大战,NOUN,B2
+虫,worm,虫,NOUN,B2
+坏,worse,更糟的,ADJ,B2
+恶化,to worsen,恶化,VERB,B2
+值得,worth,值得的,ADJ,B2
+值得,worthy,值得的,ADJ,B2
+受伤,wounded,受伤的,ADJ,B2
+愤怒,wrath,愤怒,NOUN,B2
+残骸,wreck,残骸,NOUN,B2
+夺取,to wrest,强行夺取,VERB,B2
+可怜虫,wretch,令人厌恶的人,NOUN,B2
+皱纹,wrinkle,皱纹,NOUN,B2
+书面,written,书面的,ADJ,B2
+错误,wrong,错误的,ADJ,B2
+院子,yard,院子,NOUN,B2
+渴望,yearning,向往,NOUN,B2
+酵母,yeast,酵母,NOUN,B2
+是,yes,是的,INTJ,B2
+昨天,yesterday,昨天,ADV,B2
+酸奶,yogurt,酸奶,NOUN,B2
+小姐,young lady,小姐,NOUN,B2
+年轻人,youngster,年少者,NOUN,B2
+你的,your,你的,DET,B2
+顶点,zenith,顶点,NOUN,B2
+区域,zone,区域,NOUN,B2
+西葫芦,zucchini,西葫芦,NOUN,B2
+广口瓶,jar,广口瓶,NOUN,B2
+腌制,to marinate,腌制,VERB,B2
+相异性,otherness,相异性,NOUN,B2
+在里面,inside,在里面,ADV,B2
+数字,digit,数字,NOUN,B2
+杜撰的,apocryphal,杜撰的,ADJ,B2
+纪念,commemoration,纪念,NOUN,B2
+两者都,both,两者都,DET,B2
+艺术的,artistic,艺术的,ADJ,B2
+拿出,to take out,拿出,VERB,B2
+知识的,intellectual,知识的,ADJ,B2
+装饰,ornament,装饰,NOUN,B2
+预言,prophecy,预言,NOUN,B2
+冗长的,verbose,冗长的,ADJ,B2
+自治的,autonomous,自治的,ADJ,B2
+盔甲,armor,盔甲,NOUN,B2
+停止,to desist,停止,VERB,B2
+驱逐,to evict,驱逐,VERB,B2
+使恢复精神,to refresh,使恢复精神,VERB,B2
+包含,to encompass,包含,VERB,B2
+添燃料,to stoke,添燃料,VERB,B2
+现实的,realistic,现实的,ADJ,B2
+经验的,empirical,经验的,ADJ,B2
+群岛,archipelago,群岛,NOUN,B2
+谦虚,modesty,谦虚,NOUN,B2
+功绩,feat,功绩,NOUN,B2
+激起兴趣,to intrigue,激起兴趣,VERB,B2
+矛盾的,ambivalent,矛盾的,ADJ,B2
+神性,divinity,神性,NOUN,B2
+比率,rate,比率,NOUN,B2
+错误的事,wrong,错误的事,NOUN,B2
+变黑,to blacken,变黑,VERB,B2
+统计的,statistical,统计的,ADJ,B2
+免除,to exempt,免除,VERB,B2
+殖民地,colony,殖民地,NOUN,B2
+劣势,inferiority,劣势,NOUN,B2
+无政府状态,anarchy,无政府状态,NOUN,B2
+热情,ardor,热情,NOUN,B2
+巡航,cruise,巡航,NOUN,B2
+到处,around,到处,ADV,B2
+秘密的,clandestine,秘密的,ADJ,B2
+出价,bid,出价,NOUN,B2
+无神论,atheism,无神论,NOUN,B2
+不容忍,intolerance,不容忍,NOUN,B2
+糖尿病,diabetes,糖尿病,NOUN,B2
+垫子,cushion,垫子,NOUN,B2
+存放,to deposit,存放,VERB,B2
+放大,amplification,放大,NOUN,B2
+离题,to digress,离题,VERB,B2
+植物群,flora,植物群,NOUN,B2
+经历,to undergo,经历,VERB,B2
+冒号,colon,冒号,NOUN,B2
+宇宙的,cosmic,宇宙的,ADJ,B2
+激怒,to exasperate,激怒,VERB,B2
+不纯,impurity,不纯,NOUN,B2
+讲坛,pulpit,讲坛,NOUN,B2
+掘出,to exhume,掘出,VERB,B2
+赋予,to endow,赋予,VERB,B2
+阴凉的,shady,阴凉的,ADJ,B2
+女男爵,baroness,女男爵,NOUN,B2
+或者,or rather,或者,ADV,B2
+先生,sir,先生,NOUN,B2
+使复杂化,to complicate,使复杂化,VERB,B2
+可用性,availability,可用性,NOUN,B2
+专横的,peremptory,专横的,ADJ,B2
+详尽的,elaborate,详尽的,ADJ,B2
+允许,be allowed,允许,AUX,B2
+神圣的,sacred,神圣的,ADJ,B2
+生态学,ecology,生态学,NOUN,B2
+躲避,to dodge,躲避,VERB,B2
+罢工者,striker,罢工者,NOUN,B2
+资助,to subsidize,资助,VERB,B2
+幻想,to daydream,幻想,VERB,B2
+使沮丧,to depress,使沮丧,VERB,B2
+退位,to abdicate,退位,VERB,B2
+树篱,hedge,树篱,NOUN,B2
+可用的,usable,可用的,ADJ,B2
+乏味的,tedious,乏味的,ADJ,B2
+深深地,deeply,深深地,ADV,B2
+疯狂的,insane,疯狂的,ADJ,B2
+出现,to emerge,出现,VERB,B2
+统治,reign,统治,NOUN,B2
+吊灯,chandelier,吊灯,NOUN,B2
+细微差别的,nuanced,细微差别的,ADJ,B2
+监狱,jail,监狱,NOUN,B2
+有争议的,disputed,有争议的,ADJ,B2
+初次登台,debut,初次登台,NOUN,B2
+察觉,to perceive,察觉,VERB,B2
+冷却,to cool,冷却,VERB,B2
+年长的,older,年长的,ADJ,B2
+害怕的,afraid,害怕的,ADJ,B2
+昏迷,stupor,昏迷,NOUN,B2
+模拟,to simulate,模拟,VERB,B2
+流行音乐,pop music,流行音乐,NOUN,B2
+短语,phrase,短语,NOUN,B2
+他们的,their,他们的,PRON,B2
+啁啾,to chirp,啁啾,VERB,B2
+检测,detection,检测,NOUN,B2
+提炼,to refine,提炼,VERB,B2
+监护,guardianship,监护,NOUN,B2
+三分之一,third,三分之一,NOUN,B2
+最坏的,worst,最坏的,ADJ,B2
+标本,specimen,标本,NOUN,B2
+语言的,linguistic,语言的,ADJ,B2
+扣留,to withhold,扣留,VERB,B2
+在中间,in between,在中间,ADV,B2
+足迹,footprint,足迹,NOUN,B2
+不朽的,immortal,不朽的,ADJ,B2
+纹身,tattoo,纹身,NOUN,B2
+禁令,injunction,禁令,NOUN,B2
+使边缘化,to marginalize,使边缘化,VERB,B2
+群众演员,extra,群众演员,NOUN,B2
+解剖学,anatomy,解剖学,NOUN,B2
+不同,to differ,不同,VERB,B2
+不动产,real estate,不动产,NOUN,B2
+即兴的,improvised,即兴的,ADJ,B2
+炸药,dynamite,炸药,NOUN,B2
+唤起,to evoke,唤起,VERB,B2
+警报,alert,警报,NOUN,B2
+费用,fee,费用,NOUN,B2
+证券化,securitization,证券化,NOUN,B2
+金库,vault,金库,NOUN,B2
+小屋,cottage,小屋,NOUN,B2
+咒语,incantation,咒语,NOUN,B2
+使热情,to enthuse,使热情,VERB,B2
+脓肿,abscess,脓肿,NOUN,B2
+自由的,liberal,自由的,ADJ,B2
+迷人的,enchanting,迷人的,ADJ,B2
+伪君子,hypocrite,伪君子,NOUN,B2
+预防,prevention,预防,NOUN,B2
+夷平,to level,夷平,VERB,B2
+诡计,cunning,诡计,NOUN,B2
+还,yet,还,ADV,B2
+无神论者,atheist,无神论者,NOUN,B2
+例子,instance,例子,NOUN,B2
+审查,to censor,审查,VERB,B2
+不相交的,disjoint,不相交的,ADJ,B2
+致命的,lethal,致命的,ADJ,B2
+沟渠,ditch,沟渠,NOUN,B2
+傲慢的,cocky,傲慢的,ADJ,B2
+掠夺,to despoil,掠夺,VERB,B2
+起诉,indictment,起诉,NOUN,B2
+芜菁,turnip,芜菁,NOUN,B2
+倾销,dumping,倾销,NOUN,B2
+平局,draw,平局,NOUN,B2
+纪录片,documentary,纪录片,NOUN,B2
+净化,purification,净化,NOUN,B2
+思想开明的,open-minded,思想开明的,ADJ,B2
+明确的,unambiguous,明确的,ADJ,B2
+万岁,hurrah,万岁,INTJ,B2
+在附近,near,在附近,ADP,B2
+不连贯,incoherence,不连贯,NOUN,B2
+被上诉人,respondent,被上诉人,NOUN,B2
+烹饪,cooking,烹饪,NOUN,B2
+探测器,probe,探测器,NOUN,B2
+粗面粉,semolina,粗面粉,NOUN,B2
+志愿服务,volunteering,志愿服务,NOUN,B2
+平均数,average,平均数,NOUN,B2
+象征主义,symbolism,象征主义,NOUN,B2
+反复无常,fickleness,反复无常,NOUN,B2
+调度；排序,scheduling,调度；排序,NOUN,B2
+电报,telegram,电报,NOUN,B2
+悔罪,contrition,悔罪,NOUN,B2
+笃信宗教,religiosity,笃信宗教,NOUN,B2
+逃避,evasion,逃避,NOUN,B2
+渡轮,ferry,渡轮,NOUN,B2
+黑客行为,hacking,黑客行为,NOUN,B2
+被判刑的,sentenced,被判刑的,ADJ,B2
+争执,altercation,争执,NOUN,B2
+历史主义,historicism,历史主义,NOUN,B2
+电视播出的,televised,电视播出的,ADJ,B2
+虚有权,bare ownership,虚有权,NOUN,B2
+指数化,indexing,指数化,NOUN,B2
+指数,exponent,指数,NOUN,B2
+储蓄,saving,储蓄,NOUN,B2
+问责,to hold accountable,问责,VERB,B2
+分类,sorting,分类,NOUN,B2
+提高意识,awareness raising,提高意识,NOUN,B2
+胡子,mustache,胡子,NOUN,B2
+进口,import,进口,NOUN,B2
+剪辑,editing,剪辑,NOUN,B2
+羞怯,shyness,羞怯,NOUN,B2
+适应环境,acclimatization,适应环境,NOUN,B2
+指导,guidance,指导,NOUN,B2
+多雨的,rainy,多雨的,ADJ,B2
+使灵活,to soften,使灵活,VERB,B2
+无生命的,lifeless,无生命的,ADJ,B2
+自闭症,autism,自闭症,NOUN,B2
+主导地位,predominance,主导地位,NOUN,B2
+清洁,cleaning,清洁,NOUN,B2
+位移,displacement,位移,NOUN,B2
+复苏,resuscitation,复苏,NOUN,B2
+波动的,fluctuating,波动的,ADJ,B2
+狂躁症,mania,狂躁症,NOUN,B2
+加倍,doubling,加倍,NOUN,B2
+折痕,fold,折痕,NOUN,B2
+编年史,annals,编年史,NOUN,B2
+醉酒,drunkenness,醉酒,NOUN,B2
+内在性,immanence,内在性,NOUN,B2
+巫术,sorcery,巫术,NOUN,B2
+切割,cutting,切割,NOUN,B2
+人民 / 民族,people nation,人民 / 民族,NOUN,B2
+稻草,straw,稻草,NOUN,B2
+包厢座位,stall,包厢座位,NOUN,B2
+煽动性,demagoguery,煽动性,NOUN,B2
+纪律的,disciplinary,纪律的,ADJ,B2
+拍摄,filming,拍摄,NOUN,B2
+文化涵化,acculturation,文化涵化,NOUN,B2
+拖曳,drag,拖曳,NOUN,B2
+分包,subcontracting,分包,NOUN,B2
+广告的,advertising,广告的,ADJ,B2
+安全的，安保的,security-related,安全的，安保的,ADJ,B2
+爱好,pastime,爱好,NOUN,B2
+城市化,urbanization,城市化,NOUN,B2
+被拘留者,detainee,被拘留者,NOUN,B2
+不透明性,opacity,不透明性,NOUN,B2
+斥责,to rebuke,斥责,VERB,B2
+毒品,drugs,毒品,NOUN,B2
+导电性,conductivity,导电性,NOUN,B2
+帆,sail,帆,NOUN,B2
+掠夺,plundering,掠夺,NOUN,B2
+寡头政治,oligarchy,寡头政治,NOUN,B2
+代谢的,metabolic,代谢的,ADJ,B2
+某些,some,某些,ADJ,B2
+责备,to reproach,责备,VERB,B2
+歪曲的,distorted,歪曲的,ADJ,B2
+相等的,equivalent,相等的,ADJ,B2
+肿胀的,swollen,肿胀的,ADJ,B2
+延期,postponement,延期,NOUN,B2
+恢复,to regain,恢复,VERB,B2
+枷锁,yoke,枷锁,NOUN,B2
+游泳,swimming,游泳,NOUN,B2
+纺纱,spinning,纺纱,NOUN,B2
+博学的,erudite,博学的,ADJ,B2
+阴影,shading,阴影,NOUN,B2
+语义学,semantics,语义学,NOUN,B2
+微观的,microscopic,微观的,ADJ,B2
+未知数,unknown,未知数,NOUN,B2
+钓竿,fishing rod,钓竿,NOUN,B2
+驱逐出境,deportation,驱逐出境,NOUN,B2
+减少,reduction,减少,NOUN,B2
+放荡,libertinism,放荡,NOUN,B2
+炎症,inflammation,炎症,NOUN,B2
+苍白,pallor,苍白,NOUN,B2
+邪恶,villainy,邪恶,NOUN,B2
+有争议的,contested,有争议的,ADJ,B2
+规划,planning,规划,NOUN,B2
+大脑的,cerebral,大脑的,ADJ,B2
+平息,appeasement,平息,NOUN,B2
+套房,suite,套房,NOUN,B2
+存在主义,existentialism,存在主义,NOUN,B2
+偷听,to eavesdrop,偷听,VERB,B2
+程序的,procedural,程序的,ADJ,B2
+肝脏的,hepatic,肝脏的,ADJ,B2
+合理化,to rationalize,合理化,VERB,B2
+最低点,nadir,最低点,NOUN,B2
+与...交朋友,to befriend,与...交朋友,VERB,B2
+外向的,outgoing,外向的,ADJ,B2
+认证,certification,认证,NOUN,B2
+哀伤的,plaintive,哀伤的,ADJ,B2
+挑衅的,provocative,挑衅的,ADJ,B2
+运输,transit,运输,NOUN,B2
+硫,sulfur,硫,NOUN,B2
+监管的,regulatory,监管的,ADJ,B2
+使平静,to calm down,使平静,VERB,B2
+含蓄地,implicitly,含蓄地,ADV,B2
+偏袒,favoritism,偏袒,NOUN,B2
+怀有,to harbor,怀有,VERB,B2
+令人清爽的,refreshing,令人清爽的,ADJ,B2
+涂鸦,graffiti,涂鸦,NOUN,B2
+大量,plenty,大量,NOUN,B2
+排练,rehearsal,排练,NOUN,B2
+热水器,water heater,热水器,NOUN,B2
+迂腐,pedantry,迂腐,NOUN,B2
+社会化,socialization,社会化,NOUN,B2
+服装,outfit,服装,NOUN,B2
+享乐主义的,hedonistic,享乐主义的,ADJ,B2
+恳求,supplication,恳求,NOUN,B2
+悬浮的,suspended,悬浮的,ADJ,B2
+收入,revenue,收入,NOUN,B2
+召集,convening,召集,NOUN,B2
+诱人的,alluring,诱人的,ADJ,B2
+简明的,succinct,简明的,ADJ,B2
+威权,dominance,威权,NOUN,B2
+谨慎的,prudent,谨慎的,ADJ,B2
+衰减,attenuation,衰减,NOUN,B2
+蚊帐,mosquito net,蚊帐,NOUN,B2
+遏制,curbing,遏制,NOUN,B2
+首先,firstly,首先,ADV,B2
+政党,political party,政党,NOUN,B2
+精确,precision,精确,NOUN,B2
+积极主动的,proactive,积极主动的,ADJ,B2
+出现/显得,to appear to seem,出现/显得,VERB,B2
+分开的,separated,分开的,ADJ,B2
+惩罚性的,punitive,惩罚性的,ADJ,B2
+横膈膜,diaphragm,横膈膜,NOUN,B2
+预谋,premeditation,预谋,NOUN,B2
+盈利能力,profitability,盈利能力,NOUN,B2
+实质性的,substantive,实质性的,ADJ,B2
+辫子,braid,辫子,NOUN,B2
+刺,sting,刺,NOUN,B2
+病毒性的,viral,病毒性的,ADJ,B2
+首要的,prime,首要的,ADJ,B2
+撞击,to crash into,撞击,VERB,B2
+压力,stress,压力,NOUN,B2
+奴役,servitude,奴役,NOUN,B2
+壁炉,hearth,壁炉,NOUN,B2
+哗啦声,clatter,哗啦声,NOUN,B2
+令状,warrant,令状,NOUN,B2
+时刻表,timetable,时刻表,NOUN,B2
+布景,decor,布景,NOUN,B2
+蓄水池,cistern,蓄水池,NOUN,B2
+振荡器,oscillator,振荡器,NOUN,B2
+抑制,inhibition,抑制,NOUN,B2
+陈腐的,trite,陈腐的,ADJ,B2
+果断,assertiveness,果断,NOUN,B2
+艰难,hardship,艰难,NOUN,B2
+塞卢能量膏,sellou,塞卢能量膏,NOUN,B2
+埃米尔的,emiri,埃米尔的,ADJ,B2
+古斯古斯蒸锅,couscous steamer,古斯古斯蒸锅,NOUN,B2
+外来词,loanword,外来词,NOUN,B2
+起皱,wrinkling,起皱,NOUN,B2
+基于/以此为基础,building upon,基于/以此为基础,ADV,B2
+精神奋斗,spiritual striving,精神奋斗,NOUN,B2
+辩护人,pleader,辩护人,NOUN,B2
+愚妄,folly,愚妄,NOUN,B2
+蔓延,proliferation of evil,蔓延,NOUN,B2
+上传,upload,上传,NOUN,B2
+根本/绝对,at all absolutely,根本/绝对,ADV,B2
+依照/根据,pursuant to,依照/根据,ADV,B2
+模糊,vagueness,模糊,NOUN,B2
+漏洞,vulnerability,漏洞,NOUN,B2
+塞入,to slip in,塞入,VERB,B2
+保证,suretyship,保证,NOUN,B2
+决断,decisiveness,决断,NOUN,B2
+残留物 / 废弃物,residues waste,残留物 / 废弃物,NOUN,B2
+时间性,temporality,时间性,NOUN,B2
+节奏性,rhythmicity,节奏性,NOUN,B2
+挫伤 / 外伤,contusion trauma,挫伤 / 外伤,NOUN,B2
+磋商,consultations,磋商,NOUN,B2
+位似,homothety,位似,NOUN,B2
+期望的目标,desired aim,期望的目标,NOUN,B2
+扩张主义,expansionism,扩张主义,NOUN,B2
+从众心理,herd mentality,从众心理,NOUN,B2
+困惑,to be puzzled,困惑,VERB,B2
+宿命论的,fatalist,宿命论的,ADJ,B2
+末日集合,final gathering,末日集合,NOUN,B2
+磨碎的,ground,磨碎的,ADJ,B2
+高尚,loftiness,高尚,NOUN,B2
+拾音器,pickup,拾音器,NOUN,B2
+脆的,crunchy,脆的,ADJ,B2
+顶针,thimble,顶针,NOUN,B2
+分享,sharing,分享,NOUN,B2
+衰退/退潮,receding ebbing,衰退/退潮,NOUN,B2
+新月,new moon,新月,NOUN,B2
+诗意,poetic quality,诗意,NOUN,B2
+克拉克斯布,qraqeb,克拉克斯布,NOUN,B2
+五联诗,quintain,五联诗,NOUN,B2
+熄灭的/无精打采的,extinguished listless,熄灭的/无精打采的,ADJ,B2
+弦,chord,弦,NOUN,B2
+机敏,alertness,机敏,NOUN,B2
+简洁,concision,简洁,NOUN,B2
+社会声望,social prestige,社会声望,NOUN,B2
+委员会,councils,委员会,NOUN,B2
+观看次数,views,观看次数,NOUN,B2
+成本加成销售,murabaha,成本加成销售,NOUN,B2
+寻得陪伴,finding comfort in company,寻得陪伴,NOUN,B2
+互悯,mutual compassion,互悯,NOUN,B2
+固执,stubbornness,固执,NOUN,B2
+角膜,cornea,角膜,NOUN,B2
+目的/目的地,aim destination,目的/目的地,NOUN,B2
+圣训,hadith prophetic saying,圣训,NOUN,B2
+尝试 / 试穿,to try to try on,尝试 / 试穿,VERB,B2
+纯净的,clean pure,纯净的,ADJ,B2
+党派性,partisanship,党派性,NOUN,B2
+毁坏财物,destruction of property,毁坏财物,NOUN,B2
+云,clouds,云,NOUN,B2
+共同研究,to study jointly,共同研究,VERB,B2
+烧伤,burns,烧伤,NOUN,B2
+双胞胎,twins,双胞胎,NOUN,B2
+诚实,to be honest,诚实,VERB,B2
+在...下方,under below,在...下方,ADP,B2
+冷却器 / 冷却液,cooler coolant,冷却器 / 冷却液,NOUN,B2
+手指/脚趾,finger toe,手指/脚趾,NOUN,B2
+阿拉伯化,arabization,阿拉伯化,NOUN,B2
+神话化,mythologization,神话化,NOUN,B2
+议会制,parliamentarism,议会制,NOUN,B2
+泉,spring eye,泉,NOUN,B2
+重新安置,resettlement,重新安置,NOUN,B2
+协会性质的,associative,协会性质的,ADJ,B2
+虚弱,debility,虚弱,NOUN,B2
+缝合,stitching,缝合,NOUN,B2
+泄露,disclosure,泄露,NOUN,B2
+转会,transfers,转会,NOUN,B2
+在那些日子/当时,in those days,在那些日子/当时,ADV,B2
+欢喜,gladness,欢喜,NOUN,B2
+苏丹,sultan,苏丹,NOUN,B2
+效用,usefulness avail,效用,NOUN,B2
+分期付款,in installments,分期付款,ADV,B2
+胶体的,colloidal,胶体的,ADJ,B2
+灵知主义,gnosticism,灵知主义,NOUN,B2
+鬣狗,hyena,鬣狗,NOUN,B2
+阿尔茨海默病,alzheimer's disease,阿尔茨海默病,NOUN,B2
+挥霍,prodigality,挥霍,NOUN,B2
+消极,negativity,消极,NOUN,B2
+疲劳,to get tired,疲劳,VERB,B2
+潮红,flushing,潮红,NOUN,B2
+扎根,grounding,扎根,NOUN,B2
+装嫩,to feigning youthfulness,装嫩,VERB,B2
+皮层的,cortical,皮层的,ADJ,B2
+多边形,polygon,多边形,NOUN,B2
+收缩,contraction,收缩,NOUN,B2
+烧烤,grilling,烧烤,NOUN,B2
+家谱,genealogies,家谱,NOUN,B2
+傲慢/虚荣,arrogance vanity,傲慢/虚荣,NOUN,B2
+盒子 / 罐,box can,盒子 / 罐,NOUN,B2
+马赫曾,makhzen,马赫曾,NOUN,B2
+欢呼声,ululations,欢呼声,NOUN,B2
+经验,experiences,经验,NOUN,B2
+补遗,addendum,补遗,NOUN,B2
+增加,increases,增加,NOUN,B2
+灾难,affliction,灾难,NOUN,B2
+石刑,stoning,石刑,NOUN,B2
+女方离婚,khul',女方离婚,NOUN,B2
+苏丹国,sultanate,苏丹国,NOUN,B2
+被证明,to be proven,被证明,VERB,B2
+怀疑,to be skeptical,怀疑,VERB,B2
+不及格,failing an exam,不及格,NOUN,B2
+大众,the masses,大众,NOUN,B2
+法典化,codification,法典化,NOUN,B2
+极性,polarity,极性,NOUN,B2
+专注倾听,attentive listening,专注倾听,NOUN,B2
+洗钱,money laundering,洗钱,NOUN,B2
+脊髓,spinal cord,脊髓,NOUN,B2
+破晓,dawning,破晓,NOUN,B2
+风趣,wittiness,风趣,NOUN,B2
+托管,hosting,托管,NOUN,B2
+神话性,mythicality,神话性,NOUN,B2
+征服,conquests,征服,NOUN,B2
+缆车,cable car,缆车,NOUN,B2
+及物性,transitivity,及物性,NOUN,B2
+哄婴儿,to lull a baby,哄婴儿,VERB,B2
+被拥有的,owned,被拥有的,ADJ,B2
+毅力,strong will,毅力,NOUN,B2
+极度渴望,burning eagerness,极度渴望,NOUN,B2
+配额分享,quota sharing,配额分享,NOUN,B2
+装满,to fill pack,装满,VERB,B2
+事件,events,事件,NOUN,B2
+想象的,imagined,想象的,ADJ,B2
+水力发电的,hydroelectric,水力发电的,ADJ,B2
+胶状的,gelatinous,胶状的,ADJ,B2
+榨油机,oil press,榨油机,NOUN,B2
+标准阿拉伯语,standard arabic,标准阿拉伯语,NOUN,B2
+以便,in order to so that,以便,SCONJ,B2
+刨花,shavings,刨花,NOUN,B2
+侵犯,infringement,侵犯,NOUN,B2
+头球,header,头球,NOUN,B2
+尴尬,awkwardness,尴尬,NOUN,B2
+爱做梦的/空想家,dreamy dreamer,爱做梦的/空想家,ADJ,B2
+被声称,to be alleged,被声称,VERB,B2
+抚养孩子,to raise a child,抚养孩子,VERB,B2
+位值,place value,位值,NOUN,B2
+增大,magnification,增大,NOUN,B2
+血型,blood type,血型,NOUN,B2
+品性,character trait,品性,NOUN,B2
+撒酒疯,rowdiness,撒酒疯,NOUN,B2
+伤害,causing harm,伤害,NOUN,B2
+发霉的,moldy,发霉的,ADJ,B2
+威严,commanding presence,威严,NOUN,B2
+诚实/正直,integrity trustworthiness,诚实/正直,NOUN,B2
+欢呼,cheering,欢呼,NOUN,B2
+反义关系,antonymy,反义关系,NOUN,B2
+盟友,allies,盟友,NOUN,B2
+受辱,to be humiliated,受辱,VERB,B2
+分解 / 降解,decomposition degradation,分解 / 降解,NOUN,B2
+牵连的,implicated,牵连的,ADJ,B2
+先发制人,preemption,先发制人,NOUN,B2
+词汇表,glossary,词汇表,NOUN,B2
+学识渊博的,deeply learned,学识渊博的,ADJ,B2
+圣徒奇迹,saintly miracles,圣徒奇迹,NOUN,B2
+民粹主义,populism,民粹主义,NOUN,B2
+语素,morpheme,语素,NOUN,B2
+导演,directing,导演,NOUN,B2
+重叠的,overlapping,重叠的,ADJ,B2
+语境性,contextuality,语境性,NOUN,B2
+量角器,protractor,量角器,NOUN,B2
+处罚,penalties,处罚,NOUN,B2
+晚间闲谈,evening chat,晚间闲谈,NOUN,B2
+开放,openness,开放,NOUN,B2
+顽固,obstinacy,顽固,NOUN,B2
+中间派的,centrist,中间派的,ADJ,B2
+权利,entitlement,权利,NOUN,B2
+分期,periodization,分期,NOUN,B2
+膨胀的,inflated,膨胀的,ADJ,B2
+机智,quick wit,机智,NOUN,B2
+草原,steppes,草原,NOUN,B2
+折扣,discounts,折扣,NOUN,B2
+化石,fossils,化石,NOUN,B2
+区域主义,regionalism,区域主义,NOUN,B2
+生成语法,generative grammar,生成语法,NOUN,B2
+列巴布琴,rebab,列巴布琴,NOUN,B2
+瞬间地,instantaneously,瞬间地,ADV,B2
+地方选举,local elections,地方选举,NOUN,B2
+均势,balance of power,均势,NOUN,B2
+弯曲,bending,弯曲,NOUN,B2
+燃烧的/敏锐的,ablaze keen,燃烧的/敏锐的,ADJ,B2
+器乐即兴演奏,instrumental improvisation,器乐即兴演奏,NOUN,B2
+公共浴室,public bath,公共浴室,NOUN,B2
+道堂,lodges,道堂,NOUN,B2
+出去,to exit to go out,出去,VERB,B2
+停泊,anchoring,停泊,NOUN,B2
+蕨类植物,fern,蕨类植物,NOUN,B2
+当地人,natives inhabitants,当地人,NOUN,B2
+照明主义,illuminationism,照明主义,NOUN,B2
+边界,borders,边界,NOUN,B2
+河道,watercourse,河道,NOUN,B2
+被证实,to be confirmed,被证实,VERB,B2
+初熟果实,first fruit,初熟果实,NOUN,B2
+狂欢节式的,carnivalesque,狂欢节式的,ADJ,B2
+即,that is to say,即,CCONJ,B2
+消亡,cessation passing,消亡,NOUN,B2
+判决执行,sentence enforcement,判决执行,NOUN,B2
+冲动,impulsiveness,冲动,NOUN,B2
+公用事业表,utility meter,公用事业表,NOUN,B2
+编码,encoding,编码,NOUN,B2
+沉积的,sedimentary,沉积的,ADJ,B2
+副朝,minor pilgrimage,副朝,NOUN,B2
+支出,expenditures,支出,NOUN,B2
+悲惨,wretchedness,悲惨,NOUN,B2
+封闭,closedness,封闭,NOUN,B2
+半场,half of a match,半场,NOUN,B2
+视力,eyesight,视力,NOUN,B2
+髓质的,pulpy,髓质的,ADJ,B2
+地区,regions,地区,NOUN,B2
+世俗化,secularization,世俗化,NOUN,B2
+局,directorate,局,NOUN,B2
+在...处,at with,在...处,ADP,B2
+低地,lowland,低地,NOUN,B2
+贪欲,greedy ambition,贪欲,NOUN,B2
+辩证法,dialectic,辩证法,NOUN,B2
+内在地,inwardly,内在地,ADV,B2
+自然法则,natural law,自然法则,NOUN,B2
+无效的,null and void,无效的,ADJ,B2
+清新/鲜艳,freshness bloom,清新/鲜艳,NOUN,B2
+简单化,simplism,简单化,NOUN,B2
+压抑的悲伤,suppressed grief,压抑的悲伤,NOUN,B2
+故障,glitch,故障,NOUN,B2
+互助,mutual support,互助,NOUN,B2
+存在的 / 可获得的,present available,存在的 / 可获得的,ADJ,B2
+柳叶刀 / 刺血针,lancet,柳叶刀 / 刺血针,NOUN,B2
+制度化,to institutionalize,制度化,VERB,B2
+插座,power outlet,插座,NOUN,B2
+公共喷泉,public fountain,公共喷泉,NOUN,B2
+茴香,anise,茴香,NOUN,B2
+尺寸 / 测量,size measure,尺寸 / 测量,NOUN,B2
+简化,simplification,简化,NOUN,B2
+联网的,networked,联网的,ADJ,B2
+革新主义,renewalism,革新主义,NOUN,B2
+仪式,rituals,仪式,NOUN,B2
+毫无,no,毫无,DET,B2
+好吧,well,好吧,INTJ,B2
+左边,left,左边,ADV,B2
+那么多,so much,那么多,DET,B2
+报价单,quote,报价单,NOUN,B2
+吞食,to devour,吞食,VERB,B2
+英勇的,gallant,英勇的,ADJ,B2
+请,please,请,INTJ,B2
+放大,to amplify,放大,VERB,B2
+归因于,to attribute,归因于,VERB,B2
+贬低,to debase,贬低,VERB,B2
+破坏,to ravage,破坏,VERB,B2
+橱柜,cupboard,橱柜,NOUN,B2
+征服,conquest,征服,NOUN,B2
+压倒性的,overwhelming,压倒性的,ADJ,B2
+不满,discontent,不满,NOUN,B2
+该死,damn,该死,INTJ,B2
+两者,both,两者,PRON,B2
+第七,seventh,第七,ADJ,B2
+没有一个,none,没有一个,PRON,B2
+分群,to swarm,分群,VERB,B2
+参议院,senate,参议院,NOUN,B2
+违禁的,illicit,违禁的,ADJ,B2
+原型,archetype,原型,NOUN,B2
+完全的,total,完全的,ADJ,B2
+第九,ninth,第九,ADJ,B2
+巡逻,patrol,巡逻,NOUN,B2
+使全球化,to globalize,使全球化,VERB,B2
+金属的,metallic,金属的,ADJ,B2
+市议会,city council,市议会,NOUN,B2
+准备好的,prepared,准备好的,ADJ,B2
+基于,to be based on,基于,VERB,B2
+进来,in,进来,ADV,B2
+茁壮成长,to thrive,茁壮成长,VERB,B2
+过量,overdose,过量,NOUN,B2
+软管,hose,软管,NOUN,B2
+熟练的,skillful,熟练的,ADJ,B2
+右边,right,右边,ADV,B2
+必须,have to,必须,AUX,B2
+骰子,die,骰子,NOUN,B2
+渴望,to long for,渴望,VERB,B2
+爸爸,daddy,爸爸,NOUN,B2
+妓女,whore,妓女,NOUN,B2
+枯萎,to wilt,枯萎,VERB,B2
+沉默,to fall silent,沉默,VERB,B2
+是是是,yeah yeah,是是是,INTJ,B2
+踏板摩托车,scooter,踏板摩托车,NOUN,B2
+爷爷,grandpa,爷爷,NOUN,B2
+预感,premonition,预感,NOUN,B2
+过去,over,过去,ADV,B2
+搜捕,manhunt,搜捕,NOUN,B2
+那个,that,那个,DET,B2
+面条,noodle,面条,NOUN,B2
+共同的,together,共同的,ADJ,B2
+咯咯笑,to giggle,咯咯笑,VERB,B2
+呜咽,to whimper,呜咽,VERB,B2
+伪造,to fake,伪造,VERB,B2
+经过,past,经过,ADV,B2
+少,little,少,DET,B2
+使神圣,to sanctify,使神圣,VERB,B2
+野兔,hare,野兔,NOUN,B2
+电话号码,telephone number,电话号码,NOUN,B2
+尽管如此,nevertheless,尽管如此,ADV,B2
+猎物,prey,猎物,NOUN,B2
+荒野,wilderness,荒野,NOUN,B2
+食堂,canteen,食堂,NOUN,B2
+天哪,good heavens,天哪,INTJ,B2
+在其中,with it,在其中,ADV,B2
+发电厂,power plant,发电厂,NOUN,B2
+在后面,behind it,在后面,ADV,B2
+乐意地,gladly,乐意地,ADV,B2
+哇,wow,哇,INTJ,B2
+任何事,anything,任何事,PRON,B2
+呸,yuck,呸,INTJ,B2
+定期地,regularly,定期地,ADV,B2
+性欲的,horny,性欲的,ADJ,B2
+无缝的,seamless,无缝的,ADJ,B2
+祖母绿,emerald,祖母绿,NOUN,B2
+律师事务所,law firm,律师事务所,NOUN,B2
+规律性,regularity,规律性,NOUN,B2
+显著的,pronounced,显著的,ADJ,B2
+副署,to countersign,副署,VERB,B2
+碰撞,to bump,碰撞,VERB,B2
+从哪里,from where,从哪里,ADV,B2
+令人毛骨悚然的,creepy,令人毛骨悚然的,ADJ,B2
+辖区,precinct,辖区,NOUN,B2
+拼写,to spell,拼写,VERB,B2
+小圆面包,bread roll,小圆面包,NOUN,B2
+应付,to cope,应付,VERB,B2
+下面,below,下面,ADV,B2
+骗子,crook,骗子,NOUN,B2
+酋长,chieftain,酋长,NOUN,B2
+对面,opposite,对面,ADP,B2
+流逝,to elapse,流逝,VERB,B2
+雷阵雨,thunderstorm,雷阵雨,NOUN,B2
+成为,become,成为,AUX,B2
+模糊的,diffuse,模糊的,ADJ,B2
+私生活,private life,私生活,NOUN,B2
+咆哮,to growl,咆哮,VERB,B2
+切换,to switch,切换,VERB,B2
+被爱的,loved,被爱的,ADJ,B2
+丑陋的,hideous,丑陋的,ADJ,B2
+砍倒,to fell,砍倒,VERB,B2
+从那以后,since then,从那以后,ADV,B2
+倒空,to empty,倒空,VERB,B2
+冲洗,to rinse,冲洗,VERB,B2
+使一致,to align,使一致,VERB,B2
+缓刑,probation,缓刑,NOUN,B2
+敏捷的,nimble,敏捷的,ADJ,B2
+学院,college,学院,NOUN,B2
+炸毁,to blow up,炸毁,VERB,B2
+成绩单,report card,成绩单,NOUN,B2
+耙子,rake,耙子,NOUN,B2
+分娩,to give birth,分娩,VERB,B2
+越,the more,越,ADV,B2
+破产的,broke,破产的,ADJ,B2
+越过,across,越过,ADV,B2
+胡扯,to bullshit,胡扯,VERB,B2
+在隔壁,next door,在隔壁,ADV,B2
+斗牛犬,bulldog,斗牛犬,NOUN,B2
+种类,sort,种类,NOUN,B2
+郊游,excursion,郊游,NOUN,B2
+母狗,bitch,母狗,NOUN,B2
+忽视,to overlook,忽视,VERB,B2
+关于它,about it,关于它,ADV,B2
+藏身处,hiding place,藏身处,NOUN,B2
+去,infinitive marker,去,PART,B2
+假期,holidays,假期,NOUN,B2
+背景,backdrop,背景,NOUN,B2
+有针对性的,targeted,有针对性的,ADJ,B2
+懦夫,wimp,懦夫,NOUN,B2
+分流,to shunt,分流,VERB,B2
+荒野,moor,荒野,NOUN,B2
+动力,drive,动力,NOUN,B2
+流浪汉,bum,流浪汉,NOUN,B2
+对此,it,对此,ADV,B2
+振动,to vibrate,振动,VERB,B2
+恶作剧,prank,恶作剧,NOUN,B2
+沉思,to brood,沉思,VERB,B2
+有德行的,virtuous,有德行的,ADJ,B2
+导游,guided tour,导游,NOUN,B2
+姓,last name,姓,NOUN,B2
+抓痕,scratch,抓痕,NOUN,B2
+网格,grid,网格,NOUN,B2
+烟头,cigarette butt,烟头,NOUN,B2
+赠送,to give as a gift,赠送,VERB,B2
+快乐的,gay,快乐的,ADJ,B2
+在其中,among them,在其中,ADV,B2
+雇佣劳动,wage labor,雇佣劳动,NOUN,B2
+关于,concerning,关于,ADP,B2
+失明,to go blind,失明,VERB,B2
+无味的,tasteless,无味的,ADJ,B2
+学习曲线,learning curve,学习曲线,NOUN,B2
+她,she they,她,PRON,B2
+天蓝色,sky blue,天蓝色,ADJ,B2
+圣诞树,christmas tree,圣诞树,NOUN,B2
+罗马尼亚人,romanian,罗马尼亚人,NOUN,B2
+而是,but rather,而是,CCONJ,B2
+抽搐的,twitching,抽搐的,ADJ,B2
+是的,yes,是的,PART,B2
+逼迫,to pressurize,逼迫,VERB,B2
+急诊医生,emergency doctor,急诊医生,NOUN,B2
+哎呀,yikes,哎呀,INTJ,B2
+怪人,oddball,怪人,NOUN,B2
+长大的,grown,长大的,ADJ,B2
+主题曲,theme music,主题曲,NOUN,B2
+大学生,university student,大学生,NOUN,B2
+人身伤害,bodily harm,人身伤害,NOUN,B2
+垃圾袋,trash bag,垃圾袋,NOUN,B2
+母猪,sow,母猪,NOUN,B2
+鉴于,in view of,鉴于,ADP,B2
+爆发,to break out,爆发,VERB,B2
+极度恐惧,mortal fear,极度恐惧,NOUN,B2
+松口气,to breathe again,松口气,VERB,B2
+负担重的,burdened,负担重的,ADJ,B2
+讲得通,to make sense,讲得通,VERB,B2
+样品 / 排练,sample rehearsal,样品 / 排练,NOUN,B2
+吝啬,to stint,吝啬,VERB,B2
+直的,straight,直的,NOUN,B2
+城市地图,city map,城市地图,NOUN,B2
+定居的,resident,定居的,ADJ,B2
+排队,to queue,排队,VERB,B2
+逗号,comma,逗号,PUNCT,B2
+警卫,guards,警卫,NOUN,B2
+分号,semicolon,分号,PUNCT,B2
+分享,to share divide,分享,VERB,B2
+挑选,to pick out,挑选,VERB,B2
+惯例,usual thing,惯例,NOUN,B2
+天使群,host of angels,天使群,NOUN,B2
+麻醉,to anesthetize,麻醉,VERB,B2
+女总统,president female,女总统,NOUN,B2
+关掉,to switch off,关掉,VERB,B2
+被调查的,investigated,被调查的,ADJ,B2
+水杯,drinking glass,水杯,NOUN,B2
+最坏的事,worst thing,最坏的事,NOUN,B2
+数千,thousands,数千,NOUN,B2
+隐瞒,to keep secret,隐瞒,VERB,B2
+呻吟,groan,呻吟,NOUN,B2
+可以说,so to speak,可以说,ADV,B2
+日常生活,everyday life,日常生活,NOUN,B2
+素食者,vegetarian,素食者,NOUN,B2
+心,hearts,心,NOUN,B2
+混蛋,motherfucker,混蛋,NOUN,B2
+屎,crap,屎,NOUN,B2
+隔音差的,thin-walled,隔音差的,ADJ,B2
+射手座,sagittarius,射手座,NOUN,B2
+在...时,at the,在...时,ADP,B2
+每,per,每,ADP,B2
+放下,to lay down,放下,VERB,B2
+配合,to play along,配合,VERB,B2
+介入,to step in,介入,VERB,B2
+留在这里,to stay here,留在这里,VERB,B2
+年薪,annual wage,年薪,NOUN,B2
+祝贺,congratulations,祝贺,NOUN,B2
+那个,that yonder,那个,DET,B2
+从中,from it,从中,ADV,B2
+牺牲,sacrificed,牺牲,ADJ,B2
+发球/加价,serve markup,发球/加价,NOUN,B2
+锁子甲,chain mail,锁子甲,NOUN,B2
+一致的,agreed,一致的,ADJ,B2
+助手,helper,助手,NOUN,B2
+扭曲的形象,distorted image,扭曲的形象,NOUN,B2
+德语课,german class,德语课,NOUN,B2
+过得去,to get by,过得去,VERB,B2
+扬声器,loudspeaker,扬声器,NOUN,B2
+勇气测试,test of courage,勇气测试,NOUN,B2
+紧缺商品,scarce commodity,紧缺商品,NOUN,B2
+午休,lunch break,午休,NOUN,B2
+审讯室,interrogation room,审讯室,NOUN,B2
+参观,to view,参观,VERB,B2
+委托,to commission,委托,VERB,B2
+睡过头,to oversleep,睡过头,VERB,B2
+在...前,in front of before,在...前,ADP,B2
+痒痒粉,itching powder,痒痒粉,NOUN,B2
+点赞,like,点赞,NOUN,B2
+因果的,causal,因果的,ADJ,B2
+注销,to deregister,注销,VERB,B2
+等待观望,to wait and see,等待观望,VERB,B2
+欢呼,cheers,欢呼,NOUN,B2
+人际的,interpersonal,人际的,ADJ,B2
+非法的,unlawful,非法的,ADJ,B2
+跑,ran,跑,ADJ,B2
+有风的,windy,有风的,ADJ,B2
+设备,devices,设备,NOUN,B2
+从属,to subordinate,从属,VERB,B2
+逃跑,to run away,逃跑,VERB,B2
+看电视,to watch tv,看电视,VERB,B2
+最重要的事,most important thing,最重要的事,NOUN,B2
+主要原因,main reason,主要原因,NOUN,B2
+噪音,noises,噪音,NOUN,B2
+恐惧,shit,恐惧,NOUN,B2
+信,letter mail,信,NOUN,B2
+急性子的人,hothead,急性子的人,NOUN,B2
+厢式送货车,delivery van,厢式送货车,NOUN,B2
+故意的/恶意的,deliberate malicious,故意的/恶意的,ADJ,B2
+无例外的,without exception,无例外的,ADV,B2
+工匠,handyman,工匠,NOUN,B2
+蠢事,stupid things,蠢事,NOUN,B2
+用什么,with what,用什么,ADV,B2
+祖父母,grandparents,祖父母,NOUN,B2
+许多事物,many things,许多事物,PRON,B2
+偏偏,of all things,偏偏,ADV,B2
+赞歌,song of praise,赞歌,NOUN,B2
+转开,to turn away,转开,VERB,B2
+伶牙俐齿的,glib,伶牙俐齿的,ADJ,B2
+游戏规则,game rule,游戏规则,NOUN,B2
+伤害,to do harm,伤害,VERB,B2
+办公室工作,office work,办公室工作,NOUN,B2
+私事,personal,私事,NOUN,B2
+一清二楚的,clear as day,一清二楚的,ADJ,B2
+迟到,to be delayed,迟到,VERB,B2
+倾斜的 / 古怪的,oblique weird,倾斜的 / 古怪的,ADJ,B2
+在什么上面,on what,在什么上面,ADV,B2
+再见（电话用语）,goodbye phone,再见（电话用语）,NOUN,B2
+轻快的,upbeat,轻快的,ADJ,B2
+搬出,to move out,搬出,VERB,B2
+陷入,to get into,陷入,VERB,B2
+后天,the day after tomorrow,后天,ADV,B2
+被愚弄的,bullshitted,被愚弄的,ADJ,B2
+受影响的,affected,受影响的,ADJ,B2
+刑警,detective force,刑警,NOUN,B2
+绑架者,kidnapper,绑架者,NOUN,B2
+淡化,to play down,淡化,VERB,B2
+再次,once again,再次,ADV,B2
+在...上方,over about,在...上方,ADP,B2
+一些事情,some things,一些事情,PRON,B2
+加入,to be added,加入,VERB,B2
+忙乱,hectic,忙乱,NOUN,B2
+恶心的,sick nauseous,恶心的,ADJ,B2
+您,you formal,您,PRON,B2
+紧急呼叫,emergency call,紧急呼叫,NOUN,B2
+开启,to switch on,开启,VERB,B2
+吱吱声,squeak,吱吱声,NOUN,B2
+没有,no not any,没有,DET,B2
+联系,to relate,联系,VERB,B2
+认真地,seriously,认真地,ADV,B2
+精子,sperm,精子,NOUN,B2
+起源于,to stem,起源于,VERB,B2
+露台,terrace,露台,NOUN,B2
+狂喜,rapture,狂喜,NOUN,B2
+秘密行动,stealth,秘密行动,NOUN,B2
+心理的,psychological,心理的,ADJ,B2
+一瞥,glance,一瞥,NOUN,B2
+今晚,tonight,今晚,ADV,B2
+对比,contrast,对比,NOUN,B2
+字母表,alphabet,字母表,NOUN,B2
+合成的,synthetic,合成的,ADJ,B2
+防御的,defensive,防御的,ADJ,B2
+著名的,renowned,著名的,ADJ,B2
+年表,chronology,年表,NOUN,B2
+肿瘤,tumor,肿瘤,NOUN,B2
+动物群,fauna,动物群,NOUN,B2
+分开的,separate,分开的,ADJ,B2
+目瞪口呆,to gape,目瞪口呆,VERB,B2
+雕刻,to engrave,雕刻,VERB,B2
+自治,autonomy,自治,NOUN,B2
+他,him,他,PRON,B2
+先前的,prior,先前的,ADJ,B2
+最终的,ultimate,最终的,ADJ,B2
+大气的,atmospheric,大气的,ADJ,B2
+易受伤害的,vulnerable,易受伤害的,ADJ,B2
+难以置信的,incredible,难以置信的,ADJ,B2
+水龙头,tap,水龙头,NOUN,B2
+分发,to dispense,分发,VERB,B2
+牺牲,sacrifice,牺牲,NOUN,B2
+文凭,diploma,文凭,NOUN,B2
+赤裸的,bare,赤裸的,ADJ,B2
+轨迹,trajectory,轨迹,NOUN,B2
+阶段,phase,阶段,NOUN,B2
+无能的,incompetent,无能的,ADJ,B2
+提醒物,reminder,提醒物,NOUN,B2
+题词,epigraph,题词,NOUN,B2
+通行费,toll,通行费,NOUN,B2
+强迫,to oblige,强迫,VERB,B2
+极度恐惧的,terrified,极度恐惧的,ADJ,B2
+中世纪的,medieval,中世纪的,ADJ,B2
+宽慰的,relieved,宽慰的,ADJ,B2
+证实,to corroborate,证实,VERB,B2
+单独的,alone,单独的,ADJ,B2
+文学的,literary,文学的,ADJ,B2
+施肥,to fertilize,施肥,VERB,B2
+嬉戏,to frolic,嬉戏,VERB,B2
+檐口,cornice,檐口,NOUN,B2
+减弱,to attenuate,减弱,VERB,B2
+授予,to confer,授予,VERB,B2
+驱逐出境,to deport,驱逐出境,VERB,B2
+最佳的,optimal,最佳的,ADJ,B2
+地点,spot,地点,NOUN,B2
+弄乱,to disarrange,弄乱,VERB,B2
+颤抖,to quiver,颤抖,VERB,B2
+豹,panther,豹,NOUN,B2
+教唆,to suborn,教唆,VERB,B2
+灌木丛,thicket,灌木丛,NOUN,B2
+双手灵巧的,ambidextrous,双手灵巧的,ADJ,B2
+可兑换性,convertibility,可兑换性,NOUN,B2
+取消资格,to disqualify,取消资格,VERB,B2
+表明,to manifest,表明,VERB,B2
+任性的,perverse,任性的,ADJ,B2
+纵容,to pamper,纵容,VERB,B2
+友好的,amicable,友好的,ADJ,B2
+对手,rival,对手,NOUN,B2
+不在场证明,alibi,不在场证明,NOUN,B2
+分配,to allocate,分配,VERB,B2
+难忘的,memorable,难忘的,ADJ,B2
+毁容,to disfigure,毁容,VERB,B2
+除霜,to defrost,除霜,VERB,B2
+小规模战斗,skirmish,小规模战斗,NOUN,B2
+解码,to decode,解码,VERB,B2
+老化,aging,老化,NOUN,B2
+跳跃,to caper,跳跃,VERB,B2
+同意,to assent,同意,VERB,B2
+较小的,minor,较小的,ADJ,B2
+不道德的,immoral,不道德的,ADJ,B2
+差异,discrepancy,差异,NOUN,B2
+颤抖的,tremulous,颤抖的,ADJ,B2
+兄弟姐妹,sibling,兄弟姐妹,NOUN,B2
+严厉批评,to castigate,严厉批评,VERB,B2
+赞美,to extol,赞美,VERB,B2
+易接近的,accessible,易接近的,ADJ,B2
+同盟者,confederate,同盟者,NOUN,B2
+受吸引,to gravitate,受吸引,VERB,B2
+喧嚣,din,喧嚣,NOUN,B2
+滥交的,promiscuous,滥交的,ADJ,B2
+新手；初学者,neophyte,新手；初学者,NOUN,B2
+合并,to amalgamate,合并,VERB,B2
+死后的,posthumous,死后的,ADJ,B2
+精神病的,psychiatric,精神病的,ADJ,B2
+一次性的,disposable,一次性的,ADJ,B2
+不管,regardless,不管,ADV,B2
+危险的,perilous,危险的,ADJ,B2
+使全神贯注,to engross,使全神贯注,VERB,B2
+时代错误的,anachronistic,时代错误的,ADJ,B2
+厌世者,misanthrope,厌世者,NOUN,B2
+君主制,monarchy,君主制,NOUN,B2
+理想地,ideally,理想地,ADV,B2
+难以捉摸的,elusive,难以捉摸的,ADJ,B2
+神谕,oracle,神谕,NOUN,B2
+阐明,to enunciate,阐明,VERB,B2
+临时的,provisional,临时的,ADJ,B2
+复兴,revival,复兴,NOUN,B2
+白炽的,incandescent,白炽的,ADJ,B2
+无敌的,invincible,无敌的,ADJ,B2
+解毒剂,antidote,解毒剂,NOUN,B2
+辅助的,ancillary,辅助的,ADJ,B2
+公平,equity,公平,NOUN,B2
+哀叹,to lament,哀叹,VERB,B2
+商业化,to commercialize,商业化,VERB,B2
+养肥,to fatten,养肥,VERB,B2
+不服从的,disobedient,不服从的,ADJ,B2
+摇篮,cradle,摇篮,NOUN,B2
+辣椒,chili,辣椒,NOUN,B2
+刺耳的,strident,刺耳的,ADJ,B2
+首席执行官,ceo,首席执行官,NOUN,B2
+焊接,to solder,焊接,VERB,B2
+动荡的,turbulent,动荡的,ADJ,B2
+棍棒,cudgel,棍棒,NOUN,B2
+心烦的,upset,心烦的,ADJ,B2
+逃避,to elude,逃避,VERB,B2
+双筒望远镜,binoculars,双筒望远镜,NOUN,B2
+悔恨的,remorseful,悔恨的,ADJ,B2
+抗生素,antibiotic,抗生素,NOUN,B2
+瘦骨嶙峋的,cadaverous,瘦骨嶙峋的,ADJ,B2
+深恶痛绝之物,anathema,深恶痛绝之物,NOUN,B2
+分叉,to bifurcate,分叉,VERB,B2
+尖锐的,shrill,尖锐的,ADJ,B2
+暗指,to allude,暗指,VERB,B2
+附加费,surcharge,附加费,NOUN,B2
+隔离,to sequester,隔离,VERB,B2
+欲望,lust,欲望,NOUN,B2
+自夸的,boastful,自夸的,ADJ,B2
+过渡,transition,过渡,NOUN,B2
+缓解,to alleviate,缓解,VERB,B2
+无礼的,disrespectful,无礼的,ADJ,B2
+兴高采烈,elation,兴高采烈,NOUN,B2
+无瑕疵的,impeccable,无瑕疵的,ADJ,B2
+极简主义,minimalism,极简主义,NOUN,B2
+全部曲目,repertoire,全部曲目,NOUN,B2
+脸红,to blush,脸红,VERB,B2
+斜的,oblique,斜的,ADJ,B2
+主题,motif,主题,NOUN,B2
+不知足的,insatiable,不知足的,ADJ,B2
+一瞥,glimpse,一瞥,NOUN,B2
+悲惨的,abject,悲惨的,ADJ,B2
+洗脑者,brainwasher,洗脑者,NOUN,B2
+栏杆,balustrade,栏杆,NOUN,B2
+石化,to fossilize,石化,VERB,B2
+洗涤剂,detergent,洗涤剂,NOUN,B2
+刺耳的声音,cacophony,刺耳的声音,NOUN,B2
+改变,to vary,改变,VERB,B2
+马勒,bridle,马勒,NOUN,B2
+使外在化,to externalize,使外在化,VERB,B2
+麻木的,numb,麻木的,ADJ,B2
+开始,commencement,开始,NOUN,B2
+燃烧器,burner,燃烧器,NOUN,B2
+禁运,embargo,禁运,NOUN,B2
+和谐,concord,和谐,NOUN,B2
+预言,to augur,预言,VERB,B2
+黑帮成员,gangster,黑帮成员,NOUN,B2
+不利的,adverse,不利的,ADJ,B2
+剥夺继承权,to disinherit,剥夺继承权,VERB,B2
+使熟悉,to familiarize,使熟悉,VERB,B2
+括号,bracket,括号,NOUN,B2
+城垛,battlement,城垛,NOUN,B2
+煽动叛乱,sedition,煽动叛乱,NOUN,B2
+投降,to capitulate,投降,VERB,B2
+错误的,mistaken,错误的,ADJ,B2
+有利可图的,lucrative,有利可图的,ADJ,B2
+蜡,wax,蜡,NOUN,B2
+点,dot,点,NOUN,B2
+汽车旅馆,motel,汽车旅馆,NOUN,B2
+搞砸,to bungle,搞砸,VERB,B2
+减弱,to wane,减弱,VERB,B2
+使人疏远的,alienating,使人疏远的,ADJ,B2
+地下的,underground,地下的,ADJ,B2
+爱社交的,gregarious,爱社交的,ADJ,B2
+寒冷的,frigid,寒冷的,ADJ,B2
+爱打听的,nosy,爱打听的,ADJ,B2
+散发,to exude,散发,VERB,B2
+热带的,tropical,热带的,ADJ,B2
+有害的,pernicious,有害的,ADJ,B2
+码头,pier,码头,NOUN,B2
+运动的,athletic,运动的,ADJ,B2
+缺点,drawback,缺点,NOUN,B2
+轻蔑,scorn,轻蔑,NOUN,B2
+惩罚,penalty,惩罚,NOUN,B2
+驳船,barge,驳船,NOUN,B2
+体检,checkup,体检,NOUN,B2
+道歉的,apologetic,道歉的,ADJ,B2
+存在主义的,existential,存在主义的,ADJ,B2
+即兴的,impromptu,即兴的,ADJ,B2
+弄乱,to dishevel,弄乱,VERB,B2
+男性,male,男性,NOUN,B2
+预后,prognosis,预后,NOUN,B2
+使沮丧,to dishearten,使沮丧,VERB,B2
+路障,barricade,路障,NOUN,B2
+极好的,superb,极好的,ADJ,B2
+爱慕,to adore,爱慕,VERB,B2
+病变,lesion,病变,NOUN,B2
+假的,phony,假的,ADJ,B2
+可转让的,alienable,可转让的,ADJ,B2
+警惕的,vigilant,警惕的,ADJ,B2
+缓和,to defuse,缓和,VERB,B2
+凹痕,dent,凹痕,NOUN,B2
+受启发的,inspired,受启发的,ADJ,B2
+沼泽,bog,沼泽,NOUN,B2
+意外之财,windfall,意外之财,NOUN,B2
+搜寻,to ferret,搜寻,VERB,B2
+放荡不羁的,bohemian,放荡不羁的,ADJ,B2
+天资,aptitude,天资,NOUN,B2
+嘎吱作响,to creak,嘎吱作响,VERB,B2
+对跖点,antipode,对跖点,NOUN,B2
+通勤,to commute,通勤,VERB,B2
+处理,to dispose,处理,VERB,B2
+几乎不,scarcely,几乎不,ADV,B2
+呱呱叫,to croak,呱呱叫,VERB,B2
+令人羞辱的,humiliating,令人羞辱的,ADJ,B2
+不安的,disturbed,不安的,ADJ,B2
+语法错误,solecism,语法错误,NOUN,B2
+冷漠,aloofness,冷漠,NOUN,B2
+使厌烦,to cloy,使厌烦,VERB,B2
+观众,viewer,观众,NOUN,B2
+王室,royalty,王室,NOUN,B2
+等待,to bide,等待,VERB,B2
+积聚,to amass,积聚,VERB,B2
+先驱,pioneer,先驱,NOUN,B2
+神化,to deify,神化,VERB,B2
+默许,to acquiesce,默许,VERB,B2
+时代错误,anachronism,时代错误,NOUN,B2
+很少,seldom,很少,ADV,B2
+使衰弱,to enervate,使衰弱,VERB,B2
+品味,to savor,品味,VERB,B2
+渴望,to yearn,渴望,VERB,B2
+省略,to elide,省略,VERB,B2
+描绘,to delineate,描绘,VERB,B2
+分类学,taxonomy,分类学,NOUN,B2
+飘渺的,ethereal,飘渺的,ADJ,B2
+双边的,bilateral,双边的,ADJ,B2
+进行中的,ongoing,进行中的,ADJ,B2
+异国情调的,exotic,异国情调的,ADJ,B2
+可避免的,avoidable,可避免的,ADJ,B2
+神化的,apotheotic,神化的,ADJ,B2
+滴答声,tick,滴答声,NOUN,B2
+废弃,disuse,废弃,NOUN,B2
+分析的,analytical,分析的,ADJ,B2
+稀释,to dilute,稀释,VERB,B2
+邪教,cult,邪教,NOUN,B2
+不流血的,bloodless,不流血的,ADJ,B2
+凉亭,bower,凉亭,NOUN,B2
+发光的,luminous,发光的,ADJ,B2
+听诊,to auscultate,听诊,VERB,B2
+哄笑,guffaw,哄笑,NOUN,B2
+分散,to disperse,分散,VERB,B2
+击退,to repel,击退,VERB,B2
+行为主义者,behaviorist,行为主义者,NOUN,B2
+篝火,bonfire,篝火,NOUN,B2
+开脱,to exculpate,开脱,VERB,B2
+划定界限,to demarcate,划定界限,VERB,B2
+使苦恼,to ail,使苦恼,VERB,B2
+溢价,premium,溢价,NOUN,B2
+使堕落,to deprave,使堕落,VERB,B2
+主要的,major,主要的,ADJ,B2
+基本的,elementary,基本的,ADJ,B2
+迷住,to bewitch,迷住,VERB,B2
+停滞的,stagnant,停滞的,ADJ,B2
+限制,to confine,限制,VERB,B2
+富有的,wealthy,富有的,ADJ,B2
+早熟的,precocious,早熟的,ADJ,B2
+夸张,hyperbole,夸张,NOUN,B2
+弄皱,to crumple,弄皱,VERB,B2
+灵巧,dexterity,灵巧,NOUN,B2
+引起,to beget,引起,VERB,B2
+恒定,constancy,恒定,NOUN,B2
+橡胶,rubber,橡胶,NOUN,B2
+使慌乱,to fluster,使慌乱,VERB,B2
+徘徊,to linger,徘徊,VERB,B2
+虔诚的,pious,虔诚的,ADJ,B2
+有责任的,liable,有责任的,ADJ,B2
+史无前例的,unprecedented,史无前例的,ADJ,B2
+瓦解,to disintegrate,瓦解,VERB,B2
+家务,chore,家务,NOUN,B2
+证明,to attest,证明,VERB,B2
+剥夺,to divest,剥夺,VERB,B2
+屈尊,to condescend,屈尊,VERB,B2
+共鸣的,resonant,共鸣的,ADJ,B2
+不可原谅的,unforgivable,不可原谅的,ADJ,B2
+动物园,zoo,动物园,NOUN,B2
+坚持,to persist,坚持,VERB,B2
+逐出,to dislodge,逐出,VERB,B2
+美丽地,beautifully,美丽地,ADV,B2
+半球,hemisphere,半球,NOUN,B2
+完成,to consummate,完成,VERB,B2
+谨慎的,wary,谨慎的,ADJ,B2
+潜在的,latent,潜在的,ADJ,B2
+摆架子,airs,摆架子,NOUN,B2
+震惊的,shocked,震惊的,ADJ,B2
+液体,fluid,液体,NOUN,B2
+争吵,to bicker,争吵,VERB,B2
+统计数据,statistic,统计数据,NOUN,B2
+暴行,atrocity,暴行,NOUN,B2
+听得见的,audible,听得见的,ADJ,B2
+电子学,electronics,电子学,NOUN,B2
+热情的,ardent,热情的,ADJ,B2
+外科的,surgical,外科的,ADJ,B2
+神秘的,arcane,神秘的,ADJ,B2
+非营利的,nonprofit,非营利的,ADJ,B2
+对抗,antagonism,对抗,NOUN,B2
+肢体,limb,肢体,NOUN,B2
+帆布,canvas,帆布,NOUN,B2
+迫害,to persecute,迫害,VERB,B2
+使大胆,to embolden,使大胆,VERB,B2
+支付,to defray,支付,VERB,B2
+变迁,vicissitude,变迁,NOUN,B2
+校准,to calibrate,校准,VERB,B2
+各种各样的,various,各种各样的,ADJ,B2
+赦免,to absolve,赦免,VERB,B2
+法团主义,corporatism,法团主义,NOUN,B2
+足球,soccer,足球,NOUN,B2
+吝啬的,miserly,吝啬的,ADJ,B2
+亵渎,sacrilege,亵渎,NOUN,B2
+三段论,syllogism,三段论,NOUN,B2
+引起回忆的,evocative,引起回忆的,ADJ,B2
+删节,to expurgate,删节,VERB,B2
+长篇抨击,tirade,长篇抨击,NOUN,B2
+分裂,schism,分裂,NOUN,B2
+苦行的,ascetic,苦行的,ADJ,B2
+注册,to enrol,注册,VERB,B2
+尖刻的,acerbic,尖刻的,ADJ,B2
+海盗,buccaneer,海盗,NOUN,B2
+老板主义,bossism,老板主义,NOUN,B2
+证实,corroboration,证实,NOUN,B2
+持有者,holder,持有者,NOUN,B2
+书柜,bookcase,书柜,NOUN,B2
+惰性的,inert,惰性的,ADJ,B2
+新闻业,journalism,新闻业,NOUN,B2
+辩护者,apologist,辩护者,NOUN,B2
+顶点,apex,顶点,NOUN,B2
+图书管理员,librarian,图书管理员,NOUN,B2
+天使般的,angelic,天使般的,ADJ,B2
+性情,disposition,性情,NOUN,B2
+潮湿的,humid,潮湿的,ADJ,B2
+佳酿,vintage,佳酿,NOUN,B2
+归罪,to incriminate,归罪,VERB,B2
+流行,vogue,流行,NOUN,B2
+溅,to splash,溅,VERB,B2
+满足的,fulfilled,满足的,ADJ,B2
+坚定的,staunch,坚定的,ADJ,B2
+传播,to propagate,传播,VERB,B2
+脊柱,spine,脊柱,NOUN,B2
+分离,to disjoin,分离,VERB,B2
+起诉,to prosecute,起诉,VERB,B2
+最高的,supreme,最高的,ADJ,B2
+有角的,angular,有角的,ADJ,B2
+恶性的,virulent,恶性的,ADJ,B2
+不成熟的,immature,不成熟的,ADJ,B2
+镶满宝石的,bejeweled,镶满宝石的,ADJ,B2
+冗余,redundancy,冗余,NOUN,B2
+启发,to edify,启发,VERB,B2
+优化,optimization,优化,NOUN,B2
+香料,spice,香料,NOUN,B2
+极冷的,freezing,极冷的,ADJ,B2
+肿块,bump,肿块,NOUN,B2
+草率地,summarily,草率地,ADV,B2
+证明无效,to invalidate,证明无效,VERB,B2
+斩首,to behead,斩首,VERB,B2
+排列,array,排列,NOUN,B2
+选票,ballot,选票,NOUN,B2
+推翻,to overthrow,推翻,VERB,B2
+拍打,to flap,拍打,VERB,B2
+达到顶点,to culminate,达到顶点,VERB,B2
+鞭打,to flog,鞭打,VERB,B2
+盛宴,feast,盛宴,NOUN,B2
+加强,to fortify,加强,VERB,B2
+雕刻,to carve,雕刻,VERB,B2
+谴责,to decry,谴责,VERB,B2
+使平坦,to flatten,使平坦,VERB,B2
+贫民窟,slum,贫民窟,NOUN,B2
+平分,to bisect,平分,VERB,B2
+徽章,badge,徽章,NOUN,B2
+承认,to concede,承认,VERB,B2
+使气馁,to daunt,使气馁,VERB,B2
+奢侈的,extravagant,奢侈的,ADJ,B2
+犁沟,furrow,犁沟,NOUN,B2
+自然地,naturally,自然地,ADV,B2
+觊觎,to covet,觊觎,VERB,B2
+烧灼,to cauterize,烧灼,VERB,B2
+发掘,to unearth,发掘,VERB,B2
+变位,to conjugate,变位,VERB,B2
+使茫然,to daze,使茫然,VERB,B2
+痛恨,to execrate,痛恨,VERB,B2
+永久的,perpetual,永久的,ADJ,B2
+移居国外,to emigrate,移居国外,VERB,B2
+先行词,antecedent,先行词,NOUN,B2
+排泄物,excrement,排泄物,NOUN,B2
+解开,to unravel,解开,VERB,B2
+使满足,to gratify,使满足,VERB,B2
+兽穴,den,兽穴,NOUN,B2
+无害的,innocuous,无害的,ADJ,B2
+流利,fluency,流利,NOUN,B2
+使吃惊,to amaze,使吃惊,VERB,B2
+恭敬的,respectful,恭敬的,ADJ,B2
+满足,fulfillment,满足,NOUN,B2
+矛盾修辞法,oxymoron,矛盾修辞法,NOUN,B2
+短暂的,ephemeral,短暂的,ADJ,B2
+微波炉,microwave,微波炉,NOUN,B2
+不可或缺的,integral,不可或缺的,ADJ,B2
+贬值,to depreciate,贬值,VERB,B2
+恶意,spite,恶意,NOUN,B2
+缓和的,palliative,缓和的,ADJ,B2
+启示录的,apocalyptic,启示录的,ADJ,B2
+零,zero,零,NOUN,B2
+残留的,residual,残留的,ADJ,B2
+芽,bud,芽,NOUN,B2
+坏名声,disrepute,坏名声,NOUN,B2
+人口统计的,demographic,人口统计的,ADJ,B2
+弯曲,to warp,弯曲,VERB,B2
+使人口减少,to depopulate,使人口减少,VERB,B2
+强迫,to coerce,强迫,VERB,B2
+归因于,to ascribe,归因于,VERB,B2
+热情,zeal,热情,NOUN,B2
+裤子,pants,裤子,NOUN,B2
+萎缩,atrophy,萎缩,NOUN,B2
+循环,loop,循环,NOUN,B2
+不足的,inadequate,不足的,ADJ,B2
+滴,to drip,滴,VERB,B2
+发芽,to germinate,发芽,VERB,B2
+欺骗,to dupe,欺骗,VERB,B2
+哨兵,sentinel,哨兵,NOUN,B2
+假定,to postulate,假定,VERB,B2
+上船,to embark,上船,VERB,B2
+主持,to preside,主持,VERB,B2
+预兆,to forebode,预兆,VERB,B2
+错综复杂的,byzantine,错综复杂的,ADJ,B2
+使康复,to rehabilitate,使康复,VERB,B2
+金融,finance,金融,NOUN,B2
+喷气式飞机,jet,喷气式飞机,NOUN,B2
+使饱足,to satiate,使饱足,VERB,B2
+胜利,triumph,胜利,NOUN,B2
+填鸭式学习,to cram,填鸭式学习,VERB,B2
+虾,shrimp,虾,NOUN,B2
+覆盖,to shroud,覆盖,VERB,B2
+公理的,axiomatic,公理的,ADJ,B2
+大胆的,audacious,大胆的,ADJ,B2
+磨损的,worn,磨损的,ADJ,B2
+有浮力的,buoyant,有浮力的,ADJ,B2
+饥荒,famine,饥荒,NOUN,B2
+肉,flesh,肉,NOUN,B2
+节制,abstinence,节制,NOUN,B2
+花环,garland,花环,NOUN,B2
+使聋,to deafen,使聋,VERB,B2
+屈尊,to deign,屈尊,VERB,B2
+承认,to acknowledge,承认,VERB,B2
+隔离,to segregate,隔离,VERB,B2
+反转,to reverse,反转,VERB,B2
+民主化,to democratize,民主化,VERB,B2
+亲切地,kindly,亲切地,ADV,B2
+灰白的,ashen,灰白的,ADJ,B2
+多余的,redundant,多余的,ADJ,B2
+错综复杂的,intricate,错综复杂的,ADJ,B2
+严厉的,harsh,严厉的,ADJ,B2
+分层,to stratify,分层,VERB,B2
+神秘的,occult,神秘的,ADJ,B2
+拟声词,onomatopoeia,拟声词,NOUN,B2
+见多识广的,informed,见多识广的,ADJ,B2
+纵火,arson,纵火,NOUN,B2
+冒犯的,offensive,冒犯的,ADJ,B2
+抽筋,cramp,抽筋,NOUN,B2
+以前,ago,以前,ADV,B2
+此后,thereafter,此后,ADV,B2
+妖魔化,to demonize,妖魔化,VERB,B2
+雇佣兵,mercenary,雇佣兵,NOUN,B2
+奖品,prize,奖品,NOUN,B2
+资产阶级的,bourgeois,资产阶级的,ADJ,B2
+笔记本电脑,laptop,笔记本电脑,NOUN,B2
+有才华的,talented,有才华的,ADJ,B2
+驱魔,to exorcise,驱魔,VERB,B2
+强调,to accentuate,强调,VERB,B2
+极权主义的,totalitarian,极权主义的,ADJ,B2
+泄露,to divulge,泄露,VERB,B2
+漏斗,funnel,漏斗,NOUN,B2
+杀兄弟,fratricide,杀兄弟,NOUN,B2
+迷住,to enthrall,迷住,VERB,B2
+冒犯,offense,冒犯,NOUN,B2
+假装,to feign,假装,VERB,B2
+糟糕的,awful,糟糕的,ADJ,B2
+冷漠的,apathetic,冷漠的,ADJ,B2
+猛砍,to slash,猛砍,VERB,B2
+烟草,tobacco,烟草,NOUN,B2
+溢出,to spill,溢出,VERB,B2
+枪声,gunshot,枪声,NOUN,B2
+恳求,to supplicate,恳求,VERB,B2
+暗示,hint,暗示,NOUN,B2
+安抚,to placate,安抚,VERB,B2
+堡垒,bastion,堡垒,NOUN,B2
+礼貌,civility,礼貌,NOUN,B2
+狙击手,sniper,狙击手,NOUN,B2
+剧作家,playwright,剧作家,NOUN,B2
+全神贯注的,absorbed,全神贯注的,ADJ,B2
+相似的,akin,相似的,ADJ,B2
+裂缝,fissure,裂缝,NOUN,B2
+坚持,to adhere,坚持,VERB,B2
+迷住,to captivate,迷住,VERB,B2
+非凡的,phenomenal,非凡的,ADJ,B2
+使相等,to equalize,使相等,VERB,B2
+使黯然失色,to overshadow,使黯然失色,VERB,B2
+欺骗,deceit,欺骗,NOUN,B2
+使饱和,to saturate,使饱和,VERB,B2
+谦逊的,humble,谦逊的,ADJ,B2
+勾结,to fraternize,勾结,VERB,B2
+有害的,detrimental,有害的,ADJ,B2
+火成的,igneous,火成的,ADJ,B2
+宽宏大量的,magnanimous,宽宏大量的,ADJ,B2
+神童,prodigy,神童,NOUN,B2
+使潮湿,to dampen,使潮湿,VERB,B2
+神志正常的,sane,神志正常的,ADJ,B2
+无所不在的,omnipresent,无所不在的,ADJ,B2
+自明之理,truism,自明之理,NOUN,B2
+令人兴奋的,thrilling,令人兴奋的,ADJ,B2
+半开的,ajar,半开的,ADJ,B2
+剧变,upheaval,剧变,NOUN,B2
+未受伤害的,unscathed,未受伤害的,ADJ,B2
+温顺的,docile,温顺的,ADJ,B2
+乳房,breast,乳房,NOUN,B2
+蔑视,to flout,蔑视,VERB,B2
+格式,format,格式,NOUN,B2
+渎职,malfeasance,渎职,NOUN,B2
+不祥的,sinister,不祥的,ADJ,B2
+压迫的,oppressive,压迫的,ADJ,B2
+礼仪,decorum,礼仪,NOUN,B2
+利他的,altruistic,利他的,ADJ,B2
+使清醒,to disenchant,使清醒,VERB,B2
+孤独的,solitary,孤独的,ADJ,B2
+使变性,to denature,使变性,VERB,B2
+诽谤,to vilify,诽谤,VERB,B2
+慷慨陈词,to declaim,慷慨陈词,VERB,B2
+虚假的,spurious,虚假的,ADJ,B2
+滴水嘴兽,gargoyle,滴水嘴兽,NOUN,B2
+断言,assertion,断言,NOUN,B2
+归因,attribution,归因,NOUN,B2
+使永恒,to eternalize,使永恒,VERB,B2
+讲师,instructor,讲师,NOUN,B2
+极好的,marvelous,极好的,ADJ,B2
+自恋的,narcissistic,自恋的,ADJ,B2
+轻浮的,frivolous,轻浮的,ADJ,B2
+暗示,to connote,暗示,VERB,B2
+微妙,subtlety,微妙,NOUN,B2
+保证,assurance,保证,NOUN,B2
+歹徒,outlaw,歹徒,NOUN,B2
+珐琅,enamel,珐琅,NOUN,B2
+爆发,outbreak,爆发,NOUN,B2
+获得,to gain,获得,VERB,B2
+简练的,terse,简练的,ADJ,B2
+上述的,aforementioned,上述的,ADJ,B2
+称赞,to acclaim,称赞,VERB,B2
+亵渎,to blaspheme,亵渎,VERB,B2
+消除,to dispel,消除,VERB,B2
+侵蚀,to erode,侵蚀,VERB,B2
+不诚实的,dishonest,不诚实的,ADJ,B2
+效用,utility,效用,NOUN,B2
+严惩,to chastise,严惩,VERB,B2
+赞助,auspice,赞助,NOUN,B2
+偏离,to deviate,偏离,VERB,B2
+车费,fare,车费,NOUN,B2
+根除,to extirpate,根除,VERB,B2
+多样的,diverse,多样的,ADJ,B2
+环绕,to encircle,环绕,VERB,B2
+动人的,touching,动人的,ADJ,B2
+神秘的,enigmatic,神秘的,ADJ,B2
+极地的,polar,极地的,ADJ,B2
+边缘,periphery,边缘,NOUN,B2
+撤回,to retract,撤回,VERB,B2
+移居国外者,expatriate,移居国外者,NOUN,B2
+增强,to enhance,增强,VERB,B2
+负责任的,accountable,负责任的,ADJ,B2
+非理性的,irrational,非理性的,ADJ,B2
+灭绝的,extinct,灭绝的,ADJ,B2
+鲁莽,temerity,鲁莽,NOUN,B2
+净化,to purify,净化,VERB,B2
+徒劳的,vain,徒劳的,ADJ,B2
+易碎的,brittle,易碎的,ADJ,B2
+单一的,monolithic,单一的,ADJ,B2
+等同,to equate,等同,VERB,B2
+基础设施,infrastructure,基础设施,NOUN,B2
+热情的,passionate,热情的,ADJ,B2
+公司,corporation,公司,NOUN,B2
+更近的,closer,更近的,ADJ,B2
+疲倦的,weary,疲倦的,ADJ,B2
+壁垒,bulwark,壁垒,NOUN,B2
+性感的,sexy,性感的,ADJ,B2
+成分,constituent,成分,NOUN,B2
+崇敬,to venerate,崇敬,VERB,B2
+纠正错误想法,to disabuse,纠正错误想法,VERB,B2
+津贴,stipend,津贴,NOUN,B2
+死亡率,mortality,死亡率,NOUN,B2
+移民,emigration,移民,NOUN,B2
+高级的,advanced,高级的,ADJ,B2
+病理学,pathology,病理学,NOUN,B2
+必须,to have to,必须,VERB,B2
+滋生,to infest,滋生,VERB,B2
+徽章,emblem,徽章,NOUN,B2
+独裁者,dictator,独裁者,NOUN,B2
+照明,illumination,照明,NOUN,B2
+脱衣,to undress,脱衣,VERB,B2
+一致的,congruent,一致的,ADJ,B2
+流产,to abort,流产,VERB,B2
+高官,dignitary,高官,NOUN,B2
+困惑的,perplexed,困惑的,ADJ,B2
+刺激,stimulus,刺激,NOUN,B2
+脾气坏的,grumpy,脾气坏的,ADJ,B2
+同音异义,homonymy,同音异义,NOUN,B2
+救赎,redemption,救赎,NOUN,B2
+巫术,witchcraft,巫术,NOUN,B2
+灌溉,to irrigate,灌溉,VERB,B2
+使失色,to eclipse,使失色,VERB,B2
+部分的,partial,部分的,ADJ,B2
+同质性,homogeneity,同质性,NOUN,B2
+口套,muzzle,口套,NOUN,B2
+语言学家,philologist,语言学家,NOUN,B2
+忠诚,fidelity,忠诚,NOUN,B2
+无偿还能力的,insolvent,无偿还能力的,ADJ,B2
+免费,free of charge,免费,NOUN,B2
+致命性,fatality,致命性,NOUN,B2
+低效,inefficiency,低效,NOUN,B2
+溢出,to overflow,溢出,VERB,B2
+地方性的,endemic,地方性的,ADJ,B2
+寒战,shiver,寒战,NOUN,B2
+指小词,diminutive,指小词,NOUN,B2
+松弛,laxity,松弛,NOUN,B2
+气球,balloon,气球,NOUN,B2
+磨损,wear,磨损,NOUN,B2
+逃亡,desertion,逃亡,NOUN,B2
+演讲术,elocution,演讲术,NOUN,B2
+口是心非,duplicity,口是心非,NOUN,B2
+广泛的,extended,广泛的,ADJ,B2
+十五,fifteen,十五,NUM,B2
+法老,pharaoh,法老,NOUN,B2
+热烈的,fiery,热烈的,ADJ,B2
+瓦砾,rubble,瓦砾,NOUN,B2
+保姆,babysitter,保姆,NOUN,B2
+比喻的,figurative,比喻的,ADJ,B2
+伪造,counterfeiting,伪造,NOUN,B2
+色情的,erotic,色情的,ADJ,B2
+适得其反的,counterproductive,适得其反的,ADJ,B2
+严重地,gravely,严重地,ADV,B2
+援引,to invoke,援引,VERB,B2
+闲聊,to gossip,闲聊,VERB,B2
+认知,cognition,认知,NOUN,B2
+历史性,historicity,历史性,NOUN,B2
+不完美的,imperfect,不完美的,ADJ,B2
+植入,to implant,植入,VERB,B2
+看见,to spot,看见,VERB,B2
+自我牺牲,self-denial,自我牺牲,NOUN,B2
+节日的,festive,节日的,ADJ,B2
+希腊语,greek,希腊语,NOUN,B2
+洞察力,discernment,洞察力,NOUN,B2
+累人的,tiresome,累人的,ADJ,B2
+移开,to move away,移开,VERB,B2
+告密者,snitch,告密者,NOUN,B2
+旅馆老板,hotelier,旅馆老板,NOUN,B2
+丧葬的,funereal,丧葬的,ADJ,B2
+舒适的,welcoming,舒适的,ADJ,B2
+标准化,to standardize,标准化,VERB,B2
+有疗效的,curative,有疗效的,ADJ,B2
+密谋,to plot,密谋,VERB,B2
+伊斯兰的,islamic,伊斯兰的,ADJ,B2
+好斗性,combativeness,好斗性,NOUN,B2
+公正,impartiality,公正,NOUN,B2
+愚昧,fatuity,愚昧,NOUN,B2
+给...起绰号,to nickname,给...起绰号,VERB,B2
+注释,to gloss,注释,VERB,B2
+变红,to redden,变红,VERB,B2
+阶层,stratum,阶层,NOUN,B2
+不忠的,disloyal,不忠的,ADJ,B2
+插图,illustration,插图,NOUN,B2
+明确地,explicitly,明确地,ADV,B2
+冬天的,wintry,冬天的,ADJ,B2
+繁荣的,flourishing,繁荣的,ADJ,B2
+贴花,decal,贴花,NOUN,B2
+生闷气,to sulk,生闷气,VERB,B2
+推论,corollary,推论,NOUN,B2
+零碎的,fragmentary,零碎的,ADJ,B2
+结盟,to ally,结盟,VERB,B2
+概念,conception,概念,NOUN,B2
+教学的,teaching,教学的,ADJ,B2
+偶然的,contingent,偶然的,ADJ,B2
+可悲的,deplorable,可悲的,ADJ,B2
+犬儒主义,cynicism,犬儒主义,NOUN,B2
+不可想象的,inconceivable,不可想象的,ADJ,B2
+遥控器,remote control,遥控器,NOUN,B2
+拔出,to tear out,拔出,VERB,B2
+颤抖的,trembling,颤抖的,ADJ,B2
+拖延的,dilatory,拖延的,ADJ,B2
+内脏,entrails,内脏,NOUN,B2
+传播,diffusion,传播,NOUN,B2
+移开,to set aside,移开,VERB,B2
+宏伟,grandiosity,宏伟,NOUN,B2
+易错性,fallibility,易错性,NOUN,B2
+变胖,to gain weight,变胖,VERB,B2
+解开,to undo,解开,VERB,B2
+哲学的,philosophical,哲学的,ADJ,B2
+纳税人,taxpayer,纳税人,NOUN,B2
+恶化,deterioration,恶化,NOUN,B2
+无疑地,undoubtedly,无疑地,ADV,B2
+消散,to dissipate,消散,VERB,B2
+持久的,long-lasting,持久的,ADJ,B2
+光盘,disc,光盘,NOUN,B2
+坚决地,decidedly,坚决地,ADV,B2
+肤色,complexion,肤色,NOUN,B2
+生理的,physiological,生理的,ADJ,B2
+喷射,ejection,喷射,NOUN,B2
+富有想象力的,imaginative,富有想象力的,ADJ,B2
+欢欣,jubilation,欢欣,NOUN,B2
+包含,inclusion,包含,NOUN,B2
+合页,hinge,合页,NOUN,B2
+详述,to detail,详述,VERB,B2
+支撑,to prop up,支撑,VERB,B2
+列举,enumeration,列举,NOUN,B2
+路沟,gutter,路沟,NOUN,B2
+虚构的,fictitious,虚构的,ADJ,B2
+无忧无虑的,carefree,无忧无虑的,ADJ,B2
+故意地,on purpose,故意地,ADV,B2
+预感,inkling,预感,NOUN,B2
+不忠,infidelity,不忠,NOUN,B2
+水坑,puddle,水坑,NOUN,B2
+指数的,exponential,指数的,ADJ,B2
+邮资,postage,邮资,NOUN,B2
+亭子,kiosk,亭子,NOUN,B2
+女性的,feminine,女性的,ADJ,B2
+变老,to age,变老,VERB,B2
+宏伟的,imposing,宏伟的,ADJ,B2
+可比较的,comparable,可比较的,ADJ,B2
+雪茄,cigar,雪茄,NOUN,B2
+使布满孔洞,to riddle,使布满孔洞,VERB,B2
+色情,eroticism,色情,NOUN,B2
+有缺陷的,defective,有缺陷的,ADJ,B2
+液压的,hydraulic,液压的,ADJ,B2
+吝啬,parsimony,吝啬,NOUN,B2
+法学家,jurist,法学家,NOUN,B2
+摘录,extract,摘录,NOUN,B2
+使中毒,to intoxicate,使中毒,VERB,B2
+双头的,two-headed,双头的,ADJ,B2
+象征性的,emblematic,象征性的,ADJ,B2
+贬值,devaluation,贬值,NOUN,B2
+铁路的,railway,铁路的,ADJ,B2
+忘恩负义的,ungrateful,忘恩负义的,ADJ,B2
+行程,itinerary,行程,NOUN,B2
+虚幻,unreality,虚幻,NOUN,B2
+使不便,to inconvenience,使不便,VERB,B2
+窥探,to snoop,窥探,VERB,B2
+裁军,disarmament,裁军,NOUN,B2
+使经受锻炼,to harden,使经受锻炼,VERB,B2
+使坐下,to seat,使坐下,VERB,B2
+注释家,exegete,注释家,NOUN,B2
+不可想象的,unthinkable,不可想象的,ADJ,B2
+化妆品的,cosmetic,化妆品的,ADJ,B2
+几乎不,barely,几乎不,ADV,B2
+海豹,seal,海豹,NOUN,B2
+毁灭性的,devastating,毁灭性的,ADJ,B2
+抽象,to abstract,抽象,VERB,B2
+隐士,hermit,隐士,NOUN,B2
+入侵者,invader,入侵者,NOUN,B2
+敬意,deference,敬意,NOUN,B2
+产卵,to spawn,产卵,VERB,B2
+拉丁的,latin,拉丁的,ADJ,B2
+通用的,generic,通用的,ADJ,B2
+易燃的,flammable,易燃的,ADJ,B2
+叛逆的,rebellious,叛逆的,ADJ,B2
+使平庸,to trivialize,使平庸,VERB,B2
+君主,monarch,君主,NOUN,B2
+首次亮相,to debut,首次亮相,VERB,B2
+卷曲的,curly,卷曲的,ADJ,B2
+不忠的,unfaithful,不忠的,ADJ,B2
+决疑法,casuistry,决疑法,NOUN,B2
+古怪,eccentricity,古怪,NOUN,B2
+医务室,infirmary,医务室,NOUN,B2
+混乱,tangle,混乱,NOUN,B2
+划界,demarcation,划界,NOUN,B2
+咨询的,consultative,咨询的,ADJ,B2
+恶魔般的,devilish,恶魔般的,ADJ,B2
+精选的,chosen,精选的,ADJ,B2
+法理学,jurisprudence,法理学,NOUN,B2
+市议员,councilor,市议员,NOUN,B2
+向日葵,sunflower,向日葵,NOUN,B2
+檐壁,frieze,檐壁,NOUN,B2
+后颈,nape,后颈,NOUN,B2
+腐蚀性的,corrosive,腐蚀性的,ADJ,B2
+发作,paroxysm,发作,NOUN,B2
+笔迹学,graphology,笔迹学,NOUN,B2
+人文主义者,humanist,人文主义者,NOUN,B2
+博学,erudition,博学,NOUN,B2
+转换,conversion,转换,NOUN,B2
+确切地; 正好,precisely,确切地; 正好,ADV,B2
+宣言,manifesto,宣言,NOUN,B2
+给定的,given,给定的,ADJ,B2
+使发炎,to inflame,使发炎,VERB,B2
+揭穿,to unmask,揭穿,VERB,B2
+繁茂的,exuberant,繁茂的,ADJ,B2
+空间的,spatial,空间的,ADJ,B2
+羽绒被,duvet,羽绒被,NOUN,B2
+次,time occasion,次,NOUN,B2
+闪烁,to flash,闪烁,VERB,B2
+无条件的,unconditional,无条件的,ADJ,B2
+宗教裁判所,inquisition,宗教裁判所,NOUN,B2
+护卫舰,frigate,护卫舰,NOUN,B2
+异见者,dissident,异见者,NOUN,B2
+树木茂盛的,wooded,树木茂盛的,ADJ,B2
+靠近,to bring closer,靠近,VERB,B2
+易怒的,choleric,易怒的,ADJ,B2
+一丝不苟地,scrupulously,一丝不苟地,ADV,B2
+使竖起,to bristle,使竖起,VERB,B2
+依赖,dependence,依赖,NOUN,B2
+纱线,yarn,纱线,NOUN,B2
+共有人,co-owner,共有人,NOUN,B2
+探索,exploration,探索,NOUN,B2
+宿命论,fatalism,宿命论,NOUN,B2
+不人道的,inhuman,不人道的,ADJ,B2
+可耻的,scandalous,可耻的,ADJ,B2
+描述性的,descriptive,描述性的,ADJ,B2
+宗派的,confessional,宗派的,ADJ,B2
+感动,to be moved,感动,VERB,B2
+陡峭的,steep,陡峭的,ADJ,B2
+荒凉,desolation,荒凉,NOUN,B2
+脆弱,fragility,脆弱,NOUN,B2
+钉,to nail,钉,VERB,B2
+自学的,self-taught,自学的,ADJ,B2
+使蒙羞,to dishonor,使蒙羞,VERB,B2
+条例,ordinance,条例,NOUN,B2
+无耻,shamelessness,无耻,NOUN,B2
+偶然的,fortuitous,偶然的,ADJ,B2
+引力,gravitation,引力,NOUN,B2
+滑动,to slide,滑动,VERB,B2
+猜测,to conjecture,猜测,VERB,B2
+游牧者,nomad,游牧者,NOUN,B2
+史诗的,epic,史诗的,ADJ,B2
+补充物,complement,补充物,NOUN,B2
+天窗,skylight,天窗,NOUN,B2
+不足,insufficiency,不足,NOUN,B2
+唤起,evocation,唤起,NOUN,B2
+传教,proselytism,传教,NOUN,B2
+吹嘘,bragging,吹嘘,NOUN,B2
+现行,flagrancy,现行,NOUN,B2
+袭击,to assault,袭击,VERB,B2
+损害,detriment,损害,NOUN,B2
+下冰雹,to hail,下冰雹,VERB,B2
+限制,restriction,限制,NOUN,B2
+逍遥法外,impunity,逍遥法外,NOUN,B2
+归咎,to impute,归咎,VERB,B2
+调停,to intercede,调停,VERB,B2
+冒犯,affront,冒犯,NOUN,B2
+不敬,disrespect,不敬,NOUN,B2
+编织,to knit,编织,VERB,B2
+音乐学院,conservatory,音乐学院,NOUN,B2
+擦洗,to scrub,擦洗,VERB,B2
+证词,deposition,证词,NOUN,B2
+外星的,extraterrestrial,外星的,ADJ,B2
+废除,to annul,废除,VERB,B2
+词源学,etymology,词源学,NOUN,B2
+招致,to incur,招致,VERB,B2
+倾析,to decant,倾析,VERB,B2
+美化,to beautify,美化,VERB,B2
+板球,cricket,板球,NOUN,B2
+小丑,buffoon,小丑,NOUN,B2
+不安全感,insecurity,不安全感,NOUN,B2
+芦笋,asparagus,芦笋,NOUN,B2
+同情,commiseration,同情,NOUN,B2
+可控制的,controllable,可控制的,ADJ,B2
+庇护,to shelter,庇护,VERB,B2
+不协调的,incongruous,不协调的,ADJ,B2
+诋毁,to denigrate,诋毁,VERB,B2
+感人的,moving,感人的,ADJ,B2
+无定形的,amorphous,无定形的,ADJ,B2
+辐射,to radiate,辐射,VERB,B2
+切口,incision,切口,NOUN,B2
+人道主义的,humanitarian,人道主义的,ADJ,B2
+废除,to repeal,废除,VERB,B2
+范围,reach,范围,NOUN,B2
+使生气,to anger,使生气,VERB,B2
+声名狼藉的,infamous,声名狼藉的,ADJ,B2
+吟游诗人,bard,吟游诗人,NOUN,B2
+调和的,conciliatory,调和的,ADJ,B2
+普遍性,generality,普遍性,NOUN,B2
+栓塞,embolism,栓塞,NOUN,B2
+不连贯的,incoherent,不连贯的,ADJ,B2
+蜥蜴,lizard,蜥蜴,NOUN,B2
+辨别,to discern,辨别,VERB,B2
+螺旋桨,propeller,螺旋桨,NOUN,B2
+无形的,intangible,无形的,ADJ,B2
+胚胎,embryo,胚胎,NOUN,B2
+碰撞,to crash,碰撞,VERB,B2
+公司的,corporate,公司的,ADJ,B2
+激怒,to enrage,激怒,VERB,B2
+熏蒸,to fumigate,熏蒸,VERB,B2
+概要的,schematic,概要的,ADJ,B2
+货物,freight,货物,NOUN,B2
+闪耀,to sparkle,闪耀,VERB,B2
+搞砸,to botch,搞砸,VERB,B2
+明确的,express,明确的,ADJ,B2
+好战的,belligerent,好战的,ADJ,B2
+演员阵容,cast,演员阵容,NOUN,B2
+干旱的,arid,干旱的,ADJ,B2
+行李,baggage,行李,NOUN,B2
+粗加工,to rough-hew,粗加工,VERB,B2
+极好的,fabulous,极好的,ADJ,B2
+恶名,infamy,恶名,NOUN,B2
+眉毛,brow,眉毛,NOUN,B2
+女权主义者,feminist,女权主义者,NOUN,B2
+策略,stratagem,策略,NOUN,B2
+狂欢,bacchanal,狂欢,NOUN,B2
+使沮丧,to dismay,使沮丧,VERB,B2
+虚弱的,feeble,虚弱的,ADJ,B2
+激励,to galvanize,激励,VERB,B2
+可取的,desirable,可取的,ADJ,B2
+昏睡的,lethargic,昏睡的,ADJ,B2
+令人恼火的,irritating,令人恼火的,ADJ,B2
+发芽,to sprout,发芽,VERB,B2
+刺激,to goad,刺激,VERB,B2
+秘密的,surreptitious,秘密的,ADJ,B2
+古怪的,outlandish,古怪的,ADJ,B2
+失败的,failed,失败的,ADJ,B2
+密封的,airtight,密封的,ADJ,B2
+扶壁,buttress,扶壁,NOUN,B2
+不情愿的,reluctant,不情愿的,ADJ,B2
+骤雨,squall,骤雨,NOUN,B2
+诱捕,to ensnare,诱捕,VERB,B2
+使摆脱,to extricate,使摆脱,VERB,B2
+弹出,to eject,弹出,VERB,B2
+陪审团,jury,陪审团,NOUN,B2
+印记,imprint,印记,NOUN,B2
+中途停留,stopover,中途停留,NOUN,B2
+补充,to complement,补充,VERB,B2
+可修正的,amendable,可修正的,ADJ,B2
+渴求,craving,渴求,NOUN,B2
+不规则,irregularity,不规则,NOUN,B2
+布道,homily,布道,NOUN,B2
+掠夺,looting,掠夺,NOUN,B2
+已故的,deceased,已故的,ADJ,B2
+主张,to contend,主张,VERB,B2
+学校的,school,学校的,ADJ,B2
+使移居国外,to expatriate,使移居国外,VERB,B2
+托儿所,daycare,托儿所,NOUN,B2
+改变,to alter,改变,VERB,B2
+翻阅,to leaf through,翻阅,VERB,B2
+使肿胀,to swell,使肿胀,VERB,B2
+华丽的,flowery,华丽的,ADJ,B2
+杰出的,eminent,杰出的,ADJ,B2
+世界主义的,cosmopolitan,世界主义的,ADJ,B2
+培养,cultivation,培养,NOUN,B2
+著名的,illustrious,著名的,ADJ,B2
+角蝰,asp,角蝰,NOUN,B2
+肆无忌惮的,unscrupulous,肆无忌惮的,ADJ,B2
+使惊慌,to disconcert,使惊慌,VERB,B2
+猎枪,shotgun,猎枪,NOUN,B2
+宣称,to allege,宣称,VERB,B2
+编年史,chronicle,编年史,NOUN,B2
+灌输,to indoctrinate,灌输,VERB,B2
+脱毛,to depilate,脱毛,VERB,B2
+热切的,avid,热切的,ADJ,B2
+连续地,consecutively,连续地,ADV,B2
+地毯,carpet rug,地毯,NOUN,B2
+呼喊,to exclaim,呼喊,VERB,B2
+接壤,to border,接壤,VERB,B2
+使尴尬,to embarrass,使尴尬,VERB,B2
+表示,to denote,表示,VERB,B2
+粗俗的,uncouth,粗俗的,ADJ,B2
+磨损,to wear out,磨损,VERB,B2
+邪恶的,wicked,邪恶的,ADJ,B2
+最低的,lowest,最低的,ADJ,B2
+年老的,aged,年老的,ADJ,B2
+破布,rag,破布,NOUN,B2
+不可移动的,immovable,不可移动的,ADJ,B2
+奴役,to enslave,奴役,VERB,B2
+有节制的,abstemious,有节制的,ADJ,B2
+受围困的,beleaguered,受围困的,ADJ,B2
+搜集,to glean,搜集,VERB,B2
+同意,to consent,同意,VERB,B2
+无力,impotence,无力,NOUN,B2
+恋物,fetish,恋物,NOUN,B2
+也不,nor,也不,CCONJ,B2
+风笛手,bagpiper,风笛手,NOUN,B2
+小饰品,trinket,小饰品,NOUN,B2
+拼写,spelling,拼写,NOUN,B2
+法医的,forensic,法医的,ADJ,B2
+使狂喜,to enrapture,使狂喜,VERB,B2
+哀叫,to bleat,哀叫,VERB,B2
+涌入,influx,涌入,NOUN,B2
+冷漠,apathy,冷漠,NOUN,B2
+减轻,to lighten,减轻,VERB,B2
+整洁的,dapper,整洁的,ADJ,B2
+可接受的,acceptable,可接受的,ADJ,B2
+特质,idiosyncrasy,特质,NOUN,B2
+持续的,incessant,持续的,ADJ,B2
+疼痛的,sore,疼痛的,ADJ,B2
+分歧,to diverge,分歧,VERB,B2
+泡沫,froth,泡沫,NOUN,B2
+地牢,dungeon,地牢,NOUN,B2
+虔诚的,reverent,虔诚的,ADJ,B2
+教育的,educational,教育的,ADJ,B2
+配备,endowment,配备,NOUN,B2
+崇高的,sublime,崇高的,ADJ,B2
+不可接受的,inadmissible,不可接受的,ADJ,B2
+肮脏的,filthy,肮脏的,ADJ,B2
+分歧,divergence,分歧,NOUN,B2
+极端主义者,extremist,极端主义者,NOUN,B2
+坚忍的,stoic,坚忍的,ADJ,B2
+核对,to collate,核对,VERB,B2
+废黜,to dethrone,废黜,VERB,B2
+漂浮的,floating,漂浮的,ADJ,B2
+冷落,to snub,冷落,VERB,B2
+令人羡慕的,enviable,令人羡慕的,ADJ,B2
+立为王,to enthrone,立为王,VERB,B2
+营养不良,malnutrition,营养不良,NOUN,B2
+懒惰的,slothful,懒惰的,ADJ,B2
+促进,to boost,促进,VERB,B2
+使麻木,to numb,使麻木,VERB,B2
+炖菜,stew,炖菜,NOUN,B2
+使自豪,to make proud,使自豪,VERB,B2
+根除,to uproot,根除,VERB,B2
+折磨,to torment,折磨,VERB,B2
+巡回的,itinerant,巡回的,ADJ,B2
+欺骗性的,deceptive,欺骗性的,ADJ,B2
+美食学,gastronomy,美食学,NOUN,B2
+洞穴,grotto,洞穴,NOUN,B2
+订婚,betrothal,订婚,NOUN,B2
+忧虑的,apprehensive,忧虑的,ADJ,B2
+测量,to gauge,测量,VERB,B2
+纺纱厂,spinning mill,纺纱厂,NOUN,B2
+冷静的,phlegmatic,冷静的,ADJ,B2
+纹章,coat of arms,纹章,NOUN,B2
+轻信,credulity,轻信,NOUN,B2
+人口普查,census,人口普查,NOUN,B2
+悲痛欲绝的,disconsolate,悲痛欲绝的,ADJ,B2
+数字化,to digitize,数字化,VERB,B2
+自己,self,自己,PRON,B2
+心爱的,beloved,心爱的,ADJ,B2
+不妥协的,intransigent,不妥协的,ADJ,B2
+暂停,moratorium,暂停,NOUN,B2
+胰岛素,insulin,胰岛素,NOUN,B2
+犬齿,fang,犬齿,NOUN,B2
+气态的,gaseous,气态的,ADJ,B2
+处理,to deal,处理,VERB,B2
+无限的,unlimited,无限的,ADJ,B2
+货物,shipment,货物,NOUN,B2
+花瓶,vase,花瓶,NOUN,B2
+冒泡的,bubbling,冒泡的,ADJ,B2
+奖学金生,scholarship holder,奖学金生,NOUN,B2
+使泄气,to deflate,使泄气,VERB,B2
+豪华的,opulent,豪华的,ADJ,B2
+可质疑的,contestable,可质疑的,ADJ,B2
+阐明,to elucidate,阐明,VERB,B2
+可敬的,honorable,可敬的,ADJ,B2
+碳水化合物,carbohydrate,碳水化合物,NOUN,B2
+体操运动员,gymnast,体操运动员,NOUN,B2
+咆哮,to rant,咆哮,VERB,B2
+夹层,mezzanine,夹层,NOUN,B2
+灾难性的,calamitous,灾难性的,ADJ,B2
+蒸馏,to distill,蒸馏,VERB,B2
+巨大的,immense,巨大的,ADJ,B2
+监视,to spy,监视,VERB,B2
+理想化,to idealize,理想化,VERB,B2
+厚颜无耻的,brazen,厚颜无耻的,ADJ,B2
+笨拙的,ungainly,笨拙的,ADJ,B2
+先天的,congenital,先天的,ADJ,B2
+农庄,farmstead,农庄,NOUN,B2
+虐待,mistreatment,虐待,NOUN,B2
+教学的,didactic,教学的,ADJ,B2
+去角质,to exfoliate,去角质,VERB,B2
+暴发户,upstart,暴发户,NOUN,B2
+静止的,motionless,静止的,ADJ,B2
+麻木的,insensitive,麻木的,ADJ,B2
+出纳员,cashier,出纳员,NOUN,B2
+巫师,sorcerer,巫师,NOUN,B2
+坏疽,gangrene,坏疽,NOUN,B2
+迷信的,superstitious,迷信的,ADJ,B2
+使疏远,to alienate,使疏远,VERB,B2
+腔,cavity,腔,NOUN,B2
+解密,to declassify,解密,VERB,B2
+便宜货,bargain,便宜货,NOUN,B2
+深刻的,incisive,深刻的,ADJ,B2
+有趣的,entertaining,有趣的,ADJ,B2
+截然不同的,disparate,截然不同的,ADJ,B2
+宝石,gem,宝石,NOUN,B2
+芬兰的,finnish,芬兰的,ADJ,B2
+大摇大摆,to swagger,大摇大摆,VERB,B2
+未受伤的,unharmed,未受伤的,ADJ,B2
+细木工匠,cabinetmaker,细木工匠,NOUN,B2
+使悲伤,to sadden,使悲伤,VERB,B2
+简洁,conciseness,简洁,NOUN,B2
+移交,to consign,移交,VERB,B2
+同胞,fellow citizen,同胞,NOUN,B2
+疏忽,oversight,疏忽,NOUN,B2
+引证,to adduce,引证,VERB,B2
+不成比例,disproportion,不成比例,NOUN,B2
+似是而非的,plausible,似是而非的,ADJ,B2
+耻辱,dishonor,耻辱,NOUN,B2
+沉思,contemplation,沉思,NOUN,B2
+破烂货,junk,破烂货,NOUN,B2
+笨重的,cumbersome,笨重的,ADJ,B2
+讽刺,to ironize,讽刺,VERB,B2
+荡秋千,to swing,荡秋千,VERB,B2
+认知的,cognitive,认知的,ADJ,B2
+宽恕,to condone,宽恕,VERB,B2
+异质性,heterogeneity,异质性,NOUN,B2
+繁重的,burdensome,繁重的,ADJ,B2
+贬低,to detract,贬低,VERB,B2
+冻僵的,frozen,冻僵的,ADJ,B2
+不稳定的,erratic,不稳定的,ADJ,B2
+血缘,consanguinity,血缘,NOUN,B2
+智力,intellect,智力,NOUN,B2
+灌输,to instill,灌输,VERB,B2
+伪善的,sanctimonious,伪善的,ADJ,B2
+违禁品,contraband,违禁品,NOUN,B2
+冷漠的,stolid,冷漠的,ADJ,B2
+颂扬,to exalt,颂扬,VERB,B2
+公爵夫人,duchess,公爵夫人,NOUN,B2
+屈尊,condescension,屈尊,NOUN,B2
+大错,blunder,大错,NOUN,B2
+受祝福的,blessed,受祝福的,ADJ,B2
+喧闹的,boisterous,喧闹的,ADJ,B2
+谨慎的,circumspect,谨慎的,ADJ,B2
+不正确的,incorrect,不正确的,ADJ,B2
+伪装,to camouflage,伪装,VERB,B2
+赎回,to redeem,赎回,VERB,B2
+法官,magistrate,法官,NOUN,B2
+激烈的,vehement,激烈的,ADJ,B2
+惊讶的,astonished,惊讶的,ADJ,B2
+使变窄,to narrow,使变窄,VERB,B2
+一百,hundred,一百,NOUN,B2
+吐痰,to expectorate,吐痰,VERB,B2
+结巴,to stammer,结巴,VERB,B2
+腐蚀,to corrode,腐蚀,VERB,B2
+宣福,to beatify,宣福,VERB,B2
+久坐的,sedentary,久坐的,ADJ,B2
+连环画,comic strip,连环画,NOUN,B2
+海拔,altitude,海拔,NOUN,B2
+偶像破坏者,iconoclast,偶像破坏者,NOUN,B2
+联合制作,coproduction,联合制作,NOUN,B2
+金酒,gin,金酒,NOUN,B2
+双周的,biweekly,双周的,ADJ,B2
+可获得的,attainable,可获得的,ADJ,B2
+园艺,gardening,园艺,NOUN,B2
+微不足道的,trifling,微不足道的,ADJ,B2
+表演,show,表演,NOUN,B2
+削减,to curtail,削减,VERB,B2
+在上面,on top,在上面,ADV,B2
+可疑的,doubtful,可疑的,ADJ,B2
+忧思,brooding,忧思,NOUN,B2
+小册子,brochure,小册子,NOUN,B2
+诽谤,to defame,诽谤,VERB,B2
+强加,to foist,强加,VERB,B2
+二分法,dichotomy,二分法,NOUN,B2
+挥舞,to brandish,挥舞,VERB,B2
+不知疲倦的,tireless,不知疲倦的,ADJ,B2
+仁慈,clemency,仁慈,NOUN,B2
+叛教者,apostate,叛教者,NOUN,B2
+水晶般的,crystalline,水晶般的,ADJ,B2
+擅离职守,to desert,擅离职守,VERB,B2
+易怒的,bilious,易怒的,ADJ,B2
+专制的,autocratic,专制的,ADJ,B2
+拖延,to temporize,拖延,VERB,B2
+珠宝店,jewelry store,珠宝店,NOUN,B2
+赎罪,atonement,赎罪,NOUN,B2
+游行,to parade,游行,VERB,B2
+傲慢的,haughty,傲慢的,ADJ,B2
+阴沉的,gruff,阴沉的,ADJ,B2
+放纵,binge,放纵,NOUN,B2
+肥大,hypertrophy,肥大,NOUN,B2
+使分裂,to disunite,使分裂,VERB,B2
+新奇事物,novelty,新奇事物,NOUN,B2
+越权,to overstep,越权,VERB,B2
+瞬间的,instantaneous,瞬间的,ADJ,B2
+唐突,brusqueness,唐突,NOUN,B2
+投石机,catapult,投石机,NOUN,B2
+赞助,to sponsor,赞助,VERB,B2
+解压,to decompress,解压,VERB,B2
+不同意的,disagreeing,不同意的,ADJ,B2
+制造,manufacture,制造,NOUN,B2
+幽默的,humorous,幽默的,ADJ,B2
+使窒息,to asphyxiate,使窒息,VERB,B2
+沉思的,pensive,沉思的,ADJ,B2
+使高兴,to delight,使高兴,VERB,B2
+好奇的,inquisitive,好奇的,ADJ,B2
+毕业,graduation,毕业,NOUN,B2
+狂乱的,frantic,狂乱的,ADJ,B2
+女家长,matriarch,女家长,NOUN,B2
+造林,to afforest,造林,VERB,B2
+硬纸板,cardboard,硬纸板,NOUN,B2
+恶魔般的,diabolical,恶魔般的,ADJ,B2
+无情的,ruthless,无情的,ADJ,B2
+行会,guild,行会,NOUN,B2
+有伤风化的,risque,有伤风化的,ADJ,B2
+跟踪,to stalk,跟踪,VERB,B2
+分组,to group,分组,VERB,B2
+堕落,depravity,堕落,NOUN,B2
+发生率,incidence,发生率,NOUN,B2
+现有的,existing,现有的,ADJ,B2
+第十,tenth,第十,ADJ,B2
+亚洲的,asian,亚洲的,ADJ,B2
+别处,elsewhere,别处,ADV,B2
+西方的,western,西方的,ADJ,B2
+同时地,simultaneously,同时地,ADV,B2
+警察,police officer,警察,NOUN,B2
+强化的,intensive,强化的,ADJ,B2
+十月,october,十月,NOUN,B2
+民主主义者,democrat,民主主义者,NOUN,B2
+一月,january,一月,NOUN,B2
+意大利的,italian,意大利的,ADJ,B2
+磨快,to sharpen,磨快,VERB,B2
+照亮,to light,照亮,VERB,B2
+南方的,southern,南方的,ADJ,B2
+桶,barrel,桶,NOUN,B2
+卸货,to unload,卸货,VERB,B2
+替代的,alternative,替代的,ADJ,B2
+大都市,metropolis,大都市,NOUN,B2
+射手,shooter,射手,NOUN,B2
+第八,eighth,第八,ADJ,B2
+令人恐惧的,frightening,令人恐惧的,ADJ,B2
+可设想的,conceivable,可设想的,ADJ,B2
+日本的,japanese,日本的,ADJ,B2
+高兴的,delighted,高兴的,ADJ,B2
+可辨认的,recognizable,可辨认的,ADJ,B2
+露营,to camp,露营,VERB,B2
+炮兵,artillery,炮兵,NOUN,B2
+隐喻的,metaphorical,隐喻的,ADJ,B2
+酒精的,alcoholic,酒精的,ADJ,B2
+技术上地,technically,技术上地,ADV,B2
+重新统一,reunification,重新统一,NOUN,B2
+精修,to perfect,精修,VERB,B2
+定位 / 安置,to position,定位 / 安置,VERB,B2
+色情,pornography,色情,NOUN,B2
+希腊的,greek,希腊的,ADJ,B2
+火鸡,turkey,火鸡,NOUN,B2
+装载,to load charge,装载,VERB,B2
+编程,to program,编程,VERB,B2
+残暴,brutality,残暴,NOUN,B2
+瑞典语,swedish,瑞典语,NOUN,B2
+流动性,mobility,流动性,NOUN,B2
+字面的,literal,字面的,ADJ,B2
+神话般的,mythical,神话般的,ADJ,B2
+父亲的,paternal,父亲的,ADJ,B2
+加拿大的,canadian,加拿大的,ADJ,B2
+优越性/优势,superiority,优越性/优势,NOUN,B2
+沉重地,heavily,沉重地,ADV,B2
+微小的,minimal,微小的,ADJ,B2
+奥林匹克的,olympic,奥林匹克的,ADJ,B2
+大理石,marble,大理石,NOUN,B2
+显著地,remarkably,显著地,ADV,B2
+婴儿车,stroller,婴儿车,NOUN,B2
+轻触,to skim,轻触,VERB,B2
+卡住,to wedge,卡住,VERB,B2
+触发,triggering,触发,NOUN,B2
+部分地,partially,部分地,ADV,B2
+共产主义者,communist,共产主义者,NOUN,B2
+故意地,intentionally,故意地,ADV,B2
+下士,corporal,下士,NOUN,B2
+治疗师,therapist,治疗师,NOUN,B2
+私有化,to privatize,私有化,VERB,B2
+土耳其的,turkish,土耳其的,ADJ,B2
+位于,located,位于,ADJ,B2
+热情地,warmly,热情地,ADV,B2
+科学地,scientifically,科学地,ADV,B2
+个体经营者,self-employed person,个体经营者,NOUN,B2
+管理员,administrator,管理员,NOUN,B2
+中和,to neutralize,中和,VERB,B2
+绝对的,categorical,绝对的,ADJ,B2
+天主教的,catholic,天主教的,ADJ,B2
+装饰性的,decorative,装饰性的,ADJ,B2
+连指手套,mitten,连指手套,NOUN,B2
+康复,rehabilitation,康复,NOUN,B2
+步兵,infantry,步兵,NOUN,B2
+描绘；标出,to trace,描绘；标出,VERB,B2
+气象的,meteorological,气象的,ADJ,B2
+有效地,effectively,有效地,ADV,B2
+明智地,wisely,明智地,ADV,B2
+大量地,massively,大量地,ADV,B2
+使感动,to move touch,使感动,VERB,B2
+优先考虑,to prioritize,优先考虑,VERB,B2
+有天赋的,gifted,有天赋的,ADJ,B2
+概览,overview,概览,NOUN,B2
+拳击手,boxer,拳击手,NOUN,B2
+那个,that one,那个,PRON,B2
+肌肉酸痛,muscle ache,肌肉酸痛,NOUN,B2
+比利时的,belgian,比利时的,ADJ,B2
+波兰的,polish,波兰的,ADJ,B2
+象征的,symbolic,象征的,ADJ,B2
+武装,to arm,武装,VERB,B2
+抒情的,lyrical,抒情的,ADJ,B2
+如画的；别致的,picturesque,如画的；别致的,ADJ,B2
+拧干,to wring,拧干,VERB,B2
+后退,to back up,后退,VERB,B2
+叛乱,revolt,叛乱,NOUN,B2
+公制的,metric,公制的,ADJ,B2
+烟灰缸,ashtray,烟灰缸,NOUN,B2
+在政治上,politically,在政治上,ADV,B2
+骑自行车的人,cyclist,骑自行车的人,NOUN,B2
+竞争的,competitive,竞争的,ADJ,B2
+灌输,indoctrination,灌输,NOUN,B2
+调节,adjustment,调节,NOUN,B2
+税务机关,tax authorities,税务机关,NOUN,B2
+公报,press release,公报,NOUN,B2
+担忧的,concerned,担忧的,ADJ,B2
+实验,to experiment,实验,VERB,B2
+命名,to title,命名,VERB,B2
+非法侵入,break-in,非法侵入,NOUN,B2
+露营地,campsite,露营地,NOUN,B2
+偶然地,by chance,偶然地,ADV,B2
+听众,listener,听众,NOUN,B2
+机械的,mechanical,机械的,ADJ,B2
+绞刑,hanging,绞刑,NOUN,B2
+垂死的,dying,垂死的,ADJ,B2
+熵,entropy,熵,NOUN,B2
+有声望的,prestigious,有声望的,ADJ,B2
+受益,to benefit,受益,VERB,B2
+降低,to lower,降低,VERB,B2
+身体上地,physically,身体上地,ADV,B2
+慷慨地,generously,慷慨地,ADV,B2
+倾斜,tilt,倾斜,NOUN,B2
+互补性,complementarity,互补性,NOUN,B2
+据推测,presumably,据推测,ADV,B2
+啮齿动物,rodent,啮齿动物,NOUN,B2
+普遍的,universal,普遍的,ADJ,B2
+可预测的,predictable,可预测的,ADJ,B2
+似是而非的,specious,似是而非的,ADJ,B2
+乡村的,rustic,乡村的,ADJ,B2
+讲英语的,english-speaking,讲英语的,ADJ,B2
+遗赠,to bequeath,遗赠,VERB,B2
+坐着的,seated,坐着的,ADJ,B2
+罗马的,roman,罗马的,ADJ,B2
+回廊,cloister,回廊,NOUN,B2
+马驹,foal,马驹,NOUN,B2
+大约,about,大约,ADV,B2
+初步的,preliminary,初步的,ADJ,B2
+微妙的,subtle,微妙的,ADJ,B2
+主题的,thematic,主题的,ADJ,B2
+先知,prophet,先知,NOUN,B2
+娱乐,recreation,娱乐,NOUN,B2
+追溯,to retrace,追溯,VERB,B2
+分娩,childbirth,分娩,NOUN,B2
+反论点,counterargument,反论点,NOUN,B2
+转达,to relay,转达,VERB,B2
+不情愿,reluctance,不情愿,NOUN,B2
+土堆,mound,土堆,NOUN,B2
+商品,merchandise,商品,NOUN,B2
+穿梭巴士,shuttle,穿梭巴士,NOUN,B2
+唯我论,solipsism,唯我论,NOUN,B2
+有魅力的,charismatic,有魅力的,ADJ,B2
+可达性,accessibility,可达性,NOUN,B2
+条纹,stripe,条纹,NOUN,B2
+创伤,trauma,创伤,NOUN,B2
+神学的,theological,神学的,ADJ,B2
+议会的/议员,parliamentary,议会的/议员,ADJ,B2
+控制,hold,控制,NOUN,B2
+多才多艺的,versatile,多才多艺的,ADJ,B2
+广播公司,broadcaster,广播公司,NOUN,B2
+不稳定的,precarious,不稳定的,ADJ,B2
+制服,uniform,制服,NOUN,B2
+转录,to transcribe,转录,VERB,B2
+开花,to bloom,开花,VERB,B2
+戏剧的,theatrical,戏剧的,ADJ,B2
+开花,to blossom,开花,VERB,B2
+吝啬的,parsimonious,吝啬的,ADJ,B2
+构建,to build up,构建,VERB,B2
+使无力,to emasculate,使无力,VERB,B2
+徒步旅行,hike,徒步旅行,NOUN,B2
+使清新,to freshen,使清新,VERB,B2
+单方面的,unilateral,单方面的,ADJ,B2
+有教育意义的,instructive,有教育意义的,ADJ,B2
+声学的,acoustic,声学的,ADJ,B2
+警棍,baton,警棍,NOUN,B2
+显著地,notably,显著地,ADV,B2
+犹豫不决,to dither,犹豫不决,VERB,B2
+挑剔的,fussy,挑剔的,ADJ,B2
+暂缓执行,reprieve,暂缓执行,NOUN,B2
+张贴,to post,张贴,VERB,B2
+矛盾的,paradoxical,矛盾的,ADJ,B2
+到来,advent,到来,NOUN,B2
+产生,to result,产生,VERB,B2
+长期的,perennial,长期的,ADJ,B2
+市政厅,town hall,市政厅,NOUN,B2
+经常,frequently,经常,ADV,B2
+叙事短诗,lay,叙事短诗,NOUN,B2
+坚韧,tenacity,坚韧,NOUN,B2
+保存,to conserve,保存,VERB,B2
+措辞,wording,措辞,NOUN,B2
+捆,sheaf,捆,NOUN,B2
+兜帽,hood,兜帽,NOUN,B2
+肮脏的,sordid,肮脏的,ADJ,B2
+无情的,relentless,无情的,ADJ,B2
+感官的,sensual,感官的,ADJ,B2
+仰慕者,admirer,仰慕者,NOUN,B2
+控告,to indict,控告,VERB,B2
+悬挂,to drape,悬挂,VERB,B2
+少数派的,minority,少数派的,ADJ,B2
+电视,tv,电视,NOUN,B2
+重启,to relaunch,重启,VERB,B2
+起草,to draw up,起草,VERB,B2
+分销商,distributor,分销商,NOUN,B2
+礼貌地,politely,礼貌地,ADV,B2
+擦亮,to burnish,擦亮,VERB,B2
+裸露,to strip,裸露,VERB,B2
+昂贵的,costly,昂贵的,ADJ,B2
+一丝不苟的,scrupulous,一丝不苟的,ADJ,B2
+施虐的,sadistic,施虐的,ADJ,B2
+投射,to project,投射,VERB,B2
+工业化,industrialization,工业化,NOUN,B2
+准确性,accuracy,准确性,NOUN,B2
+运动,crusade,运动,NOUN,B2
+扰乱,to disrupt,扰乱,VERB,B2
+潜意识,subconscious,潜意识,NOUN,B2
+坚持,persistence,坚持,NOUN,B2
+拥有/处置,to have at one's disposal,拥有/处置,VERB,B2
+全科医生,general practitioner,全科医生,NOUN,B2
+健忘症,amnesia,健忘症,NOUN,B2
+霸权,supremacy,霸权,NOUN,B2
+警告,to alert,警告,VERB,B2
+符合,to conform,符合,VERB,B2
+占优势的,preponderant,占优势的,ADJ,B2
+对称的,symmetrical,对称的,ADJ,B2
+种族主义者,racist,种族主义者,NOUN,B2
+特别地,particularly,特别地,ADV,B2
+关于哪个,of which,关于哪个,PRON,B2
+共鸣,to resonate,共鸣,VERB,B2
+使永存,to perpetuate,使永存,VERB,B2
+怪异的,monstrous,怪异的,ADJ,B2
+损害赔偿,damages,损害赔偿,NOUN,B2
+有礼貌的,courteous,有礼貌的,ADJ,B2
+溃败,rout,溃败,NOUN,B2
+苏打,soda,苏打,NOUN,B2
+肚脐,navel,肚脐,NOUN,B2
+坦率地,frankly,坦率地,ADV,B2
+新来者,newcomer,新来者,NOUN,B2
+分离,to decouple,分离,VERB,B2
+放回,to put back,放回,VERB,B2
+避孕套,condom,避孕套,NOUN,B2
+分手,breakup,分手,NOUN,B2
+搬家,relocation,搬家,NOUN,B2
+充足,plenitude,充足,NOUN,B2
+沥青,asphalt,沥青,NOUN,B2
+水手,sailor,水手,NOUN,B2
+精神上地,mentally,精神上地,ADV,B2
+洗钱,to launder,洗钱,VERB,B2
+丝带,ribbon,丝带,NOUN,B2
+狭隘的,narrow-minded,狭隘的,ADJ,B2
+绘图员,draftsman,绘图员,NOUN,B2
+圆柱形的,cylindrical,圆柱形的,ADJ,B2
+具体地,specifically,具体地,ADV,B2
+铲子,spade,铲子,NOUN,B2
+睡衣,pajamas,睡衣,NOUN,B2
+哺乳动物,mammal,哺乳动物,NOUN,B2
+减弱,weakening,减弱,NOUN,B2
+拥抱,to cuddle,拥抱,VERB,B2
+X光片,x-ray,X光片,NOUN,B2
+假发,wig,假发,NOUN,B2
+怀旧,nostalgia,怀旧,NOUN,B2
+躯干,torso,躯干,NOUN,B2
+批准,to ratify,批准,VERB,B2
+第三的,tertiary,第三的,ADJ,B2
+染色,to dye,染色,VERB,B2
+各自的,respective,各自的,ADJ,B2
+编造,to concoct,编造,VERB,B2
+斗殴,brawl,斗殴,NOUN,B2
+平板电脑,tablet,平板电脑,NOUN,B2
+相当地,considerably,相当地,ADV,B2
+群集,to flock,群集,VERB,B2
+婴儿,infant,婴儿,NOUN,B2
+狂热,craze,狂热,NOUN,B2
+跌倒,to tumble,跌倒,VERB,B2
+延长,to lengthen,延长,VERB,B2
+在性方面,sexually,在性方面,ADV,B2
+稳定化,stabilization,稳定化,NOUN,B2
+搬家,to move house,搬家,VERB,B2
+仔细地,carefully,仔细地,ADV,B2
+碳氢化合物,hydrocarbon,碳氢化合物,NOUN,B2
+自命不凡的,pretentious,自命不凡的,ADJ,B2
+卷曲,to curl,卷曲,VERB,B2
+最小化,to minimize,最小化,VERB,B2
+口水,drool,口水,NOUN,B2
+迂回说法,circumlocution,迂回说法,NOUN,B2
+侵蚀,to encroach,侵蚀,VERB,B2
+一口烟,puff,一口烟,NOUN,B2
+老人政治,gerontocracy,老人政治,NOUN,B2
+近似的,approximate,近似的,ADJ,B2
+重建,to recreate,重建,VERB,B2
+击倒,to strike down,击倒,VERB,B2
+享乐主义,hedonism,享乐主义,NOUN,B2
+插入,to plug in,插入,VERB,B2
+泡制,to infuse,泡制,VERB,B2
+倦怠,languor,倦怠,NOUN,B2
+下雪,to snow,下雪,VERB,B2
+勾勒,to sketch,勾勒,VERB,B2
+轻率,indiscretion,轻率,NOUN,B2
+进入,to access,进入,VERB,B2
+推翻,to oust,推翻,VERB,B2
+特权,prerogative,特权,NOUN,B2
+他/她,him her,他/她,PRON,B2
+违背,to transgress,违背,VERB,B2
+正直,probity,正直,NOUN,B2
+闲逛,to dawdle,闲逛,VERB,B2
+幼崽,offspring,幼崽,NOUN,B2
+疏忽,lapse,疏忽,NOUN,B2
+浩劫,holocaust,浩劫,NOUN,B2
+不贞,immodesty,不贞,NOUN,B2
+复杂的,sophisticated,复杂的,ADJ,B2
+暗示,to insinuate,暗示,VERB,B2
+精神变态者,psychopath,精神变态者,NOUN,B2
+规范的,canonical,规范的,ADJ,B2
+节俭,frugality,节俭,NOUN,B2
+过时的,antiquated,过时的,ADJ,B2
+省略,ellipsis,省略,NOUN,B2
+剥皮,to skin,剥皮,VERB,B2
+一...就,as soon as,一...就,ADV,B2
+砌体,masonry,砌体,NOUN,B2
+活板门,trapdoor,活板门,NOUN,B2
+不受时效限制的,not subject to limitation,不受时效限制的,ADJ,B2
+分开地，单独地,separately,分开地，单独地,ADV,B2
+电视电影,tv movie,电视电影,NOUN,B2
+繁荣,to prosper,繁荣,VERB,B2
+回形针,paper clip,回形针,NOUN,B2
+奶奶,granny,奶奶,NOUN,B2
+透支,overdraft,透支,NOUN,B2
+新生儿的,neonatal,新生儿的,ADJ,B2
+两院制的,bicameral,两院制的,ADJ,B2
+撬开,to break into,撬开,VERB,B2
+烤成焦皮,to gratinate,烤成焦皮,VERB,B2
+更可取的,preferable,更可取的,ADJ,B2
+投机者,speculator,投机者,NOUN,B2
+吹牛,braggadocio,吹牛,NOUN,B2
+面貌,facies,面貌,NOUN,B2
+轻轻地,gently,轻轻地,ADV,B2
+吉祥物,mascot,吉祥物,NOUN,B2
+猛烈的抨击,philippic,猛烈的抨击,NOUN,B2
+令人感动的,deeply moving,令人感动的,ADJ,B2
+沉思,to meditate,沉思,VERB,B2
+细致地,painstakingly,细致地,ADV,B2
+清除,to purge,清除,VERB,B2
+词语误用,catachresis,词语误用,NOUN,B2
+放弃,renunciation,放弃,NOUN,B2
+医源性的,iatrogenic,医源性的,ADJ,B2
+疫苗的,vaccine-related,疫苗的,ADJ,B2
+准时地 / 偶尔地,punctually occasionally,准时地 / 偶尔地,ADV,B2
+屠宰/击落,to slaughter shoot down,屠宰/击落,VERB,B2
+预防,prophylaxis,预防,NOUN,B2
+恢复,resumption,恢复,NOUN,B2
+首语重复修辞,anaphora,首语重复修辞,NOUN,B2
+失语症,aphasia,失语症,NOUN,B2
+巧妙地,delicately,巧妙地,ADV,B2
+应纳税的,taxable,应纳税的,ADJ,B2
+重新开始,to start again,重新开始,VERB,B2
+远程办公,remote work,远程办公,NOUN,B2
+故事片,feature film,故事片,NOUN,B2
+除了,except for,除了,ADP,B2
+不懈 / 猛烈,relentlessness,不懈 / 猛烈,NOUN,B2
+个性化的,personalized,个性化的,ADJ,B2
+先贤祠,pantheon,先贤祠,NOUN,B2
+一丝不苟地,meticulously,一丝不苟地,ADV,B2
+证明文件,supporting document,证明文件,NOUN,B2
+标记 / 参考点,landmark reference point,标记 / 参考点,NOUN,B2
+信任的,trusting,信任的,ADJ,B2
+地点,locality,地点,NOUN,B2
+去污,decontamination,去污,NOUN,B2
+大麻,hemp,大麻,NOUN,B2
+诀窍,know-how,诀窍,NOUN,B2
+辩护词,closing argument,辩护词,NOUN,B2
+分裂,split secession,分裂,NOUN,B2
+犹豫的,hesitant,犹豫的,ADJ,B2
+受污染的,contaminated,受污染的,ADJ,B2
+赎回,to buy back,赎回,VERB,B2
+香脂,balm,香脂,NOUN,B2
+否认 / 抛弃,to renounce to disown,否认 / 抛弃,VERB,B2
+喘息,respite,喘息,NOUN,B2
+减速,slowdown,减速,NOUN,B2
+清醒 / 明晰,lucidity,清醒 / 明晰,NOUN,B2
+音节,syllable,音节,NOUN,B2
+卫生,sanitation,卫生,NOUN,B2
+结局，解决,outcome ending,结局，解决,NOUN,B2
+刨,to plane,刨,VERB,B2
+易怒的,touchy,易怒的,ADJ,B2
+神学家,theologian,神学家,NOUN,B2
+公共假日,public holiday,公共假日,ADJ,B2
+历史上,historically,历史上,ADV,B2
+编剧,screenwriter,编剧,NOUN,B2
+本质,quiddity,本质,NOUN,B2
+男高音,tenor,男高音,NOUN,B2
+不稳定化,precarization,不稳定化,NOUN,B2
+充电,to recharge,充电,VERB,B2
+保理,factoring,保理,NOUN,B2
+爱抱怨的人,grumbler,爱抱怨的人,NOUN,B2
+免税,tax exemption,免税,NOUN,B2
+重新开放,to reopen,重新开放,VERB,B2
+法警,bailiff,法警,NOUN,B2
+适合的,fit,适合的,ADJ,B2
+用链条锁住；连贯,to chain to link together,用链条锁住；连贯,VERB,B2
+腹膜,peritoneum,腹膜,NOUN,B2
+电子阅读器,e-reader,电子阅读器,NOUN,B2
+去杠杆化,deleveraging,去杠杆化,NOUN,B2
+有害的,damaging,有害的,ADJ,B2
+团结,to rally,团结,VERB,B2
+共济失调,ataxia,共济失调,NOUN,B2
+幼虫,larva,幼虫,NOUN,B2
+淋巴的,lymphatic,淋巴的,ADJ,B2
+明显地,perceptibly,明显地,ADV,B2
+独立地,independently,独立地,ADV,B2
+获得,obtaining,获得,NOUN,B2
+阵雨,rain shower,阵雨,NOUN,B2
+融资,financing funding,融资,NOUN,B2
+加重,to make heavier,加重,VERB,B2
+产生,to generate engender,产生,VERB,B2
+精神分析,psychoanalysis,精神分析,NOUN,B2
+正式地,formally,正式地,ADV,B2
+盘查,to hail inspect,盘查,VERB,B2
+使担心,to worry to preoccupy,使担心,VERB,B2
+资产负债表,balance sheet,资产负债表,NOUN,B2
+毫不留情地,implacably,毫不留情地,ADV,B2
+吸引力,attractiveness,吸引力,NOUN,B2
+路面,roadway,路面,NOUN,B2
+吞并,annexation,吞并,NOUN,B2
+反犹太主义,antisemitism,反犹太主义,NOUN,B2
+编舞者,choreographer,编舞者,NOUN,B2
+检察院,prosecution service,检察院,NOUN,B2
+保加利亚的,bulgarian,保加利亚的,ADJ,B2
+熟的,cooked,熟的,ADJ,B2
+传统地,traditionally,传统地,ADV,B2
+可能的,probable likely,可能的,ADJ,B2
+不可阻挡地,inexorably,不可阻挡地,ADV,B2
+好色 / 淫荡,lubricity,好色 / 淫荡,NOUN,B2
+意外的,unforeseen,意外的,ADJ,B2
+泥状食物,mash,泥状食物,NOUN,B2
+严厉地,severely,严厉地,ADV,B2
+韵律学,prosody,韵律学,NOUN,B2
+发髻,hair bun,发髻,NOUN,B2
+双人自行车 / 搭档,tandem duo,双人自行车 / 搭档,NOUN,B2
+流量,flow rate,流量,NOUN,B2
+不变地,invariably,不变地,ADV,B2
+为...提供交通服务,to serve a route,为...提供交通服务,VERB,B2
+胸膜,pleura,胸膜,NOUN,B2
+刻痕,notch,刻痕,NOUN,B2
+增值,capital gain,增值,NOUN,B2
+藏书票,bookplate,藏书票,NOUN,B2
+共同地,jointly,共同地,ADV,B2
+增殖,proliferation,增殖,NOUN,B2
+跨国公司,multinational,跨国公司,NOUN,B2
+轻蔑地,disdainfully,轻蔑地,ADV,B2
+恶意,malevolence,恶意,NOUN,B2
+大肆吹捧,to praise lavishly,大肆吹捧,VERB,B2
+短片,short film,短片,NOUN,B2
+自由地,freely,自由地,ADV,B2
+被迫的,obliged,被迫的,ADJ,B2
+队列,cohort,队列,NOUN,B2
+镐；锄,pickaxe,镐；锄,NOUN,B2
+雌鹿,doe,雌鹿,NOUN,B2
+暑期游客,summer visitor,暑期游客,NOUN,B2
+解开,to unbridle,解开,VERB,B2
+机灵的,resourceful,机灵的,ADJ,B2
+使愚蠢,to make stupid,使愚蠢,VERB,B2
+外行,layperson,外行,NOUN,B2
+独栋房屋,detached house,独栋房屋,NOUN,B2
+平静地,calmly,平静地,ADV,B2
+致病的,pathogenic,致病的,ADJ,B2
+疾驰,gallop,疾驰,NOUN,B2
+怯懦的,pusillanimous,怯懦的,ADJ,B2
+放回 / 重新定位,to put back to reposition,放回 / 重新定位,VERB,B2
+寻觅，找到,to unearth to track down,寻觅，找到,VERB,B2
+滥用的,abusive,滥用的,ADJ,B2
+使惊恐,to appal,使惊恐,VERB,B2
+分割,to fraction,分割,VERB,B2
+潜在地,potentially,潜在地,ADV,B2
+车身,bodywork,车身,NOUN,B2
+经公证的,notarized,经公证的,ADJ,B2
+微温的,lukewarm,微温的,ADJ,B2
+间接地,indirectly,间接地,ADV,B2
+电视观众,tv viewer,电视观众,NOUN,B2
+成比例的,proportional,成比例的,ADJ,B2
+受遗赠人,legatee,受遗赠人,NOUN,B2
+性别歧视,sexism,性别歧视,NOUN,B2
+使具有细微差别,to nuance,使具有细微差别,VERB,B2
+小酒馆,bistro,小酒馆,NOUN,B2
+解除扣押,release of lien,解除扣押,NOUN,B2
+不规则的,irregular,不规则的,ADJ,B2
+采摘,picking,采摘,NOUN,B2
+不可触碰的,untouchable,不可触碰的,ADJ,B2
+垫草 / 猫砂,litter bedding,垫草 / 猫砂,NOUN,B2
+落到...身上,to fall to,落到...身上,VERB,B2
+违法者，不良分子,delinquent offender,违法者，不良分子,NOUN,B2
+结语,peroration,结语,NOUN,B2
+倾诉,to pour out,倾诉,VERB,B2
+淋巴结,lymph node,淋巴结,NOUN,B2
+飞机场,airfield,飞机场,NOUN,B2
+交响乐的,symphonic,交响乐的,ADJ,B2
+使冰冻,to chill,使冰冻,VERB,B2
+刑事的,penal,刑事的,ADJ,B2
+新鲜地,freshly,新鲜地,ADV,B2
+道德主义,moralism,道德主义,NOUN,B2
+类型学,typology,类型学,NOUN,B2
+窒息,asphyxia,窒息,NOUN,B2
+叉子,pitchfork,叉子,NOUN,B2
+存在,to subsist,存在,VERB,B2
+街头采访,street interview,街头采访,NOUN,B2
+食品的,food,食品的,ADJ,B2
+确证的,apodictic,确证的,ADJ,B2
+支票簿,checkbook,支票簿,NOUN,B2
+多媒体图书馆,media library,多媒体图书馆,NOUN,B2
+骨架,carcass,骨架,NOUN,B2
+醋栗,currant,醋栗,NOUN,B2
+抑郁的，压抑的,depressive,抑郁的，压抑的,ADJ,B2
+绘画的,pictorial,绘画的,ADJ,B2
+社会主义者,socialist,社会主义者,NOUN,B2
+追求/诉讼,pursuit lawsuit,追求/诉讼,NOUN,B2
+隔离，分离,segregation,隔离，分离,NOUN,B2
+八行诗,eight-line stanza,八行诗,NOUN,B2
+毛毛虫,caterpillar,毛毛虫,NOUN,B2
+有压力的,stressful,有压力的,ADJ,B2
+撤销,quashing,撤销,NOUN,B2
+生产至上主义的,productivist,生产至上主义的,ADJ,B2
+推/生长,to push to grow,推/生长,VERB,B2
+亲切地,cordially,亲切地,ADV,B2
+症状学,symptomatology,症状学,NOUN,B2
+真诚地,sincerely,真诚地,ADV,B2
+主权主义者,sovereigntist,主权主义者,NOUN,B2
+忠诚的,faithful loyal,忠诚的,ADJ,B2
+犹豫不决的,undecided indecisive,犹豫不决的,ADJ,B2
+谄媚地,obsequiously,谄媚地,ADV,B2
+明显地,manifestly,明显地,ADV,B2
+英勇地,heroically,英勇地,ADV,B2
+怯场,stage fright,怯场,NOUN,B2
+退休人员,retiree,退休人员,NOUN,B2
+忧郁,the blues,忧郁,NOUN,B2
+奴性地,servilely,奴性地,ADV,B2
+女服务员,hostess,女服务员,NOUN,B2
+谄媚,obsequiousness,谄媚,NOUN,B2
+令人担忧的,worrying,令人担忧的,ADJ,B2
+弄脏,to dirty to tarnish,弄脏,VERB,B2
+挂号信,registered mail,挂号信,NOUN,B2
+法学专家,jurisconsult,法学专家,NOUN,B2
+意合,parataxis,意合,NOUN,B2
+使怜悯,to move to pity,使怜悯,VERB,B2
+牡蛎,oyster,牡蛎,NOUN,B2
+纯粹地,purely,纯粹地,ADV,B2
+转售,to resell,转售,VERB,B2
+燧石,flint,燧石,NOUN,B2
+阿谀奉承,fawning flattery,阿谀奉承,NOUN,B2
+割草机,lawnmower,割草机,NOUN,B2
+很多,a lot,很多,ADV,B2
+对角线,diagonal,对角线,NOUN,B2
+笨拙,clumsiness,笨拙,NOUN,B2
+无政府主义者,anarchist,无政府主义者,NOUN,B2
+六十来个,about sixty,六十来个,NOUN,B2
+撞击 / 冒犯,to strike to offend,撞击 / 冒犯,VERB,B2
+非正式地,unofficially,非正式地,ADV,B2
+元帅,marshal,元帅,NOUN,B2
+海关官员,customs officer,海关官员,NOUN,B2
+虐待,to maltreat,虐待,VERB,B2
+热浪,heatwave,热浪,NOUN,B2
+镁,magnesium,镁,NOUN,B2
+提出上诉,to lodge an appeal,提出上诉,VERB,B2
+小册子作者,pamphleteer,小册子作者,NOUN,B2
+代际的,generational,代际的,ADJ,B2
+高山的,alpine,高山的,ADJ,B2
+精神导师,guru,精神导师,NOUN,B2
+洗劫,to strip bare,洗劫,VERB,B2
+手动地,manually,手动地,ADV,B2
+青少年的,juvenile,青少年的,ADJ,B2
+蟾蜍,toad,蟾蜍,NOUN,B2
+盛宴,treat,盛宴,NOUN,B2
+民粹主义者,populist,民粹主义者,NOUN,B2
+说唱歌手,rapper,说唱歌手,NOUN,B2
+电话学,telephony,电话学,NOUN,B2
+令人高兴的,heartening,令人高兴的,ADJ,B2
+焦躁的,agitated,焦躁的,ADJ,B2
+骨髓,marrow,骨髓,NOUN,B2
+不加区别地,indiscriminately,不加区别地,ADV,B2
+招聘人员,recruiter,招聘人员,NOUN,B2
+三角形的,triangular,三角形的,ADJ,B2
+背信弃义,perfidy,背信弃义,NOUN,B2
+痴呆，疯狂,dementia madness,痴呆，疯狂,NOUN,B2
+玷污,to taint,玷污,VERB,B2
+判例法,case law,判例法,NOUN,B2
+沿海的,coastal,沿海的,ADJ,B2
+民族主义者,nationalist,民族主义者,NOUN,B2
+交替地,alternatively,交替地,ADV,B2
+进步人士,progressive,进步人士,NOUN,B2
+夕阳,setting sun,夕阳,NOUN,B2
+产科学,obstetrics,产科学,NOUN,B2
+可重复性,reproducibility,可重复性,NOUN,B2
+连续的,consecutive,连续的,ADJ,B2
+未确定的,indeterminate unspecified,未确定的,ADJ,B2
+讲法语的,french-speaking,讲法语的,ADJ,B2
+多产的,productive,多产的,ADJ,B2
+罪犯,wrongdoer,罪犯,NOUN,B2
+食品加工的,food-processing,食品加工的,ADJ,B2
+提高意识,to raise awareness,提高意识,VERB,B2
+使乏味,to make bland,使乏味,VERB,B2
+俚语,slang,俚语,NOUN,B2
+信徒,practicing believer,信徒,NOUN,B2
+瑞典的,swedish,瑞典的,ADJ,B2
+垃圾,rubbish,垃圾,NOUN,B2
+自动售货机,vending machine,自动售货机,NOUN,B2
+无价值的,worthless,无价值的,ADJ,B2
+惊讶的,surprised,惊讶的,ADJ,B2
+消防队,fire brigade,消防队,NOUN,B2
+某人的,someone's,某人的,PRON,B2
+精确,exactness,精确,NOUN,B2
+增值税,vat,增值税,NOUN,B2
+一些,some,一些,PRON,B2
+有色的,colored,有色的,ADJ,B2
+从此以后,henceforth,从此以后,ADV,B2
+相同的,the same,相同的,ADJ,B2
+日光,daylight,日光,NOUN,B2
+体贴的,understanding,体贴的,ADJ,B2
+最爱,favorite,最爱,NOUN,B2
+建筑群,complex,建筑群,NOUN,B2
+早上好,good morning,早上好,INTJ,B2
+专注的,focused,专注的,ADJ,B2
+被驾驶的,driven,被驾驶的,ADJ,B2
+持续的,continued,持续的,ADJ,B2
+最近的,nearest,最近的,ADJ,B2
+家庭生活,family life,家庭生活,NOUN,B2
+破坏,to sabotage,破坏,VERB,B2
+即将到来的,coming,即将到来的,ADJ,B2
+抛弃,to dump,抛弃,VERB,B2
+包括,including,包括,ADP,B2
+今天早上,this morning,今天早上,ADV,B2
+十六,sixteen,十六,NUM,B2
+可怕地/非常,terribly,可怕地/非常,ADV,B2
+被感染的,infected,被感染的,ADJ,B2
+电网,power grid,电网,NOUN,B2
+哮喘的,asthmatic,哮喘的,ADJ,B2
+摊位,stand,摊位,NOUN,B2
+合并,merger,合并,NOUN,B2
+复制,to replicate,复制,VERB,B2
+扫描,to scan,扫描,VERB,B2
+边缘的,marginal,边缘的,ADJ,B2
+老式的,old-fashioned,老式的,ADJ,B2
+鼓动,to agitate,鼓动,VERB,B2
+精神的,spiritual,精神的,ADJ,B2
+牙刷,toothbrush,牙刷,NOUN,B2
+报道,reporting,报道,NOUN,B2
+出声地,aloud,出声地,ADV,B2
+八十,eighty,八十,NUM,B2
+催化,to catalyze,催化,VERB,B2
+谄媚的,unctuous,谄媚的,ADJ,B2
+十八,eighteen,十八,NUM,B2
+厌倦的,jaded,厌倦的,ADJ,B2
+人道的,humane,人道的,ADJ,B2
+目录,catalogue,目录,NOUN,B2
+妹妹,little sister,妹妹,NOUN,B2
+最少,least,最少,ADV,B2
+勇敢的,courageous,勇敢的,ADJ,B2
+导航；航行,to navigate,导航；航行,VERB,B2
+反驳,to retort,反驳,VERB,B2
+验证,to validate,验证,VERB,B2
+恶意的,malicious,恶意的,ADJ,B2
+清晰表达,articulation,清晰表达,NOUN,B2
+地方的,provincial,地方的,ADJ,B2
+可行的,viable,可行的,ADJ,B2
+变化,variation,变化,NOUN,B2
+墓地,graveyard,墓地,NOUN,B2
+比率,ratio,比率,NOUN,B2
+领域,domain,领域,NOUN,B2
+加油,to refuel,加油,VERB,B2
+你自己,yourself,你自己,PRON,B2
+算了,oh well,算了,INTJ,B2
+指导方针,guideline,指导方针,NOUN,B2
+综合征,syndrome,综合征,NOUN,B2
+头版,front page,头版,NOUN,B2
+变质的,metamorphic,变质的,ADJ,B2
+双性恋的,bisexual,双性恋的,ADJ,B2
+晚安,good night,晚安,INTJ,B2
+微弱的,faint,微弱的,ADJ,B2
+非凡的,remarkable,非凡的,ADJ,B2
+认可,to sanction,认可,VERB,B2
+非军事化,to demilitarize,非军事化,VERB,B2
+可憎的,abominable,可憎的,ADJ,B2
+道德的,moral,道德的,ADJ,B2
+半途,halfway,半途,ADV,B2
+对,versus,对,ADP,B2
+使两极分化,to polarize,使两极分化,VERB,B2
+鼓舞人心的,inspiring,鼓舞人心的,ADJ,B2
+有意义的,meaningful,有意义的,ADJ,B2
+美味的,tasty,美味的,ADJ,B2
+危险性,dangerousness,危险性,NOUN,B2
+毫无意义的,meaningless,毫无意义的,ADJ,B2
+最高的,highest,最高的,ADJ,B2
+调节,to modulate,调节,VERB,B2
+在...上面,on top of,在...上面,ADP,B2
+证实,to substantiate,证实,VERB,B2
+厌恶的,averse,厌恶的,ADJ,B2
+一点,bit,一点,NOUN,B2
+去中心化,to decentralize,去中心化,VERB,B2
+毁灭,downfall,毁灭,NOUN,B2
+加重,to aggravate,加重,VERB,B2
+犹太的,jewish,犹太的,ADJ,B2
+反社会的,antisocial,反社会的,ADJ,B2
+进行中,on,进行中,ADV,B2
+专攻,to specialize,专攻,VERB,B2
+有效的,valid,有效的,ADJ,B2
+从那里,from there,从那里,ADV,B2
+亮点,highlight,亮点,NOUN,B2
+枢机主教,cardinal,枢机主教,NOUN,B2
+法西斯主义,fascism,法西斯主义,NOUN,B2
+空军,air force,空军,NOUN,B2
+沉默寡言的,reticent,沉默寡言的,ADJ,B2
+勇敢的,plucky,勇敢的,ADJ,B2
+同情的,sympathetic,同情的,ADJ,B2
+极小的,minuscule,极小的,ADJ,B2
+配方,formulation,配方,NOUN,B2
+宣传,publicity,宣传,NOUN,B2
+服从权威,loyalty to authority,服从权威,NOUN,B2
+发垃圾信息,to spam,发垃圾信息,VERB,B2
+议员,member of parliament,议员,NOUN,B2
+可变格的,declinable,可变格的,ADJ,B2
+许多,many,许多,DET,B2
+牙齿,dentition,牙齿,NOUN,B2
+重译,retranslation,重译,NOUN,B2
+时间线,timeline,时间线,NOUN,B2
+应受责备的,reproachable,应受责备的,ADJ,B2
+有争议的,contentious,有争议的,ADJ,B2
+情感体验,emotional experience,情感体验,NOUN,B2
+铺沥青,to asphalt,铺沥青,VERB,B2
+! 表现欲,demonstrativeness,! 表现欲,NOUN,B2
+在其上,on which,在其上,PRON,B2
+阶级斗争,class struggle,阶级斗争,NOUN,B2
+神秘主义,mysticism,神秘主义,NOUN,B2
+迎向,towards,迎向,ADV,B2
+菲律宾的,filipino,菲律宾的,ADJ,B2
+修车匠,bicycle repairer,修车匠,NOUN,B2
+受过培训者,schooled person,受过培训者,NOUN,B2
+毫无良知,unscrupulousness,毫无良知,NOUN,B2
+博物馆藏品,museum piece,博物馆藏品,NOUN,B2
+边境安排,border arrangement,边境安排,NOUN,B2
+旅游的,tourist,旅游的,ADJ,B2
+贪得无厌文化,culture of greed,贪得无厌文化,NOUN,B2
+预定的,intended,预定的,ADJ,B2
+社会主义的,socialist,社会主义的,ADJ,B2
+议会选举,parliamentary elections,议会选举,NOUN,B2
+社群化,communautarization,社群化,NOUN,B2
+世俗的,worldly,世俗的,ADJ,B2
+廉价,cheapness,廉价,NOUN,B2
+寻求庇护者,asylum seeker,寻求庇护者,NOUN,B2
+不合时宜的,misplaced,不合时宜的,ADJ,B2
+调谐,to tune,调谐,VERB,B2
+成员国,member state,成员国,NOUN,B2
+合语法性,grammaticality,合语法性,NOUN,B2
+因此,hence,因此,ADV,B2
+信息技术,it,信息技术,NOUN,B2
+基本的,basal,基本的,ADJ,B2
+恶心的,nauseous,恶心的,ADJ,B2
+可预算的,budgetable,可预算的,ADJ,B2
+继承法,inheritance law,继承法,NOUN,B2
+可组合的,composable,可组合的,ADJ,B2
+数据处理,data processing,数据处理,NOUN,B2
+毕生事业,life's work,毕生事业,NOUN,B2
+疗效,healing power,疗效,NOUN,B2
+定语的,attributive,定语的,ADJ,B2
+酬金,gratuity,酬金,NOUN,B2
+橙色的,orange,橙色的,ADJ,B2
+小儿子,little son,小儿子,NOUN,B2
+半径,radius,半径,NOUN,B2
+该死的,shit,该死的,ADJ,B2
+会议的,conference-based,会议的,ADJ,B2
+工业化,to industrialize,工业化,VERB,B2
+区域化,to regionalize,区域化,VERB,B2
+弯的,bent,弯的,ADJ,B2
+评论,to commentate,评论,VERB,B2
+傻的,daft,傻的,ADJ,B2
+真人大小的,life-size,真人大小的,ADJ,B2
+澳大利亚的,australian,澳大利亚的,ADJ,B2
+她的,her,她的,DET,B2
+叹息的,sighing,叹息的,ADJ,B2
+全面的,all-round,全面的,ADJ,B2
+狂妄自大的,megalomanic,狂妄自大的,ADJ,B2
+四月,april,四月,NOUN,B2
+搬运,to lug,搬运,VERB,B2
+两者的,both,两者的,ADJ,B2
+虚构角色,fictional character,虚构角色,NOUN,B2
+童年创伤,youth trauma,童年创伤,NOUN,B2
+总统选举,presidential election,总统选举,NOUN,B2
+值得一提的,worth mentioning,值得一提的,ADJ,B2
+整洁的,well-groomed,整洁的,ADJ,B2
+家庭紧张,family tension,家庭紧张,NOUN,B2
+知识传授,knowledge transfer,知识传授,NOUN,B2
+发电厂,power station,发电厂,NOUN,B2
+学年,school year,学年,NOUN,B2
+远程办公,to telework,远程办公,VERB,B2
+家庭构成,family composition,家庭构成,NOUN,B2
+可轻描淡写的,trivializable,可轻描淡写的,ADJ,B2
+从中,from which,从中,ADV,B2
+能源危机,energy crisis,能源危机,NOUN,B2
+良性,benignity,良性,NOUN,B2
+泥炭,peat,泥炭,NOUN,B2
+剽窃,to plagiarize,剽窃,VERB,B2
+为此,for this purpose,为此,ADV,B2
+排他性的,exclusionary,排他性的,ADJ,B2
+客观化,to objectify,客观化,VERB,B2
+运动的,sporty,运动的,ADJ,B2
+可命名的,nameable,可命名的,ADJ,B2
+专横的,tyrannical,专横的,ADJ,B2
+成立,founding,成立,NOUN,B2
+仪式的,ceremonial,仪式的,ADJ,B2
+诉讼费,court fee,诉讼费,NOUN,B2
+! 情感表达,emotional expression,! 情感表达,NOUN,B2
+无关,irrelevance,无关,NOUN,B2
+阵容,line-up,阵容,NOUN,B2
+排斥,to ostracize,排斥,VERB,B2
+定价,to set rates,定价,VERB,B2
+亵渎坟墓,grave desecration,亵渎坟墓,NOUN,B2
+打蛋器,whisk,打蛋器,NOUN,B2
+隐晦的,veiled,隐晦的,ADJ,B2
+居住地,place of residence,居住地,NOUN,B2
+放下,to drop off,放下,VERB,B2
+运动,to do sports,运动,VERB,B2
+无神论的,atheistic,无神论的,ADJ,B2
+脂肪的,fatty,脂肪的,ADJ,B2
+头巾,headscarf,头巾,NOUN,B2
+生殖器,genital,生殖器,NOUN,B2
+扩散,proliferate,扩散,! VERB,B2
+化石燃料,fossil fuel,化石燃料,NOUN,B2
+弱智的,feeble-minded,弱智的,ADJ,B2
+忠于事实的,truthful,忠于事实的,ADJ,B2
+构成的,constitutive,构成的,ADJ,B2
+今晚,this evening,今晚,ADV,B2
+男同性恋者,gay man,男同性恋者,NOUN,B2
+变体,variant,变体,NOUN,B2
+有天赋的,endowed,有天赋的,ADJ,B2
+充满活力的,full of life,充满活力的,ADJ,B2
+二维的,two-dimensional,二维的,ADJ,B2
+学生,schoolboy,学生,NOUN,B2
+新建建筑,new construction,新建建筑,NOUN,B2
+惊骇的,aghast,惊骇的,ADJ,B2
+小太阳,little sun,小太阳,NOUN,B2
+国家队教练,national coach,国家队教练,NOUN,B2
+此时,by now,此时,ADV,B2
+骄傲的,side,骄傲的,ADJ,B2
+挪威的,norwegian,挪威的,ADJ,B2
+开票,to invoice,开票,VERB,B2
+巩固的,consolidating,巩固的,ADJ,B2
+引力的,gravitational,引力的,ADJ,B2
+祈祷室,prayer room,祈祷室,NOUN,B2
+说教的,moralizing,说教的,ADJ,B2
+巴西的,brazilian,巴西的,ADJ,B2
+打水,to draw water,打水,VERB,B2
+内涵的,connotative,内涵的,ADJ,B2
+可取性,desirability,可取性,NOUN,B2
+洞察,insightfulness,洞察,NOUN,B2
+主角,leading role,主角,NOUN,B2
+方法论的,methodological,方法论的,ADJ,B2
+荷兰人,dutchman,荷兰人,NOUN,B2
+大官,grand officer,大官,NOUN,B2
+相关的,associated,相关的,ADJ,B2
+直立地,upright,直立地,ADV,B2
+内疚的,guilt-ridden,内疚的,ADJ,B2
+建构主义,constructivism,建构主义,NOUN,B2
+合同的,contractual,合同的,ADJ,B2
+措辞,diction,措辞,NOUN,B2
+群体成员,group member,群体成员,NOUN,B2
+嗜血的,bloodthirsty,嗜血的,ADJ,B2
+主流的,mainstream,主流的,ADJ,B2
+那个人,the one,那个人,PRON,B2
+极硬的,very hard,极硬的,ADJ,B2
+无摩擦的,frictionless,无摩擦的,ADJ,B2
+运动的,motor,运动的,ADJ,B2
+瘫痪的,paralysed,瘫痪的,ADJ,B2
+辞藻华丽的,florid,辞藻华丽的,ADJ,B2
+东南,southeast,东南,NOUN,B2
+正确,to be correct,正确,VERB,B2
+凹的,concave,凹的,ADJ,B2
+客户服务,customer service,客户服务,NOUN,B2
+痴迷的,entranced,痴迷的,ADJ,B2
+亲切的,gracious,亲切的,ADJ,B2
+发推文,to tweet,发推文,VERB,B2
+强迫性,compulsiveness,强迫性,NOUN,B2
+关,off,关,ADP,B2
+厌恶,dislike,厌恶,NOUN,B2
+以此,with this,以此,ADV,B2
+僵化,inflexibility,僵化,NOUN,B2
+丹麦的,danish,丹麦的,ADJ,B2
+公使馆,legation,公使馆,NOUN,B2
+群体文化,group culture,群体文化,NOUN,B2
+盾,guilder,盾,NOUN,B2
+重新表述,reformulation,重新表述,NOUN,B2
+叙利亚的,syrian,叙利亚的,ADJ,B2
+熟练的,skilful,熟练的,ADJ,B2
+冰冷的,ice cold,冰冷的,ADJ,B2
+技术官僚的,technocratic,技术官僚的,ADJ,B2
+纳入,incorporation,纳入,NOUN,B2
+大学,universities,大学,NOUN,B2
+登录,to log in,登录,VERB,B2
+一百,one hundred,一百,NUM,B2
+队列的,cohort-based,队列的,ADJ,B2
+印第安人,native american,印第安人,NOUN,B2
+虔诚,religiousness,虔诚,NOUN,B2
+孕妇,pregnant woman,孕妇,NOUN,B2
+温顺的,meek,温顺的,ADJ,B2
+契约化,contractualization,契约化,NOUN,B2
+诉讼,court case,诉讼,NOUN,B2
+最终比分,final score,最终比分,NOUN,B2
+可解释的,explicable,可解释的,ADJ,B2
+健康政策,health policy,健康政策,NOUN,B2
+边防哨所,border post,边防哨所,NOUN,B2
+小礼物,small gift,小礼物,NOUN,B2
+下面的,below,下面的,ADJ,B2
+西南的,southwest,西南的,ADJ,B2
+净化的,purifying,净化的,ADJ,B2
+宗教战争,religious war,宗教战争,NOUN,B2
+危机局势,crisis situation,危机局势,NOUN,B2
+概要的,synoptic,概要的,ADJ,B2
+宽容的,tolerant,宽容的,ADJ,B2
+违约,breach of contract,违约,NOUN,B2
+气候否认,climate denial,气候否认,NOUN,B2
+液态的,liquid,液态的,ADJ,B2
+分贝,decibel,分贝,NOUN,B2
+这样的,such a,这样的,DET,B2
+扑通,splash,扑通,NOUN,B2
+成对的 / 伴随的,paired accompanied,成对的 / 伴随的,ADJ,B2
+国会议员,mp,国会议员,NOUN,B2
+专业中心,expertise center,专业中心,NOUN,B2
+搜索引擎,search engine,搜索引擎,NOUN,B2
+削弱权威,undermining authority,削弱权威,NOUN,B2
+过去,past,过去,ADP,B2
+志同道合者,kindred spirit,志同道合者,NOUN,B2
+妇科,gynaecology,妇科,NOUN,B2
+无齿的,toothless,无齿的,ADJ,B2
+增加的,increased,增加的,ADJ,B2
+流血的,bleeding,流血的,ADJ,B2
+集体劳动协议,collective labor agreement,集体劳动协议,NOUN,B2
+征税,to tax to burden,征税,VERB,B2
+! 音轨,soundtrack,! 音轨,NOUN,B2
+物理治疗,physiotherapy,物理治疗,NOUN,B2
+志愿工作,volunteer work,志愿工作,NOUN,B2
+所有权,property right,所有权,NOUN,B2
+每个,every,每个,PRON,B2
+凹凸不平的,bumpy,凹凸不平的,ADJ,B2
+踢足球,to play football,踢足球,VERB,B2
+迪厅,disco,迪厅,NOUN,B2
+群体个体,group individual,群体个体,NOUN,B2
+巴勒斯坦的,palestinian,巴勒斯坦的,ADJ,B2
+董事职位,directorship,董事职位,NOUN,B2
+四处走动,to walk around,四处走动,VERB,B2
+使贫困,to pauperize,使贫困,VERB,B2
+减,minus,减,NOUN,B2
+正题的,thetic,正题的,ADJ,B2
+玩具,toys,玩具,NOUN,B2
+潮汐运动,tidal movement,潮汐运动,NOUN,B2
+令人满意的,satisfying,令人满意的,ADJ,B2
+反之亦然,vice versa,反之亦然,ADJ,B2
+! 副本,duplicate,! 副本,NOUN,B2
+联邦化,federalization,联邦化,NOUN,B2
+多久,how long,多久,ADV,B2
+群体团结,group solidarity,群体团结,NOUN,B2
+精神状态,state of mind,精神状态,NOUN,B2
+定位,to situate,定位,VERB,B2
+娱乐,amusement,娱乐,NOUN,B2
+国内,domestic,国内,NOUN,B2
+令人失望的,dismal,令人失望的,ADJ,B2
+不费力的,effortless,不费力的,ADJ,B2
+保持沉默,to keep silent,保持沉默,VERB,B2
+上流的,posh,上流的,ADJ,B2
+天哪,gosh,天哪,INTJ,B2
+模范国家,exemplary country,模范国家,NOUN,B2
+连接的,connective,连接的,ADJ,B2
+噪音扰民,noise nuisance,噪音扰民,NOUN,B2
+颜色,colour,颜色,NOUN,B2
+手工的,manual,手工的,ADJ,B2
+堡垒,fort,堡垒,NOUN,B2
+大公国,grand duchy,大公国,NOUN,B2
+汽油,petrol,汽油,NOUN,B2
+缝,to stitch,缝,VERB,B2
+习惯行为,habitual behavior,习惯行为,NOUN,B2
+边境社区,border community,边境社区,NOUN,B2
+湿疹,eczema,湿疹,NOUN,B2
+爱尔兰的,irish,爱尔兰的,ADJ,B2
+刑法,criminal law,刑法,NOUN,B2
+轰炸,bombardment,轰炸,NOUN,B2
+对此,this,对此,ADV,B2
+与...相对,vs,与...相对,ADP,B2
+高等专业教育,higher professional education,高等专业教育,NOUN,B2
+家庭圈子,family circle,家庭圈子,NOUN,B2
+室内布置,furnishing,室内布置,NOUN,B2
+清澈的,crystal clear,清澈的,ADJ,B2
+无风的,windless,无风的,ADJ,B2
+关于那个,about that,关于那个,ADV,B2
+人格谋杀,character assassination,人格谋杀,NOUN,B2
+欺凌,to bully,欺凌,VERB,B2
+神秘化,to mystify,神秘化,VERB,B2
+大公,grand duke,大公,NOUN,B2
+放荡的,licentious,放荡的,ADJ,B2
+单向通行,one-way traffic,单向通行,NOUN,B2
+有礼貌的,mannerly,有礼貌的,ADJ,B2
+可见的,visible,可见的,ADJ,B2
+坚持,to persevere,坚持,VERB,B2
+无系统的,systemless,无系统的,ADJ,B2
+小弟弟,little brother,小弟弟,NOUN,B2
+瑞士的,swiss,瑞士的,ADJ,B2
+残奥会的,paralympic,残奥会的,ADJ,B2
+全球化进程,globalization process,全球化进程,NOUN,B2
+升华,to sublimate,升华,VERB,B2
+邮政编码,postal code,邮政编码,NOUN,B2
+劳动力市场,labor market,劳动力市场,NOUN,B2
+埃及的,egyptian,埃及的,ADJ,B2
+解离,dissociation,解离,NOUN,B2
+绞刑架幽默,gallows humor,绞刑架幽默,NOUN,B2
+不友好的,unfriendly,不友好的,ADJ,B2
+电子邮件地址,email address,电子邮件地址,NOUN,B2
+特殊性,exceptionality,特殊性,NOUN,B2
+多部分的,multipart,多部分的,ADJ,B2
+联系人,contact person,联系人,NOUN,B2
+发短信,to text,发短信,VERB,B2
+工具化,to instrumentalize,工具化,VERB,B2
+自由化,liberalize,自由化,! VERB,B2
+污染的,contaminating,污染的,ADJ,B2
+转换的,conversional,转换的,ADJ,B2
+石楠荒原,heath,石楠荒原,NOUN,B2
+小贩,peddler,小贩,NOUN,B2
+档案,dossier,档案,NOUN,B2
+邻居,neighbour,邻居,NOUN,B2
+种族主义的,racist,种族主义的,ADJ,B2
+比较的,comparative,比较的,ADJ,B2
+率领 / 提出,to lead to put forward,率领 / 提出,VERB,B2
+用完,to use up,用完,VERB,B2
+残缺的,lacunary,残缺的,ADJ,B2
+事实的,factual,事实的,ADJ,B2
+代表,on behalf of,代表,ADP,B2
+光子,photon,光子,NOUN,B2
+激昂的,heated,激昂的,ADJ,B2
+重新估值,to revalue,重新估值,VERB,B2
+表现力,expressiveness,表现力,NOUN,B2
+一个半,one and a half,一个半,NUM,B2
+执法政策,enforcement policy,执法政策,NOUN,B2
+灾难性的,catastrophic,灾难性的,ADJ,B2
+饮用水,drinking water,饮用水,NOUN,B2
+关怀的,caring,关怀的,ADJ,B2
+群体心态,group mentality,群体心态,NOUN,B2
+连接的,connecting,连接的,ADJ,B2
+伸出,to stick out,伸出,VERB,B2
+贸易壁垒,trade barrier,贸易壁垒,NOUN,B2
+证人询问,witness examination,证人询问,NOUN,B2
+拓宽,broadening,拓宽,NOUN,B2
+放心的,rest assured,放心的,ADJ,B2
+描绘的,depicting,描绘的,ADJ,B2
+知情度,informedness,知情度,NOUN,B2
+木制的,wooden,木制的,ADJ,B2
+胡搞,to mess about,胡搞,VERB,B2
+折衷主义,eclecticism,折衷主义,NOUN,B2
+向上,upwards,向上,ADV,B2
+奥地利的,austrian,奥地利的,ADJ,B2
+使复苏,to revitalize,使复苏,VERB,B2
+资助者,financier,资助者,NOUN,B2
+收藏癖,collectomania,收藏癖,NOUN,B2
+伊朗的,iranian,伊朗的,ADJ,B2
+在其中,in which,在其中,PRON,B2
+最大的,maximal,最大的,ADJ,B2
+群体规范,group norm,群体规范,NOUN,B2
+蛊惑,demagogy,蛊惑,NOUN,B2
+性病,venereal disease,性病,NOUN,B2
+仓库,depot,仓库,NOUN,B2
+提高意识,to sensitize,提高意识,VERB,B2
+为此,for this,为此,ADV,B2
+! 权威地位,position of authority,! 权威地位,NOUN,B2
+佛兰芒的,flemish,佛兰芒的,ADJ,B2
+掌舵的,steering,掌舵的,ADJ,B2
+打字,to type,打字,VERB,B2
+宗教纷争,religious strife,宗教纷争,NOUN,B2
+观望的,wait-and-see,观望的,ADJ,B2
+废除,abolition,废除,NOUN,B2
+麻烦,hassle,麻烦,NOUN,B2
+让步的,concessionary,让步的,ADJ,B2
+苟活,to vegetate,苟活,VERB,B2
+光荣,gloriousness,光荣,NOUN,B2
+吸血,to vampirize,吸血,VERB,B2
+宏观经济学的,macroeconomic,宏观经济学的,ADJ,B2
+行为方针,line of conduct,行为方针,NOUN,B2
+匈牙利的,hungarian,匈牙利的,ADJ,B2
+市长的,mayoral,市长的,ADJ,B2
+助跑,run-up,助跑,NOUN,B2
+易损的,damageable,易损的,ADJ,B2
+本地化,to localize,本地化,VERB,B2
+各种各样的,all kinds,各种各样的,DET,B2
+小手,little hand,小手,NOUN,B2
+免疫,to immunize,免疫,VERB,B2
+在最上面,at the top,在最上面,ADV,B2
+潜在的,potential,潜在的,ADJ,B2
+基督教,christianity,基督教,NOUN,B2
+人文学科,humanities,人文学科,NOUN,B2
+清点,inventorying,清点,NOUN,B2
+基本收入,basic income,基本收入,NOUN,B2
+乌克兰的,ukrainian,乌克兰的,ADJ,B2
+做运动,to play sports,做运动,VERB,B2
+家庭团聚,family reunification,家庭团聚,NOUN,B2
+派系主义,factionalism,派系主义,NOUN,B2
+整体论,holism,整体论,NOUN,B2
+简报,newsletter,简报,NOUN,B2
+真空的,vacuum,真空的,ADJ,B2
+更远处,further on,更远处,ADV,B2
+衷心的,heartfelt,衷心的,ADJ,B2
+前线,front line,前线,NOUN,B2
+自行车道,cycle path,自行车道,NOUN,B2
+无望的,bleak,无望的,ADJ,B2
+在后面,at the back,在后面,ADV,B2
+适得其反,counterproductivity,适得其反,NOUN,B2
+出租,to rent out,出租,VERB,B2
+可兑换的,convertible,可兑换的,ADJ,B2
+有序性,orderliness,有序性,NOUN,B2
+戏剧化,to theatricalize,戏剧化,VERB,B2
+恶棍的,villainous,恶棍的,ADJ,B2
+消耗的,emaciating,消耗的,ADJ,B2
+概念的,conceptual,概念的,ADJ,B2
+正确性,correctness,正确性,NOUN,B2
+沙文主义的,chauvinistic,沙文主义的,ADJ,B2
+费用,costs,费用,NOUN,B2
+同事的,collegial,同事的,ADJ,B2
+祖父母身份,grandparenthood,祖父母身份,NOUN,B2
+去,to,去,PART,B2
+葡萄牙语,portuguese,葡萄牙语,NOUN,B2
+终末的,terminal,终末的,ADJ,B2
+舱口,hatch,舱口,NOUN,B2
+持续的,continual,持续的,ADJ,B2
+确定,determine,确定,VER! B,B2
+市中心,city centre,市中心,NOUN,B2
+乳白色的,milky,乳白色的,ADJ,B2
+过生日的,having a birthday,过生日的,ADJ,B2
+钱币学的,numismatic,钱币学的,ADJ,B2
+结账,to settle up,结账,VERB,B2
+自我中心,egocentrism,自我中心,NOUN,B2
+技术化,to technologize,技术化,VERB,B2
+比利时人,belgian,比利时人,NOUN,B2
+掏空的,hollowed,掏空的,ADJ,B2
+国务秘书,state secretary,国务秘书,NOUN,B2
+浅棕色的,light brown,浅棕色的,ADJ,B2
+精炼,polish,精炼,NOUN,B2
+国歌,national anthem,国歌,NOUN,B2
+表现,showing,表现,NOUN,B2
+阴谋的,conspiratorial,阴谋的,ADJ,B2
+体面的,fatsoenlijk,体面的,ADJ,B2
+危险报告,hazard report,危险报告,NOUN,B2
+可加工的,workable,可加工的,ADJ,B2
+处女的,virginal,处女的,ADJ,B2
+数万,tens of thousands,数万,NUM,B2
+阿拉伯的,arabic,阿拉伯的,ADJ,B2
+可操纵的,manipulable,可操纵的,ADJ,B2
+主要地,largely,主要地,ADV,B2
+我自己,myself,我自己,PRON,B2
+重新绘制,redrawing,重新绘制,NOUN,B2
+中断,to break off,中断,VERB,B2
+结构性,structuredness,结构性,NOUN,B2
+噘,to pucker,噘,VERB,B2
+柏林的,berlijns,柏林的,ADJ,B2
+出处注明,source citation,出处注明,NOUN,B2
+我们自己,ourselves,我们自己,PRON,B2
+本堂神父,parish priest,本堂神父,NOUN,B2
+平衡的,balancing,平衡的,ADJ,B2
+人们,people,人们,PRON,B2
+沮丧的,dispirited,沮丧的,ADJ,B2
+解放的,liberating,解放的,ADJ,B2
+文献,documentation,文献,NOUN,B2
+描绘的,depicted,描绘的,ADJ,B2
+整理,to tidy,整理,VERB,B2
+特价,special offer,特价,NOUN,B2
+外交关系,diplomatic relations,外交关系,NOUN,B2
+评估,judgement,评估,NOUN,B2
+疯狂的,nuts,疯狂的,ADJ,B2
+可证明的,provable,可证明的,ADJ,B2
+传统服饰,traditional costume,传统服饰,NOUN,B2
+儿童权利,children's rights,儿童权利,NOUN,B2
+以此,with that,以此,ADV,B2
+乡土的,folksy,乡土的,ADJ,B2
+南非的,south african,南非的,ADJ,B2
+太阳能电池板,solar panel,太阳能电池板,NOUN,B2
+置于语境,to contextualize,置于语境,VERB,B2
+有轨电车,tram,有轨电车,NOUN,B2
+怎么会,how come,怎么会,INTJ,B2
+无习惯,habitlessness,无习惯,NOUN,B2
+有色性,coloredness,有色性,NOUN,B2
+欠下的,owed,欠下的,ADJ,B2
+增加的,increasing,增加的,ADJ,B2
+荷兰语,dutch,荷兰语,NOUN,B2
+化妆品,cosmetics,化妆品,NOUN,B2
+解释的,explanatory,解释的,ADJ,B2
+教会,church community,教会,NOUN,B2
+革命化,to revolutionize,革命化,VERB,B2
+主编,editor-in-chief,主编,NOUN,B2
+片刻,for a moment,片刻,ADV,B2
+中场球员,midfielder,中场球员,NOUN,B2
+降职,demotion,降职,NOUN,B2
+强调,to underline,强调,VERB,B2
+注视,to behold,注视,VERB,B2
+费力的,strenuous,费力的,ADJ,B2
+权威的,authoritative,权威的,ADJ,B2
+臀部,butt,臀部,NOUN,B2
+容光焕发的,radiant,容光焕发的,ADJ,B2
+哀悼,to mourn,哀悼,VERB,B2
+回复,reply,回复,NOUN,B2
+较少的,less,较少的,ADJ,B2
+举例说明,to exemplify,举例说明,VERB,B2
+系紧,to fasten,系紧,VERB,B2
+排外心理,xenophobia,排外心理,NOUN,B2
+将要,would,将要,AUX,B2
+阿尔法,alpha,阿尔法,NOUN,B2
+命名,to denominate,命名,VERB,B2
+疯子,lunatic,疯子,NOUN,B2
+眨眼,to blink,眨眼,VERB,B2
+虚张声势,to bluff,虚张声势,VERB,B2
+字面上地,literally,字面上地,ADV,B2
+冲洗,to flush,冲洗,VERB,B2
+标题,headline,标题,NOUN,B2
+牛排,steak,牛排,NOUN,B2
+在国外,abroad,在国外,ADV,B2
+细微差别,nuance,细微差别,NOUN,B2
+海洋的,marine,海洋的,ADJ,B2
+那个男人,the guy,那个男人,NOUN,B2
+忏悔,penance,忏悔,NOUN,B2
+镶边,edging,镶边,NOUN,B2
+你们的,your plural,你们的,DET,B2
+腐烂,to rot,腐烂,VERB,B2
+哎呀,darn,哎呀,INTJ,B2
+从内部,from within,从内部,ADV,B2
+法律/团队,law team,法律/团队,NOUN,B2
+像那样,like that,像那样,ADV,B2
+电动机,electric motor,电动机,NOUN,B2
+食物/生育,to food give birth,食物/生育,VERB,B2
+价值基础,values base,价值基础,NOUN,B2
+这里/到这里,here hither,这里/到这里,ADV,B2
+带子,band tape,带子,NOUN,B2
+价值观,values,价值观,NOUN,B2
+乐趣/玩笑,fun joke,乐趣/玩笑,NOUN,B2
+打电话,to call ring,打电话,VERB,B2
+语义内容,meaning content,语义内容,NOUN,B2
+令人困惑的,confusing,令人困惑的,ADJ,B2
+说明,to account for,说明,VERB,B2
+基于,based,基于,ADJ,B2
+界限,limit border,界限,NOUN,B2
+女孩/女朋友,girl girlfriend,女孩/女朋友,NOUN,B2
+同情/共情,sympathy empathy,同情/共情,NOUN,B2
+可疑的,shady suspicious,可疑的,ADJ,B2
+情报机构,intelligence service,情报机构,NOUN,B2
+约会,dejt,约会,NOUN,B2
+使熟悉,to acquaint,使熟悉,VERB,B2
+单向的,one-way,单向的,ADJ,B2
+明确的,definite,明确的,ADJ,B2
+寻求者,seeker,寻求者,NOUN,B2
+对角地,diagonally,对角地,ADV,B2
+楼上,upper floor,楼上,NOUN,B2
+被告知的,told instructed,被告知的,ADJ,B2
+梳理,mapping,梳理,NOUN,B2
+自我护理,self-care,自我护理,NOUN,B2
+甲板/轮胎,deck tire,甲板/轮胎,NOUN,B2
+向西,westward,向西,ADV,B2
+爱尔兰人,irish person,爱尔兰人,NOUN,B2
+受洗的,baptized,受洗的,ADJ,B2
+更重要的,more important,更重要的,ADJ,B2
+谢天谢地,thank god,谢天谢地,INTJ,B2
+知识交流,knowledge exchange,知识交流,NOUN,B2
+职业养老金,occupational pension,职业养老金,NOUN,B2
+不受打扰地,in peace,不受打扰地,ADV,B2
+性别平等,gender equality,性别平等,NOUN,B2
+人行道,pavement,人行道,NOUN,B2
+顶部/极好,top great,顶部/极好,NOUN,B2
+被砍倒,to be felled,被砍倒,VERB,B2
+努力/赌注,effort bet,努力/赌注,NOUN,B2
+大声地,loudly,大声地,ADV,B2
+中产阶层,middle class,中产阶层,NOUN,B2
+橙汁,orange juice,橙汁,NOUN,B2
+沙拉/生菜,salad lettuce,沙拉/生菜,NOUN,B2
+钟表,clock watch,钟表,NOUN,B2
+单曲,single,单曲,NOUN,B2
+纤维素,cellulose,纤维素,NOUN,B2
+同性恋者,gay,同性恋者,NOUN,B2
+措辞,word choice,措辞,NOUN,B2
+社会问题,social problem,社会问题,NOUN,B2
+赌场,the casinos,赌场,NOUN,B2
+海军陆战队员,marine,海军陆战队员,NOUN,B2
+正是,yes indeed,正是,INTJ,B2
+户外,outdoors,户外,ADV,B2
+能干的/优秀的,capable good,能干的/优秀的,ADJ,B2
+原住民,indigenous people,原住民,NOUN,B2
+放置,to place put,放置,VERB,B2
+硬汉,tough guy,硬汉,NOUN,B2
+确定的,sure safe,确定的,ADJ,B2
+混蛋,the devil bastard,混蛋,NOUN,B2
+有力气,to have strength,有力气,VERB,B2
+美好地,nicely nice,美好地,ADV,B2
+到了,arrived present,到了,ADV,B2
+不利于,to disfavor,不利于,VERB,B2
+的/被,of by,的/被,ADP,B2
+取消的/设定的,cancelled set,取消的/设定的,ADJ,B2
+获得/弄到,to get acquire,获得/弄到,VERB,B2
+聪明的,smart clever,聪明的,ADJ,B2
+宵禁,curfew,宵禁,NOUN,B2
+更快的,faster,更快的,ADJ,B2
+拧,to screw,拧,VERB,B2
+搭车,ride lift,搭车,NOUN,B2
+斯德哥尔摩,stockholm,斯德哥尔摩,PROPN,B2
+椰枣,date fruit,椰枣,NOUN,B2
+更便宜的,cheaper,更便宜的,ADJ,B2
+颤抖的,quivering,颤抖的,ADJ,B2
+印象深刻的,impressed,印象深刻的,ADJ,B2
+被解雇的,fired,被解雇的,ADJ,B2
+当然,clear,当然,ADV,B2
+措辞,phrasing,措辞,NOUN,B2
+狼人,werewolf,狼人,NOUN,B2
+新闻报道,news reporting,新闻报道,NOUN,B2
+大斋期,lent,大斋期,NOUN,B2
+被看见,seen,被看见,ADJ,B2
+小家伙,little one,小家伙,NOUN,B2
+一致,agree,一致,ADJ,B2
+数十个,dozens,数十个,NOUN,B2
+罪人,sinner,罪人,NOUN,B2
+新闻自由,press freedom,新闻自由,NOUN,B2
+公平的/正派的,fair decent,公平的/正派的,ADJ,B2
+太迟,too late,太迟,ADV,B2
+毒气,poison gas,毒气,NOUN,B2
+饥饿的,starved,饥饿的,ADJ,B2
+在职,professionally active,在职,NOUN,B2
+真的吗,oh really,真的吗,INTJ,B2
+存在/有,to exist there is,存在/有,VERB,B2
+意思是,to meant,意思是,VERB,B2
+手无寸铁的,unarmed,手无寸铁的,ADJ,B2
+海军陆战队,marine corps,海军陆战队,NOUN,B2
+尸体/相似的,corpse alike,尸体/相似的,NOUN,B2
+减肥,to diet,减肥,VERB,B2
+历史/故事,history story,历史/故事,NOUN,B2
+许可信号,all-clear,许可信号,NOUN,B2
+数据库,databas,数据库,NOUN,B2
+拆除,to tear down,拆除,VERB,B2
+应该,ought,应该,AUX,B2
+电力,electric power,电力,NOUN,B2
+处于,to find oneself,处于,VERB,B2
+错过,to missed,错过,VERB,B2
+临时解雇,to furlough,临时解雇,VERB,B2
+快地,fast,快地,ADV,B2
+它自己,itself,它自己,PRON,B2
+平等待遇,equal treatment,平等待遇,NOUN,B2
+猿/猴,monkey ape,猿/猴,NOUN,B2
+半小时,half hour,半小时,NOUN,B2
+层/仓库,layer storage,层/仓库,NOUN,B2
+脑震荡,concussion,脑震荡,NOUN,B2
+自我形象,self-image,自我形象,NOUN,B2
+正是,the very,正是,ADV,B2
+切入点,angle of approach,切入点,NOUN,B2
+日期,datum,日期,NOUN,B2
+闭眼,to close eyes,闭眼,VERB,B2
+在那下面,down there,在那下面,ADV,B2
+狂饮,to drink binge,狂饮,VERB,B2
+可乐,cola,可乐,NOUN,B2
+无辜地,innocent,无辜地,ADV,B2
+语言使用,language use,语言使用,NOUN,B2
+职业生涯,the career,职业生涯,NOUN,B2
+选中的,selected,选中的,ADJ,B2
+言论自由,freedom of speech,言论自由,NOUN,B2
+顶部的,top,顶部的,ADJ,B2
+待售,for sale,待售,ADJ,B2
+先生/主人,mr master,先生/主人,NOUN,B2
+病人,the sick,病人,NOUN,B2
+应该,should ought to,应该,AUX,B2
+发现物,find,发现物,NOUN,B2
+公民权,citizenship right,公民权,NOUN,B2
+报警中心,alarm center,报警中心,NOUN,B2
+底层,underclass,底层,NOUN,B2
+其他,other others,其他,DET,B2
+更多,more pl,更多,ADJ,B2
+守夜,to stay awake,守夜,VERB,B2
+安息日,sabbath,安息日,NOUN,B2
+清零,to zero out,清零,VERB,B2
+老妇人,older woman,老妇人,NOUN,B2
+它的,its,它的,PRON,B2
+银行卡,bank card,银行卡,NOUN,B2
+仓鼠轮,squirrel wheel,仓鼠轮,NOUN,B2
+针叶树,conifer,针叶树,NOUN,B2
+枪支,firearms,枪支,NOUN,B2
+医护人员,healthcare worker,医护人员,NOUN,B2
+获救,to be saved,获救,VERB,B2
+砰,bang,砰,INTJ,B2
+恐怖分子们,terrorists,恐怖分子们,NOUN,B2
+小心,to watch out,小心,VERB,B2
+哥哥,big brother,哥哥,NOUN,B2
+在那上面,up there,在那上面,ADV,B2
+零售商,retailer,零售商,NOUN,B2
+非常,mighty very,非常,ADJ,B2
+摸清,to map out,摸清,VERB,B2
+主任医师,chief physician,主任医师,NOUN,B2
+肋骨,ribs,肋骨,NOUN,B2
+祖母,paternal grandmother,祖母,NOUN,B2
+受罚,to be punished,受罚,VERB,B2
+毒贩,drug dealer,毒贩,NOUN,B2
+电话号码,phone number,电话号码,NOUN,B2
+更冷的,colder,更冷的,ADJ,B2
+努力地,hard,努力地,ADV,B2
+解雇,to dismiss fire,解雇,VERB,B2
+文化交汇,cultural encounter,文化交汇,NOUN,B2
+柑橘,citrus,柑橘,NOUN,B2
+验血,blood test,验血,NOUN,B2
+十七,seventeen,十七,NUM,B2
+晋升,advancement,晋升,NOUN,B2
+被需要,to be needed,被需要,VERB,B2
+碰撞/震惊,bump shock,碰撞/震惊,NOUN,B2
+哈利路亚,hallelujah,哈利路亚,INTJ,B2
+农场,farm yard,农场,NOUN,B2
+除了,apart from,除了,ADP,B2
+车筐,bike basket,车筐,NOUN,B2
+被算作,to be counted,被算作,VERB,B2
+猫,cats,猫,NOUN,B2
+当然,sure,当然,ADV,B2
+经验交流,experience exchange,经验交流,NOUN,B2
+被创造,to be created,被创造,VERB,B2
+肯定地,surely safe,肯定地,ADV,B2
+被绑架的,kidnapped,被绑架的,ADJ,B2
+拘留所,detention center,拘留所,NOUN,B2
+胖子,chubby,胖子,NOUN,B2
+前几天,the other day,前几天,ADV,B2
+购物,to shop be about,购物,VERB,B2
+他的/她的/它的/他们的,his her its their,他的/她的/它的/他们的,DET,B2
+着迷的,fascinated,着迷的,ADJ,B2
+门票,entrance ticket,门票,NOUN,B2
+不久,shortly,不久,ADV,B2
+哥德堡,gothenburg,哥德堡,PROPN,B2
+胡闹,to mess around,胡闹,VERB,B2
+工人阶级,working class,工人阶级,NOUN,B2
+通常/习惯于,to use to usually,通常/习惯于,VERB,B2
+叶子,leaf page,叶子,NOUN,B2
+辞职,to step down,辞职,VERB,B2
+肉丸,meatballs,肉丸,NOUN,B2
+瘫痪的,paralyzed,瘫痪的,ADJ,B2
+活着的,alive living,活着的,ADJ,B2
+所以/如此,so thus,所以/如此,ADV,B2
+困住/砍倒,to trap fell,困住/砍倒,VERB,B2
+较年轻的,younger,较年轻的,ADJ,B2
+人脉,contacts,人脉,NOUN,B2
+松脱,to come loose,松脱,VERB,B2
+战地医生,field medic,战地医生,NOUN,B2
+破碎的,broken,破碎的,ADV,B2
+最新的,latest,最新的,ADJ,B2
+生火,to light a fire,生火,VERB,B2
+工作环境,work environment,工作环境,NOUN,B2
+从事,to occupy oneself,从事,VERB,B2
+被绞死的,hanged,被绞死的,ADJ,B2
+更厚的,thicker,更厚的,ADJ,B2
+混蛋,devil bastard,混蛋,NOUN,B2
+自动取款机,atm,自动取款机,NOUN,B2
+侧面/页,side page,侧面/页,NOUN,B2
+时间问题,matter of time,时间问题,NOUN,B2
+自己的,own,自己的,DET,B2
+充满的,filled,充满的,ADJ,B2
+那个男人的,the guy's,那个男人的,NOUN,B2
+学位/考试,degree exam,学位/考试,NOUN,B2
+他/这位,he this one,他/这位,PRON,B2
+电影,film movie,电影,NOUN,B2
+尽管,although,尽管,CCONJ,B2
+书呆子,nerd,书呆子,NOUN,B2
+最好的朋友,best friend,最好的朋友,NOUN,B2
+实验室,lab,实验室,NOUN,B2
+狂欢,to party,狂欢,VERB,B2
+香脂,balsam,香脂,NOUN,B2
+居中,to center,居中,VERB,B2
+特工,special agent,特工,NOUN,B2
+更美的,more beautiful,更美的,ADJ,B2
+原子核,atomic nucleus,原子核,NOUN,B2
+被攻击的,attacked,被攻击的,ADJ,B2
+锁定的,locked,锁定的,ADJ,B2
+做/修理,to cook fix,做/修理,VERB,B2
+疯狂地,insanely,疯狂地,ADV,B2
+中央车站,central station,中央车站,NOUN,B2
+王牌,ace,王牌,NOUN,B2
+从后面,from behind,从后面,ADV,B2
+背面,back side,背面,NOUN,B2
+房主,property owner,房主,NOUN,B2
+较低的,lower,较低的,ADJ,B2
+地下世界,underworld,地下世界,NOUN,B2
+那,the it,那,DET,B2
+宗教自由,freedom of religion,宗教自由,NOUN,B2
+包,bags,包,NOUN,B2
+薯片,chips,薯片,NOUN,B2
+被关在里面的,locked in,被关在里面的,ADJ,B2
+货物/负荷,load cargo,货物/负荷,NOUN,B2
+在室内,indoors,在室内,ADV,B2
+分离/离婚,to separate divorce,分离/离婚,VERB,B2
+马尔默,malmo,马尔默,PROPN,B2
+建议,proposal suggestion,建议,NOUN,B2
+天主教徒,catholic,天主教徒,NOUN,B2
+渴望的,keen eager,渴望的,ADJ,B2
+种类,kind sort,种类,NOUN,B2
+均匀地,evenly,均匀地,ADV,B2
+稳定地,stably,稳定地,ADV,B2
+消灭,to wipe out,消灭,VERB,B2
+坠落/猛冲,to fall crash,坠落/猛冲,VERB,B2
+学生宿舍,student residence,学生宿舍,NOUN,B2
+空闲的/休假,free off,空闲的/休假,ADJ,B2
+荡妇,slut,荡妇,NOUN,B2
+刺破,to puncture deflate,刺破,VERB,B2
+所得税,income tax,所得税,NOUN,B2
+平民的,civilian,平民的,ADJ,B2
+自尊,self-esteem,自尊,NOUN,B2
+大人物,bigwig,大人物,NOUN,B2
+王牌/尸体,ace carcass,王牌/尸体,NOUN,B2
+妻子/夫人,wife mrs,妻子/夫人,NOUN,B2
+改变/交换,change exchange,改变/交换,NOUN,B2
+注册的,registered,注册的,ADJ,B2
+生活方式,lifestyle,生活方式,NOUN,B2
+它 (中性),it neuter,它 (中性),PRON,B2
+不满,dissatisfaction,不满,NOUN,B2
+奇怪地,strangely,奇怪地,ADV,B2
+鼻涕,snot,鼻涕,NOUN,B2
+集会自由,freedom of assembly,集会自由,NOUN,B2
+易燃的,inflammable,易燃的,ADJ,B2
+准备好的/完成的,ready finished,准备好的/完成的,ADJ,B2
+核战争,nuclear war,核战争,NOUN,B2
+那/去,that to,那/去,PART,B2
+有罪的/欠钱的,guilty owes,有罪的/欠钱的,ADJ,B2
+自行车头盔,bike helmet,自行车头盔,NOUN,B2
+人们,one you,人们,PRON,B2
+溜走,to sneak away,溜走,VERB,B2
+立刻,at once,立刻,ADV,B2
+性感地,sexily,性感地,ADV,B2
+第一名,number one,第一名,NOUN,B2
+被逮捕的,arrested,被逮捕的,ADJ,B2
+适合,to fit suit,适合,VERB,B2
+更长的,longer,更长的,ADJ,B2
+最远,furthest,最远,ADV,B2
+文化遗产,cultural heritage,文化遗产,NOUN,B2
+电脑程序,computer program,电脑程序,NOUN,B2
+一对,couple pair,一对,NOUN,B2
+针叶,pine needle,针叶,NOUN,B2
+被偷的,stolen,被偷的,ADJ,B2
+胜利,win,胜利,NOUN,B2
+共同决定权,co-determination,共同决定权,NOUN,B2
+令人厌恶的人,creep,令人厌恶的人,NOUN,B2
+良心问题,matter of conscience,良心问题,NOUN,B2
+时代,epoch,时代,NOUN,B2
+被欺骗,to be tricked,被欺骗,VERB,B2
+在这里面,in here,在这里面,ADV,B2
+暴露,to bare,暴露,VERB,B2
+圣诞礼物,christmas present,圣诞礼物,NOUN,B2
+巨大地,enormously,巨大地,ADV,B2
+被驱动,to be driven,被驱动,VERB,B2
+大量,lots,大量,NOUN,B2
+黑手党,mafia,黑手党,NOUN,B2
+赔率,odds,赔率,NOUN,B2
+亲属,family relatives,亲属,NOUN,B2
+魔法地,magically,魔法地,ADV,B2
+山谷,dal,山谷,NOUN,B2
+船内的,inboard,船内的,ADV,B2
+较少的,fewer,较少的,ADJ,B2
+成两半,in two,成两半,ADV,B2
+有机地,organically,有机地,ADV,B2
+当然,certainly,当然,INTJ,B2
+现在,present time,现在,NOUN,B2
+同事,coworker,同事,NOUN,B2
+岩板,rock slab,岩板,NOUN,B2
+更早的,earlier,更早的,ADJ,B2
+太阳镜,sunglasses,太阳镜,NOUN,B2
+所有/大家,all everyone,所有/大家,PRON,B2
+主题/话题,subject topic,主题/话题,NOUN,B2
+个人隐私,personal integrity,个人隐私,NOUN,B2
+包裹,parcel,包裹,NOUN,B2
+暴力地,violently,暴力地,ADV,B2
+它 (通性),it common,它 (通性),PRON,B2
+快乐地,happily,快乐地,ADV,B2
+什么样的,what kind of,什么样的,PRON,B2
+心,heart,心,ADV,B2
+小数,decimal,小数,NOUN,B2
+被拿走,to be taken,被拿走,VERB,B2
+炸药,explosives,炸药,NOUN,B2
+女同性恋的,lesbian,女同性恋的,ADJ,B2
+绑架,to kidnapped,绑架,VERB,B2
+带来/引导,to bring lead,带来/引导,VERB,B2
+稍微超过,just over,稍微超过,ADV,B2
+致死,death,致死,ADV,B2
+干邑,cognac,干邑,NOUN,B2
+抵抗运动,resistance movement,抵抗运动,NOUN,B2
+时髦的,snazzy,时髦的,ADJ,B2
+放松,chill,放松,ADJ,B2
+回忆,recall,回忆,NOUN,B2
+放,to lay put,放,VERB,B2
+这里外面,out here,这里外面,ADV,B2
+不在/离开,away gone,不在/离开,ADV,B2
+认识/感觉,to know feel,认识/感觉,VERB,B2
+避开,away,避开,ADP,B2
+敲击,knock,敲击,NOUN,B2
+侦察,to scout,侦察,VERB,B2
+行动方案,action plan,行动方案,NOUN,B2
+体贴地,thoughtfully,体贴地,ADV,B2
+向上,upward,向上,ADV,B2
+满的/醉的,full drunk,满的/醉的,ADJ,B2
+加热,to warm,加热,VERB,B2
+不,nah,不,INTJ,B2
+意见自由,freedom of opinion,意见自由,NOUN,B2
+在...旁边,beside,在...旁边,ADP,B2
+到这里,hither,到这里,ADV,B2
+高的,high tall,高的,ADJ,B2
+离开/刺,to leave stick,离开/刺,VERB,B2
+更有趣的,more fun,更有趣的,ADJ,B2
+兼职工,part-time worker,兼职工,NOUN,B2
+考虑/思考,to consider think,考虑/思考,VERB,B2
+以前,before previously,以前,ADV,B2
+确定的,determined definite,确定的,ADJ,B2
+猪,swine,猪,NOUN,B2
+游戏/玩耍,play game,游戏/玩耍,NOUN,B2
+格栅,grille,格栅,NOUN,B2
+演示的,demonstrative,演示的,ADJ,B2
+桤木,alder,桤木,NOUN,B2
+重新粉刷,to paint over,重新粉刷,VERB,B2
+核武器,nuclear weapon,核武器,NOUN,B2
+情感上,emotionally,情感上,ADV,B2
+资源短缺,resource shortage,资源短缺,NOUN,B2
+耳朵,ears,耳朵,NOUN,B2
+少数群体,minority group,少数群体,NOUN,B2
+推/碰撞,to bump push,推/碰撞,VERB,B2
+更穷的,poorer,更穷的,ADJ,B2
+每隔一个,every other,每隔一个,DET,B2
+因为,for because,因为,CCONJ,B2
+最里面的,innermost,最里面的,ADV,B2
+助学贷款,student loan,助学贷款,NOUN,B2
+美食的,gastronomic,美食的,ADJ,B2
+驼鹿,moose,驼鹿,NOUN,B2
+老妇,hag,老妇,NOUN,B2
+更大的,bigger,更大的,ADJ,B2
+谋杀未遂,attempted murder,谋杀未遂,NOUN,B2
+许多,much many,许多,ADJ,B2
+载送一程,to give a ride,载送一程,VERB,B2
+推动,to push through,推动,VERB,B2
+派,pie,派,NOUN,B2
+恰好,just precis,恰好,ADV,B2
+乐意地/宁愿,gladly willingly,乐意地/宁愿,ADV,B2
+反对,to object,反对,VERB,B2
+干净地,cleanly,干净地,ADV,B2
+种类/物种,kind species,种类/物种,NOUN,B2
+可怜虫,poor devil,可怜虫,NOUN,B2
+从上方,from above,从上方,ADV,B2
+该死的,confounded,该死的,ADJ,B2
+电脑,dator,电脑,NOUN,B2
+美丽的,fine pretty,美丽的,ADJ,B2
+文明,civilisation,文明,NOUN,B2
+犯大错,to blunder,犯大错,VERB,B2
+迷路,astray,迷路,ADJ,B2
+万岁,hooray,万岁,INTJ,B2
+科学家,scientists,科学家,NOUN,B2
+著名的/熟悉的,known famous,著名的/熟悉的,ADJ,B2
+同步,sync,同步,NOUN,B2
+中国人,the chinese,中国人,NOUN,B2
+出版自由,freedom of the press,出版自由,NOUN,B2
+这边,this way,这边,ADV,B2
+营养,nourishment,营养,NOUN,B2
+外出,away,外出,ADJ,B2
+将要/会,will shall,将要/会,AUX,B2
+可怜的,poor wretched,可怜的,ADJ,B2
+基础/理由,ground basis,基础/理由,NOUN,B2
+抚养,to raise bring up,抚养,VERB,B2
+你好,good day,你好,INTJ,B2
+主管/经理,director manager,主管/经理,NOUN,B2
+精神病院,mental hospital,精神病院,NOUN,B2
+控制,to steer control,控制,VERB,B2
+安全的/可靠的,safe secure,安全的/可靠的,ADJ,B2
+放置,to put set,放置,VERB,B2
+反映,to mirror,反映,VERB,B2
+好/很好,good well,好/很好,ADJ,B2
+帅哥/美女,good-looking person,帅哥/美女,NOUN,B2
+犹太人,jews,犹太人,NOUN,B2
+训练/锻炼,to train exercise,训练/锻炼,VERB,B2
+逃跑,to flee escape,逃跑,VERB,B2
+决定/确定,to decide determine,决定/确定,VERB,B2
+沙龙,salon,沙龙,NOUN,B2
+小吃摊,hot dog stand,小吃摊,NOUN,B2
+煎蛋卷,omelette,煎蛋卷,NOUN,B2
+未婚妻,fiancee,未婚妻,NOUN,B2
+在船上,on board,在船上,ADV,B2
+听着,listen up,听着,INTJ,B2
+场景/舞台,scene stage,场景/舞台,NOUN,B2
+最迟/最近,latest,最迟/最近,ADV,B2
+警察局长,police chief,警察局长,NOUN,B2
+吠/责骂,to bark scold,吠/责骂,VERB,B2
+滑动的,sliding,滑动的,ADJ,B2
+包含,to be included,包含,VERB,B2
+愚蠢的,idiotic,愚蠢的,ADJ,B2
+舞蹈,dans,舞蹈,NOUN,B2
+覆盖物,cover blanket,覆盖物,NOUN,B2
+数百万的,millions of,数百万的,NUM,B2
+被捕获的,caught,被捕获的,ADJ,B2
+保险箱,the safe,保险箱,NOUN,B2
+哥们,bro,哥们,NOUN,B2
+吗啡,morphine,吗啡,NOUN,B2
+十九,nineteen,十九,NUM,B2
+半年,half-year,半年,NOUN,B2
+会面/击中,meeting hit,会面/击中,NOUN,B2
+运作/起作用,to function work,运作/起作用,VERB,B2
+汉堡包,hamburger,汉堡包,NOUN,B2
+意味着,to mean entail,意味着,VERB,B2
+穿着的,dressed,穿着的,ADJ,B2
+致命地,deadly,致命地,ADV,B2
+延误的,delayed,延误的,ADJ,B2
+全部,all of it,全部,PRON,B2
+更慢,slower,更慢,ADJ,B2
+接吻,to make out,接吻,VERB,B2
+该死的,damn,该死的,ADV,B2
+开放地,open,开放地,ADV,B2
+被淘汰的,knocked out,被淘汰的,ADJ,B2
+痕迹/轨道,track trace,痕迹/轨道,NOUN,B2
+大家,all of them,大家,PRON,B2
+地毯,rug,地毯,NOUN,B2
+工作任务,work task,工作任务,NOUN,B2

--- a/dutch/expansion.csv
+++ b/dutch/expansion.csv
@@ -1,7955 +1,2153 @@
 Dutch_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
 -lijk,-ly,地,PART,B2
-Ader,vein,静脉,NOUN,B2
-African,African,词,ADJ,B1
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Alawi,Alawi,词,NOUN,C1
-Alice,Alice,词,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
-Amazigh,Amazigh,词,NOUN,C1
-Andalusian,Andalusian,词,ADJ,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
-Baai,bay,海湾,NOUN,B2
-Badkuip,bathtub,浴缸,NOUN,B2
-Balkanization,Balkanization,词,NOUN,C1
-Bank,bench,长凳,NOUN,B2
-Barrière,barrier,障碍,NOUN,B2
-Bas,bass,贝斯,NOUN,B2
-Basilicum,basil,罗勒,NOUN,B2
-Basiliek,basilica,大教堂,NOUN,B2
-Basis,base,基础,NOUN,B2
-Bastaard,bastard,混蛋,NOUN,B2
-Bataljon,battalion,营,NOUN,B2
-Bazaar,bazaar,集市,NOUN,B2
-Begunstigde,beneficiary,受益人,NOUN,B2
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bekken,basin,盆,NOUN,B2
-Beroering,turmoil,混乱,NOUN,B2
-Beter,better,越好,NOUN,B2
-Bianzhong,bianzhong,编钟,NOUN,B2
-Bijles,tutoring,补习,NOUN,B2
-Bijt,biting,尖刻的,ADJ,B2
-Biljart,billiards,台球,NOUN,B2
-Binding,binding,装订,NOUN,B2
-Biodiversiteit,biodiversity,生物多样性,NOUN,B2
-Biomassa,biomass,生物质,NOUN,B2
-Biopt,biopsy,活检,NOUN,B2
-Biotechnologie,biotechnology,生物技术,NOUN,B2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Breedsprakigheid,verbosity,冗长,NOUN,B2
-Brother He,Brother He,郃弟,NOUN,B2
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cretaceous,Cretaceous,词,ADJ,B2
-DIY,DIY,词,NOUN,C1
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-EEG,eeg,脑电图,NOUN,B2
-Ed,Ed,词,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-England,England,词,PROPN,B1
-English language,English language,词,NOUN,A2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
-Eurasian,Eurasian,词,ADJ,C1
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Fauvism,Fauvism,词,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-Franciscan,Franciscan,词,ADJ,C1
-French (noun),French,词,NOUN,B2
-French language,French language,词,NOUN,A2
-French-speaking world,French-speaking world,词,NOUN,B2
-Frenchification,Frenchification,词,NOUN,C1
-Gallic,Gallic,词,ADJ,C1
-Galsap,bile,胆汁,NOUN,B2
-Geest,ghost,鬼魂,NOUN,B2
-Gegeven,given,给定,NOUN,B2
-Geit,goat,山羊,NOUN,B2
-Gember,ginger,姜,NOUN,B2
-Gigolo,gigolo,面首,NOUN,B2
-Giraf,giraffe,长颈鹿,NOUN,B2
-Gletsjer,glacier,冰川,NOUN,B2
-Gnawa,Gnawa,词,NOUN,B2
-Gnosis,gnosis,灵知,NOUN,B2
-God,god,上帝,NOUN,B2
-Gothic,Gothic,词,ADJ,C1
-Goyaesque,Goyaesque,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gulsheid,gluttony,暴食,NOUN,B2
-Gypsy,Gypsy,词,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-Honkbal,baseball,棒球,NOUN,B2
-Hulp,go help,去帮,NOUN,B2
-Hurufiyya,Hurufiyya,词,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IT-related,IT-related,词,ADJ,C1
-Iberian,Iberian,词,ADJ,C1
-Ijdelheid,vanity,虚荣,NOUN,B2
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Inschikkingsbedrog,bid collusion,串标,NOUN,B2
-Inschikkingsbeoordeling,bid evaluation,评标,NOUN,B2
-Inschikkingsopening,bid opening,开标,NOUN,B2
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
-Italiaan,italian,意大利人,NOUN,B2
-January evening,January evening,词,NOUN,B2
-Japanner,japanese,日本人,NOUN,B2
-Jesuit,Jesuit,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
-Keerpunt,turning point,转折点,NOUN,B2
-Kelder,basement,地下室,NOUN,B2
-Klier,gland,腺体,NOUN,B2
-Knuppel,bat,蝙蝠,NOUN,B2
-Koffer,trunk,树干,NOUN,B2
-Kufic,Kufic,词,ADJ,C1
-Laagheid,baseness,卑鄙,NOUN,B2
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Lelijkheid,ugliness,丑陋,NOUN,B2
-Lijm,glue,胶水,NOUN,B2
-Ling,Ling,叫凌,NOUN,B2
-Locatie,venue,场地,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-MRI-scan,mri,核磁共振,NOUN,B2
-Machiavellian,Machiavellian,词,ADJ,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Mary,Mary,词,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Meedogenaar,benefactor,恩人,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Moestuin,vegetable garden,果园,NOUN,B2
-Mon,Mon,词,NOUN,C1
-Mr. sir,Mr. sir,先生,NOUN,B2
-Mrs.,Mrs.,词,NOUN,A1
-Ms.,Ms.,词,NOUN,C1
-Murong,Murong,慕容,NOUN,B2
-Muslim (adj),Muslim,词,ADJ,B1
-Naast,beside next to,旁边,NOUN,B2
-Nabijheid,vicinity,附近,NOUN,B2
-Natan,Natan,词,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-No.,No.,词,NOUN,C1
-Nordic,Nordic,词,ADJ,C1
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
-Onder,below,在...下面,ADP,B2
-Ondeugd,vice,恶习,NOUN,B2
-Ongedierte,vermin,害兽,NOUN,B2
-Oprecht hart,true heart,本心,NOUN,B2
-Paraplu,umbrella,雨伞,NOUN,B2
-Parisian,Parisian,词,ADJ,B1
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
-Partij,batch,一批,NOUN,B2
-Philippic (adj),Philippic,词,ADJ,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Polaris,Polaris,北极星,NOUN,B2
-Prophet birthday,Prophet birthday,词,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Qingming,retrieve qingming,拿回青冥,NOUN,B2
-Quran,Quran,词,NOUN,B2
-Raap,turnip,芜菁,NOUN,B2
-Reus,giant,巨大的,ADJ,B2
-Richtingaanwijzer,turn signal,转向灯,NOUN,B2
-Russisch,russian,俄罗斯的,ADJ,B2
-SIM card,SIM card,词,NOUN,B1
-Salafism,Salafism,词,NOUN,C1
-Schemering,twilight,暮光,NOUN,B2
-Schenking,bestowal,授予,NOUN,B2
-Schildpad,turtle,海龟,NOUN,B2
-Shiism,Shiism,词,NOUN,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Sinterklaas,santa claus,圣诞老人,NOUN,B2
-Slagveld,battlefield,战场,NOUN,B2
-Somberheid,gloominess,忧郁,NOUN,B2
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Strijd,battle,战斗,NOUN,B2
-Su Sha,Su Sha,夙砂,NOUN,B2
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-TV series,TV series,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Tajwid,Tajwid,词,NOUN,C1
-Tifinagh script,Tifinagh script,词,NOUN,C1
-Tiran,tyrant,暴君,NOUN,B2
-Tirannie,tyranny,暴政,NOUN,B2
-Toebehoor,belonging,归属感,NOUN,B2
-Toebehoor,belongings,所属物,NOUN,B2
-Tonijn,tuna,金枪鱼,NOUN,B2
-Trilling,vibration,振动,NOUN,B2
-Trompet,trumpet,小号,NOUN,B2
-Tuniek,tunic,束腰外衣,NOUN,B2
-Tunnel,tunnel,隧道,NOUN,B2
-Twee dieren,two animals,两只,NUM,B2
-Tweerichtingsstraat,two-way street,双行道,NOUN,B2
-Tyfoon,typhoon,台风,NOUN,B2
-Type,type,类型,NOUN,B2
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-Ulceratie,ulceration,溃疡,NOUN,B2
-VIP room,VIP room,贵宾室,NOUN,C1
-Variabele,variable,变量,NOUN,B2
-Variëteit,variety,种类,NOUN,B2
-Vat,vessel,船,NOUN,B2
-Ventilatie,ventilation,通风,NOUN,B2
-Verenigde Staten,us,你我,NOUN,B2
-Verering,veneration,崇敬,NOUN,B2
-Verschillende afdelingen,various departments,各部,NOUN,B2
-Vertrouwen,trust,信托,NOUN,B2
-Verwarring,bewilderment,困惑,NOUN,B2
-Vest,vest,背心,NOUN,B2
-Veteraan,veteran,老手,NOUN,B2
-Veto,veto,否决,NOUN,B2
-Video-opname,video recording,录像,NOUN,B2
-Videodisc,video disc,影碟,NOUN,B2
-Vitaliteit,vigor,活力,NOUN,B2
-Voertuigregistratie,vehicle registration,行驶证,NOUN,B2
-Voogdij,tutelage,监护,NOUN,B2
-Voorhoede,vanguard,先锋,NOUN,B2
-Vooringenomenheid,bias,偏见,NOUN,B2
-Waakzaamheid,vigilance,警惕,NOUN,B2
-Wake,vigil,守夜,NOUN,B2
-Ware vorm,true form,原形,NOUN,B2
-Weddenschap,bet,打赌,NOUN,B2
-Whistles,Whistles,词,NOUN,C1
-Wraak,vengeance,报复,NOUN,B2
-Wushk,Wushk,词,NOUN,B1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-YouTuber,YouTuber,词,NOUN,B2
-Your Highness,Your Highness,殿下,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-Zhuanghe,zhuang he,庄郃,NOUN,B2
-Zweer,ulcer,溃疡,NOUN,B2
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
-a little,a little,一点儿,ADV,B2
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
-aaien,to caress,爱抚,VERB,B2
-aan,on,,NOUN,B2
-aanbeveling van anderen,recommendation by others,他荐,NOUN,B2
-aanbieder,provider,提供者,NOUN,B2
-aandachtig luisteren,to listen attentively,倾听,VERB,B2
-aandeelhouder,shareholder,股东,NOUN,B2
-aandelenbeurs,stock market,股市,NOUN,B2
-aandrijven,to impel,推动,VERB,B2
-aangeboren,innate,天生的,ADJ,B2
-aangepast effect,modified effect,改效,NOUN,B2
-aangepast geluid,modified sound,改响,NOUN,B2
-aangepast model,modified model,改模,NOUN,B2
-aangepast systeem,modified system,改系,NOUN,B2
-aanhangwagen,trailer,预告片,NOUN,B2
-aanhouden,insistence,坚持,NOUN,B2
-aanhouden,to insist,坚持,VERB,B2
-aanhoudend,persistent,坚持不懈的,ADJ,B2
-aanklagen,to sue,起诉,VERB,B2
-aankopen,to purchase,购买,VERB,B2
-aanname,assumption,假设,NOUN,B2
-aanpassen,to modify,修改,VERB,B2
-aanschouwen,to glimpse,瞥见,VERB,B2
-aanslag,assault,袭击,NOUN,B2
-aansluiting,affiliation,隶属关系,NOUN,B2
-aanspannen,to tighten,紧握/收紧,VERB,B2
-aansporen,to exhort,劝告,VERB,B2
-aansprakelijkheid,liability,责任,NOUN,B2
-aanspreekvorm,person honorific,位,NOUN,B2
-aanspringen,to pounce,猛扑,VERB,B2
-aansteker,lighter,打火机,NOUN,B2
-aantreden,to assume office,就任,VERB,B2
-aantreffen,to run into,碰见,VERB,B2
-aanvaarding,acceptance,接受,NOUN,B2
-aanvankelijk,initially,首先,ADV,B2
-aanwezigheid,attendance,出席,NOUN,B2
-aanzetten,to spur,激励,VERB,B2
-aardbei,raspberry,覆盆子,NOUN,B2
-aardolie,petroleum,石油,NOUN,B2
-aardverschuiving,landslide,滑坡,NOUN,B2
-aarzelen,to hesitate,犹豫,VERB,B2
-aarzeling,hesitation,犹豫,NOUN,B2
-aas,bait,诱饵,NOUN,B2
-aas,lure,诱惑,NOUN,B2
-abate,abate,词,VERB,B2
-abbey,abbey,词,NOUN,B2
-abbot,abbot,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aberrant,aberrant,词,ADJ,B2
-aberziehung,aberziehung,词,NOUN,B2
-abet,abet,词,VERB,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abhorrent,abhorrent,词,ADJ,B2
-abject,abject,悲惨的,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkunft,abkunft,词,NOUN,C1
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
-able to play,able to play,能下,NOUN,B2
-ablution,ablution,词,NOUN,B2
+een beetje,a bit,一点,ADV,B2
+een beetje,a little,一点,ADJ,B2
+gehuwd paar,a married couple,夫妇,NOUN,B2
+een paar,a pair,一对,NUM,B2
+een hoop,a pile,一堆,NUM,B2
+put,a well,井,NOUN,B2
+poos,a while,一会儿,NOUN,B2
+verlaten,to abandon,放弃,VERB,B2
+verlating,abandonment,抛弃,NOUN,B2
+verachten,to abhor,憎恶,VERB,B2
+vermogen,ability,能力,NOUN,B2
+bekwaam,able,能够的,ADJ,B2
 abnormaal,abnormal,异常的,ADJ,B2
-abominate,abominate,词,VERB,B2
-abomination,abomination,词,NOUN,B2
 abortus,abortion,流产,NOUN,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,五十左右,NOUN,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about thirty,about thirty,三十左右,NOUN,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-above (noun),above,重上,NOUN,C1
-above all,above all,,NOUN,B2
-above over,above over,词,ADP,A2
-abpflegung,abpflegung,词,NOUN,C1
-abrasive,abrasive,词,ADJ,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
-abroad,abroad,在国外,ADV,B2
-abrogate,abrogate,词,VERB,B2
-abscess,abscess,脓肿,NOUN,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
-absolutely not,absolutely not,词,ADV,C1
-absolution,absolution,词,NOUN,C1
-absolutist,absolutist,词,ADJ,C1
-absorbed,absorbed,全神贯注的,ADJ,B2
-absprache,absprache,词,NOUN,C1
-abstemious,abstemious,有节制的,ADJ,B2
-abstinence,abstinence,节制,NOUN,B2
-abstract (noun),abstract,词,NOUN,C1
+schuring,abrasion,擦伤,NOUN,B2
+brutaal,abrupt,突然的,ADJ,B2
+ontvluchten,to abscond,潜逃,VERB,B2
+droomerigheid,absent-mindedness,心不在焉,NOUN,B2
+volstrekt,absolutely,绝对地,ADV,B2
 abstractie,abstraction,抽象,NOUN,B2
-abstractionism,abstractionism,词,NOUN,C1
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-absurd,preposterous,荒谬的,ADJ,B2
-absurdism,absurdism,词,NOUN,C1
-abtheilung,abtheilung,词,NOUN,C1
-abundantly,abundantly,词,ADV,C1
-abuse case,abuse case,词,NOUN,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuser,abuser,滥用者,NOUN,B2
-abuses,abuses,词,NOUN,C1
-abusive,abusive,滥用的,ADJ,B2
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-abysmal,abysmal,词,ADJ,B2
-abyss,abyss,深渊,NOUN,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
+onbegrijpelijk,abstruse,深奥的,ADJ,B2
+overvloed,abundance,丰富,NOUN,B2
+overvloedig,abundant,丰富的,ADJ,B2
 academicus,academic,学者,NOUN,B2
-accede,accede,词,VERB,B2
+versnelling,acceleration,加速,NOUN,B2
+versneller,accelerator,油门,NOUN,B2
 accent,accent,口音,NOUN,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-acceptable,acceptable,可接受的,ADJ,B2
-accessibility,accessibility,可达性,NOUN,B2
-accessibility features,accessibility features,词,NOUN,B2
-accessory,accessory,配件,NOUN,B2
-acclimatization,acclimatization,适应环境,NOUN,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompany or not,accompany or not,陪不,NOUN,B2
+aanvaarding,acceptance,接受,NOUN,B2
+toetreding,accession,即位,NOUN,B2
+per ongeluk,accidentally,意外地,ADV,B2
+onderdak,accommodation,住宿,NOUN,B2
+medeplichtige,accomplice,同谋,NOUN,B2
+volbrengen,to accomplish,完成,VERB,B2
 accord with,accord with,合乎,NOUN,B2
-according to,according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordingly consequently,accordingly consequently,词,ADV,C1
-accordion,accordion,手风琴,NOUN,B2
-accost,accost,词,VERB,B2
 account,account,账户,NOUN,B2
 accountability,accountability,问责制,NOUN,B2
 accountant,accountant,会计师,NOUN,B2
 accounting,accounting,会计,NOUN,B2
-accounting (adj),accounting,词,ADJ,C1
-accreditation,accreditation,词,NOUN,C1
 accredited,accredited,认可的,ADJ,B2
 accrue,to accrue,积累,VERB,B2
 accumulation,accumulation,积累,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
-accuracy,accuracy,准确性,NOUN,B2
-accused,accused,词,NOUN,B2
-accused person,accused person,被告,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
 accustom,to accustom,使习惯,VERB,B2
 accustomed,accustomed,习惯的,ADJ,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
-acerbate,acerbate,词,VERB,B2
-acerbic,acerbic,尖刻的,ADJ,B2
-achievable,achievable,可实现的,ADJ,B2
-achieved,achieved,词,ADJ,B1
 achievement,achievement,成就,NOUN,B2
-achterbank,back seat,后座,NOUN,B2
-achterdeur,back door,后门,NOUN,B2
-achterdeur,loophole,漏洞,NOUN,B2
-achtereenvolgens,one after another,接连地,ADV,B2
-achtereenvolgens,successively,连续地,ADV,B2
-achtergrondverhaal,inside story,内幕,NOUN,B2
-achterkant,after,تلو,NOUN,B2
-achterkant,rear part,后部,NOUN,B2
-achterstand,arrears,欠款,NOUN,B2
-achteruitrijlicht,backup light,倒车灯,NOUN,B2
-achting,esteem,尊重,NOUN,B2
-acid (adj),acid,词,ADJ,B1
-acid sour,acid sour,词,ADJ,B2
-acidic,acidic,词,ADJ,B2
 acidity,acidity,酸度,NOUN,B2
-acolyte,acolyte,词,NOUN,B2
-acorn,acorn,词,NOUN,B1
-acoustic,acoustic,声学的,ADJ,B2
 acoustics,acoustics,声学,NOUN,B2
 acquaintance,acquaintance,熟人,NOUN,B2
-acquired,acquired,词,ADJ,B2
 acquisition,acquisition,获得,NOUN,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
 acquit,to acquit,宣告无罪,VERB,B2
 acquittal,acquittal,无罪释放,NOUN,B2
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
 acrimony,acrimony,尖刻,NOUN,B2
 acrobat,acrobat,杂技演员,NOUN,B2
-acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,首字母缩略词,NOUN,B2
 across,across,穿过,ADP,B2
-across (adv),across,越过,ADV,C1
-acrostic,acrostic,词,NOUN,C1
 act jointly,act jointly,合伙,NOUN,B2
-act of kneeling,act of kneeling,词,NOUN,C1
 acting,acting,行为,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
-activation,activation,词,NOUN,B2
-active population,active population,词,NOUN,C1
-activism,activism,激进主义,NOUN,B2
-activist,activist,词,NOUN,C1
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
-actually (noun),actually,倒也,NOUN,C1
-actuate,actuate,词,VERB,B2
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
 acute,acute,剧烈的,ADJ,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
 addict,addict,上瘾者,NOUN,B2
 addiction,addiction,上瘾,NOUN,B2
-addictive,addictive,词,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherence,adherence,词,NOUN,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
 adjacency,adjacency,邻接,NOUN,B2
 adjective,adjective,形容词,NOUN,B2
-adjoin,adjoin,词,VERB,B2
-adjourn,adjourn,词,VERB,B2
-adjournment,adjournment,词,NOUN,C1
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjure,adjure,词,VERB,B2
-adjustability,adjustability,词,NOUN,C1
 administer,to administer,管理,VERB,B2
-administrative offense,administrative offense,词,NOUN,C1
-admirable,admirable,词,ADJ,B2
-admiration,admiration,词,NOUN,B2
 admire,to admire,钦佩,VERB,B2
-admirer,admirer,仰慕者,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible,admissible,词,ADJ,B2
-admissible eligible,admissible eligible,词,ADJ,C1
-admission,admission,词,NOUN,B1
-admitted,admitted,词,ADJ,B2
 admonish,to admonish,告诫,VERB,B2
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
 adopt,to adopt,收养,VERB,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
-adorable,adorable,词,ADJ,B2
-adoration worship,adoration worship,词,NOUN,C1
 adorn,to adorn,装饰,VERB,B2
 adornment,adornment,装饰品,NOUN,B2
-adoul notaries,adoul notaries,词,NOUN,C1
-adrenaline,adrenaline,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
 adulterate,to adulterate,掺杂,VERB,B2
-adultery,adultery,词,NOUN,C1
 adulthood,adulthood,成年,NOUN,B2
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
-advancement,advancement,晋升,NOUN,B2
-advent,advent,到来,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
-adversarial,adversarial,词,ADJ,B2
-adverse,adverse,不利的,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
+vooruitgaan,to advance,前进,VERB,B2
+voorschot,advance payment,预付款,NOUN,B2
+vervolgstudie,advanced study,深造,NOUN,B2
+geavanceerd,advanced technology,先进,ADJ,B2
+avonturier,adventurer,冒险家,NOUN,B2
+tegenstander,adversary,对手,NOUN,B2
 adverteren,to advertise,做广告,VERB,B2
-advertiser,advertiser,词,NOUN,B2
-advertising,advertising,广告的,ADJ,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
-adviseur,consultant,顾问,NOUN,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advisory,advisory,词,ADJ,C1
-advocaat,attorney,律师,NOUN,B2
-advocacy,advocacy,词,NOUN,C1
-advocate (noun),advocate,词,NOUN,B2
-aerodynamics,aerodynamics,词,NOUN,C1
-aeronautical,aeronautical,词,ADJ,B2
-aesthetic taste,aesthetic taste,词,NOUN,C1
-af,down,顺...而下,ADP,B2
-affability,affability,词,NOUN,C1
-affectatie,affectation,做作,NOUN,B2
-affected,affected,受影响的,ADJ,B2
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
-affidavit,affidavit,词,NOUN,B2
-affinity,affinity,词,NOUN,C1
-affirmative,affirmative,词,ADJ,B2
-affix,affix,词,NOUN,B2
-affliction,affliction,灾难,NOUN,C1
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
-affront,affront,冒犯,NOUN,B2
-afgeleid,distracted,分心的,ADJ,B2
-afhandelen,handle,把手,NOUN,B2
-afhandelen,to handle,处理,VERB,B2
-afhandeling,handling,处理,NOUN,B2
-afkeuren,to disapprove,不赞成,VERB,B2
-afkorting,shortcut,捷径,NOUN,B2
-afleiden,to distract,分心,VERB,B2
-afleiden,to infer,推断,VERB,B2
-afleiding,distraction,分心,NOUN,B2
-afname,decrease,减少,NOUN,B2
-afnemen,to decline,下降,VERB,B2
-afnemen,to take off,起飞,VERB,B2
-aforementioned,aforementioned,上述的,ADJ,B2
-afpersen,to extort,敲诈,VERB,B2
-afpersing,extortion,勒索,NOUN,B2
+reclame,advertising,广告业,NOUN,B2
 afraden,to advise against,劝阻,VERB,B2
-afraden,to dissuade,劝阻,VERB,B2
-afraid,afraid,,NOUN,B2
-afrekenen,to settle,解决,VERB,B2
-afscheid nemen,to say goodbye,告别,VERB,B2
-afschermen,to screen,筛选,VERB,B2
-afsluiten,to get off work,下班,VERB,B2
-afsluiten,to lockdown,封城,VERB,B2
-afsplitsen,to secede,脱离,VERB,B2
-afspraak,rendezvous,约会,NOUN,B2
-afstandsbedienbare auto,remote-controlled car,遥控车,NOUN,B2
-afstotend,repulsive,令人反感的,ADJ,B2
-afstuderen,graduate,毕业生,NOUN,B2
-afstuderen,to graduate,毕业,VERB,B2
-after (adv),after,词,ADV,A1
-after all just,after all just,毕竟刚,ADV,C1
-after the example of,after the example of,词,NOUN,C1
-after to,after to,词,ADP,A2
-after-class exercises,after-class exercises,课后题,NOUN,C1
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
-aftrekken,to deduct,扣除,VERB,B2
-afvoer,drain,排水沟,NOUN,B2
-afwachten,to await,等待,VERB,B2
-afwerking,finishing,装修,NOUN,B2
-afwezig zijn,to be absent,缺席,VERB,B2
-afwijkend,divergent,分歧的,ADJ,B2
-afwijking,deviation,偏离,NOUN,B2
-afwijzing,repulse,击退,NOUN,B2
+bepleiten,to advocate,提倡,VERB,B2
+lucht,aerial,航空的,ADJ,B2
+esthetisch,aesthetic,审美的,ADJ,B2
+minzaam,affable,和蔼可亲的,ADJ,B2
+feestzaal,affair hall,事殿,NOUN,B2
+affectatie,affectation,做作,NOUN,B2
+genegenheid,affection,喜爱,NOUN,B2
+liefdevol,affectionate,深情的,ADJ,B2
+filiaal,affiliate,附属机构,NOUN,B2
+aansluiting,affiliation,隶属关系,NOUN,B2
+bevestigen,to affirm,断言,VERB,B2
+bebossing,afforestation,植树造林,NOUN,B2
+achterkant,after,تلو,NOUN,B2
+nawerking,aftereffect,后遗症，后果,NOUN,B2
+later,afterward,去后,NOUN,B2
+herhaling,again,你又,NOUN,B2
+agent,agent,代理人,NOUN,B2
+agressiviteit,aggressiveness,攻击性,NOUN,B2
+wendbaar,agile,敏捷的,ADJ,B2
+wendbaarheid,agility,敏捷,NOUN,B2
+kwelling,agony,极度痛苦,NOUN,B2
+ah,ah,啊,INTJ,B2
+vooruit,ahead,在前面,ADV,B2
+richten,aim,目标,NOUN,B2
+richten,to aim,瞄准,VERB,B2
+luchtafweer,air defense,防空,NOUN,B2
+alarm,alarm,警报,NOUN,B2
+wekker,alarm clock,闹钟,NOUN,B2
+alarmeerend,alarming,令人担忧的,ADJ,B2
+helaas,alas,唉,INTJ,B2
+album,album,相册,NOUN,B2
+alcohol,alcohol,酒精,NOUN,B2
+alcoholist,alcoholic,酗酒者,NOUN,B2
+waarschuwing,alert,警觉的,ADJ,B2
+algebra,algebra,代数,NOUN,B2
+algoritme,algorithm,算法,NOUN,B2
+alien,alien,外星人,NOUN,B2
+ontvreemding,alienation,异化,NOUN,B2
+uitlijning,alignment,结盟,NOUN,B2
+alimentatie,alimony,赡养费,NOUN,B2
+alles,all,جميع,NOUN,B2
+de hele dag,all day long,一整天,NOUN,B2
+blijkbaar,allegedly,据称,ADV,B2
+allergie,allergy,过敏,NOUN,B2
+verbergingsmogelijkheid,allow hiding,许躲,NOUN,B2
+toelage,allowance,津贴,NOUN,B2
+toegestaan,allowed,被允许的,ADJ,B2
+legering,alloy,合金,NOUN,B2
+allusie,allusion,暗示,NOUN,B2
+amandel,almond,杏仁,NOUN,B2
+alleen,alone,独自,ADV,B2
+samen met,along with,随着,ADP,B2
+alfabetisch,alphabetical,按字母顺序的,ADJ,B2
+goed,alright,好的,ADV,B2
+ook nog,also too,也,ADV,B2
+gewijzigde betekenis,altered meaning,改义,NOUN,B2
+gewijzigd mechanisme,altered mechanism,改机,NOUN,B2
 afwisselen,to alternate,交替,VERB,B2
 afwisseling,alternation,轮流,NOUN,B2
-afzonderingsuitgang,seclusion exit,出关,NOUN,B2
-against it,against it,词,ADV,A2
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-aged,aged,年老的,ADJ,B2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
-agent,agent,代理人,NOUN,B2
-agglomerate,agglomerate,词,NOUN,B2
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravated,aggravated,词,ADJ,C1
-aggravating,aggravating,词,ADJ,B2
-aggravation,aggravation,词,NOUN,C1
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
-aggressor,aggressor,词,NOUN,C1
-aging,aging,老化,NOUN,B2
-agitated,agitated,焦躁的,ADJ,B2
-agitation,agitation,词,NOUN,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (adj),agnostic,词,ADJ,B2
-agnostic (noun),agnostic,词,NOUN,B2
-agnosticism,agnosticism,词,NOUN,C1
-agonize,agonize,词,VERB,B2
-agree,agree,一致,ADJ,B2
-agreeable,agreeable,词,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
-agressiviteit,aggressiveness,攻击性,NOUN,B2
-ah,ah,啊,INTJ,B2
-ah (part),ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aimless,aimless,词,ADJ,C1
-aims,aims,词,NOUN,C1
-air conditioner,air conditioner,词,NOUN,B1
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-airline,airline,词,NOUN,C1
-airs,airs,摆架子,NOUN,B2
-airtight,airtight,密封的,ADJ,B2
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-ajar,ajar,半开的,ADJ,B2
-akin,akin,相似的,ADJ,B2
-alarm,alarm,警报,NOUN,B2
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
-alarmeerend,alarming,令人担忧的,ADJ,B2
-alarmism,alarmism,词,NOUN,C1
-album,album,相册,NOUN,B2
-alchemy,alchemy,词,NOUN,C1
-alcohol,alcohol,酒精,NOUN,B2
-alcoholic,alcoholic,酒精的,ADJ,B2
-alcoholist,alcoholic,酗酒者,NOUN,B2
-alder,alder,桤木,NOUN,B2
-alert,alert,警报,NOUN,B2
-alertness,alertness,机敏,NOUN,C1
-alfabetisch,alphabetical,按字母顺序的,ADJ,B2
-algae,algae,词,NOUN,B2
-algebra,algebra,代数,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
-algemeen,generally,通常,ADV,B2
-algoritme,algorithm,算法,NOUN,B2
-alibi,alibi,不在场证明,NOUN,B2
-alien,alien,外星人,NOUN,B2
-alien (adj),alien,词,ADJ,B1
-alienable,alienable,可转让的,ADJ,B2
-alike,alike,词,ADV,B1
-alimentatie,alimony,赡养费,NOUN,B2
-alive living,alive living,活着的,ADJ,B2
-alkalinity,alkalinity,词,NOUN,C1
-all (adj),all,全,ADJ,B2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all everyone,all everyone,所有/大家,PRON,B2
-all good,all good,都好,NOUN,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,诸圣节,NOUN,B2
-all the more,all the more,更加,ADV,B2
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-allay,allay,词,VERB,C1
-alleen,alone,独自,ADV,B2
-alleen,only,而已,SCONJ,B2
-alleen hebben,to have only,唯有,VERB,B2
-alleen kunnen,can only,只能,AUX,B2
-alleen-ik,only-me,只我,NOUN,B2
-allegation,allegation,词,NOUN,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allegiance,allegiance,忠诚,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-allereerst,first of all,首先,ADV,B2
-allergie,allergy,过敏,NOUN,B2
-alles,all,جميع,NOUN,B2
-alleys,alleys,词,NOUN,B2
-allies,allies,盟友,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allocation,allocation,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
-allure,allure,词,NOUN,C1
-alluring,alluring,诱人的,ADJ,C1
-allusie,allusion,暗示,NOUN,B2
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
-alone,alone,单独的,ADJ,B2
-aloof,aloof,词,ADJ,C1
-aloofness,aloofness,冷漠,NOUN,B2
-alpha,alpha,阿尔法,NOUN,B2
-alpine,alpine,高山的,ADJ,B2
-already may particle,already may particle,词,PART,A2
-alright (noun),alright,好吧,NOUN,B1
-als,as,像,ADP,B2
-als,like,像,ADP,B2
-als,if when,如果,SCONJ,B2
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-alsof,as if,仿佛,ADV,B2
-altar,altar,词,NOUN,B2
-altercation,altercation,争执,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternative (adj),alternative,替代的,ADJ,B2
-alternatively,alternatively,交替地,ADV,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-altitude,altitude,海拔,NOUN,B2
-altogether,altogether,共,ADV,B2
 altruism,altruism,利他主义,NOUN,B2
 aluminum,aluminum,铝,NOUN,B2
-alumnus,alumnus,校友,NOUN,B2
-alvleesklier,pancreas,胰腺,NOUN,B2
-always have,always have,总有,VERB,C1
-amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
-amandel,almond,杏仁,NOUN,B2
 amateur,amateur,业余爱好者,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
 amazement,amazement,惊愕,NOUN,B2
-ambacht,craft,工艺,NOUN,B2
-ambachtsman,craftsman,工匠,NOUN,B2
-amber,amber,琥珀,NOUN,B2
-ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
 ambiguity,ambiguity,歧义,NOUN,B2
-ambivalence,ambivalence,词,NOUN,B2
-ambt aanvaarden,to take office,就职,VERB,B2
 ambulance,ambulance,救护车,NOUN,B2
 ambush,ambush,伏击,NOUN,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
 amend,to amend,修订,VERB,B2
-amendable,amendable,可修正的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
 amended interior,amended interior,改内,NOUN,B2
 amended judgment,amended judgment,改断,NOUN,B2
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
 amendment,amendment,修正案,NOUN,B2
-amendments,amendments,词,NOUN,C1
-amends,amends,补偿,NOUN,B2
 amiable,amiable,和蔼可亲的,ADJ,B2
-amicable out-of-court,amicable out-of-court,友好的 / 庭外和解的,ADJ,B2
-amino acid,amino acid,氨基酸,NOUN,C1
-amnesia,amnesia,健忘症,NOUN,B2
 amnesty,amnesty,大赦,NOUN,B2
 among,among,在……之中,ADP,B2
 among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amoral,amoral,词,ADJ,C1
-amorphous,amorphous,无定形的,ADJ,B2
-amortization,amortization,词,NOUN,C1
 amortize,to amortize,摊销,VERB,B2
-amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
 ample,ample,充足的,ADJ,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
 amplification,amplification,放大,NOUN,B2
 amplifier,amplifier,放大器,NOUN,B2
-amplitude range,amplitude range,词,NOUN,C1
 amulet,amulet,护身符,NOUN,B2
 amuse,to amuse,逗乐,VERB,B2
-amused,amused,词,ADJ,B2
-an,an,词,DET,A1
-an official standard,an official standard,标准,NOUN,B2
-anachronism,anachronism,时代错误,NOUN,B2
-anachronistic,anachronistic,时代错误的,ADJ,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,字谜游戏,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
 analog,analog,模拟的,ADJ,B2
-analogize,analogize,词,VERB,B2
-analogous similar,analogous similar,词,ADJ,C1
 analogy,analogy,类比,NOUN,B2
 analyst,analyst,分析师,NOUN,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-ananas,pineapple,菠萝,NOUN,B2
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchical,anarchical,词,ADJ,C1
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
-anarchy,anarchy,无政府状态,NOUN,B2
-anathema,anathema,深恶痛绝之物,NOUN,B2
-anatomy,anatomy,解剖学,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
 ancestors,ancestors,祖先,NOUN,B2
-ancestral,ancestral,词,ADJ,C1
 ancestry,ancestry,血统,NOUN,B2
 anchor,anchor,锚,NOUN,B2
 anchor,to anchor,抛锚,VERB,B2
 anchorage,anchorage,锚地,NOUN,B2
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
 ancient,ancient,古老的,ADJ,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
 ancient times,ancient times,古代,NOUN,B2
-ancillary,ancillary,辅助的,ADJ,B2
 and,and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
 and so on,and so on,之类,NOUN,B2
-and you,and you,而你…,NOUN,C1
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
 anecdote,anecdote,轶事,NOUN,B2
-anemic,anemic,词,ADJ,C1
-anerziehung,anerziehung,词,NOUN,C1
 anesthesia,anesthesia,麻醉,NOUN,B2
-aneurysm,aneurysm,词,NOUN,C1
-anfahrt,anfahrt,词,NOUN,C1
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angelic,angelic,天使般的,ADJ,B2
-angestaltung,angestaltung,词,NOUN,C1
-angle of approach,angle of approach,切入点,NOUN,B2
-angst,anxiety,焦虑,NOUN,B2
-angstaanjagend,terrifying,令人恐惧的,ADJ,B2
-angstig,anxious,焦虑的,ADJ,B2
-anguished,anguished,词,ADJ,C1
-angular,angular,有角的,ADJ,B2
-animal pen,animal pen,词,NOUN,B1
-animated,animated,词,ADJ,C1
+verdovingsmiddel,anesthetic,麻醉剂,NOUN,B2
+woede,anger,愤怒,NOUN,B2
+hoek,angle,角度,NOUN,B2
+smart,anguish,痛苦,NOUN,B2
 animatiefilm,animated film,动画片,NOUN,B2
-anise,anise,茴香,NOUN,B2
-annals,annals,编年史,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
-annexes,annexes,词,NOUN,C1
-annotation,annotation,注释,NOUN,B2
+vijandigheid,animosity,敌意,NOUN,B2
+enkel,ankle,脚踝,NOUN,B2
+bijlage,annex,附件,NOUN,B2
+vernietigen,to annihilate,消灭,VERB,B2
+vernietiging,annihilation,寂灭,NOUN,B2
 annoteren,to annotate,注释,VERB,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annual wage,annual wage,年薪,NOUN,B2
-annuity private income,annuity private income,词,NOUN,C1
-annulering,cancellation,取消,NOUN,B2
-annulment,annulment,词,NOUN,C1
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
+ergeren,to annoy,使恼怒,VERB,B2
+ergernis,annoyance,烦恼,NOUN,B2
+geërgerd,annoyed,恼火的,ADJ,B2
+jaarverslag,annual report,年报,NOUN,B2
+jaarlijks,annually,每年,ADV,B2
 anomalie,anomaly,异常,NOUN,B2
-anomalous,anomalous,词,ADJ,C1
-anomie,anomie,词,NOUN,C1
-anonymity,anonymity,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anonymously,anonymously,词,ADV,B2
-anorexia,anorexia,词,NOUN,C1
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansicht,ansicht,词,NOUN,C1
-ansichtkaart,postcard,明信片,NOUN,B2
-ansinnung,ansinnung,词,NOUN,C1
-ansprache,ansprache,词,NOUN,C1
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-answer questions,answer questions,答疑,VERB,C1
-answers,answers,词,NOUN,C1
-antagonism,antagonism,对抗,NOUN,B2
-antagonistic,antagonistic,词,ADJ,C1
-antecedent,antecedent,先行词,NOUN,B2
-antediluvian,antediluvian,词,ADJ,C1
-anteilung,anteilung,词,NOUN,B2
+antwoorden,to answer reply,回答,VERB,B2
+antwoordapparaat,answering machine,邮箱,NOUN,B2
 antenne,antenna,天线,NOUN,B2
-anteroom,anteroom,词,NOUN,B2
-antheilung,antheilung,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthill,anthill,词,NOUN,C1
-anthropological,anthropological,词,ADJ,C1
+bloemlezing,anthology,选集,NOUN,B2
+antropologie,anthropology,人类学,NOUN,B2
+antropomorfisme,anthropomorphism,拟人化,NOUN,B2
 anti-abstractie,anti-abstraction,反抽,NOUN,B2
 anti-actie,anti-action,反作,NOUN,B2
-anti-actuality,anti-actuality,反然,NOUN,C1
 anti-algemeenheid,anti-generality,反般,NOUN,B2
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
 anti-integratie,anti-integration,反合,NOUN,B2
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
 anti-maatregel,anti-measure,反度,NOUN,B2
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
 anti-omnipresentie,anti-omnipresence,反遍,NOUN,B2
 anti-oorlog,anti-war,反战,NOUN,B2
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-work,anti-work,反功,NOUN,C1
-antibiotic,antibiotic,抗生素,NOUN,B2
 antibiotica,antibiotics,抗生素,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
-anticipatory,anticipatory,词,ADJ,C1
-anticiperen,to anticipate,预期,VERB,B2
-anticyclone,anticyclone,反气旋,NOUN,B2
-antidote,antidote,解毒剂,NOUN,B2
-antiek,antique,古董,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigeen,antigen,抗原,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
 antilichaam,antibody,抗体,NOUN,B2
-antinomy,antinomy,词,NOUN,C1
+anticiperen,to anticipate,预期,VERB,B2
+antigeen,antigen,抗原,NOUN,B2
 antioxidant,antioxidant,抗氧化剂,NOUN,B2
-antiphrasis,antiphrasis,词,NOUN,C1
-antipode,antipode,对跖点,NOUN,B2
-antiquated,antiquated,过时的,ADJ,B2
-antique (adj),antique,古旧的,ADJ,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
+antiek,antique,古董,NOUN,B2
 antisepticum,antiseptic,防腐剂,NOUN,B2
 antithese,antithesis,对立面,NOUN,B2
 antoniem,antonym,反义词,NOUN,B2
-antonomasia,antonomasia,词,NOUN,C1
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreibung,antreibung,词,NOUN,C1
-antropologie,anthropology,人类学,NOUN,B2
-antropomorfisme,anthropomorphism,拟人化,NOUN,B2
-antsy,antsy,词,ADJ,C1
-antwoord aan Uw Hoogheid,reply to your-highness,回殿下,NOUN,B2
-antwoordapparaat,answering machine,邮箱,NOUN,B2
-antwoorden,to answer reply,回答,VERB,B2
-anvil,anvil,词,NOUN,B2
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-anxious eager,anxious eager,词,ADJ,B1
-any,any,任何,PRON,B2
-any (adj),any,词,ADJ,B1
-any (adv),any,词,ADV,B2
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anything,anything,任何事,PRON,B2
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-apart from,apart from,除了,ADP,B2
-apart from (verb),apart from,词,VERB,C1
-apartheid,apartheid,词,NOUN,C1
-apathetic,apathetic,冷漠的,ADJ,B2
-apathy,apathy,冷漠,NOUN,B2
-apex,apex,顶点,NOUN,B2
-aphasia,aphasia,失语症,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apnea,apnea,词,NOUN,C1
-apocalypse,apocalypse,词,NOUN,C1
-apocalyptic,apocalyptic,启示录的,ADJ,B2
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
-apologetic,apologetic,道歉的,ADJ,B2
-apologist,apologist,辩护者,NOUN,B2
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-apoplexy,apoplexy,中风,NOUN,B2
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
+angst,anxiety,焦虑,NOUN,B2
+angstig,anxious,焦虑的,ADJ,B2
+enig,any,任何,DET,B2
+iemand,anyone,任何人,PRON,B2
+ontschuldigen,to apologize,道歉,VERB,B2
+ontschuldiging,apology,道歉,NOUN,B2
 apostasie,apostasy,叛教,NOUN,B2
-apostate,apostate,叛教者,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostle,apostle,词,NOUN,C1
-apostrophize,apostrophize,词,VERB,C1
-apotheker,pharmacist,药剂师,NOUN,B2
-apotheosis,apotheosis,神化,NOUN,B2
-apotheotic,apotheotic,神化的,ADJ,B2
-app,app,词,NOUN,B1
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
 apparaat,apparatus,仪器,NOUN,B2
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-appeals,appeals,词,NOUN,C1
-appeasement,appeasement,平息,NOUN,B2
-appellant,appellant,上诉人,NOUN,B2
-appellate,appellate,词,ADJ,C1
-append,append,词,VERB,C1
-appendix,appendix,附录,NOUN,B2
-appertain,appertain,词,VERB,C1
-appetizers,appetizers,词,NOUN,B2
-applauderen,to applaud,鼓掌,VERB,B2
-appliance,appliance,词,NOUN,B1
-applicable,applicable,适用的,ADJ,B2
-appointments,appointments,词,NOUN,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-appreciable,appreciable,可观的,ADJ,B2
-apprehensive,apprehensive,忧虑的,ADJ,B2
-approachable,approachable,词,ADJ,C1
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-approval pleasure,approval pleasure,词,NOUN,C1
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
-approximate,approximate,近似的,ADJ,B2
 appèl,appeal,呼吁,NOUN,B2
+verzoeken,to appease,安抚,VERB,B2
+appellant,appellant,上诉人,NOUN,B2
+appendix,appendix,附录,NOUN,B2
+applauderen,to applaud,鼓掌,VERB,B2
+toepasselijkheid,applicability,适用性,NOUN,B2
+sollicitant,applicant,申请人,NOUN,B2
+gips aanbrengen,to apply a cast,打石膏,VERB,B2
+make-up aanbrengen,to apply makeup,化妆,VERB,B2
+waarderen,to appraise,评估,VERB,B2
+dankfeest,appreciation banquet,答谢宴,NOUN,B2
+arrest,apprehension,忧虑,NOUN,B2
+leerling,apprentice,学徒,NOUN,B2
+leerperiode,apprenticeship,学徒期,NOUN,B2
+benadering,approximation,近似值,NOUN,B2
 aprikoos,apricot,杏,NOUN,B2
-apt,apt,词,ADJ,C1
-aptitude,aptitude,天资,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-aqueous,aqueous,词,ADJ,B2
+schort,apron,围裙,NOUN,B2
 arabesque,arabesque,阿拉伯式花纹,NOUN,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-arbeid,toil,苦工,NOUN,B2
-arbeidszaam,hardworking,勤奋的,ADJ,B2
-arbitrage,arbitrage,词,NOUN,C1
-arbitrage,arbitration,仲裁,NOUN,B2
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
 arbitreren,to arbitrate,仲裁,VERB,B2
-arcane,arcane,神秘的,ADJ,B2
-archaeologist,archaeologist,词,NOUN,C1
-archaïsme,archaism,古语,NOUN,B2
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
+arbitrage,arbitration,仲裁,NOUN,B2
+boog,arc,弧,NOUN,B2
 archeologie,archaeology,考古学,NOUN,B2
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
-archetype,archetype,原型,NOUN,B2
+archaïsme,archaism,古语,NOUN,B2
 archipel,archipelago,群岛,NOUN,B2
 architect,architect,建筑师,NOUN,B2
 architectonisch,architectural,建筑的,ADJ,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-archival,archival,词,ADJ,C1
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-ardent,ardent,热情的,ADJ,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
-ardor,ardor,热情,NOUN,B2
+moeilijk,arduous,艰巨的,ADJ,B2
 arena,arena,竞技场,NOUN,B2
-arend,eagle,鹰,NOUN,B2
-argan,argan,词,NOUN,B1
-arguable,arguable,词,ADJ,C1
 argument,argument,争论,NOUN,B2
-argumentative,argumentative,词,ADJ,C1
-argumentativeness,argumentativeness,词,NOUN,C1
-arid,arid,干旱的,ADJ,B2
-aridity,aridity,干旱,NOUN,B2
-aristocraat,aristocrat,贵族,NOUN,B2
-aristocratic,aristocratic,词,ADJ,C1
 aristocratie,aristocracy,贵族阶层,NOUN,B2
-arithmetic (adj),arithmetic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
+aristocraat,aristocrat,贵族,NOUN,B2
 arm,arm,手臂,NOUN,B2
-armament,armament,词,NOUN,B2
-armband,armband,词,NOUN,C1
-armband,bracelet,手镯,NOUN,B2
-armed forces,armed forces,三军,NOUN,C1
-armoede,destitution,贫困,NOUN,B2
-armor,armor,盔甲,NOUN,B2
-armored,armored,词,ADJ,C1
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arousal,arousal,词,NOUN,C1
-arraign,arraign,词,VERB,C1
-arranged,arranged,词,ADJ,B2
+leuningstoel,armchair,扶手椅,NOUN,B2
+opwekken,to arouse,引起,VERB,B2
 arrangement,arrangement,安排,NOUN,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-array,array,排列,NOUN,B2
-arrest,apprehension,忧虑,NOUN,B2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrested,arrested,被逮捕的,ADJ,B2
-arrhythmia,arrhythmia,词,NOUN,C1
-arrived present,arrived present,到了,ADV,B2
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
+achterstand,arrears,欠款,NOUN,B2
 arrogantie,arrogance,傲慢,NOUN,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
 arsenaal,arsenal,军火库,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-arterial,arterial,词,ADJ,C1
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
-artichoke,artichoke,词,NOUN,B1
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
+kunstgalerij,art gallery,美术馆,NOUN,B2
+slagader,artery,动脉,NOUN,B2
 articuleren,to articulate,清晰表达,VERB,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,人为地,ADV,B2
+list,artifice,诡计,NOUN,B2
 artistisch portret,artistic portrait,艺术照,NOUN,B2
-artistry,artistry,,NOUN,B2
-artless,artless,词,ADJ,C1
-arts,physician,内科医生,NOUN,B2
-as,axis,轴,NOUN,B2
-as (adp),as,作为,ADP,A1
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as a precaution,as a precaution,词,ADV,C1
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as far as,as far as,就……而言,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as for (part),as for,词,PART,B1
-as if (adv),as if,仿佛,ADV,B2
-as long as (cconj),as long as,只要,CCONJ,B2
-as much,as much,词,ADV,A1
-as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,尽可能地,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
-as soon as,as soon as,一...就,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
-as when,as when,词,SCONJ,A1
-asbestos,asbestos,词,NOUN,C1
-ascending,ascending,词,ADJ,C1
-ascertain,ascertain,词,VERB,C1
-ascetic,ascetic,苦行的,ADJ,B2
-ascetic (noun),ascetic,词,NOUN,C1
+als,as,像,ADP,B2
+alsof,as if,仿佛,ADV,B2
+zolang,as long as,طالما,CCONJ,B2
+opstijgen,to ascend,上升,VERB,B2
 ascetisme,asceticism,苦行主义,NOUN,B2
-asharite school,asharite school,词,NOUN,C1
-ashen,ashen,灰白的,ADJ,B2
-ashes,ashes,词,NOUN,B2
-ashore,ashore,词,ADV,C1
-ashtray,ashtray,烟灰缸,NOUN,B2
-aside (noun),aside,词,NOUN,C1
-asinine,asinine,词,ADJ,C1
-asleep,asleep,词,ADJ,A2
-asp,asp,角蝰,NOUN,B2
-asparagus,asparagus,芦笋,NOUN,B2
+beschaamd,ashamed,羞愧的,ADJ,B2
 aspect,aspect,方面,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-asphalt,asphalt,沥青,NOUN,B2
-asphyxia,asphyxia,窒息,NOUN,B2
-aspirant,aspirant,词,NOUN,C1
 aspiratie,aspiration,抱负,NOUN,B2
-assail,assail,词,VERB,C1
-assailant,assailant,词,NOUN,C1
+streven,to aspire,渴望,VERB,B2
+esel,ass,驴,NOUN,B2
 assassijn,assassin,刺客,NOUN,B2
-assassinatie,assassination,暗杀,NOUN,B2
 assassineren,to assassinate,暗杀,VERB,B2
-assent (noun),assent,词,NOUN,B2
-assertion,assertion,断言,NOUN,B2
-assertiveness,assertiveness,果断,NOUN,C1
-asshole,asshole,词,NOUN,A2
-assiduity,assiduity,词,NOUN,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduously,assiduously,词,ADV,C1
-assiduousness,assiduousness,词,NOUN,C1
+assassinatie,assassination,暗杀,NOUN,B2
+aanslag,assault,袭击,NOUN,B2
+beweren,to assert,断言,VERB,B2
+bezit,asset,资产,NOUN,B2
+ijverig,assiduous,勤勉的,ADJ,B2
 assisteren,to assist,协助,VERB,B2
-associate (noun),associate,词,NOUN,B2
-associative,associative,协会性质的,ADJ,C1
-assort,assort,词,VERB,C1
-assuage,assuage,词,VERB,C1
-assurance,assurance,保证,NOUN,B2
+aantreden,to assume office,就任,VERB,B2
+aanname,assumption,假设,NOUN,B2
+verzekeren,to assure,保证,VERB,B2
 asteroïde,asteroid,小行星,NOUN,B2
-asthenia,asthenia,词,NOUN,C1
 astma,asthma,哮喘,NOUN,B2
-astonished,astonished,惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astray,astray,迷路,ADJ,B2
-astride (adp),astride,词,ADP,C1
-astride (adv),astride,词,ADV,C1
-astringent (adj),astringent,词,ADJ,C1
-astringent (noun),astringent,词,NOUN,B2
+verbazen,to astonish,使惊讶,VERB,B2
+verbazingwekkend,astonishing,令人惊讶的,ADJ,B2
+verbazing,astonishment,惊讶,NOUN,B2
 astrologie,astrology,占星术,NOUN,B2
-astronomer,astronomer,词,NOUN,B1
-astronomie,astronomy,天文学,NOUN,B2
 astronomisch,astronomical,天文学的,ADJ,B2
-asylum shelter,asylum shelter,词,NOUN,B2
-asymptomatic,asymptomatic,词,ADJ,C1
+astronomie,astronomy,天文学,NOUN,B2
+schrander,astute,精明的,ADJ,B2
 asynchroon,asynchronous,异步的,ADJ,B2
-asyndeton,asyndeton,连词省略,NOUN,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
-at home (noun),at home,家里,NOUN,C1
-at it,at it,靠近,ADV,B2
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,夜间,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
-at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
-at worst,at worst,大不了,ADV,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
-atheist,atheist,无神论者,NOUN,B2
+helemaal,at all,根本,ADV,B2
+ooit,at any time,随时,ADV,B2
+ontspannen,at ease,安心,ADJ,B2
 atheïsme,atheism,无神论,NOUN,B2
-athletic,athletic,运动的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atm,atm,自动取款机,NOUN,B2
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atomair,atomic,原子的,ADJ,B2
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atonement,atonement,赎罪,NOUN,B2
-atony,atony,词,NOUN,C1
 atoom,atom,原子,NOUN,B2
-atrocious,atrocious,词,ADJ,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-atrocity,atrocity,暴行,NOUN,B2
-atrophy,atrophy,萎缩,NOUN,B2
-attache office,attache office,词,NOUN,C1
-attached,attached,词,ADJ,B2
-attacked,attacked,被攻击的,ADJ,B2
-attainable,attainable,可获得的,ADJ,B2
-attainment,attainment,词,NOUN,C1
-attempt at crime,attempt at crime,词,NOUN,C1
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
-attent,considerate,体贴,ADJ,B2
-attention,attention,立正,INTJ,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attenuation,attenuation,衰减,NOUN,C1
-attestation,attestation,词,NOUN,C1
-attitude setting,attitude setting,态度/设置,NOUN,B2
-attractief,good-looking,好看的,ADJ,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attribution,attribution,归因,NOUN,B2
-attributists,attributists,词,NOUN,C1
+atomair,atomic,原子的,ADJ,B2
+boeten,to atone,赎罪,VERB,B2
+bijlage,attachment,附件,NOUN,B2
+bereiken,to attain,达到,VERB,B2
+bijwonen,to attend,出席,VERB,B2
+aanwezigheid,attendance,出席,NOUN,B2
+bediende,attendant,服务员,NOUN,B2
+oplettend,attentive,专心的,ADJ,B2
+kleding,attire,服装,NOUN,B2
+advocaat,attorney,律师,NOUN,B2
+eigenschap,attribute,属性,NOUN,B2
 atypisch,atypical,非典型的,ADJ,B2
-aubergine,eggplant,茄子,NOUN,B2
-audacious,audacious,大胆的,ADJ,B2
-audibility,audibility,词,NOUN,C1
-audience vragen,to seek audience,求见,VERB,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
+driestheid,audacity,大胆,NOUN,B2
 auditeren,audit,审计,NOUN,B2
 auditeren,to audit,审计,VERB,B2
-audition,audition,词,NOUN,B1
 auditor,auditor,审计员,NOUN,B2
-auditory,auditory,词,ADJ,C1
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-augury,augury,词,NOUN,C1
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspice,auspice,赞助,NOUN,B2
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
 auster,austere,严厉的,ADJ,B2
 austeriteit,austerity,紧缩,NOUN,B2
-austheilung,austheilung,词,NOUN,C1
-austreibung,austreibung,词,NOUN,C1
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarchy,autarchy,词,NOUN,C1
-autarky,autarky,词,NOUN,B2
-authenticated,authenticated,词,ADJ,C1
 authenticatie,authentication,认证,NOUN,B2
 authenticiteit,authenticity,真实性,NOUN,B2
-authoritarianism,authoritarianism,词,NOUN,C1
-authoritative,authoritative,权威的,ADJ,B2
-autism,autism,自闭症,NOUN,B2
-autistic (adj),autistic,词,ADJ,C1
-autistic (noun),autistic,词,NOUN,C1
-auto-ongeluk,car accident,车祸,NOUN,B2
-autobiografie,autobiography,自传,NOUN,B2
-autobiographical,autobiographical,词,ADJ,C1
-autocracy,autocracy,专制,NOUN,B2
-autocratic,autocratic,专制的,ADJ,B2
-autograaf,autograph,亲笔签名,NOUN,B2
-automatisch,automatically,自动地,ADV,B2
-automatiseren,to automate,使自动化,VERB,B2
-autonomy,autonomy,自治,NOUN,B2
-autopsie,autopsy,尸检,NOUN,B2
 autorisatie,authorization,授权,NOUN,B2
-autoverzekering,car insurance,车险,NOUN,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-auxiliary,auxiliary,词,ADJ,C1
-avail,avail,词,NOUN,C1
-availability,availability,可用性,NOUN,B2
+geautoriseerd,authorized,有资格的,ADJ,B2
+autobiografie,autobiography,自传,NOUN,B2
+autograaf,autograph,亲笔签名,NOUN,B2
+automatiseren,to automate,使自动化,VERB,B2
+geautomatiseerd,automated,自动化的,ADJ,B2
+automatisch,automatically,自动地,ADV,B2
+autopsie,autopsy,尸检,NOUN,B2
+lawine,avalanche,雪崩,NOUN,B2
 avant-garde,avant-garde,前卫的,ADJ,B2
-avarice,avarice,词,NOUN,C1
-avaricious,avaricious,词,ADJ,C1
-aver,aver,词,VERB,C1
+wreken,to avenge,复仇,VERB,B2
 aversie,aversion,厌恶,NOUN,B2
-avert,avert,词,VERB,C1
-avid,avid,热切的,ADJ,B2
-avocado,avocado,牛油果,NOUN,C1
-avonturier,adventurer,冒险家,NOUN,B2
-avow,avow,词,VERB,C1
-award auction,award auction,裁定 / 拍卖,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
-awareness raising,awareness raising,提高意识,NOUN,B2
-away,away,避开,ADP,B2
-away (adj),away,外出,ADJ,C1
-away gone,away gone,不在/离开,ADV,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awesome,awesome,词,ADJ,A2
-awful,awful,糟糕的,ADJ,B2
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-awning,awning,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiology,axiology,词,NOUN,C1
+vermijding,avoidance,避免,NOUN,B2
+afwachten,to await,等待,VERB,B2
+ontwaking,awakening,觉醒,NOUN,B2
+prijs,award,奖项,NOUN,B2
+bewust,aware,意识到的,ADJ,B2
+ontzag,awe,敬畏,NOUN,B2
+onhandig,awkward,尴尬的,ADJ,B2
+bijl,axe,斧头,NOUN,B2
 axioma,axiom,公理,NOUN,B2
-axioms,axioms,词,NOUN,C1
-axis axle,axis axle,词,NOUN,C1
-azijn,vinegar,醋,NOUN,B2
-baan,orbit,轨道,NOUN,B2
-babble,babble,结巴,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-baby walker,baby walker,词,NOUN,B1
-babysitter,babysitter,保姆,NOUN,B2
-baccalaureate,baccalaureate,词,NOUN,B2
-bacchanal,bacchanal,狂欢,NOUN,B2
+as,axis,轴,NOUN,B2
+bazi,ba zi,八字,NOUN,B2
 bachelor,bachelor,单身汉,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
 bachelorgraad,bachelor's degree,学士学位,NOUN,B2
-back mountain,back mountain,后山,NOUN,C1
-back side,back side,背面,NOUN,B2
-back then,back then,词,ADV,A1
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-back-up,backup,备份,NOUN,B2
-backache,backache,背痛,NOUN,B2
-backdrop,backdrop,背景,NOUN,B2
-backfire,backfire,词,VERB,C1
-backpacker,backpacker,词,NOUN,B1
-backside,backside,臀部,NOUN,B2
-backslide,backslide,词,VERB,C1
+achterdeur,back door,后门,NOUN,B2
+achterbank,back seat,后座,NOUN,B2
+ruggengraat,backbone,脊梁,NOUN,B2
+terugstroom,backflow,倒流,NOUN,B2
+rugstoot,backstab,背刺,NOUN,B2
 backstage,backstage,幕后,NOUN,B2
-backward,backward,向后,ADV,B2
+back-up,backup,备份,NOUN,B2
+achteruitrijlicht,backup light,倒车灯,NOUN,B2
 bacon,bacon,培根,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
-bactericide,bactericide,杀菌剂,NOUN,C1
 bacteriën,bacteria,细菌,NOUN,B2
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
-baden,to bathe,洗澡,VERB,B2
-badge,badge,徽章,NOUN,B2
-badger,badger,词,NOUN,C1
+slecht idee,bad idea,坏水,NOUN,B2
+slecht nieuws,bad news,坏消息,NOUN,B2
+slecht ding,bad thing,坏事,NOUN,B2
 badminton,badminton,羽毛球,NOUN,B2
-baffle,baffle,词,VERB,C1
-baggage,baggage,行李,NOUN,B2
-bagpiper,bagpiper,风笛手,NOUN,B2
-bags,bags,包,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
-bakery,bakery,词,NOUN,A2
-balance of power,balance of power,均势,NOUN,C1
-balance sheet,balance sheet,资产负债表,NOUN,B2
-baldness,baldness,词,NOUN,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballad,ballad,词,NOUN,C1
-ballast,ballast,压舱物,NOUN,B2
+borgsom,bail,保释,NOUN,B2
+aas,bait,诱饵,NOUN,B2
+gebalanceerd,balanced,平衡的,ADJ,B2
 ballet,ballet,芭蕾舞,NOUN,B2
-ballot,ballot,选票,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balsam,balsam,香脂,NOUN,B2
 balsefeer,ballpoint pen,圆珠笔,NOUN,B2
-balustrade,balustrade,栏杆,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+verbieden,to ban,禁止,VERB,B2
 banaliteit,banality,陈词滥调,NOUN,B2
-bananas,bananas,词,NOUN,A1
 band,band,乐队,NOUN,B2
-band tape,band tape,带子,NOUN,B2
-band volume,band volume,词,NOUN,C1
-bandaging,bandaging,词,NOUN,C1
 bandiet,bandit,强盗,NOUN,B2
-bandwidth,bandwidth,词,ADJ,C1
-bang,bang,砰,INTJ,B2
-banister,banister,词,NOUN,C1
-bank,sofa,沙发,NOUN,B2
-bank card,bank card,银行卡,NOUN,B2
+knal,bang,巨响,NOUN,B2
+verbanning,banishment,流放,NOUN,B2
+bankier,banker,银行家,NOUN,B2
 bank-,banking,银行的,ADJ,B2
 bankbiljet,banknote,钞票,NOUN,B2
-banket,banquet,宴会,NOUN,B2
-bankier,banker,银行家,NOUN,B2
 banner,banner,横幅,NOUN,B2
-banner headline,banner headline,词,NOUN,C1
-baptism,baptism,词,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
+banket,banquet,宴会,NOUN,B2
+gejok,banter,戏谑,NOUN,B2
+dopen,to baptize,施洗,VERB,B2
 bar,bar,酒吧,NOUN,B2
-bar of soap,bar of soap,词,NOUN,B2
-barbarian,barbarian,词,NOUN,B2
-barbarij,barbarity,残暴,NOUN,B2
 barbarisme,barbarism,野蛮,NOUN,B2
+barbarij,barbarity,残暴,NOUN,B2
 barbecue,barbecue,烧烤,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
-bard,bard,吟游诗人,NOUN,B2
-bare ownership,bare ownership,虚有权,NOUN,B2
-bargain,bargain,便宜货,NOUN,B2
-bargaining,bargaining,词,NOUN,C1
-barge,barge,驳船,NOUN,B2
-bark (noun),bark,词,NOUN,B2
-barking,barking,词,NOUN,B2
-baron,baron,词,NOUN,B2
-baroness,baroness,女男爵,NOUN,B2
-barracks,barracks,兵营,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barren,barren,词,ADJ,C1
-barrenness,barrenness,词,NOUN,C1
-barricade,barricade,路障,NOUN,B2
-barsten,crack,裂缝,NOUN,B2
-barsten,to burst,爆发,VERB,B2
-barsten,to crack,破裂,VERB,B2
-barter (noun),barter,词,NOUN,C1
-barter (verb),barter,词,VERB,C1
-base fertilizer,base fertilizer,基肥,NOUN,B2
-based,based,基于,ADJ,B2
-bash,bash,词,VERB,C1
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
+blaffen,to bark,吠叫,VERB,B2
+gerst,barley,大麦,NOUN,B2
+Barrière,barrier,障碍,NOUN,B2
+Basis,base,基础,NOUN,B2
+Honkbal,baseball,棒球,NOUN,B2
+Kelder,basement,地下室,NOUN,B2
+Laagheid,baseness,卑鄙,NOUN,B2
 basis,basic,基本的,ADJ,B2
-bask,bask,词,VERB,C1
-baste,baste,词,VERB,C1
-basting,basting,词,NOUN,C1
-bastion,bastion,堡垒,NOUN,B2
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-bathrobe,bathrobe,词,NOUN,A2
-baton,baton,警棍,NOUN,B2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
-battlement,battlement,城垛,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
-bazi,ba zi,八字,NOUN,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be crushed,be crushed,词,VERB,C1
+in feite,basically,基本上,ADV,B2
+Basilicum,basil,罗勒,NOUN,B2
+Basiliek,basilica,大教堂,NOUN,B2
+Bekken,basin,盆,NOUN,B2
+Bas,bass,贝斯,NOUN,B2
+Bastaard,bastard,混蛋,NOUN,B2
+Knuppel,bat,蝙蝠,NOUN,B2
+Partij,batch,一批,NOUN,B2
+baden,to bathe,洗澡,VERB,B2
+Badkuip,bathtub,浴缸,NOUN,B2
+Bataljon,battalion,营,NOUN,B2
+Strijd,battle,战斗,NOUN,B2
+Slagveld,battlefield,战场,NOUN,B2
+Baai,bay,海湾,NOUN,B2
+Bazaar,bazaar,集市,NOUN,B2
+kunnen,be able to,能,AUX,B2
+kunnen,to be able to,能够,VERB,B2
+afwezig zijn,to be absent,缺席,VERB,B2
+verslaafd zijn,to be addicted,上瘾,VERB,B2
+geboren worden,to be born,出生,VERB,B2
+moedig zijn,to be brave,勇善,VERB,B2
+beschadigd raken,to be damaged,受损,VERB,B2
+verslagen worden,to be defeated,会败,VERB,B2
+klaar zijn,to be done,被做,VERB,B2
+gretig zijn,to be eager,心切,VERB,B2
+verlangen naar,to be eager for,巴不得,VERB,B2
+gekozen worden,to be elected,当选,VERB,B2
+volstaan,to be enough,足够,VERB,B2
+betoverd zijn,to be entranced,出神,VERB,B2
 be forced,to be forced,被迫,VERB,B2
 be good at,to be good at,擅长,VERB,B2
 be grateful,to be grateful,感激,VERB,B2
 be hit,to be hit,中箭,VERB,B2
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
 be jealous,to be jealous,嫉妒,VERB,B2
 be late,to be late,迟到,VERB,B2
 be left over,to be left over,剩余,VERB,B2
 be on duty,to be on duty,值班,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
 be required,to be required,被要求,VERB,B2
 be responsible for,to be responsible for,负责,VERB,B2
 be right,to be right,正确,VERB,B2
-be rumored,be rumored,词,VERB,C1
 be safe,to be safe,安好,VERB,B2
-be shot,be shot,中弹,VERB,C1
 be so,to be so,然,VERB,B2
-be sorry,be sorry,抱歉,ADJ,B2
 be stolen,to be stolen,失窃,VERB,B2
 be surprised,to be surprised,感到惊讶,VERB,B2
-be tender,be tender,温柔的,ADJ,B2
 be useful,to be useful,有用,VERB,B2
 be worth,to be worth,值得,VERB,B2
 beacon,beacon,灯塔,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beans,beans,词,NOUN,A1
 bearable,bearable,可忍受的,ADJ,B2
 bearing,bearing,轴承,NOUN,B2
-beaten,beaten,被打败的,ADJ,B2
 beating,beating,跳动,NOUN,B2
-beatitude,beatitude,至福,NOUN,B2
-beautification,beautification,词,NOUN,C1
-beautifully,beautifully,美丽地,ADV,B2
-beaver,beaver,词,NOUN,C1
-beboeten,to fine,罚款,VERB,B2
-bebossing,afforestation,植树造林,NOUN,B2
-beckon,beckon,词,VERB,C1
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedenken,to devise,设计,VERB,B2
-bedevaart,pilgrimage,朝圣,NOUN,B2
-bediende,attendant,服务员,NOUN,B2
-bedreigd,endangered,濒危的,ADJ,B2
-bedreven,versed,精通的,ADJ,B2
-bedriegen,to deceive,欺骗,VERB,B2
-bedriegen,to swindle,诈骗,VERB,B2
-bedrieglijke uitdaging,deception dare,你敢骗我,NOUN,B2
-bedroefd,sad sorrowful,悲伤,ADJ,B2
-bedsheet,bedsheet,床单,NOUN,B2
-bedside,bedside,词,NOUN,C1
-beduidend,significant,重要的,ADJ,B2
-beech grove,beech grove,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beehive,beehive,词,NOUN,C1
-beeldhouwer,sculptor,雕塑家,NOUN,B2
-beeldspraak,imagery,意象,NOUN,B2
-beenderig,bony,瘦骨嶙峋的,ADJ,B2
 beep,beep,吱吱声,NOUN,B2
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
-befahrt,befahrt,词,NOUN,C1
-befall,befall,词,VERB,C1
-befassung,befassung,词,NOUN,C1
-befit,befit,词,VERB,C1
-beforderung,beforderung,词,NOUN,C1
 before,before,在...之前,ADP,B2
-before (noun),before,以前,NOUN,A1
-before one's eyes,before one's eyes,词,ADV,C1
-before previously,before previously,以前,ADV,B2
-before that,before that,词,ADV,B1
 beforehand,beforehand,事先,ADV,B2
-befuddle,befuddle,词,VERB,C1
-beg for pity,beg for pity,乞怜,VERB,B2
-begabe,begabe,词,NOUN,C1
-begeeren,to crave,渴望,VERB,B2
-begeleiden,to escort,护送,VERB,B2
-begeleider,escort guard,镖师,NOUN,B2
-begestaltung,begestaltung,词,NOUN,C1
 beggar,beggar,乞丐,NOUN,B2
 begging,begging,乞讨,NOUN,B2
 begin to start,to begin to start,开始,VERB,B2
 beginner,beginner,初学者,NOUN,B2
-beginning primer,beginning primer,词,NOUN,C1
-begrafenis,burial,埋葬,NOUN,B2
-begrip,understanding,理解,NOUN,B2
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
 behave,to behave,表现,VERB,B2
-behavioral,behavioral,词,ADJ,B2
-behaviorist,behaviorist,行为主义者,NOUN,B2
-beheading,beheading,按律当斩,NOUN,C1
-beheerder,caretaker,房屋管理员,NOUN,B2
-beheersen,to master,掌握,VERB,B2
-beheren,to manage,管理,VERB,B2
-behind (noun),behind,词,NOUN,B2
-behoove,behoove,词,VERB,C1
-behoud,preservation,保护,NOUN,B2
-beide,both,两者都,DET,B2
-beide handen,both hands,双手,NOUN,B2
 being,being,存在,NOUN,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-beitel,chisel,凿子,NOUN,B2
-bejaarde,old person,老人,NOUN,B2
-bejeweled,bejeweled,镶满宝石的,ADJ,B2
-bekend,well-known,众所周知的,ADJ,B2
-beklagen,to pity,同情,VERB,B2
-beklagenswaardig,pitiful,可怜的,ADJ,B2
-bekunft,bekunft,词,NOUN,C1
-bekwaam,able,能够的,ADJ,B2
-bekwaam,capable,有能力的,ADJ,B2
-bekwaam,proficient,熟练的,ADJ,B2
-belabor,belabor,词,VERB,C1
-belasten,to tax,征税,VERB,B2
-belastingvrij,tax-exempt,免税,ADJ,B2
-belated,belated,词,ADJ,C1
-belatedly,belatedly,词,ADV,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-beleaguered,beleaguered,受围困的,ADJ,B2
-beledigen,insult,辱骂,NOUN,B2
-beledigen,to insult,侮辱,VERB,B2
-beleefd afwijzen,to decline politely,婉拒,VERB,B2
-beleefdheid,courtesy,礼貌,NOUN,B2
-belegeren,to besiege,包围,VERB,B2
-belemmeren,to obstruct,阻碍,VERB,B2
-belemmering,impediment,障碍,NOUN,B2
-belichamen,to embody,体现,VERB,B2
-belichaming,epitome,化身,NOUN,B2
-belie,belie,词,VERB,C1
-belief creed,belief creed,词,NOUN,B2
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-believability,believability,词,NOUN,C1
 belittle,to belittle,轻视,VERB,B2
-belittling,belittling,词,NOUN,C1
 bell,bell,铃,NOUN,B2
 bell pepper,bell pepper,甜椒,NOUN,B2
-bell tower,bell tower,词,NOUN,A2
-bellen,to phone,打电话,VERB,B2
 bellicose,bellicose,好战的,ADJ,B2
-belligerent,belligerent,好战的,ADJ,B2
 bellow,to bellow,吼叫,VERB,B2
-bellows,bellows,词,NOUN,C1
-belofte,vow,誓言,NOUN,B2
-beloved,beloved,心爱的,ADJ,B2
-belovend,promising,有前途的,ADJ,B2
-below,below,下面,NOUN,B2
-bemiddelen,to mediate,调解,VERB,B2
-bemiddeling,mediation,调解,NOUN,B2
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-benadering,approximation,近似值,NOUN,B2
-benadrukken,to highlight,强调,VERB,B2
-benahme,benahme,词,NOUN,B2
-bench seat,bench seat,词,NOUN,C1
-bending,bending,弯曲,NOUN,C1
-beneath,beneath,词,ADP,B2
-beneficence,beneficence,词,NOUN,C1
-beneficial,beneficial,有益的,ADJ,B2
-benijden,envy,嫉妒,NOUN,B2
-benijden,to envy,羡慕,VERB,B2
-benutten,to utilize,利用,VERB,B2
-benzine,gasoline,汽油,NOUN,B2
-beoordeling,rating,评分,NOUN,B2
-beoordeling,review,回顾,NOUN,B2
-bepalingen,provisions,储备,NOUN,B2
-beperken,to constrain,限制,VERB,B2
-beperken,to restrict,限制,VERB,B2
-beperking,constraint,约束,NOUN,B2
-bepflegung,bepflegung,词,NOUN,B2
-bepleiten,to advocate,提倡,VERB,B2
-bequest,bequest,词,NOUN,B2
-berate,berate,词,VERB,C1
-bereave,bereave,词,VERB,C1
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-bereidheid,readiness,准备就绪,NOUN,B2
-bereidheid,willingness,乐意,NOUN,B2
-bereiken,to attain,达到,VERB,B2
-bergafdaling,mountain descent,下山,NOUN,B2
-bergketen,mountain range,山脉,NOUN,B2
-berichtung,berichtung,词,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berouw,repentance,悔恨,NOUN,B2
-berouwen,to repent,悔改,VERB,B2
-beroving,robbery,抢劫案,NOUN,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beschaafd,civilized,文明的,ADJ,B2
-beschaamd,ashamed,羞愧的,ADJ,B2
-beschadigd raken,to be damaged,受损,VERB,B2
-beschaft,beschaft,词,NOUN,C1
-bescheidenheid,modesty,谦虚,NOUN,B2
-beschermend,protective,保护的,ADJ,B2
-beschrift,beschrift,词,NOUN,C1
-beseech,beseech,词,VERB,C1
-beset,beset,词,VERB,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
-beside,beside,在...旁边,ADP,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
-besieged,besieged,词,ADJ,B2
-besieging,besieging,词,NOUN,C1
-besinnung,besinnung,词,NOUN,C1
-beslissend,decisive,决定性的,ADJ,B2
-beslisser,decision-maker,决策者,NOUN,B2
-besmettelijk,contagious,传染性的,ADJ,B2
-besmirch,besmirch,词,VERB,C1
-besparingen,savings,存款,NOUN,B2
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-best possible,best possible,词,ADJ,C1
-bestaan,to consist,组成,VERB,B2
-besteden,to expend,花费,VERB,B2
-bestelbus,van,货车,NOUN,B2
-bestial,bestial,词,ADJ,C1
-bestrijdingsmiddel,pesticide,杀虫剂,NOUN,B2
-bestuur,governance,治理,NOUN,B2
-bestuurder,executive,行政主管,NOUN,B2
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
-betegeling,tiling,铺瓷砖,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betekenen,to signify,意味着,VERB,B2
-betekenis,significance,含义,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betoverd zijn,to be entranced,出神,VERB,B2
-betoveren,to enchant,使着迷,VERB,B2
-betoverend,enchanting,迷人的,ADJ,B2
-betray one's country,betray one's country,卖国,VERB,B2
-betreibung,betreibung,词,NOUN,C1
-betrothal,betrothal,订婚,NOUN,B2
-betrothal gift,betrothal gift,聘,NOUN,C1
-betrouwbaar,reliable,可靠的,ADJ,B2
-betrouwbaarheid,reliability,可靠性,NOUN,B2
-better (adv),better,词,ADV,A1
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-beul,executioner,刽子手,NOUN,B2
-beurs,scholarship,奖学金,NOUN,B2
-beveiligingsagent,security guard,保安,NOUN,B2
-beven,shudder,战栗,NOUN,B2
-beverage,beverage,词,NOUN,B2
-bevestigen,to affirm,断言,VERB,B2
-bevoegd maken,to empower,授权,VERB,B2
-bevoordelen,favor,恩惠,NOUN,B2
-bevoordelen,to favor,偏袒,VERB,B2
-bevredigend,satisfactory,令人满意的,ADJ,B2
-bewail,bewail,词,VERB,C1
-bewandel,bewandel,词,NOUN,C1
-beware,beware,词,VERB,C1
-bewaren,to preserve,保护,VERB,B2
-beweisung,beweisung,词,NOUN,C1
-beweren,to assert,断言,VERB,B2
-bewijs,evidence,证据,NOUN,B2
-bewijs leveren,to provide evidence,举证,VERB,B2
-bewilder,bewilder,词,VERB,C1
-bewirkung,bewirkung,词,NOUN,C1
-bewolkt,cloudy,阴沉的,ADJ,B2
-bewolkt,overcast,阴天的,ADJ,B2
-bewonen,to inhabit,居住,VERB,B2
-bewoner,inhabitant,居民,NOUN,B2
-bewust,aware,意识到的,ADJ,B2
-bewusteloos,unconscious,无意识的,ADJ,B2
-bezit,asset,资产,NOUN,B2
-bezitten,to possess,拥有,VERB,B2
-bezorgd,worried,担心的,ADJ,B2
-bezwijken,to succumb,屈服,VERB,B2
-beëindiging,termination,解除,NOUN,B2
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bids,bids,词,NOUN,C1
-biecht,confession,供认,NOUN,B2
-biennial,biennial,词,NOUN,C1
-bifurcation,bifurcation,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big cat,big cat,词,NOUN,C1
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigger,bigger,更大的,ADJ,B2
-bigness,bigness,,NOUN,B2
-bigotry,bigotry,词,NOUN,C1
-bigwig,bigwig,大人物,NOUN,B2
-bij,by,通过,ADP,B2
-bijdragen,to contribute,贡献,VERB,B2
-bijeenkomst,gathering,聚集,NOUN,B2
-bijgeloof,superstition,迷信,NOUN,B2
-bijgevolg,consequently,因此,ADV,B2
-bijl,axe,斧头,NOUN,B2
-bijlage,annex,附件,NOUN,B2
-bijlage,attachment,附件,NOUN,B2
-bijvak,minor course,辅修课,NOUN,B2
-bijwonen,to attend,出席,VERB,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
-bilingual,bilingual,词,ADJ,C1
-bilingualism,bilingualism,词,NOUN,C1
-bilious,bilious,易怒的,ADJ,B2
-bilk,bilk,词,VERB,C1
-bill of exchange,bill of exchange,词,NOUN,C1
-billion,billion,十亿,NOUN,B2
-billionaire,billionaire,词,NOUN,C1
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
+toebehoren,to belong to,属于,VERB,B2
+Toebehoor,belonging,归属感,NOUN,B2
+Toebehoor,belongings,所属物,NOUN,B2
+Onder,below,在...下面,ADP,B2
+Bank,bench,长凳,NOUN,B2
+Meedogenaar,benefactor,恩人,NOUN,B2
+Begunstigde,beneficiary,受益人,NOUN,B2
+meedogenend,benevolent,仁慈的,ADJ,B2
+Naast,beside next to,旁边,NOUN,B2
+belegeren,to besiege,包围,VERB,B2
+schenken,to bestow,授予,VERB,B2
+Schenking,bestowal,授予,NOUN,B2
+Weddenschap,bet,打赌,NOUN,B2
+Beter,better,越好,NOUN,B2
+Verwarring,bewilderment,困惑,NOUN,B2
+buiten,beyond,在...之外,ADP,B2
+Bianzhong,bianzhong,编钟,NOUN,B2
+Vooringenomenheid,bias,偏见,NOUN,B2
+vooringenomen,biased,有偏见的,ADJ,B2
+Inschikkingsbedrog,bid collusion,串标,NOUN,B2
+Inschikkingsbeoordeling,bid evaluation,评标,NOUN,B2
+Inschikkingsopening,bid opening,开标,NOUN,B2
+grootste,biggest,最大,ADJ,B2
+Galsap,bile,胆汁,NOUN,B2
+Biljart,billiards,台球,NOUN,B2
 binair,binary,二进制的,ADJ,B2
-binden,tie,领带,NOUN,B2
-binden,to tie,联结,VERB,B2
-binder,binder,词,NOUN,A2
-binding (adj),binding,词,ADJ,C1
-binge,binge,放纵,NOUN,B2
-bingo,bingo,词,NOUN,B2
-binnen,within,在……之内,ADP,B2
-binnen,inside,在里面,ADV,B2
-binnengaan,to go in,进去,VERB,B2
-binnenhof,inner court,朝内,NOUN,B2
-binnenkomen,to come in,进来,VERB,B2
-binnenplaats,courtyard,庭院,NOUN,B2
-binnenstaander,insider,知情者,NOUN,B2
-binnenstad,inside city,城内,NOUN,B2
-binoculars,binoculars,双筒望远镜,NOUN,B2
-biographical,biographical,词,ADJ,C1
-biographies,biographies,词,NOUN,C1
+Binding,binding,装订,NOUN,B2
+Biodiversiteit,biodiversity,生物多样性,NOUN,B2
 biologisch,biological,生物的,ADJ,B2
-biologist,biologist,生物学家,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-biscuit,biscuit,饼干,NOUN,A2
-bistro,bistro,小酒馆,NOUN,B2
-bitch,bitch,母狗,NOUN,B2
-biting,biting,咬人,NOUN,B2
+Biomassa,biomass,生物质,NOUN,B2
+Biopt,biopsy,活检,NOUN,B2
+Biotechnologie,biotechnology,生物技术,NOUN,B2
+Bijt,biting,尖刻的,ADJ,B2
 bitter,bitter,苦的,ADJ,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
 bitterheid,bitterness,苦涩,NOUN,B2
-biweekly,biweekly,双周的,ADJ,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-blab,blab,词,VERB,C1
-black (noun),black,أسود,NOUN,C1
-black pepper,black pepper,词,NOUN,B2
-blackout,blackout,词,NOUN,C1
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blaffen,to bark,吠叫,VERB,B2
-blah,blah,词,INTJ,C1
-blame (noun),blame,只怪,NOUN,B2
-blanch,blanch,词,VERB,C1
-blandish,blandish,词,VERB,C1
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blauwe bes,blueberry,蓝莓,NOUN,B2
-blazing,blazing,炽热的,ADJ,B2
-blazing ardor,blazing ardor,词,NOUN,C1
-bleek,pale,苍白的,ADJ,B2
+zwarte markt,black market,黑市,NOUN,B2
+zwarte toga,black robe,黑衣,NOUN,B2
+schoolbord,blackboard,黑板,NOUN,B2
+chanteren,blackmail,敲诈,NOUN,B2
+chanteren,to blackmail,勒索,VERB,B2
+smid,blacksmith,铁匠,NOUN,B2
+lemmet,blade,刀片,NOUN,B2
+verwijten,blame,责备,NOUN,B2
+verwijten,to blame,责备,VERB,B2
+flauw,bland,平淡的,ADJ,B2
+vuurzee,blaze,火焰,NOUN,B2
 bleekmiddel,bleach,漂白剂,NOUN,B2
-blend,blend,词,VERB,B2
-blender,blender,搅拌机,NOUN,B2
-blending,blending,词,NOUN,C1
-blessed,blessed,受祝福的,ADJ,B2
-blight,blight,词,NOUN,C1
-blij,glad,高兴的,ADJ,B2
-blij,joyful,快乐的,ADJ,B2
-blijkbaar,allegedly,据称,ADV,B2
-blik,tin,锡,NOUN,B2
-blikvoedsel,canned food,罐头食品,NOUN,B2
-blind,blind,盲的,ADJ,B2
-blind person,blind person,词,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
-blister,blister,词,NOUN,C1
-bloat,bloat,词,VERB,C1
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
-blockhead,blockhead,笨蛋,NOUN,B2
-blocking,blocking,词,NOUN,B2
 bloeden,to bleed,出血,VERB,B2
-bloederig,bloody,血淋淋的,ADJ,B2
 bloeding,bleeding,出血,NOUN,B2
-bloeding,hemorrhage,出血,NOUN,B2
-bloedplaatje,platelet,血小板,NOUN,B2
-bloedschuld,blood debt,血债,NOUN,B2
-bloedzee,blood sea,血海,NOUN,B2
-bloem,flour,面粉,NOUN,B2
-bloemlezing,anthology,选集,NOUN,B2
-blog post,blog post,词,NOUN,C1
-blogger,blogger,词,NOUN,B2
+smet,blemish,瑕疵,NOUN,B2
+zegenen,to bless,祝福,VERB,B2
+blind,blind,盲的,ADJ,B2
+gelukzaligheid,bliss,极乐,NOUN,B2
+sneeuwstorm,blizzard,暴风雪,NOUN,B2
 blok,bloc,阵营,NOUN,B2
 blokkeren,to blockade,封锁,VERB,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
-blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-blood-related,blood-related,词,ADJ,C1
-bloodless,bloodless,不流血的,ADJ,B2
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,沾血,NOUN,B2
-bloom of youth,bloom of youth,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
-blossoming ripening,blossoming ripening,词,NOUN,C1
+bloedschuld,blood debt,血债,NOUN,B2
+bloedzee,blood sea,血海,NOUN,B2
+bloederig,bloody,血淋淋的,ADJ,B2
+vlek,blot,污点,NOUN,B2
 blouse,blouse,女衬衫,NOUN,B2
-blow beating,blow beating,词,NOUN,B2
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blue (noun),blue,词,NOUN,C1
-blueprint,blueprint,词,NOUN,C1
-blueprint diagram,blueprint diagram,词,NOUN,C1
-blunder,blunder,大错,NOUN,B2
-blunt,blunt,词,ADJ,B2
-bluntness,bluntness,直说,NOUN,B2
-blurred,blurred,词,ADJ,C1
-blurriness,blurriness,词,NOUN,C1
-blurry,blurry,词,ADJ,B2
-blurt,blurt,词,VERB,C1
-blussen,to extinguish,熄灭,VERB,B2
-bluster,bluster,词,VERB,C1
-boarder,boarder,寄宿生,NOUN,B2
-boarding,boarding,词,NOUN,C1
-boarding pass,boarding pass,登机牌,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastful,boastful,自夸的,ADJ,B2
-boastfulness,boastfulness,吹嘘,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bode,bode,词,VERB,C1
-bodem,dregs,渣滓,NOUN,B2
-bodies,bodies,词,NOUN,C1
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-boei,shackle,镣铐,NOUN,B2
-boek,measure word for books,本,NUM,B2
-boekweit,buckwheat,荞麦,NOUN,B2
-boeren,to burp,打嗝,VERB,B2
-boeten,to atone,赎罪,VERB,B2
-bog,bog,沼泽,NOUN,B2
-boggle,boggle,词,VERB,C1
-bohemian,bohemian,放荡不羁的,ADJ,B2
-boil (noun),boil,词,NOUN,C1
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
-boiling (adj),boiling,词,ADJ,C1
-boisterous,boisterous,喧闹的,ADJ,B2
-boksen,boxing,拳击,NOUN,B2
-boldness daring,boldness daring,词,NOUN,B2
-bolster (noun),bolster,词,NOUN,C1
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolted,bolted,词,ADJ,C1
-bombardement,bombing,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
-bomber,bomber,词,NOUN,C1
-bond,bond,纽带,NOUN,B2
-bondholder,bondholder,词,NOUN,C1
-bonds,bonds,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-bonfire,bonfire,篝火,NOUN,B2
-bonhomie,bonhomie,词,NOUN,C1
-bonus,bonus,奖金,NOUN,B2
-boodschap,errand,差事,NOUN,B2
-boodschapper,messenger,信使,NOUN,B2
-boog,arc,弧,NOUN,B2
-bookcase,bookcase,书柜,NOUN,B2
-booking,booking,词,NOUN,A2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,书店,NOUN,B2
-boom,boom,繁荣,NOUN,B2
-boor,drill,钻头,NOUN,B2
-boorish,boorish,词,ADJ,C1
-boos,resentful,充满愤恨的,ADJ,B2
-boos worden,to get angry,生气,VERB,B2
-boosheid,malice,恶意,NOUN,B2
-border frontier,border frontier,词,NOUN,B1
-bordering,bordering,词,ADJ,C1
-borders,borders,边界,NOUN,A1
-borduuren,to embroider,刺绣,VERB,B2
-borduurwerk,embroidery,刺绣,NOUN,B2
-boren,to bore,使厌烦,VERB,B2
-borg,guarantor,担保人,NOUN,B2
-borgsom,bail,保释,NOUN,B2
-born,born,出生的,ADJ,B2
-born (verb),born,词,VERB,A1
-borrowed,borrowed,词,ADJ,C1
-borrowed knife,borrowed knife,借刀,NOUN,B2
-borstpijn,chest pain,胸痛,NOUN,B2
-bos,woodland,林地,NOUN,B2
-bosom,bosom,词,NOUN,C1
-boss female,boss female,词,NOUN,B2
-boss manager,boss manager,词,NOUN,A1
-bossism,bossism,老板主义,NOUN,B2
-botanical,botanical,词,ADJ,C1
-botany,botany,词,NOUN,C1
-botched job,botched job,词,NOUN,B2
-both (adj),both,两者的,ADJ,B2
-both (det),both,两者都,DET,A1
-both (noun),both,词,NOUN,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
-both parties,both parties,双方,NOUN,B1
-bother (noun),bother,烦不,NOUN,B1
-botsen,to collide,碰撞,VERB,B2
-botsing,collision,碰撞,NOUN,B2
-bottle opener,bottle opener,词,NOUN,B1
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
+blauwe bes,blueberry,蓝莓,NOUN,B2
 botweg,bluntly,直率地,ADV,B2
-bounce,bounce,词,VERB,B2
-bound to,bound to,势必,ADV,B2
-boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bourgeois,bourgeois,资产阶级的,ADJ,B2
+vervagen,to blur,模糊,VERB,B2
+kostschool,boarding school,寄宿学校,NOUN,B2
+opscheppen,to boast,吹嘘,VERB,B2
+lichamelijk,bodily,身体上的,ADJ,B2
+lijfwacht,bodyguard,保镖,NOUN,B2
+ketel,boiler,锅炉,NOUN,B2
+koken,boiling,沸腾,NOUN,B2
+moedig,bold,大胆的,ADJ,B2
+durf,boldness,大胆,NOUN,B2
+bombardement,bombing,轰炸,NOUN,B2
+bond,bond,纽带,NOUN,B2
+bonus,bonus,奖金,NOUN,B2
+beenderig,bony,瘦骨嶙峋的,ADJ,B2
+boom,boom,繁荣,NOUN,B2
+kraam,booth,摊位,NOUN,B2
+grenzend,border,边境的,ADJ,B2
+boren,to bore,使厌烦,VERB,B2
+verveeld,bored,无聊的,ADJ,B2
+verveling,boredom,无聊,NOUN,B2
+ontleener,borrower,借款人,NOUN,B2
+lening,borrowing,借贷,NOUN,B2
+beide,both,两者都,DET,B2
+beide handen,both hands,双手,NOUN,B2
+storen,bother,麻烦,NOUN,B2
+storen,to bother,打扰,VERB,B2
+rotsblok,boulder,巨石,NOUN,B2
+gebonden,bound,一定的,ADJ,B2
+grens,boundary,边界,NOUN,B2
 bourgeoisie,bourgeoisie,资产阶级,NOUN,B2
-bout,bout,阵,NOUN,B2
-bouwwerf,construction site,工地,NOUN,B2
-bovendien,moreover,而且,CCONJ,B2
-bovine,bovine,词,ADJ,C1
-bow (verb),bow,词,VERB,B1
-bow tie,bow tie,领结,NOUN,B2
-bower,bower,凉亭,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
-boxer,boxer,拳击手,NOUN,B2
+boksen,boxing,拳击,NOUN,B2
 boycotten,to boycott,抵制,VERB,B2
-brace,brace,词,NOUN,C1
-bracket,bracket,括号,NOUN,B2
-braden,roast,烤肉,NOUN,B2
-braden,to roast,煎烤,VERB,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-bragging,bragging,吹嘘,NOUN,B2
-braid,braid,辫子,NOUN,C1
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,,NOUN,B2
-brainstorming,brainstorming,词,NOUN,C1
-brainwasher,brainwasher,洗脑者,NOUN,B2
-braise,braise,焖烧,VERB,C1
-brakeman,brakeman,刹车员,NOUN,B2
-brakes,brakes,词,NOUN,C1
-braking,braking,词,NOUN,C1
-bran,bran,词,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
-brandhout,firewood,木柴,NOUN,B2
-brandweerman,firefighter,消防员,NOUN,B2
-brandwond,burn,烧伤,NOUN,B2
-brass band,brass band,词,NOUN,B2
-brassware,brassware,词,NOUN,C1
-bravo,bravo,词,NOUN,B2
-brawl,brawl,斗殴,NOUN,B2
-bray,bray,词,VERB,C1
-brazen,brazen,厚颜无耻的,ADJ,B2
-brazier,brazier,词,NOUN,B1
-breach of duty,breach of duty,渎职,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-breadth,breadth,词,NOUN,C1
-breadth crossing,breadth crossing,词,NOUN,C1
-break fraction,break fraction,词,NOUN,C1
+armband,bracelet,手镯,NOUN,B2
+pralen,to brag,吹嘘,VERB,B2
+rem,brake,刹车,NOUN,B2
+gloednieuw,brand new,崭新的,ADJ,B2
+moed,bravery,勇敢,NOUN,B2
+onbeschaamdheid,brazenness,厚颜无耻,NOUN,B2
+schending,breach,违反,NOUN,B2
+contract schenden,to breach contract,违约,VERB,B2
+kapotgaan,to break down,分解,VERB,B2
 break open,to break open,撬开,VERB,B2
-break out of prison,break out of prison,越狱,VERB,C1
 break up,to break up,破裂,VERB,B2
-break-in,break-in,非法侵入,NOUN,B2
-breakage,breakage,词,NOUN,C1
 breakdown,breakdown,故障,NOUN,B2
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
-breakthrough,breakthrough,突破性,ADJ,B2
-breakup,breakup,分手,NOUN,B2
-breast,breast,乳房,NOUN,B2
 breastfeed,to breastfeed,母乳喂养,VERB,B2
 breastfeeding,breastfeeding,母乳喂养,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,呼吸,NOUN,B2
-breathing space,breathing space,词,NOUN,C1
-breathlessness,breathlessness,词,NOUN,B1
 breed,breed,品种,NOUN,B2
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
 breeze,breeze,微风,NOUN,B2
-breukteken,fraction marker,分之,PART,B2
-breviary,breviary,词,NOUN,C1
 brevity,brevity,简洁,NOUN,B2
 brewery,brewery,啤酒厂,NOUN,B2
 bribe,bribe,贿赂,NOUN,B2
 bribe,to bribe,贿赂,VERB,B2
-bribe-taker,bribe-taker,词,NOUN,C1
 bribery,bribery,贿赂,NOUN,B2
-bribes,bribes,词,NOUN,C1
 brick,brick,砖,NOUN,B2
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
 bridal chamber,bridal chamber,洞房,NOUN,B2
-bridal trousseau,bridal trousseau,词,NOUN,C1
-bridegroom,bridegroom,词,NOUN,C1
-bridle,bridle,马勒,NOUN,B2
 brief,brief,简短的,ADJ,B2
-brief (noun),brief,近点说,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brievenbus,mailbox,邮箱,NOUN,B2
-brigade,brigade,词,NOUN,C1
-brigand poet,brigand poet,词,NOUN,C1
 bright,bright,明亮的,ADJ,B2
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightly,brightly,词,ADV,C1
-brightness,brightness,词,NOUN,C1
 brilliance,brilliance,辉煌,NOUN,B2
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
-brim,brim,词,NOUN,C1
 bringing,bringing,جلب,NOUN,B2
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-briskness,briskness,轻快,NOUN,B2
-bristle (noun),bristle,词,NOUN,C1
-brittle,brittle,易碎的,ADJ,B2
-brittleness,brittleness,词,NOUN,C1
-bro,bro,哥们,NOUN,B2
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
 broadcasting,broadcasting,广播,NOUN,B2
-broadcasting station,broadcasting station,词,NOUN,C1
-broaden,broaden,词,VERB,C1
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
 brocade,brocade,锦绣,NOUN,B2
-brocade (part),brocade,锦,PART,A1
-broccoli,broccoli,西兰花,NOUN,C1
-brochure,brochure,小册子,NOUN,B2
-broeikas,greenhouse,温室,NOUN,B2
-broers en zusters,siblings,兄弟姐妹,NOUN,B2
-broil,broil,词,VERB,C1
-broke,broke,破产的,ADJ,B2
-broken,broken,破碎的,ADV,B2
-brokenness,brokenness,词,NOUN,C1
 broker,broker,经纪人,NOUN,B2
 brokerage,brokerage,经纪业,NOUN,B2
-bron,resource,资源,NOUN,B2
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,青铜色的,ADJ,B2
-brooch,brooch,词,NOUN,C1
-brood,loaf,一条面包,NOUN,B2
-brooding,brooding,忧思,NOUN,B2
-brooding (adj),brooding,词,ADJ,B2
-broodje,sandwich,三明治,NOUN,B2
-brook no delay,brook no delay,刻不容缓,ADJ,B2
 broom,broom,扫帚,NOUN,B2
-broom blow,broom blow,词,NOUN,C1
 broth,broth,肉汤,NOUN,B2
 brothel,brothel,妓院,NOUN,B2
-brother (part),brother,兄,PART,B1
 brother-in-law,brother-in-law,姐夫/妹夫,NOUN,B2
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-brow,brow,眉毛,NOUN,B2
-browbeat,browbeat,词,VERB,C1
 browse,to browse,浏览,VERB,B2
 browser,browser,浏览器,NOUN,B2
-bruidegom,groom,新郎,NOUN,B2
-bruidsschat,dowry,嫁妆,NOUN,B2
-bruinen,to tan,晒黑,VERB,B2
 bruise,bruise,瘀伤,NOUN,B2
-bruises,bruises,词,NOUN,B2
-brullen,to roar,咆哮,VERB,B2
 brush,brush,刷子,NOUN,B2
 brush,to brush,刷,VERB,B2
-brusqueness,brusqueness,唐突,NOUN,B2
-brutaal,abrupt,突然的,ADJ,B2
-brutal,brutal,词,ADJ,B2
 brutalize,to brutalize,使变得残忍,VERB,B2
-brutally,brutally,词,ADV,C1
-brute,brute,粗野的,ADJ,B2
 bubble,bubble,气泡,NOUN,B2
-bubbling,bubbling,冒泡的,ADJ,B2
-buccaneer,buccaneer,海盗,NOUN,B2
 buck,buck,美元,NOUN,B2
-buckle,buckle,词,VERB,C1
-bucolic,bucolic,词,ADJ,C1
-bud,bud,芽,NOUN,B2
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budge,budge,词,VERB,C1
-budgeting,budgeting,词,NOUN,C1
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-buffoon,buffoon,小丑,NOUN,B2
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-buiten,beyond,在...之外,ADP,B2
-buiten gebruikstelling,decommissioning,退役,NOUN,B2
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulge,bulge,词,NOUN,C1
+emmer,bucket,桶,NOUN,B2
+boekweit,buckwheat,荞麦,NOUN,B2
+insect,bug,虫子,NOUN,B2
 bulk,bulk,主体,NOUN,B2
-bull,bull,词,NOUN,B1
-bulldog,bulldog,斗牛犬,NOUN,B2
-bulldoze,bulldoze,词,VERB,C1
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bullying,bullying,词,NOUN,B2
-bulwark,bulwark,壁垒,NOUN,B2
-bum,bum,流浪汉,NOUN,B2
-bumble,bumble,词,VERB,C1
-bumblebee,bumblebee,词,NOUN,C1
-bump,bump,肿块,NOUN,B2
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bunch,bunch,一群,NOUN,B2
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bungler,bungler,笨手笨脚的人,NOUN,B2
-bunker,bunker,词,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-buoyant,buoyant,有浮力的,ADJ,B2
-burdened,burdened,负担重的,ADJ,B2
-burdensome,burdensome,繁重的,ADJ,B2
+pestkop,bully,欺凌者,NOUN,B2
 bureau,bureau,局,NOUN,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-bureaucratic,bureaucratic,官僚的,ADJ,B2
 bureaucratie,bureaucracy,官僚主义,NOUN,B2
-burger,civilian,平民,NOUN,B2
-burger stand,burger stand,,NOUN,B2
-burgerschap,citizenship,公民身份,NOUN,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque,burlesque,滑稽的,ADJ,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burned,burned,词,ADJ,B2
-burner,burner,燃烧器,NOUN,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burp (noun),burp,词,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-burst in,burst in,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
-business card,business card,名片,NOUN,B1
-business sector,business sector,商业界,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-bust,bust,词,NOUN,B1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-but (adv),but,却,ADV,A1
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but-for,but-for,词,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-butler,butler,词,NOUN,C1
-butt,butt,臀部,NOUN,B2
-buttermilk,buttermilk,词,NOUN,A2
-buttress,buttress,扶壁,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buyer purchaser,buyer purchaser,买方,NOUN,B2
-buying and selling,buying and selling,词,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by heart,by heart,词,ADV,B2
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by me,by me,以我,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
-bypass (noun),bypass,词,NOUN,C1
-bypassing,bypassing,词,NOUN,C1
+inbreker,burglar,窃贼,NOUN,B2
+begrafenis,burial,埋葬,NOUN,B2
+brandwond,burn,烧伤,NOUN,B2
+verbrand,burnt,烧焦的,ADJ,B2
+boeren,to burp,打嗝,VERB,B2
+barsten,to burst,爆发,VERB,B2
+struik,bush,灌木,NOUN,B2
+zakelijk,business,商业的,ADJ,B2
+zakenbijeenkomst,business meeting,洽谈会,NOUN,B2
+drukte,busyness,事忙,NOUN,B2
+maar,but,然而,ADV,B2
+maar ik,but i,可我,ADV,B2
+maar jij,but you,但您,NOUN,B2
+slager,butcher,屠夫,NOUN,B2
+bij,by,通过,ADP,B2
+met alle middelen,by fair means or foul,不择手段,ADV,B2
+door middel van,by means of,凭借,NOUN,B2
+vervlogen,bygone,过去的,ADJ,B2
 bypassoperatie,bypass surgery,搭桥手术,NOUN,B2
-byzantine,byzantine,错综复杂的,ADJ,B2
-cabin boy,cabin boy,词,NOUN,C1
-cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
-cable car,cable car,缆车,NOUN,B1
-cache,cache,词,NOUN,C1
-cachexia,cachexia,词,NOUN,C1
-cackle,cackle,词,VERB,C1
-cacophony,cacophony,刺耳的声音,NOUN,B2
-cactus,cactus,词,NOUN,B1
-cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
-cadence,cadence,词,NOUN,B2
-cadres,cadres,词,NOUN,C1
-caesura,caesura,词,NOUN,C1
-cafeteria,cafeteria,词,NOUN,B1
-caffeine,caffeine,词,NOUN,C1
-caftan,caftan,词,NOUN,A1
-café,pub,酒吧,NOUN,B2
-cage (verb),cage,词,VERB,C1
-caid local governor,caid local governor,词,NOUN,C1
-cajole,cajole,词,VERB,C1
-calcareous,calcareous,词,ADJ,B2
-caliber,caliber,词,NOUN,C1
-calibrated,calibrated,词,ADJ,C1
-calibrator,calibrator,词,NOUN,C1
-caliph,caliph,词,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
-call to prayer,call to prayer,词,NOUN,B2
-caller,caller,词,NOUN,A2
-calligrapher,calligrapher,词,NOUN,C1
-calling,calling,使命,NOUN,B2
-callus,callus,硬茧……,NOUN,C1
-calming,calming,令人平静的,ADJ,B2
-calmly,calmly,平静地,ADV,B2
-calorie,calorie,词,NOUN,C1
-calve,calve,词,VERB,C1
+kool,cabbage,卷心菜,NOUN,B2
+hut,cabin,小屋,NOUN,B2
+rekenmachine,calculator,计算器,NOUN,B2
+kalf,calf,小腿,NOUN,B2
+kalibratie,calibration,校准,NOUN,B2
+kalligrafie,calligraphy,书法,NOUN,B2
+gevoelloos,callous,冷酷,ADJ,B2
+rust,calm,平静,NOUN,B2
+kameel,camel,骆驼,NOUN,B2
 camera,camera,照相机,NOUN,B2
-camouflage (noun),camouflage,词,NOUN,C1
-camp (part),camp,营,PART,A2
 campagnen,to campaign,积极参与活动,VERB,B2
-camper,motorhome,露营车,NOUN,B2
-campfire,campfire,词,NOUN,C1
 camping,camping,露营,NOUN,B2
-campus,campus,词,NOUN,B2
-can (noun),can,词,NOUN,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,罐子,NOUN,B2
-can may,can may,可以,AUX,A1
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
-cancerous,cancerous,词,ADJ,C1
-candid,candid,词,ADJ,C1
-candy shop,candy shop,词,NOUN,B2
-cane,cane,手杖,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
-canning,canning,词,NOUN,C1
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-canonical,canonical,规范的,ADJ,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
-canvas,canvas,帆布,NOUN,B2
-canvass,canvass,词,VERB,C1
+alleen kunnen,can only,只能,AUX,B2
+niet geloven,to can't believe,不敢相信,VERB,B2
+onvermijdelijk,can't help,不由得,ADV,B2
+annulering,cancellation,取消,NOUN,B2
+kandidatuur,candidacy,候选资格,NOUN,B2
+snoep,candy,糖果,NOUN,B2
+blikvoedsel,canned food,罐头食品,NOUN,B2
+kanon,cannon,大炮,NOUN,B2
+niet kunnen,cannot,不能,AUX,B2
+niet kunnen verdragen,to cannot bear,不堪,VERB,B2
+niet kunnen helpen,to cannot help,忍不住,VERB,B2
 canyon,canyon,峡谷,NOUN,B2
-capable,capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacitate,capacitate,词,VERB,C1
 capaciteit,capability,能力,NOUN,B2
-capacitor condenser,capacitor condenser,词,NOUN,C1
-caper (noun),caper,词,NOUN,B2
-capillary,capillary,词,ADJ,C1
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
-capitalist,capitalist,词,NOUN,C1
-capitalization,capitalization,词,NOUN,C1
-capitulation,capitulation,词,NOUN,C1
-capping,capping,封顶,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capriool,whim,突发奇想,NOUN,B2
-capsize,capsize,词,VERB,C1
-capsule,capsule,词,NOUN,B1
-captious,captious,词,ADJ,B2
-captivated,captivated,词,ADJ,C1
-captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-captive bond,captive bond,词,NOUN,C1
-car (part),car,车,PART,C1
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-caramelize,caramelize,词,VERB,C1
-carat,carat,克拉,NOUN,B2
+bekwaam,capable,有能力的,ADJ,B2
+kap,cape,海角,NOUN,B2
+gevangname,capture,捕获,NOUN,B2
+auto-ongeluk,car accident,车祸,NOUN,B2
+autoverzekering,car insurance,车险,NOUN,B2
 caravan,caravan,房车,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrate,carbohydrate,碳水化合物,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon trading,carbon trading,碳交易,NOUN,C1
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-cardboard,cardboard,硬纸板,NOUN,B2
+koolstof,carbon,碳,NOUN,B2
+koolstoftaks,carbon tax,碳税,NOUN,B2
 cardiaal,cardiac,心脏的,ADJ,B2
-care home,care home,,NOUN,B2
-careen,careen,词,VERB,C1
-career leap,career leap,词,NOUN,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefully,carefully,仔细地,ADV,B2
-carefulness,carefulness,细心,NOUN,B2
-carelessness,carelessness,词,NOUN,C1
-carer,carer,词,NOUN,C1
-caress (noun),caress,词,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
-caricature (verb),caricature,词,VERB,B2
+zorgverlener,caregiver,护理人员,NOUN,B2
+onvoorzichtig,careless,粗心的,ADJ,B2
+aaien,to caress,爱抚,VERB,B2
+beheerder,caretaker,房屋管理员,NOUN,B2
+lading,cargo,货物,NOUN,B2
 caricatuur,caricature,讽刺画,NOUN,B2
-carnation,carnation,词,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
-carp (verb),carp,词,VERB,C1
-carpet rug,carpet rug,地毯,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
+timmerman,carpenter,木匠,NOUN,B2
+timmerwerk,carpentry,木工,NOUN,B2
+kleed,carpet,地毯,NOUN,B2
+kar,carriage,马车,NOUN,B2
 carrier,carrier,承运人,NOUN,B2
 carry forward,to carry forward,发扬,VERB,B2
 carry out,to carry out,实施,VERB,B2
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
 cart,cart,手推车,NOUN,B2
-cartel,cartel,卡特尔,NOUN,B2
 cartilage,cartilage,软骨,NOUN,B2
-cartography,cartography,词,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
-case law,case law,判例法,NOUN,B2
 cash,cash,现金,ADJ,B2
 cash,to cash,兑现,VERB,B2
-cash conversion,cash conversion,改现,NOUN,B2
 cash register,cash register,收银机,NOUN,B2
 cashew,cashew,腰果,NOUN,B2
-cashier,cashier,出纳员,NOUN,B2
 cashmere,cashmere,羊绒,NOUN,B2
-casino,casino,词,NOUN,B2
-casket,casket,词,NOUN,C1
-cassation,cassation,词,NOUN,B2
 cassava,cassava,木薯,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cast,cast,演员阵容,NOUN,B2
-cast (adj),cast,词,ADJ,C1
-cast iron,cast iron,词,NOUN,B2
-castanets,castanets,词,NOUN,B1
-caste,caste,词,NOUN,B2
-casting,casting,词,NOUN,C1
-castrate,castrate,词,VERB,C1
 casual,casual,随意的,ADJ,B2
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-casuistry,casuistry,决疑法,NOUN,B2
-catachresis,catachresis,词语误用,NOUN,B2
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
 catalog,catalog,目录,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
 catalyst,catalyst,催化剂,NOUN,B2
-catapult,catapult,投石机,NOUN,B2
-cataract,cataract,词,NOUN,B2
 catch,catch,捕捉,NOUN,B2
-catch thief,catch thief,抓贼,NOUN,C1
 catch up,to catch up,赶上,VERB,B2
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorically,categorically,词,ADV,C1
-cater,cater,词,VERB,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
 catharsis,catharsis,宣泄,NOUN,B2
 cathedral,cathedral,大教堂,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教徒,NOUN,B2
-cats,cats,猫,NOUN,B2
-cattle rancher,cattle rancher,牧场主,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-caught,caught,被捕获的,ADJ,B2
-cauldron,cauldron,词,NOUN,C1
 cauliflower,cauliflower,花椰菜,NOUN,B2
-causal,causal,因果的,ADJ,B2
-causal link,causal link,因果关系,NOUN,B2
 causation,causation,因果关系,NOUN,B2
-cause of change,cause of change,改因,NOUN,B2
 cause of death,cause of death,死因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-caustic,caustic,词,ADJ,B2
 caution,caution,谨慎,NOUN,B2
 cautious and conscientious,cautious and conscientious,兢兢业业,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
 cavalry,cavalry,骑兵,NOUN,B2
-cavern,cavern,词,NOUN,B2
-cavil,cavil,词,VERB,C1
-cavity,cavity,腔,NOUN,B2
-cavort,cavort,词,VERB,C1
 caw,to caw,呱呱叫,VERB,B2
-caw (noun),caw,词,NOUN,C1
 cease,to cease,停止,VERB,B2
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-cede,cede,词,VERB,C1
-celebrant,celebrant,词,NOUN,B2
-celerity,celerity,迅速,NOUN,B2
 celery,celery,芹菜,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial (noun),celestial,词,NOUN,B2
-celestial body,celestial body,词,NOUN,B2
 celibacy,celibacy,独身,NOUN,B2
-celibate,celibate,词,ADJ,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
-cellulose,cellulose,纤维素,NOUN,B2
 cement,cement,水泥,NOUN,B2
 cement,to cement,巩固,VERB,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-censure (verb),censure,词,VERB,C1
-census,census,人口普查,NOUN,B2
 cent,cent,分,NOUN,B2
-centenary,centenary,词,NOUN,C1
-centennial,centennial,词,ADJ,B2
-centime,centime,词,NOUN,B2
 centimeter,centimeter,厘米,NOUN,B2
-centipede,centipede,蜈蚣,NOUN,B2
-cento,cento,词,NOUN,C1
-central station,central station,中央车站,NOUN,B2
-centrale,switchboard,总机,NOUN,B2
-centrality,centrality,词,NOUN,C1
-centre,centre,词,NOUN,B2
 centrifugal force,centrifugal force,离心力,NOUN,B2
 centrifuge,centrifuge,离心机,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-ceo,ceo,首席执行官,NOUN,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
 ceramics,ceramics,陶瓷,NOUN,B2
-cereal,cereal,词,NOUN,B2
-cerebral,cerebral,大脑的,ADJ,B2
 ceremonial cap,ceremonial cap,爵弁,NOUN,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
 certain,certain,某些,DET,B2
-certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
 certificate of merit,certificate of merit,奖状,NOUN,B2
-certification,certification,认证,NOUN,C1
 certify,to certify,证明,VERB,B2
 cessation,cessation,终止,NOUN,B2
-cessation passing,cessation passing,消亡,NOUN,C1
-chain (adj),chain,词,ADJ,C1
-chain mail,chain mail,锁子甲,NOUN,B2
-chain of transmission,chain of transmission,词,NOUN,C1
 chairman,chairman,主席,NOUN,B2
-chalet,chalet,词,NOUN,B1
-chalice,chalice,词,NOUN,C1
 chalk,chalk,粉笔,NOUN,B2
 challenge,to challenge,质疑,VERB,B2
-challenges,challenges,词,NOUN,C1
 chamber,chamber,房间,NOUN,B2
-chamberlain,chamberlain,词,NOUN,C1
-chamois,chamois,词,NOUN,C1
 champagne,champagne,香槟,NOUN,B2
-chance opportunity,chance opportunity,词,NOUN,A2
 chancellor,chancellor,总理,NOUN,B2
-chancery,chancery,词,NOUN,C1
-chandelier,chandelier,吊灯,NOUN,B2
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
 change tire,to change tire,换胎,VERB,B2
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
 changed policy,changed policy,改策,NOUN,B2
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chant,chant,词,VERB,C1
-chanteren,blackmail,敲诈,NOUN,B2
-chanteren,to blackmail,勒索,VERB,B2
-chants,chants,词,NOUN,B2
 chaotic,chaotic,混乱的,ADJ,B2
 chapel,chapel,小教堂,NOUN,B2
-chaperon,chaperon,词,NOUN,C1
-chaplain,chaplain,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
 character word,character word,字,NOUN,B2
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charade,charade,词,NOUN,B2
-charades,charades,打哑谜,NOUN,B2
 charcoal,charcoal,木炭,NOUN,B2
 charge,charge,收费,NOUN,B2
 charge,to charge,充电,VERB,B2
 charger,charger,充电器,NOUN,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
 charisma,charisma,个人魅力,NOUN,B2
-charismatic,charismatic,有魅力的,ADJ,B2
-charitable,charitable,慈善的,ADJ,B2
 charity,charity,慈善,NOUN,B2
-charity hall,charity hall,善堂,NOUN,C1
 charlatan,charlatan,江湖骗子,NOUN,B2
 charm,charm,魅力,NOUN,B2
-charmer,charmer,词,NOUN,B2
 charming,charming,迷人的,ADJ,B2
 chart,chart,图表,NOUN,B2
 charter,charter,宪章,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
 chase,to chase,追逐,VERB,B2
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
-chasten,chasten,词,VERB,C1
 chastity,chastity,贞洁,NOUN,B2
-chastity probity,chastity probity,词,NOUN,C1
 chat,chat,聊天,NOUN,B2
-chatter (noun),chatter,词,NOUN,A2
-chauffeur,chauffeur,词,NOUN,C1
-chauvinism,chauvinism,沙文主义,NOUN,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheaper,cheaper,更便宜的,ADJ,B2
 cheat,to cheat,欺骗,VERB,B2
 check,check,支票,NOUN,B2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checkbook,checkbook,支票簿,NOUN,B2
-checked,checked,词,ADJ,C1
-checkers,checkers,词,NOUN,A2
-checkmark,checkmark,词,NOUN,C1
-checkmate,checkmate,词,NOUN,C1
-checkup,checkup,体检,NOUN,B2
-cheekbone,cheekbone,词,NOUN,C1
 cheer,to cheer,欢呼,VERB,B2
 cheer up,to cheer up,使高兴,VERB,B2
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
-cheers,cheers,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
 chemical,chemical,化学品,NOUN,B2
-chemicals,chemicals,词,NOUN,C1
-chemist,chemist,词,NOUN,C1
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
-chest breast,chest breast,胸部/乳房,NOUN,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chiasmus,chiasmus,词,NOUN,C1
-chic (adj),chic,词,ADJ,C1
-chickpeas,chickpeas,词,NOUN,A2
-chide,chide,词,VERB,C1
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,主要地,ADV,B2
-chieftain,chieftain,酋长,NOUN,B2
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-chili,chili,辣椒,NOUN,B2
+scheikunde,chemistry,化学,NOUN,B2
+koesteren,to cherish,珍爱,VERB,B2
+kers,cherry,樱桃,NOUN,B2
+schaak,chess,国际象棋,NOUN,B2
+borstpijn,chest pain,胸痛,NOUN,B2
+kastanje,chestnut,板栗,NOUN,B2
+kauwgom,chewing gum,口香糖,NOUN,B2
+kuiken,chick,小鸡,NOUN,B2
+kinderachtig,childish,幼稚的,ADJ,B2
 chilipeper,chili pepper,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (noun),chill,词,NOUN,B1
-chilling,chilling,词,ADJ,C1
-chime,chime,词,NOUN,C1
-chimera,chimera,词,NOUN,C1
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
+schoorsteen,chimney,烟囱,NOUN,B2
+kin,chin,下巴,NOUN,B2
 chinees,chinese language,华文,NOUN,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
 chip,chip,碎片,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chirurg,surgeon,外科医生,NOUN,B2
-chirurgie,surgery,手术,NOUN,B2
-chitchat,chitchat,词,NOUN,B2
-chivalrous,chivalrous,词,ADJ,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,唱诗班男孩,NOUN,B2
-choke,choke,词,VERB,B2
-cholera,cholera,词,NOUN,C1
+tsjilpen,to chirp,啁啾,VERB,B2
+beitel,chisel,凿子,NOUN,B2
+ridderlijkheid,chivalry,骑士精神,NOUN,B2
 cholesterol,cholesterol,胆固醇,NOUN,B2
-chomp,chomp,词,VERB,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-chore,chore,家务,NOUN,B2
-choreograph,choreograph,词,VERB,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreography,choreography,词,NOUN,C1
-chortle,chortle,词,VERB,C1
-chosen,chosen,精选的,ADJ,B2
-christen,christen,词,VERB,C1
-christianization,christianization,词,NOUN,C1
-christmas eve,christmas eve,平安夜,NOUN,B2
-christmas porridge,christmas porridge,,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
+haks,chop,砍,NOUN,B2
 chromosoom,chromosome,染色体,NOUN,B2
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicle,chronicle,编年史,NOUN,B2
-chronicler,chronicler,词,NOUN,B2
-chubby,chubby,胖子,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn,churn,词,VERB,C1
-churn skin,churn skin,词,NOUN,B2
-cider,cider,苹果酒,NOUN,B2
-cigar,cigar,雪茄,NOUN,B2
-cigarette butt,cigarette butt,烟头,NOUN,B2
-cijfer,digit,数字,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinematographic,cinematographic,电影的,ADJ,B2
+kaneel,cinnamon,肉桂,NOUN,B2
 circuit,circuit,电路,NOUN,B2
-circular (noun),circular,词,NOUN,B2
-circulating,circulating,词,ADJ,B2
-circumference,circumference,词,NOUN,C1
-circumlocution,circumlocution,迂回说法,NOUN,B2
-circumscription,circumscription,词,NOUN,C1
-circumspect,circumspect,谨慎的,ADJ,B2
-circumspection,circumspection,词,NOUN,B2
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circumvent,circumvent,词,VERB,C1
+omcirkelen,to circumscribe,限制,VERB,B2
 circus,circus,马戏团,NOUN,B2
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
-cistern,cistern,蓄水池,NOUN,B2
-citaat,quotation,报价,NOUN,B2
-citadel,citadel,词,NOUN,C1
 citatie,citation,引用,NOUN,B2
 citeren,to cite,引用,VERB,B2
-citeren,to quote,引用,VERB,B2
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic,civic,词,ADJ,C1
-civic-mindedness,civic-mindedness,词,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civility,civility,礼貌,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,有洞察力的,ADJ,B2
-clamber,clamber,词,VERB,C1
-clamorous,clamorous,词,ADJ,B2
-clampdown,clampdown,词,NOUN,C1
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestineness,clandestineness,词,NOUN,B2
-clandestinity,clandestinity,秘密状态,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clapping,clapping,词,NOUN,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarify doubts,clarify doubts,释疑,VERB,B2
-clarity evidentness,clarity evidentness,词,NOUN,C1
-clash (noun),clash,词,NOUN,C1
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class test,class test,词,NOUN,B1
+burgerschap,citizenship,公民身份,NOUN,B2
+stadhuis,city hall,市政厅,NOUN,B2
+burger,civilian,平民,NOUN,B2
+beschaafd,civilized,文明的,ADJ,B2
+gewoel,clamor,喧嚣,NOUN,B2
+klem,clamp,夹钳,NOUN,B2
+klan,clan,家族,NOUN,B2
+verduidelijken,to clarify,澄清,VERB,B2
+klassieker,classic,经典作品,NOUN,B2
 classical,classical,古典的,ADJ,B2
-classical poetry,classical poetry,词,NOUN,C1
 classicism,classicism,古典主义,NOUN,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
 classifier for paintings cloth etc.,classifier for paintings cloth etc.,幅,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
 classifier for trees,classifier for trees,棵,NUM,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
 classmate,classmate,同学,NOUN,B2
 classroom,classroom,教室,NOUN,B2
-classwork,classwork,课堂作业,NOUN,B2
-clatter,clatter,哗啦声,NOUN,C1
 clause,clause,从句,NOUN,B2
-clauses,clauses,词,NOUN,C1
 claw,claw,爪子,NOUN,B2
 clay,clay,黏土,NOUN,B2
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner,cleaner,更干净的,ADJ,B2
-cleaner (noun),cleaner,清洁剂,NOUN,B2
-cleaning,cleaning,清洁,NOUN,B2
 cleanliness,cleanliness,清洁,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanly,cleanly,干净地,ADV,B2
-cleanse,cleanse,词,VERB,C1
 cleansing,cleansing,清洗,NOUN,B2
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
 clear,to clear,清理,VERB,B2
-clear (adv),clear,当然,ADV,B2
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
 clear knowledge,clear knowledge,明知,NOUN,B2
-clear limpid,clear limpid,词,ADJ,C1
 clear soup,clear soup,江瑶清羹,NOUN,B2
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
 clear-cut,clear-cut,明确的,ADJ,B2
-clearance,clearance,词,NOUN,C1
 clearing,clearing,林中空地,NOUN,B2
-clearing of the throat,clearing of the throat,词,NOUN,C1
 clearly,clearly,清楚地,ADV,B2
 clearly demarcated,clearly demarcated,分明,ADJ,B2
 cleave,to cleave,劈开,VERB,B2
-clemency,clemency,仁慈,NOUN,B2
-clench,clench,词,VERB,C1
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
 clever,clever,聪明的,ADJ,B2
 cliche,cliche,陈词滥调,NOUN,B2
-click (noun),click,词,NOUN,C1
-clickbait,clickbait,词,NOUN,C1
-clientele,clientele,词,NOUN,B2
 clientelism,clientelism,庇护主义,NOUN,B2
 cliff,cliff,悬崖,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
 climax,climax,高潮,NOUN,B2
-climbing,climbing,词,NOUN,B1
-clinch,clinch,词,VERB,C1
 cling,to cling,紧贴,VERB,B2
-clink,clink,词,NOUN,C1
-clinking,clinking,词,NOUN,C1
 clip,clip,夹子,NOUN,B2
-clipping,clipping,词,NOUN,C1
 cloak,cloak,斗篷,NOUN,B2
-clobber,clobber,词,VERB,C1
-clock watch,clock watch,钟表,NOUN,B2
-clog (noun),clog,词,NOUN,B2
-clog (verb),clog,词,VERB,C1
-cloister,cloister,回廊,NOUN,B2
 clone,clone,克隆体,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
 close,close,近的,ADJ,B2
-close a case,close a case,结案,VERB,B2
 close account,to close account,销户,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
 close the door,to close the door,关门,VERB,B2
-close well,close well,关好,NOUN,C1
-closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
-closedness,closedness,封闭,NOUN,C1
 closeness,closeness,接近,NOUN,B2
 closet,closet,壁橱,NOUN,B2
-closing,closing,词,NOUN,B2
-closing argument,closing argument,辩护词,NOUN,B2
 closing ceremony,closing ceremony,闭幕仪式,NOUN,B2
 clot,clot,凝块,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-clouds,clouds,云,NOUN,B1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
+bewolkt,cloudy,阴沉的,ADJ,B2
 clown,clown,小丑,NOUN,B2
-cloying,cloying,词,ADJ,C1
 club,club,俱乐部,NOUN,B2
-club blow,club blow,词,NOUN,C1
-cluck,cluck,词,NOUN,C1
-clueless,clueless,词,ADJ,C1
-clump,clump,词,NOUN,C1
-clumsily,clumsily,笨拙地,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-clunky,clunky,词,ADJ,C1
 cluster,cluster,簇,NOUN,B2
-clutter,clutter,词,NOUN,C1
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-occurrence,co-occurrence,词,NOUN,C1
-co-owner,co-owner,共有人,NOUN,B2
-co-ownership,co-ownership,共有产权,NOUN,B2
+koppeling,clutch,离合器,NOUN,B2
 coach,coach,教练,NOUN,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coalesce,coalesce,词,VERB,C1
-coarse rough,coarse rough,词,ADJ,C1
-coast road,coast road,词,NOUN,B2
-coastal,coastal,沿海的,ADJ,B2
-coastal (noun),coastal,词,NOUN,B2
-coastline,coastline,词,NOUN,B2
-coat of arms,coat of arms,纹章,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-cobble,cobble,词,VERB,C1
-cobbler,cobbler,词,NOUN,B2
+steenkool,coal,煤,NOUN,B2
+overreding,coaxing,哄得,NOUN,B2
 cocaïne,cocaine,可卡因,NOUN,B2
-cock,cock,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
 cocktail,cocktail,鸡尾酒,NOUN,B2
-cocky,cocky,傲慢的,ADJ,B2
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-coddle,coddle,词,VERB,C1
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-coding,coding,词,NOUN,B2
-coffee maker,coffee maker,词,NOUN,A2
-cog,cog,词,NOUN,C1
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cogito,cogito,词,NOUN,C1
-cognac,cognac,干邑,NOUN,B2
-cognate,cognate,词,NOUN,B2
-cognitive,cognitive,认知的,ADJ,B2
-cognizance,cognizance,词,NOUN,C1
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-cohort,cohort,队列,NOUN,B2
-coil (noun),coil,词,NOUN,C1
-coin purse,coin purse,零钱包,NOUN,B2
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coitus,coitus,词,NOUN,B2
-coke,coke,可卡因,NOUN,B2
-cola,cola,可乐,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
-coldness,coldness,词,NOUN,B2
-colic,colic,词,NOUN,C1
-coliseum,coliseum,词,NOUN,B2
-collapse (noun),collapse,collapse,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
-collation,collation,词,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collections,collections,词,NOUN,C1
-collective (noun),collective,集体,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-college,college,学院,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegiality,collegiality,词,NOUN,C1
-collegiate,collegiate,词,ADJ,B2
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial,colloquial,词,ADJ,B2
-colloquial language,colloquial language,词,NOUN,C1
-colloquium,colloquium,词,NOUN,B2
-collusion,collusion,串通,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
-colonial settlers,colonial settlers,词,NOUN,C1
-colonist,colonist,词,NOUN,B2
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colophon,colophon,词,NOUN,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-coloring,coloring,词,NOUN,B2
-colorless,colorless,词,ADJ,C1
-colossal,colossal,巨大的,ADJ,B2
-colossus,colossus,词,NOUN,B2
-columnar,columnar,词,ADJ,C1
-columnist,columnist,词,NOUN,C1
+coëfficiënt,coefficient,系数,NOUN,B2
+samenleven,to coexist,共存,VERB,B2
+kist,coffin,棺材,NOUN,B2
+samenhang,cohesion,凝聚力,NOUN,B2
+samenvallen,to coincide,同时发生,VERB,B2
+toeval,coincidence,巧合,NOUN,B2
+vergiet,colander,漏勺,NOUN,B2
+koud bloed,cold blood,冷血,NOUN,B2
+koudegolf,cold wave,寒潮,NOUN,B2
+koeltjes,coldly,冷淡地,ADV,B2
+medewerker,collaborator,合作者,NOUN,B2
+instorten,collapse,倒塌,NOUN,B2
+instorten,to collapse,倒塌,VERB,B2
+kraag,collar,衣领,NOUN,B2
+botsen,to collide,碰撞,VERB,B2
+botsing,collision,碰撞,NOUN,B2
+samenspannen,to collude,勾结,VERB,B2
+dubbele punt,colon,冒号,NOUN,B2
+kolonialisme,colonialism,殖民主义,NOUN,B2
+kleur,color,颜色,NOUN,B2
+kolom,column,列,NOUN,B2
 coma,coma,昏迷,NOUN,B2
-combatant,combatant,词,NOUN,B2
-combative,combative,词,ADJ,B2
-combativeness,combativeness,好斗性,NOUN,B2
-combinations,combinations,词,NOUN,C1
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come on,come on,词,INTJ,C1
+kammen,to comb,梳头,VERB,B2
+gevecht,combat,战斗,NOUN,B2
+komen van,to come from,来自,VERB,B2
+hier komen,to come here,来到这里,VERB,B2
+binnenkomen,to come in,进来,VERB,B2
+uitkomen,to come out,出来,VERB,B2
+overkomen,to come over,顺道来访,VERB,B2
 comedian,comedian,喜剧演员,NOUN,B2
-comer,comer,词,NOUN,C1
-comfort (noun),comfort,舒适,NOUN,B2
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comicness,comicness,词,NOUN,C1
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma,comma,逗号,PUNCT,B2
-comma (noun),comma,词,NOUN,B1
-commandeer,commandeer,词,VERB,C1
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
+komeet,comet,彗星,NOUN,B2
+troosten,comfort,安慰,NOUN,B2
+troosten,to comfort,安慰,VERB,B2
+komisch,comic,喜剧的,ADJ,B2
+komst,coming,مجيء,NOUN,B2
+kom en ga,coming and going,往来,NOUN,B2
 commandocentrale,command room,指挥室,NOUN,B2
-commence,commence,词,VERB,B2
-commend,commend,词,VERB,C1
-commendable,commendable,词,ADJ,C1
-commendation,commendation,词,NOUN,C1
-commensalism,commensalism,词,NOUN,B2
-commensurability,commensurability,词,NOUN,C1
-commentaries,commentaries,词,NOUN,C1
+herdenken,to commemorate,纪念,VERB,B2
 commentator,commentator,评论员,NOUN,B2
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commiserate,commiserate,词,VERB,C1
-commiseration,commiseration,同情,NOUN,B2
-commitments,commitments,词,NOUN,C1
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commodification,commodification,词,NOUN,C1
+handel,commerce,商业,NOUN,B2
+plegen,to commit a crime,犯罪,VERB,B2
+gecommitteerd,committed,投入的,ADJ,B2
 commodity,commodity,商品,NOUN,B2
-common good,common good,词,NOUN,B2
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
-commonly,commonly,词,ADV,C1
+gemeenschappelijkheid,commonality,共同点,NOUN,B2
+gemeen,commoner,平民,NOUN,B2
 commotie,commotion,骚动,NOUN,B2
-communal work,communal work,词,NOUN,C1
-communes,communes,词,NOUN,C1
-communicativeness,communicativeness,词,NOUN,C1
-communion rail,communion rail,词,NOUN,B2
 communiqué,communique,公报,NOUN,B2
 communisme,communism,共产主义,NOUN,B2
-communist,communist,共产主义者,NOUN,B2
 communitarisme,communitarianism,社群主义,NOUN,B2
-community-related,community-related,社区的,ADJ,B2
-commuter,commuter,词,NOUN,A2
-comorbidity,comorbidity,共病,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-comparability,comparability,词,NOUN,C1
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
+gezelschap,companionship,陪伴,NOUN,B2
 compartiment,compartment,隔间,NOUN,B2
-compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
+kompas,compass,指南针,NOUN,B2
+medelijden,compassion,同情,NOUN,B2
 compatibiliteit,compatibility,兼容性,NOUN,B2
-compatible,compatible,词,ADJ,C1
-compelling,compelling,词,ADJ,C1
-compendious,compendious,词,ADJ,B2
-compendium,compendium,纲要,NOUN,B2
+landgenoot,compatriot,同胞,NOUN,B2
+dwingen,to compel,强迫,VERB,B2
 compensatieverlof,compensatory leave,调休,NOUN,B2
-competencies,competencies,词,NOUN,B2
-competition bastard,competition bastard,,NOUN,B2
-competitive exam,competitive exam,词,NOUN,B2
+concurrerendheid,competitiveness,竞争力,NOUN,B2
 compileren,to compile,编译,VERB,B2
-complacency,complacency,词,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complement,complement,补充物,NOUN,B2
 complementair,complementary,互补的,ADJ,B2
-complementarity,complementarity,互补性,NOUN,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
 completion,completion,完成,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex (noun),complex,建筑群,NOUN,B2
-complexion,complexion,肤色,NOUN,B2
 compliance,compliance,合规,NOUN,B2
-complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
 complicit,complicit,共谋的,ADJ,B2
 complicity,complicity,共犯,NOUN,B2
 compliment,compliment,称赞,NOUN,B2
-complotteren,to conspire,密谋,VERB,B2
 comply,to comply,遵守,VERB,B2
 comply with,to comply with,遵守,VERB,B2
 compose,to compose,组成,VERB,B2
-compositional,compositional,词,ADJ,C1
 compost,compost,堆肥,NOUN,B2
 composure,composure,镇定,NOUN,B2
 compound,compound,复合性,ADJ,B2
-compound (noun),compound,compound,NOUN,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
 comprehend,to comprehend,理解,VERB,B2
-comprehensibility,comprehensibility,词,NOUN,C1
 comprehension,comprehension,理解,NOUN,B2
 compress,to compress,压缩,VERB,B2
-compressed,compressed,词,ADJ,C1
-compressibility,compressibility,词,NOUN,C1
 compressor,compressor,压缩机,NOUN,B2
-comprise,comprise,词,VERB,C1
 compromise,compromise,妥协,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compunction,compunction,词,NOUN,B2
-compurgation oath,compurgation oath,词,NOUN,C1
-computability,computability,词,NOUN,C1
 compute,to compute,计算,VERB,B2
-computer mouse,computer mouse,词,NOUN,B1
-computer program,computer program,电脑程序,NOUN,B2
-computer science,computer science,词,NOUN,C1
-computer specialist,computer specialist,计算机专家,NOUN,B2
 computing,computing,计算机科学,NOUN,B2
 comrade,comrade,同志,NOUN,B2
-con artist,con artist,词,NOUN,B1
-concatenation,concatenation,词,NOUN,B2
-concavity,concavity,词,NOUN,B2
 conceal,to conceal,隐藏,VERB,B2
-concealed,concealed,词,ADJ,C1
 concealment,concealment,隐瞒,NOUN,B2
-conceit,conceit,词,NOUN,C1
 conceited,conceited,自负的,ADJ,B2
 conceive,to conceive,构想,VERB,B2
-concentrated,concentrated,浓,ADJ,B1
-concept,draft,草稿,NOUN,B2
-concepts,concepts,词,NOUN,C1
-conceptualize,conceptualize,词,VERB,C1
 concern,concern,担忧,NOUN,B2
-concerning,concerning,关于,ADP,B2
-concerning (adj),concerning,词,ADJ,B2
-concerns,concerns,词,NOUN,C1
 concert,concert,音乐会,NOUN,B2
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
-conch,conch,海螺壳,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
-conciliatory,conciliatory,调和的,ADJ,B2
 concise,concise,简洁的,ADJ,B2
-conciseness,conciseness,简洁,NOUN,B2
-concision,concision,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
 conclude,to conclude,得出结论,VERB,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
 conclusive,conclusive,决定性的,ADJ,B2
-concomitantly,concomitantly,词,ADV,B2
-concord,concord,和谐,NOUN,B2
-concordance,concordance,一致,NOUN,B2
-concordat,concordat,政教协定,NOUN,B2
 concubine,concubine,妾,NOUN,B2
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concur,concur,词,VERB,C1
-concurrence,concurrence,词,NOUN,B2
-concurrently,concurrently,词,ADV,C1
-concurrerendheid,competitiveness,竞争力,NOUN,B2
-concussion,concussion,脑震荡,NOUN,B2
 condemn,to condemn,谴责,VERB,B2
-condemned,condemned,被定罪的,ADJ,B2
 condensation,condensation,凝结,NOUN,B2
 condense,to condense,浓缩,VERB,B2
-condenser,condenser,词,NOUN,C1
-condescension,condescension,屈尊,NOUN,B2
-conditioning (adj),conditioning,词,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
 condole,to condole,哀悼,VERB,B2
 condolences,condolences,哀悼,NOUN,B2
-condom,condom,避孕套,NOUN,B2
-conducive,conducive,词,ADJ,B2
-conduciveness,conduciveness,词,NOUN,C1
-conductivity,conductivity,导电性,NOUN,B2
-conductor,conductor,词,NOUN,C1
-conduit,conduit,词,NOUN,B2
-confederal,confederal,词,ADJ,C1
-confederate,confederate,同盟者,NOUN,B2
+leiden,conduct,行为,NOUN,B2
+leiden,to conduct,أجرى,VERB,B2
+kegel,cone,圆锥体,NOUN,B2
 confederatie,confederation,邦联,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-confetti,confetti,词,NOUN,C1
-confidant,confidant,知己,NOUN,B2
-confiding,confiding,词,NOUN,C1
-configure,configure,词,VERB,C1
-configured,configured,词,ADJ,C1
-confinement,confinement,禁闭,NOUN,B2
-confines edges,confines edges,词,NOUN,C1
-confiscatie,confiscation,没收,NOUN,B2
+biecht,confession,供认,NOUN,B2
+toevertrouwen,to confide,吐露,VERB,B2
+vertrouwen,confidence,信心,NOUN,B2
+zelfverzekerd,confident,自信的,ADJ,B2
 confisqueren,to confiscate,没收,VERB,B2
+confiscatie,confiscation,没收,NOUN,B2
 conflict,conflict,冲突,NOUN,B2
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
 conformisme,conformism,因循守旧,NOUN,B2
-conformist,conformist,墨守成规者,NOUN,B2
-conformity,conformity,词,NOUN,B2
-confound,confound,词,VERB,C1
-confounded,confounded,该死的,ADJ,B2
-confronted,confronted,词,ADJ,B2
-confronteren,to face,面对,VERB,B2
-confused (adv),confused,词,ADV,B1
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusedly,confusedly,词,ADV,C1
-confusing,confusing,令人困惑的,ADJ,B2
-congeal,congeal,词,VERB,C1
-congenital,congenital,先天的,ADJ,B2
-conglomerate,conglomerate,词,NOUN,B2
-congratulations,congratulations,祝贺,NOUN,B2
-congregate,congregate,词,VERB,C1
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-conic,conic,圆锥曲线,NOUN,B2
-conifer,conifer,针叶树,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugal,conjugal,词,ADJ,B2
-conjunctural,conjunctural,词,ADJ,C1
-connector,connector,词,NOUN,B2
-connivance,connivance,词,NOUN,B2
-connive,connive,词,VERB,C1
-conquest,conquest,征服,NOUN,B2
-conquests,conquests,征服,NOUN,C1
-consanguineous,consanguineous,词,ADJ,B2
-consanguinity,consanguinity,血缘,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
-consciously,consciously,有意识地,ADV,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
-consecration,consecration,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consecutively,consecutively,连续地,ADV,B2
-consensualism,consensualism,词,NOUN,C1
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,随之发生的,ADJ,B2
-conservatism,conservatism,词,NOUN,C1
-conservatory,conservatory,音乐学院,NOUN,B2
-considerable (noun),considerable,不小,NOUN,C1
-considerably,considerably,相当地,ADV,B2
-considered,considered,词,ADJ,B1
+verward,confused,困惑的,ADJ,B2
+feliciteren,to congratulate,祝贺,VERB,B2
+gemeente,congregation,集会,NOUN,B2
+naaldbos,coniferous forest,针叶林,NOUN,B2
+vermoeden,conjecture,推测,NOUN,B2
+vervoeging,conjugation,变位,NOUN,B2
+voegwoord,conjunction,连词,NOUN,B2
+toveren,to conjure,变魔术,VERB,B2
+kenner,connoisseur,行家,NOUN,B2
+veroveraar,conqueror,征服者,NOUN,B2
+nauwgezet,conscientious,认真的,ADJ,B2
+wijden,to consecrate,奉献,VERB,B2
+opeenvolgende kaarten,consecutive cards,连牌,NOUN,B2
+toestemming,consent,同意,NOUN,B2
+bijgevolg,consequently,因此,ADV,B2
+attent,considerate,体贴,ADJ,B2
+zending,consignment,托运,NOUN,B2
+bestaan,to consist,组成,VERB,B2
 consistentie,consistency,一致性,NOUN,B2
-console (noun),console,词,NOUN,B2
-consolidation,consolidation,词,NOUN,C1
+troosten,to console,安慰,VERB,B2
 consolideren,to consolidate,巩固,VERB,B2
-consonance,consonance,词,NOUN,B2
-consortium,consortium,词,NOUN,B2
-conspirator,conspirator,词,NOUN,B2
-constancy,constancy,恒定,NOUN,B2
-constant,constantly,不断地,ADV,B2
+metgezel,consort,福晋,NOUN,B2
+opvallend,conspicuous,显著的,ADJ,B2
+complotteren,to conspire,密谋,VERB,B2
+wachtmeester,constable,警官,NOUN,B2
 constante,constant,常数,NOUN,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
-consternation,consternation,词,NOUN,B2
-constituencies,constituencies,词,NOUN,C1
-constituent,constituent,成分,NOUN,B2
-constitutionalization,constitutionalization,词,NOUN,B2
+constant,constantly,不断地,ADV,B2
+sterrenbeeld,constellation,星座,NOUN,B2
+obstipatie,constipation,便秘,NOUN,B2
+kiezersdistrict,constituency,选区,NOUN,B2
+vormen,to constitute,构成,VERB,B2
 constitutioneel,constitutional,宪法的,ADJ,B2
-constraints,constraints,词,NOUN,C1
-constrict,constrict,词,VERB,C1
-constructiveness,constructiveness,词,NOUN,C1
-construe,construe,词,VERB,C1
-consulaat,consulate,领事馆,NOUN,B2
+beperken,to constrain,限制,VERB,B2
+beperking,constraint,约束,NOUN,B2
+bouwwerf,construction site,工地,NOUN,B2
 consulair,consular,领事的,ADJ,B2
-consultations,consultations,磋商,NOUN,C1
+consulaat,consulate,领事馆,NOUN,B2
+raadplegen,to consult,咨询,VERB,B2
+raadplegen,to consult reference,参考,VERB,B2
+adviseur,consultant,顾问,NOUN,B2
 consumeren,to consume,消费,VERB,B2
-consumerist,consumerist,词,ADJ,B2
-consummate,consummate,熟练的,ADJ,B2
-consummation,consummation,词,NOUN,B2
 contact,contact,联系,NOUN,B2
-contacts,contacts,人脉,NOUN,B2
-contagion,contagion,词,NOUN,B2
-containment,containment,词,NOUN,C1
-contaminated,contaminated,受污染的,ADJ,B2
-contemn,contemn,蔑视,VERB,C1
+besmettelijk,contagious,传染性的,ADJ,B2
+verontreinigen,to contaminate,污染,VERB,B2
+overwegen,to contemplate,沉思,VERB,B2
 contemplatief,contemplative,沉思的,ADJ,B2
-contemplation,contemplation,沉思,NOUN,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contender,contender,词,NOUN,B2
-content (adj),content,词,ADJ,B2
-contents,contents,内有,NOUN,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,相邻的,ADJ,B2
-continence,continence,词,NOUN,B2
+verachting,contempt,轻视,NOUN,B2
+tevredenheid,contentment,满足,NOUN,B2
+wedstrijd,contest,比赛,NOUN,B2
 continent,continent,大陆,NOUN,B2
-continental,continental,词,ADJ,B2
 contingentie,contingency,偶然性,NOUN,B2
-continually,continually,不断地,ADV,B2
-continuously,continuously,一直,ADV,A1
+voortzetting,continuation,延续,NOUN,B2
 continuïteit,continuity,连续性,NOUN,B2
-contort,contort,词,VERB,C1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contraband,contraband,违禁品,NOUN,B2
-contract schenden,to breach contract,违约,VERB,B2
-contracted,contracted,词,ADJ,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual nature,contractual nature,词,NOUN,C1
-contractuality,contractuality,词,NOUN,C1
-contradictoriness,contradictoriness,词,NOUN,C1
-contraindicate,contraindicate,词,VERB,C1
-contraindication,contraindication,词,NOUN,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrast,contrast,对比,NOUN,B2
-contributions,contributions,词,NOUN,C1
-contrite,contrite,词,ADJ,B2
-contrition,contrition,悔罪,NOUN,B2
-contrive,contrive,词,VERB,C1
+tegenspreken,to contradict,反驳,VERB,B2
+tegenstelling,contrary,反而,NOUN,B2
+tegenstrijdige bedoeling,contrary intention,反意,NOUN,B2
+schenden,to contravene,违反,VERB,B2
+bijdragen,to contribute,贡献,VERB,B2
 control room,control room,控制室,NOUN,B2
-controlekamer,monitoring room,监控室,NOUN,B2
-controllability,controllability,词,NOUN,C1
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
-contumacy,contumacy,词,NOUN,C1
-contusion,contusion,词,NOUN,B2
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convalesce,convalesce,词,VERB,B2
-convalescence,convalescence,词,NOUN,C1
-convalescent,convalescent,词,ADJ,B2
 convene,to convene,召集,VERB,B2
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
 convenient,convenient,方便的,ADJ,B2
-convening,convening,召集,NOUN,C1
-convent,convent,词,NOUN,B2
-conventionality,conventionality,词,NOUN,C1
 converge,to converge,汇聚,VERB,B2
-convergent,convergent,词,ADJ,C1
 converse,to converse,交谈,VERB,B2
 conversely,conversely,相反地,ADV,B2
-convert (noun),convert,词,NOUN,B2
-convertibility,convertibility,可兑换性,NOUN,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
 convey,to convey,传达,VERB,B2
-conveyance,conveyance,词,NOUN,C1
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (adj),convict,词,ADJ,B2
-convict (noun),convict,词,NOUN,C1
-convicted,convicted,被判罪的,ADJ,B2
 convinced,convinced,确信的,ADJ,B2
-convoke,convoke,词,VERB,C1
-convoluted,convoluted,词,ADJ,B2
-convoy,convoy,词,NOUN,B2
-convulse,convulse,词,VERB,C1
 convulsion,convulsion,抽搐,NOUN,B2
-convulsive,convulsive,词,ADJ,B2
-cookbook,cookbook,词,NOUN,C1
-cooked,cooked,熟的,ADJ,B2
 cooked meatball,cooked meatball,丸子熟,NOUN,B2
 cooked rice,cooked rice,米饭,NOUN,B2
-cooking,cooking,烹饪,NOUN,B2
 cooking pot,cooking pot,炖锅,NOUN,B2
-cooking wine,cooking wine,料酒,NOUN,B2
 cool down,to cool down,冷却,VERB,B2
-cooler,cooler,词,ADJ,C1
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
 coolness,coolness,凉爽,NOUN,B2
-coop,coop,词,VERB,C1
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
 coordinate,coordinate,坐标,NOUN,B2
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
 cop,cop,警察,NOUN,B2
-cope with,cope with,应对,VERB,B2
-copious,copious,丰富的,ADJ,B2
 copper,copper,铜,NOUN,B2
 copyist,copyist,抄写员,NOUN,B2
 copyright,copyright,版权,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
 coral,coral,珊瑚,NOUN,B2
-coral (adj),coral,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-cord,cord,绳索,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordiality,cordiality,词,NOUN,C1
-cordially,cordially,亲切地,ADV,B2
-cordoning,cordoning,词,NOUN,C1
-core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
 corn,corn,玉米,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-cornice,cornice,檐口,NOUN,B2
-corniche,corniche,词,NOUN,C1
-corollary,corollary,推论,NOUN,B2
 coronation,coronation,加冕,NOUN,B2
-corporal,corporal,下士,NOUN,B2
-corporate,corporate,公司的,ADJ,B2
-corporation,corporation,公司,NOUN,B2
-corporatism,corporatism,法团主义,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpulent,corpulent,词,ADJ,B2
-corpuscle,corpuscle,词,NOUN,C1
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correctie,proofreading,校对,NOUN,B2
-correctional,correctional,词,ADJ,C1
-corrections,corrections,刑事司法,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlative,correlative,词,ADJ,B2
-correlatively,correlatively,词,ADV,B2
 correspond,to correspond,符合,VERB,B2
-correspondence course,correspondence course,函授,NOUN,C1
 correspondent,correspondent,记者,NOUN,B2
-correspondents,correspondents,词,NOUN,C1
-corridors,corridors,词,NOUN,C1
-corrigible,corrigible,可改正的,ADJ,B2
-corroboration,corroboration,证实,NOUN,B2
 corrosion,corrosion,腐蚀,NOUN,B2
 corrupt,corrupt,腐败的,ADJ,B2
 corrupt,to corrupt,腐败,VERB,B2
-corrupted,corrupted,,NOUN,B2
-corruptibility,corruptibility,词,NOUN,C1
-cortical,cortical,皮层的,ADJ,C1
-cosmetic,cosmetic,化妆品的,ADJ,B2
 cosmic,cosmic,宇宙的,ADJ,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,宇宙学,NOUN,B2
-cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
 cost,cost,费用,NOUN,B2
-costly,costly,昂贵的,ADJ,B2
-costumbrism,costumbrism,词,NOUN,B2
-costumes,costumes,词,NOUN,B2
 cotton,cotton,棉花,NOUN,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couch,couch,词,NOUN,B1
 cough,cough,咳嗽,NOUN,B2
 cough,to cough,咳嗽,VERB,B2
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-council-related,council-related,词,ADJ,C1
-councils,councils,委员会,NOUN,C1
-counsel,counsel,词,NOUN,B2
 counseling,counseling,咨询,NOUN,B2
-counselor,counselor,词,NOUN,C1
 count as,to count as,算,VERB,B2
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,面容,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterargument,counterargument,反论点,NOUN,B2
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,逆流,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-counterfeiting,counterfeiting,伪造,NOUN,B2
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterweight,counterweight,词,NOUN,B2
-country land,country land,词,NOUN,A1
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
+tegenwerken,counter,柜台,NOUN,B2
+tegenwerken,to counter,反击,VERB,B2
+tegenvorm,counter-form,反式,NOUN,B2
+tegenlogica,counter-logic,反逻,NOUN,B2
+tegenmaterie,counter-matter,反物,NOUN,B2
+tegenmechanisme,counter-mechanism,反机,NOUN,B2
+tegenmodel,counter-model,反模,NOUN,B2
+tegenwaarneming,counter-observation,反察,NOUN,B2
+tegenkwaliteit,counter-quality,反质,NOUN,B2
+tegenroute,counter-route,反途,NOUN,B2
+tegenvaardigheid,counter-skill,反技,NOUN,B2
+tegenzool,counter-sole,反唯,NOUN,B2
+tegenstructuur,counter-structure,反结,NOUN,B2
+tegensysteem,counter-system,反系,NOUN,B2
+tegentechniek,counter-technique,反术,NOUN,B2
+tegentrend,counter-trend,反势,NOUN,B2
+tegentype,counter-type,反型,NOUN,B2
+tegenaanval,counterattack,反击,NOUN,B2
+vals,counterfeit,假冒,ADJ,B2
+tegenhanger,counterpart,对应的人或物,NOUN,B2
 couplet,couplet,对联,NOUN,B2
-courageously,courageously,词,ADV,C1
-courgette,zucchini,西葫芦,NOUN,B2
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court clerk,court clerk,词,NOUN,C1
-court costs,court costs,词,NOUN,C1
-court hearing,court hearing,庭审,NOUN,C1
-courteous,courteous,有礼貌的,ADJ,B2
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cousin female,cousin female,词,NOUN,B2
-cove,cove,小海湾,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-cover-up,cover-up,词,NOUN,C1
-coward (adj),coward,词,ADJ,A2
-cower,cower,词,VERB,C1
-coworker,coworker,同事,NOUN,B2
-cowpeas,cowpeas,词,NOUN,B2
-coëfficiënt,coefficient,系数,NOUN,B2
-crackdown,crackdown,词,NOUN,C1
-cracker,cracker,饼干,NOUN,B2
-cracking,cracking,词,NOUN,B2
-cradle,cradle,摇篮,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramp,cramp,抽筋,NOUN,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crap,crap,屎,NOUN,B2
+verwerping door de rechtbank,court dismissal,退朝,NOUN,B2
+beleefdheid,courtesy,礼貌,NOUN,B2
+binnenplaats,courtyard,庭院,NOUN,B2
+verbond,covenant,契约,NOUN,B2
+deksel,cover,封面,NOUN,B2
+hebzucht,covetousness,贪欲,NOUN,B2
+lafaard,coward,懦夫,NOUN,B2
+lafheid,cowardice,懦弱,NOUN,B2
+laf,cowardly,懦弱的,ADJ,B2
+krab,crab,螃蟹,NOUN,B2
+barsten,crack,裂缝,NOUN,B2
+barsten,to crack,破裂,VERB,B2
+knetteren,to crackle,噼啪作响,VERB,B2
+ambacht,craft,工艺,NOUN,B2
+ambachtsman,craftsman,工匠,NOUN,B2
+vakmanschap,craftsmanship,手工艺,NOUN,B2
+kraan,crane,起重机,NOUN,B2
 crash,crash,碰撞,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-crass,crass,词,ADJ,B2
-cravenly,cravenly,词,ADV,C1
-craving,craving,渴求,NOUN,B2
-crayon,crayon,词,NOUN,C1
-craze,craze,狂热,NOUN,B2
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-creamy,creamy,词,ADJ,C1
-crease,crease,词,NOUN,C1
-credentials,credentials,国书,NOUN,B2
-credible,credible,词,ADJ,C1
+kist,crate,板条箱,NOUN,B2
+krater,crater,火山口,NOUN,B2
+begeeren,to crave,渴望,VERB,B2
+schepper,creator,创造者,NOUN,B2
+krediet,credit,信用,NOUN,B2
 creditcard,credit card,信用卡,NOUN,B2
 crediteur,creditor,债权人,NOUN,B2
 crediteurenrecht,creditor's right,债权,NOUN,B2
-creditor's rights,creditor's rights,债权,NOUN,B2
-credulity,credulity,轻信,NOUN,B2
-credulous,credulous,词,ADJ,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (verb),creep,词,VERB,B2
-creepy,creepy,令人毛骨悚然的,ADJ,B2
-cremate,cremate,词,VERB,C1
-crenelate,crenelate,词,VERB,C1
-crescendo,crescendo,词,NOUN,C1
-crescent,crescent,crescent,NOUN,B2
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-cricket,cricket,板球,NOUN,B2
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
-criminalization,criminalization,词,NOUN,C1
-crimson,crimson,词,ADJ,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis-ridden,crisis-ridden,词,ADJ,C1
-crisp,crisp,词,ADJ,C1
-criticizable,criticizable,词,ADJ,B2
-critique,critique,词,NOUN,C1
-crochet,crochet,钩针编织,NOUN,B2
-crocodile,crocodile,词,NOUN,A1
-cronyism,cronyism,词,NOUN,C1
-crook,crook,骗子,NOUN,B2
-cross-border,cross-border,边境的,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crouch (noun),crouch,词,NOUN,B2
-croup,croup,词,NOUN,C1
-crowbar,crowbar,词,NOUN,B2
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-crucible,crucible,词,NOUN,B2
-crucifixion,crucifixion,词,NOUN,C1
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruelly,cruelly,残酷地,ADV,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-cruise,cruise,巡航,NOUN,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crumb,crumb,词,NOUN,C1
-crumbs,crumbs,词,NOUN,B2
-crunching,crunching,词,NOUN,C1
-crunchy,crunchy,脆的,ADJ,B1
-crusade,crusade,运动,NOUN,B2
-crushing,crushing,词,NOUN,B2
-crusty,crusty,词,ADJ,B2
-cry weep,cry weep,词,VERB,A1
-crying shouting,crying shouting,词,NOUN,B1
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal glass,crystal glass,词,NOUN,B1
-crystalline,crystalline,水晶般的,ADJ,B2
-crystallization,crystallization,词,NOUN,C1
-crystallize,crystallize,词,VERB,C1
+kruin,crest,顶峰,NOUN,B2
+misdrijfsscène,crime scene,犯罪现场,NOUN,B2
+kritikaliteit,criticality,临界性,NOUN,B2
+kritiseren,to criticize,批评,VERB,B2
+oversteek,crossing,交叉口,NOUN,B2
+kruispunt,crossroads,十字路口,NOUN,B2
+krommen,to crouch,蹲下,VERB,B2
+kraai,crow,乌鸦,NOUN,B2
+kronen,to crown,加冕,VERB,B2
+kruimelen,to crumble,粉碎,VERB,B2
+knarsen,to crunch,嘎吱作响,VERB,B2
+verpletteren,to crush,压碎,VERB,B2
+vernietigende nederlaag,crushing defeat,惨败,NOUN,B2
+schaaldier,crustacean,甲壳类动物,NOUN,B2
+kruk,crutch,拐杖,NOUN,B2
+gehuil,crying,,NOUN,B2
+kristal,crystal,水晶,NOUN,B2
+jong,cub,幼兽,NOUN,B2
+kubus,cube,立方体,NOUN,B2
 cubisme,cubism,立体主义,NOUN,B2
-cubit,cubit,词,NOUN,B2
-cuckold,cuckold,词,VERB,C1
-cuddle (noun),cuddle,词,NOUN,C1
-cudgel,cudgel,棍棒,NOUN,B2
-cue,cue,词,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culminating,culminating,词,ADJ,C1
-culmination,culmination,词,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cultivation,cultivation,培养,NOUN,B2
+komkommer,cucumber,黄瓜,NOUN,B2
 cultiveren,to cultivate,培养,VERB,B2
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-culturalism,culturalism,词,NOUN,C1
-cultured,cultured,词,ADJ,B2
 cultureel overblijfsel,cultural relic,文物,NOUN,B2
-cumber,cumber,词,VERB,C1
-cumbersome,cumbersome,笨重的,ADJ,B2
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
-cunning,cunning,诡计,NOUN,B2
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cunningly,cunningly,词,ADV,C1
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupola,cupola,词,NOUN,C1
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curate,curate,词,VERB,C1
-curative,curative,有疗效的,ADJ,B2
-curator,curator,策展人,NOUN,B2
-curatorship,curatorship,词,NOUN,C1
+listig,cunning,狡猾的,ADJ,B2
 curb,to curb,抑制,VERB,B2
-curd,curd,词,NOUN,B2
-curdle,curdle,词,VERB,C1
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
-curiously,curiously,词,ADV,C1
-curly,curly,卷曲的,ADJ,B2
-currant,currant,醋栗,NOUN,B2
 currency,currency,货币,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
 current dynasty,current dynasty,当朝,NOUN,B2
-current events,current events,时事,NOUN,B2
-current times,current times,词,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
-curry,curry,词,NOUN,B2
 curse,curse,诅咒,NOUN,B2
 curse,to curse,诅咒,VERB,B2
 cursed,cursed,被诅咒的,ADJ,B2
-cursing,cursing,骂人,NOUN,C1
 curtain,curtain,窗帘,NOUN,B2
-curvature,curvature,词,NOUN,B2
 curve,curve,曲线,NOUN,B2
-curved,curved,词,ADJ,B2
-cushion,cushion,垫子,NOUN,B2
-cusp,cusp,词,NOUN,B2
-custodian,custodian,词,NOUN,B2
 custody,custody,监护,NOUN,B2
 custom,custom,习俗,NOUN,B2
 customary,customary,习惯的,ADJ,B2
-customary law,customary law,词,NOUN,C1
-customs (adj),customs,词,ADJ,C1
-customs officer,customs officer,海关官员,NOUN,B2
-cut off,cut off,割下,NOUN,B2
 cut off,to cut off,切断,VERB,B2
-cut off (noun),cut off,割下,NOUN,B2
 cut short,to cut short,截断,VERB,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
-cutting,cutting,切割,NOUN,B2
-cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
-cv,resume,简历,NOUN,B2
 cyanosis,cyanosis,发绀,NOUN,B2
 cyber,cyber,网络的,ADJ,B2
-cybernetics,cybernetics,词,NOUN,C1
 cybersecurity,cybersecurity,网络安全,NOUN,B2
-cyborg,cyborg,词,NOUN,C1
-cycling,cycling,词,NOUN,C1
 cyclone,cyclone,气旋,NOUN,B2
-cykel,cykel,自行车,NOUN,B2
 cylinder,cylinder,圆柱体,NOUN,B2
-cylindrical,cylindrical,圆柱形的,ADJ,B2
 cymbal,cymbal,钹,NOUN,B2
 cynical,cynical,愤世嫉俗的,ADJ,B2
-cyst,cyst,囊肿,NOUN,B2
-daad,deed,行为,NOUN,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dachshund,dachshund,词,NOUN,A1
 dad,dad,爸爸,NOUN,B2
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
-dag en nacht,day and night,昼夜,NOUN,B2
-dagdromen,to daydream,幻想,VERB,B2
-dageraad,dawn,黎明,NOUN,B2
 dagger,dagger,匕首,NOUN,B2
-daglig,daglig,词,ADJ,C1
-dagloner,day laborer,日工,NOUN,B2
-dagvaarding,summons,传票,NOUN,B2
 daily,daily,每天,ADV,B2
-daily (noun),daily,词,NOUN,B2
 daily increase,daily increase,日渐,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
-daily wage,daily wage,词,NOUN,C1
-dairy,dairy,词,ADJ,C1
-daken,to roof,房顶,VERB,B2
-dakloos,homeless,无家可归的,ADJ,B2
-dal,dal,山谷,NOUN,B2
-dally,dally,词,VERB,C1
 dam,dam,水坝,NOUN,B2
-damages,damages,损害赔偿,NOUN,B2
-damaging,damaging,有害的,ADJ,B2
-damask,damask,词,NOUN,B2
-damm,damm,池塘,NOUN,B2
 damn,damn,该死的,ADJ,B2
 damn,to damn,诅咒,VERB,B2
-damn (adv),damn,该死的,ADV,B2
-damned,damned,词,ADJ,B2
 damp,damp,潮湿,ADJ,B2
-damping,damping,词,NOUN,C1
-dan,than,比,ADP,B2
-dan jij,then you,那你,PRON,B2
-dance floor,dance floor,舞池,NOUN,B2
-dandelion,dandelion,词,NOUN,B1
-dandle,dandle,词,VERB,C1
-dandruff,dandruff,词,NOUN,B2
-dangle,dangle,词,VERB,C1
-dank,thanks,谢谢,INTJ,B2
-dankbaarheid,gratitude,感激,NOUN,B2
-dankfeest,appreciation banquet,答谢宴,NOUN,B2
 danmei,danmei,但没,NOUN,B2
-dans,dans,舞蹈,NOUN,B2
-dapper,dapper,整洁的,ADJ,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-daring bold,daring bold,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
 darken,to darken,变暗,VERB,B2
 darkness,darkness,黑暗,NOUN,B2
-darkness of night,darkness of night,词,NOUN,C1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (verb),darn,词,VERB,B2
-dart (noun),dart,词,NOUN,B2
-dart (verb),dart,词,VERB,C1
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
 dashboard,dashboard,仪表盘,NOUN,B2
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-dat,that,（引导从句）,SCONJ,B2
-dat wil zeggen,that is,即,ADV,B2
-data leak,data leak,词,NOUN,C1
-data protection,data protection,词,NOUN,B2
-databas,databas,数据库,NOUN,B2
 database,database,数据库,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
 dating,dating,年代测定,NOUN,B2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daub,daub,词,VERB,C1
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dauw,dew,露水,NOUN,B2
-dawning,dawning,破晓,NOUN,B2
-day after day,day after day,日复一日,ADV,B2
-day by day,day by day,日日,ADV,B2
-day off,day off,词,NOUN,B2
-day school,day school,词,NOUN,C1
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daycare,daycare,托儿所,NOUN,B2
-daydream (noun),daydream,词,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
-de balans houdend,hold the balance of power,举足轻重,ADJ,B2
-de facto,de facto,词,ADJ,C1
-de hand schudden,to shake hands,握手,VERB,B2
-de hele dag,all day long,一整天,NOUN,B2
-de rest,the rest,其余,NOUN,B2
-de-escalation,de-escalation,词,NOUN,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-dead person,dead person,词,NOUN,B1
-deaden,deaden,词,VERB,C1
+dageraad,dawn,黎明,NOUN,B2
+dag en nacht,day and night,昼夜,NOUN,B2
+dagloner,day laborer,日工,NOUN,B2
+dagdromen,to daydream,幻想,VERB,B2
+verblinden,to dazzle,使眼花,VERB,B2
+verblindend,dazzling,耀眼的,ADJ,B2
+doodlopende weg,dead end,死胡同,NOUN,B2
 deadline,deadline,截止日期,NOUN,B2
-deadlock,deadlock,词,NOUN,C1
-deadly,deadly,致命地,ADV,B2
-deaf person,deaf person,词,NOUN,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
+doof,deaf,聋的,ADJ,B2
 deal,deal,交易,NOUN,B2
 dealer,dealer,经销商,NOUN,B2
-deals,deals,词,NOUN,C1
-deanship,deanship,词,NOUN,C1
-dear,dear,,NOUN,B2
-dearest,dearest,最爱的人,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
-deaths,deaths,词,NOUN,C1
-debasement,debasement,词,NOUN,C1
-debauch,debauch,词,VERB,C1
-debilitate,debilitate,词,VERB,C1
-debility,debility,虚弱,NOUN,C1
-debit,debit,词,VERB,C1
-debrief,debrief,词,VERB,C1
-debris,debris,词,NOUN,B2
-debris rubble,debris rubble,词,NOUN,C1
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
 decaan,dean,院长,NOUN,B2
+dood,death,死亡,NOUN,B2
+doodswens,death wish,找死,NOUN,B2
+ontucht,debauchery,放荡,NOUN,B2
+schuldenaar,debtor,债务人,NOUN,B2
 decadent,decadent,颓废,ADJ,B2
-decal,decal,贴花,NOUN,B2
-decalogue,decalogue,词,NOUN,B2
-decamp,decamp,词,VERB,C1
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
-deceased,deceased,已故的,ADJ,B2
-deceit,deceit,欺骗,NOUN,B2
-deceived,deceived,词,ADJ,A2
-decelerate,decelerate,词,VERB,C1
+overledene,deceased,死者,NOUN,B2
+bedriegen,to deceive,欺骗,VERB,B2
 december,december,十二月,NOUN,B2
-decentralized,decentralized,词,ADJ,C1
-deceptive,deceptive,欺骗性的,ADJ,B2
-decidedly,decidedly,坚决地,ADV,B2
-decimal,decimal,小数,NOUN,B2
-decimal (adj),decimal,词,ADJ,C1
-deciphering,deciphering,词,NOUN,C1
-decision-making,decision-making,决策,NOUN,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck,deck,词,NOUN,B1
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declamatory style,declamatory style,词,NOUN,C1
-declarant,declarant,词,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declare war,declare war,宣战,VERB,B2
-declension,declension,词,NOUN,C1
-decline setting,decline setting,词,NOUN,C1
-decoding,decoding,词,NOUN,B2
-decommission,decommission,词,VERB,C1
-decompensation,decompensation,词,NOUN,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
-deconstructie,deconstruction,解构主义,NOUN,B2
-deconstructionist,deconstructionist,词,ADJ,C1
+fatsoenlijk,decent,体面的,ADJ,B2
+bedrieglijke uitdaging,deception dare,你敢骗我,NOUN,B2
+ontcijferen,to decipher,破译,VERB,B2
+beslisser,decision-maker,决策者,NOUN,B2
+beslissend,decisive,决定性的,ADJ,B2
+afnemen,to decline,下降,VERB,B2
+beleefd afwijzen,to decline politely,婉拒,VERB,B2
+buiten gebruikstelling,decommissioning,退役,NOUN,B2
+ontbinden,to decompose,分解,VERB,B2
 deconstrueren,to deconstruct,解构,VERB,B2
-decontaminate,decontaminate,词,VERB,C1
-decontamination,decontamination,去污,NOUN,B2
-decor,decor,布景,NOUN,B2
-decorated,decorated,词,ADJ,B1
-decorative,decorative,装饰性的,ADJ,B2
-decorous,decorous,词,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
-decorum,decorum,礼仪,NOUN,B2
-decoy,decoy,词,NOUN,C1
-decreasing,decreasing,词,ADJ,B2
-decrepit,decrepit,词,ADJ,B2
+deconstructie,deconstruction,解构主义,NOUN,B2
+afname,decrease,减少,NOUN,B2
 decreteren,decree,法令,NOUN,B2
 decreteren,to decree,颁布法令,VERB,B2
 decryptie,decryption,解密,NOUN,B2
-deduct points,deduct points,扣分,VERB,C1
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
-deeg,dough,面团,NOUN,B2
-deegbal,dumpling,丸子,NOUN,B2
-deelnemen,to part,分离,VERB,B2
-deeltje,particle,颗粒,NOUN,B2
-deem,deem,词,VERB,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
-deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply,deeply,深深地,ADV,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,深刻地,ADV,B2
-deface,deface,词,VERB,C1
+toewijding,dedication,奉献,NOUN,B2
+aftrekken,to deduct,扣除,VERB,B2
+daad,deed,行为,NOUN,B2
+diepfrituren,to deep-fry,油炸,VERB,B2
+smaad,defamation,诽谤,NOUN,B2
+standaard,default,违约,NOUN,B2
 defaitisme,defeatism,失败主义,NOUN,B2
-defamatory,defamatory,词,ADJ,C1
-defamiliarization,defamiliarization,词,NOUN,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
 defecteren,to defect,叛变,VERB,B2
-defection,defection,词,NOUN,B2
-defective,defective,有缺陷的,ADJ,B2
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,无防御的,ADJ,B2
-defensive,defensive,防御的,ADJ,B2
-deference,deference,敬意,NOUN,B2
-deferential,deferential,词,ADJ,C1
+verdedigen,to defend one's country,卫国,VERB,B2
+verdaagde,defendant,被告,NOUN,B2
+verzet,defiance,挑衅,NOUN,B2
+verzet,defiant,挑衅的,ADJ,B2
+gebrek,deficiency,缺乏,NOUN,B2
+gebrekkig,deficient,有缺陷的,ADJ,B2
 deficit,deficit,赤字,NOUN,B2
-deficitary,deficitary,词,ADJ,C1
-defile,defile,词,VERB,C1
-definable,definable,词,ADJ,C1
-definite,definite,明确的,ADJ,B2
 definitief,definitive,决定性的,ADJ,B2
-deflated,deflated,词,ADJ,B1
-deflationary,deflationary,词,ADJ,C1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deformity,deformity,词,NOUN,C1
-defunct,defunct,词,ADJ,C1
-degeneratie,degeneration,退化,NOUN,B2
-degenerative,degenerative,退化的,ADJ,B2
+ontbossing,deforestation,森林砍伐,NOUN,B2
+vervormen,to deform,使变形,VERB,B2
+vervorming,deformation,变形,NOUN,B2
+frauduleren,to defraud,诈骗,VERB,B2
+trotseren,to defy,违抗,VERB,B2
 degenereren,to degenerate,退化,VERB,B2
+degeneratie,degeneration,退化,NOUN,B2
 degraderen,to degrade,贬低,VERB,B2
-degraderen,to relegate,降级,VERB,B2
-degrading,degrading,词,ADJ,C1
-degrease,degrease,词,VERB,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
-dehydration dryness,dehydration dryness,词,NOUN,C1
-deice,deice,词,VERB,C1
-deification,deification,词,NOUN,C1
-dejt,dejt,约会,NOUN,B2
-deksel,cover,封面,NOUN,B2
-del,del,部分,NOUN,B2
-delayed,delayed,延误的,ADJ,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
+ontwatering,dehydration,脱水,NOUN,B2
+deïsme,deism,自然神论,NOUN,B2
+neerslachtig,dejected,沮丧的,ADJ,B2
+neerslachtigheid,dejection,沮丧,NOUN,B2
 delegeren,to delegate,委派,VERB,B2
-deleterious,deleterious,词,ADJ,B2
-deletion,deletion,词,NOUN,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-deli meats,deli meats,词,NOUN,C1
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
-deliberateness,deliberateness,词,NOUN,C1
-deliberations,deliberations,词,NOUN,C1
-deliberatively,deliberatively,词,ADV,C1
+verwijderen,to delete,删除,VERB,B2
+overwegen,to deliberate,深思熟虑,VERB,B2
 delicaat,delicate,精致的,ADJ,B2
-delicately,delicately,巧妙地,ADV,B2
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delimitation,delimitation,词,NOUN,C1
+vermaak,delight,高兴,NOUN,B2
+vermakelijk,delightful,令人愉快的,ADJ,B2
+misdadigheid,delinquency,违法行为,NOUN,B2
 delinquent,delinquent,罪犯,NOUN,B2
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-deliquesce,deliquesce,词,VERB,C1
-delirious,delirious,谵妄的,ADJ,B2
 delirium,delirium,精神错乱,NOUN,B2
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delivery van,delivery van,厢式送货车,NOUN,B2
-delouse,delouse,词,VERB,C1
-delta,delta,delta,NOUN,B2
-delude,delude,词,VERB,C1
 deluge,deluge,洪水,NOUN,B2
-deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
 delusion,delusion,幻想,NOUN,B2
-delve,delve,词,VERB,C1
-demagogic,demagogic,词,ADJ,C1
-demagogue,demagogue,词,NOUN,C1
-demagoguery,demagoguery,煽动性,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
 demanding,demanding,要求高的,ADJ,B2
-demarcation,demarcation,划界,NOUN,B2
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
-dement,dement,词,VERB,C1
-demented,demented,词,ADJ,C1
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demijohn,demijohn,词,NOUN,B2
 demilitarization,demilitarization,去武,NOUN,B2
-demobilize,demobilize,词,VERB,C1
 democratization,democratization,民主化,NOUN,B2
-demographic,demographic,人口统计的,ADJ,B2
 demon,demon,恶魔,NOUN,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demonization,demonization,词,NOUN,C1
-demons,demons,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrant,protester,示威者,NOUN,B2
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrator,demonstrator,词,NOUN,C1
-demonteren,to disassemble,拆卸,VERB,B2
-demoralization,demoralization,词,NOUN,C1
-demote,demote,词,VERB,C1
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-den,den,兽穴,NOUN,B2
-denationalize,denationalize,词,VERB,C1
 denial,denial,否认,NOUN,B2
-denial contradiction,denial contradiction,词,NOUN,C1
-denim jacket,denim jacket,词,NOUN,C1
-denkbeeldig,imaginary,虚构的,ADJ,B2
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
 denounce,to denounce,谴责,VERB,B2
 dense,dense,密集的,ADJ,B2
-dense forest,dense forest,密林,NOUN,B2
 density,density,密度,NOUN,B2
-dent,dent,凹痕,NOUN,B2
-dental,dental,词,ADJ,C1
-denude,denude,词,VERB,C1
 denunciation,denunciation,告发,NOUN,B2
-deodorize,deodorize,词,VERB,C1
-deontology,deontology,词,NOUN,C1
-department director,department director,司长,NOUN,C1
 department head,department head,厅长,NOUN,B2
 department store,department store,百货商店,NOUN,B2
-departmental,departmental,词,ADJ,B2
 departure,departure,离开,NOUN,B2
-departure lounge,departure lounge,候机室,NOUN,B2
 depend,to depend,依赖,VERB,B2
 depend on,to depend on,依赖,VERB,B2
-dependence,dependence,依赖,NOUN,B2
-dependency,dependency,词,NOUN,B2
-dependent passivity,dependent passivity,词,NOUN,C1
-deplete,deplete,词,VERB,C1
-depletion,depletion,词,NOUN,C1
-deplorable,deplorable,可悲的,ADJ,B2
 deplore,to deplore,谴责,VERB,B2
 deployment,deployment,部署,NOUN,B2
-depone,depone,词,VERB,C1
-depopulation,depopulation,词,NOUN,B2
-deportation,deportation,驱逐出境,NOUN,B2
 depose,to depose,废黜,VERB,B2
-deposed,deposed,词,ADJ,C1
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depravity,depravity,堕落,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-deprecation,deprecation,词,NOUN,C1
 depreciation,depreciation,贬值,NOUN,B2
-depredate,depredate,词,VERB,C1
-depredation,depredation,词,NOUN,C1
 depressed,depressed,沮丧的,ADJ,B2
-depressing,depressing,令人沮丧的,ADJ,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
 deprivation,deprivation,剥夺,NOUN,B2
 deprive,to deprive,剥夺,VERB,B2
-depute,depute,词,VERB,C1
 deputy,deputy,副的,ADJ,B2
-deputy (noun),deputy,副手,NOUN,B2
-deracinate,deracinate,词,VERB,C1
 derail,to derail,使脱轨,VERB,B2
-derailment,derailment,词,NOUN,C1
-derange,derange,词,VERB,C1
-derby,derby,词,NOUN,B2
-deregulate,deregulate,词,VERB,C1
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-deride,deride,词,VERB,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
-derivation,derivation,词,NOUN,C1
-dermal,dermal,词,ADJ,C1
 derogate,to derogate,贬损,VERB,B2
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-desalination,desalination,词,NOUN,C1
-descant,descant,词,VERB,C1
 descend,to descend,下降,VERB,B2
-descend go down,descend go down,词,VERB,A1
 descendant,descendant,后代,NOUN,B2
-descendants,descendants,词,NOUN,C1
-descending,descending,词,ADJ,C1
-descriptive,descriptive,描述性的,ADJ,B2
-descriptiveness,descriptiveness,词,NOUN,C1
-descry,descry,词,VERB,C1
-desecrate,desecrate,词,VERB,C1
-desecration,desecration,词,NOUN,C1
-desegregate,desegregate,词,VERB,C1
-deserter,deserter,逃兵,NOUN,B2
 desertification,desertification,荒漠化,NOUN,B2
 deserve,to deserve,值得,VERB,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desiccation,desiccation,词,NOUN,C1
 designated driver,designated driver,代驾,NOUN,B2
 desire,desire,欲望,NOUN,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desirous,desirous,词,ADJ,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
 desolaat,desolate,荒凉的,ADJ,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-desolation,desolation,荒凉,NOUN,B2
-desoriëntatie,disorientation,迷失方向,NOUN,B2
-desoriënteren,to disorient,使迷失方向,VERB,B2
-despatch,despatch,词,VERB,C1
-desperately serious,desperately serious,不得了,ADJ,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despond,despond,词,VERB,C1
-despondency,despondency,词,NOUN,C1
+verachtelijk,despicable,可鄙的,ADJ,B2
+verachten,to despise,鄙视,VERB,B2
 despoot,despot,暴君,NOUN,B2
-despotic,despotic,专制的,ADJ,B2
 despotisme,despotism,专制,NOUN,B2
-desquamation,desquamation,词,NOUN,C1
 dessert,dessert,甜点,NOUN,B2
-destine,destine,词,VERB,C1
-destitute,destitute,词,ADJ,C1
-destroyed,destroyed,被毁坏的,ADJ,B2
-destroyer,destroyer,词,NOUN,C1
+noodlot,destiny,命运,NOUN,B2
+armoede,destitution,贫困,NOUN,B2
 destructief,destructive,مدمر,ADJ,B2
-destruction of property,destruction of property,毁坏财物,NOUN,C1
-detachable,detachable,词,ADJ,C1
-detached house,detached house,独栋房屋,NOUN,B2
+losmaken,to detach,分离,VERB,B2
+losmaking,detachment,脱落,NOUN,B2
 detail,detail,细节,NOUN,B2
-detail,its details,其详,NOUN,B2
-details,details,细细,NOUN,C1
-detainee,detainee,被拘留者,NOUN,B2
+vasthouden,to detain,拘留,VERB,B2
 detective,detective,侦探,NOUN,B2
-detective force,detective force,刑警,NOUN,B2
-detector,detector,词,NOUN,C1
 detente,detente,缓和,NOUN,B2
-detention center,detention center,拘留所,NOUN,B2
-deter,deter,词,VERB,C1
-detergent,detergent,洗涤剂,NOUN,B2
-deteriorated,deteriorated,恶化的,ADJ,B2
-deterioration,deterioration,恶化,NOUN,B2
-determinant,determinant,词,NOUN,C1
-determined definite,determined definite,确定的,ADJ,B2
+verslechteren,to deteriorate,恶化,VERB,B2
+vastberaden,determined,下定决心的,ADJ,B2
 determinisme,determinism,决定论,NOUN,B2
-determinist,determinist,词,ADJ,C1
 deterministisch,deterministic,决定论的,ADJ,B2
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
+verafschuwen,to detest,厌恶,VERB,B2
+walgelijk,detestable,可恶的,ADJ,B2
 detoneren,to detonate,引爆,VERB,B2
-detractor,detractor,词,NOUN,C1
-detriment,detriment,损害,NOUN,B2
-detrimental,detrimental,有害的,ADJ,B2
-detritus,detritus,词,NOUN,C1
-deugd,virtue,美德,NOUN,B2
-deurbel,doorbell,门铃,NOUN,B2
-deurklink,door handle,门把手,NOUN,B2
-deurmat,doormat,门垫,NOUN,B2
-devaluation,devaluation,贬值,NOUN,B2
-devastated,devastated,崩溃的,ADJ,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-deviance,deviance,词,NOUN,B2
-device system,device system,词,NOUN,B1
-devices,devices,设备,NOUN,B2
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devious,devious,词,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid,devoid,词,ADJ,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolution,devolution,词,NOUN,C1
-devolve,devolve,词,VERB,C1
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devourer,devourer,吞噬者,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-devoutly,devoutly,词,ADV,C1
-dexterity,dexterity,灵巧,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
-deïsme,deism,自然神论,NOUN,B2
+omweg,detour,绕道,NOUN,B2
+ontgiften,to detoxify,解毒,VERB,B2
+verwoesten,to devastate,摧毁,VERB,B2
+verwoesting,devastation,破坏,NOUN,B2
+ontwikkeld,developed,发达的,ADJ,B2
+afwijking,deviation,偏离,NOUN,B2
+bedenken,to devise,设计,VERB,B2
+wijden,to devote,奉献,VERB,B2
+toegewijd,devoted,忠诚的,ADJ,B2
+toewijding,devotion,奉献,NOUN,B2
+dauw,dew,露水,NOUN,B2
 diabetes,diabetes,糖尿病,NOUN,B2
-diabetic,diabetic,词,ADJ,C1
-diabolical,diabolical,恶魔般的,ADJ,B2
-diachrony,diachrony,词,NOUN,C1
-diaeresis,diaeresis,词,NOUN,C1
 diagnosticeren,to diagnose,诊断,VERB,B2
-diagonal,diagonal,对角线,NOUN,B2
-diagonally,diagonally,对角地,ADV,B2
 diagram,diagram,图表,NOUN,B2
-dial (noun),dial,词,NOUN,C1
-dial (verb),dial,词,VERB,B2
 dialect,dialect,方言,NOUN,B2
-dialectic (adj),dialectic,词,ADJ,C1
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialectician,dialectician,词,NOUN,C1
-dialing code,dialing code,词,NOUN,C1
 dialogiseren,to dialogue,对话,VERB,B2
-dialogism,dialogism,词,NOUN,C1
-diameter,diameter,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
-diapers,diapers,词,NOUN,B1
-diaphanous,diaphanous,词,ADJ,C1
-diaphragm,diaphragm,横膈膜,NOUN,B2
+luier,diaper,尿布,NOUN,B2
 diarree,diarrhea,腹泻,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-diatribe,diatribe,词,NOUN,C1
-dichotomy,dichotomy,二分法,NOUN,B2
-dictation,dictation,dictation,NOUN,B2
-dictator,dictator,独裁者,NOUN,B2
-didactic,didactic,教学的,ADJ,B2
-didactics,didactics,词,NOUN,C1
-die,die,骰子,NOUN,B2
-die pijl,that arrow,那一箭,NOUN,B2
-dienaar,servant,仆人,NOUN,B2
-dienstverlener,service provider,服务商,NOUN,B2
-dienstwissel,shift swap,换班,NOUN,B2
-diep,profound,深刻的,ADJ,B2
-diepfrituren,to deep-fry,油炸,VERB,B2
-dierenteken,zodiac sign,属相,NOUN,B2
-dietary,dietary,词,ADJ,C1
-different,different,不同地,ADV,B2
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
-difficult flirt,difficult flirt,,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-diffuse,diffuse,模糊的,ADJ,B2
-diffusely,diffusely,词,ADV,C1
-diffusion spread,diffusion spread,词,NOUN,C1
-dig up,dig up,词,VERB,B2
-digestible,digestible,词,ADJ,C1
-digital currency,digital currency,数字货币,NOUN,C1
-digitized,digitized,词,ADJ,C1
-diglossia,diglossia,词,NOUN,C1
-dignified,dignified,词,ADJ,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignify,dignify,词,VERB,C1
-dignitaries,dignitaries,词,NOUN,C1
-dignitary,dignitary,高官,NOUN,B2
-digression,digression,词,NOUN,C1
-dik,fat,胖的,ADJ,B2
-dik lettertype,heavy type,重型,NOUN,B2
-dilated,dilated,词,ADJ,C1
-dilatory,dilatory,拖延的,ADJ,B2
+dobbelsteen,dice,骰子,NOUN,B2
+woordenboek,dictionary,词典,NOUN,B2
+zware aanval,difficult attack,难攻,NOUN,B2
+moeilijk probleem,difficult problem,难题,NOUN,B2
+verspreiden,to diffuse,扩散,VERB,B2
+verteren,to digest,消化,VERB,B2
+vertering,digestion,消化,NOUN,B2
+verterend,digestive,消化的,ADJ,B2
+graven,digging,挖掘,NOUN,B2
+cijfer,digit,数字,NOUN,B2
+waardigheid,dignity,尊严,NOUN,B2
+verwijden,to dilate,膨胀,VERB,B2
+verwijding,dilation,扩张,NOUN,B2
 dilemma,dilemma,困境,NOUN,B2
-dilemma,predicament,困境,NOUN,B2
-dilution,dilution,词,NOUN,C1
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-dimmed,dimmed,词,ADJ,C1
-dimple,dimple,词,NOUN,C1
-din,din,喧嚣,NOUN,B2
-dine,dine,词,VERB,C1
-dineren,to have dinner,吃晚餐,VERB,B2
-dinghy,dinghy,词,NOUN,C1
-dining hall,dining hall,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
+vlijt,diligence,勤勉,NOUN,B2
+vlijtig,diligent,勤奋的,ADJ,B2
+verminderen,to diminish,减少,VERB,B2
 dinosaurus,dinosaur,恐龙,NOUN,B2
-diocesan,diocesan,词,ADJ,C1
-diocese,diocese,词,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diploma,diploma,文凭,NOUN,B2
-diplomat,diplomat,词,NOUN,C1
-dipsomaniac,dipsomaniac,词,NOUN,C1
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directing,directing,导演,NOUN,B2
-directionality,directionality,词,NOUN,C1
-directive (adj),directive,词,ADJ,C1
-director manager,director manager,主管/经理,NOUN,B2
-directorate,directorate,局,NOUN,C1
-directory,directory,词,NOUN,C1
-dirham,dirham,词,NOUN,A1
-dirt filth,dirt filth,词,NOUN,C1
-dirt soil,dirt soil,词,NOUN,A1
-dirtier,dirtier,更脏的,ADJ,B2
-dirty bastard,dirty bastard,词,NOUN,C1
-dirty trick,dirty trick,词,NOUN,B2
-disable,disable,词,VERB,C1
-disadvantaged,disadvantaged,词,ADJ,C1
-disadvantageous,disadvantageous,不利的,ADJ,B2
-disaffect,disaffect,词,VERB,C1
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disallow,disallow,词,VERB,C1
-disapproval,disapproval,词,NOUN,C1
-disarmament,disarmament,裁军,NOUN,B2
-disarray (noun),disarray,词,NOUN,C1
-disassembly,disassembly,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
+dompelen,to dip,蘸,VERB,B2
+richtingbord,direction sign,指示牌,NOUN,B2
+richtlijn,directive,指令,NOUN,B2
+disputen,to disagree,不同意,VERB,B2
+meningsverschil,disagreement,不和,NOUN,B2
+teleurgesteld,disappointed,失望的,ADJ,B2
+teleurstellend,disappointing,令人失望的,ADJ,B2
+afkeuren,to disapprove,不赞成,VERB,B2
+ontwapenen,to disarm,解除武装,VERB,B2
+demonteren,to disassemble,拆卸,VERB,B2
+rampzalig,disastrous,灾难性的,ADJ,B2
+verloochenen,to disavow,否认,VERB,B2
 disbelief,disbelief,不信,NOUN,B2
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-disbursement,disbursement,词,NOUN,C1
-disc,disc,光盘,NOUN,B2
 discard,to discard,丢弃,VERB,B2
-discernment,discernment,洞察力,NOUN,B2
 discharge,discharge,放电,NOUN,B2
 disciple,disciple,门徒,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
-disciplinary,disciplinary,纪律的,ADJ,B2
 discipline,discipline,纪律,NOUN,B2
 discipline,to discipline,管教,VERB,B2
-discipline schenden,to violate discipline,违纪,VERB,B2
-disciplined,disciplined,词,ADJ,C1
-disclaim,disclaim,词,VERB,C1
 disclose,to disclose,揭露,VERB,B2
-disclosure,disclosure,泄露,NOUN,C1
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
 disconnect,to disconnect,断开,VERB,B2
-disconnection,disconnection,词,NOUN,C1
-disconsolation,disconsolation,词,NOUN,C1
-discontent,discontent,不满,NOUN,B2
 discontinue,to discontinue,停止,VERB,B2
-discontinuity,discontinuity,词,NOUN,B2
 discord,discord,不和,NOUN,B2
 discordance,discordance,不一致,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discounts,discounts,折扣,NOUN,B2
 discourage,to discourage,使气馁,VERB,B2
-discouragement,discouragement,词,NOUN,C1
 discourse,discourse,论述,NOUN,B2
 discourse,to discourse,论述,VERB,B2
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit,discredit,丧失信誉,NOUN,B2
 discredit,to discredit,败坏名声,VERB,B2
-discredit (noun),discredit,词,NOUN,B2
-discrediting,discrediting,词,NOUN,C1
 discreet,discreet,谨慎的,ADJ,B2
-discreetly,discreetly,词,ADV,B2
-discrepancy,discrepancy,差异,NOUN,B2
-discrete,discrete,词,ADJ,C1
-discretionary,discretionary,自由裁量的,ADJ,B2
-discretionary punishment,discretionary punishment,词,NOUN,C1
-discursive,discursive,词,ADJ,C1
 disdain,disdain,蔑视,NOUN,B2
-disdainful,disdainful,词,ADJ,C1
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disembarkation,disembarkation,词,NOUN,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenchantment,disenchantment,幻灭,NOUN,B2
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
 disengage,to disengage,脱离,VERB,B2
-disengagement,disengagement,词,NOUN,B2
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disgorge,disgorge,词,VERB,C1
 disgrace,disgrace,耻辱,NOUN,B2
-disgruntle,disgruntle,词,VERB,C1
 disguise,disguise,伪装,NOUN,B2
 disguise,to disguise,伪装,VERB,B2
 disgust,disgust,厌恶,NOUN,B2
-dish towel,dish towel,抹布,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-dishes,dishes,词,NOUN,C1
-disheveled,disheveled,蓬乱的,ADJ,B2
-dishonest,dishonest,不诚实的,ADJ,B2
-dishonor,dishonor,耻辱,NOUN,B2
-dishonorable,dishonorable,词,ADJ,C1
 dishwasher,dishwasher,洗碗机,NOUN,B2
-disillusion,disillusion,词,VERB,C1
-disillusionment,disillusionment,词,NOUN,C1
-disincline,disincline,词,VERB,C1
 disinfect,to disinfect,消毒,VERB,B2
 disinfectant,disinfectant,消毒剂,NOUN,B2
-disinflation,disinflation,词,NOUN,B2
-disinhibited,disinhibited,词,ADJ,C1
-disintegration,disintegration,词,NOUN,B2
-disinter,disinter,词,VERB,C1
-disinvestment,disinvestment,词,NOUN,C1
 disjoint,disjoint,不相交的,ADJ,B2
-disjointed,disjointed,词,ADJ,C1
 dislike,to dislike,不喜欢,VERB,B2
 dislocate,to dislocate,使脱臼,VERB,B2
 dislocation,dislocation,脱臼,NOUN,B2
-disloyalty,disloyalty,不忠,NOUN,B2
 dismantling,dismantling,拆除，瓦解,NOUN,B2
-dismay (noun),dismay,词,NOUN,C1
-dismember,dismember,词,VERB,C1
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
 dismount,to dismount,下马,VERB,B2
 disobedience,disobedience,不服从,NOUN,B2
-disobedient,disobedient,不服从的,ADJ,B2
 disobey,to disobey,违抗,VERB,B2
 disorder,disorder,混乱,NOUN,B2
 disorderly,disorderly,杂乱的,ADJ,B2
-disorganization,disorganization,无组织,NOUN,B2
-disorganize,disorganize,词,VERB,C1
-disoriented,disoriented,词,ADJ,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparagement,disparagement,词,NOUN,C1
-disparate,disparate,截然不同的,ADJ,B2
-dispassionate,dispassionate,词,ADJ,C1
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-displace,displace,词,VERB,C1
-displaced person,displaced person,词,NOUN,C1
-displacement,displacement,位移,NOUN,B2
-displeased,displeased,词,ADJ,C1
-disport,disport,词,VERB,C1
-disposable,disposable,一次性的,ADJ,B2
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposed,disposed,词,ADJ,C1
-disposition,disposition,性情,NOUN,B2
-dispossessed,dispossessed,词,ADJ,C1
-disproportionate,disproportionate,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-disputation,disputation,词,NOUN,C1
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
-disputed case,disputed case,词,NOUN,C1
-disputen,to disagree,不同意,VERB,B2
-disqualification,disqualification,词,NOUN,C1
-disquiet,disquiet,词,NOUN,C1
-disquisition,disquisition,论述,NOUN,B2
-disrepair,disrepair,词,NOUN,C1
-disrepute,disrepute,坏名声,NOUN,B2
-disrespect,disrespect,不敬,NOUN,B2
-disrespectful,disrespectful,无礼的,ADJ,B2
-disrobe,disrobe,词,VERB,C1
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfy,dissatisfy,词,VERB,C1
-dissemble,dissemble,词,VERB,C1
-dissembling,dissembling,词,ADJ,C1
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
-dissert,dissert,词,VERB,C1
+desoriënteren,to disorient,使迷失方向,VERB,B2
+desoriëntatie,disorientation,迷失方向,NOUN,B2
+verzenden,to dispatch,派遣,VERB,B2
+medicijnen uitreiken,to dispense medicine,配药,VERB,B2
+ontstemmen,to displease,使不快,VERB,B2
+ongenoegen,displeasure,不悦,NOUN,B2
+verwijdering,disposal,处理,NOUN,B2
+negeren,to disregard,忽视,VERB,B2
+ontevreden,dissatisfied,不满的,ADJ,B2
+ontleden,to dissect,解剖,VERB,B2
+verspreiden,to disseminate,传播,VERB,B2
+onenigheid,dissent,异议,NOUN,B2
 dissertatie,dissertation,论文,NOUN,B2
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
-dissociate,dissociate,词,VERB,C1
-dissolute,dissolute,放荡的,ADJ,B2
-dissonant,dissonant,词,ADJ,C1
+verkwisting,dissipation,挥霍,NOUN,B2
+ontbinding,dissolution,溶解,NOUN,B2
+oplossen,to dissolve,溶解,VERB,B2
 dissonantie,dissonance,不和谐,NOUN,B2
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distich,distich,词,NOUN,C1
-distil,distil,词,VERB,C1
-distillation,distillation,词,NOUN,C1
-distinctive,distinctive,独特的,ADJ,B2
-distinctly,distinctly,清楚地,ADV,B2
-distinguishable,distinguishable,词,ADJ,C1
-distorted image,distorted image,扭曲的形象,NOUN,B2
-distrain,distrain,词,VERB,C1
-distressing,distressing,词,ADJ,B1
-distributed,distributed,词,ADJ,C1
-distributor,distributor,分销商,NOUN,B2
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
+afraden,to dissuade,劝阻,VERB,B2
+ver,distant,遥远的,ADJ,B2
+duidelijk,distinct,明显的,ADJ,B2
+vooraanstaand,distinguished,杰出,ADJ,B2
+verdraaien,to distort,扭曲,VERB,B2
+vervorming,distortion,扭曲,NOUN,B2
+afleiden,to distract,分心,VERB,B2
+afgeleid,distracted,分心的,ADJ,B2
+afleiding,distraction,分心,NOUN,B2
 districtshoofd,district head,区长,NOUN,B2
-distrustful,distrustful,词,ADJ,C1
-disturbed,disturbed,不安的,ADJ,B2
-disuse,disuse,废弃,NOUN,B2
-dithyramb,dithyramb,词,NOUN,C1
-dive appear,dive appear,词,VERB,B2
-diver,diver,词,NOUN,B2
-divestment,divestment,词,NOUN,C1
-divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
+wantrouwen,distrust,不信任,NOUN,B2
+verontrustend,disturbing,令人不安的,ADJ,B2
+afwijkend,divergent,分歧的,ADJ,B2
+omleiden,to divert,转移,VERB,B2
 dividend,dividend,红利,NOUN,B2
-divider,divider,词,NOUN,C1
-divinatory,divinatory,词,ADJ,C1
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
-divisibility,divisibility,词,NOUN,C1
-divisive,divisive,词,ADJ,C1
-divisor,divisor,词,NOUN,C1
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
-djellaba,djellaba,词,NOUN,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
-do not want,do not want,不想,VERB,B2
-do one's best (adv),do one's best,竭力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-dobbelsteen,dice,骰子,NOUN,B2
-docile,docile,温顺的,ADJ,B2
-docilely,docilely,词,ADV,C1
-doctor visit,doctor visit,,NOUN,B2
-doctoraat,doctorate,博士学位,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
-doctrinaire,doctrinaire,教条主义的,ADJ,B2
-doctrine,doctrine,词,NOUN,B2
-documentair,documentary,纪录片的,ADJ,B2
-documented,documented,词,ADJ,C1
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
+waarzeggerij,divination,占卜,NOUN,B2
+theoloog,divine,如神,NOUN,B2
+duiken,diving,潜水,NOUN,B2
+duizeligheid,dizziness,眩晕,NOUN,B2
+duizelig,dizzy,头晕的,ADJ,B2
+niet,do not,莫,ADV,B2
+niet-gebruik,do not use,别用,NOUN,B2
+je best doen,to do one's best,尽力,VERB,B2
 doen,to do to make,做,VERB,B2
-doen,to thaw,解冻,VERB,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-doggedly,doggedly,词,ADV,C1
+volgzaamheid,docility,温顺,NOUN,B2
+dok,dock,码头,NOUN,B2
+doctoraat,doctorate,博士学位,NOUN,B2
+documentair,documentary,纪录片的,ADJ,B2
 dogma,dogma,教条,NOUN,B2
 dogmatisch,dogmatic,教条的,ADJ,B2
 dogmatisme,dogmatism,教条主义,NOUN,B2
-dok,dock,码头,NOUN,B2
+pop,doll,玩偶,NOUN,B2
 dolfijn,dolphin,海豚,NOUN,B2
-dollar,dollar,词,NOUN,C1
-dom,dumb,愚蠢的,ADJ,B2
-dom,foolish,愚蠢的,ADJ,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
-domesticate,domesticate,词,VERB,C1
+koepel,dome,圆顶,NOUN,B2
 dominant,dominant,占主导地位的,ADJ,B2
-domineering,domineering,词,ADJ,C1
-domme meid,silly girl,傻丫头,NOUN,B2
-dommel,fool,傻瓜,NOUN,B2
-dompelen,to dip,蘸,VERB,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
 donatie,donation,捐款,NOUN,B2
-donaties ophalen,to raise donations,募捐,VERB,B2
-donaties ophalen,to solicit donations,募捐,VERB,B2
-donation of goods,donation of goods,捐物,NOUN,C1
-donkey foal,donkey foal,词,NOUN,B2
+gedaan,done,事已,NOUN,B2
 donor,donor,捐赠者,NOUN,B2
-dood,death,死亡,NOUN,B2
-doodlopende weg,dead end,死胡同,NOUN,B2
-doodsrisico,risking death,冒死,NOUN,B2
-doodswens,death wish,找死,NOUN,B2
-doof,deaf,聋的,ADJ,B2
-doom,doom,词,VERB,C1
-doopvader,godfather,教父,NOUN,B2
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door lock,door lock,门锁,NOUN,C1
-door middel van,by means of,凭借,NOUN,B2
-doorbell button,doorbell button,门铃按钮,NOUN,B2
-doordrenken,to soak,浸透,VERB,B2
-doorlaatbaar,permeable,可渗透的,ADJ,B2
-doortastend,sagacious,睿智的,ADJ,B2
-doorval,falling though,虽坠,NOUN,B2
-doorway,doorway,门口,NOUN,C1
-doorzien,to see through,看穿,VERB,B2
-dope (noun),dope,词,NOUN,B2
-dopen,to baptize,施洗,VERB,B2
-doping,doping,词,NOUN,C1
-doping agents,doping agents,词,NOUN,B2
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
-dorpsvoorman,village head,村长,NOUN,B2
+deurklink,door handle,门把手,NOUN,B2
+deurbel,doorbell,门铃,NOUN,B2
+portier,doorman,门卫,NOUN,B2
+deurmat,doormat,门垫,NOUN,B2
+slaapzaal,dormitory,宿舍,NOUN,B2
 dosering,dosage,剂量,NOUN,B2
-dot,dot,点,NOUN,B2
-dotting,dotting,词,NOUN,C1
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubling,doubling,加倍,NOUN,B2
-doughy,doughy,面团状的,ADJ,B2
-douse,douse,词,VERB,C1
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downgrade,downgrade,词,VERB,C1
+deeg,dough,面团,NOUN,B2
+af,down,顺...而下,ADP,B2
 download,download,下载,NOUN,B2
-downplay,downplay,词,VERB,C1
-downplaying,downplaying,词,NOUN,C1
-downright,downright,词,ADV,B1
-downsize,downsize,词,VERB,C1
-doze (noun),doze,词,NOUN,C1
-doze (verb),doze,词,VERB,C1
-doze off,doze off,词,VERB,B2
-dozens,dozens,数十个,NOUN,B2
-draadloos,wireless,无线的,ADJ,B2
-draaien,to twist,扭曲,VERB,B2
-draconian,draconian,词,ADJ,C1
-drag,drag,拖曳,NOUN,B2
-drager,porter,搬运工,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-dragoon,dragoon,词,VERB,C1
-drainage,drainage,词,NOUN,C1
-drainage sewage,drainage sewage,词,NOUN,C1
+stortbui,downpour,倾盆大雨,NOUN,B2
+stroomafwaarts,downstream,下游,NOUN,B2
+omlaag,downwards,向下,ADV,B2
+bruidsschat,dowry,嫁妆,NOUN,B2
+concept,draft,草稿,NOUN,B2
+slepen,to drag,拖,VERB,B2
+afvoer,drain,排水沟,NOUN,B2
 dramatisch,dramatic,戏剧性的,ADJ,B2
 dramatiseren,to dramatize,戏剧化,VERB,B2
-dramatization,dramatization,词,NOUN,C1
 dramaturgie,dramaturgy,戏剧艺术,NOUN,B2
-drastic,drastic,词,ADJ,C1
-draught,draught,词,NOUN,C1
-draw blood,draw blood,抽血,VERB,B2
-drawback,drawback,缺点,NOUN,B2
-drawl,drawl,词,VERB,C1
-dread (noun),dread,胆战,NOUN,B2
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge,dredge,,NOUN,B2
-dredge (verb),dredge,词,VERB,C1
-dreigend,imminent,即将来临的,ADJ,B2
-drench,drench,词,VERB,C1
-dressed,dressed,穿着的,ADJ,B2
-dressing room,dressing room,词,NOUN,B2
-dribble,dribble,词,VERB,C1
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
-driestheid,audacity,大胆,NOUN,B2
-drift (verb),drift,词,VERB,B2
-drift excess,drift excess,词,NOUN,C1
+teruggrepen doen op,to draw on the experience of,借鉴,VERB,B2
+uitsteken,draw out,引出,NOUN,B2
+vrees,dread,恐惧,NOUN,B2
+vrees,to dread,畏惧,VERB,B2
+bodem,dregs,渣滓,NOUN,B2
+verkleeden,to dress up,盛装打扮,VERB,B2
+gedroogde tofu,dried tofu,豆干,NOUN,B2
 drijven,drifting,漂泊,NOUN,B2
-dringen,to urge,强烈要求,VERB,B2
-dringend,pressing,紧迫的,ADJ,B2
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinks,drinks,词,NOUN,C1
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-drive,drive,动力,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-drivel,drivel,词,NOUN,C1
-driving,driving,你来驾车,NOUN,C1
-drizzly,drizzly,词,ADJ,C1
+boor,drill,钻头,NOUN,B2
+oprit,driveway,车道,NOUN,B2
+motregen,drizzle,毛毛雨,NOUN,B2
 drone,drone,无人机,NOUN,B2
-drool,drool,口水,NOUN,B2
-droomerigheid,absent-mindedness,心不在焉,NOUN,B2
-droop,droop,词,VERB,C1
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
-dropper,dropper,词,NOUN,C1
-droppings,droppings,粪便,NOUN,B2
-drops,drops,词,NOUN,B1
-drowning,drowning,词,NOUN,C1
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
+laten vallen,to drop,掉落,VERB,B2
+slapheid,drowsiness,昏睡,NOUN,B2
 drug,drug,药物,NOUN,B2
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drug medication,drug medication,词,NOUN,C1
-drugs,drugs,毒品,NOUN,B2
-druif,grape,葡萄,NOUN,B2
-druk,pressure,压力,NOUN,B2
-druk,print,印记,NOUN,B2
-drukte,busyness,事忙,NOUN,B2
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
-drunkenness,drunkenness,醉酒,NOUN,B2
-dry cleaner,dry cleaner,词,NOUN,A2
-dry land,dry land,词,NOUN,B2
-dry sausage,dry sausage,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-dual,dual,词,ADJ,C1
-dual form,dual form,词,NOUN,C1
+trom,drum,鼓,NOUN,B2
 dualisme,dualism,二元论,NOUN,B2
 dualiteit,duality,二元性,NOUN,B2
-dub,dub,词,VERB,C1
-dubbele punt,colon,冒号,NOUN,B2
 dubbing,dubbing,配音,NOUN,B2
-duchess,duchess,公爵夫人,NOUN,B2
-duct pipe,duct pipe,管道,NOUN,B2
-ductile,ductile,词,ADJ,C1
-dude,dude,词,NOUN,A2
-due date maturity,due date maturity,词,NOUN,B2
-duel,duel,词,NOUN,C1
-duel,shootout,枪战,NOUN,B2
-duet,duet,二重奏,NOUN,B2
-duidelijk,distinct,明显的,ADJ,B2
-duiken,diving,潜水,NOUN,B2
-duiken,scuba diving,潜水,NOUN,B2
-duim,inch,بوصة,NOUN,B2
-duizelig,dizzy,头晕的,ADJ,B2
-duizeligheid,dizziness,眩晕,NOUN,B2
-dull-witted,dull-witted,词,ADJ,B2
-duly,duly,词,ADV,C1
-dumbfound,dumbfound,词,VERB,C1
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dump site,dump site,词,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-dungeon,dungeon,地牢,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicity,duplicity,口是心非,NOUN,B2
-durable,durable,词,ADJ,C1
-duren,to last a period of time,为期,VERB,B2
-durf,boldness,大胆,NOUN,B2
-durian,durian,榴莲,NOUN,C1
-dust coat,dust coat,词,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-duty of care,duty of care,词,NOUN,C1
-duur,duration,持续时间,NOUN,B2
+verschuldigd,due,到期的,ADJ,B2
+vanwege,due to,由于,ADP,B2
+saai,dull,枯燥的,ADJ,B2
+saaiheid,dullness,迟钝,NOUN,B2
+dom,dumb,愚蠢的,ADJ,B2
+deegbal,dumpling,丸子,NOUN,B2
 duurzaamheid,durability,耐用性,NOUN,B2
-duvet,duvet,羽绒被,NOUN,B2
-dwaasworden,to go crazy,发疯,VERB,B2
-dwaling,fallacy,谬误,NOUN,B2
-dwell,dwell,词,VERB,C1
+duur,duration,持续时间,NOUN,B2
+schemering,dusk,黄昏,NOUN,B2
 dwerg,dwarf,侏儒,NOUN,B2
-dwindle,dwindle,词,VERB,C1
-dwindling,dwindling,词,NOUN,C1
-dwingen,to compel,强迫,VERB,B2
-dyed,dyed,词,ADJ,B1
-dying,dying,垂死的,ADJ,B2
-dying (noun),dying,dying,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamics,dynamics,词,NOUN,C1
+woning,dwelling,住宅,NOUN,B2
 dynamisch,dynamic,动态的,ADJ,B2
-dynamism,dynamism,活力,NOUN,B2
-dynamite,dynamite,炸药,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
-dyspepsie,indigestion,消化不良,NOUN,B2
 dystopie,dystopia,反乌托邦,NOUN,B2
-e-mail,email,电子邮件,NOUN,B2
-e-reader,e-reader,电子阅读器,NOUN,B2
-each (noun),each,一一,NOUN,C1
-each every,each every,每,DET,A1
-each one,each one,每人,PRON,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-eagerness,eagerness,词,NOUN,B2
-earlier,earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
-early (adv),early,提早,ADV,A1
-early (noun),early,词,NOUN,B2
-early morning (adv),early morning,词,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-earnest,earnest,词,ADJ,B1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears,ears,耳朵,NOUN,B2
-ears of wheat,ears of wheat,词,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easier,easier,更容易的,ADJ,B2
-easily,easily,词,ADV,B2
-easing,easing,词,NOUN,C1
-east bank,east bank,东岸,NOUN,C1
-eastward,eastward,向东,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
-eating,eating,,NOUN,B2
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-ebb tide,ebb tide,词,NOUN,B1
-eccentric person,eccentric person,词,NOUN,C1
-ecclesial,ecclesial,词,ADJ,C1
-echoes,echoes,词,NOUN,C1
-echt,genuine,真正的,ADJ,B2
-echte wens,really want,真要,NOUN,B2
-echtgenoot,spouse,配偶,NOUN,B2
-eclectic,eclectic,词,ADJ,C1
+gretig,eager,渴望的,ADJ,B2
+arend,eagle,鹰,NOUN,B2
+vroeg,early,早,ADV,B2
+vroege ochtend,early morning,凌晨,NOUN,B2
+vroegtijdige waarschuwing,early warning,预警,NOUN,B2
+gemakkelijk te zeggen,easy to say,好说,NOUN,B2
+excentriek,eccentric,古怪的,ADJ,B2
+kerkelijk,ecclesiastical,教会的,ADJ,B2
 eclips,eclipse,日食,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-economic climate,economic climate,词,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economical,economical,词,ADJ,A1
-economically,economically,词,ADV,B1
-economize,economize,词,VERB,C1
 ecosysteem,ecosystem,生态系统,NOUN,B2
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eddy,eddy,漩涡,NOUN,B2
-edelman,nobleman,贵族,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edging,edging,镶边,NOUN,B2
-edible,edible,词,ADJ,C1
-edifying,edifying,词,ADJ,C1
-edit (noun),edit,重辑,NOUN,B2
-editing,editing,剪辑,NOUN,B2
-educational,educational,教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
-eekhoorn,squirrel,松鼠,NOUN,B2
-een beetje,a little,一点,ADJ,B2
-een beetje,a bit,一点,ADV,B2
-een hoop,a pile,一堆,NUM,B2
-een paar,a pair,一对,NUM,B2
-eenvoud,simplicity,简单,NOUN,B2
-eenzaamheid,solitude,孤独,NOUN,B2
-eerbetoon,reverence,尊敬,NOUN,B2
-eerbiedwaardig,venerable,值得尊敬的,ADJ,B2
-eerder,previously,以前,ADV,B2
-eerlijk,fair,公平的,ADJ,B2
-eerlijk,honestly,诚实地,ADV,B2
-eerste afdekking,first capping,首加缁布冠,NOUN,B2
-eerste concept,first draft,初稿,NOUN,B2
-eerste verdienste,first merit,首功,NOUN,B2
-eeuwige alliantie,eternal alliance,永结,NOUN,B2
-eeuwigheid,eternity,永恒,NOUN,B2
-efface,efface,词,VERB,C1
+hoofdartikel,editorial,社论,NOUN,B2
+opleiden,to educate,教育,VERB,B2
+opgeleid,educated,受过教育的,ADJ,B2
+EEG,eeg,脑电图,NOUN,B2
 effect,effect,效果,NOUN,B2
-effect and traces,effect and traces,词,NOUN,C1
-effectively,effectively,有效地,ADV,B2
-effects,effects,词,NOUN,B2
-effectuate,effectuate,词,VERB,C1
-effervesce,effervesce,词,VERB,C1
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,沸腾的,ADJ,B2
-effigy,effigy,词,NOUN,C1
-effort bet,effort bet,努力/赌注,NOUN,B2
-effuse,effuse,词,VERB,C1
-egalitarian,egalitarian,平等主义的,ADJ,B2
-egel,hedgehog,刺猬,NOUN,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-egg-laying,egg-laying,产卵,NOUN,B2
-ego,ego,词,NOUN,C1
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egoïstisch,selfish,自私的,ADJ,B2
-eh,eh,词,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eigendom,ownership,,NOUN,B2
-eigenschap,attribute,属性,NOUN,B2
-eight (noun),eight,词,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-einde,end,端,PART,B2
-eindelijk,last,最后,ADV,B2
-eindig,finite,有限的,ADJ,B2
-eindstadium,final stage,末期,NOUN,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
-eiser,plaintiff,原告,NOUN,B2
-eiwit,protein,蛋白质,NOUN,B2
-ejection,ejection,喷射,NOUN,B2
-elaboration,elaboration,词,NOUN,C1
-elation,elation,兴高采烈,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
-eldest,eldest,词,ADJ,A2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective,elective,词,ADJ,C1
-elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
+werkzaamheid,efficacy,功效,NOUN,B2
+aubergine,eggplant,茄子,NOUN,B2
+of,either,或者,CCONJ,B2
+uitwerken,to elaborate,制定,VERB,B2
+verheugd,elated,兴高采烈的,ADJ,B2
+elleboog,elbow,手肘,NOUN,B2
+oudste zoon,eldest son,长子,NOUN,B2
 electoraat,electorate,选民,NOUN,B2
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
-electric (noun),electric,词,NOUN,B2
-electric guitar,electric guitar,电吉他,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electric power,electric power,电力,NOUN,B2
-electrical engineering,electrical engineering,词,NOUN,C1
-electrical theory,electrical theory,词,NOUN,B2
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
-electronics,electronics,电子学,NOUN,B2
-elegance,elegance,词,NOUN,C1
-elegant,elegant,优雅的,ADJ,B2
-elegie,elegy,挽歌,NOUN,B2
 elektricien,electrician,电工,NOUN,B2
 elektronische betaling,electronic payment,电子支付,NOUN,B2
+elegant,elegant,优雅的,ADJ,B2
+elegie,elegy,挽歌,NOUN,B2
 element,element,元素,NOUN,B2
-elemental,elemental,词,ADJ,B2
-elementary,elementary,基本的,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
-elevated,elevated,词,ADJ,C1
-eleven,eleven,十一,NOUN,B2
-eleventh,eleventh,词,NUM,B1
-elf,elf,词,NOUN,C1
-elfje,little eleven,小十一,NOUN,B2
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
-eliminatie,elimination,消除,NOUN,B2
 elimineren,to eliminate,消除,VERB,B2
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,词,NOUN,C1
-elke,every,每个,DET,B2
-elke dag,every day,天天,ADV,B2
-elleboog,elbow,手肘,NOUN,B2
-ellendig,miserable,痛苦的,ADJ,B2
-ellipsis,ellipsis,省略,NOUN,B2
-ellipsis (part),ellipsis,…,PART,C1
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
-else,else,词,ADV,A1
-elucidation,elucidation,词,NOUN,C1
-elusive,elusive,难以捉摸的,ADJ,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciated,emaciated,词,ADJ,C1
-emaciation,emaciation,词,NOUN,C1
+eliminatie,elimination,消除,NOUN,B2
+welsprekend,eloquent,雄辩的,ADJ,B2
+e-mail,email,电子邮件,NOUN,B2
+emaneren,to emanate,散发,VERB,B2
 emanatie,emanation,散发物,NOUN,B2
 emanciperen,to emancipate,解放,VERB,B2
-emaneren,to emanate,散发,VERB,B2
-embalm,embalm,词,VERB,C1
-embattle,embattle,词,VERB,C1
-embers,embers,词,NOUN,B1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-emblem,emblem,徽章,NOUN,B2
-emblematic,emblematic,象征性的,ADJ,B2
-embodiment,embodiment,词,NOUN,B2
-embolism,embolism,栓塞,NOUN,B2
-emboss,emboss,词,VERB,C1
-embrace (noun),embrace,搂,NOUN,B2
-embrace each other,embrace each other,词,VERB,B2
-embroil,embroil,词,VERB,C1
-embryo,embryo,胚胎,NOUN,B2
-embryonic,embryonic,词,ADJ,C1
-emend,emend,词,VERB,B2
-emerald,emerald,祖母绿,NOUN,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
-emerging,emerging,词,ADJ,C1
-eminence,eminence,词,NOUN,C1
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emitter,emitter,词,NOUN,C1
-emmer,bucket,桶,NOUN,B2
-emolument,emolument,词,NOUN,C1
-emote,emote,词,VERB,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional life,emotional life,情感生活,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emotionally,emotionally,情感上,ADV,B2
-empathetic,empathetic,词,ADJ,B1
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-emphatically,emphatically,词,ADV,C1
-empirically,empirically,凭经验地,ADV,B2
+verlegen,embarrassed,尴尬的,ADJ,B2
+verlegen,embarrassing,令人尴尬的,ADJ,B2
+inbedden,to embed,嵌入,VERB,B2
+versieren,to embellish,装饰,VERB,B2
+verduisteren,to embezzle,贪污,VERB,B2
+verduistering,embezzlement,贪污,NOUN,B2
+belichamen,to embody,体现,VERB,B2
+omhelzen,embrace,拥抱,NOUN,B2
+omhelzen,to embrace,拥抱,VERB,B2
+borduuren,to embroider,刺绣,VERB,B2
+borduurwerk,embroidery,刺绣,NOUN,B2
+noodgeval,emergency,紧急情况,NOUN,B2
+spoedafdeling,emergency room,急诊室,NOUN,B2
+inleven,to empathize,共情,VERB,B2
+rijk,empire,帝国,NOUN,B2
 empirisch,empirical,经验的,ADJ,B2
-employability,employability,词,NOUN,B2
-employers,employers,词,NOUN,B1
-emporium,emporium,词,NOUN,C1
-empowerment,empowerment,词,NOUN,C1
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-emulation,emulation,模仿,NOUN,B2
-emulator,emulator,词,NOUN,C1
-emulsify,emulsify,词,VERB,C1
-emulsion,emulsion,词,NOUN,C1
-enamel,enamel,珐琅,NOUN,B2
-enamel (verb),enamel,词,VERB,C1
-enamor,enamor,词,VERB,C1
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encampments,encampments,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-encephalic,encephalic,词,ADJ,C1
-enchain,enchain,词,VERB,C1
-encirclement,encirclement,环绕,NOUN,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encoding,encoding,编码,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore (noun),encore,词,NOUN,C1
-encouraging,encouraging,词,ADJ,C1
-encroachment,encroachment,词,NOUN,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encrypted,encrypted,词,ADJ,B2
-encumber,encumber,词,VERB,C1
+in dienst nemen,to employ,雇用,VERB,B2
+bevoegd maken,to empower,授权,VERB,B2
+keizerin,empress,女皇,NOUN,B2
+leegte,emptiness,空虚,NOUN,B2
+holle roem,empty fame,虚名,NOUN,B2
+nabootsen,to emulate,效仿,VERB,B2
+mogelijk maken,to enable,使能够,VERB,B2
+in werking stellen,to enact,颁布,VERB,B2
+betoveren,to enchant,使着迷,VERB,B2
+betoverend,enchanting,迷人的,ADJ,B2
+omsluiten,to enclose,围住,VERB,B2
+ontmoeting,encounter,相遇,NOUN,B2
+versleuteling,encryption,加密,NOUN,B2
 encyclopedisch,encyclopedic,百科全书式的,ADJ,B2
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
-endear,endear,词,VERB,C1
-endeavor,endeavor,努力,NOUN,B2
-endeavor (verb),endeavor,词,VERB,C1
-endemic,endemic,地方性的,ADJ,B2
-endemic disease,endemic disease,词,NOUN,B2
-ending,ending,了头,NOUN,C1
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,内生的,ADJ,B2
+einde,end,端,PART,B2
+in gevaar brengen,to endanger,危及,VERB,B2
+bedreigd,endangered,濒危的,ADJ,B2
+steunen,to endorse,支持,VERB,B2
 endorsement,endorsement,背书,NOUN,B2
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowment,endowment,配备,NOUN,B2
-endue,endue,词,VERB,C1
 endurance,endurance,坚忍,NOUN,B2
 endure,to endure,忍受,VERB,B2
-enduring hardship,enduring hardship,词,NOUN,C1
-enemy army,enemy army,敌军,NOUN,C1
 enemy must,enemy must,仇必,NOUN,B2
-enemy of the state,enemy of the state,词,NOUN,C1
 enemy state,enemy state,敌国,NOUN,B2
 energetic,energetic,精力充沛的,ADJ,B2
-energize,energize,词,VERB,C1
-energy saving,energy saving,节能,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfold,enfold,词,VERB,C1
-enforceability,enforceability,词,NOUN,C1
-enfranchise,enfranchise,词,VERB,C1
-eng,scary,可怕的,ADJ,B2
 engaged,engaged,订婚的,ADJ,B2
-engender,engender,词,VERB,C1
-engine motor,engine motor,词,NOUN,C1
 engineering,engineering,工程学,NOUN,B2
 english,english,英语,NOUN,B2
-english teacher,english teacher,,NOUN,B2
 englishman,englishman,英国人,NOUN,B2
-engraft,engraft,词,VERB,C1
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
 engraving,engraving,版画,NOUN,B2
-engulf,engulf,词,VERB,C1
-enig,any,任何,DET,B2
-enigma,enigma,词,NOUN,C1
-enigmatic,enigmatic,神秘的,ADJ,B2
-enjambment,enjambment,词,NOUN,C1
-enjoin,enjoin,词,VERB,C1
-enjoyable,enjoyable,词,ADJ,B1
-enjoyed,enjoyed,词,ADJ,C1
 enjoyment,enjoyment,享受,NOUN,B2
-enkel,ankle,脚踝,NOUN,B2
-enkele gedachte,single thought,一念,NOUN,B2
-enkindle,enkindle,词,VERB,C1
-enlargement,enlargement,词,NOUN,C1
 enlighten,to enlighten,启发,VERB,B2
 enlightened,enlightened,开明的,ADJ,B2
-enlightening,enlightening,词,ADJ,C1
 enlightenment,enlightenment,澄清,NOUN,B2
 enlist,to enlist,征募,VERB,B2
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enmesh,enmesh,词,VERB,C1
 enmity,enmity,敌意,NOUN,B2
 ennoble,to ennoble,使高贵,VERB,B2
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enorm,huge,巨大的,ADJ,B2
 enormity,enormity,极恶,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
-enough (adj),enough,足够,ADJ,A1
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enquire,enquire,词,VERB,C1
-enraged,enraged,词,ADJ,C1
 enrich,to enrich,使丰富,VERB,B2
-enriching,enriching,词,ADJ,C1
 enrichment,enrichment,丰富,NOUN,B2
 enroll,to enroll,注册,VERB,B2
-enrolled,enrolled,词,ADJ,B2
 enrollment,enrollment,注册,NOUN,B2
-ensconce,ensconce,词,VERB,C1
-enshrine,enshrine,词,VERB,C1
-enshrinement,enshrinement,词,NOUN,C1
-enshroud,enshroud,词,VERB,C1
-ensign,ensign,词,NOUN,C1
-enslavement,enslavement,奴役,NOUN,B2
-enslavement by love,enslavement by love,词,NOUN,C1
-ensue,ensue,词,VERB,B2
 entangle,to entangle,使纠缠,VERB,B2
-entanglement,entanglement,缠,NOUN,C1
-entelechy,entelechy,词,NOUN,C1
 enter city,to enter city,进城,VERB,B2
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
 enterprise,enterprise,企业,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertainer,entertainer,词,NOUN,B2
-entertaining,entertaining,有趣的,ADJ,B2
 entertainment,entertainment,娱乐,NOUN,B2
 entertainment center,entertainment center,娱乐中心,NOUN,B2
 enthronement,enthronement,登基,NOUN,B2
 entice,to entice,引诱,VERB,B2
-enticement,enticement,词,NOUN,C1
 entirely,entirely,完全地,ADV,B2
 entirety,entirety,全部,NOUN,B2
-entitle,entitle,词,VERB,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
-entomb,entomb,词,VERB,C1
-entomology,entomology,词,NOUN,C1
-entrails,entrails,内脏,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entreat,entreat,词,VERB,C1
 entrench,to entrench,巩固,VERB,B2
-entrenchment,entrenchment,词,NOUN,C1
-entrepreneurship,entrepreneurship,词,NOUN,C1
 entrust,to entrust,委托,VERB,B2
 entry,entry,入口,NOUN,B2
-entwine,entwine,词,VERB,C1
-enunciative,enunciative,词,ADJ,C1
+opsommen,to enumerate,列举,VERB,B2
+uitspraak,enunciation,发音,NOUN,B2
 envelop,envelope,信封,NOUN,B2
-envelop,envelop,词,VERB,C1
-envenom,envenom,词,VERB,C1
-envious jealous,envious jealous,嫉妒的,ADJ,B2
-environ,environ,词,VERB,C1
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
-envoy,envoy,词,NOUN,B2
+jaloers,envious,嫉妒的,ADJ,B2
+milieukundig,environmental,环境的,ADJ,B2
+milieubescherming,environmental protection,环境保护,NOUN,B2
+milieurapport,environmental report,环境报告,NOUN,B2
+voorstellen,to envision,展望,VERB,B2
+benijden,envy,嫉妒,NOUN,B2
+benijden,to envy,羡慕,VERB,B2
 enzym,enzyme,酶,NOUN,B2
-eon age,eon age,词,NOUN,C1
-ephemeral,ephemeral,短暂的,ADJ,B2
-epic,epic,史诗的,ADJ,B2
-epic quality,epic quality,词,NOUN,C1
+epos,epic,史诗,NOUN,B2
 epicuristisch,epicurean,享乐主义的,ADJ,B2
 epidemie,epidemic,流行病,NOUN,B2
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epigraph,epigraph,题词,NOUN,B2
-epilepsy,epilepsy,词,NOUN,C1
-epilogue,epilogue,词,NOUN,C1
-episodic,episodic,词,ADJ,C1
 epistemologie,epistemology,认识论,NOUN,B2
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,墓志铭,NOUN,B2
-epithet,epithet,绰号,NOUN,B2
-epitomize,epitomize,词,VERB,C1
-epoch,epoch,时代,NOUN,B2
-eponymous,eponymous,词,ADJ,C1
-epos,epic,史诗,NOUN,B2
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally,equally,同样地,ADV,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equatorial,equatorial,词,ADJ,C1
-equestrian,equestrian,马术的,ADJ,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,等边的,ADJ,B2
-equilibrate,equilibrate,词,VERB,C1
-equity,equity,公平,NOUN,B2
-equivalent,equivalent,等价物,NOUN,B2
-equivalent (adj),equivalent,相等的,ADJ,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
-equivocate,equivocate,词,VERB,C1
-ere,honorary,名誉的,ADJ,B2
-erection,erection,词,NOUN,C1
-eren,to honor,尊敬,VERB,B2
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erfelijk,hereditary,遗传的,ADJ,B2
-erfenis,inheritance,遗产,NOUN,B2
-erfgenaam,heir,继承人,NOUN,B2
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergeren,to annoy,使恼怒,VERB,B2
-ergernis,annoyance,烦恼,NOUN,B2
-ergernis,resentment,愤恨,NOUN,B2
-ergestaltung,ergestaltung,词,NOUN,C1
-erhu,erhu,二胡,NOUN,B2
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
-ernst,severity,严厉,NOUN,B2
-ernstig,severe,严厉的,ADJ,B2
-erosie,erosion,侵蚀,NOUN,B2
-erpflegung,erpflegung,词,NOUN,C1
-errant,errant,词,ADJ,C1
-erratic,erratic,不稳定的,ADJ,B2
-erratum,errata,勘误,NOUN,B2
-erregelung,erregelung,词,NOUN,C1
-erroneous,erroneous,词,ADJ,C1
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
-erudite,erudite,博学的,ADJ,B2
-erupt,erupt,词,VERB,C1
-erven,to inherit,继承,VERB,B2
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
-escaleren,to escalate,升级,VERB,B2
-escaping,escaping,词,NOUN,C1
-eschatological,eschatological,词,ADJ,C1
-eschatology,eschatology,词,NOUN,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-esel,ass,驴,NOUN,B2
-esophagus,esophagus,词,NOUN,B2
-esoteric,esoteric,词,ADJ,C1
-espresso,espresso,浓缩咖啡,NOUN,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-essayistic quality,essayistic quality,词,NOUN,C1
-essence core,essence core,词,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
-essentieel,essentially,主要地,ADV,B2
-essentiële uitrusting,essential equipment,要置,NOUN,B2
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-esthetisch,aesthetic,审美的,ADJ,B2
-estimation,estimation,词,NOUN,C1
-estrange,estrange,词,VERB,C1
-estuarium,estuary,河口,NOUN,B2
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
-ethereal,ethereal,飘渺的,ADJ,B2
-ethereum,ethereum,以太坊,NOUN,B2
-ethical,ethical,道德的,ADJ,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
-ethnografie,ethnography,人种学,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-eunuch,eunuch,词,NOUN,C1
-euphonic,euphonic,悦耳的,ADJ,B2
-euphoric,euphoric,词,ADJ,C1
-europe,europe,欧洲,PROPN,B2
-euthanasia,euthanasia,词,NOUN,C1
-evacuatie,evacuation,疏散,NOUN,B2
-evacueren,to evacuate,疏散,VERB,B2
-evaluatie,evaluation,评估,NOUN,B2
-evalueren,to evaluate,评估,VERB,B2
-evanesce,evanesce,词,VERB,C1
-evangelical,evangelical,词,ADJ,C1
-evangelist,evangelist,词,NOUN,C1
-evangelization,evangelization,词,NOUN,C1
-evaporating,evaporating,词,ADJ,C1
-evasion,evasion,逃避,NOUN,B2
-eve,eve,前夕,NOUN,C1
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening meal,evening meal,晚餐,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-evenly,evenly,均匀地,ADV,B2
-events,events,事件,NOUN,C1
-eventual,eventual,词,ADJ,C1
-eventual outcome,eventual outcome,词,NOUN,C1
-eventuate,eventuate,词,VERB,C1
+belichaming,epitome,化身,NOUN,B2
+gelijkheid,equality,平等,NOUN,B2
+vergelijking,equation,方程,NOUN,B2
+paardensport,equestrianism,马术,NOUN,B2
 evenwicht,equilibrium,平衡,NOUN,B2
-evenzo,likewise,同样地,ADV,B2
-ever,ever,,NOUN,B2
-everen,to ever,里何尝,VERB,B2
-everlasting,everlasting,词,ADJ,C1
-everlastingness,everlastingness,词,NOUN,C1
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
-everydayness,everydayness,词,NOUN,B2
-everyone,everyone,各位,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evident,evident,明显的,ADJ,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
-evil,evil,邪,PART,B2
-evil (adj),evil,词,ADJ,B1
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evocative,evocative,引起回忆的,ADJ,B2
-evolueren,to evolve,进化,VERB,B2
-evolutionary,evolutionary,词,ADJ,C1
-exact,exactly,确切地,ADV,B2
-exact change,exact change,词,NOUN,C1
-exactitude,exactitude,词,NOUN,C1
-exactly just,exactly just,恰好,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exaltation,exaltation,狂热,NOUN,B2
-exalted,exalted,狂热的,ADJ,B2
-exam evening,exam evening,,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-exasperatie,exasperation,恼怒,NOUN,B2
-excavated,excavated,词,ADJ,B1
-excavation,excavation,词,NOUN,B2
-excavator,excavator,挖掘机,NOUN,B2
-excentriek,eccentric,古怪的,ADJ,B2
-except for,except for,除了,ADP,B2
-except unless,except unless,词,ADP,A2
-exceptionally,exceptionally,例外地,ADV,B2
-excess weight,excess weight,词,NOUN,C1
-excessief,excessive,过度的,ADJ,B2
-excessively,excessively,词,ADV,C1
-excessiveness,excessiveness,词,NOUN,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excision,excision,词,NOUN,C1
-excitability,excitability,兴奋性,NOUN,B2
-exclamation (punct),exclamation,词,PUNCT,A2
-exclusive dedication,exclusive dedication,词,NOUN,C1
-exclusivism,exclusivism,词,NOUN,C1
-excommunicatie,excommunication,绝罚,NOUN,B2
-excrement,excrement,排泄物,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,开脱,NOUN,B2
-excursion,excursion,郊游,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executive board,executive board,词,NOUN,C1
-executor,executor,遗嘱执行人,NOUN,B2
-executory,executory,词,ADJ,C1
-exegete,exegete,注释家,NOUN,B2
-exemplar,exemplar,楷模,NOUN,C1
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercise book,exercise book,词,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exercises,exercises,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhalation,exhalation,呼气,NOUN,B2
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhausting,exhausting,词,ADJ,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exhortation,exhortation,劝诫,NOUN,B2
-exhumation,exhumation,掘墓,NOUN,B2
-exigent,exigent,词,ADJ,C1
-exiled,exiled,词,ADJ,C1
-existential,existential,存在主义的,ADJ,B2
-existentialism,existentialism,存在主义,NOUN,B2
-exit (verb),exit,词,VERB,A1
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,过高的,ADJ,B2
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,外传的,ADJ,B2
-exotic,exotic,异国情调的,ADJ,B2
-expanse,expanse,词,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expatiate,expatiate,词,VERB,C1
-expatriate,expatriate,移居国外者,NOUN,B2
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expedite,expedite,词,VERB,C1
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,迅速的,ADJ,B2
-expenditures,expenditures,支出,NOUN,C1
-expensiveness,expensiveness,词,NOUN,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
-experimentation,experimentation,词,NOUN,C1
-experimenteel,experimental,实验的,ADJ,B2
-expert opinion,expert opinion,专家意见,NOUN,B2
-expiate,expiate,词,VERB,C1
-expiration,expiration,词,NOUN,C1
-expletive,expletive,词,NOUN,C1
-explicate,explicate,词,VERB,C1
-expliciet,explicit,明确的,ADJ,B2
-explicitly,explicitly,明确地,ADV,B2
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
-exploiteren,to exploit,剥削,VERB,B2
-exploits,exploits,词,NOUN,C1
-exploratory,exploratory,词,ADJ,C1
-explosief,explosive,爆炸性的,ADJ,B2
-explosion-proof,explosion-proof,防爆,ADJ,B2
-explosive,explosive,炸药,NOUN,B2
-explosives,explosives,炸药,NOUN,B2
-exponent,exponent,指数,NOUN,B2
-exponential,exponential,指数的,ADJ,B2
-export,export,出口,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exports,exports,词,NOUN,C1
-expositie,exposition,阐述,NOUN,B2
-expostulate,expostulate,词,VERB,C1
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expressionism,expressionism,词,NOUN,C1
-expunge,expunge,词,VERB,C1
-exquise,exquisite,精致的,ADJ,B2
-exquisiteness,exquisiteness,词,NOUN,C1
-extemporize,extemporize,词,VERB,C1
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,在外,NOUN,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinguishable,extinguishable,词,ADJ,C1
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extirpation,extirpation,切除,NOUN,B2
-extolling,extolling,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
-extra,extra,额外的,ADJ,B2
-extra (adv),extra,词,ADV,A1
-extra (noun),extra,群众演员,NOUN,B2
-extra drink,extra drink,多喝,NOUN,C1
-extract,extract,摘录,NOUN,B2
-extractie,extraction,提取,NOUN,B2
-extraheren,to extract,提取,VERB,B2
-extrapolation,extrapolation,词,NOUN,C1
-extrapoleren,to extrapolate,推断,VERB,B2
-extraterrestrial,extraterrestrial,外星的,ADJ,B2
-extravagant,extravagant,奢侈的,ADJ,B2
-extravagantie,extravagance,奢侈,NOUN,B2
-extraversie,extroversion,外向,NOUN,B2
-extraversion,extraversion,词,NOUN,C1
-extreem,extreme,أقصى,NOUN,B2
-extreme (noun),extreme,至极,NOUN,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremist,extremist,极端主义者,NOUN,B2
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-exuberance,exuberance,繁茂,NOUN,B2
-exudation,exudation,词,NOUN,C1
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyebrows,eyebrows,词,NOUN,A1
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
-faam,renown,声誉,NOUN,B2
-fabel,fable,寓言,NOUN,B2
-fabricated,fabricated,词,ADJ,B2
-fabulous,fabulous,极好的,ADJ,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facet,facet,方面,NOUN,B2
-facies,facies,面貌,NOUN,B2
-facilitation,facilitation,词,NOUN,C1
-faciliteiten,facilities,设施,NOUN,B2
-faciliteren,to facilitate,促进,VERB,B2
-factie,faction,派,NOUN,B2
-factious,factious,词,ADJ,C1
-factoring,factoring,保理,NOUN,B2
-factotum,factotum,词,NOUN,C1
-fad,fad,词,NOUN,C1
-fade away,fade away,词,VERB,C1
-fading away,fading away,词,NOUN,C1
-fag,fag,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failed,failed,失败的,ADJ,B2
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-faillietgaan,to go bankrupt,破产,VERB,B2
-failure to act,failure to act,词,NOUN,C1
-faint (noun),faint,词,NOUN,C1
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,词,ADJ,B1
-fairly,fairly,词,ADV,C1
-fairness,fairness,词,NOUN,B2
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,假新闻,NOUN,B2
-fakkel,torch,手电筒,NOUN,B2
-falconry,falconry,猎鹰术,NOUN,B2
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-fallout,fallout,词,NOUN,C1
-fallow land,fallow land,词,NOUN,B2
-false oath,false oath,词,NOUN,C1
-falsely,falsely,词,ADV,C1
-falsen,to forge,伪造,VERB,B2
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falter,falter,词,VERB,C1
-faltering,faltering,词,ADJ,C1
-familial,familial,词,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
-family (adj),family,词,ADJ,B1
-family background,family background,出身,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-famine,famine,饥荒,NOUN,B2
-famish,famish,词,VERB,C1
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fanatic,fanatic,狂热的,ADJ,B2
-fanatical,fanatical,词,ADJ,C1
-fancy,fancy,词,ADJ,B1
-fancy decoration,fancy decoration,词,NOUN,C1
-fang,fang,犬齿,NOUN,B2
-fantasize,fantasize,词,VERB,C1
-fantasizing,fantasizing,词,NOUN,C1
-far (adv),far,词,ADV,A1
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-fare,fare,车费,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farmaceutisch,pharmaceutical,制药的,ADJ,B2
-farmland,farmland,农田,NOUN,C1
-farmstead,farmstead,农庄,NOUN,B2
-farrow,farrow,词,VERB,C1
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascineren,to fascinate,使着迷,VERB,B2
-fascist (adj),fascist,词,ADJ,C1
-fascist (noun),fascist,词,NOUN,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast forward,fast forward,快进,VERB,C1
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
-fataal,fatal,致命的,ADJ,B2
-fatalism,fatalism,宿命论,NOUN,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatalist (noun),fatalist,词,NOUN,C1
-fatally,fatally,词,ADV,C1
-fateful,fateful,词,ADJ,C1
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatness,fatness,词,NOUN,C1
-fats,fats,词,NOUN,C1
-fatsoen,propriety,分寸,NOUN,B2
-fatsoenlijk,decent,体面的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatuity,fatuity,愚昧,NOUN,B2
-fatuous,fatuous,词,ADJ,C1
-fatwa,fatwa,词,NOUN,B2
-faucet,faucet,词,NOUN,C1
-faulty,faulty,词,ADJ,C1
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favoriet,favorite,最喜欢的,ADJ,B2
-favorite (noun),favorite,最爱,NOUN,B2
-favoritism,favoritism,偏袒,NOUN,B2
-fawn,fawn,词,VERB,C1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
-fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
-fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
-feast,feast,盛宴,NOUN,B2
-feat,feat,功绩,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-feces,feces,屎,NOUN,C1
-fecundate,fecundate,词,VERB,C1
-fecundity,fecundity,词,NOUN,C1
-fed up,fed up,受够了,NOUN,B2
-fed up (adj),fed up,词,ADJ,B1
-federalize,federalize,词,VERB,C1
-fee,fairy,仙女,NOUN,B2
-fee,fee,费用,NOUN,B2
-feeble,feeble,虚弱的,ADJ,B2
-feedback geven,to provide feedback,反馈,VERB,B2
-feeding,feeding,词,NOUN,C1
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-feestzaal,affair hall,事殿,NOUN,B2
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-felheid,ferocity,凶猛,NOUN,B2
-felheid,fierceness,凶猛,NOUN,B2
-felicitate,felicitate,词,VERB,C1
-feliciteren,to congratulate,祝贺,VERB,B2
-felicity,felicity,词,NOUN,C1
-feline,feline,词,ADJ,C1
-fellow citizen,fellow citizen,同胞,NOUN,B2
-felt,felt,词,NOUN,C1
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
-feminine,feminine,女性的,ADJ,B2
-feminist,feminist,女权主义者,NOUN,B2
-feminization,feminization,词,NOUN,C1
-fend,fend,词,VERB,C1
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-feniks,phoenix,拿凤,NOUN,B2
-fennec fox,fennec fox,词,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-feodaal,feudal,封建,ADJ,B2
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fermenteren,to ferment,发酵,VERB,B2
-fern,fern,蕨类植物,NOUN,B2
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferociously,ferociously,词,ADV,C1
-ferret,ferret,雪貂,NOUN,B2
-ferrule,ferrule,箍,NOUN,B2
-ferry,ferry,渡轮,NOUN,B2
-fervent,fervent,词,ADJ,C1
-fervor,fervor,词,NOUN,C1
-festival,festival,节日,NOUN,B2
-festivals,festivals,词,NOUN,C1
-festivity,festivity,词,NOUN,C1
-fete,fete,词,VERB,C1
-fetid,fetid,词,ADJ,C1
-fetish,fetish,恋物,NOUN,B2
-fetishism,fetishism,词,NOUN,B2
-fetter,fetter,词,VERB,C1
-feud end,feud end,仇终,NOUN,C1
-feudal ethics,feudal ethics,礼教,NOUN,B2
-feverish,feverish,词,ADJ,C1
-fewer,fewer,较少的,ADJ,B2
-fez,fez,词,NOUN,B2
-fiancee,fiancee,未婚妻,NOUN,B2
-fib,fib,词,VERB,C1
-fibrose,fibrosis,纤维化,NOUN,B2
-fibrous,fibrous,词,ADJ,C1
-fickleness,fickleness,反复无常,NOUN,B2
-fictief,fictional,虚构的,ADJ,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictionalize,fictionalize,词,VERB,C1
-fictitious,fictitious,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fiddle (verb),fiddle,词,VERB,C1
-fidelity,fidelity,忠诚,NOUN,B2
-fidget,fidget,词,VERB,C1
-fiduciary,fiduciary,词,ADJ,C1
-field (adj),field,词,ADJ,C1
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fiend,fiend,词,NOUN,C1
-fierce one,fierce one,词,NOUN,B2
-fiery,fiery,热烈的,ADJ,B2
-fifteen,fifteen,十五,NUM,B2
-fifth,fifth,第五,NUM,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figurative,figurative,比喻的,ADJ,B2
-figurative language,figurative language,词,NOUN,C1
-figuratively,figuratively,比喻地,ADV,B2
-figure skating,figure skating,花样滑冰,NOUN,C1
-fijne huid,fine skin,细皮,NOUN,B2
-filament,filament,词,NOUN,C1
-filch,filch,词,VERB,C1
-file a case,file a case,立案,VERB,B2
-file expense,file expense,报账,VERB,B2
-filiaal,filial,孝顺,ADJ,B2
-filiaal,affiliate,附属机构,NOUN,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filings,filings,词,NOUN,C1
-fill pack,fill pack,装满,VERB,B2
-filled,filled,充满的,ADJ,B2
-fillet (noun),fillet,词,NOUN,C1
-fillet (verb),fillet,词,VERB,C1
-filling,filling,词,NOUN,B2
-film,movie,电影,NOUN,B2
-film director,film director,词,NOUN,B2
-film movie,film movie,电影,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-filming,filming,拍摄,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
-filosoof,philosopher,哲学家,NOUN,B2
-filth garbage,filth garbage,词,NOUN,C1
-filthy,filthy,肮脏的,ADJ,B2
-fin,fin,词,NOUN,B2
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-finals,finals,决赛,NOUN,B1
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financing funding,financing funding,融资,NOUN,B2
-find,find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine print,fine print,词,NOUN,C1
-fine well,fine well,词,ADJ,A1
-finely,finely,词,ADV,C1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fingernail,fingernail,指甲,NOUN,B2
-finial,finial,词,NOUN,C1
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-fire a gun,fire a gun,开枪,VERB,B2
-fire department,fire department,词,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire kick,fire kick,词,VERB,A2
-fire station,fire station,词,NOUN,C1
-firearms,firearms,枪支,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firedamp,firedamp,词,NOUN,C1
-firework,firework,词,NOUN,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firm fixed,firm fixed,词,ADJ,B1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first aid,first aid,词,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
-first-class,first-class,一流,ADJ,B2
-firstly,firstly,首先,ADV,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisheries,fisheries,词,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing,fishing,钓鱼,NOUN,B2
-fishing rod,fishing rod,钓竿,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
-fissure,fissure,裂缝,NOUN,B2
-fistula,fistula,瘘管,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fit (noun),fit,词,NOUN,B2
-fitness,fitness,健康,NOUN,B2
-fitting out,fitting out,词,NOUN,B2
-fittings,fittings,水龙头配件,NOUN,B2
-five (adj),five,词,ADJ,C1
-five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flabby,flabby,词,ADJ,B2
-flaccid,flaccid,松弛的,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-fladderen,to flutter,飘动,VERB,B2
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrancy,flagrancy,现行,NOUN,B2
-flagrant,flagrant,词,ADJ,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
-flank,flank,侧翼,NOUN,B2
-flank (verb),flank,词,VERB,C1
-flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashback,flashback,词,NOUN,C1
-flashlight,flashlight,手电筒,NOUN,B2
-flat (noun),flat,词,NOUN,B1
-flat rate,flat rate,包干费,NOUN,B2
-flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatterer,flatterer,词,NOUN,C1
-flattering,flattering,词,ADJ,C1
-flaunt,flaunt,词,VERB,C1
-flauw,bland,平淡的,ADJ,B2
-flauwte,fainting,晕厥,NOUN,B2
-flauwvallen,to faint,昏倒,VERB,B2
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flesh,flesh,肉,NOUN,B2
-flex,flex,词,VERB,C1
-flexibel,flexible,灵活的,ADJ,B2
-flexion,flexion,词,NOUN,C1
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flinch,flinch,词,VERB,C1
-fling (noun),fling,词,NOUN,C1
-fling (verb),fling,词,VERB,C1
-flint,flint,燧石,NOUN,B2
-flinterdun,flimsy,脆弱的,ADJ,B2
-flip,flip,词,VERB,B2
-flirt,flirt,调情者,NOUN,B2
-flirt (verb),flirt,词,VERB,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-flit,flit,词,VERB,C1
-float (noun),float,词,NOUN,B2
-floating,floating,漂浮的,ADJ,B2
-floating (noun),floating,词,NOUN,C1
-floating dust,floating dust,浮尘,NOUN,B2
-flogging,flogging,词,NOUN,C1
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floor story,floor story,词,NOUN,A2
-floorboard,floorboard,木地板,NOUN,B2
-flop,flop,词,VERB,C1
-floral,floral,词,ADJ,C1
-floreren,to flourish,繁荣,VERB,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-floundering,floundering,词,NOUN,C1
-flourishing (noun),flourishing,词,NOUN,C1
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,开花,NOUN,B2
-flowery,flowery,华丽的,ADJ,B2
-fluctuating,fluctuating,波动的,ADJ,B2
-fluency,fluency,流利,NOUN,B2
-fluently,fluently,词,ADV,C1
-fluff,fluff,词,NOUN,C1
-fluid,fluid,液体,NOUN,B2
-fluid (adj),fluid,词,ADJ,B2
-fluidity,fluidity,流畅,NOUN,B2
-fluidize,fluidize,词,VERB,C1
-fluids,fluids,词,NOUN,C1
-fluistering,whisper,低语,NOUN,B2
-fluit,flute,长笛,NOUN,B2
-fluke,fluke,词,NOUN,B2
-flunk,flunk,词,VERB,C1
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flutist,flutist,词,NOUN,C1
-flutter (noun),flutter,词,NOUN,B2
-flyover,flyover,词,NOUN,C1
-flyting poems,flyting poems,词,NOUN,C1
-foal,foal,马驹,NOUN,B2
-fob,fob,词,NOUN,C1
-focalization,focalization,词,NOUN,C1
-foe,foe,敌友,NOUN,B2
-foetus,fetus,胎儿,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-fold,fold,折痕,NOUN,B2
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,枝叶,NOUN,B2
-foliar,foliar,词,ADJ,C1
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
-folkloric,folkloric,词,ADJ,C1
-follower enthusiast,follower enthusiast,词,NOUN,C1
-followers,followers,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-foment,foment,词,VERB,C1
-fond of food,fond of food,词,ADJ,B1
-fondle,fondle,词,VERB,C1
-fondness,fondness,词,NOUN,B2
-fontein,fountain,喷泉,NOUN,B2
-food,food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
-foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,镜头长度,NOUN,B2
-football camp,football camp,词,NOUN,B2
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footprint,footprint,足迹,NOUN,B2
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for each other,for each other,相互,ADV,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for hours,for hours,词,ADJ,B2
-for my sake,for my sake,词,ADV,C1
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for the,for the,词,ADP,A2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for to,for to,为,ADP,B2
-for your sake,for your sake,词,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearance,forbearance,词,NOUN,C1
-forbearing,forbearing,词,ADJ,C1
-forced labor,forced labor,词,NOUN,C1
-forceful,forceful,词,ADJ,B2
-forcing submission,forcing submission,词,NOUN,C1
-ford,ford,词,NOUN,B2
-forearm,forearm,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,外国的/陌生的,ADJ,B2
-foreknow,foreknow,词,VERB,C1
-foreman,foreman,词,NOUN,B2
-forenoon,forenoon,词,NOUN,A1
-forensic,forensic,法医的,ADJ,B2
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forest-related,forest-related,词,ADJ,B2
-forestall,forestall,词,VERB,C1
-forestry,forestry,词,ADJ,C1
-foretell,foretell,词,VERB,C1
-forewarn,forewarn,词,VERB,C1
-foreword,foreword,词,NOUN,C1
-forfeit,forfeit,词,VERB,C1
-forfeiture,forfeiture,丧失,NOUN,B2
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forger,forger,词,NOUN,C1
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgo,forgo,词,VERB,C1
-formal notice,formal notice,词,NOUN,C1
-formalisme,formalism,形式主义,NOUN,B2
-formalist (adj),formalist,词,ADJ,C1
-formalist (noun),formalist,词,NOUN,C1
-formaliteit,formality,礼节,NOUN,B2
-formally,formally,正式地,ADV,B2
-format,format,格式,NOUN,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-fornicate,fornicate,词,VERB,C1
-fornuis,stove,炉灶,NOUN,B2
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-forthcoming,forthcoming,词,ADJ,C1
-fortification,fortification,词,NOUN,C1
-fortlet,fortlet,词,NOUN,C1
-fortuitous,fortuitous,偶然的,ADJ,B2
-fortune teller,fortune teller,占卜者,NOUN,B2
-forum,forum,论坛,NOUN,B2
-forums,forums,词,NOUN,C1
-forward (verb),forward,词,VERB,B2
-fosiel,fossil,化石,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-fossils,fossils,化石,NOUN,C1
-foster,foster,词,VERB,B2
-foto,photograph,照片,NOUN,B2
-fotokopie,photocopy,复印件,NOUN,B2
-fotosynthese,photosynthesis,光合作用,NOUN,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fourth (num),fourth,词,NUM,B1
+uitrusten,to equip,装备,VERB,B2
+equivalent,equivalent,等价物,NOUN,B2
+uitroeien,to eradicate,根除,VERB,B2
+uitroeiing,eradication,根除,NOUN,B2
+wissen,to erase,擦除,VERB,B2
+gum,eraser,橡皮擦,NOUN,B2
+uitwissing,erasure,擦除,NOUN,B2
+oprichten,to erect,建立,VERB,B2
+erhu,erhu,二胡,NOUN,B2
+erosie,erosion,侵蚀,NOUN,B2
+zich vergissen,to err,犯错,VERB,B2
+boodschap,errand,差事,NOUN,B2
+erratum,errata,勘误,NOUN,B2
 fout,error,错误,NOUN,B2
+escaleren,to escalate,升级,VERB,B2
+roltrap,escalator,自动扶梯,NOUN,B2
+ontsnapping,escape,逃跑,NOUN,B2
+begeleiden,to escort,护送,VERB,B2
+begeleider,escort guard,镖师,NOUN,B2
+vooral,especially,尤其,ADV,B2
+spionage,espionage,间谍活动,NOUN,B2
+essentiële uitrusting,essential equipment,要置,NOUN,B2
+essentieel,essentially,主要地,ADV,B2
+gevestigd,established,既定的,ADJ,B2
+achting,esteem,尊重,NOUN,B2
+vervreemding,estrangement,疏离,NOUN,B2
+estuarium,estuary,河口,NOUN,B2
+eeuwige alliantie,eternal alliance,永结,NOUN,B2
+eeuwigheid,eternity,永恒,NOUN,B2
+ethereum,ethereum,以太坊,NOUN,B2
+ethnografie,ethnography,人种学,NOUN,B2
+evacueren,to evacuate,疏散,VERB,B2
+evacuatie,evacuation,疏散,NOUN,B2
+ontduiken,to evade,逃避,VERB,B2
+evalueren,to evaluate,评估,VERB,B2
+evaluatie,evaluation,评估,NOUN,B2
+verdampen,to evaporate,蒸发,VERB,B2
+verdamping,evaporation,蒸发,NOUN,B2
+ontwijkend,evasive,回避的,ADJ,B2
+gelijk,even,偶数的,ADJ,B2
+zelfs als,even if,即使,SCONJ,B2
+everen,to ever,里何尝,VERB,B2
+elke,every,每个,DET,B2
+elke dag,every day,天天,ADV,B2
+uitzetting,eviction,驱逐,NOUN,B2
+bewijs,evidence,证据,NOUN,B2
+evident,evident,明显的,ADJ,B2
+kwaad,evil,恶行,NOUN,B2
+evolueren,to evolve,进化,VERB,B2
+exact,exactly,确切地,ADV,B2
+overdreven,exaggerated,夸张的,ADJ,B2
+overdrijving,exaggeration,夸张,NOUN,B2
+onderzoek,examination,考试,NOUN,B2
+onderzoeken,to examine,检查,VERB,B2
+exasperatie,exasperation,恼怒,NOUN,B2
+uitgraven,to excavate,挖掘,VERB,B2
+uitblinken,to excel,擅长,VERB,B2
+uitmuntendheid,excellence,卓越,NOUN,B2
+excessief,excessive,过度的,ADJ,B2
+opwekken,to excite,使兴奋,VERB,B2
+opwinding,excitement,兴奋,NOUN,B2
+uitroep,exclamation,感叹,NOUN,B2
+uitsluiten,to exclude,排除,VERB,B2
+uitsluiting,exclusion,排除,NOUN,B2
+excommunicatie,excommunication,绝罚,NOUN,B2
+uitbeelden,to excoriate,严厉批评,VERB,B2
+beul,executioner,刽子手,NOUN,B2
+bestuurder,executive,行政主管,NOUN,B2
+executor,executor,遗嘱执行人,NOUN,B2
+vrijstelling,exemption,豁免,NOUN,B2
+uitademen,to exhale,呼气,VERB,B2
+uitputting,exhaustion,疲惫,NOUN,B2
+tonen,to exhibit,展览,VERB,B2
+aansporen,to exhort,劝告,VERB,B2
+ontlasten,to exonerate,使无罪,VERB,B2
+verwijderen,to expel,开除,VERB,B2
+besteden,to expend,花费,VERB,B2
+uitgave,expenditure,支出,NOUN,B2
+kosten,expense,费用,NOUN,B2
+kosten,expenses,费用,NOUN,B2
+experimenteel,experimental,实验的,ADJ,B2
+expliciet,explicit,明确的,ADJ,B2
+exploiteren,to exploit,剥削,VERB,B2
+ontdekkingsreiziger,explorer,探险家,NOUN,B2
+explosief,explosive,爆炸性的,ADJ,B2
+export,export,出口,NOUN,B2
+expositie,exposition,阐述,NOUN,B2
+uiteenzetten,to expound,阐述,VERB,B2
+uitdrukkelijk,expressly,明确地,ADV,B2
+onteigenen,to expropriate,征用,VERB,B2
+onteigening,expropriation,征用,NOUN,B2
+uitzetting,expulsion,驱逐,NOUN,B2
+exquise,exquisite,精致的,ADJ,B2
+omvang,extent,程度,NOUN,B2
+uitroeien,to exterminate,消灭,VERB,B2
+uitroeiing,extermination,灭绝,NOUN,B2
+blussen,to extinguish,熄灭,VERB,B2
+afpersen,to extort,敲诈,VERB,B2
+afpersing,extortion,勒索,NOUN,B2
+extra,extra,额外的,ADJ,B2
+extraheren,to extract,提取,VERB,B2
+extractie,extraction,提取,NOUN,B2
+uitleveren,to extradite,引渡,VERB,B2
+extrapoleren,to extrapolate,推断,VERB,B2
+extravagantie,extravagance,奢侈,NOUN,B2
+extreem,extreme,أقصى,NOUN,B2
+extraversie,extroversion,外向,NOUN,B2
+juichen,to exult,狂喜,VERB,B2
+jubel,exultation,欢腾,NOUN,B2
+wenkbrauw,eyebrow,眉毛,NOUN,B2
+wimper,eyelash,睫毛,NOUN,B2
+ooglid,eyelid,眼皮,NOUN,B2
+ooggetuige,eyewitness,目击,NOUN,B2
+fabel,fable,寓言,NOUN,B2
+stof,fabric,织物,NOUN,B2
+confronteren,to face,面对,VERB,B2
+fysiognomie,face reading,面相,NOUN,B2
+gezichtsherkenning,face recognition,认人,NOUN,B2
+facet,facet,方面,NOUN,B2
+faciliteren,to facilitate,促进,VERB,B2
+faciliteiten,facilities,设施,NOUN,B2
+factie,faction,派,NOUN,B2
+vervagen,to fade,褪色,VERB,B2
+vervaagd,faded,褪色的,ADJ,B2
+mislukte poging,failed bid,流标,NOUN,B2
+mislukking,failure,失败,NOUN,B2
+flauwvallen,to faint,昏倒,VERB,B2
+flauwte,fainting,晕厥,NOUN,B2
+eerlijk,fair,公平的,ADJ,B2
+fee,fairy,仙女,NOUN,B2
+geloof,faith,信仰,NOUN,B2
+valk,falcon,猎鹰,NOUN,B2
+val,fall,瀑布,NOUN,B2
+inslapen,to fall asleep,入睡,VERB,B2
+terugvallen,to fall back,回落,VERB,B2
+ziek worden,to fall ill,患病,VERB,B2
+verliefd worden,to fall in love,坠入爱河,VERB,B2
+dwaling,fallacy,谬误,NOUN,B2
+onmin,falling out,反目,NOUN,B2
+doorval,falling though,虽坠,NOUN,B2
+onwaarheid,falsehood,谎言,NOUN,B2
+valsheid,falsity,虚假,NOUN,B2
+gezinsruïne,family ruin,家破,NOUN,B2
+ventilator,fan,粉丝,NOUN,B2
+ver,far,远,ADV,B2
+landbouw,farming,农业,NOUN,B2
+fascineren,to fascinate,使着迷,VERB,B2
+vasten,to fast,禁食,VERB,B2
+snel,fast quick,快的,ADJ,B2
+vasten,fasting,禁食,NOUN,B2
+dik,fat,胖的,ADJ,B2
+fataal,fatal,致命的,ADJ,B2
+vader,father,父,PART,B2
+schoonvader,father-in-law,岳父/公公,NOUN,B2
 fout,fault,错误,NOUN,B2
-fout,make mistake,犯错,NOUN,B2
-fout maken,to make a mistake,弄错,VERB,B2
-fowl,fowl,词,NOUN,C1
-foyer,foyer,词,NOUN,C1
-fractal,fractal,分形,NOUN,B2
-fractional,fractional,分数的,ADJ,B2
+bevoordelen,favor,恩惠,NOUN,B2
+bevoordelen,to favor,偏袒,VERB,B2
+gunstige omstandigheden,favorable circumstances,顺境,NOUN,B2
+favoriet,favorite,最喜欢的,ADJ,B2
+haalbaarheid,feasibility,可行性,NOUN,B2
+voer,feed,饲料,NOUN,B2
+kosten,fees,酬金,NOUN,B2
+kerel,fellow,家伙,NOUN,B2
+misdrijf,felony,重罪,NOUN,B2
+vriendin,female friend,女性朋友,NOUN,B2
+vrouwelijke familieleden,female relatives,女眷,NOUN,B2
+vrouwelijkheid,femininity,女性气质,NOUN,B2
+venkel,fennel,茴香,NOUN,B2
+fermenteren,to ferment,发酵,VERB,B2
+felheid,ferocity,凶猛,NOUN,B2
+vruchtbaar,fertile,肥沃的,ADJ,B2
+meststof,fertilizer,肥料,NOUN,B2
+zweren,to fester,溃烂,VERB,B2
+festival,festival,节日,NOUN,B2
+foetus,fetus,胎儿,NOUN,B2
+vete,feud,世仇,NOUN,B2
+feodaal,feudal,封建,ADJ,B2
+weinigen,few,几下,NOUN,B2
+verloofde,fiance,未婚夫,NOUN,B2
+vezel,fiber,纤维,NOUN,B2
+fibrose,fibrosis,纤维化,NOUN,B2
+fictief,fictional,虚构的,ADJ,B2
+felheid,fierceness,凶猛,NOUN,B2
+filiaal,filial,孝顺,ADJ,B2
+eindstadium,final stage,末期,NOUN,B2
+ontdekken,to find out,找出,VERB,B2
+beboeten,to fine,罚款,VERB,B2
+fijne huid,fine skin,细皮,NOUN,B2
+vingerafdruk,fingerprint,指纹,NOUN,B2
+afwerking,finishing,装修,NOUN,B2
+eindig,finite,有限的,ADJ,B2
+rotje,firecracker,鞭炮,NOUN,B2
+brandweerman,firefighter,消防员,NOUN,B2
+haard,fireplace,壁炉,NOUN,B2
+vuurvast,fireproof,防火的,ADJ,B2
+brandhout,firewood,木柴,NOUN,B2
+stevigheid,firmness,坚定,NOUN,B2
+eerste afdekking,first capping,首加缁布冠,NOUN,B2
+eerste concept,first draft,初稿,NOUN,B2
+eerste verdienste,first merit,首功,NOUN,B2
+allereerst,first of all,首先,ADV,B2
+vuist,fist,拳头,NOUN,B2
+fitness,fitness,健康,NOUN,B2
+passend,fitting,合适的,ADJ,B2
+repareren,to fix,修理,VERB,B2
+flank,flank,侧翼,NOUN,B2
+kolf,flask,小瓶,NOUN,B2
+vleierij,flattery,奉承,NOUN,B2
+smaak,flavor,味道,NOUN,B2
+gebrek,flaw,缺陷,NOUN,B2
+vluchtig,fleeting,短暂的,ADJ,B2
+flexibel,flexible,灵活的,ADJ,B2
+flinterdun,flimsy,脆弱的,ADJ,B2
+kudde,flock,兽群,NOUN,B2
+overstroming,flood,洪水,NOUN,B2
+bloem,flour,面粉,NOUN,B2
+floreren,to flourish,繁荣,VERB,B2
+stroom,flow,流动,NOUN,B2
+fluit,flute,长笛,NOUN,B2
+fladderen,to flutter,飘动,VERB,B2
+schuim,foam,泡沫,NOUN,B2
+schuimig,foamy,多泡沫的,ADJ,B2
+voeder,fodder,饲料,NOUN,B2
+volk,folk,民间的,ADJ,B2
+voedsel,foodstuff,食品,NOUN,B2
+dommel,fool,傻瓜,NOUN,B2
+dom,foolish,愚蠢的,ADJ,B2
+voetgangersbrug,footbridge,人行天桥,NOUN,B2
+schoeisel,footwear,鞋穿,NOUN,B2
+gratis,for free,免费,ADV,B2
+verboden,forbidden,被禁止的,ADJ,B2
+verboden land,forbidden land,禁地,NOUN,B2
+gedwongen,forced,强迫的,ADJ,B2
+gedwongen,forcibly,强制地,ADV,B2
+voorspelling,forecast,预测,NOUN,B2
+voorspellen,to foresee,预见,VERB,B2
+vooruitziendheid,foresight,远见,NOUN,B2
+falsen,to forge,伪造,VERB,B2
+valsheid,forgery,伪造品,NOUN,B2
+vergetelachtig,forgetful,健忘的,ADJ,B2
+vergeving,forgiveness,宽恕,NOUN,B2
+vork,fork,叉子,NOUN,B2
+formalisme,formalism,形式主义,NOUN,B2
+formaliteit,formality,礼节,NOUN,B2
+vesting,fortress,堡垒,NOUN,B2
+gelukkig,fortunate,幸运的,ADJ,B2
+gelukkig,fortunately,幸运地,ADV,B2
+geluk,fortune,运气,NOUN,B2
+toekomstvoorspelling,fortune telling,算命,NOUN,B2
+forum,forum,论坛,NOUN,B2
+fosiel,fossil,化石,NOUN,B2
+stichten,to found,创立,VERB,B2
+vondeling,foundling,弃婴,NOUN,B2
+fontein,fountain,喷泉,NOUN,B2
+breukteken,fraction marker,分之,PART,B2
 fracture,fracture,骨折,NOUN,B2
-fractured,fractured,词,ADJ,C1
-fragility,fragility,脆弱,NOUN,B2
-fragmentary,fragmentary,零碎的,ADJ,B2
 fragrance,fragrance,香味,NOUN,B2
 frame,frame,框架,NOUN,B2
 frame,to frame,装框,VERB,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework-related,framework-related,词,ADJ,C1
-framing,framing,词,NOUN,C1
 franchise,franchise,特许经营权,NOUN,B2
 frank,frank,坦率的,ADJ,B2
-frankly,frankly,坦率地,ADV,B2
 frankness,frankness,坦率,NOUN,B2
-frantic,frantic,狂乱的,ADJ,B2
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fratricide,fratricide,杀兄弟,NOUN,B2
-fraudeur,swindler,骗子,NOUN,B2
-fraudster,fraudster,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-frauduleren,to defraud,诈骗,VERB,B2
-fray,fray,词,VERB,C1
-frayed,frayed,词,ADJ,C1
-frazzle,frazzle,词,VERB,C1
 freak,freak,怪人,NOUN,B2
-freckles,freckles,词,NOUN,B2
 free,to free,释放,VERB,B2
-free association,free association,词,NOUN,C1
-free of charge,free of charge,免费,NOUN,B2
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
-free off,free off,空闲的/休假,ADJ,B2
 free time,free time,业余时间,NOUN,B2
-free trade,free trade,词,NOUN,C1
-free will,free will,词,NOUN,B2
-freedmen clients,freedmen clients,词,NOUN,C1
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,选择自由,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freely,freely,自由地,ADV,B2
 freezer,freezer,冰柜,NOUN,B2
 freezing,freezing,冻结,NOUN,B2
-freezing (adj),freezing,极冷的,ADJ,B2
 freezing rain,freezing rain,冻雨,NOUN,B2
-freight,freight,货物,NOUN,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
 frenchman,frenchman,法国人,NOUN,B2
 frenzy,frenzy,疯狂,NOUN,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
-frequently,frequently,经常,ADV,B2
-fresco,fresco,壁画,NOUN,B2
-fresh,fresh,,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshly,freshly,新鲜地,ADV,B2
 freshness,freshness,新鲜,NOUN,B2
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-fret,fret,词,VERB,C1
-friar,friar,词,NOUN,C1
 friction,friction,摩擦,NOUN,B2
-fried,fried,词,ADJ,B1
-fried food,fried food,词,NOUN,C1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-friends with,friends with,词,ADJ,B2
 fries,fries,炸薯条,NOUN,B2
-frieze,frieze,檐壁,NOUN,B2
-frigate,frigate,护卫舰,NOUN,B2
 frighten,to frighten,使害怕,VERB,B2
-frightful,frightful,词,ADJ,B1
-frigid,frigid,寒冷的,ADJ,B2
-frill,frill,词,NOUN,C1
 fringe,fringe,边缘,NOUN,B2
-frisk,frisk,词,VERB,C1
-fritter,fritter,词,VERB,C1
-frivol,frivol,词,VERB,C1
-frivolous,frivolous,轻浮的,ADJ,B2
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from above,from above,从上方,ADV,B2
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
 from childhood,from childhood,从小,ADV,B2
-from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from here,from here,从这里,ADV,B2
-from home,from home,从家里,ADV,B2
-from it,from it,从中,ADV,B2
 from now on,from now on,今后,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from where,from where,从哪里,ADV,B2
-from within,from within,从内部,ADV,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontispiece,frontispiece,词,NOUN,C1
-frontrunner,frontrunner,词,NOUN,C1
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-frosty,frosty,词,ADJ,A1
-froth,froth,泡沫,NOUN,B2
-frown (noun),frown,frown,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frowning,frowning,词,NOUN,C1
-frozen,frozen,冻僵的,ADJ,B2
-frozen (noun),frozen,词,NOUN,B2
-fructify,fructify,词,VERB,C1
-frugality,frugality,节俭,NOUN,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,果树的,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruiting,fruiting,词,ADJ,C1
-fruitless,fruitless,词,ADJ,C1
 frustrated,frustrated,沮丧的,ADJ,B2
 frustrating,frustrating,令人沮丧的,ADJ,B2
 fry,to fry,油炸,VERB,B2
-fryer,fryer,词,NOUN,C1
 frying pan,frying pan,平底锅,NOUN,B2
-fuchsia,fuchsia,词,NOUN,C1
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fulcrum,fulcrum,词,NOUN,C1
-fulfil,fulfil,词,VERB,C1
-fulfilled,fulfilled,满足的,ADJ,B2
-fulfillment,fulfillment,满足,NOUN,B2
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full fed up,full fed up,词,ADJ,B1
 full moon,full moon,满月,NOUN,B2
-full moon banquet,full moon banquet,满月酒,NOUN,C1
 full name,full name,大名,NOUN,B2
-full payment,full payment,全款,NOUN,C1
 full power,full power,全力,NOUN,B2
-full satiated,full satiated,词,ADJ,A2
-full stop,full stop,词,NOUN,B2
-fullness,fullness,词,NOUN,C1
-fully,fully,词,ADV,C1
-fulminate,fulminate,词,VERB,C1
-fumarole,fumarole,词,NOUN,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
 fun,fun,有趣的,ADJ,B2
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
-functionaris,official,官员,NOUN,B2
-functionarissen,officials,官员,NOUN,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundamentally,fundamentally,词,ADV,C1
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,词,NOUN,C1
-funerary,funerary,丧葬的,ADJ,B2
-funereal,funereal,丧葬的,ADJ,B2
-fungal,fungal,词,ADJ,C1
-fungi,fungi,词,NOUN,B2
-fungus,fungus,真菌,NOUN,C1
-funnel,funnel,漏斗,NOUN,B2
-funniness,funniness,,NOUN,B2
-furbish,furbish,词,VERB,C1
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnished,furnished,词,ADJ,B2
 furniture,furniture,家具,NOUN,B2
-furrow,furrow,犁沟,NOUN,B2
 further,further,进一步的,ADJ,B2
-further additional,further additional,词,ADJ,B2
-further debate,further debate,再辩,NOUN,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
 furthermore,furthermore,此外,ADV,B2
-furthest,furthest,最远,ADV,B2
-furtive,furtive,鬼鬼祟祟的,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
 fuse,fuse,保险丝,NOUN,B2
 fuselage,fuselage,机身,NOUN,B2
 fusie,fusion,融合,NOUN,B2
-futile,futile,词,ADJ,C1
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurist,futurist,词,NOUN,C1
-futuristic,futuristic,词,ADJ,C1
-fuzzy,fuzzy,词,ADJ,C1
-fysiek bewijs,physical evidence,物证,NOUN,B2
-fysiognomie,face reading,面相,NOUN,B2
-fysiognomie,physiognomy,面相,NOUN,B2
-gad,gad,词,VERB,C1
 gadget,gadget,小装置,NOUN,B2
-gag,gag,词,NOUN,C1
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
+winst,gain,收益,NOUN,B2
+stelsel,galaxy,星系,NOUN,B2
 galanterie,gallantry,英勇,NOUN,B2
-galician,galician,加利西亚的,ADJ,B2
-gallant,gallant,英勇的,ADJ,B2
-gallbladder,gallbladder,词,NOUN,C1
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
-gambling,gambling,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game play,game play,游戏/比赛,NOUN,B2
-game rule,game rule,游戏规则,NOUN,B2
-gamete,gamete,配子,NOUN,B2
-gangrene,gangrene,坏疽,NOUN,B2
-gangster,gangster,黑帮成员,NOUN,B2
-gans,goose,鹅,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-gaol,gaol,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garantie,guarantee,保证,NOUN,B2
-garb,garb,词,NOUN,C1
-garbage,garbage,词,NOUN,B2
-garble,garble,词,VERB,C1
-gardening,gardening,园艺,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
-gargle (verb),gargle,词,VERB,C1
-gargoyle,gargoyle,滴水嘴兽,NOUN,B2
-garland,garland,花环,NOUN,B2
-garment (part),garment,衣,PART,B2
-garment making,garment making,词,NOUN,C1
-garner,garner,词,VERB,C1
+tuinman,gardener,园丁,NOUN,B2
+knoflook,garlic,大蒜,NOUN,B2
+kledingstuk,garment,服装,NOUN,B2
+versieren,to garnish,装饰,VERB,B2
 garnizoen,garrison,驻军,NOUN,B2
-garrison towns,garrison towns,词,NOUN,C1
+praterig,garrulous,喋喋不休的,ADJ,B2
 gas,gas,气体,NOUN,B2
-gas flame,gas flame,煤气火焰,NOUN,B2
-gas meter,gas meter,,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
-gaseous,gaseous,气态的,ADJ,B2
-gash,gash,词,NOUN,C1
-gasket,gasket,词,NOUN,B1
-gasp (noun),gasp,词,NOUN,B2
-gasp (verb),gasp,词,VERB,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomic,gastronomic,美食的,ADJ,B2
-gastronomy,gastronomy,美食学,NOUN,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gastvrij,hospitable,好客的,ADJ,B2
-gatekeeper,gatekeeper,道口看守员,NOUN,B2
-gateway,gateway,词,NOUN,C1
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauge (noun),gauge,词,NOUN,C1
-gauge meter,gauge meter,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,快乐的,ADJ,B2
-gay (noun),gay,同性恋者,NOUN,B2
-gaze (noun),gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gazette,gazette,词,NOUN,C1
-gearbox,gearbox,变速箱,NOUN,B2
-geautomatiseerd,automated,自动化的,ADJ,B2
-geautoriseerd,authorized,有资格的,ADJ,B2
-geavanceerd,advanced technology,先进,ADJ,B2
-gebalanceerd,balanced,平衡的,ADJ,B2
-gebeurtenis,occurrence,发生,NOUN,B2
-gebiedend,imperative,必要的,ADJ,B2
-gebonden,bound,一定的,ADJ,B2
-geboren worden,to be born,出生,VERB,B2
-gebrek,deficiency,缺乏,NOUN,B2
-gebrek,flaw,缺陷,NOUN,B2
-gebrekkig,deficient,有缺陷的,ADJ,B2
-gebruiken,to use chopsticks,动筷,VERB,B2
-gebruiken,to use crutches,拄拐,VERB,B2
-gecommitteerd,committed,投入的,ADJ,B2
-gedaan,done,事已,NOUN,B2
-gedeeltelijke betekenis,partial meaning,分义,NOUN,B2
-gedeeltelijke oorzaak,partial cause,分因,NOUN,B2
-gedenkteken,memorial,纪念碑,NOUN,B2
-gedroogde tofu,dried tofu,豆干,NOUN,B2
-gedwongen,forced,强迫的,ADJ,B2
-gedwongen,forcibly,强制地,ADV,B2
-geek,geek,极客,NOUN,C1
-geelzucht,jaundice,黄疸,NOUN,B2
-geerziehung,geerziehung,词,NOUN,C1
-geest,wits,心眼,NOUN,B2
-geestig,witty,机智的,ADJ,B2
-gefahrt,gefahrt,词,NOUN,B2
-gefaseerd,phased,阶段性,ADJ,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gegeven,piece of information,信息,NOUN,B2
-gegrom,growl,低吼,NOUN,B2
-geheime bijeenkomst,secret meeting,密会,NOUN,B2
-geheimhouding,secrecy,保密,NOUN,B2
-gehuil,crying,,NOUN,B2
-gehuwd paar,a married couple,夫妇,NOUN,B2
-geizig,stingy,吝啬的,ADJ,B2
-geizigheid,stinginess,吝啬；小气,NOUN,B2
-gejok,banter,戏谑,NOUN,B2
-gek,madman,疯子,NOUN,B2
-gekozen worden,to be elected,当选,VERB,B2
-gekunft,gekunft,词,NOUN,C1
-gel,gel,词,NOUN,C1
-gelach,laughter,笑声,NOUN,B2
-gelatin,gelatin,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-geld,geld,词,VERB,C1
-geleerde,scholar,学者,NOUN,B2
-gelegenheid,opportunity,机会,NOUN,B2
-geleidelijk,gradually,逐渐地,ADV,B2
-gelijk,even,偶数的,ADJ,B2
-gelijkenis,likeness,就象,NOUN,B2
-gelijkenis,resemblance,相似,NOUN,B2
-gelijkenis,similarity,相似,NOUN,B2
-gelijkheid,equality,平等,NOUN,B2
-gelijktijdig,simultaneous,同时的,ADJ,B2
-geloof,faith,信仰,NOUN,B2
-geluid maken,to make noise,闹得,VERB,B2
-geluid van activiteit,sound of activity,动静,NOUN,B2
-geluk,fortune,运气,NOUN,B2
-geluk,good luck,好运,NOUN,B2
-geluk,luck,运气,NOUN,B2
-gelukkig,fortunate,幸运的,ADJ,B2
-gelukkig,lucky,幸运的,ADJ,B2
-gelukkig,fortunately,幸运地,ADV,B2
-geluksdrukker,push luck,太得寸,NOUN,B2
-geluksstreep,lucky chance,虽侥,NOUN,B2
-gelukzaligheid,bliss,极乐,NOUN,B2
-gem,gem,宝石,NOUN,B2
-gemakkelijk te zeggen,easy to say,好说,NOUN,B2
-gemeen,commoner,平民,NOUN,B2
-gemeenschappelijk eigendom,joint ownership,共有,NOUN,B2
-gemeenschappelijkheid,commonality,共同点,NOUN,B2
-gemeente,congregation,集会,NOUN,B2
-gemeentehoofd,township head,乡长,NOUN,B2
-gemopper,grumbling,抱怨,NOUN,B2
-gemstone,gemstone,词,NOUN,C1
-genade,mercy,仁慈,NOUN,B2
-genahme,genahme,词,NOUN,C1
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
-gender equality,gender equality,性别平等,NOUN,B2
-gender parity,gender parity,词,NOUN,C1
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogical,genealogical,词,ADJ,C1
+tankstation,gas station,加油站,NOUN,B2
+benzine,gasoline,汽油,NOUN,B2
+verzamelen,to gather,聚集,VERB,B2
+bijeenkomst,gathering,聚集,NOUN,B2
+staren,gaze,目视,NOUN,B2
+staren,to gaze,凝视,VERB,B2
+versnelling,gear,齿轮,NOUN,B2
 genealogie,genealogy,家谱学,NOUN,B2
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
-genegenheid,affection,喜爱,NOUN,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
 generaliseren,to generalize,概括,VERB,B2
-generality,generality,普遍性,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generations,generations,词,NOUN,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
+algemeen,generally,通常,ADV,B2
 generator,generator,发电机,NOUN,B2
-generatrix,generatrix,母线,NOUN,B2
-generic,generic,通用的,ADJ,B2
-generously,generously,慷慨地,ADV,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetically,genetically,遗传地,ADV,B2
+gul,generous,慷慨的,ADJ,B2
 genetisch,genetic,基因的,ADJ,B2
-genezing,healing,治愈,NOUN,B2
-genial,genial,词,ADJ,C1
 genoom,genome,基因组,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gentle reproach,gentle reproach,词,NOUN,C1
-gentlemen,gentlemen,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-genuflect,genuflect,词,VERB,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geobsedeerd,obsessed,着迷的,ADJ,B2
-geocentric,geocentric,词,ADJ,C1
+echt,genuine,真正的,ADJ,B2
 geografie,geography,地理,NOUN,B2
-geographer,geographer,词,NOUN,C1
-geographically,geographically,词,ADV,C1
-geolocation,geolocation,词,NOUN,C1
 geologisch,geological,地质的,ADJ,B2
-geometer,geometer,几何学家,NOUN,B2
-geophysics,geophysics,词,NOUN,C1
 geopolitiek,geopolitical,地缘政治的,ADJ,B2
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gepensioneerd,retired,退休的,ADJ,B2
-gepflegung,gepflegung,词,NOUN,C1
-geplateerd,plated,镀层的,ADJ,B2
-gerechtelijk,judicial,司法的,ADJ,B2
-gerechtswezen,judiciary,司法官,NOUN,B2
-gereedschap,tools,工具,NOUN,B2
-gereedschapskamer,tool room,工具间,NOUN,B2
-geregelung,geregelung,词,NOUN,C1
-gerelaxeerd,relaxed,放松的,ADJ,B2
-geriatric,geriatric,词,ADJ,C1
-geriatrics,geriatrics,老年医学,NOUN,B2
-gerichtung,gerichtung,词,NOUN,B2
-gerinkel,ringing,铃声,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,德国人,NOUN,B2
-germanic,germanic,日耳曼的,ADJ,B2
-germicidal,germicidal,杀菌的,ADJ,B2
-gerontocracy,gerontocracy,老人政治,NOUN,B2
-gerst,barley,大麦,NOUN,B2
-geruststellen,to reassure,使安心,VERB,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesel,scourge,灾祸,NOUN,B2
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-geslachtsgemeenschap,intercourse,性交,NOUN,B2
-gespannen,tense,紧张的,ADJ,B2
-gesprache,gesprache,词,NOUN,C1
-gesprek,talk,谈话,NOUN,B2
-gestadig stijgen,to increase steadily,与日俱增,VERB,B2
-gestation,gestation,词,NOUN,C1
-gestural,gestural,手势的,ADJ,B2
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-getaway,getaway,词,NOUN,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-getting rich,getting rich,词,NOUN,C1
-getuigen,to witness,目击,VERB,B2
-getuigenis,witness testimony,人证,NOUN,B2
-gevaar,peril,危险,NOUN,B2
-gevangen zetten,to imprison,监禁,VERB,B2
-gevangname,capture,捕获,NOUN,B2
-gevecht,combat,战斗,NOUN,B2
-gevestigd,established,既定的,ADJ,B2
-gevoelloos,callous,冷酷,ADJ,B2
-gevolgtrekking,inference,推断,NOUN,B2
-gevulde stoombol,steamed stuffed bun,包子,NOUN,B2
-gewandel,gewandel,词,NOUN,C1
-geweer,gun,枪,NOUN,B2
-geweisung,geweisung,词,NOUN,C1
-gewetensbezwaar,scruple,顾虑,NOUN,B2
-gewijzigd mechanisme,altered mechanism,改机,NOUN,B2
-gewijzigde betekenis,altered meaning,改义,NOUN,B2
-gewirkung,gewirkung,词,NOUN,C1
-gewoel,clamor,喧嚣,NOUN,B2
-gewoonte,habitually in the past,往常,NOUN,B2
-gezegde,saying,格言,NOUN,B2
-gezellig,sociable,好交际的,ADJ,B2
-gezelschap,companionship,陪伴,NOUN,B2
-gezichtsherkenning,face recognition,认人,NOUN,B2
-gezin,home family,家,NOUN,B2
-gezinsruïne,family ruin,家破,NOUN,B2
-gezond verstand,sanity,理智,NOUN,B2
-gezondheid,soundness,好端端,NOUN,B2
-geëerd,honored,尊敬的,ADJ,B2
-geërgerd,annoyed,恼火的,ADJ,B2
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
-giant,giant,巨人,NOUN,B2
-gibber,gibber,词,VERB,C1
-gibberish,gibberish,词,NOUN,C1
-gibe,gibe,词,VERB,C1
-giddy,giddy,头晕的,ADJ,B2
-gierig,greedy,贪婪的,ADJ,B2
-gifted,gifted,有天赋的,ADJ,B2
-giftedness,giftedness,词,NOUN,C1
-gijzelaar,hostage,人质,NOUN,B2
-gilding,gilding,词,NOUN,C1
-gills,gills,词,NOUN,B2
-gin,gin,金酒,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-gips aanbrengen,to apply a cast,打石膏,VERB,B2
-girdle,girdle,词,NOUN,C1
-girl daughter,girl daughter,词,NOUN,A1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give you (noun),give you,送你,NOUN,C1
-given,given,给定的,ADJ,B2
-given datum,given datum,词,NOUN,C1
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-glacial,glacial,词,ADJ,C1
-gladden,gladden,词,VERB,C1
-gladen,to smooth,使光滑,VERB,B2
-gladiator,gladiator,词,NOUN,C1
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glamour,glamour,词,NOUN,C1
-glans,luster,光泽,NOUN,B2
-glans,radiance,光辉,NOUN,B2
-glans,shine,光泽,NOUN,B2
-glare,glare,词,VERB,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-glebe,glebe,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-glib,glib,伶牙俐齿的,ADJ,B2
-gliding,gliding,滑翔,NOUN,B2
-glijden,to glide,滑行,VERB,B2
-glimlachen,to smile,微笑,VERB,B2
-glimmer,glimmer,词,NOUN,C1
-glimpse,glimpse,一瞥,NOUN,B2
-glint,glint,词,NOUN,C1
-glisten,glisten,词,VERB,C1
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-gloating,gloating,词,NOUN,C1
-global (noun),global,全球,NOUN,B2
-gloednieuw,brand new,崭新的,ADJ,B2
-glomerulus,glomerulus,词,NOUN,C1
-glorierijk,glorious,辉煌的,ADJ,B2
-gloriously,gloriously,词,ADV,C1
-glossary,glossary,词汇表,NOUN,B2
-glossator,glossator,词,NOUN,C1
-gloves,gloves,词,NOUN,B2
-glow (verb),glow,词,VERB,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glower,glower,词,VERB,C1
-glucose,glucose,词,NOUN,C1
+kiem,germ,病菌,NOUN,B2
+kieming,germination,发芽,NOUN,B2
+boos worden,to get angry,生气,VERB,B2
+verloren gaan,to get lost,迷路,VERB,B2
+afsluiten,to get off work,下班,VERB,B2
+loskomen,to get rid of,摆脱,VERB,B2
+opstaan,to get up,起床,VERB,B2
+Geest,ghost,鬼魂,NOUN,B2
+Reus,giant,巨大的,ADJ,B2
+Gigolo,gigolo,面首,NOUN,B2
+Gember,ginger,姜,NOUN,B2
+Giraf,giraffe,长颈鹿,NOUN,B2
+teruggeven,to give back,归还,VERB,B2
+toekennen,to give to grant,予以,VERB,B2
+Gegeven,given,给定,NOUN,B2
+Gletsjer,glacier,冰川,NOUN,B2
+blij,glad,高兴的,ADJ,B2
 gluren,to glance,瞥,VERB,B2
-glut,glut,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
-glyph,glyph,词,NOUN,C1
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-go away,go away,词,VERB,C1
-go wrong,go wrong,词,VERB,C1
-gobble,gobble,词,VERB,C1
-goblin,goblin,词,NOUN,C1
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
+Klier,gland,腺体,NOUN,B2
+glijden,to glide,滑行,VERB,B2
+aanschouwen,to glimpse,瞥见,VERB,B2
+Somberheid,gloominess,忧郁,NOUN,B2
+verheerlijken,to glorify,赞美,VERB,B2
+glorierijk,glorious,辉煌的,ADJ,B2
+Lijm,glue,胶水,NOUN,B2
+Gulsheid,gluttony,暴食,NOUN,B2
+nagen,to gnaw,啃,VERB,B2
+Gnosis,gnosis,灵知,NOUN,B2
+terugkeren,to go back,回去,VERB,B2
+faillietgaan,to go bankrupt,破产,VERB,B2
+dwaasworden,to go crazy,发疯,VERB,B2
+neergaan,to go down,下去,VERB,B2
+voorgaan,to go first,先去,VERB,B2
+Hulp,go help,去帮,NOUN,B2
+binnengaan,to go in,进去,VERB,B2
+onlinegaan,to go online,上网,VERB,B2
+omhooggaan,to go up,上升,VERB,B2
+Geit,goat,山羊,NOUN,B2
+God,god,上帝,NOUN,B2
+oorlogsgod,god of war,战神,NOUN,B2
 godin,goddess,女神,NOUN,B2
-godliness,godliness,词,NOUN,C1
-godmother,godmother,词,NOUN,C1
-godson,godson,词,NOUN,A2
-goed,alright,好的,ADV,B2
-goed,properly,适当地,ADV,B2
+doopvader,godfather,教父,NOUN,B2
+geluk,good luck,好运,NOUN,B2
 goede reputatie,good reputation,清誉,NOUN,B2
-goggle,goggle,词,VERB,C1
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-gok,guess,猜测,NOUN,B2
-golf,golf,高尔夫,NOUN,B2
-golf,gulf,海湾,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
-goochelaar,magician,魔术师,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good day,good day,你好,INTJ,B2
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good heavens,good heavens,天哪,INTJ,B2
-good lord,good lord,词,INTJ,B2
-good medicine,good medicine,好药,NOUN,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good offices,good offices,词,NOUN,C1
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gootsteen,sink,水槽,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,爱传流言的,ADJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-gouge,gouge,词,VERB,C1
+attractief,good-looking,好看的,ADJ,B2
+vaarwel,goodbye,再见,INTJ,B2
+gans,goose,鹅,NOUN,B2
+prachtig,gorgeous,华丽的,ADJ,B2
+roddel,gossip,八卦,NOUN,B2
 gourmet,gourmet,美食家,NOUN,B2
-govern a country,govern a country,治国,VERB,C1
-governability,governability,可治理性,NOUN,B2
-governorate,governorate,词,NOUN,C1
-graad,grade,等级,NOUN,B2
-graan,grain,谷物,NOUN,B2
-grab,grab,揪,NOUN,B2
-gracefulness,gracefulness,词,NOUN,C1
+bestuur,governance,治理,NOUN,B2
+regerings-,governmental,政府的,ADJ,B2
 gracieus,graceful,优雅的,ADJ,B2
-grade (verb),grade,分级,VERB,C1
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation,graduation,毕业,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
+graad,grade,等级,NOUN,B2
+geleidelijk,gradually,逐渐地,ADV,B2
+afstuderen,graduate,毕业生,NOUN,B2
+afstuderen,to graduate,毕业,VERB,B2
 graf,graft,嫁接,NOUN,B2
-graf,tomb,坟墓,NOUN,B2
-graffiti,graffiti,涂鸦,NOUN,C1
+graan,grain,谷物,NOUN,B2
 gram,gram,克,NOUN,B2
-grammatical,grammatical,词,ADJ,C1
-gramophone,gramophone,词,NOUN,C1
-granary,granary,词,NOUN,C1
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,夸张的,ADJ,B2
-grandiloquently,grandiloquently,词,ADV,C1
+grote afstand,grand distance,雄远,NOUN,B2
+kleindochter,granddaughter,孙女,NOUN,B2
 grandioos,grandiose,浮夸的,ADJ,B2
-grandparent,grandparent,词,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granitic,granitic,词,ADJ,C1
-granny,granny,奶奶,NOUN,B2
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-granule,granule,词,NOUN,C1
-grapefruit,grapefruit,词,NOUN,A2
-grapes,grapes,词,NOUN,A1
-graph,graph,词,NOUN,C1
-graphic artist,graphic artist,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphics card,graphics card,显卡,NOUN,B2
-grappen,to joke,开玩笑,VERB,B2
-grapple,grapple,词,VERB,C1
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grasshopper,grasshopper,词,NOUN,B1
-grassroots,grassroots,词,ADJ,C1
-grate,grate,词,VERB,C1
-grater,grater,词,NOUN,B2
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratis,for free,免费,ADV,B2
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gravely,gravely,严重地,ADV,B2
-graven,digging,挖掘,NOUN,B2
-gravid,gravid,怀孕的,ADJ,B2
-gravitas,gravitas,词,NOUN,C1
-gravity of loss,gravity of loss,词,NOUN,C1
-gray hair,gray hair,词,NOUN,B2
-grayish,grayish,词,ADJ,C1
-grease (noun),grease,词,NOUN,C1
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,曾祖父,NOUN,B2
-greaten,greaten,词,VERB,C1
-greatest,greatest,词,NOUN,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊语,NOUN,B2
-green blue,green blue,青,ADJ,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green-clad,green-clad,,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-greetings,greetings,,NOUN,B2
-gregarious,gregarious,爱社交的,ADJ,B2
-grenadier,grenadier,词,NOUN,C1
-grens,boundary,边界,NOUN,B2
-grenzend,border,边境的,ADJ,B2
-gretig,eager,渴望的,ADJ,B2
-gretig zijn,to be eager,心切,VERB,B2
-grid,grid,网格,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
-grieve,grieve,词,VERB,C1
-grieved,grieved,词,ADJ,B2
-grievously unjust,grievously unjust,词,ADJ,C1
-grijnzen,to grin,咧嘴笑,VERB,B2
-grijpen,grip,握法,NOUN,B2
+subsidie,grant,拨款,NOUN,B2
+druif,grape,葡萄,NOUN,B2
 grijpen,to grasp,抓住,VERB,B2
-grijpen,to grip,紧握,VERB,B2
-grijpen,to seize,抓住,VERB,B2
-grijs,grey,灰色的,ADJ,B2
-grill (noun),grill,词,NOUN,B2
-grille,grille,格栅,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grimace,grimace,词,NOUN,C1
-grimmig,grim,严酷的,ADJ,B2
-grinder,grinder,词,NOUN,C1
-grip (noun),grip,握呀,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-gripe,gripe,词,VERB,C1
-grit,grit,词,NOUN,C1
-groan,groan,呻吟,NOUN,B2
-grocer,grocer,词,NOUN,A2
-grocery,grocery,词,NOUN,B2
+vastgrijpen,to grasp firmly,抓紧,VERB,B2
+weide,grassland,草地,NOUN,B2
+dankbaarheid,gratitude,感激,NOUN,B2
+zwaartekracht,gravity,重力,NOUN,B2
+weiden,to graze,吃草,VERB,B2
+weidegang,grazing,放牧,NOUN,B2
+vetten,to grease,涂油,VERB,B2
+vet,greasy,油腻的,ADJ,B2
+grote gunst,great favor,大恩,NOUN,B2
+grote belediging,great offense,冒犯大,NOUN,B2
+grootheid,greatness,伟大,NOUN,B2
+gierig,greedy,贪婪的,ADJ,B2
 groen oog,green eye,碧眼,NOUN,B2
 groene ogen,green eyes,想碧眼,NOUN,B2
 groene technologie,green technology,绿色技术,NOUN,B2
 groenoog,green-eyed,让碧眼,NOUN,B2
-grooming,grooming,词,NOUN,C1
-grootheid,greatness,伟大,NOUN,B2
-grootmacht,powerful nation,强国,NOUN,B2
-grootste,biggest,最大,ADJ,B2
-grooved,grooved,词,ADJ,C1
-grope,grope,词,VERB,C1
-grote afstand,grand distance,雄远,NOUN,B2
-grote belediging,great offense,冒犯大,NOUN,B2
-grote gunst,great favor,大恩,NOUN,B2
-grotesque,grotesque,怪诞的,ADJ,B2
-grotto,grotto,洞穴,NOUN,B2
-ground (adj),ground,磨碎的,ADJ,B1
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds of judgment,grounds of judgment,词,NOUN,C1
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group leader,group leader,组长,NOUN,C1
-group photo,group photo,合影,NOUN,B1
-grouping,grouping,词,NOUN,B2
-grouse,grouse,词,VERB,C1
-grovel,grovel,词,VERB,C1
-growing,growing,词,ADJ,B2
-grown,grown,长大的,ADJ,B2
-grub,grub,词,NOUN,C1
-grueling,grueling,词,ADJ,C1
-grumbler,grumbler,爱抱怨的人,NOUN,B2
-grunt,grunt,词,VERB,B2
-guarantees,guarantees,词,NOUN,C1
-guarding,guarding,守住,NOUN,C1
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-guerrilla,guerrilla,词,NOUN,C1
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guffaw,guffaw,哄笑,NOUN,B2
-guidebook,guidebook,词,NOUN,B1
-guiding light,guiding light,词,NOUN,C1
-guild (adj),guild,词,ADJ,C1
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-gul,generous,慷慨的,ADJ,B2
-gullible,gullible,易受骗的,ADJ,B2
-gum,eraser,橡皮擦,NOUN,B2
-gunshot,gunshot,枪声,NOUN,B2
-gunstige omstandigheden,favorable circumstances,顺境,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-guru,guru,精神导师,NOUN,B2
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-gutter,gutter,路沟,NOUN,B2
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
+broeikas,greenhouse,温室,NOUN,B2
+grijs,grey,灰色的,ADJ,B2
+klacht,grievance,弊端,NOUN,B2
+grimmig,grim,严酷的,ADJ,B2
+smeer,grime,污垢,NOUN,B2
+grijnzen,to grin,咧嘴笑,VERB,B2
+grijpen,grip,握法,NOUN,B2
+grijpen,to grip,紧握,VERB,B2
+kreunen,to groan,呻吟,VERB,B2
+bruidegom,groom,新郎,NOUN,B2
+terrein,grounds,论据,NOUN,B2
+gegrom,growl,低吼,NOUN,B2
+wrok,grudge,怨恨,NOUN,B2
+mopperen,to grumble,抱怨,VERB,B2
+gemopper,grumbling,抱怨,NOUN,B2
+garantie,guarantee,保证,NOUN,B2
+borg,guarantor,担保人,NOUN,B2
+voogd,guardian,守卫,NOUN,B2
+voogdij,guardianship,监护,NOUN,B2
+gok,guess,猜测,NOUN,B2
+schuld,guilt,内疚,NOUN,B2
+golf,gulf,海湾,NOUN,B2
+slikken,to gulp,吞咽,VERB,B2
+tandvlees,gum,牙龈,NOUN,B2
+geweer,gun,枪,NOUN,B2
+windstoot,gust,阵风,NOUN,B2
 gymnasium,gymnasium,体育馆,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gynecologist,gynecologist,词,NOUN,C1
-gyroscope,gyroscope,词,NOUN,C1
-haalbaarheid,feasibility,可行性,NOUN,B2
-haard,fireplace,壁炉,NOUN,B2
-haasten,rush,赶往,NOUN,B2
-haasten,to rush,冲,VERB,B2
-haat,hatred,仇恨,NOUN,B2
-habitability,habitability,词,NOUN,C1
-habitus,habitus,词,NOUN,C1
-habous endowments,habous endowments,词,NOUN,C1
-hacker,hacker,黑客,NOUN,C1
-hacking,hacking,黑客行为,NOUN,B2
-hackneyed,hackneyed,词,ADJ,C1
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hag,hag,老妇,NOUN,B2
-hagel,hail,冰雹,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-hair-raising,hair-raising,词,ADJ,B2
-hairy,hairy,词,ADJ,C1
-hakawati,hakawati,词,NOUN,B2
-haks,chop,砍,NOUN,B2
-hal,hall,殿,PART,B2
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
-half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall (part),hall,殿,PART,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
-hallowed,hallowed,词,ADJ,C1
-hallucinatie,hallucination,幻觉,NOUN,B2
-halo,halo,词,NOUN,B2
-ham,ham,火腿,NOUN,B2
-hamburger,hamburger,汉堡包,NOUN,B2
-hand,hand,手,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
-handboei,handcuff,手铐,NOUN,B2
-handbrake,handbrake,手刹,NOUN,C1
-handel,commerce,商业,NOUN,B2
-handelaar,merchant,商人,NOUN,B2
-handelen,haggling,计较,NOUN,B2
+hè,ha,哈,INTJ,B2
+gewoonte,habitually in the past,往常,NOUN,B2
 handelen,to haggle,讨价还价,VERB,B2
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handle (noun),handle,把手,NOUN,B2
-handlebars,handlebars,词,NOUN,C1
-handschrift,handwriting,笔迹,NOUN,B2
+handelen,haggling,计较,NOUN,B2
+hagel,hail,冰雹,NOUN,B2
+kapsel,hairstyle,发型,NOUN,B2
+hal,hall,殿,PART,B2
+hallucinatie,hallucination,幻觉,NOUN,B2
+stoppen,to halt,停止,VERB,B2
+ham,ham,火腿,NOUN,B2
+hand,hand,手,NOUN,B2
+overhandigen,to hand over,交付,VERB,B2
 handtas,handbag,手提包,NOUN,B2
+handboei,handcuff,手铐,NOUN,B2
 handwerk,handicraft,工艺品,NOUN,B2
-handwritten document,handwritten document,手写件,NOUN,C1
-handyman,handyman,工匠,NOUN,B2
-hanged,hanged,被绞死的,ADJ,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hanging,hanging,绞刑,NOUN,B2
-hangover,hangover,词,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy cheerful,happy cheerful,词,ADJ,B1
-happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-hard,hard,努力地,ADV,B2
-hard (adv),hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-harder,harder,词,ADJ,A2
-hardship,hardship,艰难,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
-hare,hare,野兔,NOUN,B2
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
+zakdoek,handkerchief,手帕,NOUN,B2
+afhandelen,handle,把手,NOUN,B2
+afhandelen,to handle,处理,VERB,B2
+afhandeling,handling,处理,NOUN,B2
+overdracht,handover,拿给,NOUN,B2
+mooi man,handsome guy,帅哥,NOUN,B2
+handschrift,handwriting,笔迹,NOUN,B2
+schrijfoefening,handwriting practice,练字,NOUN,B2
+plagen,to harass,骚扰,VERB,B2
+plagerij,harassment,骚扰,NOUN,B2
+haven,harbor,港口,NOUN,B2
+moeilijk,hard to choose,难以抉择,ADJ,B2
+moeilijk,hard to distinguish,难以区分,ADJ,B2
+moeilijk,hard to maintain,难以维持,ADJ,B2
+moeilijk,hard to speak of,难以启齿,ADJ,B2
+arbeidszaam,hardworking,勤奋的,ADJ,B2
+schaden,harm,伤害,NOUN,B2
+schaden,to harm,损害,VERB,B2
+onschadelijk,harmless,无害的,ADJ,B2
 harmonisch,harmonious,和谐的,ADJ,B2
 harp,harp,竖琴,NOUN,B2
-harried,harried,词,ADJ,C1
-harsh,harsh,严厉的,ADJ,B2
-harshly,harshly,词,ADV,C1
-harshness,harshness,词,NOUN,B2
-hartslag,heartbeat,心跳,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hastily,hastily,急忙,ADV,B2
-hatching,hatching,词,NOUN,C1
-haughtily,haughtily,词,ADV,C1
-haughty,haughty,傲慢的,ADJ,B2
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have time,have time,词,VERB,B2
-have to,have to,必须,AUX,B2
-have to (adv),have to,不得不,ADV,A1
-haven,harbor,港口,NOUN,B2
-haven,port,港口,NOUN,B2
-having a cold,having a cold,感冒的,ADJ,B2
-having item,having item,有件,NOUN,C1
-hazard lights,hazard lights,双闪,NOUN,C1
+oogsten,to harvest,收割,VERB,B2
+haat,hatred,仇恨,NOUN,B2
+hoogmoed,haughtiness,傲慢,NOUN,B2
+ongeluk hebben,to have an accident,遭遇意外,VERB,B2
+dineren,to have dinner,吃晚餐,VERB,B2
+alleen hebben,to have only,唯有,VERB,B2
+verplichting,have to,还得,NOUN,B2
+hooi,hay,干草,NOUN,B2
 hazelnoot,hazelnut,榛子,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headline,headline,标题,NOUN,B2
-headlines,headlines,词,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healer,healer,词,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-heap cluster,heap cluster,词,NOUN,C1
-hearing aid,hearing aid,词,NOUN,B2
-hearsay,hearsay,词,NOUN,C1
-heart,heart,心,ADV,B2
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-hearth,hearth,壁炉,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartrending,heartrending,词,ADJ,C1
-hearts,hearts,心,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavily,heavily,沉重地,ADV,B2
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-hebzucht,covetousness,贪欲,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hectic,hectic,忙乱,NOUN,B2
-hectic (adj),hectic,词,ADJ,C1
-hedge,hedge,树篱,NOUN,B2
-hedonism,hedonism,享乐主义,NOUN,B2
-hedonist,hedonist,词,NOUN,C1
-hedonistic,hedonistic,享乐主义的,ADJ,B2
-heedlessness,heedlessness,词,NOUN,C1
-heer,lord,领主,NOUN,B2
-heer Yu,lord yu,玉大人,NOUN,B2
-hefen,hefen,河粉,NOUN,C1
-heft,hilt,剑柄,NOUN,B2
-hehe,hehe,嘿嘿,INTJ,B2
-heiligdom,sanctuary,避难所,NOUN,B2
-heiligheid,holiness,神圣,NOUN,B2
-heiligtum,shrine,مشعر,NOUN,B2
-heinous,heinous,词,ADJ,C1
-heks,witch,女巫,NOUN,B2
-helaas,alas,唉,INTJ,B2
-heldhaftig,valiant,英勇的,ADJ,B2
-helemaal,at all,根本,ADV,B2
-hellen,to incline,使倾斜,VERB,B2
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello bye,hello bye,词,INTJ,B2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
-helpen,to help assistance,帮助,VERB,B2
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-hem,him,他吧,NOUN,B2
-hematoma,hematoma,血肿,NOUN,B2
+kop,heading,标题,NOUN,B2
+hoofdtelefoon,headphones,耳机,NOUN,B2
+genezing,healing,治愈,NOUN,B2
+hoop,heap,堆,NOUN,B2
+zaak horen,to hear a case,审理,VERB,B2
+onbekend,heard beile,听说贝勒,NOUN,B2
+hartslag,heartbeat,心跳,NOUN,B2
+verwarmen,to heat,加热,VERB,B2
+hittegolf,heat wave,热浪,NOUN,B2
 hemelse geur,heavenly fragrance,天香,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemiplegia,hemiplegia,词,NOUN,C1
-hemisphere,hemisphere,半球,NOUN,B2
-hemistich,hemistich,词,NOUN,C1
+zwaarte,heaviness,沉重 / 笨重,NOUN,B2
+stijve etiquette,heavy etiquette,礼太重,NOUN,B2
+zware knoop,heavy knot,重结,NOUN,B2
+zware machine,heavy machine,重机,NOUN,B2
+dik lettertype,heavy type,重型,NOUN,B2
+zwaar werk,heavy work,重功,NOUN,B2
+egel,hedgehog,刺猬,NOUN,B2
+hehe,hehe,嘿嘿,INTJ,B2
+erfgenaam,heir,继承人,NOUN,B2
+helpen,to help assistance,帮助,VERB,B2
+hulpeloos,helpless,无助的,ADJ,B2
 hemoglobine,hemoglobin,血红蛋白,NOUN,B2
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostasis,hemostasis,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
+bloeding,hemorrhage,出血,NOUN,B2
 hen,hen,母鸡,NOUN,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hepatic,hepatic,肝脏的,ADJ,B2
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,PRON,B2
-her their,her their,词,DET,A1
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
-herbaceous,herbaceous,草本的,ADJ,B2
-herbal tea,herbal tea,花草茶,NOUN,B2
-herbalism,herbalism,词,NOUN,C1
-herbalist,herbalist,词,NOUN,B1
-herbarium,herbarium,词,NOUN,C1
-herberg,inn,小旅馆,NOUN,B2
-herbetekenis,re-meaning,再义,NOUN,B2
-herbewijs,re-evidence,重据,NOUN,B2
-herbicide,herbicide,除草剂,NOUN,B2
-herbouwen,to rebuild,重建,VERB,B2
-herbruskeheid,re-abruptness,再骤,NOUN,B2
-herbs,herbs,词,NOUN,B2
-herconstrueren,to reconstruct,重建,VERB,B2
-hercreatie,re-creation,再作,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
-herdenken,to commemorate,纪念,VERB,B2
+kudde,herd,兽群,NOUN,B2
 herder,herder,牧民,NOUN,B2
-herder,shepherd,牧羊人,NOUN,B2
-here (noun),here,此地,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here is,here is,词,ADV,A1
-here you go,here you go,请,INTJ,B2
-hereafter,hereafter,词,NOUN,C1
-hereniging,reunion,重聚,NOUN,B2
-heresiarch,heresiarch,词,NOUN,C1
-heretical,heretical,词,ADJ,C1
-heretical innovation,heretical innovation,词,NOUN,C1
-herfruit,re-fruit,再果,NOUN,B2
-hergebruik,reuse,重用,NOUN,B2
-hergevecht,re-battle,重战,NOUN,B2
-hergrens,re-boundary,重界,NOUN,B2
-herhaald,repeated,反复的,ADJ,B2
-herhaling,again,你又,NOUN,B2
-herhoeveelheid,re-quantity,再量,NOUN,B2
-herinner,re-inner,再内,NOUN,B2
-herinnering,remembrance,纪念,NOUN,B2
-herintypen,retype,再型,NOUN,B2
-herinzending,re-submission,再上,NOUN,B2
-herkennen,to know to recognize,认识,VERB,B2
-herlaag,re-layering,改层,NOUN,B2
-herleven,to revive,复兴,VERB,B2
-herlimiet,re-limit,重限,NOUN,B2
-herlogica,re-logic,再逻,NOUN,B2
-herloopbaan,re-course,重途,NOUN,B2
-hermeneutics,hermeneutics,词,NOUN,C1
-hermeneutisch,hermeneutic,诠释学的,ADJ,B2
-hermetic,hermetic,词,ADJ,C1
-hermit,hermit,隐士,NOUN,B2
-hermitage,hermitage,词,NOUN,B2
-hernia,hernia,词,NOUN,C1
-hernieuwbaar,renewable,可再生的,ADJ,B2
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,词,NOUN,B1
-heron,heron,词,NOUN,C1
-heropbouw,reconstruction,重建,NOUN,B2
-heroperatie,reoperation,再术,NOUN,B2
-herorde,re-order,重序,NOUN,B2
-heroverwegen,to reconsider,重新考虑,VERB,B2
-heroverweging,reconsideration,重思,NOUN,B2
-heroïsch,heroic,英勇的,ADJ,B2
-herpad,re-path,重径,NOUN,B2
-herpas,re-pace,重骤,NOUN,B2
-herplanning,replanning,再策,NOUN,B2
-herprijzing,reprice,再价,NOUN,B2
-herreden,re-reason,重理,NOUN,B2
-herroepen,to revoke,撤销,VERB,B2
-herrouting,re-routing,改轨,NOUN,B2
-hersequencing,re-sequencing,改骤,NOUN,B2
-herstellen,to restore,恢复,VERB,B2
-herstructurering,restructuring,重组,NOUN,B2
-heruitvoering,re-enactment,再演,NOUN,B2
-herverkoop,resale,转售,NOUN,B2
-hervertellen,to retell,转述,VERB,B2
-hervorming,reshaping,改形,NOUN,B2
-herzien,to see again,再见,VERB,B2
-hesitant,hesitant,犹豫的,ADJ,B2
-heteluchtballon,hot air balloon,热气球,NOUN,B2
-heterodox,heterodox,异端的,ADJ,B2
-heterodoxy,heterodoxy,词,NOUN,C1
-heterogeen,heterogeneous,异质的,ADJ,B2
-heterosexual,heterosexual,词,ADJ,C1
-heup,hip,臀部,NOUN,B2
-heuristic,heuristic,词,ADJ,C1
-heuvel,hills,丘陵,NOUN,B2
-hexadecimal,hexadecimal,词,ADJ,C1
-hexagon,hexagon,六边形,NOUN,B2
-heyday,heyday,词,NOUN,C1
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
-hideous,hideous,丑陋的,ADJ,B2
-hider,hider,词,NOUN,B2
-hiding ambush,hiding ambush,词,NOUN,B2
-hiding place,hiding place,藏身处,NOUN,B2
 hier,here,此地,NOUN,B2
-hier komen,to come here,来到这里,VERB,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,高中毕业生,NOUN,B2
-high school student,high school student,词,NOUN,B2
-high tall,high tall,高的,ADJ,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
-highlighter,highlighter,词,NOUN,C1
-hijack,hijack,词,VERB,C1
-hike,hike,徒步旅行,NOUN,B2
-him (noun),him,他吧,NOUN,B2
-him dative,him dative,词,PRON,A2
-him her,him her,他/她,PRON,B2
-himself herself,himself herself,词,PRON,A1
-hinge,hinge,合页,NOUN,B2
-hinkelen,to limp,跛行,VERB,B2
-hint,hint,暗示,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
-hirsute,hirsute,词,ADJ,C1
-his (pron),his,词,PRON,A1
-his certainty,his certainty,他定,NOUN,C1
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,他/她自己的,DET,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,西班牙的,ADJ,B2
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
-historicism,historicism,历史主义,NOUN,B2
-historicist,historicist,历史主义者,NOUN,B2
-historicization,historicization,词,NOUN,C1
+erfelijk,hereditary,遗传的,ADJ,B2
+ketterij,heresy,异端,NOUN,B2
+ketter,heretic,异端,NOUN,B2
+hermeneutisch,hermeneutic,诠释学的,ADJ,B2
+heroïsch,heroic,英勇的,ADJ,B2
+aarzelen,to hesitate,犹豫,VERB,B2
+aarzeling,hesitation,犹豫,NOUN,B2
+heterogeen,heterogeneous,异质的,ADJ,B2
+zich verstoppen,to hide oneself,躲藏,VERB,B2
+schuilplaats,hideout,藏身处,NOUN,B2
+verstop,hiding,ٱختباء,NOUN,B2
+hiërarchisch,hierarchical,等级的,ADJ,B2
+middelbare school,high school,高中,NOUN,B2
+vloed,high tide,涨潮,NOUN,B2
+hoger,higher,更高的,ADJ,B2
+benadrukken,to highlight,强调,VERB,B2
+hoogheid,highness,殿下,NOUN,B2
+snelweg,highway,公路,NOUN,B2
+wandeling,hiking,徒步,NOUN,B2
+heuvel,hills,丘陵,NOUN,B2
+heft,hilt,剑柄,NOUN,B2
+hem,him,他吧,NOUN,B2
+heup,hip,臀部,NOUN,B2
+huur,hiring,招聘,NOUN,B2
+zijn,his,他的,DET,B2
+vertrek,his departure,他走,NOUN,B2
+sis,hiss,嘶嘶声,NOUN,B2
 historicus,historian,历史学家,NOUN,B2
 historisch,historic,历史性的,ADJ,B2
-history story,history story,历史/故事,NOUN,B2
-histrionic,histrionic,词,ADJ,C1
-hit beat,hit beat,词,VERB,A2
-hitch,hitch,词,NOUN,B2
-hither,hither,到这里,ADV,B2
-hittegolf,heat wave,热浪,NOUN,B2
-hiërarchisch,hierarchical,等级的,ADJ,B2
+slag,hit,击中,NOUN,B2
 hmm,hmm,嗯,INTJ,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
 hobby,hobby,爱好,NOUN,B2
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hoe,how,又怎会,NOUN,B2
-hoe dan ook,somehow,以某种方式,ADV,B2
-hoek,angle,角度,NOUN,B2
-hoeveel,how much,多少,PRON,B2
-hoger,higher,更高的,ADJ,B2
-hol,hollow,洼地,NOUN,B2
-hold,hold,控制,NOUN,B2
-hold catch,hold catch,词,VERB,A1
-hold together,hold together,词,VERB,C1
-holder,holder,持有者,NOUN,B2
-holding,holding,别放,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holdup,holdup,词,NOUN,B2
-holiday feast,holiday feast,词,NOUN,A2
-holidaymaker,holidaymaker,词,NOUN,C1
-holidays,holidays,假期,NOUN,B2
+de balans houdend,hold the balance of power,举足轻重,ADJ,B2
+heiligheid,holiness,神圣,NOUN,B2
 holistisch,holistic,整体的,ADJ,B2
-holle roem,empty fame,虚名,NOUN,B2
-holm oak,holm oak,词,NOUN,C1
-holocaust,holocaust,浩劫,NOUN,B2
-hologram,hologram,词,NOUN,C1
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home (adv),home,词,ADV,B1
-home automation,home automation,词,NOUN,B1
-home hearth,home hearth,词,NOUN,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,顾家的,ADJ,B2
-homelessness,homelessness,词,NOUN,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,,NOUN,B2
-homework duty,homework duty,词,NOUN,A2
-homiletic,homiletic,词,ADJ,C1
-homily,homily,布道,NOUN,B2
-hominization,hominization,词,NOUN,C1
+hol,hollow,洼地,NOUN,B2
+gezin,home family,家,NOUN,B2
+dakloos,homeless,无家可归的,ADJ,B2
+moord,homicide,杀人,NOUN,B2
 homogeen,homogeneous,同质的,ADJ,B2
-homonym,homonym,词,NOUN,C1
-homonymy,homonymy,同音异义,NOUN,B2
 homoseksueel,homosexual,同性恋的,ADJ,B2
-homothety,homothety,位似,NOUN,C1
-honor culture,honor culture,荣誉文化,NOUN,B2
-honorability,honorability,词,NOUN,C1
-honorable,honorable,可敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-hoofd,on head,当头,NOUN,B2
-hoofd,principal,委托人,NOUN,B2
-hoofdartikel,editorial,社论,NOUN,B2
-hoofdpersonage,protagonist,主角,NOUN,B2
-hoofdstroom,mainstream,主流,NOUN,B2
-hoofdtelefoon,headphones,耳机,NOUN,B2
-hoofdvak,major course,专业课,NOUN,B2
-hoogheid,highness,殿下,NOUN,B2
-hoogmoed,haughtiness,傲慢,NOUN,B2
-hooi,hay,干草,NOUN,B2
-hooligan,hooligan,流氓,NOUN,B2
-hoop,heap,堆,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
-hoped-for,hoped-for,词,ADJ,C1
-hopeful,hopeful,词,ADJ,C1
-hopelessly,hopelessly,绝望地,ADV,B2
-hopelessness,hopelessness,词,NOUN,C1
+eerlijk,honestly,诚实地,ADV,B2
+huwelijksreis,honeymoon,蜜月,NOUN,B2
+toeteren,to honk,按喇叭,VERB,B2
+eren,to honor,尊敬,VERB,B2
+ere,honorary,名誉的,ADJ,B2
+geëerd,honored,尊敬的,ADJ,B2
 hopen,to hope to wish,希望,VERB,B2
-horde,horde,词,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
-horny,horny,性欲的,ADJ,B2
-horoscope,horoscope,星座运势,NOUN,B2
-horrified,horrified,惊骇的,ADJ,B2
+verschrikken,to horrify,使惊骇,VERB,B2
+verschrikkelijk,horrifying,令人毛骨悚然的,ADJ,B2
 horror,horror,恐怖,NOUN,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hose,hose,软管,NOUN,B2
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitalization,hospitalization,词,NOUN,C1
-host of angels,host of angels,天使群,NOUN,B2
-hostel,hostel,词,NOUN,C1
-hostess,hostess,女服务员,NOUN,B2
-hosting,hosting,托管,NOUN,C1
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
-hotbed,hotbed,词,NOUN,C1
+paardenvertrek,horse departure,马去,NOUN,B2
+gastvrij,hospitable,好客的,ADJ,B2
+ontvangen,to host,接待,VERB,B2
+gijzelaar,hostage,人质,NOUN,B2
+vijandig,hostile,敌对的,ADJ,B2
+vijandigheid,hostility,敌意,NOUN,B2
+heteluchtballon,hot air balloon,热气球,NOUN,B2
 hotel,hotel,酒店,NOUN,B2
-hotel industry,hotel industry,词,NOUN,C1
-hotelier,hotelier,旅馆老板,NOUN,B2
 hotelkamer,hotel room,酒店房间,NOUN,B2
-hothead,hothead,急性子的人,NOUN,B2
-houding,stance,立场,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-house search,house search,词,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
-houtblok,log,日志,NOUN,B2
-houtoor,wood ear mushroom,木耳,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (noun),how,又怎会,NOUN,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how many (pron),how many,多少,PRON,A1
-how much,how much,多少,ADV,B2
-how to do it,how to do it,办呢,ADV,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hubris,hubris,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
+zweven,to hover,盘旋,VERB,B2
+hoe,how,又怎会,NOUN,B2
+hoeveel,how much,多少,PRON,B2
 huilen,to howl,嚎叫,VERB,B2
-hulpeloos,helpless,无助的,ADJ,B2
-human being,human being,词,NOUN,B1
+knuffelen,to hug,拥抱,VERB,B2
+enorm,huge,巨大的,ADJ,B2
+hè,huh,哈,INTJ,B2
+neuriën,to hum,哼唱,VERB,B2
 human capacity,human capacity,人会,NOUN,B2
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
 human nature,human nature,人性,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humanist,humanist,人文主义者,NOUN,B2
-humanitarian,humanitarian,人道主义的,ADJ,B2
 humanization,humanization,人性化,NOUN,B2
-humble,humble,谦逊的,ADJ,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
-humid,humid,潮湿的,ADJ,B2
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
 humidity,humidity,湿度,NOUN,B2
 humiliate,to humiliate,羞辱,VERB,B2
-humiliating,humiliating,令人羞辱的,ADJ,B2
 humiliation,humiliation,羞辱,NOUN,B2
 humility,humility,谦逊,NOUN,B2
-humming,humming,词,NOUN,B2
-hummingbird,hummingbird,词,NOUN,B2
-humorist,humorist,词,NOUN,C1
-humorous,humorous,幽默的,ADJ,B2
-hump,hump,词,NOUN,C1
-hunch,hunch,词,NOUN,B2
 hunchbacked,hunchbacked,驼背的,ADJ,B2
 hundred,hundred,百,NUM,B2
-hundred (noun),hundred,一百,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hundreds (num),hundreds,词,NUM,B2
 hungry,hungry,饥饿的,ADJ,B2
 hunting,hunting,狩猎,NOUN,B2
-hurrah,hurrah,万岁,INTJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
 hurry,to hurry,赶快,VERB,B2
 hurt,to hurt,受伤,VERB,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hut,cabin,小屋,NOUN,B2
 hut,hut,小屋,NOUN,B2
-hut,shack,棚屋,NOUN,B2
-huur,hiring,招聘,NOUN,B2
-huurder,tenant,租户,NOUN,B2
-huwbaar,marriageable,适婚,NOUN,B2
-huwelijksalliantie,marriage alliance,联姻,NOUN,B2
-huwelijksreis,honeymoon,蜜月,NOUN,B2
-hyaline,hyaline,词,ADJ,C1
 hybrid,hybrid,杂交的,ADJ,B2
-hybridism,hybridism,词,NOUN,C1
 hybridization,hybridization,杂交,NOUN,B2
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydraulic,hydraulic,液压的,ADJ,B2
 hydro energy,hydro energy,水能,NOUN,B2
-hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
 hydrogen,hydrogen,氢,NOUN,B2
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrology,hydrology,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
 hygiene,hygiene,卫生,NOUN,B2
-hygienic,hygienic,卫生的,ADJ,B2
 hymn,hymn,赞美诗,NOUN,B2
-hymnal,hymnal,词,NOUN,C1
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
 hyper-use,hyper-use,超用,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbole,hyperbole,夸张,NOUN,B2
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hyperthermia,hyperthermia,体温过高,NOUN,B2
-hypertrophy,hypertrophy,肥大,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
 hypocrisy,hypocrisy,虚伪,NOUN,B2
-hypocrite,hypocrite,伪君子,NOUN,B2
-hypotension,hypotension,词,NOUN,C1
-hypotensive,hypotensive,词,ADJ,C1
-hypothekeren,to mortgage,抵押,VERB,B2
 hypothermia,hypothermia,体温过低,NOUN,B2
-hypothesize,hypothesize,词,VERB,B2
 hypothetical,hypothetical,假设的,ADJ,B2
-hypothetically,hypothetically,词,ADV,C1
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
 hysterical,hysterical,歇斯底里的,ADJ,B2
-hè,ha,哈,INTJ,B2
-hè,huh,哈,INTJ,B2
-i,i,我连,NOUN,B2
 i don't deserve your praise,i don't deserve your praise,不敢当,INTJ,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
 ice cream,ice cream,冰淇淋,NOUN,B2
-ice cube,ice cube,词,NOUN,A2
 ice hockey,ice hockey,冰球,NOUN,B2
-ice pick,ice pick,,NOUN,B2
 ice rink,ice rink,溜冰场,NOUN,B2
 ice-cold,ice-cold,冰冷的,ADJ,B2
-icicle,icicle,词,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconicity,iconicity,词,NOUN,C1
-iconoclast,iconoclast,偶像破坏者,NOUN,B2
-iconoclastic,iconoclastic,词,ADJ,C1
-iconographic,iconographic,词,ADJ,C1
 icy,icy,冰冷的,ADJ,B2
 id,id,证件,NOUN,B2
 id card,id card,身份证,NOUN,B2
@@ -7957,13350 +2155,6780 @@ id photo,id photo,证件照,NOUN,B2
 ideal,ideal,理想,NOUN,B2
 idealisme,idealism,理想主义,NOUN,B2
 idealist,idealist,理想主义者,NOUN,B2
-ideally,ideally,理想地,ADV,B2
-ideational,ideational,词,ADJ,C1
 identiek,identical,完全相同的,ADJ,B2
-identifier,identifier,词,NOUN,C1
-identitarianism,identitarianism,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
 ideologisch,ideological,意识形态的,ADJ,B2
-ideologization,ideologization,词,NOUN,C1
-idiomatic,idiomatic,词,ADJ,C1
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncrasy,idiosyncrasy,特质,NOUN,B2
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiot,idiot,傻瓜,ADJ,B2
-idiotic,idiotic,愚蠢的,ADJ,B2
 idiotie,idiocy,愚蠢,NOUN,B2
-idolatry,idolatry,词,NOUN,B2
-idyllic,idyllic,词,ADJ,C1
-iemand,anyone,任何人,PRON,B2
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
-igneous,igneous,火成的,ADJ,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominious,ignominious,词,ADJ,C1
-ignominy,ignominy,耻辱,NOUN,B2
-ijverig,assiduous,勤勉的,ADJ,B2
-ik,me,لي,NOUN,B2
-iliac,iliac,词,ADJ,C1
+inactief,idle,懒惰的,ADJ,B2
+als,if when,如果,SCONJ,B2
+ontsteking,ignition,点火,NOUN,B2
+onwetendheid,ignorance,无知,NOUN,B2
+onwetend,ignorant,无知的,ADJ,B2
+ziek,ill,生病的,ADJ,B2
 illegaliteit,illegality,非法,NOUN,B2
-illegally,illegally,词,ADV,C1
 illegitiem,illegitimate,非法的,ADJ,B2
-illicit,illicit,违禁的,ADJ,B2
-illiteracy,illiteracy,词,NOUN,C1
-illiterate,illiterate,词,ADJ,B2
-illogical,illogical,不合逻辑的,ADJ,B2
-illumination,illumination,照明,NOUN,B2
-illuminationism,illuminationism,照明主义,NOUN,C1
-illuminator,illuminator,彩饰画家,NOUN,B2
-illusory,illusory,词,ADJ,C1
-illustrative,illustrative,词,ADJ,C1
-illustrious,illustrious,著名的,ADJ,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imaginative,imaginative,富有想象力的,ADJ,B2
-imagined,imagined,想象的,ADJ,C1
-imaging,imaging,词,NOUN,C1
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
-imbecility,imbecility,愚蠢,NOUN,B2
-imitatief,imitative,模仿性,ADJ,B2
+ziekte,illness,疾病,NOUN,B2
+verlichten,to illuminate,照亮,VERB,B2
+beeldspraak,imagery,意象,NOUN,B2
+denkbeeldig,imaginary,虚构的,ADJ,B2
 imiteren,to imitate,模仿,VERB,B2
-immaculate,immaculate,词,ADJ,C1
-immanent,immanent,词,ADJ,C1
-immature,immature,不成熟的,ADJ,B2
-immediacy,immediacy,词,NOUN,C1
-immemorial,immemorial,词,ADJ,C1
-immense,immense,巨大的,ADJ,B2
-immensely,immensely,词,ADV,B2
-immensity,immensity,词,NOUN,C1
-immerse,immerse,词,VERB,C1
-immersed,immersed,词,ADJ,C1
+imitatief,imitative,模仿性,ADJ,B2
+onmeetbaar,immeasurable,不可估量的,ADJ,B2
+onmiddellijk,immediate,立即的,ADJ,B2
+onderdompeling,immersion,沉浸,NOUN,B2
 immigrant,immigrant,移民,NOUN,B2
-imminence,imminence,就将,NOUN,C1
-immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immodesty,immodesty,不贞,NOUN,B2
-immoral,immoral,不道德的,ADJ,B2
-immorality,immorality,词,NOUN,C1
-immortal,immortal,不朽的,ADJ,B2
+dreigend,imminent,即将来临的,ADJ,B2
+onsterfelijkheid,immortality,不朽,NOUN,B2
+immuun,immune,免疫的,ADJ,B2
 immunisatie,immunization,免疫,NOUN,B2
 immunotherapie,immunotherapy,免疫治疗,NOUN,B2
-immuun,immune,免疫的,ADJ,B2
-impartial,impartial,词,ADJ,C1
-impartiality,impartiality,公正,NOUN,B2
-impasse,impasse,词,NOUN,C1
-impassive,impassive,词,ADJ,C1
-impassively,impassively,无动于衷地,ADV,B2
-impatience,impatience,词,NOUN,C1
-impeccable,impeccable,无瑕疵的,ADJ,B2
-imperatively,imperatively,词,ADV,C1
-imperceptible,imperceptible,词,ADJ,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperfect,imperfect,不完美的,ADJ,B2
-imperfection,imperfection,词,NOUN,C1
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,太医,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
-imperialist,imperialist,帝国主义的,ADJ,B2
-imperious,imperious,词,ADJ,C1
-impersonal,impersonal,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbably,imperturbably,词,ADV,C1
-impetuosity,impetuosity,词,NOUN,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implacably,implacably,毫不留情地,ADV,B2
-implantation,implantation,词,NOUN,C1
-implausible,implausible,词,ADJ,C1
+stoornis,impairment,左手废,NOUN,B2
+meedelen,to impart,传授,VERB,B2
+ongeduldig,impatient,不耐烦的,ADJ,B2
+belemmering,impediment,障碍,NOUN,B2
+aandrijven,to impel,推动,VERB,B2
+ondoordringbaar,impenetrable,不可穿透的,ADJ,B2
+gebiedend,imperative,必要的,ADJ,B2
+keizerlijk,imperial,帝国的,ADJ,B2
+keizerlijk hof,imperial court,朝廷,NOUN,B2
+wil van de keizerlijke vader,imperial father's will,父皇要,NOUN,B2
+keizerlijke garde,imperial guard,御林,NOUN,B2
+keizerlijke verwanten,imperial relatives,皇亲,NOUN,B2
 implementatie,implementation,实施,NOUN,B2
-implicated,implicated,牵连的,ADJ,C1
-impliciet,implicit,含蓄的,ADJ,B2
 impliciteren,to implicate,连累,VERB,B2
-implicitly,implicitly,含蓄地,ADV,B2
-impoliteness,impoliteness,词,NOUN,C1
-import,import,进口,NOUN,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
-imports,imports,词,NOUN,C1
-imposing,imposing,宏伟的,ADJ,B2
-imposition,imposition,词,NOUN,C1
-impostor,impostor,骗子,NOUN,B2
-imposture,imposture,词,NOUN,C1
-impotent,impotent,词,ADJ,C1
-impound lot,impound lot,词,NOUN,B1
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
-impressed,impressed,印象深刻的,ADJ,B2
+impliciet,implicit,含蓄的,ADJ,B2
+smeken,to implore,恳求,VERB,B2
+onmogelijkheid,impossibility,不可能,NOUN,B2
 impressionisme,impressionism,印象主义,NOUN,B2
-impressions,impressions,感想,NOUN,B2
-imprint,imprint,印记,NOUN,B2
-imprisoned,imprisoned,被监禁的,ADJ,B2
-impromptu,impromptu,即兴的,ADJ,B2
-improvidence,improvidence,词,NOUN,C1
+gevangen zetten,to imprison,监禁,VERB,B2
+onjuist,improper,不合适的,ADJ,B2
 improviseerd,improvised,即兴的,ADJ,B2
-imprudence,imprudence,词,NOUN,C1
-imprudent,imprudent,词,ADJ,C1
+onbeschoftheid,impudence,厚颜无耻,NOUN,B2
+onbeschoft,impudent,无礼的,ADJ,B2
 impulsief,impulsive,冲动的,ADJ,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-impunity,impunity,逍遥法外,NOUN,B2
-impure,impure,词,ADJ,C1
-imputation,imputation,词,NOUN,C1
+onreinheid,impurity,不纯,NOUN,B2
 in,in,在...里面,ADP,B2
-in (adv),in,进来,ADV,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in addition to,in addition to,除...之外,ADP,B2
-in agreement,in agreement,词,ADV,C1
-in anticipation of,in anticipation of,词,ADV,C1
-in between,in between,在中间,ADV,B2
-in book,in book,书里,NOUN,C1
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in de lucht,in the sky,天上,NOUN,B2
-in de wind,in wind,临风,NOUN,B2
-in deficit,in deficit,词,ADJ,C1
-in detail,in detail,详细地,ADV,B2
-in dienst nemen,to employ,雇用,VERB,B2
-in every detail,in every detail,词,ADV,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
-in feite,basically,基本上,ADV,B2
-in front of before,in front of before,在...前,ADP,B2
-in gevaar brengen,to endanger,危及,VERB,B2
-in here,in here,在这里面,ADV,B2
-in het geheel,overall,总体上,ADV,B2
 in het geval,in case,如果,SCONJ,B2
-in high spirits,in high spirits,兴致勃勃,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
-in its entirety,in its entirety,词,ADV,C1
-in me,in me,我中,NOUN,C1
-in mind,in mind,记住,ADV,B2
-in need,in need,词,ADJ,A2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in orde brengen,to put in order,收拾,VERB,B2
-in order,in order,依次,ADV,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
-in plaats daarvan,instead,代替,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in private,in private,私下地,ADV,B2
-in question,in question,词,ADV,C1
-in return,in return,作为回报,NOUN,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,在那里面,ADV,B2
-in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
-in time (adj),in time,词,ADJ,B1
-in two,in two,成两半,ADV,B2
-in vain,in vain,徒劳,NOUN,B2
-in view of,in view of,鉴于,ADP,B2
-in werking stellen,to enact,颁布,VERB,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccessible,inaccessible,词,ADJ,C1
-inaccurate,inaccurate,词,ADJ,C1
-inactief,idle,懒惰的,ADJ,B2
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inademen,to inhale,吸入,VERB,B2
-inadequate,inadequate,不足的,ADJ,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadmissible,inadmissible,不可接受的,ADJ,B2
-inadvertent,inadvertent,词,ADJ,C1
-inadvertently,inadvertently,词,ADV,B2
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inattentive,inattentive,词,ADJ,C1
-inaudible,inaudible,词,ADJ,B2
-inbedden,to embed,嵌入,VERB,B2
-inboard,inboard,船内的,ADV,B2
-inborn nature,inborn nature,词,NOUN,C1
-inbreker,burglar,窃贼,NOUN,B2
-incandescence,incandescence,词,NOUN,C1
-incandescent,incandescent,白炽的,ADJ,B2
+in detail,in detail,详细地,ADV,B2
+voor,in front of,在……前面,ADP,B2
+om,in order to,以期,SCONJ,B2
+persoonlijk,in person,亲自地,ADV,B2
+ondanks,to in spite of,不顾,VERB,B2
+in de lucht,in the sky,天上,NOUN,B2
+op tijd,in time,及时地,ADV,B2
+tevergeefs,in vain,徒劳,ADV,B2
+in de wind,in wind,临风,NOUN,B2
+schriftelijk,in writing,书面,NOUN,B2
+onvermogen,inability,无能,NOUN,B2
+onpasse,inappropriate,不恰当的,ADJ,B2
+inwijden,to inaugurate,启用,VERB,B2
+inwijding,inauguration,开幕,NOUN,B2
 incantatie,incantation,咒语,NOUN,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incarceration,incarceration,词,NOUN,C1
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
+wierook,incense,香,NOUN,B2
 incentief,incentive,激励,NOUN,B2
-incentivization,incentivization,词,NOUN,C1
-inceptive,inceptive,词,ADJ,C1
-incessant,incessant,持续的,ADJ,B2
-incest,incest,词,NOUN,C1
-inchoative,inchoative,词,ADJ,C1
+duim,inch,بوصة,NOUN,B2
 incident,incident,事件,NOUN,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
 incinereren,to incinerate,焚烧,VERB,B2
-incipient,incipient,初期的,ADJ,B2
-incision,incision,切口,NOUN,B2
-incisive,incisive,深刻的,ADJ,B2
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,严酷的,ADJ,B2
-inclined prone,inclined prone,词,ADJ,C1
-incognito,incognito,词,ADJ,C1
-incoherence,incoherence,不连贯,NOUN,B2
-incoherent,incoherent,不连贯的,ADJ,B2
-income tax,income tax,所得税,NOUN,B2
-incommunicado,incommunicado,词,ADJ,C1
+opstoken,to incite,煽动,VERB,B2
+opstokking,incitement,煽动,NOUN,B2
+neiging,inclination,倾向,NOUN,B2
+hellen,to incline,使倾斜,VERB,B2
+inkomsten en uitgaven,income and expense,收支,NOUN,B2
+inkomend,incoming,进来的,ADJ,B2
 incompatibiliteit,incompatibility,不兼容,NOUN,B2
-incompatible,incompatible,词,ADJ,C1
-incompetence,incompetence,词,NOUN,C1
-incompetent,incompetent,无能的,ADJ,B2
-incomplete (noun),incomplete,不全,NOUN,C1
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable,inconceivable,不可想象的,ADJ,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,不协调,NOUN,B2
-incongruous,incongruous,不协调的,ADJ,B2
-inconsiderate,inconsiderate,词,ADJ,C1
+onvolledig,incomplete,不完整的,ADJ,B2
+onbegrijpelijk,incomprehensible,不可理解的,ADJ,B2
 inconsistent,inconsistent,不一致的,ADJ,B2
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontestably,incontestably,词,ADV,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increases,increases,增加,NOUN,C1
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
-incremental,incremental,渐进性,ADJ,B2
+gestadig stijgen,to increase steadily,与日俱增,VERB,B2
+steeds,increasingly,越来越,ADV,B2
 incubator,incubator,孵化器,NOUN,B2
-inculcate,inculcate,词,VERB,C1
-incumbent,incumbent,词,ADJ,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-indebted,indebted,负债的,ADJ,B2
-indecent,indecent,词,ADJ,C1
-indecipherable,indecipherable,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
-independently,independently,独立地,ADV,B2
-indeterminate,indeterminate,词,ADJ,C1
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+schuldenlast,indebtedness,负债,NOUN,B2
+onbeslist,indecisive,犹豫不决的,ADJ,B2
+onuitwisbaar,indelible,不可磨灭的,ADJ,B2
+onbeschrijfelijk,indescribable,难以形容的,ADJ,B2
 index,index,索引,NOUN,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
-indexing,indexing,指数化,NOUN,B2
 indicator,indicator,指标,NOUN,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indigent,indigent,词,ADJ,C1
-indignity,indignity,词,NOUN,C1
-indirect,indirect,词,ADJ,C1
-indirectly,indirectly,间接地,ADV,B2
-indiscreet,indiscreet,词,ADJ,C1
-indiscretion,indiscretion,轻率,NOUN,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinct,indistinct,模糊的,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualisme,individualism,个人主义,NOUN,B2
-individually,individually,词,ADV,C1
-individuele opdracht,individual assignment,个人作业,NOUN,B2
-indolent,indolent,词,ADJ,C1
-indomitable,indomitable,词,ADJ,C1
-indoors,indoors,在室内,ADV,B2
-induceren,to induce,引起,VERB,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-indulge,indulge,词,VERB,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrious,industrious,勤劳的,ADJ,B2
-inedible,inedible,词,ADJ,C1
-ineffable,ineffable,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-inefficiënt,inefficient,低效的,ADJ,B2
-inenten,to vaccinate,接种疫苗,VERB,B2
-inenting,vaccination,疫苗接种,NOUN,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inequity,inequity,词,NOUN,C1
-inert,inert,惰性的,ADJ,B2
-inertness,inertness,词,NOUN,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexpressible,inexpressible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infamous,infamous,声名狼藉的,ADJ,B2
-infamy,infamy,恶名,NOUN,B2
-infant,infant,婴儿,NOUN,B2
-infantilism,infantilism,词,NOUN,C1
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-inferential,inferential,词,ADJ,C1
-infertility,infertility,词,NOUN,C1
-infidelity,infidelity,不忠,NOUN,B2
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infinitely,infinitely,词,ADV,B2
-infinitive marker,infinitive marker,去,PART,B2
-infinity,infinity,词,NOUN,C1
-infirmary,infirmary,医务室,NOUN,B2
-inflamed,inflamed,激烈的,ADJ,B2
-inflammable,inflammable,易燃的,ADJ,B2
-inflammation,inflammation,炎症,NOUN,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflated,inflated,膨胀的,ADJ,B1
-inflationary,inflationary,词,ADJ,C1
-inflection,inflection,词尾,NOUN,B2
-influencer,influencer,网红,NOUN,B2
-influential,influential,词,ADJ,C1
-influential person,influential person,词,NOUN,C1
-influx,influx,涌入,NOUN,B2
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
-informant,informant,线人,NOUN,B2
-informatics,informatics,词,NOUN,B2
-information desk,information desk,词,NOUN,B1
-information exchange,information exchange,词,NOUN,B2
-informative,informative,提供信息的,ADJ,B2
-informed,informed,见多识广的,ADJ,B2
-informeel,informal,非正式的,ADJ,B2
-informer,informer,词,NOUN,C1
-informeren,to inquire,询问,VERB,B2
-informers,informers,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructural,infrastructural,词,ADJ,C1
-infringement,infringement,侵犯,NOUN,C1
-ingratitude,ingratitude,词,NOUN,C1
-ingredients,ingredients,词,NOUN,B1
-inharmonious,inharmonious,词,ADJ,C1
+onverschillig,indifferent,冷漠的,ADJ,B2
 inheems,indigenous,本土的,ADJ,B2
+dyspepsie,indigestion,消化不良,NOUN,B2
+ontsteld,indignant,愤慨的,ADJ,B2
+ontsteltenis,indignation,愤慨,NOUN,B2
+onmisbaar,indispensable,不可或缺的,ADJ,B2
+individuele opdracht,individual assignment,个人作业,NOUN,B2
+individualisme,individualism,个人主义,NOUN,B2
+induceren,to induce,引起,VERB,B2
+keten,industry chain,产业链,NOUN,B2
+inefficiënt,inefficient,低效的,ADJ,B2
+ongelijkheid,inequality,不平等,NOUN,B2
+onervaren,inexperienced,生疏的,ADJ,B2
+verliefdheid,infatuation,迷恋,NOUN,B2
+afleiden,to infer,推断,VERB,B2
+gevolgtrekking,inference,推断,NOUN,B2
+oneindig,infinite,无限的,ADJ,B2
+opblazen,to inflate,使膨胀,VERB,B2
+influencer,influencer,网红,NOUN,B2
+informeel,informal,非正式的,ADJ,B2
+informant,informant,线人,NOUN,B2
+schenden,to infringe,侵犯,VERB,B2
+vindingrijk,ingenious,灵巧的,ADJ,B2
+innemen,to ingest,服用,VERB,B2
+bewonen,to inhabit,居住,VERB,B2
+bewoner,inhabitant,居民,NOUN,B2
+inademen,to inhale,吸入,VERB,B2
 inherent,inherent,固有的,ADJ,B2
-inherent (noun),inherent,自有,NOUN,C1
-inherited,inherited,词,ADJ,C1
-inhibited,inhibited,词,ADJ,B2
-inhibition,inhibition,抑制,NOUN,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhuman,inhuman,不人道的,ADJ,B2
-inhumanity,inhumanity,词,NOUN,C1
-inimitability,inimitability,词,NOUN,C1
-initial,initial,花押字,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
-initiation,initiation,词,NOUN,C1
+erven,to inherit,继承,VERB,B2
+erfenis,inheritance,遗产,NOUN,B2
+remmen,to inhibit,抑制,VERB,B2
+aanvankelijk,initially,首先,ADV,B2
 injecteren,to inject,注射,VERB,B2
 injectie,injection,注射,NOUN,B2
-injury recovery,injury recovery,好伤,NOUN,C1
-inkling,inkling,预感,NOUN,B2
-inkomend,incoming,进来的,ADJ,B2
-inkomsten en uitgaven,income and expense,收支,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inleggen,to pickle,腌渍,VERB,B2
-inleven,to empathize,共情,VERB,B2
-inmate,inmate,词,NOUN,C1
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
-innemen,to ingest,服用,VERB,B2
-inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
-inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
+verwonden,to injure,使受伤,VERB,B2
+herberg,inn,小旅馆,NOUN,B2
+aangeboren,innate,天生的,ADJ,B2
 innerlijk,inner,内部的,ADJ,B2
-innermost,innermost,最里面的,ADV,B2
-innocent,innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
-innocuous,innocuous,无害的,ADJ,B2
-innuendo,innuendo,词,NOUN,C1
-inopportune,inopportune,词,ADJ,C1
-inorganic,inorganic,词,ADJ,C1
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
-inquisitive,inquisitive,好奇的,ADJ,B2
-insane,insane,疯狂的,ADJ,B2
-insanely,insanely,疯狂地,ADV,B2
-insatiable,insatiable,不知足的,ADJ,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect,bug,虫子,NOUN,B2
+binnenhof,inner court,朝内,NOUN,B2
+onschuld,innocence,无辜,NOUN,B2
+informeren,to inquire,询问,VERB,B2
+onderzoek,inquiry,调查,NOUN,B2
 insect,insect,昆虫,NOUN,B2
-insect-proof,insect-proof,防虫,ADJ,C1
 insecticide,insecticide,杀虫剂,NOUN,B2
-insecurity,insecurity,不安全感,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensitive,insensitive,麻木的,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
-insertion,insertion,词,NOUN,B2
-inside (adv),inside,在里面,ADV,A1
-inside in,inside in,里,NOUN,B2
-inside of,inside of,在...里面,ADP,B2
-insidiously,insidiously,词,ADV,B2
-insincere,insincere,词,ADJ,C1
-insinuation,insinuation,暗示,NOUN,B2
-insipid,insipid,词,ADJ,C1
-insistence persistence,insistence persistence,词,NOUN,B2
-inslapen,to fall asleep,入睡,VERB,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
-insolent conceit,insolent conceit,词,NOUN,C1
-insolvent,insolvent,无偿还能力的,ADJ,B2
+onveilig,insecure,不安全的,ADJ,B2
+onafscheidelijk,inseparable,不可分割的,ADJ,B2
+invoegen,to insert,插入,VERB,B2
+binnen,inside,在里面,ADV,B2
+binnenstad,inside city,城内,NOUN,B2
+achtergrondverhaal,inside story,内幕,NOUN,B2
+binnenstaander,insider,知情者,NOUN,B2
+voortvarend,insidious,潜伏的,ADJ,B2
+onbeduidend,insignificant,微不足道的,ADJ,B2
+aanhouden,to insist,坚持,VERB,B2
+aanhouden,insistence,坚持,NOUN,B2
+onbeschoftheid,insolence,无礼,NOUN,B2
+onbeschoft,insolent,傲慢的,ADJ,B2
 insolventie,insolvency,无偿付能力,NOUN,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
+slaapeloosheid,insomnia,失眠,NOUN,B2
 inspecteren,to inspect,检查,VERB,B2
-inspectorate,inspectorate,词,NOUN,C1
-inspired,inspired,受启发的,ADJ,B2
-instabiel,unstable,不稳定的,ADJ,B2
-installation assembly,installation assembly,词,NOUN,C1
-installed,installed,词,ADJ,C1
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
-instantaneous,instantaneous,瞬间的,ADJ,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instantly,instantly,词,ADV,C1
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instinctuality,instinctuality,词,NOUN,C1
-institutionalized,institutionalized,词,ADJ,C1
-institutioneel,institutional,机构的,ADJ,B2
-instorten,collapse,倒塌,NOUN,B2
-instorten,to collapse,倒塌,VERB,B2
-instructeren,to instruct,指导,VERB,B2
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructor,instructor,讲师,NOUN,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insufficiency,insufficiency,不足,NOUN,B2
-insulator,insulator,词,NOUN,B2
-insulin,insulin,胰岛素,NOUN,B2
-insult (noun),insult,insult,NOUN,C1
-insurances,insurances,词,NOUN,C1
-insured,insured,词,NOUN,B2
-insurer,insurer,词,NOUN,C1
-insurgency,insurgency,词,NOUN,C1
-intake,intake,词,NOUN,C1
-intangible,intangible,无形的,ADJ,B2
+termijn,installment,分期付款,NOUN,B2
+ogenblik,instant,فور,NOUN,B2
+in plaats daarvan,instead,代替,ADV,B2
 integendeel,instead on the contrary,反而,ADV,B2
-integer,integer,词,NOUN,C1
-integral,integral,不可或缺的,ADJ,B2
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-intellect,intellect,智力,NOUN,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
+institutioneel,institutional,机构的,ADJ,B2
+instructeren,to instruct,指导,VERB,B2
+isolatie,insulation,绝缘,NOUN,B2
+beledigen,insult,辱骂,NOUN,B2
+beledigen,to insult,侮辱,VERB,B2
+onoverkomelijk,insurmountable,不可逾越的,ADJ,B2
+opstand,insurrection,起义,NOUN,B2
+onbeschadigd,intact,完好无损的,ADJ,B2
 intelligent,intelligent,聪明的,ADJ,B2
-intelligently,intelligently,词,ADV,C1
-intelligible,intelligible,词,ADJ,C1
-intemperate,intemperate,词,ADJ,C1
-intended,intended,,NOUN,B2
-intended meaning,intended meaning,词,NOUN,C1
-intensification,intensification,词,NOUN,C1
+voornemen,to intend,打算,VERB,B2
 intensiteit,intensity,强度,NOUN,B2
-intensive care,intensive care,重症监护,NOUN,B2
 intentie,intent,意图,NOUN,B2
-intentionality,intentionality,词,NOUN,C1
-intentionally,intentionally,故意地,ADV,B2
-intentions,intentions,词,NOUN,C1
-interactivity,interactivity,词,NOUN,C1
+opzettelijk,intentional,故意的,ADJ,B2
 intercepteren,to intercept,拦截,VERB,B2
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,interdiction,词,NOUN,C1
-interest rate,interest rate,利率,NOUN,B2
-interesting things,interesting things,词,NOUN,C1
+geslachtsgemeenschap,intercourse,性交,NOUN,B2
 interface,interface,接口,NOUN,B2
-interim (adj),interim,词,ADJ,C1
-interim (noun),interim,词,NOUN,B2
-interjection,interjection,词,NOUN,C1
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
-intermediate,intermediate,中级的,ADJ,B2
-intermission,intermission,词,NOUN,C1
+tussenpersoon,intermediary,中间人,NOUN,B2
 intermittent,intermittent,间歇的,ADJ,B2
-intern,intern,词,NOUN,C1
-internal affairs,internal affairs,内政,NOUN,C1
 internal force,internal force,内力,NOUN,B2
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
 international student,international student,留学生,NOUN,B2
-internationalization,internationalization,词,NOUN,C1
 internet,internet,互联网,NOUN,B2
-interpellation,interpellation,词,NOUN,C1
-interpersonal,interpersonal,人际的,ADJ,B2
 interpreter,interpreter,口译员,NOUN,B2
-interpretive,interpretive,词,ADJ,C1
 interrogation,interrogation,审问,NOUN,B2
-interrogation room,interrogation room,审讯室,NOUN,B2
 interrupt,to interrupt,打断,VERB,B2
-interrupted,interrupted,词,ADJ,B2
-intertextuality,intertextuality,词,NOUN,C1
-intertwined,intertwined,词,ADJ,C1
-interval,interval,词,NOUN,C1
 interview,interview,面试,NOUN,B2
 interview,to interview,采访,VERB,B2
-interviewer,interviewer,词,NOUN,C1
 intestine,intestine,肠,NOUN,B2
-intestines,intestines,词,NOUN,B2
 intimate,intimate,亲密的,ADJ,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimately,intimately,词,ADV,C1
 intimidation,intimidation,恐吓,NOUN,B2
-into (adp),into,词,ADP,A1
-into (adv),into,词,ADV,B1
-intolerable,intolerable,词,ADJ,C1
-intolerant,intolerant,不容忍的,ADJ,B2
 intonation,intonation,语调,NOUN,B2
-intonational quality,intonational quality,词,NOUN,C1
-intoxication,intoxication,词,NOUN,C1
 intractable,intractable,难处理的,ADJ,B2
-intransigence,intransigence,词,NOUN,C1
-intransigent,intransigent,不妥协的,ADJ,B2
-intravenous drip,intravenous drip,输液,NOUN,B2
-intrekken,to move in,搬入,VERB,B2
 intrepid,intrepid,无畏的,ADJ,B2
-intrepidity,intrepidity,词,NOUN,C1
-intricacy,intricacy,词,NOUN,C1
-intricate,intricate,错综复杂的,ADJ,B2
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
 intrinsic,intrinsic,固有的,ADJ,B2
-intrinsically,intrinsically,词,ADV,C1
-introductory,introductory,词,ADJ,C1
-introversion,introversion,词,NOUN,B2
 introverted,introverted,内向的,ADJ,B2
 intruder,intruder,入侵者,NOUN,B2
 intrusion,intrusion,闯入,NOUN,B2
-intrusive,intrusive,词,ADJ,C1
-intuitionist,intuitionist,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-inure,inure,词,VERB,C1
 invade,to invade,入侵,VERB,B2
-invader,invader,入侵者,NOUN,B2
-invalidated,invalidated,词,ADJ,C1
-invariable,invariable,词,ADJ,C1
-invariably,invariably,不变地,ADV,B2
 invention,invention,发明,NOUN,B2
 inventor,inventor,发明家,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigated,investigated,被调查的,ADJ,B2
-investigative,investigative,词,ADJ,C1
 investigator,investigator,调查员,NOUN,B2
-investment (adj),investment,词,ADJ,C1
-invincibility,invincibility,不胜,NOUN,C1
-invincible,invincible,无敌的,ADJ,B2
-inviolate,inviolate,词,ADJ,C1
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite offer,invite offer,词,VERB,A2
-invited,invited,词,ADJ,C1
-invocation,invocation,词,NOUN,C1
-invocations,invocations,词,NOUN,C1
-invoegen,to insert,插入,VERB,B2
 invoice,invoice,发票,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
-involuntary,involuntary,无意识的,ADJ,B2
-invulnerability,invulnerability,词,NOUN,C1
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-inwijden,to inaugurate,启用,VERB,B2
-inwijding,inauguration,开幕,NOUN,B2
-iodine deficiency,iodine deficiency,词,NOUN,C1
-ion,ion,词,NOUN,C1
 irascibility,irascibility,易怒,NOUN,B2
 irascible,irascible,易怒的,ADJ,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰语,NOUN,B2
-irish person,irish person,爱尔兰人,NOUN,B2
-irksome,irksome,词,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
 ironic,ironic,讽刺的,ADJ,B2
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
-irrational,irrational,非理性的,ADJ,B2
 irreconcilable,irreconcilable,不可调和的,ADJ,B2
 irrefutable,irrefutable,无可辩驳的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irregular,irregular,不规则的,ADJ,B2
-irregularity,irregularity,不规则,NOUN,B2
 irrelevant,irrelevant,不相关的,ADJ,B2
-irreligious,irreligious,词,ADJ,C1
-irremediably,irremediably,词,ADV,B2
 irreplaceable,irreplaceable,不可替代的,ADJ,B2
 irreproachable,irreproachable,无可指责的,ADJ,B2
 irresistible,irresistible,不可抗拒的,ADJ,B2
 irresponsible,irresponsible,不负责任的,ADJ,B2
-irretrievable,irretrievable,词,ADJ,C1
 irreversible,irreversible,不可逆转的,ADJ,B2
 irrigatiekanaal,irrigation canal,灌溉渠,NOUN,B2
-irrigation,irrigation,词,NOUN,B2
-irritable boredom,irritable boredom,词,NOUN,C1
-irritatie,irritation,刺激,NOUN,B2
 irriteren,to irritate,激怒,VERB,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamization,islamization,词,NOUN,C1
-islander,islander,词,NOUN,C1
-isolated reports,isolated reports,词,NOUN,C1
-isolatie,insulation,绝缘,NOUN,B2
+irritatie,irritation,刺激,NOUN,B2
 isotoop,isotope,同位素,NOUN,B2
-isthmus,isthmus,词,NOUN,C1
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
-it neuter,it neuter,它 (中性),PRON,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-itinerant,itinerant,巡回的,ADJ,B2
-itinerary,itinerary,行程,NOUN,B2
-its,its,它的,PRON,B2
-its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-jaarlijks,annually,每年,ADV,B2
-jaarverslag,annual report,年报,NOUN,B2
-jack plug,jack plug,词,NOUN,C1
-jackal,jackal,词,NOUN,B2
-jade,jade,这玉,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
-jadeite,jadeite,翡翠,NOUN,C1
-jadewerk,jade ware,玉器,NOUN,B2
-jail,jail,监狱,NOUN,B2
-jailer,jailer,词,NOUN,B2
-jaloers,envious,嫉妒的,ADJ,B2
-jaloersheid,jealousy,嫉妒,NOUN,B2
-jam,jam,果酱,NOUN,B2
-janitor,janitor,词,NOUN,B2
-jargon,jargon,行话,NOUN,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jarring,jarring,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jasmine tea,jasmine tea,词,NOUN,C1
-jaws,jaws,词,NOUN,C1
-je best doen,to do one's best,尽力,VERB,B2
-jeans,jeans,牛仔裤,NOUN,B2
-jersey,jersey,词,NOUN,B1
-jest,jest,词,NOUN,C1
-jet,jet,喷气式飞机,NOUN,B2
-jet-black,jet-black,乌黑,ADJ,B2
-jeuk,itching,瘙痒,NOUN,B2
+Italiaan,italian,意大利人,NOUN,B2
 jeukken,itch,痒,NOUN,B2
 jeukken,to itch,发痒,VERB,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jeweler,jeweler,词,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewelry set,jewelry set,词,NOUN,C1
-jewelry store,jewelry store,珠宝店,NOUN,B2
-jews,jews,犹太人,NOUN,B2
+jeuk,itching,瘙痒,NOUN,B2
+detail,its details,其详,NOUN,B2
+jade,jade,这玉,NOUN,B2
+jadewerk,jade ware,玉器,NOUN,B2
+jam,jam,果酱,NOUN,B2
+Japanner,japanese,日本人,NOUN,B2
+pot,jar,广口瓶,NOUN,B2
+jargon,jargon,行话,NOUN,B2
+geelzucht,jaundice,黄疸,NOUN,B2
+kaak,jaw,下巴,NOUN,B2
+jaloersheid,jealousy,嫉妒,NOUN,B2
+juweel,jewel,宝石,NOUN,B2
 jianghu,jianghu,江湖,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
 jiaolong,jiaolong,娇龙,NOUN,B2
 jin,jin,斤,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocular,jocular,词,ADJ,C1
-jocularity,jocularity,词,NOUN,B2
-jog,jog,词,VERB,A1
-joggen,to run to jog,跑步,VERB,B2
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,生活乐趣,NOUN,B2
-joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-joker,joker,词,NOUN,C1
-joking,joking,词,NOUN,B2
-jong,cub,幼兽,NOUN,B2
-jongeling,youngster,年少者,NOUN,B2
-jongheer,young master,少庄主,NOUN,B2
-journal,journal,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
+toetreden,to join,加入,VERB,B2
+gemeenschappelijk eigendom,joint ownership,共有,NOUN,B2
+grappen,to joke,开玩笑,VERB,B2
 journalist,journalist,记者,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-journeying,journeying,词,NOUN,C1
-joust,joust,词,NOUN,B1
-jubel,exultation,欢腾,NOUN,B2
-jubilant,jubilant,词,ADJ,C1
-jubilation,jubilation,欢欣,NOUN,B2
+reis,journey,旅程,NOUN,B2
+blij,joyful,快乐的,ADJ,B2
 jubileum,jubilee,禧年,NOUN,B2
-judge sentence,judge sentence,词,VERB,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
-juichen,to exult,狂喜,VERB,B2
-juist,right,正确的,ADJ,B2
-juist,just right,恰到好处,ADV,B2
-jujube,jujube,枣子,NOUN,B2
-jumble,jumble,词,NOUN,B2
-junction,junction,词,NOUN,C1
-juncture,juncture,词,NOUN,B2
+gerechtelijk,judicial,司法的,ADJ,B2
+gerechtswezen,judiciary,司法官,NOUN,B2
 jungle,jungle,丛林,NOUN,B2
-jungles,jungles,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junkie,junkie,词,NOUN,C1
-junta,junta,词,NOUN,C1
-jurisconsult,jurisconsult,法学专家,NOUN,B2
 jurisdictie,jurisdiction,管辖权,NOUN,B2
-jurist,jurist,法学家,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
-jury,jury,陪审团,NOUN,B2
-jury service,jury service,陪审,NOUN,C1
+rechtsgebied,jurisdiction area,辖区,NOUN,B2
 jurylid,juror,陪审员,NOUN,B2
-just,just,公正,ADJ,B2
-just as,just as,词,ADV,A2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
-justified,justified,有根据的,ADJ,B2
-justness,justness,公正,NOUN,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
-juweel,jewel,宝石,NOUN,B2
-juxtapose,juxtapose,词,VERB,C1
-kaak,jaw,下巴,NOUN,B2
-kaart,map,地图,NOUN,B2
-kade,quay,码头,NOUN,B2
-kaleidoscope,kaleidoscope,词,NOUN,B2
-kalf,calf,小腿,NOUN,B2
-kalibratie,calibration,校准,NOUN,B2
-kalligrafie,calligraphy,书法,NOUN,B2
-kameel,camel,骆驼,NOUN,B2
-kamergenoot,roommate,室友,NOUN,B2
-kammen,to comb,梳头,VERB,B2
-kandidatuur,candidacy,候选资格,NOUN,B2
-kaneel,cinnamon,肉桂,NOUN,B2
-kanon,cannon,大炮,NOUN,B2
-kap,cape,海角,NOUN,B2
-kapotgaan,to break down,分解,VERB,B2
-kapsel,hairstyle,发型,NOUN,B2
-kar,carriage,马车,NOUN,B2
+zoals in het verleden,just as in the past,一如既往,ADV,B2
+juist,just right,恰到好处,ADV,B2
+rechtvaardigen,to justify,证明...正当,VERB,B2
 karate,karate,空手道,NOUN,B2
-kasbah,kasbah,词,NOUN,B1
-kastanje,chestnut,板栗,NOUN,B2
-kauwgom,chewing gum,口香糖,NOUN,B2
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenly,keenly,词,ADV,C1
-keenness,keenness,词,NOUN,B2
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-keer,times,倍,NOUN,B2
-kegel,cone,圆锥体,NOUN,B2
-keizerin,empress,女皇,NOUN,B2
-keizerlijk,imperial,帝国的,ADJ,B2
-keizerlijk hof,imperial court,朝廷,NOUN,B2
-keizerlijke garde,imperial guard,御林,NOUN,B2
-keizerlijke verwanten,imperial relatives,皇亲,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kenmerk,trait,特征,NOUN,B2
-kenner,connoisseur,行家,NOUN,B2
-kentekenplaatbeperking,license plate restriction,限号,NOUN,B2
-kept,kept,词,ADJ,B2
-kerel,fellow,家伙,NOUN,B2
-kerkelijk,ecclesiastical,教会的,ADJ,B2
-kerosene,kerosene,火油,NOUN,C1
-kers,cherry,樱桃,NOUN,B2
-ketel,boiler,锅炉,NOUN,B2
 ketel,kettle,水壶,NOUN,B2
-keten,industry chain,产业链,NOUN,B2
-ketter,heretic,异端,NOUN,B2
-ketterij,heresy,异端,NOUN,B2
-key point,key point,要点,NOUN,C1
-khul',khul',女方离婚,NOUN,C1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kidnapper,kidnapper,绑架者,NOUN,B2
-kids,kids,孩子,NOUN,B2
-kiem,germ,病菌,NOUN,B2
-kieming,germination,发芽,NOUN,B2
-kiezersdistrict,constituency,选区,NOUN,B2
-kijk naar jou,look at you,你看你,NOUN,B2
-killed,killed,词,NOUN,B2
-killing,killing,词,NOUN,B2
+kind,kid,小孩,NOUN,B2
+nier,kidney,肾脏,NOUN,B2
+twee vliegen in één klap,kill two birds with one stone,一举两得,ADJ,B2
+moordenaar,killer,杀手,NOUN,B2
 kilogram,kilogram,千克,NOUN,B2
 kilometer,kilometer,公里,NOUN,B2
-kin,chin,下巴,NOUN,B2
-kin,kin,词,NOUN,B2
-kind,kid,小孩,NOUN,B2
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kinderachtig,childish,幼稚的,ADJ,B2
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindly,kindly,亲切地,ADV,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
+vriendelijk,kind,仁慈的,ADJ,B2
+vriendelijkheid,kindness,仁慈,NOUN,B2
 kinetisch,kinetic,运动的,ADJ,B2
-king,king,王,PART,B2
-kiosk,kiosk,亭子,NOUN,B2
-kist,coffin,棺材,NOUN,B2
-kist,crate,板条箱,NOUN,B2
-kit,kit,词,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
-kitten,kitten,小猫,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-klaar zijn,to be done,被做,VERB,B2
-klacht,grievance,弊端,NOUN,B2
-klan,clan,家族,NOUN,B2
-klassieker,classic,经典作品,NOUN,B2
-kleding,attire,服装,NOUN,B2
-kledingstuk,garment,服装,NOUN,B2
-kleed,carpet,地毯,NOUN,B2
-kleedkamer,locker room,更衣室,NOUN,B2
-klein,tiny,微小的,ADJ,B2
-kleindochter,granddaughter,孙女,NOUN,B2
-klem,clamp,夹钳,NOUN,B2
-kleur,color,颜色,NOUN,B2
-klomp,lump,块,NOUN,B2
-kloof,rift,裂痕,NOUN,B2
-kluis,safe,保险箱,NOUN,B2
-knack,knack,窍,NOUN,C1
-knal,bang,巨响,NOUN,B2
-knarsen,to crunch,嘎吱作响,VERB,B2
-kneader,kneader,词,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-kneerigheid,servility,奴性,NOUN,B2
-knetteren,to crackle,噼啪作响,VERB,B2
-knieën,to squat,蹲,VERB,B2
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knijpen,pinch,捏,NOUN,B2
-knijpen,to pinch,捏,VERB,B2
-knijpen,to squeeze,挤压,VERB,B2
-knipperen,to wink,眨眼,VERB,B2
-knock,knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-knoflook,garlic,大蒜,NOUN,B2
+verwantschap,kinship,亲属关系,NOUN,B2
+vlieger,kite,风筝,NOUN,B2
 knoop,knot,结,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledgeably,knowledgeably,词,ADV,C1
-known famous,known famous,著名的/熟悉的,ADJ,B2
-knuffelen,to hug,拥抱,VERB,B2
-koeltjes,coldly,冷淡地,ADV,B2
-koepel,dome,圆顶,NOUN,B2
-koesteren,to cherish,珍爱,VERB,B2
-kohl,kohl,词,NOUN,A1
-koken,boiling,沸腾,NOUN,B2
-kolf,flask,小瓶,NOUN,B2
-kolom,column,列,NOUN,B2
-kolonialisme,colonialism,殖民主义,NOUN,B2
-kom en ga,coming and going,往来,NOUN,B2
-komeet,comet,彗星,NOUN,B2
-komen van,to come from,来自,VERB,B2
-komisch,comic,喜剧的,ADJ,B2
-komkommer,cucumber,黄瓜,NOUN,B2
-kompas,compass,指南针,NOUN,B2
-komst,coming,مجيء,NOUN,B2
-kool,cabbage,卷心菜,NOUN,B2
-koolstof,carbon,碳,NOUN,B2
-koolstoftaks,carbon tax,碳税,NOUN,B2
-kop,heading,标题,NOUN,B2
-koppelaar,matchmaker,媒,NOUN,B2
-koppeling,clutch,离合器,NOUN,B2
-koppig,obstinate,固执的,ADJ,B2
-kortetermijn,short-term,短期的,ADJ,B2
-kostbaarheid,preciousness,珍贵,NOUN,B2
-kosten,expense,费用,NOUN,B2
-kosten,expenses,费用,NOUN,B2
-kosten,fees,酬金,NOUN,B2
-kostschool,boarding school,寄宿学校,NOUN,B2
-koud bloed,cold blood,冷血,NOUN,B2
-koudegolf,cold wave,寒潮,NOUN,B2
-kraag,collar,衣领,NOUN,B2
-kraai,crow,乌鸦,NOUN,B2
-kraam,booth,摊位,NOUN,B2
-kraan,crane,起重机,NOUN,B2
-krab,crab,螃蟹,NOUN,B2
-krabben,to scratch,抓,VERB,B2
-krater,crater,火山口,NOUN,B2
-krediet,credit,信用,NOUN,B2
-kreeft,lobster,龙虾,NOUN,B2
-kreunen,moan,呻吟,NOUN,B2
-kreunen,to groan,呻吟,VERB,B2
-kreunen,to moan,呻吟,VERB,B2
-kristal,crystal,水晶,NOUN,B2
-kritikaliteit,criticality,临界性,NOUN,B2
-kritiseren,to criticize,批评,VERB,B2
-krommen,to crouch,蹲下,VERB,B2
-kronen,to crown,加冕,VERB,B2
-kruiden,to season,调味,VERB,B2
-kruimelen,to crumble,粉碎,VERB,B2
-kruin,crest,顶峰,NOUN,B2
-kruispunt,crossroads,十字路口,NOUN,B2
-kruk,crutch,拐杖,NOUN,B2
-kubus,cube,立方体,NOUN,B2
-kudde,flock,兽群,NOUN,B2
-kudde,herd,兽群,NOUN,B2
-kuiken,chick,小鸡,NOUN,B2
-kunnen,be able to,能,AUX,B2
-kunnen,to be able to,能够,VERB,B2
-kunstgalerij,art gallery,美术馆,NOUN,B2
-kussen,pad,垫,NOUN,B2
-kwaad,evil,恶行,NOUN,B2
-kwalificaties,qualifications,资格,NOUN,B2
-kwalitatief,qualitative,定性的,ADJ,B2
-kwartaal,quarter of a year,季度,NOUN,B2
-kwartaaltijdschrift,quarterly magazine,季刊,NOUN,B2
-kwartel,quail,鹌鹑,NOUN,B2
-kwelling,agony,极度痛苦,NOUN,B2
-kwik,mercury,汞,NOUN,B2
-laagwater,low tide,退潮,NOUN,B2
-laat staan,let alone,别说,ADV,B2
-laazima,laazima,词,NOUN,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labor-related,labor-related,词,ADJ,C1
-laboratory (adj),laboratory,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laborious striving,laborious striving,词,NOUN,C1
-laboriously,laboriously,词,ADV,C1
-labour market,labour market,词,NOUN,B1
-labyrinth,labyrinth,词,NOUN,C1
-labyrinthine,labyrinthine,词,ADJ,C1
-lace,lace,词,NOUN,C1
-lach,your laugh,你笑,NOUN,B2
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-laconically,laconically,词,ADV,C1
+herkennen,to know to recognize,认识,VERB,B2
+ontbreken,to lack,缺乏,VERB,B2
 laconisch,laconic,简洁的,ADJ,B2
-laconism,laconism,简洁,NOUN,B2
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-lading,cargo,货物,NOUN,B2
-ladle,ladle,词,NOUN,A2
-laf,cowardly,懦弱的,ADJ,B2
-lafaard,coward,懦夫,NOUN,B2
-lafheid,cowardice,懦弱,NOUN,B2
-lagoon,lagoon,词,NOUN,C1
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
 lam,lamb,羔羊,NOUN,B2
-lam braden,to roast lamb,烤羊,VERB,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lament (noun),lament,词,NOUN,C1
-lamentable,lamentable,词,ADJ,C1
-lamp niche,lamp niche,词,NOUN,C1
-lampoon,lampoon,词,NOUN,C1
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
 land,land,土地,NOUN,B2
-land (adj),land,بري,ADJ,B2
-land expansion,land expansion,拓土,NOUN,B2
-land register,land register,地籍,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landbouw,farming,农业,NOUN,B2
-landfill,landfill,填埋,NOUN,C1
-landgenoot,compatriot,同胞,NOUN,B2
-landgoed,manor,庄园,NOUN,B2
-landhuis,mansion,豪宅,NOUN,B2
 landing,landing,着陆,NOUN,B2
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landmine,landmine,词,NOUN,C1
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
-landschap,scenery,风景,NOUN,B2
-lang,tall,高的,ADJ,B2
-lang wachten,to wait long,久等,VERB,B2
-lange tijd,long time,长时间,ADV,B2
-language use,language use,语言使用,NOUN,B2
-languid,languid,词,ADJ,C1
-languor,languor,倦怠,NOUN,B2
-lapse,lapse,疏忽,NOUN,B2
-lapse of time,lapse of time,词,NOUN,C1
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large estate,large estate,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
-large-scale (noun),large-scale,大举,NOUN,C1
-larger,larger,再大,NOUN,B2
-larva,larva,幼虫,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
-lassen,welding,焊接,NOUN,B2
-lassitude,lassitude,词,NOUN,C1
-last (num),last,词,NUM,A2
-last evening,last evening,,NOUN,B2
-last name,last name,姓,NOUN,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
-lasting,lasting,词,ADJ,C1
-late,late,晚才,NOUN,B2
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-laten vallen,to drop,掉落,VERB,B2
+verhuurder,landlord,房东,NOUN,B2
+aardverschuiving,landslide,滑坡,NOUN,B2
+strook,lane,小巷,NOUN,B2
+ronde,lap,大腿部,NOUN,B2
+strottenhoofd,larynx,喉,NOUN,B2
+eindelijk,last,最后,ADV,B2
+duren,to last a period of time,为期,VERB,B2
+vorig jaar,last year,去年,NOUN,B2
+vertraging,late,晚,ADV,B2
 later,later,后来,ADV,B2
-later,afterward,去后,NOUN,B2
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
-lateral side,lateral side,词,ADJ,C1
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin,latin,拉丁语,NOUN,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latitude leeway,latitude leeway,词,NOUN,C1
-laudable,laudable,词,ADJ,C1
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,洗钱,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
+gelach,laughter,笑声,NOUN,B2
 laundry,laundry,洗衣,NOUN,B2
-laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
 laundry room,laundry room,洗衣房,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
 lava,lava,熔岩,NOUN,B2
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
 law enforcement,law enforcement,执法,NOUN,B2
-law firm,law firm,律师事务所,NOUN,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
 lawful,lawful,合法的,ADJ,B2
-lawine,avalanche,雪崩,NOUN,B2
-lawlessness,lawlessness,词,NOUN,C1
 lawn,lawn,草坪,NOUN,B2
-lawnmower,lawnmower,割草机,NOUN,B2
 lawsuit,lawsuit,诉讼,NOUN,B2
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lawyer female,lawyer female,词,NOUN,B2
 lax,lax,松懈的,ADJ,B2
-laxative,laxative,词,NOUN,C1
-laxity,laxity,松弛,NOUN,B2
-lay,lay,叙事短诗,NOUN,B2
-lay (adj),lay,词,ADJ,C1
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
-layer storage,layer storage,层/仓库,NOUN,B2
 layoff,layoff,解雇,NOUN,B2
-layperson,layperson,外行,NOUN,B2
 laziness,laziness,懒惰,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
-lead actor,lead actor,主演,NOUN,B2
 lead thousand,lead thousand,率千,NOUN,B2
 lead to,to lead to,通向,VERB,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
-leading (noun),leading,正带,NOUN,C1
-leaf litter,leaf litter,词,NOUN,C1
-leaf page,leaf page,叶子,NOUN,B2
-leafiness,leafiness,词,NOUN,C1
 leaflet,leaflet,传单,NOUN,B2
-leafy,leafy,枝叶茂密的,ADJ,B2
 leak,to leak,泄漏,VERB,B2
-leak escape,leak escape,词,NOUN,B1
 lean,to lean,倾斜,VERB,B2
 leap,leap,跳跃,NOUN,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
 learning,learning,学习,NOUN,B2
-learning curve,learning curve,学习曲线,NOUN,B2
 lease,lease,租约,NOUN,B2
-leash,leash,词,NOUN,B2
-leasing,leasing,词,NOUN,C1
-least (adj),least,词,ADJ,A1
 leather,leather,皮革,NOUN,B2
-leather goods,leather goods,词,NOUN,C1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
 leave out,to leave out,省略,VERB,B2
 lecture,to lecture,教导,VERB,B2
-led astray,led astray,词,ADJ,C1
-leegte,emptiness,空虚,NOUN,B2
-leek,leek,词,NOUN,A2
-leerboek,textbook,教科书,NOUN,B2
-leerling,apprentice,学徒,NOUN,B2
-leerperiode,apprenticeship,学徒期,NOUN,B2
 left,left,左边,ADV,B2
-left (noun),left,左,NOUN,A1
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
 left side,left side,左侧,NOUN,B2
-left-handed,left-handed,词,ADJ,C1
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leftovers,leftovers,剩菜,NOUN,B2
-leg of lamb,leg of lamb,词,NOUN,B1
 legacy,legacy,遗产,NOUN,B2
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal expert,legal expert,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
-legal representative,legal representative,词,NOUN,C1
 legality,legality,合法性,NOUN,B2
-legalization,legalization,词,NOUN,C1
 legally,legally,合法地,ADV,B2
-legatee,legatee,受遗赠人,NOUN,B2
-leger,military,军队,NOUN,B2
-legering,alloy,合金,NOUN,B2
-legible,legible,词,ADJ,C1
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legion unit,legion unit,,NOUN,B2
-legislative elections,legislative elections,词,NOUN,C1
-legislator,legislator,词,NOUN,C1
-legislature,legislature,立法机关,NOUN,B2
 legitimacy,legitimacy,合法性,NOUN,B2
-legitimization,legitimization,词,NOUN,B2
-leiden,conduct,行为,NOUN,B2
-leiden,to conduct,أجرى,VERB,B2
 leisure,leisure,闲暇,NOUN,B2
-leisurely,leisurely,词,ADJ,C1
-lemmet,blade,刀片,NOUN,B2
 lemon,lemon,柠檬,NOUN,B2
-lemon verbena,lemon verbena,词,NOUN,B2
-lemonade,lemonade,词,NOUN,A2
 lend,to lend,借出,VERB,B2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-lengthy,lengthy,词,ADJ,C1
 leniency,leniency,宽厚,NOUN,B2
 lenient,lenient,宽大的,ADJ,B2
-lening,borrowing,借贷,NOUN,B2
-lens,lens,词,NOUN,C1
-lent,lent,大斋期,NOUN,B2
-lentig,vernal,春季的,ADJ,B2
-lentil lens,lentil lens,词,NOUN,C1
-lentils,lentils,词,NOUN,A2
-lesbian,lesbian,女同性恋的,ADJ,B2
-lesion,lesion,病变,NOUN,B2
-less,less,较少的,ADJ,B2
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
 lest,lest,唯恐,SCONJ,B2
 let,let,让,AUX,B2
-let alone (cconj),let alone,何况,CCONJ,B1
-lethal,lethal,致命的,ADJ,B2
-lethality,lethality,词,NOUN,C1
-lethargic,lethargic,昏睡的,ADJ,B2
-lethargy,lethargy,词,NOUN,C1
-letten,to mind,介意,VERB,B2
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
+laat staan,let alone,别说,ADV,B2
+lexicologie,lexicology,词汇学,NOUN,B2
+aansprakelijkheid,liability,责任,NOUN,B2
+liaison,liaison,联络,NOUN,B2
 leugenaar,liar,骗子,NOUN,B2
-leuning,railing,栏杆,NOUN,B2
-leuningstoel,armchair,扶手椅,NOUN,B2
+liberalisme,liberalism,自由主义,NOUN,B2
+liberalisering,liberalization,自由化,NOUN,B2
+kentekenplaatbeperking,license plate restriction,限号,NOUN,B2
+ontucht,licentiousness,放荡,NOUN,B2
+likken,to lick,舔,VERB,B2
+lid,lid,盖子,NOUN,B2
+neerliggen,to lie down,躺,VERB,B2
 leven,life,生命,NOUN,B2
 leven en dood,life and death,生死,NOUN,B2
-leven en dood,life-and-death,决生,NOUN,B2
-leven wagen,to risk life,拼命,VERB,B2
-levendig,vivid,生动的,ADJ,B2
-levensduur,lifetime,一生,NOUN,B2
 levenslange gevangenisstraf,life imprisonment,无期徒刑,NOUN,B2
 levenslange straf,life retribution,偿命,NOUN,B2
-lever,lever,词,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-leverage,leverage,词,NOUN,B2
-leverancier,supplier,供应商,NOUN,B2
-leveren,supply,供应,NOUN,B2
-leveren,to supply,供货,VERB,B2
-levity,levity,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-lexical,lexical,词,ADJ,C1
-lexicologie,lexicology,词汇学,NOUN,B2
-lezing,reading,阅读,NOUN,B2
-liabilities,liabilities,词,NOUN,C1
-liable,liable,有责任的,ADJ,B2
-liaison,liaison,联络,NOUN,B2
-libel,libel,词,NOUN,C1
-liberalisering,liberalization,自由化,NOUN,B2
-liberalisme,liberalism,自由主义,NOUN,B2
-libertinism,libertinism,放荡,NOUN,B2
-liberty,liberty,词,NOUN,B2
-librarian,librarian,图书管理员,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licensor,licensor,词,NOUN,C1
-lichamelijk,bodily,身体上的,ADJ,B2
-lichen,lichen,词,NOUN,B2
+leven en dood,life-and-death,决生,NOUN,B2
+levensduur,lifetime,一生,NOUN,B2
+optillen,to lift,举起,VERB,B2
+aansteker,lighter,打火机,NOUN,B2
+vuurtoren,lighthouse,灯塔,NOUN,B2
 lichtheid,lightness,轻盈,NOUN,B2
-lid,lid,盖子,NOUN,B2
-liefde,sweetheart,爱人,NOUN,B2
-liefdevol,affectionate,深情的,ADJ,B2
-liefhebben,to love,爱,VERB,B2
-life (part),life,生,PART,A2
-life connection,life connection,连命,NOUN,C1
-life sentence,life sentence,无期徒刑,NOUN,B2
-life span,life span,寿命,NOUN,B1
-lifeguard,lifeguard,词,NOUN,B2
-lifeless,lifeless,无生命的,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
-light (adj),light,清淡,ADJ,B1
-light blue,light blue,词,ADJ,A1
-light bulb,light bulb,词,NOUN,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,词,NOUN,A1
-lightest,lightest,最轻,NOUN,C1
-lighting,lighting,词,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
-ligpositie,reclining,躺下,NOUN,B2
-lijfwacht,bodyguard,保镖,NOUN,B2
-lijkaam zien,to see corpse,见尸,VERB,B2
-lijken,to resemble,像,VERB,B2
-like,like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like as,like as,如同/好像,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,词,ADV,B1
-likeable,likeable,词,ADJ,C1
-likely (adj),likely,词,ADJ,A1
-likely (adv),likely,词,ADV,A1
-likely source,likely source,词,NOUN,C1
-likeur,liquor,烈酒,NOUN,B2
-likken,to lick,舔,VERB,B2
-lily,lily,百合,NOUN,B2
-limb,limb,肢体,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
-limit border,limit border,界限,NOUN,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
+als,like,像,ADP,B2
+gelijkenis,likeness,就象,NOUN,B2
+evenzo,likewise,同样地,ADV,B2
 limoen,lime,石灰,NOUN,B2
-limpidity,limpidity,词,NOUN,C1
-line queue,line queue,词,NOUN,B1
-lineages,lineages,词,NOUN,C1
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-linguist,linguist,词,NOUN,C1
-linguistic intuition,linguistic intuition,词,NOUN,C1
-lining understudy,lining understudy,词,NOUN,B1
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linkage (noun),linkage,词,NOUN,C1
-linking,linking,词,NOUN,C1
+hinkelen,to limp,跛行,VERB,B2
+opstellen,to line up,排成一行,VERB,B2
+stam,lineage,血统,NOUN,B2
 linnen,linen,线麻,NOUN,B2
+taalkunde,linguistics,语言学,NOUN,B2
 lip,lip,嘴唇,NOUN,B2
-lip service,lip service,词,NOUN,C1
 lippenstift,lipstick,口红,NOUN,B2
 liquidatie,liquidation,清算,NOUN,B2
 liquiditeit,liquidity,流动性,NOUN,B2
-lisp (noun),lisp,词,NOUN,C1
-list,artifice,诡计,NOUN,B2
-listen (intj),listen,词,INTJ,B2
-listen up,listen up,听着,INTJ,B2
-listener,listener,听众,NOUN,B2
-listening,listening,也听,NOUN,B2
-listig,cunning,狡猾的,ADJ,B2
-listing,listing,词,NOUN,C1
-listless,listless,词,ADJ,C1
-litanies,litanies,词,NOUN,C1
+likeur,liquor,烈酒,NOUN,B2
+opsommen,to list,列举,VERB,B2
+aandachtig luisteren,to listen attentively,倾听,VERB,B2
 liter,liter,升,NOUN,B2
-literalism,literalism,词,NOUN,C1
-literally,literally,字面上地,ADV,B2
-literariness,literariness,词,NOUN,C1
-literary thefts,literary thefts,词,NOUN,C1
-lithe,lithe,词,ADJ,C1
-lithography,lithography,词,NOUN,C1
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litotes understatement,litotes understatement,词,NOUN,C1
-litteken,scar,疤痕,NOUN,B2
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
-little,little,少,DET,B2
-little (adj),little,词,ADJ,A1
-little (adv),little,词,ADV,A2
-little bitch,little bitch,小婊子,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
-little girl,little girl,词,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little thing,little thing,词,NOUN,B2
-liturgy,liturgy,词,NOUN,C1
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
-lizard,lizard,蜥蜴,NOUN,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loading,loading,词,NOUN,B2
-loanword,loanword,外来词,NOUN,C1
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,词,ADJ,C1
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
-local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locker,locker,词,NOUN,C1
-locksmith,locksmith,词,NOUN,C1
-locomotive,locomotive,词,NOUN,C1
-lodges,lodges,道堂,NOUN,C1
-loft,loft,词,NOUN,C1
-loftiness,loftiness,高尚,NOUN,C1
-logarithm,logarithm,词,NOUN,C1
-logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logistical,logistical,词,ADJ,C1
-logistics (adj),logistics,词,ADJ,C1
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
+procespartij,litigant,诉讼当事人,NOUN,B2
+elfje,little eleven,小十一,NOUN,B2
+negentje,little nine,小九,NOUN,B2
+vee,livestock,家畜,NOUN,B2
+brood,loaf,一条面包,NOUN,B2
+kreeft,lobster,龙虾,NOUN,B2
 lokaliseren,to locate,定位,VERB,B2
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,,NOUN,B2
-long absence,long absence,久违,NOUN,C1
-long lease,long lease,词,NOUN,C1
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance runner,long-distance runner,长跑运动员,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longest,longest,أطول,NOUN,B1
-longevity,longevity,词,NOUN,C1
-loodrecht,perpendicular,垂直的,ADJ,B2
-loofah,loofah,丝瓜,NOUN,C1
-looi,tanning,晒黑,NOUN,B2
-looiër,tanner,制革工,NOUN,B2
-look around,look around,词,VERB,C1
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loon,wages,工资,NOUN,B2
-loop,loop,循环,NOUN,B2
-loop,run,跑步,NOUN,B2
-loopholes,loopholes,词,NOUN,C1
-loopneus,runny nose,流鼻涕,NOUN,B2
-loose thread,loose thread,线头,NOUN,B2
-looseness,looseness,词,NOUN,C1
-looting,looting,掠夺,NOUN,B2
-lopen,running,进行中的,NOUN,B2
-loper,runner,跑步者,NOUN,B2
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
-lord god,lord god,上帝,NOUN,B2
-lordship,lordship,词,NOUN,C1
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
-losgeld,ransom,赎金,NOUN,B2
-loskomen,to get rid of,摆脱,VERB,B2
-loslaten,to unleash,释放,VERB,B2
-losmaken,to detach,分离,VERB,B2
+vergrendelen,to lock,锁上,VERB,B2
+afsluiten,to lockdown,封城,VERB,B2
+kleedkamer,locker room,更衣室,NOUN,B2
+onderdak,lodging,住宿,NOUN,B2
+verheven,lofty,崇高的,ADJ,B2
+houtblok,log,日志,NOUN,B2
+lange tijd,long time,长时间,ADV,B2
+touringcar,long-distance bus,长途车,NOUN,B2
+verlangen,longing,渴望,NOUN,B2
+zorgen voor,to look after,照料,VERB,B2
+kijk naar jou,look at you,你看你,NOUN,B2
+neerkijken op,to look down upon,看不起,VERB,B2
+zoeken,to look for,寻找,VERB,B2
+zoeken om te vinden,to look for to find,找,VERB,B2
+uitkijk,lookout,瞭望,NOUN,B2
+achterdeur,loophole,漏洞,NOUN,B2
 losmaken,to loosen,放松,VERB,B2
-losmaking,detachment,脱落,NOUN,B2
-losses,losses,词,NOUN,B1
-lost tradition,lost tradition,失传,NOUN,C1
-lotar,lotar,词,NOUN,C1
+heer,lord,领主,NOUN,B2
+heer Yu,lord yu,玉大人,NOUN,B2
+woorden van de heer,lord's words,主说,NOUN,B2
+verlies,lose,上丢,NOUN,B2
 loterij,lottery,彩票,NOUN,B2
-lots,lots,大量,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
-loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
 lounge,lounge,休息室,NOUN,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-lovely,lovely,美好的,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
+waardeloos,lousy,糟糕的,ADJ,B2
+liefhebben,to love,爱,VERB,B2
+minnaar,lover,爱人,NOUN,B2
+laagwater,low tide,退潮,NOUN,B2
 loyaliteit,loyalty,忠诚,NOUN,B2
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucht,aerial,航空的,ADJ,B2
-luchtafweer,air defense,防空,NOUN,B2
-lucid,lucid,词,ADJ,C1
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck turn,luck turn,词,NOUN,A2
-lucky (noun),lucky,吉祥,NOUN,B2
-lucky find,lucky find,意外发现,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucrative,lucrative,有利可图的,ADJ,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-luier,diaper,尿布,NOUN,B2
-lukewarm,lukewarm,微温的,ADJ,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-lullaby,lullaby,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-luminous,luminous,发光的,ADJ,B2
-lump in throat,lump in throat,词,NOUN,C1
-lunar,lunar,词,ADJ,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunatic,lunatic,疯子,NOUN,B2
+geluk,luck,运气,NOUN,B2
+gelukkig,lucky,幸运的,ADJ,B2
+geluksstreep,lucky chance,虽侥,NOUN,B2
+klomp,lump,块,NOUN,B2
 lunch,lunch,午餐,NOUN,B2
-lunch break,lunch break,午休,NOUN,B2
-lupini beans,lupini beans,词,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
-lurid,lurid,词,ADJ,C1
-lust,lust,欲望,NOUN,B2
-lute,lute,词,NOUN,C1
-lychee,lychee,荔枝,NOUN,C1
+aas,lure,诱惑,NOUN,B2
+glans,luster,光泽,NOUN,B2
 lymf,lymph,淋巴,NOUN,B2
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyre,lyre,词,NOUN,B2
-lyricism,lyricism,词,NOUN,C1
-maagd,maiden,少女,NOUN,B2
-maagpijn,stomachache,肚子痛,NOUN,B2
-maandelijks,monthly,每月的,ADJ,B2
-maandelijks examen,monthly exam,月考,NOUN,B2
-maankoek,mooncake,月饼,NOUN,B2
-maanmaand,month moon,月,NOUN,B2
-maar,but,然而,ADV,B2
-maar ik,but i,可我,ADV,B2
-maar jij,but you,但您,NOUN,B2
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machination,machination,词,NOUN,C1
-machine learning,machine learning,机器学习,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-machinery,machinery,词,NOUN,C1
-macht,might,威力,NOUN,B2
-macro,macro,宏观,ADJ,C1
-mad,mad,词,ADJ,A1
-made,made,制成的,ADJ,B2
-maelstrom,maelstrom,词,NOUN,C1
-mafia,mafia,黑手党,NOUN,B2
-magically,magically,魔法地,ADV,B2
-magistrate,magistrate,法官,NOUN,B2
-magnanimous,magnanimous,宽宏大量的,ADJ,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
+tekst,lyrics,歌词,NOUN,B2
+gek,madman,疯子,NOUN,B2
+goochelaar,magician,魔术师,NOUN,B2
 magneet,magnet,磁铁,NOUN,B2
-magnesium,magnesium,镁,NOUN,B2
-magnetic,magnetic,磁的,ADJ,B2
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
-magnifying glass,magnifying glass,词,NOUN,C1
-magnitude,magnitude,词,NOUN,C1
-magus,magus,词,NOUN,C1
-maieutic,maieutic,词,ADJ,C1
-mail (verb),mail,寄送,VERB,C1
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-main thing,main thing,词,NOUN,B2
+vergroten,to magnify,放大,VERB,B2
+meid,maid,女仆,NOUN,B2
+maagd,maiden,少女,NOUN,B2
+meid,maidservant,女仆,NOUN,B2
+brievenbus,mailbox,邮箱,NOUN,B2
+hoofdstroom,mainstream,主流,NOUN,B2
 majesteit,majesty,陛下,NOUN,B2
-majesteit,your majesty,陛下,NOUN,B2
-major,major,主要的,ADJ,B2
-major case,major case,大案,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
-make amends,make amends,词,VERB,C1
-make flexible,make flexible,词,VERB,C1
+hoofdvak,major course,专业课,NOUN,B2
+fout maken,to make a mistake,弄错,VERB,B2
+toespraak houden,to make a speech,发言,VERB,B2
+toegeven,to make do,做,VERB,B2
+fout,make mistake,犯错,NOUN,B2
+geluid maken,to make noise,闹得,VERB,B2
+zeker weten,to make sure,确保,VERB,B2
+vergoeden,to make up for,弥补,VERB,B2
 make-up,makeup,化妆品,NOUN,B2
-make-up aanbrengen,to apply makeup,化妆,VERB,B2
-makeover,makeover,改容,NOUN,C1
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-making,making,词,NOUN,B2
-maladjusted,maladjusted,适应不良的,ADJ,B2
-maladjustment,maladjustment,词,NOUN,C1
-malaria,malaria,疟疾,NOUN,B2
-male goat,male goat,词,NOUN,B2
-malefic,malefic,邪恶的,ADJ,B2
-malevolence,malevolence,恶意,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malfeasance,malfeasance,渎职,NOUN,B2
-malhun,malhun,词,NOUN,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
-malignity,malignity,词,NOUN,C1
-maliki school,maliki school,词,NOUN,C1
-mall,mall,词,NOUN,B2
-malleability,malleability,词,NOUN,C1
-malleable,malleable,词,ADJ,C1
-mallow greens,mallow greens,词,NOUN,B2
-malmo,malmo,马尔默,PROPN,B2
-malnutrition,malnutrition,营养不良,NOUN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mammal,mammal,哺乳动物,NOUN,B2
-mammalian,mammalian,词,ADJ,C1
+ziekte,malady,弊病,NOUN,B2
+boosheid,malice,恶意,NOUN,B2
 man,man,男人,NOUN,B2
-managed,managed,,NOUN,B2
-management pipe,management pipe,管理层/管道,NOUN,B2
+beheren,to manage,管理,VERB,B2
 manager,manager,经理,NOUN,B2
-managing director,managing director,总经理,NOUN,B2
 mandaat,mandate,命令,NOUN,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-mane,mane,词,NOUN,C1
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-manhunt,manhunt,搜捕,NOUN,B2
-mania,mania,狂躁症,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifestly,manifestly,明显地,ADV,B2
-manipulatie,manipulation,操纵,NOUN,B2
-manipulator,manipulator,词,NOUN,C1
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
-manners,manners,词,NOUN,B2
-mannish,mannish,像男人的,ADJ,B2
 manoeuvre,maneuver,策略,NOUN,B2
-manor (part),manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
-manslaughter,manslaughter,词,NOUN,C1
-mantra,mantra,心诀,NOUN,B2
-manually,manually,手动地,ADV,B2
-manufacturing,manufacturing,词,NOUN,B1
-manumission,manumission,词,NOUN,C1
-manure (noun),manure,词,NOUN,C1
+manipulatie,manipulation,操纵,NOUN,B2
+landgoed,manor,庄园,NOUN,B2
+landhuis,mansion,豪宅,NOUN,B2
 manuscript,manuscript,手稿,NOUN,B2
-many,many,多……,NOUN,B2
-many (adj),many,多,ADJ,A1
-many a,many a,词,ADJ,C1
-many things,many things,许多事物,PRON,B2
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapping,mapping,梳理,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
+velen,many,许多,ADJ,B2
+vaak,many times,多次,ADV,B2
+kaart,map,地图,NOUN,B2
 marathon,marathon,马拉松,NOUN,B2
-mare,mare,词,NOUN,B2
 marge,margin,边缘,NOUN,B2
 marginalisatie,marginalization,边缘化,NOUN,B2
-marginally,marginally,边缘地,ADV,B2
-marinade,marinade,词,NOUN,B2
-marine,marine,海洋的,ADJ,B2
-marine (noun),marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
 marineren,to marinate,腌制,VERB,B2
-marital conjugal,marital conjugal,词,ADJ,C1
-marker,marker,词,NOUN,B2
 markeren,mark,标记,NOUN,B2
 markeren,to mark,标记,VERB,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
 marketing,marketing,营销,NOUN,B2
-markets,markets,词,NOUN,C1
-maroon,maroon,深红色,ADJ,B2
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshal,marshal,元帅,NOUN,B2
+huwelijksalliantie,marriage alliance,联姻,NOUN,B2
+huwbaar,marriageable,适婚,NOUN,B2
 martelaarschap,martyrdom,殉难,NOUN,B2
-martelen,to torture,折磨,VERB,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martyr,martyr,词,NOUN,C1
-marvel (noun),marvel,词,NOUN,B2
-marvelous,marvelous,极好的,ADJ,B2
-mascot,mascot,吉祥物,NOUN,B2
-masculine,masculine,男性的,ADJ,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-mash,mash,泥状食物,NOUN,B2
-mask (verb),mask,词,VERB,C1
-masochism,masochism,词,NOUN,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,大众媒体,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massa,solid,3D模型 / 实体,NOUN,B2
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,按摩师,NOUN,B2
-mast (noun),mast,词,NOUN,C1
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
+verwonderen,to marvel,使惊奇,VERB,B2
+beheersen,to master,掌握,VERB,B2
 masterdiploma,master's degree,硕士学位,NOUN,B2
-masterly,masterly,词,ADJ,B2
-mastermind,mastermind,词,NOUN,C1
-mat,mat,词,NOUN,B2
-matches,matches,词,NOUN,C1
-matching use,matching use,配用,NOUN,C1
+meesterwoord,master's word,爷说,NOUN,B2
+meesterwerk,masterpiece,杰作,NOUN,B2
+meesterschap,mastery,精通,NOUN,B2
+passen,to match,相配,VERB,B2
+passend,matching,配套,ADJ,B2
 matchtijd,matching time,对时,NOUN,B2
-mate,mate,词,NOUN,A2
-material (adj),material,词,ADJ,C1
+koppelaar,matchmaker,媒,NOUN,B2
 materialisme,materialism,唯物主义,NOUN,B2
-maternal,maternal,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-mathematician,mathematician,词,NOUN,C1
-matige regen,moderate rain,中雨,NOUN,B2
-matiging,moderation,克制,NOUN,B2
-matras,mattress,床垫,NOUN,B2
-matriarch,matriarch,女家长,NOUN,B2
-matriarchy,matriarchy,词,NOUN,C1
+tante,maternal aunt,姨母,NOUN,B2
+oom,maternal uncle,舅舅,NOUN,B2
+wiskunde,math,数学,NOUN,B2
+wiskundig,mathematical,数学的,ADJ,B2
 matrix,matrix,矩阵,NOUN,B2
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
-mausoleum,mausoleum,词,NOUN,B1
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawkishness,mawkishness,词,NOUN,C1
-mawwal,mawwal,词,NOUN,B2
-maximization,maximization,词,NOUN,C1
-maximum (noun),maximum,词,NOUN,B2
-may (aux),may,词,AUX,A1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe possible,maybe possible,可能,ADV,A1
-maze,maze,词,NOUN,C1
-maze labyrinth,maze labyrinth,词,NOUN,C1
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-mead,mead,词,NOUN,C1
-meager,meager,词,ADJ,C1
-mean (noun),mean,词,NOUN,C1
-meander,meander,词,NOUN,C1
-meaning content,meaning content,语义内容,NOUN,B2
-meanness,meanness,词,NOUN,C1
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,克制的,ADJ,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mechanically,mechanically,词,ADV,C1
-mechanics,mechanics,词,NOUN,C1
+matras,mattress,床垫,NOUN,B2
+rijp,mature,成熟的,ADJ,B2
+rijpheid,maturity,成熟,NOUN,B2
+stelregel,maxim,格言,NOUN,B2
+ik,me,لي,NOUN,B2
+weide,meadow,草地,NOUN,B2
+tussentijd,meantime,同时,NOUN,B2
+boek,measure word for books,本,NUM,B2
 mechanisme,mechanism,机制,NOUN,B2
 mechanistisch,mechanistic,机制性,ADJ,B2
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
-medal awarding,medal awarding,授勋,NOUN,B2
-medallion,medallion,词,NOUN,C1
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-medelijden,compassion,同情,NOUN,B2
-medeplichtige,accomplice,同谋,NOUN,B2
-medewerker,collaborator,合作者,NOUN,B2
 media,media,媒体,NOUN,B2
-media (adj),media,词,ADJ,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media professionals,media professionals,词,NOUN,C1
-media-related,media-related,词,ADJ,B2
 mediaan,median,中位数,NOUN,B2
-median (adj),median,词,ADJ,C1
-mediator,mediator,调解人,NOUN,C1
-medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical examiner,medical examiner,法医,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication completion,medication completion,完药,NOUN,C1
-medicijnen uitreiken,to dispense medicine,配药,VERB,B2
-medicine pool,medicine pool,药池,NOUN,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+bemiddelen,to mediate,调解,VERB,B2
+bemiddeling,mediation,调解,NOUN,B2
 medisch dossier,medical record,病历,NOUN,B2
+middelmatig,mediocre,平庸的,ADJ,B2
 meditatie,meditation,冥想,NOUN,B2
 medium,medium,媒介,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-meedelen,to impart,传授,VERB,B2
-meedogenend,benevolent,仁慈的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meer,more,更多,ADJ,B2
-meerdere,superior,更好的,ADJ,B2
-meerdere,several,几个,DET,B2
-meest,most,大多数,ADJ,B2
-meesterschap,mastery,精通,NOUN,B2
-meesterwerk,masterpiece,杰作,NOUN,B2
-meesterwoord,master's word,爷说,NOUN,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-meeuw,seagull,海鸥,NOUN,B2
-megabyte,megabyte,词,NOUN,C1
-megalomaniac,megalomaniac,词,ADJ,C1
-megaphone,megaphone,扩音器,NOUN,C1
-meid,maid,女仆,NOUN,B2
-meid,maidservant,女仆,NOUN,B2
-meineed,perjury,伪证,NOUN,B2
-mejuffrouw,miss,小姐,NOUN,B2
 melancholie,melancholy,忧郁,ADJ,B2
-melancholy,melancholy,忧郁,NOUN,B2
-mellifluous,mellifluous,词,ADJ,C1
-mellifluousness,mellifluousness,词,NOUN,C1
 melodie,melody,旋律,NOUN,B2
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
 meloen betasten,melon groping,摸瓜,NOUN,B2
-melon,melon,香瓜,NOUN,C1
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-membrane,membrane,词,NOUN,C1
-memoir,memoir,回忆录,NOUN,B2
+smelten,to melt,融化,VERB,B2
 memorandum,memorandum,备忘录,NOUN,B2
-memorial (adj),memorial,词,ADJ,C1
+gedenkteken,memorial,纪念碑,NOUN,B2
 memorisatie,memorization,记忆,NOUN,B2
-memorizer,memorizer,词,NOUN,C1
-men,men,词,NOUN,C1
-menace,menace,词,NOUN,C1
-mendacious,mendacious,词,ADJ,C1
-meneer,mr.,先生,NOUN,B2
-meneer,sir,郎,PART,B2
-mengsel,mixture,混合物,NOUN,B2
-meningsverschil,disagreement,不和,NOUN,B2
-meninx,meninx,词,NOUN,C1
-menses,menses,词,NOUN,B2
-mental hospital,mental hospital,精神病院,NOUN,B2
-mentally,mentally,精神上地,ADV,B2
+repareren,to mend,修补,VERB,B2
 mentor,mentor,导师,NOUN,B2
-mentoring,mentoring,词,NOUN,B2
 menu,menu,菜单,NOUN,B2
-mercenaries,mercenaries,词,NOUN,C1
-mercenary,mercenary,雇佣兵,NOUN,B2
-mercenary (adj),mercenary,词,ADJ,C1
-merchandise,merchandise,商品,NOUN,B2
-merchant ship,merchant ship,商船,NOUN,C1
-merciful,merciful,词,ADJ,B2
-mercilessly,mercilessly,词,ADV,C1
-mercurial,mercurial,词,ADJ,C1
-merely (noun),merely,不就,NOUN,C1
-merged,merged,词,ADJ,C1
-merger fusion,merger fusion,词,NOUN,B1
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
+handelaar,merchant,商人,NOUN,B2
+kwik,mercury,汞,NOUN,B2
+genade,mercy,仁慈,NOUN,B2
+samenvoegen,merge,合并,NOUN,B2
+samenvoegen,to merge,合并,VERB,B2
+verdienste,merit,功绩,NOUN,B2
 meritocratie,meritocracy,精英管理,NOUN,B2
-merits,merits,词,NOUN,C1
-merriment,merriment,词,NOUN,C1
-message errand,message errand,消息/差事,NOUN,B2
-messaging,messaging,词,NOUN,C1
-meststof,fertilizer,肥料,NOUN,B2
-met alle middelen,by fair means or foul,不择手段,ADV,B2
-met moeite,with difficulty,困难地,ADV,B2
+zeemeermin,mermaid,美人鱼,NOUN,B2
+boodschapper,messenger,信使,NOUN,B2
+rommelig,messy,混乱的,ADJ,B2
 metabolisme,metabolism,新陈代谢,NOUN,B2
 metafysica,metaphysics,形而上学,NOUN,B2
-metalepsis,metalepsis,词,NOUN,C1
-metalinguistic,metalinguistic,词,ADJ,C1
-metallurgy,metallurgy,词,NOUN,C1
-metamorphosis,metamorphosis,词,NOUN,C1
-metaphysical,metaphysical,词,ADJ,C1
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological observations,meteorological observations,词,NOUN,C1
-metering,metering,词,ADJ,C1
-metgezel,consort,福晋,NOUN,B2
-methane,methane,词,NOUN,C1
-methodical,methodical,词,ADJ,C1
 methodologie,methodology,方法论,NOUN,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
+nauwkeurig,meticulous,一丝不苟的,ADJ,B2
 metonymie,metonymy,转喻,NOUN,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolises,metropolises,词,NOUN,C1
-metropolitan,metropolitan,词,ADJ,C1
-mettle,mettle,词,NOUN,C1
-mezzanine,mezzanine,夹层,NOUN,B2
-michelen,to target,针对,VERB,B2
-micheling,targeting,定位,NOUN,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
 microscoop,microscope,显微镜,NOUN,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-microwave,microwave,微波炉,NOUN,B2
-mid-morning,mid-morning,词,NOUN,C1
-midday heat,midday heat,词,NOUN,B1
-middel,remedy,补救措施,NOUN,B2
-middelbare school,high school,高中,NOUN,B2
-middelmatig,mediocre,平庸的,ADJ,B2
 midden,middle,中间,NOUN,B2
 midden,midst,中间,NOUN,B2
-middle (adj),middle,词,ADJ,B2
-middle (noun),middle,中,NOUN,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midpoint,midpoint,词,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty,mighty,词,ADJ,B1
-mighty very,mighty very,非常,ADJ,B2
+macht,might,威力,NOUN,B2
 migraine,migraine,偏头痛,NOUN,B2
-migrant,migrant,词,NOUN,B2
-migratory,migratory,词,ADJ,C1
 migreren,to migrate,迁移,VERB,B2
-mildew,mildew,词,VERB,C1
-milieubescherming,environmental protection,环境保护,NOUN,B2
-milieukundig,environmental,环境的,ADJ,B2
-milieurapport,environmental report,环境报告,NOUN,B2
+leger,military,军队,NOUN,B2
 militaire inlichtingendienst,military intelligence,军情,NOUN,B2
-militaire macht,military power,兵权,NOUN,B2
 militaire orde,military order,军令,NOUN,B2
-militant,militant,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
-military merit,military merit,军功,NOUN,C1
-military pay,military pay,军饷,NOUN,B2
+militaire macht,military power,兵权,NOUN,B2
 militie,militia,民兵,NOUN,B2
-miljoen,million,百万,NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,词,NOUN,C1
-milkman,milkman,词,NOUN,C1
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
 millennium,millennium,千年,NOUN,B2
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
-million (noun),million,百万,NOUN,B2
-millionaire,millionaire,百万富翁,NOUN,B2
-millions of,millions of,数百万的,NUM,B2
-mime (noun),mime,词,NOUN,C1
-mimicry,mimicry,词,NOUN,B2
-minaret,minaret,词,NOUN,B1
-minatory,minatory,词,ADJ,C1
-minced meat,minced meat,词,NOUN,A2
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mindset,mindset,词,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
-mineral (adj),mineral,词,ADJ,C1
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
-minibus,minibus,中巴,NOUN,B2
-minimalism,minimalism,极简主义,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimization,minimization,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
+miljoen,million,百万,NOUN,B2
+letten,to mind,介意,VERB,B2
 minister,minister,部长,NOUN,B2
-minister (part),minister,臣,PART,B2
-minnaar,lover,爱人,NOUN,B2
-minnares,mistress,情妇,NOUN,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
-minority group,minority group,少数群体,NOUN,B2
-minutes,minutes,词,NOUN,B2
-minzaam,affable,和蔼可亲的,ADJ,B2
-miraculous,miraculous,词,ADJ,C1
-mirage,mirage,词,NOUN,C1
-mirthful,mirthful,词,ADJ,C1
-misanthrope,misanthrope,厌世者,NOUN,B2
-misanthropic,misanthropic,词,ADJ,C1
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misdadigheid,delinquency,违法行为,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-misdemeanor,misdemeanor,词,NOUN,B2
-misdrijf,felony,重罪,NOUN,B2
-misdrijfsscène,crime scene,犯罪现场,NOUN,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-miserly,miserly,吝啬的,ADJ,B2
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
-misjudge,misjudge,词,VERB,C1
+bijvak,minor course,辅修课,NOUN,B2
+munt,mint,薄荷,NOUN,B2
+verduistering,misappropriation,挪用,NOUN,B2
+ellendig,miserable,痛苦的,ADJ,B2
+ongeluk,misfortune,不幸,NOUN,B2
 misleiden,to mislead,误导,VERB,B2
-mislukking,failure,失败,NOUN,B2
-mislukte poging,failed bid,流标,NOUN,B2
-mismatch,mismatch,词,NOUN,C1
-miss teacher,miss teacher,小姐/老师,NOUN,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-missile,missile,导弹,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missions,missions,词,NOUN,C1
-missive,missive,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-missnahme,missnahme,词,NOUN,C1
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
+mejuffrouw,miss,小姐,NOUN,B2
 mist,mist,薄雾,NOUN,B2
-mistaken,mistaken,错误的,ADJ,B2
-mistreatment,mistreatment,虐待,NOUN,B2
-misunderstood,misunderstood,词,ADJ,C1
+vergissen,to mistake,弄错,VERB,B2
+minnares,mistress,情妇,NOUN,B2
 misverstaan,to misunderstand,误解,VERB,B2
 misverstand,misunderstanding,误解,NOUN,B2
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitigation,mitigation,词,NOUN,C1
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mitten,mitten,连指手套,NOUN,B2
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixer,mixer,词,NOUN,C1
-mixing,mixing,词,NOUN,B2
-mob,mob,词,NOUN,B2
+mengsel,mixture,混合物,NOUN,B2
+kreunen,moan,呻吟,NOUN,B2
+kreunen,to moan,呻吟,VERB,B2
 mobiele betaling,mobile payment,移动支付,NOUN,B2
-mobile (noun),mobile,词,NOUN,B2
 mobilisatie,mobilization,动员,NOUN,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-mockery,mockery,词,NOUN,C1
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
-modder,mud,泥,NOUN,B2
-model,model,模型,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
-modellering,modeling,造型,NOUN,B2
-modem,modem,词,NOUN,C1
-moderate snow,moderate snow,中雪,NOUN,C1
-moderator,moderator,词,NOUN,C1
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,现代,NOUN,B2
-modernisering,modernization,现代化,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
-modestly,modestly,词,ADV,C1
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
-modificatie,modification,修改,NOUN,B2
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified structure,modified structure,改结,NOUN,C1
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
-modulation,modulation,词,NOUN,C1
-module,module,词,NOUN,C1
 modus,mode,方式,NOUN,B2
-moed,bravery,勇敢,NOUN,B2
-moed,valor,勇气,NOUN,B2
-moeder,mother,娘,PART,B2
-moederlijke geruststelling,mother's reassurance,娘放心,NOUN,B2
-moedig,bold,大胆的,ADJ,B2
-moedig zijn,to be brave,勇善,VERB,B2
-moeilijk,arduous,艰巨的,ADJ,B2
-moeilijk,hard to choose,难以抉择,ADJ,B2
-moeilijk,hard to distinguish,难以区分,ADJ,B2
-moeilijk,hard to maintain,难以维持,ADJ,B2
-moeilijk,hard to speak of,难以启齿,ADJ,B2
-moeilijk probleem,difficult problem,难题,NOUN,B2
-moeras,swamp,沼泽,NOUN,B2
-moeras,wetland,湿地,NOUN,B2
-moeten,should,应该,AUX,B2
-mogelijk maken,to enable,使能够,VERB,B2
-moisten,moisten,词,VERB,C1
-moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
+model,model,模型,NOUN,B2
+modellering,modeling,造型,NOUN,B2
+matige regen,moderate rain,中雨,NOUN,B2
+matiging,moderation,克制,NOUN,B2
+modernisering,modernization,现代化,NOUN,B2
+bescheidenheid,modesty,谦虚,NOUN,B2
+modificatie,modification,修改,NOUN,B2
+aangepast effect,modified effect,改效,NOUN,B2
+aangepast model,modified model,改模,NOUN,B2
+aangepast geluid,modified sound,改响,NOUN,B2
+aangepast systeem,modified system,改系,NOUN,B2
+aanpassen,to modify,修改,VERB,B2
+vochtig,moist,潮湿的,ADJ,B2
+schimmel,mold,鞋楦,NOUN,B2
 molecuul,molecule,分子,NOUN,B2
-mollify,mollify,词,VERB,C1
-molten,molten,词,ADJ,C1
-molting,molting,词,NOUN,C1
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,暂时地,ADV,B2
-momentous,momentous,词,ADJ,C1
 momentum,momentum,势头,NOUN,B2
-mommy,mommy,词,NOUN,B1
-monarch,monarch,君主,NOUN,B2
-monarchy,monarchy,君主制,NOUN,B2
-monasticism,monasticism,词,NOUN,C1
-mondelinge beschikking,oral decree,口谕,NOUN,B2
-mondvol,mouthful,一口,NOUN,B2
-monetization,monetization,词,NOUN,C1
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
-monkey ape,monkey ape,猿/猴,NOUN,B2
-monologue,monologue,词,NOUN,B2
-monoloog,soliloquy,独白,NOUN,B2
+controlekamer,monitoring room,监控室,NOUN,B2
 monopolie,monopoly,垄断,NOUN,B2
-monotheism,monotheism,词,NOUN,C1
-monotonic,monotonic,词,ADJ,C1
-monotony,monotony,词,NOUN,C1
 monster,monster,怪物,NOUN,B2
-month ago,month ago,月前,NOUN,B2
-monthly (adv),monthly,按月,ADV,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
+maanmaand,month moon,月,NOUN,B2
+maandelijks,monthly,每月的,ADJ,B2
+maandelijks examen,monthly exam,月考,NOUN,B2
 monument,monument,纪念碑,NOUN,B2
-monumental,monumental,词,ADJ,C1
-moodiness,moodiness,词,NOUN,B2
-mooi,pretty,漂亮的,ADJ,B2
-mooi man,handsome guy,帅哥,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-moor,moor,荒野,NOUN,B2
-moord,homicide,杀人,NOUN,B2
-moordenaar,killer,杀手,NOUN,B2
-moordwapen,murder weapon,凶器,NOUN,B2
-mooring,mooring,词,NOUN,C1
-moose,moose,驼鹿,NOUN,B2
-mop (noun),mop,词,NOUN,B2
-mopperen,to grumble,抱怨,VERB,B2
+maankoek,mooncake,月饼,NOUN,B2
 moraal,moral,道德,NOUN,B2
 moraal,morals,道德,NOUN,B2
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral portrait,moral portrait,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,人心,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralization,moralization,词,NOUN,C1
-morally,morally,词,ADV,C1
-morass,morass,词,NOUN,C1
-moratorium,moratorium,暂停,NOUN,B2
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
-more,more,مزيد,NOUN,B2
-more (adj),more,更多,ADJ,A2
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,更贵的,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
-more personal,more personal,词,ADJ,C1
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover (cconj),moreover,而且,CCONJ,B2
+meer,more,更多,ADJ,B2
+bovendien,moreover,而且,CCONJ,B2
+ochtendkrant,morning newspaper,晨报,NOUN,B2
 morfologie,morphology,形态学,NOUN,B2
-morgue,morgue,词,NOUN,B1
-morning (adj),morning,词,ADJ,C1
-moroccanization,moroccanization,词,NOUN,C1
-morocco leather,morocco leather,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morpheme,morpheme,语素,NOUN,C1
-morphine,morphine,吗啡,NOUN,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortality,mortality,死亡率,NOUN,B2
-mortuary,mortuary,词,NOUN,B2
+hypothekeren,to mortgage,抵押,VERB,B2
+mozaïek,mosaic,马赛克,NOUN,B2
+mug,mosquito,蚊子,NOUN,B2
 mos,moss,苔藓,NOUN,B2
-mosquito net,mosquito net,蚊帐,NOUN,B2
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-most,most,大多数,DET,B2
-most (adj),most,大多数,ADJ,A1
-most (noun),most,大部分,NOUN,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-motel,motel,汽车旅馆,NOUN,B2
-moth,moth,词,NOUN,B2
-mother (part),mother,娘,PART,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
+meest,most,大多数,ADJ,B2
+voornamelijk,mostly,主要地,ADV,B2
+moeder,mother,娘,PART,B2
+moederlijke geruststelling,mother's reassurance,娘放心,NOUN,B2
+schoonmoeder,mother-in-law,岳母,NOUN,B2
 motief,motive,动机,NOUN,B2
-motion picture,motion picture,词,NOUN,C1
-motionless,motionless,静止的,ADJ,B2
-motive for murder,motive for murder,词,NOUN,C1
-motley,motley,词,ADJ,B2
 motor,motor,发动机,NOUN,B2
 motorfiets,motorcycle,摩托车,NOUN,B2
-motorist,motorist,词,NOUN,C1
-motregen,drizzle,毛毛雨,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mound,mound,土堆,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-mouth animal,mouth animal,词,NOUN,B1
-move fast,move fast,快搬,NOUN,C1
-moving,moving,感人的,ADJ,B2
-mow,mow,词,VERB,B2
-mozaïek,mosaic,马赛克,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-much,much,很多,ADV,B2
-much (adj),much,词,ADJ,A1
-much many,much many,许多,ADJ,B2
-mucous,mucous,词,ADJ,C1
-muddied,muddied,词,ADJ,C1
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-muezzin,muezzin,词,NOUN,B2
-muffin,muffin,玛芬蛋糕,NOUN,B2
-mufti,mufti,词,NOUN,C1
-mug,mosquito,蚊子,NOUN,B2
-mug (noun),mug,词,NOUN,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multiple,multiple,词,ADJ,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-munt,mint,薄荷,NOUN,B2
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder case,murder case,词,NOUN,B2
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
-murderer female,murderer female,词,NOUN,B2
-murk of dawn,murk of dawn,词,NOUN,C1
-murky,murky,词,ADJ,C1
+camper,motorhome,露营车,NOUN,B2
+bergafdaling,mountain descent,下山,NOUN,B2
+bergketen,mountain range,山脉,NOUN,B2
+mondvol,mouthful,一口,NOUN,B2
+verhuizing,move,搬家,NOUN,B2
+opzijgaan,to move aside,移开,VERB,B2
+intrekken,to move in,搬入,VERB,B2
+film,movie,电影,NOUN,B2
+meneer,mr.,先生,NOUN,B2
+MRI-scan,mri,核磁共振,NOUN,B2
+veel,much,多,DET,B2
+slijm,mucus,黏液,NOUN,B2
+modder,mud,泥,NOUN,B2
+verward,muddled,混乱的,ADJ,B2
+vermenigvuldigen,to multiply,乘；增加,VERB,B2
+moordwapen,murder weapon,凶器,NOUN,B2
 murmur,murmur,低语,NOUN,B2
-murmuring,murmuring,词,NOUN,C1
-muscle ache,muscle ache,肌肉酸痛,NOUN,B2
 muscle pain,muscle pain,肌肉痛,NOUN,B2
-muscular,muscular,词,ADJ,C1
-muse,muse,词,VERB,B2
 museum,museum,博物馆,NOUN,B2
 mushroom,mushroom,蘑菇,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
-musical,musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
 musical score,musical score,乐谱,NOUN,B2
-musicality,musicality,词,NOUN,C1
-musk,musk,麝香,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustache,mustache,胡子,NOUN,B2
-mustard,mustard,词,NOUN,A1
-mutable,mutable,词,ADJ,C1
-mutagenic,mutagenic,词,ADJ,C1
 mutation,mutation,突变,NOUN,B2
-mutazilites,mutazilites,词,NOUN,C1
 mute,mute,沉默的；哑的,ADJ,B2
-mute person,mute person,词,NOUN,B2
-mutilate,mutilate,词,VERB,C1
-mutiny (noun),mutiny,兵变,NOUN,B2
 mutter,to mutter,嘟囔,VERB,B2
-muttering,muttering,念叨,NOUN,C1
 mutton,mutton,羊肉,NOUN,B2
-mutual affection,mutual affection,词,NOUN,C1
 mutual aid,mutual aid,互助,NOUN,B2
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
 mutual generation,mutual generation,相生,NOUN,B2
 mutual insurance,mutual insurance,互助保险,NOUN,B2
-mutual pulling,mutual pulling,词,NOUN,C1
 mutual restriction,mutual restriction,相克,NOUN,B2
-mutual support,mutual support,互助,NOUN,C1
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
 mutually,mutually,相互地,ADV,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzle,muzzle,口套,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
 my big one,my big one,我偌大,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
 my place,my place,我处,NOUN,B2
 my residence,my residence,我府,NOUN,B2
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myelin,myelin,词,NOUN,C1
-myriad,myriad,词,ADJ,C1
 myself,myself,我自,NOUN,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
 mythology,mythology,神话学,NOUN,B2
-naaien,to sew,缝纫,VERB,B2
-naaier,tailor,裁缝,NOUN,B2
-naaiwerk,sewing,缝纫,NOUN,B2
-naaldbos,coniferous forest,针叶林,NOUN,B2
-naar,toward,朝向,ADP,B2
-naar hartelust,one's heart's content,尽情,ADV,B2
-naast elkaar staan,to stand side by side,并列,VERB,B2
-nabijheid,proximity,邻近,NOUN,B2
-nabootsen,to emulate,效仿,VERB,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtelijk,nocturnal,夜间的,ADJ,B2
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-naden,suture,缝合,NOUN,B2
-naden,to suture,缝合,VERB,B2
-nadir,nadir,最低点,NOUN,B2
-nagen,to gnaw,啃,VERB,B2
-nah,nah,不,INTJ,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
 naivety,naivety,天真,NOUN,B2
-name-calling,name-calling,词,NOUN,C1
-named,named,词,ADP,C1
 nanny,nanny,保姆,NOUN,B2
 nanotechnology,nanotechnology,纳米技术,NOUN,B2
 nap,nap,午睡,NOUN,B2
-nape,nape,后颈,NOUN,B2
 napkin,napkin,餐巾,NOUN,B2
 narcissism,narcissism,自恋,NOUN,B2
-narcissistic,narcissistic,自恋的,ADJ,B2
-narcotics,narcotics,词,NOUN,C1
 narrate,to narrate,叙述,VERB,B2
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
 narrative,narrative,叙述；故事,NOUN,B2
-narrative (adj),narrative,词,ADJ,C1
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
 narrator,narrator,叙述者,NOUN,B2
-narrators,narrators,词,NOUN,C1
-narrowing,narrowing,变窄,NOUN,B2
 narrowness,narrowness,狭窄,NOUN,B2
-nascent,nascent,词,ADJ,C1
-nastreven,to pursue,追求,VERB,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
 nationalism,nationalism,民族主义,NOUN,B2
-nationalist,nationalist,民族主义者,NOUN,B2
 nationalization,nationalization,国有化,NOUN,B2
 nationalize,to nationalize,国有化,VERB,B2
-nationwide,nationwide,全国,NOUN,B2
-native (noun),native,词,NOUN,C1
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
 natural,natural,自然的,ADJ,B2
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-naturalization,naturalization,入籍,NOUN,B2
-naturally,naturally,自然地,ADV,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-nauwgezet,conscientious,认真的,ADJ,B2
-nauwkeurig,meticulous,一丝不苟的,ADJ,B2
-naval,naval,词,ADJ,C1
 navigation,navigation,导航；航行,NOUN,B2
-navigational,navigational,词,ADJ,C1
-nawerking,aftereffect,后遗症，后果,NOUN,B2
 nazi,nazi,纳粹分子,NOUN,B2
 near,near,近,ADJ,B2
-near (adv),near,词,ADV,A1
-near-dry,near-dry,近干,NOUN,B2
 nearby,nearby,附近,NOUN,B2
-nearest (noun),nearest,词,NOUN,B2
 nearly,nearly,几乎,ADV,B2
-nearness,nearness,词,NOUN,B2
 nebula,nebula,星云,NOUN,B2
-nebulous,nebulous,词,ADJ,C1
 necessarily,necessarily,必然地,ADV,B2
-necessarily incumbent,necessarily incumbent,词,ADV,C1
 necklace,necklace,项链,NOUN,B2
-necklace chain,necklace chain,词,NOUN,A1
-neckline,neckline,词,NOUN,C1
-necrosis,necrosis,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
-nederzetting,settlement,解决,NOUN,B2
 need,need,需要,AUX,B2
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
-neergaan,to go down,下去,VERB,B2
-neerkijken op,to look down upon,看不起,VERB,B2
-neerliggen,to lie down,躺,VERB,B2
-neerslachtig,dejected,沮丧的,ADJ,B2
-neerslachtigheid,dejection,沮丧,NOUN,B2
-nefarious,nefarious,词,ADJ,C1
 negate,to negate,否定,VERB,B2
 negation,negation,否定,NOUN,B2
-negativity,negativity,消极,NOUN,B2
-negentje,little nine,小九,NOUN,B2
-negeren,to disregard,忽视,VERB,B2
 neglect,to neglect,忽视,VERB,B2
-neglect (noun),neglect,词,NOUN,C1
 negligence,negligence,疏忽；过失,NOUN,B2
 negligent,negligent,疏忽的,ADJ,B2
 negligible,negligible,微不足道的,ADJ,B2
 negligible not,negligible not,不可忽视,ADJ,B2
 negotiations,negotiations,谈判,NOUN,B2
-negotiator,negotiator,词,NOUN,C1
 neigh,to neigh,嘶鸣,VERB,B2
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
 neighboring,neighboring,邻近的,ADJ,B2
-neighbors,neighbors,词,NOUN,B1
-neiging,inclination,倾向,NOUN,B2
-neiging,propensity,倾向,NOUN,B2
 neither,neither,也不,CCONJ,B2
-neither (adv),neither,词,ADV,A1
-neither (det),neither,词,DET,A2
-neither nor,neither nor,词,CCONJ,A2
-nemesis,nemesis,词,NOUN,C1
-neming,taking,拍摄,NOUN,B2
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
-neophyte,neophyte,新手；初学者,NOUN,B2
 nephew,nephew,侄子,NOUN,B2
-nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
 nerve,nerve,神经,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
 nervousness,nervousness,紧张,NOUN,B2
-nesting box,nesting box,词,NOUN,B1
 net,net,网,NOUN,B2
-nettle,nettle,词,NOUN,C1
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neural,neural,词,ADJ,C1
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neuriën,to hum,哼唱,VERB,B2
-neurological,neurological,词,ADJ,C1
-neuron,neuron,神经元,NOUN,B2
-neuroscience,neuroscience,词,NOUN,C1
 neurosis,neurosis,神经症,NOUN,B2
-neuroticism,neuroticism,词,NOUN,C1
 neutrality,neutrality,中立,NOUN,B2
-neutron,neutron,词,NOUN,C1
-nevertheless,nevertheless,尽管如此,ADV,B2
-new beginning,new beginning,词,NOUN,C1
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
 new year's day,new year's day,元旦,NOUN,B2
-newcomer,newcomer,新来者,NOUN,B2
-newly,newly,词,ADV,C1
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
-news bulletin,news bulletin,词,NOUN,B2
-news report,news report,词,NOUN,B1
-news reporting,news reporting,新闻报道,NOUN,B2
 next,next,接下来,ADV,B2
-next day,next day,词,NOUN,A2
 next door,next door,隔壁,NOUN,B2
-next following,next following,词,ADJ,C1
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
-next to (adv),next to,词,ADV,B2
-next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
 nibble,to nibble,啃,VERB,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,,NOUN,B2
-niche,niche,词,NOUN,C1
-nickel,nickel,镍,NOUN,B2
-nicken,to nod,点头,VERB,B2
-niemand,nobody,没有人,PRON,B2
-nier,renal,肾脏的,ADJ,B2
-nier,kidney,肾脏,NOUN,B2
-niet,do not,莫,ADV,B2
-niet doen,won't do,不行,ADJ,B2
-niet doen,to won't do,不成,VERB,B2
-niet geloven,to can't believe,不敢相信,VERB,B2
-niet kunnen,cannot,不能,AUX,B2
-niet kunnen helpen,to cannot help,忍不住,VERB,B2
-niet kunnen verdragen,to cannot bear,不堪,VERB,B2
-niet meer,no longer,不再,ADV,B2
-niet moeten,should not,不该,AUX,B2
-niet nodig,no need,不用,AUX,B2
-niet-abstractie,non-abstraction,非抽,NOUN,B2
-niet-baan,non-orbit,非轨,NOUN,B2
-niet-begrip,non-concept,非概,NOUN,B2
-niet-beheer,non-management,管不,NOUN,B2
-niet-bewijs,non-evidence,非据,NOUN,B2
-niet-bijstand,non-assistance,勿助,NOUN,B2
-niet-constructie,non-construction,非建,NOUN,B2
-niet-contingent,non-contingent,非偶,NOUN,B2
-niet-gebruik,do not use,别用,NOUN,B2
-niet-gedachte,non-thought,非念,NOUN,B2
-niet-geest,non-mind,非心,NOUN,B2
-niet-geluid,non-sound,非响,NOUN,B2
-niet-handelen,non-action,非作,NOUN,B2
-niet-inductie,non-induction,非归,NOUN,B2
-niet-inferentie,non-inference,非推,NOUN,B2
-niet-model,non-model,非模,NOUN,B2
-niet-niveau,non-level,非级,NOUN,B2
-niet-orde,non-order,非序,NOUN,B2
-niet-schaduw,non-shadow,非影,NOUN,B2
-niet-specifiek,non-specific,非殊,NOUN,B2
-niet-spoor,non-trace,非迹,NOUN,B2
-niet-staat,non-state,非态,NOUN,B2
-niet-stof,non-substance,非质,NOUN,B2
-niet-strategie,non-strategy,非略,NOUN,B2
-niet-verdienste,non-merit,非功,NOUN,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
 night view,night view,夜景,NOUN,B2
 nightclub,nightclub,夜总会,NOUN,B2
 nightingale,nightingale,夜莺,NOUN,B2
 nihilism,nihilism,虚无主义,NOUN,B2
-nihilistic,nihilistic,词,ADJ,C1
-nimble,nimble,敏捷的,ADJ,B2
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,氮,NOUN,B2
 no,no,不,ADV,B2
-no (part),no,词,PART,B2
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
 no harm,no harm,没事吧,NOUN,B2
-no heaven,no heaven,无天,NOUN,C1
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-nobility of character,nobility of character,词,NOUN,C1
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
-node,node,词,NOUN,C1
-noise row,noise row,词,NOUN,C1
-noises,noises,噪音,NOUN,B2
-noisome,noisome,词,ADJ,C1
-nomad,nomad,游牧者,NOUN,B2
+niet meer,no longer,不再,ADV,B2
+ongeacht,no matter,不论,CCONJ,B2
+niet nodig,no need,不用,AUX,B2
+edelman,nobleman,贵族,NOUN,B2
+niemand,nobody,没有人,PRON,B2
+nachtelijk,nocturnal,夜间的,ADJ,B2
+nicken,to nod,点头,VERB,B2
 nomadisme,nomadism,游牧生活,NOUN,B2
-nomads,nomads,词,NOUN,B2
-nominal,nominal,词,ADJ,C1
 nominatie,nomination,提名,NOUN,B2
-nominee,nominee,词,NOUN,C1
-non-above,non-above,非上,NOUN,C1
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
-non-concrete,non-concrete,非具,NOUN,C1
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
+onvermogen,non-ability,非能,NOUN,B2
+niet-abstractie,non-abstraction,非抽,NOUN,B2
+niet-handelen,non-action,非作,NOUN,B2
+niet-bijstand,non-assistance,勿助,NOUN,B2
+ongeloof,non-belief,非信,NOUN,B2
+niet-begrip,non-concept,非概,NOUN,B2
+niet-constructie,non-construction,非建,NOUN,B2
+niet-contingent,non-contingent,非偶,NOUN,B2
+niet-bewijs,non-evidence,非据,NOUN,B2
+niet-inductie,non-induction,非归,NOUN,B2
+niet-inferentie,non-inference,非推,NOUN,B2
+niet-niveau,non-level,非级,NOUN,B2
+niet-beheer,non-management,管不,NOUN,B2
+niet-verdienste,non-merit,非功,NOUN,B2
+niet-geest,non-mind,非心,NOUN,B2
+niet-model,non-model,非模,NOUN,B2
+niet-baan,non-orbit,非轨,NOUN,B2
+niet-orde,non-order,非序,NOUN,B2
+niet-schaduw,non-shadow,非影,NOUN,B2
+niet-geluid,non-sound,非响,NOUN,B2
+niet-specifiek,non-specific,非殊,NOUN,B2
+niet-staat,non-state,非态,NOUN,B2
+niet-strategie,non-strategy,非略,NOUN,B2
+niet-stof,non-substance,非质,NOUN,B2
+niet-gedachte,non-thought,非念,NOUN,B2
+niet-spoor,non-trace,非迹,NOUN,B2
 non-war,non-war,非战,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
 noncompliant,noncompliant,违规,ADJ,B2
-nonconformist,nonconformist,词,NOUN,C1
 none,none,没有一个,DET,B2
-none (pron),none,没有一个,PRON,A2
-nonexistent,nonexistent,词,ADJ,C1
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonprofit,nonprofit,非营利的,ADJ,B2
-noodgeval,emergency,紧急情况,NOUN,B2
-noodle,noodle,面条,NOUN,B2
-noodles,noodles,面条,NOUN,A1
-noodlot,destiny,命运,NOUN,B2
 noon,noon,正午,NOUN,B2
 nope,nope,不,INTJ,B2
 norm,norm,规范,NOUN,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalization,normalization,词,NOUN,C1
 normally,normally,通常地,ADV,B2
-normativity,normativity,词,NOUN,C1
-northward,northward,向北,ADV,B2
-nosology,nosology,词,NOUN,C1
-nostalgia,nostalgia,怀旧,NOUN,B2
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
-nosy,nosy,爱打听的,ADJ,B2
 not,not,不,PART,B2
 not about,to not about,不关,VERB,B2
-not afraid,not afraid,不怕,VERB,B2
 not allow,not allow,不许,AUX,B2
 not allowed,not allowed,不准,ADJ,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
-not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
-not catch up,not catch up,非赶,NOUN,B2
 not come,to not come,不来,VERB,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
 not have,to not have,没,VERB,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
 not only,not only,不光,CCONJ,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
 notable,notable,显著的,ADJ,B2
-notables,notables,词,NOUN,B2
-notably,notably,显著地,ADV,B2
 notarization,notarization,公证,NOUN,B2
-notarized,notarized,经公证的,ADJ,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
-note patch,note patch,词,NOUN,C1
 notebook,notebook,笔记本,NOUN,B2
-notepad,notepad,记事本,NOUN,B2
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
-notifications,notifications,词,NOUN,C1
 notify,to notify,通知,VERB,B2
-notion,notion,词,NOUN,B2
 notorious,notorious,臭名昭著的,ADJ,B2
-notoriously,notoriously,词,ADV,C1
-notwithstanding,notwithstanding,词,ADP,C1
 noumenon,noumenon,本体,NOUN,B2
-nourishment,nourishment,营养,NOUN,B2
 novelistic,novelistic,小说般的,ADJ,B2
-novelty,novelty,新奇事物,NOUN,B2
 november,november,十一月,NOUN,B2
-novice,novice,词,NOUN,C1
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
-nuance,nuance,细微差别,NOUN,B2
-nuanced,nuanced,细微差别的,ADJ,B2
-nuclear (noun),nuclear,词,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,核能,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nugget,nugget,词,NOUN,C1
-null and void,null and void,无效的,ADJ,C1
-nullify,nullify,词,VERB,C1
 nullity,nullity,无效；无能,NOUN,B2
-numb,numb,麻木的,ADJ,B2
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
 number two,number two,二号,NOUN,B2
-numbering,numbering,词,NOUN,C1
-numeral,numeral,词,NOUN,C1
-numerical,numerical,词,ADJ,C1
-nunation,nunation,词,NOUN,C1
 nursery,nursery,托儿所,NOUN,B2
-nursing home,nursing home,养老院,NOUN,C1
 nurture,to nurture,养育,VERB,B2
 nurturing,nurturing,养好,NOUN,B2
-nuteloos,useless,无用的,ADJ,B2
-nutritional,nutritional,词,ADJ,C1
-nylon,nylon,尼龙,NOUN,C1
-o,o,词,PART,B1
-o mijn god,oh my god,我的天,INTJ,B2
-o'clock (adv),o'clock,词,ADV,B2
-o'clock (noun),o'clock,点,NOUN,B2
-oak,oak,词,NOUN,B1
 oar,oar,桨,NOUN,B2
 oasis,oasis,绿洲,NOUN,B2
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
-obdurate,obdurate,词,ADJ,C1
 obedient,obedient,顺从的,ADJ,B2
-obelisk,obelisk,词,NOUN,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obese,obese,肥胖的,ADJ,B2
 obesity,obesity,肥胖,NOUN,B2
 obey,to obey,服从,VERB,B2
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-objectivism,objectivism,词,NOUN,C1
 objectivity,objectivity,客观性,NOUN,B2
-obligatory,obligatory,词,ADJ,C1
-obliged,obliged,被迫的,ADJ,B2
-obliging,obliging,词,ADJ,B2
-oblique,oblique,斜的,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-obliteration,obliteration,词,NOUN,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
 obscene,obscene,淫秽的,ADJ,B2
-obscenity,obscenity,词,NOUN,C1
 obscurantisme,obscurantism,蒙昧主义,NOUN,B2
-obscurantist,obscurantist,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,词,ADJ,C1
+waarneming,observation,观察,NOUN,B2
 observatorium,observatory,天文台,NOUN,B2
-observers,observers,词,NOUN,C1
-obsess,obsess,词,VERB,B2
+waarnemer,observer,观察者,NOUN,B2
+geobsedeerd,obsessed,着迷的,ADJ,B2
 obsessie,obsession,痴迷,NOUN,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
+verouderd,obsolete,过时的,ADJ,B2
 obstakel,obstacle,障碍,NOUN,B2
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstinately,obstinately,词,ADV,C1
-obstipatie,constipation,便秘,NOUN,B2
-obstreperous,obstreperous,词,ADJ,C1
+koppig,obstinate,固执的,ADJ,B2
+belemmeren,to obstruct,阻碍,VERB,B2
 obstructie,obstruction,阻塞,NOUN,B2
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-occasional,occasional,词,ADJ,C1
-occult,occult,神秘的,ADJ,B2
-occultism,occultism,神秘学,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-ochtendkrant,morning newspaper,晨报,NOUN,B2
-octave,octave,词,NOUN,C1
-octopus,octopus,词,NOUN,B2
-ocular,ocular,词,ADJ,C1
-oddball,oddball,怪人,NOUN,B2
-oddly,oddly,词,ADV,B2
-odds,odds,赔率,NOUN,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-of,either,或者,CCONJ,B2
-of,whether,能否,NOUN,B2
-of,whether or not,是否,SCONJ,B2
-of (part),of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of by,of by,的/被,ADP,B2
-of course,of course,当然,INTJ,B2
-of first instance,of first instance,词,ADJ,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-off-center,off-center,词,ADJ,C1
-off-track,off-track,词,ADJ,C1
-offcuts,offcuts,词,NOUN,C1
-offense,offense,冒犯,NOUN,B2
-offensive (noun),offensive,词,NOUN,C1
+uiteraard,obviously,显然,ADV,B2
+soms,occasionally,偶尔,ADV,B2
+gebeurtenis,occurrence,发生,NOUN,B2
+vreemd,odd,奇怪的,ADJ,B2
+van,of,之,PART,B2
+terreinwagen,off-road vehicle,越野车,NOUN,B2
 offer,offering,祭品,NOUN,B2
-office work,office work,办公室工作,NOUN,B2
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
+functionaris,official,官员,NOUN,B2
 officieel,officially,正式地,ADV,B2
-officious,officious,词,ADJ,C1
-offshoring,offshoring,词,NOUN,B2
-offspring,offspring,幼崽,NOUN,B2
-ogenblik,instant,فور,NOUN,B2
+functionarissen,officials,官员,NOUN,B2
 oh,oh,哇,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oil tanker,oil tanker,词,NOUN,C1
-oilfield,oilfield,词,NOUN,C1
-ok,ok,好的,INTJ,B2
-okay,okay,好的,ADJ,B2
-okay (noun),okay,好啊,NOUN,C1
-old (noun),old,夙,NOUN,B1
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
-old thief,old thief,老贼,NOUN,C1
-old-age,old-age,晚年,NOUN,C1
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oldest,oldest,词,ADJ,C1
-oleander,oleander,词,NOUN,B2
-olfactory,olfactory,词,ADJ,C1
-oligarchy,oligarchy,寡头政治,NOUN,B2
-oligopoly,oligopoly,寡头垄断,NOUN,B2
-olives,olives,词,NOUN,A2
-om,in order to,以期,SCONJ,B2
-omcirkelen,to circumscribe,限制,VERB,B2
-omdraaien,to turn around,转身,VERB,B2
-omelet,omelet,欧姆蛋,NOUN,B2
-omelette,omelette,煎蛋卷,NOUN,B2
-omgekeerde omvatting,reverse inclusion,反纳,NOUN,B2
-omgekeerde reflectie,reverse reflection,反影,NOUN,B2
-omgeving,surroundings,周围,NOUN,B2
-omhelzen,embrace,拥抱,NOUN,B2
-omhelzen,to embrace,拥抱,VERB,B2
-omhoog,up,向上,ADV,B2
-omhooggaan,to go up,上升,VERB,B2
-omkering,reversal,突变,NOUN,B2
-omlaag,downwards,向下,ADV,B2
-omleiden,to divert,转移,VERB,B2
-omnipotent,omnipotent,词,ADJ,C1
-omnipresent,omnipresent,无所不在的,ADJ,B2
-omniscient,omniscient,词,ADJ,C1
-omsluiten,to enclose,围住,VERB,B2
-omvang,extent,程度,NOUN,B2
-omverwerpen,to overturn,打翻,VERB,B2
-omweg,detour,绕道,NOUN,B2
-on board,on board,在船上,ADV,B2
-on condition,on condition,词,SCONJ,C1
-on one hand,on one hand,一方面,ADV,B2
-on purpose,on purpose,故意地,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that day,on that day,词,ADV,C1
-on the spot,on the spot,当场,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,准时,ADV,B2
-on top,on top,在上面,ADV,B2
-on upon,on upon,在...上,ADP,B2
-on what,on what,在什么上面,ADV,B2
-onaanvaardbaar,unacceptable,不可接受的,ADJ,B2
-onafscheidelijk,inseparable,不可分割的,ADJ,B2
-onbeduidend,insignificant,微不足道的,ADJ,B2
-onbegrijpelijk,abstruse,深奥的,ADJ,B2
-onbegrijpelijk,incomprehensible,不可理解的,ADJ,B2
-onbeheersbaar,uncontrollable,无法控制的,ADJ,B2
-onbekend,heard beile,听说贝勒,NOUN,B2
-onbelangrijk,unimportant,不重要的,ADJ,B2
-onbeleefd,rude,粗鲁的,ADJ,B2
-onbeleefdheid,rudeness,粗鲁,NOUN,B2
-onbereikbaar,unattainable,难以获得的,ADJ,B2
-onbeschaamdheid,brazenness,厚颜无耻,NOUN,B2
-onbeschadigd,intact,完好无损的,ADJ,B2
-onbeschoft,impudent,无礼的,ADJ,B2
-onbeschoft,insolent,傲慢的,ADJ,B2
-onbeschoftheid,impudence,厚颜无耻,NOUN,B2
-onbeschoftheid,insolence,无礼,NOUN,B2
-onbeschrijfelijk,indescribable,难以形容的,ADJ,B2
-onbeslist,indecisive,犹豫不决的,ADJ,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
-oncology,oncology,词,NOUN,C1
-ondanks,to in spite of,不顾,VERB,B2
-onderbroek,underpants,内裤,NOUN,B2
-onderdak,accommodation,住宿,NOUN,B2
-onderdak,lodging,住宿,NOUN,B2
-onderdompeling,immersion,沉浸,NOUN,B2
-onderdrukken,to oppress,压迫,VERB,B2
-onderdrukken,to repress,镇压,VERB,B2
-onderdrukken,to suppress,压制,VERB,B2
-onderdrukkend,repressive,压制的,ADJ,B2
-onderdrukking,oppression,压迫,NOUN,B2
-onderdrukking,repression,镇压,NOUN,B2
-onderdrukking,suppression,抑,NOUN,B2
-ondermijnen,to undermine,破坏,VERB,B2
-onderneming,undertaking,事业,NOUN,B2
-onderschatten,to underestimate,低估,VERB,B2
-onderschatting,underestimation,小看,NOUN,B2
-ondertekenen,to sign for,签收,VERB,B2
-ondertekenen,to underwrite,承保,VERB,B2
-onderwerp,topic,话题,NOUN,B2
-onderwijs,teaching,教学,NOUN,B2
-onderwijzen,to teach,教,VERB,B2
-onderzoek,examination,考试,NOUN,B2
-onderzoek,inquiry,调查,NOUN,B2
-onderzoeken,to examine,检查,VERB,B2
-onderzoeken,to research,研究,VERB,B2
-onderzoeken,to scrutinize,仔细检查,VERB,B2
-ondoordringbaar,impenetrable,不可穿透的,ADJ,B2
-ondraaglijk,unbearable,难以忍受的,ADJ,B2
-one (det),one,词,DET,C1
-one (noun),one,one,NOUN,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one handful,one handful,一把,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-oneindig,infinite,无限的,ADJ,B2
-onenigheid,dissent,异议,NOUN,B2
-onerous,onerous,词,ADJ,C1
-onervaren,inexperienced,生疏的,ADJ,B2
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-onfortuinlijk,unfortunate,不幸的,ADJ,B2
-ongeacht,no matter,不论,CCONJ,B2
-ongeduldig,impatient,不耐烦的,ADJ,B2
-ongekoeld,uncooled,未寒,NOUN,B2
-ongelijk,unequal,不平等的,ADJ,B2
-ongelijkheid,inequality,不平等,NOUN,B2
-ongeloof,non-belief,非信,NOUN,B2
-ongelooflijk,unbelievable,难以置信的,ADJ,B2
-ongeluk,misfortune,不幸,NOUN,B2
-ongeluk hebben,to have an accident,遭遇意外,VERB,B2
-ongelukkig,unlucky,倒霉的,ADJ,B2
-ongemakkelijk,reluctantly,不情愿地,ADV,B2
-ongenoegen,displeasure,不悦,NOUN,B2
-ongeveer,roughly,大约,ADV,B2
-ongewilligheid,unwillingness,不甘,NOUN,B2
-ongewoon,unusual,不寻常的,ADJ,B2
-ongoing,ongoing,进行中的,ADJ,B2
-ongoing (noun),ongoing,词,NOUN,B2
-onhandig,awkward,尴尬的,ADJ,B2
-onheilspellend,ominous,不祥的,ADJ,B2
-onjuist,improper,不合适的,ADJ,B2
-online,online,词,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-onlinegaan,to go online,上网,VERB,B2
-only,only,唯一的,DET,B2
-only (sconj),only,而已,SCONJ,B2
-only bringing,only bringing,只带,NOUN,C1
-only son,only son,独子,NOUN,C1
-onmeetbaar,immeasurable,不可估量的,ADJ,B2
-onmiddellijk,immediate,立即的,ADJ,B2
-onmiddellijk voordeel nastrevend,seeking instant benefit,急功近利,ADJ,B2
-onmin,falling out,反目,NOUN,B2
-onmisbaar,indispensable,不可或缺的,ADJ,B2
-onmogelijkheid,impossibility,不可能,NOUN,B2
-onomatopoeia,onomatopoeia,拟声词,NOUN,B2
-onontkenbaar,undeniable,不可否认的,ADJ,B2
-onoverkomelijk,insurmountable,不可逾越的,ADJ,B2
-onpasse,inappropriate,不恰当的,ADJ,B2
-onprettig,unpleasant,令人不快的,ADJ,B2
-onrechtvaardig,unjust,不公正的,ADJ,B2
-onreinheid,impurity,不纯,NOUN,B2
-onroerend,real estate,房地产,ADJ,B2
-onrust,unease,不安,NOUN,B2
-onrustig,uneasy,不安的,ADJ,B2
-onschadelijk,harmless,无害的,ADJ,B2
-onschuld,innocence,无辜,NOUN,B2
-onsterfelijkheid,immortality,不朽,NOUN,B2
-ontbinden,to decompose,分解,VERB,B2
-ontbinden,to untie,解开,VERB,B2
-ontbinding,dissolution,溶解,NOUN,B2
-ontbossing,deforestation,森林砍伐,NOUN,B2
-ontbreken,to lack,缺乏,VERB,B2
-ontcijferen,to decipher,破译,VERB,B2
-ontdekken,to find out,找出,VERB,B2
-ontdekkingsreiziger,explorer,探险家,NOUN,B2
-ontduiken,to evade,逃避,VERB,B2
-onteigenen,to expropriate,征用,VERB,B2
-onteigening,expropriation,征用,NOUN,B2
-ontevreden,dissatisfied,不满的,ADJ,B2
-ontgiften,to detoxify,解毒,VERB,B2
-onthullen,to uncover,揭露,VERB,B2
-onthulling,unveiling ceremony,揭幕仪式,NOUN,B2
-ontlasten,to exonerate,使无罪,VERB,B2
-ontleden,to dissect,解剖,VERB,B2
-ontleener,borrower,借款人,NOUN,B2
-ontmoeting,encounter,相遇,NOUN,B2
-ontologie,ontology,本体论,NOUN,B2
-ontschuldigen,to apologize,道歉,VERB,B2
-ontschuldiging,apology,道歉,NOUN,B2
-ontslag,resignation,辞职,NOUN,B2
-ontsnapping,escape,逃跑,NOUN,B2
-ontspannen,at ease,安心,ADJ,B2
-ontspanning,relaxation,缓和,NOUN,B2
-ontsteking,ignition,点火,NOUN,B2
-ontsteld,indignant,愤慨的,ADJ,B2
-ontsteltenis,indignation,愤慨,NOUN,B2
-ontstemmen,to displease,使不快,VERB,B2
-ontucht,debauchery,放荡,NOUN,B2
-ontucht,licentiousness,放荡,NOUN,B2
-ontvangen,to host,接待,VERB,B2
-ontvanger,receiver,接收器,NOUN,B2
-ontvluchten,to abscond,潜逃,VERB,B2
-ontvouwen,to unfold,展开,VERB,B2
-ontvreemding,alienation,异化,NOUN,B2
-ontwaking,awakening,觉醒,NOUN,B2
-ontwapenen,to disarm,解除武装,VERB,B2
-ontwatering,dehydration,脱水,NOUN,B2
-ontwijkend,evasive,回避的,ADJ,B2
-ontwikkeld,developed,发达的,ADJ,B2
-ontzag,awe,敬畏,NOUN,B2
-ontzitten,to terrify,使恐惧,VERB,B2
-onuitwisbaar,indelible,不可磨灭的,ADJ,B2
-onveilig,insecure,不安全的,ADJ,B2
-onveiligheid,precariousness,不稳定性,NOUN,B2
-onvermijdelijk,can't help,不由得,ADV,B2
-onvermogen,inability,无能,NOUN,B2
-onvermogen,non-ability,非能,NOUN,B2
-onverschillig,indifferent,冷漠的,ADJ,B2
-onverstoord,unruffled,从容,ADJ,B2
-onverwacht,unexpectedly,出乎意料地,ADV,B2
-onvolledig,incomplete,不完整的,ADJ,B2
-onvoorspelbaar,unpredictable,不可预测的,ADJ,B2
-onvoorstelbaar,unimaginable,难以想象的,ADJ,B2
-onvoorzichtig,careless,粗心的,ADJ,B2
-onwaardigheid,unworthy,你不配,NOUN,B2
-onwaarheid,falsehood,谎言,NOUN,B2
-onwaarschijnlijk,unlikely,不太可能的,ADJ,B2
-onwetend,ignorant,无知的,ADJ,B2
-onwetendheid,ignorance,无知,NOUN,B2
-onzin uitpraten,to talk nonsense,胡言乱语,VERB,B2
-ooggetuige,eyewitness,目击,NOUN,B2
-ooglid,eyelid,眼皮,NOUN,B2
-oogsten,to harvest,收割,VERB,B2
-ooit,at any time,随时,ADV,B2
-ook nog,also too,也,ADV,B2
-oom,maternal uncle,舅舅,NOUN,B2
-oops,oops,词,INTJ,C1
-oorlog voeren,to wage war,作战,VERB,B2
-oorlogsgod,god of war,战神,NOUN,B2
-oozing,oozing,词,NOUN,B2
-op een gegeven moment,sometime,在某个时候,ADV,B2
-op tijd,in time,及时地,ADV,B2
-opacity,opacity,不透明性,NOUN,B2
-opaque,opaque,词,ADJ,C1
-opblazen,to inflate,使膨胀,VERB,B2
-opbreken,to set off,出发,VERB,B2
-opdrachten ontvangen,to receive orders,受命,VERB,B2
-opeenvolgende kaarten,consecutive cards,连牌,NOUN,B2
-opeenvolging,succession,连续,NOUN,B2
-open,open,开着的,ADJ,B2
-open (adv),open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-openbaar,publicly,公开地,ADV,B2
-openbare orde,public order,治安,NOUN,B2
-openbaring,revelation,启示,NOUN,B2
-opengevoelig,open-minded,思想开明的,ADJ,B2
-opening,opening,开口,NOUN,B2
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
-openlijk,openly,公开地,ADV,B2
-openness,openness,开放,NOUN,B2
-opera,opera,歌剧,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
-operator,operator,经营者,NOUN,B2
-operetta,operetta,词,NOUN,C1
-opgeleid,educated,受过教育的,ADJ,B2
-ophopen,to pile up,堆积,VERB,B2
-opium den,opium den,词,NOUN,B2
-opleiden,to educate,教育,VERB,B2
-oplettend,attentive,专心的,ADJ,B2
-oplichting,scam,骗局,NOUN,B2
-oplosmiddel,solvent,溶剂,NOUN,B2
-oplossen,to dissolve,溶解,VERB,B2
-opmerkzaam,perceptive,敏锐的,ADJ,B2
-opofferen,to sacrifice,牺牲,VERB,B2
-oppervlakkig,superficial,表面的,ADJ,B2
-opportune,opportune,词,ADJ,C1
-opportunism,opportunism,词,NOUN,C1
-opportunist,opportunist,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opportunity used,opportunity used,机会,NOUN,B2
-opposing,opposing,词,ADJ,C1
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
-oppressed,oppressed,词,ADJ,B1
-oppressive weight,oppressive weight,词,NOUN,C1
-opprobrium,opprobrium,词,NOUN,C1
-oprecht,upright,正直的,ADJ,B2
-oprechtheid,sincerity,真诚,NOUN,B2
-oprichten,to erect,建立,VERB,B2
-oprit,driveway,车道,NOUN,B2
-oproer,uproar,骚动,NOUN,B2
-opruimen,to tidy up,整理,VERB,B2
-opscheppen,to boast,吹嘘,VERB,B2
-opscheuren,to tear up,流泪,VERB,B2
-opsommen,to enumerate,列举,VERB,B2
-opsommen,to list,列举,VERB,B2
-opstaan,to get up,起床,VERB,B2
-opstand,insurrection,起义,NOUN,B2
-opstand,rebellion,叛乱,NOUN,B2
-opstand,uprising,起义,NOUN,B2
-opstandeling,rebel,反叛者,NOUN,B2
-opstandig hart,rebellious heart,反心,NOUN,B2
-opstanding,resurrection,复活,NOUN,B2
-opstellen,to line up,排成一行,VERB,B2
-opstijgen,takeoff,起飞,NOUN,B2
-opstijgen,to ascend,上升,VERB,B2
-opstoken,to incite,煽动,VERB,B2
-opstokking,incitement,煽动,NOUN,B2
-opt,opt,词,VERB,C1
-optica,optics,光学,NOUN,B2
-optician,optician,词,NOUN,C1
-optics perspective,optics perspective,词,NOUN,C1
-opties,options,期权,NOUN,B2
-optillen,to lift,举起,VERB,B2
-optimisme,optimism,乐观,NOUN,B2
-optimistisch,optimistic,乐观的,ADJ,B2
-optimization,optimization,优化,NOUN,B2
-optimum,optimum,词,NOUN,C1
-optioneel,optional,可选的,ADJ,B2
-optisch,optical,光学的,ADJ,B2
-opulence,opulence,词,NOUN,C1
-opulent,opulent,豪华的,ADJ,B2
-opvallend,conspicuous,显著的,ADJ,B2
-opvragen,to retrieve,取回,VERB,B2
-opvraging,retrieval,检索,NOUN,B2
-opwaarts,upturn,好转,NOUN,B2
-opwekken,to arouse,引起,VERB,B2
-opwekken,to excite,使兴奋,VERB,B2
-opwekken,to rouse,唤醒,VERB,B2
-opwinding,excitement,兴奋,NOUN,B2
-opzettelijk,intentional,故意的,ADJ,B2
-opzijgaan,to move aside,移开,VERB,B2
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
-oraal,oral,口头的,ADJ,B2
-oracle,oracle,神谕,NOUN,B2
-oracular,oracular,词,ADJ,C1
-oral cavity,oral cavity,口腔,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange (noun),orange,橙,NOUN,B1
-orange color,orange color,词,ADJ,A1
-orange juice,orange juice,橙汁,NOUN,B2
-orator speaker,orator speaker,词,NOUN,C1
-oratory,oratory,词,NOUN,C1
-orbital,orbital,词,ADJ,C1
-orchard,orchard,果园,NOUN,B2
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-ordeal,ordeal,苦难,NOUN,B2
-order mission,order mission,词,NOUN,A2
-orderly,orderly,有序的,ADJ,B2
-ordinance,ordinance,条例,NOUN,B2
-ordinarily,ordinarily,通常,ADV,B2
-ordinary day,ordinary day,平日,NOUN,B2
-ordinary people,ordinary people,老百姓,NOUN,B2
-ore,ore,矿石,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organism,organism,词,NOUN,C1
-organization body,organization body,词,NOUN,B1
-organizer,organizer,组织者,NOUN,B2
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
-orientation direction,orientation direction,词,NOUN,B1
-original,original,重原,NOUN,B2
-original document,original document,原件,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
-originality,originality,独创性,NOUN,B2
-originally,originally,最初,ADV,B2
-originally (part),originally,原,PART,B2
-originator,originator,词,NOUN,C1
-orison prayer,orison prayer,词,NOUN,C1
-ornament,ornament,装饰,NOUN,B2
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-orphan,orphan,孤儿,NOUN,B2
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,无父母的,ADJ,B2
-orthodox,orthodox,正统的,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
-oscillate,to oscillate,振荡,VERB,B2
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-oscillator,oscillator,振荡器,NOUN,C1
-osseous,osseous,词,ADJ,C1
-ostensible,ostensible,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentation,ostentation,词,NOUN,C1
-ostentatious,ostentatious,词,ADJ,C1
-ostracism,ostracism,词,NOUN,C1
-ostrich,ostrich,词,NOUN,B2
-other,other,其他的,DET,B2
-other (noun),other,…别,NOUN,B2
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
-other people,other people,人家,NOUN,B2
-otherness,otherness,相异性,NOUN,B2
-others,others,他人,NOUN,B2
-others (pron),others,词,PRON,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-oude bediende,old servant,老奴,NOUN,B2
+o mijn god,oh my god,我的天,INTJ,B2
+zalf,ointment,药膏,NOUN,B2
+ouderdom,old age,老年,NOUN,B2
 oude man,old man,老人,NOUN,B2
 oude meester,old master,老太爷,NOUN,B2
+bejaarde,old person,老人,NOUN,B2
+oude bediende,old servant,老奴,NOUN,B2
 oude vrouw,old woman,老妇人,NOUN,B2
-ouder,parents,父母,NOUN,B2
-ouderdom,old age,老年,NOUN,B2
 oudere broer,older brother,大哥哥,NOUN,B2
-oudste zoon,eldest son,长子,NOUN,B2
-ought,ought,应该,AUX,B2
-ought to,ought to,词,AUX,A2
-ounce,ounce,词,NOUN,C1
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-out here,out here,这里外面,ADV,B2
-out of,out of,从...出来,ADP,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,格格不入的,ADJ,B2
-out there,out there,词,ADV,B2
-outbreak,outbreak,爆发,NOUN,B2
-outburst,outburst,迸发,NOUN,B2
-outcast,outcast,被遗弃者,NOUN,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoor pool,outdoor pool,词,NOUN,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,外部的,ADJ,B2
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outfit,outfit,服装,NOUN,B2
-outgoing,outgoing,外向的,ADJ,C1
-outhouse,outhouse,茅房,NOUN,B2
-outing,outing,郊游,NOUN,B2
-outlandish,outlandish,古怪的,ADJ,B2
-outlast,outlast,词,VERB,B2
-outlaw,outlaw,歹徒,NOUN,B2
-outlet,outlet,出口,NOUN,B2
-outline,outline,大纲,NOUN,B2
-outline,to outline,勾勒,VERB,B2
-outlook,outlook,前景,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outrage,outrage,愤怒,NOUN,B2
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outset,outset,词,NOUN,C1
-outside of,outside of,在...之外,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outsider,outsider,外人,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
-outsourcing,outsourcing,外包,NOUN,B2
-outstanding,outstanding,杰出的,ADJ,B2
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward,outward,向外,ADV,B2
-outward (adj),outward,词,ADJ,C1
-outward journey,outward journey,词,NOUN,C1
-ovarian,ovarian,词,ADJ,C1
-oven,oven,烤箱,NOUN,B2
-over,over,在...上方,ADP,B2
-over (adv),over,过去,ADV,B2
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
-over there,over there,在那边,ADV,B2
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overbidding,overbidding,词,NOUN,C1
-overbodig,superfluous,多余的,ADJ,B2
-overconsumption,overconsumption,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
-overdomein,over-domain,超畴,NOUN,B2
-overdose,overdose,过量,NOUN,B2
-overdracht,handover,拿给,NOUN,B2
-overdraft,overdraft,透支,NOUN,B2
-overdreven,exaggerated,夸张的,ADJ,B2
-overdrijving,exaggeration,夸张,NOUN,B2
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overgangs-,transitional,过渡的,ADJ,B2
-overgeven,surrender,投降,NOUN,B2
-overgeven,to surrender,投降,VERB,B2
-overgeven,to vomit,呕吐,VERB,B2
-overhandigen,to hand over,交付,VERB,B2
-overhead,overhead,词,NOUN,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overkomen,to come over,顺道来访,VERB,B2
-overlap,overlap,重叠,NOUN,B2
-overlapping,overlapping,重叠的,ADJ,C1
-overledene,deceased,死者,NOUN,B2
-overleving,survival,生存,NOUN,B2
-overlijden,to pass away,流逝,VERB,B2
-overload surcharge,overload surcharge,词,NOUN,C1
-overloop,overflow,溢出,NOUN,B2
-overly familiar,overly familiar,词,ADJ,B2
-overnacht,overnight,一夜之间,ADV,B2
-overreach,overreach,词,NOUN,C1
-overreding,coaxing,哄得,NOUN,B2
-overrijden,to run over,碾过,VERB,B2
-overrule,overrule,词,VERB,C1
-overschot,surplus,过剩,NOUN,B2
-overschrijven,to overdraw,透支,VERB,B2
-overseas,overseas,词,ADV,B2
-oversight,oversight,疏忽,NOUN,B2
-oversteek,crossing,交叉口,NOUN,B2
-overstrategie,over-strategy,超策,NOUN,B2
-overstroke,over-stroke,超程,NOUN,B2
-overstroming,flood,洪水,NOUN,B2
-overt,overt,词,ADJ,C1
-overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overtreding,transgression,违犯,NOUN,B2
-overtreding,violation,侵越,NOUN,B2
-overtreffen,to surpass,超过,VERB,B2
-overtuigen,to persuade,说服,VERB,B2
-overtuiging,persuasion,说服,NOUN,B2
-overuren,overtime,加班,NOUN,B2
-overvloed,abundance,丰富,NOUN,B2
-overvloedig,abundant,丰富的,ADJ,B2
-overwegen,to contemplate,沉思,VERB,B2
-overwegen,to deliberate,深思熟虑,VERB,B2
-overweight,overweight,词,ADJ,C1
-overwelderen,to overwhelm,使不知所措,VERB,B2
-overwhelming,overwhelming,压倒性的,ADJ,B2
-overwork,overwork,词,NOUN,C1
-overzeese Chinees,overseas chinese,华侨,NOUN,B2
-ow,ow,词,INTJ,C1
-own,own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-owned,owned,被拥有的,ADJ,A1
-oxidation,oxidation,词,NOUN,C1
-oxide,oxide,氧化物,NOUN,B2
-oxidized,oxidized,词,ADJ,C1
-oxymoron,oxymoron,矛盾修辞法,NOUN,B2
-oyster,oyster,牡蛎,NOUN,B2
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-paar,pair,一对,NOUN,B2
-paardensport,equestrianism,马术,NOUN,B2
-paardenvertrek,horse departure,马去,NOUN,B2
-paarse yin,purple yin,紫阴,NOUN,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
-pact,pact,协定,NOUN,B2
-pacts,pacts,词,NOUN,C1
-padding,padding,词,NOUN,C1
-paddle,paddle,词,VERB,C1
-padlock,padlock,词,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pain hurt,pain hurt,疼痛,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,词,ADJ,C1
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-painstakingly,painstakingly,细致地,ADV,B2
-paint dye,paint dye,词,VERB,A1
-paintbrush,paintbrush,画笔；毛笔,NOUN,B2
-pairing,pairing,可配,NOUN,C1
-pajamas,pajamas,睡衣,NOUN,B2
-pakket,packet,小包裹,NOUN,B2
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-palatable,palatable,词,ADJ,C1
-paleography,paleography,词,NOUN,C1
-palimpsest,palimpsest,词,NOUN,C1
-palisade,palisade,词,NOUN,C1
-palliative,palliative,缓和的,ADJ,B2
-pallid,pallid,词,ADJ,C1
-pallor,pallor,苍白,NOUN,B2
-palm,palm,手掌,NOUN,B2
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
-palmboom,palm tree,棕榈树,NOUN,B2
-palpable,palpable,词,ADJ,C1
-paltriness,paltriness,词,NOUN,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
-panda,panda,熊猫,NOUN,B2
-pandemie,pandemic,大流行病,NOUN,B2
-paneel,panel,小组,NOUN,B2
-panegyriek,panegyric,颂词,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-pannenkoek,pancake,煎饼,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
-pantheon,pantheon,先贤祠,NOUN,B2
-panther,panther,豹,NOUN,B2
-pantheïsme,pantheism,泛神论,NOUN,B2
-panties,panties,词,NOUN,C1
-pants,pants,裤子,NOUN,B2
-pants trousers,pants trousers,词,NOUN,A1
-pantseren,to pant,喘气,VERB,B2
-papaja,papaya,木瓜,NOUN,B2
-papal bull,papal bull,词,NOUN,B2
-papegaai,parrot,鹦鹉,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-papierknipsel,paper cutting,剪纸,NOUN,B2
-papierwerk,paperwork,文书工作,NOUN,B2
-parable,parable,寓言,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-parade,parade,游行,NOUN,B2
-paradigma,paradigm,范例,NOUN,B2
-paradise heaven,paradise heaven,词,NOUN,B1
-paradox,paradox,悖论,NOUN,B2
-paradoxical,paradoxical,矛盾的,ADJ,B2
-paradoxically,paradoxically,词,ADV,C1
-paragoon,paragon,典范,NOUN,B2
-paragraaf,paragraph,段落,NOUN,B2
-paragraph heel,paragraph heel,词,NOUN,C1
-paralipsis,paralipsis,词,NOUN,C1
-parallel,parallel,平行的,ADJ,B2
-parallelism,parallelism,词,NOUN,C1
-paralogism,paralogism,谬误推理,NOUN,B2
-paralyse,paralysis,瘫痪,NOUN,B2
-paralyseren,to paralyze,使瘫痪,VERB,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
-paramedicus,paramedic,急救人员,NOUN,B2
-parameter,parameter,参数,NOUN,B2
-paramount,paramount,词,ADJ,C1
-paranoia,paranoia,词,NOUN,C1
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parataxis,parataxis,意合,NOUN,B2
-parcel,parcel,包裹,NOUN,B2
-parch,parch,词,VERB,C1
-parchment,parchment,词,NOUN,C1
-pardon (noun),pardon,莫怪,NOUN,B2
-parent-friendly,parent-friendly,,NOUN,B2
-parenthesis,parenthesis,词,NOUN,C1
-paresis,paresis,词,NOUN,C1
-pariah,pariah,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parishioner,parishioner,教区居民,NOUN,B2
-parishioners,parishioners,词,NOUN,C1
-pariteit,parity,平等,NOUN,B2
-parkeerplaats,parking,停车,NOUN,B2
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
-parley,parley,词,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parlor,parlor,词,NOUN,C1
-paronomase,paronomasia,近音词双关,NOUN,B2
-paronym,paronym,词,NOUN,C1
-paroxysm,paroxysm,发作,NOUN,B2
-parquet,parquet,词,NOUN,C1
-parse,parse,解析,VERB,B2
-parsimonious,parsimonious,吝啬的,ADJ,B2
-parsimony,parsimony,吝啬,NOUN,B2
-part forever,part forever,永别,VERB,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-partial,partial,部分的,ADJ,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-participatief,participatory,参与式的,ADJ,B2
-particle (part),particle,么,PART,B2
-particulariteit,particularity,特点,NOUN,B2
-particularize,particularize,词,VERB,B2
-particularly,particularly,特别地,ADV,B2
-partisan (adj),partisan,词,ADJ,C1
-partisan (noun),partisan,词,NOUN,C1
-partisanship,partisanship,党派性,NOUN,C1
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
-partner female,partner female,词,NOUN,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-party to the contract,party to the contract,词,NOUN,B2
-pas dan,only then,才,ADV,B2
-pashalik,pashalik,词,NOUN,C1
-pass (noun),pass,过得,NOUN,C1
-passable,passable,词,ADJ,C1
-passage,passage,段落,NOUN,B2
-passed,passed,递,ADJ,B2
-passen,to match,相配,VERB,B2
-passen op,to take care,照顾,VERB,B2
-passend,fitting,合适的,ADJ,B2
-passend,matching,配套,ADJ,B2
-passerby,passerby,词,NOUN,C1
-passionate,passionate,热情的,ADJ,B2
-passionate love,passionate love,词,NOUN,C1
-passive reliance on others,passive reliance on others,词,NOUN,C1
-past,past,经过,ADV,B2
-past (adj),past,past,ADJ,A1
-past events,past events,往事,NOUN,B2
-past exam papers,past exam papers,真题,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
-pasta,pasta,意大利面,NOUN,B2
-paste,paste,酱,NOUN,B2
-pastime,pastime,爱好,NOUN,B2
-pastoral (adj),pastoral,词,ADJ,C1
-pastoral (noun),pastoral,词,NOUN,C1
-pastry chef,pastry chef,词,NOUN,C1
-pasture,pasture,牧场,NOUN,B2
-pat,to pat,轻拍,VERB,B2
-patch,patch,补丁,NOUN,B2
-patch tire,patch tire,补胎,VERB,C1
-patent,patent,专利,NOUN,B2
-patently,patently,显然地,ADV,B2
-paternal aunt,paternal aunt,姑母,NOUN,B2
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
-pathogenic,pathogenic,致病的,ADJ,B2
-pathological,pathological,病态的,ADJ,B2
-pathology,pathology,病理学,NOUN,B2
-patient,patient,耐心的,ADJ,B2
-patient female,patient female,词,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patiently,patiently,词,ADV,C1
-patriarch,patriarch,词,NOUN,C1
-patriarchy,patriarchy,父权制,NOUN,B2
-patriot,patriot,词,NOUN,B2
-patriotism,patriotism,爱国主义,NOUN,B2
-patrol,patrol,巡逻,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
-patronage,patronage,赞助,NOUN,B2
-paucity,paucity,词,NOUN,C1
-pauper,pauper,词,NOUN,B2
-pause,pause,暂停,NOUN,B2
-pave,pave,词,VERB,C1
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
-pavilion,pavilion,亭子,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-paving stone,paving stone,词,NOUN,A2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-pay respects,to pay respects,参见,VERB,B2
-pay smilingly,to pay smilingly,笑付,VERB,B2
-pay tax,to pay tax,纳税,VERB,B2
-payment all,payment all,付都,NOUN,B2
-payments,payments,词,NOUN,C1
-pea,pea,词,NOUN,C1
-peaceful,peaceful,和平的,ADJ,B2
-peacefully,peacefully,词,ADV,C1
-peach,peach,桃子,NOUN,B2
-peach tree,peach tree,词,NOUN,C1
-peak,peak,顶峰,NOUN,B2
-peanut,peanut,花生,NOUN,B2
-peanut field,peanut field,词,NOUN,B2
-pearl,pearl,珍珠,NOUN,B2
-peasant,peasant,农民,NOUN,B2
-pebble,pebble,卵石,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
-peculiar,peculiar,奇怪的,ADJ,B2
-peculiarity,peculiarity,词,NOUN,B2
-pecuniary,pecuniary,词,ADJ,C1
-pedagogical,pedagogical,教学的,ADJ,B2
-pedagogy,pedagogy,教育学,NOUN,B2
-pedal,pedal,词,NOUN,B1
-pedantic,pedantic,词,ADJ,C1
-pedantically,pedantically,词,ADV,C1
-pedantry,pedantry,迂腐,NOUN,B2
-pedestrian,pedestrian,行人,NOUN,B2
-pedestrian bridge,pedestrian bridge,天桥,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-pediment,pediment,词,NOUN,C1
-pee,to pee,小便,VERB,B2
-peek,peek,词,VERB,C1
-peel,peel,皮,NOUN,B2
-peel,to peel,削皮,VERB,B2
-peel (noun),peel,词,NOUN,B2
-peephole,peephole,门镜,NOUN,B2
-peer,peer,同龄人,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-pees,tendon,肌腱,NOUN,B2
-peg,peg,词,NOUN,C1
-pejorative,pejorative,词,ADJ,C1
-pelgrim,pilgrim,朝圣者,NOUN,B2
-pellucid,pellucid,词,ADJ,C1
-pelvis,pelvis,词,NOUN,B2
-pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalties,penalties,处罚,NOUN,C1
-penalty,penalty,惩罚,NOUN,B2
-penalty payment,penalty payment,词,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-penchant,penchant,词,NOUN,C1
-pencil case,pencil case,词,NOUN,C1
-pending,pending,词,ADJ,B1
-penetrate,to penetrate,穿透,VERB,B2
-penetratie,penetration,渗透,NOUN,B2
-penguin,penguin,词,NOUN,A1
-penis,penis,词,NOUN,B2
-penitence,penitence,词,NOUN,C1
-penitent,penitent,词,ADJ,C1
-penitentiary,penitentiary,词,ADJ,C1
-pennant,pennant,词,NOUN,C1
-penniless,penniless,词,ADJ,B1
-pensioen,retirement,退休,NOUN,B2
-pensioengaan,to retire,退休,VERB,B2
-pensive,pensive,沉思的,ADJ,B2
-penury,penury,词,NOUN,C1
-people nation,people nation,人民 / 民族,NOUN,B2
-peppermint,peppermint,词,NOUN,C1
-per,per,每,ADP,B2
-per ongeluk,accidentally,意外地,ADV,B2
-percentage,percentage,百分比,NOUN,B2
-perceptibly,perceptibly,明显地,ADV,B2
-perceptie,perception,感知,NOUN,B2
-perception opinion,perception opinion,看法,NOUN,B2
-perceptual,perceptual,词,ADJ,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-peremptorily,peremptorily,词,ADV,C1
-peremptory,peremptory,专横的,ADJ,B2
-perennial,perennial,长期的,ADJ,B2
-perfectie,perfection,完美,NOUN,B2
-perfectly,perfectly,词,ADV,A2
-perfidious,perfidious,词,ADJ,C1
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-performer,performer,词,NOUN,C1
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-peri-urban,peri-urban,城市周边的,ADJ,B2
-perifeer,peripheral,外围的,ADJ,B2
-perilla,perilla,紫苏,NOUN,B2
-perilous,perilous,危险的,ADJ,B2
-period,period,句号,PUNCT,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periodical,periodical,词,NOUN,C1
-periodiek,periodically,定期地,ADV,B2
-periodization,periodization,分期,NOUN,C1
-periphery,periphery,边缘,NOUN,B2
-periphrasis,periphrasis,词,NOUN,C1
-perishing,perishing,,NOUN,B2
-peritoneum,peritoneum,腹膜,NOUN,B2
-perks,perks,词,NOUN,C1
-permanentie,permanence,持久,NOUN,B2
-permanently,permanently,词,ADV,C1
-permeability,permeability,词,NOUN,C1
-permissible,permissible,词,ADJ,C1
-permutations,permutations,词,NOUN,C1
-pernicious,pernicious,有害的,ADJ,B2
-peroration,peroration,结语,NOUN,B2
-perpetual,perpetual,永久的,ADJ,B2
-perplex,perplex,词,VERB,C1
-perplexed,perplexed,困惑的,ADJ,B2
-persimmon,persimmon,柿子,NOUN,C1
-persistence,persistence,坚持,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
-personable,personable,词,ADJ,C1
-personal,personal,私事,NOUN,B2
-personal best,personal best,,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
-personalization,personalization,词,NOUN,C1
-personalized,personalized,个性化的,ADJ,B2
-personally experience,personally experience,亲历,VERB,C1
-personeel,personnel,人员,NOUN,B2
-personification,personification,词,NOUN,C1
-persoonlijk,in person,亲自地,ADV,B2
-persoonlijk,personally,就个人而言,ADV,B2
-persoonlijk record,personal record,个人纪录,NOUN,B2
-persoonlijke vete,personal enmity,私仇,NOUN,B2
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicacious,perspicacious,词,ADJ,C1
-perspicacity,perspicacity,词,NOUN,B2
-pertinent,pertinent,词,ADJ,C1
-pertinently,pertinently,词,ADV,B2
-pervasive,pervasive,词,ADJ,C1
-perverse,perverse,任性的,ADJ,B2
-perversity,perversity,词,NOUN,C1
-pessimisme,pessimism,悲观主义,NOUN,B2
-pessimistisch,pessimistic,悲观的,ADJ,B2
-pest,pest,词,NOUN,C1
-pesticides,pesticides,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-pestkop,bully,欺凌者,NOUN,B2
-petal,petal,词,NOUN,C1
-peterselie,parsley,欧芹,NOUN,B2
-petition for review,petition for review,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-pettiness,pettiness,词,NOUN,C1
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-peuterschool,preschool,幼儿园,NOUN,B2
-phantasmagorical,phantasmagorical,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharaoh,pharaoh,法老,NOUN,B2
-pharisee,pharisee,法利赛人,NOUN,B2
-pharynx,pharynx,词,NOUN,B2
-phased (adv),phased,词,ADV,B1
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-pheasant,pheasant,词,NOUN,C1
-phenomenal,phenomenal,非凡的,ADJ,B2
-phenomenological,phenomenological,词,ADJ,C1
-phew,phew,词,INTJ,C1
-philanthropic,philanthropic,词,ADJ,C1
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philologist,philologist,语言学家,NOUN,B2
-philology,philology,词,NOUN,C1
-philosophical,philosophical,哲学的,ADJ,B2
-philosophizing,philosophizing,词,NOUN,C1
-philosophy of life,philosophy of life,词,NOUN,B2
-phishing,phishing,词,NOUN,B2
-phlebitis,phlebitis,静脉炎,NOUN,B2
-phlegmatic,phlegmatic,冷静的,ADJ,B2
-phloem,phloem,词,ADJ,C1
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
-phone credit,phone credit,词,NOUN,B1
-phone number,phone number,电话号码,NOUN,B2
-phoneme,phoneme,词,NOUN,C1
-phony,phony,假的,ADJ,B2
-phosphate,phosphate,词,NOUN,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-phosphorus,phosphorus,词,NOUN,C1
-photo album,photo album,影集,NOUN,C1
-photogenic,photogenic,词,ADJ,C1
-photographic,photographic,词,ADJ,C1
-photogravure,photogravure,词,NOUN,C1
-photophobia,photophobia,词,NOUN,C1
-phototypy,phototypy,词,NOUN,C1
-phraseology,phraseology,词,NOUN,C1
-phrasing,phrasing,措辞,NOUN,B2
-physically,physically,身体上地,ADV,B2
-physicist,physicist,词,NOUN,C1
-physiological,physiological,生理的,ADJ,B2
-physiotherapist,physiotherapist,词,NOUN,B1
-pianist,pianist,词,NOUN,C1
-piano music,piano music,词,NOUN,B2
-picaresque,picaresque,词,ADJ,C1
-pick up a car,pick up a car,取车,VERB,B2
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickle (noun),pickle,词,NOUN,C1
-pickles,pickles,词,NOUN,B2
-picknick,picnic,野餐,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-pictorial,pictorial,绘画的,ADJ,B2
-picture photo,picture photo,词,NOUN,A2
-pidgin,pidgin,词,NOUN,C1
-pie,pie,派,NOUN,B2
-piece of bread,piece of bread,词,NOUN,B2
-piecework,piecework,词,NOUN,C1
-pier,pier,码头,NOUN,B2
-piety pity,piety pity,词,NOUN,B2
-pijnstiller,painkiller,止痛药,NOUN,B2
-pil,pill,药丸,NOUN,B2
-pile heap,pile heap,词,NOUN,C1
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pills,pills,词,NOUN,B2
-pimp,pimp,词,NOUN,C1
-pimple,pimple,词,NOUN,B2
-pinch (noun),pinch,词,NOUN,C1
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
-pioneer,pioneer,先驱,NOUN,B2
-pious,pious,虔诚的,ADJ,B2
-piously,piously,词,ADV,C1
-pipa,pipa,琵琶,NOUN,B2
-pipe dream,pipe dream,词,NOUN,C1
-piquant,piquant,词,ADJ,C1
-piraat,pirate,海盗,NOUN,B2
-piracy,piracy,词,NOUN,B2
-piramide,pyramid,金字塔,NOUN,B2
-pirated,pirated,词,ADJ,B2
-pistache,pistachio,开心果,NOUN,B2
-piston,piston,词,NOUN,C1
-pistool,pistol,手枪,NOUN,B2
-pitch,pitch,词,NOUN,B1
-pitch darkness,pitch darkness,词,NOUN,C1
-pitchfork,pitchfork,叉子,NOUN,B2
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pittance,pittance,词,NOUN,C1
-pity (adj),pity,怜悯,ADJ,B2
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,pivotal,词,ADJ,C1
-pizza,pizza,词,NOUN,B1
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place value,place value,位值,NOUN,C1
-placed before,placed before,词,ADJ,B2
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
-placid,placid,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
-plagen,to harass,骚扰,VERB,B2
-plagerij,harassment,骚扰,NOUN,B2
-plagiaat,plagiarism,剽窃,NOUN,B2
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plaintive,plaintive,哀伤的,ADJ,C1
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
-planning,planning,规划,NOUN,B2
-plantage,plantation,人工林,NOUN,B2
-plantain,plantain,芭蕉,NOUN,B2
-planten,plant,植物,NOUN,B2
-planten,to plant,种植,VERB,B2
-plasma,plasma,血浆,NOUN,B2
-plastic,plastic,塑料的,ADJ,B2
-plastic (noun),plastic,词,NOUN,B1
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
-plateau,plateau,高原,NOUN,B2
-platform,platform,平台,NOUN,B2
-platforms,platforms,词,NOUN,C1
-platinum,platinum,词,NOUN,B2
-platitude,platitude,词,NOUN,C1
-plausibility,plausibility,词,NOUN,B2
-plausible,plausible,似是而非的,ADJ,B2
-play game,play game,游戏/玩耍,NOUN,B2
-playable,playable,可演奏的,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
-playmate,playmate,玩伴,NOUN,B2
-plays,plays,词,NOUN,C1
-playwright,playwright,剧作家,NOUN,B2
-plea,plea,辩护,NOUN,B2
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please,please,请,ADV,B2
-please,to please,使高兴,VERB,B2
-please (adv),please,please,ADV,B2
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-plebiscite,plebiscite,词,NOUN,B2
-plechtig,solemn,庄严的,ADJ,B2
-pledge,pledge,抵押,NOUN,B2
-pledge,to pledge,保证,VERB,B2
-pledge (noun),pledge,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plegen,to commit a crime,犯罪,VERB,B2
-pleister,plaster,石膏,NOUN,B2
-plenary,plenary,词,ADJ,C1
-plenitude,plenitude,充足,NOUN,B2
-plentiful,plentiful,词,ADJ,B2
-plenty,plenty,大量,NOUN,B2
-pleonasm,pleonasm,赘述,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
-pliers,pliers,钳子,NOUN,B2
-plight,plight,处境,NOUN,B2
-ploeg,squad,小队,NOUN,B2
-ploegendienst,shift rotation,倒班,NOUN,B2
-plot,plot,情节,NOUN,B2
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plot twist,plot twist,词,NOUN,C1
-plow,plow,词,NOUN,B2
-plow handle,plow handle,词,NOUN,C1
-plowing,plowing,犁地,NOUN,B2
-plug,plug,插头,NOUN,B2
-pluimvee,poultry,家禽,NOUN,B2
-plum,plum,李子,NOUN,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-plumb,plumb,词,NOUN,C1
-plumber,plumber,水管工,NOUN,B2
-plumbing,plumbing,管道工程,NOUN,B2
-plump,plump,词,ADJ,C1
-plunder,plunder,掠夺,NOUN,B2
-plundering,plundering,掠夺,NOUN,B2
-plunge,plunge,词,VERB,C1
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
-pluralism,pluralism,多元主义,NOUN,B2
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
-plush toy,plush toy,毛绒玩具,NOUN,B2
-plutocracy,plutocracy,财阀政治,NOUN,B2
-pneumonia,pneumonia,词,NOUN,C1
-poach,poach,词,VERB,C1
-pocket,pocket,口袋,NOUN,B2
-podcast,podcast,播客,NOUN,B2
-podcasting,podcasting,词,NOUN,B1
-poeder,powder,粉末,NOUN,B2
-poetic,poetic,词,ADJ,C1
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
-poetry collection,poetry collection,诗集,NOUN,B2
-poignant,poignant,词,ADJ,C1
-point grade,point grade,词,NOUN,A2
-point in time,point in time,时间点,NOUN,B2
-point of view,point of view,词,NOUN,C1
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,徒劳地,ADV,B2
-pointwise,pointwise,词,ADJ,C1
-poison,to poison,毒害,VERB,B2
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,,NOUN,B2
-poisoning,poisoning,中毒,NOUN,B2
-poke,poke,词,VERB,B2
-polar,polar,极地的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polarity,polarity,极性,NOUN,C1
-polarization,polarization,两极分化 / 极化,NOUN,B2
-polemic,polemic,词,NOUN,C1
-polemical,polemical,论战的,ADJ,B2
-polemicist,polemicist,词,NOUN,C1
-police chief,police chief,警察局长,NOUN,B2
-police officer female,police officer female,词,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police report,police report,,NOUN,B2
-police search,police search,词,NOUN,C1
-policeman,policeman,警察,NOUN,B2
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politely,politely,礼貌地,ADV,B2
-politeness,politeness,词,NOUN,C1
-politic,politic,词,ADJ,C1
-political party,political party,政党,NOUN,B2
-politically,politically,在政治上,ADV,B2
-politicization,politicization,词,NOUN,C1
-poll,poll,民意调查,NOUN,B2
-pollinic,pollinic,词,ADJ,C1
-pollster,pollster,词,NOUN,C1
-pollutant,pollutant,污染物,NOUN,B2
-pols,pulse,脉搏,NOUN,B2
-polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,连词叠用,NOUN,B2
-polytunnel,polytunnel,大棚,NOUN,B2
-pomegranate,pomegranate,石榴,NOUN,B2
-pomelo,pomelo,柚子,NOUN,B2
-pomp,pomp,词,NOUN,C1
-pomp,pump,泵,NOUN,B2
-pompous,pompous,浮夸的,ADJ,B2
-pompously,pompously,词,ADV,C1
-ponderous,ponderous,词,ADJ,C1
-pool,pool,水池,NOUN,B2
-pool (part),pool,池,PART,B2
-pooled,pooled,词,ADJ,C1
-poor devil,poor devil,可怜虫,NOUN,B2
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,最穷的,ADJ,B2
-poos,a while,一会儿,NOUN,B2
-poos,while,一会儿,NOUN,B2
-pop,doll,玩偶,NOUN,B2
-pop,pop,词,NOUN,B1
-pop,puppet,木偶,NOUN,B2
-popcorn,popcorn,词,ADJ,C1
-poppy,poppy,词,NOUN,B1
-pops,pops,词,NOUN,C1
-populate,to populate,居住,VERB,B2
-populism,populism,民粹主义,NOUN,C1
-populist,populist,民粹主义者,NOUN,B2
-populous,populous,词,ADJ,C1
-porcelain,porcelain,瓷器,NOUN,B2
-porch,porch,门廊,NOUN,B2
-pork,pork,词,NOUN,B2
-porno,porn,色情,NOUN,B2
-pornografisch,pornographic,色情的,ADJ,B2
-porosity,porosity,词,NOUN,C1
-porous,porous,词,ADJ,C1
-port harbor,port harbor,词,NOUN,A1
-portable,portable,词,ADJ,C1
-portentous,portentous,词,ADJ,C1
-portfolios,portfolios,词,NOUN,C1
-portico,portico,词,NOUN,C1
-portie,portion,部分,NOUN,B2
-portier,doorman,门卫,NOUN,B2
-portion serving,portion serving,部分 / 一份,NOUN,B2
-portrayal,portrayal,词,NOUN,B2
-portretteren,to portray,描绘,VERB,B2
-posit,posit,词,VERB,B2
-positionering,positioning,定位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivism,positivism,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-possessive particle,possessive particle,的,PART,A1
-possible future,possible future,词,ADJ,C1
-post,post,邮件,NOUN,B2
-post ontvangen,to receive mail,收件,VERB,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-poster,poster,海报,NOUN,B2
-posterity,posterity,词,NOUN,C1
-posthumous,posthumous,死后的,ADJ,B2
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
-postponement,postponement,延期,NOUN,B2
-postscript,postscript,词,NOUN,C1
-postulaat,postulate,假定,NOUN,B2
-posture,posture,作势,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-postzegel,stamp,邮票,NOUN,B2
-pot,jar,广口瓶,NOUN,B2
-pot,pot,锅,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
-potential (adj),potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potion,potion,词,NOUN,B2
-pottenbakkerij,pottery,陶器,NOUN,B2
-potter,potter,词,NOUN,B2
-pouch,pouch,词,NOUN,C1
-poultice,poultice,词,NOUN,B2
-pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power outlet,power outlet,插座,NOUN,B1
-power plant,power plant,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powers,powers,词,NOUN,C1
-prachtig,gorgeous,华丽的,ADJ,B2
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatisme,pragmatism,实用主义,NOUN,B2
-pragmatist,pragmatist,词,NOUN,C1
-prairie,prairie,词,NOUN,C1
-praise singer,praise singer,词,NOUN,C1
-praiseworthy,praiseworthy,词,ADJ,C1
-praktijk,practitioner,从业者,NOUN,B2
-praktisch,practically,几乎,ADV,B2
-pralen,to brag,吹嘘,VERB,B2
-prank,prank,恶作剧,NOUN,B2
-praterig,garrulous,喋喋不休的,ADJ,B2
-prawn,prawn,词,NOUN,C1
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-preacher,preacher,传教士,NOUN,B2
-preambule,preamble,序言,NOUN,B2
-precarious,precarious,不稳定的,ADJ,B2
-precarization,precarization,不稳定化,NOUN,B2
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
-precedent,precedent,先例,NOUN,B2
-precies,precise,精确的,ADJ,B2
-precinct,precinct,辖区,NOUN,B2
-precipice,precipice,词,NOUN,C1
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-precisely,precisely,确切地; 正好,ADV,B2
-precision,precision,精确,NOUN,B2
-preclude,preclude,词,VERB,C1
-precocious,precocious,早熟的,ADJ,B2
-precocious talent,precocious talent,词,NOUN,C1
-preconception,preconception,词,NOUN,B2
-predictable,predictable,可预测的,ADJ,B2
-predilection,predilection,词,NOUN,C1
-predominance,predominance,主导地位,NOUN,B2
-predominant,predominant,词,ADJ,B2
-predominantly,predominantly,词,ADV,C1
-preek,sermon,布道,NOUN,B2
-preekstoel,pulpit,讲坛,NOUN,B2
-preeminence,preeminence,词,NOUN,B2
-preeminent,preeminent,词,ADJ,C1
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
-prefect,prefect,词,NOUN,B1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-preferable,preferable,更可取的,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-preken,to preach,布道,VERB,B2
-prelate,prelate,词,NOUN,C1
-preliminary,preliminary,初步的,ADJ,B2
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,词,ADJ,C1
-premature baby,premature baby,词,NOUN,B2
-prematurely,prematurely,词,ADV,C1
-prematurity,prematurity,词,NOUN,C1
-premeditate,premeditate,词,VERB,C1
-premeditation,premeditation,预谋,NOUN,B2
-premiss,premise,前提,NOUN,B2
-premium,premium,溢价,NOUN,B2
-première,premier,总理,NOUN,B2
-premonition,premonition,预感,NOUN,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
-prepared,prepared,准备好的,ADJ,B2
-preparedness,preparedness,词,NOUN,B1
-preponderance,preponderance,词,NOUN,C1
-preponderant,preponderant,占优势的,ADJ,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-prerogative,prerogative,特权,NOUN,B2
-prescient,prescient,词,ADJ,C1
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-president,president,总统,NOUN,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
-presidentieel,presidential,总统的,ADJ,B2
-presidentschap,presidency,总统任期,NOUN,B2
-press freedom,press freedom,新闻自由,NOUN,B2
-presumed,presumed,推定的,ADJ,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-presumptuous,presumptuous,词,ADJ,C1
-pretekst,pretext,借口,NOUN,B2
-pretender,pretender,词,NOUN,C1
-pretending to forget,pretending to forget,词,VERB,C1
-pretension,pretension,词,NOUN,C1
-pretentious,pretentious,自命不凡的,ADJ,B2
-preterition,preterition,假托,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalence,prevalence,词,NOUN,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
-preventive,preventive,词,ADJ,B2
-preview,preview,词,NOUN,C1
-previous,previous,,NOUN,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prices,prices,词,NOUN,C1
-prickly,prickly,词,ADJ,C1
-pride arrogance,pride arrogance,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-prijs,award,奖项,NOUN,B2
-prijsbepaling,pricing,定价 / 收费,NOUN,B2
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
-primary school teacher,primary school teacher,词,NOUN,C1
-primate,primate,词,NOUN,C1
-prime,prime,首要的,ADJ,B1
-prime matter,prime matter,词,NOUN,C1
-primeval forest,primeval forest,原始森林,NOUN,C1
-primitief,primitive,原始的,ADJ,B2
-primordial chaos,primordial chaos,词,NOUN,C1
-principal (adj),principal,词,ADJ,B2
-principality,principality,词,NOUN,C1
-printed,printed,词,ADJ,C1
-printed form,printed form,词,NOUN,B1
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-priority,priority,优先的,ADJ,B2
-prisma,prism,棱镜,NOUN,B2
-pristine,pristine,词,ADJ,C1
-privacy,privacy,隐私,NOUN,B2
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-private life,private life,私生活,NOUN,B2
-privatization,privatization,词,NOUN,B2
-privileged,privileged,词,ADJ,B2
-prize,prize,奖品,NOUN,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-proactive,proactive,积极主动的,ADJ,B2
-probabilistisch,probabilistic,概率的,ADJ,B2
-probable,probable,可能的,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probation,probation,缓刑,NOUN,B2
-probationary,probationary,词,ADJ,B2
-probative,probative,词,ADJ,C1
-probe,probe,探测器,NOUN,B2
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-probity,probity,正直,NOUN,B2
-problematic,problematic,词,ADJ,B2
-problematic issue,problematic issue,词,NOUN,C1
-procedural,procedural,程序的,ADJ,B2
-procedure,procedure,程序,NOUN,B2
-procedures,procedures,词,NOUN,C1
-procespartij,litigant,诉讼当事人,NOUN,B2
-process technique,process technique,词,NOUN,B1
-processing (adj),processing,词,ADJ,C1
-processor,processor,处理器,NOUN,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
-prodigal,prodigal,词,ADJ,C1
-prodigality,prodigality,挥霍,NOUN,C1
-prodigious,prodigious,词,ADJ,C1
-prodigy,prodigy,神童,NOUN,B2
-product,product,产品,NOUN,B2
-productive,productive,多产的,ADJ,B2
-productivist,productivist,生产至上主义的,ADJ,B2
-productiviteit,productivity,生产力,NOUN,B2
-profane,profane,词,ADJ,C1
-profess,profess,词,VERB,B2
-professional,professional,专业人士,NOUN,B2
-professional ethics,professional ethics,词,NOUN,C1
-professionalism,professionalism,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professorship,professorship,词,NOUN,C1
-profeteren,to prophesy,预言,VERB,B2
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
-profitability,profitability,盈利能力,NOUN,B2
-profitable,profitable,词,ADJ,B2
-profits,profits,词,NOUN,B2
-profligate,profligate,词,ADJ,C1
-profuse,profuse,词,ADJ,C1
-profusion,profusion,词,NOUN,C1
-prognosis,prognosis,预后,NOUN,B2
-program schedule,program schedule,词,NOUN,A2
-programmed,programmed,词,ADJ,C1
-programmeren,programming,编程,NOUN,B2
-programmeur,programmer,程序员,NOUN,B2
-progression,progression,词,NOUN,C1
-progressive,progressive,进步人士,NOUN,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
-project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projection,projection,词,NOUN,C1
-projections,projections,词,NOUN,C1
-projectopdracht,project assignment,项目作业,NOUN,B2
-projector,projector,投影仪,NOUN,B2
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
-proletariaat,proletariat,无产阶级,NOUN,B2
-proliferation,proliferation,增殖,NOUN,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolific,prolific,多产的,ADJ,B2
-prominence,prominence,词,NOUN,B2
-prominent,prominent,突出的,ADJ,B2
-prominent family,prominent family,望族,NOUN,C1
-promis,promissory note,本票,NOUN,B2
-promiscuous,promiscuous,滥交的,ADJ,B2
-promoted,promoted,词,ADJ,B1
-promotor,promoter,推动者,NOUN,B2
-prompt,prompt,词,ADJ,C1
-prompt,promptly,迅速地,ADV,B2
-promptness,promptness,词,NOUN,C1
-promulgeren,to promulgate,颁布,VERB,B2
-prone,prone,词,ADJ,C1
-pronoun,pronoun,词,NOUN,B1
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-propaedeutic,propaedeutic,词,ADJ,C1
-propaganda,propaganda,宣传,NOUN,B2
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-propeller,propeller,螺旋桨,NOUN,B2
-property owner,property owner,房主,NOUN,B2
-prophecy,prophecy,预言,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-propitious,propitious,词,ADJ,C1
-proponent,proponent,词,NOUN,C1
-proportional,proportional,成比例的,ADJ,B2
-proportionality,proportionality,词,NOUN,C1
-proportionally,proportionally,词,ADV,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
-prose writer,prose writer,词,NOUN,C1
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutions,prosecutions,词,NOUN,C1
-prosecutor's office,prosecutor's office,词,NOUN,B2
-proselyte,proselyte,词,NOUN,C1
-proselytism,proselytism,传教,NOUN,B2
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
-prostituee,prostitute,妓女,NOUN,B2
-prostitution,prostitution,词,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protectionisme,protectionism,保护主义,NOUN,B2
-protective cover,protective cover,词,NOUN,C1
-protector,protector,保护者,NOUN,B2
-protest,protest,抗议,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
-protocol,protocol,协议,NOUN,B2
-proton,proton,词,NOUN,C1
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-proudly,proudly,词,ADV,C1
-proverbs,proverbs,词,NOUN,C1
-providential,providential,词,ADJ,C1
-provinces,provinces,词,NOUN,C1
-provinciale weg,provincial highway,省道,NOUN,B2
-provision,provision,词,NOUN,C1
-provisionally,provisionally,词,ADV,C1
-provocatie,provocation,挑衅,NOUN,B2
-provocative,provocative,挑衅的,ADJ,B2
-provoceren,to provoke,激怒,VERB,B2
-prow,prow,词,NOUN,C1
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-proza,prose,散文,NOUN,B2
-prozaïsch,prosaic,平淡无奇的,ADJ,B2
-prudent,prudent,谨慎的,ADJ,B2
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-psalm,psalm,诗篇,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
-psoriasis,psoriasis,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychiatric,psychiatric,精神病的,ADJ,B2
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychologically,psychologically,词,ADV,C1
-psychopath,psychopath,精神变态者,NOUN,B2
-psychopathy,psychopathy,词,NOUN,C1
-psychose,psychosis,精神病,NOUN,B2
-puberteit,puberty,青春期,NOUN,B2
-public (noun),public,公众,NOUN,B1
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publiek,public,公众,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puerperal,puerperal,词,ADJ,C1
-puff,puff,一口烟,NOUN,B2
-puff pastry,puff pastry,词,NOUN,C1
-pugnacious,pugnacious,词,ADJ,C1
-pugnacity,pugnacity,词,NOUN,C1
-puissant,puissant,词,ADJ,C1
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
-pulling,pulling,拔,NOUN,B2
-pulmonaal,pulmonary,肺的,ADJ,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
-punch,punch,拳击,NOUN,B2
-punch (verb),punch,词,VERB,B2
-punch drink,punch drink,词,NOUN,C1
-punctie,puncture,穿刺,NOUN,B2
-punctilious,punctilious,词,ADJ,C1
-punctuality,punctuality,守时,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
-punctuatie,punctuation,标点符号,NOUN,B2
-punctueel,punctual,准时的,ADJ,B2
-puncture tap,puncture tap,词,NOUN,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
-punitive,punitive,惩罚性的,ADJ,B2
-punt,tip,提示,NOUN,B2
-puny,puny,瘦弱的,ADJ,B2
-pupil female,pupil female,词,NOUN,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-purely,purely,纯粹地,ADV,B2
-purification,purification,净化,NOUN,B2
-puritanical,puritanical,词,ADJ,C1
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-purse,purse,词,NOUN,B1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-pus,pus,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put,a well,井,NOUN,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-putrid,putrid,词,ADJ,C1
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quackery,quackery,词,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifying,qualifying,词,ADJ,C1
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,可量化的,ADJ,B2
-quantum,quantum,量子的,ADJ,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarry,quarry,词,NOUN,B1
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quasi,quasi,词,ADV,B2
-queer,queer,词,ADJ,C1
-quench,quench,词,VERB,C1
-querulous,querulous,词,ADJ,C1
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
-questioning (adj),questioning,词,ADJ,C1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-quibble,quibble,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiescent,quiescent,词,ADJ,C1
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
-quietude,quietude,词,NOUN,C1
-quill,quill,词,NOUN,C1
-quilt,quilt,被子,NOUN,B2
-quint,quint,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quivering,quivering,颤抖的,ADJ,B2
-quixotic,quixotic,词,ADJ,C1
-quota,quota,配额,NOUN,B2
-quota sharing,quota sharing,配额分享,NOUN,C1
-quotable,quotable,可估价的,ADJ,B2
-quotidian,quotidian,词,ADJ,C1
-quotient,quotient,词,NOUN,B2
-raadplegen,to consult,咨询,VERB,B2
-raadplegen,to consult reference,参考,VERB,B2
-raadsel,riddle,谜语,NOUN,B2
-raaf,raven,乌鸦,NOUN,B2
-raamglas,window glass,窗玻璃,NOUN,B2
-rabbi,rabbi,拉比,NOUN,B2
-racist,racist,种族主义者,NOUN,B2
-racket,racket,球拍,NOUN,B2
-racketeering,racketeering,词,NOUN,B2
-radar,radar,词,NOUN,B2
-radiant,radiant,容光焕发的,ADJ,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radiator,radiator,暖气片,NOUN,B2
-radicalism,radicalism,词,NOUN,C1
-radically,radically,彻底地,ADV,B2
-radijs,radish,小萝卜,NOUN,B2
-radio,radio,收音机,NOUN,B2
-radio silence,radio silence,词,NOUN,C1
-radioactief,radioactive,放射性的,ADJ,B2
-radioactivity,radioactivity,词,NOUN,C1
-radiography rays,radiography rays,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
-radiostation,radio station,广播电台,NOUN,B2
-radiotherapy,radiotherapy,放疗,NOUN,B2
-rag,rag,破布,NOUN,B2
-rags,rags,词,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-rai,rai,词,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
-railroad,railroad,词,NOUN,B2
-rails,rails,词,NOUN,C1
-railway,railway,铁路的,ADJ,B2
-rain clouds,rain clouds,词,NOUN,C1
-rain shower,rain shower,阵雨,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy,rainy,多雨的,ADJ,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise (noun),raise,词,NOUN,B1
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-rajaz poem,rajaz poem,词,NOUN,C1
-rake,rake,耙子,NOUN,B2
-rally (noun),rally,词,NOUN,B2
-rallying,rallying,词,NOUN,C1
-ram,ram,公羊,NOUN,B2
-rambunctious,rambunctious,词,ADJ,C1
-ramp,ramp,坡道,NOUN,B2
-rampart,rampart,词,NOUN,C1
-rampzalig,disastrous,灾难性的,ADJ,B2
-ramshackle,ramshackle,词,ADJ,C1
-ran,ran,跑,ADJ,B2
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancorous,rancorous,词,ADJ,C1
-rancune,rancor,怨恨,NOUN,B2
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-rang,rank,等级,NOUN,B2
-range zone,range zone,词,NOUN,C1
-ranger,ranger,词,NOUN,B2
-rangschikking,ranking,等级,NOUN,B2
-rank,vine,藤蔓,NOUN,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-ranking classification,ranking classification,词,NOUN,C1
-rantsoen,ration,配给,NOUN,B2
-rapacious,rapacious,词,ADJ,C1
-rapacity,rapacity,词,NOUN,C1
-rapidly,rapidly,词,ADV,B2
-rapier,rapier,词,NOUN,C1
-rapper,rapper,说唱歌手,NOUN,B2
-rapporteur,rapporteur,词,NOUN,C1
-rapprochement,rapprochement,和解,NOUN,B2
-rapture,rapture,狂喜,NOUN,B2
-rapturous,rapturous,词,ADJ,C1
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,稀薄,NOUN,B2
-rarity,rarity,希罕,NOUN,C1
-rash,rash,皮疹,NOUN,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-raspy,raspy,词,ADJ,C1
-rat,rat,老鼠,NOUN,B2
-ratdicht,rat-proof,防鼠,ADJ,B2
-rate percentage,rate percentage,词,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
-rational,rational,词,ADJ,B2
-rationalisatie,rationalization,合理化,NOUN,B2
-rationalisme,rationalism,理性主义,NOUN,B2
-rationalist,rationalist,词,NOUN,B2
-rationaliteit,rationality,理性,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
-rattling,rattling,词,NOUN,C1
-raucous,raucous,词,ADJ,C1
-rauw,raw,生的,ADJ,B2
-ravage (noun),ravage,词,NOUN,C1
-ravenous,ravenous,词,ADJ,C1
-ravine,ravine,沟壑,NOUN,B2
-raw ore,raw ore,词,ADJ,C1
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-raze,raze,词,VERB,C1
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,再判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-reality,re-reality,再实,NOUN,C1
-re-route,re-route,重路,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-shape,re-shape,重形,NOUN,C1
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,再综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach,reach,范围,NOUN,B2
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reactie,reaction,反应,NOUN,B2
-reactief,reactive,反应的,ADJ,B2
-reactionary,reactionary,反动,ADJ,B2
-reactor,reactor,反应堆,NOUN,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
-readiness to help,readiness to help,词,NOUN,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
-reaffirm,reaffirm,词,VERB,B2
-reageren,to respond to,回应,VERB,B2
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
-realisme,realism,现实主义,NOUN,B2
-realist,realist,词,NOUN,C1
-reality TV,reality TV,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rearing,rearing,养有,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reassuring,reassuring,词,ADJ,B1
-rebab,rebab,列巴布琴,NOUN,B2
-rebellious,rebellious,叛逆的,ADJ,B2
-rebirth,rebirth,词,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (noun),rebound,词,NOUN,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recede,recede,词,VERB,C1
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-recess,recess,词,NOUN,C1
-recessie,recession,衰退,NOUN,B2
-recharge (noun),recharge,词,NOUN,B2
-recht,straight,径直地,ADV,B2
-rechtsgebied,jurisdiction area,辖区,NOUN,B2
-rechtsstaat,rule of law,法治,NOUN,B2
-rechttoe,straightforward,直率的,ADJ,B2
-rechtvaardig,righteous,正直的,ADJ,B2
-rechtvaardige verontwaardiging,righteous indignation,义愤,NOUN,B2
-rechtvaardigen,to justify,证明...正当,VERB,B2
-rechtvaardigheid,righteousness,亦正,NOUN,B2
-rechtzetten,to straighten,弄直,VERB,B2
-recidivism,recidivism,词,NOUN,B2
-reciprocally,reciprocally,词,ADV,B2
-reciprocate,reciprocate,词,VERB,C1
-recitation,recitation,词,NOUN,C1
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,收复,NOUN,B2
-reclame,advertising,广告业,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-recognized,recognized,词,NOUN,B2
-recombination,recombination,再结,NOUN,C1
-recommended,recommended,词,ADJ,C1
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconnoiter,reconnoiter,词,VERB,C1
-reconquest,reconquest,词,NOUN,C1
-record,record,记录,NOUN,B2
-record player,record player,唱机,NOUN,B2
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recount,to recount,转述,VERB,B2
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recourse,recourse,求助,NOUN,B2
-recreation,recreation,娱乐,NOUN,B2
-recruit,recruit,新兵,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
-recruitment,recruitment,招聘,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectangular,rectangular,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-rectify,to rectify,纠正,VERB,B2
-rector,rector,词,NOUN,C1
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
-recurrence,recurrence,往复,NOUN,B2
-recurring,recurring,词,ADJ,C1
-recursive,recursive,词,ADJ,C1
-recusal,recusal,回避,NOUN,B2
-recycled item,recycled item,再物,NOUN,B2
-recycling,recycling,回收利用,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redact,redact,词,VERB,C1
-redding van een fang,rescue a-fang,救阿方,NOUN,B2
-redefinition,redefinition,改界,NOUN,B2
-redemption,redemption,救赎,NOUN,B2
-redeneren,to reason,推理,VERB,B2
-redenering,reasoning,论证,NOUN,B2
-redevelopment,redevelopment,词,NOUN,C1
-redolent,redolent,词,ADJ,C1
-redoubtable,redoubtable,词,ADJ,C1
-redress,redress,词,VERB,B2
-reduction,reduction,减少,NOUN,B2
-reductionism,reductionism,词,NOUN,C1
-redundancy,redundancy,冗余,NOUN,B2
-reed bed,reed bed,词,NOUN,B2
-reed pen,reed pen,词,NOUN,C1
-reef,reef,词,NOUN,B2
-reefs,reefs,词,NOUN,B2
-reel,reel,词,NOUN,C1
-refereed,refereed,词,ADJ,C1
-reference framework,reference framework,词,NOUN,C1
-references,references,词,NOUN,C1
-referendum,referendum,公民投票,NOUN,B2
-referendum-related,referendum-related,词,ADJ,B2
-referral,referral,词,NOUN,C1
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
-refining,refining,提炼,NOUN,B2
-reflect,to reflect,反映,VERB,B2
-reflective,reflective,词,ADJ,C1
-reflex,reflex,词,NOUN,C1
-reforestation,reforestation,重新造林,NOUN,B2
-reform,to reform,改革,VERB,B2
-reformatory,reformatory,词,NOUN,C1
-reformism,reformism,改唯,NOUN,B2
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-refractory,refractory,词,ADJ,C1
-refrain,refrain,副歌,NOUN,B2
-refrain,to refrain,克制,VERB,B2
-refrain (noun),refrain,叠句,NOUN,B2
-refreshing,refreshing,令人清爽的,ADJ,B2
-refrigeration,refrigeration,词,NOUN,C1
-refuge,refuge,避难所,NOUN,B2
-refulgent,refulgent,词,ADJ,C1
-refund,refund,退款,NOUN,B2
-refurbish,refurbish,词,VERB,C1
-refusal,refusal,拒绝,NOUN,B2
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refutable,refutable,可反驳的,ADJ,B2
-refutation,refutation,词,NOUN,C1
-regal,regal,词,ADJ,C1
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regarding this,regarding this,对此,ADV,B2
-regardless,regardless,不管,ADV,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regenboog,rainbow,彩虹,NOUN,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,再生,NOUN,B2
-regenjas,raincoat,雨衣,NOUN,B2
-regent,regent,词,NOUN,C1
-regenwoud,rainforest,雨林,NOUN,B2
-regerings-,governmental,政府的,ADJ,B2
-regime,regime,政权,NOUN,B2
-regimen,regimen,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-register (noun),register,词,NOUN,B1
-registered,registered,注册的,ADJ,B2
-registered mail,registered mail,挂号信,NOUN,B2
-registration number,registration number,词,NOUN,C1
-regress,to regress,倒退,VERB,B2
-regression,regression,倒退,NOUN,B2
-regressive,regressive,退步的,ADJ,B2
-regret,to regret,后悔,VERB,B2
-regrettable,regrettable,词,ADJ,B2
-regularity,regularity,规律性,NOUN,B2
-regularization,regularization,词,NOUN,C1
-regularly,regularly,定期地,ADV,B2
-regulated,regulated,词,ADJ,C1
-regulator,regulator,词,NOUN,C1
-regulatory,regulatory,监管的,ADJ,B2
-rehabilitative,rehabilitative,词,ADJ,B2
-rehearsal,rehearsal,排练,NOUN,B2
-reification,reification,词,NOUN,C1
-reimburse,to reimburse,偿还,VERB,B2
-rein,rein,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
-reinforce,to reinforce,加强,VERB,B2
-reinforced,reinforced,词,ADJ,C1
-reining,reining,勒马,NOUN,B2
-reins,reins,词,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
-reis,journey,旅程,NOUN,B2
-reissue,to reissue,补办,VERB,B2
-reissue (noun),reissue,词,NOUN,C1
-reiterate,to reiterate,重申,VERB,B2
-rejection,rejection,拒绝,NOUN,B2
-rejoice,to rejoice,欢欣,VERB,B2
-rekenmachine,calculator,计算器,NOUN,B2
-relapse,relapse,再犯,NOUN,B2
-relapse (verb),relapse,词,VERB,B2
-relate to narrate,to relate to narrate,叙述,VERB,B2
-relating to birth,relating to birth,词,ADJ,C1
-relational,relational,词,ADJ,B2
-relatively speaking,relatively speaking,相对而言,ADV,B2
-relativism,relativism,相对主义,NOUN,B2
-relativist,relativist,词,ADJ,C1
-relativity,relativity,词,NOUN,C1
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
-relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-released,released,获释的,ADJ,B2
-relentless,relentless,无情的,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
-relevant,relevant,相关的,ADJ,B2
-relevantie,relevance,相关性,NOUN,B2
-relieved,relieved,宽慰的,ADJ,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religiously,religiously,词,ADV,C1
-relikwie,relic,圣物,NOUN,B2
-relinquish,relinquish,词,VERB,C1
-relinquishment,relinquishment,词,NOUN,C1
-reluctance,reluctance,不情愿,NOUN,B2
-reluctant,reluctant,不情愿的,ADJ,B2
-rem,brake,刹车,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
-remains spoils,remains spoils,遗体，战利品,NOUN,B2
-remand,remand,词,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
-remark (verb),remark,词,VERB,B2
-remarkably,remarkably,显著地,ADV,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
-remediation,remediation,词,NOUN,B2
-reminder,reminder,提醒物,NOUN,B2
-reminisce,reminisce,词,VERB,C1
-reminiscence,reminiscence,词,NOUN,C1
-reminiscent,reminiscent,词,ADJ,C1
-remiss,remiss,词,ADJ,C1
-remission,remission,词,NOUN,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remmen,to inhibit,抑制,VERB,B2
-remnant,remnant,词,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remorseful,remorseful,悔恨的,ADJ,B2
-remote control,remote control,遥控器,NOUN,B2
-remote work,remote work,远程办公,NOUN,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-removal deletion,removal deletion,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removing roots,removing roots,除根,NOUN,C1
-renaissance,renaissance,复兴,NOUN,B2
-renascent,renascent,词,ADJ,C1
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
-rendition,rendition,词,NOUN,C1
-renegade,renegade,词,NOUN,C1
-renewable energy,renewable energy,可再生能源,NOUN,C1
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
-renminbi,renminbi,人民币,NOUN,B2
-rennen,to run quickly,奔驰,VERB,B2
-rennen,to rush about,奔波,VERB,B2
-renounce,renounce,词,VERB,C1
-rent a car,rent a car,租车,VERB,C1
-rental,rental,词,ADJ,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
-reopening,reopening,词,NOUN,C1
-reordering,reordering,改序,NOUN,B2
-reorganisatie,reorganization,重组,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-reparable,reparable,词,ADJ,C1
-reparatie,repair,修理,NOUN,B2
-repareren,to fix,修理,VERB,B2
-repareren,to mend,修补,VERB,B2
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repatriation,repatriation,词,NOUN,C1
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
-repelling,repelling,词,VERB,C1
-repercussie,repercussion,反响,NOUN,B2
-repertoire,repertoire,全部曲目,NOUN,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
-reply,reply,回复,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report card,report card,成绩单,NOUN,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
-repressed,repressed,词,ADJ,C1
-reprieve,reprieve,暂缓执行,NOUN,B2
-reprisal,reprisal,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
-reprobate,reprobate,词,NOUN,C1
-reproducibility,reproducibility,可重复性,NOUN,B2
-reproductie,reproduction,繁殖,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
-reprogramming,reprogramming,改程,NOUN,B2
-reptiles,reptiles,词,NOUN,B2
-republicanism,republicanism,词,NOUN,C1
-republikeins,republican,共和的,ADJ,B2
-repudiate,repudiate,词,VERB,C1
-repudiation,repudiation,词,NOUN,C1
-repugnant,repugnant,词,ADJ,C1
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
-request to rest,request to rest,请息,NOUN,C1
-required course,required course,必修课,NOUN,C1
-requirements,requirements,词,NOUN,C1
-requisite,requisite,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,重播,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
-rescind,rescind,词,VERB,C1
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resection,resection,切除术,NOUN,B2
-resent,resent,词,VERB,C1
-reservaat,reserve,预备,NOUN,B2
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
-reservering,reservation,预订,NOUN,B2
-reserves,reserves,储备,NOUN,B2
-reservoir,reservoir,水库,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
-residence housing,residence housing,词,NOUN,A2
-resident,resident,定居的,ADJ,B2
-residential,residential,词,ADJ,B2
-residual,residual,残留的,ADJ,B2
-residue,residue,词,NOUN,C1
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
-resigned submission,resigned submission,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resin,resin,词,NOUN,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistant,resistant,词,ADJ,C1
-resistor,resistor,词,NOUN,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
-resolve doubts,resolve doubts,解惑,VERB,B2
-resonant,resonant,共鸣的,ADJ,B2
-resonantie,resonance,共鸣,NOUN,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respectful,respectful,恭敬的,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respective,respective,各自的,ADJ,B2
-respectvol,respectful deferential,恭敬,ADJ,B2
-respiration,respiration,呼吸作用,NOUN,B2
-respiratoir,respiratory,呼吸的,ADJ,B2
-respite,respite,喘息,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
-respondent,respondent,被上诉人,NOUN,B2
-responsiviteit,responsiveness,反应性,NOUN,B2
-rest,remainder,剩余部分,NOUN,B2
-rest stop,rest stop,词,NOUN,B1
-restate,restate,词,VERB,B2
-restaurant,restaurant,餐厅,NOUN,B2
-restauratie,restoration,恢复,NOUN,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-restock,restock,补货,VERB,C1
-restrain,restrain,词,VERB,C1
-restriction,restriction,限制,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
-resumption,resumption,恢复,NOUN,B2
-resurgent,resurgent,词,ADJ,C1
-resuscitate,resuscitate,词,VERB,C1
-resuscitation,resuscitation,复苏,NOUN,B2
-retailer,retailer,零售商,NOUN,B2
-retaliate,retaliate,词,VERB,C1
-retaliation,retaliation,词,NOUN,C1
-retention,retention,我留,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-retina,retina,词,NOUN,B2
-retinue,retinue,词,NOUN,B2
-retiree,retiree,退休人员,NOUN,B2
-retirement pension,retirement pension,退休金,NOUN,B2
-retoriek,rhetoric,修辞,NOUN,B2
-retorisch,rhetorical,修辞的,ADJ,B2
-retorische vraag,rhetorical question,宁非,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retroactive,retroactive,词,ADJ,C1
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-retrospective (noun),retrospective,词,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
-revel,revel,词,VERB,C1
-revelry,revelry,狂欢,NOUN,B2
-revenue,revenue,收入,NOUN,C1
-revenues,revenues,词,NOUN,C1
-reverberation,reverberation,词,NOUN,C1
-reverent,reverent,虔诚的,ADJ,B2
-reverentially,reverentially,词,ADV,C1
-reverie,reverie,词,NOUN,C1
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
-revile,revile,词,VERB,C1
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revival,revival,复兴,NOUN,B2
-revivalism,revivalism,词,NOUN,C1
-revocation,revocation,词,NOUN,C1
-revolver,revolver,词,NOUN,C1
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald,ribald,词,ADJ,C1
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribs,ribs,肋骨,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-richer,richer,更富的,ADJ,B2
-richten,aim,目标,NOUN,B2
-richten,to aim,瞄准,VERB,B2
-richtingbord,direction sign,指示牌,NOUN,B2
-richtlijn,directive,指令,NOUN,B2
-rickety,rickety,词,ADJ,C1
-ricochet,ricochet,词,NOUN,C1
-ridderlijkheid,chivalry,骑士精神,NOUN,B2
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridicule (noun),ridicule,词,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
-rife,rife,词,ADJ,C1
-riffraff,riffraff,词,NOUN,C1
-right (intj),right,词,INTJ,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rights and interests,rights and interests,权益,NOUN,B2
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
-rijden,to ride,骑,VERB,B2
-rijk,empire,帝国,NOUN,B2
-rijk,realm,领域,NOUN,B2
-rijk bedeeld,richly endowed by nature,得天独厚,ADJ,B2
-rijm,rhyme,韵脚,NOUN,B2
-rijp,mature,成熟的,ADJ,B2
-rijpauze,ride break,骑破,NOUN,B2
-rijpheid,maturity,成熟,NOUN,B2
-rile,rile,词,VERB,C1
-rim,rim,词,NOUN,C1
-rings,rings,词,NOUN,B2
-ringtone,ringtone,词,NOUN,C1
-ringweg,ring road,绕城,NOUN,B2
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
-riskant,risky,危险的,ADJ,B2
-risks,risks,词,NOUN,C1
-risque,risque,有伤风化的,ADJ,B2
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
-ritueel,ritual,仪式,NOUN,B2
-rival,rival,对手,NOUN,B2
-rivaliteit,rivalry,竞争,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-river-gauging,river-gauging,词,ADJ,C1
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-rivieroever,riverbank,河岸,NOUN,B2
-road (adj),road,词,ADJ,B2
-roadblock,roadblock,,NOUN,B2
-roadway,roadway,路面,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roar (noun),roar,词,NOUN,B2
-roast (noun),roast,烤透呢,NOUN,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
-robe,robe,词,NOUN,B2
-robot,robot,机器人,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotics,robotics,词,NOUN,C1
-robotization,robotization,词,NOUN,C1
-robust,robust,强健的,ADJ,B2
-robustness,robustness,词,NOUN,C1
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rock slab,rock slab,岩板,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rod,rod,词,NOUN,B1
-roddel,gossip,八卦,NOUN,B2
-roekeloos,reckless,鲁莽的,ADJ,B2
-roekeloosheid,recklessness,轻率,NOUN,B2
-roeren,to stir,搅拌,VERB,B2
-roestvrij,rust-proof,防锈,ADJ,B2
-roet,soot,烟灰,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
-rogue,rogue,词,NOUN,B2
-roken,smoking,吸烟,NOUN,B2
-rolled,rolled,词,ADJ,C1
-rollen,to roll,滚动,VERB,B2
-roller skate,roller skate,词,NOUN,B1
-rolling,rolling,词,NOUN,C1
-rolluik,roller blind,卷帘,NOUN,B2
-rolmodel,role model,榜样,NOUN,B2
-roltrap,escalator,自动扶梯,NOUN,B2
-romance,romance,浪漫,NOUN,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-rommel,rascal,无赖,NOUN,B2
-rommelig,messy,混乱的,ADJ,B2
-rond,round,圆的,ADJ,B2
-ronde,lap,大腿部,NOUN,B2
-rondreis,tour,旅行,NOUN,B2
-rondzwerven,to roam,漫游,VERB,B2
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-roofachtig,predatory,掠夺的,ADJ,B2
-roofdier,predator,捕食者,NOUN,B2
-roominess,roominess,词,NOUN,C1
-roots,roots,词,NOUN,C1
-rose bush,rose bush,词,NOUN,B1
-roster,roster,词,NOUN,C1
-rot decomposition,rot decomposition,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
-rotje,firecracker,鞭炮,NOUN,B2
-rotsblok,boulder,巨石,NOUN,B2
-rotsenborder,rockery,假山,NOUN,B2
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
-rout,rout,溃败,NOUN,B2
-route,route,路线,NOUN,B2
-router,router,路由器,NOUN,B2
-routine,routine,常规,NOUN,B2
-routing,routing,词,NOUN,C1
-rove,rove,词,VERB,C1
-rover,robber,强盗,NOUN,B2
-row series,row series,词,NOUN,B1
-rowboat,rowboat,词,NOUN,B2
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal court,royal court,词,NOUN,C1
-royalty,royalty,王室,NOUN,B2
-rubber,rubber,橡胶,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubble,rubble,瓦砾,NOUN,B2
-rubicund,rubicund,词,ADJ,C1
-ruby,ruby,词,NOUN,C1
-ruckus,ruckus,词,NOUN,C1
-rudely,rudely,词,ADV,C1
-rudimentary,rudimentary,词,ADJ,C1
-rueful,rueful,词,ADJ,C1
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
-ruggengraat,backbone,脊梁,NOUN,B2
-rugstoot,backstab,背刺,NOUN,B2
-rugzijde,reverse side,反面,NOUN,B2
-ruin relic,ruin relic,词,NOUN,B2
-ruined,ruined,词,ADJ,B2
-rulebook,rulebook,规则体系,NOUN,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-rumination,rumination,词,NOUN,C1
-ruminative,ruminative,词,ADJ,C1
-rummage,rummage,词,VERB,C1
-rumors,rumors,词,NOUN,B2
-run away fled,run away fled,词,VERB,A1
-run over,run over,被碾过的,ADJ,B2
-run-down,run-down,词,ADJ,C1
-rung,rung,词,NOUN,C1
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
-runway,runway,词,NOUN,C1
-ruptuur,rupture,破裂,NOUN,B2
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-ruse,ruse,词,NOUN,C1
-rush (noun),rush,赶往,NOUN,B2
-rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
-rust,calm,平静,NOUN,B2
-rust,rust,铁锈,NOUN,B2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rustic,rustic,乡村的,ADJ,B2
-rustig,tranquil,宁静的,ADJ,B2
-rusty,rusty,词,ADJ,C1
-ruthless,ruthless,无情的,ADJ,B2
-ruwheid,roughness,粗糙,NOUN,B2
-ruzie,quarreling,再吵,NOUN,B2
-ruzie maken,to quarrel,争吵,VERB,B2
-ruïne,ruin,废墟,NOUN,B2
-ruïnes,ruins,废墟,NOUN,B2
-saai,dull,枯燥的,ADJ,B2
-saai,tedious,乏味的,ADJ,B2
-saaiheid,dullness,迟钝,NOUN,B2
-sabbath,sabbath,安息日,NOUN,B2
-sabbatical,sabbatical,词,NOUN,C1
-saber,saber,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-saccharine,saccharine,词,ADJ,C1
-sacred,sacred,神圣的,ADJ,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrilege,sacrilege,亵渎,NOUN,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
-saddening,saddening,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddle pad,saddle pad,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadistic,sadistic,施虐的,ADJ,B2
-sadly,sadly,词,ADV,B2
-safe container,safe container,词,NOUN,C1
-safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
-safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-sagacity,sagacity,词,NOUN,B2
-sage,sage,词,NOUN,C1
-sagittarius,sagittarius,射手座,NOUN,B2
-sail,sail,帆,NOUN,B2
-sailboat,sailboat,,NOUN,B2
-sailor,sailor,水手,NOUN,B2
-sailors,sailors,词,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-sake,sake,缘故,NOUN,B2
-salacious,salacious,词,ADJ,C1
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salade,salad,沙拉,NOUN,B2
-salaried,salaried,词,ADJ,B2
-salesman,salesman,词,NOUN,B2
-salient,salient,词,ADJ,C1
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-saliva,saliva,词,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salt shaker,salt shaker,,NOUN,B2
-salted,salted,词,ADJ,B2
-salubrious,salubrious,词,ADJ,C1
-salutary,salutary,词,ADJ,C1
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-sama,sama,词,NOUN,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-samen met,along with,随着,ADP,B2
-samenhang,cohesion,凝聚力,NOUN,B2
-samenleven,to coexist,共存,VERB,B2
-samenspannen,to collude,勾结,VERB,B2
-samenvallen,to coincide,同时发生,VERB,B2
-samenvoegen,merge,合并,NOUN,B2
-samenvoegen,to merge,合并,VERB,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimonious,sanctimonious,伪善的,ADJ,B2
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
-sanctity,sanctity,词,NOUN,C1
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
-sandal,sandal,凉鞋,NOUN,B2
-sands,sands,词,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sane,sane,神志正常的,ADJ,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
-santur,santur,词,NOUN,C1
-sap,sap,词,NOUN,C1
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sardonic,sardonic,词,ADJ,C1
-sat,sat,词,NOUN,B1
-satchel,satchel,词,NOUN,C1
-sated,sated,词,ADJ,B2
-satire,satire,讽刺,NOUN,B2
-satirisch,satirical,讽刺的,ADJ,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-saucepan,saucepan,平底锅,NOUN,B2
-saucy,saucy,下流的,ADJ,B2
-sauna,sauna,桑拿,NOUN,B2
-saunter,saunter,词,VERB,C1
-savage,savage,savage,NOUN,B2
-savant,savant,词,NOUN,C1
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
-saving,saving,储蓄,NOUN,B2
-saving the root,saving the root,救本,NOUN,C1
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-sawdust,sawdust,词,NOUN,C1
-say he,say he,说他,NOUN,C1
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,秤,NOUN,B2
-scallion,scallion,词,NOUN,B2
-scalpel,scalpel,手术刀,NOUN,B2
-scaly,scaly,有鳞的,ADJ,B2
-scammer,scammer,词,NOUN,B2
-scan,scan,扫描件,NOUN,B2
-scandalous,scandalous,可耻的,ADJ,B2
-scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
-scarcely,scarcely,几乎不,ADV,B2
-scarecrow,scarecrow,词,NOUN,C1
-scarf shawl,scarf shawl,词,NOUN,A1
-scathing,scathing,词,ADJ,C1
-scatterbrained,scatterbrained,词,ADJ,B2
-scattering,scattering,词,NOUN,B2
-scenario,screenplay,剧本,NOUN,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
-sceptical,sceptical,词,ADJ,C1
-schaak,chess,国际象棋,NOUN,B2
-schaaldier,crustacean,甲壳类动物,NOUN,B2
-schaar,scissors,剪刀,NOUN,B2
-schaars,scarce,稀少的,ADJ,B2
-schaarste,scarcity,短缺,NOUN,B2
-schaden,harm,伤害,NOUN,B2
-schaden,to harm,损害,VERB,B2
-schadevergoeding,reparation,赔偿,NOUN,B2
-schakelaar,switch,开关,NOUN,B2
-schakelruimte,switch room,配电室,NOUN,B2
-schameloos,shameless,无耻的,ADJ,B2
-schamen,to shame,使羞愧,VERB,B2
-schandelijk,shameful,可耻的,ADJ,B2
-schat,sweetie,亲爱的,NOUN,B2
-scheduling,scheduling,调度；排序,NOUN,B2
-scheepswerf,shipyard,造船厂,NOUN,B2
-scheermes,razor,剃刀,NOUN,B2
-scheikunde,chemistry,化学,NOUN,B2
-schema,schema,词,NOUN,B2
-schema,scheme,计划,NOUN,B2
-schemering,dusk,黄昏,NOUN,B2
-schenden,to contravene,违反,VERB,B2
-schenden,to infringe,侵犯,VERB,B2
-schenden,to violate,违反,VERB,B2
-schending,breach,违反,NOUN,B2
-schenken,to bestow,授予,VERB,B2
-schep,shovel,铲子,NOUN,B2
-schepper,creator,创造者,NOUN,B2
-schijn,pretense,假装,NOUN,B2
-schijn,sham,假冒,NOUN,B2
-schijnbaar,seemingly,表面上,ADV,B2
-schil,shell,壳,NOUN,B2
-schimmel,mold,鞋楦,NOUN,B2
-schism,schism,分裂,NOUN,B2
-schizofrenie,schizophrenia,精神分裂症,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-schoeisel,footwear,鞋穿,NOUN,B2
-schoen,shoes,鞋子,NOUN,B2
-schoenverwijdering,shoe removal,鞋脱,NOUN,B2
-schokken,to shock,震惊,VERB,B2
-scholar learned,scholar learned,词,NOUN,C1
-scholarship holder,scholarship holder,奖学金生,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school,school,学校的,ADJ,B2
-school (adj),school,学校的,ADJ,B1
-school bag,school bag,词,NOUN,A2
-school bench,school bench,词,NOUN,A1
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-schoolbag,schoolbag,词,NOUN,A1
-schoolbord,blackboard,黑板,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schools,scholastic,经院哲学的,ADJ,B2
-schoolyard,schoolyard,词,NOUN,A1
-schoonmoeder,mother-in-law,岳母,NOUN,B2
-schoonvader,father-in-law,岳父/公公,NOUN,B2
-schoonzus,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-schoorsteen,chimney,烟囱,NOUN,B2
-schort,apron,围裙,NOUN,B2
-schrander,astute,精明的,ADJ,B2
-schriftelijk,in writing,书面,NOUN,B2
-schrijfoefening,handwriting practice,练字,NOUN,B2
-schrijfwaren,stationery,文具,NOUN,B2
-schroeiend,scorching,灼热的,ADJ,B2
-schroevendraaier,screwdriver,螺丝刀,NOUN,B2
-schroot,scrap,碎屑,NOUN,B2
-schuilplaats,hideout,藏身处,NOUN,B2
-schuim,foam,泡沫,NOUN,B2
-schuimig,foamy,多泡沫的,ADJ,B2
-schuld,guilt,内疚,NOUN,B2
-schuldenaar,debtor,债务人,NOUN,B2
-schuldenlast,indebtedness,负债,NOUN,B2
-schuldig zijn,to owe,欠,VERB,B2
-schuring,abrasion,擦伤,NOUN,B2
-schurk,scoundrel,恶棍,NOUN,B2
-schurk,villain,反派,NOUN,B2
-schuur,shed,棚屋,NOUN,B2
-scientifically,scientifically,科学地,ADV,B2
-scientists,scientists,科学家,NOUN,B2
-scintillate,scintillate,词,VERB,C1
-scoff (verb),scoff,词,VERB,C1
-scoop,scoop,词,NOUN,B2
-scooter,scooter,踏板摩托车,NOUN,B2
-score,score,比分,NOUN,B2
-scorn,scorn,轻蔑,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scorpion,scorpion,词,NOUN,A1
-scour,scour,词,VERB,C1
-scouting locating,scouting locating,定位 / 侦察,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-scratch,scratch,抓痕,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
-screenwriter,screenwriter,编剧,NOUN,B2
-screw (noun),screw,词,NOUN,C1
-screw up,screw up,词,VERB,C1
-scribal misreading,scribal misreading,词,NOUN,C1
-scribble (noun),scribble,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-script,script,剧本,NOUN,B2
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulous,scrupulous,一丝不苟的,ADJ,B2
-scrupulously,scrupulously,一丝不苟地,ADV,B2
-scrupulousness,scrupulousness,词,NOUN,C1
-scrutiny,scrutiny,明察,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-sculptuur,sculpture,雕塑,NOUN,B2
-scumbag,scumbag,词,NOUN,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scurvy,scurvy,词,NOUN,C1
-scuttle,scuttle,词,VERB,C1
-scythe,scythe,镰刀,NOUN,B2
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seal,seal,海豹,NOUN,B2
-seam,seam,词,NOUN,C1
-seamless,seamless,无缝的,ADJ,B2
-seaplane,seaplane,水上飞机,NOUN,B2
-seaport,seaport,海港,NOUN,C1
-search engine optimization,search engine optimization,词,NOUN,C1
-search warrant,search warrant,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seats,seats,词,NOUN,C1
-seaweed,seaweed,词,NOUN,C1
-secession,secession,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-second (num),second,词,NUM,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-secondary sword,secondary sword,从剑,NOUN,C1
-secondment,secondment,词,NOUN,C1
-secret (adj),secret,秘密的,ADJ,B2
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
-secretariaat,secretariat,秘书处,NOUN,B2
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-sectarianism,sectarianism,词,NOUN,C1
-section chief,section chief,课长,NOUN,B2
-sector,sector,部门,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secular,secular,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
-secularization,secularization,世俗化,NOUN,C1
-seculierisme,secularism,世俗主义,NOUN,B2
-secure (adj),secure,词,ADJ,B1
-securitisatie,securitization,证券化,NOUN,B2
-security matter,security matter,词,NOUN,C1
-security service,security service,词,NOUN,C1
-security-related,security-related,安全的，安保的,ADJ,B2
-securocratic,securocratic,词,ADJ,C1
-sedan,sedan,轿车,NOUN,B2
-sedate,sedate,词,ADJ,C1
-sedative,sedative,词,NOUN,C1
-sedentary,sedentary,久坐的,ADJ,B2
-sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
-sediment,sediment,词,NOUN,C1
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-sedition,sedition,煽动叛乱,NOUN,B2
-seditious,seditious,词,ADJ,C1
-sedulous,sedulous,词,ADJ,C1
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seedy,seedy,词,ADJ,C1
-seeker,seeker,寻求者,NOUN,B2
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking intercession,seeking intercession,词,NOUN,C1
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-segregation,segregation,隔离，分离,NOUN,B2
-seismisch,seismic,地震的,ADJ,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-seizoensgebonden,seasonal,季节性的,ADJ,B2
-sektarisch,sectarian,宗派的,ADJ,B2
-sekte,sect,教派,NOUN,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
-selectief,selective,选择的，挑选的,ADJ,B2
-selectively,selectively,有选择地,ADV,B2
-selector,selector,词,NOUN,C1
-self,self,自己,PRON,B2
-self (noun),self,我可,NOUN,B1
-self-abasement,self-abasement,词,NOUN,C1
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
-self-deception,self-deception,词,NOUN,C1
-self-defense,self-defense,自卫,NOUN,B2
-self-denial,self-denial,自我牺牲,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-image,self-image,自我形象,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-taught,self-taught,自学的,ADJ,B2
-selfie,selfie,自拍,NOUN,B2
-selfish (noun),selfish,selfish,NOUN,B2
-selfless,selfless,词,ADJ,B2
-selfless devotion,selfless devotion,词,NOUN,C1
-sellou,sellou,塞卢能量膏,NOUN,B2
-semantic,semantic,词,ADJ,C1
-semantics,semantics,语义学,NOUN,B2
-semblance,semblance,词,NOUN,C1
-semester,semester,学期,NOUN,B2
-semicolon,semicolon,分号,PUNCT,B2
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
-seminar,seminar,研讨会,NOUN,B2
-seminary,seminary,词,NOUN,C1
-semiologie,semiology,符号学，症状学,NOUN,B2
-semiotica,semiotics,符号学,NOUN,B2
-semolina,semolina,粗面粉,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-sending,sending,词,NOUN,B1
-senescence,senescence,词,NOUN,B2
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
-senioriteit,seniority,资历,NOUN,B2
-sensationalism,sensationalism,词,NOUN,C1
-sense of duty,sense of duty,责任感,NOUN,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
-sensibly,sensibly,明智地,ADV,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
-sensitization,sensitization,词,NOUN,B2
-sensor,sensor,传感器,NOUN,B2
-sensor donor,sensor donor,传感器/捐献者,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensual,sensual,感官的,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentence verdict,sentence verdict,词,NOUN,B2
-sentenced,sentenced,被判刑的,ADJ,B2
-sentencing,sentencing,量刑,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentient,sentient,词,ADJ,C1
-sentiment,sentiment,情感,NOUN,B2
-sentinel,sentinel,哨兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separated,separated,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
-separatism,separatism,词,NOUN,C1
-separatist,separatist,词,NOUN,C1
-sequential,sequential,词,ADJ,C1
-sequentie,sequence,顺序，片段,NOUN,B2
-seraphic,seraphic,词,ADJ,C1
-seren,serene,宁静的,ADJ,B2
-serendipity,serendipity,词,NOUN,C1
-serenely,serenely,词,ADV,C1
-sereniteit,serenity,宁静,NOUN,B2
-sergeant,sergeant,中士,NOUN,B2
-serial,serial,词,NOUN,B1
-serialized drama,serialized drama,连续剧,NOUN,B2
-seriemoordenaar,serial killer,连环杀手,NOUN,B2
-seriously,seriously,认真地,ADV,B2
-serous,serous,词,ADJ,C1
-serpentine,serpentine,词,ADJ,C1
-serum,serum,词,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
-serveerster,waitress,女服务员,NOUN,B2
-server,server,服务器,NOUN,B2
-service counter,service counter,词,NOUN,B1
-service favor,service favor,词,NOUN,A2
-service of process,service of process,词,NOUN,C1
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-service year,service year,,NOUN,B2
-serviceweg,service road,辅路,NOUN,B2
-servile,servile,词,ADJ,C1
-servilely,servilely,奴性地,ADV,B2
-serving,serving,词,NOUN,B2
-servitude,servitude,奴役,NOUN,C1
-sesam,sesame,芝麻,NOUN,B2
-set,set,一套,NOUN,B2
-set a record,set a record,创造纪录,VERB,B2
-set of ideals,set of ideals,思想体系,NOUN,B2
-set square,set square,词,NOUN,B2
-set-off,set-off,词,NOUN,C1
-setting,setting,词,NOUN,B1
-setting splinting,setting splinting,词,NOUN,C1
-setting sun,setting sun,夕阳,NOUN,B2
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seven (adj),seven,词,ADJ,B2
-seventeen,seventeen,十七,NUM,B2
-sever,sever,词,VERB,C1
-several,several,若干,NOUN,B2
-several (det),several,几个,DET,A2
-several (part),several,数,PART,B2
-several times (adv),several times,词,ADV,C1
-several times (noun),several times,几遍,NOUN,B2
-severance,severance,词,NOUN,C1
-severely,severely,严厉地,ADV,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
-sewing needle,sewing needle,词,NOUN,C1
-sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexily,sexily,性感地,ADV,B2
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
-sexually,sexually,在性方面,ADV,B2
-sexy,sexy,性感的,ADJ,B2
-sfouf,sfouf,词,NOUN,B2
-sh,sh,词,INTJ,C1
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shadows,shadows,词,NOUN,C1
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shaft,shaft,词,NOUN,B2
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shambles,shambles,词,NOUN,C1
-shame culture,shame culture,羞耻文化,NOUN,B2
-shame disgrace,shame disgrace,词,NOUN,B2
-shame pity,shame pity,遗憾,NOUN,B2
-shameless person,shameless person,厚颜无耻的人,NOUN,B2
-shamelessness,shamelessness,无耻,NOUN,B2
-shampoo,shampoo,洗发水,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shards,shards,词,NOUN,B2
-shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-sharply,sharply,词,ADV,B2
-shavings,shavings,刨花,NOUN,C1
-she (noun),she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-sheaf,sheaf,捆,NOUN,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet of paper,sheet of paper,词,NOUN,B2
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift (noun),shift,轮班,NOUN,C1
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shining,shining,词,ADJ,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
-shipment,shipment,货物,NOUN,B2
-shirk,shirk,词,VERB,C1
-shit,shit,恐惧,NOUN,B2
-shit crap,shit crap,废话,NOUN,B2
-shitty,shitty,词,ADJ,B2
-shiver,shiver,寒战,NOUN,B2
-shivers,shivers,词,NOUN,B2
-shocked,shocked,震惊的,ADJ,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoe polish,shoe polish,词,NOUN,B2
-shoelace,shoelace,词,NOUN,C1
-shoot at,shoot at,词,VERB,C1
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shopkeeper,shopkeeper,词,NOUN,C1
-shopping mall,shopping mall,商场,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short film,short film,短片,NOUN,B2
-short news item,short news item,短新闻,NOUN,B2
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-shortcomings,shortcomings,词,NOUN,C1
-shorter,shorter,更短的,ADJ,B2
-shortest,shortest,词,NOUN,B2
-shortly,shortly,不久,ADV,B2
-shotgun,shotgun,猎枪,NOUN,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-should ought to,should ought to,应该,AUX,B2
-show,show,表演,NOUN,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-showy,showy,词,ADJ,B2
-shred,shred,词,NOUN,B2
-shriek,shriek,词,VERB,C1
-shrill,shrill,尖锐的,ADJ,B2
-shrimp,shrimp,虾,NOUN,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrivel,shrivel,词,VERB,C1
-shrub,shrub,词,NOUN,C1
-shrug,shrug,词,VERB,C1
-shrunken,shrunken,词,ADJ,B2
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shutdown,shutdown,词,NOUN,C1
-shuttle,shuttle,穿梭巴士,NOUN,B2
-shyness,shyness,羞怯,NOUN,B2
-sibilant,sibilant,词,ADJ,C1
-sibling,sibling,兄弟姐妹,NOUN,B2
-sibyl,sibyl,词,NOUN,C1
-sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickle,sickle,词,NOUN,B2
-sickly,sickly,词,ADJ,C1
-sickness,sickness,词,NOUN,B2
-side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-sideburn,sideburn,词,NOUN,B1
-siege time,siege time,攻城时,NOUN,C1
-sifted,sifted,词,ADJ,C1
-sightseeing,sightseeing,词,NOUN,C1
-sign brand,sign brand,词,NOUN,C1
-signatory,signatory,签署者,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signed,signed,词,ADJ,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silenced,silenced,词,ADJ,C1
-silencing,silencing,词,NOUN,C1
-silent quiet,silent quiet,词,ADJ,A1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-silly thing,silly thing,词,NOUN,C1
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
-silvery,silvery,词,ADJ,C1
-simian,simian,词,ADJ,C1
-similarly,similarly,同样地,ADV,B2
-simony,simony,词,NOUN,C1
-simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplism,simplism,简单化,NOUN,C1
-simulatie,simulation,模拟,NOUN,B2
-simulator,simulator,词,NOUN,C1
-simultaneously with,simultaneously with,词,ADV,C1
-since (part),since,以来,PART,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerely,sincerely,真诚地,ADV,B2
-sincerity devotion,sincerity devotion,词,NOUN,B2
-sinecure,sinecure,词,NOUN,C1
-sinew,sinew,词,NOUN,C1
-single,single,单曲,NOUN,B2
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-singular (adj),singular,词,ADJ,C1
-singular (noun),singular,词,NOUN,B2
-singularity,singularity,单一性,NOUN,B2
-sinister,sinister,不祥的,ADJ,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sinuous,sinuous,词,ADJ,C1
-sir (part),sir,郎,PART,B2
-sirene,siren,汽笛,NOUN,B2
-sirene,strait,海峡,NOUN,B2
-siroop,syrup,糖浆,NOUN,B2
-sis,hiss,嘶嘶声,NOUN,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit down,to sit down,坐下,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-site,site,词,NOUN,B1
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-situation circumstances,situation circumstances,情形,NOUN,B2
-six-line stanza,six-line stanza,词,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixth,sixth,,NOUN,B2
-size measure,size measure,尺寸 / 测量,NOUN,A2
-skate (noun),skate,词,NOUN,A2
-skater,skater,,NOUN,B2
-skating,skating,滑冰,NOUN,B2
-skeletal,skeletal,词,ADJ,C1
-skeleton,skeleton,骨架,NOUN,B2
-skeptic,skeptic,词,NOUN,C1
-skeptical,skeptical,怀疑的,ADJ,B2
-skepticism,skepticism,怀疑主义,NOUN,B2
-sketch,sketch,素描,NOUN,B2
-sketchiness,sketchiness,词,NOUN,C1
-ski,ski,滑雪板,NOUN,B2
-ski resort,ski resort,滑雪场,NOUN,C1
-skid slip-up,skid slip-up,词,NOUN,C1
-skiff,skiff,词,NOUN,C1
-skiing,skiing,滑雪,NOUN,B2
-skilled,skilled,熟练的,ADJ,B2
-skillful,skillful,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skillfulness,skillfulness,词,NOUN,B2
-skin hide,skin hide,皮肤/皮革,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-skirmish,skirmish,小规模战斗,NOUN,B2
-sky blue,sky blue,天蓝色,ADJ,B2
-skylight,skylight,天窗,NOUN,B2
-slaapeloosheid,insomnia,失眠,NOUN,B2
-slaapzaal,dormitory,宿舍,NOUN,B2
-slack,slack,词,ADJ,B2
-slack off,slack off,词,VERB,C1
-slackening dip,slackening dip,词,NOUN,C1
-slackness,slackness,词,NOUN,C1
-slag,hit,击中,NOUN,B2
-slagader,artery,动脉,NOUN,B2
-slager,butcher,屠夫,NOUN,B2
-slak,snail,蜗牛,NOUN,B2
-slake,slake,词,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slammer jail,slammer jail,词,NOUN,C1
-slander,slander,诽谤,NOUN,B2
-slander,to slander,诽谤,VERB,B2
-slander (noun),slander,词,NOUN,B2
-slang,slang,俚语,NOUN,B2
-slanted,slanted,斜,ADJ,B2
-slap,slap,拍击,NOUN,B2
-slap,to slap,打耳光,VERB,B2
-slapeloosheid lijden,to suffer from insomnia,失眠,VERB,B2
-slapheid,drowsiness,昏睡,NOUN,B2
-slaughter,slaughter,屠杀,NOUN,B2
-slaughter,to slaughter,割喉,VERB,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-slecht ding,bad thing,坏事,NOUN,B2
-slecht idee,bad idea,坏水,NOUN,B2
-slecht nieuws,bad news,坏消息,NOUN,B2
-slechter,worse,更糟的,ADJ,B2
-sleek,sleek,词,ADJ,C1
-sleep,sleep,睡眠,NOUN,B2
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleeper,sleeper,词,NOUN,C1
-sleeping pill,sleeping pill,安眠药,NOUN,B2
-sleeplessness,sleeplessness,失眠,NOUN,B2
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
-sleeve,sleeve,袖子,NOUN,B2
-sleigh,sleigh,雪橇,NOUN,C1
-slender,slender,纤细的,ADJ,B2
-slenderness,slenderness,纤细,NOUN,B2
-slepen,to drag,拖,VERB,B2
-slice,slice,薄片,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-slick,slick,词,ADJ,C1
-slide,slide,滑动,NOUN,B2
-sliding,sliding,滑动的,ADJ,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
-slijm,mucus,黏液,NOUN,B2
-slijm,phlegm,痰,NOUN,B2
-slikken,to gulp,吞咽,VERB,B2
-slim,slim,苗条,ADJ,B2
-slimy,slimy,粘滑的,ADJ,B2
-sling,sling,词,NOUN,C1
-slip,to slip,滑倒,VERB,B2
-slip (noun),slip,词,NOUN,C1
-slip in,slip in,塞入,VERB,B2
-slipper,slipper,拖鞋,NOUN,B2
-slippery,slippery,滑的,ADJ,B2
-slit,slit,词,NOUN,C1
-slither,slither,词,VERB,C1
-slogan,slogan,口号,NOUN,B2
-slopen,to sneak,潜行,VERB,B2
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slothful,slothful,懒惰的,ADJ,B2
-slovenly,slovenly,词,ADJ,C1
-slow down,to slow down,放慢,VERB,B2
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
-slower,slower,更慢,ADJ,B2
-slowly,slowly,缓慢地,ADV,B2
-slowness,slowness,缓慢,NOUN,B2
-sluggish,sluggish,迟钝的,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slum,slum,贫民窟,NOUN,B2
-slur,slur,词,VERB,C1
-slurpen,sip,小口喝,NOUN,B2
-slurpen,to sip,小口喝,VERB,B2
-slut,slut,荡妇,NOUN,B2
-sluw,shrewd,精明的,ADJ,B2
-sly,sly,狡猾的,ADJ,B2
-slyly,slyly,词,ADV,C1
-slyness,slyness,狡猾,NOUN,B2
-smaad,defamation,诽谤,NOUN,B2
-smaak,flavor,味道,NOUN,B2
-smaakvoorkeur,taste preference,口味,NOUN,B2
-small bag,small bag,词,NOUN,C1
-small basket,small basket,词,NOUN,C1
-small boat,small boat,小船,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small sword,small sword,词,NOUN,C1
-small things,small things,琐事,NOUN,B2
-small window,small window,词,NOUN,A2
-smallest,smallest,最小的,ADJ,B2
-smallness,smallness,小小,NOUN,B2
-smart,anguish,痛苦,NOUN,B2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
-smash,to smash,粉碎,VERB,B2
-smashing,smashing,砸过,NOUN,B2
-smattering,smattering,少量,NOUN,B2
-smear,smear,抹,NOUN,C1
-smeer,grime,污垢,NOUN,B2
-smeken,to implore,恳求,VERB,B2
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smelten,to melt,融化,VERB,B2
-smelting,smelting,词,NOUN,C1
-smet,blemish,瑕疵,NOUN,B2
-smid,blacksmith,铁匠,NOUN,B2
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoker,smoker,词,NOUN,C1
-smoking (adj),smoking,词,ADJ,C1
-smokkelaar,smuggler,走私者,NOUN,B2
-smokkelen,smuggling,走私,NOUN,B2
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smoothness,smoothness,词,NOUN,C1
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
-smugness,smugness,词,NOUN,C1
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snap (verb),snap,词,VERB,C1
-snare,snare,词,NOUN,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneaker,sneaker,词,NOUN,A1
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sneer,sneer,词,VERB,C1
-sneeuwschaduw,snow shadow,雪影姐姐,NOUN,B2
-sneeuwstorm,blizzard,暴风雪,NOUN,B2
-sneeuwvlok,snowflake,雪花,NOUN,B2
-sneeze (noun),sneeze,词,NOUN,C1
-sneezing,sneezing,词,NOUN,C1
-snel,fast quick,快的,ADJ,B2
-snel,rapid,迅速的,ADJ,B2
-snel,quickly,迅速地,ADV,B2
-snelweg,highway,公路,NOUN,B2
-sniffle,sniffle,词,VERB,C1
-snikken,sobbing,抽泣,NOUN,B2
-snikken,to sob,啜泣,VERB,B2
-sniper,sniper,狙击手,NOUN,B2
-snippet,snippet,词,NOUN,C1
-snitch,snitch,告密者,NOUN,B2
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snoep,candy,糖果,NOUN,B2
-snoepje,sweet,糖果,NOUN,B2
-snooping,snooping,词,NOUN,C1
-snore (noun),snore,打呼,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowdrift,snowdrift,词,NOUN,B1
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-snuit,snout,口鼻,NOUN,B2
-snurken,to snore,打鼾,VERB,B2
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so much so many,so much so many,词,ADV,C1
-so thus,so thus,所以/如此,ADV,B2
-so to speak,so to speak,可以说,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-so-called,so-called,,NOUN,B2
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
-sobriquet,sobriquet,词,NOUN,C1
-sobriëteit,sobriety,清醒,NOUN,B2
-soccer,soccer,足球,NOUN,B2
-sociaal compromis,social compromise,社会妥协,NOUN,B2
-sociaal vertrouwen,social trust,社会信任,NOUN,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social problem,social problem,社会问题,NOUN,B2
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social standard,social standard,社会标准,NOUN,C1
-social status,social status,社会地位,NOUN,C1
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social turmoil,social turmoil,社会动荡,NOUN,C1
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-sociale afstand,social distancing,社交距离,NOUN,B2
-sociale arbitrage,social arbitration,社会仲裁,NOUN,B2
-sociale harmonie,social harmony,社会和谐,NOUN,B2
-sociale identiteit,social identity,社会身份,NOUN,B2
-sociale interactie,social interaction,社会互动,NOUN,B2
-sociale klasse,social class,社会阶层,NOUN,B2
-sociale mobilisatie,social mobilization,社会动员,NOUN,B2
-sociale ontwaking,social awakening,社会觉醒,NOUN,B2
-sociale organisatie,social organization,社会组织,NOUN,B2
-sociale praktijk,social practice,社会实践,NOUN,B2
-sociale stabiliteit,social stability,社会稳定,NOUN,B2
-sociale statistiek,social statistics,社会统计,NOUN,B2
-sociale stratificatie,social stratification,社会分层,NOUN,B2
-sociale trend,social trend,社会趋势,NOUN,B2
-sociale verzoening,social reconciliation,社会和解,NOUN,B2
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义者,NOUN,B2
-socialization,socialization,社会化,NOUN,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,词,ADV,C1
-sociological,sociological,词,ADJ,C1
-sociologie,sociology,社会学,NOUN,B2
-socioloog,sociologist,社会学家,NOUN,B2
-socket,socket,词,NOUN,C1
-soda,soda,苏打,NOUN,B2
-soeverein,sovereign,主权的,ADJ,B2
-soevereiniteit,sovereignty,主权,NOUN,B2
-softball,softball,垒球,NOUN,B2
-softness,softness,词,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software,software,软件,NOUN,B2
-software (adj),software,词,ADJ,C1
-soil erosion,soil erosion,水土流失,NOUN,C1
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar physics,solar physics,词,NOUN,C1
-soldaat,soldiers,官兵,NOUN,B2
-solecism,solecism,语法错误,NOUN,B2
-solely,solely,词,ADV,C1
-solemn (noun),solemn,solemn,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solemnly,solemnly,词,ADV,C1
-solfege,solfege,词,NOUN,C1
-solicitation,solicitation,词,NOUN,C1
-soliciteren,to solicit,恳求,VERB,B2
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solicitude,solicitude,关怀,NOUN,B2
-solid substantial,solid substantial,词,ADJ,B2
-solid-state drive,solid-state drive,固态硬盘,NOUN,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-solipsism,solipsism,唯我论,NOUN,B2
-solitary,solitary,孤独的,ADJ,B2
-sollicitant,applicant,申请人,NOUN,B2
-soloist,soloist,词,NOUN,C1
-solstice,solstice,词,NOUN,C1
-solute,solute,词,NOUN,C1
-solvabiliteit,solvency,偿付能力,NOUN,B2
-solve a case,solve a case,破案,VERB,B2
-somber,somber,词,ADJ,B2
-some,some,某些,ADJ,B2
-some (noun),some,词,NOUN,B2
-some many a,some many a,词,DET,A2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-somebody,somebody,词,PRON,A1
-someone stealing,someone stealing,有人偷,NOUN,C1
-something,something,شي,NOUN,B2
-something better,something better,词,NOUN,C1
-somewhere,somewhere,,NOUN,B2
-somewhere else,somewhere else,词,ADV,B1
-sommige,some out,出些,NOUN,B2
-somnolent,somnolent,词,ADJ,C1
-soms,occasionally,偶尔,ADV,B2
-son of a bitch,son of a bitch,词,NOUN,B2
-son-in-law,son-in-law,词,NOUN,A2
-sonata,sonata,词,NOUN,C1
-song (part),song,歌,PART,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sonorous,sonorous,词,ADJ,C1
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soothing,soothing,词,ADJ,C1
-soothsayer,soothsayer,词,NOUN,B2
-sophist,sophist,诡辩家,NOUN,B2
-sophisterij,sophistry,诡辩,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sophisticated,sophisticated,复杂的,ADJ,B2
-sophomoric,sophomoric,词,ADJ,C1
-soporific,soporific,词,ADJ,C1
-sorcerer,sorcerer,巫师,NOUN,B2
-sorcery,sorcery,巫术,NOUN,B2
-sordid,sordid,肮脏的,ADJ,B2
-sore,sore,疼痛的,ADJ,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry,sorry,抱歉,ADJ,B2
-sorry (intj),sorry,对不起,INTJ,B2
-sorry (noun),sorry,词,NOUN,A1
-sort,sort,种类,NOUN,B2
-sorteren,to sort,分类,VERB,B2
-sortie,sortie,词,NOUN,C1
-sorting,sorting,分类,NOUN,B2
-sought,sought,,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-soul spirit,soul spirit,词,NOUN,B2
-soulmate,soulmate,词,NOUN,C1
-sound card,sound card,声卡,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-sour cherry,sour cherry,词,NOUN,C1
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
-south gate,south gate,南关,NOUN,B2
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southward,southward,向南,ADV,B2
-souvenir,souvenir,纪念品,NOUN,B2
-sovereign,sovereign,君主,NOUN,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-sow,sow,母猪,NOUN,B2
-sowing,sowing,播种,NOUN,B2
-soy,soy,词,NOUN,C1
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space,space,空间,NOUN,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
-spaceship,spaceship,宇宙飞船,NOUN,B2
-spaciousness,spaciousness,词,NOUN,C1
-spade,spade,铲子,NOUN,B2
-spadix,spadix,词,NOUN,C1
-spam (noun),spam,词,NOUN,B1
-span cleaner,span cleaner,词,NOUN,B2
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
-spanish,spanish,西班牙语,NOUN,B2
-spanking,spanking,词,NOUN,B2
-spannen,strain,压力,NOUN,B2
-spannen,to strain,努力,VERB,B2
-spanning,suspense,悬念,NOUN,B2
-spar,spar,词,VERB,C1
-spare,to spare,节省,VERB,B2
-spare (adj),spare,词,ADJ,B1
-spare (noun),spare,词,NOUN,C1
-spare time,spare time,业余,NOUN,B2
-spark,spark,火花,NOUN,B2
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
-sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
-spasm,spasm,痉挛,NOUN,B2
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spate,spate,词,NOUN,C1
-spatula,spatula,刮刀,NOUN,B2
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
-spear,spear,长矛,NOUN,B2
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special topic,special topic,专题,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialist,specialist,专家,NOUN,B2
-specialization,specialization,专业化,NOUN,B2
-specialized,specialized,专业的,ADJ,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specialty,specialty,专业,NOUN,B2
-species,species,物种,NOUN,B2
-specifically,specifically,具体地,ADV,B2
-specification,specification,规格,NOUN,B2
-specifications,specifications,词,NOUN,C1
-specificity,specificity,词,NOUN,C1
-specimen,specimen,标本,NOUN,B2
-specious,specious,似是而非的,ADJ,B2
-spectacle,spectacle,词,NOUN,B2
-spectacles,spectacles,眼镜,NOUN,B2
-spectacular,spectacular,壮观的,ADJ,B2
-specter,specter,词,NOUN,C1
-spectral,spectral,幽灵般的,ADJ,B2
-spectrometer,spectrometer,词,NOUN,C1
-spectrum,spectrum,光谱,NOUN,B2
-speculation,speculation,推测,NOUN,B2
-speculative,speculative,词,ADJ,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-speelgoed,toy,玩具,NOUN,B2
-spell,spell,咒语,NOUN,B2
-spelling,spelling,拼写,NOUN,B2
-spend the night,spend the night,词,VERB,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-spent,spent,词,ADJ,B2
-sperm,sperm,精子,NOUN,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-spice,spice,香料,NOUN,B2
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spin,to spin,旋转,VERB,B2
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
-spine,spine,脊柱,NOUN,B2
-spinning,spinning,纺纱,NOUN,B2
-spinning mill,spinning mill,纺纱厂,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spion,spy,间谍,NOUN,B2
-spionage,espionage,间谍活动,NOUN,B2
-spiral,spiral,词,NOUN,C1
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit training,spirit training,练神,NOUN,B2
-spirited,spirited,活泼的,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
-spirituality,spirituality,灵性,NOUN,B2
-spit,to spit,吐,VERB,B2
-spite,spite,恶意,NOUN,B2
-spiteful,spiteful,怀恨的,ADJ,B2
-spittle,spittle,唾沫,NOUN,B2
-splay,splay,词,VERB,C1
-spleen,spleen,词,NOUN,B2
-splendid,splendid,极好的,ADJ,B2
-splendor,splendor,辉煌,NOUN,B2
-splint,splint,夹板,NOUN,B2
-splinter (noun),splinter,词,NOUN,B2
-split,split,分裂,NOUN,B2
-split,to split,分裂,VERB,B2
-split (noun),split,词,NOUN,C1
-split secession,split secession,分裂,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoedafdeling,emergency room,急诊室,NOUN,B2
-spoiled,spoiled,词,ADJ,B2
-spoiled child,spoiled child,词,NOUN,B1
-spoiler,spoiler,词,NOUN,C1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-spoliation,spoliation,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
-sponsor (noun),sponsor,词,NOUN,B2
-sponsorship,sponsorship,赞助,NOUN,B2
-spontaneity,spontaneity,词,NOUN,C1
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-spoor,trace,痕迹,NOUN,B2
-spoorweg,railway,铁路,NOUN,B2
-sporadic,sporadic,词,ADJ,C1
-sporadically,sporadically,词,ADV,B2
-sport,sport,运动,NOUN,B2
-sports,sports,体育,NOUN,B2
-sports car,sports car,跑车,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-spot goods,spot goods,现货,NOUN,C1
-spraakzaam,talkative,健谈的,ADJ,B2
-spraakzaamheid,talkativeness,多嘴,NOUN,B2
-spray,spray,喷雾,NOUN,B2
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
-spreading,spreading,词,NOUN,C1
-spree,spree,词,NOUN,C1
-spreekwoord,proverb,谚语,NOUN,B2
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-sproeien,to sprinkle,撒,VERB,B2
-spry,spry,词,ADJ,C1
-spurious,spurious,虚假的,ADJ,B2
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-sputum,sputum,词,NOUN,C1
-squabble (noun),squabble,词,NOUN,B2
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squall,squall,骤雨,NOUN,B2
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak,squeak,吱吱声,NOUN,B2
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squid,squid,鱿鱼,NOUN,B2
-squire,squire,词,NOUN,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-staand,standing,站立的,ADJ,B2
-stab (noun),stab,捅,NOUN,C1
-stabiel,steady,稳定的,ADJ,B2
-stabilization,stabilization,稳定化,NOUN,B2
-stably,stably,稳定地,ADV,B2
-stack (noun),stack,词,NOUN,B2
-stadhuis,city hall,市政厅,NOUN,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
-stagiair,trainee,实习生,NOUN,B2
-staging,staging,上演,NOUN,B2
-stagnant,stagnant,停滞的,ADJ,B2
-stagnatie,stagnation,停滞,NOUN,B2
-stagneren,to stall,拖延,VERB,B2
-staid,staid,词,ADJ,C1
-staircase,staircase,词,NOUN,B1
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalemate,stalemate,词,NOUN,C1
-stalking,stalking,词,NOUN,C1
-stall,stall,包厢座位,NOUN,B2
-stalling,stalling,词,NOUN,B2
-stalwart,stalwart,词,ADJ,C1
-stam,lineage,血统,NOUN,B2
-stamina,stamina,词,NOUN,C1
-stammering,stammering,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stampede,stampede,溃逃,NOUN,B2
-stanch,stanch,词,VERB,C1
-standaard,default,违约,NOUN,B2
-standaardisering,standardization,标准化,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
-standby,standby,待机,VERB,C1
-standing (adv),standing,词,ADV,A1
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-standpoint,standpoint,立场,NOUN,B2
-stands,stands,词,NOUN,B2
-stanza,stanza,词,NOUN,B2
-stap,steps,台阶,NOUN,B2
-staple,staple,词,NOUN,C1
-stapler,stapler,词,NOUN,A2
-stapsgewijs,progressively,逐渐地,ADV,B2
-star celebrity,star celebrity,词,NOUN,B1
-star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-staren,gaze,目视,NOUN,B2
-staren,to gaze,凝视,VERB,B2
-stark,stark,词,ADJ,B2
-starling,starling,词,NOUN,B2
-start of school year,start of school year,词,NOUN,B1
-starter,starter,词,NOUN,C1
-starting point,starting point,出发点,NOUN,B2
-starting premise,starting premise,词,NOUN,C1
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-starved,starved,饥饿的,ADJ,B2
-state (adj),state,词,ADJ,B1
-state federal,state federal,州,NOUN,B2
-state of emergency,state of emergency,词,NOUN,C1
-state relatives,state relatives,国戚,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-statements,statements,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-statics,statics,词,NOUN,C1
-stationery shop,stationery shop,文具店,NOUN,B2
-statisch,static,静态的,ADJ,B2
-statism,statism,词,NOUN,C1
-statistiek,statistics,统计学,NOUN,B2
-statistisch,statistical,统计的,ADJ,B2
-statization,statization,词,NOUN,C1
-status,status,地位,NOUN,B2
-statute,statute,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-statutory rape,statutory rape,词,NOUN,C1
-staunch,staunch,坚定的,ADJ,B2
-stave,stave,词,NOUN,C1
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadfastness,steadfastness,词,NOUN,B2
-steadily,steadily,稳定地,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
-steak,steak,牛排,NOUN,B2
-stealth,stealth,秘密行动,NOUN,B2
-stealthily,stealthily,词,ADV,B2
-stealthy,stealthy,词,ADJ,C1
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steeds,increasingly,越来越,ADV,B2
-steek,stitch,针脚,NOUN,B2
-steenkool,coal,煤,NOUN,B2
-steering (noun),steering,词,NOUN,C1
-steering control,steering control,词,NOUN,C1
-steiger,scaffold,脚手架,NOUN,B2
-steken,to stab,刺,VERB,B2
-steken,to sting,刺,VERB,B2
-stekken nemen,to take cuttings,扦插,VERB,B2
-stelling,theorem,定理,NOUN,B2
-stelregel,maxim,格言,NOUN,B2
-stelsel,galaxy,星系,NOUN,B2
-stem,vote,投票,NOUN,B2
-stem (adj),stem,词,ADJ,C1
-stem cell,stem cell,干细胞,NOUN,C1
-stemmen,voting,投票,NOUN,B2
-stemming,stemming,词,ADJ,B1
-stenose,stenosis,狭窄,NOUN,B2
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-stepfather,stepfather,词,NOUN,A1
-steppe,steppe,词,NOUN,C1
-steppes,steppes,草原,NOUN,B2
-stepson,stepson,词,NOUN,A2
-steranijs,star anise,八角,NOUN,B2
-stereotype,stereotype,刻板印象,NOUN,B2
-stereotypical,stereotypical,词,ADJ,C1
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-sterile,sterile,无菌的,ADJ,B2
-sterility,sterility,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-sterk,stellar,杰出的,ADJ,B2
-stern (adj),stern,词,ADJ,C1
-stern (noun),stern,词,NOUN,C1
-sterrenbeeld,constellation,星座,NOUN,B2
-sterrenhemel,starry sky,星空,NOUN,B2
-sterven,to part by death,死别,VERB,B2
-steunen,to endorse,支持,VERB,B2
-steunen,to prop,撑,VERB,B2
-stevedore,stevedore,词,NOUN,C1
-stevige greep,tight grip,手握紧,NOUN,B2
-stevigheid,firmness,坚定,NOUN,B2
-stew,stew,炖菜,NOUN,B2
-stichten,to found,创立,VERB,B2
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiefmoeder,stepmother,后母,NOUN,B2
-stiff glove,stiff glove,,NOUN,B2
-stifle,stifle,词,VERB,C1
-stifling,stifling,词,ADJ,B2
-stigma,stigma,耻辱,NOUN,B2
-stigmatization,stigmatization,词,NOUN,B2
-stijfheid,rigidity,僵硬,NOUN,B2
-stijfheid,stiffness,僵硬,NOUN,B2
-stijging,rise,上涨,NOUN,B2
-stijve etiquette,heavy etiquette,礼太重,NOUN,B2
-stikken,to suffocate,窒息,VERB,B2
-stil,silent,沉默的,ADJ,B2
-stiletto,stiletto,词,NOUN,C1
-still also,still also,还,ADV,A1
-stillness,stillness,静中,NOUN,B2
-stilstand,standstill,停滞,NOUN,B2
-stilted,stilted,词,ADJ,C1
-stimulating,stimulating,词,ADJ,C1
-stimulus,stimulus,刺激,NOUN,B2
-sting,sting,刺,NOUN,B2
-stink,stink,恶臭,NOUN,B2
-stinken,to stink,发臭,VERB,B2
-stinkend,stinking,发臭的,ADJ,B2
-stipend,stipend,津贴,NOUN,B2
-stipulation,stipulation,词,NOUN,C1
-stir-fry,stir-fry,炒,VERB,B1
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
-stock-market,stock-market,词,ADJ,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stocking,stocking,词,NOUN,C1
-stodgy,stodgy,词,ADJ,C1
-stof,fabric,织物,NOUN,B2
-stoic,stoic,坚忍的,ADJ,B2
-stoically,stoically,词,ADV,C1
-stolen,stolen,被偷的,ADJ,B2
-stolen one,stolen one,词,NOUN,B2
-stolid,stolid,冷漠的,ADJ,B2
-stomach ache,stomach ache,词,NOUN,C1
-stomen,steam,蒸汽,NOUN,B2
-stomen,to steam,蒸,VERB,B2
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stool,stool,词,NOUN,C1
-stoornis,impairment,左手废,NOUN,B2
-stoot,surge,激增,NOUN,B2
-stop bleeding,stop bleeding,止血,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-stopover,stopover,中途停留,NOUN,B2
-stoppen,to halt,停止,VERB,B2
-stoppen,to stop me,拦我,VERB,B2
-storage room,storage room,储藏室,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-storen,bother,麻烦,NOUN,B2
-storen,to bother,打扰,VERB,B2
-stork,stork,词,NOUN,B1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-stormachtig,stormy,有暴风雨的,ADJ,B2
-storming,storming,词,NOUN,C1
-stortbui,downpour,倾盆大雨,NOUN,B2
-stortvloed,torrent,激流,NOUN,B2
-story history,story history,词,NOUN,A1
-stout,stout,词,ADJ,C1
-stoven,to stew,炖,VERB,B2
-stowage,stowage,词,NOUN,C1
-stoïcisme,stoicism,斯多葛主义,NOUN,B2
-straal,ray,光线,NOUN,B2
-strabismus,strabismus,词,NOUN,B2
-straight,straight,直的,NOUN,B2
-straight (adj),straight,直,ADJ,A1
-straight ahead,straight ahead,词,ADV,B2
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
-straitened circumstances,straitened circumstances,词,NOUN,C1
-straitjacket,straitjacket,词,NOUN,C1
-strak,taut,绷紧的,ADJ,B2
-strand,strand,词,NOUN,C1
-strangely,strangely,奇怪地,ADV,B2
-stranger,stranger,陌生人,NOUN,B2
-strangest,strangest,词,NOUN,C1
-strangle,to strangle,扼杀,VERB,B2
-strangulation,strangulation,词,NOUN,C1
-strap,strap,带子,NOUN,B2
-strapping,strapping,词,ADJ,C1
-stratagem,stratagem,策略,NOUN,B2
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratification,stratification,词,NOUN,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-stratum,stratum,阶层,NOUN,B2
-straw,straw,稻草,NOUN,B2
-strawberry,strawberry,草莓,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-stream,stream,溪流,NOUN,B2
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street kid,street kid,词,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-streng,rigorous,严格的,ADJ,B2
-strengthening,strengthening,词,NOUN,C1
-strenuous,strenuous,费力的,ADJ,B2
-stress (noun),stress,压力,NOUN,B1
-stressed,stressed,焦虑的,ADJ,B2
-stressful,stressful,有压力的,ADJ,B2
-stretch,stretch,伸展,NOUN,B2
-stretch out,stretch out,词,VERB,B2
-stretched,stretched,词,ADJ,C1
-stretcher,stretcher,担架,NOUN,B2
-streven,to aspire,渴望,VERB,B2
-strictly,strictly,词,ADV,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-strictness,strictness,词,NOUN,B2
-stride (noun),stride,词,NOUN,C1
-strident,strident,刺耳的,ADJ,B2
-strife,strife,词,NOUN,B2
-strijden,to work hard for sth to strive for success,争气,VERB,B2
-strike-related,strike-related,词,ADJ,C1
-strikebreaker,strikebreaker,词,NOUN,C1
-striking,striking,惊人的,ADJ,B2
-string,string,细绳,NOUN,B2
-string instruments,string instruments,词,NOUN,C1
-string music,string music,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-strip,strip,条带,NOUN,B2
-striped,striped,有条纹的,ADJ,B2
-striving,striving,词,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-stroll,stroll,闲逛,NOUN,B2
-stroll,to stroll,散步,VERB,B2
-stroll (noun),stroll,走走,NOUN,B2
-stroller,stroller,婴儿车,NOUN,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
-strook,lane,小巷,NOUN,B2
-stroom,flow,流动,NOUN,B2
-stroomafwaarts,downstream,下游,NOUN,B2
-strottenhoofd,larynx,喉,NOUN,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structured,structured,词,ADJ,C1
-structures,structures,词,NOUN,C1
-struik,bush,灌木,NOUN,B2
-stubborn,stubborn,固执的,ADJ,B2
-stubbornness,stubbornness,固执,NOUN,B2
-stuck,stuck,卡住的,ADJ,B2
-student,undergraduate,本科生,NOUN,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studies,studies,学业,NOUN,B2
-studious,studious,词,ADJ,C1
-study tour,study tour,游学,NOUN,C1
-stuff,to stuff,填塞,VERB,B2
-stuffed,stuffed,词,ADJ,B1
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stumble (noun),stumble,词,NOUN,C1
-stunner,stunner,词,NOUN,B2
-stunning,stunning,极好的,ADJ,B2
-stunt,stunt,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupefied,stupefied,词,ADJ,C1
-stupendous,stupendous,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
-stupidity,stupidity,愚蠢,NOUN,B2
-stupor,stupor,昏迷,NOUN,B2
-sturdy,sturdy,坚固的,ADJ,B2
-sturen,to steer,引导,VERB,B2
-stuttering,stuttering,词,NOUN,C1
-stuurwiel,steering wheel,方向盘,NOUN,B2
-stylist,stylist,词,NOUN,C1
-stylistics,stylistics,词,NOUN,C1
-stymie,stymie,词,VERB,C1
-suave,suave,词,ADJ,C1
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subconscious,subconscious,潜意识,NOUN,B2
-subcontracting,subcontracting,分包,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subdue,to subdue,制服,VERB,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,受法律管辖的,ADJ,B2
-subject topic,subject topic,主题/话题,NOUN,B2
-subjection,subjection,词,NOUN,B2
-subjective,subjective,主观的,ADJ,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
-subjugate,to subjugate,征服,VERB,B2
-sublimation,sublimation,词,NOUN,C1
-sublime,sublime,崇高的,ADJ,B2
-subliminal,subliminal,词,ADJ,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submarine,submarine,潜水艇,NOUN,B2
-submerge,to submerge,淹没,VERB,B2
-submission,submission,顺从,NOUN,B2
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordinate,subordinate,下属,NOUN,B2
-subordination,subordination,隶属,NOUN,C1
-subpoena,subpoena,词,NOUN,B2
-subscribe,to subscribe,订阅,VERB,B2
-subscriber,subscriber,订阅者,NOUN,B2
-subsequently,subsequently,词,ADV,C1
-subservient,subservient,词,ADJ,C1
-subside,to subside,平息,VERB,B2
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,辅助性原则,NOUN,B2
-subsidiary,subsidiary,子公司,NOUN,B2
-subsidie,grant,拨款,NOUN,B2
-subsistence,subsistence,生计,NOUN,B2
-substance,substance,物质,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantially,substantially,词,ADV,B2
-substantiation,substantiation,论证,NOUN,B2
-substantive,substantive,实质性的,ADJ,B2
-substitute,substitute,替代品,NOUN,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subtitle,subtitle,字幕,NOUN,B2
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-subtle,subtle,微妙的,ADJ,B2
-subtlety,subtlety,微妙,NOUN,B2
-subtly,subtly,词,ADV,C1
-suburban,suburban,词,ADJ,C1
-suburbs,suburbs,郊区,NOUN,B2
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
-succinct,succinct,简明的,ADJ,B2
-succinctly,succinctly,简洁地,ADV,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-such a thing,such a thing,词,PRON,B1
-sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suffering (adj),suffering,词,ADJ,C1
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffocating,suffocating,词,ADJ,B2
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestibility,suggestibility,词,NOUN,C1
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal,suicidal,自杀的,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-suite,suite,套房,NOUN,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
-sulfide,sulfide,词,NOUN,C1
-sulfur,sulfur,硫,NOUN,B2
-sulfuric,sulfuric,词,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sullenness,sullenness,词,NOUN,C1
-sully,sully,词,VERB,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultriness,sultriness,词,NOUN,B2
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-summarily,summarily,草率地,ADV,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
-sumptuousness,sumptuousness,词,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower,sunflower,向日葵,NOUN,B2
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
-sunny day,sunny day,晴天,NOUN,C1
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super (adv),super,词,ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-proof,super-proof,超证,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-theory,super-theory,超论,NOUN,C1
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-superb,superb,极好的,ADJ,B2
-supercilious,supercilious,词,ADJ,C1
-supercomprehensief,super-comprehensive,超遍,NOUN,B2
-superficiality,superficiality,词,NOUN,C1
-supergedachte,super-thought,超思,NOUN,B2
-supergraad,super-grade,超级,NOUN,B2
-superhero,superhero,超级英雄,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior,superior,上级,NOUN,B2
-superior upper,superior upper,词,ADJ,C1
-superiority,superiority,优越性/优势,NOUN,B2
-superkwaliteit,super-quality,超质,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supernumerary,supernumerary,词,ADJ,C1
-superprincipe,super-principle,超则,NOUN,B2
-supersede,supersede,词,VERB,C1
-supersysteem,super-system,超制,NOUN,B2
-superviseren,to supervise,监督,VERB,B2
-supine,supine,词,ADJ,C1
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplication,supplication,恳求,NOUN,B2
-supplies,supplies,必需品,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-support medium,support medium,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supported,supported,词,ADJ,B2
-supporter advocate,supporter advocate,词,NOUN,B1
-supporters,supporters,词,NOUN,B2
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,团结的,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-supposition,supposition,词,NOUN,C1
-suppository,suppository,词,NOUN,C1
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
-suppression of us,suppression of us,压咱,NOUN,C1
-suppuration,suppuration,词,NOUN,C1
-supremacy,supremacy,霸权,NOUN,B2
-supreme,supreme,最高的,ADJ,B2
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-surcharge,surcharge,附加费,NOUN,B2
-sure,sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-surety bond,surety bond,词,NOUN,C1
-suretyship,suretyship,保证,NOUN,C1
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surging effusive,surging effusive,词,ADJ,C1
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus,surplus,过剩的,ADJ,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
-surrealisme,surrealism,超现实主义,NOUN,B2
-surrender (noun),surrender,就交,NOUN,B2
-surreptitious,surreptitious,秘密的,ADJ,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrogate,surrogate,词,NOUN,C1
-surrounding area,surrounding area,周边,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
-susha,susha,夙砂大,NOUN,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspicions,suspicions,词,NOUN,C1
-sustain,sustain,词,VERB,C1
-svelte,svelte,词,ADJ,C1
-swab,swab,词,NOUN,B2
-swagger (noun),swagger,词,NOUN,B2
-swap,swap,词,VERB,B2
-swarm,swarm,蜂群,NOUN,B2
-swarthy,swarthy,词,ADJ,C1
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweatshirt,sweatshirt,词,NOUN,C1
-sweden,sweden,瑞典,PROPN,B2
-swedish,swedish,瑞典语,NOUN,B2
-sweep (noun),sweep,词,NOUN,B2
-sweepings,sweepings,扫出的垃圾,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swiftness,swiftness,词,NOUN,C1
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,词,NOUN,C1
-swimming,swimming,游泳,NOUN,B2
-swimwear,swimwear,,NOUN,B2
-swine,swine,猪,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swirl,swirl,词,VERB,C1
-switch key,switch key,词,NOUN,C1
-switchman,switchman,词,NOUN,C1
-swollen,swollen,肿胀的,ADJ,B2
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsmanship,swordsmanship,剑术,NOUN,B2
-sycofantie,sycophancy,阿谀奉承,NOUN,B2
-sycophant,sycophant,词,NOUN,C1
-sycophantic,sycophantic,词,ADJ,B2
-syllabification,syllabification,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
-syllabus,syllabus,教学大纲,NOUN,B2
-syllogism,syllogism,三段论,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbolism,symbolism,象征主义,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symfonie,symphony,交响乐,NOUN,B2
-symmetric,symmetric,词,ADJ,C1
-symmetrie,symmetry,对称,NOUN,B2
-sympathie,sympathy,同情,NOUN,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symphonic,symphonic,交响乐的,ADJ,B2
-symposium,symposium,研讨会,NOUN,B2
-symptom (noun),symptom,症状,NOUN,B2
-symptomatisch,symptomatic,症状的,ADJ,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-symptoms,symptoms,词,NOUN,B1
-symptoom,symptom,症,PART,B2
-synaptic,synaptic,词,ADJ,C1
-sync,sync,同步,NOUN,B2
-synchronisatie,synchronization,同步,NOUN,B2
-synchronisch,synchronous,同步的,ADJ,B2
-synchronized,synchronized,词,ADJ,C1
-synchrony,synchrony,词,NOUN,C1
-syncopate,syncopate,词,VERB,C1
-syncretism,syncretism,词,NOUN,C1
-syndicate,syndicate,词,NOUN,C1
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,元音合并,NOUN,B2
-synergie,synergy,协同效应,NOUN,B2
-synoniem,synonymy,同义关系,NOUN,B2
-synonym,synonym,词,NOUN,C1
-synopsis,synopsis,词,NOUN,C1
-syntactic,syntactic,词,ADJ,C1
-syntaxis,syntax,句法,NOUN,B2
-synthese,synthesis,综合,NOUN,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-systematically,systematically,系统地,ADV,B2
-systemisch,systemic,全身性的,ADJ,B2
-t-shirt,t-shirt,T 恤衫,NOUN,B2
-taalkunde,linguistics,语言学,NOUN,B2
-tab,tab,词,NOUN,C1
-tabernacle,tabernacle,词,NOUN,C1
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tablecloth,tablecloth,词,NOUN,C1
-tablet,tablet,平板电脑,NOUN,B2
-taboe,taboo,禁忌,NOUN,B2
-taboo (adj),taboo,词,ADJ,C1
-tachometer,tachometer,转速表,NOUN,B2
-taciet,tacit,心照不宣的,ADJ,B2
-taciet,tacitly,默不作声地,ADV,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-tackling,tackling,马具,NOUN,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,俗气的事,NOUN,B2
-tact,tact,词,NOUN,C1
-tactful appeasement,tactful appeasement,词,NOUN,C1
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactiek,tactic,策略,NOUN,B2
-tactiek,tactics,战术,NOUN,B2
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tadel,rebuke,责备,NOUN,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-taille,waist,腰,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
-taking command,taking command,挂帅,NOUN,B2
-tale,tale,词,NOUN,A1
-talented,talented,有才华的,ADJ,B2
-talisman,talisman,词,NOUN,B2
-talk show,talk show,脱口秀,NOUN,C1
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-tall and slender,tall and slender,词,ADJ,C1
-tally,tally,词,VERB,C1
-tamable,tamable,词,ADJ,C1
-tambourine,tambourine,词,NOUN,B2
-tame (adj),tame,词,ADJ,A1
-taming,taming,词,NOUN,C1
-tamper,tamper,词,VERB,C1
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tandpasta,toothpaste,牙膏,NOUN,B2
-tandpijn,toothache,牙痛,NOUN,B2
-tandvlees,gum,牙龈,NOUN,B2
-tangent,tangent,切线,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tangle,tangle,混乱,NOUN,B2
-tank,tank,坦克,NOUN,B2
-tank cistern,tank cistern,词,NOUN,C1
-tankstation,gas station,加油站,NOUN,B2
-tanned,tanned,词,ADJ,B2
-tannery,tannery,词,NOUN,B2
-tantamount,tantamount,词,ADJ,C1
-tante,maternal aunt,姨母,NOUN,B2
-tantrum,tantrum,词,NOUN,C1
-tape,tape,词,NOUN,A2
-tapestry,tapestry,词,NOUN,C1
-tarab,tarab,词,NOUN,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
-tarief,tariff,费率,NOUN,B2
-taro,taro,芋头,NOUN,B2
-tarragon,tarragon,龙蒿,NOUN,B2
-tarry,tarry,词,VERB,C1
-tart pie,tart pie,词,NOUN,C1
-tarwe,wheat,小麦,NOUN,B2
-tastbaarheid,touchability,能触摸,NOUN,B2
-tasteless,tasteless,无味的,ADJ,B2
-tasting,tasting,词,NOUN,C1
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tatter,tatter,词,NOUN,C1
-tattoo,tattoo,纹身,NOUN,B2
-tautology,tautology,词,NOUN,C1
-taverne,tavern,酒馆,NOUN,B2
-tawdry,tawdry,词,ADJ,C1
-tax (adj),tax,词,ADJ,C1
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax return,tax return,报税,NOUN,B2
-tax revenue,tax revenue,税收,NOUN,B2
-taxable,taxable,应纳税的,ADJ,B2
-taxi,taxi,出租车,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-taxonomy,taxonomy,分类学,NOUN,B2
-taxpayer,taxpayer,纳税人,NOUN,B2
-te,too,太,ADV,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
-teamgenoot,teammate,队友,NOUN,B2
-teapot,teapot,词,NOUN,C1
-tearing,tearing,tearing,NOUN,B2
-teasing playful,teasing playful,词,ADJ,C1
-technically,technically,技术上地,ADV,B2
-technicus,technician,技术员,NOUN,B2
-techniek,technique,技巧,NOUN,B2
-technocrat,technocrat,词,NOUN,C1
-technocratie,technocracy,技术官僚主义,NOUN,B2
-tectonic,tectonic,词,ADJ,C1
-teddy bear,teddy bear,词,NOUN,B2
-tedious painful,tedious painful,词,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-teetotal,teetotal,词,ADJ,C1
-tegel,tile,瓦片,NOUN,B2
-tegenaanval,counterattack,反击,NOUN,B2
-tegenhanger,counterpart,对应的人或物,NOUN,B2
-tegenkwaliteit,counter-quality,反质,NOUN,B2
-tegenlogica,counter-logic,反逻,NOUN,B2
-tegenmaterie,counter-matter,反物,NOUN,B2
-tegenmechanisme,counter-mechanism,反机,NOUN,B2
-tegenmodel,counter-model,反模,NOUN,B2
-tegenroute,counter-route,反途,NOUN,B2
-tegenspreken,to contradict,反驳,VERB,B2
-tegenstander,adversary,对手,NOUN,B2
-tegenstelling,contrary,反而,NOUN,B2
-tegenstrijdige bedoeling,contrary intention,反意,NOUN,B2
-tegenstructuur,counter-structure,反结,NOUN,B2
-tegensysteem,counter-system,反系,NOUN,B2
-tegentechniek,counter-technique,反术,NOUN,B2
-tegentrend,counter-trend,反势,NOUN,B2
-tegentype,counter-type,反型,NOUN,B2
-tegenvaardigheid,counter-skill,反技,NOUN,B2
-tegenvorm,counter-form,反式,NOUN,B2
-tegenwaarneming,counter-observation,反察,NOUN,B2
-tegenwerken,counter,柜台,NOUN,B2
-tegenwerken,to counter,反击,VERB,B2
-tegenwerken,to oppose,反对,VERB,B2
-tegenwerping,rebuttal,反驳,NOUN,B2
-tegenzool,counter-sole,反唯,NOUN,B2
-tekortkoming,shortcoming,缺点,NOUN,B2
-tekst,lyrics,歌词,NOUN,B2
-tekstbericht,text message,短信,NOUN,B2
-telecommunications,telecommunications,词,NOUN,C1
-telegram,telegram,电报,NOUN,B2
-telegraph lightning,telegraph lightning,词,NOUN,C1
-teleologie,teleology,目的论,NOUN,B2
-telepathy,telepathy,词,NOUN,C1
-telephone ringing,telephone ringing,词,NOUN,C1
-telephony,telephony,电话学,NOUN,B2
-telescoop,telescope,望远镜,NOUN,B2
-teleurgesteld,disappointed,失望的,ADJ,B2
-teleurstellend,disappointing,令人失望的,ADJ,B2
-televised,televised,电视播出的,ADJ,B2
-television set,television set,词,NOUN,B1
-teller,teller,词,NOUN,B2
-telling-off,telling-off,词,NOUN,B1
-telltale,telltale,词,ADJ,C1
-temerity,temerity,鲁莽,NOUN,B2
-temmen,to tame,驯服,VERB,B2
-temperament,temper,脾气,NOUN,B2
-temperament,temperament,气质,NOUN,B2
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-template,template,词,NOUN,C1
-tempobepaler,pace-setter,标兵,NOUN,B2
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
-temptation,temptation,词,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-ten tweede,secondly,其次,ADV,B2
-tenable,tenable,词,ADJ,C1
-tenacity,tenacity,坚韧,NOUN,B2
-tend,tend,词,VERB,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tenderloin,tenderloin,里脊,NOUN,B2
-tenement,tenement,词,NOUN,C1
-tenet,tenet,词,NOUN,C1
-tennis,tennis,网球,NOUN,B2
-tenor,tenor,男高音,NOUN,B2
-tens,tens,词,NOUN,B2
-tense (noun),tense,词,NOUN,B1
-tense angry,tense angry,词,ADJ,A2
-tense excited,tense excited,词,ADJ,B2
-tensile,tensile,词,ADJ,C1
-tentatief,tentative,暂定的,ADJ,B2
-tenth (noun),tenth,词,NOUN,B2
-tenuous,tenuous,词,ADJ,C1
-tenure,tenure,词,NOUN,B2
-tepid,tepid,词,ADJ,C1
-teratogenic,teratogenic,致畸的,ADJ,B2
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-termijn,installment,分期付款,NOUN,B2
-terminaal,terminal,终点站,NOUN,B2
-terminal (adj),terminal,终末的,ADJ,B2
-terminologie,terminology,术语,NOUN,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,,NOUN,B2
-terrein,grounds,论据,NOUN,B2
-terreinwagen,off-road vehicle,越野车,NOUN,B2
-terrestrisch,terrestrial,地球的,ADJ,B2
-terribleness,terribleness,,NOUN,B2
-terrified,terrified,极度恐惧的,ADJ,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
-territoriaal,territorial,领土的,ADJ,B2
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
-terrorist,terrorist,恐怖分子,NOUN,B2
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terse,terse,简练的,ADJ,B2
-terseness,terseness,词,NOUN,C1
-tertiary,tertiary,第三的,ADJ,B2
-terugbetalen,to repay,偿还,VERB,B2
-terugbetaling,repayment,偿还,NOUN,B2
-teruggetrokken,taciturn,沉默寡言的,ADJ,B2
-teruggeven,to give back,归还,VERB,B2
-teruggrepen doen op,to draw on the experience of,借鉴,VERB,B2
-terughoudendheid,restraint,隐忍,NOUN,B2
-terugkeer,reversion,重归,NOUN,B2
-terugkeren,to go back,回去,VERB,B2
-terugkeren,to return first,先回,VERB,B2
-terugroepen,to recall,回忆,VERB,B2
-terugschieten,to renege,食言,VERB,B2
-terugslag,setback,挫折,NOUN,B2
-terugstroom,backflow,倒流,NOUN,B2
-terugtrekken,retreat,撤退,NOUN,B2
-terugtrekken,to retreat,撤退,VERB,B2
-terugtrekking,withdrawal,撤回,NOUN,B2
-terugvallen,to fall back,回落,VERB,B2
-terugvorderen,to reclaim,收回,VERB,B2
-test drive,test drive,,NOUN,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testator,testator,词,NOUN,C1
-testicular,testicular,词,ADJ,C1
-testikel,testicle,睾丸,NOUN,B2
-testimony deposition,testimony deposition,词,NOUN,C1
-tether,tether,词,NOUN,C1
-tevergeefs,in vain,徒劳,ADV,B2
-tevredenheid,contentment,满足,NOUN,B2
-tevredenheid,satisfaction,满意,NOUN,B2
-textiel,textile,纺织,NOUN,B2
-textuality,textuality,词,NOUN,C1
-texture,texture,词,NOUN,C1
-than (adp),than,比,ADP,A1
-thank god,thank god,谢天谢地,INTJ,B2
-thanks (intj),thanks,谢谢,INTJ,A1
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-tharid,tharid,词,NOUN,B2
-that,that,那个,DET,B2
-that (noun),that,将那,NOUN,C1
-that (sconj),that,词,SCONJ,A1
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
-that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way,that way,往那边,ADV,B2
-that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,复合词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,复合词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,复合词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,名词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,名词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,名词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,名词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,复合词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,复合词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,复合词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,复合词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,收银台,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,骑兵,NOUN,B2
-the chain,the chain,词,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,ADV,B2
-the day after tomorrow (noun),the day after tomorrow,词,NOUN,B2
-the day before yesterday,the day before yesterday,词,ADV,C1
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the emperor,the emperor,皇帝,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,复合词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,复合词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,复合词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masculine,the masculine,词,DET,A2
-the masses,the masses,大众,NOUN,C1
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,复合词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the more,the more,越,ADV,B2
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,复合词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
-the north pole,the north pole,北极,NOUN,B2
-the one (det),the one,词,DET,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,前几天晚上,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,同一个,PRON,B2
-the same (det),the same,词,DET,A2
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unseen,the unseen,词,NOUN,C1
-the unstellung,the unstellung,复合词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,复合词,NOUN,B2
-the urbewegung,the urbewegung,复合词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,复合词,NOUN,B2
-the urrechnung,the urrechnung,复合词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,复合词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,复合词,NOUN,B2
-the verminderung,the verminderung,复合词,NOUN,B2
-the verstbindung,the verstbindung,复合词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,复合词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,复合词,NOUN,B2
-the ververtiefung,the ververtiefung,复合词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the very,the very,正是,ADV,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,复合词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,复合词,NOUN,B2
-the zerordnung,the zerordnung,复合词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-theeplantage,tea plantation,茶园,NOUN,B2
-their,their,他们的,DET,B2
-them dative,them dative,词,PRON,A2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-theocratie,theocracy,神权政治,NOUN,B2
-theodicy,theodicy,词,NOUN,C1
-theologian,theologian,神学家,NOUN,B2
-theologie,theology,神学,NOUN,B2
-theoloog,divine,如神,NOUN,B2
-theoretisch,theoretically,理论上,ADV,B2
-theorize,theorize,词,VERB,B2
-therapist,therapist,治疗师,NOUN,B2
-there,there,那儿,NOUN,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-there's still time,to there's still time,来得及,VERB,B2
-thereafter,thereafter,此后,ADV,B2
-thereby,thereby,从而,ADV,B2
-therefore (sconj),therefore,所以,SCONJ,B2
-thereupon,thereupon,随后,ADV,B2
-thermal (noun),thermal,词,NOUN,B2
-thermodynamics,thermodynamics,热力学,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-thesaurus,thesaurus,词,NOUN,C1
-these,these,这些,DET,B2
-these (pron),these,词,PRON,A1
-these three,these three,这三,NOUN,B2
-thesis,thesis,论文,NOUN,B2
-thespian,thespian,词,NOUN,C1
-they female,they female,她们,PRON,B2
-they things,they things,它们,PRON,B2
-they two,they two,词,PRON,A1
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thicket,thicket,灌木丛,NOUN,B2
-thickets,thickets,词,NOUN,B2
-thickness,thickness,厚度,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thief presence,thief presence,有贼,NOUN,B2
-thigh,thigh,大腿,NOUN,B2
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-think to want,to think to want,想,VERB,B2
-thinker,thinker,词,NOUN,C1
-thinking,thinking,思维,NOUN,B2
-thinner,thinner,更薄的,ADJ,B2
-thinness,thinness,瘦,NOUN,B2
-third,third,三分之一,NOUN,B2
-third (num),third,词,NUM,B1
-third bestowal,third bestowal,三授,NOUN,B2
-third place,third place,季军,NOUN,B2
-thirsty,thirsty,口渴的,ADJ,B2
-this,this,您这,NOUN,B2
-this battle,this battle,此战,NOUN,B2
-this capital,this capital,这京,NOUN,C1
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this item,this item,这件,NOUN,B2
-this masculine,this masculine,词,DET,A1
-this matter,this matter,这事,NOUN,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
-this way,this way,这样,PRON,B2
-this way (adv),this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-this-camp,this-camp,这营,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
-thorny,thorny,词,ADJ,C1
-thoroughly,thoroughly,词,ADV,B2
-those,those,那些,DET,B2
-thoughtful,thoughtful,体贴的,ADJ,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
-thousand (noun),thousand,词,NOUN,B2
-thousands,thousands,数千,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thrall,thrall,词,NOUN,C1
-thread,thread,线,NOUN,B2
-thread (verb),thread,词,VERB,C1
-threadbare,threadbare,词,ADJ,C1
-threads,threads,词,NOUN,B2
-threatened,threatened,词,ADJ,C1
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
-three-d printing,three-d printing,3D打印,NOUN,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-threshing floor,threshing floor,词,NOUN,B2
-threshold,threshold,门槛,NOUN,B2
-thrifty,thrifty,节俭的,ADJ,B2
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thrilling,thrilling,令人兴奋的,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throng,throng,词,NOUN,C1
-throughout,throughout,词,ADP,B1
-throw,throw,投掷,NOUN,B2
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-throwing,throwing,词,NOUN,B2
-thrust,thrust,猛推,NOUN,B2
-thrust toward,thrust toward,插向,NOUN,B2
-thug,thug,暴徒,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thunderstorm,thunderstorm,雷阵雨,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thwart,to thwart,阻挠,VERB,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-tick,tick,滴答声,NOUN,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,检票,NOUN,B2
-ticket window,ticket window,售票窗口,NOUN,B2
-tickle,tickle,发痒,NOUN,B2
-tidal,tidal,潮汐,ADJ,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidy (adj),tidy,词,ADJ,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tiende,tithe,什一税,NOUN,B2
-tier,tier,分阶,NOUN,C1
-tight narrow,tight narrow,词,ADJ,B1
-tight-fitting,tight-fitting,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightly,tightly,词,ADV,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-tights,tights,词,NOUN,C1
-tijdelijk,temporarily,临时地,ADV,B2
-tijdelijke weigering,temporary refusal,暂不,NOUN,B2
-tilt,tilt,倾斜,NOUN,B2
-timber,timber,词,NOUN,C1
-timbre,timbre,词,NOUN,C1
-time clock,time clock,打卡机,NOUN,B2
-time era,time era,词,NOUN,A2
-time limit,time limit,词,NOUN,B1
-time occasion,time occasion,次,NOUN,B2
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time out,time out,词,NOUN,B2
-time to go to bed,time to go to bed,该睡觉了,ADV,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
-timetable,timetable,时刻表,NOUN,B2
-timid,timid,词,ADJ,B2
-timing,timing,时机,NOUN,B2
-timmerman,carpenter,木匠,NOUN,B2
-timmerwerk,carpentry,木工,NOUN,B2
-timorous,timorous,词,ADJ,C1
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (adj),tint,词,ADJ,C1
-tint (noun),tint,词,NOUN,C1
-tinteling,tingling,麻木感,NOUN,B2
-tiny minute,tiny minute,词,ADJ,C1
-tips,tips,词,NOUN,C1
-tirade,tirade,长篇抨击,NOUN,B2
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tireless,tireless,不知疲倦的,ADJ,B2
-tirelessly,tirelessly,词,ADV,C1
-tiresome,tiresome,累人的,ADJ,B2
-tissue (adj),tissue,词,ADJ,C1
-titanic,titanic,词,ADJ,C1
-titillate,titillate,词,VERB,C1
-titling,titling,词,NOUN,C1
-tits,tits,词,NOUN,C1
-titular,titular,词,ADJ,C1
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdicate,to abdicate,退位,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abort,to abort,流产,VERB,B2
-to abound,to abound,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,动词,VERB,B2
-to absolve,to absolve,赦免,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,动词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abwandeln,to abwandeln,动词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to accentuate,to accentuate,强调,VERB,B2
-to access,to access,进入,VERB,B2
-to acclaim,to acclaim,称赞,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to acknowledge,to acknowledge,承认,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to acquiesce,to acquiesce,默许,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adduce,to adduce,引证,VERB,B2
-to adhere,to adhere,坚持,VERB,B2
-to adhere join,to adhere join,词,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to adore,to adore,爱慕,VERB,B2
-to afforest,to afforest,造林,VERB,B2
-to age,to age,变老,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to agree with,to agree with,词,VERB,B2
-to ail,to ail,使苦恼,VERB,B2
-to aim (verb),to aim,词,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alienate,to alienate,使疏远,VERB,B2
-to align,to align,使一致,VERB,B2
-to allege,to allege,宣称,VERB,B2
-to alleviate,to alleviate,缓解,VERB,B2
-to allocate,to allocate,分配,VERB,B2
-to allude,to allude,暗指,VERB,B2
-to ally,to ally,结盟,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter,to alter,改变,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to amalgamate,to amalgamate,合并,VERB,B2
-to amass,to amass,积聚,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to amplify,to amplify,放大,VERB,B2
-to anathematize,to anathematize,词,VERB,C1
-to anchor (verb),to anchor,停泊,VERB,B2
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to anger,to anger,使生气,VERB,B2
-to animate,to animate,词,VERB,B2
-to annul,to annul,废除,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antagonize,to antagonize,使对立,VERB,B2
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,叛教,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to appear in court,to appear in court,词,VERB,B2
-to appear to seem,to appear to seem,出现/显得,VERB,B2
-to apply be valid,to apply be valid,适用/有效,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to apprehend,to apprehend,逮捕,VERB,B2
-to arm,to arm,武装,VERB,B2
-to armor,to armor,装甲,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
-to ascribe,to ascribe,归因于,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphyxiate,to asphyxiate,使窒息,VERB,B2
-to assault,to assault,袭击,VERB,B2
-to assent,to assent,同意,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt (verb),to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attenuate,to attenuate,减弱,VERB,B2
-to attest,to attest,证明,VERB,B2
-to audit (verb),to audit,审核,VERB,B2
-to augur,to augur,预言,VERB,B2
-to auscultate,to auscultate,听诊,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await orders,to await orders,待命,VERB,B2
-to back up,to back up,后退,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to bandage (verb),to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to bare,to bare,暴露,VERB,B2
-to bargain (verb),to bargain,词,VERB,C1
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to barricade (verb),to barricade,词,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be (verb),to be,一身,VERB,A1
-to be able (aux),to be able,能够,AUX,B1
-to be able to (verb),to be able to,词,VERB,B2
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be added,to be added,加入,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be based on,to be based on,基于,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be content,to be content,词,VERB,C1
-to be contradicted,to be contradicted,词,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be dissonant,to be dissonant,词,VERB,C1
-to be driven,to be driven,被驱动,VERB,B2
-to be equivalent,to be equivalent,词,VERB,C1
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be forbidden,to be forbidden,词,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be good for,to be good for,词,VERB,B2
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be happy,to be happy,词,VERB,A2
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be liable,to be liable,负责,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be moved,to be moved,感动,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be necessary must,to be necessary must,词,VERB,A2
-to be needed,to be needed,被需要,VERB,B2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticeable,to be noticeable,词,VERB,C1
-to be noticed,to be noticed,被注意到,VERB,B2
-to be observed,to be observed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,进行中,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be related,to be related,词,VERB,C1
-to be released,to be released,词,VERB,B2
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be responsible,to be responsible,负责,VERB,B2
-to be said,to be said,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be struck,to be struck,被打击,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,不知道,VERB,B2
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be valid,to be valid,有效,VERB,B2
-to be vigilant,to be vigilant,词,VERB,B2
-to be visible,to be visible,可见,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to bear to endure,to bear to endure,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to beatify,to beatify,宣福,VERB,B2
-to beautify,to beautify,美化,VERB,B2
-to become (aux),to become,词,AUX,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become alert,to become alert,词,VERB,B2
-to become bold,to become bold,词,VERB,C1
-to become certain,to become certain,词,VERB,B2
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to befriend,to befriend,与...交朋友,VERB,B2
-to beget,to beget,引起,VERB,B2
-to begin to cut into,to begin to cut into,词,VERB,C1
-to behave rudely,to behave rudely,词,VERB,C1
-to behead,to behead,斩首,VERB,B2
-to behold,to behold,注视,VERB,B2
-to bequeath,to bequeath,遗赠,VERB,B2
-to bet invest,to bet invest,词,VERB,B2
-to betroth,to betroth,词,VERB,C1
-to bewitch,to bewitch,迷住,VERB,B2
-to bicker,to bicker,争吵,VERB,B2
-to bid farewell,to bid farewell,词,VERB,B1
-to bide,to bide,等待,VERB,B2
-to bifurcate,to bifurcate,分叉,VERB,B2
-to bisect,to bisect,平分,VERB,B2
-to blacken,to blacken,变黑,VERB,B2
-to blackmail (verb),to blackmail,敲诈,VERB,B2
-to blaspheme,to blaspheme,亵渎,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to bleat,to bleat,哀叫,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to blink,to blink,眨眼,VERB,B2
-to bloom,to bloom,开花,VERB,B2
-to blossom,to blossom,开花,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to blow up,to blow up,炸毁,VERB,B2
-to bluff,to bluff,虚张声势,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to blush,to blush,脸红,VERB,B2
-to board (verb),to board,词,VERB,C1
-to boil cook,to boil cook,词,VERB,B1
-to bombard,to bombard,轰炸,VERB,B2
-to boost,to boost,促进,VERB,B2
-to border,to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to botch,to botch,搞砸,VERB,B2
-to bottle (verb),to bottle,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to box,to box,拳击,VERB,B2
-to brandish,to brandish,挥舞,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break in,to break in,词,VERB,B2
-to break into,to break into,撬开,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to breathe again,to breathe again,松口气,VERB,B2
-to bribe (verb),to bribe,行贿,VERB,B2
-to bridle (verb),to bridle,词,VERB,C1
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring closer,to bring closer,靠近,VERB,B2
-to bring here,to bring here,词,VERB,C1
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to bristle,to bristle,使竖起,VERB,B2
-to brood,to brood,沉思,VERB,B2
-to brush (verb),to brush,刷,VERB,B2
-to bullshit,to bullshit,胡扯,VERB,B2
-to bump,to bump,碰撞,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to bungle,to bungle,搞砸,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to burnish,to burnish,擦亮,VERB,B2
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to calibrate,to calibrate,校准,VERB,B2
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call out,to call out,词,VERB,C1
-to call ring,to call ring,打电话,VERB,B2
-to call to contact,to call to contact,词,VERB,A2
-to calm down,to calm down,使平静,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to caper,to caper,跳跃,VERB,B2
-to capitulate,to capitulate,投降,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to captivate,to captivate,迷住,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carry on,to carry on,词,VERB,C1
-to carve,to carve,雕刻,VERB,B2
-to cash (verb),to cash,兑现,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to cast (verb),to cast,词,VERB,B2
-to castigate,to castigate,严厉批评,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,瞥见,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to catechize,to catechize,词,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to cauterize,to cauterize,烧灼,VERB,B2
-to cement (verb),to cement,词,VERB,B2
-to censor,to censor,审查,VERB,B2
-to center,to center,居中,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to chair (verb),to chair,词,VERB,C1
-to change clothes,to change clothes,更衣,VERB,B1
-to change trains,to change trains,词,VERB,A1
-to charge (verb),to charge,充电,VERB,B2
-to chastise,to chastise,严惩,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chill,to chill,使冰冻,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,割礼,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clean out,to clean out,词,VERB,C1
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close eyes,to close eyes,闭眼,VERB,B2
-to cloy,to cloy,使厌烦,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to coax,to coax,哄骗,VERB,B2
-to codify,to codify,编纂,VERB,B2
-to coerce,to coerce,强迫,VERB,B2
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to collate,to collate,核对,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to commercialize,to commercialize,商业化,VERB,B2
-to commission,to commission,委托,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,交融,VERB,B2
-to commute,to commute,通勤,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to complement,to complement,补充,VERB,B2
-to complete finish,to complete finish,词,VERB,B2
-to complicate,to complicate,使复杂化,VERB,B2
-to compose (noun),to compose,合成,NOUN,B2
-to computerize,to computerize,词,VERB,C1
-to concede,to concede,承认,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concoct,to concoct,编造,VERB,B2
-to condescend,to condescend,屈尊,VERB,B2
-to condition,to condition,制约,VERB,B2
-to condone,to condone,宽恕,VERB,B2
-to conduct (verb),to conduct,指挥,VERB,B2
-to confer,to confer,授予,VERB,B2
-to confine,to confine,限制,VERB,B2
-to conform,to conform,符合,VERB,B2
-to conjecture,to conjecture,猜测,VERB,B2
-to conjugate,to conjugate,变位,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to connote,to connote,暗示,VERB,B2
-to consent,to consent,同意,VERB,B2
-to conserve,to conserve,保存,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to consign,to consign,移交,VERB,B2
-to constipate,to constipate,词,VERB,C1
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consummate,to consummate,完成,VERB,B2
-to contend,to contend,主张,VERB,B2
-to contest,to contest,质疑,VERB,B2
-to cook fix,to cook fix,做/修理,VERB,B2
-to cool,to cool,冷却,VERB,B2
-to cope,to cope,应付,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to corroborate,to corroborate,证实,VERB,B2
-to corrode,to corrode,腐蚀,VERB,B2
-to corrupt (verb),to corrupt,词,VERB,B2
-to cough (verb),to cough,咳嗽,VERB,B2
-to counter (verb),to counter,抗辩,VERB,B2
-to countersign,to countersign,副署,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,词,VERB,C1
-to covet,to covet,觊觎,VERB,B2
-to crack (verb),to crack,词,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to cram,to cram,填鸭式学习,VERB,B2
-to crash,to crash,碰撞,VERB,B2
-to crash into,to crash into,撞击,VERB,B2
-to creak,to creak,嘎吱作响,VERB,B2
-to croak,to croak,呱呱叫,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,挤在一起,VERB,B2
-to crumple,to crumple,弄皱,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to cuddle,to cuddle,拥抱,VERB,B2
-to culminate,to culminate,达到顶点,VERB,B2
-to curl,to curl,卷曲,VERB,B2
-to curse (verb),to curse,词,VERB,B2
-to curtail,to curtail,削减,VERB,B2
-to curve,to curve,弯曲,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to dam up,to dam up,词,VERB,C1
-to damn (verb),to damn,词,VERB,B2
-to dampen,to dampen,使潮湿,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to daunt,to daunt,使气馁,VERB,B2
-to dawdle,to dawdle,闲逛,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daze,to daze,使茫然,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deafen,to deafen,使聋,VERB,B2
-to deal,to deal,处理,VERB,B2
-to debase,to debase,贬低,VERB,B2
-to debut,to debut,首次亮相,VERB,B2
-to decant,to decant,倾析,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,大量削减,VERB,B2
-to declaim,to declaim,慷慨陈词,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declassify,to declassify,解密,VERB,B2
-to decode,to decode,解码,VERB,B2
-to decompress,to decompress,解压,VERB,B2
-to decontextualize,to decontextualize,词,VERB,C1
-to decouple,to decouple,分离,VERB,B2
-to decree (verb),to decree,旨,VERB,B2
-to decry,to decry,谴责,VERB,B2
-to defame,to defame,诽谤,VERB,B2
-to default (verb),to default,拖欠,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to defer,to defer,推迟,VERB,B2
-to deflate,to deflate,使泄气,VERB,B2
-to defray,to defray,支付,VERB,B2
-to defrost,to defrost,除霜,VERB,B2
-to defuse,to defuse,缓和,VERB,B2
-to deify,to deify,神化,VERB,B2
-to deign,to deign,屈尊,VERB,B2
-to dejta,to dejta,约会,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delegitimize,to delegitimize,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to delight,to delight,使高兴,VERB,B2
-to delimit,to delimit,词,VERB,C1
-to delineate,to delineate,描绘,VERB,B2
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to delude oneself,to delude oneself,词,VERB,B2
-to demarcate,to demarcate,划定界限,VERB,B2
-to democratize,to democratize,民主化,VERB,B2
-to demonize,to demonize,妖魔化,VERB,B2
-to denature,to denature,使变性,VERB,B2
-to denigrate,to denigrate,诋毁,VERB,B2
-to denominate,to denominate,命名,VERB,B2
-to denote,to denote,表示,VERB,B2
-to densify,to densify,词,VERB,C1
-to depersonalize,to depersonalize,词,VERB,C1
-to depilate,to depilate,脱毛,VERB,B2
-to deploy unfold,to deploy unfold,词,VERB,C1
-to depopulate,to depopulate,使人口减少,VERB,B2
-to deport,to deport,驱逐出境,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deprave,to deprave,使堕落,VERB,B2
-to depreciate,to depreciate,贬值,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,起源于,VERB,B2
-to desert,to desert,擅离职守,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to desist,to desist,停止,VERB,B2
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to despoil,to despoil,掠夺,VERB,B2
-to destock,to destock,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to detail,to detail,详述,VERB,B2
-to dethrone,to dethrone,废黜,VERB,B2
-to detract,to detract,贬低,VERB,B2
-to deviate,to deviate,偏离,VERB,B2
-to devour,to devour,吞食,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to digitize,to digitize,数字化,VERB,B2
-to digress,to digress,离题,VERB,B2
-to dilute,to dilute,稀释,VERB,B2
-to dimension (verb),to dimension,词,VERB,C1
-to dirty (verb),to dirty,词,VERB,C1
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disabuse,to disabuse,纠正错误想法,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disarrange,to disarrange,弄乱,VERB,B2
-to disarray (verb),to disarray,词,VERB,C1
-to discern,to discern,辨别,VERB,B2
-to discipline (verb),to discipline,处分,VERB,B2
-to disconcert,to disconcert,使惊慌,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to discourse (verb),to discourse,论述,VERB,B2
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disembark,to disembark,下船,VERB,B2
-to disenchant,to disenchant,使清醒,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disentangle,to disentangle,解开,VERB,B2
-to disfavor,to disfavor,不利于,VERB,B2
-to disfigure,to disfigure,毁容,VERB,B2
-to disguise (verb),to disguise,伪装,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to dishearten,to dishearten,使沮丧,VERB,B2
-to dishevel,to dishevel,弄乱,VERB,B2
-to dishonor,to dishonor,使蒙羞,VERB,B2
-to disinherit,to disinherit,剥夺继承权,VERB,B2
-to disintegrate,to disintegrate,瓦解,VERB,B2
-to disjoin,to disjoin,分离,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dislodge,to dislodge,逐出,VERB,B2
-to dismay,to dismay,使沮丧,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disoblige,to disoblige,词,VERB,C1
-to dispel,to dispel,消除,VERB,B2
-to dispense,to dispense,分发,VERB,B2
-to disperse,to disperse,分散,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to dispose,to dispose,处理,VERB,B2
-to dispossess,to dispossess,剥夺,VERB,B2
-to disproportion (verb),to disproportion,词,VERB,C1
-to disqualify,to disqualify,取消资格,VERB,B2
-to disrespect (verb),to disrespect,词,VERB,C1
-to disrupt,to disrupt,扰乱,VERB,B2
-to dissent (verb),to dissent,词,VERB,C1
-to dissipate,to dissipate,消散,VERB,B2
-to distance (verb),to distance,词,VERB,C1
-to distill,to distill,蒸馏,VERB,B2
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to disunite,to disunite,使分裂,VERB,B2
-to dither,to dither,犹豫不决,VERB,B2
-to diverge,to diverge,分歧,VERB,B2
-to divest,to divest,剥夺,VERB,B2
-to divulge,to divulge,泄露,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do hair,to do hair,词,VERB,C1
-to do harm,to do harm,伤害,VERB,B2
-to do justice to,to do justice to,词,VERB,C1
-to do make,to do make,词,VERB,A1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to dodge,to dodge,躲避,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to dote,to dote,词,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape,to drape,悬挂,VERB,B2
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw support from,to draw support from,借助,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drip,to drip,滴,VERB,B2
-to drive herd,to drive herd,词,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,驾驶,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry in the sun (verb),to dry in the sun,晾晒,VERB,B2
-to dry out,to dry out,词,VERB,C1
-to dry up,to dry up,使干枯,VERB,B2
-to duck (verb),to duck,词,VERB,C1
-to dull (verb),to dull,词,VERB,C1
-to dupe,to dupe,欺骗,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dust off,to dust off,词,VERB,C1
-to dye,to dye,染色,VERB,B2
-to each other (adv),to each other,词,ADV,C1
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eavesdrop,to eavesdrop,偷听,VERB,B2
-to eclipse,to eclipse,使失色,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to edify,to edify,启发,VERB,B2
-to eject,to eject,弹出,VERB,B2
-to elapse,to elapse,流逝,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to elevate,to elevate,提升,VERB,B2
-to elide,to elide,省略,VERB,B2
-to elucidate,to elucidate,阐明,VERB,B2
-to elude,to elude,逃避,VERB,B2
-to emasculate,to emasculate,使无力,VERB,B2
-to embark,to embark,上船,VERB,B2
-to embarrass,to embarrass,使尴尬,VERB,B2
-to embolden,to embolden,使大胆,VERB,B2
-to emerge,to emerge,出现,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to empty,to empty,倒空,VERB,B2
-to encircle,to encircle,环绕,VERB,B2
-to encode,to encode,编码,VERB,B2
-to encompass,to encompass,包含,VERB,B2
-to encore (verb),to encore,词,VERB,C1
-to encroach,to encroach,侵蚀,VERB,B2
-to endow,to endow,赋予,VERB,B2
-to enervate,to enervate,使衰弱,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engross,to engross,使全神贯注,VERB,B2
-to enhance,to enhance,增强,VERB,B2
-to enrage,to enrage,激怒,VERB,B2
-to enrapture,to enrapture,使狂喜,VERB,B2
-to enslave,to enslave,奴役,VERB,B2
-to ensnare,to ensnare,诱捕,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthrall,to enthrall,迷住,VERB,B2
-to enthrone,to enthrone,立为王,VERB,B2
-to enunciate,to enunciate,阐明,VERB,B2
-to envy (verb),to envy,羡慕,VERB,B2
-to equal (verb),to equal,无异,VERB,B2
-to equalize,to equalize,使相等,VERB,B2
-to equate,to equate,等同,VERB,B2
-to erect behave,to erect behave,建造,VERB,B2
-to erode,to erode,侵蚀,VERB,B2
-to espy,to espy,窥探,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to eternalize,to eternalize,使永恒,VERB,B2
-to evangelize,to evangelize,传福音,VERB,B2
-to evict,to evict,驱逐,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to evoke,to evoke,唤起,VERB,B2
-to exalt,to exalt,颂扬,VERB,B2
-to exasperate,to exasperate,激怒,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to exclaim,to exclaim,呼喊,VERB,B2
-to exculpate,to exculpate,开脱,VERB,B2
-to execrate,to execrate,痛恨,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exemplify,to exemplify,举例说明,VERB,B2
-to exempt,to exempt,免除,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exfoliate,to exfoliate,去角质,VERB,B2
-to exhume,to exhume,掘出,VERB,B2
-to exist there is,to exist there is,存在/有,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to exorcise,to exorcise,驱魔,VERB,B2
-to expatriate,to expatriate,使移居国外,VERB,B2
-to expectorate,to expectorate,吐痰,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to expurgate,to expurgate,删节,VERB,B2
-to extirpate,to extirpate,根除,VERB,B2
-to extol,to extol,赞美,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extricate,to extricate,使摆脱,VERB,B2
-to exude,to exude,散发,VERB,B2
-to fail to fulfill,to fail to fulfill,未履行,VERB,B2
-to fake,to fake,伪造,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall silent,to fall silent,沉默,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to familiarize,to familiarize,使熟悉,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fasten,to fasten,系紧,VERB,B2
-to fatten,to fatten,养肥,VERB,B2
-to favor (verb),to favor,偏向,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign,to feign,假装,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to fell,to fell,砍倒,VERB,B2
-to ferret,to ferret,搜寻,VERB,B2
-to fertilize,to fertilize,施肥,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to finally,to finally,你可算,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fit suit,to fit suit,适合,VERB,B2
-to fix to prepare,to fix to prepare,词,VERB,A2
-to fix to set,to fix to set,词,VERB,B1
-to flame,to flame,燃烧,VERB,B2
-to flap,to flap,拍打,VERB,B2
-to flash,to flash,闪烁,VERB,B2
-to flatten,to flatten,使平坦,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flock,to flock,群集,VERB,B2
-to flog,to flog,鞭打,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flout,to flout,蔑视,VERB,B2
-to flow in,to flow in,词,VERB,C1
-to flow into,to flow into,词,VERB,C1
-to fluctuate,to fluctuate,波动,VERB,B2
-to flush,to flush,冲洗,VERB,B2
-to flush out,to flush out,词,VERB,B2
-to fluster,to fluster,使慌乱,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to foist,to foist,强加,VERB,B2
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to forebode,to forebode,预兆,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to form to train,to form to train,词,VERB,B1
-to fortify,to fortify,加强,VERB,B2
-to fossilize,to fossilize,石化,VERB,B2
-to fraction,to fraction,分割,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to frame (verb),to frame,陷害,VERB,B2
-to fraternize,to fraternize,勾结,VERB,B2
-to frequent,to frequent,常去,VERB,B2
-to freshen,to freshen,使清新,VERB,B2
-to frighten away,to frighten away,词,VERB,C1
-to frolic,to frolic,嬉戏,VERB,B2
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to fumigate,to fumigate,熏蒸,VERB,B2
-to function to work,to function to work,词,VERB,B1
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse (verb),to fuse,融合,VERB,B2
-to gain,to gain,获得,VERB,B2
-to gain weight,to gain weight,变胖,VERB,B2
-to galvanize,to galvanize,激励,VERB,B2
-to gape,to gape,目瞪口呆,VERB,B2
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to gauge,to gauge,测量,VERB,B2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to germinate,to germinate,发芽,VERB,B2
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get along,to get along,词,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get by,to get by,过得去,VERB,B2
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get fond of,to get fond of,词,VERB,C1
-to get into,to get into,陷入,VERB,B2
-to get into debt,to get into debt,词,VERB,C1
-to get off,to get off,词,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get stuck,to get stuck,卡住,VERB,B2
-to get tired,to get tired,疲劳,VERB,A2
-to get to know,to get to know,词,VERB,B1
-to gift (verb),to gift,词,VERB,B1
-to giggle,to giggle,咯咯笑,VERB,B2
-to gild,to gild,镀金,VERB,B2
-to gird,to gird,束紧,VERB,B2
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give as a gift,to give as a gift,赠送,VERB,B2
-to give birth,to give birth,分娩,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glean,to glean,搜集,VERB,B2
-to gloss,to gloss,注释,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go blind,to go blind,失明,VERB,B2
-to go deep into,to go deep into,深入,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,麻木,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go there,to go there,词,VERB,B1
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up again,to go up again,词,VERB,B1
-to go up in smoke,to go up in smoke,词,VERB,B2
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to goad,to goad,刺激,VERB,B2
-to gossip,to gossip,闲聊,VERB,B2
-to graduate (verb),to graduate,毕业,VERB,B2
-to gratify,to gratify,使满足,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to gravitate,to gravitate,受吸引,VERB,B2
-to gray,to gray,变白,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to group,to group,分组,VERB,B2
-to grow fond of,to grow fond of,词,VERB,C1
-to grow old,to grow old,词,VERB,A1
-to growl,to growl,咆哮,VERB,B2
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,猜中,VERB,B2
-to guillotine,to guillotine,斩首,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to gurgle (verb),to gurgle,词,VERB,C1
-to gush,to gush,涌出,VERB,B2
-to hail,to hail,下冰雹,VERB,B2
-to hail inspect,to hail inspect,盘查,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to handcuff,to handcuff,给…戴手铐,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,词,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harangue (verb),to harangue,词,VERB,B2
-to harbor,to harbor,怀有,VERB,B2
-to harden,to harden,使经受锻炼,VERB,B2
-to harm (verb),to harm,害,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,使和谐,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have (aux),to have,词,AUX,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to have to,to have to,必须,VERB,B2
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear that,to hear that,听说,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hide to disappear,to hide to disappear,词,VERB,A2
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up,to hold up,词,VERB,B2
-to hold up stop,to hold up stop,词,VERB,A2
-to hollow out,to hollow out,词,VERB,C1
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to hook (verb),to hook,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to humanize,to humanize,使人性化,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idolize,to idolize,崇拜,VERB,B2
-to ignite,to ignite,词,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to imbue,to imbue,词,VERB,C1
-to immobilize,to immobilize,词,VERB,C1
-to implant,to implant,植入,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to imprint (verb),to imprint,词,VERB,C1
-to impute,to impute,归咎,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incarcerate,to incarcerate,监禁,VERB,B2
-to incentivize,to incentivize,词,VERB,C1
-to inconvenience,to inconvenience,使不便,VERB,B2
-to incriminate,to incriminate,归罪,VERB,B2
-to indicate interpret,to indicate interpret,表明/解释,VERB,B2
-to indispose,to indispose,词,VERB,C1
-to indoctrinate,to indoctrinate,灌输,VERB,B2
-to induce to lead to,to induce to lead to,词,VERB,C1
-to infest,to infest,滋生,VERB,B2
-to inflame,to inflame,使发炎,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict,to inflict,词,VERB,C1
-to inflict to impose,to inflict to impose,施加,VERB,B2
-to inform to reach,to inform to reach,词,VERB,A2
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insinuate,to insinuate,暗示,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to instill,to instill,灌输,VERB,B2
-to institute (verb),to institute,词,VERB,C1
-to institutionalize,to institutionalize,制度化,VERB,C1
-to interact,to interact,词,VERB,C1
-to intercede,to intercede,调停,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to interview (verb),to interview,采访,VERB,B2
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intoxicate,to intoxicate,使中毒,VERB,B2
-to intrigue,to intrigue,激起兴趣,VERB,B2
-to intuit,to intuit,词,VERB,C1
-to invalidate,to invalidate,证明无效,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoke,to invoke,援引,VERB,B2
-to irrigate,to irrigate,灌溉,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to itch (verb),to itch,痒,VERB,B2
-to jam,to jam,堵塞,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,加入 / 附着,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to knead,to knead,词,VERB,A1
-to kneel,to kneel,词,VERB,B1
-to knit,to knit,编织,VERB,B2
-to knock down,to knock down,词,VERB,B2
-to knock to pound,to knock to pound,词,VERB,A2
-to knot (verb),to knot,词,VERB,C1
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack basis,to lack basis,无据,VERB,B2
-to lament,to lament,哀叹,VERB,B2
-to languish,to languish,词,VERB,C1
-to laugh smile,to laugh smile,笑,VERB,A1
-to launder,to launder,洗钱,VERB,B2
-to lay down,to lay down,放下,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to lay put,to lay put,放,VERB,B2
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,使入歧途,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to lean out,to lean out,探出身体,VERB,B2
-to leap (verb),to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to,to leave to,词,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to legislate,to legislate,词,VERB,C1
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lengthen,to lengthen,延长,VERB,B2
-to lessen,to lessen,词,VERB,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to levy,to levy,征收,VERB,C1
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,对...说谎,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,点燃,VERB,B2
-to lighten,to lighten,减轻,VERB,B2
-to like (aux),to like,词,AUX,A2
-to linger,to linger,徘徊,VERB,B2
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live in,to live in,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to load charge,to load charge,装载,VERB,B2
-to loathe,to loathe,厌恶,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to loiter,to loiter,词,VERB,C1
-to long,to long,渴望,VERB,B2
-to long for,to long for,渴望,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to loot (verb),to loot,词,VERB,C1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower,to lower,降低,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lunge,to lunge,词,VERB,C1
-to lure (verb),to lure,词,VERB,B2
-to lurk,to lurk,词,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to maim,to maim,词,VERB,C1
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make bland,to make bland,使乏味,VERB,B2
-to make drowsy,to make drowsy,词,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make heavier,to make heavier,加重,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,使独立,VERB,B2
-to make lasting,to make lasting,词,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make one's way,to make one's way,词,VERB,B2
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make proud,to make proud,使自豪,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manifest,to manifest,表明,VERB,B2
-to manure (verb),to manure,词,VERB,C1
-to map out,to map out,摸清,VERB,B2
-to mark (verb),to mark,标记,VERB,B1
-to mark out,to mark out,标示,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to mash (verb),to mash,词,VERB,A2
-to massacre (verb),to massacre,词,VERB,C1
-to mast,to mast,降伏,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to head to,to mean to head to,词,VERB,A2
-to mean to think,to mean to think,词,VERB,C1
-to meant,to meant,意思是,VERB,B2
-to meddle,to meddle,干涉,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mention to remember,to mention to remember,词,VERB,A2
-to merge (noun),to merge,词,NOUN,B2
-to mess around,to mess around,胡闹,VERB,B2
-to mime (verb),to mime,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to mirror,to mirror,反映,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to missed,to missed,错过,VERB,B2
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to moan (verb),to moan,词,VERB,B2
-to modernize,to modernize,词,VERB,C1
-to moon (verb),to moon,词,VERB,A2
-to moor (verb),to moor,词,VERB,B2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to mourn,to mourn,哀悼,VERB,B2
-to move away,to move away,移开,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to move touch,to move touch,使感动,VERB,B2
-to mud,to mud,弄脏,VERB,B2
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to mutiny,to mutiny,煽动叛乱,VERB,B2
-to nail,to nail,钉,VERB,B2
-to narrow,to narrow,使变窄,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need must,to need must,词,VERB,A2
-to nickname,to nickname,给...起绰号,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note down,to note down,词,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to nuance,to nuance,使具有细微差别,VERB,B2
-to numb,to numb,使麻木,VERB,B2
-to object,to object,反对,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to occur to,to occur to,词,VERB,B2
-to ogle,to ogle,窥视,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to orient to guide,to orient to guide,词,VERB,C1
-to oust,to oust,推翻,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to outline (verb),to outline,勾勒,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overestimate,to overestimate,词,VERB,C1
-to overflow,to overflow,溢出,VERB,B2
-to overlook,to overlook,忽视,VERB,B2
-to overshadow,to overshadow,使黯然失色,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to overstep,to overstep,越权,VERB,B2
-to overthrow,to overthrow,推翻,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,平息,VERB,B2
-to package (verb),to package,词,VERB,C1
-to paint over,to paint over,重新粉刷,VERB,B2
-to pair,to pair,配对,VERB,B2
-to pamper,to pamper,纵容,VERB,B2
-to panic (verb),to panic,词,VERB,C1
-to parade,to parade,游行,VERB,B2
-to party,to party,狂欢,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to perceive,to perceive,察觉,VERB,B2
-to perforate,to perforate,词,VERB,C1
-to perform umrah,to perform umrah,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to perpetrate,to perpetrate,词,VERB,C1
-to perpetuate,to perpetuate,使永存,VERB,B2
-to persecute,to persecute,迫害,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to pick out,to pick out,挑选,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to placate,to placate,安抚,VERB,B2
-to place put,to place put,放置,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant (verb),to plant,种植,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to pledge mutually,to pledge mutually,词,VERB,C1
-to plot,to plot,密谋,VERB,B2
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plug in,to plug in,插入,VERB,B2
-to plunder,to plunder,掠夺,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to point to clock in,to point to clock in,指 / 打卡,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to pollute,to pollute,词,VERB,B2
-to portend,to portend,词,VERB,B2
-to postpone to carry over,to postpone to carry over,推迟,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to powder,to powder,撒粉,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to preserve to protect,to preserve to protect,词,VERB,C1
-to preside,to preside,主持,VERB,B2
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to prick,to prick,扎,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to prop up,to prop up,支撑,VERB,B2
-to prosecute,to prosecute,起诉,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pull out hair,to pull out hair,词,VERB,C1
-to pull through,to pull through,词,VERB,B2
-to pump (verb),to pump,词,VERB,C1
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purge,to purge,清除,VERB,B2
-to purify,to purify,净化,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push through,to push through,推动,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,使走上正轨,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to quiver,to quiver,颤抖,VERB,B2
-to race down,to race down,词,VERB,C1
-to radiate,to radiate,辐射,VERB,B2
-to rage (verb),to rage,怒,VERB,B2
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rant,to rant,咆哮,VERB,B2
-to ratify,to ratify,批准,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to rationalize,to rationalize,合理化,VERB,B2
-to ravage,to ravage,破坏,VERB,B2
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to rebuke,to rebuke,斥责,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to recreate,to recreate,重建,VERB,B2
-to redden,to redden,变红,VERB,B2
-to redeem,to redeem,赎回,VERB,B2
-to rediscover,to rediscover,重新发现,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to refine,to refine,提炼,VERB,B2
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to regain,to regain,恢复,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relativize,to relativize,词,VERB,C1
-to relay,to relay,转达,VERB,B2
-to release from prison,to release from prison,释放,VERB,B2
-to release let go,to release let go,释放/放手,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remove to pull out,to remove to pull out,词,VERB,A2
-to remunerate,to remunerate,词,VERB,C1
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repeal,to repeal,废除,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to report to authorities,to report to authorities,举报,VERB,B2
-to reproach,to reproach,责备,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resonate,to resonate,共鸣,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retrace,to retrace,追溯,VERB,B2
-to retract,to retract,撤回,VERB,B2
-to retreat (verb),to retreat,后退,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return home,to return home,词,VERB,B1
-to return something,to return something,词,VERB,A2
-to return to restore,to return to restore,词,VERB,C1
-to reverse,to reverse,反转,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to riddle,to riddle,使布满孔洞,VERB,B2
-to ride along,to ride along,词,VERB,B1
-to ridicule (verb),to ridicule,词,VERB,C1
-to rinse,to rinse,冲洗,VERB,B2
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to root out,to root out,词,VERB,C1
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to rough-hew,to rough-hew,粗加工,VERB,B2
-to round (verb),to round,词,VERB,A2
-to ruffle,to ruffle,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to sadden,to sadden,使悲伤,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanctify,to sanctify,使神圣,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to satiate,to satiate,使饱足,VERB,B2
-to saturate,to saturate,使饱和,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to savor,to savor,品味,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scamper,to scamper,词,VERB,B2
-to scare away,to scare away,惊飞,VERB,B2
-to scent,to scent,词,VERB,B2
-to scheme (verb),to scheme,词,VERB,C1
-to scourge (verb),to scourge,词,VERB,C1
-to scout,to scout,侦察,VERB,B2
-to scram,to scram,词,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to screw,to screw,拧,VERB,B2
-to scribble (verb),to scribble,词,VERB,C1
-to scrimp,to scrimp,词,VERB,C1
-to scrub,to scrub,擦洗,VERB,B2
-to sculpt,to sculpt,词,VERB,C1
-to search apply,to search apply,寻找/申请,VERB,B2
-to seat,to seat,使坐下,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to see emperor,to see emperor,面圣,VERB,C1
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segregate,to segregate,隔离,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sense (verb),to sense,词,VERB,B2
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sequester,to sequester,隔离,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set aside,to set aside,移开,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sew in,to sew in,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to shape (verb),to shape,塑造,VERB,B2
-to share divide,to share divide,分享,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shelter,to shelter,庇护,VERB,B2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shoe (verb),to shoe,词,VERB,C1
-to shoot through,to shoot through,射穿,VERB,C1
-to shop be about,to shop be about,购物,VERB,B2
-to shop for groceries,to shop for groceries,词,VERB,A2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shroud,to shroud,覆盖,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shunt,to shunt,分流,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sidestep,to sidestep,词,VERB,C1
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to singe,to singe,词,VERB,B2
-to sip (verb),to sip,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to skein,to skein,绕成线团,VERB,B2
-to sketch,to sketch,勾勒,VERB,B2
-to skewer,to skewer,串起,VERB,B2
-to skim,to skim,轻触,VERB,B2
-to skin,to skin,剥皮,VERB,B2
-to skip,to skip,跳过,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slap (verb),to slap,词,VERB,B2
-to slash,to slash,猛砍,VERB,B2
-to slaughter (verb),to slaughter,宰,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slay,to slay,词,VERB,C1
-to slice (verb),to slice,词,VERB,C1
-to slight (verb),to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to slope down,to slope down,词,VERB,B2
-to snack (verb),to snack,词,VERB,C1
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to sneak away,to sneak away,溜走,VERB,B2
-to snoop,to snoop,窥探,VERB,B2
-to snort (verb),to snort,词,VERB,B2
-to snow,to snow,下雪,VERB,B2
-to snub,to snub,冷落,VERB,B2
-to soften,to soften,使灵活,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort out,to sort out,词,VERB,B2
-to sour (verb),to sour,词,VERB,C1
-to sparkle,to sparkle,闪耀,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to spawn,to spawn,产卵,VERB,B2
-to spell,to spell,拼写,VERB,B2
-to spend time,to spend time,词,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spill,to spill,溢出,VERB,B2
-to spirit away,to spirit away,变走,VERB,B2
-to splash,to splash,溅,VERB,B2
-to splint,to splint,用夹板固定,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to spot,to spot,看见,VERB,B2
-to spout,to spout,喷射,VERB,B2
-to spray,to spray,喷洒,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to sprout,to sprout,发芽,VERB,B2
-to spy,to spy,监视,VERB,B2
-to spy on,to spy on,词,VERB,C1
-to squeak,to squeak,吱吱叫,VERB,B2
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stalk,to stalk,跟踪,VERB,B2
-to stammer,to stammer,结巴,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steal sword,to steal sword,偷剑,NOUN,B2
-to steam (verb),to steam,蒸煮,VERB,B2
-to steep (verb),to steep,词,VERB,C1
-to steer control,to steer control,控制,VERB,B2
-to stem from,to stem from,源于,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stiffen,to stiffen,词,VERB,C1
-to stifle smother,to stifle smother,词,VERB,B2
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stock up,to stock up,进货,VERB,B2
-to stoke,to stoke,添燃料,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop down,to stop down,词,VERB,C1
-to straighten up,to straighten up,词,VERB,B2
-to strain (verb),to strain,词,VERB,B2
-to stratify,to stratify,分层,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to stride (verb),to stride,词,VERB,B2
-to strike down,to strike down,击倒,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip,to strip,裸露,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive for,to strive for,争取,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stun,to stun,词,VERB,C1
-to stutter,to stutter,词,VERB,B2
-to stylize,to stylize,风格化,VERB,B2
-to subordinate,to subordinate,从属,VERB,B2
-to suborn,to suborn,教唆,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to succeed to pass,to succeed to pass,词,VERB,A2
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to suit agree,to suit agree,词,VERB,B2
-to sulk,to sulk,生闷气,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to supplicate,to supplicate,恳求,VERB,B2
-to supply (verb),to supply,供给,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surge (verb),to surge,词,VERB,B2
-to surname (verb),to surname,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture (verb),to suture,缝合,VERB,B2
-to swagger,to swagger,大摇大摆,VERB,B2
-to swallow up,to swallow up,词,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to swell,to swell,使肿胀,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take amiss,to take amiss,词,VERB,C1
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take on,to take on,词,VERB,C1
-to take one's time,to take one's time,词,VERB,B2
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to talk chat,to talk chat,聊天/谈论,VERB,B2
-to tap to type,to tap to type,词,VERB,C1
-to tarnish,to tarnish,词,VERB,C1
-to task (verb),to task,词,VERB,C1
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to teach reading,to teach reading,词,VERB,B2
-to tear down,to tear down,拆除,VERB,B2
-to tear out,to tear out,拔出,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to tell to narrate,to tell to narrate,词,VERB,A2
-to temper (verb),to temper,词,VERB,B2
-to temporize,to temporize,拖延,VERB,B2
-to tense (verb),to tense,词,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,认为,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrill,to thrill,使兴奋,VERB,B2
-to thrive,to thrive,茁壮成长,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrown,to thrown,扔,VERB,B2
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
-to tie (verb),to tie,系,VERB,B2
-to tinker,to tinker,词,VERB,B1
-to tip,to tip,透露,VERB,B2
-to tip over,to tip over,翻倒,VERB,B2
-to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toast (verb),to toast,词,VERB,B2
-to toil (verb),to toil,词,VERB,C1
-to topple,to topple,词,VERB,C1
-to torment,to torment,折磨,VERB,B2
-to total (verb),to total,共计,VERB,B2
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to transcribe,to transcribe,转录,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transgress,to transgress,违背,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to trick (verb),to trick,欺骗,VERB,B2
-to trigger (verb),to trigger,引发,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tumble,to tumble,跌倒,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to twinkle,to twinkle,词,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbalance,to unbalance,词,VERB,C1
-to unbend,to unbend,润滑,VERB,B2
-to unblind,to unblind,使醒悟,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to unbutton,to unbutton,解开纽扣,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to underline,to underline,强调,VERB,B2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to undo,to undo,解开,VERB,B2
-to undress,to undress,脱衣,VERB,B2
-to unearth,to unearth,发掘,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unhook,to unhook,摘下,VERB,B2
-to unmask,to unmask,揭穿,VERB,B2
-to unplug,to unplug,词,VERB,C1
-to unravel,to unravel,解开,VERB,B2
-to unroll,to unroll,词,VERB,C1
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to untangle,to untangle,词,VERB,C1
-to unwrap,to unwrap,词,VERB,B1
-to uproot,to uproot,根除,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to venerate,to venerate,崇敬,VERB,B2
-to vent,to vent,倾诉,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to vibrate,to vibrate,振动,VERB,B2
-to view,to view,参观,VERB,B2
-to vilify,to vilify,诽谤,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to wane,to wane,减弱,VERB,B2
-to want (aux),to want,欲,AUX,A2
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to warp,to warp,弯曲,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch out,to watch out,小心,VERB,B2
-to watch tv,to watch tv,看电视,VERB,B2
-to water (verb),to water,浇,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to wear down,to wear down,词,VERB,B2
-to wear out,to wear out,磨损,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,使厌倦,VERB,B2
-to wed,to wed,词,VERB,C1
-to wedge,to wedge,卡住,VERB,B2
-to weed (verb),to weed,词,VERB,C1
-to weigh down,to weigh down,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whimper,to whimper,呜咽,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to wield,to wield,行使,VERB,B2
-to wilt,to wilt,枯萎,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to withhold,to withhold,扣留,VERB,B2
-to woo,to woo,词,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to worship (verb),to worship,崇拜,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn,to yearn,渴望,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-to zero out,to zero out,清零,VERB,B2
-toad,toad,蟾蜍,NOUN,B2
-toast,toast,你敬酒,NOUN,B2
-tobacco,tobacco,烟草,NOUN,B2
-today (noun),today,今,NOUN,B2
-today's,today's,词,ADJ,C1
-toebehoren,to belong to,属于,VERB,B2
-toegestaan,allowed,被允许的,ADJ,B2
-toegeven,to make do,做,VERB,B2
-toegewijd,devoted,忠诚的,ADJ,B2
-toekennen,to give to grant,予以,VERB,B2
-toekomstvoorspelling,fortune telling,算命,NOUN,B2
-toelage,allowance,津贴,NOUN,B2
-toepasselijkheid,applicability,适用性,NOUN,B2
-toereikendheid,sufficiency,充足,NOUN,B2
-toeristisch,touristic,旅游的,ADJ,B2
-toespraak houden,to make a speech,发言,VERB,B2
-toestemming,consent,同意,NOUN,B2
-toeteren,to honk,按喇叭,VERB,B2
-toetreden,to join,加入,VERB,B2
-toetreding,accession,即位,NOUN,B2
-toeval,coincidence,巧合,NOUN,B2
-toevertrouwen,to confide,吐露,VERB,B2
-toevlucht,resort,度假胜地,NOUN,B2
-toewijding,dedication,奉献,NOUN,B2
-toewijding,devotion,奉献,NOUN,B2
-toezicht,surveillance,监视,NOUN,B2
-toezichthouder,supervisor,主管,NOUN,B2
-tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-together,together,共同的,ADJ,B2
-togetherness,togetherness,词,NOUN,C1
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toiling,toiling,词,ADJ,C1
-told instructed,told instructed,被告知的,ADJ,B2
-tolerance dependence,tolerance dependence,词,NOUN,C1
-tolerantie,tolerance,宽容,NOUN,B2
-tome,tome,词,NOUN,C1
-tomorrow (noun),tomorrow,明天,NOUN,B2
-ton,ton,吨,NOUN,B2
-tonality,tonality,词,NOUN,C1
-toneelstuk,play,剧本,NOUN,B2
-toneelstuk,stage play,舞台剧,NOUN,B2
-toneeltekst,script for play,剧本,NOUN,B2
-tonen,to exhibit,展览,VERB,B2
-tonic (adj),tonic,词,ADJ,C1
-tonic (noun),tonic,词,NOUN,C1
-tonsil,tonsil,词,NOUN,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
-tooling,tooling,词,NOUN,C1
-top,summit,顶峰,NOUN,B2
-top,top,顶部,NOUN,B2
-top (adj),top,顶部的,ADJ,C1
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-toplaag,top dressing,追肥,NOUN,B2
-topograaf,surveyor,测量员,NOUN,B2
-topografie,topography,地形,NOUN,B2
-toren,to tear,撕碎,VERB,B2
-torment (noun),torment,词,NOUN,C1
-tormentor,tormentor,词,NOUN,B2
-torments,torments,词,NOUN,B2
-tornado,tornado,龙卷风,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torque,torque,词,NOUN,C1
-torrid,torrid,词,ADJ,C1
-torsie,torsion,扭转,NOUN,B2
-torso,torso,躯干,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-tortuous,tortuous,词,ADJ,C1
-torture ordeal,torture ordeal,词,NOUN,C1
-toss,toss,词,VERB,B2
-tot,up to,为止,ADP,B2
-totaal,totally,完全地,ADV,B2
-total (adj),total,完全的,ADJ,B2
-totalitarian,totalitarian,极权主义的,ADJ,B2
-totalitarianism,totalitarianism,词,NOUN,C1
-totality,totality,词,NOUN,C1
-totem,totem,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
-touching,touching,动人的,ADJ,B2
-touchstone,touchstone,词,NOUN,C1
-touchy,touchy,易怒的,ADJ,B2
-tough guy,tough guy,硬汉,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
-touringcar,long-distance bus,长途车,NOUN,B2
-tout,tout,词,VERB,C1
-tovenaar,wizard,巫师,NOUN,B2
-toveren,to conjure,变魔术,VERB,B2
-towering,towering,词,ADJ,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
-township road,township road,乡道,NOUN,B2
-toxicity,toxicity,词,NOUN,C1
-toxin,toxin,词,NOUN,C1
-trace element,trace element,微量元素,NOUN,C1
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracking,tracking,词,NOUN,C1
-tracksuit,tracksuit,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
-tractor,tractor,拖拉机,NOUN,B2
-trade (verb),trade,词,VERB,A2
-trade fair,trade fair,展销会,NOUN,C1
-trade unionist,trade unionist,词,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditionally,traditionally,传统地,ADV,B2
-traditions,traditions,词,NOUN,B1
-traduce,traduce,词,VERB,C1
-traffic light,traffic light,红绿灯,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficker,trafficker,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-tragedie,tragedy,悲剧,NOUN,B2
-tragically,tragically,悲剧地,ADV,B2
-tragicness,tragicness,词,NOUN,C1
-tragisch,tragic,悲剧的,ADJ,B2
-trail,trail,词,NOUN,B1
-train ride,train ride,词,NOUN,A1
-train ticket,train ticket,词,NOUN,A1
-trainer,trainer,教练,NOUN,B2
-trainer bastard,trainer bastard,,NOUN,B2
-training center,training center,培训中心,NOUN,C1
-traits qualities,traits qualities,词,NOUN,C1
-trance,trance,词,NOUN,C1
-tranen,tears,眼泪,NOUN,B2
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transactie,transaction,交易,NOUN,B2
-transatlantic,transatlantic,词,ADJ,C1
-transbesluit,trans-decision,超断,NOUN,B2
-transcend,transcend,词,VERB,C1
-transcendent,transcendent,卓越的,ADJ,B2
-transcendentie,transcendence,超越,NOUN,B2
-transcript,transcript,词,NOUN,C1
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferee,transferee,词,NOUN,C1
-transferor,transferor,词,NOUN,C1
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
-transfix,transfix,词,VERB,C1
-transformer converter,transformer converter,词,NOUN,C1
-transgast,trans-guest,超客,NOUN,B2
-transhumance,transhumance,词,NOUN,B2
-transient,transient,词,ADJ,C1
-transistor,transistor,词,NOUN,C1
-transit,transit,运输,NOUN,C1
-transitivity,transitivity,及物性,NOUN,C1
-transitory,transitory,词,ADJ,C1
-translatology,translatology,词,NOUN,C1
-translucent,translucent,词,ADJ,C1
-transmissie,transmission,传输,NOUN,B2
-transmission to you,transmission to you,传你,NOUN,B2
-transmit,to transmit,传输,VERB,B2
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
-transparent,transparent,透明的,ADJ,B2
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport (adj),transport,词,ADJ,C1
-transport service,transport service,词,NOUN,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transpose,transpose,词,VERB,C1
-transzaak,trans-matter,超物,NOUN,B2
-trap,trap,陷阱,NOUN,B2
-trapdoor,trapdoor,活板门,NOUN,B2
-trapped,trapped,词,ADJ,A2
-trapping,trapping,词,NOUN,C1
-trash,trash,垃圾,NOUN,B2
-trash bag,trash bag,垃圾袋,NOUN,B2
-trash can,trash can,词,NOUN,A2
-trauma,trauma,创伤,NOUN,B2
-traumatic,traumatic,创伤的,ADJ,B2
-travail,travail,词,NOUN,C1
-travel,travel,出行,NOUN,B2
-travel fatigue,travel fatigue,车马劳顿,NOUN,B2
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
-travesty,travesty,词,NOUN,C1
-tray,tray,托盘,NOUN,B2
-treacherous,treacherous,背叛的,ADJ,B2
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
-treacherousness,treacherousness,阴险,NOUN,B2
-treachery,treachery,背叛,NOUN,B2
-tread,to tread,踏上,VERB,B2
-treason,treason,叛国罪,NOUN,B2
-treasure,treasure,财宝,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
-treasury,treasury,国库,NOUN,B2
-treat,treat,盛宴,NOUN,B2
-treat guests,to treat guests,请客,VERB,B2
-treatise,treatise,词,NOUN,C1
-treinstation,train station,火车站,NOUN,B2
-trek (noun),trek,词,NOUN,C1
-tremble,to tremble,颤抖,VERB,B2
-trembling,trembling,颤抖的,ADJ,B2
-tremendous,tremendous,词,ADJ,B2
-tremor,tremor,颤抖,NOUN,B2
-tremulous,tremulous,颤抖的,ADJ,B2
-trench,trench,沟渠,NOUN,B2
-trench coat,trench coat,词,NOUN,C1
-trenchant,trenchant,词,ADJ,C1
-trend,trend,趋势,NOUN,B2
-trending,trending,词,ADJ,C1
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-trial,trial,试验,NOUN,B2
-trial run,trial run,词,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tributary,tributary,支流,NOUN,B2
-trick,trick,诡计,NOUN,B2
-trick,to trick,欺骗,VERB,B2
-tricky,tricky,词,ADJ,B2
-tricolor,tricolor,词,ADJ,C1
-trifle,trifle,琐事,NOUN,B2
-trifling,trifling,微不足道的,ADJ,B2
-trigger,trigger,触发器,NOUN,B2
-trigger,to trigger,触发,VERB,B2
-trigger (adj),trigger,词,ADJ,C1
-trigger imprint,trigger imprint,印记,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-triggering,triggering,触发,NOUN,B2
-trigonometry,trigonometry,词,NOUN,C1
-trilemma,trilemma,三难困境,NOUN,B2
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trilogy,trilogy,三部曲,NOUN,B2
-trim,trim,词,VERB,C1
-trinket,trinket,小饰品,NOUN,B2
-triple,triple,三倍的,ADJ,B2
-trite,trite,陈腐的,ADJ,B2
-triumph,triumph,胜利,NOUN,B2
-trivia,trivia,词,NOUN,C1
-triviality,triviality,琐碎,NOUN,B2
-trocar,trocar,词,NOUN,C1
-troglodyte,troglodyte,词,NOUN,C1
-trom,drum,鼓,NOUN,B2
-troop,troop,部队,NOUN,B2
-troop dispatch,troop dispatch,出兵,NOUN,B2
-troost,solace,安慰,NOUN,B2
-troosten,comfort,安慰,NOUN,B2
-troosten,to comfort,安慰,VERB,B2
-troosten,to console,安慰,VERB,B2
-trophy,trophy,奖杯,NOUN,B2
-tropic,tropic,词,NOUN,C1
-trots,pride,骄傲,NOUN,B2
-trotseren,to defy,违抗,VERB,B2
-trouble,to trouble,有劳,VERB,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
-troublesome,troublesome,麻烦的,ADJ,B2
-troupe,troupe,剧团,NOUN,B2
-trout,trout,词,NOUN,C1
-trowel,trowel,词,NOUN,B2
-truce,truce,休战,NOUN,B2
-truculent,truculent,词,ADJ,C1
-true concession,true concession,真让,NOUN,B2
-true qi,true qi,真气,NOUN,C1
-truism,truism,自明之理,NOUN,B2
-truly,truly,确实,ADV,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trust in God,trust in God,词,NOUN,C1
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-try out,try out,词,VERB,C1
-tsjilpen,to chirp,啁啾,VERB,B2
-tsunami,tsunami,海啸,NOUN,C1
-tuberculosis,tuberculosis,结核病,NOUN,B2
-tug,tug,词,VERB,C1
-tuinman,gardener,园丁,NOUN,B2
-tumble (noun),tumble,词,NOUN,C1
-tumor,tumor,肿瘤,NOUN,B2
-tumoral,tumoral,词,ADJ,C1
-tumult,tumult,词,NOUN,C1
-tumultuous,tumultuous,词,ADJ,C1
-tuning,tuning,词,NOUN,C1
-turban,turban,词,NOUN,B2
-turbid,turbid,词,ADJ,C1
-turbine,turbine,词,NOUN,C1
-turbulence,turbulence,词,NOUN,C1
-turgid,turgid,词,ADJ,C1
-turkey,turkey,火鸡,NOUN,B2
-turmeric,turmeric,词,NOUN,B2
-turn of phrase,turn of phrase,词,NOUN,C1
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
-turnoff,turnoff,词,NOUN,B2
-turntable,turntable,,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
-tussenpersoon,intermediary,中间人,NOUN,B2
-tussentijd,meantime,同时,NOUN,B2
-tutelary,tutelary,词,ADJ,C1
-tutor,tutor,导师,NOUN,C1
-tv,tv,电视,NOUN,B2
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-twee vliegen in één klap,kill two birds with one stone,一举两得,ADJ,B2
-tweede keer,second time,再而,NOUN,B2
-tweezers,tweezers,词,NOUN,C1
-twenty-five,twenty-five,词,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twijfelachtig,questionable,可疑的,ADJ,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
-twist (noun),twist,词,NOUN,C1
-twitching,twitching,抽搐的,ADJ,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-tycoon,tycoon,词,NOUN,C1
-type like,type like,类型/比如,NOUN,B2
-typically,typically,词,ADV,C1
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
-ubiquitous,ubiquitous,词,ADJ,C1
-uil,owl,猫头鹰,NOUN,B2
-uitademen,to exhale,呼气,VERB,B2
-uitbeelden,to excoriate,严厉批评,VERB,B2
-uitblinken,to excel,擅长,VERB,B2
-uitdrukkelijk,expressly,明确地,ADV,B2
-uiteenzetten,to expound,阐述,VERB,B2
-uiteindelijk,ultimately,最终,ADV,B2
-uiteraard,obviously,显然,ADV,B2
-uiterste,utmost,你尽,NOUN,B2
-uitgave,expenditure,支出,NOUN,B2
-uitgestrekt,vast,巨大的,ADJ,B2
-uitgraven,to excavate,挖掘,VERB,B2
-uitkijk,lookout,瞭望,NOUN,B2
-uitkomen,to come out,出来,VERB,B2
-uitleveren,to extradite,引渡,VERB,B2
-uitlijning,alignment,结盟,NOUN,B2
-uitmuntendheid,excellence,卓越,NOUN,B2
-uitnemen,to take out,拿出,VERB,B2
-uitpakken,to unpack,拆包,VERB,B2
-uitplanten,to plant out,定植,VERB,B2
-uitputting,exhaustion,疲惫,NOUN,B2
-uitroeien,to eradicate,根除,VERB,B2
-uitroeien,to exterminate,消灭,VERB,B2
-uitroeiing,eradication,根除,NOUN,B2
-uitroeiing,extermination,灭绝,NOUN,B2
-uitroep,exclamation,感叹,NOUN,B2
-uitrusten,to equip,装备,VERB,B2
-uitslag,rash,轻率的,ADJ,B2
-uitsluiten,to exclude,排除,VERB,B2
-uitsluiting,exclusion,排除,NOUN,B2
-uitspraak,enunciation,发音,NOUN,B2
-uitspraak,utterance,话语,NOUN,B2
-uitsteken,draw out,引出,NOUN,B2
-uitstel,procrastination,拖延,NOUN,B2
-uitstellen,to procrastinate,拖延,VERB,B2
-uitwerken,to elaborate,制定,VERB,B2
-uitwerken,to work out,成功,VERB,B2
-uitwissing,erasure,擦除,NOUN,B2
-uitworteling,uprooting,背井离乡,NOUN,B2
-uitzetting,eviction,驱逐,NOUN,B2
-uitzetting,expulsion,驱逐,NOUN,B2
-ulterior,ulterior,词,ADJ,C1
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
-um,um,嗯,INTJ,B2
-umbrage,umbrage,词,NOUN,C1
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unambiguous,unambiguous,明确的,ADJ,B2
-unanimity,unanimity,词,NOUN,C1
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
-unbelieving,unbelieving,词,ADJ,C1
-unbridled,unbridled,肆无忌惮的,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
-uncompromising,uncompromising,词,ADJ,B2
-unconditional,unconditional,无条件的,ADJ,B2
-unconquerable,unconquerable,词,ADJ,C1
-unconscious (noun),unconscious,词,NOUN,C1
-unconsciousness,unconsciousness,词,NOUN,C1
-uncountable,uncountable,词,ADJ,C1
-uncouth,uncouth,粗俗的,ADJ,B2
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncultivated,uncultivated,词,ADJ,B2
-undaunted,undaunted,词,ADJ,C1
-undead,undead,词,NOUN,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under below,under below,在...下方,ADP,A2
-under the,under the,词,ADP,B2
-underclass,underclass,底层,NOUN,B2
-undercover agent,undercover agent,卧底,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
-underground,underground,地下的,ADJ,B2
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underling,underling,词,NOUN,C1
-underlying,underlying,词,ADJ,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-understood,understood,词,ADJ,A1
-undervaluing,undervaluing,词,NOUN,C1
-underwater,underwater,词,ADJ,B2
-underworld,underworld,地下世界,NOUN,B2
-undeserved,undeserved,词,ADJ,C1
-undisturbed,undisturbed,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undulate,undulate,词,VERB,C1
-unearned,unearned,浪得,NOUN,C1
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
-unequivocal,unequivocal,词,ADJ,C1
-unerring,unerring,词,ADJ,C1
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected event,unexpected event,变故,NOUN,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful,unfaithful,不忠的,ADJ,B2
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfettered,unfettered,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
-unfolding,unfolding,词,NOUN,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable,unforgivable,不可原谅的,ADJ,B2
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfounded,unfounded,词,ADJ,C1
-ungabe,ungabe,词,NOUN,C1
-ungainly,ungainly,笨拙的,ADJ,B2
-ungestaltung,ungestaltung,词,NOUN,C1
-ungrateful,ungrateful,忘恩负义的,ADJ,B2
-unhappiness,unhappiness,词,NOUN,C1
-unharmed,unharmed,未受伤的,ADJ,B2
-unhealthy,unhealthy,词,ADJ,C1
-unhurried patience,unhurried patience,词,NOUN,C1
-uniciteit,uniqueness,独特,NOUN,B2
-unicorn,unicorn,词,NOUN,C1
-unified examination,unified examination,统考,NOUN,B2
-uniform,uniform,制服,NOUN,B2
-unilateral,unilateral,单方面的,ADJ,B2
-unilateralism,unilateralism,词,NOUN,C1
-unimpeachable,unimpeachable,词,ADJ,C1
-unimpeded,unimpeded,词,ADJ,C1
-uninhabited,uninhabited,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
-union (adj),union,词,ADJ,C1
-unionisme,unionism,工会主义,NOUN,B2
-unionist,unionist,词,ADJ,B2
-unique (noun),unique,词,NOUN,B2
-universal total,universal total,词,ADJ,C1
-universaliteit,universality,普遍性,NOUN,B2
-universele toepasbaarheid,universal applicability,普适性,NOUN,B2
-university (adj),university,词,ADJ,C1
-university student,university student,大学生,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unknown,unknown,未知数,NOUN,B2
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
-unleashed,unleashed,词,ADJ,C1
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlimited,unlimited,无限的,ADJ,B2
-unlocked,unlocked,词,NOUN,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unmitigated,unmitigated,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unnatural,unnatural,不自然的,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unobtrusive,unobtrusive,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
-unprecedented,unprecedented,史无前例的,ADJ,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpublished,unpublished,词,ADJ,B2
-unpunished,unpunished,未受惩罚的,ADJ,B2
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreasonable,unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unreflective,unreflective,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
-unrichtung,unrichtung,词,NOUN,C1
-unscathed,unscathed,未受伤害的,ADJ,B2
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
-unsecured,unsecured,,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unseen realities,unseen realities,词,NOUN,C1
-unsetzung,unsetzung,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsociable,unsociable,词,ADJ,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsprache,unsprache,词,NOUN,C1
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsuccessful,unsuccessful,词,ADJ,C1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untenable,untenable,词,ADJ,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-unthinkable,unthinkable,不可想象的,ADJ,B2
-untidiness,untidiness,凌乱,NOUN,B2
-untidy,untidy,词,ADJ,C1
-until to,until to,词,ADP,A2
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouchable,untouchable,不可触碰的,ADJ,B2
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untreibung,untreibung,词,NOUN,B2
-unviable,unviable,词,ADJ,C1
-unwandel,unwandel,词,NOUN,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwise,unwise,词,ADJ,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
-upbraid,upbraid,词,VERB,C1
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-upgraden,to upgrade,升级,VERB,B2
-upheaval,upheaval,剧变,NOUN,B2
-uphold,uphold,词,VERB,C1
-upholding of rights,upholding of rights,词,NOUN,C1
-upload (noun),upload,词,NOUN,C1
-upper class,upper class,上层,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-uprightness,uprightness,词,NOUN,B2
-uprooted,uprooted,词,ADJ,C1
-ups and downs,ups and downs,词,NOUN,B2
-upset,upset,心烦的,ADJ,B2
-upshot,upshot,词,NOUN,C1
-upstart,upstart,暴发户,NOUN,B2
-upstart (adj),upstart,词,ADJ,C1
-upward,upward,向上,ADV,B2
-urban area,urban area,词,NOUN,C1
-urbane,urbane,词,ADJ,C1
-urbanism,urbanism,词,NOUN,B2
-urbanization,urbanization,城市化,NOUN,B2
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urgentie,urgency,紧急,NOUN,B2
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,C1
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
-usable,usable,可用的,ADJ,B2
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
-usb flash drive,usb flash drive,U盘,NOUN,B2
-used,used,词,ADJ,C1
-usefulness avail,usefulness avail,效用,NOUN,C1
-useless zero,useless zero,词,ADJ,A2
-uselessly,uselessly,词,ADV,C1
-using this,using this,用这,NOUN,C1
-usual thing,usual thing,惯例,NOUN,B2
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-usurpation,usurpation,词,NOUN,C1
-usury,usury,词,NOUN,C1
-utensil,utensil,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
-utilitair,utilitarian,功利的,ADJ,B2
-utilitarisme,utilitarianism,功利主义,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
-utmost extreme end,utmost extreme end,词,NOUN,C1
-utter,utter,词,ADJ,C1
-utterance-related,utterance-related,词,ADJ,C1
-vaak,many times,多次,ADV,B2
-vaarwel,goodbye,再见,INTJ,B2
-vacant,vacant,空缺的,ADJ,B2
-vacant lot,vacant lot,空地,NOUN,C1
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccin,vaccine,疫苗,NOUN,B2
-vaccinal,vaccinal,词,ADJ,C1
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vacillate,vacillate,词,VERB,C1
-vacuous,vacuous,词,ADJ,C1
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum cleaner,vacuum cleaner,词,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vader,father,父,PART,B2
-vagabond,vagabond,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
-vagary,vagary,词,NOUN,C1
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vaguely,vaguely,词,ADV,C1
-vagueness,vagueness,模糊,NOUN,C1
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vainglory,vainglory,词,NOUN,C1
-vakantie,vacation,假期,NOUN,B2
-vakmanschap,craftsmanship,手工艺,NOUN,B2
-val,fall,瀑布,NOUN,B2
-vale of tears,vale of tears,词,NOUN,C1
-valedictory,valedictory,词,ADJ,C1
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
-valk,falcon,猎鹰,NOUN,B2
-vals,counterfeit,假冒,ADJ,B2
-valsheid,falsity,虚假,NOUN,B2
-valsheid,forgery,伪造品,NOUN,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-valve,valve,词,NOUN,C1
-vampier,vampire,吸血鬼,NOUN,B2
-van,of,之,PART,B2
-vanavond,tonight,今晚,NOUN,B2
-vandaag,today,今天,NOUN,B2
-vanilla,vanilla,词,NOUN,C1
-vanishing,vanishing,词,NOUN,C1
-vanquish,vanquish,词,VERB,C1
-vanwege,due to,由于,ADP,B2
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
-variables,variables,词,NOUN,C1
-variegate,variegate,词,VERB,C1
-various,various,各种各样的,ADJ,B2
-varnish,varnish,清漆,NOUN,B2
-varying,varying,词,ADJ,B2
-vase,vase,花瓶,NOUN,B2
-vassal,vassal,之臣,NOUN,C1
-vastberaden,determined,下定决心的,ADJ,B2
-vastberaden,resolute,坚决的,ADJ,B2
-vastbinden,to tie up,绑,VERB,B2
-vasten,fasting,禁食,NOUN,B2
-vasten,to fast,禁食,VERB,B2
-vastgrijpen,to grasp firmly,抓紧,VERB,B2
-vasthouden,to detain,拘留,VERB,B2
-vasthoudend,tenacious,顽强的,ADJ,B2
-vastness,vastness,词,NOUN,B2
-vastspelden,to pin,别住,VERB,B2
-vaststellen,to stipulate,规定,VERB,B2
-vault,vault,金库,NOUN,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunt,vaunt,词,VERB,C1
-vaunted,vaunted,词,ADJ,B2
-vector,vector,词,NOUN,C1
-vee,livestock,家畜,NOUN,B2
-veel,much,多,DET,B2
-veer,veer,词,VERB,C1
-vegen,sweep,扫,NOUN,B2
-vegen,to sweep,打扫,VERB,B2
-vegen,to wipe,擦,VERB,B2
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehemence,vehemence,词,NOUN,C1
-vehement,vehement,激烈的,ADJ,B2
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiligheidsrapport,safety report,安全报告,NOUN,B2
-vel,sheet,床单,NOUN,B2
-velarization,velarization,词,NOUN,C1
-velen,many,许多,ADJ,B2
-veneer,veneer,词,NOUN,C1
-venial,venial,词,ADJ,C1
-venkel,fennel,茴香,NOUN,B2
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-ventilator,fan,粉丝,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-venture (noun),venture,词,NOUN,B2
-ver,distant,遥远的,ADJ,B2
-ver,far,远,ADV,B2
-verachtelijk,despicable,可鄙的,ADJ,B2
-verachtelijk,vile,卑鄙的,ADJ,B2
-verachten,to abhor,憎恶,VERB,B2
-verachten,to despise,鄙视,VERB,B2
-verachting,contempt,轻视,NOUN,B2
-veracity,veracity,词,NOUN,C1
-verafschuwen,to detest,厌恶,VERB,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbalize,verbalize,词,VERB,B2
-verbanning,banishment,流放,NOUN,B2
-verbatim,verbatim,词,ADV,C1
-verbazen,to astonish,使惊讶,VERB,B2
-verbazing,astonishment,惊讶,NOUN,B2
-verbazingwekkend,astonishing,令人惊讶的,ADJ,B2
-verbergingsmogelijkheid,allow hiding,许躲,NOUN,B2
-verbieden,to ban,禁止,VERB,B2
-verblijf,sojourn,逗留,NOUN,B2
-verblijfplaats,whereabouts,行踪,NOUN,B2
-verblinden,to dazzle,使眼花,VERB,B2
-verblindend,dazzling,耀眼的,ADJ,B2
-verbod,prohibition,禁止,NOUN,B2
-verboden,forbidden,被禁止的,ADJ,B2
-verboden land,forbidden land,禁地,NOUN,B2
-verbond,covenant,契约,NOUN,B2
-verbosely,verbosely,词,ADV,C1
-verbrand,burnt,烧焦的,ADJ,B2
-verbranden,to scald,烫伤,VERB,B2
-verbreden,to widen,加宽,VERB,B2
-verdaagde,defendant,被告,NOUN,B2
-verdacht,suspicious,可疑的,ADJ,B2
-verdampen,to evaporate,蒸发,VERB,B2
-verdamping,evaporation,蒸发,NOUN,B2
-verdant,verdant,词,ADJ,C1
-verdedigen,to defend one's country,卫国,VERB,B2
-verdenking,suspicion,怀疑,NOUN,B2
-verdienste,merit,功绩,NOUN,B2
-verdovingsmiddel,anesthetic,麻醉剂,NOUN,B2
-verdraaien,to distort,扭曲,VERB,B2
-verduidelijken,to clarify,澄清,VERB,B2
-verduisteren,to embezzle,贪污,VERB,B2
-verduistering,embezzlement,贪污,NOUN,B2
-verduistering,misappropriation,挪用,NOUN,B2
-verdwijnen,to vanish,消失,VERB,B2
-vereenvoudigen,to simplify,简化,VERB,B2
-vereist,required,必需的,ADJ,B2
-verenigd,united,联合的,ADJ,B2
-vereren,to revere,尊敬,VERB,B2
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-verge,verge,词,NOUN,C1
-vergelijking,equation,方程,NOUN,B2
-vergelijking,simile,明喻,NOUN,B2
-vergestaltung,vergestaltung,词,NOUN,C1
-vergetelachtig,forgetful,健忘的,ADJ,B2
-vergeven,pardon,赦免,NOUN,B2
-vergeven,to pardon,赦免,VERB,B2
-vergeving,forgiveness,宽恕,NOUN,B2
-vergiet,colander,漏勺,NOUN,B2
-vergissen,to mistake,弄错,VERB,B2
-vergoeden,to make up for,弥补,VERB,B2
-vergoeding,remuneration,报酬,NOUN,B2
-vergrendelen,to lock,锁上,VERB,B2
-vergroten,to magnify,放大,VERB,B2
-verheerlijken,to glorify,赞美,VERB,B2
-verheugd,elated,兴高采烈的,ADJ,B2
-verheven,lofty,崇高的,ADJ,B2
-verhongeren,to starve,挨饿,VERB,B2
-verhouding,proportion,比例,NOUN,B2
-verhuizen,to relocate,调动,VERB,B2
-verhuizing,move,搬家,NOUN,B2
-verhuurder,landlord,房东,NOUN,B2
-verification,verification,词,NOUN,C1
-verifiëren,to verify,核实,VERB,B2
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkeersbeperking,traffic restriction,限行,NOUN,B2
-verkeersbord,road sign,路标,NOUN,B2
-verkenner,scout,侦察员,NOUN,B2
-verkenning,reconnaissance,侦察,NOUN,B2
-verklaren,to state,说明,VERB,B2
-verkleeden,to dress up,盛装打扮,VERB,B2
-verkoop,sales,打折,NOUN,B2
-verkoper,seller,售货员,NOUN,B2
-verkrijgen,to procure,获取,VERB,B2
-verkunft,verkunft,词,NOUN,C1
-verkwisting,dissipation,挥霍,NOUN,B2
-verlangen,longing,渴望,NOUN,B2
-verlangen naar,to be eager for,巴不得,VERB,B2
-verlaten,to abandon,放弃,VERB,B2
-verlating,abandonment,抛弃,NOUN,B2
-verleden,past,过去的,ADJ,B2
-verlegen,embarrassed,尴尬的,ADJ,B2
-verlegen,embarrassing,令人尴尬的,ADJ,B2
-verlegenheid,timidity,胆怯,NOUN,B2
-verleiden,to seduce,引诱,VERB,B2
-verlengen,to prolong,延长,VERB,B2
-verlenging,renewal,更新,NOUN,B2
-verlichten,to illuminate,照亮,VERB,B2
-verlichten,to relieve,缓解,VERB,B2
-verliefd worden,to fall in love,坠入爱河,VERB,B2
-verliefdheid,infatuation,迷恋,NOUN,B2
-verlies,lose,上丢,NOUN,B2
-verlof nemen,to take a leave of absence,休学,VERB,B2
-verloochenen,to disavow,否认,VERB,B2
-verloofde,fiance,未婚夫,NOUN,B2
-verlopen,overdue,逾期,ADJ,B2
-verloren gaan,to get lost,迷路,VERB,B2
-verlosser,savior,救星,NOUN,B2
-verlossing,salvation,拯救,NOUN,B2
-vermaak,delight,高兴,NOUN,B2
-vermakelijk,delightful,令人愉快的,ADJ,B2
-vermaning,reprimand,训斥,NOUN,B2
-vermenigvuldigen,to multiply,乘；增加,VERB,B2
-vermijding,avoidance,避免,NOUN,B2
-vermilion,vermilion,词,NOUN,B2
-verminderen,to diminish,减少,VERB,B2
-vermoeden,conjecture,推测,NOUN,B2
-vermoeden,to presume,假定,VERB,B2
-vermoeidheid,tiredness,疲劳,NOUN,B2
-vermoeien,to tire,使疲倦,VERB,B2
-vermogen,ability,能力,NOUN,B2
-vernacular,vernacular,词,NOUN,C1
-vernahme,vernahme,词,NOUN,C1
-vernier,vernier,词,NOUN,C1
-vernietigen,to annihilate,消灭,VERB,B2
-vernietigende nederlaag,crushing defeat,惨败,NOUN,B2
-vernietiging,annihilation,寂灭,NOUN,B2
-veronderstellen,to suppose,假设,VERB,B2
-veronderstelling,presumption,自负,NOUN,B2
-verontreinigen,to contaminate,污染,VERB,B2
-verontrustend,disturbing,令人不安的,ADJ,B2
-verouderd,obsolete,过时的,ADJ,B2
-veroveraar,conqueror,征服者,NOUN,B2
-verpakking,packaging,包装,NOUN,B2
-verpflegung,verpflegung,词,NOUN,C1
-verpletteren,to crush,压碎,VERB,B2
-verplichting,have to,还得,NOUN,B2
-verrader,traitor,叛徒,NOUN,B2
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
-versatile,versatile,多才多艺的,ADJ,B2
-versatility,versatility,词,NOUN,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verschrikkelijk,horrifying,令人毛骨悚然的,ADJ,B2
-verschrikken,to horrify,使惊骇,VERB,B2
-verschrikken,to scare,惊吓,VERB,B2
-verschuiven,shift,轮班,NOUN,B2
-verschuiven,to shift,改变,VERB,B2
-verschuldigd,due,到期的,ADJ,B2
-verse,verse,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versieren,to embellish,装饰,VERB,B2
-versieren,to garnish,装饰,VERB,B2
-versification,versification,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-verslaafd zijn,to be addicted,上瘾,VERB,B2
-verslagen worden,to be defeated,会败,VERB,B2
-verslechteren,to deteriorate,恶化,VERB,B2
-versleten,ragged,破烂的,ADJ,B2
-versleuteling,encryption,加密,NOUN,B2
-versneller,accelerator,油门,NOUN,B2
-versnelling,acceleration,加速,NOUN,B2
-versnelling,gear,齿轮,NOUN,B2
-verspillen,to squander,浪费,VERB,B2
-verspilling,squandering,挥霍,NOUN,B2
-versplinteren,to shatter,粉碎,VERB,B2
-versprache,versprache,词,NOUN,C1
-verspreid,scattered,分散的,ADJ,B2
-verspreiden,to diffuse,扩散,VERB,B2
-verspreiden,to disseminate,传播,VERB,B2
-verspreiden,to scatter,分散,VERB,B2
-verstandig,sensible,明智的,ADJ,B2
-verstikking,suffocation,窒息,NOUN,B2
-verstop,hiding,ٱختباء,NOUN,B2
-verstuiking,sprain,扭伤,NOUN,B2
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-vertebra,vertebra,词,NOUN,B2
-vertegenwoordigend,representative,有代表性的,ADJ,B2
-vertegenwoordigendheid,representativeness,代表性,NOUN,B2
-vertegenwoordiging,representation,代表,NOUN,B2
-verteilung,verteilung,词,NOUN,C1
-verteren,to digest,消化,VERB,B2
-verterend,digestive,消化的,ADJ,B2
-vertering,digestion,消化,NOUN,B2
-vertex,vertex,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
-verticaal,vertical,垂直的,ADJ,B2
-vertigo,vertigo,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertraging,late,晚,ADV,B2
-vertrappen,to trample,踩踏,VERB,B2
-vertreibung,vertreibung,词,NOUN,C1
-vertrek,his departure,他走,NOUN,B2
-vertrouwen,confidence,信心,NOUN,B2
-vertrouwen,reliance,信赖,NOUN,B2
-vertrouwen,to rely,依赖,VERB,B2
-vertrouwen op,to rely on,依靠,VERB,B2
-vervaagd,faded,褪色的,ADJ,B2
-vervagen,to blur,模糊,VERB,B2
-vervagen,to fade,褪色,VERB,B2
-verveeld,bored,无聊的,ADJ,B2
-verveling,boredom,无聊,NOUN,B2
-vervlogen,bygone,过去的,ADJ,B2
-vervoeging,conjugation,变位,NOUN,B2
-vervolging,prosecution,起诉,NOUN,B2
-vervolgstudie,advanced study,深造,NOUN,B2
-vervormen,to deform,使变形,VERB,B2
-vervorming,deformation,变形,NOUN,B2
-vervorming,distortion,扭曲,NOUN,B2
-vervreemding,estrangement,疏离,NOUN,B2
-verwandel,verwandel,词,NOUN,C1
-verwantschap,kinship,亲属关系,NOUN,B2
-verward,confused,困惑的,ADJ,B2
-verward,muddled,混乱的,ADJ,B2
-verwarmen,to heat,加热,VERB,B2
-verwarren,to puzzle,使困惑,VERB,B2
-verweisung,verweisung,词,NOUN,C1
-verwerping door de rechtbank,court dismissal,退朝,NOUN,B2
-verwijden,to dilate,膨胀,VERB,B2
-verwijderen,to delete,删除,VERB,B2
-verwijderen,to expel,开除,VERB,B2
-verwijdering,disposal,处理,NOUN,B2
-verwijdering,removal,移除,NOUN,B2
-verwijding,dilation,扩张,NOUN,B2
-verwijt,reproach,责备,NOUN,B2
-verwijten,blame,责备,NOUN,B2
-verwijten,to blame,责备,VERB,B2
-verwirkung,verwirkung,词,NOUN,C1
-verwittiging,see off,送走,NOUN,B2
-verwoesten,to devastate,摧毁,VERB,B2
-verwoesting,devastation,破坏,NOUN,B2
-verwonden,to injure,使受伤,VERB,B2
-verwonderen,to marvel,使惊奇,VERB,B2
-very deep,very deep,很深,ADJ,B2
-very fine,very fine,极细的,ADJ,B2
-very good,very good,很好,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-verzadiging,satiety,饱足,NOUN,B2
-verzamelen,to gather,聚集,VERB,B2
-verzegelen,to seal,密封,VERB,B2
-verzekeren,to assure,保证,VERB,B2
-verzenden,to dispatch,派遣,VERB,B2
-verzenden,to ship out,出货,VERB,B2
-verzet,defiant,挑衅的,ADJ,B2
-verzet,defiance,挑衅,NOUN,B2
-verzoeken,to appease,安抚,VERB,B2
-verzoenen,to reconcile,和解,VERB,B2
-verzoening,reconciliation,和解,NOUN,B2
-vestige,vestige,词,NOUN,C1
-vesting,fortress,堡垒,NOUN,B2
-vet,greasy,油腻的,ADJ,B2
-vete,feud,世仇,NOUN,B2
-veterinarian,veterinarian,词,NOUN,C1
-vetten,to grease,涂油,VERB,B2
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-vezel,fiber,纤维,NOUN,B2
-vial,vial,词,NOUN,C1
-vibrant,vibrant,词,ADJ,C1
-vicarious,vicarious,词,ADJ,C1
-vice-minister,vice-minister,侍郎,NOUN,B2
-vicious,vicious,词,ADJ,B2
-vicissitude,vicissitude,变迁,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-video on demand,video on demand,点播,NOUN,C1
-videotape,videotape,词,NOUN,C1
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigilant,vigilant,警惕的,ADJ,B2
-vignette,vignette,词,NOUN,C1
-vigor of prime,vigor of prime,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
-vijandig,hostile,敌对的,ADJ,B2
-vijandigheid,animosity,敌意,NOUN,B2
-vijandigheid,hostility,敌意,NOUN,B2
-vile,vile,可憎地,ADV,B2
-villa,villa,别墅,NOUN,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainy,villainy,邪恶,NOUN,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vindingrijk,ingenious,灵巧的,ADJ,B2
-vineyard,vineyard,葡萄园,NOUN,C1
-vingerafdruk,fingerprint,指纹,NOUN,B2
-vintage,vintage,佳酿,NOUN,B2
-violate regulations,violate regulations,违规,VERB,C1
-violations,violations,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violet (adj),violet,词,ADJ,C1
-violet (noun),violet,词,NOUN,B2
-viool,violin,小提琴,NOUN,B2
-viper,viper,词,NOUN,B2
-viral,viral,病毒性的,ADJ,C1
-virtual reality,virtual reality,虚拟现实,NOUN,B2
-virtuoso,virtuoso,词,NOUN,C1
-virtuous,virtuous,有德行的,ADJ,B2
-virulent,virulent,恶性的,ADJ,B2
-virus,virus,病毒,NOUN,B2
-viscosity,viscosity,词,NOUN,C1
-viscount,viscount,词,NOUN,C1
-visibility,visibility,能见度,NOUN,B2
-visionary,visionary,词,NOUN,C1
-visiting ban,visiting ban,,NOUN,B2
-viskeus,viscous,黏稠的,ADJ,B2
-visor,visor,词,NOUN,B2
-visualize,visualize,词,VERB,C1
-visum,visa,签证,NOUN,B2
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vitiate,vitiate,词,VERB,C1
-vitriolic,vitriolic,词,ADJ,C1
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
-vlakte,plain,平原,NOUN,B2
-vleierij,flattery,奉承,NOUN,B2
-vlek,blot,污点,NOUN,B2
-vlieger,kite,风筝,NOUN,B2
-vliegtuig,plane,飞机,NOUN,B2
-vlijt,diligence,勤勉,NOUN,B2
-vlijtig,diligent,勤奋的,ADJ,B2
-vloed,high tide,涨潮,NOUN,B2
-vlot,smoothly,顺利,ADV,B2
-vluchtig,fleeting,短暂的,ADJ,B2
-vluchtig,volatile,易变的,ADJ,B2
-vocaal,vocal,直言的,ADJ,B2
-vocabulary,vocabulary,词,NOUN,C1
-vocal range,vocal range,词,NOUN,C1
-vocalization,vocalization,词,NOUN,C1
-vocation,vocation,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vochtig,moist,潮湿的,ADJ,B2
-vociferous,vociferous,词,ADJ,C1
-vodka,vodka,词,NOUN,C1
-voeder,fodder,饲料,NOUN,B2
-voeding,sustenance,食物,NOUN,B2
-voedsel,foodstuff,食品,NOUN,B2
-voegwoord,conjunction,连词,NOUN,B2
-voelen,sense,感觉,NOUN,B2
-voelen,to sense,隐约感到,VERB,B2
-voer,feed,饲料,NOUN,B2
-voetgangersbrug,footbridge,人行天桥,NOUN,B2
-vogue,vogue,流行,NOUN,B2
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-voicing,voicing,词,NOUN,C1
-void,void,最无,NOUN,B2
-volatility,volatility,词,NOUN,C1
-volbrengen,to accomplish,完成,VERB,B2
-volcanic,volcanic,词,ADJ,C1
-volgen,to track,追踪,VERB,B2
-volgepakt,packed,打包,ADJ,B2
-volgzaamheid,docility,温顺,NOUN,B2
-volharding,perseverance,毅力,NOUN,B2
-volition,volition,词,NOUN,C1
-volk,folk,民间的,ADJ,B2
-volksgezondheid,public welfare,公益性,NOUN,B2
-volleyball,volleyball,排球,NOUN,B2
-volmacht,power of attorney,委托书,NOUN,B2
-volstaan,to be enough,足够,VERB,B2
-volstaan,to suffice,足够,VERB,B2
-volstrekt,absolutely,绝对地,ADV,B2
-voltage,voltage,词,NOUN,C1
-voluble,voluble,词,ADJ,C1
-volume measure,volume measure,词,NOUN,B2
-volumetric,volumetric,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-voluntariness,voluntariness,词,NOUN,C1
-voluntarist,voluntarist,词,ADJ,C1
-volunteering,volunteering,志愿服务,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-vomit (noun),vomit,词,NOUN,B2
-vomiting,vomiting,词,NOUN,C1
-vondeling,foundling,弃婴,NOUN,B2
-vonnissen,to sentence,判决,VERB,B2
-voogd,guardian,守卫,NOUN,B2
-voogdij,guardianship,监护,NOUN,B2
-voor,in front of,在……前面,ADP,B2
-vooraanstaand,distinguished,杰出,ADJ,B2
-voorafgaan,to precede,在...之前,VERB,B2
-vooral,especially,尤其,ADV,B2
-voorbereiden,to prepare a lesson,预习,VERB,B2
-voorbijgaan,to pass by,经过,VERB,B2
-voorbijgang,passing,过世,NOUN,B2
-voordoen,to pretend,假装,VERB,B2
-voordoen,to pretend to be,冒充,VERB,B2
-voorgaan,to go first,先去,VERB,B2
-voorganger,predecessor,前任,NOUN,B2
-vooringenomen,biased,有偏见的,ADJ,B2
-voorloper,precursor,先驱,NOUN,B2
-voornamelijk,mostly,主要地,ADV,B2
-voornemen,to intend,打算,VERB,B2
-vooroordeel,prejudice,偏见,NOUN,B2
-voorraad,stockpile,储备,NOUN,B2
-voorschot,advance payment,预付款,NOUN,B2
-voorschrift,precept,戒律,NOUN,B2
-voorschrift,prescription,处方,NOUN,B2
-voorschrijven,to prescribe,开处方,VERB,B2
-voorspellen,to foresee,预见,VERB,B2
-voorspelling,forecast,预测,NOUN,B2
-voorspelling,prediction,预测,NOUN,B2
-voorstad,suburb,郊区,NOUN,B2
-voorstel,proposition,主张,NOUN,B2
-voorstellen,to envision,展望,VERB,B2
-voorstellen,to propose,提议,VERB,B2
+omelet,omelet,欧姆蛋,NOUN,B2
 voorteken,omen,预兆,NOUN,B2
-voortgaan,to proceed,继续进行,VERB,B2
-voortgang maken,to progress,进步,VERB,B2
-voortgangsrapport,progress report,进度报告,NOUN,B2
-voortvarend,insidious,潜伏的,ADJ,B2
-voortzetting,continuation,延续,NOUN,B2
-vooruit,ahead,在前面,ADV,B2
-vooruitgaan,to advance,前进,VERB,B2
-vooruitzetten,to shift to an earlier date,提前,VERB,B2
-vooruitzicht,prospect,前景,NOUN,B2
-vooruitziendheid,foresight,远见,NOUN,B2
-voorwaarde,prerequisite,前提,NOUN,B2
-voorwaardelijke invrijheidstelling,parole,假释,NOUN,B2
-voorwoord,preface,序言,NOUN,B2
-voorzichtigheid,prudence,谨慎,NOUN,B2
-voorzien in,to provide for,供应,VERB,B2
-voorzorg,precaution,预防措施,NOUN,B2
-voracious,voracious,词,ADJ,C1
-voracity,voracity,词,NOUN,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorig jaar,last year,去年,NOUN,B2
-vork,fork,叉子,NOUN,B2
-vorkunft,vorkunft,词,NOUN,C1
-vormen,shape,形状,NOUN,B2
-vormen,to constitute,构成,VERB,B2
-vormen,to shape,塑造,VERB,B2
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-votary,votary,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
-votive offering,votive offering,词,NOUN,C1
-vouch,vouch,词,VERB,C1
-voucher,voucher,代金券,NOUN,B2
-vouchsafe,vouchsafe,词,VERB,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vraagstelling,questioning,质问,NOUN,B2
-vragen,to question,质疑,VERB,B2
-vreemd,odd,奇怪的,ADJ,B2
-vreemde troepen,strange troops,怪兵,NOUN,B2
-vreemdeling,weirdo,怪人,NOUN,B2
-vreemdheid,strangeness,奇怪,NOUN,B2
-vrees,dread,恐惧,NOUN,B2
-vrees,to dread,畏惧,VERB,B2
-vriendelijk,kind,仁慈的,ADJ,B2
-vriendelijkheid,kindness,仁慈,NOUN,B2
-vriendin,female friend,女性朋友,NOUN,B2
-vrijstelling,exemption,豁免,NOUN,B2
-vrijwillig,voluntarily,自愿地,ADV,B2
-vroeg,early,早,ADV,B2
-vroege ochtend,early morning,凌晨,NOUN,B2
-vroegtijdige waarschuwing,early warning,预警,NOUN,B2
-vrouwelijke familieleden,female relatives,女眷,NOUN,B2
-vrouwelijkheid,femininity,女性气质,NOUN,B2
-vruchtbaar,fertile,肥沃的,ADJ,B2
-vruchtgebruik,usufruct,用益权,NOUN,B2
-vuist,fist,拳头,NOUN,B2
-vulgair,vulgar,粗俗的,ADJ,B2
-vulgariteit,vulgarity,粗俗,NOUN,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulture,vulture,词,NOUN,B2
-vuurtoren,lighthouse,灯塔,NOUN,B2
-vuurvast,fireproof,防火的,ADJ,B2
-vuurzee,blaze,火焰,NOUN,B2
-waaien,to wind,缠绕,VERB,B2
-waardeloos,lousy,糟糕的,ADJ,B2
-waarderen,to appraise,评估,VERB,B2
-waardering,valuation,估值,NOUN,B2
-waardigheid,dignity,尊严,NOUN,B2
-waarheid zoeken in feiten,to seek truth from facts,实事求是,VERB,B2
-waarnemer,observer,观察者,NOUN,B2
-waarneming,observation,观察,NOUN,B2
-waarschijnlijkheid,probability,概率,NOUN,B2
-waarschuwing,alert,警觉的,ADJ,B2
-waarzeggerij,divination,占卜,NOUN,B2
-wacht,sentry,卫兵,NOUN,B2
-wacht,wait,等待,NOUN,B2
-wacht op mij,wait for me,等我,NOUN,B2
-wachtkamer,waiting room,候诊室,NOUN,B2
-wachtmeester,constable,警官,NOUN,B2
-wachtrij,queue,队列,NOUN,B2
-wading,wading,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-waft,waft,词,VERB,C1
-wage earner,wage earner,词,NOUN,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage murder unit,wage murder unit,词,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-wager,wager,词,NOUN,C1
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wailing,wailing,词,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waive,waive,词,VERB,C1
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-wakker worden,to wake up,叫醒,VERB,B2
-walgelijk,detestable,可恶的,ADJ,B2
-walker,walker,词,NOUN,C1
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wall-mounted,wall-mounted,词,ADJ,C1
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
-walvis,whale,鲸鱼,NOUN,B2
-wan,wan,词,ADJ,B2
-wandeling,hiking,徒步,NOUN,B2
-wander,to wander,漫步,VERB,B2
-wanderer,wanderer,词,NOUN,C1
-wandering,wandering,漫游,NOUN,B2
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
-wankelen,to stagger,蹒跚,VERB,B2
-wanneer,when,当...时,SCONJ,B2
-want (adp),want,我要,ADP,A2
-want to lure,want to lure,想引,NOUN,B2
-want to need will,to want to need will,要,VERB,B2
-wanted,wanted,故意的,ADJ,B2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-wantrouwen,distrust,不信任,NOUN,B2
-war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warble (verb),warble,词,VERB,C1
-ward,ward,病房,NOUN,B2
-warden,warden,看守人,NOUN,B2
-wardrobe,wardrobe,衣柜,NOUN,B2
-warehouse store,warehouse store,词,NOUN,B1
-warm,warm,温暖的,ADJ,B2
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,更暖的,ADJ,B2
-warming,warming,变暖,NOUN,B2
-warmonger,warmonger,词,NOUN,C1
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrant,warrant,令状,NOUN,B2
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wary,wary,谨慎的,ADJ,B2
-was,to was,是,VERB,B2
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-washer,washer,词,NOUN,B2
-washing,washing,洗涤,NOUN,B2
-washing machine,washing machine,洗衣机,NOUN,B2
-waste disposal site,waste disposal site,词,NOUN,B1
-waste of time,waste of time,浪费时间,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wasteland,wasteland,荒地,NOUN,B2
-wastewater,wastewater,废水,NOUN,C1
-wat,what,什么,ADV,B2
-watch,to watch,观看,VERB,B2
-watch of the night,watch of the night,词,NOUN,C1
-watch over,watch over,词,VERB,C1
-watchmaking,watchmaking,词,NOUN,C1
-watchtower,watchtower,词,NOUN,B2
-water,to water,浇水,VERB,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water falling,water falling,水落,NOUN,B2
-water garment,water garment,水衣,NOUN,C1
-water heater,water heater,热水器,NOUN,B2
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-water spinach,water spinach,空心菜,NOUN,B2
-watercolor,watercolor,水彩画,NOUN,B2
-watercourse,watercourse,河道,NOUN,B1
-waterfall,waterfall,瀑布,NOUN,B2
-watering,watering,词,NOUN,B2
-watermelon,watermelon,西瓜,NOUN,B2
-watermelon seed,watermelon seed,西瓜子,NOUN,B2
-waterproof (verb),waterproof,词,VERB,C1
-watershed,watershed,词,NOUN,C1
-waterskin,waterskin,词,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-wax,wax,蜡,NOUN,B2
-waxen,waxen,词,ADJ,C1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
-way out,way out,出路,NOUN,B2
-waylay,waylay,词,VERB,C1
-we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
-we two,we two,我俩,PRON,B2
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weakly,weakly,词,ADV,C1
-weakness,weakness,弱点,NOUN,B2
-weal,weal,词,NOUN,C1
-wealthy,wealthy,富有的,ADJ,B2
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
-wean,to wean,断奶,VERB,B2
-weaning,weaning,断奶,NOUN,B2
-weapon arms,weapon arms,词,NOUN,A1
-wear,wear,磨损,NOUN,B2
-wear tear,wear tear,词,NOUN,C1
-wearily,wearily,词,ADV,C1
-weariness,weariness,疲倦,NOUN,B2
-wearisome,wearisome,词,ADJ,C1
-weary,weary,疲倦的,ADJ,B2
-weather,weather,天气,NOUN,B2
-weather forecast,weather forecast,词,NOUN,B1
-weathering,weathering,词,NOUN,C1
-weave,to weave,编织,VERB,B2
-weaver,weaver,词,NOUN,B1
-weaving,weaving,编织,NOUN,B2
-website,website,网站,NOUN,B2
-wedding anniversary,wedding anniversary,结婚纪念日,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
-wedding photo,wedding photo,婚纱照,NOUN,B2
-wederzijds,reciprocal,互惠的,ADJ,B2
-wedijveren,to vie,竞争,VERB,B2
-wedstrijd,contest,比赛,NOUN,B2
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
-weefsel,tissue,组织,NOUN,B2
-weekdag,weekday,工作日,NOUN,B2
-weekheid,too soft,太软,NOUN,B2
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weeknummer,week number,周次,NOUN,B2
-weektest,weekly test,周测,NOUN,B2
-weelderig,sumptuous,奢华的,ADJ,B2
-weeping,weeping,痛哭,NOUN,C1
+onheilspellend,ominous,不祥的,ADJ,B2
 weglaten,to omit,省略,VERB,B2
-wegnemen,to take away,拿走,VERB,B2
-wegpakken,to snatch,抢夺,VERB,B2
-weide,grassland,草地,NOUN,B2
-weide,meadow,草地,NOUN,B2
-weidegang,grazing,放牧,NOUN,B2
-weiden,to graze,吃草,VERB,B2
-weighing,weighing,词,NOUN,B2
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
-weinigen,few,几下,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
-wekker,alarm clock,闹钟,NOUN,B2
-welcome (intj),welcome,词,INTJ,A1
-welcome (noun),welcome,词,NOUN,A2
-welcome committee,welcome committee,,NOUN,B2
-welcoming,welcoming,舒适的,ADJ,B2
-weld,weld,词,VERB,C1
-welder,welder,词,NOUN,C1
-welfare home,welfare home,福利院,NOUN,C1
-welke,which,哪个,DET,B2
-welke,which one,哪一个,PRON,B2
-welkom,welcome,欢迎,NOUN,B2
-welkomstbanket,welcome banquet,欢迎宴,NOUN,B2
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
-well-crafted,well-crafted,词,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-liked,well-liked,词,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welp,puppy,小狗,NOUN,B2
-welsprekend,eloquent,雄辩的,ADJ,B2
-welter,welter,词,NOUN,C1
-welvarend,prosperous,繁荣的,ADJ,B2
-welzijn,welfare,福利,NOUN,B2
-wend,wend,词,VERB,C1
-wendbaar,agile,敏捷的,ADJ,B2
-wendbaarheid,agility,敏捷,NOUN,B2
-wenen,to wail,哀号,VERB,B2
-wenkbrauw,eyebrow,眉毛,NOUN,B2
-wereld,whole world,全世界,NOUN,B2
-wereldbeeld,worldview,世界观,NOUN,B2
-wereldwijde aandacht krijgen,to receive worldwide attention,举世瞩目,VERB,B2
-weren,to rebut,反驳,VERB,B2
-werewolf,werewolf,狼人,NOUN,B2
-werkloos,unemployed,失业的,ADJ,B2
-werkzaamheid,efficacy,功效,NOUN,B2
-wervel,vortex,漩涡,NOUN,B2
-wervelwind,whirlwind,旋风；漩涡,NOUN,B2
-westelijke regio,western regions,西域,NOUN,B2
-westerner,westerner,词,NOUN,B2
-westward,westward,向西,ADV,B2
-westward (noun),westward,往西,NOUN,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wharf,wharf,码头,NOUN,B2
-what (adv),what,词,ADV,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
-when (adp),when,之时,ADP,B2
-when (sconj),when,当,SCONJ,A1
-when than,when than,词,SCONJ,A2
-when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (cconj),whereas,词,CCONJ,B2
-whereas (sconj),whereas,词,SCONJ,C1
-whereas since,whereas since,词,SCONJ,A2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whet,whet,词,VERB,C1
-whether,whether,是否,SCONJ,B2
-whether (part),whether,词,PART,A1
-which (det),which,哪个,DET,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
-whiny,whiny,词,ADJ,C1
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
-whirring,whirring,词,NOUN,C1
-whisk whip,whisk whip,词,NOUN,B1
-whistleblower,whistleblower,词,NOUN,C1
-whistling,whistling,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whiting,whiting,词,NOUN,B2
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-wholehearted,wholehearted,词,ADJ,C1
-wholesale (adv),wholesale,词,ADV,B1
-wholesome,wholesome,词,ADJ,C1
-whore,whore,妓女,NOUN,B2
-whose (det),whose,词,DET,B2
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
-wicked,wicked,邪恶的,ADJ,B2
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,加宽,NOUN,B2
-widower,widower,词,NOUN,C1
-widowhood,widowhood,词,NOUN,C1
-wie,whom,谁,PRON,B2
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
-wiens,whose,谁的,PRON,B2
-wierook,incense,香,NOUN,B2
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wig,wig,假发,NOUN,B2
-wijden,to consecrate,奉献,VERB,B2
-wijden,to devote,奉献,VERB,B2
-wijdverbreid,widespread,广泛的,ADJ,B2
-wijnglas,wine cup,这酒盏,NOUN,B2
-wil van de keizerlijke vader,imperial father's will,父皇要,NOUN,B2
-wild,wild,野生的,ADJ,B2
-wild beast,wild beast,猛兽,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
-wilderness,wilderness,荒野,NOUN,B2
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
-wilful,willful,任性的,ADJ,B2
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will shall,will shall,将要/会,AUX,B2
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
-willekeurige tirannie,rampant tyranny,横行,NOUN,B2
-willen,willing,肯,AUX,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willow,willow,词,NOUN,B2
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-wimp,wimp,懦夫,NOUN,B2
-wimper,eyelash,睫毛,NOUN,B2
-win,win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-windfall,windfall,意外之财,NOUN,B2
-winding,winding,蜿蜒的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
-windowsill,windowsill,窗台,NOUN,C1
-windstoot,gust,阵风,NOUN,B2
-windy,windy,有风的,ADJ,B2
-windy day,windy day,风天,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winkel,shopping,购物,NOUN,B2
-winkel,store,商店,NOUN,B2
-winnen,to winnow,筛选,VERB,B2
-winning bid price,winning bid price,中标价,NOUN,B2
-winsome,winsome,词,ADJ,C1
-winst,gain,收益,NOUN,B2
-winstgevend,profit-making,营利性,ADJ,B2
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wintry,wintry,冬天的,ADJ,B2
-wired,wired,词,ADJ,C1
-wisely,wisely,明智地,ADV,B2
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wiskunde,math,数学,NOUN,B2
-wiskundig,mathematical,数学的,ADJ,B2
-wissen,to erase,擦除,VERB,B2
-wisser,wiper,雨刷,NOUN,B2
-wistful,wistful,词,ADJ,C1
-wit,wit,词,NOUN,C1
-witch hunt,witch hunt,词,NOUN,C1
-witchcraft,witchcraft,巫术,NOUN,B2
-with each other,with each other,词,ADV,A2
-with me,with me,词,PRON,A1
-with the aim of,with the aim of,词,ADP,C1
-with what,with what,用什么,ADV,B2
-with you,with you,词,PRON,A1
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawal fold,withdrawal fold,词,NOUN,C1
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without exception,without exception,无例外的,ADV,B2
-withstand,withstand,词,VERB,C1
-witness female,witness female,词,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,词,NOUN,C1
-wittiness,wittiness,风趣,NOUN,B2
-witty saying,witty saying,词,NOUN,C1
-wizened,wizened,词,ADJ,C1
-woe (intj),woe,词,INTJ,B2
-woe (noun),woe,词,NOUN,C1
-woede,anger,愤怒,NOUN,B2
-woeden,rage,愤怒,NOUN,B2
-woeden,to rage,狂怒,VERB,B2
-wol,wool,羊毛,NOUN,B2
-wolf,wolf,狼,NOUN,B2
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wonder (noun),wonder,太妙,NOUN,C1
-wonderbaar,wonderful,极好的,ADJ,B2
-wonderen,wonder,奇迹,NOUN,B2
-wonderen,to wonder,觉得奇怪,VERB,B2
-wonderful,wonderful,极好地,ADV,B2
-wonen,to reside,居住,VERB,B2
-woning,dwelling,住宅,NOUN,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
-woorden van de heer,lord's words,主说,NOUN,B2
-woordenboek,dictionary,词典,NOUN,B2
-woordierig,prolix,冗长的,ADJ,B2
-woordierigheid,prolixity,冗长,NOUN,B2
-word choice,word choice,措辞,NOUN,B2
-wording,wording,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workday,workday,词,NOUN,C1
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working,working,词,ADJ,C1
-working class,working class,工人阶级,NOUN,B2
-working method,working method,工作方式,NOUN,B2
-workout,workout,词,NOUN,C1
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldliness,worldliness,词,NOUN,C1
-worm,worm,虫,NOUN,B2
-wormwood,wormwood,词,NOUN,A2
-worn,worn,磨损的,ADJ,B2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry (noun),worry,多虑,NOUN,C1
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worse,worse,更糟的事,NOUN,B2
-worsen,to worsen,恶化,VERB,B2
-worsening,worsening,词,NOUN,C1
-worship,worship,崇拜,NOUN,B2
-worship,to worship,崇拜,VERB,B2
-worst,worst,最差的,ADV,B2
-worst (noun),worst,词,NOUN,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-wortel,root,根,NOUN,B2
-worthiness,worthiness,真配,NOUN,C1
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would,would,将要,AUX,B2
-would like,would like,词,AUX,A2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wound,to wound,使受伤,VERB,B2
-wounded,wounded,受伤的,ADJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wrap,to wrap,包裹,VERB,B2
-wrapper,wrapper,词,NOUN,C1
-wrapping,wrapping,包装,NOUN,B2
-wrath,wrath,愤怒,NOUN,B2
-wrathful,wrathful,词,ADJ,C1
-wreck,wreck,残骸,NOUN,B2
-wreckage,wreckage,词,NOUN,C1
-wreken,to avenge,复仇,VERB,B2
-wrench,wrench,词,NOUN,C1
-wrest,to wrest,强行夺取,VERB,B2
-wrestling,wrestling,摔跤,NOUN,B2
-wretch,wretch,令人厌恶的人,NOUN,B2
-wretched,wretched,词,ADJ,C1
-wretchedness,wretchedness,悲惨,NOUN,C1
-wrijving,rubbing,摩擦,NOUN,B2
-wrinkle,wrinkle,皱纹,NOUN,B2
-wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
-writ,writ,词,NOUN,C1
-writhe,writhe,词,VERB,C1
-writing,writing,文字,NOUN,B2
-written,written,书面的,ADJ,B2
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
-wrok,grudge,怨恨,NOUN,B2
-wrong,wrong,错误的事,NOUN,B2
-wrong mistake,wrong mistake,错误,ADJ,B2
-wrongdoer,wrongdoer,罪犯,NOUN,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
-wudang,wudang,武当,NOUN,B2
-x-ray,x-ray,X光片,NOUN,B2
-xenophobia,xenophobia,排外心理,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
-yard,yard,院子,NOUN,B2
-yarn,yarn,纱线,NOUN,B2
-yawn,to yawn,打哈欠,VERB,B2
-yeah,yeah,词,INTJ,A1
-yeah yeah,yeah yeah,是是是,INTJ,B2
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
-yearn for,to yearn for,渴望,VERB,B2
-yearning,yearning,向往,NOUN,B2
-years,years,数年,NOUN,B2
-yeast,yeast,酵母,NOUN,B2
-yell,to yell,大吼,VERB,B2
-yeoman,yeoman,词,NOUN,C1
-yep,yep,是的,INTJ,B2
-yes,yes,是啊,NOUN,B2
-yes (adv),yes,词,ADV,A2
-yes (part),yes,是的,PART,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yesterday,yesterday,بارحة,NOUN,B2
-yesteryear,yesteryear,词,NOUN,C1
-yield,to yield,产出,VERB,B2
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yo,yo,哟,PART,B2
-yoga,yoga,瑜伽,NOUN,B2
-yoga practice,yoga practice,瑜伽练习,NOUN,B2
-yogurt,yogurt,酸奶,NOUN,B2
-yoke,yoke,枷锁,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you can,you can,您能,NOUN,B2
-you cannot live,you cannot live,你也活不,NOUN,B2
-you dative,you dative,词,PRON,A2
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you formal,you formal,您,PRON,B2
-you masculine,you masculine,词,PRON,A1
-you plural,you plural,你们,PRON,B2
-you polite,you polite,您,PRON,B2
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
-young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,最年轻的,ADJ,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your pl,your pl,你们的,DET,B2
-your plural,your plural,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,你的,PRON,B2
-youth people,youth people,词,NOUN,C1
-youthful,youthful,词,ADJ,C1
-youthful vigor,youthful vigor,词,NOUN,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
-yuanxiao,yuanxiao,元宵,NOUN,B2
-yuck,yuck,呸,INTJ,B2
-zaag,saw,锯子,NOUN,B2
-zaaien,to sow,播种,VERB,B2
-zaak horen,to hear a case,审理,VERB,B2
-zajal,zajal,词,NOUN,B2
-zak,sack,麻袋,NOUN,B2
-zakdoek,handkerchief,手帕,NOUN,B2
-zakelijk,business,商业的,ADJ,B2
-zakenbijeenkomst,business meeting,洽谈会,NOUN,B2
-zalf,ointment,药膏,NOUN,B2
-zandstorm,sandstorm,沙尘暴,NOUN,B2
-zany,zany,词,ADJ,C1
-zeal,zeal,热情,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zeef,sieve,筛子,NOUN,B2
-zeemeermin,mermaid,美人鱼,NOUN,B2
-zegenen,to bless,祝福,VERB,B2
-zeilen,sailing,航行,NOUN,B2
-zeker,sure,确定的,ADJ,B2
-zeker weten,to make sure,确保,VERB,B2
-zekerstellen,to secure,保护,VERB,B2
-zelf,self,自我,NOUN,B2
-zelfopoffering,self-sacrifice,舍己,NOUN,B2
-zelfs als,even if,即使,SCONJ,B2
-zelfverzekerd,confident,自信的,ADJ,B2
-zelfverzekerd,self-confident,自信的,ADJ,B2
-zellige tiles,zellige tiles,词,NOUN,A2
-zen master,zen master,禅师,NOUN,B2
-zending,consignment,托运,NOUN,B2
-zenit,zenith,顶点,NOUN,B2
-zephyr,zephyr,词,NOUN,C1
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
-zero,zero,零,NOUN,B2
-zeroing,zeroing,词,NOUN,C1
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
-zeven,to sift,筛选,VERB,B2
-zich inspannen,to try hard to,力图,VERB,B2
-zich vergissen,to err,犯错,VERB,B2
-zich verstoppen,to hide oneself,躲藏,VERB,B2
-ziek,ill,生病的,ADJ,B2
-ziek worden,to fall ill,患病,VERB,B2
-ziekte,illness,疾病,NOUN,B2
-ziekte,malady,弊病,NOUN,B2
-zijde,silk,丝绸,NOUN,B2
-zijden doek,silk cloth,丝绸,NOUN,B2
-zijdeur,side door,侧门,NOUN,B2
-zijn,his,他的,DET,B2
-zingen,singing,歌唱,NOUN,B2
-zink,zinc,锌,NOUN,B2
-zinneloos,senseless,无意义的,ADJ,B2
-zo,that way,那样,PRON,B2
-zoals in het verleden,just as in the past,一如既往,ADV,B2
-zoeken,seeking,寻求,NOUN,B2
-zoeken,to look for,寻找,VERB,B2
-zoeken,to search for,寻找,VERB,B2
-zoeken,to seek,寻找,VERB,B2
-zoeken om te vinden,to look for to find,找,VERB,B2
-zoektocht,quest,探索,NOUN,B2
-zoete droom,sweet dream,美梦,NOUN,B2
-zoeten,to sweeten,使变甜,VERB,B2
-zolang,as long as,طالما,CCONJ,B2
-zombie,zombie,僵尸,NOUN,B2
-zonde,sin,罪,NOUN,B2
-zone,zone,区域,NOUN,B2
-zongzi,zongzi,粽子,NOUN,B2
-zonneschijn,sunshine,阳光,NOUN,B2
-zonsopgang,sunrise,日出,NOUN,B2
-zool,sole,鞋底,NOUN,B2
-zorgen,worry,担忧,NOUN,B2
-zorgen,to worry,担心,VERB,B2
-zorgen voor,to look after,照料,VERB,B2
-zorgen voor,to take care of,照顾,VERB,B2
-zorgverlener,caregiver,护理人员,NOUN,B2
-zout,salty,咸的,ADJ,B2
-zucht,sigh,叹息,NOUN,B2
-zuchten,to sigh with sorrow,感慨,VERB,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zuidelijk leger,southern army,南军,NOUN,B2
-zuiverheid,purity,纯洁,NOUN,B2
-zukunft,zukunft,词,NOUN,C1
-zullen,will,将要,AUX,B2
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
-zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
-zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuur,sour,酸的,ADJ,B2
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
-zwaai,swing,秋千,NOUN,B2
-zwaaien,to sway,摇摆,VERB,B2
-zwaan,swan,天鹅,NOUN,B2
-zwaar werk,heavy work,重功,NOUN,B2
-zwaardloosheid,swordless,剑不,NOUN,B2
-zwaardvechter,swordsman,剑客,NOUN,B2
-zwaarte,heaviness,沉重 / 笨重,NOUN,B2
-zwaartekracht,gravity,重力,NOUN,B2
-zware aanval,difficult attack,难攻,NOUN,B2
-zware knoop,heavy knot,重结,NOUN,B2
-zware machine,heavy machine,重机,NOUN,B2
-zwarte markt,black market,黑市,NOUN,B2
-zwarte toga,black robe,黑衣,NOUN,B2
-zweep,to whip,鞭打,VERB,B2
-zweren,to fester,溃烂,VERB,B2
-zweten,to sweat,出汗,VERB,B2
-zweven,to hover,盘旋,VERB,B2
-zwijgen,to silence,خرس,VERB,B2
+aan,on,,NOUN,B2
+hoofd,on head,当头,NOUN,B2
+achtereenvolgens,one after another,接连地,ADV,B2
 één boek,one book,一本,NUM,B2
 één dag,one day,一天,NUM,B2
 één familie,one family,一家,NUM,B2
 één flat,one flat,一张,NUM,B2
 één hoofd,one head,一头,NUM,B2
 één nacht,one night,一晚,NUM,B2
-één schot,one shot,一枪,NUM,B2
 één set,one set,一套,NUM,B2
+één schot,one shot,一枪,NUM,B2
+naar hartelust,one's heart's content,尽情,ADV,B2
+alleen,only,而已,SCONJ,B2
+pas dan,only then,才,ADV,B2
+alleen-ik,only-me,只我,NOUN,B2
+ontologie,ontology,本体论,NOUN,B2
+open,open,开着的,ADJ,B2
+opengevoelig,open-minded,思想开明的,ADJ,B2
+opening,opening,开口,NOUN,B2
+openlijk,openly,公开地,ADV,B2
+opera,opera,歌剧,NOUN,B2
+operator,operator,经营者,NOUN,B2
+gelegenheid,opportunity,机会,NOUN,B2
+tegenwerken,to oppose,反对,VERB,B2
+onderdrukken,to oppress,压迫,VERB,B2
+onderdrukking,oppression,压迫,NOUN,B2
+optisch,optical,光学的,ADJ,B2
+optica,optics,光学,NOUN,B2
+optimisme,optimism,乐观,NOUN,B2
+optimistisch,optimistic,乐观的,ADJ,B2
+optioneel,optional,可选的,ADJ,B2
+opties,options,期权,NOUN,B2
+oraal,oral,口头的,ADJ,B2
+mondelinge beschikking,oral decree,口谕,NOUN,B2
+baan,orbit,轨道,NOUN,B2
+orchard,orchard,果园,NOUN,B2
+ordeal,ordeal,苦难,NOUN,B2
+orderly,orderly,有序的,ADJ,B2
+ordinarily,ordinarily,通常,ADV,B2
+ordinary day,ordinary day,平日,NOUN,B2
+ordinary people,ordinary people,老百姓,NOUN,B2
+organizer,organizer,组织者,NOUN,B2
+original,original,重原,NOUN,B2
+original document,original document,原件,NOUN,B2
+originality,originality,独创性,NOUN,B2
+originally,originally,最初,ADV,B2
+orphan,orphan,孤儿,NOUN,B2
+orthodox,orthodox,正统的,ADJ,B2
+oscillate,to oscillate,振荡,VERB,B2
+other,other,其他的,DET,B2
+otherness,otherness,相异性,NOUN,B2
+others,others,他人,NOUN,B2
+out of,out of,从...出来,ADP,B2
+outburst,outburst,迸发,NOUN,B2
+outcast,outcast,被遗弃者,NOUN,B2
+outhouse,outhouse,茅房,NOUN,B2
+outing,outing,郊游,NOUN,B2
+outlet,outlet,出口,NOUN,B2
+outline,outline,大纲,NOUN,B2
+outline,to outline,勾勒,VERB,B2
+outlook,outlook,前景,NOUN,B2
+outrage,outrage,愤怒,NOUN,B2
+outsourcing,outsourcing,外包,NOUN,B2
+outstanding,outstanding,杰出的,ADJ,B2
+oven,oven,烤箱,NOUN,B2
+over,over,在...上方,ADP,B2
+over there,over there,在那边,ADV,B2
+overdomein,over-domain,超畴,NOUN,B2
+overstrategie,over-strategy,超策,NOUN,B2
+overstroke,over-stroke,超程,NOUN,B2
+in het geheel,overall,总体上,ADV,B2
+bewolkt,overcast,阴天的,ADJ,B2
+overschrijven,to overdraw,透支,VERB,B2
+verlopen,overdue,逾期,ADJ,B2
+overloop,overflow,溢出,NOUN,B2
+overlap,overlap,重叠,NOUN,B2
+overnacht,overnight,一夜之间,ADV,B2
+overzeese Chinees,overseas chinese,华侨,NOUN,B2
+overuren,overtime,加班,NOUN,B2
+omverwerpen,to overturn,打翻,VERB,B2
+overwelderen,to overwhelm,使不知所措,VERB,B2
+schuldig zijn,to owe,欠,VERB,B2
+uil,owl,猫头鹰,NOUN,B2
+eigendom,ownership,,NOUN,B2
+oxide,oxide,氧化物,NOUN,B2
+tempobepaler,pace-setter,标兵,NOUN,B2
+verpakking,packaging,包装,NOUN,B2
+volgepakt,packed,打包,ADJ,B2
+pakket,packet,小包裹,NOUN,B2
+pact,pact,协定,NOUN,B2
+kussen,pad,垫,NOUN,B2
+pijnstiller,painkiller,止痛药,NOUN,B2
+paar,pair,一对,NOUN,B2
+bleek,pale,苍白的,ADJ,B2
+palm,palm,手掌,NOUN,B2
+palmboom,palm tree,棕榈树,NOUN,B2
+pannenkoek,pancake,煎饼,NOUN,B2
+alvleesklier,pancreas,胰腺,NOUN,B2
+pandemie,pandemic,大流行病,NOUN,B2
+panegyriek,panegyric,颂词,NOUN,B2
+paneel,panel,小组,NOUN,B2
+pantseren,to pant,喘气,VERB,B2
+pantheïsme,pantheism,泛神论,NOUN,B2
+papaja,papaya,木瓜,NOUN,B2
+papierknipsel,paper cutting,剪纸,NOUN,B2
+papierwerk,paperwork,文书工作,NOUN,B2
+parade,parade,游行,NOUN,B2
+paradigma,paradigm,范例,NOUN,B2
+paradox,paradox,悖论,NOUN,B2
+paragoon,paragon,典范,NOUN,B2
+paragraaf,paragraph,段落,NOUN,B2
+parallel,parallel,平行的,ADJ,B2
+paralyse,paralysis,瘫痪,NOUN,B2
+paralyseren,to paralyze,使瘫痪,VERB,B2
+paramedicus,paramedic,急救人员,NOUN,B2
+parameter,parameter,参数,NOUN,B2
+vergeven,pardon,赦免,NOUN,B2
+vergeven,to pardon,赦免,VERB,B2
+ouder,parents,父母,NOUN,B2
+pariteit,parity,平等,NOUN,B2
+parkeerplaats,parking,停车,NOUN,B2
+voorwaardelijke invrijheidstelling,parole,假释,NOUN,B2
+paronomase,paronomasia,近音词双关,NOUN,B2
+papegaai,parrot,鹦鹉,NOUN,B2
+peterselie,parsley,欧芹,NOUN,B2
+deelnemen,to part,分离,VERB,B2
+sterven,to part by death,死别,VERB,B2
+gedeeltelijke oorzaak,partial cause,分因,NOUN,B2
+gedeeltelijke betekenis,partial meaning,分义,NOUN,B2
+participatief,participatory,参与式的,ADJ,B2
+deeltje,particle,颗粒,NOUN,B2
+particulariteit,particularity,特点,NOUN,B2
+overlijden,to pass away,流逝,VERB,B2
+voorbijgaan,to pass by,经过,VERB,B2
+passage,passage,段落,NOUN,B2
+voorbijgang,passing,过世,NOUN,B2
+verleden,past,过去的,ADJ,B2
+past exam papers,past exam papers,真题,NOUN,B2
+pasta,pasta,意大利面,NOUN,B2
+paste,paste,酱,NOUN,B2
+pasture,pasture,牧场,NOUN,B2
+pat,to pat,轻拍,VERB,B2
+patch,patch,补丁,NOUN,B2
+patent,patent,专利,NOUN,B2
+paternal aunt,paternal aunt,姑母,NOUN,B2
+pathological,pathological,病态的,ADJ,B2
+patient,patient,耐心的,ADJ,B2
+patriarchy,patriarchy,父权制,NOUN,B2
+patriotism,patriotism,爱国主义,NOUN,B2
+pause,pause,暂停,NOUN,B2
+pavilion,pavilion,亭子,NOUN,B2
+pay respects,to pay respects,参见,VERB,B2
+pay smilingly,to pay smilingly,笑付,VERB,B2
+pay tax,to pay tax,纳税,VERB,B2
+payment all,payment all,付都,NOUN,B2
+peaceful,peaceful,和平的,ADJ,B2
+peach,peach,桃子,NOUN,B2
+peak,peak,顶峰,NOUN,B2
+peanut,peanut,花生,NOUN,B2
+pearl,pearl,珍珠,NOUN,B2
+peasant,peasant,农民,NOUN,B2
+peculiar,peculiar,奇怪的,ADJ,B2
+pedagogical,pedagogical,教学的,ADJ,B2
+pedagogy,pedagogy,教育学,NOUN,B2
+pedestrian,pedestrian,行人,NOUN,B2
+pedestrian bridge,pedestrian bridge,天桥,NOUN,B2
+pee,to pee,小便,VERB,B2
+peel,peel,皮,NOUN,B2
+peel,to peel,削皮,VERB,B2
+peer,peer,同龄人,NOUN,B2
+penetrate,to penetrate,穿透,VERB,B2
+penetratie,penetration,渗透,NOUN,B2
+percentage,percentage,百分比,NOUN,B2
+perceptie,perception,感知,NOUN,B2
+opmerkzaam,perceptive,敏锐的,ADJ,B2
+perfectie,perfection,完美,NOUN,B2
+gevaar,peril,危险,NOUN,B2
+periodiek,periodically,定期地,ADV,B2
+perifeer,peripheral,外围的,ADJ,B2
+meineed,perjury,伪证,NOUN,B2
+permanentie,permanence,持久,NOUN,B2
+doorlaatbaar,permeable,可渗透的,ADJ,B2
+loodrecht,perpendicular,垂直的,ADJ,B2
+volharding,perseverance,毅力,NOUN,B2
+aanhoudend,persistent,坚持不懈的,ADJ,B2
+aanspreekvorm,person honorific,位,NOUN,B2
+persoonlijke vete,personal enmity,私仇,NOUN,B2
+persoonlijk record,personal record,个人纪录,NOUN,B2
+persoonlijk,personally,就个人而言,ADV,B2
+personeel,personnel,人员,NOUN,B2
+overtuigen,to persuade,说服,VERB,B2
+overtuiging,persuasion,说服,NOUN,B2
+pessimisme,pessimism,悲观主义,NOUN,B2
+pessimistisch,pessimistic,悲观的,ADJ,B2
+bestrijdingsmiddel,pesticide,杀虫剂,NOUN,B2
+aardolie,petroleum,石油,NOUN,B2
+farmaceutisch,pharmaceutical,制药的,ADJ,B2
+apotheker,pharmacist,药剂师,NOUN,B2
+gefaseerd,phased,阶段性,ADJ,B2
+filosoof,philosopher,哲学家,NOUN,B2
+slijm,phlegm,痰,NOUN,B2
+feniks,phoenix,拿凤,NOUN,B2
+bellen,to phone,打电话,VERB,B2
+fotokopie,photocopy,复印件,NOUN,B2
+foto,photograph,照片,NOUN,B2
+fotosynthese,photosynthesis,光合作用,NOUN,B2
+fysiek bewijs,physical evidence,物证,NOUN,B2
+arts,physician,内科医生,NOUN,B2
+fysiognomie,physiognomy,面相,NOUN,B2
+inleggen,to pickle,腌渍,VERB,B2
+picknick,picnic,野餐,NOUN,B2
+gegeven,piece of information,信息,NOUN,B2
+ophopen,to pile up,堆积,VERB,B2
+pelgrim,pilgrim,朝圣者,NOUN,B2
+bedevaart,pilgrimage,朝圣,NOUN,B2
+pil,pill,药丸,NOUN,B2
+vastspelden,to pin,别住,VERB,B2
+knijpen,pinch,捏,NOUN,B2
+knijpen,to pinch,捏,VERB,B2
+ananas,pineapple,菠萝,NOUN,B2
+piraat,pirate,海盗,NOUN,B2
+pistache,pistachio,开心果,NOUN,B2
+pistool,pistol,手枪,NOUN,B2
+beklagenswaardig,pitiful,可怜的,ADJ,B2
+beklagen,to pity,同情,VERB,B2
+plagiaat,plagiarism,剽窃,NOUN,B2
+vlakte,plain,平原,NOUN,B2
+eiser,plaintiff,原告,NOUN,B2
+vliegtuig,plane,飞机,NOUN,B2
+planten,plant,植物,NOUN,B2
+planten,to plant,种植,VERB,B2
+uitplanten,to plant out,定植,VERB,B2
+plantage,plantation,人工林,NOUN,B2
+pleister,plaster,石膏,NOUN,B2
+plastic,plastic,塑料的,ADJ,B2
+plateau,plateau,高原,NOUN,B2
+geplateerd,plated,镀层的,ADJ,B2
+bloedplaatje,platelet,血小板,NOUN,B2
+platform,platform,平台,NOUN,B2
+toneelstuk,play,剧本,NOUN,B2
+playmate,playmate,玩伴,NOUN,B2
+plea,plea,辩护,NOUN,B2
+please,please,请,ADV,B2
+please,to please,使高兴,VERB,B2
+pledge,pledge,抵押,NOUN,B2
+pledge,to pledge,保证,VERB,B2
+pliers,pliers,钳子,NOUN,B2
+plight,plight,处境,NOUN,B2
+plot,plot,情节,NOUN,B2
+plowing,plowing,犁地,NOUN,B2
+plug,plug,插头,NOUN,B2
+plum,plum,李子,NOUN,B2
+plumber,plumber,水管工,NOUN,B2
+plumbing,plumbing,管道工程,NOUN,B2
+plunder,plunder,掠夺,NOUN,B2
+pluralism,pluralism,多元主义,NOUN,B2
+plush toy,plush toy,毛绒玩具,NOUN,B2
+plutocracy,plutocracy,财阀政治,NOUN,B2
+pocket,pocket,口袋,NOUN,B2
+podcast,podcast,播客,NOUN,B2
+poetry collection,poetry collection,诗集,NOUN,B2
+point in time,point in time,时间点,NOUN,B2
+poison,to poison,毒害,VERB,B2
+poisoning,poisoning,中毒,NOUN,B2
+polarization,polarization,两极分化 / 极化,NOUN,B2
+polemical,polemical,论战的,ADJ,B2
+policeman,policeman,警察,NOUN,B2
+poll,poll,民意调查,NOUN,B2
+pollutant,pollutant,污染物,NOUN,B2
+pomegranate,pomegranate,石榴,NOUN,B2
+pomelo,pomelo,柚子,NOUN,B2
+pool,pool,水池,NOUN,B2
+populate,to populate,居住,VERB,B2
+porch,porch,门廊,NOUN,B2
+porno,porn,色情,NOUN,B2
+pornografisch,pornographic,色情的,ADJ,B2
+haven,port,港口,NOUN,B2
+drager,porter,搬运工,NOUN,B2
+portie,portion,部分,NOUN,B2
+portretteren,to portray,描绘,VERB,B2
+positionering,positioning,定位,NOUN,B2
+bezitten,to possess,拥有,VERB,B2
+post,post,邮件,NOUN,B2
+ansichtkaart,postcard,明信片,NOUN,B2
+poster,poster,海报,NOUN,B2
+postulaat,postulate,假定,NOUN,B2
+pot,pot,锅,NOUN,B2
+pottenbakkerij,pottery,陶器,NOUN,B2
+pluimvee,poultry,家禽,NOUN,B2
+aanspringen,to pounce,猛扑,VERB,B2
+poeder,powder,粉末,NOUN,B2
+volmacht,power of attorney,委托书,NOUN,B2
+grootmacht,powerful nation,强国,NOUN,B2
+praktisch,practically,几乎,ADV,B2
+praktijk,practitioner,从业者,NOUN,B2
+pragmatisme,pragmatism,实用主义,NOUN,B2
+preken,to preach,布道,VERB,B2
+preambule,preamble,序言,NOUN,B2
+onveiligheid,precariousness,不稳定性,NOUN,B2
+voorzorg,precaution,预防措施,NOUN,B2
+voorafgaan,to precede,在...之前,VERB,B2
+precedent,precedent,先例,NOUN,B2
+voorschrift,precept,戒律,NOUN,B2
+kostbaarheid,preciousness,珍贵,NOUN,B2
+precies,precise,精确的,ADJ,B2
+voorloper,precursor,先驱,NOUN,B2
+roofdier,predator,捕食者,NOUN,B2
+roofachtig,predatory,掠夺的,ADJ,B2
+voorganger,predecessor,前任,NOUN,B2
+dilemma,predicament,困境,NOUN,B2
+voorspelling,prediction,预测,NOUN,B2
+voorwoord,preface,序言,NOUN,B2
+vooroordeel,prejudice,偏见,NOUN,B2
+première,premier,总理,NOUN,B2
+premiss,premise,前提,NOUN,B2
+voorbereiden,to prepare a lesson,预习,VERB,B2
+absurd,preposterous,荒谬的,ADJ,B2
+voorwaarde,prerequisite,前提,NOUN,B2
+peuterschool,preschool,幼儿园,NOUN,B2
+voorschrijven,to prescribe,开处方,VERB,B2
+voorschrift,prescription,处方,NOUN,B2
+behoud,preservation,保护,NOUN,B2
+bewaren,to preserve,保护,VERB,B2
+presidentschap,presidency,总统任期,NOUN,B2
+president,president,总统,NOUN,B2
+presidentieel,presidential,总统的,ADJ,B2
+dringend,pressing,紧迫的,ADJ,B2
+druk,pressure,压力,NOUN,B2
+vermoeden,to presume,假定,VERB,B2
+veronderstelling,presumption,自负,NOUN,B2
+voordoen,to pretend,假装,VERB,B2
+voordoen,to pretend to be,冒充,VERB,B2
+schijn,pretense,假装,NOUN,B2
+pretekst,pretext,借口,NOUN,B2
+mooi,pretty,漂亮的,ADJ,B2
+eerder,previously,以前,ADV,B2
+prijsbepaling,pricing,定价 / 收费,NOUN,B2
+trots,pride,骄傲,NOUN,B2
+primitief,primitive,原始的,ADJ,B2
+hoofd,principal,委托人,NOUN,B2
+druk,print,印记,NOUN,B2
+prisma,prism,棱镜,NOUN,B2
+privacy,privacy,隐私,NOUN,B2
+probabilistisch,probabilistic,概率的,ADJ,B2
+waarschijnlijkheid,probability,概率,NOUN,B2
+procedure,procedure,程序,NOUN,B2
+voortgaan,to proceed,继续进行,VERB,B2
+processor,processor,处理器,NOUN,B2
+uitstellen,to procrastinate,拖延,VERB,B2
+uitstel,procrastination,拖延,NOUN,B2
+verkrijgen,to procure,获取,VERB,B2
+product,product,产品,NOUN,B2
+productiviteit,productivity,生产力,NOUN,B2
+professional,professional,专业人士,NOUN,B2
+bekwaam,proficient,熟练的,ADJ,B2
+winstgevend,profit-making,营利性,ADJ,B2
+diep,profound,深刻的,ADJ,B2
+programmeur,programmer,程序员,NOUN,B2
+programmeren,programming,编程,NOUN,B2
+voortgang maken,to progress,进步,VERB,B2
+voortgangsrapport,progress report,进度报告,NOUN,B2
+stapsgewijs,progressively,逐渐地,ADV,B2
+verbod,prohibition,禁止,NOUN,B2
+projectopdracht,project assignment,项目作业,NOUN,B2
+projector,projector,投影仪,NOUN,B2
+proletariaat,proletariat,无产阶级,NOUN,B2
+woordierig,prolix,冗长的,ADJ,B2
+woordierigheid,prolixity,冗长,NOUN,B2
+verlengen,to prolong,延长,VERB,B2
+prominent,prominent,突出的,ADJ,B2
+belovend,promising,有前途的,ADJ,B2
+promis,promissory note,本票,NOUN,B2
+promotor,promoter,推动者,NOUN,B2
+prompt,promptly,迅速地,ADV,B2
+promulgeren,to promulgate,颁布,VERB,B2
+correctie,proofreading,校对,NOUN,B2
+steunen,to prop,撑,VERB,B2
+propaganda,propaganda,宣传,NOUN,B2
+neiging,propensity,倾向,NOUN,B2
+goed,properly,适当地,ADV,B2
+profeteren,to prophesy,预言,VERB,B2
+verhouding,proportion,比例,NOUN,B2
+voorstellen,to propose,提议,VERB,B2
+voorstel,proposition,主张,NOUN,B2
+fatsoen,propriety,分寸,NOUN,B2
+prozaïsch,prosaic,平淡无奇的,ADJ,B2
+proza,prose,散文,NOUN,B2
+vervolging,prosecution,起诉,NOUN,B2
+vooruitzicht,prospect,前景,NOUN,B2
+welvarend,prosperous,繁荣的,ADJ,B2
+prostituee,prostitute,妓女,NOUN,B2
+hoofdpersonage,protagonist,主角,NOUN,B2
+protectionisme,protectionism,保护主义,NOUN,B2
+beschermend,protective,保护的,ADJ,B2
+eiwit,protein,蛋白质,NOUN,B2
+protest,protest,抗议,NOUN,B2
+demonstrant,protester,示威者,NOUN,B2
+protocol,protocol,协议,NOUN,B2
+spreekwoord,proverb,谚语,NOUN,B2
+bewijs leveren,to provide evidence,举证,VERB,B2
+feedback geven,to provide feedback,反馈,VERB,B2
+voorzien in,to provide for,供应,VERB,B2
+aanbieder,provider,提供者,NOUN,B2
+provinciale weg,provincial highway,省道,NOUN,B2
+bepalingen,provisions,储备,NOUN,B2
+provocatie,provocation,挑衅,NOUN,B2
+provoceren,to provoke,激怒,VERB,B2
+nabijheid,proximity,邻近,NOUN,B2
+voorzichtigheid,prudence,谨慎,NOUN,B2
+psychose,psychosis,精神病,NOUN,B2
+café,pub,酒吧,NOUN,B2
+puberteit,puberty,青春期,NOUN,B2
+publiek,public,公众,NOUN,B2
+openbare orde,public order,治安,NOUN,B2
+volksgezondheid,public welfare,公益性,NOUN,B2
+openbaar,publicly,公开地,ADV,B2
+pulmonaal,pulmonary,肺的,ADJ,B2
+preekstoel,pulpit,讲坛,NOUN,B2
+pols,pulse,脉搏,NOUN,B2
+pomp,pump,泵,NOUN,B2
+punch,punch,拳击,NOUN,B2
+punctueel,punctual,准时的,ADJ,B2
+punctuatie,punctuation,标点符号,NOUN,B2
+punctie,puncture,穿刺,NOUN,B2
+pop,puppet,木偶,NOUN,B2
+welp,puppy,小狗,NOUN,B2
+aankopen,to purchase,购买,VERB,B2
+zuiverheid,purity,纯洁,NOUN,B2
+paarse yin,purple yin,紫阴,NOUN,B2
+nastreven,to pursue,追求,VERB,B2
+geluksdrukker,push luck,太得寸,NOUN,B2
+in orde brengen,to put in order,收拾,VERB,B2
+verwarren,to puzzle,使困惑,VERB,B2
+piramide,pyramid,金字塔,NOUN,B2
+kwartel,quail,鹌鹑,NOUN,B2
+kwalificaties,qualifications,资格,NOUN,B2
+kwalitatief,qualitative,定性的,ADJ,B2
+ruzie maken,to quarrel,争吵,VERB,B2
+ruzie,quarreling,再吵,NOUN,B2
+kwartaal,quarter of a year,季度,NOUN,B2
+kwartaaltijdschrift,quarterly magazine,季刊,NOUN,B2
+kade,quay,码头,NOUN,B2
+zoektocht,quest,探索,NOUN,B2
+vragen,to question,质疑,VERB,B2
+twijfelachtig,questionable,可疑的,ADJ,B2
+vraagstelling,questioning,质问,NOUN,B2
+wachtrij,queue,队列,NOUN,B2
+snel,quickly,迅速地,ADV,B2
+quilt,quilt,被子,NOUN,B2
+quota,quota,配额,NOUN,B2
+citaat,quotation,报价,NOUN,B2
+citeren,to quote,引用,VERB,B2
+rabbi,rabbi,拉比,NOUN,B2
+racket,racket,球拍,NOUN,B2
+glans,radiance,光辉,NOUN,B2
+radiator,radiator,暖气片,NOUN,B2
+radio,radio,收音机,NOUN,B2
+radiostation,radio station,广播电台,NOUN,B2
+radioactief,radioactive,放射性的,ADJ,B2
+radijs,radish,小萝卜,NOUN,B2
+woeden,rage,愤怒,NOUN,B2
+woeden,to rage,狂怒,VERB,B2
+versleten,ragged,破烂的,ADJ,B2
+leuning,railing,栏杆,NOUN,B2
+spoorweg,railway,铁路,NOUN,B2
+regenboog,rainbow,彩虹,NOUN,B2
+regenjas,raincoat,雨衣,NOUN,B2
+regenwoud,rainforest,雨林,NOUN,B2
+donaties ophalen,to raise donations,募捐,VERB,B2
+ram,ram,公羊,NOUN,B2
+ramp,ramp,坡道,NOUN,B2
+willekeurige tirannie,rampant tyranny,横行,NOUN,B2
+rancune,rancor,怨恨,NOUN,B2
+rang,rank,等级,NOUN,B2
+rangschikking,ranking,等级,NOUN,B2
+losgeld,ransom,赎金,NOUN,B2
+snel,rapid,迅速的,ADJ,B2
+rapprochement,rapprochement,和解,NOUN,B2
+rommel,rascal,无赖,NOUN,B2
+uitslag,rash,轻率的,ADJ,B2
+aardbei,raspberry,覆盆子,NOUN,B2
+rat,rat,老鼠,NOUN,B2
+ratdicht,rat-proof,防鼠,ADJ,B2
+beoordeling,rating,评分,NOUN,B2
+rantsoen,ration,配给,NOUN,B2
+rationalisme,rationalism,理性主义,NOUN,B2
+rationaliteit,rationality,理性,NOUN,B2
+rationalisatie,rationalization,合理化,NOUN,B2
+raaf,raven,乌鸦,NOUN,B2
+rauw,raw,生的,ADJ,B2
+straal,ray,光线,NOUN,B2
+scheermes,razor,剃刀,NOUN,B2
+herbruskeheid,re-abruptness,再骤,NOUN,B2
+hergevecht,re-battle,重战,NOUN,B2
+hergrens,re-boundary,重界,NOUN,B2
+herloopbaan,re-course,重途,NOUN,B2
+hercreatie,re-creation,再作,NOUN,B2
+heruitvoering,re-enactment,再演,NOUN,B2
+herbewijs,re-evidence,重据,NOUN,B2
+herfruit,re-fruit,再果,NOUN,B2
+herinner,re-inner,再内,NOUN,B2
+herlaag,re-layering,改层,NOUN,B2
+herlimiet,re-limit,重限,NOUN,B2
+herlogica,re-logic,再逻,NOUN,B2
+herbetekenis,re-meaning,再义,NOUN,B2
+herorde,re-order,重序,NOUN,B2
+herpas,re-pace,重骤,NOUN,B2
+herpad,re-path,重径,NOUN,B2
+herhoeveelheid,re-quantity,再量,NOUN,B2
+herreden,re-reason,重理,NOUN,B2
+herrouting,re-routing,改轨,NOUN,B2
+hersequencing,re-sequencing,改骤,NOUN,B2
+herinzending,re-submission,再上,NOUN,B2
+reactie,reaction,反应,NOUN,B2
+reactief,reactive,反应的,ADJ,B2
+reactor,reactor,反应堆,NOUN,B2
+bereidheid,readiness,准备就绪,NOUN,B2
+lezing,reading,阅读,NOUN,B2
+onroerend,real estate,房地产,ADJ,B2
+realisme,realism,现实主义,NOUN,B2
+echte wens,really want,真要,NOUN,B2
+rijk,realm,领域,NOUN,B2
+achterkant,rear part,后部,NOUN,B2
+redeneren,to reason,推理,VERB,B2
+redenering,reasoning,论证,NOUN,B2
+geruststellen,to reassure,使安心,VERB,B2
+opstandeling,rebel,反叛者,NOUN,B2
+opstand,rebellion,叛乱,NOUN,B2
+opstandig hart,rebellious heart,反心,NOUN,B2
+herbouwen,to rebuild,重建,VERB,B2
+tadel,rebuke,责备,NOUN,B2
+weren,to rebut,反驳,VERB,B2
+tegenwerping,rebuttal,反驳,NOUN,B2
+terugroepen,to recall,回忆,VERB,B2
+post ontvangen,to receive mail,收件,VERB,B2
+opdrachten ontvangen,to receive orders,受命,VERB,B2
+wereldwijde aandacht krijgen,to receive worldwide attention,举世瞩目,VERB,B2
+ontvanger,receiver,接收器,NOUN,B2
+recessie,recession,衰退,NOUN,B2
+wederzijds,reciprocal,互惠的,ADJ,B2
+roekeloos,reckless,鲁莽的,ADJ,B2
+roekeloosheid,recklessness,轻率,NOUN,B2
+terugvorderen,to reclaim,收回,VERB,B2
+ligpositie,reclining,躺下,NOUN,B2
+aanbeveling van anderen,recommendation by others,他荐,NOUN,B2
+verzoenen,to reconcile,和解,VERB,B2
+verzoening,reconciliation,和解,NOUN,B2
+verkenning,reconnaissance,侦察,NOUN,B2
+heroverwegen,to reconsider,重新考虑,VERB,B2
+heroverweging,reconsideration,重思,NOUN,B2
+herconstrueren,to reconstruct,重建,VERB,B2
+heropbouw,reconstruction,重建,NOUN,B2
+record,record,记录,NOUN,B2
+record player,record player,唱机,NOUN,B2
+recount,to recount,转述,VERB,B2
+recruitment,recruitment,招聘,NOUN,B2
+rectify,to rectify,纠正,VERB,B2
+recurrence,recurrence,往复,NOUN,B2
+recusal,recusal,回避,NOUN,B2
+recycling,recycling,回收利用,NOUN,B2
+redefinition,redefinition,改界,NOUN,B2
+referendum,referendum,公民投票,NOUN,B2
+refining,refining,提炼,NOUN,B2
+reflect,to reflect,反映,VERB,B2
+reforestation,reforestation,重新造林,NOUN,B2
+reform,to reform,改革,VERB,B2
+reformism,reformism,改唯,NOUN,B2
+refrain,refrain,副歌,NOUN,B2
+refrain,to refrain,克制,VERB,B2
+refuge,refuge,避难所,NOUN,B2
+refund,refund,退款,NOUN,B2
+refusal,refusal,拒绝,NOUN,B2
+regarding this,regarding this,对此,ADV,B2
+regime,regime,政权,NOUN,B2
+regress,to regress,倒退,VERB,B2
+regression,regression,倒退,NOUN,B2
+regressive,regressive,退步的,ADJ,B2
+regret,to regret,后悔,VERB,B2
+reimburse,to reimburse,偿还,VERB,B2
+reinforce,to reinforce,加强,VERB,B2
+reissue,to reissue,补办,VERB,B2
+reiterate,to reiterate,重申,VERB,B2
+rejection,rejection,拒绝,NOUN,B2
+rejoice,to rejoice,欢欣,VERB,B2
+relapse,relapse,再犯,NOUN,B2
+relate to narrate,to relate to narrate,叙述,VERB,B2
+relatively speaking,relatively speaking,相对而言,ADV,B2
+relativism,relativism,相对主义,NOUN,B2
+ontspanning,relaxation,缓和,NOUN,B2
+gerelaxeerd,relaxed,放松的,ADJ,B2
+degraderen,to relegate,降级,VERB,B2
+relevantie,relevance,相关性,NOUN,B2
+relevant,relevant,相关的,ADJ,B2
+betrouwbaarheid,reliability,可靠性,NOUN,B2
+betrouwbaar,reliable,可靠的,ADJ,B2
+vertrouwen,reliance,信赖,NOUN,B2
+relikwie,relic,圣物,NOUN,B2
+verlichten,to relieve,缓解,VERB,B2
+verhuizen,to relocate,调动,VERB,B2
+ongemakkelijk,reluctantly,不情愿地,ADV,B2
+vertrouwen,to rely,依赖,VERB,B2
+vertrouwen op,to rely on,依靠,VERB,B2
+rest,remainder,剩余部分,NOUN,B2
+middel,remedy,补救措施,NOUN,B2
+herinnering,remembrance,纪念,NOUN,B2
+afstandsbedienbare auto,remote-controlled car,遥控车,NOUN,B2
+verwijdering,removal,移除,NOUN,B2
+vergoeding,remuneration,报酬,NOUN,B2
+renaissance,renaissance,复兴,NOUN,B2
+nier,renal,肾脏的,ADJ,B2
+afspraak,rendezvous,约会,NOUN,B2
+terugschieten,to renege,食言,VERB,B2
+hernieuwbaar,renewable,可再生的,ADJ,B2
+verlenging,renewal,更新,NOUN,B2
+renminbi,renminbi,人民币,NOUN,B2
+faam,renown,声誉,NOUN,B2
+heroperatie,reoperation,再术,NOUN,B2
+reorganisatie,reorganization,重组,NOUN,B2
+reparatie,repair,修理,NOUN,B2
+schadevergoeding,reparation,赔偿,NOUN,B2
+terugbetalen,to repay,偿还,VERB,B2
+terugbetaling,repayment,偿还,NOUN,B2
+herhaald,repeated,反复的,ADJ,B2
+berouwen,to repent,悔改,VERB,B2
+berouw,repentance,悔恨,NOUN,B2
+repercussie,repercussion,反响,NOUN,B2
+herplanning,replanning,再策,NOUN,B2
+antwoord aan Uw Hoogheid,reply to your-highness,回殿下,NOUN,B2
+vertegenwoordiging,representation,代表,NOUN,B2
+vertegenwoordigend,representative,有代表性的,ADJ,B2
+vertegenwoordigendheid,representativeness,代表性,NOUN,B2
+onderdrukken,to repress,镇压,VERB,B2
+onderdrukking,repression,镇压,NOUN,B2
+onderdrukkend,repressive,压制的,ADJ,B2
+herprijzing,reprice,再价,NOUN,B2
+vermaning,reprimand,训斥,NOUN,B2
+verwijt,reproach,责备,NOUN,B2
+reproductie,reproduction,繁殖,NOUN,B2
+republikeins,republican,共和的,ADJ,B2
+afwijzing,repulse,击退,NOUN,B2
+afstotend,repulsive,令人反感的,ADJ,B2
+vereist,required,必需的,ADJ,B2
+herverkoop,resale,转售,NOUN,B2
+redding van een fang,rescue a-fang,救阿方,NOUN,B2
+onderzoeken,to research,研究,VERB,B2
+gelijkenis,resemblance,相似,NOUN,B2
+lijken,to resemble,像,VERB,B2
+boos,resentful,充满愤恨的,ADJ,B2
+ergernis,resentment,愤恨,NOUN,B2
+reservering,reservation,预订,NOUN,B2
+reservaat,reserve,预备,NOUN,B2
+reservoir,reservoir,水库,NOUN,B2
+hervorming,reshaping,改形,NOUN,B2
+wonen,to reside,居住,VERB,B2
+ontslag,resignation,辞职,NOUN,B2
+vastberaden,resolute,坚决的,ADJ,B2
+resonantie,resonance,共鸣,NOUN,B2
+toevlucht,resort,度假胜地,NOUN,B2
+bron,resource,资源,NOUN,B2
+respectvol,respectful deferential,恭敬,ADJ,B2
+respiratoir,respiratory,呼吸的,ADJ,B2
+reageren,to respond to,回应,VERB,B2
+responsiviteit,responsiveness,反应性,NOUN,B2
+restaurant,restaurant,餐厅,NOUN,B2
+restauratie,restoration,恢复,NOUN,B2
+herstellen,to restore,恢复,VERB,B2
+terughoudendheid,restraint,隐忍,NOUN,B2
+beperken,to restrict,限制,VERB,B2
+herstructurering,restructuring,重组,NOUN,B2
+cv,resume,简历,NOUN,B2
+opstanding,resurrection,复活,NOUN,B2
+hervertellen,to retell,转述,VERB,B2
+pensioengaan,to retire,退休,VERB,B2
+gepensioneerd,retired,退休的,ADJ,B2
+pensioen,retirement,退休,NOUN,B2
+terugtrekken,retreat,撤退,NOUN,B2
+terugtrekken,to retreat,撤退,VERB,B2
+opvraging,retrieval,检索,NOUN,B2
+opvragen,to retrieve,取回,VERB,B2
+Qingming,retrieve qingming,拿回青冥,NOUN,B2
+terugkeren,to return first,先回,VERB,B2
+herintypen,retype,再型,NOUN,B2
+hereniging,reunion,重聚,NOUN,B2
+hergebruik,reuse,重用,NOUN,B2
+openbaring,revelation,启示,NOUN,B2
+vereren,to revere,尊敬,VERB,B2
+eerbetoon,reverence,尊敬,NOUN,B2
+omkering,reversal,突变,NOUN,B2
+omgekeerde omvatting,reverse inclusion,反纳,NOUN,B2
+omgekeerde reflectie,reverse reflection,反影,NOUN,B2
+rugzijde,reverse side,反面,NOUN,B2
+terugkeer,reversion,重归,NOUN,B2
+beoordeling,review,回顾,NOUN,B2
+herleven,to revive,复兴,VERB,B2
+herroepen,to revoke,撤销,VERB,B2
+retoriek,rhetoric,修辞,NOUN,B2
+retorisch,rhetorical,修辞的,ADJ,B2
+retorische vraag,rhetorical question,宁非,NOUN,B2
+rijm,rhyme,韵脚,NOUN,B2
+rijk bedeeld,richly endowed by nature,得天独厚,ADJ,B2
+raadsel,riddle,谜语,NOUN,B2
+rijden,to ride,骑,VERB,B2
+rijpauze,ride break,骑破,NOUN,B2
+kloof,rift,裂痕,NOUN,B2
+juist,right,正确的,ADJ,B2
+rechtvaardig,righteous,正直的,ADJ,B2
+rechtvaardige verontwaardiging,righteous indignation,义愤,NOUN,B2
+rechtvaardigheid,righteousness,亦正,NOUN,B2
+stijfheid,rigidity,僵硬,NOUN,B2
+streng,rigorous,严格的,ADJ,B2
+ringweg,ring road,绕城,NOUN,B2
+gerinkel,ringing,铃声,NOUN,B2
+stijging,rise,上涨,NOUN,B2
+leven wagen,to risk life,拼命,VERB,B2
+doodsrisico,risking death,冒死,NOUN,B2
+riskant,risky,危险的,ADJ,B2
+ritueel,ritual,仪式,NOUN,B2
+rivaliteit,rivalry,竞争,NOUN,B2
+rivieroever,riverbank,河岸,NOUN,B2
+verkeersbord,road sign,路标,NOUN,B2
+rondzwerven,to roam,漫游,VERB,B2
+brullen,to roar,咆哮,VERB,B2
+braden,roast,烤肉,NOUN,B2
+braden,to roast,煎烤,VERB,B2
+lam braden,to roast lamb,烤羊,VERB,B2
+rover,robber,强盗,NOUN,B2
+beroving,robbery,抢劫案,NOUN,B2
+robot,robot,机器人,NOUN,B2
+robust,robust,强健的,ADJ,B2
+rotsenborder,rockery,假山,NOUN,B2
+rolmodel,role model,榜样,NOUN,B2
+rollen,to roll,滚动,VERB,B2
+rolluik,roller blind,卷帘,NOUN,B2
+romance,romance,浪漫,NOUN,B2
+daken,to roof,房顶,VERB,B2
+kamergenoot,roommate,室友,NOUN,B2
+wortel,root,根,NOUN,B2
+ongeveer,roughly,大约,ADV,B2
+ruwheid,roughness,粗糙,NOUN,B2
+rond,round,圆的,ADJ,B2
+opwekken,to rouse,唤醒,VERB,B2
+route,route,路线,NOUN,B2
+router,router,路由器,NOUN,B2
+routine,routine,常规,NOUN,B2
+wrijving,rubbing,摩擦,NOUN,B2
+onbeleefd,rude,粗鲁的,ADJ,B2
+onbeleefdheid,rudeness,粗鲁,NOUN,B2
+ruïne,ruin,废墟,NOUN,B2
+ruïnes,ruins,废墟,NOUN,B2
+rechtsstaat,rule of law,法治,NOUN,B2
+loop,run,跑步,NOUN,B2
+aantreffen,to run into,碰见,VERB,B2
+overrijden,to run over,碾过,VERB,B2
+rennen,to run quickly,奔驰,VERB,B2
+joggen,to run to jog,跑步,VERB,B2
+loper,runner,跑步者,NOUN,B2
+lopen,running,进行中的,NOUN,B2
+loopneus,runny nose,流鼻涕,NOUN,B2
+ruptuur,rupture,破裂,NOUN,B2
+haasten,rush,赶往,NOUN,B2
+haasten,to rush,冲,VERB,B2
+rennen,to rush about,奔波,VERB,B2
+Russisch,russian,俄罗斯的,ADJ,B2
+rust,rust,铁锈,NOUN,B2
+roestvrij,rust-proof,防锈,ADJ,B2
+zak,sack,麻袋,NOUN,B2
+opofferen,to sacrifice,牺牲,VERB,B2
+bedroefd,sad sorrowful,悲伤,ADJ,B2
+kluis,safe,保险箱,NOUN,B2
+veiligheidsrapport,safety report,安全报告,NOUN,B2
+doortastend,sagacious,睿智的,ADJ,B2
+zeilen,sailing,航行,NOUN,B2
+sake,sake,缘故,NOUN,B2
+salade,salad,沙拉,NOUN,B2
+verkoop,sales,打折,NOUN,B2
+zout,salty,咸的,ADJ,B2
+verlossing,salvation,拯救,NOUN,B2
+heiligdom,sanctuary,避难所,NOUN,B2
+sandal,sandal,凉鞋,NOUN,B2
+zandstorm,sandstorm,沙尘暴,NOUN,B2
+broodje,sandwich,三明治,NOUN,B2
+gezond verstand,sanity,理智,NOUN,B2
+Sinterklaas,santa claus,圣诞老人,NOUN,B2
+verzadiging,satiety,饱足,NOUN,B2
+satire,satire,讽刺,NOUN,B2
+satirisch,satirical,讽刺的,ADJ,B2
+tevredenheid,satisfaction,满意,NOUN,B2
+bevredigend,satisfactory,令人满意的,ADJ,B2
+besparingen,savings,存款,NOUN,B2
+verlosser,savior,救星,NOUN,B2
+zaag,saw,锯子,NOUN,B2
+afscheid nemen,to say goodbye,告别,VERB,B2
+gezegde,saying,格言,NOUN,B2
+steiger,scaffold,脚手架,NOUN,B2
+verbranden,to scald,烫伤,VERB,B2
+scalpel,scalpel,手术刀,NOUN,B2
+oplichting,scam,骗局,NOUN,B2
+scan,scan,扫描件,NOUN,B2
+litteken,scar,疤痕,NOUN,B2
+schaars,scarce,稀少的,ADJ,B2
+schaarste,scarcity,短缺,NOUN,B2
+verschrikken,to scare,惊吓,VERB,B2
+eng,scary,可怕的,ADJ,B2
+verspreiden,to scatter,分散,VERB,B2
+verspreid,scattered,分散的,ADJ,B2
+landschap,scenery,风景,NOUN,B2
+schema,scheme,计划,NOUN,B2
+schizofrenie,schizophrenia,精神分裂症,NOUN,B2
+geleerde,scholar,学者,NOUN,B2
+beurs,scholarship,奖学金,NOUN,B2
+schools,scholastic,经院哲学的,ADJ,B2
+schaar,scissors,剪刀,NOUN,B2
+schroeiend,scorching,灼热的,ADJ,B2
+score,score,比分,NOUN,B2
+schurk,scoundrel,恶棍,NOUN,B2
+gesel,scourge,灾祸,NOUN,B2
+verkenner,scout,侦察员,NOUN,B2
+schroot,scrap,碎屑,NOUN,B2
+krabben,to scratch,抓,VERB,B2
+afschermen,to screen,筛选,VERB,B2
+scenario,screenplay,剧本,NOUN,B2
+schroevendraaier,screwdriver,螺丝刀,NOUN,B2
+script,script,剧本,NOUN,B2
+toneeltekst,script for play,剧本,NOUN,B2
+gewetensbezwaar,scruple,顾虑,NOUN,B2
+onderzoeken,to scrutinize,仔细检查,VERB,B2
+duiken,scuba diving,潜水,NOUN,B2
+beeldhouwer,sculptor,雕塑家,NOUN,B2
+sculptuur,sculpture,雕塑,NOUN,B2
+meeuw,seagull,海鸥,NOUN,B2
+verzegelen,to seal,密封,VERB,B2
+zoeken,to search for,寻找,VERB,B2
+kruiden,to season,调味,VERB,B2
+seizoensgebonden,seasonal,季节性的,ADJ,B2
+afsplitsen,to secede,脱离,VERB,B2
+afzonderingsuitgang,seclusion exit,出关,NOUN,B2
+tweede keer,second time,再而,NOUN,B2
+ten tweede,secondly,其次,ADV,B2
+geheimhouding,secrecy,保密,NOUN,B2
+geheime bijeenkomst,secret meeting,密会,NOUN,B2
+secretariaat,secretariat,秘书处,NOUN,B2
+sekte,sect,教派,NOUN,B2
+sektarisch,sectarian,宗派的,ADJ,B2
+sector,sector,部门,NOUN,B2
+seculierisme,secularism,世俗主义,NOUN,B2
+zekerstellen,to secure,保护,VERB,B2
+securitisatie,securitization,证券化,NOUN,B2
+beveiligingsagent,security guard,保安,NOUN,B2
+sedan,sedan,轿车,NOUN,B2
+verleiden,to seduce,引诱,VERB,B2
+herzien,to see again,再见,VERB,B2
+lijkaam zien,to see corpse,见尸,VERB,B2
+verwittiging,see off,送走,NOUN,B2
+doorzien,to see through,看穿,VERB,B2
+zoeken,to seek,寻找,VERB,B2
+audience vragen,to seek audience,求见,VERB,B2
+waarheid zoeken in feiten,to seek truth from facts,实事求是,VERB,B2
+zoeken,seeking,寻求,NOUN,B2
+onmiddellijk voordeel nastrevend,seeking instant benefit,急功近利,ADJ,B2
+schijnbaar,seemingly,表面上,ADV,B2
+seismisch,seismic,地震的,ADJ,B2
+grijpen,to seize,抓住,VERB,B2
+selectief,selective,选择的，挑选的,ADJ,B2
+zelf,self,自我,NOUN,B2
+zelfverzekerd,self-confident,自信的,ADJ,B2
+zelfopoffering,self-sacrifice,舍己,NOUN,B2
+egoïstisch,selfish,自私的,ADJ,B2
+verkoper,seller,售货员,NOUN,B2
+semester,semester,学期,NOUN,B2
+seminar,seminar,研讨会,NOUN,B2
+semiologie,semiology,符号学，症状学,NOUN,B2
+semiotica,semiotics,符号学,NOUN,B2
+senioriteit,seniority,资历,NOUN,B2
+voelen,sense,感觉,NOUN,B2
+voelen,to sense,隐约感到,VERB,B2
+zinneloos,senseless,无意义的,ADJ,B2
+verstandig,sensible,明智的,ADJ,B2
+sensor,sensor,传感器,NOUN,B2
+vonnissen,to sentence,判决,VERB,B2
+sentiment,sentiment,情感,NOUN,B2
+wacht,sentry,卫兵,NOUN,B2
+sequentie,sequence,顺序，片段,NOUN,B2
+seren,serene,宁静的,ADJ,B2
+sereniteit,serenity,宁静,NOUN,B2
+sergeant,sergeant,中士,NOUN,B2
+seriemoordenaar,serial killer,连环杀手,NOUN,B2
+preek,sermon,布道,NOUN,B2
+dienaar,servant,仆人,NOUN,B2
+server,server,服务器,NOUN,B2
+dienstverlener,service provider,服务商,NOUN,B2
+serviceweg,service road,辅路,NOUN,B2
+kneerigheid,servility,奴性,NOUN,B2
+sesam,sesame,芝麻,NOUN,B2
+set,set,一套,NOUN,B2
+opbreken,to set off,出发,VERB,B2
+terugslag,setback,挫折,NOUN,B2
+afrekenen,to settle,解决,VERB,B2
+nederzetting,settlement,解决,NOUN,B2
+meerdere,several,几个,DET,B2
+ernstig,severe,严厉的,ADJ,B2
+ernst,severity,严厉,NOUN,B2
+naaien,to sew,缝纫,VERB,B2
+naaiwerk,sewing,缝纫,NOUN,B2
+hut,shack,棚屋,NOUN,B2
+boei,shackle,镣铐,NOUN,B2
+de hand schudden,to shake hands,握手,VERB,B2
+schijn,sham,假冒,NOUN,B2
+schamen,to shame,使羞愧,VERB,B2
+schandelijk,shameful,可耻的,ADJ,B2
+schameloos,shameless,无耻的,ADJ,B2
+shampoo,shampoo,洗发水,NOUN,B2
+vormen,shape,形状,NOUN,B2
+vormen,to shape,塑造,VERB,B2
+aandeelhouder,shareholder,股东,NOUN,B2
+versplinteren,to shatter,粉碎,VERB,B2
+schuur,shed,棚屋,NOUN,B2
+vel,sheet,床单,NOUN,B2
+schil,shell,壳,NOUN,B2
+herder,shepherd,牧羊人,NOUN,B2
+verschuiven,shift,轮班,NOUN,B2
+verschuiven,to shift,改变,VERB,B2
+ploegendienst,shift rotation,倒班,NOUN,B2
+dienstwissel,shift swap,换班,NOUN,B2
+vooruitzetten,to shift to an earlier date,提前,VERB,B2
+glans,shine,光泽,NOUN,B2
+verzenden,to ship out,出货,VERB,B2
+scheepswerf,shipyard,造船厂,NOUN,B2
+schokken,to shock,震惊,VERB,B2
+schoenverwijdering,shoe removal,鞋脱,NOUN,B2
+schoen,shoes,鞋子,NOUN,B2
+duel,shootout,枪战,NOUN,B2
+winkel,shopping,购物,NOUN,B2
+kortetermijn,short-term,短期的,ADJ,B2
+tekortkoming,shortcoming,缺点,NOUN,B2
+afkorting,shortcut,捷径,NOUN,B2
+moeten,should,应该,AUX,B2
+niet moeten,should not,不该,AUX,B2
+schep,shovel,铲子,NOUN,B2
+sluw,shrewd,精明的,ADJ,B2
+heiligtum,shrine,مشعر,NOUN,B2
+beven,shudder,战栗,NOUN,B2
+broers en zusters,siblings,兄弟姐妹,NOUN,B2
+zijdeur,side door,侧门,NOUN,B2
+zeef,sieve,筛子,NOUN,B2
+zeven,to sift,筛选,VERB,B2
+zucht,sigh,叹息,NOUN,B2
+zuchten,to sigh with sorrow,感慨,VERB,B2
+ondertekenen,to sign for,签收,VERB,B2
+betekenis,significance,含义,NOUN,B2
+beduidend,significant,重要的,ADJ,B2
+betekenen,to signify,意味着,VERB,B2
+zwijgen,to silence,خرس,VERB,B2
+stil,silent,沉默的,ADJ,B2
+zijde,silk,丝绸,NOUN,B2
+zijden doek,silk cloth,丝绸,NOUN,B2
+domme meid,silly girl,傻丫头,NOUN,B2
+gelijkenis,similarity,相似,NOUN,B2
+vergelijking,simile,明喻,NOUN,B2
+eenvoud,simplicity,简单,NOUN,B2
+vereenvoudigen,to simplify,简化,VERB,B2
+simulatie,simulation,模拟,NOUN,B2
+gelijktijdig,simultaneous,同时的,ADJ,B2
+zonde,sin,罪,NOUN,B2
+oprechtheid,sincerity,真诚,NOUN,B2
+zingen,singing,歌唱,NOUN,B2
+enkele gedachte,single thought,一念,NOUN,B2
+gootsteen,sink,水槽,NOUN,B2
+slurpen,sip,小口喝,NOUN,B2
+slurpen,to sip,小口喝,VERB,B2
+meneer,sir,郎,PART,B2
+sirene,siren,汽笛,NOUN,B2
+schoonzus,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
+sit down,to sit down,坐下,VERB,B2
+situation circumstances,situation circumstances,情形,NOUN,B2
+skeleton,skeleton,骨架,NOUN,B2
+skeptical,skeptical,怀疑的,ADJ,B2
+skepticism,skepticism,怀疑主义,NOUN,B2
+sketch,sketch,素描,NOUN,B2
+skiing,skiing,滑雪,NOUN,B2
+skilled,skilled,熟练的,ADJ,B2
+slander,slander,诽谤,NOUN,B2
+slander,to slander,诽谤,VERB,B2
+slap,slap,拍击,NOUN,B2
+slap,to slap,打耳光,VERB,B2
+slaughter,slaughter,屠杀,NOUN,B2
+slaughter,to slaughter,割喉,VERB,B2
+sleep,sleep,睡眠,NOUN,B2
+sleeping pill,sleeping pill,安眠药,NOUN,B2
+sleeplessness,sleeplessness,失眠,NOUN,B2
+sleeve,sleeve,袖子,NOUN,B2
+slice,slice,薄片,NOUN,B2
+slide,slide,滑动,NOUN,B2
+slip,to slip,滑倒,VERB,B2
+slipper,slipper,拖鞋,NOUN,B2
+slippery,slippery,滑的,ADJ,B2
+slogan,slogan,口号,NOUN,B2
+slow down,to slow down,放慢,VERB,B2
+slowly,slowly,缓慢地,ADV,B2
+slowness,slowness,缓慢,NOUN,B2
+sluggish,sluggish,迟钝的,ADJ,B2
+sly,sly,狡猾的,ADJ,B2
+slyness,slyness,狡猾,NOUN,B2
+smallest,smallest,最小的,ADJ,B2
+smallness,smallness,小小,NOUN,B2
+smash,to smash,粉碎,VERB,B2
+smashing,smashing,砸过,NOUN,B2
+smattering,smattering,少量,NOUN,B2
+glimlachen,to smile,微笑,VERB,B2
+roken,smoking,吸烟,NOUN,B2
+gladen,to smooth,使光滑,VERB,B2
+vlot,smoothly,顺利,ADV,B2
+smokkelaar,smuggler,走私者,NOUN,B2
+smokkelen,smuggling,走私,NOUN,B2
+slak,snail,蜗牛,NOUN,B2
+wegpakken,to snatch,抢夺,VERB,B2
+slopen,to sneak,潜行,VERB,B2
+snurken,to snore,打鼾,VERB,B2
+snuit,snout,口鼻,NOUN,B2
+sneeuwschaduw,snow shadow,雪影姐姐,NOUN,B2
+sneeuwvlok,snowflake,雪花,NOUN,B2
+doordrenken,to soak,浸透,VERB,B2
+snikken,to sob,啜泣,VERB,B2
+snikken,sobbing,抽泣,NOUN,B2
+sobriëteit,sobriety,清醒,NOUN,B2
+gezellig,sociable,好交际的,ADJ,B2
+sociale arbitrage,social arbitration,社会仲裁,NOUN,B2
+sociale ontwaking,social awakening,社会觉醒,NOUN,B2
+sociale klasse,social class,社会阶层,NOUN,B2
+sociaal compromis,social compromise,社会妥协,NOUN,B2
+sociale afstand,social distancing,社交距离,NOUN,B2
+sociale harmonie,social harmony,社会和谐,NOUN,B2
+sociale identiteit,social identity,社会身份,NOUN,B2
+sociale interactie,social interaction,社会互动,NOUN,B2
+sociale mobilisatie,social mobilization,社会动员,NOUN,B2
+sociale organisatie,social organization,社会组织,NOUN,B2
+sociale praktijk,social practice,社会实践,NOUN,B2
+sociale verzoening,social reconciliation,社会和解,NOUN,B2
+sociale stabiliteit,social stability,社会稳定,NOUN,B2
+sociale statistiek,social statistics,社会统计,NOUN,B2
+sociale stratificatie,social stratification,社会分层,NOUN,B2
+sociale trend,social trend,社会趋势,NOUN,B2
+sociaal vertrouwen,social trust,社会信任,NOUN,B2
+socioloog,sociologist,社会学家,NOUN,B2
+sociologie,sociology,社会学,NOUN,B2
+bank,sofa,沙发,NOUN,B2
+softball,softball,垒球,NOUN,B2
+software,software,软件,NOUN,B2
+verblijf,sojourn,逗留,NOUN,B2
+troost,solace,安慰,NOUN,B2
+soldaat,soldiers,官兵,NOUN,B2
+zool,sole,鞋底,NOUN,B2
+plechtig,solemn,庄严的,ADJ,B2
+soliciteren,to solicit,恳求,VERB,B2
+donaties ophalen,to solicit donations,募捐,VERB,B2
+massa,solid,3D模型 / 实体,NOUN,B2
+solid-state drive,solid-state drive,固态硬盘,NOUN,B2
+monoloog,soliloquy,独白,NOUN,B2
+eenzaamheid,solitude,孤独,NOUN,B2
+solvabiliteit,solvency,偿付能力,NOUN,B2
+oplosmiddel,solvent,溶剂,NOUN,B2
+sommige,some out,出些,NOUN,B2
+hoe dan ook,somehow,以某种方式,ADV,B2
+op een gegeven moment,sometime,在某个时候,ADV,B2
+roet,soot,烟灰,NOUN,B2
+sophisterij,sophistry,诡辩,NOUN,B2
+sorry,sorry,抱歉,ADJ,B2
+sorteren,to sort,分类,VERB,B2
+geluid van activiteit,sound of activity,动静,NOUN,B2
+gezondheid,soundness,好端端,NOUN,B2
+zuur,sour,酸的,ADJ,B2
+zuidelijk leger,southern army,南军,NOUN,B2
+souvenir,souvenir,纪念品,NOUN,B2
+soeverein,sovereign,主权的,ADJ,B2
+soevereiniteit,sovereignty,主权,NOUN,B2
+zaaien,to sow,播种,VERB,B2
+sowing,sowing,播种,NOUN,B2
+space,space,空间,NOUN,B2
+spaceship,spaceship,宇宙飞船,NOUN,B2
+spanish,spanish,西班牙语,NOUN,B2
+spare,to spare,节省,VERB,B2
+spare time,spare time,业余,NOUN,B2
+spark,spark,火花,NOUN,B2
+spasm,spasm,痉挛,NOUN,B2
+spear,spear,长矛,NOUN,B2
+special topic,special topic,专题,NOUN,B2
+specialist,specialist,专家,NOUN,B2
+specialization,specialization,专业化,NOUN,B2
+specialized,specialized,专业的,ADJ,B2
+specialty,specialty,专业,NOUN,B2
+species,species,物种,NOUN,B2
+specification,specification,规格,NOUN,B2
+spectacles,spectacles,眼镜,NOUN,B2
+spectacular,spectacular,壮观的,ADJ,B2
+spectral,spectral,幽灵般的,ADJ,B2
+spectrum,spectrum,光谱,NOUN,B2
+speculation,speculation,推测,NOUN,B2
+spell,spell,咒语,NOUN,B2
+spin,to spin,旋转,VERB,B2
+spirit training,spirit training,练神,NOUN,B2
+spirituality,spirituality,灵性,NOUN,B2
+spit,to spit,吐,VERB,B2
+spiteful,spiteful,怀恨的,ADJ,B2
+splendid,splendid,极好的,ADJ,B2
+splendor,splendor,辉煌,NOUN,B2
+splint,splint,夹板,NOUN,B2
+split,split,分裂,NOUN,B2
+split,to split,分裂,VERB,B2
+sponsorship,sponsorship,赞助,NOUN,B2
+sport,sport,运动,NOUN,B2
+sports car,sports car,跑车,NOUN,B2
+echtgenoot,spouse,配偶,NOUN,B2
+verstuiking,sprain,扭伤,NOUN,B2
+spray,spray,喷雾,NOUN,B2
+sproeien,to sprinkle,撒,VERB,B2
+aanzetten,to spur,激励,VERB,B2
+spion,spy,间谍,NOUN,B2
+ploeg,squad,小队,NOUN,B2
+verspillen,to squander,浪费,VERB,B2
+verspilling,squandering,挥霍,NOUN,B2
+knieën,to squat,蹲,VERB,B2
+knijpen,to squeeze,挤压,VERB,B2
+eekhoorn,squirrel,松鼠,NOUN,B2
+steken,to stab,刺,VERB,B2
+toneelstuk,stage play,舞台剧,NOUN,B2
+wankelen,to stagger,蹒跚,VERB,B2
+stagnatie,stagnation,停滞,NOUN,B2
+stagneren,to stall,拖延,VERB,B2
+postzegel,stamp,邮票,NOUN,B2
+houding,stance,立场,NOUN,B2
+naast elkaar staan,to stand side by side,并列,VERB,B2
+standaardisering,standardization,标准化,NOUN,B2
+staand,standing,站立的,ADJ,B2
+stilstand,standstill,停滞,NOUN,B2
+steranijs,star anise,八角,NOUN,B2
+sterrenhemel,starry sky,星空,NOUN,B2
+verhongeren,to starve,挨饿,VERB,B2
+verklaren,to state,说明,VERB,B2
+statisch,static,静态的,ADJ,B2
+schrijfwaren,stationery,文具,NOUN,B2
+statistisch,statistical,统计的,ADJ,B2
+statistiek,statistics,统计学,NOUN,B2
+status,status,地位,NOUN,B2
+stabiel,steady,稳定的,ADJ,B2
+stomen,steam,蒸汽,NOUN,B2
+stomen,to steam,蒸,VERB,B2
+gevulde stoombol,steamed stuffed bun,包子,NOUN,B2
+sturen,to steer,引导,VERB,B2
+stuurwiel,steering wheel,方向盘,NOUN,B2
+sterk,stellar,杰出的,ADJ,B2
+stenose,stenosis,狭窄,NOUN,B2
+stiefmoeder,stepmother,后母,NOUN,B2
+stap,steps,台阶,NOUN,B2
+stereotype,stereotype,刻板印象,NOUN,B2
+stoven,to stew,炖,VERB,B2
+stijfheid,stiffness,僵硬,NOUN,B2
+stigma,stigma,耻辱,NOUN,B2
+steken,to sting,刺,VERB,B2
+geizigheid,stinginess,吝啬；小气,NOUN,B2
+geizig,stingy,吝啬的,ADJ,B2
+stinken,to stink,发臭,VERB,B2
+stinkend,stinking,发臭的,ADJ,B2
+vaststellen,to stipulate,规定,VERB,B2
+roeren,to stir,搅拌,VERB,B2
+steek,stitch,针脚,NOUN,B2
+aandelenbeurs,stock market,股市,NOUN,B2
+voorraad,stockpile,储备,NOUN,B2
+stoïcisme,stoicism,斯多葛主义,NOUN,B2
+maagpijn,stomachache,肚子痛,NOUN,B2
+stoppen,to stop me,拦我,VERB,B2
+winkel,store,商店,NOUN,B2
+stormachtig,stormy,有暴风雨的,ADJ,B2
+fornuis,stove,炉灶,NOUN,B2
+recht,straight,径直地,ADV,B2
+rechtzetten,to straighten,弄直,VERB,B2
+rechttoe,straightforward,直率的,ADJ,B2
+spannen,strain,压力,NOUN,B2
+spannen,to strain,努力,VERB,B2
+sirene,strait,海峡,NOUN,B2
+vreemde troepen,strange troops,怪兵,NOUN,B2
+vreemdheid,strangeness,奇怪,NOUN,B2
+stranger,stranger,陌生人,NOUN,B2
+strangle,to strangle,扼杀,VERB,B2
+strap,strap,带子,NOUN,B2
+strawberry,strawberry,草莓,NOUN,B2
+stream,stream,溪流,NOUN,B2
+stressed,stressed,焦虑的,ADJ,B2
+stretch,stretch,伸展,NOUN,B2
+stretcher,stretcher,担架,NOUN,B2
+string,string,细绳,NOUN,B2
+strip,strip,条带,NOUN,B2
+stroll,stroll,闲逛,NOUN,B2
+stroll,to stroll,散步,VERB,B2
+stubborn,stubborn,固执的,ADJ,B2
+stuck,stuck,卡住的,ADJ,B2
+studies,studies,学业,NOUN,B2
+stuff,to stuff,填塞,VERB,B2
+stunning,stunning,极好的,ADJ,B2
+stupidity,stupidity,愚蠢,NOUN,B2
+sturdy,sturdy,坚固的,ADJ,B2
+subdue,to subdue,制服,VERB,B2
+subjective,subjective,主观的,ADJ,B2
+subjugate,to subjugate,征服,VERB,B2
+submarine,submarine,潜水艇,NOUN,B2
+submerge,to submerge,淹没,VERB,B2
+submission,submission,顺从,NOUN,B2
+subordinate,subordinate,下属,NOUN,B2
+subscribe,to subscribe,订阅,VERB,B2
+subscriber,subscriber,订阅者,NOUN,B2
+subside,to subside,平息,VERB,B2
+subsidiary,subsidiary,子公司,NOUN,B2
+subsistence,subsistence,生计,NOUN,B2
+substance,substance,物质,NOUN,B2
+substantiation,substantiation,论证,NOUN,B2
+substitute,substitute,替代品,NOUN,B2
+subtitle,subtitle,字幕,NOUN,B2
+voorstad,suburb,郊区,NOUN,B2
+opeenvolging,succession,连续,NOUN,B2
+achtereenvolgens,successively,连续地,ADV,B2
+bezwijken,to succumb,屈服,VERB,B2
+aanklagen,to sue,起诉,VERB,B2
+slapeloosheid lijden,to suffer from insomnia,失眠,VERB,B2
+volstaan,to suffice,足够,VERB,B2
+toereikendheid,sufficiency,充足,NOUN,B2
+stikken,to suffocate,窒息,VERB,B2
+verstikking,suffocation,窒息,NOUN,B2
+top,summit,顶峰,NOUN,B2
+dagvaarding,summons,传票,NOUN,B2
+weelderig,sumptuous,奢华的,ADJ,B2
+zonsopgang,sunrise,日出,NOUN,B2
+zonneschijn,sunshine,阳光,NOUN,B2
+supercomprehensief,super-comprehensive,超遍,NOUN,B2
+supergraad,super-grade,超级,NOUN,B2
+superprincipe,super-principle,超则,NOUN,B2
+superkwaliteit,super-quality,超质,NOUN,B2
+supersysteem,super-system,超制,NOUN,B2
+supergedachte,super-thought,超思,NOUN,B2
+oppervlakkig,superficial,表面的,ADJ,B2
+overbodig,superfluous,多余的,ADJ,B2
+meerdere,superior,更好的,ADJ,B2
+bijgeloof,superstition,迷信,NOUN,B2
+superviseren,to supervise,监督,VERB,B2
+toezichthouder,supervisor,主管,NOUN,B2
+leverancier,supplier,供应商,NOUN,B2
+leveren,supply,供应,NOUN,B2
+leveren,to supply,供货,VERB,B2
+veronderstellen,to suppose,假设,VERB,B2
+onderdrukken,to suppress,压制,VERB,B2
+onderdrukking,suppression,抑,NOUN,B2
+zeker,sure,确定的,ADJ,B2
+stoot,surge,激增,NOUN,B2
+chirurg,surgeon,外科医生,NOUN,B2
+chirurgie,surgery,手术,NOUN,B2
+overtreffen,to surpass,超过,VERB,B2
+overschot,surplus,过剩,NOUN,B2
+surrealisme,surrealism,超现实主义,NOUN,B2
+overgeven,surrender,投降,NOUN,B2
+overgeven,to surrender,投降,VERB,B2
+omgeving,surroundings,周围,NOUN,B2
+toezicht,surveillance,监视,NOUN,B2
+topograaf,surveyor,测量员,NOUN,B2
+overleving,survival,生存,NOUN,B2
+susha,susha,夙砂大,NOUN,B2
+spanning,suspense,悬念,NOUN,B2
+verdenking,suspicion,怀疑,NOUN,B2
+verdacht,suspicious,可疑的,ADJ,B2
+voeding,sustenance,食物,NOUN,B2
+naden,suture,缝合,NOUN,B2
+naden,to suture,缝合,VERB,B2
+moeras,swamp,沼泽,NOUN,B2
+zwaan,swan,天鹅,NOUN,B2
+zwaaien,to sway,摇摆,VERB,B2
+zweten,to sweat,出汗,VERB,B2
+vegen,sweep,扫,NOUN,B2
+vegen,to sweep,打扫,VERB,B2
+snoepje,sweet,糖果,NOUN,B2
+zoete droom,sweet dream,美梦,NOUN,B2
+zoeten,to sweeten,使变甜,VERB,B2
+liefde,sweetheart,爱人,NOUN,B2
+schat,sweetie,亲爱的,NOUN,B2
+bedriegen,to swindle,诈骗,VERB,B2
+fraudeur,swindler,骗子,NOUN,B2
+zwaai,swing,秋千,NOUN,B2
+schakelaar,switch,开关,NOUN,B2
+schakelruimte,switch room,配电室,NOUN,B2
+centrale,switchboard,总机,NOUN,B2
+zwaardloosheid,swordless,剑不,NOUN,B2
+zwaardvechter,swordsman,剑客,NOUN,B2
+sycofantie,sycophancy,阿谀奉承,NOUN,B2
+syllabus,syllabus,教学大纲,NOUN,B2
+symmetrie,symmetry,对称,NOUN,B2
+sympathie,sympathy,同情,NOUN,B2
+symfonie,symphony,交响乐,NOUN,B2
+symposium,symposium,研讨会,NOUN,B2
+symptoom,symptom,症,PART,B2
+symptomatisch,symptomatic,症状的,ADJ,B2
+synchronisatie,synchronization,同步,NOUN,B2
+synchronisch,synchronous,同步的,ADJ,B2
+synergie,synergy,协同效应,NOUN,B2
+synoniem,synonymy,同义关系,NOUN,B2
+syntaxis,syntax,句法,NOUN,B2
+synthese,synthesis,综合,NOUN,B2
+siroop,syrup,糖浆,NOUN,B2
+systemisch,systemic,全身性的,ADJ,B2
+taboe,taboo,禁忌,NOUN,B2
+taciet,tacit,心照不宣的,ADJ,B2
+taciet,tacitly,默不作声地,ADV,B2
+teruggetrokken,taciturn,沉默寡言的,ADJ,B2
+tactiek,tactic,策略,NOUN,B2
+tactiek,tactics,战术,NOUN,B2
+naaier,tailor,裁缝,NOUN,B2
+verlof nemen,to take a leave of absence,休学,VERB,B2
+wegnemen,to take away,拿走,VERB,B2
+passen op,to take care,照顾,VERB,B2
+zorgen voor,to take care of,照顾,VERB,B2
+stekken nemen,to take cuttings,扦插,VERB,B2
+afnemen,to take off,起飞,VERB,B2
+ambt aanvaarden,to take office,就职,VERB,B2
+uitnemen,to take out,拿出,VERB,B2
+opstijgen,takeoff,起飞,NOUN,B2
+neming,taking,拍摄,NOUN,B2
+gesprek,talk,谈话,NOUN,B2
+onzin uitpraten,to talk nonsense,胡言乱语,VERB,B2
+spraakzaam,talkative,健谈的,ADJ,B2
+spraakzaamheid,talkativeness,多嘴,NOUN,B2
+lang,tall,高的,ADJ,B2
+temmen,to tame,驯服,VERB,B2
+bruinen,to tan,晒黑,VERB,B2
+tangent,tangent,切线,NOUN,B2
+tank,tank,坦克,NOUN,B2
+looiër,tanner,制革工,NOUN,B2
+looi,tanning,晒黑,NOUN,B2
+michelen,to target,针对,VERB,B2
+micheling,targeting,定位,NOUN,B2
+tarief,tariff,费率,NOUN,B2
+smaakvoorkeur,taste preference,口味,NOUN,B2
+strak,taut,绷紧的,ADJ,B2
+taverne,tavern,酒馆,NOUN,B2
+belasten,to tax,征税,VERB,B2
+belastingvrij,tax-exempt,免税,ADJ,B2
+taxi,taxi,出租车,NOUN,B2
+theeplantage,tea plantation,茶园,NOUN,B2
+onderwijzen,to teach,教,VERB,B2
+onderwijs,teaching,教学,NOUN,B2
+teamgenoot,teammate,队友,NOUN,B2
+toren,to tear,撕碎,VERB,B2
+opscheuren,to tear up,流泪,VERB,B2
+tranen,tears,眼泪,NOUN,B2
+technicus,technician,技术员,NOUN,B2
+techniek,technique,技巧,NOUN,B2
+technocratie,technocracy,技术官僚主义,NOUN,B2
+saai,tedious,乏味的,ADJ,B2
+teleologie,teleology,目的论,NOUN,B2
+telescoop,telescope,望远镜,NOUN,B2
+temperament,temper,脾气,NOUN,B2
+temperament,temperament,气质,NOUN,B2
+tijdelijk,temporarily,临时地,ADV,B2
+tijdelijke weigering,temporary refusal,暂不,NOUN,B2
+vasthoudend,tenacious,顽强的,ADJ,B2
+huurder,tenant,租户,NOUN,B2
+tenderloin,tenderloin,里脊,NOUN,B2
+pees,tendon,肌腱,NOUN,B2
+tennis,tennis,网球,NOUN,B2
+gespannen,tense,紧张的,ADJ,B2
+tentatief,tentative,暂定的,ADJ,B2
+terminaal,terminal,终点站,NOUN,B2
+beëindiging,termination,解除,NOUN,B2
+terminologie,terminology,术语,NOUN,B2
+terrestrisch,terrestrial,地球的,ADJ,B2
+ontzitten,to terrify,使恐惧,VERB,B2
+angstaanjagend,terrifying,令人恐惧的,ADJ,B2
+territoriaal,territorial,领土的,ADJ,B2
+terrorist,terrorist,恐怖分子,NOUN,B2
+testikel,testicle,睾丸,NOUN,B2
+tekstbericht,text message,短信,NOUN,B2
+leerboek,textbook,教科书,NOUN,B2
+textiel,textile,纺织,NOUN,B2
+dan,than,比,ADP,B2
+dank,thanks,谢谢,INTJ,B2
+dat,that,（引导从句）,SCONJ,B2
+die pijl,that arrow,那一箭,NOUN,B2
+dat wil zeggen,that is,即,ADV,B2
+zo,that way,那样,PRON,B2
+doen,to thaw,解冻,VERB,B2
+de rest,the rest,其余,NOUN,B2
+dan jij,then you,那你,PRON,B2
+theocratie,theocracy,神权政治,NOUN,B2
+theologie,theology,神学,NOUN,B2
+stelling,theorem,定理,NOUN,B2
+theoretisch,theoretically,理论上,ADV,B2
+there,there,那儿,NOUN,B2
+there's still time,to there's still time,来得及,VERB,B2
+thereby,thereby,从而,ADV,B2
+thereupon,thereupon,随后,ADV,B2
+these,these,这些,DET,B2
+these three,these three,这三,NOUN,B2
+thesis,thesis,论文,NOUN,B2
+they things,they things,它们,PRON,B2
+thickness,thickness,厚度,NOUN,B2
+thief presence,thief presence,有贼,NOUN,B2
+thigh,thigh,大腿,NOUN,B2
+think to want,to think to want,想,VERB,B2
+thinking,thinking,思维,NOUN,B2
+thinness,thinness,瘦,NOUN,B2
+third,third,三分之一,NOUN,B2
+third bestowal,third bestowal,三授,NOUN,B2
+thirsty,thirsty,口渴的,ADJ,B2
+this,this,您这,NOUN,B2
+this battle,this battle,此战,NOUN,B2
+this item,this item,这件,NOUN,B2
+this way,this way,这样,PRON,B2
+this-camp,this-camp,这营,NOUN,B2
+those,those,那些,DET,B2
+thoughtful,thoughtful,体贴的,ADJ,B2
+thread,thread,线,NOUN,B2
+three-d printing,three-d printing,3D打印,NOUN,B2
+threshold,threshold,门槛,NOUN,B2
+thrifty,thrifty,节俭的,ADJ,B2
+throw,throw,投掷,NOUN,B2
+thrust,thrust,猛推,NOUN,B2
+thrust toward,thrust toward,插向,NOUN,B2
+thug,thug,暴徒,NOUN,B2
+thwart,to thwart,阻挠,VERB,B2
+tidal,tidal,潮汐,ADJ,B2
+opruimen,to tidy up,整理,VERB,B2
+binden,tie,领带,NOUN,B2
+binden,to tie,联结,VERB,B2
+vastbinden,to tie up,绑,VERB,B2
+stevige greep,tight grip,手握紧,NOUN,B2
+aanspannen,to tighten,紧握/收紧,VERB,B2
+tegel,tile,瓦片,NOUN,B2
+betegeling,tiling,铺瓷砖,NOUN,B2
+keer,times,倍,NOUN,B2
+verlegenheid,timidity,胆怯,NOUN,B2
+timing,timing,时机,NOUN,B2
+blik,tin,锡,NOUN,B2
+tinteling,tingling,麻木感,NOUN,B2
+klein,tiny,微小的,ADJ,B2
+punt,tip,提示,NOUN,B2
+vermoeien,to tire,使疲倦,VERB,B2
+vermoeidheid,tiredness,疲劳,NOUN,B2
+weefsel,tissue,组织,NOUN,B2
+tiende,tithe,什一税,NOUN,B2
+vandaag,today,今天,NOUN,B2
+tofu,tofu,豆腐,NOUN,B2
+arbeid,toil,苦工,NOUN,B2
+tolerantie,tolerance,宽容,NOUN,B2
+graf,tomb,坟墓,NOUN,B2
+ton,ton,吨,NOUN,B2
+vanavond,tonight,今晚,NOUN,B2
+te,too,太,ADV,B2
+weekheid,too soft,太软,NOUN,B2
+gereedschapskamer,tool room,工具间,NOUN,B2
+gereedschap,tools,工具,NOUN,B2
+tandpijn,toothache,牙痛,NOUN,B2
+tandpasta,toothpaste,牙膏,NOUN,B2
+top,top,顶部,NOUN,B2
+toplaag,top dressing,追肥,NOUN,B2
+onderwerp,topic,话题,NOUN,B2
+topografie,topography,地形,NOUN,B2
+fakkel,torch,手电筒,NOUN,B2
+tornado,tornado,龙卷风,NOUN,B2
+stortvloed,torrent,激流,NOUN,B2
+torsie,torsion,扭转,NOUN,B2
+martelen,to torture,折磨,VERB,B2
+totaal,totally,完全地,ADV,B2
+tastbaarheid,touchability,能触摸,NOUN,B2
+rondreis,tour,旅行,NOUN,B2
+toeristisch,touristic,旅游的,ADJ,B2
+naar,toward,朝向,ADP,B2
+gemeentehoofd,township head,乡长,NOUN,B2
+speelgoed,toy,玩具,NOUN,B2
+spoor,trace,痕迹,NOUN,B2
+volgen,to track,追踪,VERB,B2
+tractor,tractor,拖拉机,NOUN,B2
+verkeersbeperking,traffic restriction,限行,NOUN,B2
+tragedie,tragedy,悲剧,NOUN,B2
+tragisch,tragic,悲剧的,ADJ,B2
+aanhangwagen,trailer,预告片,NOUN,B2
+treinstation,train station,火车站,NOUN,B2
+stagiair,trainee,实习生,NOUN,B2
+kenmerk,trait,特征,NOUN,B2
+verrader,traitor,叛徒,NOUN,B2
+vertrappen,to trample,踩踏,VERB,B2
+rustig,tranquil,宁静的,ADJ,B2
+transbesluit,trans-decision,超断,NOUN,B2
+transgast,trans-guest,超客,NOUN,B2
+transzaak,trans-matter,超物,NOUN,B2
+transactie,transaction,交易,NOUN,B2
+transcendentie,transcendence,超越,NOUN,B2
+transcendent,transcendent,卓越的,ADJ,B2
+overtreding,transgression,违犯,NOUN,B2
+overgangs-,transitional,过渡的,ADJ,B2
+transmissie,transmission,传输,NOUN,B2
+transmission to you,transmission to you,传你,NOUN,B2
+transmit,to transmit,传输,VERB,B2
+transparent,transparent,透明的,ADJ,B2
+trap,trap,陷阱,NOUN,B2
+trash,trash,垃圾,NOUN,B2
+travel,travel,出行,NOUN,B2
+travel fatigue,travel fatigue,车马劳顿,NOUN,B2
+tray,tray,托盘,NOUN,B2
+treacherous,treacherous,背叛的,ADJ,B2
+treachery,treachery,背叛,NOUN,B2
+tread,to tread,踏上,VERB,B2
+treason,treason,叛国罪,NOUN,B2
+treasure,treasure,财宝,NOUN,B2
+treasury,treasury,国库,NOUN,B2
+treat guests,to treat guests,请客,VERB,B2
+tremble,to tremble,颤抖,VERB,B2
+tremor,tremor,颤抖,NOUN,B2
+trench,trench,沟渠,NOUN,B2
+trend,trend,趋势,NOUN,B2
+trial,trial,试验,NOUN,B2
+tributary,tributary,支流,NOUN,B2
+trick,trick,诡计,NOUN,B2
+trick,to trick,欺骗,VERB,B2
+trifle,trifle,琐事,NOUN,B2
+trigger,trigger,触发器,NOUN,B2
+trigger,to trigger,触发,VERB,B2
+triple,triple,三倍的,ADJ,B2
+triviality,triviality,琐碎,NOUN,B2
+troop,troop,部队,NOUN,B2
+trophy,trophy,奖杯,NOUN,B2
+trouble,to trouble,有劳,VERB,B2
+troublesome,troublesome,麻烦的,ADJ,B2
+troupe,troupe,剧团,NOUN,B2
+truce,truce,休战,NOUN,B2
+true concession,true concession,真让,NOUN,B2
+Ware vorm,true form,原形,NOUN,B2
+Oprecht hart,true heart,本心,NOUN,B2
+Trompet,trumpet,小号,NOUN,B2
+Koffer,trunk,树干,NOUN,B2
+Vertrouwen,trust,信托,NOUN,B2
+zich inspannen,to try hard to,力图,VERB,B2
+Tonijn,tuna,金枪鱼,NOUN,B2
+Tuniek,tunic,束腰外衣,NOUN,B2
+Tunnel,tunnel,隧道,NOUN,B2
+Beroering,turmoil,混乱,NOUN,B2
+omdraaien,to turn around,转身,VERB,B2
+Richtingaanwijzer,turn signal,转向灯,NOUN,B2
+Keerpunt,turning point,转折点,NOUN,B2
+Raap,turnip,芜菁,NOUN,B2
+Schildpad,turtle,海龟,NOUN,B2
+Voogdij,tutelage,监护,NOUN,B2
+Bijles,tutoring,补习,NOUN,B2
+Schemering,twilight,暮光,NOUN,B2
+draaien,to twist,扭曲,VERB,B2
+Twee dieren,two animals,两只,NUM,B2
+Tweerichtingsstraat,two-way street,双行道,NOUN,B2
+Type,type,类型,NOUN,B2
+Tyfoon,typhoon,台风,NOUN,B2
+Tirannie,tyranny,暴政,NOUN,B2
+Tiran,tyrant,暴君,NOUN,B2
+Lelijkheid,ugliness,丑陋,NOUN,B2
+Zweer,ulcer,溃疡,NOUN,B2
+Ulceratie,ulceration,溃疡,NOUN,B2
+uiteindelijk,ultimately,最终,ADV,B2
+Paraplu,umbrella,雨伞,NOUN,B2
+onaanvaardbaar,unacceptable,不可接受的,ADJ,B2
+onbereikbaar,unattainable,难以获得的,ADJ,B2
+ondraaglijk,unbearable,难以忍受的,ADJ,B2
+ongelooflijk,unbelievable,难以置信的,ADJ,B2
+bewusteloos,unconscious,无意识的,ADJ,B2
+onbeheersbaar,uncontrollable,无法控制的,ADJ,B2
+ongekoeld,uncooled,未寒,NOUN,B2
+onthullen,to uncover,揭露,VERB,B2
+onontkenbaar,undeniable,不可否认的,ADJ,B2
+onderschatten,to underestimate,低估,VERB,B2
+onderschatting,underestimation,小看,NOUN,B2
+student,undergraduate,本科生,NOUN,B2
+ondermijnen,to undermine,破坏,VERB,B2
+onderbroek,underpants,内裤,NOUN,B2
+begrip,understanding,理解,NOUN,B2
+onderneming,undertaking,事业,NOUN,B2
+ondertekenen,to underwrite,承保,VERB,B2
+onrust,unease,不安,NOUN,B2
+onrustig,uneasy,不安的,ADJ,B2
+werkloos,unemployed,失业的,ADJ,B2
+ongelijk,unequal,不平等的,ADJ,B2
+onverwacht,unexpectedly,出乎意料地,ADV,B2
+ontvouwen,to unfold,展开,VERB,B2
+onfortuinlijk,unfortunate,不幸的,ADJ,B2
+onvoorstelbaar,unimaginable,难以想象的,ADJ,B2
+onbelangrijk,unimportant,不重要的,ADJ,B2
+unionisme,unionism,工会主义,NOUN,B2
+uniciteit,uniqueness,独特,NOUN,B2
+verenigd,united,联合的,ADJ,B2
+universele toepasbaarheid,universal applicability,普适性,NOUN,B2
+universaliteit,universality,普遍性,NOUN,B2
+onrechtvaardig,unjust,不公正的,ADJ,B2
+loslaten,to unleash,释放,VERB,B2
+onwaarschijnlijk,unlikely,不太可能的,ADJ,B2
+ongelukkig,unlucky,倒霉的,ADJ,B2
+uitpakken,to unpack,拆包,VERB,B2
+onprettig,unpleasant,令人不快的,ADJ,B2
+onvoorspelbaar,unpredictable,不可预测的,ADJ,B2
+onverstoord,unruffled,从容,ADJ,B2
+instabiel,unstable,不稳定的,ADJ,B2
+ontbinden,to untie,解开,VERB,B2
+ongewoon,unusual,不寻常的,ADJ,B2
+onthulling,unveiling ceremony,揭幕仪式,NOUN,B2
+ongewilligheid,unwillingness,不甘,NOUN,B2
+onwaardigheid,unworthy,你不配,NOUN,B2
+omhoog,up,向上,ADV,B2
+tot,up to,为止,ADP,B2
+upgraden,to upgrade,升级,VERB,B2
+oprecht,upright,正直的,ADJ,B2
+opstand,uprising,起义,NOUN,B2
+oproer,uproar,骚动,NOUN,B2
+uitworteling,uprooting,背井离乡,NOUN,B2
+opwaarts,upturn,好转,NOUN,B2
+dringen,to urge,强烈要求,VERB,B2
+urgentie,urgency,紧急,NOUN,B2
+Verenigde Staten,us,你我,NOUN,B2
+gebruiken,to use chopsticks,动筷,VERB,B2
+gebruiken,to use crutches,拄拐,VERB,B2
+nuteloos,useless,无用的,ADJ,B2
+vruchtgebruik,usufruct,用益权,NOUN,B2
+utilitair,utilitarian,功利的,ADJ,B2
+utilitarisme,utilitarianism,功利主义,NOUN,B2
+benutten,to utilize,利用,VERB,B2
+uiterste,utmost,你尽,NOUN,B2
+uitspraak,utterance,话语,NOUN,B2
+vacant,vacant,空缺的,ADJ,B2
+vakantie,vacation,假期,NOUN,B2
+inenten,to vaccinate,接种疫苗,VERB,B2
+inenting,vaccination,疫苗接种,NOUN,B2
+vaccin,vaccine,疫苗,NOUN,B2
+heldhaftig,valiant,英勇的,ADJ,B2
+moed,valor,勇气,NOUN,B2
+waardering,valuation,估值,NOUN,B2
+vampier,vampire,吸血鬼,NOUN,B2
+bestelbus,van,货车,NOUN,B2
+Voorhoede,vanguard,先锋,NOUN,B2
+verdwijnen,to vanish,消失,VERB,B2
+Ijdelheid,vanity,虚荣,NOUN,B2
+Variabele,variable,变量,NOUN,B2
+Variëteit,variety,种类,NOUN,B2
+Verschillende afdelingen,various departments,各部,NOUN,B2
+uitgestrekt,vast,巨大的,ADJ,B2
+Moestuin,vegetable garden,果园,NOUN,B2
+Voertuigregistratie,vehicle registration,行驶证,NOUN,B2
+Ader,vein,静脉,NOUN,B2
+eerbiedwaardig,venerable,值得尊敬的,ADJ,B2
+Verering,veneration,崇敬,NOUN,B2
+Wraak,vengeance,报复,NOUN,B2
+Ventilatie,ventilation,通风,NOUN,B2
+Locatie,venue,场地,NOUN,B2
+Breedsprakigheid,verbosity,冗长,NOUN,B2
+verifiëren,to verify,核实,VERB,B2
+Ongedierte,vermin,害兽,NOUN,B2
+lentig,vernal,春季的,ADJ,B2
+bedreven,versed,精通的,ADJ,B2
+verticaal,vertical,垂直的,ADJ,B2
+Vat,vessel,船,NOUN,B2
+Vest,vest,背心,NOUN,B2
+Veteraan,veteran,老手,NOUN,B2
+Veto,veto,否决,NOUN,B2
+Trilling,vibration,振动,NOUN,B2
+Ondeugd,vice,恶习,NOUN,B2
+Nabijheid,vicinity,附近,NOUN,B2
+Videodisc,video disc,影碟,NOUN,B2
+Video-opname,video recording,录像,NOUN,B2
+wedijveren,to vie,竞争,VERB,B2
+Wake,vigil,守夜,NOUN,B2
+Waakzaamheid,vigilance,警惕,NOUN,B2
+Vitaliteit,vigor,活力,NOUN,B2
+verachtelijk,vile,卑鄙的,ADJ,B2
+villa,villa,别墅,NOUN,B2
+dorpsvoorman,village head,村长,NOUN,B2
+schurk,villain,反派,NOUN,B2
+rank,vine,藤蔓,NOUN,B2
+azijn,vinegar,醋,NOUN,B2
+schenden,to violate,违反,VERB,B2
+discipline schenden,to violate discipline,违纪,VERB,B2
+overtreding,violation,侵越,NOUN,B2
+viool,violin,小提琴,NOUN,B2
+deugd,virtue,美德,NOUN,B2
+virus,virus,病毒,NOUN,B2
+visum,visa,签证,NOUN,B2
+viskeus,viscous,黏稠的,ADJ,B2
+levendig,vivid,生动的,ADJ,B2
+vocaal,vocal,直言的,ADJ,B2
+vluchtig,volatile,易变的,ADJ,B2
+vrijwillig,voluntarily,自愿地,ADV,B2
+overgeven,to vomit,呕吐,VERB,B2
+wervel,vortex,漩涡,NOUN,B2
+stem,vote,投票,NOUN,B2
+stemmen,voting,投票,NOUN,B2
+voucher,voucher,代金券,NOUN,B2
+belofte,vow,誓言,NOUN,B2
+vulgair,vulgar,粗俗的,ADJ,B2
+vulgariteit,vulgarity,粗俗,NOUN,B2
+oorlog voeren,to wage war,作战,VERB,B2
+loon,wages,工资,NOUN,B2
+wenen,to wail,哀号,VERB,B2
+taille,waist,腰,NOUN,B2
+wacht,wait,等待,NOUN,B2
+wacht op mij,wait for me,等我,NOUN,B2
+lang wachten,to wait long,久等,VERB,B2
+wachtkamer,waiting room,候诊室,NOUN,B2
+serveerster,waitress,女服务员,NOUN,B2
+wakker worden,to wake up,叫醒,VERB,B2
+wander,to wander,漫步,VERB,B2
+wandering,wandering,漫游,NOUN,B2
+want to lure,want to lure,想引,NOUN,B2
+want to need will,to want to need will,要,VERB,B2
+wanted,wanted,故意的,ADJ,B2
+ward,ward,病房,NOUN,B2
+warden,warden,看守人,NOUN,B2
+wardrobe,wardrobe,衣柜,NOUN,B2
+warm,warm,温暖的,ADJ,B2
+warming,warming,变暖,NOUN,B2
+was,to was,是,VERB,B2
+washing,washing,洗涤,NOUN,B2
+washing machine,washing machine,洗衣机,NOUN,B2
+wasteland,wasteland,荒地,NOUN,B2
+watch,to watch,观看,VERB,B2
+water,to water,浇水,VERB,B2
+water falling,water falling,水落,NOUN,B2
+water spinach,water spinach,空心菜,NOUN,B2
+watercolor,watercolor,水彩画,NOUN,B2
+waterfall,waterfall,瀑布,NOUN,B2
+watermelon,watermelon,西瓜,NOUN,B2
+watermelon seed,watermelon seed,西瓜子,NOUN,B2
+way out,way out,出路,NOUN,B2
+we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
+we two,we two,我俩,PRON,B2
+weakness,weakness,弱点,NOUN,B2
+wean,to wean,断奶,VERB,B2
+weaning,weaning,断奶,NOUN,B2
+weariness,weariness,疲倦,NOUN,B2
+weather,weather,天气,NOUN,B2
+weave,to weave,编织,VERB,B2
+weaving,weaving,编织,NOUN,B2
+website,website,网站,NOUN,B2
+wedding anniversary,wedding anniversary,结婚纪念日,NOUN,B2
+wedding photo,wedding photo,婚纱照,NOUN,B2
+weeknummer,week number,周次,NOUN,B2
+weekdag,weekday,工作日,NOUN,B2
+weektest,weekly test,周测,NOUN,B2
+vreemdeling,weirdo,怪人,NOUN,B2
+welkom,welcome,欢迎,NOUN,B2
+welkomstbanket,welcome banquet,欢迎宴,NOUN,B2
+lassen,welding,焊接,NOUN,B2
+welzijn,welfare,福利,NOUN,B2
+bekend,well-known,众所周知的,ADJ,B2
+westelijke regio,western regions,西域,NOUN,B2
+moeras,wetland,湿地,NOUN,B2
+walvis,whale,鲸鱼,NOUN,B2
+wat,what,什么,ADV,B2
+tarwe,wheat,小麦,NOUN,B2
+wanneer,when,当...时,SCONJ,B2
+verblijfplaats,whereabouts,行踪,NOUN,B2
+of,whether,能否,NOUN,B2
+of,whether or not,是否,SCONJ,B2
+welke,which,哪个,DET,B2
+welke,which one,哪一个,PRON,B2
+poos,while,一会儿,NOUN,B2
+capriool,whim,突发奇想,NOUN,B2
+zweep,to whip,鞭打,VERB,B2
+wervelwind,whirlwind,旋风；漩涡,NOUN,B2
+fluistering,whisper,低语,NOUN,B2
+wereld,whole world,全世界,NOUN,B2
+wie,whom,谁,PRON,B2
+wiens,whose,谁的,PRON,B2
+verbreden,to widen,加宽,VERB,B2
+wijdverbreid,widespread,广泛的,ADJ,B2
+wild,wild,野生的,ADJ,B2
+zullen,will,将要,AUX,B2
+wilful,willful,任性的,ADJ,B2
+willen,willing,肯,AUX,B2
+bereidheid,willingness,乐意,NOUN,B2
+waaien,to wind,缠绕,VERB,B2
+raamglas,window glass,窗玻璃,NOUN,B2
+wijnglas,wine cup,这酒盏,NOUN,B2
+knipperen,to wink,眨眼,VERB,B2
+winnen,to winnow,筛选,VERB,B2
+vegen,to wipe,擦,VERB,B2
+wisser,wiper,雨刷,NOUN,B2
+draadloos,wireless,无线的,ADJ,B2
+heks,witch,女巫,NOUN,B2
+met moeite,with difficulty,困难地,ADV,B2
+terugtrekking,withdrawal,撤回,NOUN,B2
+binnen,within,在……之内,ADP,B2
+getuigen,to witness,目击,VERB,B2
+getuigenis,witness testimony,人证,NOUN,B2
+geest,wits,心眼,NOUN,B2
+geestig,witty,机智的,ADJ,B2
+tovenaar,wizard,巫师,NOUN,B2
+wolf,wolf,狼,NOUN,B2
+niet doen,won't do,不行,ADJ,B2
+niet doen,to won't do,不成,VERB,B2
+wonderen,wonder,奇迹,NOUN,B2
+wonderen,to wonder,觉得奇怪,VERB,B2
+wonderbaar,wonderful,极好的,ADJ,B2
+houtoor,wood ear mushroom,木耳,NOUN,B2
+bos,woodland,林地,NOUN,B2
+wol,wool,羊毛,NOUN,B2
+strijden,to work hard for sth to strive for success,争气,VERB,B2
+uitwerken,to work out,成功,VERB,B2
+wereldbeeld,worldview,世界观,NOUN,B2
+worm,worm,虫,NOUN,B2
+bezorgd,worried,担心的,ADJ,B2
+zorgen,worry,担忧,NOUN,B2
+zorgen,to worry,担心,VERB,B2
+slechter,worse,更糟的,ADJ,B2
+worsen,to worsen,恶化,VERB,B2
+worship,worship,崇拜,NOUN,B2
+worship,to worship,崇拜,VERB,B2
+wound,to wound,使受伤,VERB,B2
+wounded,wounded,受伤的,ADJ,B2
+wrap,to wrap,包裹,VERB,B2
+wrapping,wrapping,包装,NOUN,B2
+wrath,wrath,愤怒,NOUN,B2
+wreck,wreck,残骸,NOUN,B2
+wrest,to wrest,强行夺取,VERB,B2
+wrestling,wrestling,摔跤,NOUN,B2
+wretch,wretch,令人厌恶的人,NOUN,B2
+wrinkle,wrinkle,皱纹,NOUN,B2
+wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
+writing,writing,文字,NOUN,B2
+written,written,书面的,ADJ,B2
+wrong,wrong,错误的事,NOUN,B2
+wrong mistake,wrong mistake,错误,ADJ,B2
+wudang,wudang,武当,NOUN,B2
+yard,yard,院子,NOUN,B2
+yawn,to yawn,打哈欠,VERB,B2
+yearn for,to yearn for,渴望,VERB,B2
+yearning,yearning,向往,NOUN,B2
+years,years,数年,NOUN,B2
+yeast,yeast,酵母,NOUN,B2
+yell,to yell,大吼,VERB,B2
+yes,yes,是啊,NOUN,B2
+yesterday,yesterday,بارحة,NOUN,B2
+yield,to yield,产出,VERB,B2
+yoga,yoga,瑜伽,NOUN,B2
+yogurt,yogurt,酸奶,NOUN,B2
+you can,you can,您能,NOUN,B2
+you cannot live,you cannot live,你也活不,NOUN,B2
+you plural,you plural,你们,PRON,B2
+you polite,you polite,您,PRON,B2
+jongheer,young master,少庄主,NOUN,B2
+jongeling,youngster,年少者,NOUN,B2
+lach,your laugh,你笑,NOUN,B2
+majesteit,your majesty,陛下,NOUN,B2
+yuanxiao,yuanxiao,元宵,NOUN,B2
+zenit,zenith,顶点,NOUN,B2
+Zhuanghe,zhuang he,庄郃,NOUN,B2
+zink,zinc,锌,NOUN,B2
+dierenteken,zodiac sign,属相,NOUN,B2
+zombie,zombie,僵尸,NOUN,B2
+zone,zone,区域,NOUN,B2
+courgette,zucchini,西葫芦,NOUN,B2
+cushion,cushion,垫子,NOUN,B2
+peremptory,peremptory,专横的,ADJ,B2
+availability,availability,可用性,NOUN,B2
+to intrigue,to intrigue,激起兴趣,VERB,B2
+to bombard,to bombard,轰炸,VERB,B2
+to digress,to digress,离题,VERB,B2
+to exasperate,to exasperate,激怒,VERB,B2
+gullible,gullible,易受骗的,ADJ,B2
+baroness,baroness,女男爵,NOUN,B2
+conquest,conquest,征服,NOUN,B2
+to evict,to evict,驱逐,VERB,B2
+abyss,abyss,深渊,NOUN,B2
+cruise,cruise,巡航,NOUN,B2
+prophecy,prophecy,预言,NOUN,B2
+sacred,sacred,神圣的,ADJ,B2
+sterile,sterile,无菌的,ADJ,B2
+to evangelize,to evangelize,传福音,VERB,B2
+calling,calling,使命,NOUN,B2
+to disembark,to disembark,下船,VERB,B2
+to frequent,to frequent,常去,VERB,B2
+to encompass,to encompass,包含,VERB,B2
+ardor,ardor,热情,NOUN,B2
+to gild,to gild,镀金,VERB,B2
+to exhume,to exhume,掘出,VERB,B2
+to exempt,to exempt,免除,VERB,B2
+to apprehend,to apprehend,逮捕,VERB,B2
+giant,giant,巨人,NOUN,B2
+to endow,to endow,赋予,VERB,B2
+armor,armor,盔甲,NOUN,B2
+to stoke,to stoke,添燃料,VERB,B2
+to cool,to cool,冷却,VERB,B2
+feat,feat,功绩,NOUN,B2
+to desist,to desist,停止,VERB,B2
+anarchy,anarchy,无政府状态,NOUN,B2
+to dodge,to dodge,躲避,VERB,B2
+pebble,pebble,卵石,NOUN,B2
+to blacken,to blacken,变黑,VERB,B2
+to condition,to condition,制约,VERB,B2
+to complicate,to complicate,使复杂化,VERB,B2
+ornament,ornament,装饰,NOUN,B2
+insane,insane,疯狂的,ADJ,B2
+abscess,abscess,脓肿,NOUN,B2
+cunning,cunning,诡计,NOUN,B2
+specimen,specimen,标本,NOUN,B2
+to refine,to refine,提炼,VERB,B2
+hypocrite,hypocrite,伪君子,NOUN,B2
+in between,in between,在中间,ADV,B2
+ethical,ethical,道德的,ADJ,B2
+alert,alert,警报,NOUN,B2
+nuanced,nuanced,细微差别的,ADJ,B2
+stupor,stupor,昏迷,NOUN,B2
+hedge,hedge,树篱,NOUN,B2
+jail,jail,监狱,NOUN,B2
+fee,fee,费用,NOUN,B2
+archetype,archetype,原型,NOUN,B2
+dynamite,dynamite,炸药,NOUN,B2
+illicit,illicit,违禁的,ADJ,B2
+to devour,to devour,吞食,VERB,B2
+patrol,patrol,巡逻,NOUN,B2
+to perceive,to perceive,察觉,VERB,B2
+to abdicate,to abdicate,退位,VERB,B2
+to censor,to censor,审查,VERB,B2
+vault,vault,金库,NOUN,B2
+unambiguous,unambiguous,明确的,ADJ,B2
+overwhelming,overwhelming,压倒性的,ADJ,B2
+deeply,deeply,深深地,ADV,B2
+to withhold,to withhold,扣留,VERB,B2
+to amplify,to amplify,放大,VERB,B2
+gallant,gallant,英勇的,ADJ,B2
+chandelier,chandelier,吊灯,NOUN,B2
+usable,usable,可用的,ADJ,B2
+to evoke,to evoke,唤起,VERB,B2
+anatomy,anatomy,解剖学,NOUN,B2
+to despoil,to despoil,掠夺,VERB,B2
+cocky,cocky,傲慢的,ADJ,B2
+atheist,atheist,无神论者,NOUN,B2
+immortal,immortal,不朽的,ADJ,B2
+to debase,to debase,贬低,VERB,B2
+lethal,lethal,致命的,ADJ,B2
+footprint,footprint,足迹,NOUN,B2
+hurrah,hurrah,万岁,INTJ,B2
+sovereign,sovereign,君主,NOUN,B2
+discontent,discontent,不满,NOUN,B2
+to ravage,to ravage,破坏,VERB,B2
+tattoo,tattoo,纹身,NOUN,B2
+to emerge,to emerge,出现,VERB,B2
+wig,wig,假发,NOUN,B2
+emblematic,emblematic,象征性的,ADJ,B2
+gaseous,gaseous,气态的,ADJ,B2
+show,show,表演,NOUN,B2
+disarmament,disarmament,裁军,NOUN,B2
+impartiality,impartiality,公正,NOUN,B2
+carefully,carefully,仔细地,ADV,B2
+ungrateful,ungrateful,忘恩负义的,ADJ,B2
+shamelessness,shamelessness,无耻,NOUN,B2
+to give birth,to give birth,分娩,VERB,B2
+duplicity,duplicity,口是心非,NOUN,B2
+power plant,power plant,发电厂,NOUN,B2
+unharmed,unharmed,未受伤的,ADJ,B2
+corporal,corporal,下士,NOUN,B2
+nevertheless,nevertheless,尽管如此,ADV,B2
+to bleat,to bleat,哀叫,VERB,B2
+congenital,congenital,先天的,ADJ,B2
+to border,to border,接壤,VERB,B2
+to conjecture,to conjecture,猜测,VERB,B2
+irregularity,irregularity,不规则,NOUN,B2
+wisely,wisely,明智地,ADV,B2
+to sadden,to sadden,使悲伤,VERB,B2
+intentionally,intentionally,故意地,ADV,B2
+wear,wear,磨损,NOUN,B2
+dilatory,dilatory,拖延的,ADJ,B2
+figurative,figurative,比喻的,ADJ,B2
+turkey,turkey,火鸡,NOUN,B2
+looting,looting,掠夺,NOUN,B2
+infinitive marker,infinitive marker,去,PART,B2
+sexually,sexually,在性方面,ADV,B2
+to hail,to hail,下冰雹,VERB,B2
+to diverge,to diverge,分歧,VERB,B2
+monarch,monarch,君主,NOUN,B2
+welcoming,welcoming,舒适的,ADJ,B2
+cashier,cashier,出纳员,NOUN,B2
+to abort,to abort,流产,VERB,B2
+to radiate,to radiate,辐射,VERB,B2
+illustrious,illustrious,著名的,ADJ,B2
+fortuitous,fortuitous,偶然的,ADJ,B2
+homonymy,homonymy,同音异义,NOUN,B2
+rebellious,rebellious,叛逆的,ADJ,B2
+unthinkable,unthinkable,不可想象的,ADJ,B2
+embolism,embolism,栓塞,NOUN,B2
+to numb,to numb,使麻木,VERB,B2
+restriction,restriction,限制,NOUN,B2
+daycare,daycare,托儿所,NOUN,B2
+to desert,to desert,擅离职守,VERB,B2
+imposing,imposing,宏伟的,ADJ,B2
+decal,decal,贴花,NOUN,B2
+scientifically,scientifically,科学地,ADV,B2
+yeah yeah,yeah yeah,是是是,INTJ,B2
+snitch,snitch,告密者,NOUN,B2
+epigraph,epigraph,题词,NOUN,B2
+explicitly,explicitly,明确地,ADV,B2
+to dispense,to dispense,分发,VERB,B2
+embryo,embryo,胚胎,NOUN,B2
+consanguinity,consanguinity,血缘,NOUN,B2
+break-in,break-in,非法侵入,NOUN,B2
+wording,wording,措辞,NOUN,B2
+wimp,wimp,懦夫,NOUN,B2
+to arm,to arm,武装,VERB,B2
+nomad,nomad,游牧者,NOUN,B2
+purification,purification,净化,NOUN,B2
+hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
+paroxysm,paroxysm,发作,NOUN,B2
+frozen,frozen,冻僵的,ADJ,B2
+noodle,noodle,面条,NOUN,B2
+languor,languor,倦怠,NOUN,B2
+good heavens,good heavens,天哪,INTJ,B2
+cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
+invader,invader,入侵者,NOUN,B2
+commiseration,commiseration,同情,NOUN,B2
+to gape,to gape,目瞪口呆,VERB,B2
+superiority,superiority,优越性/优势,NOUN,B2
+partial,partial,部分的,ADJ,B2
+conservatory,conservatory,音乐学院,NOUN,B2
+little,little,少,DET,B2
+distributor,distributor,分销商,NOUN,B2
+horny,horny,性欲的,ADJ,B2
+dignitary,dignitary,高官,NOUN,B2
+to spy,to spy,监视,VERB,B2
+to uproot,to uproot,根除,VERB,B2
+together,together,共同的,ADJ,B2
+humanist,humanist,人文主义者,NOUN,B2
+indiscretion,indiscretion,轻率,NOUN,B2
+self,self,自己,PRON,B2
+philosophical,philosophical,哲学的,ADJ,B2
+infidelity,infidelity,不忠,NOUN,B2
+hotelier,hotelier,旅馆老板,NOUN,B2
+to tear out,to tear out,拔出,VERB,B2
+to rough-hew,to rough-hew,粗加工,VERB,B2
+philologist,philologist,语言学家,NOUN,B2
+to snoop,to snoop,窥探,VERB,B2
+law firm,law firm,律师事务所,NOUN,B2
+manhunt,manhunt,搜捕,NOUN,B2
+advent,advent,到来,NOUN,B2
+infamy,infamy,恶名,NOUN,B2
+on top,on top,在上面,ADV,B2
+gifted,gifted,有天赋的,ADJ,B2
+to seat,to seat,使坐下,VERB,B2
+cosmetic,cosmetic,化妆品的,ADJ,B2
+remarkably,remarkably,显著地,ADV,B2
+complement,complement,补充物,NOUN,B2
+melancholy,melancholy,忧郁,NOUN,B2
+admirer,admirer,仰慕者,NOUN,B2
+dependence,dependence,依赖,NOUN,B2
+generality,generality,普遍性,NOUN,B2
+technically,technically,技术上地,ADV,B2
+fifteen,fifteen,十五,NUM,B2
+laxity,laxity,松弛,NOUN,B2
+cigar,cigar,雪茄,NOUN,B2
+to whimper,to whimper,呜咽,VERB,B2
+private life,private life,私生活,NOUN,B2
+considerably,considerably,相当地,ADV,B2
+sunflower,sunflower,向日葵,NOUN,B2
+to anger,to anger,使生气,VERB,B2
+chieftain,chieftain,酋长,NOUN,B2
+conciliatory,conciliatory,调和的,ADJ,B2
+physiological,physiological,生理的,ADJ,B2
+insensitive,insensitive,麻木的,ADJ,B2
+past,past,经过,ADV,B2
+self-denial,self-denial,自我牺牲,NOUN,B2
+witchcraft,witchcraft,巫术,NOUN,B2
+tumor,tumor,肿瘤,NOUN,B2
+to gain weight,to gain weight,变胖,VERB,B2
+muzzle,muzzle,口套,NOUN,B2
+to wear out,to wear out,磨损,VERB,B2
+broke,broke,破产的,ADJ,B2
+credulity,credulity,轻信,NOUN,B2
+to harden,to harden,使经受锻炼,VERB,B2
+imprint,imprint,印记,NOUN,B2
+to strike down,to strike down,击倒,VERB,B2
+to strip,to strip,裸露,VERB,B2
+spinning mill,spinning mill,纺纱厂,NOUN,B2
+therapist,therapist,治疗师,NOUN,B2
+fellow citizen,fellow citizen,同胞,NOUN,B2
+time occasion,time occasion,次,NOUN,B2
+heavily,heavily,沉重地,ADV,B2
+proselytism,proselytism,传教,NOUN,B2
+to access,to access,进入,VERB,B2
+to empty,to empty,倒空,VERB,B2
+babysitter,babysitter,保姆,NOUN,B2
+rapture,rapture,狂喜,NOUN,B2
+damages,damages,损害赔偿,NOUN,B2
+novelty,novelty,新奇事物,NOUN,B2
+farmstead,farmstead,农庄,NOUN,B2
+yuck,yuck,呸,INTJ,B2
+to gossip,to gossip,闲聊,VERB,B2
+to debut,to debut,首次亮相,VERB,B2
+sailor,sailor,水手,NOUN,B2
+to fake,to fake,伪造,VERB,B2
+scholarship holder,scholarship holder,奖学金生,NOUN,B2
+generic,generic,通用的,ADJ,B2
+to overflow,to overflow,溢出,VERB,B2
+stratum,stratum,阶层,NOUN,B2
+to bristle,to bristle,使竖起,VERB,B2
+cardboard,cardboard,硬纸板,NOUN,B2
+to wedge,to wedge,卡住,VERB,B2
+unconditional,unconditional,无条件的,ADJ,B2
+stroller,stroller,婴儿车,NOUN,B2
+reminder,reminder,提醒物,NOUN,B2
+taxpayer,taxpayer,纳税人,NOUN,B2
+pharaoh,pharaoh,法老,NOUN,B2
+to long for,to long for,渴望,VERB,B2
+to prop up,to prop up,支撑,VERB,B2
+unfaithful,unfaithful,不忠的,ADJ,B2
+propeller,propeller,螺旋桨,NOUN,B2
+apostate,apostate,叛教者,NOUN,B2
+a little,a little,一点儿,ADV,B2
+last name,last name,姓,NOUN,B2
+cavity,cavity,腔,NOUN,B2
+immodesty,immodesty,不贞,NOUN,B2
+census,census,人口普查,NOUN,B2
+to thrive,to thrive,茁壮成长,VERB,B2
+flagrancy,flagrancy,现行,NOUN,B2
+thunderstorm,thunderstorm,雷阵雨,NOUN,B2
+to nail,to nail,钉,VERB,B2
+gastronomy,gastronomy,美食学,NOUN,B2
+puff,puff,一口烟,NOUN,B2
+itinerary,itinerary,行程,NOUN,B2
+triggering,triggering,触发,NOUN,B2
+insulin,insulin,胰岛素,NOUN,B2
+demarcation,demarcation,划界,NOUN,B2
+mentally,mentally,精神上地,ADV,B2
+instantaneous,instantaneous,瞬间的,ADJ,B2
+to distill,to distill,蒸馏,VERB,B2
+on purpose,on purpose,故意地,ADV,B2
+to implant,to implant,植入,VERB,B2
+scandalous,scandalous,可耻的,ADJ,B2
+to be based on,to be based on,基于,VERB,B2
+extract,extract,摘录,NOUN,B2
+squall,squall,骤雨,NOUN,B2
+feminine,feminine,女性的,ADJ,B2
+insecurity,insecurity,不安全感,NOUN,B2
+consecutively,consecutively,连续地,ADV,B2
+gutter,gutter,路沟,NOUN,B2
+complexion,complexion,肤色,NOUN,B2
+blessed,blessed,受祝福的,ADJ,B2
+to move touch,to move touch,使感动,VERB,B2
+fetish,fetish,恋物,NOUN,B2
+coat of arms,coat of arms,纹章,NOUN,B2
+ellipsis,ellipsis,省略,NOUN,B2
+co-owner,co-owner,共有人,NOUN,B2
+frugality,frugality,节俭,NOUN,B2
+hedonism,hedonism,享乐主义,NOUN,B2
+mitten,mitten,连指手套,NOUN,B2
+combativeness,combativeness,好斗性,NOUN,B2
+funereal,funereal,丧葬的,ADJ,B2
+to ally,to ally,结盟,VERB,B2
+to load charge,to load charge,装载,VERB,B2
+stealth,stealth,秘密行动,NOUN,B2
+x-ray,x-ray,X光片,NOUN,B2
+to plug in,to plug in,插入,VERB,B2
+clemency,clemency,仁慈,NOUN,B2
+depravity,depravity,堕落,NOUN,B2
+marine,marine,海洋的,ADJ,B2
+to intercede,to intercede,调停,VERB,B2
+fatalism,fatalism,宿命论,NOUN,B2
+deplorable,deplorable,可悲的,ADJ,B2
+kiosk,kiosk,亭子,NOUN,B2
+autonomy,autonomy,自治,NOUN,B2
+defensive,defensive,防御的,ADJ,B2
+flowery,flowery,华丽的,ADJ,B2
+carbohydrate,carbohydrate,碳水化合物,NOUN,B2
+insufficiency,insufficiency,不足,NOUN,B2
+condescension,condescension,屈尊,NOUN,B2
+to move away,to move away,移开,VERB,B2
+to parade,to parade,游行,VERB,B2
+wintry,wintry,冬天的,ADJ,B2
+infirmary,infirmary,医务室,NOUN,B2
+to dishonor,to dishonor,使蒙羞,VERB,B2
+cigarette butt,cigarette butt,烟头,NOUN,B2
+seal,seal,海豹,NOUN,B2
+villainy,villainy,邪恶,NOUN,B2
+swedish,swedish,瑞典语,NOUN,B2
+fragmentary,fragmentary,零碎的,ADJ,B2
+illumination,illumination,照明,NOUN,B2
+psychopath,psychopath,精神变态者,NOUN,B2
+fictitious,fictitious,虚构的,ADJ,B2
+baton,baton,警棍,NOUN,B2
+to age,to age,变老,VERB,B2
+school,school,学校的,ADJ,B2
+failed,failed,失败的,ADJ,B2
+discernment,discernment,洞察力,NOUN,B2
+insolvent,insolvent,无偿还能力的,ADJ,B2
+to indoctrinate,to indoctrinate,灌输,VERB,B2
+inkling,inkling,预感,NOUN,B2
+hypertrophy,hypertrophy,肥大,NOUN,B2
+torso,torso,躯干,NOUN,B2
+uniform,uniform,制服,NOUN,B2
+rag,rag,破布,NOUN,B2
+to giggle,to giggle,咯咯笑,VERB,B2
+overdose,overdose,过量,NOUN,B2
+diabolical,diabolical,恶魔般的,ADJ,B2
+to insinuate,to insinuate,暗示,VERB,B2
+to consent,to consent,同意,VERB,B2
+inconceivable,inconceivable,不可想象的,ADJ,B2
+grotto,grotto,洞穴,NOUN,B2
+didactic,didactic,教学的,ADJ,B2
+ejection,ejection,喷射,NOUN,B2
+offspring,offspring,幼崽,NOUN,B2
+frigate,frigate,护卫舰,NOUN,B2
+sorcerer,sorcerer,巫师,NOUN,B2
+epic,epic,史诗的,ADJ,B2
+magistrate,magistrate,法官,NOUN,B2
+canonical,canonical,规范的,ADJ,B2
+to knit,to knit,编织,VERB,B2
+to spot,to spot,看见,VERB,B2
+relieved,relieved,宽慰的,ADJ,B2
+alcoholic,alcoholic,酒精的,ADJ,B2
+desolation,desolation,荒凉,NOUN,B2
+soda,soda,苏打,NOUN,B2
+lapse,lapse,疏忽,NOUN,B2
+sperm,sperm,精子,NOUN,B2
+impunity,impunity,逍遥法外,NOUN,B2
+politically,politically,在政治上,ADV,B2
+reach,reach,范围,NOUN,B2
+greek,greek,希腊语,NOUN,B2
+wilderness,wilderness,荒野,NOUN,B2
+to bring closer,to bring closer,靠近,VERB,B2
+him her,him her,他/她,PRON,B2
+trembling,trembling,颤抖的,ADJ,B2
+to plot,to plot,密谋,VERB,B2
+to sketch,to sketch,勾勒,VERB,B2
+to corroborate,to corroborate,证实,VERB,B2
+ordinance,ordinance,条例,NOUN,B2
+mistreatment,mistreatment,虐待,NOUN,B2
+extremist,extremist,极端主义者,NOUN,B2
+to irrigate,to irrigate,灌溉,VERB,B2
+carpet rug,carpet rug,地毯,NOUN,B2
+jewelry store,jewelry store,珠宝店,NOUN,B2
+disc,disc,光盘,NOUN,B2
+deceased,deceased,已故的,ADJ,B2
+imperfect,imperfect,不完美的,ADJ,B2
+moratorium,moratorium,暂停,NOUN,B2
+jubilation,jubilation,欢欣,NOUN,B2
+inhuman,inhuman,不人道的,ADJ,B2
+excursion,excursion,郊游,NOUN,B2
+to inconvenience,to inconvenience,使不便,VERB,B2
+tv,tv,电视,NOUN,B2
+tablet,tablet,平板电脑,NOUN,B2
+die,die,骰子,NOUN,B2
+circumspect,circumspect,谨慎的,ADJ,B2
+regularity,regularity,规律性,NOUN,B2
+to flash,to flash,闪烁,VERB,B2
+exponential,exponential,指数的,ADJ,B2
+diploma,diploma,文凭,NOUN,B2
+gardening,gardening,园艺,NOUN,B2
+to undress,to undress,脱衣,VERB,B2
+counterfeiting,counterfeiting,伪造,NOUN,B2
+hermit,hermit,隐士,NOUN,B2
+corollary,corollary,推论,NOUN,B2
+homily,homily,布道,NOUN,B2
+deference,deference,敬意,NOUN,B2
+incompetent,incompetent,无能的,ADJ,B2
+idiosyncrasy,idiosyncrasy,特质,NOUN,B2
+diffuse,diffuse,模糊的,ADJ,B2
+cognitive,cognitive,认知的,ADJ,B2
+holocaust,holocaust,浩劫,NOUN,B2
+unlimited,unlimited,无限的,ADJ,B2
+to lighten,to lighten,减轻,VERB,B2
+seriously,seriously,认真地,ADV,B2
+to wilt,to wilt,枯萎,VERB,B2
+to impute,to impute,归咎,VERB,B2
+precisely,precisely,确切地; 正好,ADV,B2
+prepared,prepared,准备好的,ADJ,B2
+to crash,to crash,碰撞,VERB,B2
+rubble,rubble,瓦砾,NOUN,B2
+redemption,redemption,救赎,NOUN,B2
+influx,influx,涌入,NOUN,B2
+to nickname,to nickname,给...起绰号,VERB,B2
+to overstep,to overstep,越权,VERB,B2
+cylindrical,cylindrical,圆柱形的,ADJ,B2
+the more,the more,越,ADV,B2
+to skim,to skim,轻触,VERB,B2
+have to,have to,必须,AUX,B2
+motionless,motionless,静止的,ADJ,B2
+to sanctify,to sanctify,使神圣,VERB,B2
+dying,dying,垂死的,ADJ,B2
+to undo,to undo,解开,VERB,B2
+listener,listener,听众,NOUN,B2
+devaluation,devaluation,贬值,NOUN,B2
+hiding place,hiding place,藏身处,NOUN,B2
+holidays,holidays,假期,NOUN,B2
+endowment,endowment,配备,NOUN,B2
+gerontocracy,gerontocracy,老人政治,NOUN,B2
+incoherent,incoherent,不连贯的,ADJ,B2
+circumlocution,circumlocution,迂回说法,NOUN,B2
+descriptive,descriptive,描述性的,ADJ,B2
+anything,anything,任何事,PRON,B2
+to invoke,to invoke,援引,VERB,B2
+drool,drool,口水,NOUN,B2
+remote control,remote control,遥控器,NOUN,B2
+alone,alone,单独的,ADJ,B2
+duchess,duchess,公爵夫人,NOUN,B2
+inadmissible,inadmissible,不可接受的,ADJ,B2
+shiver,shiver,寒战,NOUN,B2
+fiery,fiery,热烈的,ADJ,B2
+jurist,jurist,法学家,NOUN,B2
+to snow,to snow,下雪,VERB,B2
+to intoxicate,to intoxicate,使中毒,VERB,B2
+fragility,fragility,脆弱,NOUN,B2
+to narrow,to narrow,使变窄,VERB,B2
+free of charge,free of charge,免费,NOUN,B2
+subconscious,subconscious,潜意识,NOUN,B2
+to blow up,to blow up,炸毁,VERB,B2
+hose,hose,软管,NOUN,B2
+that,that,那个,DET,B2
+yarn,yarn,纱线,NOUN,B2
+to torment,to torment,折磨,VERB,B2
+to group,to group,分组,VERB,B2
+hare,hare,野兔,NOUN,B2
+gravely,gravely,严重地,ADV,B2
+to delight,to delight,使高兴,VERB,B2
+to back up,to back up,后退,VERB,B2
+to rinse,to rinse,冲洗,VERB,B2
+to inflame,to inflame,使发炎,VERB,B2
+emblem,emblem,徽章,NOUN,B2
+superior,superior,上级,NOUN,B2
+ashtray,ashtray,烟灰缸,NOUN,B2
+to make proud,to make proud,使自豪,VERB,B2
+to instill,to instill,灌输,VERB,B2
+to be moved,to be moved,感动,VERB,B2
+to unmask,to unmask,揭穿,VERB,B2
+casuistry,casuistry,决疑法,NOUN,B2
+moving,moving,感人的,ADJ,B2
+to expatriate,to expatriate,使移居国外,VERB,B2
+to swell,to swell,使肿胀,VERB,B2
+to redden,to redden,变红,VERB,B2
+duvet,duvet,羽绒被,NOUN,B2
+to have to,to have to,必须,VERB,B2
+tiresome,tiresome,累人的,ADJ,B2
+to stammer,to stammer,结巴,VERB,B2
+dictator,dictator,独裁者,NOUN,B2
+fatuity,fatuity,愚昧,NOUN,B2
+to spawn,to spawn,产卵,VERB,B2
+to repeal,to repeal,废除,VERB,B2
+to skin,to skin,剥皮,VERB,B2
+lay,lay,叙事短诗,NOUN,B2
+to lengthen,to lengthen,延长,VERB,B2
+to recreate,to recreate,重建,VERB,B2
+physically,physically,身体上地,ADV,B2
+counterargument,counterargument,反论点,NOUN,B2
+to riddle,to riddle,使布满孔洞,VERB,B2
+effectively,effectively,有效地,ADV,B2
+skylight,skylight,天窗,NOUN,B2
+pathology,pathology,病理学,NOUN,B2
+defective,defective,有缺陷的,ADJ,B2
+premonition,premonition,预感,NOUN,B2
+stopover,stopover,中途停留,NOUN,B2
+to dissipate,to dissipate,消散,VERB,B2
+chosen,chosen,精选的,ADJ,B2
+hinge,hinge,合页,NOUN,B2
+to detail,to detail,详述,VERB,B2
+hold,hold,控制,NOUN,B2
+to assault,to assault,袭击,VERB,B2
+imaginative,imaginative,富有想象力的,ADJ,B2
+to fall silent,to fall silent,沉默,VERB,B2
+to sulk,to sulk,生闷气,VERB,B2
+fidelity,fidelity,忠诚,NOUN,B2
+report card,report card,成绩单,NOUN,B2
+hydraulic,hydraulic,液压的,ADJ,B2
+nape,nape,后颈,NOUN,B2
+endemic,endemic,地方性的,ADJ,B2
+to set aside,to set aside,移开,VERB,B2
+detriment,detriment,损害,NOUN,B2
+tangle,tangle,混乱,NOUN,B2
+to infest,to infest,滋生,VERB,B2
+contrast,contrast,对比,NOUN,B2
+humanitarian,humanitarian,人道主义的,ADJ,B2
+scrupulously,scrupulously,一丝不苟地,ADV,B2
+generously,generously,慷慨地,ADV,B2
+decorative,decorative,装饰性的,ADJ,B2
+frieze,frieze,檐壁,NOUN,B2
+educational,educational,教育的,ADJ,B2
+perplexed,perplexed,困惑的,ADJ,B2
+whore,whore,妓女,NOUN,B2
+to oust,to oust,推翻,VERB,B2
+specifically,specifically,具体地,ADV,B2
+bragging,bragging,吹嘘,NOUN,B2
+fang,fang,犬齿,NOUN,B2
+deterioration,deterioration,恶化,NOUN,B2
+boxer,boxer,拳击手,NOUN,B2
+grid,grid,网格,NOUN,B2
+to gloss,to gloss,注释,VERB,B2
+parsimony,parsimony,吝啬,NOUN,B2
+curly,curly,卷曲的,ADJ,B2
+decidedly,decidedly,坚决地,ADV,B2
+swollen,swollen,肿胀的,ADJ,B2
+to shelter,to shelter,庇护,VERB,B2
+exegete,exegete,注释家,NOUN,B2
+to eclipse,to eclipse,使失色,VERB,B2
+explosive,explosive,炸药,NOUN,B2
+entrails,entrails,内脏,NOUN,B2
+asphalt,asphalt,沥青,NOUN,B2
+muscle ache,muscle ache,肌肉酸痛,NOUN,B2
+feminist,feminist,女权主义者,NOUN,B2
+pajamas,pajamas,睡衣,NOUN,B2
+floating,floating,漂浮的,ADJ,B2
+condom,condom,避孕套,NOUN,B2
+scooter,scooter,踏板摩托车,NOUN,B2
+to give as a gift,to give as a gift,赠送,VERB,B2
+gangrene,gangrene,坏疽,NOUN,B2
+lizard,lizard,蜥蜴,NOUN,B2
+stabilization,stabilization,稳定化,NOUN,B2
+railway,railway,铁路的,ADJ,B2
+curative,curative,有疗效的,ADJ,B2
+stimulus,stimulus,刺激,NOUN,B2
+from where,from where,从哪里,ADV,B2
+terrified,terrified,极度恐惧的,ADJ,B2
+to lower,to lower,降低,VERB,B2
+self-taught,self-taught,自学的,ADJ,B2
+hanging,hanging,绞刑,NOUN,B2
+regularly,regularly,定期地,ADV,B2
+skillful,skillful,熟练的,ADJ,B2
+electronics,electronics,电子学,NOUN,B2
+to divulge,to divulge,泄露,VERB,B2
+to center,to center,居中,VERB,B2
+find,find,发现物,NOUN,B2
+to mirror,to mirror,反映,VERB,B2
+hemp,hemp,大麻,NOUN,B2
+apathetic,apathetic,冷漠的,ADJ,B2
+the anform,the anform,复合词,NOUN,B2
+in view of,in view of,鉴于,ADP,B2
+to collate,to collate,核对,VERB,B2
+lucrative,lucrative,有利可图的,ADJ,B2
+profitability,profitability,盈利能力,NOUN,B2
+bump shock,bump shock,碰撞/震惊,NOUN,B2
+supremacy,supremacy,霸权,NOUN,B2
+student loan,student loan,助学贷款,NOUN,B2
+terminus,terminus,,NOUN,B2
+strident,strident,刺耳的,ADJ,B2
+windfall,windfall,意外之财,NOUN,B2
+annals,annals,编年史,NOUN,B2
+staunch,staunch,坚定的,ADJ,B2
+the anbruch,the anbruch,名词,NOUN,B2
+watertight,watertight,,NOUN,B2
+inert,inert,惰性的,ADJ,B2
+limit border,limit border,界限,NOUN,B2
+brittle,brittle,易碎的,ADJ,B2
+getheilung,getheilung,词,NOUN,B2
+neonatal,neonatal,新生儿的,ADJ,B2
+fernsucht,fernsucht,词,NOUN,B2
+to cope,to cope,应付,VERB,B2
+the missbildung,the missbildung,复合词,NOUN,B2
+grown,grown,长大的,ADJ,B2
+unterpflegung,unterpflegung,词,NOUN,B2
+getreibung,getreibung,词,NOUN,B2
+emergency doctor,emergency doctor,急诊医生,NOUN,B2
+einteilung,einteilung,词,NOUN,B2
+the abmessung,the abmessung,复合词,NOUN,B2
+untersinnung,untersinnung,词,NOUN,B2
+lord god,lord god,上帝,NOUN,B2
+hintersucht,hintersucht,词,NOUN,B2
+gerichtung,gerichtung,词,NOUN,B2
+the adressat,the adressat,名词,NOUN,B2
+the weitmischung,the weitmischung,复合词,NOUN,B2
+nimble,nimble,敏捷的,ADJ,B2
+scratch,scratch,抓痕,NOUN,B2
+the verwandlung,the verwandlung,复合词,NOUN,B2
+creepy,creepy,令人毛骨悚然的,ADJ,B2
+the verstleitung,the verstleitung,复合词,NOUN,B2
+the tiefbindung,the tiefbindung,复合词,NOUN,B2
+einweisung,einweisung,词,NOUN,B2
+the aktnadel,the aktnadel,名词,NOUN,B2
+the auserweiterung,the auserweiterung,复合词,NOUN,B2
+college,college,学院,NOUN,B2
+sting,sting,刺,NOUN,B2
+to anesthetize,to anesthetize,麻醉,VERB,B2
+emerald,emerald,祖母绿,NOUN,B2
+to fell,to fell,砍倒,VERB,B2
+zersucht,zersucht,词,NOUN,B2
+the berechnung,the berechnung,复合词,NOUN,B2
+the anreiz,the anreiz,名词,NOUN,B2
+the erzheilung,the erzheilung,复合词,NOUN,B2
+the akademie,the akademie,名词,NOUN,B2
+guards,guards,警卫,NOUN,B2
+to switch off,to switch off,关掉,VERB,B2
+telegram,telegram,电报,NOUN,B2
+firstly,firstly,首先,ADV,B2
+beteilung,beteilung,词,NOUN,B2
+the anwerk,the anwerk,复合词,NOUN,B2
+concerning,concerning,关于,ADP,B2
+mania,mania,狂躁症,NOUN,B2
+the hochleitung,the hochleitung,复合词,NOUN,B2
+the weitstoff,the weitstoff,复合词,NOUN,B2
+einsprache,einsprache,词,NOUN,B2
+the hochordnung,the hochordnung,复合词,NOUN,B2
+erfahrt,erfahrt,词,NOUN,B2
+eingabe,eingabe,词,NOUN,B2
+the beminderung,the beminderung,复合词,NOUN,B2
+nahfahrt,nahfahrt,词,NOUN,B2
+burdened,burdened,负担重的,ADJ,B2
+the nachleitung,the nachleitung,复合词,NOUN,B2
+oddball,oddball,怪人,NOUN,B2
+to breathe again,to breathe again,松口气,VERB,B2
+the gewendung,the gewendung,复合词,NOUN,B2
+fickleness,fickleness,反复无常,NOUN,B2
+aussinnung,aussinnung,词,NOUN,B2
+the grundstoff,the grundstoff,复合词,NOUN,B2
+to countersign,to countersign,副署,VERB,B2
+bum,bum,流浪汉,NOUN,B2
+aufweisung,aufweisung,词,NOUN,B2
+but rather,but rather,而是,CCONJ,B2
+the erzwendung,the erzwendung,复合词,NOUN,B2
+the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
+the unleitung,the unleitung,复合词,NOUN,B2
+oberleitung,oberleitung,词,NOUN,B2
+whether,whether,是否,SCONJ,B2
+the aushandlung,the aushandlung,复合词,NOUN,B2
+einerziehung,einerziehung,词,NOUN,B2
+so to speak,so to speak,可以说,ADV,B2
+the ausstellung,the ausstellung,复合词,NOUN,B2
+the ansage,the ansage,名词,NOUN,B2
+to share divide,to share divide,分享,VERB,B2
+theme music,theme music,主题曲,NOUN,B2
+nachsuchung,nachsuchung,词,NOUN,B2
+christmas tree,christmas tree,圣诞树,NOUN,B2
+thin-walled,thin-walled,隔音差的,ADJ,B2
+the vorrechnung,the vorrechnung,复合词,NOUN,B2
+the mitstellung,the mitstellung,复合词,NOUN,B2
+the tiefleitung,the tiefleitung,复合词,NOUN,B2
+crap,crap,屎,NOUN,B2
+to vibrate,to vibrate,振动,VERB,B2
+einwirkung,einwirkung,词,NOUN,B2
+the untererweiterung,the untererweiterung,复合词,NOUN,B2
+the abweisung,the abweisung,名词,NOUN,B2
+nachsinnung,nachsinnung,词,NOUN,B2
+unfassung,unfassung,词,NOUN,B2
+to break out,to break out,爆发,VERB,B2
+the ursammlung,the ursammlung,复合词,NOUN,B2
+to bump,to bump,碰撞,VERB,B2
+fishing rod,fishing rod,钓竿,NOUN,B2
+the nachbindung,the nachbindung,复合词,NOUN,B2
+from it,from it,从中,ADV,B2
+weitweisung,weitweisung,词,NOUN,B2
+the abkraft,the abkraft,复合词,NOUN,B2
+the aufleitung,the aufleitung,复合词,NOUN,B2
+to queue,to queue,排队,VERB,B2
+annual wage,annual wage,年薪,NOUN,B2
+erzregelung,erzregelung,词,NOUN,B2
+people nation,people nation,人民 / 民族,NOUN,B2
+prank,prank,恶作剧,NOUN,B2
+learning curve,learning curve,学习曲线,NOUN,B2
+the erwendung,the erwendung,复合词,NOUN,B2
+moor,moor,荒野,NOUN,B2
+benahme,benahme,词,NOUN,B2
+to stint,to stint,吝啬,VERB,B2
+the erzwerk,the erzwerk,复合词,NOUN,B2
+thousands,thousands,数千,NOUN,B2
+the erzmischung,the erzmischung,复合词,NOUN,B2
+to lay down,to lay down,放下,VERB,B2
+vorderfassung,vorderfassung,词,NOUN,B2
+everyday life,everyday life,日常生活,NOUN,B2
+city map,city map,城市地图,NOUN,B2
+host of angels,host of angels,天使群,NOUN,B2
+wage labor,wage labor,雇佣劳动,NOUN,B2
+to step in,to step in,介入,VERB,B2
+sort,sort,种类,NOUN,B2
+ausweisung,ausweisung,词,NOUN,B2
+vorwandel,vorwandel,词,NOUN,B2
+the abwert,the abwert,复合词,NOUN,B2
+the vorwert,the vorwert,复合词,NOUN,B2
+german class,german class,德语课,NOUN,B2
+the adoption,the adoption,名词,NOUN,B2
+hearts,hearts,心,NOUN,B2
+crook,crook,骗子,NOUN,B2
+hochweisung,hochweisung,词,NOUN,B2
+to make sense,to make sense,讲得通,VERB,B2
+to keep secret,to keep secret,隐瞒,VERB,B2
+bitch,bitch,母狗,NOUN,B2
+the zurechnung,the zurechnung,复合词,NOUN,B2
+semicolon,semicolon,分号,PUNCT,B2
+resident,resident,定居的,ADJ,B2
+the gebindung,the gebindung,复合词,NOUN,B2
+evil,evil,邪,PART,B2
+sky blue,sky blue,天蓝色,ADJ,B2
+vegetarian,vegetarian,素食者,NOUN,B2
+she they,she they,她,PRON,B2
+chain mail,chain mail,锁子甲,NOUN,B2
+the missordnung,the missordnung,复合词,NOUN,B2
+the verstwerk,the verstwerk,复合词,NOUN,B2
+twitching,twitching,抽搐的,ADJ,B2
+zusicht,zusicht,词,NOUN,B2
+urgestaltung,urgestaltung,词,NOUN,B2
+to overlook,to overlook,忽视,VERB,B2
+the mitbildung,the mitbildung,复合词,NOUN,B2
+motherfucker,motherfucker,混蛋,NOUN,B2
+the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
+the alpinismus,the alpinismus,名词,NOUN,B2
+yikes,yikes,哎呀,INTJ,B2
+sow,sow,母猪,NOUN,B2
+urgabe,urgabe,词,NOUN,B2
+erweisung,erweisung,词,NOUN,B2
+virtuous,virtuous,有德行的,ADJ,B2
+to go blind,to go blind,失明,VERB,B2
+zufahrt,zufahrt,词,NOUN,B2
+backdrop,backdrop,背景,NOUN,B2
+probation,probation,缓刑,NOUN,B2
+comma,comma,逗号,PUNCT,B2
+seamless,seamless,无缝的,ADJ,B2
+distorted image,distorted image,扭曲的形象,NOUN,B2
+sagittarius,sagittarius,射手座,NOUN,B2
+to stay here,to stay here,留在这里,VERB,B2
+verschaft,verschaft,词,NOUN,B2
+unweisung,unweisung,词,NOUN,B2
+the abholung,the abholung,名词,NOUN,B2
+gay,gay,快乐的,ADJ,B2
+ausgestaltung,ausgestaltung,词,NOUN,B2
+hinterleitung,hinterleitung,词,NOUN,B2
+to pick out,to pick out,挑选,VERB,B2
+president female,president female,女总统,NOUN,B2
+to abschweifen,to abschweifen,动词,VERB,B2
+the aufwandlung,the aufwandlung,复合词,NOUN,B2
+the erzkraft,the erzkraft,复合词,NOUN,B2
+cleaning,cleaning,清洁,NOUN,B2
+timetable,timetable,时刻表,NOUN,B2
+einnahme,einnahme,词,NOUN,B2
+the zerbildung,the zerbildung,复合词,NOUN,B2
+drinking glass,drinking glass,水杯,NOUN,B2
+weitsuchung,weitsuchung,词,NOUN,B2
+the hochstoff,the hochstoff,复合词,NOUN,B2
+to brood,to brood,沉思,VERB,B2
+the antrag,the antrag,名词,NOUN,B2
+tasteless,tasteless,无味的,ADJ,B2
+sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
+to bullshit,to bullshit,胡扯,VERB,B2
+any,any,任何,PRON,B2
+university student,university student,大学生,NOUN,B2
+to growl,to growl,咆哮,VERB,B2
+the aufwendung,the aufwendung,复合词,NOUN,B2
+serve markup,serve markup,发球/加价,NOUN,B2
+the weitminderung,the weitminderung,复合词,NOUN,B2
+the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
+the einmessung,the einmessung,复合词,NOUN,B2
+the urheilung,the urheilung,复合词,NOUN,B2
+rake,rake,耙子,NOUN,B2
+to spell,to spell,拼写,VERB,B2
+sacrificed,sacrificed,牺牲,ADJ,B2
+to get by,to get by,过得去,VERB,B2
+hintertheilung,hintertheilung,词,NOUN,B2
+the vorordnung,the vorordnung,复合词,NOUN,B2
+to align,to align,使一致,VERB,B2
+geteilung,geteilung,词,NOUN,B2
+urwandel,urwandel,词,NOUN,B2
+the mitheilung,the mitheilung,复合词,NOUN,B2
+precinct,precinct,辖区,NOUN,B2
+the verststoff,the verststoff,复合词,NOUN,B2
+romanian,romanian,罗马尼亚人,NOUN,B2
+the vorstellung,the vorstellung,复合词,NOUN,B2
+helper,helper,助手,NOUN,B2
+the andrang,the andrang,名词,NOUN,B2
+hinterrechnung,hinterrechnung,词,NOUN,B2
+the abhang,the abhang,名词,NOUN,B2
+weitwandel,weitwandel,词,NOUN,B2
+investigated,investigated,被调查的,ADJ,B2
+auswandel,auswandel,词,NOUN,B2
+unnahme,unnahme,词,NOUN,B2
+the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
+hinterrichtung,hinterrichtung,词,NOUN,B2
+the bemessung,the bemessung,复合词,NOUN,B2
+misstreibung,misstreibung,词,NOUN,B2
+bodily harm,bodily harm,人身伤害,NOUN,B2
+that yonder,that yonder,那个,DET,B2
+vortheilung,vortheilung,词,NOUN,B2
+the aktivist,the aktivist,名词,NOUN,B2
+naherziehung,naherziehung,词,NOUN,B2
+pastime,pastime,爱好,NOUN,B2
+the aufstoff,the aufstoff,复合词,NOUN,B2
+refreshing,refreshing,令人清爽的,ADJ,B2
+ausforderung,ausforderung,词,NOUN,B2
+the unmischung,the unmischung,复合词,NOUN,B2
+the beleitung,the beleitung,复合词,NOUN,B2
+the bewendung,the bewendung,复合词,NOUN,B2
+the aufheilung,the aufheilung,复合词,NOUN,B2
+to elapse,to elapse,流逝,VERB,B2
+mortal fear,mortal fear,极度恐惧,NOUN,B2
+the aktion,the aktion,名词,NOUN,B2
+trash bag,trash bag,垃圾袋,NOUN,B2
+the anbeginn,the anbeginn,名词,NOUN,B2
+worst thing,worst thing,最坏的事,NOUN,B2
+usual thing,usual thing,惯例,NOUN,B2
+per,per,每,ADP,B2
+the hochbindung,the hochbindung,复合词,NOUN,B2
+to abtrocken,to abtrocken,动词,VERB,B2
+to pressurize,to pressurize,逼迫,VERB,B2
+at the,at the,在...时,ADP,B2
+the zuwandlung,the zuwandlung,复合词,NOUN,B2
+groan,groan,呻吟,NOUN,B2
+to shunt,to shunt,分流,VERB,B2
+bulldog,bulldog,斗牛犬,NOUN,B2
+to play along,to play along,配合,VERB,B2
+agreed,agreed,一致的,ADJ,B2
+ursicht,ursicht,词,NOUN,B2
+hideous,hideous,丑陋的,ADJ,B2
+the ausbildung,the ausbildung,复合词,NOUN,B2
+the gemischung,the gemischung,复合词,NOUN,B2
+drive,drive,动力,NOUN,B2
+wiedertreibung,wiedertreibung,词,NOUN,B2
+urteilung,urteilung,词,NOUN,B2
+fernrechnung,fernrechnung,词,NOUN,B2
+unfahrt,unfahrt,词,NOUN,B2
+separated,separated,分开的,ADJ,B2
+the unbildung,the unbildung,复合词,NOUN,B2
+the zuhandlung,the zuhandlung,复合词,NOUN,B2
+anteilung,anteilung,词,NOUN,B2
+anrichtung,anrichtung,词,NOUN,B2
+erschaft,erschaft,词,NOUN,B2
+interpersonal,interpersonal,人际的,ADJ,B2
+the allianz,the allianz,名词,NOUN,B2
+the anteil,the anteil,名词,NOUN,B2
+hothead,hothead,急性子的人,NOUN,B2
+tiefsuchung,tiefsuchung,词,NOUN,B2
+the zererweiterung,the zererweiterung,复合词,NOUN,B2
+the aktuar,the aktuar,名词,NOUN,B2
+nahfassung,nahfassung,词,NOUN,B2
+the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
+billion,billion,十亿,NOUN,B2
+the anheilung,the anheilung,复合词,NOUN,B2
+to turn away,to turn away,转开,VERB,B2
+to get into,to get into,陷入,VERB,B2
+the abheilung,the abheilung,复合词,NOUN,B2
+without exception,without exception,无例外的,ADV,B2
+to view,to view,参观,VERB,B2
+vordersinnung,vordersinnung,词,NOUN,B2
+to deregister,to deregister,注销,VERB,B2
+how much,how much,多少,ADV,B2
+ran,ran,跑,ADJ,B2
+the day after tomorrow,the day after tomorrow,后天,ADV,B2
+the absteigerung,the absteigerung,复合词,NOUN,B2
+ausschrift,ausschrift,词,NOUN,B2
+the abgrund,the abgrund,名词,NOUN,B2
+to subordinate,to subordinate,从属,VERB,B2
+zersicht,zersicht,词,NOUN,B2
+the urvertiefung,the urvertiefung,复合词,NOUN,B2
+the mitkraft,the mitkraft,复合词,NOUN,B2
+the urverbesserung,the urverbesserung,复合词,NOUN,B2
+deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
+causal,causal,因果的,ADJ,B2
+windy,windy,有风的,ADJ,B2
+office work,office work,办公室工作,NOUN,B2
+zusprache,zusprache,词,NOUN,B2
+the nachbildung,the nachbildung,复合词,NOUN,B2
+untreibung,untreibung,词,NOUN,B2
+besprache,besprache,词,NOUN,B2
+many things,many things,许多事物,PRON,B2
+the bevertiefung,the bevertiefung,复合词,NOUN,B2
+the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
+the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
+unwandel,unwandel,词,NOUN,B2
+hinterfassung,hinterfassung,词,NOUN,B2
+to watch tv,to watch tv,看电视,VERB,B2
+to wait and see,to wait and see,等待观望,VERB,B2
+noises,noises,噪音,NOUN,B2
+grandparents,grandparents,祖父母,NOUN,B2
+to move out,to move out,搬出,VERB,B2
+the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
+the aktpunkt,the aktpunkt,名词,NOUN,B2
+the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
+the akkumulator,the akkumulator,名词,NOUN,B2
+the ererweiterung,the ererweiterung,复合词,NOUN,B2
+mitsetzung,mitsetzung,词,NOUN,B2
+bullshitted,bullshitted,被愚弄的,ADJ,B2
+upbeat,upbeat,轻快的,ADJ,B2
+the einwerk,the einwerk,复合词,NOUN,B2
+vorderweisung,vorderweisung,词,NOUN,B2
+nachrichtung,nachrichtung,词,NOUN,B2
+to abdanken,to abdanken,动词,VERB,B2
+scarce commodity,scarce commodity,紧缺商品,NOUN,B2
+lunch break,lunch break,午休,NOUN,B2
+wiedersprache,wiedersprache,词,NOUN,B2
+the erleitung,the erleitung,复合词,NOUN,B2
+to absagen,to absagen,动词,VERB,B2
+vordersetzung,vordersetzung,词,NOUN,B2
+in front of before,in front of before,在...前,ADP,B2
+misstheilung,misstheilung,词,NOUN,B2
+test of courage,test of courage,勇气测试,NOUN,B2
+the unwandlung,the unwandlung,复合词,NOUN,B2
+gesinnung,gesinnung,词,NOUN,B2
+shit,shit,恐惧,NOUN,B2
+hinterwandel,hinterwandel,词,NOUN,B2
+the anschlag,the anschlag,名词,NOUN,B2
+the altruismus,the altruismus,名词,NOUN,B2
+the verhandlung,the verhandlung,复合词,NOUN,B2
+song of praise,song of praise,赞歌,NOUN,B2
+aufforderung,aufforderung,词,NOUN,B2
+the urstoff,the urstoff,复合词,NOUN,B2
+the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
+on what,on what,在什么上面,ADV,B2
+unpflegung,unpflegung,词,NOUN,B2
+stupid things,stupid things,蠢事,NOUN,B2
+itching powder,itching powder,痒痒粉,NOUN,B2
+to be delayed,to be delayed,迟到,VERB,B2
+urschrift,urschrift,词,NOUN,B2
+to abschlafen,to abschlafen,动词,VERB,B2
+affected,affected,受影响的,ADJ,B2
+hintersuchung,hintersuchung,词,NOUN,B2
+zernahme,zernahme,词,NOUN,B2
+glib,glib,伶牙俐齿的,ADJ,B2
+wiedersucht,wiedersucht,词,NOUN,B2
+to abzwecken,to abzwecken,动词,VERB,B2
+the bekraft,the bekraft,复合词,NOUN,B2
+the alpen,the alpen,名词,NOUN,B2
+like,like,点赞,NOUN,B2
+besuchung,besuchung,词,NOUN,B2
+interrogation room,interrogation room,审讯室,NOUN,B2
+aussetzung,aussetzung,词,NOUN,B2
+hinterwendung,hinterwendung,词,NOUN,B2
+fernschaft,fernschaft,词,NOUN,B2
+obersuchung,obersuchung,词,NOUN,B2
+the unterordnung,the unterordnung,复合词,NOUN,B2
+most important thing,most important thing,最重要的事,NOUN,B2
+the aufordnung,the aufordnung,复合词,NOUN,B2
+main reason,main reason,主要原因,NOUN,B2
+to play down,to play down,淡化,VERB,B2
+the geverbesserung,the geverbesserung,复合词,NOUN,B2
+oberbildung,oberbildung,词,NOUN,B2
+the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
+weitsicht,weitsicht,词,NOUN,B2
+the aufwert,the aufwert,复合词,NOUN,B2
+to run away,to run away,逃跑,VERB,B2
+delivery van,delivery van,厢式送货车,NOUN,B2
+the amboss,the amboss,名词,NOUN,B2
+einschaft,einschaft,词,NOUN,B2
+the gebildung,the gebildung,复合词,NOUN,B2
+antheilung,antheilung,词,NOUN,B2
+the beerweiterung,the beerweiterung,复合词,NOUN,B2
+the missstoff,the missstoff,复合词,NOUN,B2
+the weitordnung,the weitordnung,复合词,NOUN,B2
+to commission,to commission,委托,VERB,B2
+zersuchung,zersuchung,词,NOUN,B2
+wiedersicht,wiedersicht,词,NOUN,B2
+hochkunft,hochkunft,词,NOUN,B2
+the aufbewegung,the aufbewegung,复合词,NOUN,B2
+of all things,of all things,偏偏,ADV,B2
+the unterleitung,the unterleitung,复合词,NOUN,B2
+nachtheilung,nachtheilung,词,NOUN,B2
+untertreibung,untertreibung,词,NOUN,B2
+the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
+personal,personal,私事,NOUN,B2
+missschrift,missschrift,词,NOUN,B2
+the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
+vorderrichtung,vorderrichtung,词,NOUN,B2
+to abstimmen,to abstimmen,动词,VERB,B2
+wiederordnung,wiederordnung,词,NOUN,B2
+the missbewegung,the missbewegung,复合词,NOUN,B2
+vorteilung,vorteilung,词,NOUN,B2
+unerziehung,unerziehung,词,NOUN,B2
+to do harm,to do harm,伤害,VERB,B2
+the weitheilung,the weitheilung,复合词,NOUN,B2
+the akkord,the akkord,名词,NOUN,B2
+unlawful,unlawful,非法的,ADJ,B2
+oberwandlung,oberwandlung,词,NOUN,B2
+kidnapper,kidnapper,绑架者,NOUN,B2
+the weitwendung,the weitwendung,复合词,NOUN,B2
+clear as day,clear as day,一清二楚的,ADJ,B2
+the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
+to abteilen,to abteilen,动词,VERB,B2
+the ackerbau,the ackerbau,名词,NOUN,B2
+the missvertiefung,the missvertiefung,复合词,NOUN,B2
+geforderung,geforderung,词,NOUN,B2
+to oversleep,to oversleep,睡过头,VERB,B2
+the gestoff,the gestoff,复合词,NOUN,B2
+loudspeaker,loudspeaker,扬声器,NOUN,B2
+the mitordnung,the mitordnung,复合词,NOUN,B2
+goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
+the tiefstoff,the tiefstoff,复合词,NOUN,B2
+erforderung,erforderung,词,NOUN,B2
+missschaft,missschaft,词,NOUN,B2
+wiederkunft,wiederkunft,词,NOUN,B2
+the unminderung,the unminderung,复合词,NOUN,B2
+ausfahrt,ausfahrt,词,NOUN,B2
+oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
+the nachmessung,the nachmessung,复合词,NOUN,B2
+game rule,game rule,游戏规则,NOUN,B2
+aufrichtung,aufrichtung,词,NOUN,B2
+mitfahrt,mitfahrt,词,NOUN,B2
+obererziehung,obererziehung,词,NOUN,B2
+the anbindung,the anbindung,复合词,NOUN,B2
+with what,with what,用什么,ADV,B2
+handyman,handyman,工匠,NOUN,B2
+urnahme,urnahme,词,NOUN,B2
+devices,devices,设备,NOUN,B2
+detective force,detective force,刑警,NOUN,B2
+the alphabet,the alphabet,名词,NOUN,B2
+the vorbindung,the vorbindung,复合词,NOUN,B2
+wiedersinnung,wiedersinnung,词,NOUN,B2
+weitregelung,weitregelung,词,NOUN,B2
+the hochsammlung,the hochsammlung,复合词,NOUN,B2
+zuschaft,zuschaft,词,NOUN,B2
+the anbieter,the anbieter,名词,NOUN,B2
+the albatros,the albatros,名词,NOUN,B2
+letter mail,letter mail,信,NOUN,B2
+once again,once again,再次,ADV,B2
+the abwurf,the abwurf,名词,NOUN,B2
+wiedererziehung,wiedererziehung,词,NOUN,B2
+the verform,the verform,复合词,NOUN,B2
+the nachstoff,the nachstoff,复合词,NOUN,B2
+the misskraft,the misskraft,复合词,NOUN,B2
+ferntheilung,ferntheilung,词,NOUN,B2
+cheers,cheers,欢呼,NOUN,B2
+emergency call,emergency call,紧急呼叫,NOUN,B2
+eleven,eleven,十一,NOUN,B2
+german person,german person,德国人,NOUN,B2
+hectic,hectic,忙乱,NOUN,B2
+to be added,to be added,加入,VERB,B2
+hintersicht,hintersicht,词,NOUN,B2
+to switch on,to switch on,开启,VERB,B2
+the zerrechnung,the zerrechnung,复合词,NOUN,B2
+the verstellung,the verstellung,复合词,NOUN,B2
+wiedersuchung,wiedersuchung,词,NOUN,B2
+sick nauseous,sick nauseous,恶心的,ADJ,B2
+you formal,you formal,您,PRON,B2
+congratulations,congratulations,祝贺,NOUN,B2
+zurichtung,zurichtung,词,NOUN,B2
+bepflegung,bepflegung,词,NOUN,B2
+hinterregelung,hinterregelung,词,NOUN,B2
+gesucht,gesucht,词,NOUN,B2
+zerteilung,zerteilung,词,NOUN,B2
+vorderleitung,vorderleitung,词,NOUN,B2
+nachweisung,nachweisung,词,NOUN,B2
+nachwirkung,nachwirkung,词,NOUN,B2
+the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
+the zerhandlung,the zerhandlung,复合词,NOUN,B2
+the abstoff,the abstoff,复合词,NOUN,B2
+straight,straight,直的,NOUN,B2
+over about,over about,在...上方,ADP,B2
+squeak,squeak,吱吱声,NOUN,B2
+the unterheilung,the unterheilung,复合词,NOUN,B2
+some things,some things,一些事情,PRON,B2
+most,most,大多数,DET,B2
+no not any,no not any,没有,DET,B2
+ursetzung,ursetzung,词,NOUN,B2
+at it,at it,靠近,ADV,B2
+the ausleitung,the ausleitung,复合词,NOUN,B2
+expert opinion,expert opinion,专家意见,NOUN,B2
+the auswendung,the auswendung,复合词,NOUN,B2
+to descend from,to descend from,起源于,VERB,B2
+the hochminderung,the hochminderung,复合词,NOUN,B2
+your pl,your pl,你们的,DET,B2
+yours,yours,你的,PRON,B2
+pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
+erwirkung,erwirkung,词,NOUN,B2
+abfassung,abfassung,词,NOUN,B2
+the abhandlung,the abhandlung,复合词,NOUN,B2
+the alias,the alias,名词,NOUN,B2
+yoga practice,yoga practice,瑜伽练习,NOUN,B2
+the urmischung,the urmischung,复合词,NOUN,B2
+aussuchung,aussuchung,词,NOUN,B2
+nachfassung,nachfassung,词,NOUN,B2
+unschaft,unschaft,词,NOUN,B2
+anschrift,anschrift,词,NOUN,B2
+erztheilung,erztheilung,词,NOUN,B2
+at night,at night,夜间,ADV,B2
+the anordnung,the anordnung,复合词,NOUN,B2
+untersetzung,untersetzung,词,NOUN,B2
+the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
+the nachheilung,the nachheilung,复合词,NOUN,B2
+the missrechnung,the missrechnung,复合词,NOUN,B2
+the unwendung,the unwendung,复合词,NOUN,B2
+hochforderung,hochforderung,词,NOUN,B2
+the beordnung,the beordnung,复合词,NOUN,B2
+to abtun,to abtun,动词,VERB,B2
+vorderwandel,vorderwandel,词,NOUN,B2
+the zerordnung,the zerordnung,复合词,NOUN,B2
+aussucht,aussucht,词,NOUN,B2
+the anbettlung,the anbettlung,名词,NOUN,B2
+wiederleitung,wiederleitung,词,NOUN,B2
+to circumcise,to circumcise,割礼,VERB,B2
+the vermacht,the vermacht,复合词,NOUN,B2
+justified,justified,有根据的,ADJ,B2
+the geform,the geform,复合词,NOUN,B2
+hinterweisung,hinterweisung,词,NOUN,B2
+mitsicht,mitsicht,词,NOUN,B2
+nachsucht,nachsucht,词,NOUN,B2
+passed,passed,递,ADJ,B2
+nachschaft,nachschaft,词,NOUN,B2
+the ververbesserung,the ververbesserung,复合词,NOUN,B2
+vorerziehung,vorerziehung,词,NOUN,B2
+weitteilung,weitteilung,词,NOUN,B2
+the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
+the urrechnung,the urrechnung,复合词,NOUN,B2
+different,different,不同地,ADV,B2
+period,period,句号,PUNCT,B2
+the zerkraft,the zerkraft,复合词,NOUN,B2
+misssicht,misssicht,词,NOUN,B2
+joie de vivre,joie de vivre,生活乐趣,NOUN,B2
+the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
+the urstellung,the urstellung,复合词,NOUN,B2
+for each other,for each other,相互,ADV,B2
+hochgabe,hochgabe,词,NOUN,B2
+kitten,kitten,小猫,NOUN,B2
+outside of,outside of,在...之外,ADP,B2
+fernkunft,fernkunft,词,NOUN,B2
+to be valid,to be valid,有效,VERB,B2
+wiederfahrt,wiederfahrt,词,NOUN,B2
+to be liable,to be liable,负责,VERB,B2
+the vorkraft,the vorkraft,复合词,NOUN,B2
+the verminderung,the verminderung,复合词,NOUN,B2
+to abwandeln,to abwandeln,动词,VERB,B2
+the urbewegung,the urbewegung,复合词,NOUN,B2
+to absichern,to absichern,动词,VERB,B2
+the grundbildung,the grundbildung,复合词,NOUN,B2
+the ververtiefung,the ververtiefung,复合词,NOUN,B2
+ersetzung,ersetzung,词,NOUN,B2
+all the more,all the more,更加,ADV,B2
+to squeak,to squeak,吱吱叫,VERB,B2
+aberziehung,aberziehung,词,NOUN,B2
+mittheilung,mittheilung,词,NOUN,B2
+the altertum,the altertum,名词,NOUN,B2
+zerregelung,zerregelung,词,NOUN,B2
+mitpflegung,mitpflegung,词,NOUN,B2
+worse,worse,更糟的事,NOUN,B2
+the versthandlung,the versthandlung,复合词,NOUN,B2
+gefahrt,gefahrt,词,NOUN,B2
+managing director,managing director,总经理,NOUN,B2
+erzfahrt,erzfahrt,词,NOUN,B2
+coke,coke,可卡因,NOUN,B2
+as possible,as possible,尽可能地,ADV,B2
+waste of time,waste of time,浪费时间,NOUN,B2
+the unstellung,the unstellung,复合词,NOUN,B2
+aufgestaltung,aufgestaltung,词,NOUN,B2
+versinnung,versinnung,词,NOUN,B2
+missfassung,missfassung,词,NOUN,B2
+the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
+the abbindung,the abbindung,复合词,NOUN,B2
+masseur,masseur,按摩师,NOUN,B2
+all saints' day,all saints' day,诸圣节,NOUN,B2
+the angriff,the angriff,名词,NOUN,B2
+doorbell button,doorbell button,门铃按钮,NOUN,B2
+endeavor,endeavor,努力,NOUN,B2
+dearest,dearest,最爱的人,NOUN,B2
+relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
+nachwandel,nachwandel,词,NOUN,B2
+the verstbindung,the verstbindung,复合词,NOUN,B2
+the abordnung,the abordnung,复合词,NOUN,B2
+to lie to,to lie to,对...说谎,VERB,B2
+where i,where i,,NOUN,B2
+ground basis,ground basis,基础/理由,NOUN,B2
+existential,existential,存在主义的,ADJ,B2
+bare ownership,bare ownership,虚有权,NOUN,B2
+humble,humble,谦逊的,ADJ,B2
+burger stand,burger stand,,NOUN,B2
+neophyte,neophyte,新手；初学者,NOUN,B2
+swine,swine,猪,NOUN,B2
+athletic,athletic,运动的,ADJ,B2
+to place put,to place put,放置,VERB,B2
+urbanization,urbanization,城市化,NOUN,B2
+antibiotic,antibiotic,抗生素,NOUN,B2
+here hither,here hither,这里/到这里,ADV,B2
+forensic,forensic,法医的,ADJ,B2
+matter of time,matter of time,时间问题,NOUN,B2
+cover blanket,cover blanket,覆盖物,NOUN,B2
+to complement,to complement,补充,VERB,B2
+totalitarian,totalitarian,极权主义的,ADJ,B2
+e-reader,e-reader,电子阅读器,NOUN,B2
+sync,sync,同步,NOUN,B2
+ready finished,ready finished,准备好的/完成的,ADJ,B2
+self-care,self-care,自我护理,NOUN,B2
+to encroach,to encroach,侵蚀,VERB,B2
+liable,liable,有责任的,ADJ,B2
+disrespect,disrespect,不敬,NOUN,B2
+indexing,indexing,指数化,NOUN,B2
+mighty very,mighty very,非常,ADJ,B2
+to incriminate,to incriminate,归罪,VERB,B2
+spice,spice,香料,NOUN,B2
+public holiday,public holiday,公共假日,ADJ,B2
+more pl,more pl,更多,ADJ,B2
+symbolism,symbolism,象征主义,NOUN,B2
+to spill,to spill,溢出,VERB,B2
+to transgress,to transgress,违背,VERB,B2
+upset,upset,心烦的,ADJ,B2
+listen up,listen up,听着,INTJ,B2
+airs,airs,摆架子,NOUN,B2
+to deprave,to deprave,使堕落,VERB,B2
+surely safe,surely safe,肯定地,ADV,B2
+one-way,one-way,单向的,ADJ,B2
+anathema,anathema,深恶痛绝之物,NOUN,B2
+implicitly,implicitly,含蓄地,ADV,B2
+ascetic,ascetic,苦行的,ADJ,B2
+colder,colder,更冷的,ADJ,B2
+sulfur,sulfur,硫,NOUN,B2
+fjeld cleft,fjeld cleft,,NOUN,B2
+lethargic,lethargic,昏睡的,ADJ,B2
+six-year-old,six-year-old,,NOUN,B2
+approximate,approximate,近似的,ADJ,B2
+deceit,deceit,欺骗,NOUN,B2
+unknown,unknown,未知数,NOUN,B2
+to auscultate,to auscultate,听诊,VERB,B2
+hard,hard,努力地,ADV,B2
+minority group,minority group,少数群体,NOUN,B2
+proposal suggestion,proposal suggestion,建议,NOUN,B2
+more,more,مزيد,NOUN,B2
+scrupulous,scrupulous,一丝不苟的,ADJ,B2
+all everyone,all everyone,所有/大家,PRON,B2
+play game,play game,游戏/玩耍,NOUN,B2
+painless,painless,,NOUN,B2
+bulwark,bulwark,壁垒,NOUN,B2
+cerebral,cerebral,大脑的,ADJ,B2
+shrimp,shrimp,虾,NOUN,B2
+buffoon,buffoon,小丑,NOUN,B2
+triumph,triumph,胜利,NOUN,B2
+nineteen,nineteen,十九,NUM,B2
+disposable,disposable,一次性的,ADJ,B2
+cats,cats,猫,NOUN,B2
+tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
+socialization,socialization,社会化,NOUN,B2
+bike basket,bike basket,车筐,NOUN,B2
+prognosis,prognosis,预后,NOUN,B2
+lifeless,lifeless,无生命的,ADJ,B2
+buoyant,buoyant,有浮力的,ADJ,B2
+to disfavor,to disfavor,不利于,VERB,B2
+fissure,fissure,裂缝,NOUN,B2
+to deafen,to deafen,使聋,VERB,B2
+the career,the career,职业生涯,NOUN,B2
+supplication,supplication,恳求,NOUN,B2
+temerity,temerity,鲁莽,NOUN,B2
+drag,drag,拖曳,NOUN,B2
+hair bun,hair bun,发髻,NOUN,B2
+complementarity,complementarity,互补性,NOUN,B2
+locked,locked,锁定的,ADJ,B2
+layer storage,layer storage,层/仓库,NOUN,B2
+beautifully,beautifully,美丽地,ADV,B2
+fare,fare,车费,NOUN,B2
+to consummate,to consummate,完成,VERB,B2
+to allege,to allege,宣称,VERB,B2
+numb,numb,麻木的,ADJ,B2
+to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
+outlaw,outlaw,歹徒,NOUN,B2
+conductivity,conductivity,导电性,NOUN,B2
+to retrace,to retrace,追溯,VERB,B2
+to perpetuate,to perpetuate,使永存,VERB,B2
+to dishevel,to dishevel,弄乱,VERB,B2
+to depilate,to depilate,脱毛,VERB,B2
+to disenchant,to disenchant,使清醒,VERB,B2
+brawl,brawl,斗殴,NOUN,B2
+punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
+equal treatment,equal treatment,平等待遇,NOUN,B2
+to deal,to deal,处理,VERB,B2
+chief physician,chief physician,主任医师,NOUN,B2
+professionally active,professionally active,在职,NOUN,B2
+premeditation,premeditation,预谋,NOUN,B2
+idiotic,idiotic,愚蠢的,ADJ,B2
+swimming,swimming,游泳,NOUN,B2
+short film,short film,短片,NOUN,B2
+to disrupt,to disrupt,扰乱,VERB,B2
+the casinos,the casinos,赌场,NOUN,B2
+buccaneer,buccaneer,海盗,NOUN,B2
+like that,like that,像那样,ADV,B2
+to absolve,to absolve,赦免,VERB,B2
+to bump push,to bump push,推/碰撞,VERB,B2
+trinket,trinket,小饰品,NOUN,B2
+shuttle,shuttle,穿梭巴士,NOUN,B2
+junior jersey,junior jersey,,NOUN,B2
+to be felled,to be felled,被砍倒,VERB,B2
+nonprofit,nonprofit,非营利的,ADJ,B2
+news reporting,news reporting,新闻报道,NOUN,B2
+would,would,将要,AUX,B2
+to recharge,to recharge,充电,VERB,B2
+roadway,roadway,路面,NOUN,B2
+precarization,precarization,不稳定化,NOUN,B2
+outdoors,outdoors,户外,ADV,B2
+to buy back,to buy back,赎回,VERB,B2
+meaning content,meaning content,语义内容,NOUN,B2
+to adore,to adore,爱慕,VERB,B2
+to reopen,to reopen,重新开放,VERB,B2
+one you,one you,人们,PRON,B2
+omnipresent,omnipresent,无所不在的,ADJ,B2
+slum,slum,贫民窟,NOUN,B2
+co-determination,co-determination,共同决定权,NOUN,B2
+resuscitation,resuscitation,复苏,NOUN,B2
+elementary,elementary,基本的,ADJ,B2
+ace carcass,ace carcass,王牌/尸体,NOUN,B2
+curfew,curfew,宵禁,NOUN,B2
+shyness,shyness,羞怯,NOUN,B2
+surreptitious,surreptitious,秘密的,ADJ,B2
+to allude,to allude,暗指,VERB,B2
+from behind,from behind,从后面,ADV,B2
+resource shortage,resource shortage,资源短缺,NOUN,B2
+lunatic,lunatic,疯子,NOUN,B2
+to extirpate,to extirpate,根除,VERB,B2
+plenitude,plenitude,充足,NOUN,B2
+to eternalize,to eternalize,使永恒,VERB,B2
+ferry,ferry,渡轮,NOUN,B2
+fulfillment,fulfillment,满足,NOUN,B2
+nuclear war,nuclear war,核战争,NOUN,B2
+insanely,insanely,疯狂地,ADV,B2
+to dismay,to dismay,使沮丧,VERB,B2
+occupational pension,occupational pension,职业养老金,NOUN,B2
+cudgel,cudgel,棍棒,NOUN,B2
+sadistic,sadistic,施虐的,ADJ,B2
+his her its their,his her its their,他的/她的/它的/他们的,DET,B2
+to decant,to decant,倾析,VERB,B2
+to decouple,to decouple,分离,VERB,B2
+airtight,airtight,密封的,ADJ,B2
+acerbic,acerbic,尖刻的,ADJ,B2
+to bluff,to bluff,虚张声势,VERB,B2
+cloister,cloister,回廊,NOUN,B2
+to put set,to put set,放置,VERB,B2
+selected,selected,选中的,ADJ,B2
+disturbed,disturbed,不安的,ADJ,B2
+palliative,palliative,缓和的,ADJ,B2
+obliged,obliged,被迫的,ADJ,B2
+vigilant,vigilant,警惕的,ADJ,B2
+appeasement,appeasement,平息,NOUN,B2
+to disfigure,to disfigure,毁容,VERB,B2
+ideally,ideally,理想地,ADV,B2
+to meant,to meant,意思是,VERB,B2
+should ought to,should ought to,应该,AUX,B2
+crusade,crusade,运动,NOUN,B2
+from within,from within,从内部,ADV,B2
+outcome ending,outcome ending,结局，解决,NOUN,B2
+thicker,thicker,更厚的,ADJ,B2
+shady suspicious,shady suspicious,可疑的,ADJ,B2
+playwright,playwright,剧作家,NOUN,B2
+sexy,sexy,性感的,ADJ,B2
+values base,values base,价值基础,NOUN,B2
+jews,jews,犹太人,NOUN,B2
+to dawdle,to dawdle,闲逛,VERB,B2
+to saturate,to saturate,使饱和,VERB,B2
+cradle,cradle,摇篮,NOUN,B2
+mammal,mammal,哺乳动物,NOUN,B2
+sail,sail,帆,NOUN,B2
+irish person,irish person,爱尔兰人,NOUN,B2
+autism,autism,自闭症,NOUN,B2
+dator,dator,电脑,NOUN,B2
+superb,superb,极好的,ADJ,B2
+to bungle,to bungle,搞砸,VERB,B2
+slut,slut,荡妇,NOUN,B2
+enamel,enamel,珐琅,NOUN,B2
+meticulously,meticulously,一丝不苟地,ADV,B2
+to map out,to map out,摸清,VERB,B2
+phlegmatic,phlegmatic,冷静的,ADJ,B2
+to freshen,to freshen,使清新,VERB,B2
+solecism,solecism,语法错误,NOUN,B2
+doctor visit,doctor visit,,NOUN,B2
+dans,dans,舞蹈,NOUN,B2
+cooked,cooked,熟的,ADJ,B2
+super dead,super dead,,NOUN,B2
+thicket,thicket,灌木丛,NOUN,B2
+film movie,film movie,电影,NOUN,B2
+to fasten,to fasten,系紧,VERB,B2
+historicism,historicism,历史主义,NOUN,B2
+racist,racist,种族主义者,NOUN,B2
+to slash,to slash,猛砍,VERB,B2
+detention center,detention center,拘留所,NOUN,B2
+sinister,sinister,不祥的,ADJ,B2
+deleveraging,deleveraging,去杠杆化,NOUN,B2
+tax exemption,tax exemption,免税,NOUN,B2
+to digitize,to digitize,数字化,VERB,B2
+dissatisfaction,dissatisfaction,不满,NOUN,B2
+implacably,implacably,毫不留情地,ADV,B2
+phone number,phone number,电话号码,NOUN,B2
+lent,lent,大斋期,NOUN,B2
+repertoire,repertoire,全部曲目,NOUN,B2
+win,win,胜利,NOUN,B2
+shocked,shocked,震惊的,ADJ,B2
+bog,bog,沼泽,NOUN,B2
+instructor,instructor,讲师,NOUN,B2
+filthy,filthy,肮脏的,ADJ,B2
+to overshadow,to overshadow,使黯然失色,VERB,B2
+clock watch,clock watch,钟表,NOUN,B2
+to familiarize,to familiarize,使熟悉,VERB,B2
+corporate,corporate,公司的,ADJ,B2
+authoritative,authoritative,权威的,ADJ,B2
+landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
+band tape,band tape,带子,NOUN,B2
+dent,dent,凹痕,NOUN,B2
+impromptu,impromptu,即兴的,ADJ,B2
+orange juice,orange juice,橙汁,NOUN,B2
+periphery,periphery,边缘,NOUN,B2
+gastronomic,gastronomic,美食的,ADJ,B2
+to beget,to beget,引起,VERB,B2
+to manifest,to manifest,表明,VERB,B2
+to purify,to purify,净化,VERB,B2
+spinning,spinning,纺纱,NOUN,B2
+guffaw,guffaw,哄笑,NOUN,B2
+to venerate,to venerate,崇敬,VERB,B2
+cellulose,cellulose,纤维素,NOUN,B2
+to preside,to preside,主持,VERB,B2
+tremulous,tremulous,颤抖的,ADJ,B2
+syllable,syllable,音节,NOUN,B2
+sanitation,sanitation,卫生,NOUN,B2
+checkup,checkup,体检,NOUN,B2
+psychoanalysis,psychoanalysis,精神分析,NOUN,B2
+capital gain,capital gain,增值,NOUN,B2
+fresh,fresh,,NOUN,B2
+royalty,royalty,王室,NOUN,B2
+cleanly,cleanly,干净地,ADV,B2
+to know feel,to know feel,认识/感觉,VERB,B2
+evidence bag,evidence bag,,NOUN,B2
+to placate,to placate,安抚,VERB,B2
+optimization,optimization,优化,NOUN,B2
+steak,steak,牛排,NOUN,B2
+little one,little one,小家伙,NOUN,B2
+advancement,advancement,晋升,NOUN,B2
+suicide candidate,suicide candidate,,NOUN,B2
+slam,slam,,NOUN,B2
+libertinism,libertinism,放荡,NOUN,B2
+reluctance,reluctance,不情愿,NOUN,B2
+surcharge,surcharge,附加费,NOUN,B2
+binoculars,binoculars,双筒望远镜,NOUN,B2
+extraterrestrial,extraterrestrial,外星的,ADJ,B2
+hallelujah,hallelujah,哈利路亚,INTJ,B2
+extravagant,extravagant,奢侈的,ADJ,B2
+to attest,to attest,证明,VERB,B2
+to rant,to rant,咆哮,VERB,B2
+to fatten,to fatten,养肥,VERB,B2
+antagonism,antagonism,对抗,NOUN,B2
+snot,snot,鼻涕,NOUN,B2
+gender equality,gender equality,性别平等,NOUN,B2
+will shall,will shall,将要/会,AUX,B2
+told instructed,told instructed,被告知的,ADJ,B2
+reduction,reduction,减少,NOUN,B2
+aloofness,aloofness,冷漠,NOUN,B2
+up there,up there,在那上面,ADV,B2
+retailer,retailer,零售商,NOUN,B2
+longer,longer,更长的,ADJ,B2
+fewer,fewer,较少的,ADJ,B2
+just precis,just precis,恰好,ADV,B2
+to disqualify,to disqualify,取消资格,VERB,B2
+to elide,to elide,省略,VERB,B2
+to meditate,to meditate,沉思,VERB,B2
+overdraft,overdraft,透支,NOUN,B2
+existentialism,existentialism,存在主义,NOUN,B2
+substandard,substandard,,NOUN,B2
+to missed,to missed,错过,VERB,B2
+to extol,to extol,赞美,VERB,B2
+vaccine-related,vaccine-related,疫苗的,ADJ,B2
+in here,in here,在这里面,ADV,B2
+antidote,antidote,解毒剂,NOUN,B2
+pernicious,pernicious,有害的,ADJ,B2
+present time,present time,现在,NOUN,B2
+nuclear weapon,nuclear weapon,核武器,NOUN,B2
+freedom of assembly,freedom of assembly,集会自由,NOUN,B2
+speculator,speculator,投机者,NOUN,B2
+to exorcise,to exorcise,驱魔,VERB,B2
+field medic,field medic,战地医生,NOUN,B2
+lucidity,lucidity,清醒 / 明晰,NOUN,B2
+beleaguered,beleaguered,受围困的,ADJ,B2
+humid,humid,潮湿的,ADJ,B2
+salon,salon,沙龙,NOUN,B2
+infant,infant,婴儿,NOUN,B2
+to blaspheme,to blaspheme,亵渎,VERB,B2
+to consider think,to consider think,考虑/思考,VERB,B2
+honorable,honorable,可敬的,ADJ,B2
+to be taken,to be taken,被拿走,VERB,B2
+bejeweled,bejeweled,镶满宝石的,ADJ,B2
+snazzy,snazzy,时髦的,ADJ,B2
+intricate,intricate,错综复杂的,ADJ,B2
+holder,holder,持有者,NOUN,B2
+fired,fired,被解雇的,ADJ,B2
+ataxia,ataxia,共济失调,NOUN,B2
+online dating profile,online dating profile,,NOUN,B2
+sibling,sibling,兄弟姐妹,NOUN,B2
+to flee escape,to flee escape,逃跑,VERB,B2
+kidnapped,kidnapped,被绑架的,ADJ,B2
+slowdown,slowdown,减速,NOUN,B2
+disrepute,disrepute,坏名声,NOUN,B2
+to flush,to flush,冲洗,VERB,B2
+to culminate,to culminate,达到顶点,VERB,B2
+press freedom,press freedom,新闻自由,NOUN,B2
+demonstrative,demonstrative,演示的,ADJ,B2
+mosquito net,mosquito net,蚊帐,NOUN,B2
+furrow,furrow,犁沟,NOUN,B2
+underclass,underclass,底层,NOUN,B2
+unscathed,unscathed,未受伤害的,ADJ,B2
+effort bet,effort bet,努力/赌注,NOUN,B2
+except for,except for,除了,ADP,B2
+rubber,rubber,橡胶,NOUN,B2
+thrilling,thrilling,令人兴奋的,ADJ,B2
+observation skill,observation skill,,NOUN,B2
+to wane,to wane,减弱,VERB,B2
+foal,foal,马驹,NOUN,B2
+asp,asp,角蝰,NOUN,B2
+gaping,gaping,,NOUN,B2
+fluid,fluid,液体,NOUN,B2
+meeting hit,meeting hit,会面/击中,NOUN,B2
+freedom of speech,freedom of speech,言论自由,NOUN,B2
+ribs,ribs,肋骨,NOUN,B2
+unilateral,unilateral,单方面的,ADJ,B2
+to object,to object,反对,VERB,B2
+much many,much many,许多,ADJ,B2
+of by,of by,的/被,ADP,B2
+nourishment,nourishment,营养,NOUN,B2
+corporation,corporation,公司,NOUN,B2
+perennial,perennial,长期的,ADJ,B2
+the safe,the safe,保险箱,NOUN,B2
+bud,bud,芽,NOUN,B2
+cricket,cricket,板球,NOUN,B2
+din,din,喧嚣,NOUN,B2
+bridle,bridle,马勒,NOUN,B2
+to captivate,to captivate,迷住,VERB,B2
+slothful,slothful,懒惰的,ADJ,B2
+millions of,millions of,数百万的,NUM,B2
+philippic,philippic,猛烈的抨击,NOUN,B2
+baggage,baggage,行李,NOUN,B2
+self-esteem,self-esteem,自尊,NOUN,B2
+mapping,mapping,梳理,NOUN,B2
+strangely,strangely,奇怪地,ADV,B2
+to embolden,to embolden,使大胆,VERB,B2
+freedom of opinion,freedom of opinion,意见自由,NOUN,B2
+to appear to seem,to appear to seem,出现/显得,VERB,B2
+terrorists,terrorists,恐怖分子们,NOUN,B2
+nah,nah,不,INTJ,B2
+to creak,to creak,嘎吱作响,VERB,B2
+fluency,fluency,流利,NOUN,B2
+bro,bro,哥们,NOUN,B2
+to coerce,to coerce,强迫,VERB,B2
+fascinated,fascinated,着迷的,ADJ,B2
+painstakingly,painstakingly,细致地,ADV,B2
+decor,decor,布景,NOUN,B2
+moose,moose,驼鹿,NOUN,B2
+scheduling,scheduling,调度；排序,NOUN,B2
+editing,editing,剪辑,NOUN,B2
+citrus,citrus,柑橘,NOUN,B2
+attempted murder,attempted murder,谋杀未遂,NOUN,B2
+to enunciate,to enunciate,阐明,VERB,B2
+to bisect,to bisect,平分,VERB,B2
+to calibrate,to calibrate,校准,VERB,B2
+to blossom,to blossom,开花,VERB,B2
+good day,good day,你好,INTJ,B2
+to discern,to discern,辨别,VERB,B2
+assurance,assurance,保证,NOUN,B2
+kind sort,kind sort,种类,NOUN,B2
+to plane,to plane,刨,VERB,B2
+itinerant,itinerant,巡回的,ADJ,B2
+to flog,to flog,鞭打,VERB,B2
+rock slab,rock slab,岩板,NOUN,B2
+to sparkle,to sparkle,闪耀,VERB,B2
+care home,care home,,NOUN,B2
+miserly,miserly,吝啬的,ADJ,B2
+sordid,sordid,肮脏的,ADJ,B2
+outlandish,outlandish,古怪的,ADJ,B2
+arid,arid,干旱的,ADJ,B2
+to emasculate,to emasculate,使无力,VERB,B2
+trusting,trusting,信任的,ADJ,B2
+keen eager,keen eager,渴望的,ADJ,B2
+witness protection,witness protection,,NOUN,B2
+costly,costly,昂贵的,ADJ,B2
+to warm,to warm,加热,VERB,B2
+to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
+to demarcate,to demarcate,划定界限,VERB,B2
+to diet,to diet,减肥,VERB,B2
+to stay awake,to stay awake,守夜,VERB,B2
+to connote,to connote,暗示,VERB,B2
+obtaining,obtaining,获得,NOUN,B2
+luminous,luminous,发光的,ADJ,B2
+prodigy,prodigy,神童,NOUN,B2
+tobacco,tobacco,烟草,NOUN,B2
+multinational,multinational,跨国公司,NOUN,B2
+disrespectful,disrespectful,无礼的,ADJ,B2
+to function work,to function work,运作/起作用,VERB,B2
+split secession,split secession,分裂,NOUN,B2
+couple pair,couple pair,一对,NOUN,B2
+civilisation,civilisation,文明,NOUN,B2
+notarized,notarized,经公证的,ADJ,B2
+deck tire,deck tire,甲板/轮胎,NOUN,B2
+psychiatric,psychiatric,精神病的,ADJ,B2
+abroad,abroad,在国外,ADV,B2
+contaminated,contaminated,受污染的,ADJ,B2
+underworld,underworld,地下世界,NOUN,B2
+to enthrone,to enthrone,立为王,VERB,B2
+insatiable,insatiable,不知足的,ADJ,B2
+fluctuating,fluctuating,波动的,ADJ,B2
+for sale,for sale,待售,ADJ,B2
+to soften,to soften,使灵活,VERB,B2
+to conjugate,to conjugate,变位,VERB,B2
+to bring lead,to bring lead,带来/引导,VERB,B2
+suite,suite,套房,NOUN,B2
+recall,recall,回忆,NOUN,B2
+thoughtfully,thoughtfully,体贴地,ADV,B2
+ajar,ajar,半开的,ADJ,B2
+brain activity,brain activity,,NOUN,B2
+motel,motel,汽车旅馆,NOUN,B2
+spelling,spelling,拼写,NOUN,B2
+parcel,parcel,包裹,NOUN,B2
+dungeon,dungeon,地牢,NOUN,B2
+polar,polar,极地的,ADJ,B2
+cultural heritage,cultural heritage,文化遗产,NOUN,B2
+kind species,kind species,种类/物种,NOUN,B2
+to be created,to be created,被创造,VERB,B2
+to declaim,to declaim,慷慨陈词,VERB,B2
+arrived present,arrived present,到了,ADV,B2
+respondent,respondent,被上诉人,NOUN,B2
+to dethrone,to dethrone,废黜,VERB,B2
+to drip,to drip,滴,VERB,B2
+lust,lust,欲望,NOUN,B2
+enormously,enormously,巨大地,ADV,B2
+light-year,light-year,,NOUN,B2
+inboard,inboard,船内的,ADV,B2
+filled,filled,充满的,ADJ,B2
+younger,younger,较年轻的,ADJ,B2
+catachresis,catachresis,词语误用,NOUN,B2
+tv movie,tv movie,电视电影,NOUN,B2
+to come loose,to come loose,松脱,VERB,B2
+to calm down,to calm down,使平静,VERB,B2
+sophisticated,sophisticated,复杂的,ADJ,B2
+balsam,balsam,香脂,NOUN,B2
+to supplicate,to supplicate,恳求,VERB,B2
+limb,limb,肢体,NOUN,B2
+audacious,audacious,大胆的,ADJ,B2
+aged,aged,年老的,ADJ,B2
+student residence,student residence,学生宿舍,NOUN,B2
+respectful,respectful,恭敬的,ADJ,B2
+to fossilize,to fossilize,石化,VERB,B2
+roadblock,roadblock,,NOUN,B2
+charismatic,charismatic,有魅力的,ADJ,B2
+dozens,dozens,数十个,NOUN,B2
+constancy,constancy,恒定,NOUN,B2
+decimal,decimal,小数,NOUN,B2
+to denigrate,to denigrate,诋毁,VERB,B2
+integral,integral,不可或缺的,ADJ,B2
+intangible,intangible,无形的,ADJ,B2
+famine,famine,饥荒,NOUN,B2
+guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
+so-called,so-called,,NOUN,B2
+to relay,to relay,转达,VERB,B2
+to reproach,to reproach,责备,VERB,B2
+that to,that to,那/去,PART,B2
+bubbling,bubbling,冒泡的,ADJ,B2
+all-clear,all-clear,许可信号,NOUN,B2
+service year,service year,,NOUN,B2
+to contend,to contend,主张,VERB,B2
+drunkenness,drunkenness,醉酒,NOUN,B2
+to democratize,to democratize,民主化,VERB,B2
+preliminary investigation,preliminary investigation,,NOUN,B2
+anachronistic,anachronistic,时代错误的,ADJ,B2
+igneous,igneous,火成的,ADJ,B2
+to disabuse,to disabuse,纠正错误想法,VERB,B2
+chili,chili,辣椒,NOUN,B2
+reprieve,reprieve,暂缓执行,NOUN,B2
+marvelous,marvelous,极好的,ADJ,B2
+databas,databas,数据库,NOUN,B2
+doe,doe,雌鹿,NOUN,B2
+larva,larva,幼虫,NOUN,B2
+bicameral,bicameral,两院制的,ADJ,B2
+jet,jet,喷气式飞机,NOUN,B2
+demographic,demographic,人口统计的,ADJ,B2
+anaphora,anaphora,首语重复修辞,NOUN,B2
+to goad,to goad,刺激,VERB,B2
+to equate,to equate,等同,VERB,B2
+opacity,opacity,不透明性,NOUN,B2
+wicked,wicked,邪恶的,ADJ,B2
+taxonomy,taxonomy,分类学,NOUN,B2
+advertising,advertising,广告的,ADJ,B2
+pathogenic,pathogenic,致病的,ADJ,B2
+bookcase,bookcase,书柜,NOUN,B2
+malmo,malmo,马尔默,PROPN,B2
+to yearn,to yearn,渴望,VERB,B2
+relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
+attractiveness,attractiveness,吸引力,NOUN,B2
+loathing,loathing,,NOUN,B2
+tilt,tilt,倾斜,NOUN,B2
+amendable,amendable,可修正的,ADJ,B2
+to segregate,to segregate,隔离,VERB,B2
+to make stupid,to make stupid,使愚蠢,VERB,B2
+incision,incision,切口,NOUN,B2
+to annul,to annul,废除,VERB,B2
+incandescent,incandescent,白炽的,ADJ,B2
+to embark,to embark,上船,VERB,B2
+cornice,cornice,檐口,NOUN,B2
+to accentuate,to accentuate,强调,VERB,B2
+altercation,altercation,争执,NOUN,B2
+glimpse,glimpse,一瞥,NOUN,B2
+darn,darn,哎呀,INTJ,B2
+phenomenal,phenomenal,非凡的,ADJ,B2
+trapdoor,trapdoor,活板门,NOUN,B2
+prosody,prosody,韵律学,NOUN,B2
+best friend,best friend,最好的朋友,NOUN,B2
+to decode,to decode,解码,VERB,B2
+drugs,drugs,毒品,NOUN,B2
+courteous,courteous,有礼貌的,ADJ,B2
+ballot,ballot,选票,NOUN,B2
+boastful,boastful,自夸的,ADJ,B2
+jointly,jointly,共同地,ADV,B2
+lower,lower,较低的,ADJ,B2
+predominance,predominance,主导地位,NOUN,B2
+to raise bring up,to raise bring up,抚养,VERB,B2
+balm,balm,香脂,NOUN,B2
+masonry,masonry,砌体,NOUN,B2
+to leave stick,to leave stick,离开/刺,VERB,B2
+drug dealer,drug dealer,毒贩,NOUN,B2
+invincible,invincible,无敌的,ADJ,B2
+political party,political party,政党,NOUN,B2
+bard,bard,吟游诗人,NOUN,B2
+hint,hint,暗示,NOUN,B2
+disobedient,disobedient,不服从的,ADJ,B2
+scorn,scorn,轻蔑,NOUN,B2
+the guy,the guy,那个男人,NOUN,B2
+last evening,last evening,,NOUN,B2
+strenuous,strenuous,费力的,ADJ,B2
+to encircle,to encircle,环绕,VERB,B2
+chore,chore,家务,NOUN,B2
+to use to usually,to use to usually,通常/习惯于,VERB,B2
+iatrogenic,iatrogenic,医源性的,ADJ,B2
+too late,too late,太迟,ADV,B2
+prerogative,prerogative,特权,NOUN,B2
+to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
+choreographer,choreographer,编舞者,NOUN,B2
+to burnish,to burnish,擦亮,VERB,B2
+amnesia,amnesia,健忘症,NOUN,B2
+prayer trap,prayer trap,,NOUN,B2
+to splash,to splash,溅,VERB,B2
+to bequeath,to bequeath,遗赠,VERB,B2
+subtle,subtle,微妙的,ADJ,B2
+nerd,nerd,书呆子,NOUN,B2
+to daunt,to daunt,使气馁,VERB,B2
+to carve,to carve,雕刻,VERB,B2
+bastion,bastion,堡垒,NOUN,B2
+berkeley coach,berkeley coach,,NOUN,B2
+in two,in two,成两半,ADV,B2
+schism,schism,分裂,NOUN,B2
+to savor,to savor,品味,VERB,B2
+to alleviate,to alleviate,缓解,VERB,B2
+explosives,explosives,炸药,NOUN,B2
+jury,jury,陪审团,NOUN,B2
+corporatism,corporatism,法团主义,NOUN,B2
+from above,from above,从上方,ADV,B2
+to train exercise,to train exercise,训练/锻炼,VERB,B2
+rival,rival,对手,NOUN,B2
+middle class,middle class,中产阶层,NOUN,B2
+resistance movement,resistance movement,抵抗运动,NOUN,B2
+to expurgate,to expurgate,删节,VERB,B2
+to lament,to lament,哀叹,VERB,B2
+minimalism,minimalism,极简主义,NOUN,B2
+matter of conscience,matter of conscience,良心问题,NOUN,B2
+ethereal,ethereal,飘渺的,ADJ,B2
+sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
+to bifurcate,to bifurcate,分叉,VERB,B2
+ride lift,ride lift,搭车,NOUN,B2
+mafia,mafia,黑手党,NOUN,B2
+security-related,security-related,安全的，安保的,ADJ,B2
+plundering,plundering,掠夺,NOUN,B2
+to capitulate,to capitulate,投降,VERB,B2
+virulent,virulent,恶性的,ADJ,B2
+stew,stew,炖菜,NOUN,B2
+inadequate,inadequate,不足的,ADJ,B2
+malnutrition,malnutrition,营养不良,NOUN,B2
+alibi,alibi,不在场证明,NOUN,B2
+feeble,feeble,虚弱的,ADJ,B2
+displacement,displacement,位移,NOUN,B2
+byzantine,byzantine,错综复杂的,ADJ,B2
+to depreciate,to depreciate,贬值,VERB,B2
+intransigent,intransigent,不妥协的,ADJ,B2
+apologist,apologist,辩护者,NOUN,B2
+inflammation,inflammation,炎症,NOUN,B2
+ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
+to enervate,to enervate,使衰弱,VERB,B2
+to vilify,to vilify,诽谤,VERB,B2
+to fluster,to fluster,使慌乱,VERB,B2
+to disarrange,to disarrange,弄乱,VERB,B2
+incongruous,incongruous,不协调的,ADJ,B2
+to fraternize,to fraternize,勾结,VERB,B2
+to edify,to edify,启发,VERB,B2
+abstemious,abstemious,有节制的,ADJ,B2
+prize,prize,奖品,NOUN,B2
+to augur,to augur,预言,VERB,B2
+hepatic,hepatic,肝脏的,ADJ,B2
+postponement,postponement,延期,NOUN,B2
+humiliating,humiliating,令人羞辱的,ADJ,B2
+pious,pious,虔诚的,ADJ,B2
+freight,freight,货物,NOUN,B2
+to daze,to daze,使茫然,VERB,B2
+incessant,incessant,持续的,ADJ,B2
+spurious,spurious,虚假的,ADJ,B2
+abject,abject,悲惨的,ADJ,B2
+nosy,nosy,爱打听的,ADJ,B2
+promiscuous,promiscuous,滥交的,ADJ,B2
+to denote,to denote,表示,VERB,B2
+to exculpate,to exculpate,开脱,VERB,B2
+import,import,进口,NOUN,B2
+to scrub,to scrub,擦洗,VERB,B2
+to disconcert,to disconcert,使惊慌,VERB,B2
+dexterity,dexterity,灵巧,NOUN,B2
+corroboration,corroboration,证实,NOUN,B2
+to ascribe,to ascribe,归因于,VERB,B2
+stagnant,stagnant,停滞的,ADJ,B2
+format,format,格式,NOUN,B2
+craving,craving,渴求,NOUN,B2
+bonfire,bonfire,篝火,NOUN,B2
+gargoyle,gargoyle,滴水嘴兽,NOUN,B2
+gunshot,gunshot,枪声,NOUN,B2
+to acclaim,to acclaim,称赞,VERB,B2
+stoic,stoic,坚忍的,ADJ,B2
+tick,tick,滴答声,NOUN,B2
+sane,sane,神志正常的,ADJ,B2
+to rebuke,to rebuke,斥责,VERB,B2
+to ail,to ail,使苦恼,VERB,B2
+atrocity,atrocity,暴行,NOUN,B2
+oracle,oracle,神谕,NOUN,B2
+wealthy,wealthy,富有的,ADJ,B2
+irrational,irrational,非理性的,ADJ,B2
+deportation,deportation,驱逐出境,NOUN,B2
+bracket,bracket,括号,NOUN,B2
+terse,terse,简练的,ADJ,B2
+to enslave,to enslave,奴役,VERB,B2
+given,given,给定的,ADJ,B2
+to flap,to flap,拍打,VERB,B2
+inhibition,inhibition,抑制,NOUN,B2
+to snub,to snub,冷落,VERB,B2
+to extricate,to extricate,使摆脱,VERB,B2
+frigid,frigid,寒冷的,ADJ,B2
+evocative,evocative,引起回忆的,ADJ,B2
+impeccable,impeccable,无瑕疵的,ADJ,B2
+to commercialize,to commercialize,商业化,VERB,B2
+to enrapture,to enrapture,使狂喜,VERB,B2
+apologetic,apologetic,道歉的,ADJ,B2
+opulent,opulent,豪华的,ADJ,B2
+barge,barge,驳船,NOUN,B2
+cultivation,cultivation,培养,NOUN,B2
+infamous,infamous,声名狼藉的,ADJ,B2
+to fortify,to fortify,加强,VERB,B2
+reverent,reverent,虔诚的,ADJ,B2
+to divest,to divest,剥夺,VERB,B2
+to disinherit,to disinherit,剥夺继承权,VERB,B2
+hyperbole,hyperbole,夸张,NOUN,B2
+to boost,to boost,促进,VERB,B2
+to fertilize,to fertilize,施肥,VERB,B2
+to satiate,to satiate,使饱足,VERB,B2
+arcane,arcane,神秘的,ADJ,B2
+discrepancy,discrepancy,差异,NOUN,B2
+to deport,to deport,驱逐出境,VERB,B2
+to cram,to cram,填鸭式学习,VERB,B2
+to fumigate,to fumigate,熏蒸,VERB,B2
+cramp,cramp,抽筋,NOUN,B2
+touching,touching,动人的,ADJ,B2
+immature,immature,不成熟的,ADJ,B2
+bacchanal,bacchanal,狂欢,NOUN,B2
+feast,feast,盛宴,NOUN,B2
+to botch,to botch,搞砸,VERB,B2
+scarcely,scarcely,几乎不,ADV,B2
+evasion,evasion,逃避,NOUN,B2
+to disperse,to disperse,分散,VERB,B2
+behaviorist,behaviorist,行为主义者,NOUN,B2
+beloved,beloved,心爱的,ADJ,B2
+to elude,to elude,逃避,VERB,B2
+bohemian,bohemian,放荡不羁的,ADJ,B2
+akin,akin,相似的,ADJ,B2
+brainwasher,brainwasher,洗脑者,NOUN,B2
+bossism,bossism,老板主义,NOUN,B2
+weary,weary,疲倦的,ADJ,B2
+apathy,apathy,冷漠,NOUN,B2
+skirmish,skirmish,小规模战斗,NOUN,B2
+shrill,shrill,尖锐的,ADJ,B2
+affront,affront,冒犯,NOUN,B2
+to deify,to deify,神化,VERB,B2
+garland,garland,花环,NOUN,B2
+brow,brow,眉毛,NOUN,B2
+to covet,to covet,觊觎,VERB,B2
+to sprout,to sprout,发芽,VERB,B2
+funnel,funnel,漏斗,NOUN,B2
+to gravitate,to gravitate,受吸引,VERB,B2
+to disintegrate,to disintegrate,瓦解,VERB,B2
+incoherence,incoherence,不连贯,NOUN,B2
+to ensnare,to ensnare,诱捕,VERB,B2
+constituent,constituent,成分,NOUN,B2
+fratricide,fratricide,杀兄弟,NOUN,B2
+ardent,ardent,热情的,ADJ,B2
+to forebode,to forebode,预兆,VERB,B2
+acceptable,acceptable,可接受的,ADJ,B2
+exotic,exotic,异国情调的,ADJ,B2
+to dilute,to dilute,稀释,VERB,B2
+cistern,cistern,蓄水池,NOUN,B2
+badge,badge,徽章,NOUN,B2
+to enrage,to enrage,激怒,VERB,B2
+ashen,ashen,灰白的,ADJ,B2
+aging,aging,老化,NOUN,B2
+diaphragm,diaphragm,横膈膜,NOUN,B2
+magnanimous,magnanimous,宽宏大量的,ADJ,B2
+sorcery,sorcery,巫术,NOUN,B2
+excrement,excrement,排泄物,NOUN,B2
+belligerent,belligerent,好战的,ADJ,B2
+detergent,detergent,洗涤剂,NOUN,B2
+sniper,sniper,狙击手,NOUN,B2
+bourgeois,bourgeois,资产阶级的,ADJ,B2
+to shroud,to shroud,覆盖,VERB,B2
+demagoguery,demagoguery,煽动性,NOUN,B2
+to erode,to erode,侵蚀,VERB,B2
+to denature,to denature,使变性,VERB,B2
+to alter,to alter,改变,VERB,B2
+to exude,to exude,散发,VERB,B2
+betrothal,betrothal,订婚,NOUN,B2
+to adhere,to adhere,坚持,VERB,B2
+to deign,to deign,屈尊,VERB,B2
+to allocate,to allocate,分配,VERB,B2
+antipode,antipode,对跖点,NOUN,B2
+anachronism,anachronism,时代错误,NOUN,B2
+docile,docile,温顺的,ADJ,B2
+to cloy,to cloy,使厌烦,VERB,B2
+to delineate,to delineate,描绘,VERB,B2
+to flatten,to flatten,使平坦,VERB,B2
+stipend,stipend,津贴,NOUN,B2
+to dispose,to dispose,处理,VERB,B2
+worn,worn,磨损的,ADJ,B2
+to gratify,to gratify,使满足,VERB,B2
+uncouth,uncouth,粗俗的,ADJ,B2
+disuse,disuse,废弃,NOUN,B2
+to galvanize,to galvanize,激励,VERB,B2
+to retract,to retract,撤回,VERB,B2
+aforementioned,aforementioned,上述的,ADJ,B2
+convertibility,convertibility,可兑换性,NOUN,B2
+absorbed,absorbed,全神贯注的,ADJ,B2
+to beautify,to beautify,美化,VERB,B2
+sore,sore,疼痛的,ADJ,B2
+vogue,vogue,流行,NOUN,B2
+elusive,elusive,难以捉摸的,ADJ,B2
+to confine,to confine,限制,VERB,B2
+to cauterize,to cauterize,烧灼,VERB,B2
+to unearth,to unearth,发掘,VERB,B2
+to dishearten,to dishearten,使沮丧,VERB,B2
+unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
+amorphous,amorphous,无定形的,ADJ,B2
+attribution,attribution,归因,NOUN,B2
+to stratify,to stratify,分层,VERB,B2
+frivolous,frivolous,轻浮的,ADJ,B2
+wax,wax,蜡,NOUN,B2
+soccer,soccer,足球,NOUN,B2
+mezzanine,mezzanine,夹层,NOUN,B2
+saving,saving,储蓄,NOUN,B2
+apprehensive,apprehensive,忧虑的,ADJ,B2
+to unravel,to unravel,解开,VERB,B2
+to overthrow,to overthrow,推翻,VERB,B2
+buttress,buttress,扶壁,NOUN,B2
+assertion,assertion,断言,NOUN,B2
+to germinate,to germinate,发芽,VERB,B2
+unprecedented,unprecedented,史无前例的,ADJ,B2
+bloodless,bloodless,不流血的,ADJ,B2
+remorseful,remorseful,悔恨的,ADJ,B2
+shipment,shipment,货物,NOUN,B2
+to engross,to engross,使全神贯注,VERB,B2
+chronicle,chronicle,编年史,NOUN,B2
+phony,phony,假的,ADJ,B2
+oblique,oblique,斜的,ADJ,B2
+to glean,to glean,搜集,VERB,B2
+to eject,to eject,弹出,VERB,B2
+vase,vase,花瓶,NOUN,B2
+vicissitude,vicissitude,变迁,NOUN,B2
+burner,burner,燃烧器,NOUN,B2
+stratagem,stratagem,策略,NOUN,B2
+to bewitch,to bewitch,迷住,VERB,B2
+shotgun,shotgun,猎枪,NOUN,B2
+adverse,adverse,不利的,ADJ,B2
+mistaken,mistaken,错误的,ADJ,B2
+bower,bower,凉亭,NOUN,B2
+unforgivable,unforgivable,不可原谅的,ADJ,B2
+ancillary,ancillary,辅助的,ADJ,B2
+bagpiper,bagpiper,风笛手,NOUN,B2
+to amalgamate,to amalgamate,合并,VERB,B2
+den,den,兽穴,NOUN,B2
+reluctant,reluctant,不情愿的,ADJ,B2
+spine,spine,脊柱,NOUN,B2
+to exclaim,to exclaim,呼喊,VERB,B2
+to condescend,to condescend,屈尊,VERB,B2
+ephemeral,ephemeral,短暂的,ADJ,B2
+immoral,immoral,不道德的,ADJ,B2
+inspired,inspired,受启发的,ADJ,B2
+to deflate,to deflate,使泄气,VERB,B2
+wary,wary,谨慎的,ADJ,B2
+abstinence,abstinence,节制,NOUN,B2
+sacrilege,sacrilege,亵渎,NOUN,B2
+to gauge,to gauge,测量,VERB,B2
+erudite,erudite,博学的,ADJ,B2
+spite,spite,恶意,NOUN,B2
+to depopulate,to depopulate,使人口减少,VERB,B2
+favoritism,favoritism,偏袒,NOUN,B2
+auspice,auspice,赞助,NOUN,B2
+confederate,confederate,同盟者,NOUN,B2
+sublime,sublime,崇高的,ADJ,B2
+misanthrope,misanthrope,厌世者,NOUN,B2
+equity,equity,公平,NOUN,B2
+hemisphere,hemisphere,半球,NOUN,B2
+deceptive,deceptive,欺骗性的,ADJ,B2
+exponent,exponent,指数,NOUN,B2
+cacophony,cacophony,刺耳的声音,NOUN,B2
+battlement,battlement,城垛,NOUN,B2
+enigmatic,enigmatic,神秘的,ADJ,B2
+froth,froth,泡沫,NOUN,B2
+aptitude,aptitude,天资,NOUN,B2
+to enthrall,to enthrall,迷住,VERB,B2
+balustrade,balustrade,栏杆,NOUN,B2
+barricade,barricade,路障,NOUN,B2
+to gain,to gain,获得,VERB,B2
+to assent,to assent,同意,VERB,B2
+concord,concord,和谐,NOUN,B2
+avid,avid,热切的,ADJ,B2
+zeal,zeal,热情,NOUN,B2
+to elucidate,to elucidate,阐明,VERB,B2
+decorum,decorum,礼仪,NOUN,B2
+to embarrass,to embarrass,使尴尬,VERB,B2
+asparagus,asparagus,芦笋,NOUN,B2
+dapper,dapper,整洁的,ADJ,B2
+alienable,alienable,可转让的,ADJ,B2
+fabulous,fabulous,极好的,ADJ,B2
+to equalize,to equalize,使相等,VERB,B2
+cast,cast,演员阵容,NOUN,B2
+to attenuate,to attenuate,减弱,VERB,B2
+gregarious,gregarious,爱社交的,ADJ,B2
+apotheotic,apotheotic,神化的,ADJ,B2
+apex,apex,顶点,NOUN,B2
+contrition,contrition,悔罪,NOUN,B2
+ruthless,ruthless,无情的,ADJ,B2
+crystalline,crystalline,水晶般的,ADJ,B2
+burdensome,burdensome,繁重的,ADJ,B2
+to disunite,to disunite,使分裂,VERB,B2
+to exfoliate,to exfoliate,去角质,VERB,B2
+risque,risque,有伤风化的,ADJ,B2
+cumbersome,cumbersome,笨重的,ADJ,B2
+bilious,bilious,易怒的,ADJ,B2
+gin,gin,金酒,NOUN,B2
+biweekly,biweekly,双周的,ADJ,B2
+brooding,brooding,忧思,NOUN,B2
+to decompress,to decompress,解压,VERB,B2
+intellect,intellect,智力,NOUN,B2
+contraband,contraband,违禁品,NOUN,B2
+autocratic,autocratic,专制的,ADJ,B2
+to condone,to condone,宽恕,VERB,B2
+stolid,stolid,冷漠的,ADJ,B2
+to swagger,to swagger,大摇大摆,VERB,B2
+to declassify,to declassify,解密,VERB,B2
+binge,binge,放纵,NOUN,B2
+trifling,trifling,微不足道的,ADJ,B2
+frantic,frantic,狂乱的,ADJ,B2
+to asphyxiate,to asphyxiate,使窒息,VERB,B2
+to foist,to foist,强加,VERB,B2
+sedentary,sedentary,久坐的,ADJ,B2
+dishonor,dishonor,耻辱,NOUN,B2
+humorous,humorous,幽默的,ADJ,B2
+to consign,to consign,移交,VERB,B2
+immense,immense,巨大的,ADJ,B2
+erratic,erratic,不稳定的,ADJ,B2
+haughty,haughty,傲慢的,ADJ,B2
+cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
+to beatify,to beatify,宣福,VERB,B2
+to redeem,to redeem,赎回,VERB,B2
+inquisitive,inquisitive,好奇的,ADJ,B2
+incisive,incisive,深刻的,ADJ,B2
+conciseness,conciseness,简洁,NOUN,B2
+brazen,brazen,厚颜无耻的,ADJ,B2
+to adduce,to adduce,引证,VERB,B2
+to temporize,to temporize,拖延,VERB,B2
+brochure,brochure,小册子,NOUN,B2
+tireless,tireless,不知疲倦的,ADJ,B2
+matriarch,matriarch,女家长,NOUN,B2
+vehement,vehement,激烈的,ADJ,B2
+to curtail,to curtail,削减,VERB,B2
+to expectorate,to expectorate,吐痰,VERB,B2
+to stalk,to stalk,跟踪,VERB,B2
+astonished,astonished,惊讶的,ADJ,B2
+catapult,catapult,投石机,NOUN,B2
+disparate,disparate,截然不同的,ADJ,B2
+brusqueness,brusqueness,唐突,NOUN,B2
+entertaining,entertaining,有趣的,ADJ,B2
+to alienate,to alienate,使疏远,VERB,B2
+pensive,pensive,沉思的,ADJ,B2
+atonement,atonement,赎罪,NOUN,B2
+to corrode,to corrode,腐蚀,VERB,B2
+to afforest,to afforest,造林,VERB,B2
+altitude,altitude,海拔,NOUN,B2
+plausible,plausible,似是而非的,ADJ,B2
+to brandish,to brandish,挥舞,VERB,B2
+sanctimonious,sanctimonious,伪善的,ADJ,B2
+boisterous,boisterous,喧闹的,ADJ,B2
+iconoclast,iconoclast,偶像破坏者,NOUN,B2
+blunder,blunder,大错,NOUN,B2
+ungainly,ungainly,笨拙的,ADJ,B2
+upstart,upstart,暴发户,NOUN,B2
+to defame,to defame,诽谤,VERB,B2
+biting,biting,咬人,NOUN,B2
+to exalt,to exalt,颂扬,VERB,B2
+dichotomy,dichotomy,二分法,NOUN,B2
+bargain,bargain,便宜货,NOUN,B2
+attainable,attainable,可获得的,ADJ,B2
+oversight,oversight,疏忽,NOUN,B2
+gem,gem,宝石,NOUN,B2
+to detract,to detract,贬低,VERB,B2
+contemplation,contemplation,沉思,NOUN,B2
+graduation,graduation,毕业,NOUN,B2
+to skein,to skein,绕成线团,VERB,B2
+slenderness,slenderness,纤细,NOUN,B2
+hygienic,hygienic,卫生的,ADJ,B2
+curator,curator,策展人,NOUN,B2
+horrified,horrified,惊骇的,ADJ,B2
+scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
+reclamation,reclamation,收复,NOUN,B2
+bungler,bungler,笨手笨脚的人,NOUN,B2
+to lead astray,to lead astray,使入歧途,VERB,B2
+to spirit away,to spirit away,变走,VERB,B2
+appreciable,appreciable,可观的,ADJ,B2
+deteriorated,deteriorated,恶化的,ADJ,B2
+cove,cove,小海湾,NOUN,B2
+intermediate,intermediate,中级的,ADJ,B2
+gamete,gamete,配子,NOUN,B2
+scythe,scythe,镰刀,NOUN,B2
+idiot,idiot,傻瓜,ADJ,B2
+to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
+to humanize,to humanize,使人性化,VERB,B2
+fractional,fractional,分数的,ADJ,B2
+centipede,centipede,蜈蚣,NOUN,B2
+to idolize,to idolize,崇拜,VERB,B2
+set of ideals,set of ideals,思想体系,NOUN,B2
+epithet,epithet,绰号,NOUN,B2
+autocracy,autocracy,专制,NOUN,B2
+to plunder,to plunder,掠夺,VERB,B2
+equestrian,equestrian,马术的,ADJ,B2
+celerity,celerity,迅速,NOUN,B2
+musk,musk,麝香,NOUN,B2
+to splint,to splint,用夹板固定,VERB,B2
+seaplane,seaplane,水上飞机,NOUN,B2
+to go numb,to go numb,麻木,VERB,B2
+to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
+insinuation,insinuation,暗示,NOUN,B2
+cane,cane,手杖,NOUN,B2
+shameless person,shameless person,厚颜无耻的人,NOUN,B2
+excitability,excitability,兴奋性,NOUN,B2
+inflection,inflection,词尾,NOUN,B2
+hooligan,hooligan,流氓,NOUN,B2
+disquisition,disquisition,论述,NOUN,B2
+to fail to fulfill,to fail to fulfill,未履行,VERB,B2
+to gush,to gush,涌出,VERB,B2
+annotation,annotation,注释,NOUN,B2
+fanatic,fanatic,狂热的,ADJ,B2
+gatekeeper,gatekeeper,道口看守员,NOUN,B2
+emulation,emulation,模仿,NOUN,B2
+charitable,charitable,慈善的,ADJ,B2
+cattle rancher,cattle rancher,牧场主,NOUN,B2
+to codify,to codify,编纂,VERB,B2
+narrowing,narrowing,变窄,NOUN,B2
+countercurrent,countercurrent,逆流,NOUN,B2
+inclement,inclement,严酷的,ADJ,B2
+every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
+confinement,confinement,禁闭,NOUN,B2
+sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
+to put on track,to put on track,使走上正轨,VERB,B2
+stampede,stampede,溃逃,NOUN,B2
+to gray,to gray,变白,VERB,B2
+confidant,confidant,知己,NOUN,B2
+wharf,wharf,码头,NOUN,B2
+brute,brute,粗野的,ADJ,B2
+to elevate,to elevate,提升,VERB,B2
+babble,babble,结巴,NOUN,B2
+to dispossess,to dispossess,剥夺,VERB,B2
+to crowd together,to crowd together,挤在一起,VERB,B2
+to guess right,to guess right,猜中,VERB,B2
+to espy,to espy,窥探,VERB,B2
+collusion,collusion,串通,NOUN,B2
+concordance,concordance,一致,NOUN,B2
+colossal,colossal,巨大的,ADJ,B2
+fortune teller,fortune teller,占卜者,NOUN,B2
+devourer,devourer,吞噬者,NOUN,B2
+flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
+contiguous,contiguous,相邻的,ADJ,B2
+widening,widening,加宽,NOUN,B2
+to unbutton,to unbutton,解开纽扣,VERB,B2
+to defer,to defer,推迟,VERB,B2
+spatula,spatula,刮刀,NOUN,B2
+to disentangle,to disentangle,解开,VERB,B2
+to apostatize,to apostatize,叛教,VERB,B2
+untidiness,untidiness,凌乱,NOUN,B2
+governability,governability,可治理性,NOUN,B2
+discredit,discredit,丧失信誉,NOUN,B2
+to handcuff,to handcuff,给…戴手铐,VERB,B2
+to fluctuate,to fluctuate,波动,VERB,B2
+generatrix,generatrix,母线,NOUN,B2
+long-distance runner,long-distance runner,长跑运动员,NOUN,B2
+prolific,prolific,多产的,ADJ,B2
+galician,galician,加利西亚的,ADJ,B2
+to meddle,to meddle,干涉,VERB,B2
+exalted,exalted,狂热的,ADJ,B2
+involuntary,involuntary,无意识的,ADJ,B2
+ferret,ferret,雪貂,NOUN,B2
+ballast,ballast,压舱物,NOUN,B2
+illogical,illogical,不合逻辑的,ADJ,B2
+to guillotine,to guillotine,斩首,VERB,B2
+bunch,bunch,一群,NOUN,B2
+justness,justness,公正,NOUN,B2
+disenchantment,disenchantment,幻灭,NOUN,B2
+grandiloquent,grandiloquent,夸张的,ADJ,B2
+fruit tree,fruit tree,果树的,ADJ,B2
+hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+suicidal,suicidal,自杀的,ADJ,B2
+doctrinaire,doctrinaire,教条主义的,ADJ,B2
+quotable,quotable,可估价的,ADJ,B2
+tickle,tickle,发痒,NOUN,B2
+compendium,compendium,纲要,NOUN,B2
+tackling,tackling,马具,NOUN,B2
+leafy,leafy,枝叶茂密的,ADJ,B2
+to vent,to vent,倾诉,VERB,B2
+to gird,to gird,束紧,VERB,B2
+furtive,furtive,鬼鬼祟祟的,ADJ,B2
+exculpation,exculpation,开脱,NOUN,B2
+countenance,countenance,面容,NOUN,B2
+falconry,falconry,猎鹰术,NOUN,B2
+conic,conic,圆锥曲线,NOUN,B2
+disloyalty,disloyalty,不忠,NOUN,B2
+to thrill,to thrill,使兴奋,VERB,B2
+herbaceous,herbaceous,草本的,ADJ,B2
+inflamed,inflamed,激烈的,ADJ,B2
+informative,informative,提供信息的,ADJ,B2
+aridity,aridity,干旱,NOUN,B2
+to encode,to encode,编码,VERB,B2
+epitaph,epitaph,墓志铭,NOUN,B2
+indistinct,indistinct,模糊的,ADJ,B2
+expeditious,expeditious,迅速的,ADJ,B2
+varnish,varnish,清漆,NOUN,B2
+to go deep into,to go deep into,深入,VERB,B2
+duet,duet,二重奏,NOUN,B2
+home-loving,home-loving,顾家的,ADJ,B2
+to coax,to coax,哄骗,VERB,B2
+pharisee,pharisee,法利赛人,NOUN,B2
+gravid,gravid,怀孕的,ADJ,B2
+condemned,condemned,被定罪的,ADJ,B2
+delirious,delirious,谵妄的,ADJ,B2
+apotheosis,apotheosis,神化,NOUN,B2
+squid,squid,鱿鱼,NOUN,B2
+unbridled,unbridled,肆无忌惮的,ADJ,B2
+grotesque,grotesque,怪诞的,ADJ,B2
+blazing,blazing,炽热的,ADJ,B2
+to be unaware,to be unaware,不知道,VERB,B2
+out of place,out of place,格格不入的,ADJ,B2
+revelry,revelry,狂欢,NOUN,B2
+to wield,to wield,行使,VERB,B2
+excavator,excavator,挖掘机,NOUN,B2
+to powder,to powder,撒粉,VERB,B2
+flaccid,flaccid,松弛的,ADJ,B2
+egalitarian,egalitarian,平等主义的,ADJ,B2
+cord,cord,绳索,NOUN,B2
+disadvantageous,disadvantageous,不利的,ADJ,B2
+foliage,foliage,枝叶,NOUN,B2
+winding,winding,蜿蜒的,ADJ,B2
+to antagonize,to antagonize,使对立,VERB,B2
+apoplexy,apoplexy,中风,NOUN,B2
+land register,land register,地籍,NOUN,B2
+intolerant,intolerant,不容忍的,ADJ,B2
+to release from prison,to release from prison,释放,VERB,B2
+conformist,conformist,墨守成规者,NOUN,B2
+empirically,empirically,凭经验地,ADV,B2
+incongruity,incongruity,不协调,NOUN,B2
+slender,slender,纤细的,ADJ,B2
+to harmonize,to harmonize,使和谐,VERB,B2
+wild beast,wild beast,猛兽,NOUN,B2
+to mutiny,to mutiny,煽动叛乱,VERB,B2
+brakeman,brakeman,刹车员,NOUN,B2
+bureaucratic,bureaucratic,官僚的,ADJ,B2
+disorganization,disorganization,无组织,NOUN,B2
+horoscope,horoscope,星座运势,NOUN,B2
+copious,copious,丰富的,ADJ,B2
+dissolute,dissolute,放荡的,ADJ,B2
+disheveled,disheveled,蓬乱的,ADJ,B2
+to skewer,to skewer,串起,VERB,B2
+concordat,concordat,政教协定,NOUN,B2
+to mud,to mud,弄脏,VERB,B2
+incipient,incipient,初期的,ADJ,B2
+corrigible,corrigible,可改正的,ADJ,B2
+germicidal,germicidal,杀菌的,ADJ,B2
+effervescent,effervescent,沸腾的,ADJ,B2
+high school graduate,high school graduate,高中毕业生,NOUN,B2
+phlebitis,phlebitis,静脉炎,NOUN,B2
+ferrule,ferrule,箍,NOUN,B2
+unnatural,unnatural,不自然的,ADJ,B2
+heterodox,heterodox,异端的,ADJ,B2
+burlesque,burlesque,滑稽的,ADJ,B2
+exaltation,exaltation,狂热,NOUN,B2
+mannish,mannish,像男人的,ADJ,B2
+exuberance,exuberance,繁茂,NOUN,B2
+to armor,to armor,装甲,VERB,B2
+slimy,slimy,粘滑的,ADJ,B2
+ski,ski,滑雪板,NOUN,B2
+consummate,consummate,熟练的,ADJ,B2
+choirboy,choirboy,唱诗班男孩,NOUN,B2
+to lean out,to lean out,探出身体,VERB,B2
+maroon,maroon,深红色,ADJ,B2
+industrious,industrious,勤劳的,ADJ,B2
+geometer,geometer,几何学家,NOUN,B2
+exorbitant,exorbitant,过高的,ADJ,B2
+consequent,consequent,随之发生的,ADJ,B2
+sweepings,sweepings,扫出的垃圾,NOUN,B2
+to curve,to curve,弯曲,VERB,B2
+discretionary,discretionary,自由裁量的,ADJ,B2
+to pacify,to pacify,平息,VERB,B2
+very fine,very fine,极细的,ADJ,B2
+to jam,to jam,堵塞,VERB,B2
+tacky thing,tacky thing,俗气的事,NOUN,B2
+deserter,deserter,逃兵,NOUN,B2
+extirpation,extirpation,切除,NOUN,B2
+amends,amends,补偿,NOUN,B2
+defenseless,defenseless,无防御的,ADJ,B2
+imperialist,imperialist,帝国主义的,ADJ,B2
+germanic,germanic,日耳曼的,ADJ,B2
+scaly,scaly,有鳞的,ADJ,B2
+short news item,short news item,短新闻,NOUN,B2
+hispanic,hispanic,西班牙的,ADJ,B2
+flashlight,flashlight,手电筒,NOUN,B2
+endogenous,endogenous,内生的,ADJ,B2
+to stylize,to stylize,风格化,VERB,B2
+swarm,swarm,蜂群,NOUN,B2
+loose thread,loose thread,线头,NOUN,B2
+imbecility,imbecility,愚蠢,NOUN,B2
+conch,conch,海螺壳,NOUN,B2
+maladjusted,maladjusted,适应不良的,ADJ,B2
+historicist,historicist,历史主义者,NOUN,B2
+gossipy,gossipy,爱传流言的,ADJ,B2
+t-shirt,t-shirt,T 恤衫,NOUN,B2
+hexagon,hexagon,六边形,NOUN,B2
+floorboard,floorboard,木地板,NOUN,B2
+exhumation,exhumation,掘墓,NOUN,B2
+parishioner,parishioner,教区居民,NOUN,B2
+to make independent,to make independent,使独立,VERB,B2
+to pair,to pair,配对,VERB,B2
+unpunished,unpunished,未受惩罚的,ADJ,B2
+figuratively,figuratively,比喻地,ADV,B2
+distinctive,distinctive,独特的,ADJ,B2
+fittings,fittings,水龙头配件,NOUN,B2
+pompous,pompous,浮夸的,ADJ,B2
+euphonic,euphonic,悦耳的,ADJ,B2
+equilateral,equilateral,等边的,ADJ,B2
+puny,puny,瘦弱的,ADJ,B2
+bronze-colored,bronze-colored,青铜色的,ADJ,B2
+despotic,despotic,专制的,ADJ,B2
+spirited,spirited,活泼的,ADJ,B2
+latin,latin,拉丁语,NOUN,B2
+rarefaction,rarefaction,稀薄,NOUN,B2
+fluidity,fluidity,流畅,NOUN,B2
+exhortation,exhortation,劝诫,NOUN,B2
+crochet,crochet,钩针编织,NOUN,B2
+clairvoyant,clairvoyant,有洞察力的,ADJ,B2
+gestural,gestural,手势的,ADJ,B2
+quantifiable,quantifiable,可量化的,ADJ,B2
+flirt,flirt,调情者,NOUN,B2
+exhalation,exhalation,呼气,NOUN,B2
+atrophy,atrophy,萎缩,NOUN,B2
+to frolic,to frolic,嬉戏,VERB,B2
+to defuse,to defuse,缓和,VERB,B2
+delicately,delicately,巧妙地,ADV,B2
+to fraction,to fraction,分割,VERB,B2
+to deviate,to deviate,偏离,VERB,B2
+personalized,personalized,个性化的,ADJ,B2
+to drape,to drape,悬挂,VERB,B2
+fold,fold,折痕,NOUN,B2
+rustic,rustic,乡村的,ADJ,B2
+doubling,doubling,加倍,NOUN,B2
+breast,breast,乳房,NOUN,B2
+to flout,to flout,蔑视,VERB,B2
+particularly,particularly,特别地,ADV,B2
+upheaval,upheaval,剧变,NOUN,B2
+to serve a route,to serve a route,为...提供交通服务,VERB,B2
+mound,mound,土堆,NOUN,B2
+pallor,pallor,苍白,NOUN,B2
+rout,rout,溃败,NOUN,B2
+resourceful,resourceful,机灵的,ADJ,B2
+awareness raising,awareness raising,提高意识,NOUN,B2
+granny,granny,奶奶,NOUN,B2
+sheaf,sheaf,捆,NOUN,B2
+locality,locality,地点,NOUN,B2
+facies,facies,面貌,NOUN,B2
+aphasia,aphasia,失语症,NOUN,B2
+feature film,feature film,故事片,NOUN,B2
+perpetual,perpetual,永久的,ADJ,B2
+probe,probe,探测器,NOUN,B2
+to commute,to commute,通勤,VERB,B2
+to reverse,to reverse,反转,VERB,B2
+water heater,water heater,热水器,NOUN,B2
+proliferation,proliferation,增殖,NOUN,B2
+pantheon,pantheon,先贤祠,NOUN,B2
+detainee,detainee,被拘留者,NOUN,B2
+summarily,summarily,草率地,ADV,B2
+to defrost,to defrost,除霜,VERB,B2
+perilous,perilous,危险的,ADJ,B2
+to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
+to execrate,to execrate,痛恨,VERB,B2
+to resonate,to resonate,共鸣,VERB,B2
+factoring,factoring,保理,NOUN,B2
+detached house,detached house,独栋房屋,NOUN,B2
+to amass,to amass,积聚,VERB,B2
+independently,independently,独立地,ADV,B2
+severely,severely,严厉地,ADV,B2
+traditionally,traditionally,传统地,ADV,B2
+tenacity,tenacity,坚韧,NOUN,B2
+politely,politely,礼貌地,ADV,B2
+paper clip,paper clip,回形针,NOUN,B2
+to unbridle,to unbridle,解开,VERB,B2
+yoke,yoke,枷锁,NOUN,B2
+cohort,cohort,队列,NOUN,B2
+respective,respective,各自的,ADJ,B2
+newcomer,newcomer,新来者,NOUN,B2
+bookplate,bookplate,藏书票,NOUN,B2
+frankly,frankly,坦率地,ADV,B2
+passionate,passionate,热情的,ADJ,B2
+panther,panther,豹,NOUN,B2
+antisemitism,antisemitism,反犹太主义,NOUN,B2
+to generate engender,to generate engender,产生,VERB,B2
+to sequester,to sequester,隔离,VERB,B2
+invariably,invariably,不变地,ADV,B2
+stall,stall,包厢座位,NOUN,B2
+major,major,主要的,ADJ,B2
+expatriate,expatriate,移居国外者,NOUN,B2
+gallop,gallop,疾驰,NOUN,B2
+array,array,排列,NOUN,B2
+malfeasance,malfeasance,渎职,NOUN,B2
+to ratify,to ratify,批准,VERB,B2
+to defray,to defray,支付,VERB,B2
+to gratinate,to gratinate,烤成焦皮,VERB,B2
+various,various,各种各样的,ADJ,B2
+to flock,to flock,群集,VERB,B2
+to appal,to appal,使惊恐,VERB,B2
+to crash into,to crash into,撞击,VERB,B2
+communist,communist,共产主义者,NOUN,B2
+lymphatic,lymphatic,淋巴的,ADJ,B2
+paradoxical,paradoxical,矛盾的,ADJ,B2
+supreme,supreme,最高的,ADJ,B2
+bump,bump,肿块,NOUN,B2
+librarian,librarian,图书管理员,NOUN,B2
+craze,craze,狂热,NOUN,B2
+pedantry,pedantry,迂腐,NOUN,B2
+bulgarian,bulgarian,保加利亚的,ADJ,B2
+syllogism,syllogism,三段论,NOUN,B2
+to conserve,to conserve,保存,VERB,B2
+grumbler,grumbler,爱抱怨的人,NOUN,B2
+prophylaxis,prophylaxis,预防,NOUN,B2
+to invalidate,to invalidate,证明无效,VERB,B2
+to suborn,to suborn,教唆,VERB,B2
+solipsism,solipsism,唯我论,NOUN,B2
+to curl,to curl,卷曲,VERB,B2
+to start again,to start again,重新开始,VERB,B2
+detrimental,detrimental,有害的,ADJ,B2
+mortality,mortality,死亡率,NOUN,B2
+to prosper,to prosper,繁荣,VERB,B2
+televised,televised,电视播出的,ADJ,B2
+tirade,tirade,长篇抨击,NOUN,B2
+rainy,rainy,多雨的,ADJ,B2
+hesitant,hesitant,犹豫的,ADJ,B2
+fit,fit,适合的,ADJ,B2
+preliminary,preliminary,初步的,ADJ,B2
+semantics,semantics,语义学,NOUN,B2
+kindly,kindly,亲切地,ADV,B2
+to tumble,to tumble,跌倒,VERB,B2
+truism,truism,自明之理,NOUN,B2
+civility,civility,礼貌,NOUN,B2
+to dye,to dye,染色,VERB,B2
+respite,respite,喘息,NOUN,B2
+annexation,annexation,吞并,NOUN,B2
+oligarchy,oligarchy,寡头政治,NOUN,B2
+disciplinary,disciplinary,纪律的,ADJ,B2
+to dither,to dither,犹豫不决,VERB,B2
+bailiff,bailiff,法警,NOUN,B2
+to croak,to croak,呱呱叫,VERB,B2
+accuracy,accuracy,准确性,NOUN,B2
+calmly,calmly,平静地,ADV,B2
+predictable,predictable,可预测的,ADJ,B2
+to hail inspect,to hail inspect,盘查,VERB,B2
+narcissistic,narcissistic,自恋的,ADJ,B2
+mash,mash,泥状食物,NOUN,B2
+nostalgia,nostalgia,怀旧,NOUN,B2
+inexorably,inexorably,不可阻挡地,ADV,B2
+vintage,vintage,佳酿,NOUN,B2
+solitary,solitary,孤独的,ADJ,B2
+to make heavier,to make heavier,加重,VERB,B2
+to rally,to rally,团结,VERB,B2
+relentless,relentless,无情的,ADJ,B2
+pioneer,pioneer,先驱,NOUN,B2
+frequently,frequently,经常,ADV,B2
+pleura,pleura,胸膜,NOUN,B2
+mascot,mascot,吉祥物,NOUN,B2
+accessibility,accessibility,可达性,NOUN,B2
+penalty,penalty,惩罚,NOUN,B2
+damaging,damaging,有害的,ADJ,B2
+trauma,trauma,创伤,NOUN,B2
+merchandise,merchandise,商品,NOUN,B2
+to demonize,to demonize,妖魔化,VERB,B2
+not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
+prosecution service,prosecution service,检察院,NOUN,B2
+to ferret,to ferret,搜寻,VERB,B2
+to crumple,to crumple,弄皱,VERB,B2
+to acquiesce,to acquiesce,默许,VERB,B2
+to caper,to caper,跳跃,VERB,B2
+balance sheet,balance sheet,资产负债表,NOUN,B2
+filming,filming,拍摄,NOUN,B2
+separately,separately,分开地，单独地,ADV,B2
+preponderant,preponderant,占优势的,ADJ,B2
+pretentious,pretentious,自命不凡的,ADJ,B2
+hike,hike,徒步旅行,NOUN,B2
+potentially,potentially,潜在地,ADV,B2
+straw,straw,稻草,NOUN,B2
+acoustic,acoustic,声学的,ADJ,B2
+naturally,naturally,自然地,ADV,B2
+know-how,know-how,诀窍,NOUN,B2
+to behead,to behead,斩首,VERB,B2
+to cuddle,to cuddle,拥抱,VERB,B2
+to chastise,to chastise,严惩,VERB,B2
+to decry,to decry,谴责,VERB,B2
+precarious,precarious,不稳定的,ADJ,B2
+flesh,flesh,肉,NOUN,B2
+lubricity,lubricity,好色 / 淫荡,NOUN,B2
+talented,talented,有才华的,ADJ,B2
+apocalyptic,apocalyptic,启示录的,ADJ,B2
+to disjoin,to disjoin,分离,VERB,B2
+offense,offense,冒犯,NOUN,B2
+rain shower,rain shower,阵雨,NOUN,B2
+peritoneum,peritoneum,腹膜,NOUN,B2
+hacking,hacking,黑客行为,NOUN,B2
+layperson,layperson,外行,NOUN,B2
+fulfilled,fulfilled,满足的,ADJ,B2
+awful,awful,糟糕的,ADJ,B2
+to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
+braggadocio,braggadocio,吹牛,NOUN,B2
+tertiary,tertiary,第三的,ADJ,B2
+planning,planning,规划,NOUN,B2
+screenwriter,screenwriter,编剧,NOUN,B2
+to concoct,to concoct,编造,VERB,B2
+to dislodge,to dislodge,逐出,VERB,B2
+to dupe,to dupe,欺骗,VERB,B2
+tenor,tenor,男高音,NOUN,B2
+resonant,resonant,共鸣的,ADJ,B2
+supporting document,supporting document,证明文件,NOUN,B2
+touchy,touchy,易怒的,ADJ,B2
+to dispel,to dispel,消除,VERB,B2
+antiquated,antiquated,过时的,ADJ,B2
+unforeseen,unforeseen,意外的,ADJ,B2
+to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
+occult,occult,神秘的,ADJ,B2
+probable likely,probable likely,可能的,ADJ,B2
+to blush,to blush,脸红,VERB,B2
+to bloom,to bloom,开花,VERB,B2
+to feign,to feign,假装,VERB,B2
+notch,notch,刻痕,NOUN,B2
+summer visitor,summer visitor,暑期游客,NOUN,B2
+subcontracting,subcontracting,分包,NOUN,B2
+volunteering,volunteering,志愿服务,NOUN,B2
+to break into,to break into,撬开,VERB,B2
+spade,spade,铲子,NOUN,B2
+subtlety,subtlety,微妙,NOUN,B2
+abusive,abusive,滥用的,ADJ,B2
+persistence,persistence,坚持,NOUN,B2
+cutting,cutting,切割,NOUN,B2
+revival,revival,复兴,NOUN,B2
+to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
+precocious,precocious,早熟的,ADJ,B2
+regulatory,regulatory,监管的,ADJ,B2
+versatile,versatile,多才多艺的,ADJ,B2
+gently,gently,轻轻地,ADV,B2
+microwave,microwave,微波炉,NOUN,B2
+harsh,harsh,严厉的,ADJ,B2
+to purge,to purge,清除,VERB,B2
+taxable,taxable,应纳税的,ADJ,B2
+flow rate,flow rate,流量,NOUN,B2
+financing funding,financing funding,融资,NOUN,B2
+breakup,breakup,分手,NOUN,B2
+historically,historically,历史上,ADV,B2
+preferable,preferable,更可取的,ADJ,B2
+elation,elation,兴高采烈,NOUN,B2
+to pamper,to pamper,纵容,VERB,B2
+to persecute,to persecute,迫害,VERB,B2
+deeply moving,deeply moving,令人感动的,ADJ,B2
+onomatopoeia,onomatopoeia,拟声词,NOUN,B2
+resumption,resumption,恢复,NOUN,B2
+pusillanimous,pusillanimous,怯懦的,ADJ,B2
+their,their,他们的,DET,B2
+decontamination,decontamination,去污,NOUN,B2
+to launder,to launder,洗钱,VERB,B2
+to concede,to concede,承认,VERB,B2
+perceptibly,perceptibly,明显地,ADV,B2
+closing argument,closing argument,辩护词,NOUN,B2
+sentinel,sentinel,哨兵,NOUN,B2
+precision,precision,精确,NOUN,B2
+parsimonious,parsimonious,吝啬的,ADJ,B2
+quiddity,quiddity,本质,NOUN,B2
+bodywork,bodywork,车身,NOUN,B2
+renunciation,renunciation,放弃,NOUN,B2
+canvas,canvas,帆布,NOUN,B2
+formally,formally,正式地,ADV,B2
+loop,loop,循环,NOUN,B2
+mercenary,mercenary,雇佣兵,NOUN,B2
+angelic,angelic,天使般的,ADJ,B2
+disdainfully,disdainfully,轻蔑地,ADV,B2
+lesion,lesion,病变,NOUN,B2
+residual,residual,残留的,ADJ,B2
+cooking,cooking,烹饪,NOUN,B2
+sorting,sorting,分类,NOUN,B2
+to castigate,to castigate,严厉批评,VERB,B2
+innocuous,innocuous,无害的,ADJ,B2
+perverse,perverse,任性的,ADJ,B2
+dishonest,dishonest,不诚实的,ADJ,B2
+to transcribe,to transcribe,转录,VERB,B2
+posthumous,posthumous,死后的,ADJ,B2
+freely,freely,自由地,ADV,B2
+recreation,recreation,娱乐,NOUN,B2
+oxymoron,oxymoron,矛盾修辞法,NOUN,B2
+redundancy,redundancy,冗余,NOUN,B2
+angular,angular,有角的,ADJ,B2
+sedition,sedition,煽动叛乱,NOUN,B2
+to warp,to warp,弯曲,VERB,B2
+pickaxe,pickaxe,镐；锄,NOUN,B2
+notably,notably,显著地,ADV,B2
+semolina,semolina,粗面粉,NOUN,B2
+antecedent,antecedent,先行词,NOUN,B2
+acclimatization,acclimatization,适应环境,NOUN,B2
+probity,probity,正直,NOUN,B2
+sensual,sensual,感官的,ADJ,B2
+malevolence,malevolence,恶意,NOUN,B2
+theologian,theologian,神学家,NOUN,B2
+remote work,remote work,远程办公,NOUN,B2
+specious,specious,似是而非的,ADJ,B2
+drawback,drawback,缺点,NOUN,B2
+to conform,to conform,符合,VERB,B2
+to confer,to confer,授予,VERB,B2
+to strip bare,to strip bare,洗劫,VERB,B2
+practicing believer,practicing believer,信徒,NOUN,B2
+to make bland,to make bland,使乏味,VERB,B2
+pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
+peroration,peroration,结语,NOUN,B2
+indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+food-processing,food-processing,食品加工的,ADJ,B2
+parataxis,parataxis,意合,NOUN,B2
+to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
+hostess,hostess,女服务员,NOUN,B2
+obstetrics,obstetrics,产科学,NOUN,B2
+wrongdoer,wrongdoer,罪犯,NOUN,B2
+to pour out,to pour out,倾诉,VERB,B2
+guru,guru,精神导师,NOUN,B2
+freshly,freshly,新鲜地,ADV,B2
+perfidy,perfidy,背信弃义,NOUN,B2
+cordially,cordially,亲切地,ADV,B2
+street interview,street interview,街头采访,NOUN,B2
+manually,manually,手动地,ADV,B2
+slang,slang,俚语,NOUN,B2
+eight-line stanza,eight-line stanza,八行诗,NOUN,B2
+diagonal,diagonal,对角线,NOUN,B2
+customs officer,customs officer,海关官员,NOUN,B2
+depressive,depressive,抑郁的，压抑的,ADJ,B2
+lawnmower,lawnmower,割草机,NOUN,B2
+proportional,proportional,成比例的,ADJ,B2
+picking,picking,采摘,NOUN,B2
+airfield,airfield,飞机场,NOUN,B2
+apodictic,apodictic,确证的,ADJ,B2
+indirectly,indirectly,间接地,ADV,B2
+to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
+to fall to,to fall to,落到...身上,VERB,B2
+magnesium,magnesium,镁,NOUN,B2
+quashing,quashing,撤销,NOUN,B2
+recruiter,recruiter,招聘人员,NOUN,B2
+toad,toad,蟾蜍,NOUN,B2
+sovereigntist,sovereigntist,主权主义者,NOUN,B2
+clumsiness,clumsiness,笨拙,NOUN,B2
+media library,media library,多媒体图书馆,NOUN,B2
+caterpillar,caterpillar,毛毛虫,NOUN,B2
+sincerely,sincerely,真诚地,ADV,B2
+to move to pity,to move to pity,使怜悯,VERB,B2
+typology,typology,类型学,NOUN,B2
+heatwave,heatwave,热浪,NOUN,B2
+stressful,stressful,有压力的,ADJ,B2
+unofficially,unofficially,非正式地,ADV,B2
+to chill,to chill,使冰冻,VERB,B2
+triangular,triangular,三角形的,ADJ,B2
+pitchfork,pitchfork,叉子,NOUN,B2
+french-speaking,french-speaking,讲法语的,ADJ,B2
+symptomatology,symptomatology,症状学,NOUN,B2
+dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
+to raise awareness,to raise awareness,提高意识,VERB,B2
+about sixty,about sixty,六十来个,NOUN,B2
+indiscriminately,indiscriminately,不加区别地,ADV,B2
+the blues,the blues,忧郁,NOUN,B2
+legatee,legatee,受遗赠人,NOUN,B2
+to resell,to resell,转售,VERB,B2
+juvenile,juvenile,青少年的,ADJ,B2
+consecutive,consecutive,连续的,ADJ,B2
+penal,penal,刑事的,ADJ,B2
+pamphleteer,pamphleteer,小册子作者,NOUN,B2
+segregation,segregation,隔离，分离,NOUN,B2
+moralism,moralism,道德主义,NOUN,B2
+sexism,sexism,性别歧视,NOUN,B2
+case law,case law,判例法,NOUN,B2
+to nuance,to nuance,使具有细微差别,VERB,B2
+setting sun,setting sun,夕阳,NOUN,B2
+to subsist,to subsist,存在,VERB,B2
+coastal,coastal,沿海的,ADJ,B2
+lukewarm,lukewarm,微温的,ADJ,B2
+marrow,marrow,骨髓,NOUN,B2
+bistro,bistro,小酒馆,NOUN,B2
+untouchable,untouchable,不可触碰的,ADJ,B2
+alternatively,alternatively,交替地,ADV,B2
+stage fright,stage fright,怯场,NOUN,B2
+socialist,socialist,社会主义者,NOUN,B2
+obsequiousness,obsequiousness,谄媚,NOUN,B2
+heartening,heartening,令人高兴的,ADJ,B2
+as soon as,as soon as,一...就,ADV,B2
+heroically,heroically,英勇地,ADV,B2
+flint,flint,燧石,NOUN,B2
+delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
+to maltreat,to maltreat,虐待,VERB,B2
+obsequiously,obsequiously,谄媚地,ADV,B2
+telephony,telephony,电话学,NOUN,B2
+food,food,食品的,ADJ,B2
+carcass,carcass,骨架,NOUN,B2
+faithful loyal,faithful loyal,忠诚的,ADJ,B2
+symphonic,symphonic,交响乐的,ADJ,B2
+undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+treat,treat,盛宴,NOUN,B2
+generational,generational,代际的,ADJ,B2
+alpine,alpine,高山的,ADJ,B2
+servilely,servilely,奴性地,ADV,B2
+checkbook,checkbook,支票簿,NOUN,B2
+productive,productive,多产的,ADJ,B2
+tv viewer,tv viewer,电视观众,NOUN,B2
+release of lien,release of lien,解除扣押,NOUN,B2
+asphyxia,asphyxia,窒息,NOUN,B2
+registered mail,registered mail,挂号信,NOUN,B2
+to push to grow,to push to grow,推/生长,VERB,B2
+a lot,a lot,很多,ADV,B2
+populist,populist,民粹主义者,NOUN,B2
+rapper,rapper,说唱歌手,NOUN,B2
+marshal,marshal,元帅,NOUN,B2
+purely,purely,纯粹地,ADV,B2
+currant,currant,醋栗,NOUN,B2
+anarchist,anarchist,无政府主义者,NOUN,B2
+manifestly,manifestly,明显地,ADV,B2
+irregular,irregular,不规则的,ADJ,B2
+jurisconsult,jurisconsult,法学专家,NOUN,B2
+lymph node,lymph node,淋巴结,NOUN,B2
+litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
+worrying,worrying,令人担忧的,ADJ,B2
+to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
+oyster,oyster,牡蛎,NOUN,B2
+underground,underground,地下的,ADJ,B2
+retiree,retiree,退休人员,NOUN,B2
+reproducibility,reproducibility,可重复性,NOUN,B2
+agitated,agitated,焦躁的,ADJ,B2
+nationalist,nationalist,民族主义者,NOUN,B2
+fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+productivist,productivist,生产至上主义的,ADJ,B2
+pictorial,pictorial,绘画的,ADJ,B2
+to taint,to taint,玷污,VERB,B2
+fingernail,fingernail,指甲,NOUN,B2
+marginally,marginally,边缘地,ADV,B2
+biologist,biologist,生物学家,NOUN,B2
+polysyndeton,polysyndeton,连词叠用,NOUN,B2
+recourse,recourse,求助,NOUN,B2
+subject to the law,subject to the law,受法律管辖的,ADJ,B2
+deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
+remains spoils,remains spoils,遗体，战利品,NOUN,B2
+to mark out,to mark out,标示,VERB,B2
+sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
+geriatrics,geriatrics,老年医学,NOUN,B2
+playable,playable,可演奏的,ADJ,B2
+to commune,to commune,交融,VERB,B2
+hyperthermia,hyperthermia,体温过高,NOUN,B2
+to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
+preterition,preterition,假托,NOUN,B2
+nitrogen,nitrogen,氮,NOUN,B2
+preacher,preacher,传教士,NOUN,B2
+about thirty,about thirty,三十左右,NOUN,B2
+to spout,to spout,喷射,VERB,B2
+traumatic,traumatic,创伤的,ADJ,B2
+several,several,若干,NOUN,B2
+parable,parable,寓言,NOUN,B2
+to stem from,to stem from,源于,VERB,B2
+priority,priority,优先的,ADJ,B2
+to tip over,to tip over,翻倒,VERB,B2
+foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
+be tender,be tender,温柔的,ADJ,B2
+fistula,fistula,瘘管,NOUN,B2
+to catch sight of,to catch sight of,瞥见,VERB,B2
+artificially,artificially,人为地,ADV,B2
+forfeiture,forfeiture,丧失,NOUN,B2
+recruit,recruit,新兵,NOUN,B2
+genetically,genetically,遗传地,ADV,B2
+scouting locating,scouting locating,定位 / 侦察,NOUN,B2
+subsidiarity,subsidiarity,辅助性原则,NOUN,B2
+dish towel,dish towel,抹布,NOUN,B2
+co-ownership,co-ownership,共有产权,NOUN,B2
+momentarily,momentarily,暂时地,ADV,B2
+to rediscover,to rediscover,重新发现,VERB,B2
+paralogism,paralogism,谬误推理,NOUN,B2
+cyst,cyst,囊肿,NOUN,B2
+resection,resection,切除术,NOUN,B2
+patently,patently,显然地,ADV,B2
+ticket window,ticket window,售票窗口,NOUN,B2
+to weary to tire,to weary to tire,使厌倦,VERB,B2
+tuberculosis,tuberculosis,结核病,NOUN,B2
+overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
+blender,blender,搅拌机,NOUN,B2
+degenerative,degenerative,退化的,ADJ,B2
+fresco,fresco,壁画,NOUN,B2
+receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
+on upon,on upon,在...上,ADP,B2
+to unhook,to unhook,摘下,VERB,B2
+footage,footage,镜头长度,NOUN,B2
+droppings,droppings,粪便,NOUN,B2
+computer specialist,computer specialist,计算机专家,NOUN,B2
+cruelly,cruelly,残酷地,ADV,B2
+progressive,progressive,进步人士,NOUN,B2
+selectively,selectively,有选择地,ADV,B2
+lily,lily,百合,NOUN,B2
+illuminator,illuminator,彩饰画家,NOUN,B2
+acronym,acronym,首字母缩略词,NOUN,B2
+similarly,similarly,同样地,ADV,B2
+bedsheet,bedsheet,床单,NOUN,B2
+surplus,surplus,过剩的,ADJ,B2
+to mast,to mast,降伏,VERB,B2
+to drive lead,to drive lead,驾驶,VERB,B2
+fishing,fishing,钓鱼,NOUN,B2
+lucky find,lucky find,意外发现,NOUN,B2
+cross-border,cross-border,边境的,ADJ,B2
+community-related,community-related,社区的,ADJ,B2
+dynamism,dynamism,活力,NOUN,B2
+great-grandfather,great-grandfather,曾祖父,NOUN,B2
+supportive,supportive,团结的,ADJ,B2
+tarragon,tarragon,龙蒿,NOUN,B2
+regeneration,regeneration,再生,NOUN,B2
+scales,scales,秤,NOUN,B2
+trilemma,trilemma,三难困境,NOUN,B2
+indebted,indebted,负债的,ADJ,B2
+skating,skating,滑冰,NOUN,B2
+malaria,malaria,疟疾,NOUN,B2
+boastfulness,boastfulness,吹嘘,NOUN,B2
+anagram,anagram,字谜游戏,NOUN,B2
+cinematographic,cinematographic,电影的,ADJ,B2
+fake news,fake news,假新闻,NOUN,B2
+derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
+hematoma,hematoma,血肿,NOUN,B2
+malefic,malefic,邪恶的,ADJ,B2
+enslavement,enslavement,奴役,NOUN,B2
+chauvinism,chauvinism,沙文主义,NOUN,B2
+striped,striped,有条纹的,ADJ,B2
+oligopoly,oligopoly,寡头垄断,NOUN,B2
+breathing,breathing,呼吸,NOUN,B2
+laundering,laundering,洗钱,NOUN,B2
+systematically,systematically,系统地,ADV,B2
+accordion,accordion,手风琴,NOUN,B2
+naturalization,naturalization,入籍,NOUN,B2
+to postpone to carry over,to postpone to carry over,推迟,VERB,B2
+suburbs,suburbs,郊区,NOUN,B2
+ignominy,ignominy,耻辱,NOUN,B2
+neuron,neuron,神经元,NOUN,B2
+psalm,psalm,诗篇,NOUN,B2
+signatory,signatory,签署者,NOUN,B2
+solicitude,solicitude,关怀,NOUN,B2
+teratogenic,teratogenic,致畸的,ADJ,B2
+radically,radically,彻底地,ADV,B2
+masculine,masculine,男性的,ADJ,B2
+to join to adhere,to join to adhere,加入 / 附着,VERB,B2
+ravine,ravine,沟壑,NOUN,B2
+barracks,barracks,兵营,NOUN,B2
+distinctly,distinctly,清楚地,ADV,B2
+presumed,presumed,推定的,ADJ,B2
+to dry up,to dry up,使干枯,VERB,B2
+breach of duty,breach of duty,渎职,NOUN,B2
+occultism,occultism,神秘学,NOUN,B2
+peri-urban,peri-urban,城市周边的,ADJ,B2
+eddy,eddy,漩涡,NOUN,B2
+accused person,accused person,被告,NOUN,B2
+punctuality,punctuality,守时,NOUN,B2
+impostor,impostor,骗子,NOUN,B2
+asyndeton,asyndeton,连词省略,NOUN,B2
+saucepan,saucepan,平底锅,NOUN,B2
+current events,current events,时事,NOUN,B2
+rerun,rerun,重播,NOUN,B2
+laconism,laconism,简洁,NOUN,B2
+shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
+to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
+about fifty,about fifty,五十左右,NOUN,B2
+herbal tea,herbal tea,花草茶,NOUN,B2
+to point to clock in,to point to clock in,指 / 打卡,VERB,B2
+capping,capping,封顶,NOUN,B2
+to incarcerate,to incarcerate,监禁,VERB,B2
+paintbrush,paintbrush,画笔；毛笔,NOUN,B2
+magnetic,magnetic,磁的,ADJ,B2
+clandestinity,clandestinity,秘密状态,NOUN,B2
+beatitude,beatitude,至福,NOUN,B2
+clumsily,clumsily,笨拙地,ADV,B2
+to inflict to impose,to inflict to impose,施加,VERB,B2
+amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
+amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
+small boat,small boat,小船,NOUN,B2
+ok,ok,好的,INTJ,B2
+sophist,sophist,诡辩家,NOUN,B2
+measured,measured,克制的,ADJ,B2
+deeply profoundly,deeply profoundly,深刻地,ADV,B2
+ticket validation,ticket validation,检票,NOUN,B2
+divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
+cosmology,cosmology,宇宙学,NOUN,B2
+funerary,funerary,丧葬的,ADJ,B2
+to unbend,to unbend,润滑,VERB,B2
+bookstore,bookstore,书店,NOUN,B2
+to unblind,to unblind,使醒悟,VERB,B2
+coin purse,coin purse,零钱包,NOUN,B2
+buyer purchaser,buyer purchaser,买方,NOUN,B2
+succinctly,succinctly,简洁地,ADV,B2
+striking,striking,惊人的,ADJ,B2
+activism,activism,激进主义,NOUN,B2
+cider,cider,苹果酒,NOUN,B2
+portion serving,portion serving,部分 / 一份,NOUN,B2
+each one,each one,每人,PRON,B2
+to scare away,to scare away,惊飞,VERB,B2
+duct pipe,duct pipe,管道,NOUN,B2
+continually,continually,不断地,ADV,B2
+award auction,award auction,裁定 / 拍卖,NOUN,B2
+initial,initial,花押字,NOUN,B2
+time clock,time clock,打卡机,NOUN,B2
+legislature,legislature,立法机关,NOUN,B2
+flowering,flowering,开花,NOUN,B2
+quantum,quantum,量子的,ADJ,B2
+stationery shop,stationery shop,文具店,NOUN,B2
+exceptionally,exceptionally,例外地,ADV,B2
+fed up,fed up,受够了,NOUN,B2
+pleonasm,pleonasm,赘述,NOUN,B2
+opportunity used,opportunity used,机会,NOUN,B2
+patronage,patronage,赞助,NOUN,B2
+laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
+millionaire,millionaire,百万富翁,NOUN,B2
+obese,obese,肥胖的,ADJ,B2
+flat rate,flat rate,包干费,NOUN,B2
+amicable out-of-court,amicable out-of-court,友好的 / 庭外和解的,ADJ,B2
+to ogle,to ogle,窥视,VERB,B2
+accessory,accessory,配件,NOUN,B2
+to flame,to flame,燃烧,VERB,B2
+achievable,achievable,可实现的,ADJ,B2
+trilogy,trilogy,三部曲,NOUN,B2
+egg-laying,egg-laying,产卵,NOUN,B2
+allegiance,allegiance,忠诚,NOUN,B2
+refutable,refutable,可反驳的,ADJ,B2
+ore,ore,矿石,NOUN,B2
+syneresis,syneresis,元音合并,NOUN,B2
+beneficial,beneficial,有益的,ADJ,B2
+to contest,to contest,质疑,VERB,B2
+impassively,impassively,无动于衷地,ADV,B2
+comorbidity,comorbidity,共病,NOUN,B2
+exoteric,exoteric,外传的,ADJ,B2
+boarder,boarder,寄宿生,NOUN,B2
+thermodynamics,thermodynamics,热力学,NOUN,B2
+knowledge exchange,knowledge exchange,知识交流,NOUN,B2
+sure safe,sure safe,确定的,ADJ,B2
+greetings,greetings,,NOUN,B2
+entrance ticket,entrance ticket,门票,NOUN,B2
+ears,ears,耳朵,NOUN,B2
+parent-friendly,parent-friendly,,NOUN,B2
+certainly,certainly,当然,INTJ,B2
+sliding,sliding,滑动的,ADJ,B2
+lab,lab,实验室,NOUN,B2
+morphine,morphine,吗啡,NOUN,B2
+fine pretty,fine pretty,美丽的,ADJ,B2
+gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
+clear,clear,当然,ADV,B2
+top great,top great,顶部/极好,NOUN,B2
+twenty-two-year-old,twenty-two-year-old,,NOUN,B2
+pier,pier,码头,NOUN,B2
+in peace,in peace,不受打扰地,ADV,B2
+penance,penance,忏悔,NOUN,B2
+to be needed,to be needed,被需要,VERB,B2
+bike helmet,bike helmet,自行车头盔,NOUN,B2
+sailboat,sailboat,,NOUN,B2
+suicidal thought,suicidal thought,,NOUN,B2
+regardless,regardless,不管,ADV,B2
+electric motor,electric motor,电动机,NOUN,B2
+family relatives,family relatives,亲属,NOUN,B2
+fast,fast,快地,ADV,B2
+monarchy,monarchy,君主制,NOUN,B2
+pain relief,pain relief,,NOUN,B2
+fair decent,fair decent,公平的/正派的,ADJ,B2
+to zero out,to zero out,清零,VERB,B2
+swim training,swim training,,NOUN,B2
+mental hospital,mental hospital,精神病院,NOUN,B2
+sense of shame,sense of shame,,NOUN,B2
+locked in,locked in,被关在里面的,ADJ,B2
+pants,pants,裤子,NOUN,B2
+stolen,stolen,被偷的,ADJ,B2
+to be included,to be included,包含,VERB,B2
+funniness,funniness,,NOUN,B2
+outbreak,outbreak,爆发,NOUN,B2
+premium,premium,溢价,NOUN,B2
+grille,grille,格栅,NOUN,B2
+single,single,单曲,NOUN,B2
+medical help,medical help,,NOUN,B2
+gothenburg,gothenburg,哥德堡,PROPN,B2
+managed,managed,,NOUN,B2
+english teacher,english teacher,,NOUN,B2
+literally,literally,字面上地,ADV,B2
+leaf page,leaf page,叶子,NOUN,B2
+to light a fire,to light a fire,生火,VERB,B2
+mr master,mr master,先生/主人,NOUN,B2
+pine needle,pine needle,针叶,NOUN,B2
+funeral home,funeral home,,NOUN,B2
+sweetness,sweetness,,NOUN,B2
+hooray,hooray,万岁,INTJ,B2
+angle of approach,angle of approach,切入点,NOUN,B2
+thereafter,thereafter,此后,ADV,B2
+although,although,尽管,CCONJ,B2
+latest,latest,最新的,ADJ,B2
+change exchange,change exchange,改变/交换,NOUN,B2
+work environment,work environment,工作环境,NOUN,B2
+to fit suit,to fit suit,适合,VERB,B2
+to be driven,to be driven,被驱动,VERB,B2
+to be counted,to be counted,被算作,VERB,B2
+its,its,它的,PRON,B2
+social problem,social problem,社会问题,NOUN,B2
+indigenous people,indigenous people,原住民,NOUN,B2
+bigwig,bigwig,大人物,NOUN,B2
+something,something,شي,NOUN,B2
+magically,magically,魔法地,ADV,B2
+number one,number one,第一名,NOUN,B2
+he this one,he this one,他/这位,PRON,B2
+concussion,concussion,脑震荡,NOUN,B2
+bank card,bank card,银行卡,NOUN,B2
+known famous,known famous,著名的/熟悉的,ADJ,B2
+bigger,bigger,更大的,ADJ,B2
+alive living,alive living,活着的,ADJ,B2
+following page,following page,,NOUN,B2
+more important,more important,更重要的,ADJ,B2
+to screw,to screw,拧,VERB,B2
+fun joke,fun joke,乐趣/玩笑,NOUN,B2
+agree,agree,一致,ADJ,B2
+to step down,to step down,辞职,VERB,B2
+monkey ape,monkey ape,猿/猴,NOUN,B2
+conifer,conifer,针叶树,NOUN,B2
+sure,sure,当然,ADV,B2
+to steer control,to steer control,控制,VERB,B2
+starved,starved,饥饿的,ADJ,B2
+artistry,artistry,,NOUN,B2
+to trap fell,to trap fell,困住/砍倒,VERB,B2
+half-year,half-year,半年,NOUN,B2
+hither,hither,到这里,ADV,B2
+guest tester,guest tester,,NOUN,B2
+contacts,contacts,人脉,NOUN,B2
+computer program,computer program,电脑程序,NOUN,B2
+hanged,hanged,被绞死的,ADJ,B2
+butt,butt,臀部,NOUN,B2
+to bicker,to bicker,争吵,VERB,B2
+violently,violently,暴力地,ADV,B2
+to decide determine,to decide determine,决定/确定,VERB,B2
+so thus,so thus,所以/如此,ADV,B2
+to wipe out,to wipe out,消灭,VERB,B2
+citizenship right,citizenship right,公民权,NOUN,B2
+at once,at once,立刻,ADV,B2
+to drink binge,to drink binge,狂饮,VERB,B2
+to dampen,to dampen,使潮湿,VERB,B2
+to denominate,to denominate,命名,VERB,B2
+test drive,test drive,,NOUN,B2
+disposition,disposition,性情,NOUN,B2
+itself,itself,它自己,PRON,B2
+the sick,the sick,病人,NOUN,B2
+more beautiful,more beautiful,更美的,ADJ,B2
+atomic nucleus,atomic nucleus,原子核,NOUN,B2
+to paint over,to paint over,重新粉刷,VERB,B2
+working class,working class,工人阶级,NOUN,B2
+to harbor,to harbor,怀有,VERB,B2
+sentenced,sentenced,被判刑的,ADJ,B2
+upper floor,upper floor,楼上,NOUN,B2
+salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
+scientists,scientists,科学家,NOUN,B2
+lots,lots,大量,NOUN,B2
+poor wretched,poor wretched,可怜的,ADJ,B2
+welcome committee,welcome committee,,NOUN,B2
+self-image,self-image,自我形象,NOUN,B2
+to find oneself,to find oneself,处于,VERB,B2
+ace,ace,王牌,NOUN,B2
+your plural,your plural,你们的,DET,B2
+values,values,价值观,NOUN,B2
+goodbye kiss,goodbye kiss,,NOUN,B2
+atm,atm,自动取款机,NOUN,B2
+sun sensitivity,sun sensitivity,,NOUN,B2
+load cargo,load cargo,货物/负荷,NOUN,B2
+egg card,egg card,,NOUN,B2
+wife mrs,wife mrs,妻子/夫人,NOUN,B2
+below,below,下面,NOUN,B2
+definite,definite,明确的,ADJ,B2
+evenly,evenly,均匀地,ADV,B2
+determined definite,determined definite,确定的,ADJ,B2
+healthcare worker,healthcare worker,医护人员,NOUN,B2
+to behold,to behold,注视,VERB,B2
+freedom of the press,freedom of the press,出版自由,NOUN,B2
+heroin vapor,heroin vapor,,NOUN,B2
+nuance,nuance,细微差别,NOUN,B2
+bags,bags,包,NOUN,B2
+other others,other others,其他,DET,B2
+degree exam,degree exam,学位/考试,NOUN,B2
+oh really,oh really,真的吗,INTJ,B2
+back side,back side,背面,NOUN,B2
+to quiver,to quiver,颤抖,VERB,B2
+scene stage,scene stage,场景/舞台,NOUN,B2
+long,long,,NOUN,B2
+director manager,director manager,主管/经理,NOUN,B2
+hag,hag,老妇,NOUN,B2
+stably,stably,稳定地,ADV,B2
+electric power,electric power,电力,NOUN,B2
+to rot,to rot,腐烂,VERB,B2
+income tax,income tax,所得税,NOUN,B2
+eating,eating,,NOUN,B2
+mustache,mustache,胡子,NOUN,B2
+safe secure,safe secure,安全的/可靠的,ADJ,B2
+squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
+sinner,sinner,罪人,NOUN,B2
+shortly,shortly,不久,ADV,B2
+to enhance,to enhance,增强,VERB,B2
+attacked,attacked,被攻击的,ADJ,B2
+chubby,chubby,胖子,NOUN,B2
+every other,every other,每隔一个,DET,B2
+caught,caught,被捕获的,ADJ,B2
+arrested,arrested,被逮捕的,ADJ,B2
+firearms,firearms,枪支,NOUN,B2
+to food give birth,to food give birth,食物/生育,VERB,B2
+diagonally,diagonally,对角地,ADV,B2
+to occupy oneself,to occupy oneself,从事,VERB,B2
+the guy's,the guy's,那个男人的,NOUN,B2
+good well,good well,好/很好,ADJ,B2
+impressed,impressed,印象深刻的,ADJ,B2
+emotionally,emotionally,情感上,ADV,B2
+innocent,innocent,无辜地,ADV,B2
+experience exchange,experience exchange,经验交流,NOUN,B2
+good behavior,good behavior,,NOUN,B2
+green-clad,green-clad,,NOUN,B2
+broken,broken,破碎的,ADV,B2
+chips,chips,薯片,NOUN,B2
+difficult flirt,difficult flirt,,NOUN,B2
+cognac,cognac,干邑,NOUN,B2
+hot dog stand,hot dog stand,小吃摊,NOUN,B2
+corpse alike,corpse alike,尸体/相似的,NOUN,B2
+big brother,big brother,哥哥,NOUN,B2
+what kind of,what kind of,什么样的,PRON,B2
+ceo,ceo,首席执行官,NOUN,B2
+to call ring,to call ring,打电话,VERB,B2
+confusing,confusing,令人困惑的,ADJ,B2
+loudly,loudly,大声地,ADV,B2
+to be punished,to be punished,受罚,VERB,B2
+like this,like this,,NOUN,B2
+armorer,armorer,,NOUN,B2
+to account for,to account for,说明,VERB,B2
+dejt,dejt,约会,NOUN,B2
+to prosecute,to prosecute,起诉,VERB,B2
+it common,it common,它 (通性),PRON,B2
+self-evident,self-evident,,NOUN,B2
+informed,informed,见多识广的,ADJ,B2
+faster,faster,更快的,ADJ,B2
+action plan,action plan,行动方案,NOUN,B2
+seen,seen,被看见,ADJ,B2
+chill,chill,放松,ADJ,B2
+to mourn,to mourn,哀悼,VERB,B2
+to tear down,to tear down,拆除,VERB,B2
+to furlough,to furlough,临时解雇,VERB,B2
+subject topic,subject topic,主题/话题,NOUN,B2
+out here,out here,这里外面,ADV,B2
+pavement,pavement,人行道,NOUN,B2
+astray,astray,迷路,ADJ,B2
+epoch,epoch,时代,NOUN,B2
+phrasing,phrasing,措辞,NOUN,B2
+older woman,older woman,老妇人,NOUN,B2
+registered,registered,注册的,ADJ,B2
+elite unit,elite unit,,NOUN,B2
+zero,zero,零,NOUN,B2
+to be tricked,to be tricked,被欺骗,VERB,B2
+pre,pre,,NOUN,B2
+upward,upward,向上,ADV,B2
+lifestyle,lifestyle,生活方式,NOUN,B2
+christmas present,christmas present,圣诞礼物,NOUN,B2
+apart from,apart from,除了,ADP,B2
+part-time worker,part-time worker,兼职工,NOUN,B2
+central station,central station,中央车站,NOUN,B2
+based,based,基于,ADJ,B2
+cola,cola,可乐,NOUN,B2
+to be saved,to be saved,获救,VERB,B2
+smart clever,smart clever,聪明的,ADJ,B2
+to underline,to underline,强调,VERB,B2
+date fruit,date fruit,椰枣,NOUN,B2
+civilian,civilian,平民的,ADJ,B2
+trigger mechanism,trigger mechanism,,NOUN,B2
+sought,sought,,NOUN,B2
+to exist there is,to exist there is,存在/有,VERB,B2
+personal integrity,personal integrity,个人隐私,NOUN,B2
+to separate divorce,to separate divorce,分离/离婚,VERB,B2
+history story,history story,历史/故事,NOUN,B2
+away gone,away gone,不在/离开,ADV,B2
+legion unit,legion unit,,NOUN,B2
+the other day,the other day,前几天,ADV,B2
+dear,dear,,NOUN,B2
+xenophobia,xenophobia,排外心理,NOUN,B2
+stockholm,stockholm,斯德哥尔摩,PROPN,B2
+word choice,word choice,措辞,NOUN,B2
+ever,ever,,NOUN,B2
+indoors,indoors,在室内,ADV,B2
+omelette,omelette,煎蛋卷,NOUN,B2
+the it,the it,那,DET,B2
+to blink,to blink,眨眼,VERB,B2
+to acknowledge,to acknowledge,承认,VERB,B2
+cultural encounter,cultural encounter,文化交汇,NOUN,B2
+own,own,自己的,DET,B2
+the very,the very,正是,ADV,B2
+heart,heart,心,ADV,B2
+to mess around,to mess around,胡闹,VERB,B2
+cancelled set,cancelled set,取消的/设定的,ADJ,B2
+innermost,innermost,最里面的,ADV,B2
+sunglasses,sunglasses,太阳镜,NOUN,B2
+furthest,furthest,最远,ADV,B2
+to cook fix,to cook fix,做/修理,VERB,B2
+for because,for because,因为,CCONJ,B2
+pie,pie,派,NOUN,B2
+before previously,before previously,以前,ADV,B2
+beside,beside,在...旁边,ADP,B2
+coworker,coworker,同事,NOUN,B2
+yes indeed,yes indeed,正是,INTJ,B2
+to sneak away,to sneak away,溜走,VERB,B2
+headline,headline,标题,NOUN,B2
+farm yard,farm yard,农场,NOUN,B2
+to shop be about,to shop be about,购物,VERB,B2
+to kidnapped,to kidnapped,绑架,VERB,B2
+language use,language use,语言使用,NOUN,B2
+to watch out,to watch out,小心,VERB,B2
+eidsvold,eidsvold,,NOUN,B2
+to exemplify,to exemplify,举例说明,VERB,B2
+alarm center,alarm center,报警中心,NOUN,B2
+alder,alder,桤木,NOUN,B2
+blood test,blood test,验血,NOUN,B2
+dal,dal,山谷,NOUN,B2
+odds,odds,赔率,NOUN,B2
+to close eyes,to close eyes,闭眼,VERB,B2
+happily,happily,快乐地,ADV,B2
+devil bastard,devil bastard,混蛋,NOUN,B2
+cheaper,cheaper,更便宜的,ADJ,B2
+to bide,to bide,等待,VERB,B2
+capable good,capable good,能干的/优秀的,ADJ,B2
+property owner,property owner,房主,NOUN,B2
+dot,dot,点,NOUN,B2
+to acquaint,to acquaint,使熟悉,VERB,B2
+edging,edging,镶边,NOUN,B2
+the devil bastard,the devil bastard,混蛋,NOUN,B2
+alpha,alpha,阿尔法,NOUN,B2
+super high,super high,,NOUN,B2
+poor devil,poor devil,可怜虫,NOUN,B2
+to puncture deflate,to puncture deflate,刺破,VERB,B2
+sexily,sexily,性感地,ADV,B2
+more fun,more fun,更有趣的,ADJ,B2
+side page,side page,侧面/页,NOUN,B2
+to push through,to push through,推动,VERB,B2
+organically,organically,有机地,ADV,B2
+paralyzed,paralyzed,瘫痪的,ADJ,B2
+to regain,to regain,恢复,VERB,B2
+paternal grandmother,paternal grandmother,祖母,NOUN,B2
+to bark scold,to bark scold,吠/责骂,VERB,B2
+on board,on board,在船上,ADV,B2
+reply,reply,回复,NOUN,B2
+to get acquire,to get acquire,获得/弄到,VERB,B2
+ongoing,ongoing,进行中的,ADJ,B2
+ought,ought,应该,AUX,B2
+baptized,baptized,受洗的,ADJ,B2
+the chinese,the chinese,中国人,NOUN,B2
+free off,free off,空闲的/休假,ADJ,B2
+intelligence service,intelligence service,情报机构,NOUN,B2
+half hour,half hour,半小时,NOUN,B2
+to dismiss fire,to dismiss fire,解雇,VERB,B2
+seventeen,seventeen,十七,NUM,B2
+freedom of religion,freedom of religion,宗教自由,NOUN,B2
+police chief,police chief,警察局长,NOUN,B2
+lesbian,lesbian,女同性恋的,ADJ,B2
+knock,knock,敲击,NOUN,B2
+down there,down there,在那下面,ADV,B2
+high tall,high tall,高的,ADJ,B2
+death,death,致死,ADV,B2
+radiant,radiant,容光焕发的,ADJ,B2
+to have strength,to have strength,有力气,VERB,B2
+sabbath,sabbath,安息日,NOUN,B2
+marine corps,marine corps,海军陆战队,NOUN,B2
+bang,bang,砰,INTJ,B2
+seeker,seeker,寻求者,NOUN,B2
+to fall crash,to fall crash,坠落/猛冲,VERB,B2
+it neuter,it neuter,它 (中性),PRON,B2
+milk tooth,milk tooth,,NOUN,B2
+poison gas,poison gas,毒气,NOUN,B2
+full drunk,full drunk,满的/醉的,ADJ,B2
+tough guy,tough guy,硬汉,NOUN,B2
+to party,to party,狂欢,VERB,B2
+nicely nice,nicely nice,美好地,ADV,B2
+to lay put,to lay put,放,VERB,B2
+werewolf,werewolf,狼人,NOUN,B2
+to scout,to scout,侦察,VERB,B2
+good-looking person,good-looking person,帅哥/美女,NOUN,B2
+gangster,gangster,黑帮成员,NOUN,B2
+girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
+creep,creep,令人厌恶的人,NOUN,B2
+eider hunter,eider hunter,,NOUN,B2
+some,some,某些,ADJ,B2
+just over,just over,稍微超过,ADV,B2
+to give a ride,to give a ride,载送一程,VERB,B2
+fiancee,fiancee,未婚妻,NOUN,B2
+law team,law team,法律/团队,NOUN,B2
+quivering,quivering,颤抖的,ADJ,B2
+unarmed,unarmed,手无寸铁的,ADJ,B2
+meatballs,meatballs,肉丸,NOUN,B2
+datum,datum,日期,NOUN,B2
+inflammable,inflammable,易燃的,ADJ,B2
+confounded,confounded,该死的,ADJ,B2
+shedding,shedding,,NOUN,B2
+to blunder,to blunder,犯大错,VERB,B2
+to linger,to linger,徘徊,VERB,B2
+special agent,special agent,特工,NOUN,B2
+to bare,to bare,暴露,VERB,B2
+poorer,poorer,更穷的,ADJ,B2
+thank god,thank god,谢天谢地,INTJ,B2
+sixth,sixth,,NOUN,B2
+late,late,晚才,NOUN,B2
+delayed,delayed,延误的,ADJ,B2
+hamburger,hamburger,汉堡包,NOUN,B2
+rug,rug,地毯,NOUN,B2
+less,less,较少的,ADJ,B2
+many,many,多……,NOUN,B2
+dressed,dressed,穿着的,ADJ,B2
+rash,rash,皮疹,NOUN,B2
+knocked out,knocked out,被淘汰的,ADJ,B2
+earlier,earlier,更早的,ADJ,B2
+all of it,all of it,全部,PRON,B2
+overfall,overfall,,NOUN,B2
+away,away,避开,ADP,B2
+work task,work task,工作任务,NOUN,B2
+to mean entail,to mean entail,意味着,VERB,B2
+slower,slower,更慢,ADJ,B2
+all of them,all of them,大家,PRON,B2
+somewhere,somewhere,,NOUN,B2
+track trace,track trace,痕迹/轨道,NOUN,B2
+deadly,deadly,致命地,ADV,B2
+fair hair,fair hair,,NOUN,B2
+to make out,to make out,接吻,VERB,B2
+skater,skater,,NOUN,B2
+trainer,trainer,教练,NOUN,B2
+backward,backward,向后,ADV,B2
+to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
+retirement pension,retirement pension,退休金,NOUN,B2
+gas flame,gas flame,煤气火焰,NOUN,B2
+europe,europe,欧洲,PROPN,B2
+self-defense,self-defense,自卫,NOUN,B2
+closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
+visiting ban,visiting ban,,NOUN,B2
+to think opine,to think opine,认为,VERB,B2
+evening meal,evening meal,晚餐,NOUN,B2
+thinner,thinner,更薄的,ADJ,B2
+westward,westward,向西,ADV,B2
+calming,calming,令人平静的,ADJ,B2
+her,her,她的,PRON,B2
+competition bastard,competition bastard,,NOUN,B2
+attitude setting,attitude setting,态度/设置,NOUN,B2
+turntable,turntable,,NOUN,B2
+okay,okay,好的,ADJ,B2
+convicted,convicted,被判罪的,ADJ,B2
+fifth,fifth,第五,NUM,B2
+shorter,shorter,更短的,ADJ,B2
+bigness,bigness,,NOUN,B2
+starting point,starting point,出发点,NOUN,B2
+beaten,beaten,被打败的,ADJ,B2
+intended,intended,,NOUN,B2
+outer,outer,外部的,ADJ,B2
+police report,police report,,NOUN,B2
+catholic,catholic,天主教徒,NOUN,B2
+steadily,steadily,稳定地,ADV,B2
+superhero,superhero,超级英雄,NOUN,B2
+to dejta,to dejta,约会,VERB,B2
+the cash register,the cash register,收银台,NOUN,B2
+protector,protector,保护者,NOUN,B2
+outward,outward,向外,ADV,B2
+born,born,出生的,ADJ,B2
+cleaner,cleaner,更干净的,ADJ,B2
+only,only,唯一的,DET,B2
+cykel,cykel,自行车,NOUN,B2
+destroyed,destroyed,被毁坏的,ADJ,B2
+ice pick,ice pick,,NOUN,B2
+tax return,tax return,报税,NOUN,B2
+dirtier,dirtier,更脏的,ADJ,B2
+sensibly,sensibly,明智地,ADV,B2
+to release let go,to release let go,释放/放手,VERB,B2
+tragically,tragically,悲剧地,ADV,B2
+lovely,lovely,美好的,ADJ,B2
+kids,kids,孩子,NOUN,B2
+sensor donor,sensor donor,传感器/捐献者,NOUN,B2
+sauna,sauna,桑拿,NOUN,B2
+to search apply,to search apply,寻找/申请,VERB,B2
+bow tie,bow tie,领结,NOUN,B2
+here you go,here you go,请,INTJ,B2
+to apply be valid,to apply be valid,适用/有效,VERB,B2
+in vain,in vain,徒劳,NOUN,B2
+shit crap,shit crap,废话,NOUN,B2
+like as,like as,如同/好像,ADV,B2
+upper class,upper class,上层,NOUN,B2
+poorest,poorest,最穷的,ADJ,B2
+sweden,sweden,瑞典,PROPN,B2
+salt shaker,salt shaker,,NOUN,B2
+state federal,state federal,州,NOUN,B2
+del,del,部分,NOUN,B2
+vile,vile,可憎地,ADV,B2
+inside of,inside of,在...里面,ADP,B2
+doughy,doughy,面团状的,ADJ,B2
+exactly just,exactly just,恰好,ADV,B2
+his her own,his her own,他/她自己的,DET,B2
+worst,worst,最差的,ADV,B2
+sentencing,sentencing,量刑,NOUN,B2
+of course,of course,当然,INTJ,B2
+christmas eve,christmas eve,平安夜,NOUN,B2
+time to go to bed,time to go to bed,该睡觉了,ADV,B2
+sense of duty,sense of duty,责任感,NOUN,B2
+that way,that way,往那边,ADV,B2
+giddy,giddy,头晕的,ADJ,B2
+rulebook,rulebook,规则体系,NOUN,B2
+electric guitar,electric guitar,电吉他,NOUN,B2
+richer,richer,更富的,ADJ,B2
+pain hurt,pain hurt,疼痛,ADJ,B2
+corrections,corrections,刑事司法,NOUN,B2
+to erect behave,to erect behave,建造,VERB,B2
+to tip,to tip,透露,VERB,B2
+trigger imprint,trigger imprint,印记,NOUN,B2
+yep,yep,是的,INTJ,B2
+compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
+dance floor,dance floor,舞池,NOUN,B2
+to be struck,to be struck,被打击,VERB,B2
+gas meter,gas meter,,NOUN,B2
+cracker,cracker,饼干,NOUN,B2
+corrupted,corrupted,,NOUN,B2
+to thrown,to thrown,扔,VERB,B2
+orphaned,orphaned,无父母的,ADJ,B2
+honor culture,honor culture,荣誉文化,NOUN,B2
+shame culture,shame culture,羞耻文化,NOUN,B2
+muffin,muffin,玛芬蛋糕,NOUN,B2
+saucy,saucy,下流的,ADJ,B2
+wonderful,wonderful,极好地,ADV,B2
+youngest,youngest,最年轻的,ADJ,B2
+personal best,personal best,,NOUN,B2
+life sentence,life sentence,无期徒刑,NOUN,B2
+warmer,warmer,更暖的,ADJ,B2
+pointlessly,pointlessly,徒劳地,ADV,B2
+devastated,devastated,崩溃的,ADJ,B2
+run over,run over,被碾过的,ADJ,B2
+supplies,supplies,必需品,NOUN,B2
+afraid,afraid,,NOUN,B2
+probable,probable,可能的,ADJ,B2
+stink,stink,恶臭,NOUN,B2
+to decimate,to decimate,大量削减,VERB,B2
+to light ignite,to light ignite,点燃,VERB,B2
+equally,equally,同样地,ADV,B2
+attention,attention,立正,INTJ,B2
+chest breast,chest breast,胸部/乳房,NOUN,B2
+terribleness,terribleness,,NOUN,B2
+game play,game play,游戏/比赛,NOUN,B2
+to be responsible,to be responsible,负责,VERB,B2
+in return,in return,作为回报,NOUN,B2
+to be ongoing,to be ongoing,进行中,VERB,B2
+mass media,mass media,大众媒体,NOUN,B2
+imprisoned,imprisoned,被监禁的,ADJ,B2
+swimwear,swimwear,,NOUN,B2
+in addition to,in addition to,除...之外,ADP,B2
+stiff glove,stiff glove,,NOUN,B2
+small things,small things,琐事,NOUN,B2
+message errand,message errand,消息/差事,NOUN,B2
+unsecured,unsecured,,NOUN,B2
+irish,irish,爱尔兰语,NOUN,B2
+to be noticed,to be noticed,被注意到,VERB,B2
+above all,above all,,NOUN,B2
+hopelessly,hopelessly,绝望地,ADV,B2
+dredge,dredge,,NOUN,B2
+nuclear power,nuclear power,核能,NOUN,B2
+the same,the same,同一个,PRON,B2
+to get stuck,to get stuck,卡住,VERB,B2
+shame pity,shame pity,遗憾,NOUN,B2
+foreign strange,foreign strange,外国的/陌生的,ADJ,B2
+much,much,很多,ADV,B2
+business sector,business sector,商业界,NOUN,B2
+eastward,eastward,向东,ADV,B2
+cartel,cartel,卡特尔,NOUN,B2
+poisoned,poisoned,,NOUN,B2
+trainer bastard,trainer bastard,,NOUN,B2
+chiefly,chiefly,主要地,ADV,B2
+miss teacher,miss teacher,小姐/老师,NOUN,B2
+more expensive,more expensive,更贵的,ADJ,B2
+made,made,制成的,ADJ,B2
+brain damage,brain damage,,NOUN,B2
+the other evening,the other evening,前几天晚上,ADV,B2
+applicable,applicable,适用的,ADJ,B2
+to spray,to spray,喷洒,VERB,B2
+having a cold,having a cold,感冒的,ADJ,B2
+the cavalry,the cavalry,骑兵,NOUN,B2
+easier,easier,更容易的,ADJ,B2
+envious jealous,envious jealous,嫉妒的,ADJ,B2
+northward,northward,向北,ADV,B2
+in there,in there,在那里面,ADV,B2
+working method,working method,工作方式,NOUN,B2
+to box,to box,拳击,VERB,B2
+medical examiner,medical examiner,法医,NOUN,B2
+homeward,homeward,,NOUN,B2
+to be visible,to be visible,可见,VERB,B2
+from here,from here,从这里,ADV,B2
+blockhead,blockhead,笨蛋,NOUN,B2
+damm,damm,池塘,NOUN,B2
+to skip,to skip,跳过,VERB,B2
+backside,backside,臀部,NOUN,B2
+in private,in private,私下地,ADV,B2
+freedom of choice,freedom of choice,选择自由,NOUN,B2
+the emperor,the emperor,皇帝,NOUN,B2
+espresso,espresso,浓缩咖啡,NOUN,B2
+management pipe,management pipe,管理层/管道,NOUN,B2
+type like,type like,类型/比如,NOUN,B2
+southward,southward,向南,ADV,B2
+previous,previous,,NOUN,B2
+christmas porridge,christmas porridge,,NOUN,B2
+skin hide,skin hide,皮肤/皮革,NOUN,B2
+can jar,can jar,罐子,NOUN,B2
+to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
+exam evening,exam evening,,NOUN,B2
+consciously,consciously,有意识地,ADV,B2
+in mind,in mind,记住,ADV,B2
+to indicate interpret,to indicate interpret,表明/解释,VERB,B2
+emotional life,emotional life,情感生活,NOUN,B2
+to long,to long,渴望,VERB,B2
+perception opinion,perception opinion,看法,NOUN,B2
+released,released,获释的,ADJ,B2
+causal link,causal link,因果关系,NOUN,B2
+depressing,depressing,令人沮丧的,ADJ,B2
+standpoint,standpoint,立场,NOUN,B2
+truly,truly,确实,ADV,B2
+perishing,perishing,,NOUN,B2
+abuser,abuser,滥用者,NOUN,B2
+leftovers,leftovers,剩菜,NOUN,B2
+niceness,niceness,,NOUN,B2
+as far as,as far as,就……而言,ADV,B2
+to talk chat,to talk chat,聊天/谈论,VERB,B2
+from home,from home,从家里,ADV,B2
+tern path,tern path,,NOUN,B2
+partial norm,partial norm,分范,NOUN,B2
+one machine,one machine,一架,NUM,B2
+proactive,proactive,积极主动的,ADJ,B2
+domestic debt,domestic debt,内债,NOUN,B2
+sufficient flight,sufficient flight,飞够,NOUN,B2
+he she,he she,伊,PRON,B2
+mangosteen,mangosteen,山竹,NOUN,B2
+meridian,meridian,经脉,NOUN,B2
+toast,toast,你敬酒,NOUN,B2
+just,just,公正,ADJ,B2
+social custom,social custom,社会习俗,NOUN,B2
+amended generality,amended generality,改般,NOUN,B2
+jeans,jeans,牛仔裤,NOUN,B2
+crafty,crafty,狡猾,ADJ,B2
+trite,trite,陈腐的,ADJ,B2
+to wash with water,to wash with water,水洗,VERB,B2
+half-day,half-day,半天,NOUN,B2
+to extort a bribe,to extort a bribe,索贿,VERB,B2
+sub-reality,sub-reality,分实,NOUN,B2
+hard to measure,hard to measure,难以衡量,ADJ,B2
+to for example,to for example,比如,VERB,B2
+rethinking,rethinking,重想,NOUN,B2
+warrant,warrant,令状,NOUN,B2
+recounting,recounting,再叙,NOUN,B2
+to concern all,to concern all,凡事,VERB,B2
+timely,timely,适时,ADJ,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+foul smell,foul smell,骚味,NOUN,B2
+human life,human life,人命,NOUN,B2
+social value,social value,社会价值,NOUN,B2
+to donate blood,to donate blood,献血,VERB,B2
+hardship,hardship,艰难,NOUN,B2
+rehearsal,rehearsal,排练,NOUN,B2
+otherwise,otherwise,要不,PART,B2
+shooting star,shooting star,流星,NOUN,B2
+changed work,changed work,改工,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+your arrow,your arrow,若非你一箭,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
+amended synthesis,amended synthesis,改综,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+feudal ethics,feudal ethics,礼教,NOUN,B2
+very deep,very deep,很深,ADJ,B2
+bungee jumping,bungee jumping,蹦极,NOUN,B2
+non-knot,non-knot,非结,NOUN,B2
+bizarre case,bizarre case,奇案,NOUN,B2
+provocative,provocative,挑衅的,ADJ,B2
+non-possible,non-possible,非可,NOUN,B2
+main camp,main camp,大营,NOUN,B2
+imperial father,imperial father,父皇,NOUN,B2
+tendering,tendering,招标,NOUN,B2
+characteristic feature,characteristic feature,特点,NOUN,B2
+adversity,adversity,逆境,NOUN,B2
+partial basis,partial basis,分据,NOUN,B2
+waist token,waist token,腰牌,NOUN,B2
+sister yu,sister yu,俞姐,NOUN,B2
+no matter what,no matter what,无论,ADV,B2
+one building,one building,一座,NUM,B2
+to finally,to finally,你可算,VERB,B2
+how enough,how enough,哪够,NOUN,B2
+plenty,plenty,大量,NOUN,B2
+which seat,which seat,哪座,NOUN,B2
+succinct,succinct,简明的,ADJ,B2
+to seek peace,to seek peace,主和,VERB,B2
+case details,case details,案情,NOUN,B2
+motto,motto,座右铭,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+social activity,social activity,社会活动,NOUN,B2
+survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
+malicious words,malicious words,恶言,NOUN,B2
+social mediation,social mediation,社会调解,NOUN,B2
+gearbox,gearbox,变速箱,NOUN,B2
+hyper-target,hyper-target,超的,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+departure lounge,departure lounge,候机室,NOUN,B2
+social fairness,social fairness,社会公平,NOUN,B2
+to hope for,to hope for,盼望,VERB,B2
+great victory,great victory,大胜,NOUN,B2
+not bad,not bad,不错,ADJ,B2
+amended particular,amended particular,改特,NOUN,B2
+shopping mall,shopping mall,商场,NOUN,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
+wanting you,wanting you,要你,NOUN,B2
+to be afraid,to be afraid,害怕,VERB,B2
+re-criterion,re-criterion,重准,NOUN,B2
+non-technique,non-technique,非术,NOUN,B2
+cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
+earnest sincere,earnest sincere,恳切,ADJ,B2
+town mayor,town mayor,镇长,NOUN,B2
+traditional chinese painting,traditional chinese painting,国画,NOUN,B2
+acrobatics,acrobatics,杂技,NOUN,B2
+disposable diaper,disposable diaper,纸尿裤,NOUN,B2
+prudent,prudent,谨慎的,ADJ,B2
+inner heart,inner heart,内心,NOUN,B2
+walnut,walnut,核桃,NOUN,B2
+affordability,affordability,得起,NOUN,B2
+how dare,how dare,岂敢,NOUN,B2
+non-iron,non-iron,免烫,ADJ,B2
+to do what,to do what,干嘛,VERB,B2
+virtual reality,virtual reality,虚拟现实,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+kneeling,kneeling,跪,NOUN,B2
+reverse result,reverse result,反果,NOUN,B2
+dense forest,dense forest,密林,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+changed route,changed route,改路,NOUN,B2
+to thresh,to thresh,脱粒,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+overthinking,overthinking,你想多,NOUN,B2
+non-necessary,non-necessary,非必,NOUN,B2
+incremental,incremental,渐进性,ADJ,B2
+outer-gate,outer-gate,外门,NOUN,B2
+star search,star search,找星,NOUN,B2
+reverse origin,reverse origin,反原,NOUN,B2
+adequacy,adequacy,也不错,NOUN,B2
+inversion,inversion,反演,NOUN,B2
+from away from,from away from,离,ADP,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+that evening,that evening,当晚,NOUN,B2
+film roll,film roll,胶卷,NOUN,B2
+upper part,upper part,上部,NOUN,B2
+to shut up,to shut up,闭嘴,VERB,B2
+not good,not good,不好,ADJ,B2
+social progress,social progress,社会进步,NOUN,B2
+altogether,altogether,共,ADV,B2
+modified ability,modified ability,改能,NOUN,B2
+sucking,sucking,嗦,NOUN,B2
+not very good,not very good,不太好,ADJ,B2
+spiral pattern,spiral pattern,旋纹,NOUN,B2
+sticky note,sticky note,便签,NOUN,B2
+could it be,could it be,难不成,ADJ,B2
+outfit,outfit,服装,NOUN,B2
+meridians,meridians,筋脉,NOUN,B2
+re-grading,re-grading,改级,NOUN,B2
+my scrutiny,my scrutiny,我看你,NOUN,B2
+it is a pity,it is a pity,可惜,ADJ,B2
+polytunnel,polytunnel,大棚,NOUN,B2
+summer grass,summer grass,夏草,NOUN,B2
+now,now,此刻,NOUN,B2
+brook no delay,brook no delay,刻不容缓,ADJ,B2
+cilantro,cilantro,香菜,NOUN,B2
+further debate,further debate,再辩,NOUN,B2
+to act rashly,to act rashly,妄动,VERB,B2
+will surely,will surely,定会,AUX,B2
+heavy snow,heavy snow,大雪,NOUN,B2
+foot-warming,foot-warming,捂脚,NOUN,B2
+floating dust,floating dust,浮尘,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+cut off,cut off,割下,NOUN,B2
+surfing,surfing,冲浪,NOUN,B2
+well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
+not intentional,not intentional,不是故意,ADJ,B2
+all day,all day,整天,ADV,B2
+modern dance,modern dance,现代舞,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+to ambush,to ambush,埋伏,VERB,B2
+alumnus,alumnus,校友,NOUN,B2
+to transfer schools,to transfer schools,转学,VERB,B2
+um,um,嗯,INTJ,B2
+altered art,altered art,改艺,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+heart disease,heart disease,心脏病,NOUN,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+singularity,singularity,单一性,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+big data,big data,大数据,NOUN,B2
+charades,charades,打哑谜,NOUN,B2
+this matter,this matter,这事,NOUN,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+bloodshed,bloodshed,血腥,NOUN,B2
+re-argument,re-argument,重论,NOUN,B2
+foreign debt,foreign debt,外债,NOUN,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+side effect,side effect,副作用,NOUN,B2
+measure word flat objects,measure word flat objects,张,NOUN,B2
+hyper-origin,hyper-origin,超原,NOUN,B2
+but also,but also,但也,NOUN,B2
+captive,captive,俘虏,NOUN,B2
+cannot stay,cannot stay,不住,PART,B2
+moisture-proof,moisture-proof,防潮,ADJ,B2
+taking command,taking command,挂帅,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+re-concretization,re-concretization,再具,NOUN,B2
+jianghu world,jianghu world,江湖上,NOUN,B2
+as expected,as expected,果然,ADV,B2
+to return a car,to return a car,送车,VERB,B2
+for to,for to,为,ADP,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+entrapment,entrapment,身陷,NOUN,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+running around,running around,跑遍,NOUN,B2
+this indeed,this indeed,这倒,NOUN,B2
+quick lie-down,quick lie-down,快躺,NOUN,B2
+notepad,notepad,记事本,NOUN,B2
+courtyard guard,courtyard guard,护院,NOUN,B2
+major case,major case,大案,NOUN,B2
+elective course,elective course,选修课,NOUN,B2
+tactile paving,tactile paving,盲道,NOUN,B2
+to befriend,to befriend,与...交朋友,VERB,B2
+to not run,to not run,别跑,VERB,B2
+to raise funds,to raise funds,筹资,VERB,B2
+anti-universality,anti-universality,反普,NOUN,B2
+credentials,credentials,国书,NOUN,B2
+enoki mushroom,enoki mushroom,金针菇,NOUN,B2
+gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
+shh,shh,嘘,INTJ,B2
+to file for record,to file for record,备案,VERB,B2
+bound to,bound to,势必,ADV,B2
+grab,grab,揪,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
+sports exercise,sports exercise,运动,NOUN,B2
+red robe,red robe,红衣,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+borrowed knife,borrowed knife,借刀,NOUN,B2
+sound sleep,sound sleep,你踏实睡,NOUN,B2
+reincarnation,reincarnation,再体,NOUN,B2
+express car,express car,快车,NOUN,B2
+non-view,non-view,非观,NOUN,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to lose bid,to lose bid,落标,VERB,B2
+super-form,super-form,超形,NOUN,B2
+car wash,car wash,洗车,NOUN,B2
+can be at,can be at,可在,NOUN,B2
+to fall behind,to fall behind,落后,VERB,B2
+void,void,最无,NOUN,B2
+older sister,older sister,姐姐,NOUN,B2
+fax,fax,传真,NOUN,B2
+sha dynasty,sha dynasty,砂朝,NOUN,B2
+multi-level garage,multi-level garage,立体车库,NOUN,B2
+heaven and earth,heaven and earth,天地,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+to statistics,to statistics,统计,VERB,B2
+dignified manner,dignified manner,威仪,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+emphasize,emphasize,着重,ADV,B2
+to reflect on,to reflect on,思考,VERB,B2
+that pair,that pair,那付,NOUN,B2
+your photo,your photo,照你,NOUN,B2
+loud and clear,loud and clear,响亮,ADJ,B2
+unreasonable,unreasonable,不情,NOUN,B2
+cause of defeat,cause of defeat,败因,NOUN,B2
+good medicine,good medicine,好药,NOUN,B2
+that which,that which,所,PART,B2
+counter-boundary,counter-boundary,反界,NOUN,B2
+classifier for documents portions,classifier for documents portions,份,NOUN,B2
+plain and simple,plain and simple,朴素,ADJ,B2
+too small,too small,太小,ADJ,B2
+all night,all night,通宵,NOUN,B2
+plasma,plasma,血浆,NOUN,B2
+subcategory,subcategory,分目,NOUN,B2
+year by year,year by year,逐年,ADV,B2
+i,i,我连,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+to lack basis,to lack basis,无据,VERB,B2
+cantaloupe,cantaloupe,哈密瓜,NOUN,B2
+to not lose,to not lose,别丢,VERB,B2
+worry-free,worry-free,无忧,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+breakthrough,breakthrough,突破性,ADJ,B2
+lover sweetheart,lover sweetheart,情人,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
+traffic light,traffic light,红绿灯,NOUN,B2
+audio equipment,audio equipment,音响,NOUN,B2
+neighborhood head,neighborhood head,里长,NOUN,B2
+paternity leave,paternity leave,陪产假,NOUN,B2
+exchange goods,exchange goods,换货,NOUN,B2
+next week,next week,下周,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+to linkage,to linkage,联动,VERB,B2
+eyes,eyes,眼中,NOUN,B2
+nadir,nadir,最低点,NOUN,B2
+social morality,social morality,社会公德,NOUN,B2
+to die for,to die for,死要,VERB,B2
+quick removal,quick removal,赶快脱,NOUN,B2
+i'm afraid,i'm afraid,恐怕,ADV,B2
+extreme height,extreme height,极高,NOUN,B2
+marriage leave,marriage leave,婚假,NOUN,B2
+special-purpose trip,special-purpose trip,专程,ADV,B2
+housework,housework,家务,NOUN,B2
+i-than,i-than,我比,NOUN,B2
+mulberry,mulberry,桑葚,NOUN,B2
+inner side,inner side,内侧,NOUN,B2
+sex appeal,sex appeal,性感,NOUN,B2
+trans-idealism,trans-idealism,超唯,NOUN,B2
+to recommend for admission,to recommend for admission,保送,VERB,B2
+usb flash drive,usb flash drive,U盘,NOUN,B2
+holy decree,holy decree,圣令,NOUN,B2
+to study deeply,to study deeply,钻研,VERB,B2
+why not,why not,何不,ADV,B2
+super-distinction,super-distinction,超殊,NOUN,B2
+my taking,my taking,我拿,NOUN,B2
+foe,foe,敌友,NOUN,B2
+explosion-proof,explosion-proof,防爆,ADJ,B2
+this route,this route,这路,NOUN,B2
+birthmark,birthmark,胎记,NOUN,B2
+financial center,financial center,金融中心,NOUN,B2
+pounding,pounding,捶,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+be sorry,be sorry,抱歉,ADJ,B2
+trans-induction,trans-induction,超归,NOUN,B2
+to seek you,to seek you,寻你,VERB,B2
+eldest brother,eldest brother,做大哥,NOUN,B2
+second letter,second letter,再信,NOUN,B2
+counter-belief,counter-belief,反信,NOUN,B2
+past events,past events,往事,NOUN,B2
+swordsmanship,swordsmanship,剑术,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+logic modification,logic modification,改逻,NOUN,B2
+crowded,crowded,拥挤,ADJ,B2
+super-internal,super-internal,超内,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+nuclear energy,nuclear energy,核能,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+law,law,法,PART,B2
+zen master,zen master,禅师,NOUN,B2
+bluntness,bluntness,直说,NOUN,B2
+intravenous drip,intravenous drip,输液,NOUN,B2
+for a time,for a time,一度,ADV,B2
+cause of change,cause of change,改因,NOUN,B2
+equally matched,equally matched,不相上下,ADJ,B2
+external hard drive,external hard drive,移动硬盘,NOUN,B2
+immobility,immobility,都无动,NOUN,B2
+land expansion,land expansion,拓土,NOUN,B2
+pushover,pushover,善茬,NOUN,B2
+family background,family background,出身,NOUN,B2
+on the spot,on the spot,当场,ADV,B2
+sea level rise,sea level rise,海平面上升,NOUN,B2
+no not,no not,不,ADV,B2
+nephews,nephews,子侄,NOUN,B2
+common sense,common sense,常识,NOUN,B2
+capable,capable,有本事,NOUN,B2
+revised image,revised image,改影,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+according to,according to,要照,NOUN,B2
+spending,spending,行用,NOUN,B2
+re-analysis,re-analysis,重析,NOUN,B2
+homestay,homestay,民宿,NOUN,B2
+at worst,at worst,大不了,ADV,B2
+stuffed crab,stuffed crab,蟹酿,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+creditor's rights,creditor's rights,债权,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+sick leave,sick leave,病假,NOUN,B2
+month ago,month ago,月前,NOUN,B2
+altered path,altered path,改径,NOUN,B2
+to pay off,to pay off,清偿,VERB,B2
+medal awarding,medal awarding,授勋,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+in those days,in those days,当年,NOUN,B2
+cutting grass,cutting grass,斩草,NOUN,B2
+main street,main street,大街,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+exchange meeting,exchange meeting,交流会,NOUN,B2
+high-speed,high-speed,高速,ADJ,B2
+senior male student,senior male student,学长,NOUN,B2
+trans-er,trans-er,超而,NOUN,B2
+over-skill,over-skill,超技,NOUN,B2
+can-exit,can-exit,还出得来,NOUN,B2
+polyester,polyester,涤纶,NOUN,B2
+retrial,retrial,再审,NOUN,B2
+then he,then he,那他,NOUN,B2
+to eavesdrop,to eavesdrop,偷听,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+not catch up,not catch up,非赶,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+good faith,good faith,信义,NOUN,B2
+recycled item,recycled item,再物,NOUN,B2
+non-number,non-number,非数,NOUN,B2
+amended possibility,amended possibility,改可,NOUN,B2
+initial stage,initial stage,初期,NOUN,B2
+social awareness,social awareness,社会觉悟,NOUN,B2
+coral reef,coral reef,珊瑚礁,NOUN,B2
+to send mail,to send mail,寄件,VERB,B2
+death news,death news,死讯,NOUN,B2
+able to play,able to play,能下,NOUN,B2
+supreme fate,supreme fate,上缘,NOUN,B2
+re-tolerance,re-tolerance,再容,NOUN,B2
+white blood cell,white blood cell,白细胞,NOUN,B2
+mock exam,mock exam,模拟考,NOUN,B2
+heavy effect,heavy effect,重效,NOUN,B2
+hearth,hearth,壁炉,NOUN,B2
+to wanted,to wanted,通缉,VERB,B2
+to dry clean,to dry clean,干洗,VERB,B2
+return destination,return destination,回哪,NOUN,B2
+historical site,historical site,古迹,NOUN,B2
+patient sufferer,patient sufferer,患者,NOUN,B2
+simple pure,simple pure,单纯,ADJ,B2
+re-basis,re-basis,再据,NOUN,B2
+taro,taro,芋头,NOUN,B2
+re-route,re-route,重路,NOUN,B2
+listening,listening,也听,NOUN,B2
+stone,stone,石,PART,B2
+main road,main road,主路,NOUN,B2
+sub-method,sub-method,分法,NOUN,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+moonlight,moonlight,月色,NOUN,B2
+your word,your word,听你,NOUN,B2
+happy event,happy event,喜事,NOUN,B2
+this sword,this sword,这剑,NOUN,B2
+jujube,jujube,枣子,NOUN,B2
+proclamation,proclamation,宣大,NOUN,B2
+eavesdropping,eavesdropping,偷听,NOUN,B2
+procedural,procedural,程序的,ADJ,B2
+medical care,medical care,医疗,NOUN,B2
+missile,missile,导弹,NOUN,B2
+inside in,inside in,里,NOUN,B2
+great joy,great joy,大喜,NOUN,B2
+direct sales,direct sales,直销,NOUN,B2
+radiotherapy,radiotherapy,放疗,NOUN,B2
+you except,you except,你除,NOUN,B2
+herbicide,herbicide,除草剂,NOUN,B2
+over-degree,over-degree,超阶,NOUN,B2
+core course,core course,核心课,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+non-theory,non-theory,非论,NOUN,B2
+to not seen,to not seen,不见,VERB,B2
+all at once,all at once,一下子,ADV,B2
+re-verification,re-verification,改证,NOUN,B2
+mutual treatment,mutual treatment,相待,NOUN,B2
+too big,too big,太大,ADJ,B2
+to break a record,to break a record,打破纪录,VERB,B2
+final exam,final exam,期末考,NOUN,B2
+anti-static,anti-static,防静电,ADJ,B2
+boundless,boundless,无疆,NOUN,B2
+to serve as,to serve as,充当,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+re-substance,re-substance,再质,NOUN,B2
+light rain,light rain,小雨,NOUN,B2
+undercover agent,undercover agent,卧底,NOUN,B2
+little bitch,little bitch,小婊子,NOUN,B2
+who polite,who polite,哪位,PRON,B2
+to pioneer,to pioneer,首创,VERB,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+over-model,over-model,超模,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+certain fall,certain fall,必倒,NOUN,B2
+anticyclone,anticyclone,反气旋,NOUN,B2
+safe haven,safe haven,避风港,NOUN,B2
+supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
+reordering,reordering,改序,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+air raid,air raid,空袭,NOUN,B2
+to fall down,to fall down,倒下,VERB,B2
+historical record,historical record,历史纪录,NOUN,B2
+re-possibility,re-possibility,重可,NOUN,B2
+larger,larger,再大,NOUN,B2
+wind speed,wind speed,风速,NOUN,B2
+award ceremony,award ceremony,颁奖典礼,NOUN,B2
+super-special,super-special,超特,NOUN,B2
+graduate student,graduate student,研究生,NOUN,B2
+machine learning,machine learning,机器学习,NOUN,B2
+random posting,random posting,乱贴,NOUN,B2
+unwinnable,unwinnable,打不赢,NOUN,B2
+postwar,postwar,战后,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+third place,third place,季军,NOUN,B2
+family happiness,family happiness,天伦之乐,NOUN,B2
+hot water,hot water,热水,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+two days,two days,两天,NUM,B2
+guqin,guqin,古琴,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
+table grape,table grape,提子,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+over-order,over-order,超序,NOUN,B2
+everyone,everyone,各位,NOUN,B2
+heavy capacity,heavy capacity,重容,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+pipa,pipa,琵琶,NOUN,B2
+so as not to,so as not to,免得,SCONJ,B2
+war cessation,war cessation,战息,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
+perilla,perilla,紫苏,NOUN,B2
+re-specialization,re-specialization,重特,NOUN,B2
+panda,panda,熊猫,NOUN,B2
+sum total,sum total,总而,NOUN,B2
+adolescent,adolescent,青少年,NOUN,B2
+rights and interests,rights and interests,权益,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+unstoppable,unstoppable,不可阻挡,ADJ,B2
+why bother,why bother,何必,ADV,B2
+overthrow,overthrow,扳倒,NOUN,B2
+chest stab,chest stab,胸刺,NOUN,B2
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
+rashly,rashly,轻举,ADV,B2
+social structure,social structure,社会结构,NOUN,B2
+revealing,revealing,现出,NOUN,B2
+amended unity,amended unity,改一,NOUN,B2
+hedonistic,hedonistic,享乐主义的,ADJ,B2
+to strive for,to strive for,争取,VERB,B2
+two people,two people,两名,NUM,B2
+social movement,social movement,社会运动,NOUN,B2
+dare gamble,dare gamble,敢赌,NOUN,B2
+change of mind,change of mind,改念,NOUN,B2
+push further,push further,进尺,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+hyper-intent,hyper-intent,超意,NOUN,B2
+to send back,to send back,传回,VERB,B2
+social ethos,social ethos,社会风气,NOUN,B2
+non-observation,non-observation,非察,NOUN,B2
+ceramic art,ceramic art,陶艺,NOUN,B2
+re-observation,re-observation,再观,NOUN,B2
+young wife,young wife,小媳,NOUN,B2
+visibility,visibility,能见度,NOUN,B2
+excretion,excretion,排泄,NOUN,B2
+eavesdrop,eavesdrop,营听,NOUN,B2
+senior,senior,前辈,NOUN,B2
+to wiretap,to wiretap,监听,VERB,B2
+entering home,entering home,进家,NOUN,B2
+hundred million,hundred million,亿,NUM,B2
+ginseng,ginseng,人参,NOUN,B2
+non-sudden,non-sudden,非骤,NOUN,B2
+later stage,later stage,后期,NOUN,B2
+windy day,windy day,风天,NOUN,B2
+nickel,nickel,镍,NOUN,B2
+scenic spot,scenic spot,名胜,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+super-observation,super-observation,超察,NOUN,B2
+big dipper,big dipper,北斗七星,NOUN,B2
+quite good,quite good,挺好,NOUN,B2
+limbs,limbs,手脚,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+unsolved case,unsolved case,疑案,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to love dearly,to love dearly,心疼,VERB,B2
+military pay,military pay,军饷,NOUN,B2
+over-side,over-side,超方,NOUN,B2
+annual leave,annual leave,年假,NOUN,B2
+to be far from,to be far from,绝非,VERB,B2
+substantive,substantive,实质性的,ADJ,B2
+empress mother,empress mother,你母后,NOUN,B2
+both eyes,both eyes,双眼,NOUN,B2
+rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
+waiter attendant,waiter attendant,服务员,NOUN,B2
+your head,your head,你头上,NOUN,B2
+but majesty,but majesty,可陛,NOUN,B2
+energy saving,energy saving,节能,NOUN,B2
+to use force,to use force,动武,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+national record,national record,全国纪录,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
+to work part-time,to work part-time,打工,VERB,B2
+social phenomenon,social phenomenon,社会现象,NOUN,B2
+super-number,super-number,超数,NOUN,B2
+king,king,王,PART,B2
+flanking,flanking,包抄,NOUN,B2
+coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
+snow lotus,snow lotus,雪莲,NOUN,B2
+musical,musical,音乐剧,NOUN,B2
+personal effort,personal effort,亲力,NOUN,B2
+at the instant sth happens,at the instant sth happens,临时,ADV,B2
+next meeting,next meeting,下回遇,NOUN,B2
+to await orders,to await orders,待命,VERB,B2
+equal size,equal size,等大,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+re-generalization,re-generalization,重般,NOUN,B2
+project report,project report,项目报告,NOUN,B2
+local tyrant,local tyrant,豪强,NOUN,B2
+chinese cabbage,chinese cabbage,白菜,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+peephole,peephole,门镜,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+army morale,army morale,军心,NOUN,B2
+social hierarchy,social hierarchy,社会等级,NOUN,B2
+that is to say,that is to say,也就是说,SCONJ,B2
+value change,value change,改值,NOUN,B2
+what kind,what kind,什么样,PRON,B2
+punitive,punitive,惩罚性的,ADJ,B2
+mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+to follow up,to follow up,追问,VERB,B2
+non-righteousness,non-righteousness,非义,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+your parents,your parents,你爹娘,NOUN,B2
+two sons,two sons,儿俩,NOUN,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+over-form,over-form,超式,NOUN,B2
+hard to determine,hard to determine,难以确定,ADJ,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+don't,don't,可别,AUX,B2
+to be located at,to be located at,位于,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
+amber,amber,琥珀,NOUN,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
+architecture photo,architecture photo,建筑照,NOUN,B2

--- a/english/expansion.csv
+++ b/english/expansion.csv
@@ -1,19303 +1,7759 @@
 English_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
--ly,-ly,地,PART,B2
-African,African,词,ADJ,B1
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Alawi,Alawi,词,NOUN,C1
-Alice,Alice,词,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
-Amazigh,Amazigh,词,NOUN,C1
-American (adj),American,美国人,ADJ,B2
-Andalusian,Andalusian,词,ADJ,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
-Balkanization,Balkanization,词,NOUN,C1
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Brussels,Brussels,词,ADJ,C1
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Calvinism,Calvinism,词,NOUN,C1
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese (noun),Chinese,中文,NOUN,C1
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Christian (adj),Christian,词,ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cretaceous,Cretaceous,词,ADJ,B2
-DIY,DIY,词,NOUN,C1
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-Ed,Ed,词,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-England,England,词,PROPN,B1
-English (noun),English,词,NOUN,A2
-English language,English language,词,NOUN,A2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
-Eurasian,Eurasian,词,ADJ,C1
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Fauvism,Fauvism,词,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-Franciscan,Franciscan,词,ADJ,C1
-French (adj),French,法语,ADJ,C1
-French language,French language,词,NOUN,A2
-French-speaking world,French-speaking world,词,NOUN,B2
-Frenchification,Frenchification,词,NOUN,C1
-Friday evening,Friday evening,词,NOUN,C1
-Gallic,Gallic,词,ADJ,C1
-German (adj),German,德国人,ADJ,C1
-Gnawa,Gnawa,词,NOUN,B2
-Gothic,Gothic,词,ADJ,C1
-Goyaesque,Goyaesque,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gypsy,Gypsy,词,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-Hurufiyya,Hurufiyya,词,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IT-related,IT-related,词,ADJ,C1
-Iberian,Iberian,词,ADJ,C1
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Irish (noun),Irish,词,NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
-Israeli,Israeli,词,ADJ,B2
-Italian (adj),Italian,意大利的,ADJ,C1
-January evening,January evening,词,NOUN,B2
-Japanese (adj),Japanese,日本的,ADJ,C1
-Japanese person,Japanese person,词,NOUN,C1
-Jesuit,Jesuit,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
-Kufic,Kufic,词,ADJ,C1
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Latin (noun),Latin,词,NOUN,C1
-Limburgish,Limburgish,词,ADJ,C1
-Lu family,Lu family,有鲁家,NOUN,C1
-Machiavellian,Machiavellian,词,ADJ,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Marxist,Marxist,词,ADJ,C1
-Mary,Mary,词,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Mon,Mon,词,NOUN,C1
-Moroccan,Moroccan,词,ADJ,B2
-Mrs.,Mrs.,词,NOUN,A1
-Ms.,Ms.,词,NOUN,C1
-Muslim (adj),Muslim,词,ADJ,B1
-Natan,Natan,词,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-No.,No.,词,NOUN,C1
-Nordic,Nordic,词,ADJ,C1
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
-Parisian,Parisian,词,ADJ,B1
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
-Philippic (adj),Philippic,词,ADJ,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Prophet birthday,Prophet birthday,词,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Quran,Quran,词,NOUN,B2
-Rotterdam,Rotterdam,词,ADJ,C1
-SIM card,SIM card,词,NOUN,B1
-Salafism,Salafism,词,NOUN,C1
-Saturday evening,Saturday evening,词,NOUN,C1
-Serbian,Serbian,词,ADJ,C1
-Shiism,Shiism,词,NOUN,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Surinamese,Surinamese,词,ADJ,C1
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-Swedish (adj),Swedish,瑞典的,ADJ,B2
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-TV series,TV series,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Tajwid,Tajwid,词,NOUN,C1
-Thai,Thai,词,ADJ,C1
-Tifinagh script,Tifinagh script,词,NOUN,C1
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-VIP room,VIP room,贵宾室,NOUN,C1
-Whistles,Whistles,词,NOUN,C1
-Wushk,Wushk,词,NOUN,B1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-YouTuber,YouTuber,词,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
 a bit,a bit,一点,ADV,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
 a little,a little,一点儿,ADV,B2
-a little (adj),a little,一点,ADJ,B2
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a married couple,a married couple,夫妇,NOUN,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a pair,a pair,一对,NUM,B2
-a pile,a pile,一堆,NUM,B2
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
-a well,a well,井,NOUN,B2
 a while,a while,一会儿,NOUN,B2
-abbey,abbey,词,NOUN,B2
-abbot,abbot,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aberziehung,aberziehung,词,NOUN,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abkunft,abkunft,词,NOUN,C1
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
 able to play,able to play,能下,NOUN,B2
-ablution,ablution,词,NOUN,B2
-abolition,abolition,废除,NOUN,B2
-abomination,abomination,词,NOUN,B2
-about,about,大约,ADV,B2
-about (adv),about,大约,ADV,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,词,NOUN,B2
-about it,about it,关于它,ADV,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about that,about that,关于那个,ADV,B2
-about thirty,about thirty,三十左右,NOUN,B2
-about this,about this,词,ADV,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-about which,about which,词,PRON,B2
 above,above,上面,ADV,B2
-above (adv),above,上面,ADV,B2
-above (noun),above,重上,NOUN,C1
-above all,above all,词,NOUN,B2
-above average,above average,词,ADJ,C1
-above over,above over,词,ADP,A2
-above-mentioned,above-mentioned,词,ADJ,B2
-abpflegung,abpflegung,词,NOUN,C1
-abrasion,abrasion,擦伤,NOUN,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
 abroad,abroad,国外,NOUN,B2
-abroad (noun),abroad,国外,NOUN,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
-absolutely not,absolutely not,词,ADV,C1
-absolution,absolution,词,NOUN,C1
-absolutist,absolutist,词,ADJ,C1
-absprache,absprache,词,NOUN,C1
-abstract (noun),abstract,词,NOUN,C1
-abstractionism,abstractionism,词,NOUN,C1
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-absurdism,absurdism,词,NOUN,C1
-abtheilung,abtheilung,词,NOUN,C1
-abundantly,abundantly,词,ADV,C1
-abuse case,abuse case,词,NOUN,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuser,abuser,词,NOUN,B2
-abuses,abuses,词,NOUN,C1
-abusive,abusive,滥用的,ADJ,B2
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-academic,academic,学者,NOUN,B2
-academic (noun),academic,学者,NOUN,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
 academician,academician,院士,NOUN,B2
 acceleration,acceleration,加速,NOUN,B2
-accelerator,accelerator,油门,NOUN,B2
 accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-accessibility features,accessibility features,词,NOUN,B2
 accession,accession,即位,NOUN,B2
-accessory,accessory,词,NOUN,B2
 accidental,accidental,偶然的,ADJ,B2
 accidentally,accidentally,意外地,ADV,B2
 acclimatization,acclimatization,适应环境,NOUN,B2
 accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
-accord with,accord with,合乎,NOUN,B2
 according to,according to,根据,ADP,B2
 according to,according to,要照,NOUN,B2
-according to (noun),according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordingly consequently,accordingly consequently,词,ADV,C1
-accordion,accordion,手风琴,NOUN,B2
 accountant,accountant,会计师,NOUN,B2
-accounting,accounting,会计,NOUN,B2
-accounting (adj),accounting,词,ADJ,C1
-accreditation,accreditation,词,NOUN,C1
 accredited,accredited,认可的,ADJ,B2
 acculturation,acculturation,文化涵化,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
-accused,accused,词,NOUN,B2
-accused person,accused person,词,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
 accustomed,accustomed,习惯的,ADJ,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
-achievable,achievable,词,ADJ,B2
-achieved,achieved,词,ADJ,B1
 acid,acid,酸,NOUN,B2
-acid (adj),acid,词,ADJ,B1
-acid sour,acid sour,词,ADJ,B2
 acidity,acidity,酸度,NOUN,B2
-acolyte,acolyte,词,NOUN,B2
-acorn,acorn,词,NOUN,B1
 acoustics,acoustics,声学,NOUN,B2
-acquired,acquired,词,ADJ,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
 acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,首字母缩略词,NOUN,B2
-across,across,越过,ADV,B2
-across (adv),across,越过,ADV,C1
-acrostic,acrostic,词,NOUN,C1
-act jointly,act jointly,合伙,NOUN,B2
-act of kneeling,act of kneeling,词,NOUN,C1
+to act,to act,行动,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+to act rashly,to act rashly,妄动,VERB,B2
 acting,acting,行为,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
-activation,activation,词,NOUN,B2
-active population,active population,词,NOUN,C1
-activism,activism,词,NOUN,B2
-activist,activist,词,NOUN,C1
-activities,activities,词,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
 actual,actual,实际的,ADJ,B2
-actually (noun),actually,倒也,NOUN,C1
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
 adaptation,adaptation,适应,NOUN,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
 additional,additional,额外的,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
 adequacy,adequacy,也不错,NOUN,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherence,adherence,词,NOUN,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
-adjournment,adjournment,词,NOUN,C1
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjustment,adjustment,调节,NOUN,B2
 administrative,administrative,行政的,ADJ,B2
-administrative offense,administrative offense,词,NOUN,C1
-administrator,administrator,管理员,NOUN,B2
-admiration,admiration,词,NOUN,B2
-admirer,admirer,仰慕者,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible eligible,admissible eligible,词,ADJ,C1
-admission,admission,词,NOUN,B1
-admitted,admitted,词,ADJ,B2
 admittedly,admittedly,诚然,ADV,B2
 adolescent,adolescent,青少年,NOUN,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
-adoration worship,adoration worship,词,NOUN,C1
-adoul notaries,adoul notaries,词,NOUN,C1
-adrenaline,adrenaline,词,NOUN,C1
-adulation,adulation,词,NOUN,C1
 adult,adult,成年的,ADJ,B2
-adult (adj),adult,成年,ADJ,B2
-adultery,adultery,词,NOUN,C1
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
+to advance,to advance,前进,VERB,B2
 advance payment,advance payment,预付款,NOUN,B2
-advanced,advanced,高级的,ADJ,B2
-advanced study,advanced study,深造,NOUN,B2
 advanced technology,advanced technology,先进,ADJ,B2
-advancement,advancement,晋升,NOUN,B2
-advent,advent,到来,NOUN,B2
 adversity,adversity,逆境,NOUN,B2
-advertiser,advertiser,词,NOUN,B2
 advertising,advertising,广告的,ADJ,B2
-advertising (adj),advertising,广告的,ADJ,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advisory,advisory,词,ADJ,C1
-advocacy,advocacy,词,NOUN,C1
-aerodynamics,aerodynamics,词,NOUN,C1
-aeronautical,aeronautical,词,ADJ,B2
-aesthetic taste,aesthetic taste,词,NOUN,C1
+to advise against,to advise against,劝阻,VERB,B2
+to advocate,to advocate,提倡,VERB,B2
 aesthetics,aesthetics,美学,NOUN,B2
-affability,affability,词,NOUN,C1
-affair hall,affair hall,事殿,NOUN,B2
-affected,affected,受影响的,ADJ,B2
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
-affinity,affinity,词,NOUN,C1
-affliction,affliction,灾难,NOUN,C1
 affordability,affordability,得起,NOUN,B2
 afforestation,afforestation,植树造林,NOUN,B2
-afraid (noun),afraid,词,NOUN,B2
 after,after,تلو,NOUN,B2
 after,after,在...之后,SCONJ,B2
-after (adv),after,词,ADV,A1
-after (noun),after,以后,NOUN,B2
-after (sconj),after,after,SCONJ,A1
 after all,after all,毕竟,ADV,B2
-after all just,after all just,毕竟刚,ADV,C1
 after that,after that,此后,ADV,B2
-after the example of,after the example of,词,NOUN,C1
-after this,after this,词,ADV,B2
-after to,after to,词,ADP,A2
 after which,after which,之后,ADV,B2
-after-class exercises,after-class exercises,课后题,NOUN,C1
 aftereffect,aftereffect,后遗症，后果,NOUN,B2
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
-afterward,afterward,去后,NOUN,B2
 again,again,你又,NOUN,B2
-again (noun),again,你又,NOUN,B2
-against it,against it,词,ADV,A2
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravated,aggravated,词,ADJ,C1
-aggravation,aggravation,词,NOUN,C1
-aggression,aggression,侵略,NOUN,B2
 aggressiveness,aggressiveness,攻击性,NOUN,B2
-aggressor,aggressor,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
-agitated,agitated,焦躁的,ADJ,B2
-agitation,agitation,词,NOUN,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (adj),agnostic,词,ADJ,B2
-agnosticism,agnosticism,词,NOUN,C1
-agree,agree,一致,ADJ,B2
-agree (adj),agree,一致,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
 agricultural,agricultural,农业的,ADJ,B2
 ah,ah,啊,INTJ,B2
-ah (part),ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aims,aims,词,NOUN,C1
-air conditioner,air conditioner,词,NOUN,B1
+to aim,to aim,瞄准,VERB,B2
 air conditioning,air conditioning,空调,NOUN,B2
-air defense,air defense,防空,NOUN,B2
-air force,air force,空军,NOUN,B2
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
 alarm clock,alarm clock,闹钟,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
-alarmism,alarmism,词,NOUN,C1
 alas,alas,唉,INTJ,B2
-alchemy,alchemy,词,NOUN,C1
-alcoholic,alcoholic,酒精的,ADJ,B2
-alcoholic (adj),alcoholic,酒精的,ADJ,B2
-alder,alder,桤木,NOUN,B2
-alderman,alderman,词,NOUN,B2
 alert,alert,警觉的,ADJ,B2
-alert (adj),alert,alert,ADJ,B1
-alertness,alertness,机敏,NOUN,C1
-algae,algae,词,NOUN,B2
 algebra,algebra,代数,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
-alien,alien,外星人的,ADJ,B2
-alien (adj),alien,词,ADJ,B1
 alienation,alienation,异化,NOUN,B2
-alive living,alive living,活着的,ADJ,B2
-alkalinity,alkalinity,词,NOUN,C1
 all,all,全,ADJ,B2
 all,all,全部,ADV,B2
 all,all,جميع,NOUN,B2
 all,all,所有,PRON,B2
-all (adj),all,全,ADJ,B2
-all (adv),all,全都,ADV,B2
-all (noun),all,全体,NOUN,B2
-all (pron),all,全部,PRON,A2
 all along,all along,一路上,NOUN,B2
 all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
 all day long,all day long,一整天,NOUN,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all everyone,all everyone,所有/大家,PRON,B2
 all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
 all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,词,NOUN,B2
-all the more,all the more,词,ADV,B2
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allegation,allegation,词,NOUN,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allegiance,allegiance,词,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-alleys,alleys,词,NOUN,B2
-allies,allies,盟友,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allocation,allocation,词,NOUN,C1
 allow hiding,allow hiding,许躲,NOUN,B2
 allowance,allowance,津贴,NOUN,B2
 allowed,allowed,被允许的,ADJ,B2
 allusion,allusion,暗示,NOUN,B2
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
 alone,alone,独自,ADV,B2
-alone (adv),alone,单独,ADV,A1
 along with,along with,随着,ADP,B2
-alpine,alpine,高山的,ADJ,B2
-already may particle,already may particle,词,PART,A2
-alright (noun),alright,好吧,NOUN,B1
-also,also,也要,AUX,B2
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
 also too,also too,也,ADV,B2
-also will,also will,也会,NOUN,C1
-alteration,alteration,词,NOUN,B2
 altercation,altercation,争执,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
 altered meaning,altered meaning,改义,NOUN,B2
-altered mechanism,altered mechanism,改机,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
 altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternating,alternating,交替的,ADJ,B2
 alternation,alternation,轮流,NOUN,B2
-alternative,alternative,替代的,ADJ,B2
-alternative (adj),alternative,替代的,ADJ,B2
-alternatively,alternatively,交替地,ADV,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-although (cconj),although,词,CCONJ,B2
-altogether,altogether,共,ADV,B2
 aluminum,aluminum,铝,NOUN,B2
 alumnus,alumnus,校友,NOUN,B2
-always have,always have,总有,VERB,C1
-amalgam conflation,amalgam conflation,词,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
 amber,amber,琥珀,NOUN,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
 ambiguous,ambiguous,模棱两可的,ADJ,B2
-ambivalence,ambivalence,词,NOUN,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
 amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
 amended division,amended division,改分,NOUN,B2
 amended essence,amended essence,改本,NOUN,B2
 amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
-amended interior,amended interior,改内,NOUN,B2
-amended judgment,amended judgment,改断,NOUN,B2
-amended necessity,amended necessity,改必,NOUN,C1
 amended particular,amended particular,改特,NOUN,B2
 amended possibility,amended possibility,改可,NOUN,B2
 amended synthesis,amended synthesis,改综,NOUN,B2
 amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
-amendments,amendments,词,NOUN,C1
-amends,amends,词,NOUN,C1
 american,american,美国的,ADJ,B2
 american,american,美国人,NOUN,B2
-amicable out-of-court,amicable out-of-court,词,ADJ,B2
-amino acid,amino acid,氨基酸,NOUN,C1
-among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amphitheater lecture hall,amphitheater lecture hall,词,NOUN,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
 amplifier,amplifier,放大器,NOUN,B2
-amplitude range,amplitude range,词,NOUN,C1
-amputation,amputation,截肢,NOUN,B2
 amulet,amulet,护身符,NOUN,B2
-amused,amused,词,ADJ,B2
-amusement,amusement,娱乐,NOUN,B2
 amusing,amusing,有趣的,ADJ,B2
 an official standard,an official standard,标准,NOUN,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,字谜游戏,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
 analog,analog,模拟的,ADJ,B2
-analogous similar,analogous similar,词,ADJ,C1
 analyst,analyst,分析师,NOUN,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
 ancestors,ancestors,祖先,NOUN,B2
+to anchor,to anchor,抛锚,VERB,B2
 anchorage,anchorage,锚地,NOUN,B2
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
-ancient times,ancient times,古代,NOUN,B2
 and,and,我也,SCONJ,B2
-and (noun),and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
 and so forth,and so forth,依此类推,ADV,B2
-and so on,and so on,之类,NOUN,B2
-and you,and you,而你…,NOUN,C1
-anerziehung,anerziehung,词,NOUN,C1
 anesthetic,anesthetic,麻醉剂,NOUN,B2
-aneurysm,aneurysm,词,NOUN,C1
-anfahrt,anfahrt,词,NOUN,C1
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angestaltung,angestaltung,词,NOUN,C1
-angle of approach,angle of approach,切入点,NOUN,B2
-animal pen,animal pen,词,NOUN,B1
-animated film,animated film,动画片,NOUN,B2
 animation,animation,动画,NOUN,B2
-anise,anise,茴香,NOUN,B2
 annals,annals,编年史,NOUN,B2
 annex,annex,附件,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
-annexes,annexes,词,NOUN,C1
 annihilation,annihilation,寂灭,NOUN,B2
 annoyed,annoyed,恼火的,ADJ,B2
 annual,annual,年度,NOUN,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
 annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annual report,annual report,年报,NOUN,B2
-annual wage,annual wage,年薪,NOUN,B2
-annuity private income,annuity private income,词,NOUN,C1
-annulment,annulment,词,NOUN,C1
-anomie,anomie,词,NOUN,C1
-anonymity,anonymity,词,NOUN,C1
-anonymously,anonymously,词,ADV,B2
-anorexia,anorexia,词,NOUN,C1
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansicht,ansicht,词,NOUN,C1
-ansinnung,ansinnung,词,NOUN,C1
-ansprache,ansprache,词,NOUN,C1
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-answer questions,answer questions,答疑,VERB,C1
 answering machine,answering machine,邮箱,NOUN,B2
-answers,answers,词,NOUN,C1
 ant,ant,蚂蚁,NOUN,B2
-anteilung,anteilung,词,NOUN,B2
-anteroom,anteroom,词,NOUN,B2
-antheilung,antheilung,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthill,anthill,词,NOUN,C1
 anthropomorphism,anthropomorphism,拟人化,NOUN,B2
-anti-Semitic,anti-Semitic,词,ADJ,C1
-anti-abstraction,anti-abstraction,反抽,NOUN,B2
-anti-action,anti-action,反作,NOUN,B2
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
 anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
-anti-generality,anti-generality,反般,NOUN,B2
-anti-integration,anti-integration,反合,NOUN,B2
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
-anti-measure,anti-measure,反度,NOUN,B2
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
-anti-omnipresence,anti-omnipresence,反遍,NOUN,B2
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
 anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
 anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-war,anti-war,反战,NOUN,B2
-anti-work,anti-work,反功,NOUN,C1
-antibiotics,antibiotics,抗生素,NOUN,B2
 antibody,antibody,抗体,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
 anticyclone,anticyclone,反气旋,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
 antigen,antigen,抗原,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
-antinomy,antinomy,词,NOUN,C1
-antioxidant,antioxidant,抗氧化剂,NOUN,B2
-antiphrasis,antiphrasis,词,NOUN,C1
 antique,antique,古老的,ADJ,B2
-antique (noun),antique,古董,NOUN,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
-antiseptic (noun),antiseptic,消毒剂,NOUN,B2
 antithesis,antithesis,对立面,NOUN,B2
-antonomasia,antonomasia,词,NOUN,C1
 antonym,antonym,反义词,NOUN,B2
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreibung,antreibung,词,NOUN,C1
-anvil,anvil,词,NOUN,B2
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-anxious eager,anxious eager,词,ADJ,B1
+to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
 any,any,任何,PRON,B2
-any (adj),any,词,ADJ,B1
-any (adv),any,词,ADV,B2
-any (pron),any,任何,PRON,B2
 anyway,anyway,好歹,PRON,B2
-anyway (pron),anyway,好歹,PRON,B2
 apart,apart,分开,ADV,B2
-apart from,apart from,除了,ADP,B2
-apart from (verb),apart from,词,VERB,C1
-aphasia,aphasia,失语症,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apnea,apnea,词,NOUN,C1
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
-apolitical,apolitical,词,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apology for disrespect,apology for disrespect,失敬失敬,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
 apostasy,apostasy,叛教,NOUN,B2
-apostate,apostate,叛教者,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostle,apostle,词,NOUN,C1
-app,app,词,NOUN,B1
-appeal (noun),appeal,上诉,NOUN,B2
-appeals,appeals,词,NOUN,C1
 appeasement,appeasement,平息,NOUN,B2
 appellant,appellant,上诉人,NOUN,B2
-appellate,appellate,词,ADJ,C1
-appetizers,appetizers,词,NOUN,B2
-applicable,applicable,词,ADJ,B2
-appointments,appointments,词,NOUN,B2
-appraisal,appraisal,估价,NOUN,C1
+to apply makeup,to apply makeup,化妆,VERB,B2
 appreciation,appreciation,欣赏,NOUN,B2
-appreciation banquet,appreciation banquet,答谢宴,NOUN,B2
 apprentice,apprentice,学徒,NOUN,B2
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,词,NOUN,B2
-approval pleasure,approval pleasure,词,NOUN,C1
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
+to approach,to approach,靠近,VERB,B2
 approximately,approximately,大约,ADV,B2
 apricot,apricot,杏,NOUN,B2
-april,april,四月,NOUN,B2
 apron,apron,围裙,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-aqueous,aqueous,词,ADJ,B2
-arabic,arabic,阿拉伯的,ADJ,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
 arc,arc,弧,NOUN,B2
 archaeological,archaeological,考古的,ADJ,B2
-archaeologist,archaeologist,词,NOUN,C1
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
 archipelago,archipelago,群岛,NOUN,B2
 architecture,architecture,建筑,NOUN,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-archival,archival,词,ADJ,C1
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
-argan,argan,词,NOUN,B1
-argentinian,argentinian,词,ADJ,B2
 argumentation,argumentation,论证体系,NOUN,B2
-argumentativeness,argumentativeness,词,NOUN,C1
-arithmetic (adj),arithmetic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
-armament,armament,词,NOUN,B2
-armband,armband,词,NOUN,C1
 armchair,armchair,扶手椅,NOUN,B2
 armed,armed,武装的,ADJ,B2
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armored,armored,词,ADJ,C1
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
 army morale,army morale,军心,NOUN,B2
 around,around,到处,ADV,B2
-around (adv),around,到处,ADV,B2
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arousal,arousal,词,NOUN,C1
-arranged,arranged,词,ADJ,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
 arrears,arrears,欠款,NOUN,B2
 arrest,arrest,逮捕,NOUN,B2
-arrest (noun),arrest,arrest,NOUN,A2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrested,arrested,被逮捕的,ADJ,B2
-arrhythmia,arrhythmia,词,NOUN,C1
-arrived present,arrived present,到了,ADV,B2
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
-art collection,art collection,画集,NOUN,C1
-art gallery,art gallery,美术馆,NOUN,B2
-arterial,arterial,词,ADJ,C1
-artichoke,artichoke,词,NOUN,B1
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,人为地,ADV,B2
-artillery,artillery,炮兵,NOUN,B2
-artistic portrait,artistic portrait,艺术照,NOUN,B2
-artistry,artistry,,NOUN,B2
-artwork,artwork,词,NOUN,B2
 as,as,像,ADP,B2
-as (adp),as,作为,ADP,A1
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as a precaution,as a precaution,词,ADV,C1
-as a result of which,as a result of which,词,ADV,B2
 as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
 as expected,as expected,果然,ADV,B2
-as far as,as far as,词,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as for (part),as for,词,PART,B1
 as if,as if,好像,SCONJ,B2
-as if (adv),as if,仿佛,ADV,B2
 as long as,as long as,طالما,CCONJ,B2
 as long as,as long as,只要,SCONJ,B2
-as long as (cconj),as long as,只要,CCONJ,B2
-as many,as many,词,NUM,B2
-as much,as much,词,ADV,A1
 as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,词,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
 as soon as,as soon as,一...就,SCONJ,B2
-as soon as (adv),as soon as,一...就,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
 as well as,as well as,以及,CCONJ,B2
-as well as (sconj),as well as,词,SCONJ,B2
-as when,as when,词,SCONJ,A1
-asbestos,asbestos,词,NOUN,C1
-ascending,ascending,词,ADJ,C1
 ascension,ascension,升天,NOUN,B2
-ascetic (noun),ascetic,词,NOUN,C1
-asexual,asexual,无性的,ADJ,B2
-asharite school,asharite school,词,NOUN,C1
-ashes,ashes,词,NOUN,B2
-ashtray,ashtray,烟灰缸,NOUN,B2
-asian,asian,亚洲的,ADJ,B2
-aside (noun),aside,词,NOUN,C1
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-asphalt,asphalt,沥青,NOUN,B2
-asphyxia,asphyxia,窒息,NOUN,B2
-assailant,assailant,词,NOUN,C1
 assassin,assassin,刺客,NOUN,B2
-assent (noun),assent,词,NOUN,B2
 assessment,assessment,评估,NOUN,B2
 assets,assets,资产,NOUN,B2
-asshole,asshole,词,NOUN,A2
-assiduity,assiduity,词,NOUN,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduously,assiduously,词,ADV,C1
-assiduousness,assiduousness,词,NOUN,C1
-associate (noun),associate,词,NOUN,B2
-associated,associated,相关的,ADJ,B2
-associative,associative,协会性质的,ADJ,C1
-assortment,assortment,词,NOUN,C1
-asthenia,asthenia,词,NOUN,C1
+to assume office,to assume office,就任,VERB,B2
 asthma,asthma,哮喘,NOUN,B2
-asthmatic,asthmatic,哮喘的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astray,astray,迷路,ADJ,B2
-astride (adv),astride,词,ADV,C1
-astringent (noun),astringent,词,NOUN,B2
-astronomer,astronomer,词,NOUN,B1
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
-asylum shelter,asylum shelter,词,NOUN,B2
-asymptomatic,asymptomatic,词,ADJ,C1
-asyndeton,asyndeton,词,NOUN,B2
 at all,at all,根本,ADV,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
 at any time,at any time,随时,ADV,B2
 at ease,at ease,安心,ADJ,B2
 at home,at home,在家,ADV,B2
-at home (noun),at home,家里,NOUN,C1
-at it,at it,词,ADV,B2
 at least,at least,至少,ADV,B2
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,词,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
 at that time,at that time,当时/那时,ADV,B2
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the bottom,at the bottom,词,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
 at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
 at the same time,at the same time,同时,ADV,B2
-at the top,at the top,在最上面,ADV,B2
 at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
 at worst,at worst,大不了,ADV,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
 atheism,atheism,无神论,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atm,atm,自动取款机,NOUN,B2
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atony,atony,词,NOUN,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-attache office,attache office,词,NOUN,C1
-attached,attached,词,ADJ,B2
-attacked,attacked,被攻击的,ADJ,B2
 attacker,attacker,攻击者,NOUN,B2
-attainment,attainment,词,NOUN,C1
-attempt at crime,attempt at crime,词,NOUN,C1
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
+to attempt,to attempt,企图,VERB,B2
 attendance,attendance,出席,NOUN,B2
-attention (intj),attention,词,INTJ,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attestation,attestation,词,NOUN,C1
-attitude setting,attitude setting,态度/设置,NOUN,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attributists,attributists,词,NOUN,C1
-attributive,attributive,定语的,ADJ,B2
 atypical,atypical,非典型的,ADJ,B2
 audio equipment,audio equipment,音响,NOUN,B2
-audition,audition,词,NOUN,B1
+to audit,to audit,审计,VERB,B2
 auditor,auditor,审计员,NOUN,B2
-auditory,auditory,词,ADJ,C1
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
-austerity,austerity,紧缩,NOUN,B2
-austheilung,austheilung,词,NOUN,C1
-australian,australian,澳大利亚的,ADJ,B2
-austreibung,austreibung,词,NOUN,C1
-austrian,austrian,奥地利的,ADJ,B2
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarky,autarky,词,NOUN,B2
-authenticated,authenticated,词,ADJ,C1
 authentication,authentication,认证,NOUN,B2
-authoritarianism,authoritarianism,词,NOUN,C1
-authority figure,authority figure,词,NOUN,B2
-authority structure,authority structure,权威结构,NOUN,B2
 authorized,authorized,有资格的,ADJ,B2
 autism,autism,自闭症,NOUN,B2
-autistic (noun),autistic,词,NOUN,C1
 automatically,automatically,自动地,ADV,B2
 automation,automation,自动化,NOUN,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-auxiliary,auxiliary,词,ADJ,C1
-avarice,avarice,词,NOUN,C1
 average,average,平均数,NOUN,B2
-average (noun),average,平均数,NOUN,B2
-averageness,averageness,词,NOUN,B2
-avocado,avocado,牛油果,NOUN,C1
+to await,to await,等待,VERB,B2
+to await orders,to await orders,待命,VERB,B2
 awakening,awakening,觉醒,NOUN,B2
-award auction,award auction,词,NOUN,B2
+to award,to award,分配,VERB,B2
 award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
 awareness raising,awareness raising,提高意识,NOUN,B2
-away,away,避开,ADP,B2
-away (adj),away,外出,ADJ,C1
-away (adp),away,避开,ADP,B2
-away gone,away gone,不在/离开,ADV,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-awning,awning,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiology,axiology,词,NOUN,C1
 axiom,axiom,公理,NOUN,B2
-axioms,axioms,词,NOUN,C1
-axis axle,axis axle,词,NOUN,C1
-ba zi,ba zi,八字,NOUN,B2
-babble,babble,结巴,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-baby walker,baby walker,词,NOUN,B1
-babysitter,babysitter,保姆,NOUN,B2
-baccalaureate,baccalaureate,词,NOUN,B2
 bachelor,bachelor,单身汉,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
 bachelor's degree,bachelor's degree,学士学位,NOUN,B2
 back,back,背面,NOUN,B2
-back (noun),back,人背,NOUN,B2
 back door,back door,后门,NOUN,B2
-back mountain,back mountain,后山,NOUN,C1
 back seat,back seat,后座,NOUN,B2
-back side,back side,背面,NOUN,B2
-back then,back then,词,ADV,A1
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
 backache,backache,背痛,NOUN,B2
-backflow,backflow,倒流,NOUN,B2
-backpacker,backpacker,词,NOUN,B1
-backside,backside,词,NOUN,B2
 backstab,backstab,背刺,NOUN,B2
 backstage,backstage,幕后,NOUN,B2
 backup,backup,备份,NOUN,B2
-backup light,backup light,倒车灯,NOUN,B2
-backward,backward,向后,ADV,B2
-backyard,backyard,词,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
-bactericide,bactericide,杀菌剂,NOUN,C1
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
-bad idea,bad idea,坏水,NOUN,B2
 bad luck,bad luck,倒霉,NOUN,B2
-bad news,bad news,坏消息,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
 bad thing,bad thing,坏事,NOUN,B2
-badly,badly,坏地,ADV,B2
-badminton,badminton,羽毛球,NOUN,B2
-bags,bags,包,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
 baker,baker,面包师,NOUN,B2
-bakery,bakery,词,NOUN,A2
-balance of power,balance of power,均势,NOUN,C1
-balance sheet,balance sheet,资产负债表,NOUN,B2
-balancing,balancing,平衡的,ADJ,B2
-baldness,baldness,词,NOUN,B2
-ballad,ballad,词,NOUN,C1
 ballet,ballet,芭蕾舞,NOUN,B2
-balloon,balloon,气球,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
-ballpoint pen,ballpoint pen,圆珠笔,NOUN,B2
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balsam,balsam,香脂,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
 bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
 ban,ban,禁令,NOUN,B2
 banal,banal,陈腐的,ADJ,B2
 banana,banana,香蕉,NOUN,B2
-bananas,bananas,词,NOUN,A1
-band tape,band tape,带子,NOUN,B2
-band volume,band volume,词,NOUN,C1
 bandage,bandage,绷带,NOUN,B2
-bandaging,bandaging,词,NOUN,C1
-bandwidth,bandwidth,词,ADJ,C1
-bang,bang,砰,INTJ,B2
-bang (intj),bang,砰,INTJ,B2
 banishment,banishment,流放,NOUN,B2
-bank card,bank card,银行卡,NOUN,B2
 banking,banking,银行的,ADJ,B2
 banknote,banknote,钞票,NOUN,B2
-banner headline,banner headline,词,NOUN,C1
-baptism,baptism,词,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
-bar of soap,bar of soap,词,NOUN,B2
-barbarian,barbarian,词,NOUN,B2
 barbaric,barbaric,野蛮的,ADJ,B2
-barbarization,barbarization,野蛮化,NOUN,B2
-barbecue,barbecue,烧烤,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
 bare ownership,bare ownership,虚有权,NOUN,B2
-bareheaded,bareheaded,词,ADJ,C1
-barely,barely,几乎不,ADV,B2
-bargaining,bargaining,词,NOUN,C1
-bark (noun),bark,词,NOUN,B2
-barking,barking,词,NOUN,B2
 barley,barley,大麦,NOUN,B2
-barracks,barracks,词,NOUN,B2
-barrel,barrel,桶,NOUN,B2
-barrenness,barrenness,词,NOUN,C1
-barter (noun),barter,词,NOUN,C1
-basal,basal,基本的,ADJ,B2
 base fertilizer,base fertilizer,基肥,NOUN,B2
 baseball,baseball,棒球,NOUN,B2
-based,based,基于,ADJ,B2
 baseness,baseness,卑鄙,NOUN,B2
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic attitude,basic attitude,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
-basic income,basic income,基本收入,NOUN,B2
 basil,basil,罗勒,NOUN,B2
 basin,basin,盆,NOUN,B2
-basing,basing,词,NOUN,C1
-bass,bass,贝斯,NOUN,B2
 bastard,bastard,混蛋,NOUN,B2
-basting,basting,词,NOUN,C1
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-bathrobe,bathrobe,词,NOUN,A2
-baton,baton,警棍,NOUN,B2
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
 battlefield,battlefield,战场,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bayberry,bayberry,杨梅,NOUN,B2
 be,be,是,AUX,B2
+to be able,to be able,能,VERB,B2
 be able to,be able to,能,AUX,B2
+to be able to,to be able to,能够,VERB,B2
+to be absent,to be absent,缺席,VERB,B2
+to be addicted,to be addicted,上瘾,VERB,B2
+to be afraid,to be afraid,害怕,VERB,B2
 be allowed,be allowed,允许,AUX,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be crushed,be crushed,词,VERB,C1
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
-be rumored,be rumored,词,VERB,C1
-be shot,be shot,中弹,VERB,C1
+to be ashamed,to be ashamed,感到羞愧,VERB,B2
+to be based on,to be based on,基于,VERB,B2
+to be born,to be born,出生,VERB,B2
+to be called,to be called,叫做,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+to be damaged,to be damaged,受损,VERB,B2
+to be done,to be done,被做,VERB,B2
+to be enough,to be enough,足够,VERB,B2
+to be far from,to be far from,绝非,VERB,B2
+to be forced,to be forced,被迫,VERB,B2
+to be jealous,to be jealous,嫉妒,VERB,B2
+to be late,to be late,迟到,VERB,B2
+to be left over,to be left over,剩余,VERB,B2
+to be located,to be located,位于,VERB,B2
+to be located at,to be located at,位于,VERB,B2
+to be missing,to be missing,缺少,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+to be required,to be required,被要求,VERB,B2
+to be right,to be right,正确,VERB,B2
+to be silent,to be silent,沉默,VERB,B2
 be sorry,be sorry,抱歉,ADJ,B2
-be tender,be tender,温柔的,ADJ,B2
-be willing,be willing,愿意,AUX,B2
-be worthy of,be worthy of,不愧,ADV,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beans,beans,词,NOUN,A1
+to be surprised,to be surprised,感到惊讶,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+to be useful,to be useful,有用,VERB,B2
+to be worth,to be worth,值得,VERB,B2
 bearing,bearing,轴承,NOUN,B2
-beaten,beaten,被打败的,ADJ,B2
 beating,beating,跳动,NOUN,B2
-beatitude,beatitude,词,NOUN,B2
-beautification,beautification,词,NOUN,C1
-beaver,beaver,词,NOUN,C1
 because,because,因为,CCONJ,B2
-because (cconj),because,词,CCONJ,A2
 because of,because of,因为,ADP,B2
-because of this,because of this,词,ADV,A2
-become,become,成为,AUX,B2
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedsheet,bedsheet,床单,NOUN,B2
-bedside,bedside,词,NOUN,C1
-beech grove,beech grove,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beehive,beehive,词,NOUN,C1
+to become invalid,to become invalid,作废,VERB,B2
 beep,beep,吱吱声,NOUN,B2
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
-befahrt,befahrt,词,NOUN,C1
-befassung,befassung,词,NOUN,C1
-beforderung,beforderung,词,NOUN,C1
 before,before,之前,ADV,B2
 before,before,在...之前,SCONJ,B2
-before (adv),before,先前,ADV,A1
-before (noun),before,以前,NOUN,A1
-before (sconj),before,在……之前,SCONJ,B2
-before one's eyes,before one's eyes,词,ADV,C1
-before previously,before previously,以前,ADV,B2
-before that,before that,词,ADV,B1
-beg for pity,beg for pity,乞怜,VERB,B2
-begabe,begabe,词,NOUN,C1
-begestaltung,begestaltung,词,NOUN,C1
 begging,begging,乞讨,NOUN,B2
+to begin to start,to begin to start,开始,VERB,B2
 beginner,beginner,初学者,NOUN,B2
-beginning primer,beginning primer,词,NOUN,C1
-behavioral,behavioral,词,ADJ,B2
-behavioral pattern,behavioral pattern,词,NOUN,C1
-beheading,beheading,按律当斩,NOUN,C1
 behind,behind,在后面,ADV,B2
-behind (adv),behind,词,ADV,A1
-behind (noun),behind,词,NOUN,B2
 behind it,behind it,在后面,ADV,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-bekunft,bekunft,词,NOUN,C1
-belatedly,belatedly,词,ADV,C1
-belgian,belgian,比利时的,ADJ,B2
-belgian (noun),belgian,比利时人,NOUN,C1
-belief creed,belief creed,词,NOUN,B2
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-belittling,belittling,词,NOUN,C1
 bell pepper,bell pepper,甜椒,NOUN,B2
-bell tower,bell tower,词,NOUN,A2
-bellows,bellows,词,NOUN,C1
 belly,belly,肚子,NOUN,B2
 belonging,belonging,归属感,NOUN,B2
 belongings,belongings,所属物,NOUN,B2
 beloved,beloved,爱人,NOUN,B2
-beloved (noun),beloved,心爱,NOUN,B2
 below,below,下面,NOUN,B2
-below (adj),below,下面的,ADJ,B1
-below (adv),below,下面,ADV,B2
-below (noun),below,词,NOUN,B2
-benahme,benahme,词,NOUN,B2
-bench seat,bench seat,词,NOUN,C1
 bend,bend,弯道,NOUN,B2
-bend (noun),bend,弯,NOUN,B2
-bending,bending,弯曲,NOUN,C1
-beneficial,beneficial,词,ADJ,B2
 benevolence,benevolence,仁慈,NOUN,B2
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-bepflegung,bepflegung,词,NOUN,B2
-bequest,bequest,词,NOUN,B2
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-berichtung,berichtung,词,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beschaft,beschaft,词,NOUN,C1
-beschrift,beschrift,词,NOUN,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
-beside,beside,在...旁边,ADP,B2
-beside next to,beside next to,旁边,NOUN,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
-besieged,besieged,词,ADJ,B2
-besieging,besieging,词,NOUN,C1
-besinnung,besinnung,词,NOUN,C1
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-best possible,best possible,词,ADJ,C1
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
 bet,bet,打赌,NOUN,B2
-bet (noun),bet,赌注,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betreibung,betreibung,词,NOUN,C1
-betrothal gift,betrothal gift,聘,NOUN,C1
-better,better,越好,NOUN,B2
-better (adv),better,词,ADV,A1
-better (noun),better,越好,NOUN,B2
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-beverage,beverage,词,NOUN,B2
-bewandel,bewandel,词,NOUN,C1
-beweisung,beweisung,词,NOUN,C1
-bewirkung,bewirkung,词,NOUN,C1
-bianzhong,bianzhong,编钟,NOUN,B2
 bias,bias,偏见,NOUN,B2
 bible,bible,圣经,NOUN,B2
 bibliography,bibliography,参考书目,NOUN,B2
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid collusion,bid collusion,串标,NOUN,B2
-bid evaluation,bid evaluation,评标,NOUN,B2
-bid opening,bid opening,开标,NOUN,B2
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bids,bids,词,NOUN,C1
-biennial,biennial,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big cat,big cat,词,NOUN,C1
 big data,big data,大数据,NOUN,B2
 big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigger,bigger,更大的,ADJ,B2
 biggest,biggest,最大,ADJ,B2
-bigness,bigness,,NOUN,B2
-bigotry,bigotry,词,NOUN,C1
-bigwig,bigwig,大人物,NOUN,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
 bile,bile,胆汁,NOUN,B2
-bilingual,bilingual,词,ADJ,C1
-bill of exchange,bill of exchange,词,NOUN,C1
 billiards,billiards,台球,NOUN,B2
 billion,billion,十亿,NOUN,B2
-billion (noun),billion,词,NOUN,B2
-billionaire,billionaire,词,NOUN,C1
-binder,binder,词,NOUN,A2
-binding (adj),binding,词,ADJ,C1
 biodiversity,biodiversity,生物多样性,NOUN,B2
-biographies,biographies,词,NOUN,C1
-biologist,biologist,生物学家,NOUN,B2
-biomass,biomass,生物质,NOUN,B2
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
 birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-biscuit,biscuit,饼干,NOUN,A2
-bistro,bistro,小酒馆,NOUN,B2
 bite,bite,一口,NOUN,B2
-bite (noun),bite,咬得,NOUN,B2
 biting,biting,尖刻的,ADJ,B2
-biting (noun),biting,咬人,NOUN,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
-bitterness,bitterness,苦涩,NOUN,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
 bizarre case,bizarre case,奇案,NOUN,B2
-black (noun),black,أسود,NOUN,C1
-black market,black market,黑市,NOUN,B2
-black pepper,black pepper,词,NOUN,B2
 black robe,black robe,黑衣,NOUN,B2
 blackberry,blackberry,黑莓,NOUN,B2
-blackbird,blackbird,词,NOUN,B2
 blackboard,blackboard,黑板,NOUN,B2
-blackout,blackout,词,NOUN,C1
 blacksmith,blacksmith,铁匠,NOUN,B2
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blah,blah,词,INTJ,C1
 blame,blame,责备,NOUN,B2
-blame (noun),blame,只怪,NOUN,B2
-blazing ardor,blazing ardor,词,NOUN,C1
-bleak,bleak,无望的,ADJ,B2
 bleeding,bleeding,出血,NOUN,B2
-bleeding (adj),bleeding,流血的,ADJ,B2
-blender,blender,搅拌机,NOUN,B2
-blending,blending,词,NOUN,C1
-blessed,blessed,受祝福的,ADJ,B2
 blind,blind,百叶窗,NOUN,B2
-blind (noun),blind,盲人,NOUN,B2
-blind person,blind person,词,NOUN,B2
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
 bloc,bloc,阵营,NOUN,B2
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
-blockhead,blockhead,词,NOUN,B2
-blocking,blocking,词,NOUN,B2
+to blockade,to blockade,封锁,VERB,B2
 blog,blog,博客,NOUN,B2
-blog post,blog post,词,NOUN,C1
-blogger,blogger,词,NOUN,B2
-blood debt,blood debt,血债,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
 blood pressure,blood pressure,血压,NOUN,B2
-blood sea,blood sea,血海,NOUN,B2
 blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-blood-related,blood-related,词,ADJ,C1
 bloodshed,bloodshed,血腥,NOUN,B2
 bloodstain,bloodstain,血染,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-bloom of youth,bloom of youth,词,NOUN,C1
-blossoming ripening,blossoming ripening,词,NOUN,C1
 blouse,blouse,女衬衫,NOUN,B2
 blow,blow,打击,NOUN,B2
-blow (noun),blow,他打,NOUN,A2
-blow beating,blow beating,词,NOUN,B2
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blue (noun),blue,词,NOUN,C1
 blueberry,blueberry,蓝莓,NOUN,B2
-blueprint diagram,blueprint diagram,词,NOUN,C1
-bluntness,bluntness,直说,NOUN,B2
-blurred,blurred,词,ADJ,C1
-blurry,blurry,词,ADJ,B2
-boarder,boarder,词,NOUN,B2
-boarding,boarding,词,NOUN,C1
 boarding pass,boarding pass,登机牌,NOUN,B2
 boarding school,boarding school,寄宿学校,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastfulness,boastfulness,吹嘘,NOUN,B2
 boasting,boasting,夸耀,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bodies,bodies,词,NOUN,C1
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-boil (noun),boil,词,NOUN,C1
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
 boiler,boiler,锅炉,NOUN,B2
 boiling,boiling,沸腾,NOUN,B2
-boiling (adj),boiling,词,ADJ,C1
-boldness daring,boldness daring,词,NOUN,B2
-bolster (noun),bolster,词,NOUN,C1
-bolted,bolted,词,ADJ,C1
-bombardment,bombardment,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
-bomber,bomber,词,NOUN,C1
-bondholder,bondholder,词,NOUN,C1
-bonds,bonds,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-booking,booking,词,NOUN,A2
 booklet,booklet,小册子,NOUN,B2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,词,NOUN,B2
-boorish,boorish,词,ADJ,C1
 border,border,边境的,ADJ,B2
-border (adj),border,border,ADJ,C1
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,边境检查,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border frontier,border frontier,词,NOUN,B1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,词,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,词,NOUN,B2
-bordering,bordering,词,ADJ,C1
-borders,borders,边界,NOUN,A1
 bored,bored,无聊的,ADJ,B2
-born (adj),born,词,ADJ,B2
-born (noun),born,词,NOUN,B2
-borrowed,borrowed,词,ADJ,C1
 borrowed knife,borrowed knife,借刀,NOUN,B2
 borrower,borrower,借款人,NOUN,B2
 borrowing,borrowing,借贷,NOUN,B2
-bosom,bosom,词,NOUN,C1
-boss female,boss female,词,NOUN,B2
-boss manager,boss manager,词,NOUN,A1
-botany,botany,词,NOUN,C1
-botched job,botched job,词,NOUN,B2
 both,both,两者都,CCONJ,B2
 both,both,两者,PRON,B2
-both (adj),both,两者的,ADJ,B2
-both (cconj),both,both,CCONJ,A2
-both (noun),both,词,NOUN,B2
-both (pron),both,两者,PRON,B2
-both ears,both ears,两耳,NOUN,C1
 both eyes,both eyes,双眼,NOUN,B2
-both hands,both hands,双手,NOUN,B2
-both parties,both parties,双方,NOUN,B1
 bother,bother,麻烦,NOUN,B2
-bother (noun),bother,烦不,NOUN,B1
-bottle opener,bottle opener,词,NOUN,B1
-bottom out,bottom out,底儿掉,NOUN,C1
-boulder,boulder,巨石,NOUN,B2
 bound to,bound to,势必,ADV,B2
 boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bout,bout,阵,NOUN,B2
-bovine,bovine,词,ADJ,C1
 bow,bow,蝴蝶结,NOUN,B2
-bow (noun),bow,月弓,NOUN,C1
-bow tie,bow tie,词,NOUN,B2
 bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
-boxer,boxer,拳击手,NOUN,B2
-brabant,brabant,布拉班特的,ADJ,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-bragging,bragging,吹嘘,NOUN,B2
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,词,NOUN,B2
-brainy,brainy,词,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakes,brakes,词,NOUN,C1
-braking,braking,词,NOUN,C1
-bran,bran,词,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
+to brake,to brake,刹车,VERB,B2
 brand new,brand new,崭新的,ADJ,B2
-brass band,brass band,词,NOUN,B2
-brassware,brassware,词,NOUN,C1
 bravery,bravery,勇敢,NOUN,B2
-bravo,bravo,词,NOUN,B2
-brazier,brazier,词,NOUN,B1
-brazilian,brazilian,巴西的,ADJ,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of duty,breach of duty,词,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-bread roll,bread roll,小圆面包,NOUN,B2
-breadth crossing,breadth crossing,词,NOUN,C1
-break (noun),break,break,NOUN,A2
-break fraction,break fraction,词,NOUN,C1
-break out of prison,break out of prison,越狱,VERB,C1
-break-in,break-in,非法侵入,NOUN,B2
-breakage,breakage,词,NOUN,C1
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
+to break a record,to break a record,打破纪录,VERB,B2
+to break down,to break down,分解,VERB,B2
+to break open,to break open,撬开,VERB,B2
+to break up,to break up,破裂,VERB,B2
 breakthrough,breakthrough,突破性,ADJ,B2
-breakthrough (noun),breakthrough,突破,NOUN,B2
+to breastfeed,to breastfeed,母乳喂养,VERB,B2
 breastfeeding,breastfeeding,母乳喂养,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,呼吸,NOUN,B2
-breathing space,breathing space,词,NOUN,C1
-breathlessness,breathlessness,词,NOUN,B1
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
-breviary,breviary,词,NOUN,C1
-brewery,brewery,啤酒厂,NOUN,B2
-bribe-taker,bribe-taker,词,NOUN,C1
-bribes,bribes,词,NOUN,C1
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
-bridal chamber,bridal chamber,洞房,NOUN,B2
-bridal trousseau,bridal trousseau,词,NOUN,C1
+to bribe,to bribe,贿赂,VERB,B2
 brief,brief,近点说,NOUN,B2
-brief (noun),brief,近点说,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-brigade,brigade,词,NOUN,C1
-brigand poet,brigand poet,词,NOUN,C1
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brightly,brightly,词,ADV,C1
-brightness,brightness,词,NOUN,C1
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
+to bring back,to bring back,带回,VERB,B2
 bringing,bringing,جلب,NOUN,B2
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-briskness,briskness,轻快,NOUN,B2
 briton,briton,英国人,NOUN,B2
-brittleness,brittleness,词,NOUN,C1
-bro,bro,哥们,NOUN,B2
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
-broadcaster,broadcaster,广播公司,NOUN,B2
+to broadcast,to broadcast,播出,VERB,B2
 broadcasting,broadcasting,广播,NOUN,B2
-broadcasting station,broadcasting station,词,NOUN,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade,brocade,锦绣,NOUN,B2
-brocade (part),brocade,锦,PART,A1
-broccoli,broccoli,西兰花,NOUN,C1
-broke,broke,破产的,ADJ,B2
-broken,broken,破碎的,ADV,B2
-broken (adv),broken,破碎的,ADV,B2
-brokenness,brokenness,词,NOUN,C1
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,词,ADJ,B2
-brooch,brooch,词,NOUN,C1
-brooding (adj),brooding,词,ADJ,B2
 brook,brook,小溪,NOUN,B2
 brook no delay,brook no delay,刻不容缓,ADJ,B2
-broom blow,broom blow,词,NOUN,C1
 broth,broth,肉汤,NOUN,B2
-brother (part),brother,兄,PART,B1
-brother he,brother he,郃弟,NOUN,B2
 brother-in-law,brother-in-law,姐夫/妹夫,NOUN,B2
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
 browser,browser,浏览器,NOUN,B2
-bruises,bruises,词,NOUN,B2
-brutality,brutality,残暴,NOUN,B2
-brutalizing,brutalizing,词,ADJ,C1
-brutally,brutally,词,ADV,C1
-brute,brute,粗野的,ADJ,B2
-buckwheat,buckwheat,荞麦,NOUN,B2
-bucolic,bucolic,词,ADJ,C1
+to brush,to brush,刷,VERB,B2
 buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budgetable,budgetable,可预算的,ADJ,B2
 budgetary,budgetary,预算的,ADJ,B2
-budgeting,budgeting,词,NOUN,C1
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bullying,bullying,词,NOUN,B2
-bumblebee,bumblebee,词,NOUN,C1
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bundling,bundling,词,NOUN,C1
 bungee jumping,bungee jumping,蹦极,NOUN,B2
-burdened,burdened,负担重的,ADJ,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-burger stand,burger stand,,NOUN,B2
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque (adj),burlesque,词,ADJ,B2
-burn (noun),burn,烧,NOUN,B2
-burned,burned,词,ADJ,B2
 burning,burning,灼热的,ADJ,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burnt,burnt,烧焦的,ADJ,B2
-burp (noun),burp,词,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burst in,burst in,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
-bushy,bushy,词,ADJ,C1
 business,business,商业的,ADJ,B2
-business (adj),business,商业的,ADJ,C1
-business card,business card,名片,NOUN,B1
-business meeting,business meeting,洽谈会,NOUN,B2
-business sector,business sector,词,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
 busyness,busyness,事忙,NOUN,B2
 but,but,然而,ADV,B2
-but (adv),but,却,ADV,A1
-but (sconj),but,但他,SCONJ,B2
 but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but i,but i,可我,ADV,B2
 but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but you,but you,但您,NOUN,B2
-but-for,but-for,词,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-buttermilk,buttermilk,词,NOUN,A2
 buttocks,buttocks,屁股,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
 buyer,buyer,买家,NOUN,B2
-buyer purchaser,buyer purchaser,词,NOUN,B2
-buying and selling,buying and selling,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance,by chance,偶然地,ADV,B2
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
 by fair means or foul,by fair means or foul,不择手段,ADV,B2
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by heart,by heart,词,ADV,B2
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
 by means of,by means of,通过,ADP,B2
-by means of (noun),by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
 by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
 by the way,by the way,顺便说一下,ADV,B2
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
 bygone,bygone,过去的,ADJ,B2
-bypass surgery,bypass surgery,搭桥手术,NOUN,B2
-bypassing,bypassing,词,NOUN,C1
 cabbage,cabbage,卷心菜,NOUN,B2
-cabin boy,cabin boy,词,NOUN,C1
-cable car,cable car,缆车,NOUN,B1
-cachexia,cachexia,词,NOUN,C1
-cactus,cactus,词,NOUN,B1
-cadence,cadence,词,NOUN,B2
-cadres,cadres,词,NOUN,C1
-caesura,caesura,词,NOUN,C1
 cafe,cafe,咖啡馆,NOUN,B2
-cafeteria,cafeteria,词,NOUN,B1
-caffeine,caffeine,词,NOUN,C1
-caftan,caftan,词,NOUN,A1
-cage (verb),cage,词,VERB,C1
-caid local governor,caid local governor,词,NOUN,C1
-calamitous,calamitous,灾难性的,ADJ,B2
 calamity,calamity,灾难,NOUN,B2
-calcareous,calcareous,词,ADJ,B2
 calculation,calculation,计算,NOUN,B2
 calf,calf,小腿,NOUN,B2
-caliber,caliber,词,NOUN,C1
-calibrated,calibrated,词,ADJ,C1
-calibrator,calibrator,词,NOUN,C1
-caliph,caliph,词,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
 call,call,电话,NOUN,B2
-call to prayer,call to prayer,词,NOUN,B2
-calligrapher,calligrapher,词,NOUN,C1
 calligraphy,calligraphy,书法,NOUN,B2
 calling,calling,使命,NOUN,B2
-callous,callous,冷酷,ADJ,B2
-callus,callus,硬茧……,NOUN,C1
 calm,calm,平静,NOUN,B2
-calm (noun),calm,安安,NOUN,A2
-calming,calming,令人平静的,ADJ,B2
-calmly,calmly,平静地,ADV,B2
+to calm,to calm,使平静,VERB,B2
 calmness,calmness,平静,NOUN,B2
-calorie,calorie,词,NOUN,C1
 camel,camel,骆驼,NOUN,B2
-camp (part),camp,营,PART,A2
-campsite,campsite,露营地,NOUN,B2
-campus-like,campus-like,词,ADJ,B2
-can (noun),can,词,NOUN,B2
+to campaign,to campaign,积极参与活动,VERB,B2
 can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,词,NOUN,B2
-can may,can may,可以,AUX,A1
-can only,can only,只能,AUX,B2
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
 can't help,can't help,不由得,ADV,B2
-can't help doing sth,can't help doing sth,不禁,ADV,B2
 can-exit,can-exit,还出得来,NOUN,B2
-canadian,canadian,加拿大的,ADJ,B2
-canal belt,canal belt,词,NOUN,C1
 cancellation,cancellation,取消,NOUN,B2
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
-cancerous,cancerous,词,ADJ,C1
-candy shop,candy shop,词,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
 canned food,canned food,罐头食品,NOUN,B2
-canning,canning,词,NOUN,C1
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot reach,cannot reach,不到,VERB,B2
 cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-canonical,canonical,规范的,ADJ,B2
 cantaloupe,cantaloupe,哈密瓜,NOUN,B2
 canteen,canteen,食堂,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
 capability,capability,能力,NOUN,B2
 capable,capable,有本事,NOUN,B2
-capable (noun),capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacitor condenser,capacitor condenser,词,NOUN,C1
 cape,cape,海角,NOUN,B2
-caper (noun),caper,词,NOUN,B2
-capillary,capillary,词,ADJ,C1
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,词,NOUN,B2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
-capitalist,capitalist,词,NOUN,C1
-capitalization,capitalization,词,NOUN,C1
-capitulation,capitulation,词,NOUN,C1
-capping,capping,词,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capsule,capsule,词,NOUN,B1
-captious,captious,词,ADJ,B2
-captivated,captivated,词,ADJ,C1
 captivating,captivating,迷人的,ADJ,B2
 captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-captive bond,captive bond,词,NOUN,C1
 captivity,captivity,囚禁,NOUN,B2
-car (part),car,车,PART,C1
+to capture,to capture,获取,VERB,B2
 car accident,car accident,车祸,NOUN,B2
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
-car insurance,car insurance,车险,NOUN,B2
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
 car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-carat,carat,克拉,NOUN,B2
 caravan,caravan,房车,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrate,carbohydrate,碳水化合物,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon tax,carbon tax,碳税,NOUN,B2
-carbon trading,carbon trading,碳交易,NOUN,C1
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-cardboard,cardboard,硬纸板,NOUN,B2
 cardiac,cardiac,心脏的,ADJ,B2
-cardinal,cardinal,枢机主教,NOUN,B2
 care,care,照料,NOUN,B2
-care (noun),care,上心,NOUN,A1
-care home,care home,,NOUN,B2
-care worker,care worker,词,NOUN,B2
-career leap,career leap,词,NOUN,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-carefree,carefree,无忧无虑的,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefully,carefully,仔细地,ADV,B2
-carefulness,carefulness,细心,NOUN,B2
+to care for,to care for,照顾,VERB,B2
 caregiver,caregiver,护理人员,NOUN,B2
-carelessness,carelessness,词,NOUN,C1
-carer,carer,词,NOUN,C1
-caress (noun),caress,词,NOUN,B2
 caretaker,caretaker,房屋管理员,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
 caricatural,caricatural,漫画的,ADJ,B2
-caricature (verb),caricature,词,VERB,B2
-caring,caring,关怀的,ADJ,B2
-carnation,carnation,词,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
 carpenter,carpenter,木匠,NOUN,B2
 carpentry,carpentry,木工,NOUN,B2
-carpet rug,carpet rug,地毯,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
-carrier,carrier,承运人,NOUN,B2
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
-cartel,cartel,词,NOUN,B2
+to carry out,to carry out,实施,VERB,B2
 cartilage,cartilage,软骨,NOUN,B2
-cartography,cartography,词,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
 case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
-case law,case law,判例法,NOUN,B2
-cash,cash,现金,ADJ,B2
-cash (adj),cash,cash,ADJ,A2
-cash conversion,cash conversion,改现,NOUN,B2
 cash register,cash register,收银机,NOUN,B2
 cashew,cashew,腰果,NOUN,B2
-cashier,cashier,出纳员,NOUN,B2
 cashmere,cashmere,羊绒,NOUN,B2
-casket,casket,词,NOUN,C1
-cassation,cassation,词,NOUN,B2
 cassava,cassava,木薯,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cast (adj),cast,词,ADJ,C1
-cast iron,cast iron,词,NOUN,B2
-castanets,castanets,词,NOUN,B1
-caste,caste,词,NOUN,B2
-casting,casting,词,NOUN,C1
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-casuistry,casuistry,决疑法,NOUN,B2
-catachresis,catachresis,词语误用,NOUN,B2
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
-cataract,cataract,词,NOUN,B2
-catastrophic,catastrophic,灾难性的,ADJ,B2
-catch,catch,捕捉,NOUN,B2
-catch (noun),catch,catch,NOUN,B2
-catch thief,catch thief,抓贼,NOUN,C1
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorical,categorical,绝对的,ADJ,B2
-categorically,categorically,词,ADV,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
+to catch up,to catch up,赶上,VERB,B2
 catharsis,catharsis,宣泄,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catholic,catholic,天主教的,ADJ,B2
-catholic (noun),catholic,天主教徒,NOUN,C1
-catholicism,catholicism,天主教,NOUN,B2
-cats,cats,猫,NOUN,B2
-cattle rancher,cattle rancher,牧场主,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-caught,caught,被捕获的,ADJ,B2
-cauldron,cauldron,词,NOUN,C1
 cauliflower,cauliflower,花椰菜,NOUN,B2
-causal,causal,因果的,ADJ,B2
-causal link,causal link,词,NOUN,B2
+to cause,to cause,引起,VERB,B2
 cause of change,cause of change,改因,NOUN,B2
 cause of death,cause of death,死因,NOUN,B2
 cause of defeat,cause of defeat,败因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-caustic,caustic,词,ADJ,B2
 cautious and conscientious,cautious and conscientious,兢兢业业,ADJ,B2
 cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
 cavalry,cavalry,骑兵,NOUN,B2
-cavern,cavern,词,NOUN,B2
-cavity,cavity,腔,NOUN,B2
-caw (noun),caw,词,NOUN,C1
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-celebrant,celebrant,词,NOUN,B2
-celerity,celerity,迅速,NOUN,B2
+to caw,to caw,呱呱叫,VERB,B2
 celery,celery,芹菜,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial (noun),celestial,词,NOUN,B2
-celestial body,celestial body,词,NOUN,B2
 celibacy,celibacy,独身,NOUN,B2
-celibate,celibate,词,ADJ,B2
 cell phone,cell phone,手机,NOUN,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cellar,cellar,地窖,NOUN,B2
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
 cellular,cellular,细胞的,ADJ,B2
-cellulose,cellulose,纤维素,NOUN,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-census,census,人口普查,NOUN,B2
-centenary,centenary,词,NOUN,C1
-centennial,centennial,词,ADJ,B2
-centime,centime,词,NOUN,B2
+to cement,to cement,巩固,VERB,B2
 centimeter,centimeter,厘米,NOUN,B2
-centipede,centipede,蜈蚣,NOUN,B2
-cento,cento,词,NOUN,C1
 central,central,中心的,ADJ,B2
-central station,central station,中央车站,NOUN,B2
 centralization,centralization,集中化,NOUN,B2
-centre,centre,词,NOUN,B2
-centrifugal force,centrifugal force,离心力,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-century-old,century-old,词,ADJ,B2
 ceramic art,ceramic art,陶艺,NOUN,B2
 ceramics,ceramics,陶瓷,NOUN,B2
-cereal,cereal,词,NOUN,B2
 cerebral,cerebral,大脑的,ADJ,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
-ceremonial cap,ceremonial cap,爵弁,NOUN,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
 certain,certain,某些,DET,B2
-certain (det),certain,某些,DET,B2
 certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
-certainly (intj),certainly,当然,INTJ,B2
-certificate of merit,certificate of merit,奖状,NOUN,B2
 cessation,cessation,终止,NOUN,B2
-cessation passing,cessation passing,消亡,NOUN,C1
-chain (adj),chain,词,ADJ,C1
-chain mail,chain mail,锁子甲,NOUN,B2
-chain of transmission,chain of transmission,词,NOUN,C1
 chairman,chairman,主席,NOUN,B2
 chairperson,chairperson,主席,NOUN,B2
-chalet,chalet,词,NOUN,B1
-chalice,chalice,词,NOUN,C1
-challenges,challenges,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
-chamberlain,chamberlain,词,NOUN,C1
-chamois,chamois,词,NOUN,C1
-chance opportunity,chance opportunity,词,NOUN,A2
+to challenge,to challenge,质疑,VERB,B2
 chancellor,chancellor,总理,NOUN,B2
-chancery,chancery,词,NOUN,C1
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change (noun),change,变动,NOUN,A1
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
 change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
-changed policy,changed policy,改策,NOUN,B2
 changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
 changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chants,chants,词,NOUN,B2
 chapel,chapel,小教堂,NOUN,B2
-chaplain,chaplain,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-character assassination,character assassination,人格谋杀,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
-character word,character word,字,NOUN,B2
 characteristic,characteristic,典型的,ADJ,B2
-characteristic (adj),characteristic,特征性,ADJ,B2
 characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charade,charade,词,NOUN,B2
 charades,charades,打哑谜,NOUN,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
-charitable,charitable,慈善的,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
-charmer,charmer,词,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
+to charge,to charge,充电,VERB,B2
 chase,chase,追逐,NOUN,B2
-chase (noun),chase,追他,NOUN,B2
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
 chastity,chastity,贞洁,NOUN,B2
-chastity probity,chastity probity,词,NOUN,C1
 chat,chat,聊天,NOUN,B2
-chat (noun),chat,聊吧,NOUN,A2
-chauvinism,chauvinism,沙文主义,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheaper,cheaper,更便宜的,ADJ,B2
-cheapness,cheapness,廉价,NOUN,B2
 check,check,支票,NOUN,B2
-check (noun),check,支票,NOUN,A2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checkbook,checkbook,支票簿,NOUN,B2
-checked,checked,词,ADJ,C1
-checkers,checkers,词,NOUN,A2
-checkmark,checkmark,词,NOUN,C1
-checkout,checkout,收银台,NOUN,B2
-cheekbone,cheekbone,词,NOUN,C1
 cheeky,cheeky,厚颜无耻的,ADJ,B2
+to cheer on,to cheer on,加油,VERB,B2
+to cheer up,to cheer up,使高兴,VERB,B2
 cheerful,cheerful,愉快的,ADJ,B2
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
-cheers (noun),cheers,欢呼,NOUN,B2
 chef,chef,厨师,NOUN,B2
 chemical,chemical,化学的,ADJ,B2
-chemical (adj),chemical,化学品,ADJ,B2
-chemicals,chemicals,词,NOUN,C1
-chemist,chemist,词,NOUN,C1
 chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
 chess,chess,国际象棋,NOUN,B2
-chest breast,chest breast,词,NOUN,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest pain,chest pain,胸痛,NOUN,B2
 chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chestnut,chestnut,板栗,NOUN,B2
 chewing gum,chewing gum,口香糖,NOUN,B2
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chiasmus,chiasmus,词,NOUN,C1
-chic (adj),chic,词,ADJ,C1
-chic (noun),chic,词,NOUN,C1
-chickpeas,chickpeas,词,NOUN,A2
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,词,ADV,B2
-chieftain,chieftain,酋长,NOUN,B2
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childbirth,childbirth,分娩,NOUN,B2
-childcare,childcare,词,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
 chili pepper,chili pepper,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (adj),chill,放松,ADJ,B2
-chilling,chilling,词,ADJ,C1
-chimera,chimera,词,NOUN,C1
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
 chinese,chinese,中国的,ADJ,B2
 chinese,chinese,中文,NOUN,B2
 chinese cabbage,chinese cabbage,白菜,NOUN,B2
-chinese chess,chinese chess,象棋,NOUN,B2
-chinese language,chinese language,华文,NOUN,B2
-chinese zodiac,chinese zodiac,生肖,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chitchat,chitchat,词,NOUN,B2
-chivalrous,chivalrous,词,ADJ,B2
+to chirp,to chirp,啁啾,VERB,B2
 chivalry,chivalry,骑士精神,NOUN,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,词,NOUN,C1
-cholera,cholera,词,NOUN,C1
-choleric,choleric,易怒的,ADJ,B2
 cholesterol,cholesterol,胆固醇,NOUN,B2
 chop,chop,砍,NOUN,B2
-chop (noun),chop,砍了,NOUN,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreographic,choreographic,词,ADJ,C1
-choreography,choreography,词,NOUN,C1
-chosen,chosen,精选的,ADJ,B2
-christian,christian,基督徒,NOUN,B2
-christianity,christianity,基督教,NOUN,B2
-christianization,christianization,词,NOUN,C1
 christmas,christmas,圣诞节,NOUN,B2
-christmas eve,christmas eve,词,NOUN,B2
-christmas porridge,christmas porridge,词,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
 chromosome,chromosome,染色体,NOUN,B2
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicler,chronicler,词,NOUN,B2
-chronological,chronological,词,ADJ,C1
-chubby,chubby,胖子,NOUN,B2
-church community,church community,教会,NOUN,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn skin,churn skin,词,NOUN,B2
-cider,cider,词,NOUN,B2
-cigar,cigar,雪茄,NOUN,B2
-cigarette butt,cigarette butt,烟头,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinematographic,cinematographic,电影的,ADJ,B2
 cinnamon,cinnamon,肉桂,NOUN,B2
-circular (adj),circular,词,ADJ,C1
-circular (noun),circular,词,NOUN,B2
-circulating,circulating,词,ADJ,B2
 circulation,circulation,循环,NOUN,B2
 circumcision,circumcision,割礼,NOUN,B2
-circumference,circumference,词,NOUN,C1
-circumlocution,circumlocution,迂回说法,NOUN,B2
-circumspect,circumspect,谨慎的,ADJ,B2
-circumspection,circumspection,词,NOUN,B2
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
-cistern,cistern,蓄水池,NOUN,B2
-citadel,citadel,词,NOUN,C1
 citizenship,citizenship,公民身份,NOUN,B2
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city centre,city centre,市中心,NOUN,B2
 city council,city council,市议会,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
 city hall,city hall,市政厅,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic,civic,词,ADJ,C1
-civic-mindedness,civic-mindedness,词,NOUN,B2
-civil servant,civil servant,公务员,NOUN,B2
-civil war,civil war,词,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilian (adj),civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civilized,civilized,文明的,ADJ,B2
 claim,claim,要求,NOUN,B2
-claim (noun),claim,说法,NOUN,B2
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,词,ADJ,B2
-clamorous,clamorous,词,ADJ,B2
-clampdown,clampdown,词,NOUN,C1
 clan,clan,家族,NOUN,B2
-clandestine,clandestine,秘密的,ADJ,B2
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestineness,clandestineness,词,NOUN,B2
-clandestinity,clandestinity,词,NOUN,B2
-clapping,clapping,词,NOUN,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarity evidentness,clarity evidentness,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-class test,class test,词,NOUN,B1
 classic,classic,经典作品,NOUN,B2
-classic (noun),classic,经典,NOUN,C1
-classical poetry,classical poetry,词,NOUN,C1
 classicism,classicism,古典主义,NOUN,B2
-classicist,classicist,词,ADJ,B2
 classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for paintings cloth etc.,classifier for paintings cloth etc.,幅,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trees,classifier for trees,棵,NUM,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
 classmate,classmate,同学,NOUN,B2
-classwork,classwork,课堂作业,NOUN,B2
 clause,clause,从句,NOUN,B2
-clauses,clauses,词,NOUN,C1
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
+to clean up,to clean up,清理,VERB,B2
 cleaner,cleaner,清洁剂,NOUN,B2
-cleaner (adj),cleaner,词,ADJ,B2
 cleaning,cleaning,清洁,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanly,cleanly,干净地,ADV,B2
-cleansing,cleansing,清洗,NOUN,B2
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
-clear (adv),clear,当然,ADV,B2
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
-clear knowledge,clear knowledge,明知,NOUN,B2
-clear limpid,clear limpid,词,ADJ,C1
-clear soup,clear soup,江瑶清羹,NOUN,B2
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
+to clear,to clear,清理,VERB,B2
 clear-cut,clear-cut,明确的,ADJ,B2
-clearance,clearance,词,NOUN,C1
 clearing,clearing,林中空地,NOUN,B2
-clearing of the throat,clearing of the throat,词,NOUN,C1
-clearly demarcated,clearly demarcated,分明,ADJ,B2
-clemency,clemency,仁慈,NOUN,B2
 clergy,clergy,神职人员,NOUN,B2
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
 cliche,cliche,陈词滥调,NOUN,B2
-click (noun),click,词,NOUN,C1
-clientele,clientele,词,NOUN,B2
-clientelism,clientelism,庇护主义,NOUN,B2
 cliff,cliff,悬崖,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
 climate change,climate change,气候变化,NOUN,B2
-climate denial,climate denial,气候否认,NOUN,B2
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
-climbing,climbing,词,NOUN,B1
-clinking,clinking,词,NOUN,C1
-clipping,clipping,词,NOUN,C1
+to climb a mountain,to climb a mountain,爬山,VERB,B2
 cloakroom,cloakroom,衣帽间,NOUN,B2
-clock watch,clock watch,钟表,NOUN,B2
-clog (noun),clog,词,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
 close,close,近的,ADJ,B2
-close (adj),close,密切,ADJ,B2
-close a case,close a case,结案,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
-close well,close well,关好,NOUN,C1
-closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
-closedness,closedness,封闭,NOUN,C1
-closely,closely,词,ADV,B2
+to close account,to close account,销户,VERB,B2
+to close the door,to close the door,关门,VERB,B2
 closeness,closeness,接近,NOUN,B2
-closer (adv),closer,词,ADV,B2
-closing,closing,词,NOUN,B2
-closing argument,closing argument,辩护词,NOUN,B2
 closing ceremony,closing ceremony,闭幕仪式,NOUN,B2
 closure,closure,关闭,NOUN,B2
 clot,clot,凝块,NOUN,B2
 cloth,cloth,布,NOUN,B2
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-clouds,clouds,云,NOUN,B1
 cloudy,cloudy,阴沉的,ADJ,B2
 cloudy day,cloudy day,阴天,NOUN,B2
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
-cloying,cloying,词,ADJ,C1
-club blow,club blow,词,NOUN,C1
-clueless,clueless,词,ADJ,C1
-clumsily,clumsily,词,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-co-,co-,词,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-occurrence,co-occurrence,词,NOUN,C1
-co-owner,co-owner,共有人,NOUN,B2
-co-ownership,co-ownership,共有产权,NOUN,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coarse rough,coarse rough,词,ADJ,C1
-coast road,coast road,词,NOUN,B2
-coastal,coastal,沿海的,ADJ,B2
-coastal (noun),coastal,词,NOUN,B2
-coastline,coastline,词,NOUN,B2
-coat of arms,coat of arms,纹章,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-coaxing,coaxing,哄得,NOUN,B2
-cobbler,cobbler,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-code of conduct,code of conduct,词,NOUN,C1
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-coding,coding,词,NOUN,B2
+to coach,to coach,辅导,VERB,B2
 coefficient,coefficient,系数,NOUN,B2
 coercion,coercion,胁迫,NOUN,B2
-coffee maker,coffee maker,词,NOUN,A2
-cog,cog,词,NOUN,C1
-cogito,cogito,词,NOUN,C1
-cognac,cognac,干邑,NOUN,B2
-cognate,cognate,词,NOUN,B2
-cognition,cognition,认知,NOUN,B2
-cognitive,cognitive,认知的,ADJ,B2
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
 coherence,coherence,连贯性,NOUN,B2
-cohort,cohort,队列,NOUN,B2
-cohort-based,cohort-based,队列的,ADJ,B2
-coin purse,coin purse,词,NOUN,B2
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
 coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coitus,coitus,词,NOUN,B2
-coke,coke,词,NOUN,B2
-cola,cola,可乐,NOUN,B2
 colander,colander,漏勺,NOUN,B2
 cold,cold,寒冷,NOUN,B2
-cold (noun),cold,cold,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold blood,cold blood,冷血,NOUN,B2
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold wave,cold wave,寒潮,NOUN,B2
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
 coldly,coldly,冷淡地,ADV,B2
-coldness,coldness,词,NOUN,B2
-colic,colic,词,NOUN,C1
-coliseum,coliseum,词,NOUN,B2
 collaborator,collaborator,合作者,NOUN,B2
 collapse,collapse,倒塌,NOUN,B2
-collapse (noun),collapse,collapse,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
-collateral,collateral,附属的,ADJ,B2
-collation,collation,词,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,词,ADJ,B2
-collectie,collectie,词,NOUN,B2
-collections,collections,词,NOUN,C1
 collective,collective,集体的,ADJ,B2
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivization,collectivization,词,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiate,collegiate,词,ADJ,B2
 collision,collision,碰撞,NOUN,B2
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial,colloquial,词,ADJ,B2
-colloquial language,colloquial language,词,NOUN,C1
-colloquium,colloquium,词,NOUN,B2
-collusion,collusion,串通,NOUN,B2
 colon,colon,冒号,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
 colonel,colonel,上校,NOUN,B2
-colonial,colonial,词,ADJ,C1
-colonial settlers,colonial settlers,词,NOUN,C1
 colonialism,colonialism,殖民主义,NOUN,B2
-colonist,colonist,词,NOUN,B2
-colonization,colonization,殖民化,NOUN,B2
-colonizing,colonizing,词,ADJ,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colophon,colophon,词,NOUN,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-colored,colored,有色的,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
+to color,to color,着色,VERB,B2
 colorful,colorful,五颜六色的,ADJ,B2
-coloring,coloring,词,NOUN,B2
-colorless,colorless,词,ADJ,C1
-colossal,colossal,巨大的,ADJ,B2
-colossus,colossus,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-columnar,columnar,词,ADJ,C1
-columnist,columnist,词,NOUN,C1
-combatant,combatant,词,NOUN,B2
+to comb,to comb,梳头,VERB,B2
+to combat,to combat,对抗,VERB,B2
 combating,combating,打击,NOUN,B2
-combative,combative,词,ADJ,B2
-combativeness,combativeness,好斗性,NOUN,B2
-combinations,combinations,词,NOUN,C1
-combinatorial,combinatorial,词,ADJ,B2
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combining,combining,词,ADJ,B2
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come on,come on,词,INTJ,C1
+to come back,to come back,回来,VERB,B2
+to come from,to come from,来自,VERB,B2
+to come here,to come here,来到这里,VERB,B2
+to come in,to come in,进来,VERB,B2
+to come out,to come out,出来,VERB,B2
+to come over,to come over,顺道来访,VERB,B2
+to come up,to come up,出现,VERB,B2
 comedian,comedian,喜剧演员,NOUN,B2
-comer,comer,词,NOUN,C1
 comfort,comfort,安慰,NOUN,B2
-comfort (noun),comfort,舒适,NOUN,B2
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
 comic,comic,喜剧的,ADJ,B2
-comic (adj),comic,喜剧的,ADJ,B2
-comic strip,comic strip,连环画,NOUN,B2
-comicness,comicness,词,NOUN,C1
 coming,coming,مجيء,NOUN,B2
-coming (adj),coming,即将到来的,ADJ,C1
-coming and going,coming and going,往来,NOUN,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma,comma,逗号,PUNCT,B2
-comma (noun),comma,词,NOUN,B1
-command room,command room,指挥室,NOUN,B2
+to command,to command,命令,VERB,B2
 commander,commander,指挥官,NOUN,B2
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
-commandment,commandment,词,NOUN,C1
-commemoration,commemoration,纪念,NOUN,B2
-commendable,commendable,词,ADJ,C1
-commensalism,commensalism,词,NOUN,B2
-commentaries,commentaries,词,NOUN,C1
 commentator,commentator,评论员,NOUN,B2
 commercial,commercial,商业的,ADJ,B2
-commercial (adj),commercial,商业性,ADJ,B1
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commiseration,commiseration,同情,NOUN,B2
 commissioner,commissioner,专员,NOUN,B2
-commitments,commitments,词,NOUN,C1
+to commit a crime,to commit a crime,犯罪,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
 committed,committed,投入的,ADJ,B2
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commodification,commodification,词,NOUN,C1
-common good,common good,词,NOUN,B2
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
 common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
 commonality,commonality,共同点,NOUN,B2
 commoner,commoner,平民,NOUN,B2
-commonly,commonly,词,ADV,C1
-commonplace,commonplace,词,ADJ,C1
 commotion,commotion,骚动,NOUN,B2
-communal work,communal work,词,NOUN,C1
-communautarization,communautarization,社群化,NOUN,B2
-communes,communes,词,NOUN,C1
-communicativeness,communicativeness,词,NOUN,C1
-communion rail,communion rail,词,NOUN,B2
 communique,communique,公报,NOUN,B2
 communism,communism,共产主义,NOUN,B2
 communist,communist,شيوعي,ADJ,B2
-communist (noun),communist,共产主义者,NOUN,C1
-communitarian,communitarian,词,ADJ,C1
 communitarianism,communitarianism,社群主义,NOUN,B2
-community-related,community-related,社区的,ADJ,B2
-comorbidity,comorbidity,词,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
 companionship,companionship,陪伴,NOUN,B2
-comparable,comparable,可比较的,ADJ,B2
-comparative,comparative,比较的,ADJ,B2
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
 comparison,comparison,比较,NOUN,B2
 compartment,compartment,隔间,NOUN,B2
-compartmental,compartmental,词,ADJ,C1
-compassion sympathy,compassion sympathy,词,NOUN,B2
 compassionate,compassionate,有同情心的,ADJ,B2
 compatibility,compatibility,兼容性,NOUN,B2
 compatriot,compatriot,同胞,NOUN,B2
-compendious,compendious,词,ADJ,B2
-compendium,compendium,纲要,NOUN,B2
-compensatory leave,compensatory leave,调休,NOUN,B2
-competencies,competencies,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competition bastard,competition bastard,,NOUN,B2
-competitive,competitive,竞争的,ADJ,B2
-competitive exam,competitive exam,词,NOUN,B2
 compilation,compilation,汇编,NOUN,B2
-complacency,complacency,词,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complement,complement,补充物,NOUN,B2
 complementary,complementary,互补的,ADJ,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
 complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
 completion,completion,完成,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex,complex,建筑群,NOUN,B2
-complex (noun),complex,建筑群,NOUN,B2
-complexion,complexion,肤色,NOUN,B2
 compliant,compliant,符合的,ADJ,B2
 complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
 complicity,complicity,共犯,NOUN,B2
-composable,composable,可组合的,ADJ,B2
+to comply with,to comply with,遵守,VERB,B2
 composed,composed,稳重的,ADJ,B2
 composer,composer,作曲家,NOUN,B2
-compositional,compositional,词,ADJ,C1
 compost,compost,堆肥,NOUN,B2
-compostable,compostable,词,ADJ,B2
 composure,composure,镇定,NOUN,B2
 compound,compound,复合性,ADJ,B2
-compound (adj),compound,复合性,ADJ,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
 comprehension,comprehension,理解,NOUN,B2
-compressed,compressed,词,ADJ,C1
-compressible,compressible,词,ADJ,C1
 compressor,compressor,压缩机,NOUN,B2
-compulsion,compulsion,词,NOUN,C1
+to compromise,to compromise,危及,VERB,B2
 compulsive,compulsive,强迫性的,ADJ,B2
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compunction,compunction,词,NOUN,B2
-compurgation oath,compurgation oath,词,NOUN,C1
-computer mouse,computer mouse,词,NOUN,B1
-computer program,computer program,电脑程序,NOUN,B2
-computer science,computer science,词,NOUN,C1
-computer specialist,computer specialist,计算机专家,NOUN,B2
 computing,computing,计算机科学,NOUN,B2
-con artist,con artist,词,NOUN,B1
-concatenation,concatenation,词,NOUN,B2
-concave,concave,凹的,ADJ,B2
-concavity,concavity,词,NOUN,B2
-concealed,concealed,词,ADJ,C1
 concealment,concealment,隐瞒,NOUN,B2
-conceit,conceit,词,NOUN,C1
-conceited,conceited,自负的,ADJ,B2
-conceivable,conceivable,可设想的,ADJ,B2
-concentrated,concentrated,浓,ADJ,B1
-concentric,concentric,词,ADJ,C1
-conception,conception,概念,NOUN,B2
-concepts,concepts,词,NOUN,C1
-conceptual,conceptual,概念的,ADJ,B2
-concerned,concerned,担忧的,ADJ,B2
-concerning,concerning,关于,ADP,B2
-concerning (adj),concerning,词,ADJ,B2
-concerns,concerns,词,NOUN,C1
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
+to concern,to concern,涉及,VERB,B2
+to concern all,to concern all,凡事,VERB,B2
 concession,concession,让步,NOUN,B2
-concessionary,concessionary,让步的,ADJ,B2
-conch,conch,词,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
-conciliatory,conciliatory,调和的,ADJ,B2
 concise,concise,简洁的,ADJ,B2
-concision,concision,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,词,ADJ,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
 conclusive,conclusive,决定性的,ADJ,B2
-concomitantly,concomitantly,词,ADV,B2
-concordance,concordance,一致,NOUN,B2
-concordat,concordat,政教协定,NOUN,B2
 concrete,concrete,具体的,ADJ,B2
-concrete (adj),concrete,具体,ADJ,B1
-concretization,concretization,词,NOUN,C1
 concubine,concubine,妾,NOUN,B2
 concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concurrence,concurrence,词,NOUN,B2
-concurrently,concurrently,词,ADV,C1
-concussion,concussion,脑震荡,NOUN,B2
 condemnation,condemnation,谴责,NOUN,B2
-condemned,condemned,被定罪的,ADJ,B2
-condensation,condensation,凝结,NOUN,B2
-condenser,condenser,词,NOUN,C1
-condescending,condescending,屈尊的,ADJ,B2
-condescension,condescension,屈尊,NOUN,B2
-conditioning (adj),conditioning,词,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
+to condole,to condole,哀悼,VERB,B2
 condolence,condolence,哀悼,NOUN,B2
 condolences,condolences,哀悼,NOUN,B2
-condom,condom,避孕套,NOUN,B2
-conducive,conducive,词,ADJ,B2
+to conduct,to conduct,أجرى,VERB,B2
 conductivity,conductivity,导电性,NOUN,B2
-conductor,conductor,词,NOUN,C1
-conduit,conduit,词,NOUN,B2
 cone,cone,圆锥体,NOUN,B2
-confederal,confederal,词,ADJ,C1
 confederation,confederation,邦联,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-confessional,confessional,宗派的,ADJ,B2
-confetti,confetti,词,NOUN,C1
-confidant,confidant,知己,NOUN,B2
-confiding,confiding,词,NOUN,C1
-configured,configured,词,ADJ,C1
-confinement,confinement,禁闭,NOUN,B2
-confines edges,confines edges,词,NOUN,C1
 confiscation,confiscation,没收,NOUN,B2
-conflictual,conflictual,词,ADJ,C1
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
-conforming,conforming,词,ADJ,B2
-conformist,conformist,墨守成规者,NOUN,B2
-conformist (adj),conformist,词,ADJ,B2
-conformity,conformity,词,NOUN,B2
-confounded,confounded,该死的,ADJ,B2
 confrontation,confrontation,对抗,NOUN,B2
-confronted,confronted,词,ADJ,B2
-confronting,confronting,词,ADJ,B2
-confused (adv),confused,词,ADV,B1
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusedly,confusedly,词,ADV,C1
-confusing,confusing,令人困惑的,ADJ,B2
-congenital,congenital,先天的,ADJ,B2
 congestion,congestion,拥堵,NOUN,B2
-conglomerate,conglomerate,词,NOUN,B2
 congratulation,congratulation,祝贺,NOUN,B2
-congratulations,congratulations,恭喜,INTJ,B2
-congratulations (noun),congratulations,祝贺,NOUN,B2
-congregation,congregation,集会,NOUN,B2
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-congruent,congruent,一致的,ADJ,B2
-conic,conic,圆锥曲线,NOUN,B2
-conifer,conifer,针叶树,NOUN,B2
-coniferous forest,coniferous forest,针叶林,NOUN,B2
 conjecture,conjecture,推测,NOUN,B2
-conjugal,conjugal,词,ADJ,B2
 conjugation,conjugation,变位,NOUN,B2
-conjunctural,conjunctural,词,ADJ,C1
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connector,connector,词,NOUN,B2
-connivance,connivance,词,NOUN,B2
-conniving,conniving,词,ADJ,C1
 connoisseur,connoisseur,行家,NOUN,B2
 connotation,connotation,内涵,NOUN,B2
-connotative,connotative,内涵的,ADJ,B2
 conqueror,conqueror,征服者,NOUN,B2
-conquest,conquest,征服,NOUN,B2
-conquests,conquests,征服,NOUN,C1
-consanguineous,consanguineous,词,ADJ,B2
-consanguinity,consanguinity,血缘,NOUN,B2
 conscientious,conscientious,认真的,ADJ,B2
-conscientious objection,conscientious objection,词,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
-consciously,consciously,词,ADV,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
-consecutive cards,consecutive cards,连牌,NOUN,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consecutively,consecutively,连续地,ADV,B2
-consensualism,consensualism,词,NOUN,C1
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,词,ADJ,B2
 consequently,consequently,因此,ADV,B2
-conservatism,conservatism,词,NOUN,C1
-conservatory,conservatory,音乐学院,NOUN,B2
 considerable,considerable,相当大的,ADJ,B2
-considerable (noun),considerable,不小,NOUN,C1
-considerably,considerably,相当地,ADV,B2
-considerate,considerate,体贴,ADJ,B2
 consignment,consignment,托运,NOUN,B2
 consistency,consistency,一致性,NOUN,B2
 consolation,consolation,安慰,NOUN,B2
-console (noun),console,词,NOUN,B2
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consolidation,consolidation,词,NOUN,C1
-consonance,consonance,词,NOUN,B2
-consort,consort,福晋,NOUN,B2
-consortium,consortium,词,NOUN,B2
 conspicuous,conspicuous,显著的,ADJ,B2
-conspirator,conspirator,词,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
 constable,constable,警官,NOUN,B2
 constant,constant,常数,NOUN,B2
-constant (noun),constant,常量,NOUN,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
 constellation,constellation,星座,NOUN,B2
-consternation,consternation,词,NOUN,B2
 constipation,constipation,便秘,NOUN,B2
-constituencies,constituencies,词,NOUN,C1
 constituency,constituency,选区,NOUN,B2
 constitutional,constitutional,宪法的,ADJ,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
-constitutionalization,constitutionalization,词,NOUN,B2
-constitutive,constitutive,构成的,ADJ,B2
-constraints,constraints,词,NOUN,C1
 construction site,construction site,工地,NOUN,B2
 constructive,constructive,建设性的,ADJ,B2
-constructivism,constructivism,建构主义,NOUN,B2
 consul,consul,领事,NOUN,B2
 consular,consular,领事的,ADJ,B2
 consulate,consulate,领事馆,NOUN,B2
-consultations,consultations,磋商,NOUN,C1
-consultative,consultative,咨询的,ADJ,B2
-consumerist,consumerist,词,ADJ,B2
-consummate (adj),consummate,词,ADJ,B2
-consummation,consummation,词,NOUN,B2
 consumption,consumption,消费,NOUN,B2
-consumptive,consumptive,词,ADJ,B2
-contact person,contact person,联系人,NOUN,B2
-contacts,contacts,人脉,NOUN,B2
-contactual,contactual,词,ADJ,B2
-contagion,contagion,词,NOUN,B2
-containment,containment,词,NOUN,C1
-contaminated,contaminated,受污染的,ADJ,B2
-contaminating,contaminating,污染的,ADJ,B2
-contemn,contemn,蔑视,VERB,C1
 contemplative,contemplative,沉思的,ADJ,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contender,contender,词,NOUN,B2
-content (adj),content,词,ADJ,B2
-contentious,contentious,有争议的,ADJ,B2
 contentment,contentment,满足,NOUN,B2
-contents,contents,内有,NOUN,B2
-contestable,contestable,可质疑的,ADJ,B2
 contested,contested,有争议的,ADJ,B2
 contextual,contextual,语境的,ADJ,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,相邻的,ADJ,B2
-continence,continence,词,NOUN,B2
-continental,continental,词,ADJ,B2
-contingent,contingent,偶然的,ADJ,B2
-continual,continual,持续的,ADJ,B2
-continually,continually,词,ADV,B2
-continued,continued,持续的,ADJ,B2
 continuity,continuity,连续性,NOUN,B2
-continuously,continuously,一直,ADV,A1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contracted,contracted,词,ADJ,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual,contractual,合同的,ADJ,B2
-contractual nature,contractual nature,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
+to contract,to contract,收缩,VERB,B2
 contradiction,contradiction,矛盾,NOUN,B2
-contradictory,contradictory,矛盾的,ADJ,B2
-contraindication,contraindication,词,NOUN,C1
-contrary,contrary,反而,NOUN,B2
-contrary (adj),contrary,词,ADJ,C1
-contrary intention,contrary intention,反意,NOUN,B2
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrastive,contrastive,词,ADJ,C1
-contributions,contributions,词,NOUN,C1
-contrite,contrite,词,ADJ,B2
+to contrast,to contrast,对比,VERB,B2
 contrition,contrition,悔罪,NOUN,B2
 control,control,控制,NOUN,B2
-control (noun),control,管管,NOUN,B2
 control room,control room,控制室,NOUN,B2
-controllable,controllable,可控制的,ADJ,B2
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
 controversial,controversial,有争议的,ADJ,B2
-contumacy,contumacy,词,NOUN,C1
-contusion,contusion,词,NOUN,B2
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convalescence,convalescence,词,NOUN,C1
-convalescent,convalescent,词,ADJ,B2
-convenant,convenant,词,NOUN,C1
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
-convent,convent,词,NOUN,B2
-conventional,conventional,传统的,ADJ,B2
-conventionality,conventionality,词,NOUN,C1
-convergent,convergent,词,ADJ,C1
-conversation technique,conversation technique,词,NOUN,C1
 conversely,conversely,相反地,ADV,B2
-conversion,conversion,转换,NOUN,B2
-conversional,conversional,转换的,ADJ,B2
-convert (noun),convert,词,NOUN,B2
-convertible,convertible,可兑换的,ADJ,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (adj),convict,词,ADJ,B2
-convict (noun),convict,词,NOUN,C1
-convicted,convicted,被判罪的,ADJ,B2
-conviviality,conviviality,温馨,NOUN,B2
-convoluted,convoluted,词,ADJ,B2
-convolutional,convolutional,词,ADJ,B2
-convoy,convoy,词,NOUN,B2
 convulsion,convulsion,抽搐,NOUN,B2
-convulsive,convulsive,词,ADJ,B2
-cookbook,cookbook,词,NOUN,C1
-cooked,cooked,熟的,ADJ,B2
 cooked meatball,cooked meatball,丸子熟,NOUN,B2
-cooked rice,cooked rice,米饭,NOUN,B2
 cooking,cooking,烹饪,NOUN,B2
 cooking pot,cooking pot,炖锅,NOUN,B2
 cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,词,ADJ,B2
-cooler,cooler,词,ADJ,C1
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
-cooling,cooling,冷却,NOUN,B2
 coolness,coolness,凉爽,NOUN,B2
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
+to coordinate,to coordinate,协调,VERB,B2
 coordinator,coordinator,协调员,NOUN,B2
-copious,copious,丰富的,ADJ,B2
-coproduction,coproduction,联合制作,NOUN,B2
+to copy,to copy,复制,VERB,B2
 copyist,copyist,抄写员,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
 coral,coral,珊瑚,NOUN,B2
-coral (adj),coral,词,ADJ,C1
 coral reef,coral reef,珊瑚礁,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordially,cordially,亲切地,ADV,B2
-cordoning,cordoning,词,NOUN,C1
 core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-corniche,corniche,词,NOUN,C1
-corollary,corollary,推论,NOUN,B2
 coronation,coronation,加冕,NOUN,B2
-corporal,corporal,下士,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpulent,corpulent,词,ADJ,B2
-corpuscle,corpuscle,词,NOUN,C1
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
+to correct,to correct,纠正,VERB,B2
 correction,correction,纠正,NOUN,B2
-correctional,correctional,词,ADJ,C1
-corrections,corrections,词,NOUN,B2
-correctness,correctness,正确性,NOUN,B2
-correlative,correlative,词,ADJ,B2
-correlatively,correlatively,词,ADV,B2
-correspondence,correspondence,通信,NOUN,B2
-correspondence course,correspondence course,函授,NOUN,C1
 correspondent,correspondent,记者,NOUN,B2
-correspondents,correspondents,词,NOUN,C1
-corridors,corridors,词,NOUN,C1
-corrigible,corrigible,词,ADJ,B2
 corrosion,corrosion,腐蚀,NOUN,B2
-corrosive,corrosive,腐蚀性的,ADJ,B2
-corrupted,corrupted,词,NOUN,B2
-cortical,cortical,皮层的,ADJ,C1
-cosmetic,cosmetic,化妆品的,ADJ,B2
-cosmetics,cosmetics,化妆品,NOUN,B2
+to corrupt,to corrupt,腐败,VERB,B2
 cosmic,cosmic,宇宙的,ADJ,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,词,NOUN,B2
-cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
-costs,costs,费用,NOUN,B2
-costumbrism,costumbrism,词,NOUN,B2
-costumes,costumes,词,NOUN,B2
-cosy,cosy,词,ADJ,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
+to cost,to cost,花费,VERB,B2
+to cough,to cough,咳嗽,VERB,B2
 could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-council-related,council-related,词,ADJ,C1
-councilor,councilor,市议员,NOUN,B2
-councils,councils,委员会,NOUN,C1
-counselor,counselor,词,NOUN,C1
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,面容,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
+to counter,to counter,反击,VERB,B2
 counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
 counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
 counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-form,counter-form,反式,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
 counter-image,counter-image,反象,NOUN,B2
 counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-logic,counter-logic,反逻,NOUN,B2
 counter-matter,counter-matter,反物,NOUN,B2
-counter-mechanism,counter-mechanism,反机,NOUN,B2
-counter-model,counter-model,反模,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-observation,counter-observation,反察,NOUN,B2
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quality,counter-quality,反质,NOUN,B2
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-route,counter-route,反途,NOUN,B2
 counter-segment,counter-segment,反段,NOUN,B2
-counter-skill,counter-skill,反技,NOUN,B2
-counter-sole,counter-sole,反唯,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
 counter-structure,counter-structure,反结,NOUN,B2
-counter-system,counter-system,反系,NOUN,B2
-counter-technique,counter-technique,反术,NOUN,B2
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-trend,counter-trend,反势,NOUN,B2
 counter-type,counter-type,反型,NOUN,B2
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counterargument,counterargument,反论点,NOUN,B2
 counterattack,counterattack,反击,NOUN,B2
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,逆流,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-counterfeit,counterfeit,假冒,ADJ,B2
-counterfeiting,counterfeiting,伪造,NOUN,B2
-countermeasure,countermeasure,反制,NOUN,C1
 counterpart,counterpart,对应的人或物,NOUN,B2
-counterproductive,counterproductive,适得其反的,ADJ,B2
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-counterweight,counterweight,词,NOUN,B2
 countess,countess,女伯爵,NOUN,B2
 countless,countless,无数的,ADJ,B2
-country land,country land,词,NOUN,A1
 county,county,县,NOUN,B2
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
-couplet,couplet,对联,NOUN,B2
-courageously,courageously,词,ADV,C1
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court clerk,court clerk,词,NOUN,C1
-court costs,court costs,词,NOUN,C1
 court dismissal,court dismissal,退朝,NOUN,B2
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
 courtyard,courtyard,庭院,NOUN,B2
 courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cousin female,cousin female,词,NOUN,B2
-cove,cove,小海湾,NOUN,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-cover-up,cover-up,词,NOUN,C1
 covetousness,covetousness,贪欲,NOUN,B2
-coward (adj),coward,词,ADJ,A2
 cowardice,cowardice,懦弱,NOUN,B2
 cowardly,cowardly,懦弱的,ADJ,B2
-coworker,coworker,同事,NOUN,B2
-cowpeas,cowpeas,词,NOUN,B2
-cracker,cracker,词,NOUN,B2
-cracking,cracking,词,NOUN,B2
+to crack,to crack,破裂,VERB,B2
 craftsmanship,craftsmanship,手工艺,NOUN,B2
 crafty,crafty,狡猾,ADJ,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crap,crap,屎,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-crass,crass,词,ADJ,B2
-cravenly,cravenly,词,ADV,C1
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-creamy,creamy,词,ADJ,C1
 creativity,creativity,创造力,NOUN,B2
 creator,creator,创造者,NOUN,B2
 credentials,credentials,国书,NOUN,B2
-credible,credible,词,ADJ,C1
 credit card,credit card,信用卡,NOUN,B2
 creditor,creditor,债权人,NOUN,B2
-creditor's right,creditor's right,债权,NOUN,B2
 creditor's rights,creditor's rights,债权,NOUN,B2
-credulity,credulity,轻信,NOUN,B2
-credulous,credulous,词,ADJ,B2
 creed,creed,信条,NOUN,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (noun),creep,令人厌恶的人,NOUN,B2
-cremation,cremation,词,NOUN,B2
-crescent,crescent,crescent,NOUN,B2
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
 crime scene,crime scene,犯罪现场,NOUN,B2
 criminal,criminal,犯罪的,ADJ,B2
-criminal (adj),criminal,刑事,ADJ,C1
-criminal law,criminal law,刑法,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
 criminality,criminality,犯罪,NOUN,B2
-criminalization,criminalization,词,NOUN,C1
-crimson,crimson,词,ADJ,C1
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisis-ridden,crisis-ridden,词,ADJ,C1
-criticizable,criticizable,词,ADJ,B2
-crochet,crochet,词,NOUN,C1
-crocodile,crocodile,词,NOUN,A1
-cronyism,cronyism,词,NOUN,C1
+to criminalize,to criminalize,定罪,VERB,B2
 cross,cross,十字架,NOUN,B2
-cross (noun),cross,十字架,NOUN,B1
-cross-border,cross-border,边境的,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
 crossing,crossing,交叉口,NOUN,B2
-crossing the border,crossing the border,词,NOUN,B2
 crossroads,crossroads,十字路口,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-crouch (noun),crouch,词,NOUN,B2
-croup,croup,词,NOUN,C1
-crowbar,crowbar,词,NOUN,B2
 crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-crucible,crucible,词,NOUN,B2
-crucifixion,crucifixion,词,NOUN,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruelly,cruelly,残酷地,ADV,B2
+to crown,to crown,加冕,VERB,B2
 cruelty,cruelty,残忍,NOUN,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crumb,crumb,词,NOUN,C1
-crumbs,crumbs,词,NOUN,B2
-crunching,crunching,词,NOUN,C1
-crunchy,crunchy,脆的,ADJ,B1
-crushing,crushing,词,NOUN,B2
-crushing defeat,crushing defeat,惨败,NOUN,B2
 crustacean,crustacean,甲壳类动物,NOUN,B2
-crusty,crusty,词,ADJ,B2
 crutch,crutch,拐杖,NOUN,B2
-cry weep,cry weep,词,VERB,A1
 crying,crying,,NOUN,B2
-crying shouting,crying shouting,词,NOUN,B1
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystal glass,crystal glass,词,NOUN,B1
-crystallization,crystallization,词,NOUN,C1
 cubism,cubism,立体主义,NOUN,B2
-cubit,cubit,词,NOUN,B2
 cucumber,cucumber,黄瓜,NOUN,B2
-cuddle (noun),cuddle,词,NOUN,C1
-culminating,culminating,词,ADJ,C1
-culmination,culmination,词,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-cultural relic,cultural relic,文物,NOUN,B2
-culturalism,culturalism,词,NOUN,C1
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cultured,cultured,词,ADJ,B2
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
 cunning,cunning,诡计,NOUN,B2
-cunning (adj),cunning,狡猾,ADJ,B1
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cunningly,cunningly,词,ADV,C1
-cupboard,cupboard,橱柜,NOUN,B2
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curative,curative,有疗效的,ADJ,B2
-curator,curator,策展人,NOUN,B2
-curatorship,curatorship,词,NOUN,C1
-curbing,curbing,遏制,NOUN,B2
-curd,curd,词,NOUN,B2
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
-curiously,curiously,词,ADV,C1
-curly,curly,卷曲的,ADJ,B2
-currant,currant,醋栗,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
 current,current,电流,NOUN,B2
-current (noun),current,电流,NOUN,A2
-current dynasty,current dynasty,当朝,NOUN,B2
-current events,current events,词,NOUN,B2
-current times,current times,词,NOUN,B2
 curriculum,curriculum,课程,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
 cursed,cursed,被诅咒的,ADJ,B2
-cursing,cursing,骂人,NOUN,C1
 curtain rod,curtain rod,窗帘杆,NOUN,B2
-curvature,curvature,词,NOUN,B2
-curved,curved,词,ADJ,B2
-cusp,cusp,词,NOUN,B2
-custodian,custodian,词,NOUN,B2
-customary,customary,习惯的,ADJ,B2
-customary law,customary law,词,NOUN,C1
-customer orientation,customer orientation,词,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
 customs,customs,海关,NOUN,B2
-customs (adj),customs,词,ADJ,C1
-customs officer,customs officer,海关官员,NOUN,B2
 cut,cut,切口,NOUN,B2
-cut (noun),cut,割伤,NOUN,A2
 cut off,cut off,割下,NOUN,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
+to cut off,to cut off,切断,VERB,B2
+to cut short,to cut short,截断,VERB,B2
 cutting,cutting,切割,NOUN,B2
 cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
 cyanosis,cyanosis,发绀,NOUN,B2
 cybersecurity,cybersecurity,网络安全,NOUN,B2
-cycle path,cycle path,自行车道,NOUN,B2
+to cycle,to cycle,骑自行车,VERB,B2
 cyclical,cyclical,周期的,ADJ,B2
-cycling,cycling,词,NOUN,C1
-cyclist,cyclist,骑自行车的人,NOUN,B2
 cyclone,cyclone,气旋,NOUN,B2
-cykel,cykel,词,NOUN,B2
-cylindrical,cylindrical,圆柱形的,ADJ,B2
 cymbal,cymbal,钹,NOUN,B2
-cynicism,cynicism,犬儒主义,NOUN,B2
-cyst,cyst,囊肿,NOUN,B2
-czech,czech,词,ADJ,B2
-dachshund,dachshund,词,NOUN,A1
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
 daddy,daddy,爸爸,NOUN,B2
-daft,daft,傻的,ADJ,B2
-daglig,daglig,词,ADJ,C1
 daily,daily,每天,ADV,B2
-daily (adv),daily,按天,ADV,C1
-daily (noun),daily,词,NOUN,B2
 daily increase,daily increase,日渐,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
 daily newspaper,daily newspaper,日报,NOUN,B2
-daily wage,daily wage,词,NOUN,C1
-dairy,dairy,词,ADJ,C1
-dal,dal,山谷,NOUN,B2
-damageable,damageable,易损的,ADJ,B2
-damages,damages,损害赔偿,NOUN,B2
-damaging,damaging,有害的,ADJ,B2
-damask,damask,词,NOUN,B2
-damm,damm,词,NOUN,B2
-damn,damn,该死,INTJ,B2
-damn (adj),damn,诅咒,ADJ,B2
-damn (adv),damn,该死的,ADV,B2
-damned,damned,词,ADJ,B2
-damping,damping,词,NOUN,C1
+to damage,to damage,损坏,VERB,B2
+to damn,to damn,诅咒,VERB,B2
 dance,dance,舞蹈,NOUN,B2
-dance (noun),dance,舞蹈,NOUN,A2
-dance floor,dance floor,词,NOUN,B2
-dandelion,dandelion,词,NOUN,B1
-dandruff,dandruff,词,NOUN,B2
-dangerousness,dangerousness,危险性,NOUN,B2
-danish,danish,丹麦的,ADJ,B2
-danmei,danmei,但没,NOUN,B2
-dans,dans,舞蹈,NOUN,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
 dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-daring bold,daring bold,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
-darkness of night,darkness of night,词,NOUN,C1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (intj),darn,哎呀,INTJ,B2
-dart (noun),dart,词,NOUN,B2
-dash (noun),dash,点跑,NOUN,C1
-dashboard,dashboard,仪表盘,NOUN,B2
-dashing,dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data leak,data leak,词,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-data protection,data protection,词,NOUN,B2
-databas,databas,数据库,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
 dating,dating,年代测定,NOUN,B2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dawning,dawning,破晓,NOUN,B2
 day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,后天,NOUN,B2
 day and night,day and night,昼夜,NOUN,B2
 day by day,day by day,日日,ADV,B2
 day laborer,day laborer,日工,NOUN,B2
-day off,day off,词,NOUN,B2
-day out,day out,词,NOUN,B2
-day school,day school,词,NOUN,C1
 day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daycare,daycare,托儿所,NOUN,B2
-daydream (noun),daydream,词,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daylight,daylight,日光,NOUN,B2
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
 dazzling,dazzling,耀眼的,ADJ,B2
-de facto,de facto,词,ADJ,C1
-de-escalation,de-escalation,词,NOUN,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
 dead end,dead end,死胡同,NOUN,B2
-dead person,dead person,词,NOUN,B1
-deadlock,deadlock,词,NOUN,C1
-deadly,deadly,致命地,ADV,B2
-deadly (adv),deadly,致命地,ADV,B2
-deaf person,deaf person,词,NOUN,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
-deals,deals,词,NOUN,C1
+to deal with,to deal with,处理,VERB,B2
 dean,dean,院长,NOUN,B2
-deanship,deanship,词,NOUN,C1
-dear,dear,,NOUN,B2
-dear (noun),dear,dear,NOUN,B2
-dearest,dearest,词,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
 death news,death news,死讯,NOUN,B2
 death penalty,death penalty,死刑,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
 death wish,death wish,找死,NOUN,B2
-deaths,deaths,词,NOUN,C1
-debasement,debasement,词,NOUN,C1
-debatable,debatable,有争议的,ADJ,B2
+to debate,to debate,辩论,VERB,B2
 debauchery,debauchery,放荡,NOUN,B2
-debility,debility,虚弱,NOUN,C1
-debris,debris,词,NOUN,B2
-debris rubble,debris rubble,词,NOUN,C1
 debtor,debtor,债务人,NOUN,B2
 debts,debts,债务,NOUN,B2
-decadence,decadence,衰落,NOUN,B2
-decadent,decadent,颓废,ADJ,B2
-decal,decal,贴花,NOUN,B2
-decalogue,decalogue,词,NOUN,B2
-deceased,deceased,已故的,ADJ,B2
-deceased (adj),deceased,已故的,ADJ,B2
-deceived,deceived,词,ADJ,A2
 december,december,十二月,NOUN,B2
 decency,decency,体面,NOUN,B2
 decentralization,decentralization,权力下放,NOUN,B2
-decentralized,decentralized,词,ADJ,C1
 deception dare,deception dare,你敢骗我,NOUN,B2
-decibel,decibel,分贝,NOUN,B2
-decidedly,decidedly,坚决地,ADV,B2
-decimal,decimal,小数,NOUN,B2
-decimal (adj),decimal,词,ADJ,C1
-deciphering,deciphering,词,NOUN,C1
 decision-maker,decision-maker,决策者,NOUN,B2
-decision-making,decision-making,决策,NOUN,B2
 decisive,decisive,决定性的,ADJ,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declamatory style,declamatory style,词,NOUN,C1
-declarant,declarant,词,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declension,declension,词,NOUN,C1
-declinable,declinable,可变格的,ADJ,B2
 decline,decline,衰退,NOUN,B2
-decline setting,decline setting,词,NOUN,C1
-decoding,decoding,词,NOUN,B2
-decommissioning,decommissioning,退役,NOUN,B2
-decompensation,decompensation,词,NOUN,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
 deconstruction,deconstruction,解构主义,NOUN,B2
-deconstructionist,deconstructionist,词,ADJ,C1
-decontamination,decontamination,去污,NOUN,B2
-decor,decor,布景,NOUN,B2
-decorated,decorated,词,ADJ,B1
-decorative,decorative,装饰性的,ADJ,B2
-decorous,decorous,词,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
 decrease,decrease,减少,NOUN,B2
-decreasing,decreasing,词,ADJ,B2
-decrepit,decrepit,词,ADJ,B2
+to decree,to decree,颁布法令,VERB,B2
 dedication,dedication,奉献,NOUN,B2
-deduct points,deduct points,扣分,VERB,C1
 deduction,deduction,扣除,NOUN,B2
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
 deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,词,ADV,B2
-defamatory,defamatory,词,ADJ,C1
-defamiliarization,defamiliarization,词,NOUN,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
+to defeat,to defeat,击败,VERB,B2
 defeatism,defeatism,失败主义,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
-defection,defection,词,NOUN,B2
-defective,defective,有缺陷的,ADJ,B2
-defectiveness,defectiveness,词,NOUN,C1
+to defect,to defect,叛变,VERB,B2
+to defect to the enemy,to defect to the enemy,投敌,VERB,B2
 defendant,defendant,被告,NOUN,B2
 defender,defender,防守者,NOUN,B2
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,词,ADJ,C1
-deference,deference,敬意,NOUN,B2
-deferential,deferential,词,ADJ,C1
 defiance,defiance,挑衅,NOUN,B2
 defiant,defiant,挑衅的,ADJ,B2
 deficiency,deficiency,缺乏,NOUN,B2
 deficient,deficient,有缺陷的,ADJ,B2
-deficitary,deficitary,词,ADJ,C1
-definable,definable,词,ADJ,C1
-definite,definite,明确的,ADJ,B2
 definitive,definitive,决定性的,ADJ,B2
-deflated,deflated,词,ADJ,B1
-deflationary,deflationary,词,ADJ,C1
 deformation,deformation,变形,NOUN,B2
-deformed,deformed,畸形的,ADJ,B2
-deformity,deformity,词,NOUN,C1
 degeneration,degeneration,退化,NOUN,B2
-degenerative,degenerative,退化的,ADJ,B2
 degradation,degradation,降级,NOUN,B2
-degrading,degrading,词,ADJ,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
 dehydration,dehydration,脱水,NOUN,B2
-dehydration dryness,dehydration dryness,词,NOUN,C1
-deification,deification,词,NOUN,C1
 deism,deism,自然神论,NOUN,B2
 deity,deity,神,NOUN,B2
 dejected,dejected,沮丧的,ADJ,B2
 dejection,dejection,沮丧,NOUN,B2
-dejt,dejt,约会,NOUN,B2
-del,del,词,NOUN,B2
-delayed,delayed,延误的,ADJ,B2
 delegate,delegate,代表,NOUN,B2
 delegation,delegation,代表团,NOUN,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
-deleterious,deleterious,词,ADJ,B2
-deletion,deletion,词,NOUN,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-deli meats,deli meats,词,NOUN,C1
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
+to deliberate,to deliberate,深思熟虑,VERB,B2
 deliberately,deliberately,故意地,ADV,B2
-deliberateness,deliberateness,词,NOUN,C1
 deliberation,deliberation,深思熟虑,NOUN,B2
-deliberations,deliberations,词,NOUN,C1
-deliberatively,deliberatively,词,ADV,C1
 delicacy,delicacy,美食,NOUN,B2
-delicately,delicately,巧妙地,ADV,B2
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delighted,delighted,高兴的,ADJ,B2
-delimitation,delimitation,词,NOUN,C1
 delinquent,delinquent,罪犯,NOUN,B2
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-delirious,delirious,谵妄的,ADJ,B2
 delirium,delirium,精神错乱,NOUN,B2
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delivery van,delivery van,厢式送货车,NOUN,B2
-delta,delta,delta,NOUN,B2
-deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
 delusion,delusion,幻想,NOUN,B2
-demagogic,demagogic,词,ADJ,C1
-demagogue,demagogue,词,NOUN,C1
 demagoguery,demagoguery,煽动性,NOUN,B2
-demagogy,demagogy,蛊惑,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
-demanding,demanding,要求高的,ADJ,B2
-demarcation,demarcation,划界,NOUN,B2
-demeanor,demeanor,仪态,NOUN,B2
-demented,demented,词,ADJ,C1
+to demand,to demand,要求,VERB,B2
 dementia,dementia,痴呆,NOUN,B2
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demijohn,demijohn,词,NOUN,B2
-demilitarization,demilitarization,去武,NOUN,B2
-democrat,democrat,民主主义者,NOUN,B2
 democratization,democratization,民主化,NOUN,B2
 demography,demography,人口学,NOUN,B2
 demolition,demolition,拆除,NOUN,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demonization,demonization,词,NOUN,C1
-demons,demons,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demonstrator,demonstrator,词,NOUN,C1
-demoralization,demoralization,词,NOUN,C1
-demotion,demotion,降职,NOUN,B2
-denial contradiction,denial contradiction,词,NOUN,C1
-denim jacket,denim jacket,词,NOUN,C1
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
 denotation,denotation,外延,NOUN,B2
 dense forest,dense forest,密林,NOUN,B2
-dental,dental,词,ADJ,C1
-dentition,dentition,牙齿,NOUN,B2
 denunciation,denunciation,告发,NOUN,B2
-deontology,deontology,词,NOUN,C1
-department director,department director,司长,NOUN,C1
-department head,department head,厅长,NOUN,B2
-department store,department store,百货商店,NOUN,B2
-departmental,departmental,词,ADJ,B2
 departure lounge,departure lounge,候机室,NOUN,B2
-dependence,dependence,依赖,NOUN,B2
-dependency,dependency,词,NOUN,B2
+to depend on,to depend on,依赖,VERB,B2
 dependent,dependent,依赖的,ADJ,B2
-dependent passivity,dependent passivity,词,NOUN,C1
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-depletion,depletion,词,NOUN,C1
-deplorable,deplorable,可悲的,ADJ,B2
-depopulation,depopulation,词,NOUN,B2
 deportation,deportation,驱逐出境,NOUN,B2
-deposed,deposed,词,ADJ,C1
-deposition,deposition,证词,NOUN,B2
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depot,depot,仓库,NOUN,B2
-depravity,depravity,堕落,NOUN,B2
-deprecation,deprecation,词,NOUN,C1
 depreciation,depreciation,贬值,NOUN,B2
-depredation,depredation,词,NOUN,C1
-depressing,depressing,词,ADJ,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
 deprivation,deprivation,剥夺,NOUN,B2
-deputation,deputation,代表团,NOUN,B2
 deputy,deputy,副的,ADJ,B2
 deputy,deputy,议员,NOUN,B2
-deputy (adj),deputy,副,ADJ,B2
-derailment,derailment,词,NOUN,C1
-derby,derby,词,NOUN,B2
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
-derivation,derivation,词,NOUN,C1
-dermal,dermal,词,ADJ,C1
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-desalination,desalination,词,NOUN,C1
-descend go down,descend go down,词,VERB,A1
-descendants,descendants,词,NOUN,C1
-descending,descending,词,ADJ,C1
 descent,descent,下降,NOUN,B2
-describable,describable,词,ADJ,C1
-descriptive,descriptive,描述性的,ADJ,B2
-descriptiveness,descriptiveness,词,NOUN,C1
-desecration,desecration,词,NOUN,C1
-deserter,deserter,词,NOUN,C1
 desertification,desertification,荒漠化,NOUN,B2
-desertion,desertion,逃亡,NOUN,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccation,desiccation,词,NOUN,C1
-designated driver,designated driver,代驾,NOUN,B2
 designation,designation,指定,NOUN,B2
 designer,designer,设计者,NOUN,B2
-desirability,desirability,可取性,NOUN,B2
-desirable,desirable,可取的,ADJ,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desirous,desirous,词,ADJ,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-desolation,desolation,荒凉,NOUN,B2
-desperately serious,desperately serious,不得了,ADJ,B2
+to desire,to desire,渴望,VERB,B2
 despicable,despicable,可鄙的,ADJ,B2
-despite,despite,虽有,NOUN,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despondency,despondency,词,NOUN,C1
-despotic,despotic,词,ADJ,C1
+to despise,to despise,鄙视,VERB,B2
 despotism,despotism,专制,NOUN,B2
-desquamation,desquamation,词,NOUN,C1
 destabilization,destabilization,动摇,NOUN,B2
-destined,destined,,NOUN,B2
-destitution,destitution,贫困,NOUN,B2
-destroy,destroy,毁掉,NOUN,B2
-destroyed,destroyed,词,ADJ,B2
-destroyer,destroyer,词,NOUN,C1
-destruction of property,destruction of property,毁坏财物,NOUN,C1
 destructive,destructive,مدمر,ADJ,B2
-detachable,detachable,词,ADJ,C1
-detached house,detached house,独栋房屋,NOUN,B2
 detachment,detachment,脱落,NOUN,B2
-details,details,细细,NOUN,C1
 detainee,detainee,被拘留者,NOUN,B2
-detection,detection,检测,NOUN,B2
-detective force,detective force,刑警,NOUN,B2
-detector,detector,词,NOUN,C1
 detente,detente,缓和,NOUN,B2
 detention,detention,拘留,NOUN,B2
-detention center,detention center,拘留所,NOUN,B2
-deteriorated,deteriorated,恶化的,ADJ,B2
-deterioration,deterioration,恶化,NOUN,B2
-determinant,determinant,词,NOUN,C1
 determination,determination,决心,NOUN,B2
-determine,determine,确定,VER! B,B2
-determined definite,determined definite,确定的,ADJ,B2
-determinist,determinist,词,ADJ,C1
 deterministic,deterministic,决定论的,ADJ,B2
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
 detestable,detestable,可恶的,ADJ,B2
 detonation,detonation,爆炸,NOUN,B2
-detractor,detractor,词,NOUN,C1
-detriment,detriment,损害,NOUN,B2
-detritus,detritus,词,NOUN,C1
-devaluation,devaluation,贬值,NOUN,B2
-devastated,devastated,词,ADJ,B2
-devastating,devastating,毁灭性的,ADJ,B2
 devastation,devastation,破坏,NOUN,B2
 developed,developed,发达的,ADJ,B2
 developer,developer,开发商,NOUN,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-deviance,deviance,词,NOUN,B2
 deviation,deviation,偏离,NOUN,B2
-device system,device system,词,NOUN,B1
-devices,devices,设备,NOUN,B2
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devilish,devilish,恶魔般的,ADJ,B2
-devious,devious,词,ADJ,B2
-devoid,devoid,词,ADJ,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolution,devolution,词,NOUN,C1
-devoted,devoted,尽心,ADV,B2
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devourer,devourer,吞噬者,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-devoutly,devoutly,词,ADV,C1
 dew,dew,露水,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
 diabetes,diabetes,糖尿病,NOUN,B2
-diabetic,diabetic,词,ADJ,C1
-diabolical,diabolical,恶魔般的,ADJ,B2
-diachrony,diachrony,词,NOUN,C1
-diaeresis,diaeresis,词,NOUN,C1
-diagonal,diagonal,对角线,NOUN,B2
-diagonally,diagonally,对角地,ADV,B2
-dial (noun),dial,词,NOUN,C1
-dialectic (adj),dialectic,词,ADJ,C1
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialectician,dialectician,词,NOUN,C1
-dialing code,dialing code,词,NOUN,C1
-dialogism,dialogism,词,NOUN,C1
-diameter,diameter,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
+to dialogue,to dialogue,对话,VERB,B2
 diaper,diaper,尿布,NOUN,B2
-diapers,diapers,词,NOUN,B1
-diaphanous,diaphanous,词,ADJ,C1
-diaphragm,diaphragm,横膈膜,NOUN,B2
 diarrhea,diarrhea,腹泻,NOUN,B2
 diaspora,diaspora,流散,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-diatribe,diatribe,词,NOUN,C1
-dictation,dictation,dictation,NOUN,B2
-dictator,dictator,独裁者,NOUN,B2
 dictatorship,dictatorship,独裁统治,NOUN,B2
-diction,diction,措辞,NOUN,B2
 dictionary,dictionary,词典,NOUN,B2
-didactic,didactic,教学的,ADJ,B2
-didactics,didactics,词,NOUN,C1
 die,die,骰子,NOUN,B2
-die (noun),die,骰子,NOUN,B2
-dietary,dietary,词,ADJ,C1
-different (adv),different,词,ADV,B2
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
+to die for,to die for,死要,VERB,B2
 differentiation,differentiation,区分,NOUN,B2
 difficult attack,difficult attack,难攻,NOUN,B2
-difficult flirt,difficult flirt,,NOUN,B2
-difficult problem,difficult problem,难题,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-diffuse,diffuse,模糊的,ADJ,B2
-diffusely,diffusely,词,ADV,C1
-diffusion,diffusion,传播,NOUN,B2
-diffusion spread,diffusion spread,词,NOUN,C1
-dig up,dig up,词,VERB,B2
-digestible,digestible,词,ADJ,C1
-digestion,digestion,消化,NOUN,B2
 digestive,digestive,消化的,ADJ,B2
 digging,digging,挖掘,NOUN,B2
 digit,digit,数字,NOUN,B2
-digital currency,digital currency,数字货币,NOUN,C1
-digitization,digitization,数字化,NOUN,B2
-digitized,digitized,词,ADJ,C1
-diglossia,diglossia,词,NOUN,C1
-dignified,dignified,词,ADJ,C1
 dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignitaries,dignitaries,词,NOUN,C1
-dignitary,dignitary,高官,NOUN,B2
-digression,digression,词,NOUN,C1
-dike,dike,词,NOUN,B2
-dilated,dilated,词,ADJ,C1
-dilation,dilation,扩张,NOUN,B2
-dilatory,dilatory,拖延的,ADJ,B2
 diligence,diligence,勤勉,NOUN,B2
-dilution,dilution,词,NOUN,C1
-dim sum,dim sum,点心,NOUN,B1
-diminutive,diminutive,指小词,NOUN,B2
-dimmed,dimmed,词,ADJ,C1
-dinghy,dinghy,词,NOUN,C1
-dining hall,dining hall,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
-diocesan,diocesan,词,ADJ,C1
-diocese,diocese,词,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diplomat,diplomat,词,NOUN,C1
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-dipsomaniac,dipsomaniac,词,NOUN,C1
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
+to direct,to direct,对准,VERB,B2
 direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directing,directing,导演,NOUN,B2
-direction sign,direction sign,指示牌,NOUN,B2
-directionality,directionality,词,NOUN,C1
 directive,directive,指令,NOUN,B2
-directive (adj),directive,词,ADJ,C1
 directly,directly,直接地,ADV,B2
-directness,directness,词,NOUN,C1
-director manager,director manager,主管/经理,NOUN,B2
-directorate,directorate,局,NOUN,C1
-directorship,directorship,董事职位,NOUN,B2
-directory,directory,词,NOUN,C1
-dirham,dirham,词,NOUN,A1
-dirt filth,dirt filth,词,NOUN,C1
-dirt soil,dirt soil,词,NOUN,A1
-dirtier,dirtier,词,ADJ,B2
-dirty bastard,dirty bastard,词,NOUN,C1
-dirty trick,dirty trick,词,NOUN,B2
 disability,disability,残疾,NOUN,B2
-disadvantaged,disadvantaged,词,ADJ,C1
-disadvantageous,disadvantageous,不利的,ADJ,B2
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disagreeing,disagreeing,不同意的,ADJ,B2
 disagreement,disagreement,不和,NOUN,B2
-disapproval,disapproval,词,NOUN,C1
-disarmament,disarmament,裁军,NOUN,B2
-disassembly,disassembly,词,NOUN,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disbursement,disbursement,词,NOUN,C1
-disc,disc,光盘,NOUN,B2
-discernment,discernment,洞察力,NOUN,B2
 discharge,discharge,放电,NOUN,B2
 disciple,disciple,门徒,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
 disciplinary,disciplinary,纪律的,ADJ,B2
-disciplined,disciplined,词,ADJ,C1
-disclosure,disclosure,泄露,NOUN,C1
-disco,disco,迪厅,NOUN,B2
-disconnection,disconnection,词,NOUN,C1
-disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
-disconsolation,disconsolation,词,NOUN,C1
-discontinuity,discontinuity,词,NOUN,B2
+to discipline,to discipline,管教,VERB,B2
 discordance,discordance,不一致,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discounts,discounts,折扣,NOUN,B2
-discouragement,discouragement,词,NOUN,C1
+to discourse,to discourse,论述,VERB,B2
 discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit,discredit,丧失信誉,NOUN,B2
-discrediting,discrediting,词,NOUN,C1
-discreetly,discreetly,词,ADV,B2
-discrete,discrete,词,ADJ,C1
 discretion,discretion,谨慎,NOUN,B2
-discretionary,discretionary,词,ADJ,C1
-discretionary punishment,discretionary punishment,词,NOUN,C1
-discursive,discursive,词,ADJ,C1
-disdainful,disdainful,词,ADJ,C1
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disembarkation,disembarkation,词,NOUN,C1
-disenchantment,disenchantment,幻灭,NOUN,B2
-disengagement,disengagement,词,NOUN,B2
-dish towel,dish towel,抹布,NOUN,B2
-disharmony,disharmony,不和谐,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-dishes,dishes,词,NOUN,C1
-disheveled,disheveled,蓬乱的,ADJ,B2
-dishonorable,dishonorable,词,ADJ,C1
-disillusionment,disillusionment,词,NOUN,C1
+to disguise,to disguise,伪装,VERB,B2
 disinfectant,disinfectant,消毒剂,NOUN,B2
-disinflation,disinflation,词,NOUN,B2
 disinformation,disinformation,虚假信息,NOUN,B2
-disinhibited,disinhibited,词,ADJ,C1
-disintegration,disintegration,词,NOUN,B2
-disinterested,disinterested,公正的,ADJ,B2
-disinvestment,disinvestment,词,NOUN,C1
-disjointed,disjointed,词,ADJ,C1
 disk,disk,唱片,NOUN,B2
-dislike,dislike,厌恶,NOUN,B2
 dislocation,dislocation,脱臼,NOUN,B2
-disloyal,disloyal,不忠的,ADJ,B2
-disloyalty,disloyalty,不忠,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
 dismantling,dismantling,拆除，瓦解,NOUN,B2
-dismay (noun),dismay,词,NOUN,C1
 dismissal,dismissal,解雇,NOUN,B2
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
 disobedience,disobedience,不服从,NOUN,B2
 disorderly,disorderly,杂乱的,ADJ,B2
-disorganization,disorganization,无组织,NOUN,B2
-disorientation,disorientation,迷失方向,NOUN,B2
-disoriented,disoriented,词,ADJ,C1
-disparagement,disparagement,词,NOUN,C1
 disparity,disparity,差异,NOUN,B2
-dispassionate,dispassionate,词,ADJ,C1
-dispatch,dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displaced person,displaced person,词,NOUN,C1
 displacement,displacement,位移,NOUN,B2
-displeased,displeased,词,ADJ,C1
+to display,to display,显示,VERB,B2
 displeasure,displeasure,不悦,NOUN,B2
 disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposed,disposed,词,ADJ,C1
-dispossessed,dispossessed,词,ADJ,C1
-disproportion,disproportion,不成比例,NOUN,B2
-disproportionate,disproportionate,词,ADJ,C1
-disputation,disputation,词,NOUN,C1
 dispute,dispute,争论,NOUN,B2
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
-disputed,disputed,有争议的,ADJ,B2
-disputed case,disputed case,词,NOUN,C1
-disqualification,disqualification,词,NOUN,C1
-disquisition,disquisition,论述,NOUN,B2
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfied,dissatisfied,不满的,ADJ,B2
-dissembling,dissembling,词,ADJ,C1
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
 dissertation,dissertation,论文,NOUN,B2
-dissident,dissident,异见者,NOUN,B2
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
 dissipation,dissipation,挥霍,NOUN,B2
-dissociation,dissociation,解离,NOUN,B2
-dissolution,dissolution,溶解,NOUN,B2
-dissonant,dissonant,词,ADJ,C1
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-distich,distich,词,NOUN,C1
-distillation,distillation,词,NOUN,C1
-distinctive,distinctive,词,ADJ,C1
-distinctly,distinctly,词,ADV,B2
-distinguishable,distinguishable,词,ADJ,C1
-distinguished,distinguished,杰出,ADJ,B2
 distorted,distorted,歪曲的,ADJ,B2
-distorted image,distorted image,扭曲的形象,NOUN,B2
 distortion,distortion,扭曲,NOUN,B2
-distressing,distressing,词,ADJ,B1
-distributed,distributed,词,ADJ,C1
-distributor,distributor,分销商,NOUN,B2
 district head,district head,区长,NOUN,B2
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
-distrustful,distrustful,词,ADJ,C1
 disturbance,disturbance,干扰,NOUN,B2
-dithyramb,dithyramb,词,NOUN,C1
 dive,dive,跳水,NOUN,B2
-dive (noun),dive,词,NOUN,B2
-dive appear,dive appear,词,VERB,B2
-diver,diver,词,NOUN,B2
-divergence,divergence,分歧,NOUN,B2
 divergent,divergent,分歧的,ADJ,B2
-diverging,diverging,词,ADJ,C1
-divestment,divestment,词,NOUN,C1
-divide cleavage,divide cleavage,词,NOUN,B2
-divider,divider,词,NOUN,C1
 divination,divination,占卜,NOUN,B2
-divinatory,divinatory,词,ADJ,C1
-divine,divine,如神,NOUN,B2
-divine (noun),divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
 diving,diving,潜水,NOUN,B2
-divinity,divinity,神性,NOUN,B2
-divisibility,divisibility,词,NOUN,C1
-divisible,divisible,词,ADJ,B2
-divisive,divisive,词,ADJ,C1
-divisor,divisor,词,NOUN,C1
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
+to divorce,to divorce,离婚,VERB,B2
 dizziness,dizziness,眩晕,NOUN,B2
-djellaba,djellaba,词,NOUN,B2
-do not,do not,莫,ADV,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not use,do not use,别用,NOUN,B2
-do not want,do not want,不想,VERB,B2
 do one's best,do one's best,尽力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-docilely,docilely,词,ADV,C1
 docility,docility,温顺,NOUN,B2
-doctor visit,doctor visit,,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
 doctorate,doctorate,博士学位,NOUN,B2
-doctrinaire,doctrinaire,教条主义的,ADJ,B2
+to document,to document,记录,VERB,B2
 documentary,documentary,纪录片的,ADJ,B2
-documentary (adj),documentary,纪录的,ADJ,B2
-documentation,documentation,文献,NOUN,B2
-documented,documented,词,ADJ,C1
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doggedly,doggedly,词,ADV,C1
 dogmatism,dogmatism,教条主义,NOUN,B2
-dollar,dollar,词,NOUN,C1
 dolphin,dolphin,海豚,NOUN,B2
 dome,dome,圆顶,NOUN,B2
-domestic,domestic,国内,NOUN,B2
-domestic (noun),domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
 domestic debt,domestic debt,内债,NOUN,B2
 domestic licensed goods,domestic licensed goods,国行,NOUN,B2
 domestication,domestication,驯化,NOUN,B2
-dominance,dominance,威权,NOUN,B2
-domineering,domineering,词,ADJ,C1
-domineeringness,domineeringness,支配欲,NOUN,B2
 don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
-donation of goods,donation of goods,捐物,NOUN,C1
 done,done,事已,NOUN,B2
-donkey foal,donkey foal,词,NOUN,B2
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door handle,door handle,门把手,NOUN,B2
-door lock,door lock,门锁,NOUN,C1
 doorbell,doorbell,门铃,NOUN,B2
-doorbell button,doorbell button,词,NOUN,B2
-doorkeeper,doorkeeper,词,NOUN,B1
 doorman,doorman,门卫,NOUN,B2
 doormat,doormat,门垫,NOUN,B2
-doorway,doorway,门口,NOUN,C1
-doping,doping,词,NOUN,C1
-doping agents,doping agents,词,NOUN,B2
 dormitory,dormitory,宿舍,NOUN,B2
 dosage,dosage,剂量,NOUN,B2
-dossier,dossier,档案,NOUN,B2
-dotting,dotting,词,NOUN,C1
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
+to double,to double,加倍,VERB,B2
 doubling,doubling,加倍,NOUN,B2
-doubtful,doubtful,可疑的,ADJ,B2
+to doubt,to doubt,怀疑,VERB,B2
 dough,dough,面团,NOUN,B2
-doughy,doughy,词,ADJ,B2
 down,down,顺...而下,ADP,B2
-down (adp),down,下,ADP,B2
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downfall,downfall,毁灭,NOUN,B2
 download,download,下载,NOUN,B2
-downplaying,downplaying,词,NOUN,C1
+to download,to download,下载,VERB,B2
 downpour,downpour,倾盆大雨,NOUN,B2
-downright,downright,词,ADV,B1
-downstairs,downstairs,词,ADV,B1
 downstream,downstream,下游,NOUN,B2
 downwards,downwards,向下,ADV,B2
-dowry,dowry,嫁妆,NOUN,B2
-doze (noun),doze,词,NOUN,C1
-doze off,doze off,词,VERB,B2
-dozens,dozens,数十个,NOUN,B2
-draconian,draconian,词,ADJ,C1
-draftsman,draftsman,绘图员,NOUN,B2
 drag,drag,拖曳,NOUN,B2
-drag (noun),drag,拖曳,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-drainage,drainage,词,NOUN,C1
-drainage sewage,drainage sewage,词,NOUN,C1
-dramatization,dramatization,词,NOUN,C1
 dramaturgy,dramaturgy,戏剧艺术,NOUN,B2
-drastic,drastic,词,ADJ,C1
-draw,draw,平局,NOUN,B2
-draw (noun),draw,平局,NOUN,B2
-draw out,draw out,引出,NOUN,B2
 dread,dread,恐惧,NOUN,B2
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge (noun),dredge,词,NOUN,B2
 dregs,dregs,渣滓,NOUN,B2
-dressed,dressed,穿着的,ADJ,B2
-dressing room,dressing room,词,NOUN,B2
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
-dried tofu,dried tofu,豆干,NOUN,B2
+to dress,to dress,给...穿衣,VERB,B2
+to dress up,to dress up,盛装打扮,VERB,B2
 drift,drift,漂移,NOUN,B2
-drift (noun),drift,漂流,NOUN,C1
-drift excess,drift excess,词,NOUN,C1
-drifting,drifting,漂泊,NOUN,B2
-drink (noun),drink,饮料,NOUN,A2
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinking water,drinking water,饮用水,NOUN,B2
-drinks,drinks,词,NOUN,C1
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-drive (noun),drive,动力,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-driven,driven,被驾驶的,ADJ,B2
+to drink a toast,to drink a toast,干杯,VERB,B2
 driver's license,driver's license,驾驶证,NOUN,B2
-driving,driving,你来驾车,NOUN,C1
-drizzly,drizzly,词,ADJ,C1
-drool,drool,口水,NOUN,B2
 drop,drop,滴,NOUN,B2
-drop (noun),drop,掉付,NOUN,B1
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
-dropper,dropper,词,NOUN,C1
-droppings,droppings,粪便,NOUN,B2
-drops,drops,词,NOUN,B1
-drowning,drowning,词,NOUN,C1
 drowsiness,drowsiness,昏睡,NOUN,B2
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drug medication,drug medication,词,NOUN,C1
 drugs,drugs,毒品,NOUN,B2
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
 drunkenness,drunkenness,醉酒,NOUN,B2
-dry cleaner,dry cleaner,词,NOUN,A2
-dry land,dry land,词,NOUN,B2
-dry sausage,dry sausage,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-dual form,dual form,词,NOUN,C1
+to dry,to dry,弄干,VERB,B2
+to dry in the sun,to dry in the sun,晾晒,VERB,B2
 duality,duality,二元性,NOUN,B2
 dubbing,dubbing,配音,NOUN,B2
-duchess,duchess,公爵夫人,NOUN,B2
-duct pipe,duct pipe,词,NOUN,B2
-ductile,ductile,词,ADJ,C1
-due date maturity,due date maturity,词,NOUN,B2
 due to,due to,由于,ADP,B2
-duet,duet,二重奏,NOUN,B2
-dull-witted,dull-witted,词,ADJ,B2
 dullness,dullness,迟钝,NOUN,B2
-duly,duly,词,ADV,C1
-dump site,dump site,词,NOUN,B2
-dumping,dumping,倾销,NOUN,B2
-dumpling,dumpling,丸子,NOUN,B2
-dune,dune,沙丘,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicate,duplicate,! 副本,NOUN,B2
-duplicate (noun),duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
-duplicity,duplicity,口是心非,NOUN,B2
 durability,durability,耐用性,NOUN,B2
-durian,durian,榴莲,NOUN,C1
 during the day,during the day,在白天,ADV,B2
 dusk,dusk,黄昏,NOUN,B2
-dust coat,dust coat,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
 dutch,dutch,荷兰的,ADJ,B2
-dutch (noun),dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty of care,duty of care,词,NOUN,C1
-duty of confidentiality,duty of confidentiality,词,NOUN,B2
-duvet,duvet,羽绒被,NOUN,B2
-dwindling,dwindling,词,NOUN,C1
-dyed,dyed,词,ADJ,B1
-dying,dying,垂死的,ADJ,B2
-dying (noun),dying,dying,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamics,dynamics,词,NOUN,C1
-dynamism,dynamism,活力,NOUN,B2
 dynasty,dynasty,王朝,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
-e-reader,e-reader,电子阅读器,NOUN,B2
 each,each,每个,PRON,B2
-each (noun),each,一一,NOUN,C1
-each (pron),each,各自,PRON,B2
-each every,each every,每,DET,A1
-each one,each one,词,PRON,B2
 each other,each other,互相,PRON,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-eagerness,eagerness,词,NOUN,B2
 eagle,eagle,鹰,NOUN,B2
 earlier,earlier,刚才,ADV,B2
-earlier (adj),earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
 early,early,早,ADV,B2
-early (adv),early,提早,ADV,A1
-early (noun),early,词,NOUN,B2
 early morning,early morning,凌晨,NOUN,B2
-early morning (adv),early morning,词,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-early warning,early warning,预警,NOUN,B2
-earnest,earnest,词,ADJ,B1
 earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears,ears,耳朵,NOUN,B2
-ears of wheat,ears of wheat,词,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easier,easier,词,ADJ,B2
-easily,easily,词,ADV,B2
-easing,easing,词,NOUN,C1
+to earnestly request,to earnestly request,恳请,VERB,B2
 east,east,东方,NOUN,B2
-east bank,east bank,东岸,NOUN,C1
-eastern,eastern,东方的,ADJ,B2
-eastward,eastward,词,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
-easy to say,easy to say,好说,NOUN,B2
-eating,eating,,NOUN,B2
-eating habit,eating habit,词,NOUN,C1
 eavesdrop,eavesdrop,营听,NOUN,B2
 eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb tide,ebb tide,词,NOUN,B1
 eccentric,eccentric,古怪的,ADJ,B2
-eccentric person,eccentric person,词,NOUN,C1
-eccentricity,eccentricity,古怪,NOUN,B2
-ecclesial,ecclesial,词,ADJ,C1
 ecclesiastical,ecclesiastical,教会的,ADJ,B2
-echoes,echoes,词,NOUN,C1
-eclectic,eclectic,词,ADJ,C1
-eclecticism,eclecticism,折衷主义,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-economic climate,economic climate,词,NOUN,B2
-economic cycle,economic cycle,词,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economical,economical,词,ADJ,A1
-economically,economically,词,ADV,B1
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eczema,eczema,湿疹,NOUN,B2
-eddy,eddy,词,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edging,edging,镶边,NOUN,B2
 edict,edict,法令,NOUN,B2
-edifying,edifying,词,ADJ,C1
-edit,edit,重辑,NOUN,B2
 editing,editing,剪辑,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
 editorial,editorial,社论,NOUN,B2
-editorial office,editorial office,词,NOUN,B2
 educated,educated,受过教育的,ADJ,B2
-educational,educational,教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
 eeg,eeg,脑电图,NOUN,B2
-effect and traces,effect and traces,词,NOUN,C1
-effect-seeking,effect-seeking,词,NOUN,C1
-effectively,effectively,有效地,ADV,B2
 effectiveness,effectiveness,功效,NOUN,B2
-effects,effects,词,NOUN,B2
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,词,ADJ,C1
 efficacy,efficacy,功效,NOUN,B2
-effigy,effigy,词,NOUN,C1
-effort bet,effort bet,努力/赌注,NOUN,B2
-effortless,effortless,不费力的,ADJ,B2
-egalitarian,egalitarian,平等主义的,ADJ,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-egg-laying,egg-laying,词,NOUN,B2
 eggplant,eggplant,茄子,NOUN,B2
-ego,ego,词,NOUN,C1
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egyptian,egyptian,埃及的,ADJ,B2
-eh,eh,词,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eight (noun),eight,词,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-eighteen,eighteen,十八,NUM,B2
-eighth,eighth,第八,ADJ,B2
-eighty,eighty,八十,NUM,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
-either (adv),either,词,ADV,B2
-ejection,ejection,喷射,NOUN,B2
-elaboration,elaboration,词,NOUN,C1
+to elaborate,to elaborate,制定,VERB,B2
 elasticity,elasticity,弹性,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
 elderly,elderly,老年人,NOUN,B2
-elderly (noun),elderly,老弱,NOUN,B2
-eldest,eldest,词,ADJ,A2
 eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-eldest son,eldest son,长子,NOUN,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective,elective,词,ADJ,C1
 elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
 electorate,electorate,选民,NOUN,B2
-electric (noun),electric,词,NOUN,B2
-electric guitar,electric guitar,词,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electric power,electric power,电力,NOUN,B2
-electrical engineering,electrical engineering,词,NOUN,C1
-electrical theory,electrical theory,词,NOUN,B2
 electrician,electrician,电工,NOUN,B2
-electrification,electrification,词,NOUN,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
-electronic payment,electronic payment,电子支付,NOUN,B2
-elegance,elegance,词,NOUN,C1
-elegy,elegy,挽歌,NOUN,B2
-elemental,elemental,词,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
 elephant,elephant,大象,NOUN,B2
-elevated,elevated,词,ADJ,C1
 elevation,elevation,提升,NOUN,B2
 eleven,eleven,十一,NUM,B2
-eleven (noun),eleven,词,NOUN,B2
-eleventh,eleventh,词,NUM,B1
-elf,elf,词,NOUN,C1
 elimination,elimination,消除,NOUN,B2
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,词,NOUN,C1
-ellipsis,ellipsis,省略,NOUN,B2
-ellipsis (part),ellipsis,…,PART,C1
-elocution,elocution,演讲术,NOUN,B2
 eloquence,eloquence,口才,NOUN,B2
 eloquent,eloquent,雄辩的,ADJ,B2
-elsewhere,elsewhere,别处,ADV,B2
-elucidation,elucidation,词,NOUN,C1
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciated,emaciated,词,ADJ,C1
-emaciating,emaciating,消耗的,ADJ,B2
-emaciation,emaciation,词,NOUN,C1
-email address,email address,电子邮件地址,NOUN,B2
 emanation,emanation,散发物,NOUN,B2
-emancipation,emancipation,解放,NOUN,B2
-embalm,embalm,词,VERB,C1
-embers,embers,词,NOUN,B1
-emblem,emblem,徽章,NOUN,B2
-emblematic,emblematic,象征性的,ADJ,B2
-embodiment,embodiment,词,NOUN,B2
-embolism,embolism,栓塞,NOUN,B2
 embrace,embrace,拥抱,NOUN,B2
-embrace (noun),embrace,搂,NOUN,B2
-embrace each other,embrace each other,词,VERB,B2
-embryo,embryo,胚胎,NOUN,B2
-embryonic,embryonic,词,ADJ,C1
 emergence,emergence,涌现,NOUN,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
 emergency room,emergency room,急诊室,NOUN,B2
-emigration,emigration,移民,NOUN,B2
-eminence,eminence,词,NOUN,C1
-eminent,eminent,杰出的,ADJ,B2
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emitter,emitter,词,NOUN,C1
-emolument,emolument,词,NOUN,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
-emotional life,emotional life,词,NOUN,B2
 emotionality,emotionality,感性/情绪化,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emotionally,emotionally,情感上,ADV,B2
-empathetic,empathetic,词,ADJ,B1
 emperor,emperor,皇帝,NOUN,B2
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-emphatically,emphatically,词,ADV,C1
-empirically,empirically,凭经验地,ADV,B2
 empiricism,empiricism,经验主义,NOUN,B2
-employability,employability,词,NOUN,B2
-employers,employers,词,NOUN,B1
-emporium,emporium,词,NOUN,C1
-empowerment,empowerment,词,NOUN,C1
 empress,empress,女皇,NOUN,B2
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
 emptiness,emptiness,空虚,NOUN,B2
-empty fame,empty fame,虚名,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-emulation,emulation,模仿,NOUN,B2
-emulator,emulator,词,NOUN,C1
-emulsion,emulsion,词,NOUN,C1
-enamel (verb),enamel,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encampments,encampments,词,NOUN,C1
-encephalic,encephalic,词,ADJ,C1
-enchanting,enchanting,迷人的,ADJ,B2
 encirclement,encirclement,环绕,NOUN,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encoding,encoding,编码,NOUN,C1
 encounter,encounter,相遇,NOUN,B2
-encounter (noun),encounter,遇上,NOUN,B2
-encouraging,encouraging,词,ADJ,C1
-encroachment,encroachment,词,NOUN,C1
-encrypted,encrypted,词,ADJ,B2
 encyclopedia,encyclopedia,百科全书,NOUN,B2
 encyclopedic,encyclopedic,百科全书式的,ADJ,B2
 end,end,端,PART,B2
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
-endeavor (noun),endeavor,词,NOUN,B2
-endemic,endemic,地方性的,ADJ,B2
-endemic disease,endemic disease,词,NOUN,B2
-ending,ending,了头,NOUN,C1
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,词,ADJ,C1
+to end up,to end up,最终到达,VERB,B2
 endorsement,endorsement,背书,NOUN,B2
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowed,endowed,有天赋的,ADJ,B2
-endowment,endowment,配备,NOUN,B2
 endurance,endurance,坚忍,NOUN,B2
-enduring hardship,enduring hardship,词,NOUN,C1
-enemy army,enemy army,敌军,NOUN,C1
-enemy must,enemy must,仇必,NOUN,B2
-enemy of the state,enemy of the state,词,NOUN,C1
 enemy state,enemy state,敌国,NOUN,B2
-energy crisis,energy crisis,能源危机,NOUN,B2
 energy saving,energy saving,节能,NOUN,B2
-enfeoffment,enfeoffment,封王,NOUN,C1
-enforceability,enforceability,词,NOUN,C1
 enforcement,enforcement,执行,NOUN,B2
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-engine motor,engine motor,词,NOUN,C1
+to engage in,to engage in,从事,VERB,B2
 english,english,英国的,ADJ,B2
 english,english,英语,NOUN,B2
-english teacher,english teacher,,NOUN,B2
-english-speaking,english-speaking,讲英语的,ADJ,B2
-englishman,englishman,英国人,NOUN,B2
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
 engraving,engraving,版画,NOUN,B2
-engrossing,engrossing,词,ADJ,B2
-enjambment,enjambment,词,NOUN,C1
-enjoyable,enjoyable,词,ADJ,B1
-enjoyed,enjoyed,词,ADJ,C1
-enjoyment,enjoyment,享受,NOUN,B2
-enlargement,enlargement,词,NOUN,C1
 enlightened,enlightened,开明的,ADJ,B2
-enlightening,enlightening,词,ADJ,C1
 enlightenment,enlightenment,澄清,NOUN,B2
-enlistment,enlistment,入伍,NOUN,C1
 enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
 enough,enough,足够,ADV,B2
-enough (adv),enough,词,ADV,B2
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enraged,enraged,词,ADJ,C1
-enriching,enriching,词,ADJ,C1
 enrichment,enrichment,丰富,NOUN,B2
-enrolled,enrolled,词,ADJ,B2
-enrollment,enrollment,注册,NOUN,B2
-enshrinement,enshrinement,词,NOUN,C1
-ensign,ensign,词,NOUN,C1
-enslavement,enslavement,奴役,NOUN,B2
-enslavement by love,enslavement by love,词,NOUN,C1
-entail strenuous effort,entail strenuous effort,吃力,NOUN,B2
-entanglement,entanglement,缠,NOUN,C1
-entelechy,entelechy,词,NOUN,C1
-entering city,entering city,入城,NOUN,C1
 entering home,entering home,进家,NOUN,B2
 enterprise,enterprise,企业,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertainer,entertainer,词,NOUN,B2
-entertainment center,entertainment center,娱乐中心,NOUN,B2
 enthronement,enthronement,登基,NOUN,B2
 enthusiasm,enthusiasm,热情,NOUN,B2
 enthusiast,enthusiast,爱好者,NOUN,B2
-enticement,enticement,词,NOUN,C1
 entirety,entirety,全部,NOUN,B2
-entitled to exist,entitled to exist,词,ADJ,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
 entity,entity,实体,NOUN,B2
-entomology,entomology,词,NOUN,C1
 entourage,entourage,随从,NOUN,B2
-entrails,entrails,内脏,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrapment,entrapment,身陷,NOUN,B2
-entrenchment,entrenchment,词,NOUN,C1
-entropy,entropy,熵,NOUN,B2
-enumeration,enumeration,列举,NOUN,B2
 enunciation,enunciation,发音,NOUN,B2
-enunciative,enunciative,词,ADJ,C1
-enviable,enviable,令人羡慕的,ADJ,B2
-envious jealous,envious jealous,词,ADJ,B2
 environmental,environmental,环境的,ADJ,B2
 environmental protection,environmental protection,环境保护,NOUN,B2
-environmental report,environmental report,环境报告,NOUN,B2
 environmental technology,environmental technology,环保技术,NOUN,B2
-envoy,envoy,词,NOUN,B2
-enwetens,enwetens,词,ADV,C1
+to envy,to envy,羡慕,VERB,B2
 enzyme,enzyme,酶,NOUN,B2
-eon age,eon age,词,NOUN,C1
-epic,epic,史诗的,ADJ,B2
-epic (adj),epic,史诗的,ADJ,C1
-epic quality,epic quality,词,NOUN,C1
 epicurean,epicurean,享乐主义的,ADJ,B2
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epilepsy,epilepsy,词,NOUN,C1
-epilogue,epilogue,词,NOUN,C1
-episodic,episodic,词,ADJ,C1
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,墓志铭,NOUN,B2
-epithet,epithet,绰号,NOUN,B2
 epitome,epitome,化身,NOUN,B2
-epoch,epoch,时代,NOUN,B2
-eponymous,eponymous,词,ADJ,C1
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally,equally,词,ADV,B2
+to equal,to equal,无异,VERB,B2
 equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equatorial,equatorial,词,ADJ,C1
-equestrian,equestrian,马术的,ADJ,B2
 equestrianism,equestrianism,马术,NOUN,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,词,ADJ,C1
 equipped,equipped,配备的,ADJ,B2
 equivalent,equivalent,相等的,ADJ,B2
-equivalent (noun),equivalent,equivalent,NOUN,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
 eradication,eradication,根除,NOUN,B2
 eraser,eraser,橡皮擦,NOUN,B2
 erasure,erasure,擦除,NOUN,B2
-erection,erection,词,NOUN,C1
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergestaltung,ergestaltung,词,NOUN,C1
-ergonomics,ergonomics,词,NOUN,C1
 erhu,erhu,二胡,NOUN,B2
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
 erosion,erosion,侵蚀,NOUN,B2
-erotic,erotic,色情的,ADJ,B2
-eroticism,eroticism,色情,NOUN,B2
-erpflegung,erpflegung,词,NOUN,C1
-errata,errata,勘误,NOUN,B2
-erregelung,erregelung,词,NOUN,C1
-erroneous,erroneous,词,ADJ,C1
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
 erudite,erudite,博学的,ADJ,B2
-erudition,erudition,博学,NOUN,B2
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
 escalation,escalation,升级,NOUN,B2
 escape,escape,逃跑,NOUN,B2
-escape (noun),escape,脱不,NOUN,B1
-escaping,escaping,词,NOUN,C1
-eschatological,eschatological,词,ADJ,C1
-eschatology,eschatology,词,NOUN,C1
 escort,escort,护卫,NOUN,B2
-escort (noun),escort,你带人,NOUN,B2
-escort agency,escort agency,镖局,NOUN,B2
 escort guard,escort guard,镖师,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-esophagus,esophagus,词,NOUN,B2
-esoteric,esoteric,词,ADJ,C1
-esotericism,esotericism,词,NOUN,B2
-espresso,espresso,词,NOUN,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-essayistic quality,essayistic quality,词,NOUN,C1
-essence core,essence core,词,NOUN,B2
-essential equipment,essential equipment,要置,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
 essentially,essentially,主要地,ADV,B2
-establishment,establishment,机构,NOUN,B2
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-estimation,estimation,词,NOUN,C1
+to estimate,to estimate,估计,VERB,B2
 estrangement,estrangement,疏离,NOUN,B2
 estuary,estuary,河口,NOUN,B2
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-eternal alliance,eternal alliance,永结,NOUN,B2
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
-ethereum,ethereum,以太坊,NOUN,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
 ethnicity,ethnicity,种族,NOUN,B2
 ethnography,ethnography,人种学,NOUN,B2
 ethnology,ethnology,民族学,NOUN,B2
-etymology,etymology,词源学,NOUN,B2
 eulogy,eulogy,赞辞,NOUN,B2
-eunuch,eunuch,词,NOUN,C1
-euphemistic,euphemistic,词,ADJ,B2
-euphonic,euphonic,词,ADJ,C1
-euphoric,euphoric,词,ADJ,C1
-europe,europe,欧洲,PROPN,B2
 european,european,欧洲的,ADJ,B2
-euthanasia,euthanasia,词,NOUN,C1
 evacuation,evacuation,疏散,NOUN,B2
-evangelical,evangelical,词,ADJ,C1
-evangelist,evangelist,词,NOUN,C1
-evangelization,evangelization,词,NOUN,C1
-evaporating,evaporating,词,ADJ,C1
 evaporation,evaporation,蒸发,NOUN,B2
 evasion,evasion,逃避,NOUN,B2
 evasive,evasive,回避的,ADJ,B2
-eve,eve,前夕,NOUN,C1
 even,even,偶数的,ADJ,B2
-even (adj),even,均匀,ADJ,B2
 even if,even if,即使,SCONJ,B2
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening meal,evening meal,晚餐,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-evenly,evenly,均匀地,ADV,B2
-events,events,事件,NOUN,C1
-eventual outcome,eventual outcome,词,NOUN,C1
-ever,ever,,NOUN,B2
-ever (noun),ever,ever,NOUN,B2
-everlasting,everlasting,词,ADJ,C1
-everlastingness,everlastingness,词,NOUN,C1
-every,every,每个,PRON,B2
-every (pron),every,每个,PRON,B2
-every day,every day,天天,ADV,B2
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
-every time,every time,每次,NOUN,C1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
-everydayness,everydayness,词,NOUN,B2
 everyone,everyone,各位,NOUN,B2
-everyone (noun),everyone,人人,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
 eviction,eviction,驱逐,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
 evil,evil,恶行,NOUN,B2
-evil (adj),evil,词,ADJ,B1
-evil (part),evil,邪,PART,B2
-evil move,evil move,邪招,NOUN,C1
-evocation,evocation,唤起,NOUN,B2
-evolutionary,evolutionary,词,ADJ,C1
 exacerbation,exacerbation,加剧,NOUN,B2
-exact change,exact change,词,NOUN,C1
-exactitude,exactitude,词,NOUN,C1
-exactly just,exactly just,词,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exactness,exactness,精确,NOUN,B2
-exaggerated,exaggerated,夸张的,ADJ,B2
 exaggeration,exaggeration,夸张,NOUN,B2
-exaltation,exaltation,词,NOUN,C1
-exalted,exalted,狂热的,ADJ,B2
-exam evening,exam evening,词,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
 examination,examination,考试,NOUN,B2
 exasperation,exasperation,恼怒,NOUN,B2
-excavated,excavated,词,ADJ,B1
-excavation,excavation,词,NOUN,B2
-excavator,excavator,挖掘机,NOUN,B2
 excellence,excellence,卓越,NOUN,B2
-except for,except for,除了,ADP,B2
-except unless,except unless,词,ADP,A2
-exceptionality,exceptionality,特殊性,NOUN,B2
-exceptionally,exceptionally,词,ADV,B2
 excess,excess,过量,NOUN,B2
-excess weight,excess weight,词,NOUN,C1
-excessively,excessively,词,ADV,C1
-excessiveness,excessiveness,词,NOUN,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
+to exchange,to exchange,交换,VERB,B2
 exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excision,excision,词,NOUN,C1
-excitability,excitability,兴奋性,NOUN,B2
 exclamation,exclamation,感叹,NOUN,B2
-exclamation (punct),exclamation,词,PUNCT,A2
 excluded,excluded,排除在外的,ADJ,B2
 exclusion,exclusion,排除,NOUN,B2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusive dedication,exclusive dedication,词,NOUN,C1
 exclusively,exclusively,专门地,ADV,B2
-exclusivism,exclusivism,词,NOUN,C1
 exclusivity,exclusivity,排他性,NOUN,B2
 excommunication,excommunication,绝罚,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
 excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,开脱,NOUN,B2
-excursion,excursion,郊游,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executioner,executioner,刽子手,NOUN,B2
-executive board,executive board,词,NOUN,C1
+to excuse,to excuse,原谅,VERB,B2
 executor,executor,遗嘱执行人,NOUN,B2
-executory,executory,词,ADJ,C1
-exegesis,exegesis,注释,NOUN,B2
-exegete,exegete,注释家,NOUN,B2
-exemplar,exemplar,楷模,NOUN,C1
-exemplary country,exemplary country,模范国家,NOUN,B2
 exemption,exemption,豁免,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercise book,exercise book,词,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exercises,exercises,词,NOUN,B2
-exhalation,exhalation,词,NOUN,C1
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhausting,exhausting,词,ADJ,B2
 exhaustion,exhaustion,疲惫,NOUN,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhortation,exhortation,词,NOUN,C1
-exhumation,exhumation,词,NOUN,C1
-exile,exile,流亡,NOUN,B2
-exiled,exiled,词,ADJ,C1
 existentialism,existentialism,存在主义,NOUN,B2
-existing,existing,现有的,ADJ,B2
-exit (verb),exit,词,VERB,A1
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,词,ADJ,C1
-exorcism,exorcism,词,NOUN,C1
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,词,ADJ,B2
-exoticism,exoticism,词,NOUN,B2
-expanse,expanse,词,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expansive,expansive,扩张的,ADJ,B2
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,迅速的,ADJ,B2
-expenditures,expenditures,支出,NOUN,C1
 expenses,expenses,费用,NOUN,B2
-expensiveness,expensiveness,词,NOUN,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experienced,experienced,老练的,ADJ,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
 experimental,experimental,实验的,ADJ,B2
-experimentation,experimentation,词,NOUN,C1
-expert opinion,expert opinion,词,NOUN,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiration,expiration,词,NOUN,C1
 expiry,expiry,失效,NOUN,B2
-explanatory,explanatory,解释的,ADJ,B2
-expletive,expletive,词,NOUN,C1
-explicable,explicable,可解释的,ADJ,B2
-explicitly,explicitly,明确地,ADV,B2
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
 exploitation,exploitation,利用,NOUN,B2
-exploits,exploits,词,NOUN,C1
-exploration,exploration,探索,NOUN,B2
-exploratory,exploratory,词,ADJ,C1
 explosion-proof,explosion-proof,防爆,ADJ,B2
 explosive,explosive,炸药,NOUN,B2
-explosive (noun),explosive,词,NOUN,B2
-explosives,explosives,炸药,NOUN,B2
 exponent,exponent,指数,NOUN,B2
-exponential,exponential,指数的,ADJ,B2
 export,export,出口,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exports,exports,词,NOUN,C1
-express,express,明确的,ADJ,B2
-express (adj),express,明确的,ADJ,C1
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expression of opinion,expression of opinion,词,NOUN,B2
-expressionism,expressionism,词,NOUN,C1
-expressiveness,expressiveness,表现力,NOUN,B2
 expressly,expressly,明确地,ADV,B2
-expropriation,expropriation,征用,NOUN,B2
-expulsion,expulsion,驱逐,NOUN,B2
-exquisiteness,exquisiteness,词,NOUN,C1
-extended,extended,广泛的,ADJ,B2
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
 extensive,extensive,广泛的,ADJ,B2
 exterior,exterior,有外,NOUN,B2
 extermination,extermination,灭绝,NOUN,B2
 external hard drive,external hard drive,移动硬盘,NOUN,B2
 extinction,extinction,灭绝,NOUN,B2
-extinguishable,extinguishable,词,ADJ,C1
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extirpation,extirpation,词,NOUN,C1
-extolling,extolling,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
+to extort a bribe,to extort a bribe,索贿,VERB,B2
 extortion,extortion,勒索,NOUN,B2
 extra,extra,群众演员,NOUN,B2
-extra (adv),extra,词,ADV,A1
-extra (noun),extra,群众演员,NOUN,B2
-extra drink,extra drink,多喝,NOUN,C1
-extract,extract,摘录,NOUN,B2
 extraction,extraction,提取,NOUN,B2
-extramarital,extramarital,词,ADJ,C1
-extrapolation,extrapolation,词,NOUN,C1
 extravagance,extravagance,奢侈,NOUN,B2
-extraversion,extraversion,词,NOUN,C1
 extreme,extreme,أقصى,NOUN,B2
-extreme (noun),extreme,至极,NOUN,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremist,extremist,极端主义者,NOUN,B2
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
 extroversion,extroversion,外向,NOUN,B2
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-exuberance,exuberance,词,NOUN,C1
-exuberant,exuberant,繁茂的,ADJ,B2
-exudation,exudation,词,NOUN,C1
 exultation,exultation,欢腾,NOUN,B2
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
 eyebrow,eyebrow,眉毛,NOUN,B2
-eyebrows,eyebrows,词,NOUN,A1
 eyelash,eyelash,睫毛,NOUN,B2
 eyelid,eyelid,眼皮,NOUN,B2
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
-eyewitness,eyewitness,目击,NOUN,B2
 fable,fable,寓言,NOUN,B2
-fabricated,fabricated,词,ADJ,B2
 fabrication,fabrication,捏造,NOUN,B2
-fabulist,fabulist,幻想家,NOUN,B2
-face reading,face reading,面相,NOUN,B2
-face recognition,face recognition,认人,NOUN,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facies,facies,面貌,NOUN,B2
-facilitation,facilitation,词,NOUN,C1
 facilities,facilities,设施,NOUN,B2
-facsimile,facsimile,副本,NOUN,B2
-facticity,facticity,词,NOUN,C1
-faction,faction,派,NOUN,B2
-factionalism,factionalism,派系主义,NOUN,B2
-factious,factious,词,ADJ,C1
-factoring,factoring,保理,NOUN,B2
-factotum,factotum,词,NOUN,C1
-factual,factual,事实的,ADJ,B2
 faculty,faculty,学院,NOUN,B2
-fade away,fade away,词,VERB,C1
 faded,faded,褪色的,ADJ,B2
-fading away,fading away,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failed,failed,失败的,ADJ,B2
-failed bid,failed bid,流标,NOUN,B2
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-failure to act,failure to act,词,NOUN,C1
-faint (noun),faint,词,NOUN,C1
+to faint,to faint,昏倒,VERB,B2
 fainting,fainting,晕厥,NOUN,B2
 fair,fair,交易会,NOUN,B2
-fair (noun),fair,fair,NOUN,B1
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,词,ADJ,B1
-fairly,fairly,词,ADV,C1
-fairness,fairness,词,NOUN,B2
 fairy tale,fairy tale,童话,NOUN,B2
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,假新闻,NOUN,B2
+to fake,to fake,伪造,VERB,B2
 falcon,falcon,猎鹰,NOUN,B2
-falconry,falconry,猎鹰术,NOUN,B2
-fall (noun),fall,你倒,NOUN,B1
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallibility,fallibility,易错性,NOUN,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-falling out,falling out,反目,NOUN,B2
-falling though,falling though,虽坠,NOUN,B2
-fallow land,fallow land,词,NOUN,B2
-false oath,false oath,词,NOUN,C1
-falsely,falsely,词,ADV,C1
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falsification,falsification,词,NOUN,C1
+to fall asleep,to fall asleep,入睡,VERB,B2
+to fall behind,to fall behind,落后,VERB,B2
+to fall down,to fall down,倒下,VERB,B2
+to fall ill,to fall ill,患病,VERB,B2
+to fall in love,to fall in love,坠入爱河,VERB,B2
+to fall into,to fall into,陷入,VERB,B2
+to fall silent,to fall silent,沉默,VERB,B2
 falsity,falsity,虚假,NOUN,B2
-faltering,faltering,词,ADJ,C1
-familial,familial,词,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
 familiarity,familiarity,مألوف,NOUN,B2
-family (adj),family,词,ADJ,B1
 family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
 family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family life,family life,家庭生活,NOUN,B2
 family member,family member,家庭成员,NOUN,B2
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family ruin,family ruin,家破,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,词,NOUN,B2
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
 famous family,famous family,名门,NOUN,B2
-fanatic,fanatic,狂热的,ADJ,B2
-fanatical,fanatical,词,ADJ,C1
 fanaticism,fanaticism,狂热,NOUN,B2
-fancy decoration,fancy decoration,词,NOUN,C1
-fang,fang,犬齿,NOUN,B2
-fantasizing,fantasizing,词,NOUN,C1
 far,far,远的,ADJ,B2
-far (adj),far,很远,ADJ,B2
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farmland,farmland,农田,NOUN,C1
-farmstead,farmstead,农庄,NOUN,B2
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascism,fascism,法西斯主义,NOUN,B2
-fascist (adj),fascist,词,ADJ,C1
-fascist (noun),fascist,词,NOUN,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast (adv),fast,快地,ADV,B2
-fast forward,fast forward,快进,VERB,C1
+to fast,to fast,禁食,VERB,B2
 fast quick,fast quick,快的,ADJ,B2
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
 fasting,fasting,禁食,NOUN,B2
 fat,fat,脂肪,NOUN,B2
-fat (noun),fat,脂肪,NOUN,B2
-fatalism,fatalism,宿命论,NOUN,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatalist (noun),fatalist,词,NOUN,C1
-fatality,fatality,致命性,NOUN,B2
-fatally,fatally,词,ADV,C1
-fateful,fateful,词,ADJ,C1
-father,father,父,PART,B2
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
 father-in-law,father-in-law,岳父/公公,NOUN,B2
-fatness,fatness,词,NOUN,C1
-fats,fats,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatuity,fatuity,愚昧,NOUN,B2
-fatuous,fatuous,词,ADJ,C1
-fatwa,fatwa,词,NOUN,B2
-faucet,faucet,词,NOUN,C1
-faulty,faulty,词,ADJ,C1
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favorable circumstances,favorable circumstances,顺境,NOUN,B2
-favorite,favorite,最爱,NOUN,B2
-favorite (noun),favorite,最爱,NOUN,B2
-favoritism,favoritism,偏袒,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+to favor,to favor,偏袒,VERB,B2
 fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
 fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
 feasibility,feasibility,可行性,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-february,february,二月,NOUN,B2
-feces,feces,屎,NOUN,C1
-fecundity,fecundity,词,NOUN,C1
-fed up (adj),fed up,词,ADJ,B1
-fed up (noun),fed up,词,NOUN,B2
 federalism,federalism,联邦主义,NOUN,B2
-federalization,federalization,联邦化,NOUN,B2
 federation,federation,联邦,NOUN,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
 feed,feed,饲料,NOUN,B2
-feed (noun),feed,词,NOUN,B2
-feeding,feeding,词,NOUN,C1
 feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
 feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
 fees,fees,酬金,NOUN,B2
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-felicity,felicity,词,NOUN,C1
-feline,feline,词,ADJ,C1
-fellow citizen,fellow citizen,同胞,NOUN,B2
-felony,felony,重罪,NOUN,B2
-felt,felt,词,NOUN,C1
 female,female,雌性,NOUN,B2
-female (noun),female,女性,NOUN,B2
 female friend,female friend,女性朋友,NOUN,B2
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female relatives,female relatives,女眷,NOUN,B2
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
-feminine,feminine,女性的,ADJ,B2
 femininity,femininity,女性气质,NOUN,B2
 feminism,feminism,女权主义,NOUN,B2
-feminist,feminist,女权主义者,NOUN,B2
-feminization,feminization,词,NOUN,C1
 fencing,fencing,击剑,NOUN,B2
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-fennec fox,fennec fox,词,NOUN,B2
 fennel,fennel,茴香,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
 fermentation,fermentation,发酵,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fern,fern,蕨类植物,NOUN,B2
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferociously,ferociously,词,ADV,C1
 ferocity,ferocity,凶猛,NOUN,B2
-ferret,ferret,雪貂,NOUN,B2
-ferrule,ferrule,词,NOUN,C1
 ferry,ferry,渡轮,NOUN,B2
 fertility,fertility,肥沃,NOUN,B2
 fertilization,fertilization,施肥,NOUN,B2
 fertilizer,fertilizer,肥料,NOUN,B2
-fervent,fervent,词,ADJ,C1
-fervor,fervor,词,NOUN,C1
-festivals,festivals,词,NOUN,C1
-festive,festive,节日的,ADJ,B2
-festivity,festivity,词,NOUN,C1
-fetid,fetid,词,ADJ,C1
-fetish,fetish,恋物,NOUN,B2
-fetishism,fetishism,词,NOUN,B2
 fetus,fetus,胎儿,NOUN,B2
-feud end,feud end,仇终,NOUN,C1
-feudal,feudal,封建,ADJ,B2
 feudal ethics,feudal ethics,礼教,NOUN,B2
 feudalism,feudalism,封建主义,NOUN,B2
-feverish,feverish,词,ADJ,C1
-few,few,几下,NOUN,B2
-few (noun),few,几下,NOUN,B2
-fewer,fewer,较少的,ADJ,B2
-fez,fez,词,NOUN,B2
-fiancee,fiancee,未婚妻,NOUN,B2
 fiber,fiber,纤维,NOUN,B2
 fibrosis,fibrosis,纤维化,NOUN,B2
-fibrous,fibrous,词,ADJ,C1
 fickleness,fickleness,反复无常,NOUN,B2
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictitious,fictitious,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fidelity,fidelity,忠诚,NOUN,B2
-fiduciary,fiduciary,词,ADJ,C1
-fief,fief,词,NOUN,B2
-field (adj),field,词,ADJ,C1
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fiend,fiend,词,NOUN,C1
-fierce one,fierce one,词,NOUN,B2
 fierceness,fierceness,凶猛,NOUN,B2
-fiery,fiery,热烈的,ADJ,B2
-fifteen,fifteen,十五,NUM,B2
 fifth,fifth,خامس,ADJ,B2
-fifth (num),fifth,词,NUM,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figuration,figuration,群演,NOUN,B2
-figurative,figurative,比喻的,ADJ,B2
-figurative language,figurative language,词,NOUN,C1
-figuratively,figuratively,词,ADV,C1
-figure skating,figure skating,花样滑冰,NOUN,C1
-filament,filament,词,NOUN,C1
-filial,filial,孝顺,ADJ,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filings,filings,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
-fill pack,fill pack,装满,VERB,B2
-filled,filled,充满的,ADJ,B2
-fillet (noun),fillet,词,NOUN,C1
-filling,filling,词,NOUN,B2
-film art,film art,词,NOUN,C1
-film director,film director,词,NOUN,B2
-film industry,film industry,电影业,NOUN,B2
-film movie,film movie,电影,NOUN,B2
+to fight,to fight,对抗,VERB,B2
+to file a case,to file a case,立案,VERB,B2
+to file for record,to file for record,备案,VERB,B2
+to fill in,to fill in,填写,VERB,B2
 film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,词,NOUN,B2
 filming,filming,拍摄,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
 filter,filter,过滤器,NOUN,B2
-filth garbage,filth garbage,词,NOUN,C1
-fin,fin,词,NOUN,B2
 final,final,决赛,NOUN,B2
-final (noun),final,决赛,NOUN,B1
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
 final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
-final stage,final stage,末期,NOUN,B2
-finality,finality,词,NOUN,C1
-finals,finals,决赛,NOUN,B1
+to finally,to finally,你可算,VERB,B2
+to finance,to finance,资助,VERB,B2
 finances,finances,财政,NOUN,B2
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financier,financier,资助者,NOUN,B2
 financing,financing,融资,NOUN,B2
-financing funding,financing funding,融资,NOUN,B2
-find,find,发现物,NOUN,B2
-find (noun),find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
+to find out,to find out,找出,VERB,B2
 finding,finding,发现,NOUN,B2
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
 fine,fine,罚款,NOUN,B2
-fine (noun),fine,词,NOUN,B1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine print,fine print,词,NOUN,C1
-fine skin,fine skin,细皮,NOUN,B2
-fine well,fine well,词,ADJ,A1
-finely,finely,词,ADV,C1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fingernail,fingernail,指甲,NOUN,B2
+to fine,to fine,罚款,VERB,B2
 fingerprint,fingerprint,指纹,NOUN,B2
-finial,finial,词,NOUN,C1
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
 finishing,finishing,装修,NOUN,B2
-finnish,finnish,芬兰的,ADJ,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-fire brigade,fire brigade,消防队,NOUN,B2
-fire department,fire department,词,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire kick,fire kick,词,VERB,A2
-fire station,fire station,词,NOUN,C1
-firearms,firearms,枪支,NOUN,B2
+to fire,to fire,开火,VERB,B2
 firecracker,firecracker,鞭炮,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firedamp,firedamp,词,NOUN,C1
 firefighter,firefighter,消防员,NOUN,B2
 fireplace,fireplace,壁炉,NOUN,B2
 fireproof,fireproof,防火的,ADJ,B2
 firewood,firewood,木柴,NOUN,B2
 fireworks,fireworks,烟花,NOUN,B2
 firm,firm,坚固的,ADJ,B2
-firm (adj),firm,坚定,ADJ,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firm fixed,firm fixed,词,ADJ,B1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
 firmness,firmness,坚定,NOUN,B2
 first,first,首先,ADV,B2
-first (adv),first,先,ADV,A2
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first aid,first aid,词,NOUN,B2
-first capping,first capping,首加缁布冠,NOUN,B2
 first draft,first draft,初稿,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
-first merit,first merit,首功,NOUN,B2
 first name,first name,名字,NOUN,B2
 first of all,first of all,首先,ADV,B2
-first-class,first-class,一流,ADJ,B2
-firstly,firstly,首先,ADV,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisheries,fisheries,词,NOUN,B2
+to fish,to fish,钓鱼,VERB,B2
 fisherman,fisherman,渔夫,NOUN,B2
-fishery,fishery,词,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing,fishing,钓鱼,NOUN,B2
 fishing rod,fishing rod,钓竿,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
 fission,fission,裂变,NOUN,B2
-fistula,fistula,瘘管,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fit (adj),fit,适合的,ADJ,B2
-fit (noun),fit,词,NOUN,B2
-fitting out,fitting out,词,NOUN,B2
-fittings,fittings,词,NOUN,C1
-five (adj),five,词,ADJ,C1
 five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fixation,fixation,词,NOUN,C1
 fixed,fixed,固定的,ADJ,B2
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabby,flabby,词,ADJ,B2
-flaccid,flaccid,松弛的,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrancy,flagrancy,现行,NOUN,B2
-flagrant,flagrant,词,ADJ,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable,flammable,易燃的,ADJ,B2
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flank (verb),flank,词,VERB,C1
 flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flashback,flashback,词,NOUN,C1
-flashlight,flashlight,词,NOUN,B2
-flask,flask,小瓶,NOUN,B2
 flat,flat,扁平的,ADJ,B2
-flat (adj),flat,平,ADJ,B2
-flat rate,flat rate,词,NOUN,B2
-flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatterer,flatterer,词,NOUN,C1
-flattering,flattering,词,ADJ,C1
-flattery,flattery,奉承,NOUN,B2
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
 fleeting,fleeting,短暂的,ADJ,B2
-flemish,flemish,佛兰芒的,ADJ,B2
 flexibility,flexibility,灵活性,NOUN,B2
-flexion,flexion,词,NOUN,C1
-fling (noun),fling,词,NOUN,C1
-flint,flint,燧石,NOUN,B2
-flirt (noun),flirt,词,NOUN,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-float (noun),float,词,NOUN,B2
-floating,floating,漂浮的,ADJ,B2
-floating (noun),floating,词,NOUN,C1
 floating dust,floating dust,浮尘,NOUN,B2
-flock,flock,兽群,NOUN,B2
-flogging,flogging,词,NOUN,C1
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floor story,floor story,词,NOUN,A2
-floorboard,floorboard,词,NOUN,C1
-floral,floral,词,ADJ,C1
-florid,florid,辞藻华丽的,ADJ,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-floundering,floundering,词,NOUN,C1
-flourishing,flourishing,繁荣的,ADJ,B2
-flourishing (noun),flourishing,词,NOUN,C1
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,词,NOUN,B2
-flowery,flowery,华丽的,ADJ,B2
+to flow,to flow,流动,VERB,B2
 fluctuating,fluctuating,波动的,ADJ,B2
 fluctuation,fluctuation,波动,NOUN,B2
-fluently,fluently,词,ADV,C1
-fluid (adj),fluid,词,ADJ,B2
-fluidity,fluidity,词,NOUN,C1
-fluids,fluids,词,NOUN,C1
-fluke,fluke,词,NOUN,B2
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
 flute,flute,长笛,NOUN,B2
-flutist,flutist,词,NOUN,C1
-flutter (noun),flutter,词,NOUN,B2
 fly,fly,苍蝇,NOUN,B2
-fly (noun),fly,苍蝇,NOUN,B2
-flying,flying,词,ADJ,B2
-flyover,flyover,词,NOUN,C1
-flyting poems,flyting poems,词,NOUN,C1
 foamy,foamy,多泡沫的,ADJ,B2
-focalization,focalization,词,NOUN,C1
-focused,focused,专注的,ADJ,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
 fold,fold,折痕,NOUN,B2
-fold (noun),fold,折痕,NOUN,B2
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,枝叶,NOUN,B2
-foliar,foliar,词,ADJ,C1
 foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
 folk,folk,民间的,ADJ,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
 folklore,folklore,民俗,NOUN,B2
-folkloric,folkloric,词,ADJ,C1
-folksy,folksy,乡土的,ADJ,B2
+to follow up,to follow up,追问,VERB,B2
 follow-up,follow-up,跟进,NOUN,B2
-follower enthusiast,follower enthusiast,词,NOUN,C1
-followers,followers,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-fond of food,fond of food,词,ADJ,B1
-fondness,fondness,词,NOUN,B2
-food,food,食品的,ADJ,B2
-food (adj),food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
 foodstuff,foodstuff,食品,NOUN,B2
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
 foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,镜头长度,NOUN,B2
-football camp,football camp,词,NOUN,B2
-football player,football player,词,NOUN,C1
 footbridge,footbridge,人行天桥,NOUN,B2
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
 footwear,footwear,鞋穿,NOUN,B2
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
 for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for each other,for each other,词,ADV,B2
 for example,for example,例如,ADV,B2
+to for example,to for example,比如,VERB,B2
 for free,for free,免费,ADV,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for hours,for hours,词,ADJ,B2
 for it,for it,为此,ADV,B2
-for my sake,for my sake,词,ADV,C1
 for now,for now,暂时,ADV,B2
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,词,ADV,B2
-for the,for the,词,ADP,A2
-for the sake of,for the sake of,为了,ADP,B2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what,for what,为了什么,ADV,B2
-for what purpose,for what purpose,词,ADV,B2
 for years,for years,多年,ADV,B2
-for your sake,for your sake,词,ADV,B2
-forbearance,forbearance,词,NOUN,C1
-forbearing,forbearing,词,ADJ,C1
-forbidden,forbidden,被禁止的,ADJ,B2
-forbidden land,forbidden land,禁地,NOUN,B2
+to force,to force,强迫,VERB,B2
 forced,forced,强迫的,ADJ,B2
-forced labor,forced labor,词,NOUN,C1
-forceful,forceful,词,ADJ,B2
 forcibly,forcibly,强制地,ADV,B2
-forcing submission,forcing submission,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
 forecast,forecast,预测,NOUN,B2
-forecast (noun),forecast,预报,NOUN,B2
-foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
 foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,词,ADJ,B2
-foreman,foreman,词,NOUN,B2
-forenoon,forenoon,词,NOUN,A1
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
 foresight,foresight,远见,NOUN,B2
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forest-related,forest-related,词,ADJ,B2
-forestry,forestry,词,ADJ,C1
-foreword,foreword,词,NOUN,C1
-forfeiture,forfeiture,丧失,NOUN,B2
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forger,forger,词,NOUN,C1
 forgetful,forgetful,健忘的,ADJ,B2
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-formal notice,formal notice,词,NOUN,C1
 formalism,formalism,形式主义,NOUN,B2
-formalist (adj),formalist,词,ADJ,C1
-formalist (noun),formalist,词,NOUN,C1
 formality,formality,礼节,NOUN,B2
-formally,formally,正式地,ADV,B2
 formation,formation,组建,NOUN,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-formulation,formulation,配方,NOUN,B2
-fort,fort,堡垒,NOUN,B2
-forthcoming,forthcoming,词,ADJ,C1
-fortification,fortification,词,NOUN,C1
-fortlet,fortlet,词,NOUN,C1
-fortuitous,fortuitous,偶然的,ADJ,B2
-fortune teller,fortune teller,占卜者,NOUN,B2
-fortune telling,fortune telling,算命,NOUN,B2
 forty,forty,四十,NUM,B2
 forum,forum,论坛,NOUN,B2
-forums,forums,词,NOUN,C1
-forward (verb),forward,词,VERB,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-fossils,fossils,化石,NOUN,C1
 foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
 founder,founder,创始人,NOUN,B2
-founding,founding,成立,NOUN,B2
 foundling,foundling,弃婴,NOUN,B2
-foundry,foundry,铸造厂,NOUN,B2
 fountain,fountain,喷泉,NOUN,B2
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fourteen,fourteen,十四,NUM,B2
 fourth,fourth,第四,ADJ,B2
-fourth (adj),fourth,第四,ADJ,B2
-fractal,fractal,分形,NOUN,B2
-fraction marker,fraction marker,分之,PART,B2
-fractional,fractional,分数的,ADJ,B2
-fractured,fractured,词,ADJ,C1
-fragility,fragility,脆弱,NOUN,B2
-fragmentary,fragmentary,零碎的,ADJ,B2
 fragmentation,fragmentation,碎片化,NOUN,B2
 fragrant,fragrant,芬芳的,ADJ,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework-related,framework-related,词,ADJ,C1
-framing,framing,词,NOUN,C1
+to frame,to frame,装框,VERB,B2
 frankness,frankness,坦率,NOUN,B2
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudster,fraudster,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-frayed,frayed,词,ADJ,C1
-freckles,freckles,词,NOUN,B2
-free association,free association,词,NOUN,C1
-free of charge,free of charge,免费,NOUN,B2
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
-free off,free off,空闲的/休假,ADJ,B2
 free time,free time,业余时间,NOUN,B2
-free trade,free trade,词,NOUN,C1
-free will,free will,词,NOUN,B2
-freedmen clients,freedmen clients,词,NOUN,C1
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,词,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freely,freely,自由地,ADV,B2
 freezing,freezing,冻结,NOUN,B2
-freezing (noun),freezing,冷冻,NOUN,B2
 freezing rain,freezing rain,冻雨,NOUN,B2
 french,french,法国的,ADJ,B2
 french,french,法语,NOUN,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
 frenchman,frenchman,法国人,NOUN,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
 frequent,frequent,频繁的,ADJ,B2
-fresco,fresco,壁画,NOUN,B2
-fresh,fresh,,NOUN,B2
-fresh (noun),fresh,fresh,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshly,freshly,新鲜地,ADV,B2
 freshness,freshness,新鲜,NOUN,B2
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-friar,friar,词,NOUN,C1
 friction,friction,摩擦,NOUN,B2
-frictionless,frictionless,无摩擦的,ADJ,B2
 friday,friday,星期五,NOUN,B2
-fried,fried,词,ADJ,B1
-fried food,fried food,词,NOUN,C1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-friends with,friends with,词,ADJ,B2
-frieze,frieze,檐壁,NOUN,B2
-frigate,frigate,护卫舰,NOUN,B2
-frightening,frightening,令人恐惧的,ADJ,B2
-frightful,frightful,词,ADJ,B1
-frisian,frisian,词,ADJ,B2
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from above,from above,从上方,ADV,B2
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
 from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
-from childhood,from childhood,从小,ADV,B2
 from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from here,from here,词,ADV,B2
-from home,from home,词,ADV,B2
-from it,from it,从中,ADV,B2
 from now on,from now on,今后,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from there,from there,从那里,ADV,B2
-from this,from this,词,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from where,from where,从哪里,ADV,B2
-from which,from which,从中,ADV,B2
-from within,from within,从内部,ADV,B2
 front door,front door,正门,NOUN,B2
-front line,front line,前线,NOUN,B2
-front page,front page,头版,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontispiece,frontispiece,词,NOUN,C1
-frontrunner,frontrunner,词,NOUN,C1
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-frosty,frosty,词,ADJ,A1
-frown (noun),frown,frown,NOUN,B2
-frowning,frowning,词,NOUN,C1
-frozen,frozen,冻僵的,ADJ,B2
-frozen (noun),frozen,词,NOUN,B2
-frugality,frugality,节俭,NOUN,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,果树的,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruiting,fruiting,词,ADJ,C1
-fruitless,fruitless,词,ADJ,C1
 frustration,frustration,挫折,NOUN,B2
-fryer,fryer,词,NOUN,C1
 frying pan,frying pan,平底锅,NOUN,B2
-fuchsia,fuchsia,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fulcrum,fulcrum,词,NOUN,C1
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full fed up,full fed up,词,ADJ,B1
 full moon,full moon,满月,NOUN,B2
-full moon banquet,full moon banquet,满月酒,NOUN,C1
-full name,full name,大名,NOUN,B2
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full power,full power,全力,NOUN,B2
-full satiated,full satiated,词,ADJ,A2
-full stop,full stop,词,NOUN,B2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,全职,ADJ,B2
-fullness,fullness,词,NOUN,C1
-fully,fully,词,ADV,C1
-fumarole,fumarole,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
 fun,fun,有趣的,ADJ,B2
-fun (adj),fun,好玩,ADJ,A1
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
+to function,to function,运作,VERB,B2
 functional,functional,功能的,ADJ,B2
 functionalism,functionalism,功能主义,NOUN,B2
-functionality,functionality,功能性,NOUN,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundamental rights,fundamental rights,词,NOUN,C1
 fundamentalism,fundamentalism,原教旨主义,NOUN,B2
-fundamentally,fundamentally,词,ADV,C1
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,词,NOUN,C1
-funerary,funerary,词,ADJ,B2
-funereal,funereal,丧葬的,ADJ,B2
-fungal,fungal,词,ADJ,C1
-fungi,fungi,词,NOUN,B2
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funniness,funniness,,NOUN,B2
-furnished,furnished,词,ADJ,B2
-furnishing,furnishing,室内布置,NOUN,B2
 further,further,进一步,ADV,B2
-further (adv),further,词,ADV,B2
-further additional,further additional,词,ADJ,B2
 further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
 furthermore,furthermore,此外,ADV,B2
-furthest,furthest,最远,ADV,B2
-furtive,furtive,鬼鬼祟祟的,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
 fuselage,fuselage,机身,NOUN,B2
 fusion,fusion,融合,NOUN,B2
-fussy,fussy,挑剔的,ADJ,B2
-futile,futile,词,ADJ,C1
 futility,futility,无用,NOUN,B2
 future,future,未来的,ADJ,B2
-future (adj),future,未来的,ADJ,C1
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurism,futurism,未来主义,NOUN,B2
-futurist,futurist,词,NOUN,C1
-futuristic,futuristic,词,ADJ,C1
-fuzzy,fuzzy,词,ADJ,C1
 gain,gain,收益,NOUN,B2
-gain (noun),gain,可得,NOUN,B2
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
-galician,galician,加利西亚的,ADJ,B2
 gallantry,gallantry,英勇,NOUN,B2
-gallbladder,gallbladder,词,NOUN,C1
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
-galvanization,galvanization,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
 gamble,gamble,赌博,NOUN,B2
-gamble (noun),gamble,就赌,NOUN,C1
-gambling,gambling,词,NOUN,C1
-game play,game play,词,NOUN,B2
-game rule,game rule,游戏规则,NOUN,B2
-gamete,gamete,配子,NOUN,B2
-gangrene,gangrene,坏疽,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garbage,garbage,词,NOUN,B2
 gardener,gardener,园丁,NOUN,B2
-gardening,gardening,园艺,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
 garlic,garlic,大蒜,NOUN,B2
-garment,garment,衣,PART,B2
-garment (noun),garment,服装,NOUN,C1
-garment making,garment making,词,NOUN,C1
-garrison towns,garrison towns,词,NOUN,C1
 garrulous,garrulous,喋喋不休的,ADJ,B2
-gas flame,gas flame,煤气火焰,NOUN,B2
-gas meter,gas meter,词,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
 gas station,gas station,加油站,NOUN,B2
-gaseous,gaseous,气态的,ADJ,B2
-gasket,gasket,词,NOUN,B1
 gasoline,gasoline,汽油,NOUN,B2
-gasp (noun),gasp,词,NOUN,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomic,gastronomic,美食的,ADJ,B2
-gastronomy,gastronomy,美食学,NOUN,B2
 gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatekeeper,gatekeeper,道口看守员,NOUN,B2
-gateway,gateway,词,NOUN,C1
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
 gathering,gathering,聚集,NOUN,B2
-gauge (noun),gauge,词,NOUN,C1
-gauge meter,gauge meter,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,同性恋者,NOUN,B2
-gay (noun),gay,同性恋者,NOUN,B2
-gay man,gay man,男同性恋者,NOUN,B2
 gaze,gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gazette,gazette,词,NOUN,C1
 gearbox,gearbox,变速箱,NOUN,B2
-geek,geek,极客,NOUN,C1
-geerziehung,geerziehung,词,NOUN,C1
-gefahrt,gefahrt,词,NOUN,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gekunft,gekunft,词,NOUN,C1
-gelatin,gelatin,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-gemstone,gemstone,词,NOUN,C1
-genahme,genahme,词,NOUN,C1
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
 gender,gender,性别,NOUN,B2
-gender equality,gender equality,性别平等,NOUN,B2
-gender parity,gender parity,词,NOUN,C1
 gene,gene,基因,NOUN,B2
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogical,genealogical,词,ADJ,C1
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
 genealogy,genealogy,家谱学,NOUN,B2
 general,general,一般的,ADJ,B2
 general,general,将军,NOUN,B2
-general (noun),general,将军,NOUN,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-general practitioner,general practitioner,全科医生,NOUN,B2
-generality,generality,普遍性,NOUN,B2
 generalization,generalization,概括,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generations,generations,词,NOUN,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
-generatrix,generatrix,母线,NOUN,B2
-generic,generic,通用的,ADJ,B2
 generosity,generosity,慷慨,NOUN,B2
-generously,generously,慷慨地,ADV,B2
-genesis,genesis,起源,NOUN,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetic modification,genetic modification,词,NOUN,B2
-genetically,genetically,遗传地,ADV,B2
-genial,genial,词,ADJ,C1
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,词,NOUN,B2
 genome,genome,基因组,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gentle reproach,gentle reproach,词,NOUN,C1
-gentlemen,gentlemen,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-gentrification,gentrification,词,NOUN,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geocentric,geocentric,词,ADJ,C1
-geographer,geographer,词,NOUN,C1
-geographically,geographically,词,ADV,C1
 geography,geography,地理,NOUN,B2
-geolocation,geolocation,词,NOUN,C1
 geological,geological,地质的,ADJ,B2
-geometer,geometer,词,NOUN,C1
 geometric,geometric,几何的,ADJ,B2
-geophysics,geophysics,词,NOUN,C1
 geopolitics,geopolitics,地缘政治,NOUN,B2
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gepflegung,gepflegung,词,NOUN,C1
-geregelung,geregelung,词,NOUN,C1
-geriatric,geriatric,词,ADJ,C1
-geriatrics,geriatrics,老年医学,NOUN,B2
-gerichtung,gerichtung,词,NOUN,B2
 germ,germ,病菌,NOUN,B2
 german,german,德国的,ADJ,B2
 german,german,德国人,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,词,NOUN,B2
-germanic,germanic,词,ADJ,C1
-germicidal,germicidal,词,ADJ,C1
 germination,germination,发芽,NOUN,B2
-gerontocracy,gerontocracy,老人政治,NOUN,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-gesprache,gesprache,词,NOUN,C1
-gestation,gestation,词,NOUN,C1
-gestural,gestural,词,ADJ,C1
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-getaway,getaway,词,NOUN,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-getting rich,getting rich,词,NOUN,C1
-gewandel,gewandel,词,NOUN,C1
-geweisung,geweisung,词,NOUN,C1
-gewirkung,gewirkung,词,NOUN,C1
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
+to get angry,to get angry,生气,VERB,B2
+to get lost,to get lost,迷路,VERB,B2
+to get off work,to get off work,下班,VERB,B2
+to get rid of,to get rid of,摆脱,VERB,B2
+to get up,to get up,起床,VERB,B2
+to get used to,to get used to,习惯于,VERB,B2
 giant,giant,巨大的,ADJ,B2
-giant (adj),giant,巨大的,ADJ,B1
-gibberish,gibberish,词,NOUN,C1
-giddy,giddy,词,ADJ,B2
-gifted,gifted,有天赋的,ADJ,B2
-giftedness,giftedness,词,NOUN,C1
-gigantic,gigantic,巨大的,ADJ,B2
-gigolo,gigolo,面首,NOUN,B2
-gilding,gilding,词,NOUN,C1
-gills,gills,词,NOUN,B2
 ginger,ginger,姜,NOUN,B2
 ginseng,ginseng,人参,NOUN,B2
 giraffe,giraffe,长颈鹿,NOUN,B2
-girl daughter,girl daughter,词,NOUN,A1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give you (noun),give you,送你,NOUN,C1
-given,given,给定,NOUN,B2
-given (adj),given,给定的,ADJ,A1
-given datum,given datum,词,NOUN,C1
+to give back,to give back,归还,VERB,B2
+to give up,to give up,放弃,VERB,B2
 given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-glacial,glacial,词,ADJ,C1
 glacier,glacier,冰川,NOUN,B2
-gladiator,gladiator,词,NOUN,C1
 gladly,gladly,乐意地,ADV,B2
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
 glasses,glasses,眼镜,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glebe,glebe,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-glib,glib,伶牙俐齿的,ADJ,B2
 gliding,gliding,滑翔,NOUN,B2
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-gloating,gloating,词,NOUN,C1
-global (noun),global,全球,NOUN,B2
+to glimpse,to glimpse,瞥见,VERB,B2
 global warming,global warming,气候变暖,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-glomerulus,glomerulus,词,NOUN,C1
 gloominess,gloominess,忧郁,NOUN,B2
 gloomy,gloomy,阴郁的,ADJ,B2
-glorification,glorification,赞美,NOUN,B2
-gloriously,gloriously,词,ADV,C1
-gloriousness,gloriousness,光荣,NOUN,B2
-glossary,glossary,词汇表,NOUN,B2
-glossator,glossator,词,NOUN,C1
-gloves,gloves,词,NOUN,B2
 glow,glow,光芒,NOUN,B2
-glow (noun),glow,光辉,NOUN,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glucose,glucose,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
 gluttony,gluttony,暴食,NOUN,B2
-glyph,glyph,词,NOUN,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
 gnosis,gnosis,灵知,NOUN,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-go away,go away,词,VERB,C1
+to go back,to go back,回去,VERB,B2
+to go bankrupt,to go bankrupt,破产,VERB,B2
+to go crazy,to go crazy,发疯,VERB,B2
+to go down,to go down,下去,VERB,B2
+to go forward,to go forward,往后,VERB,B2
 go help,go help,去帮,NOUN,B2
-go wrong,go wrong,词,VERB,C1
-goalkeeper,goalkeeper,词,NOUN,B2
-goblin,goblin,词,NOUN,C1
+to go home,to go home,回家,VERB,B2
+to go in,to go in,进去,VERB,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to go out,to go out,出去,VERB,B2
+to go through,to go through,经历,VERB,B2
+to go up,to go up,上升,VERB,B2
 god,god,上帝,NOUN,B2
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-god of war,god of war,战神,NOUN,B2
 goddess,goddess,女神,NOUN,B2
 godfather,godfather,教父,NOUN,B2
-godliness,godliness,词,NOUN,C1
-godmother,godmother,词,NOUN,C1
-godson,godson,词,NOUN,A2
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
 good,good,خير,NOUN,B2
-good (noun),good,但好,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good day,good day,你好,INTJ,B2
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
 good heavens,good heavens,天哪,INTJ,B2
-good lord,good lord,词,INTJ,B2
 good luck,good luck,好运,NOUN,B2
 good medicine,good medicine,好药,NOUN,B2
-good morning,good morning,早上好,INTJ,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good night,good night,晚安,INTJ,B2
-good offices,good offices,词,NOUN,C1
-good reputation,good reputation,清誉,NOUN,B2
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
 good-looking,good-looking,好看的,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-good-naturedness,good-naturedness,词,NOUN,B2
 goodbye,goodbye,再见,INTJ,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gosh,gosh,天哪,INTJ,B2
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,词,ADJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-govern a country,govern a country,治国,VERB,C1
-governability,governability,可治理性,NOUN,B2
-governable,governable,可管理的,ADJ,B2
-governess,governess,词,NOUN,C1
 governmental,governmental,政府的,ADJ,B2
-governorate,governorate,词,NOUN,C1
 grab,grab,揪,NOUN,B2
-grab (noun),grab,揪,NOUN,B2
-gracefulness,gracefulness,词,NOUN,C1
-gracious,gracious,亲切的,ADJ,B2
 gradation,gradation,渐变,NOUN,B2
-grade (verb),grade,分级,VERB,C1
 grading,grading,评分；记号,NOUN,B2
 gradual,gradual,逐渐的,ADJ,B2
 gradually,gradually,逐渐地,ADV,B2
-graduate school,graduate school,研究生院,NOUN,C1
+to graduate,to graduate,毕业,VERB,B2
 graduate student,graduate student,研究生,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-grail,grail,词,NOUN,B2
 gram,gram,克,NOUN,B2
 grammar,grammar,语法,NOUN,B2
-grammatical,grammatical,词,ADJ,C1
-grammaticality,grammaticality,合语法性,NOUN,B2
-gramophone,gramophone,词,NOUN,C1
-granary,granary,词,NOUN,C1
 grand distance,grand distance,雄远,NOUN,B2
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand master,grand master,大师,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
 grandchild,grandchild,孙辈,NOUN,B2
-grandeur,grandeur,宏伟,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,夸张的,ADJ,B2
-grandiloquently,grandiloquently,词,ADV,C1
-grandiosity,grandiosity,宏伟,NOUN,B2
 grandpa,grandpa,爷爷,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granite,granite,花岗岩,NOUN,B2
-granitic,granitic,词,ADJ,C1
-granny,granny,奶奶,NOUN,B2
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-granule,granule,词,NOUN,C1
 grape,grape,葡萄,NOUN,B2
-grapefruit,grapefruit,词,NOUN,A2
-grapes,grapes,词,NOUN,A1
-graphic artist,graphic artist,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphic designer,graphic designer,词,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-graphology,graphology,笔迹学,NOUN,B2
-grasp,grasp,把及,NOUN,B2
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grasshopper,grasshopper,词,NOUN,B1
 grassland,grassland,草地,NOUN,B2
-grassroots,grassroots,词,ADJ,C1
-grater,grater,词,NOUN,B2
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
 gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-gravel,gravel,砾石,NOUN,B2
-gravely,gravely,严重地,ADV,B2
-gravid,gravid,怀孕的,ADJ,B2
-gravitas,gravitas,词,NOUN,C1
-gravitation,gravitation,引力,NOUN,B2
-gravitational,gravitational,引力的,ADJ,B2
-gravity of loss,gravity of loss,词,NOUN,C1
-gray hair,gray hair,词,NOUN,B2
-grayish,grayish,词,ADJ,C1
 grazing,grazing,放牧,NOUN,B2
+to grease,to grease,涂油,VERB,B2
 greasy,greasy,油腻的,ADJ,B2
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
 great favor,great favor,大恩,NOUN,B2
 great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
 great offense,great offense,冒犯大,NOUN,B2
 great power,great power,大国,NOUN,B2
 great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,曾祖父,NOUN,B2
-greatest,greatest,词,NOUN,B2
 greatness,greatness,伟大,NOUN,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊语,NOUN,B2
-greek (adj),greek,希腊的,ADJ,B2
-green blue,green blue,青,ADJ,B2
 green eye,green eye,碧眼,NOUN,B2
 green eyes,green eyes,想碧眼,NOUN,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green technology,green technology,绿色技术,NOUN,B2
-green-clad,green-clad,,NOUN,B2
-green-eyed,green-eyed,让碧眼,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
 greeting,greeting,问候,NOUN,B2
-greetings,greetings,,NOUN,B2
-grenade,grenade,手榴弹,NOUN,B2
-grenadier,grenadier,词,NOUN,C1
-grey area,grey area,词,NOUN,B2
-grid,grid,网格,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
 grievance,grievance,弊端,NOUN,B2
-grieved,grieved,词,ADJ,B2
-grievously unjust,grievously unjust,词,ADJ,C1
-grille,grille,格栅,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grimness,grimness,词,NOUN,C1
-grinder,grinder,词,NOUN,C1
 grip,grip,握法,NOUN,B2
-grip (noun),grip,握呀,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-groan,groan,呻吟,NOUN,B2
-groan (noun),groan,词,NOUN,B2
-grocer,grocer,词,NOUN,A2
-grooming,grooming,词,NOUN,C1
-grooved,grooved,词,ADJ,C1
-grotesque,grotesque,怪诞的,ADJ,B2
-grotto,grotto,洞穴,NOUN,B2
-ground (adj),ground,磨碎的,ADJ,B1
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds,grounds,论据,NOUN,B2
-grounds of judgment,grounds of judgment,词,NOUN,C1
-groundwater pollution,groundwater pollution,词,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,群体工作,NOUN,B2
-grouping,grouping,词,NOUN,B2
-growing,growing,词,ADJ,B2
-growl,growl,低吼,NOUN,B2
-grown,grown,长大的,ADJ,B2
-growth rate,growth rate,词,NOUN,C1
-gruff,gruff,阴沉的,ADJ,B2
-grumbler,grumbler,爱抱怨的人,NOUN,B2
+to grow up,to grow up,成长,VERB,B2
 grumbling,grumbling,抱怨,NOUN,B2
-grumpy,grumpy,脾气坏的,ADJ,B2
-guarantees,guarantees,词,NOUN,C1
 guarantor,guarantor,担保人,NOUN,B2
+to guard,to guard,看守,VERB,B2
 guardian,guardian,守卫,NOUN,B2
-guardianship,guardianship,监护,NOUN,B2
-guarding,guarding,守住,NOUN,C1
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-guerrilla,guerrilla,词,NOUN,C1
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
 guess,guess,猜测,NOUN,B2
-guess (noun),guess,一猜,NOUN,B2
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
 guidance,guidance,指导,NOUN,B2
-guidebook,guidebook,词,NOUN,B1
-guided tour,guided tour,导游,NOUN,B2
-guiding light,guiding light,词,NOUN,C1
-guild,guild,行会,NOUN,B2
-guild (adj),guild,词,ADJ,C1
-guilder,guilder,盾,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-guitarist,guitarist,吉他手,NOUN,B2
+to guide,to guide,引导,VERB,B2
 guqin,guqin,古琴,NOUN,B2
-guru,guru,精神导师,NOUN,B2
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-gutter,gutter,路沟,NOUN,B2
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
 gym,gym,健身房,NOUN,B2
 gymnasium,gymnasium,体育馆,NOUN,B2
-gymnast,gymnast,体操运动员,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gynaecology,gynaecology,妇科,NOUN,B2
-gynecologist,gynecologist,词,NOUN,C1
-ha,ha,哈,INTJ,B2
-habit formation,habit formation,词,NOUN,C1
-habitability,habitability,词,NOUN,C1
-habitlessness,habitlessness,无习惯,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-habitually in the past,habitually in the past,往常,NOUN,B2
-habituation,habituation,习惯化,NOUN,B2
-habitus,habitus,词,NOUN,C1
-habous endowments,habous endowments,词,NOUN,C1
-hacker,hacker,黑客,NOUN,C1
+to hack,to hack,入侵；盗版,VERB,B2
 hacking,hacking,黑客行为,NOUN,B2
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hag,hag,老妇,NOUN,B2
-haggling,haggling,计较,NOUN,B2
-haha,haha,哈哈,INTJ,B2
 hail,hail,冰雹,NOUN,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-hair-raising,hair-raising,词,ADJ,B2
-haircut,haircut,词,NOUN,C1
 hairdresser,hairdresser,理发师,NOUN,B2
 hairstyle,hairstyle,发型,NOUN,B2
-hairy,hairy,词,ADJ,C1
-hakawati,hakawati,词,NOUN,B2
 half,half,一半的,ADJ,B2
-half (adj),half,词,ADJ,A1
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
 half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway,halfway,半途,ADV,B2
-halfway (noun),halfway,中途,NOUN,C1
 hall,hall,殿,PART,B2
-hall (part),hall,殿,PART,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
 hallucination,hallucination,幻觉,NOUN,B2
-halo,halo,词,NOUN,B2
-hamburger,hamburger,汉堡包,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
+to hand over,to hand over,交付,VERB,B2
 handbag,handbag,手提包,NOUN,B2
-handball,handball,手球,NOUN,C1
-handbrake,handbrake,手刹,NOUN,C1
 handguard,handguard,护手,NOUN,B2
 handicraft,handicraft,工艺品,NOUN,B2
-handiness,handiness,趁手,NOUN,C1
 handkerchief,handkerchief,手帕,NOUN,B2
 handle,handle,把手,NOUN,B2
-handle (noun),handle,把手,NOUN,B2
-handlebars,handlebars,词,NOUN,C1
 handover,handover,拿给,NOUN,B2
 handsome guy,handsome guy,帅哥,NOUN,B2
 handwriting,handwriting,笔迹,NOUN,B2
-handwriting practice,handwriting practice,练字,NOUN,B2
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-handyman,handyman,工匠,NOUN,B2
-hanged,hanged,被绞死的,ADJ,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hanging,hanging,绞刑,NOUN,B2
-hangover,hangover,词,NOUN,B2
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy cheerful,happy cheerful,词,ADJ,B1
+to hang up,to hang up,挂断,VERB,B2
 happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-harbour,harbour,词,NOUN,B2
-hard,hard,努力地,ADV,B2
-hard (adv),hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
+to harass,to harass,骚扰,VERB,B2
 hard to choose,hard to choose,难以抉择,ADJ,B2
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
 hard to decide,hard to decide,难以决定,ADJ,B2
 hard to determine,hard to determine,难以确定,ADJ,B2
-hard to distinguish,hard to distinguish,难以区分,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to maintain,hard to maintain,难以维持,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
 hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
 hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
 hard to speak of,hard to speak of,难以启齿,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-harder,harder,词,ADJ,A2
 hardness,hardness,硬度,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
 hardworking,hardworking,勤奋的,ADJ,B2
 hare,hare,野兔,NOUN,B2
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
+to harm,to harm,损害,VERB,B2
 harmonious,harmonious,和谐的,ADJ,B2
 harmonization,harmonization,协调,NOUN,B2
 harp,harp,竖琴,NOUN,B2
-harshly,harshly,词,ADV,C1
-harshness,harshness,词,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hassle,hassle,麻烦,NOUN,B2
+to harvest,to harvest,收割,VERB,B2
 haste,haste,匆忙,NOUN,B2
 hastily,hastily,急忙,ADV,B2
 hasty,hasty,仓促的,ADJ,B2
-hatch,hatch,舱口,NOUN,B2
-hatching,hatching,词,NOUN,C1
 hate,hate,仇恨,NOUN,B2
-hate (noun),hate,只有恨,NOUN,A1
-haughtily,haughtily,词,ADV,C1
 haughtiness,haughtiness,傲慢,NOUN,B2
 have,have,有,AUX,B2
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have time,have time,词,VERB,B2
+to have an accident,to have an accident,遭遇意外,VERB,B2
+to have breakfast,to have breakfast,吃早餐,VERB,B2
+to have dinner,to have dinner,吃晚餐,VERB,B2
 have to,have to,总得,ADV,B2
 have to,have to,必须,AUX,B2
 have to,have to,还得,NOUN,B2
-have to (adv),have to,不得不,ADV,A1
-have to (noun),have to,还得,NOUN,B2
-having a birthday,having a birthday,过生日的,ADJ,B2
-having a cold,having a cold,词,ADJ,B2
-having item,having item,有件,NOUN,C1
-hay,hay,干草,NOUN,B2
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
 hazelnut,hazelnut,榛子,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headlines,headlines,词,NOUN,B2
 headphones,headphones,耳机,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-healer,healer,词,NOUN,B2
 healing,healing,治愈,NOUN,B2
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,医疗保健,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-heap cluster,heap cluster,词,NOUN,C1
-heard beile,heard beile,听说贝勒,NOUN,B2
+to hear a case,to hear a case,审理,VERB,B2
 hearing,hearing,听证会,NOUN,B2
-hearing aid,hearing aid,词,NOUN,B2
-hearsay,hearsay,词,NOUN,C1
-heart,heart,心,ADV,B2
-heart (adv),heart,心,ADV,B2
 heart attack,heart attack,心脏病发作,NOUN,B2
 heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt,heartfelt,衷心的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartlessness,heartlessness,词,NOUN,B2
-hearts,hearts,心,NOUN,B2
-heat wave,heat wave,热浪,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
+to heat,to heat,加热,VERB,B2
 heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
 heavenly fragrance,heavenly fragrance,天香,NOUN,B2
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavily,heavily,沉重地,ADV,B2
 heaviness,heaviness,沉重 / 笨重,NOUN,B2
 heavy body,heavy body,重体,NOUN,B2
 heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
 heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
 heavy etiquette,heavy etiquette,礼太重,NOUN,B2
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy knot,heavy knot,重结,NOUN,B2
-heavy machine,heavy machine,重机,NOUN,B2
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
 heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-heavy type,heavy type,重型,NOUN,B2
 heavy work,heavy work,重功,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hectic (adj),hectic,词,ADJ,C1
-hectic (noun),hectic,忙乱,NOUN,B2
 hedgehog,hedgehog,刺猬,NOUN,B2
-hedonism,hedonism,享乐主义,NOUN,B2
-hedonist,hedonist,词,NOUN,C1
-heedlessness,heedlessness,词,NOUN,C1
 heel,heel,脚后跟,NOUN,B2
-hefen,hefen,河粉,NOUN,C1
 hegemony,hegemony,霸权,NOUN,B2
-hehe,hehe,嘿嘿,INTJ,B2
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello bye,hello bye,词,INTJ,B2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
 help,help,帮助,NOUN,B2
-help (noun),help,你要帮,NOUN,A1
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-hem,hem,边缘,NOUN,B2
-hematoma,hematoma,血肿,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemiplegia,hemiplegia,词,NOUN,C1
-hemistich,hemistich,词,NOUN,C1
 hemoglobin,hemoglobin,血红蛋白,NOUN,B2
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostasis,hemostasis,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
 hen,hen,母鸡,NOUN,B2
-hence,hence,因此,ADV,B2
-henceforth,henceforth,从此以后,ADV,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hepatic,hepatic,肝脏的,ADJ,B2
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,DET,B2
-her (det),her,她的,DET,B2
-her their,her their,词,DET,A1
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
 herb,herb,草药,NOUN,B2
-herbaceous,herbaceous,草本的,ADJ,B2
-herbal tea,herbal tea,词,NOUN,B2
-herbalism,herbalism,词,NOUN,C1
-herbalist,herbalist,词,NOUN,B1
-herbarium,herbarium,词,NOUN,C1
 herbicide,herbicide,除草剂,NOUN,B2
-herbs,herbs,词,NOUN,B2
 herd,herd,兽群,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
-herder,herder,牧民,NOUN,B2
 here,here,此地,NOUN,B2
-here (noun),here,此地,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here is,here is,词,ADV,A1
-here you go,here you go,词,INTJ,B2
-hereafter,hereafter,词,NOUN,C1
 hereby,hereby,特此,ADV,B2
 hereditary,hereditary,遗传的,ADJ,B2
 heredity,heredity,遗传,NOUN,B2
-herein,herein,词,ADV,B1
-heresiarch,heresiarch,词,NOUN,C1
 heresy,heresy,异端,NOUN,B2
-heretical,heretical,词,ADJ,C1
-heretical innovation,heretical innovation,词,NOUN,C1
 hermeneutic,hermeneutic,诠释学的,ADJ,B2
-hermeneutics,hermeneutics,词,NOUN,C1
-hermit,hermit,隐士,NOUN,B2
-hermitage,hermitage,词,NOUN,B2
-hernia,hernia,词,NOUN,C1
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,词,NOUN,B1
 heroism,heroism,英雄主义,NOUN,B2
-heron,heron,词,NOUN,C1
-hesitant,hesitant,犹豫的,ADJ,B2
-heterodox,heterodox,词,ADJ,C1
-heterodoxy,heterodoxy,词,NOUN,C1
-heterogeneity,heterogeneity,异质性,NOUN,B2
-heuristic,heuristic,词,ADJ,C1
-hexadecimal,hexadecimal,词,ADJ,C1
-hexagon,hexagon,词,NOUN,C1
-heyday,heyday,词,NOUN,C1
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+to hide oneself,to hide oneself,躲藏,VERB,B2
 hideout,hideout,藏身处,NOUN,B2
-hider,hider,词,NOUN,B2
 hiding,hiding,ٱختباء,NOUN,B2
-hiding ambush,hiding ambush,词,NOUN,B2
-hiding place,hiding place,藏身处,NOUN,B2
 hierarchical,hierarchical,等级的,ADJ,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
 high school,high school,高中,NOUN,B2
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,词,NOUN,B2
-high school student,high school student,词,NOUN,B2
-high tall,high tall,高的,ADJ,B2
 high tide,high tide,涨潮,NOUN,B2
-high-grade,high-grade,高档,ADJ,B2
 high-speed,high-speed,高速,ADJ,B2
-higher,higher,更高的,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highest,highest,最高的,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
-highlight,highlight,亮点,NOUN,B2
-highlighter,highlighter,词,NOUN,C1
 highness,highness,殿下,NOUN,B2
-hijacking,hijacking,词,NOUN,C1
-hiking,hiking,徒步,NOUN,B2
 hills,hills,丘陵,NOUN,B2
-hilt,hilt,剑柄,NOUN,B2
-him,him,他吧,NOUN,B2
-him (noun),him,他吧,NOUN,B2
-him dative,him dative,词,PRON,A2
-him her,him her,他/她,PRON,B2
-himself herself,himself herself,词,PRON,A1
 hindrance,hindrance,障碍,NOUN,B2
-hinge,hinge,合页,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
 hiring,hiring,招聘,NOUN,B2
-hirsute,hirsute,词,ADJ,C1
 his,his,他的,DET,B2
-his (det),his,他的,DET,A1
-his certainty,his certainty,他定,NOUN,C1
-his departure,his departure,他走,NOUN,B2
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,词,DET,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,词,ADJ,C1
-hiss,hiss,嘶嘶声,NOUN,B2
 historian,historian,历史学家,NOUN,B2
 historical record,historical record,历史纪录,NOUN,B2
 historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
 historicism,historicism,历史主义,NOUN,B2
-historicist,historicist,词,NOUN,C1
-historicity,historicity,历史性,NOUN,B2
-historicization,historicization,词,NOUN,C1
 historiography,historiography,史学,NOUN,B2
-history education,history education,词,NOUN,C1
-history story,history story,历史/故事,NOUN,B2
-histrionic,histrionic,词,ADJ,C1
 hit,hit,击中,NOUN,B2
-hit (noun),hit,必中,NOUN,B2
-hit beat,hit beat,词,VERB,A2
-hitch,hitch,词,NOUN,B2
-hither,hither,到这里,ADV,B2
 hmm,hmm,嗯,INTJ,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hold,hold,控制,NOUN,B2
-hold (noun),hold,控制,NOUN,B2
-hold catch,hold catch,词,VERB,A1
+to hold a meeting,to hold a meeting,开会,VERB,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+to hold accountable,to hold accountable,问责,VERB,B2
+to hold back,to hold back,憋,VERB,B2
+to hold on,to hold on,抓住,VERB,B2
 hold the balance of power,hold the balance of power,举足轻重,ADJ,B2
-hold together,hold together,词,VERB,C1
-holding,holding,抱有,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holdup,holdup,词,NOUN,B2
-holiday feast,holiday feast,词,NOUN,A2
-holidaymaker,holidaymaker,词,NOUN,C1
-holidays,holidays,假期,NOUN,B2
 holiness,holiness,神圣,NOUN,B2
-holism,holism,整体论,NOUN,B2
 hollow,hollow,洼地,NOUN,B2
-hollowed,hollowed,掏空的,ADJ,B2
-holm oak,holm oak,词,NOUN,C1
-holocaust,holocaust,浩劫,NOUN,B2
-hologram,hologram,词,NOUN,C1
 holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home (adv),home,词,ADV,B1
-home automation,home automation,词,NOUN,B1
 home family,home family,家,NOUN,B2
-home hearth,home hearth,词,NOUN,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,顾家的,ADJ,B2
 homeland,homeland,家乡,NOUN,B2
-homelessness,homelessness,词,NOUN,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
 homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,词,NOUN,B2
-homework duty,homework duty,词,NOUN,A2
-homiletic,homiletic,词,ADJ,C1
-homily,homily,布道,NOUN,B2
-hominization,hominization,词,NOUN,C1
-homogeneity,homogeneity,同质性,NOUN,B2
-homonym,homonym,词,NOUN,C1
-homonymy,homonymy,同音异义,NOUN,B2
-homosexual,homosexual,同性恋的,ADJ,B2
 homosexuality,homosexuality,同性恋,NOUN,B2
-homothety,homothety,位似,NOUN,C1
-honor culture,honor culture,词,NOUN,B2
-honorability,honorability,词,NOUN,C1
+to honk,to honk,按喇叭,VERB,B2
+to honor,to honor,尊敬,VERB,B2
 honorary,honorary,名誉的,ADJ,B2
 honored,honored,尊敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-hood,hood,兜帽,NOUN,B2
-hooligan,hooligan,流氓,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
 hope,hope,希望,NOUN,B2
-hope (noun),hope,还望,NOUN,A2
-hoped-for,hoped-for,词,ADJ,C1
+to hope for,to hope for,盼望,VERB,B2
 hopefully,hopefully,希望,ADV,B2
-hopelessly,hopelessly,词,ADV,B2
-hopelessness,hopelessness,词,NOUN,C1
-horde,horde,词,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
 hormone,hormone,激素,NOUN,B2
 horny,horny,性欲的,ADJ,B2
-horoscope,horoscope,星座运势,NOUN,B2
-horrified,horrified,惊骇的,ADJ,B2
 horrifying,horrifying,令人毛骨悚然的,ADJ,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-horse departure,horse departure,马去,NOUN,B2
 horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
-hospitalization,hospitalization,词,NOUN,C1
-host of angels,host of angels,天使群,NOUN,B2
-hostel,hostel,词,NOUN,C1
-hostess,hostess,女服务员,NOUN,B2
-hosting,hosting,托管,NOUN,C1
-hot air balloon,hot air balloon,热气球,NOUN,B2
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
+to host,to host,接待,VERB,B2
 hot water,hot water,热水,NOUN,B2
-hotbed,hotbed,词,NOUN,C1
-hotel industry,hotel industry,词,NOUN,C1
 hotel room,hotel room,酒店房间,NOUN,B2
-hotelier,hotelier,旅馆老板,NOUN,B2
-hothead,hothead,急性子的人,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-house search,house search,词,NOUN,B2
-household (adj),household,词,ADJ,B2
-household income,household income,词,NOUN,B2
 housework,housework,家务,NOUN,B2
-housing,housing,住房,NOUN,B2
 how,how,又怎会,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (noun),how,又怎会,NOUN,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
 how could there be,how could there be,哪有,PRON,B2
 how dare,how dare,岂敢,NOUN,B2
 how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
 how many,how many,多少,NUM,B2
-how many (pron),how many,多少,PRON,A1
 how much,how much,多少,PRON,B2
-how much (adv),how much,词,ADV,B2
-how to do it,how to do it,办呢,ADV,B2
 however,however,然而,CCONJ,B2
-however (cconj),however,然而,CCONJ,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
+to hug,to hug,拥抱,VERB,B2
 huh,huh,哈,INTJ,B2
+to hum,to hum,哼唱,VERB,B2
 human,human,人类的,ADJ,B2
-human (adj),human,人类,ADJ,A1
-human being,human being,词,NOUN,B1
-human capacity,human capacity,人会,NOUN,B2
-human law,human law,人法,NOUN,C1
 human life,human life,人命,NOUN,B2
 human nature,human nature,人性,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humanist,humanist,人文主义者,NOUN,B2
-humanitarian,humanitarian,人道主义的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
 humanization,humanization,人性化,NOUN,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
 humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
 humidity,humidity,湿度,NOUN,B2
+to humiliate,to humiliate,羞辱,VERB,B2
 humiliation,humiliation,羞辱,NOUN,B2
-humming,humming,词,NOUN,B2
-hummingbird,hummingbird,词,NOUN,B2
-humorist,humorist,词,NOUN,C1
-hump,hump,词,NOUN,C1
 hunchbacked,hunchbacked,驼背的,ADJ,B2
-hundred,hundred,一百,NOUN,B2
-hundred (noun),hundred,一百,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hundreds (num),hundreds,词,NUM,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
+to hunt,to hunt,打猎,VERB,B2
+to hunt down,to hunt down,追杀,VERB,B2
 hunter,hunter,猎人,NOUN,B2
 hunting,hunting,狩猎,NOUN,B2
-hurrah,hurrah,万岁,INTJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
 hurry,hurry,匆忙,NOUN,B2
-hurry (noun),hurry,快些,NOUN,A1
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hyaline,hyaline,词,ADJ,C1
 hybrid,hybrid,杂交的,ADJ,B2
-hybridism,hybridism,词,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
 hybridization,hybridization,杂交,NOUN,B2
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydraulic,hydraulic,液压的,ADJ,B2
 hydro energy,hydro energy,水能,NOUN,B2
-hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
 hygiene,hygiene,卫生,NOUN,B2
-hygienic,hygienic,卫生的,ADJ,B2
 hymn,hymn,赞美诗,NOUN,B2
-hymnal,hymnal,词,NOUN,C1
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
 hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
 hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
 hyper-target,hyper-target,超的,NOUN,B2
-hyper-use,hyper-use,超用,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hyperthermia,hyperthermia,体温过高,NOUN,B2
-hypertrophy,hypertrophy,肥大,NOUN,B2
 hypnosis,hypnosis,催眠,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
-hypotension,hypotension,词,NOUN,C1
-hypotensive,hypotensive,词,ADJ,C1
-hypothetically,hypothetically,词,ADV,C1
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
-hysterical,hysterical,歇斯底里的,ADJ,B2
-i,i,我连,NOUN,B2
-i don't deserve your praise,i don't deserve your praise,不敢当,INTJ,B2
-i hate,i hate,我恨,NOUN,B2
 i'm afraid,i'm afraid,恐怕,ADV,B2
 i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
-ice cold,ice cold,冰冷的,ADJ,B2
 ice cream,ice cream,冰淇淋,NOUN,B2
-ice cube,ice cube,词,NOUN,A2
-ice hockey,ice hockey,冰球,NOUN,B2
-ice pick,ice pick,词,NOUN,B2
 ice rink,ice rink,溜冰场,NOUN,B2
 ice-cold,ice-cold,冰冷的,ADJ,B2
-icicle,icicle,词,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconicity,iconicity,词,NOUN,C1
-iconographic,iconographic,词,ADJ,C1
 icy,icy,冰冷的,ADJ,B2
 id,id,证件,NOUN,B2
-id card,id card,身份证,NOUN,B2
-id photo,id photo,证件照,NOUN,B2
 ideal,ideal,理想,NOUN,B2
-ideal (noun),ideal,理想,NOUN,B2
 idealism,idealism,理想主义,NOUN,B2
 idealist,idealist,理想主义者,NOUN,B2
-idealization,idealization,词,NOUN,B2
-ideational,ideational,词,ADJ,C1
-identifier,identifier,词,NOUN,C1
-identitarianism,identitarianism,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
 ideological,ideological,意识形态的,ADJ,B2
-ideologization,ideologization,词,NOUN,C1
 idiocy,idiocy,愚蠢,NOUN,B2
 idiom,idiom,习语,NOUN,B2
-idiomatic,idiomatic,词,ADJ,C1
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncrasy,idiosyncrasy,特质,NOUN,B2
-idiot,idiot,傻瓜,ADJ,B2
-idiot (adj),idiot,词,ADJ,A2
-idiotic,idiotic,愚蠢的,ADJ,B2
-idolatry,idolatry,词,NOUN,B2
-idyll,idyll,田园诗,NOUN,B2
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if i,if i,我若,SCONJ,B2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
 if when,if when,如果,SCONJ,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominy,ignominy,耻辱,NOUN,B2
-iliac,iliac,词,ADJ,C1
 illegality,illegality,非法,NOUN,B2
-illegally,illegally,词,ADV,C1
-illiteracy,illiteracy,词,NOUN,C1
-illiterate,illiterate,词,ADJ,B2
-illogical,illogical,不合逻辑的,ADJ,B2
-illumination,illumination,照明,NOUN,B2
-illuminationism,illuminationism,照明主义,NOUN,C1
-illuminator,illuminator,彩饰画家,NOUN,B2
-illusory,illusory,词,ADJ,C1
-illustration,illustration,插图,NOUN,B2
-illustrative,illustrative,词,ADJ,C1
-illustrious,illustrious,著名的,ADJ,B2
-image formation,image formation,词,NOUN,B2
 imagery,imagery,意象,NOUN,B2
 imaginary,imaginary,虚构的,ADJ,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imaginative,imaginative,富有想象力的,ADJ,B2
-imagined,imagined,想象的,ADJ,C1
-imaging,imaging,词,NOUN,C1
-imam,imam,伊玛目,NOUN,B2
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
-imbecility,imbecility,词,NOUN,C1
 imitation,imitation,模仿,NOUN,B2
 imitative,imitative,模仿性,ADJ,B2
-immaculate,immaculate,词,ADJ,C1
 immanence,immanence,内在性,NOUN,B2
-immanent,immanent,词,ADJ,C1
 immeasurable,immeasurable,不可估量的,ADJ,B2
-immediacy,immediacy,词,NOUN,C1
-immemorial,immemorial,词,ADJ,C1
-immensely,immensely,词,ADV,B2
-immensity,immensity,词,NOUN,C1
-immersed,immersed,词,ADJ,C1
 immersion,immersion,沉浸,NOUN,B2
-imminence,imminence,就将,NOUN,C1
+to immigrate,to immigrate,移入,VERB,B2
 imminent,imminent,即将来临的,ADJ,B2
 immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immodesty,immodesty,不贞,NOUN,B2
-immorality,immorality,词,NOUN,C1
 immortality,immortality,不朽,NOUN,B2
-immovable,immovable,不可移动的,ADJ,B2
 immunization,immunization,免疫,NOUN,B2
-immunotherapy,immunotherapy,免疫治疗,NOUN,B2
-impairment,impairment,左手废,NOUN,B2
-impartial,impartial,词,ADJ,C1
-impartiality,impartiality,公正,NOUN,B2
-impasse,impasse,词,NOUN,C1
-impassive,impassive,词,ADJ,C1
-impassively,impassively,词,ADV,B2
-impatience,impatience,词,NOUN,C1
+to impart,to impart,传授,VERB,B2
 impediment,impediment,障碍,NOUN,B2
-imperatively,imperatively,词,ADV,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperfect,imperfect,不完美的,ADJ,B2
-imperfection,imperfection,词,NOUN,C1
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
+to impel,to impel,推动,VERB,B2
 imperial court,imperial court,朝廷,NOUN,B2
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
 imperial father,imperial father,父皇,NOUN,B2
-imperial father's will,imperial father's will,父皇要,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
 imperial guard,imperial guard,御林,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
 imperial physician,imperial physician,御医,NOUN,B2
-imperial relatives,imperial relatives,皇亲,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
 imperialism,imperialism,帝国主义,NOUN,B2
-imperialist,imperialist,词,ADJ,C1
-imperious,imperious,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbably,imperturbably,词,ADV,C1
-impetuosity,impetuosity,词,NOUN,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implacably,implacably,毫不留情地,ADV,B2
-implantation,implantation,词,NOUN,C1
-implicated,implicated,牵连的,ADJ,C1
-implicitly,implicitly,含蓄地,ADV,B2
+to implore,to implore,恳求,VERB,B2
 impolite,impolite,不礼貌的,ADJ,B2
-impoliteness,impoliteness,词,NOUN,C1
 import,import,进口,NOUN,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
 importation,importation,进口,NOUN,B2
-imports,imports,词,NOUN,C1
-imposing,imposing,宏伟的,ADJ,B2
-imposition,imposition,词,NOUN,C1
 impossibility,impossibility,不可能,NOUN,B2
-impostor,impostor,词,NOUN,B2
-imposture,imposture,词,NOUN,C1
-impotence,impotence,无力,NOUN,B2
-impotent,impotent,词,ADJ,C1
-impound lot,impound lot,词,NOUN,B1
-impoverished,impoverished,词,ADJ,B2
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
-impressed,impressed,印象深刻的,ADJ,B2
 impressionism,impressionism,印象主义,NOUN,B2
-impressions,impressions,感想,NOUN,B2
-imprint,imprint,印记,NOUN,B2
-imprisoned,imprisoned,词,ADJ,B2
+to imprison,to imprison,监禁,VERB,B2
 imprisonment,imprisonment,监禁,NOUN,B2
 improper,improper,不合适的,ADJ,B2
 improvement,improvement,好转,NOUN,B2
-improvidence,improvidence,词,NOUN,C1
 improvisation,improvisation,即兴创作,NOUN,B2
-imprudence,imprudence,词,NOUN,C1
-imprudent,imprudent,词,ADJ,C1
 impudence,impudence,厚颜无耻,NOUN,B2
 impulsive,impulsive,冲动的,ADJ,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-impunity,impunity,逍遥法外,NOUN,B2
-impure,impure,词,ADJ,C1
 impurity,impurity,不纯,NOUN,B2
-imputation,imputation,词,NOUN,C1
 in,in,进来,ADV,B2
-in (adv),in,进来,ADV,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
 in addition,in addition,此外,ADV,B2
-in addition to,in addition to,词,ADP,B2
 in advance,in advance,事先,ADV,B2
-in agreement,in agreement,词,ADV,C1
-in anticipation of,in anticipation of,词,ADV,C1
 in between,in between,在中间,ADV,B2
-in book,in book,书里,NOUN,C1
 in case,in case,如果,SCONJ,B2
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in deficit,in deficit,词,ADJ,C1
-in detail,in detail,详细地,ADV,B2
-in every detail,in every detail,词,ADV,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
 in front,in front,在前面,ADV,B2
 in front of,in front of,在……前面,ADP,B2
-in front of before,in front of before,在...前,ADP,B2
-in here,in here,在这里面,ADV,B2
-in high spirits,in high spirits,兴高采烈,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
 in it,in it,在里面,ADV,B2
-in its entirety,in its entirety,词,ADV,C1
-in love,in love,恋爱中的,ADJ,B2
-in me,in me,我中,NOUN,C1
-in mind,in mind,词,ADV,B2
-in need,in need,词,ADJ,A2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
 in order to,in order to,以期,SCONJ,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
 in person,in person,亲自地,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in private,in private,词,ADV,B2
-in question,in question,词,ADV,C1
-in return,in return,词,NOUN,B2
 in short,in short,简而言之,ADV,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,在后面,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the sky,in the sky,天上,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,词,ADV,B2
 in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
 in time,in time,及时地,ADV,B2
-in time (adj),in time,词,ADJ,B1
-in two,in two,成两半,ADV,B2
-in unison,in unison,词,ADV,B2
 in vain,in vain,徒劳,ADV,B2
-in vain (noun),in vain,词,NOUN,B2
-in view of,in view of,鉴于,ADP,B2
-in which,in which,在其中,PRON,B2
-in wind,in wind,临风,NOUN,B2
-in writing,in writing,书面,NOUN,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccessible,inaccessible,词,ADJ,C1
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inactivity,inactivity,不活跃,NOUN,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadmissible,inadmissible,不可接受的,ADJ,B2
-inadvertently,inadvertently,词,ADV,B2
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inattentive,inattentive,词,ADJ,C1
+to inaugurate,to inaugurate,启用,VERB,B2
 inauguration,inauguration,开幕,NOUN,B2
-inboard,inboard,船内的,ADV,B2
-inborn nature,inborn nature,词,NOUN,C1
-incandescence,incandescence,词,NOUN,C1
 incantation,incantation,咒语,NOUN,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incarceration,incarceration,词,NOUN,C1
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
 incense,incense,香,NOUN,B2
-incentivization,incentivization,词,NOUN,C1
-inceptive,inceptive,词,ADJ,C1
-incest,incest,词,NOUN,C1
 inch,inch,بوصة,NOUN,B2
-inchoative,inchoative,词,ADJ,C1
-incidence,incidence,发生率,NOUN,B2
-incidental,incidental,词,ADJ,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
-incipient,incipient,词,ADJ,C1
+to incinerate,to incinerate,焚烧,VERB,B2
+to incite,to incite,煽动,VERB,B2
 incitement,incitement,煽动,NOUN,B2
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,严酷的,ADJ,B2
 inclination,inclination,倾向,NOUN,B2
-inclined prone,inclined prone,词,ADJ,C1
-including,including,包括,ADP,B2
-including (adv),including,词,ADV,A2
-inclusion,inclusion,包含,NOUN,B2
-incognito,incognito,词,ADJ,C1
+to incline,to incline,使倾斜,VERB,B2
 incoherence,incoherence,不连贯,NOUN,B2
-incoherent,incoherent,不连贯的,ADJ,B2
-income and expense,income and expense,收支,NOUN,B2
-income tax,income tax,所得税,NOUN,B2
-incoming,incoming,进来的,ADJ,B2
-incommunicado,incommunicado,词,ADJ,C1
 incompatibility,incompatibility,不兼容,NOUN,B2
-incompetence,incompetence,词,NOUN,C1
 incomplete,incomplete,不完整的,ADJ,B2
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,词,NOUN,B2
 incomprehensible,incomprehensible,不可理解的,ADJ,B2
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable,inconceivable,不可想象的,ADJ,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,不协调,NOUN,B2
-inconsiderate,inconsiderate,词,ADJ,C1
-inconsistency,inconsistency,不一致,NOUN,B2
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontestably,incontestably,词,ADV,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorporation,incorporation,纳入,NOUN,B2
-incorrect,incorrect,不正确的,ADJ,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
 increase,increase,增加,NOUN,B2
-increase (noun),increase,就越,NOUN,B1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increased,increased,增加的,ADJ,B2
-increases,increases,增加,NOUN,C1
-increasing,increasing,增加的,ADJ,B2
-increasingly,increasingly,越来越,ADV,B2
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
 incremental,incremental,渐进性,ADJ,B2
 incubation,incubation,孵化,NOUN,B2
 incubator,incubator,孵化器,NOUN,B2
-inculcate,inculcate,词,VERB,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-indebted,indebted,负债的,ADJ,B2
 indebtedness,indebtedness,负债,NOUN,B2
-indecent,indecent,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
 indecisive,indecisive,犹豫不决的,ADJ,B2
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
 indelible,indelible,不可磨灭的,ADJ,B2
-independently,independently,独立地,ADV,B2
 indescribable,indescribable,难以形容的,ADJ,B2
-indeterminate,indeterminate,词,ADJ,C1
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
 index,index,索引,NOUN,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
 indexing,indexing,指数化,NOUN,B2
-indian (adj),indian,词,ADJ,B2
-indication,indication,指示,NOUN,B2
 indicator,indicator,指标,NOUN,B2
 indifference,indifference,冷漠,NOUN,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indigent,indigent,词,ADJ,C1
 indigestion,indigestion,消化不良,NOUN,B2
-indignity,indignity,词,NOUN,C1
-indirect,indirect,词,ADJ,C1
-indirectly,indirectly,间接地,ADV,B2
-indiscreet,indiscreet,词,ADJ,C1
-indiscretion,indiscretion,轻率,NOUN,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinct,indistinct,模糊的,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
 individual,individual,单独的,ADJ,B2
-individual (adj),individual,个人的,ADJ,B2
-individual assignment,individual assignment,个人作业,NOUN,B2
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
 individualism,individualism,个人主义,NOUN,B2
 individuality,individuality,个性,NOUN,B2
-individualization,individualization,词,NOUN,C1
-individually,individually,词,ADV,C1
-indoctrination,indoctrination,灌输,NOUN,B2
-indomitable,indomitable,词,ADJ,C1
-indonesian,indonesian,词,ADJ,B2
-indoors,indoors,在室内,ADV,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrialization,industrialization,工业化,NOUN,B2
-industrious,industrious,词,ADJ,C1
 industry chain,industry chain,产业链,NOUN,B2
-inedible,inedible,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-ineffectiveness,ineffectiveness,词,NOUN,B2
-inefficiency,inefficiency,低效,NOUN,B2
 inefficient,inefficient,低效的,ADJ,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inequity,inequity,词,NOUN,C1
 inertia,inertia,惯性,NOUN,B2
-inertness,inertness,词,NOUN,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable (noun),inevitable,词,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexperienced,inexperienced,生疏的,ADJ,B2
-inexpressible,inexpressible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infamy,infamy,恶名,NOUN,B2
-infantilism,infantilism,词,NOUN,C1
-infantry,infantry,步兵,NOUN,B2
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-infected,infected,被感染的,ADJ,B2
 inference,inference,推断,NOUN,B2
-inferential,inferential,词,ADJ,C1
-inferiority,inferiority,劣势,NOUN,B2
-infertility,infertility,词,NOUN,C1
-infidelity,infidelity,不忠,NOUN,B2
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infinitely,infinitely,词,ADV,B2
-infinitive marker,infinitive marker,去,PART,B2
-infinity,infinity,词,NOUN,C1
-infirmary,infirmary,医务室,NOUN,B2
-inflamed,inflamed,激烈的,ADJ,B2
-inflammable,inflammable,易燃的,ADJ,B2
 inflammation,inflammation,炎症,NOUN,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflated,inflated,膨胀的,ADJ,B1
-inflationary,inflationary,词,ADJ,C1
-inflection,inflection,词尾,NOUN,B2
-inflexibility,inflexibility,僵化,NOUN,B2
-influential person,influential person,词,NOUN,C1
-influx,influx,涌入,NOUN,B2
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
+to influence,to influence,影响,VERB,B2
 informant,informant,线人,NOUN,B2
-informatics,informatics,词,NOUN,B2
-information desk,information desk,词,NOUN,B1
-information exchange,information exchange,词,NOUN,B2
-informative,informative,提供信息的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informer,informer,词,NOUN,C1
-informers,informers,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructural,infrastructural,词,ADJ,C1
-infringement,infringement,侵犯,NOUN,C1
-ingratitude,ingratitude,词,NOUN,C1
-ingredients,ingredients,词,NOUN,B1
-inhabited,inhabited,词,ADJ,C1
-inharmonious,inharmonious,词,ADJ,C1
-inherence,inherence,词,NOUN,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inherited,inherited,词,ADJ,C1
-inhibited,inhibited,词,ADJ,B2
-inhibition,inhibition,抑制,NOUN,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhuman,inhuman,不人道的,ADJ,B2
-inhumanity,inhumanity,词,NOUN,C1
-inimitability,inimitability,词,NOUN,C1
-initial (noun),initial,词,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
+to infringe,to infringe,侵犯,VERB,B2
 initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
 initially,initially,首先,ADV,B2
-initiation,initiation,词,NOUN,C1
-injured,injured,受伤的,ADJ,B2
-injury recovery,injury recovery,好伤,NOUN,C1
 injustice,injustice,不公,NOUN,B2
 ink,ink,墨水,NOUN,B2
-inkling,inkling,预感,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
-inner court,inner court,朝内,NOUN,B2
 inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
 inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
-innermost,innermost,最里面的,ADV,B2
-innocent,innocent,无辜地,ADV,B2
-innocent (adv),innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
 innovative,innovative,创新的,ADJ,B2
-innuendo,innuendo,词,NOUN,C1
-inopportune,inopportune,词,ADJ,C1
-inorganic,inorganic,词,ADJ,C1
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
-inquisition,inquisition,宗教裁判所,NOUN,B2
-insanely,insanely,疯狂地,ADV,B2
 inscription,inscription,刻有,NOUN,B2
-insect-proof,insect-proof,防虫,ADJ,C1
 insecticide,insecticide,杀虫剂,NOUN,B2
-insecurity,insecurity,不安全感,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensitive,insensitive,麻木的,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
 inseparable,inseparable,不可分割的,ADJ,B2
-insertion,insertion,词,NOUN,B2
 inside,inside,在里面,ADV,B2
 inside,inside,内部,NOUN,B2
-inside (adv),inside,在里面,ADV,A1
-inside (noun),inside,内,NOUN,B2
-inside city,inside city,城内,NOUN,B2
 inside in,inside in,里,NOUN,B2
-inside of,inside of,词,ADP,B2
-inside story,inside story,内幕,NOUN,B2
 insider,insider,知情者,NOUN,B2
-insidiously,insidiously,词,ADV,B2
-insightfulness,insightfulness,洞察,NOUN,B2
-insinuation,insinuation,暗示,NOUN,B2
 insistence,insistence,坚持,NOUN,B2
-insistence persistence,insistence persistence,词,NOUN,B2
 insolence,insolence,无礼,NOUN,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
-insolent conceit,insolent conceit,词,NOUN,C1
 insolvency,insolvency,无偿付能力,NOUN,B2
-insolvent,insolvent,无偿还能力的,ADJ,B2
 insomnia,insomnia,失眠,NOUN,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
-inspectorate,inspectorate,词,NOUN,C1
-inspiring,inspiring,鼓舞人心的,ADJ,B2
-instability,instability,不稳定,NOUN,B2
 installation,installation,安装,NOUN,B2
-installation assembly,installation assembly,词,NOUN,C1
-installed,installed,词,ADJ,C1
 installment,installment,分期付款,NOUN,B2
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
 instant,instant,فور,NOUN,B2
-instantaneous,instantaneous,瞬间的,ADJ,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instantly,instantly,词,ADV,C1
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
-instead on the contrary,instead on the contrary,反而,ADV,B2
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instinctuality,instinctuality,词,NOUN,C1
 institutional,institutional,机构的,ADJ,B2
-institutionalization,institutionalization,制度化,NOUN,B2
-institutionalized,institutionalized,词,ADJ,C1
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructive,instructive,有教育意义的,ADJ,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insufficiency,insufficiency,不足,NOUN,B2
-insulator,insulator,词,NOUN,B2
-insulin,insulin,胰岛素,NOUN,B2
 insult,insult,辱骂,NOUN,B2
-insult (noun),insult,insult,NOUN,C1
-insurances,insurances,词,NOUN,C1
-insured,insured,词,NOUN,B2
-insurer,insurer,词,NOUN,C1
+to insure,to insure,保证,VERB,B2
 insurmountable,insurmountable,不可逾越的,ADJ,B2
 insurrection,insurrection,起义,NOUN,B2
-integer,integer,词,NOUN,C1
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intellectual life,intellectual life,词,NOUN,B2
 intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
-intelligently,intelligently,词,ADV,C1
-intemperate,intemperate,词,ADJ,C1
-intended,intended,预定的,ADJ,B2
-intended (noun),intended,intended,NOUN,B2
-intended meaning,intended meaning,词,NOUN,C1
-intensification,intensification,词,NOUN,C1
+to intensify,to intensify,加剧,VERB,B2
 intensity,intensity,强度,NOUN,B2
-intensive,intensive,强化的,ADJ,B2
 intensive care,intensive care,重症监护,NOUN,B2
-intentionality,intentionality,词,NOUN,C1
-intentionally,intentionally,故意地,ADV,B2
-intentions,intentions,词,NOUN,C1
 interactive,interactive,交互式的,ADJ,B2
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
 intercourse,intercourse,性交,NOUN,B2
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,interdiction,词,NOUN,C1
-interest rate,interest rate,利率,NOUN,B2
-interesting things,interesting things,词,NOUN,C1
-interim (adj),interim,词,ADJ,C1
-interim (noun),interim,词,NOUN,B2
+to interest,to interest,使感兴趣,VERB,B2
 interior,interior,内部,NOUN,B2
-interjection,interjection,词,NOUN,C1
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
-interlocutor,interlocutor,对话者,NOUN,B2
 intermediary,intermediary,中间人,NOUN,B2
-intermission,intermission,词,NOUN,C1
-intern,intern,词,NOUN,C1
-internal affairs,internal affairs,内政,NOUN,C1
-internal force,internal force,内力,NOUN,B2
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
-international student,international student,留学生,NOUN,B2
-internationalization,internationalization,词,NOUN,C1
 internship,internship,实习,NOUN,B2
-interpellation,interpellation,词,NOUN,C1
-interpersonal,interpersonal,人际的,ADJ,B2
 interpretation,interpretation,解释,NOUN,B2
 interpreter,interpreter,口译员,NOUN,B2
-interpretive,interpretive,词,ADJ,C1
-interrogation room,interrogation room,审讯室,NOUN,B2
-interrupted,interrupted,词,ADJ,B2
 intersection,intersection,交叉点,NOUN,B2
-intertextuality,intertextuality,词,NOUN,C1
-intertwined,intertwined,词,ADJ,C1
-interviewer,interviewer,词,NOUN,C1
+to intervene,to intervene,干预,VERB,B2
+to interview,to interview,采访,VERB,B2
 intestine,intestine,肠,NOUN,B2
-intestines,intestines,词,NOUN,B2
 intimacy,intimacy,亲密,NOUN,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimately,intimately,词,ADV,C1
 intimidation,intimidation,恐吓,NOUN,B2
-into (adv),into,词,ADV,B1
-intolerable,intolerable,词,ADJ,C1
-intolerance,intolerance,不容忍,NOUN,B2
-intolerant,intolerant,不容忍的,ADJ,B2
 intonation,intonation,语调,NOUN,B2
-intonational quality,intonational quality,词,NOUN,C1
-intoxication,intoxication,词,NOUN,C1
-intransigence,intransigence,词,NOUN,C1
 intravenous drip,intravenous drip,输液,NOUN,B2
-intrepidity,intrepidity,词,NOUN,C1
-intricacy,intricacy,词,NOUN,C1
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
-intrinsically,intrinsically,词,ADV,C1
-introductory,introductory,词,ADJ,C1
 introspection,introspection,内省,NOUN,B2
-introversion,introversion,词,NOUN,B2
-intruder,intruder,入侵者,NOUN,B2
 intrusion,intrusion,闯入,NOUN,B2
-intuitionist,intuitionist,词,ADJ,C1
-invader,invader,入侵者,NOUN,B2
-invalidated,invalidated,词,ADJ,C1
-invalidity,invalidity,词,NOUN,C1
-invariably,invariably,不变地,ADV,B2
+to invade,to invade,入侵,VERB,B2
 inventory,inventory,库存,NOUN,B2
-inventorying,inventorying,清点,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
 inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigated,investigated,被调查的,ADJ,B2
-investigative,investigative,词,ADJ,C1
-investment (adj),investment,词,ADJ,C1
-invincibility,invincibility,不胜,NOUN,C1
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite offer,invite offer,词,VERB,A2
-invited,invited,词,ADJ,C1
-invocation,invocation,词,NOUN,C1
-invocations,invocations,词,NOUN,C1
-invoicing,invoicing,词,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
-involuntary,involuntary,无意识的,ADJ,B2
-involved party,involved party,词,NOUN,C1
-invulnerability,invulnerability,词,NOUN,C1
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-iodine deficiency,iodine deficiency,词,NOUN,C1
-ion,ion,词,NOUN,C1
-iranian,iranian,伊朗的,ADJ,B2
-irascibility,irascibility,易怒,NOUN,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰的,ADJ,B2
-irish person,irish person,爱尔兰人,NOUN,B2
 iron,iron,铁的,ADJ,B2
-iron (adj),iron,铁的,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
+to iron,to iron,熨烫,VERB,B2
 irrationality,irrationality,非理性,NOUN,B2
 irreconcilable,irreconcilable,不可调和的,ADJ,B2
 irrefutable,irrefutable,无可辩驳的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irregular,irregular,不规则的,ADJ,B2
-irregularity,irregularity,不规则,NOUN,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irreligious,irreligious,词,ADJ,C1
-irremediably,irremediably,词,ADV,B2
 irreplaceable,irreplaceable,不可替代的,ADJ,B2
-irretrievable,irretrievable,词,ADJ,C1
-irreversibility,irreversibility,词,NOUN,C1
 irreversible,irreversible,不可逆转的,ADJ,B2
-irrigation,irrigation,词,NOUN,B2
 irrigation canal,irrigation canal,灌溉渠,NOUN,B2
-irritability,irritability,词,NOUN,C1
 irritable,irritable,易怒的,ADJ,B2
-irritable boredom,irritable boredom,词,NOUN,C1
-irritating,irritating,令人恼火的,ADJ,B2
 irritation,irritation,刺激,NOUN,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamic,islamic,伊斯兰的,ADJ,B2
-islamization,islamization,词,NOUN,C1
-islander,islander,词,NOUN,C1
 isolated,isolated,孤立的,ADJ,B2
-isolated reports,isolated reports,词,NOUN,C1
 isolation,isolation,隔绝,NOUN,B2
-isthmus,isthmus,词,NOUN,C1
-it,it,对此,ADV,B2
-it (noun),it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
+to issue,to issue,颁布,VERB,B2
 it is a pity,it is a pity,可惜,ADJ,B2
-it neuter,it neuter,它 (中性),PRON,B2
 italian,italian,意大利人,NOUN,B2
+to itch,to itch,发痒,VERB,B2
 itching,itching,瘙痒,NOUN,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-itinerary,itinerary,行程,NOUN,B2
-its,its,它的,PRON,B2
-its details,its details,其详,NOUN,B2
 its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-jack plug,jack plug,词,NOUN,C1
-jackal,jackal,词,NOUN,B2
 jade,jade,这玉,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
 jade ware,jade ware,玉器,NOUN,B2
-jadeite,jadeite,翡翠,NOUN,C1
-jailer,jailer,词,NOUN,B2
 jam,jam,果酱,NOUN,B2
-janitor,janitor,词,NOUN,B2
-january,january,一月,NOUN,B2
 japanese,japanese,日本人,NOUN,B2
 jar,jar,广口瓶,NOUN,B2
 jargon,jargon,行话,NOUN,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jasmine tea,jasmine tea,词,NOUN,C1
 jaundice,jaundice,黄疸,NOUN,B2
-jaws,jaws,词,NOUN,C1
 jeans,jeans,牛仔裤,NOUN,B2
-jersey,jersey,词,NOUN,B1
-jest,jest,词,NOUN,C1
-jet-black,jet-black,乌黑,ADJ,B2
 jew,jew,犹太人,NOUN,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jeweler,jeweler,词,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewelry set,jewelry set,词,NOUN,C1
-jewelry store,jewelry store,珠宝店,NOUN,B2
-jewish,jewish,犹太的,ADJ,B2
-jews,jews,犹太人,NOUN,B2
-jianghu,jianghu,江湖,NOUN,B2
 jianghu world,jianghu world,江湖上,NOUN,B2
-jiaolong,jiaolong,娇龙,NOUN,B2
 jin,jin,斤,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocularity,jocularity,词,NOUN,B2
-jog,jog,词,VERB,A1
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,词,NOUN,B2
 joint,joint,平等的,ADJ,B2
-joint (adj),joint,联席,ADJ,B2
 joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
 joint ownership,joint ownership,共有,NOUN,B2
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-jointness,jointness,词,NOUN,C1
-joker,joker,词,NOUN,C1
-joking,joking,词,NOUN,B2
-journal,journal,词,NOUN,C1
 journal article,journal article,期刊论文,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-journeying,journeying,词,NOUN,C1
-joust,joust,词,NOUN,B1
-jubilation,jubilation,欢欣,NOUN,B2
 jubilee,jubilee,禧年,NOUN,B2
-judge sentence,judge sentence,词,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
-judicial,judicial,司法,NOUN,B2
-judicial (adj),judicial,司法的,ADJ,B2
+to judge,to judge,判断,VERB,B2
 judiciary,judiciary,司法官,NOUN,B2
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
 jujube,jujube,枣子,NOUN,B2
-july,july,七月,NOUN,B2
-jumble,jumble,词,NOUN,B2
 jump,jump,跳跃,NOUN,B2
-jump (noun),jump,跳跃,NOUN,B1
-junction,junction,词,NOUN,C1
-juncture,juncture,词,NOUN,B2
-june,june,六月,NOUN,B2
 jungle,jungle,丛林,NOUN,B2
-jungles,jungles,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junk,junk,破烂货,NOUN,B2
-junkie,junkie,词,NOUN,C1
-junta,junta,词,NOUN,C1
-jurisconsult,jurisconsult,法学专家,NOUN,B2
-jurisdiction area,jurisdiction area,辖区,NOUN,B2
-jurisprudence,jurisprudence,法理学,NOUN,B2
-jurist,jurist,法学家,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
-jury service,jury service,陪审,NOUN,C1
 just,just,公正,ADJ,B2
-just (adj),just,公正,ADJ,B2
-just as,just as,词,ADV,A2
-just as in the past,just as in the past,一如既往,ADV,B2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,随便地,ADV,B2
 just now,just now,刚刚,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
 just right,just right,恰到好处,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
 justification,justification,理由,NOUN,B2
-justified,justified,词,ADJ,B2
-justness,justness,公正,NOUN,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
-juxtapose,juxtapose,词,VERB,C1
-kaleidoscope,kaleidoscope,词,NOUN,B2
 karate,karate,空手道,NOUN,B2
-kasbah,kasbah,词,NOUN,B1
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenness,keenness,词,NOUN,B2
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kept,kept,词,ADJ,B2
-kerosene,kerosene,火油,NOUN,C1
 kettle,kettle,水壶,NOUN,B2
-key point,key point,要点,NOUN,C1
 keyboard,keyboard,键盘,NOUN,B2
-khul',khul',女方离婚,NOUN,C1
 kick,kick,踢,NOUN,B2
-kick (noun),kick,词,NOUN,B1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kidnapper,kidnapper,绑架者,NOUN,B2
-kids,kids,词,NOUN,B2
 kill two birds with one stone,kill two birds with one stone,一举两得,ADJ,B2
-killed,killed,词,NOUN,B2
-killing,killing,词,NOUN,B2
 kilogram,kilogram,千克,NOUN,B2
 kilometer,kilometer,公里,NOUN,B2
-kin,kin,词,NOUN,B2
 kind,kind,仁慈的,ADJ,B2
-kind (adj),kind,亲切,ADJ,A1
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindly,kindly,慈祥,ADJ,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
 king,king,王,PART,B2
-king (part),king,王,PART,B2
 kinship,kinship,亲属关系,NOUN,B2
-kiosk,kiosk,亭子,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
+to kiss,to kiss,亲吻,VERB,B2
 kite,kite,风筝,NOUN,B2
-kitten,kitten,词,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-knack,knack,窍,NOUN,C1
-kneader,kneader,词,NOUN,C1
 kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knock,knock,敲击,NOUN,B2
-knock (noun),knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-knowledgeably,knowledgeably,词,ADV,C1
-known,known,已知的,ADJ,B2
-known famous,known famous,著名的/熟悉的,ADJ,B2
-kohl,kohl,词,NOUN,A1
-laazima,laazima,词,NOUN,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,词,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-labor-related,labor-related,词,ADJ,C1
-laboratory (adj),laboratory,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laborious striving,laborious striving,词,NOUN,C1
-laboriously,laboriously,词,ADV,C1
-labour market,labour market,词,NOUN,B1
-labyrinth,labyrinth,词,NOUN,C1
-lace,lace,词,NOUN,C1
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-laconically,laconically,词,ADV,C1
-laconism,laconism,词,NOUN,B2
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-lacunary,lacunary,残缺的,ADJ,B2
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-ladle,ladle,词,NOUN,A2
-lagoon,lagoon,词,NOUN,C1
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lament (noun),lament,词,NOUN,C1
-lamp niche,lamp niche,词,NOUN,C1
-lampoon,lampoon,词,NOUN,C1
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
-land (adj),land,بري,ADJ,B2
+to know nothing,to know nothing,一无所知,VERB,B2
+to lack,to lack,缺乏,VERB,B2
+to lack basis,to lack basis,无据,VERB,B2
 land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,土地政策,NOUN,B2
-land register,land register,地籍,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land use,land use,词,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landfill,landfill,填埋,NOUN,C1
-landmark (adj),landmark,标志性,ADJ,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landmine,landmine,词,NOUN,C1
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
 landslide,landslide,滑坡,NOUN,B2
-language use,language use,语言使用,NOUN,B2
-languor,languor,倦怠,NOUN,B2
-lapidary,lapidary,词,ADJ,B2
-lapse,lapse,疏忽,NOUN,B2
-lapse of time,lapse of time,词,NOUN,C1
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large estate,large estate,词,NOUN,C1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
 large-scale,large-scale,大规模的,ADJ,B2
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larva,larva,幼虫,NOUN,B2
 larynx,larynx,喉,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
-lassitude,lassitude,词,NOUN,C1
 last,last,最后,ADV,B2
-last (adv),last,词,ADV,B2
-last (num),last,词,NUM,A2
-last evening,last evening,,NOUN,B2
-last name,last name,姓,NOUN,B2
-last night,last night,昨晚,ADV,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
 last year,last year,去年,NOUN,B2
-lasting,lasting,词,ADJ,C1
 late,late,晚,ADV,B2
 late,late,晚才,NOUN,B2
-late (adv),late,迟,ADV,A1
-late (noun),late,晚才,NOUN,B2
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
 late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
 lateral,lateral,侧面的,ADJ,B2
-lateral side,lateral side,词,ADJ,C1
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin,latin,拉丁的,ADJ,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latitude leeway,latitude leeway,词,NOUN,C1
-laugh (noun),laugh,词,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
 laughter,laughter,笑声,NOUN,B2
 launch,launch,发射,NOUN,B2
-launch (noun),launch,词,NOUN,B1
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,洗钱,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
-laundry detergent,laundry detergent,词,NOUN,B2
-laundry room,laundry room,洗衣房,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
 law,law,法,PART,B2
-law (part),law,法,PART,B2
-law enforcement,law enforcement,执法,NOUN,B2
-law firm,law firm,律师事务所,NOUN,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
-lawless,lawless,无法的,ADJ,B2
-lawlessness,lawlessness,词,NOUN,C1
-lawnmower,lawnmower,割草机,NOUN,B2
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lawyer female,lawyer female,词,NOUN,B2
-laxative,laxative,词,NOUN,C1
-laxity,laxity,松弛,NOUN,B2
-lay,lay,叙事短诗,NOUN,B2
-lay (adj),lay,词,ADJ,C1
-lay (noun),lay,叙事短诗,NOUN,B2
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
-layer storage,layer storage,层/仓库,NOUN,B2
 layman,layman,外行,NOUN,B2
 layoff,layoff,解雇,NOUN,B2
-layperson,layperson,外行,NOUN,B2
 laziness,laziness,懒惰,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
 lead,lead,铅,NOUN,B2
-lead (noun),lead,铅,NOUN,B2
-lead actor,lead actor,主演,NOUN,B2
 lead thousand,lead thousand,率千,NOUN,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
+to lead to,to lead to,通向,VERB,B2
 leading,leading,领先的,ADJ,B2
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf litter,leaf litter,词,NOUN,C1
-leaf page,leaf page,叶子,NOUN,B2
-leafiness,leafiness,词,NOUN,C1
-leafy,leafy,枝叶茂密的,ADJ,B2
-leak escape,leak escape,词,NOUN,B1
+to leak,to leak,泄漏,VERB,B2
 lean,lean,瘦的,ADJ,B2
-lean (adj),lean,词,ADJ,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
+to leap,to leap,跨越,VERB,B2
 learning,learning,学习,NOUN,B2
-learning curve,learning curve,学习曲线,NOUN,B2
-leash,leash,词,NOUN,B2
-leasing,leasing,词,NOUN,C1
-least,least,最少,ADV,B2
-least (adv),least,最少,ADV,B2
-leather goods,leather goods,词,NOUN,C1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
 leave,leave,休假,NOUN,B2
-leave (noun),leave,休假,NOUN,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
+to leave behind,to leave behind,留下,VERB,B2
+to lecture,to lecture,教导,VERB,B2
 lecturer,lecturer,演讲者,NOUN,B2
-led astray,led astray,词,ADJ,C1
 ledger,ledger,总账,NOUN,B2
-leek,leek,词,NOUN,A2
 left,left,左边的,ADJ,B2
 left,left,左边,ADV,B2
 left,left,左,NOUN,B2
-left (adj),left,向左,ADJ,B1
-left (noun),left,左,NOUN,A1
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
 left side,left side,左侧,NOUN,B2
-left-handed,left-handed,词,ADJ,C1
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leftovers,leftovers,词,NOUN,B2
-leg of lamb,leg of lamb,词,NOUN,B1
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal expert,legal expert,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
 legal profession,legal profession,律师业,NOUN,B2
-legal representative,legal representative,词,NOUN,C1
-legality,legality,合法性,NOUN,B2
-legalization,legalization,词,NOUN,C1
-legatee,legatee,受遗赠人,NOUN,B2
-legation,legation,公使馆,NOUN,B2
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legion unit,legion unit,,NOUN,B2
 legislative,legislative,立法的,ADJ,B2
-legislative elections,legislative elections,词,NOUN,C1
-legislator,legislator,词,NOUN,C1
-legislature,legislature,词,NOUN,B2
 legitimacy,legitimacy,合法性,NOUN,B2
-legitimization,legitimization,词,NOUN,B2
-leisurely,leisurely,词,ADJ,C1
-lemon verbena,lemon verbena,词,NOUN,B2
-lemonade,lemonade,词,NOUN,A2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-leniency,leniency,宽厚,NOUN,B2
-lent,lent,大斋期,NOUN,B2
-lentil lens,lentil lens,词,NOUN,C1
-lentils,lentils,词,NOUN,A2
-lesbian,lesbian,女同性恋的,ADJ,B2
-less,less,更少,ADV,B2
-less (adv),less,较少,ADV,A1
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
+to legitimize,to legitimize,使合法,VERB,B2
 lest,lest,唯恐,SCONJ,B2
 let,let,让,AUX,B2
-let alone,let alone,别说,ADV,B2
-let alone (cconj),let alone,何况,CCONJ,B1
-lethality,lethality,词,NOUN,C1
-lethargy,lethargy,词,NOUN,C1
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
+to let go,to let go,放开,VERB,B2
 lettuce,lettuce,生菜,NOUN,B2
-lever,lever,词,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-lexical,lexical,词,ADJ,C1
 lexicology,lexicology,词汇学,NOUN,B2
-liabilities,liabilities,词,NOUN,C1
-liaison,liaison,联络,NOUN,B2
-liberalism,liberalism,自由主义,NOUN,B2
 liberalization,liberalization,自由化,NOUN,B2
-liberalize,liberalize,自由化,! VERB,B2
-liberating,liberating,解放的,ADJ,B2
 liberation,liberation,解放,NOUN,B2
 libertinism,libertinism,放荡,NOUN,B2
 license plate,license plate,车牌,NOUN,B2
-license plate restriction,license plate restriction,限号,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licensor,licensor,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
 licentiousness,licentiousness,放荡,NOUN,B2
-lichen,lichen,词,NOUN,B2
-lie (noun),lie,说谎,NOUN,C1
+to lie down,to lie down,躺,VERB,B2
 lieutenant,lieutenant,中尉,NOUN,B2
-life (part),life,生,PART,A2
-life and death,life and death,生死,NOUN,B2
-life connection,life connection,连命,NOUN,C1
 life imprisonment,life imprisonment,无期徒刑,NOUN,B2
 life retribution,life retribution,偿命,NOUN,B2
-life sentence,life sentence,词,NOUN,B2
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-and-death,life-and-death,决生,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifeguard,lifeguard,词,NOUN,B2
 lifeless,lifeless,无生命的,ADJ,B2
-lifelong,lifelong,终身,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
 light,light,轻的,ADJ,B2
-light (adj),light,清淡,ADJ,B1
-light blue,light blue,词,ADJ,A1
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb,light bulb,词,NOUN,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light grey,light grey,词,ADJ,B2
-light load,light load,轻装,NOUN,C1
 light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,词,NOUN,A1
-lightest,lightest,最轻,NOUN,C1
 lighthouse,lighthouse,灯塔,NOUN,B2
-lighting,lighting,词,NOUN,B2
 lightness,lightness,轻盈,NOUN,B2
 lightning,lightning,闪电,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
 like,like,像,ADP,B2
-like (adp),like,就像,ADP,B2
-like (noun),like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like as,like as,词,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,词,ADV,B1
-likeable,likeable,词,ADJ,C1
-likely (adv),likely,词,ADV,A1
-likely source,likely source,词,NOUN,C1
 likeness,likeness,就象,NOUN,B2
-lily,lily,百合,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
 limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
 lime,lime,石灰,NOUN,B2
-liminal,liminal,词,ADJ,B2
-limit border,limit border,界限,NOUN,B2
+to limit,to limit,限制,VERB,B2
 limited,limited,有限的,ADJ,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limpidity,limpidity,词,NOUN,C1
-line of conduct,line of conduct,行为方针,NOUN,B2
-line queue,line queue,词,NOUN,B1
-line-up,line-up,阵容,NOUN,B2
+to line up,to line up,排成一行,VERB,B2
 lineage,lineage,血统,NOUN,B2
-lineages,lineages,词,NOUN,C1
 linear,linear,线性的,ADJ,B2
 linen,linen,线麻,NOUN,B2
 lines,lines,台词,NOUN,B2
-ling,ling,叫凌,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,词,ADJ,B2
-linguist,linguist,词,NOUN,C1
-linguistic intuition,linguistic intuition,词,NOUN,C1
 linguistics,linguistics,语言学,NOUN,B2
-lining understudy,lining understudy,词,NOUN,B1
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linking,linking,词,NOUN,C1
-lip service,lip service,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
-liquid,liquid,液态的,ADJ,B2
-liquid (adj),liquid,液态的,ADJ,B2
-lisp (noun),lisp,词,NOUN,C1
-listen (intj),listen,词,INTJ,B2
-listen up,listen up,听着,INTJ,B2
-listener,listener,听众,NOUN,B2
+to list,to list,列举,VERB,B2
+to listen attentively,to listen attentively,倾听,VERB,B2
 listening,listening,也听,NOUN,B2
-listing,listing,词,NOUN,C1
-litanies,litanies,词,NOUN,C1
 liter,liter,升,NOUN,B2
-literal,literal,字面的,ADJ,B2
-literalism,literalism,词,NOUN,C1
-literariness,literariness,词,NOUN,C1
-literary thefts,literary thefts,词,NOUN,C1
-lithography,lithography,词,NOUN,C1
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litotes understatement,litotes understatement,词,NOUN,C1
 litre,litre,升,NOUN,B2
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
 little,little,少,DET,B2
-little (adv),little,词,ADV,A2
-little (det),little,少,DET,A1
 little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,词,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
 little eleven,little eleven,小十一,NOUN,B2
-little finger,little finger,词,NOUN,B2
-little girl,little girl,词,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,小心脏,NOUN,B2
 little nine,little nine,小九,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little sister,little sister,妹妹,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little thing,little thing,词,NOUN,B2
-little town,little town,词,NOUN,C1
-liturgical,liturgical,词,ADJ,C1
-liturgy,liturgy,词,NOUN,C1
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
 lively,lively,热闹的,ADJ,B2
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
 living room,living room,客厅,NOUN,B2
-lizard,lizard,蜥蜴,NOUN,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loading,loading,词,NOUN,B2
-loanword,loanword,外来词,NOUN,C1
-loathing,loathing,,NOUN,B2
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
+to load,to load,装载,VERB,B2
 local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-located,located,位于,ADJ,B2
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locker,locker,词,NOUN,C1
-locker room,locker room,更衣室,NOUN,B2
-locksmith,locksmith,词,NOUN,C1
-locomotive,locomotive,词,NOUN,C1
-lodges,lodges,道堂,NOUN,C1
+to lock up,to lock up,关押,VERB,B2
 lodging,lodging,住宿,NOUN,B2
-loftiness,loftiness,高尚,NOUN,C1
-logarithm,logarithm,词,NOUN,C1
 logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logistical,logistical,词,ADJ,C1
 logistics,logistics,后勤,NOUN,B2
-logistics (adj),logistics,词,ADJ,C1
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,,NOUN,B2
-long (noun),long,long,NOUN,B2
-long absence,long absence,久违,NOUN,C1
 long ago,long ago,早已,ADV,B2
-long lease,long lease,词,NOUN,C1
+to long for,to long for,渴望,VERB,B2
 long live,long live,万岁,INTJ,B2
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
 long time,long time,长时间,ADV,B2
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance bus,long-distance bus,长途车,NOUN,B2
-long-distance runner,long-distance runner,长跑运动员,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-lasting,long-lasting,持久的,ADJ,B2
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longest,longest,أطول,NOUN,B1
-longevity,longevity,词,NOUN,C1
-loofah,loofah,丝瓜,NOUN,C1
 look,look,看,NOUN,B2
-look (noun),look,看,NOUN,A2
-look around,look around,词,VERB,C1
-look at you,look at you,你看你,NOUN,B2
+to look after,to look after,照料,VERB,B2
+to look at,to look at,观看,VERB,B2
+to look up,to look up,查阅,VERB,B2
 lookout,lookout,瞭望,NOUN,B2
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loopholes,loopholes,词,NOUN,C1
-loose thread,loose thread,词,NOUN,C1
-looseness,looseness,词,NOUN,C1
-loot,loot,战利品,NOUN,B2
-looting,looting,掠夺,NOUN,B2
-loquat,loquat,枇杷,NOUN,C1
 lord,lord,领主,NOUN,B2
-lord god,lord god,上帝,NOUN,B2
-lord yu,lord yu,玉大人,NOUN,B2
-lord's words,lord's words,主说,NOUN,B2
-lordship,lordship,词,NOUN,C1
-lose,lose,上丢,NOUN,B2
-lose an election,lose an election,落选,VERB,C1
-losses,losses,词,NOUN,B1
-lost,lost,迷失的,ADJ,B2
-lost tradition,lost tradition,失传,NOUN,C1
-lotar,lotar,词,NOUN,C1
-lots,lots,大量,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
+to lose bid,to lose bid,落标,VERB,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to lose weight,to lose weight,减肥,VERB,B2
 loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
 louse,louse,虱子,NOUN,B2
 lousy,lousy,糟糕的,ADJ,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-loved,loved,被爱的,ADJ,B2
-lovely,lovely,词,ADJ,B2
+to love,to love,爱,VERB,B2
+to love dearly,to love dearly,心疼,VERB,B2
 lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
 low tide,low tide,退潮,NOUN,B2
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowest,lowest,最低的,ADJ,B2
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lu ke,lu ke,陆珂,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck turn,luck turn,词,NOUN,A2
 lucky,lucky,幸运的,ADJ,B2
-lucky (noun),lucky,吉祥,NOUN,B2
 lucky chance,lucky chance,虽侥,NOUN,B2
-lucky find,lucky find,意外发现,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-lukewarm,lukewarm,微温的,ADJ,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-lump in throat,lump in throat,词,NOUN,C1
-lunar,lunar,词,ADJ,C1
 lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunch break,lunch break,午休,NOUN,B2
-lupini beans,lupini beans,词,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
 luster,luster,光泽,NOUN,B2
-lute,lute,词,NOUN,C1
-lychee,lychee,荔枝,NOUN,C1
 lymph,lymph,淋巴,NOUN,B2
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyre,lyre,词,NOUN,B2
-lyrical,lyrical,抒情的,ADJ,B2
-lyricism,lyricism,词,NOUN,C1
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machination,machination,词,NOUN,C1
-machine (adj),machine,词,ADJ,B2
 machine learning,machine learning,机器学习,NOUN,B2
-machinery,machinery,词,NOUN,C1
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
-macroscopic,macroscopic,宏观的,ADJ,B2
 madam,madam,夫人,NOUN,B2
-made,made,词,ADJ,B2
 madman,madman,疯子,NOUN,B2
-maelstrom,maelstrom,词,NOUN,C1
-mafia,mafia,黑手党,NOUN,B2
 magical,magical,魔法的,ADJ,B2
-magically,magically,魔法地,ADV,B2
 magician,magician,魔术师,NOUN,B2
-magistrate,magistrate,法官,NOUN,B2
 magnanimity,magnanimity,宽宏大量,NOUN,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
-magnesium,magnesium,镁,NOUN,B2
-magnetic,magnetic,词,ADJ,B2
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
-magnifying glass,magnifying glass,词,NOUN,C1
-magus,magus,词,NOUN,C1
+to magnify,to magnify,放大,VERB,B2
 maidservant,maidservant,女仆,NOUN,B2
-maieutic,maieutic,词,ADJ,C1
 mail,mail,邮件,NOUN,B2
-mail (verb),mail,寄送,VERB,C1
 mailbox,mailbox,邮箱,NOUN,B2
 main,main,主要的,ADJ,B2
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
 main road,main road,主路,NOUN,B2
 main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-main thing,main thing,词,NOUN,B2
 mainland,mainland,大陆,NOUN,B2
-mainstream,mainstream,主流的,ADJ,B2
-mainstream (noun),mainstream,主流,NOUN,B2
 majestic,majestic,宏伟的,ADJ,B2
 majesty,majesty,陛下,NOUN,B2
 major,major,少校,NOUN,B2
-major (noun),major,主修,NOUN,B2
-major case,major case,大案,NOUN,B2
-major course,major course,专业课,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
-make amends,make amends,词,VERB,C1
-make flexible,make flexible,词,VERB,C1
-make mistake,make mistake,犯错,NOUN,B2
-makeover,makeover,改容,NOUN,C1
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-making,making,词,NOUN,B2
-maladjusted,maladjusted,词,ADJ,C1
-maladjustment,maladjustment,词,NOUN,C1
-malady,malady,弊病,NOUN,B2
-malaria,malaria,疟疾,NOUN,B2
+to make do,to make do,做,VERB,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to make sure,to make sure,确保,VERB,B2
+to make up for,to make up for,弥补,VERB,B2
 male,male,男性的,ADJ,B2
-male (adj),male,男性的,ADJ,B2
-male goat,male goat,词,NOUN,B2
-malefic,malefic,邪恶的,ADJ,B2
-malevolence,malevolence,恶意,NOUN,B2
 malfunction,malfunction,故障,NOUN,B2
-malhun,malhun,词,NOUN,B2
 malicious words,malicious words,恶言,NOUN,B2
-malignity,malignity,词,NOUN,C1
-maliki school,maliki school,词,NOUN,C1
-malleability,malleability,词,NOUN,C1
-mallow greens,mallow greens,词,NOUN,B2
-malmo,malmo,马尔默,PROPN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mammalian,mammalian,词,ADJ,C1
-managed,managed,,NOUN,B2
-management pipe,management pipe,词,NOUN,B2
-managing director,managing director,词,NOUN,B2
 mandate,mandate,命令,NOUN,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-mane,mane,词,NOUN,C1
-mango,mango,芒果,NOUN,B2
 mangosteen,mangosteen,山竹,NOUN,B2
 mangrove,mangrove,红树林,NOUN,B2
 manhunt,manhunt,搜捕,NOUN,B2
 mania,mania,狂躁症,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifestly,manifestly,明显地,ADV,B2
-manifesto,manifesto,宣言,NOUN,B2
-manifold,manifold,词,ADJ,B2
-manipulable,manipulable,可操纵的,ADJ,B2
-manipulator,manipulator,词,NOUN,C1
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
 manner,manner,方式,NOUN,B2
-mannerly,mannerly,有礼貌的,ADJ,B2
-mannish,mannish,词,ADJ,C1
 manor,manor,庄园,NOUN,B2
 manor,manor,庄,PART,B2
-manor (part),manor,庄,PART,B2
 manor lord,manor lord,庄主,NOUN,B2
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manually,manually,手动地,ADV,B2
-manufacture,manufacture,制造,NOUN,B2
-manufacture (noun),manufacture,词,NOUN,C1
-manufacturer,manufacturer,制造商,NOUN,B2
-manufacturing,manufacturing,词,NOUN,B1
-manumission,manumission,词,NOUN,C1
-manure (noun),manure,词,NOUN,C1
-many,many,许多,DET,B2
-many (det),many,词,DET,B2
-many (noun),many,多……,NOUN,B2
-many (pron),many,词,PRON,B1
-many a,many a,词,ADJ,C1
-many things,many things,许多事物,PRON,B2
 many times,many times,多次,ADV,B2
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapping,mapping,梳理,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
 marathon,marathon,马拉松,NOUN,B2
-marble,marble,大理石,NOUN,B2
-marbly,marbly,词,ADJ,B2
-mare,mare,词,NOUN,B2
 marginalization,marginalization,边缘化,NOUN,B2
-marginally,marginally,边缘地,ADV,B2
-marinade,marinade,词,NOUN,B2
-marine,marine,海洋的,ADJ,B2
-marine (noun),marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
-marital conjugal,marital conjugal,词,ADJ,C1
+to marinate,to marinate,腌制,VERB,B2
 maritime,maritime,海事的,ADJ,B2
-marker,marker,词,NOUN,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
 marketing,marketing,营销,NOUN,B2
-markets,markets,词,NOUN,C1
-maroon,maroon,词,ADJ,C1
 marriage alliance,marriage alliance,联姻,NOUN,B2
-marriage contract,marriage contract,婚约,NOUN,C1
 marriage leave,marriage leave,婚假,NOUN,B2
-marriageable,marriageable,适婚,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marshal,marshal,元帅,NOUN,B2
-marshy,marshy,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
 martyrdom,martyrdom,殉难,NOUN,B2
-marvel (noun),marvel,词,NOUN,B2
-mascot,mascot,吉祥物,NOUN,B2
-masculine (adj),masculine,词,ADJ,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-mash,mash,泥状食物,NOUN,B2
-mask (verb),mask,词,VERB,C1
-masochism,masochism,词,NOUN,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,词,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,词,NOUN,B2
-massively,massively,大量地,ADV,B2
+to marvel,to marvel,使惊奇,VERB,B2
 master,master,大师,NOUN,B2
 master,master,爷,PART,B2
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
+to master,to master,掌握,VERB,B2
 master's degree,master's degree,硕士学位,NOUN,B2
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
 master's word,master's word,爷说,NOUN,B2
-masterly,masterly,词,ADJ,B2
-mastermind,mastermind,词,NOUN,C1
-mat,mat,词,NOUN,B2
 match,match,火柴,NOUN,B2
-matches,matches,词,NOUN,C1
-matching,matching,配套,ADJ,B2
-matching time,matching time,对时,NOUN,B2
-matching use,matching use,配用,NOUN,C1
-matchmaker,matchmaker,媒,NOUN,B2
-material (adj),material,词,ADJ,C1
+to match,to match,相配,VERB,B2
 materialism,materialism,唯物主义,NOUN,B2
-maternal,maternal,词,ADJ,C1
 maternal aunt,maternal aunt,姨母,NOUN,B2
-maternal grace,maternal grace,母恩难,NOUN,B2
 maternal grandmother,maternal grandmother,外婆,NOUN,B2
 maternal uncle,maternal uncle,舅舅,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-math,math,数学,NOUN,B2
 mathematical,mathematical,数学的,ADJ,B2
-mathematician,mathematician,词,NOUN,C1
-matriarchy,matriarchy,词,NOUN,C1
 matrix,matrix,矩阵,NOUN,B2
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
 maturity,maturity,成熟,NOUN,B2
-mausoleum,mausoleum,词,NOUN,B1
-mawkishness,mawkishness,词,NOUN,C1
-mawwal,mawwal,词,NOUN,B2
-maxim,maxim,格言,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
-maximization,maximization,词,NOUN,C1
-maximum,maximum,最大,ADJ,B2
-maximum (adj),maximum,最大的,ADJ,A2
 may,may,五月,NOUN,B2
-may (noun),may,可否,NOUN,B1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe possible,maybe possible,可能,ADV,A1
-mayoral,mayoral,市长的,ADJ,B2
-maze labyrinth,maze labyrinth,词,NOUN,C1
 me,me,لي,NOUN,B2
-me (noun),me,我?,NOUN,B2
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-mead,mead,词,NOUN,C1
 mean,mean,刻薄的,ADJ,B2
-mean (adj),mean,刻薄的,ADJ,B2
-mean (noun),mean,词,NOUN,C1
-meander,meander,词,NOUN,C1
-meandering,meandering,蜿蜒的,ADJ,B2
-meaning content,meaning content,语义内容,NOUN,B2
-meaningless,meaningless,毫无意义的,ADJ,B2
-meanness,meanness,词,NOUN,C1
 means,means,手段,NOUN,B2
-measurable,measurable,词,ADJ,C1
-measure word events items,measure word events items,件,NOUN,A1
+to measure,to measure,测量,VERB,B2
 measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word for books,measure word for books,本,NUM,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,词,ADJ,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mechanical,mechanical,机械的,ADJ,B2
-mechanically,mechanically,词,ADV,C1
-mechanics,mechanics,词,NOUN,C1
 mechanistic,mechanistic,机制性,ADJ,B2
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
 medal awarding,medal awarding,授勋,NOUN,B2
-medallion,medallion,词,NOUN,C1
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-media (adj),media,词,ADJ,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media professionals,media professionals,词,NOUN,C1
-media-related,media-related,词,ADJ,B2
 median,median,中位数,NOUN,B2
-median (adj),median,词,ADJ,C1
 mediation,mediation,调解,NOUN,B2
-mediator,mediator,调解人,NOUN,C1
 medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical examiner,medical examiner,词,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,词,NOUN,C1
 medical record,medical record,病历,NOUN,B2
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
 mediocre,mediocre,平庸的,ADJ,B2
 mediocrity,mediocrity,庸庸碌碌,NOUN,B2
 mediterranean,mediterranean,地中海的,ADJ,B2
 medium,medium,媒介,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-meek,meek,温顺的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-megabyte,megabyte,词,NOUN,C1
-megalomania,megalomania,词,NOUN,B2
-megalomaniac,megalomaniac,词,ADJ,C1
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
 melancholic,melancholic,忧郁的,ADJ,B2
-melancholy,melancholy,忧郁,ADJ,B2
-melancholy (noun),melancholy,忧郁,NOUN,C1
-mellifluousness,mellifluousness,词,NOUN,C1
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
-melon,melon,香瓜,NOUN,C1
-melon groping,melon groping,摸瓜,NOUN,B2
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
-membrane,membrane,词,NOUN,C1
-memoir,memoir,回忆录,NOUN,B2
-memorandum,memorandum,备忘录,NOUN,B2
 memorial,memorial,纪念碑,NOUN,B2
-memorial (adj),memorial,词,ADJ,C1
-memorization,memorization,记忆,NOUN,B2
-memorizer,memorizer,词,NOUN,C1
-memory loss,memory loss,词,NOUN,C1
-men,men,词,NOUN,C1
-meninx,meninx,词,NOUN,C1
-menses,menses,词,NOUN,B2
-mental hospital,mental hospital,精神病院,NOUN,B2
+to mend,to mend,修补,VERB,B2
 mentality,mentality,心态,NOUN,B2
-mentally,mentally,精神上地,ADV,B2
 mention,mention,提及,NOUN,B2
-mention (noun),mention,可言,NOUN,C1
-mentioned,mentioned,词,ADJ,B2
-mentoring,mentoring,词,NOUN,B2
-mercantile,mercantile,词,ADJ,C1
-mercenaries,mercenaries,词,NOUN,C1
-mercenary (adj),mercenary,词,ADJ,C1
-merchant ship,merchant ship,商船,NOUN,C1
-merciful,merciful,词,ADJ,B2
-mercilessly,mercilessly,词,ADV,C1
-mercy blow,mercy blow,词,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
 merge,merge,合并,NOUN,B2
-merged,merged,词,ADJ,C1
-merger fusion,merger fusion,词,NOUN,B1
 meridian,meridian,经脉,NOUN,B2
 meridians,meridians,筋脉,NOUN,B2
 merit,merit,功绩,NOUN,B2
 meritocracy,meritocracy,精英管理,NOUN,B2
-merits,merits,词,NOUN,C1
-merriment,merriment,词,NOUN,C1
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-message errand,message errand,词,NOUN,B2
-messaging,messaging,词,NOUN,C1
 messenger,messenger,信使,NOUN,B2
 messy,messy,混乱的,ADJ,B2
 metabolic,metabolic,代谢的,ADJ,B2
-metalepsis,metalepsis,词,NOUN,C1
-metalinguistic,metalinguistic,词,ADJ,C1
-metallic,metallic,金属的,ADJ,B2
-metallurgy,metallurgy,词,NOUN,C1
-metamorphosis,metamorphosis,词,NOUN,C1
-metaphorical,metaphorical,隐喻的,ADJ,B2
-metaphysical,metaphysical,词,ADJ,C1
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological,meteorological,气象的,ADJ,B2
-meteorological observations,meteorological observations,词,NOUN,C1
-metering,metering,词,ADJ,C1
-methane,methane,词,NOUN,C1
-methodical,methodical,词,ADJ,C1
-methodological,methodological,方法论的,ADJ,B2
 methodology,methodology,方法论,NOUN,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
 metonymy,metonymy,转喻,NOUN,B2
-metric,metric,公制的,ADJ,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolis,metropolis,大都市,NOUN,B2
-metropolises,metropolises,词,NOUN,C1
-metropolitan,metropolitan,词,ADJ,C1
 mexican,mexican,墨西哥的,ADJ,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
-microeconomic,microeconomic,词,ADJ,B2
 microscopic,microscopic,微观的,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-mid-morning,mid-morning,词,NOUN,C1
-midday heat,midday heat,词,NOUN,B1
 middle,middle,中间,NOUN,B2
-middle (adj),middle,词,ADJ,B2
-middle (adv),middle,词,ADV,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
-midpoint,midpoint,词,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
-might,might,威力,NOUN,B2
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty man,mighty man,词,NOUN,B2
-mighty very,mighty very,非常,ADJ,B2
 migraine,migraine,偏头痛,NOUN,B2
-migrant,migrant,词,NOUN,B2
 migration,migration,移民,NOUN,B2
-migratory,migratory,词,ADJ,C1
-mildew,mildew,词,VERB,C1
 mile,mile,英里,NOUN,B2
-militaristic,militaristic,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
-military,military,军队,NOUN,B2
-military (noun),military,词,NOUN,B2
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
 military campaign,military campaign,战役,NOUN,B2
-military intelligence,military intelligence,军情,NOUN,B2
-military merit,military merit,军功,NOUN,C1
-military order,military order,军令,NOUN,B2
-military pay,military pay,军饷,NOUN,B2
-military power,military power,兵权,NOUN,B2
 militia,militia,民兵,NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,词,NOUN,C1
-milkman,milkman,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
 mill,mill,磨坊,NOUN,B2
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
 millennium,millennium,千年,NOUN,B2
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
 million,million,百万,NOUN,B2
-million (noun),million,百万,NOUN,B2
-millionaire,millionaire,词,NOUN,B2
-millions of,millions of,数百万的,NUM,B2
-mime (noun),mime,词,NOUN,C1
-mimicry,mimicry,词,NOUN,B2
-minaret,minaret,词,NOUN,B1
-minced meat,minced meat,词,NOUN,A2
 mind,mind,精神,NOUN,B2
-mind (noun),mind,头脑,NOUN,B2
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mindset,mindset,词,NOUN,B2
 mine,mine,矿井,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
-mineral (adj),mineral,词,ADJ,C1
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
 minibus,minibus,中巴,NOUN,B2
-minimal,minimal,微小的,ADJ,B2
-minimization,minimization,词,NOUN,C1
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
-minister,minister,臣,PART,B2
-minister (part),minister,臣,PART,B2
 ministerial,ministerial,部长的,ADJ,B2
 ministry,ministry,部,NOUN,B2
-minivan,minivan,词,NOUN,B2
 minor,minor,未成年人,NOUN,B2
-minor (noun),minor,未成年人,NOUN,B2
-minor course,minor course,辅修课,NOUN,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
-minority,minority,少数派的,ADJ,B2
-minority (noun),minority,少数,NOUN,B2
-minority group,minority group,少数群体,NOUN,B2
 mint,mint,薄荷,NOUN,B2
-minus,minus,减,NOUN,B2
-minutes,minutes,词,NOUN,B2
-mirage,mirage,词,NOUN,C1
 misappropriation,misappropriation,挪用,NOUN,B2
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-misconception,misconception,词,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-misdemeanor,misdemeanor,词,NOUN,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
 misleading,misleading,诡辩的,ADJ,B2
-misplaced,misplaced,不合时宜的,ADJ,B2
 miss,miss,小姐,NOUN,B2
-miss (noun),miss,小姐,NOUN,B2
-miss teacher,miss teacher,词,NOUN,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-missile,missile,导弹,NOUN,B2
-missionizing,missionizing,词,ADJ,C1
-missions,missions,词,NOUN,C1
-missive,missive,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-missnahme,missnahme,词,NOUN,C1
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
-mistreatment,mistreatment,虐待,NOUN,B2
-misunderstood,misunderstood,词,ADJ,C1
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
-mitigating,mitigating,词,ADJ,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitigation,mitigation,词,NOUN,C1
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mitten,mitten,连指手套,NOUN,B2
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
+to mistake,to mistake,弄错,VERB,B2
+to mistreat,to mistreat,أساء,VERB,B2
 mixed,mixed,混合的,ADJ,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixer,mixer,词,NOUN,C1
-mixing,mixing,词,NOUN,B2
 mixture,mixture,混合物,NOUN,B2
 moan,moan,呻吟,NOUN,B2
+to moan,to moan,呻吟,VERB,B2
 mobile,mobile,移动的,ADJ,B2
-mobile (adj),mobile,流动,ADJ,B2
-mobile payment,mobile payment,移动支付,NOUN,B2
 mobile phone,mobile phone,手机,NOUN,B2
-mobility,mobility,流动性,NOUN,B2
 mobilization,mobilization,动员,NOUN,B2
 mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-mockery,mockery,词,NOUN,C1
-modal particle,modal particle,啊,PART,B2
 modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
-mode,mode,方式,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
 modeling,modeling,造型,NOUN,B2
-modem,modem,词,NOUN,C1
-moderate rain,moderate rain,中雨,NOUN,B2
-moderate snow,moderate snow,中雪,NOUN,C1
 moderation,moderation,克制,NOUN,B2
-moderator,moderator,词,NOUN,C1
-modern dance,modern dance,现代舞,NOUN,B2
 modern times,modern times,近代,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
 modernization,modernization,现代化,NOUN,B2
-modestly,modestly,词,ADV,C1
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
 modification,modification,修改,NOUN,B2
 modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified effect,modified effect,改效,NOUN,B2
-modified model,modified model,改模,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
 modified sound,modified sound,改响,NOUN,B2
-modified structure,modified structure,改结,NOUN,C1
 modified system,modified system,改系,NOUN,B2
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
 modular,modular,模块化的,ADJ,B2
-modulation,modulation,词,NOUN,C1
 moist,moist,潮湿的,ADJ,B2
-moisten,moisten,词,VERB,C1
-moisture,moisture,词,NOUN,B2
 moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
 mold,mold,鞋楦,NOUN,B2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
-molten,molten,词,ADJ,C1
-molting,molting,词,NOUN,C1
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,暂时地,ADV,B2
 momentum,momentum,势头,NOUN,B2
-mommy,mommy,词,NOUN,B1
-monarch,monarch,君主,NOUN,B2
 monastery,monastery,修道院,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monasticism,monasticism,词,NOUN,C1
 monday,monday,星期一,NOUN,B2
-monetary,monetary,金钱的,ADJ,B2
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
-monitoring,monitoring,监控,NOUN,B2
+to monitor,to monitor,监控,VERB,B2
 monitoring room,monitoring room,监控室,NOUN,B2
-monkey ape,monkey ape,猿/猴,NOUN,B2
-monologue,monologue,词,NOUN,B2
-monopolistic,monopolistic,垄断的,ADJ,B2
-monotheism,monotheism,词,NOUN,C1
-monotonic,monotonic,词,ADJ,C1
-monotony,monotony,词,NOUN,C1
-monstrous,monstrous,怪异的,ADJ,B2
+to monopolize,to monopolize,垄断,VERB,B2
 month ago,month ago,月前,NOUN,B2
-month moon,month moon,月,NOUN,B2
 monthly,monthly,每月的,ADV,B2
-monthly (adj),monthly,每月的,ADJ,B2
 monthly exam,monthly exam,月考,NOUN,B2
 monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-moodiness,moodiness,词,NOUN,B2
 mooncake,mooncake,月饼,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-mooring,mooring,词,NOUN,C1
-moose,moose,驼鹿,NOUN,B2
-mop (noun),mop,词,NOUN,B2
-moral,moral,道德的,ADJ,B2
-moral (adj),moral,道德的,ADJ,C1
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral portrait,moral portrait,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,士气,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralization,moralization,词,NOUN,C1
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morally,morally,词,ADV,C1
-morals,morals,道德,NOUN,B2
-morass,morass,词,NOUN,C1
-moratorium,moratorium,暂停,NOUN,B2
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
 more,more,更多,ADJ,B2
 more,more,مزيد,NOUN,B2
-more (adj),more,更多,ADJ,A2
-more (noun),more,你越,NOUN,B2
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,词,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
 more often,more often,更频繁,ADV,B2
-more personal,more personal,词,ADJ,C1
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover,moreover,而且,CCONJ,B2
-moreover (adv),moreover,况且,ADV,B2
-morgue,morgue,词,NOUN,B1
-morning (adj),morning,词,ADJ,C1
 morning newspaper,morning newspaper,晨报,NOUN,B2
-moroccanization,moroccanization,词,NOUN,C1
-morocco leather,morocco leather,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morpheme,morpheme,语素,NOUN,C1
-morphine,morphine,吗啡,NOUN,B2
 morphological,morphological,形态的,ADJ,B2
-morphology,morphology,形态学,NOUN,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortar,mortar,词,NOUN,C1
-mortuary,mortuary,词,NOUN,B2
+to mortgage,to mortgage,抵押,VERB,B2
 mosaic,mosaic,马赛克,NOUN,B2
-moslem,moslem,词,NOUN,C1
 mosque,mosque,清真寺,NOUN,B2
 mosquito,mosquito,蚊子,NOUN,B2
-mosquito net,mosquito net,蚊帐,NOUN,B2
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
 most,most,最,ADV,B2
-most (adv),most,最,ADV,B2
-most (det),most,词,DET,B2
-most (noun),most,大部分,NOUN,B2
-most (pron),most,词,PRON,C1
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-moth,moth,词,NOUN,B2
 mother,mother,娘,PART,B2
-mother (part),mother,娘,PART,B2
-mother's reassurance,mother's reassurance,娘放心,NOUN,B2
 mother's words,mother's words,娘说,NOUN,B2
 mother-in-law,mother-in-law,岳母,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
-motion picture,motion picture,词,NOUN,C1
-motionless,motionless,静止的,ADJ,B2
-motive for murder,motive for murder,词,NOUN,C1
-motley,motley,词,ADJ,B2
-motor,motor,运动的,ADJ,B2
-motor (adj),motor,运动的,ADJ,C1
 motorhome,motorhome,露营车,NOUN,B2
-motorist,motorist,词,NOUN,C1
-motorway,motorway,词,NOUN,B2
 motto,motto,座右铭,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountain descent,mountain descent,下山,NOUN,B2
 mountain range,mountain range,山脉,NOUN,B2
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-mouth animal,mouth animal,词,NOUN,B1
 mouthful,mouthful,一口,NOUN,B2
 move,move,搬家,NOUN,B2
-move (noun),move,下子,NOUN,B1
-move fast,move fast,快搬,NOUN,C1
+to move aside,to move aside,移开,VERB,B2
+to move in,to move in,搬入,VERB,B2
 movie,movie,电影,NOUN,B2
-moving,moving,感人的,ADJ,B2
-mow,mow,词,VERB,B2
-mp,mp,国会议员,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
 mr.,mr.,先生,NOUN,B2
-mr. sir,mr. sir,先生,NOUN,B2
-mri,mri,核磁共振,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-much,much,多,DET,B2
-much (adv),much,词,ADV,B2
-much (det),much,许多,DET,A1
-much many,much many,许多,ADJ,B2
-mucous,mucous,词,ADJ,C1
-muddied,muddied,词,ADJ,C1
 muddled,muddled,混乱的,ADJ,B2
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-muezzin,muezzin,词,NOUN,B2
-muffin,muffin,词,NOUN,B2
-mufti,mufti,词,NOUN,C1
 mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
 multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-municipal,municipal,市政的,ADJ,B2
 municipality,municipality,市镇,NOUN,B2
 munificence,munificence,慷慨,NOUN,B2
-munitions,munitions,军械,NOUN,C1
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder case,murder case,词,NOUN,B2
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
+to murder,to murder,谋杀,VERB,B2
 murder weapon,murder weapon,凶器,NOUN,B2
-murderer female,murderer female,词,NOUN,B2
-murk of dawn,murk of dawn,词,NOUN,C1
 murmur,murmur,低语,NOUN,B2
-murmuring,murmuring,词,NOUN,C1
-murong,murong,慕容,NOUN,B2
-muscle ache,muscle ache,肌肉酸痛,NOUN,B2
 muscle pain,muscle pain,肌肉痛,NOUN,B2
-muscular,muscular,词,ADJ,C1
-museum piece,museum piece,博物馆藏品,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
 musical,musical,موسيقي,ADJ,B2
 musical,musical,音乐剧,NOUN,B2
-musical (noun),musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
 musical score,musical score,乐谱,NOUN,B2
-musicality,musicality,词,NOUN,C1
 musician,musician,音乐家,NOUN,B2
-musk,musk,麝香,NOUN,B2
-muslim,muslim,مسلم,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
 mustache,mustache,胡子,NOUN,B2
-mustard,mustard,词,NOUN,A1
-mutagenic,mutagenic,词,ADJ,C1
 mutation,mutation,突变,NOUN,B2
-mutazilites,mutazilites,词,NOUN,C1
-mute person,mute person,词,NOUN,B2
-mutilate,mutilate,词,VERB,C1
 mutiny,mutiny,哗变,NOUN,B2
-muttering,muttering,念叨,NOUN,C1
+to mutter,to mutter,嘟囔,VERB,B2
 mutton,mutton,羊肉,NOUN,B2
-mutual affection,mutual affection,词,NOUN,C1
 mutual aid,mutual aid,互助,NOUN,B2
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
 mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
-mutual generation,mutual generation,相生,NOUN,B2
 mutual insurance,mutual insurance,互助保险,NOUN,B2
-mutual pulling,mutual pulling,词,NOUN,C1
 mutual restriction,mutual restriction,相克,NOUN,B2
-mutual support,mutual support,互助,NOUN,C1
 mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
 mutually,mutually,相互地,ADV,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzle,muzzle,口套,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
 my,my,我的,DET,B2
-my (det),my,我的,DET,A1
-my audience,my audience,我要见,NOUN,B2
-my big one,my big one,我偌大,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
 my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my place,my place,我处,NOUN,B2
-my residence,my residence,我府,NOUN,B2
 my scrutiny,my scrutiny,我看你,NOUN,B2
 my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myelin,myelin,词,NOUN,C1
-myself,myself,我自,NOUN,B2
-myself (pron),myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythical,mythical,神话般的,ADJ,B2
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
 mythology,mythology,神话学,NOUN,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-nah,nah,不,INTJ,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
+to nag,to nag,唠叨,VERB,B2
 naivety,naivety,天真,NOUN,B2
-name-calling,name-calling,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-named,named,词,ADP,C1
+to name,to name,命名,VERB,B2
 namely,namely,即,ADV,B2
 nanny,nanny,保姆,NOUN,B2
 nap,nap,午睡,NOUN,B2
-nape,nape,后颈,NOUN,B2
-narcotics,narcotics,词,NOUN,C1
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
-narrative (adj),narrative,词,ADJ,C1
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
-narrator,narrator,叙述者,NOUN,B2
-narrators,narrators,词,NOUN,C1
-narrow-minded,narrow-minded,狭隘的,ADJ,B2
-narrowing,narrowing,变窄,NOUN,B2
 narrowness,narrowness,狭窄,NOUN,B2
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
 national highway,national highway,国道,NOUN,B2
 national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
 nationalism,nationalism,民族主义,NOUN,B2
-nationalist,nationalist,民族主义者,NOUN,B2
 nationality,nationality,国籍,NOUN,B2
 nationalization,nationalization,国有化,NOUN,B2
-nationwide,nationwide,全国,NOUN,B2
-native (noun),native,词,NOUN,C1
-native american,native american,印第安人,NOUN,B2
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-naturalization,naturalization,入籍,NOUN,B2
+to nationalize,to nationalize,国有化,VERB,B2
 nature reserve,nature reserve,自然保护区,NOUN,B2
 naughty,naughty,淘气的,ADJ,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-navel,navel,肚脐,NOUN,B2
-navigational,navigational,词,ADJ,C1
 navy,navy,海军,NOUN,B2
-nazi,nazi,纳粹分子,NOUN,B2
 near,near,近,ADJ,B2
 near,near,靠近,ADV,B2
-near (adj),near,近,ADJ,B2
-near (adv),near,词,ADV,A1
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,附近的,ADJ,B2
-nearby (adj),nearby,附近的,ADJ,B1
-nearby (noun),nearby,附近,NOUN,B2
-nearest,nearest,最近的,ADJ,B2
-nearest (noun),nearest,词,NOUN,B2
-nearness,nearness,词,NOUN,B2
-neatly,neatly,词,ADV,B2
 nebula,nebula,星云,NOUN,B2
 necessarily,necessarily,必然地,ADV,B2
-necessarily incumbent,necessarily incumbent,词,ADV,C1
 necklace,necklace,项链,NOUN,B2
-necklace chain,necklace chain,词,NOUN,A1
-neckline,neckline,词,NOUN,C1
-necrosis,necrosis,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
 need,need,需要,AUX,B2
 need,need,需求,NOUN,B2
-need (noun),need,得要,NOUN,A2
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
 negation,negation,否定,NOUN,B2
-negativity,negativity,消极,NOUN,B2
+to neglect,to neglect,忽视,VERB,B2
 negligible,negligible,微不足道的,ADJ,B2
-negligible not,negligible not,不可忽视,ADJ,B2
 negotiations,negotiations,谈判,NOUN,B2
-negotiator,negotiator,词,NOUN,C1
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
 neighborhood head,neighborhood head,里长,NOUN,B2
 neighboring,neighboring,邻近的,ADJ,B2
-neighbors,neighbors,词,NOUN,B1
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,词,NOUN,B2
 neither,neither,也不,CCONJ,B2
-neither (adv),neither,词,ADV,A1
-neither (cconj),neither,也不,CCONJ,B2
-neither nor,neither nor,词,CCONJ,A2
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
 nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
-nervousness,nervousness,紧张,NOUN,B2
-nesting box,nesting box,词,NOUN,B1
 net,net,网,NOUN,B2
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neural,neural,词,ADJ,C1
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neuron,neuron,神经元,NOUN,B2
 neurosis,neurosis,神经症,NOUN,B2
-neuroticism,neuroticism,词,NOUN,C1
 neutrality,neutrality,中立,NOUN,B2
-neutron,neutron,词,NOUN,C1
 nevertheless,nevertheless,尽管如此,ADV,B2
-new beginning,new beginning,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
-new year's day,new year's day,元旦,NOUN,B2
-new year's eve dinner,new year's eve dinner,年夜饭,NOUN,B2
-newly,newly,词,ADV,C1
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
 news,news,新闻,NOUN,B2
-news bulletin,news bulletin,词,NOUN,B2
-news report,news report,词,NOUN,B1
-news reporting,news reporting,新闻报道,NOUN,B2
-newsletter,newsletter,简报,NOUN,B2
 next,next,接下来,ADV,B2
-next (adv),next,其次,ADV,B2
-next day,next day,词,NOUN,A2
 next door,next door,隔壁,NOUN,B2
-next door (adv),next door,在隔壁,ADV,B2
-next following,next following,词,ADJ,C1
 next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
 next to,next to,在...旁边,ADP,B2
-next to (adv),next to,词,ADV,B2
 next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,词,NOUN,B2
-niche,niche,词,NOUN,C1
 nickel,nickel,镍,NOUN,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
-night view,night view,夜景,NOUN,B2
 nightingale,nightingale,夜莺,NOUN,B2
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
 ninety,ninety,九十,NUM,B2
-ninth,ninth,第九,ADJ,B2
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,氮,NOUN,B2
 no,no,毫无,DET,B2
 no,no,不,INTJ,B2
 no,no,不,PART,B2
-no (det),no,毫无,DET,A2
-no (intj),no,词,INTJ,A1
-no (part),no,词,PART,B2
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no harm,no harm,没事吧,NOUN,B2
-no heaven,no heaven,无天,NOUN,C1
 no longer,no longer,不再,ADV,B2
 no matter,no matter,不论,CCONJ,B2
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
 no matter what,no matter what,无论,ADV,B2
-no need,no need,不用,AUX,B2
 no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
 nobility,nobility,贵族气质,NOUN,B2
-nobility of character,nobility of character,词,NOUN,C1
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
 nobleman,nobleman,贵族,NOUN,B2
-node,node,词,NOUN,C1
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noise row,noise row,词,NOUN,C1
-noises,noises,噪音,NOUN,B2
-nomad,nomad,游牧者,NOUN,B2
+to nod,to nod,点头,VERB,B2
 nomadism,nomadism,游牧生活,NOUN,B2
-nomads,nomads,词,NOUN,B2
-non-ability,non-ability,非能,NOUN,B2
-non-above,non-above,非上,NOUN,C1
-non-abstraction,non-abstraction,非抽,NOUN,B2
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-action,non-action,非作,NOUN,B2
-non-analysis,non-analysis,非分,NOUN,C1
 non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
 non-assistance,non-assistance,勿助,NOUN,B2
-non-belief,non-belief,非信,NOUN,B2
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
 non-concept,non-concept,非概,NOUN,B2
-non-concrete,non-concrete,非具,NOUN,C1
-non-construction,non-construction,非建,NOUN,B2
 non-contingent,non-contingent,非偶,NOUN,B2
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-evidence,non-evidence,非据,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
 non-induction,non-induction,非归,NOUN,B2
 non-inference,non-inference,非推,NOUN,B2
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
 non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
 non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-level,non-level,非级,NOUN,B2
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-management,non-management,管不,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-merit,non-merit,非功,NOUN,B2
 non-mind,non-mind,非心,NOUN,B2
-non-model,non-model,非模,NOUN,B2
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
 non-necessary,non-necessary,非必,NOUN,B2
 non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
 non-observation,non-observation,非察,NOUN,B2
-non-orbit,non-orbit,非轨,NOUN,B2
-non-order,non-order,非序,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
 non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shadow,non-shadow,非影,NOUN,B2
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-sound,non-sound,非响,NOUN,B2
-non-specific,non-specific,非殊,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
 non-standard,non-standard,非标,NOUN,B2
-non-state,non-state,非态,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
 non-strategy,non-strategy,非略,NOUN,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-substance,non-substance,非质,NOUN,B2
 non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
 non-technique,non-technique,非术,NOUN,B2
 non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-thought,non-thought,非念,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-trace,non-trace,非迹,NOUN,B2
 non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
 non-view,non-view,非观,NOUN,B2
-non-war,non-war,非战,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-noncompliant,noncompliant,违规,ADJ,B2
-nonconformist,nonconformist,词,NOUN,C1
-none,none,没有一个,DET,B2
-none (det),none,毫无,DET,B2
-nonexistent,nonexistent,词,ADJ,C1
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonviolence,nonviolence,词,NOUN,B2
 noodle,noodle,面条,NOUN,B2
-noodles,noodles,面条,NOUN,A1
 nope,nope,不,INTJ,B2
-nor,nor,也不,CCONJ,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalization,normalization,词,NOUN,C1
-normativity,normativity,词,NOUN,C1
 north,north,北,NOUN,B2
-northeast,northeast,词,NOUN,C1
 northern,northern,北方的,ADJ,B2
-northward,northward,词,ADV,B2
-norwegian,norwegian,挪威的,ADJ,B2
-nosology,nosology,词,NOUN,C1
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
 not,not,不,ADV,B2
-not (adv),not,非,ADV,B2
-not afraid,not afraid,不怕,VERB,B2
 not allow,not allow,不许,AUX,B2
-not allowed,not allowed,不准,ADJ,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
 not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
 not catch up,not catch up,非赶,NOUN,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
 not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,未必,ADV,B2
-not only,not only,不光,CCONJ,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不怎么,ADV,B2
-not very good,not very good,不太好,ADJ,B2
+to not run,to not run,别跑,VERB,B2
+to not seen,to not seen,不见,VERB,B2
 not yet,not yet,未,ADV,B2
-notables,notables,词,NOUN,B2
 notarization,notarization,公证,NOUN,B2
-notarized,notarized,经公证的,ADJ,B2
 notary,notary,公证人,NOUN,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
-note patch,note patch,词,NOUN,C1
+to note,to note,记录,VERB,B2
 notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
-notifications,notifications,词,NOUN,C1
-notoriously,notoriously,词,ADV,C1
-notwithstanding,notwithstanding,词,ADP,C1
+to notice,to notice,注意到,VERB,B2
+to notify,to notify,通知,VERB,B2
 noumenon,noumenon,本体,NOUN,B2
-nourishment,nourishment,营养,NOUN,B2
-novelistic,novelistic,小说般的,ADJ,B2
-novelty,novelty,新奇事物,NOUN,B2
 november,november,十一月,NOUN,B2
-novice,novice,词,NOUN,C1
 now,now,此刻,NOUN,B2
-now (noun),now,此刻,NOUN,B2
 nuanced,nuanced,细微差别的,ADJ,B2
-nuclear (noun),nuclear,词,NOUN,B2
 nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,词,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nugget,nugget,词,NOUN,C1
-null and void,null and void,无效的,ADJ,C1
 nullity,nullity,无效；无能,NOUN,B2
-numb powder,numb powder,五麻散,NOUN,B2
 number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
 number two,number two,二号,NOUN,B2
-numbering,numbering,词,NOUN,C1
 numbness,numbness,麻木,NOUN,B2
-numerical,numerical,词,ADJ,C1
-numerous,numerous,众多的,ADJ,B2
-numismatic,numismatic,钱币学的,ADJ,B2
 nun,nun,修女,NOUN,B2
-nunation,nunation,词,NOUN,C1
 nursery,nursery,托儿所,NOUN,B2
-nursing home,nursing home,养老院,NOUN,C1
-nurturing,nurturing,养好,NOUN,B2
 nut,nut,坚果,NOUN,B2
-nutritional,nutritional,词,ADJ,C1
-nuts,nuts,疯狂的,ADJ,B2
-nylon,nylon,尼龙,NOUN,C1
-o,o,词,PART,B1
-o'clock,o'clock,点,NOUN,B2
-o'clock (adv),o'clock,词,ADV,B2
-oak,oak,词,NOUN,B1
 oar,oar,桨,NOUN,B2
 oasis,oasis,绿洲,NOUN,B2
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
 obedience,obedience,服从,NOUN,B2
-obelisk,obelisk,词,NOUN,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obese,obese,词,ADJ,B2
 obesity,obesity,肥胖,NOUN,B2
-obey orders,obey orders,听命,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
 objection,objection,异议,NOUN,B2
 objective,objective,客观的,ADJ,B2
-objective (adj),objective,客观,ADJ,B2
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-objectivism,objectivism,词,NOUN,C1
 objectivity,objectivity,客观性,NOUN,B2
 obligation,obligation,义务,NOUN,B2
-obligatory,obligatory,词,ADJ,C1
-obliged,obliged,被迫的,ADJ,B2
-obliging,obliging,词,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliteration,obliteration,词,NOUN,C1
-obscenity,obscenity,词,NOUN,C1
 obscurantism,obscurantism,蒙昧主义,NOUN,B2
-obscurantist,obscurantist,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observable,observable,词,ADJ,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,词,ADJ,C1
 observer,observer,观察者,NOUN,B2
-observers,observers,词,NOUN,C1
-obsessed,obsessed,着迷的,ADJ,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstinately,obstinately,词,ADV,C1
+to obstruct,to obstruct,阻碍,VERB,B2
 obstruction,obstruction,阻塞,NOUN,B2
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-occasional,occasional,词,ADJ,C1
-occultism,occultism,词,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
-occupied,occupied,被占用的,ADJ,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-octave,octave,词,NOUN,C1
-october,october,十月,NOUN,B2
-octopus,octopus,词,NOUN,B2
-ocular,ocular,词,ADJ,C1
-oddball,oddball,怪人,NOUN,B2
-oddly,oddly,词,ADV,B2
-odds,odds,赔率,NOUN,B2
-odometer,odometer,里程表,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-of,of,之,PART,B2
-of (part),of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of by,of by,的/被,ADP,B2
 of course,of course,理所当然的,ADJ,B2
 of course,of course,当然,ADV,B2
-of course (adj),of course,词,ADJ,B2
-of course (intj),of course,词,INTJ,C1
-of first instance,of first instance,词,ADJ,C1
-of it,of it,词,ADV,B2
-of old,of old,词,ADV,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,词,ADJ,B2
-of which,of which,关于哪个,PRON,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
-off-center,off-center,词,ADJ,C1
-off-road vehicle,off-road vehicle,越野车,NOUN,B2
-off-track,off-track,词,ADJ,C1
-offcuts,offcuts,词,NOUN,C1
-offence,offence,词,NOUN,B2
-offensive (noun),offensive,词,NOUN,C1
 offer,offer,报价,NOUN,B2
-offer (noun),offer,提议,NOUN,B2
 offering,offering,祭品,NOUN,B2
-office work,office work,办公室工作,NOUN,B2
-official (noun),official,官,NOUN,B2
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
 officials,officials,官员,NOUN,B2
-offshoring,offshoring,词,NOUN,B2
-offspring,offspring,幼崽,NOUN,B2
 oh,oh,哦,INTJ,B2
-oh (part),oh,呀,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
 oh my god,oh my god,我的天,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oh well,oh well,算了,INTJ,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oil tanker,oil tanker,词,NOUN,C1
-ok,ok,词,INTJ,B2
 okay,okay,好的,INTJ,B2
-okay (intj),okay,好的,INTJ,A1
-okay (noun),okay,好啊,NOUN,C1
-old (noun),old,夙,NOUN,B1
 old age,old age,老年,NOUN,B2
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old jiang,old jiang,老江,NOUN,B2
 old man,old man,老人,NOUN,B2
-old master,old master,老太爷,NOUN,B2
 old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
-old person,old person,老人,NOUN,B2
 old servant,old servant,老奴,NOUN,B2
-old thief,old thief,老贼,NOUN,C1
 old woman,old woman,老妇人,NOUN,B2
-old-age,old-age,晚年,NOUN,C1
-old-fashioned,old-fashioned,老式的,ADJ,B2
-older,older,年长的,ADJ,B2
-older brother,older brother,大哥哥,NOUN,B2
-older brother's wife,older brother's wife,嫂子,NOUN,C1
 older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oldest,oldest,词,ADJ,C1
-oleander,oleander,词,NOUN,B2
 oligarchy,oligarchy,寡头政治,NOUN,B2
-oligopoly,oligopoly,寡头垄断,NOUN,B2
-olives,olives,词,NOUN,A2
-olympic,olympic,奥林匹克的,ADJ,B2
 omelet,omelet,欧姆蛋,NOUN,B2
-omelette,omelette,煎蛋卷,NOUN,B2
 on,on,,NOUN,B2
-on (adv),on,进行中,ADV,A2
-on (noun),on,on,NOUN,B2
-on behalf of,on behalf of,代表,ADP,B2
-on board,on board,在船上,ADV,B2
-on condition,on condition,词,SCONJ,C1
-on head,on head,当头,NOUN,B2
 on it,on it,在上面,ADV,B2
-on one hand,on one hand,一方面,ADV,B2
-on purpose,on purpose,故意地,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on that day,on that day,词,ADV,C1
 on the contrary,on the contrary,相反,ADV,B2
-on the one hand,on the one hand,词,ADV,B2
 on the other hand,on the other hand,另一方面,ADV,B2
 on the spot,on the spot,当场,ADV,B2
 on the way,on the way,在路上,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,按时,ADV,B2
-on top,on top,在上面,ADV,B2
-on top of,on top of,在...上面,ADP,B2
-on upon,on upon,在...上,ADP,B2
-on what,on what,在什么上面,ADV,B2
-on which,on which,在其上,PRON,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
 once more,once more,再次,ADV,B2
 one,one,人们,PRON,B2
-one (adj),one,词,ADJ,A2
-one (det),one,词,DET,C1
-one (noun),one,one,NOUN,B2
-one (pron),one,词,PRON,B2
 one after another,one after another,接连地,ADV,B2
-one and a half,one and a half,一个半,NUM,B2
-one book,one book,一本,NUM,B2
 one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day,one day,一天,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one family,one family,一家,NUM,B2
 one flat,one flat,一张,NUM,B2
-one handful,one handful,一把,NUM,B2
-one head,one head,一头,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
 one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one night,one night,一晚,NUM,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
 one set,one set,一套,NUM,B2
 one shot,one shot,一枪,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
-one's heart's content,one's heart's content,尽情,ADV,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
 one-sided,one-sided,单方面的,ADJ,B2
-one-sidedness,one-sidedness,词,NOUN,B2
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
 oneself,oneself,自己,PRON,B2
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-ongoing (noun),ongoing,词,NOUN,B2
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,词,NOUN,C1
 only,only,唯一的,ADJ,B2
-only (adj),only,唯一,ADJ,B2
-only (det),only,词,DET,B2
-only (sconj),only,而已,SCONJ,B2
-only bringing,only bringing,只带,NOUN,C1
-only just,only just,才,ADV,B2
-only son,only son,独子,NOUN,C1
-only then,only then,才,ADV,B2
-only-me,only-me,只我,NOUN,B2
-oops,oops,词,INTJ,C1
-oozing,oozing,词,NOUN,B2
 opacity,opacity,不透明性,NOUN,B2
 open,open,开着的,ADJ,B2
-open (adj),open,开阔,ADJ,B2
-open (adv),open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
 open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-minded,open-minded,思想开明的,ADJ,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
 openly,openly,公开地,ADV,B2
-openness,openness,开放,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
 operator,operator,经营者,NOUN,B2
-operetta,operetta,词,NOUN,C1
-opium den,opium den,词,NOUN,B2
-opportunism,opportunism,词,NOUN,C1
-opportunist,opportunist,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opportunity used,opportunity used,词,NOUN,B2
-opposing,opposing,词,ADJ,C1
 opposite,opposite,对立面,NOUN,B2
-opposite (adp),opposite,对面,ADP,B2
-opposite (noun),opposite,反的,NOUN,B2
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
 opposition,opposition,对立,NOUN,B2
-oppressed,oppressed,词,ADJ,B1
-oppressive weight,oppressive weight,词,NOUN,C1
-opprobrium,opprobrium,词,NOUN,C1
-optical illusion,optical illusion,词,NOUN,C1
-optician,optician,词,NOUN,C1
 optics,optics,光学,NOUN,B2
-optics perspective,optics perspective,词,NOUN,C1
+to optimize,to optimize,优化,VERB,B2
 optional,optional,可选的,ADJ,B2
-options,options,期权,NOUN,B2
-opulence,opulence,词,NOUN,C1
 or,or,或是,NOUN,B2
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
 or rather,or rather,或者,ADV,B2
-or something,or something,词,ADV,C1
-oral cavity,oral cavity,口腔,NOUN,B2
 oral decree,oral decree,口谕,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange,orange,橙色的,ADJ,B2
-orange (adj),orange,橙色的,ADJ,B2
-orange color,orange color,词,ADJ,A1
-orange juice,orange juice,橙汁,NOUN,B2
-orator speaker,orator speaker,词,NOUN,C1
-oratory,oratory,词,NOUN,C1
-orbital,orbital,词,ADJ,C1
-orchid,orchid,兰,NOUN,B2
 ordeal,ordeal,苦难,NOUN,B2
-order mission,order mission,词,NOUN,A2
-orderliness,orderliness,有序性,NOUN,B2
-ordinance,ordinance,条例,NOUN,B2
 ordinary day,ordinary day,平日,NOUN,B2
-ordinary people,ordinary people,老百姓,NOUN,B2
-ore,ore,词,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organization body,organization body,词,NOUN,B1
 organized,organized,有组织的,ADJ,B2
 organizer,organizer,组织者,NOUN,B2
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
 orientation,orientation,取向,NOUN,B2
-orientation direction,orientation direction,词,NOUN,B1
 original,original,重原,NOUN,B2
-original (noun),original,正本,NOUN,B2
 original document,original document,原件,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
 originality,originality,独创性,NOUN,B2
-originally (part),originally,原,PART,B2
-originating,originating,词,ADJ,B1
-originator,originator,词,NOUN,C1
-orison prayer,orison prayer,词,NOUN,C1
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,词,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-osseous,osseous,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentation,ostentation,词,NOUN,C1
-ostracism,ostracism,词,NOUN,C1
-ostrich,ostrich,词,NOUN,B2
 other,other,其他的,DET,B2
 other,other,其他,NOUN,B2
-other (det),other,词,DET,B2
-other (noun),other,…别,NOUN,B2
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
 other people,other people,旁人,NOUN,B2
 other side,other side,对面,NOUN,B2
 otherness,otherness,相异性,NOUN,B2
 others,others,他人,NOUN,B2
 others,others,他人,PRON,B2
-others (noun),others,他人,NOUN,B2
 otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherwise (part),otherwise,要不,PART,B2
-otherworldly,otherworldly,词,ADJ,C1
 ouch,ouch,哎哟,INTJ,B2
-ought,ought,应该,AUX,B2
-ought to,ought to,词,AUX,A2
-ounce,ounce,词,NOUN,C1
 our,our,我们的,DET,B2
-our (det),our,我们的,DET,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out (adp),out,词,ADP,B2
-out here,out here,这里外面,ADV,B2
 out of,out of,从...出来,ADP,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,格格不入的,ADJ,B2
-out there,out there,词,ADV,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor pool,outdoor pool,词,NOUN,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,外部的,ADJ,B2
 outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
 outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outhouse,outhouse,茅房,NOUN,B2
 outing,outing,郊游,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outset,outset,词,NOUN,C1
+to outline,to outline,勾勒,VERB,B2
 outside,outside,外部,NOUN,B2
-outside (adp),outside,词,ADP,B2
-outside (noun),outside,外,NOUN,B2
-outside of,outside of,词,ADP,B2
 outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,词,NOUN,B2
-outsider,outsider,无亲无故,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
 outsourcing,outsourcing,外包,NOUN,B2
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward (adj),outward,词,ADJ,C1
-outward (adv),outward,词,ADV,B2
-outward journey,outward journey,词,NOUN,C1
-ovarian,ovarian,词,ADJ,C1
 over,over,过去,ADV,B2
-over (adv),over,过去,ADV,B2
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
 over there,over there,在那边,ADV,B2
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
 over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
 over-domain,over-domain,超畴,NOUN,B2
-over-energy,over-energy,超能,NOUN,C1
 over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
 over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
 over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
 over-side,over-side,超方,NOUN,B2
 over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-strategy,over-strategy,超策,NOUN,B2
-over-stroke,over-stroke,超程,NOUN,B2
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overbidding,overbidding,词,NOUN,C1
-overconsumption,overconsumption,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
 overdose,overdose,过量,NOUN,B2
-overdraft,overdraft,透支,NOUN,B2
-overdue,overdue,逾期,ADJ,B2
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overlapping,overlapping,重叠的,ADJ,C1
-overload surcharge,overload surcharge,词,NOUN,C1
-overly familiar,overly familiar,词,ADJ,B2
-overreach,overreach,词,NOUN,C1
-overseas chinese,overseas chinese,华侨,NOUN,B2
-overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
 overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overview,overview,概览,NOUN,B2
-overwork,overwork,词,NOUN,C1
-ow,ow,词,INTJ,C1
-owed,owed,欠下的,ADJ,B2
-own,own,自己的,DET,B2
-own (det),own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-owned,owned,被拥有的,ADJ,A1
+to overturn,to overturn,打翻,VERB,B2
 ownership,ownership,,NOUN,B2
-ox,ox,词,NOUN,C1
-oxidation,oxidation,词,NOUN,C1
 oxide,oxide,氧化物,NOUN,B2
-oxidized,oxidized,词,ADJ,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oyster,oyster,牡蛎,NOUN,B2
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-pace-setter,pace-setter,标兵,NOUN,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
 packaging,packaging,包装,NOUN,B2
 packed,packed,打包,ADJ,B2
 packet,packet,小包裹,NOUN,B2
-pacts,pacts,词,NOUN,C1
-pad,pad,垫,NOUN,B2
-padding,padding,词,NOUN,C1
-padlock,padlock,词,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pain hurt,pain hurt,词,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,词,ADJ,C1
 painkiller,painkiller,止痛药,NOUN,B2
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstakingly,painstakingly,细致地,ADV,B2
-paint dye,paint dye,词,VERB,A1
-paintbrush,paintbrush,词,NOUN,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-pajamas,pajamas,睡衣,NOUN,B2
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-paleography,paleography,词,NOUN,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palimpsest,palimpsest,词,NOUN,C1
-palisade,palisade,词,NOUN,C1
+to paint,to paint,粉刷,VERB,B2
 pallor,pallor,苍白,NOUN,B2
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
 palm tree,palm tree,棕榈树,NOUN,B2
-paltriness,paltriness,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
 pancake,pancake,煎饼,NOUN,B2
 pancreas,pancreas,胰腺,NOUN,B2
 panda,panda,熊猫,NOUN,B2
 panegyric,panegyric,颂词,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
-pantheism,pantheism,泛神论,NOUN,B2
-pantheon,pantheon,先贤祠,NOUN,B2
-panties,panties,词,NOUN,C1
-pants trousers,pants trousers,词,NOUN,A1
-papal bull,papal bull,词,NOUN,B2
-papaya,papaya,木瓜,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
-paper cutting,paper cutting,剪纸,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-parable,parable,寓言,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-paradise heaven,paradise heaven,词,NOUN,B1
-paradoxically,paradoxically,词,ADV,C1
+to pant,to pant,喘气,VERB,B2
 paragraph,paragraph,段落,NOUN,B2
-paragraph heel,paragraph heel,词,NOUN,C1
-paralipsis,paralipsis,词,NOUN,C1
 parallel,parallel,平行的,ADJ,B2
-parallelism,parallelism,词,NOUN,C1
-paralogism,paralogism,谬误推理,NOUN,B2
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
 paralysis,paralysis,瘫痪,NOUN,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
 paramedic,paramedic,急救人员,NOUN,B2
-paranoia,paranoia,词,NOUN,C1
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parataxis,parataxis,意合,NOUN,B2
-parcel,parcel,包裹,NOUN,B2
-parchment,parchment,词,NOUN,C1
 pardon,pardon,赦免,NOUN,B2
-pardoning,pardoning,词,NOUN,C1
-parent-friendly,parent-friendly,,NOUN,B2
-parenthesis,parenthesis,词,NOUN,C1
+to pardon,to pardon,赦免,VERB,B2
 parents,parents,父母,NOUN,B2
-paresis,paresis,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parishioner,parishioner,词,NOUN,C1
-parishioners,parishioners,词,NOUN,C1
 parity,parity,平等,NOUN,B2
+to park,to park,停车,VERB,B2
 parking lot,parking lot,停车场,NOUN,B2
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parliamentary,parliamentary,议会的/议员,ADJ,B2
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
 parody,parody,戏仿,NOUN,B2
-paronomasia,paronomasia,近音词双关,NOUN,B2
-paronym,paronym,词,NOUN,C1
-paroxysm,paroxysm,发作,NOUN,B2
-parquet,parquet,词,NOUN,C1
 parrot,parrot,鹦鹉,NOUN,B2
-parse,parse,解析,VERB,B2
-parsimony,parsimony,吝啬,NOUN,B2
 parsley,parsley,欧芹,NOUN,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-partial,partial,部分的,ADJ,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial cause,partial cause,分因,NOUN,B2
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial meaning,partial meaning,分义,NOUN,B2
-partial nature,partial nature,分性,NOUN,C1
+to part,to part,分离,VERB,B2
 partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-partially,partially,部分地,ADV,B2
 participant,participant,参与者,NOUN,B2
 participation,participation,参与,NOUN,B2
 participatory,participatory,参与式的,ADJ,B2
-particle (part),particle,么,PART,B2
 particularity,particularity,特点,NOUN,B2
-partisan (adj),partisan,词,ADJ,C1
-partisanship,partisanship,党派性,NOUN,C1
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
 partly,partly,部分地,ADV,B2
-partner female,partner female,词,NOUN,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-party to the contract,party to the contract,词,NOUN,B2
-pashalik,pashalik,词,NOUN,C1
-pass (noun),pass,过得,NOUN,C1
-passable,passable,词,ADJ,C1
-passed,passed,词,ADJ,B2
-passerby,passerby,词,NOUN,C1
+to pass,to pass,通过,VERB,B2
+to pass away,to pass away,流逝,VERB,B2
+to pass by,to pass by,经过,VERB,B2
+to pass on,to pass on,转交,VERB,B2
 passing,passing,过世,NOUN,B2
-passionate love,passionate love,词,NOUN,C1
-passive reliance on others,passive reliance on others,词,NOUN,C1
 past,past,过去的,ADJ,B2
 past,past,经过,ADV,B2
-past (adj),past,past,ADJ,A1
-past (adp),past,词,ADP,B2
-past (adv),past,经过,ADV,B2
 past events,past events,往事,NOUN,B2
-past exam papers,past exam papers,真题,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
 paste,paste,酱,NOUN,B2
 pastime,pastime,爱好,NOUN,B2
 pastor,pastor,牧师,NOUN,B2
-pastoral (noun),pastoral,词,NOUN,C1
-pastry chef,pastry chef,词,NOUN,C1
 pasture,pasture,牧场,NOUN,B2
+to pat,to pat,轻拍,VERB,B2
 patch,patch,补丁,NOUN,B2
-patch tire,patch tire,补胎,VERB,C1
-patently,patently,显然地,ADV,B2
-paternal,paternal,父亲的,ADJ,B2
 paternal aunt,paternal aunt,姑母,NOUN,B2
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
 paternity leave,paternity leave,陪产假,NOUN,B2
 pathetic,pathetic,可悲的,ADJ,B2
-pathogenic,pathogenic,致病的,ADJ,B2
-pathology,pathology,病理学,NOUN,B2
 patient,patient,耐心的,ADJ,B2
-patient (adj),patient,patient,ADJ,A2
-patient female,patient female,词,NOUN,B2
 patient sufferer,patient sufferer,患者,NOUN,B2
-patiently,patiently,词,ADV,C1
 patriarchy,patriarchy,父权制,NOUN,B2
-patricide,patricide,词,NOUN,B2
-patriot,patriot,词,NOUN,B2
 patriotism,patriotism,爱国主义,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
 patron,patron,赞助人,NOUN,B2
-patronage,patronage,词,NOUN,B2
-pauper,pauper,词,NOUN,B2
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
-pavilion,pavilion,亭子,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-paving,paving,铺路,NOUN,B2
-paving stone,paving stone,词,NOUN,A2
-paw,paw,爪子,NOUN,B2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-payment all,payment all,付都,NOUN,B2
-payments,payments,词,NOUN,C1
-pea,pea,词,NOUN,C1
-peacefully,peacefully,词,ADV,C1
+to pause,to pause,暂停,VERB,B2
+to pay attention,to pay attention,注意,VERB,B2
+to pay off,to pay off,清偿,VERB,B2
+to pay smilingly,to pay smilingly,笑付,VERB,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
 peach,peach,桃子,NOUN,B2
-peach tree,peach tree,词,NOUN,C1
-peanut field,peanut field,词,NOUN,B2
 pear,pear,梨,NOUN,B2
 pearl,pearl,珍珠,NOUN,B2
-peat,peat,泥炭,NOUN,B2
-peculiarity,peculiarity,词,NOUN,B2
 pedagogy,pedagogy,教育学,NOUN,B2
-pedal,pedal,词,NOUN,B1
-pedantically,pedantically,词,ADV,C1
-pedantry,pedantry,迂腐,NOUN,B2
-peddler,peddler,小贩,NOUN,B2
-pedestrian bridge,pedestrian bridge,天桥,NOUN,B2
 pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-pediment,pediment,词,NOUN,C1
-peek,peek,词,VERB,C1
 peel,peel,皮,NOUN,B2
+to peel,to peel,削皮,VERB,B2
 peephole,peephole,门镜,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-pelvis,pelvis,词,NOUN,B2
-pelvis basin,pelvis basin,词,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalties,penalties,处罚,NOUN,C1
-penalty payment,penalty payment,词,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-pencil case,pencil case,词,NOUN,C1
-pending,pending,词,ADJ,B1
 penetration,penetration,渗透,NOUN,B2
-penguin,penguin,词,NOUN,A1
-penitence,penitence,词,NOUN,C1
-penitentiary,penitentiary,词,ADJ,C1
-pennant,pennant,词,NOUN,C1
-penniless,penniless,词,ADJ,B1
 people,people,人们,NOUN,B2
-people (pron),people,词,PRON,B2
 people nation,people nation,人民 / 民族,NOUN,B2
 pepper,pepper,胡椒,NOUN,B2
-per,per,每,ADP,B2
 percentage,percentage,百分比,NOUN,B2
-perceptibly,perceptibly,明显地,ADV,B2
-perception opinion,perception opinion,词,NOUN,B2
-perceptual,perceptual,词,ADJ,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-peremptorily,peremptorily,词,ADV,C1
-perfectly,perfectly,词,ADV,A2
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-peri-urban,peri-urban,词,ADJ,B2
 perilla,perilla,紫苏,NOUN,B2
-period (punct),period,词,PUNCT,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periodical,periodical,词,NOUN,C1
 periodically,periodically,定期地,ADV,B2
-periodization,periodization,分期,NOUN,C1
-periphrasis,periphrasis,词,NOUN,C1
-perishing,perishing,词,NOUN,B2
-peritoneum,peritoneum,腹膜,NOUN,B2
-perks,perks,词,NOUN,C1
 permanence,permanence,持久,NOUN,B2
-permeability,permeability,词,NOUN,C1
-permissible,permissible,词,ADJ,C1
-permutations,permutations,词,NOUN,C1
-peroration,peroration,结语,NOUN,B2
+to permit,to permit,允许,VERB,B2
 perpendicular,perpendicular,垂直的,ADJ,B2
 perpetrator,perpetrator,肇事者,NOUN,B2
-perplexed,perplexed,困惑的,ADJ,B2
 perseverance,perseverance,毅力,NOUN,B2
-persimmon,persimmon,柿子,NOUN,C1
-person honorific,person honorific,位,NOUN,B2
 person in charge,person in charge,负责人,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
-personal (noun),personal,私事,NOUN,B2
-personal best,personal best,词,NOUN,B2
 personal effort,personal effort,亲力,NOUN,B2
-personal enmity,personal enmity,私仇,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
-personal record,personal record,个人纪录,NOUN,B2
-personalization,personalization,词,NOUN,C1
-personalized,personalized,个性化的,ADJ,B2
 personally,personally,就个人而言,ADV,B2
-personally experience,personally experience,亲历,VERB,C1
-personification,personification,词,NOUN,C1
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicacity,perspicacity,词,NOUN,B2
-pertinently,pertinently,词,ADV,B2
-perversity,perversity,词,NOUN,C1
 pessimism,pessimism,悲观主义,NOUN,B2
-pest,pest,词,NOUN,C1
-pesticides,pesticides,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-petition for review,petition for review,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
-pettiness,pettiness,词,NOUN,C1
-phantasmagorical,phantasmagorical,词,ADJ,C1
-pharaoh,pharaoh,法老,NOUN,B2
-pharisee,pharisee,法利赛人,NOUN,B2
 pharmacist,pharmacist,药剂师,NOUN,B2
-pharynx,pharynx,词,NOUN,B2
 phased,phased,阶段性,ADJ,B2
-phased (adv),phased,词,ADV,B1
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-pheasant,pheasant,词,NOUN,C1
-phenomenological,phenomenological,词,ADJ,C1
-phew,phew,词,INTJ,C1
-philanthropy,philanthropy,慈善,NOUN,B2
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philologist,philologist,语言学家,NOUN,B2
-philology,philology,词,NOUN,C1
 philosopher,philosopher,哲学家,NOUN,B2
-philosophical,philosophical,哲学的,ADJ,B2
-philosophizing,philosophizing,词,NOUN,C1
-philosophy of life,philosophy of life,词,NOUN,B2
-phishing,phishing,词,NOUN,B2
-phlebitis,phlebitis,词,NOUN,C1
 phlegm,phlegm,痰,NOUN,B2
-phloem,phloem,词,ADJ,C1
 phobia,phobia,恐惧症,NOUN,B2
-phoenix,phoenix,拿凤,NOUN,B2
-phoenix camp,phoenix camp,凤字营,NOUN,B2
 phoenix character,phoenix character,带凤字,NOUN,B2
 phoenix coronet,phoenix coronet,凤冠,NOUN,B2
 phone call,phone call,通话,NOUN,B2
-phone credit,phone credit,词,NOUN,B1
-phone number,phone number,电话号码,NOUN,B2
-phoneme,phoneme,词,NOUN,C1
 phonetics,phonetics,语音学,NOUN,B2
 phonology,phonology,音系学,NOUN,B2
-phosphate,phosphate,词,NOUN,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-phosphorus,phosphorus,词,NOUN,C1
-photo album,photo album,影集,NOUN,C1
-photo model,photo model,词,NOUN,B2
 photocopy,photocopy,复印件,NOUN,B2
-photogenic,photogenic,词,ADJ,C1
-photographic,photographic,词,ADJ,C1
+to photocopy,to photocopy,复印,VERB,B2
+to photograph,to photograph,拍照,VERB,B2
 photography,photography,摄影,NOUN,B2
-photogravure,photogravure,词,NOUN,C1
-photon,photon,光子,NOUN,B2
-photophobia,photophobia,词,NOUN,C1
 photosynthesis,photosynthesis,光合作用,NOUN,B2
-phototypy,phototypy,词,NOUN,C1
-phraseology,phraseology,词,NOUN,C1
-phrasing,phrasing,措辞,NOUN,B2
-physical evidence,physical evidence,物证,NOUN,B2
-physically,physically,身体上地,ADV,B2
-physicist,physicist,词,NOUN,C1
 physiognomy,physiognomy,面相,NOUN,B2
-physiological,physiological,生理的,ADJ,B2
 physiology,physiology,生理学,NOUN,B2
-physiotherapist,physiotherapist,词,NOUN,B1
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-pianist,pianist,词,NOUN,C1
-piano music,piano music,词,NOUN,B2
-picaresque,picaresque,词,ADJ,C1
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickles,pickles,词,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
+to pick up,to pick up,捡起,VERB,B2
+to pickle,to pickle,腌渍,VERB,B2
 picnic,picnic,野餐,NOUN,B2
-pictorial,pictorial,绘画的,ADJ,B2
-picture photo,picture photo,词,NOUN,A2
-picturesque,picturesque,如画的；别致的,ADJ,B2
-pidgin,pidgin,词,NOUN,C1
-pie,pie,派,NOUN,B2
-piece of bread,piece of bread,词,NOUN,B2
 piece of information,piece of information,信息,NOUN,B2
-piecework,piecework,词,NOUN,C1
 piety,piety,虔诚,NOUN,B2
-piety pity,piety pity,词,NOUN,B2
 pigeon,pigeon,鸽子,NOUN,B2
-pile heap,pile heap,词,NOUN,C1
+to pile up,to pile up,堆积,VERB,B2
 pilgrimage,pilgrimage,朝圣,NOUN,B2
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pills,pills,词,NOUN,B2
-pimp,pimp,词,NOUN,C1
-pimple,pimple,词,NOUN,B2
-pinch,pinch,捏,NOUN,B2
-pinch (noun),pinch,词,NOUN,C1
+to pin,to pin,别住,VERB,B2
 pine,pine,松树,NOUN,B2
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
 pineapple,pineapple,菠萝,NOUN,B2
 pink,pink,粉色的,ADJ,B2
-pink (adj),pink,粉红色的,ADJ,B2
-piously,piously,词,ADV,C1
+to pioneer,to pioneer,首创,VERB,B2
 pipa,pipa,琵琶,NOUN,B2
-pipe dream,pipe dream,词,NOUN,C1
-piracy,piracy,词,NOUN,B2
-pirated,pirated,词,ADJ,B2
 pistachio,pistachio,开心果,NOUN,B2
-piston,piston,词,NOUN,C1
 pit,pit,坑,NOUN,B2
-pitch darkness,pitch darkness,词,NOUN,C1
-pitchfork,pitchfork,叉子,NOUN,B2
-piteous,piteous,词,ADJ,C1
 pitiful,pitiful,可怜的,ADJ,B2
-pity,pity,可惜,ADJ,B2
-pity (adj),pity,怜悯,ADJ,B2
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,pivotal,词,ADJ,C1
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-place value,place value,位值,NOUN,C1
-placed before,placed before,词,ADJ,B2
+to pity,to pity,同情,VERB,B2
+to place,to place,放置,VERB,B2
 placement,placement,放置,NOUN,B2
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
 plagiarism,plagiarism,剽窃,NOUN,B2
 plain,plain,平原,NOUN,B2
-plain (noun),plain,平原,NOUN,B2
 plain and simple,plain and simple,朴素,ADJ,B2
 plaintiff,plaintiff,原告,NOUN,B2
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
+to plan,to plan,计划,VERB,B2
 planning,planning,规划,NOUN,B2
-plantain,plantain,芭蕉,NOUN,B2
-plantation,plantation,人工林,NOUN,B2
 planting,planting,种植,NOUN,B2
 plasma,plasma,血浆,NOUN,B2
 plastic,plastic,塑料的,ADJ,B2
-plastic (adj),plastic,塑料,ADJ,B1
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
 plateau,plateau,高原,NOUN,B2
-plated,plated,镀层的,ADJ,B2
 platelet,platelet,血小板,NOUN,B2
-platforms,platforms,词,NOUN,C1
-platinum,platinum,词,NOUN,B2
 play,play,剧本,NOUN,B2
-play (noun),play,戏,NOUN,B2
-play game,play game,游戏/玩耍,NOUN,B2
-playable,playable,可演奏的,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
-playmate,playmate,玩伴,NOUN,B2
-plays,plays,词,NOUN,C1
 plea,plea,辩护,NOUN,B2
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please,please,请,ADV,B2
-please (adv),please,please,ADV,B2
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-plebiscite,plebiscite,词,NOUN,B2
+to please,to please,使高兴,VERB,B2
 pledge,pledge,抵押,NOUN,B2
-pledge (noun),pledge,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plentiful,plentiful,词,ADJ,B2
-plenty,plenty,充足地,ADV,B2
-plenty (adv),plenty,词,ADV,B2
-pleonasm,pleonasm,词,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
 pliers,pliers,钳子,NOUN,B2
-plight,plight,处境,NOUN,B2
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plot twist,plot twist,词,NOUN,C1
-plow,plow,词,NOUN,B2
-plow handle,plow handle,词,NOUN,C1
 plowing,plowing,犁地,NOUN,B2
 plum,plum,李子,NOUN,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
 plumbing,plumbing,管道工程,NOUN,B2
 plunder,plunder,掠夺,NOUN,B2
 plundering,plundering,掠夺,NOUN,B2
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
 pluralism,pluralism,多元主义,NOUN,B2
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
 plush toy,plush toy,毛绒玩具,NOUN,B2
 plutocracy,plutocracy,财阀政治,NOUN,B2
-pneumonia,pneumonia,词,NOUN,C1
-podcasting,podcasting,词,NOUN,B1
-poetic,poetic,词,ADJ,C1
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
 poetry collection,poetry collection,诗集,NOUN,B2
-point grade,point grade,词,NOUN,A2
-point in time,point in time,时间点,NOUN,B2
-point of view,point of view,词,NOUN,C1
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,词,ADV,B2
-pointwise,pointwise,词,ADJ,C1
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,词,NOUN,B2
+to point,to point,指向,VERB,B2
+to point out,to point out,指出,VERB,B2
+to poison,to poison,毒害,VERB,B2
 poisonous,poisonous,有毒的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polaris,polaris,北极星,NOUN,B2
-polarity,polarity,极性,NOUN,C1
 polarization,polarization,两极分化 / 极化,NOUN,B2
 pole,pole,极,NOUN,B2
-polemic,polemic,词,NOUN,C1
-polemicist,polemicist,词,NOUN,C1
-police chief,police chief,警察局长,NOUN,B2
-police officer,police officer,警察,NOUN,B2
-police officer female,police officer female,词,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police report,police report,,NOUN,B2
-police search,police search,词,NOUN,C1
-police station,police station,警察局,NOUN,B2
-policy-related,policy-related,词,ADJ,C1
-polish,polish,波兰的,ADJ,B2
-polish (adj),polish,波兰的,ADJ,B2
-polish (noun),polish,精炼,NOUN,C1
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politeness,politeness,词,NOUN,C1
-political party,political party,政党,NOUN,B2
-politically,politically,在政治上,ADV,B2
-politicization,politicization,词,NOUN,C1
 pollination,pollination,授粉,NOUN,B2
-pollinic,pollinic,词,ADJ,C1
-pollster,pollster,词,NOUN,C1
 pollutant,pollutant,污染物,NOUN,B2
-polluted,polluted,受污染的,ADJ,B2
 polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,连词叠用,NOUN,B2
 polytunnel,polytunnel,大棚,NOUN,B2
 pomegranate,pomegranate,石榴,NOUN,B2
-pomelo,pomelo,柚子,NOUN,B2
-pomp,pomp,词,NOUN,C1
-pompous,pompous,词,ADJ,C1
-pompously,pompously,词,ADV,C1
-pool,pool,池,PART,B2
-pool (part),pool,池,PART,B2
-pooled,pooled,词,ADJ,C1
-poor devil,poor devil,可怜虫,NOUN,B2
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,词,ADJ,B2
-pop music,pop music,流行音乐,NOUN,B2
-popcorn,popcorn,词,ADJ,C1
-poppy,poppy,词,NOUN,B1
-pops,pops,词,NOUN,C1
-populism,populism,民粹主义,NOUN,C1
-populist,populist,民粹主义者,NOUN,B2
-porcelain,porcelain,瓷器,NOUN,B2
-pork,pork,词,NOUN,B2
+to popularize,to popularize,推广,VERB,B2
+to populate,to populate,居住,VERB,B2
 porn,porn,色情,NOUN,B2
 pornographic,pornographic,色情的,ADJ,B2
-pornography,pornography,色情,NOUN,B2
-porosity,porosity,词,NOUN,C1
 porridge,porridge,粥,NOUN,B2
-port harbor,port harbor,词,NOUN,A1
 porter,porter,搬运工,NOUN,B2
-portfolios,portfolios,词,NOUN,C1
-portion serving,portion serving,词,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portrayal,portrayal,词,NOUN,B2
-portuguese,portuguese,葡萄牙语,NOUN,B2
-posh,posh,上流的,ADJ,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
 positioning,positioning,定位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivism,positivism,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-possible future,possible future,词,ADJ,C1
 post office,post office,邮局,NOUN,B2
-postage,postage,邮资,NOUN,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postal code,postal code,邮政编码,NOUN,B2
 postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-posterity,posterity,词,NOUN,C1
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
 postponement,postponement,延期,NOUN,B2
-postscript,postscript,词,NOUN,C1
 postulate,postulate,假定,NOUN,B2
-postulate (noun),postulate,公设,NOUN,B2
-posture,posture,作势,NOUN,B2
 postwar,postwar,战后,NOUN,B2
 pot,pot,锅,NOUN,B2
-potency,potency,药效,NOUN,B2
-potential,potential,潜在的,ADJ,B2
-potential (adj),potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potion,potion,词,NOUN,B2
-potter,potter,词,NOUN,B2
-pouch,pouch,词,NOUN,C1
-poultice,poultice,词,NOUN,B2
 poultry,poultry,家禽,NOUN,B2
+to pounce,to pounce,猛扑,VERB,B2
 pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power grid,power grid,电网,NOUN,B2
 power of attorney,power of attorney,委托书,NOUN,B2
-power outlet,power outlet,插座,NOUN,B1
 power plant,power plant,发电厂,NOUN,B2
-power station,power station,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powerful nation,powerful nation,强国,NOUN,B2
-powers,powers,词,NOUN,C1
 practically,practically,几乎,ADV,B2
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatism,pragmatism,实用主义,NOUN,B2
-pragmatist,pragmatist,词,NOUN,C1
 praise,praise,赞扬,NOUN,B2
-praise (noun),praise,完都赞,NOUN,B2
-praise singer,praise singer,词,NOUN,C1
-praiseworthy,praiseworthy,词,ADJ,C1
-prawn,prawn,词,NOUN,C1
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer room,prayer room,祈祷室,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-preacher,preacher,传教士,NOUN,B2
-preaching,preaching,劝诫,NOUN,B2
 preamble,preamble,序言,NOUN,B2
 precariousness,precariousness,不稳定性,NOUN,B2
-precarization,precarization,不稳定化,NOUN,B2
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
 precept,precept,戒律,NOUN,B2
 preciousness,preciousness,珍贵,NOUN,B2
-precipice,precipice,词,NOUN,C1
-precisely,precisely,确切地; 正好,ADV,B2
-precision,precision,精确,NOUN,B2
-precocious talent,precocious talent,词,NOUN,C1
-preconception,preconception,词,NOUN,B2
 predicament,predicament,困境,NOUN,B2
-predilection,predilection,词,NOUN,C1
-predisposition,predisposition,词,NOUN,B2
 predominance,predominance,主导地位,NOUN,B2
-predominant,predominant,词,ADJ,B2
-preeminence,preeminence,词,NOUN,B2
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
 preface,preface,序言,NOUN,B2
-prefect,prefect,词,NOUN,B1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
 prefecture,prefecture,省政府,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-preferable,preferable,更可取的,ADJ,B2
 preferably,preferably,更愿意,ADV,B2
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-prejudiced,prejudiced,词,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-prelate,prelate,词,NOUN,C1
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,词,ADJ,C1
-premature baby,premature baby,词,NOUN,B2
-prematurely,prematurely,词,ADV,C1
-prematurity,prematurity,词,NOUN,C1
-premeditation,premeditation,预谋,NOUN,B2
 premonition,premonition,预感,NOUN,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
 preparation,preparation,准备,NOUN,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
 prepared,prepared,准备好的,ADJ,B2
-preparedness,preparedness,词,NOUN,B1
-preponderance,preponderance,词,NOUN,C1
 prerequisite,prerequisite,前提,NOUN,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-preschool,preschool,幼儿园,NOUN,B2
 present,present,在场的,ADJ,B2
-present (adj),present,在场,ADJ,B2
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
 presenter,presenter,主持人,NOUN,B2
 preservation,preservation,保护,NOUN,B2
 preservative,preservative,防腐剂,NOUN,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
 presidential,presidential,总统的,ADJ,B2
-presidential election,presidential election,总统选举,NOUN,B2
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
+to press,to press,按,VERB,B2
 press conference,press conference,新闻发布会,NOUN,B2
-press freedom,press freedom,新闻自由,NOUN,B2
-press release,press release,公报,NOUN,B2
 prestige,prestige,声望,NOUN,B2
-prestigious,prestigious,有声望的,ADJ,B2
-presumably,presumably,据推测,ADV,B2
-presumed,presumed,词,ADJ,B2
 presumption,presumption,自负,NOUN,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-pretender,pretender,词,NOUN,C1
-pretending to forget,pretending to forget,词,VERB,C1
+to pretend to be,to pretend to be,冒充,VERB,B2
 pretense,pretense,假装,NOUN,B2
-pretension,pretension,词,NOUN,C1
-preterition,preterition,假托,NOUN,B2
 pretext,pretext,借口,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalence,prevalence,词,NOUN,C1
-preventive,preventive,词,ADJ,B2
-previous (noun),previous,词,NOUN,B2
 previously,previously,以前,ADV,B2
 prey,prey,猎物,NOUN,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prices,prices,词,NOUN,C1
 pricing,pricing,定价 / 收费,NOUN,B2
-prickly,prickly,词,ADJ,C1
-pride arrogance,pride arrogance,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-primary school,primary school,小学,NOUN,B2
-primary school teacher,primary school teacher,词,NOUN,C1
-prime matter,prime matter,词,NOUN,C1
 prime minister,prime minister,总理,NOUN,B2
-primeval forest,primeval forest,原始森林,NOUN,C1
-primordial chaos,primordial chaos,词,NOUN,C1
 principal,principal,委托人,NOUN,B2
-principal (noun),principal,本金,NOUN,B2
-principality,principality,词,NOUN,C1
 print,print,印记,NOUN,B2
-print (noun),print,版画,NOUN,C1
-printed,printed,词,ADJ,C1
-printed form,printed form,词,NOUN,B1
 printer,printer,打印机,NOUN,B2
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-priority,priority,优先的,ADJ,B2
-priority (adj),priority,词,ADJ,B2
 prism,prism,棱镜,NOUN,B2
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
 private debt,private debt,私债,NOUN,B2
-private life,private life,私生活,NOUN,B2
-privatization,privatization,词,NOUN,B2
-privileged,privileged,词,ADJ,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-probable,probable,词,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probationary,probationary,词,ADJ,B2
 probe,probe,探测器,NOUN,B2
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-problematic,problematic,词,ADJ,B2
-problematic issue,problematic issue,词,NOUN,C1
-procedures,procedures,词,NOUN,C1
-process technique,process technique,词,NOUN,B1
-processable,processable,词,ADJ,C1
-processing (adj),processing,词,ADJ,C1
-processing (noun),processing,词,NOUN,B2
-procession,procession,行列,NOUN,B2
+to process,to process,处理,VERB,B2
 processor,processor,处理器,NOUN,B2
+to proclaim,to proclaim,宣布,VERB,B2
 proclamation,proclamation,宣大,NOUN,B2
 procrastination,procrastination,拖延,NOUN,B2
-prodigality,prodigality,挥霍,NOUN,C1
-productive,productive,多产的,ADJ,B2
-productivist,productivist,生产至上主义的,ADJ,B2
+to procure,to procure,获取,VERB,B2
 productivity,productivity,生产力,NOUN,B2
 professional,professional,专业人士,NOUN,B2
-professional (noun),professional,词,NOUN,B2
-professional ethics,professional ethics,词,NOUN,C1
-professional formation,professional formation,词,NOUN,B2
-professionalism,professionalism,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professorship,professorship,词,NOUN,C1
 profit-making,profit-making,营利性,ADJ,B2
-profitability,profitability,盈利能力,NOUN,B2
-profitable,profitable,词,ADJ,B2
-profits,profits,词,NOUN,B2
-profusion,profusion,词,NOUN,C1
-program schedule,program schedule,词,NOUN,A2
-programmed,programmed,词,ADJ,C1
 programmer,programmer,程序员,NOUN,B2
 programming,programming,编程,NOUN,B2
-progress report,progress report,进度报告,NOUN,B2
-progression,progression,词,NOUN,C1
+to progress,to progress,进步,VERB,B2
 progressive,progressive,渐进的,ADJ,B2
-progressive (noun),progressive,进步人士,NOUN,B2
 progressively,progressively,逐渐地,ADV,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
 prohibition,prohibition,禁止,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-project assignment,project assignment,项目作业,NOUN,B2
 project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projection,projection,词,NOUN,C1
-projections,projections,词,NOUN,C1
 projector,projector,投影仪,NOUN,B2
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
-proletariat,proletariat,无产阶级,NOUN,B2
-proliferate,proliferate,扩散,! VERB,B2
-proliferation,proliferation,增殖,NOUN,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolixity,prolixity,冗长,NOUN,B2
-prominence,prominence,词,NOUN,B2
-prominent family,prominent family,望族,NOUN,C1
 promising,promising,有前途的,ADJ,B2
 promissory note,promissory note,本票,NOUN,B2
-promoted,promoted,词,ADJ,B1
-promoter,promoter,推动者,NOUN,B2
 promptly,promptly,迅速地,ADV,B2
-promptness,promptness,词,NOUN,C1
-prone,prone,词,ADJ,C1
-pronoun,pronoun,词,NOUN,B1
-pronounced,pronounced,显著的,ADJ,B2
 pronunciation,pronunciation,发音,NOUN,B2
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-proofreading,proofreading,校对,NOUN,B2
-propaedeutic,propaedeutic,词,ADJ,C1
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-propeller,propeller,螺旋桨,NOUN,B2
 properly,properly,适当地,ADV,B2
-property owner,property owner,房主,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophet,prophet,先知,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-proponent,proponent,词,NOUN,C1
-proportional,proportional,成比例的,ADJ,B2
-proportionality,proportionality,词,NOUN,C1
-proportionally,proportionally,词,ADV,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proposition,proposition,主张,NOUN,B2
-propriety,propriety,分寸,NOUN,B2
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
+to prophesy,to prophesy,预言,VERB,B2
 prose,prose,散文,NOUN,B2
-prose writer,prose writer,词,NOUN,C1
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutions,prosecutions,词,NOUN,C1
-prosecutor's office,prosecutor's office,词,NOUN,B2
-proselyte,proselyte,词,NOUN,C1
-proselytism,proselytism,传教,NOUN,B2
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
 prostitute,prostitute,妓女,NOUN,B2
-prostitution,prostitution,词,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
 protectionism,protectionism,保护主义,NOUN,B2
 protective,protective,保护的,ADJ,B2
-protective cover,protective cover,词,NOUN,C1
-protector,protector,词,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
+to protest,to protest,抗议,VERB,B2
 protester,protester,示威者,NOUN,B2
-proton,proton,词,NOUN,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-proudly,proudly,词,ADV,C1
-provable,provable,可证明的,ADJ,B2
 proverb,proverb,谚语,NOUN,B2
-proverbs,proverbs,词,NOUN,C1
+to provide for,to provide for,供应,VERB,B2
 provided that,provided that,只要,SCONJ,B2
-provinces,provinces,词,NOUN,C1
-provincial highway,provincial highway,省道,NOUN,B2
-provision,provision,词,NOUN,C1
-provisionally,provisionally,词,ADV,C1
 provisions,provisions,储备,NOUN,B2
 provocation,provocation,挑衅,NOUN,B2
-prow,prow,词,NOUN,C1
 proximity,proximity,邻近,NOUN,B2
 proxy,proxy,代理人,NOUN,B2
 prudence,prudence,谨慎,NOUN,B2
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-psalm,psalm,词,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
-psoriasis,psoriasis,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychologically,psychologically,词,ADV,C1
 psychologist,psychologist,心理学家,NOUN,B2
-psychopath,psychopath,精神变态者,NOUN,B2
-psychopathy,psychopathy,词,NOUN,C1
 psychosis,psychosis,精神病,NOUN,B2
-puberty,puberty,青春期,NOUN,B2
 public,public,公众,NOUN,B2
-public (noun),public,公众,NOUN,B1
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public order,public order,治安,NOUN,B2
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-public welfare,public welfare,公益性,NOUN,B2
 publicly,publicly,公开地,ADV,B2
 publisher,publisher,出版商,NOUN,B2
-publishing house,publishing house,出版社,NOUN,B2
-puddle,puddle,水坑,NOUN,B2
-puerperal,puerperal,词,ADJ,C1
-puff,puff,一口烟,NOUN,B2
-puff pastry,puff pastry,词,NOUN,C1
-pugnacity,pugnacity,词,NOUN,C1
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
 pulling,pulling,拔,NOUN,B2
 pulmonary,pulmonary,肺的,ADJ,B2
 pulpit,pulpit,讲坛,NOUN,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
-punch (verb),punch,词,VERB,B2
-punch drink,punch drink,词,NOUN,C1
-punctuality,punctuality,词,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
 punctuation,punctuation,标点符号,NOUN,B2
-puncture,puncture,穿刺,NOUN,B2
-puncture tap,puncture tap,词,NOUN,C1
-punishable,punishable,词,ADJ,B2
-puny,puny,词,ADJ,C1
 pupil,pupil,学生,NOUN,B2
-pupil female,pupil female,词,NOUN,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-purchase price,purchase price,词,NOUN,B2
-purely,purely,纯粹地,ADV,B2
 purification,purification,净化,NOUN,B2
-purifying,purifying,净化的,ADJ,B2
-purity,purity,纯洁,NOUN,B2
 purple,purple,紫色,ADJ,B2
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purple yin,purple yin,紫阴,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-pus,pus,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-push luck,push luck,太得寸,NOUN,B2
 pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put forward,put forward,提出,VERB,B2
-putrid,putrid,词,ADJ,C1
+to put down,to put down,放下,VERB,B2
+to put on,to put on,穿上,VERB,B2
 pyramid,pyramid,金字塔,NOUN,B2
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quackery,quackery,词,NOUN,B2
 quail,quail,鹌鹑,NOUN,B2
 qualifications,qualifications,资格,NOUN,B2
 qualified,qualified,合格的,ADJ,B2
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifying,qualifying,词,ADJ,C1
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,词,ADJ,B2
-quantum,quantum,词,ADJ,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarreling,quarreling,再吵,NOUN,B2
-quarry,quarry,词,NOUN,B1
-quarter of a year,quarter of a year,季度,NOUN,B2
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly magazine,quarterly magazine,季刊,NOUN,B2
-quarterly report,quarterly report,季报,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quasi,quasi,词,ADV,B2
-quaternary,quaternary,词,ADJ,B2
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
+to quarrel,to quarrel,争吵,VERB,B2
 questionable,questionable,可疑的,ADJ,B2
-questioning (adj),questioning,词,ADJ,C1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
 quick lie-down,quick lie-down,快躺,NOUN,B2
 quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
-quietude,quietude,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,好些,ADJ,B2
 quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quivering,quivering,颤抖的,ADJ,B2
-quota sharing,quota sharing,配额分享,NOUN,C1
-quotable,quotable,可估价的,ADJ,B2
 quotation,quotation,报价,NOUN,B2
-quote,quote,报价单,NOUN,B2
-quote (noun),quote,报价单,NOUN,B2
-quotient,quotient,词,NOUN,B2
-rabbi,rabbi,拉比,NOUN,B2
 rabbit,rabbit,兔子,NOUN,B2
-rabble,rabble,词,NOUN,C1
-racist,racist,种族主义的,ADJ,B2
-racist (adj),racist,种族主义的,ADJ,C1
 racket,racket,球拍,NOUN,B2
-racketeering,racketeering,词,NOUN,B2
 radiance,radiance,光辉,NOUN,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
 radiator,radiator,暖气片,NOUN,B2
-radicalism,radicalism,词,NOUN,C1
-radically,radically,词,ADV,B2
-radio silence,radio silence,词,NOUN,C1
 radio station,radio station,广播电台,NOUN,B2
 radioactive,radioactive,放射性的,ADJ,B2
-radioactivity,radioactivity,词,NOUN,C1
-radiography rays,radiography rays,词,NOUN,C1
 radiotherapy,radiotherapy,放疗,NOUN,B2
 radish,radish,小萝卜,NOUN,B2
-radius,radius,半径,NOUN,B2
-rag,rag,破布,NOUN,B2
-rags,rags,词,NOUN,B2
-rai,rai,词,NOUN,B2
+to rage,to rage,狂怒,VERB,B2
 raid,raid,突袭,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
 railing,railing,栏杆,NOUN,B2
-rails,rails,词,NOUN,C1
-railway,railway,铁路的,ADJ,B2
-railway (adj),railway,铁路的,ADJ,C1
-rain clouds,rain clouds,词,NOUN,C1
-rain shower,rain shower,阵雨,NOUN,B2
+to rain,to rain,下雨,VERB,B2
 rainstorm,rainstorm,暴雨,NOUN,B2
 rainy,rainy,多雨的,ADJ,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise (noun),raise,词,NOUN,B1
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-rajaz poem,rajaz poem,词,NOUN,C1
-rallying,rallying,词,NOUN,C1
+to raise funds,to raise funds,筹资,VERB,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
 ram,ram,公羊,NOUN,B2
 ramp,ramp,坡道,NOUN,B2
 rampant tyranny,rampant tyranny,横行,NOUN,B2
-rampart,rampart,词,NOUN,C1
-ran,ran,跑,ADJ,B2
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-range zone,range zone,词,NOUN,C1
-rank conferral,rank conferral,授衔,NOUN,C1
 ranking,ranking,等级,NOUN,B2
-ranking classification,ranking classification,词,NOUN,C1
-rapacity,rapacity,词,NOUN,C1
-rapier,rapier,词,NOUN,C1
-rapper,rapper,说唱歌手,NOUN,B2
-rapporteur,rapporteur,词,NOUN,C1
-rare earth,rare earth,稀土,NOUN,B2
+to rape,to rape,强奸,VERB,B2
 rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,词,NOUN,C1
-rarity,rarity,希罕,NOUN,C1
-rash,rash,皮疹,NOUN,B2
-rash (noun),rash,词,NOUN,B2
 rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
 raspberry,raspberry,覆盆子,NOUN,B2
-rat-proof,rat-proof,防鼠,ADJ,B2
-rate percentage,rate percentage,词,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
 rating,rating,评分,NOUN,B2
-rationalist,rationalist,词,NOUN,B2
 rationality,rationality,理性,NOUN,B2
-rationalization,rationalization,合理化,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
-rattling,rattling,词,NOUN,C1
-ravage (noun),ravage,词,NOUN,C1
-raven,raven,乌鸦,NOUN,B2
-ravine,ravine,词,NOUN,B2
 raw material,raw material,原材料,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-raw ore,raw ore,词,ADJ,C1
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-abruptness,re-abruptness,再骤,NOUN,B2
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
 re-analysis,re-analysis,重析,NOUN,B2
 re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
 re-basis,re-basis,再据,NOUN,B2
-re-battle,re-battle,重战,NOUN,B2
-re-boundary,re-boundary,重界,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
 re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
 re-course,re-course,重途,NOUN,B2
-re-creation,re-creation,再作,NOUN,B2
 re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-enactment,re-enactment,再演,NOUN,B2
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-evidence,re-evidence,重据,NOUN,B2
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-fruit,re-fruit,再果,NOUN,B2
 re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
 re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-inner,re-inner,再内,NOUN,B2
 re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,重绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
 re-judgment,re-judgment,重判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-layering,re-layering,改层,NOUN,B2
-re-limit,re-limit,重限,NOUN,B2
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-logic,re-logic,再逻,NOUN,B2
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-meaning,re-meaning,再义,NOUN,B2
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
 re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
 re-order,re-order,重序,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-pace,re-pace,重骤,NOUN,B2
 re-path,re-path,重径,NOUN,B2
-re-popularization,re-popularization,再普,NOUN,B2
 re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,重程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-quantity,re-quantity,再量,NOUN,B2
-re-reality,re-reality,再实,NOUN,C1
-re-reason,re-reason,重理,NOUN,B2
 re-route,re-route,重路,NOUN,B2
-re-routing,re-routing,改轨,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-sequencing,re-sequencing,改骤,NOUN,B2
-re-shape,re-shape,重形,NOUN,C1
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
 re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-submission,re-submission,再上,NOUN,B2
 re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
 re-synthesis,re-synthesis,重综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
 re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
 re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach,reach,范围,NOUN,B2
-reach (noun),reach,范围,NOUN,B1
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reachable,reachable,可到达的,ADJ,B2
-reactionary,reactionary,反动,ADJ,B2
 reactive,reactive,反应的,ADJ,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
 reader,reader,读者,NOUN,B2
 readiness,readiness,准备就绪,NOUN,B2
-readiness to help,readiness to help,词,NOUN,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
 real estate,real estate,房地产,ADJ,B2
 real estate,real estate,不动产,NOUN,B2
-real estate (adj),real estate,房地产,ADJ,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
 realism,realism,现实主义,NOUN,B2
-realist,realist,词,NOUN,C1
-reality TV,reality TV,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-really want,really want,真要,NOUN,B2
-reappearance,reappearance,再现,NOUN,C1
-rear,rear,后面的,ADJ,B2
-rear (adj),rear,后部,ADJ,A1
-rear part,rear part,后部,NOUN,B2
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reasoned,reasoned,词,ADJ,B2
 reasoning,reasoning,论证,NOUN,B2
 reassurance,reassurance,安抚,NOUN,B2
-reassuring,reassuring,词,ADJ,B1
-rebab,rebab,列巴布琴,NOUN,B2
-rebellious,rebellious,叛逆的,ADJ,B2
-rebellious heart,rebellious heart,反心,NOUN,B2
-rebirth,rebirth,词,NOUN,B2
-rebound (noun),rebound,词,NOUN,C1
-rebuke,rebuke,责备,NOUN,B2
+to rebel,to rebel,反叛,VERB,B2
+to rebuke,to rebuke,斥责,VERB,B2
 rebuttal,rebuttal,反驳,NOUN,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recall (noun),recall,词,NOUN,B2
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
+to receive mail,to receive mail,收件,VERB,B2
 receiver,receiver,接收器,NOUN,B2
-receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-recharge (noun),recharge,词,NOUN,B2
-recidivism,recidivism,词,NOUN,B2
-reciprocally,reciprocally,词,ADV,B2
-recitation,recitation,词,NOUN,C1
 recklessness,recklessness,轻率,NOUN,B2
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,收复,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
 reclining,reclining,躺下,NOUN,B2
-recognizable,recognizable,可辨认的,ADJ,B2
-recognized,recognized,词,NOUN,B2
-recombination,recombination,再结,NOUN,C1
-recommendation by others,recommendation by others,他荐,NOUN,B2
-recommended,recommended,词,ADJ,C1
+to recommend for admission,to recommend for admission,保送,VERB,B2
 reconciliation,reconciliation,和解,NOUN,B2
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconquest,reconquest,词,NOUN,C1
-reconsideration,reconsideration,重思,NOUN,B2
 reconstruction,reconstruction,重建,NOUN,B2
-record player,record player,唱机,NOUN,B2
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
 recounting,recounting,再叙,NOUN,B2
-recourse,recourse,求助,NOUN,B2
-recruit,recruit,新兵,NOUN,B2
-recruit (noun),recruit,词,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
 recruitment,recruitment,招聘,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectangular,rectangular,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-rector,rector,词,NOUN,C1
+to recuperate,to recuperate,恢复,VERB,B2
 recuperation,recuperation,养伤,NOUN,B2
-recurrence,recurrence,往复,NOUN,B2
-recurring,recurring,词,ADJ,C1
-recursive,recursive,词,ADJ,C1
-recusal,recusal,回避,NOUN,B2
 recycled item,recycled item,再物,NOUN,B2
 recycling,recycling,回收利用,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
 red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redefinition,redefinition,改界,NOUN,B2
-redemption,redemption,救赎,NOUN,B2
-redesign,redesign,词,NOUN,C1
-redevelopment,redevelopment,词,NOUN,C1
-redrawing,redrawing,重新绘制,NOUN,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
 reduction,reduction,减少,NOUN,B2
-reductionism,reductionism,词,NOUN,C1
-reed bed,reed bed,词,NOUN,B2
-reed pen,reed pen,词,NOUN,C1
-reef,reef,词,NOUN,B2
-reefs,reefs,词,NOUN,B2
-reel,reel,词,NOUN,C1
-refereed,refereed,词,ADJ,C1
-reference framework,reference framework,词,NOUN,C1
-references,references,词,NOUN,C1
-referendum-related,referendum-related,词,ADJ,B2
-referral,referral,词,NOUN,C1
 refined,refined,精炼的,ADJ,B2
 refinement,refinement,修养,NOUN,B2
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
 refining,refining,提炼,NOUN,B2
+to reflect on,to reflect on,思考,VERB,B2
 reflection,reflection,思考,NOUN,B2
-reflex,reflex,词,NOUN,C1
 reforestation,reforestation,重新造林,NOUN,B2
 reform,reform,改革,NOUN,B2
-reformatory,reformatory,词,NOUN,C1
-reformism,reformism,改唯,NOUN,B2
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-reformulation,reformulation,重新表述,NOUN,B2
 refrain,refrain,副歌,NOUN,B2
-refreshing,refreshing,令人清爽的,ADJ,B2
-refrigeration,refrigeration,词,NOUN,C1
 refuge,refuge,避难所,NOUN,B2
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refutable,refutable,词,ADJ,B2
-refutation,refutation,词,NOUN,C1
-regard (noun),regard,得顾,NOUN,C1
-regarding this,regarding this,对此,ADV,B2
-regardless,regardless,不管,ADP,B2
-regardless (adp),regardless,词,ADP,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,再生,NOUN,B2
-regent,regent,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-register (noun),register,词,NOUN,B1
-registered,registered,注册的,ADJ,B2
-registered mail,registered mail,挂号信,NOUN,B2
+to regain,to regain,恢复,VERB,B2
 registration,registration,注册,NOUN,B2
-registration number,registration number,词,NOUN,C1
 regression,regression,倒退,NOUN,B2
 regret,regret,后悔,NOUN,B2
-regret (noun),regret,反悔,NOUN,B2
-regrettable,regrettable,词,ADJ,B2
-regularity,regularity,规律性,NOUN,B2
-regularization,regularization,词,NOUN,C1
 regularly,regularly,定期地,ADV,B2
-regulated,regulated,词,ADJ,C1
+to regulate,to regulate,调节,VERB,B2
 regulations,regulations,法规,NOUN,B2
-regulator,regulator,词,NOUN,C1
-regulatory,regulatory,监管的,ADJ,B2
-rehabilitation,rehabilitation,康复,NOUN,B2
-rehabilitative,rehabilitative,词,ADJ,B2
-reification,reification,词,NOUN,C1
-rein,rein,词,NOUN,C1
+to reimburse,to reimburse,偿还,VERB,B2
 reincarnation,reincarnation,再体,NOUN,B2
-reinforced,reinforced,词,ADJ,C1
 reinforcement,reinforcement,增援,NOUN,B2
-reining,reining,勒马,NOUN,B2
-reins,reins,词,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
-reissue (noun),reissue,词,NOUN,C1
+to reissue,to reissue,补办,VERB,B2
 rejection,rejection,拒绝,NOUN,B2
+to rejoice,to rejoice,欢欣,VERB,B2
 relapse,relapse,再犯,NOUN,B2
-relapse (noun),relapse,复发,NOUN,B2
-relating to birth,relating to birth,词,ADJ,C1
-relation,relation,词,NOUN,B1
-relational,relational,词,ADJ,B2
 relative,relative,亲属,NOUN,B2
-relative (noun),relative,亲…,NOUN,B2
 relatively,relatively,相对地,ADV,B2
-relatively speaking,relatively speaking,相对而言,ADV,B2
 relativism,relativism,相对主义,NOUN,B2
-relativist,relativist,词,ADJ,C1
-relativity,relativity,词,NOUN,C1
 relaxation,relaxation,缓和,NOUN,B2
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
-relaxed loose,relaxed loose,词,ADJ,B2
 release,release,释放,NOUN,B2
-release (noun),release,撒开,NOUN,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-released,released,词,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
 relevance,relevance,相关性,NOUN,B2
 reliability,reliability,可靠性,NOUN,B2
 reliance,reliance,信赖,NOUN,B2
 relic,relic,圣物,NOUN,B2
 religiosity,religiosity,笃信宗教,NOUN,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiously,religiously,词,ADV,C1
-religiousness,religiousness,虔诚,NOUN,B2
-relinquishment,relinquishment,词,NOUN,C1
-relocation,relocation,搬家,NOUN,B2
+to relocate,to relocate,调动,VERB,B2
 reluctantly,reluctantly,不情愿地,ADV,B2
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
+to rely on,to rely on,依靠,VERB,B2
 remains,remains,残骸,NOUN,B2
-remains spoils,remains spoils,遗体，战利品,NOUN,B2
-remand,remand,词,NOUN,B2
 remanufacture,remanufacture,再制,NOUN,B2
-remark (noun),remark,你说得,NOUN,B2
-remarkably,remarkably,显著地,ADV,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
-remediation,remediation,词,NOUN,B2
-remedy (noun),remedy,解方,NOUN,B1
 remembrance,remembrance,纪念,NOUN,B2
-reminiscence,reminiscence,词,NOUN,C1
-remission,remission,词,NOUN,C1
-remittance,remittance,汇款,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remote control,remote control,遥控器,NOUN,B2
-remote work,remote work,远程办公,NOUN,B2
-remote-controlled car,remote-controlled car,遥控车,NOUN,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-removal deletion,removal deletion,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,移除的,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
 remuneration,remuneration,报酬,NOUN,B2
 renal,renal,肾脏的,ADJ,B2
-renewable energy,renewable energy,可再生能源,NOUN,C1
+to renew,to renew,更新,VERB,B2
 renewal,renewal,更新,NOUN,B2
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
 renminbi,renminbi,人民币,NOUN,B2
 renovation,renovation,翻新,NOUN,B2
-rent a car,rent a car,租车,VERB,C1
-rental,rental,词,ADJ,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
-reopening,reopening,词,NOUN,C1
-reoperation,reoperation,再术,NOUN,B2
 reordering,reordering,改序,NOUN,B2
 reorganization,reorganization,重组,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-repair (noun),repair,整,NOUN,B2
-repatriation,repatriation,词,NOUN,C1
+to repay,to repay,偿还,VERB,B2
 repayment,repayment,偿还,NOUN,B2
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
-repeated,repeated,反复的,ADJ,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
 repeatedly,repeatedly,反复地,ADV,B2
-repelling,repelling,词,VERB,C1
 repentance,repentance,悔恨,NOUN,B2
 repetition,repetition,重复,NOUN,B2
-rephotography,rephotography,再影,NOUN,C1
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
-replanning,replanning,再策,NOUN,B2
-reply to your-highness,reply to your-highness,回殿下,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report card,report card,成绩单,NOUN,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
-reporting,reporting,报道,NOUN,B2
+to reply,to reply,回复,VERB,B2
 repositioning,repositioning,重新定位,NOUN,B2
-representational,representational,词,ADJ,C1
-representative,representative,有代表性的,ADJ,B2
-representative (adj),representative,代表性的,ADJ,B2
 representativeness,representativeness,代表性,NOUN,B2
-repressed,repressed,词,ADJ,C1
 repression,repression,镇压,NOUN,B2
-reprice,reprice,再价,NOUN,B2
 reprimand,reprimand,训斥,NOUN,B2
-reprint,reprint,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
-reproachable,reproachable,应受责备的,ADJ,B2
-reproducibility,reproducibility,可重复性,NOUN,B2
+to reproach,to reproach,责备,VERB,B2
 reproduction,reproduction,繁殖,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
 reprogramming,reprogramming,改程,NOUN,B2
-reptiles,reptiles,词,NOUN,B2
 republican,republican,共和的,ADJ,B2
-republicanism,republicanism,词,NOUN,C1
-repudiation,repudiation,词,NOUN,C1
-repulse,repulse,击退,NOUN,B2
 repulsive,repulsive,令人反感的,ADJ,B2
-request to rest,request to rest,请息,NOUN,C1
+to request,to request,请求,VERB,B2
 required,required,必需的,ADJ,B2
-required course,required course,必修课,NOUN,C1
-requirements,requirements,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,词,NOUN,B2
 resale,resale,转售,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
+to rescue,to rescue,拯救,VERB,B2
 rescue a-fang,rescue a-fang,救阿方,NOUN,B2
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resection,resection,切除术,NOUN,B2
+to research,to research,研究,VERB,B2
 resemblance,resemblance,相似,NOUN,B2
 reserve,reserve,预备,NOUN,B2
-reserve (noun),reserve,保护区,NOUN,B2
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
 reserved,reserved,保留的,ADJ,B2
-reserves,reserves,储备,NOUN,B2
 reservoir,reservoir,水库,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
-reshaping,reshaping,改形,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
-residence housing,residence housing,词,NOUN,A2
-resident,resident,定居的,ADJ,B2
-resident (adj),resident,定居的,ADJ,B2
-residential,residential,词,ADJ,B2
-residue,residue,词,NOUN,C1
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
-resigned submission,resigned submission,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resin,resin,词,NOUN,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistant,resistant,词,ADJ,C1
-resistor,resistor,词,NOUN,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
 respect,respect,尊重,NOUN,B2
-respect (noun),respect,词,NOUN,A1
-respectful deferential,respectful deferential,恭敬,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respectively,respectively,词,ADV,C1
-respiration,respiration,呼吸作用,NOUN,B2
 respiratory,respiratory,呼吸的,ADJ,B2
-respite,respite,喘息,NOUN,B2
+to respond to,to respond to,回应,VERB,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
 respondent,respondent,被上诉人,NOUN,B2
-responsiveness,responsiveness,反应性,NOUN,B2
-rest assured,rest assured,放心的,ADJ,B2
-rest stop,rest stop,词,NOUN,B1
-restock,restock,补货,VERB,C1
+to rest,to rest,休息,VERB,B2
 restraint,restraint,隐忍,NOUN,B2
-restriction,restriction,限制,NOUN,B2
 restructuring,restructuring,重组,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
 resume,resume,简历,NOUN,B2
-resume (noun),resume,履历,NOUN,B2
-resumption,resumption,恢复,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+to resurrect,to resurrect,复活,VERB,B2
 resurrection,resurrection,复活,NOUN,B2
 resuscitation,resuscitation,复苏,NOUN,B2
-retailer,retailer,零售商,NOUN,B2
-retaliation,retaliation,词,NOUN,C1
-retarded,retarded,词,ADJ,C1
 retention,retention,留你,NOUN,B2
 rethinking,rethinking,重想,NOUN,B2
-reticent,reticent,沉默寡言的,ADJ,B2
-retina,retina,词,NOUN,B2
-retinue,retinue,词,NOUN,B2
 retired,retired,退休的,ADJ,B2
-retiree,retiree,退休人员,NOUN,B2
-retirement pension,retirement pension,退休金,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retranslation,retranslation,重译,NOUN,B2
+to retreat,to retreat,撤退,VERB,B2
 retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
 retrieval,retrieval,检索,NOUN,B2
-retrieve qingming,retrieve qingming,拿回青冥,NOUN,B2
-retrospective (noun),retrospective,词,NOUN,C1
 return,return,返回,NOUN,B2
-return (noun),return,你回,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
+to return a car,to return a car,送车,VERB,B2
 return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
+to return first,to return first,先回,VERB,B2
 returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-retype,retype,再型,NOUN,B2
-reunification,reunification,重新统一,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-reuse,reuse,重用,NOUN,B2
 revaluation,revaluation,重新评估,NOUN,B2
 revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
 revelation,revelation,启示,NOUN,B2
-revelry,revelry,狂欢,NOUN,B2
-revenues,revenues,词,NOUN,C1
-reverberation,reverberation,词,NOUN,C1
 reverence,reverence,尊敬,NOUN,B2
-reverentially,reverentially,词,ADV,C1
 reversal,reversal,突变,NOUN,B2
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse inclusion,reverse inclusion,反纳,NOUN,B2
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
 reverse origin,reverse origin,反原,NOUN,B2
-reverse reflection,reverse reflection,反影,NOUN,B2
 reverse result,reverse result,反果,NOUN,B2
 reverse side,reverse side,反面,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
-reversion,reversion,重归,NOUN,B2
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
+to review,to review,复习,VERB,B2
 revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
 revision,revision,复习,NOUN,B2
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revivalism,revivalism,词,NOUN,C1
-revocation,revocation,词,NOUN,C1
-revolt,revolt,叛乱,NOUN,B2
+to revive,to revive,复兴,VERB,B2
 revolutionary,revolutionary,革命的,ADJ,B2
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical question,rhetorical question,宁非,NOUN,B2
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
+to reward,to reward,奖励,VERB,B2
 rhyme,rhyme,韵脚,NOUN,B2
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribbon,ribbon,丝带,NOUN,B2
-ribs,ribs,肋骨,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
 rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-richer,richer,词,ADJ,B2
 richly endowed by nature,richly endowed by nature,得天独厚,ADJ,B2
-rickety,rickety,词,ADJ,C1
 ride,ride,行程,NOUN,B2
-ride (noun),ride,匹马去,NOUN,B2
-ride break,ride break,骑破,NOUN,B2
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
 rider,rider,骑手,NOUN,B2
-ridicule (noun),ridicule,词,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
-riffraff,riffraff,词,NOUN,C1
-right,right,右边,ADV,B2
-right (adv),right,右边,ADV,B2
-right (intj),right,词,INTJ,C1
-right (noun),right,右,NOUN,A1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-righteous indignation,righteous indignation,义愤,NOUN,B2
-righteousness,righteousness,亦正,NOUN,B2
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rightly,rightly,正确地,ADV,B2
 rights,rights,权利,NOUN,B2
 rights and interests,rights and interests,权益,NOUN,B2
 rigidity,rigidity,僵硬,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
-ring road,ring road,绕城,NOUN,B2
-ringing,ringing,铃声,NOUN,B2
-rings,rings,词,NOUN,B2
-ringtone,ringtone,词,NOUN,C1
+to ring,to ring,鸣响,VERB,B2
 riot,riot,骚乱,NOUN,B2
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
 rise,rise,上涨,NOUN,B2
-rise (noun),rise,词,NOUN,B2
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
-risking death,risking death,冒死,NOUN,B2
-risks,risks,词,NOUN,C1
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
+to risk,to risk,冒险,VERB,B2
+to risk life,to risk life,拼命,VERB,B2
 rivalry,rivalry,竞争,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-river-gauging,river-gauging,词,ADJ,C1
 riverbank,riverbank,河岸,NOUN,B2
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-road (adj),road,词,ADJ,B2
-road sign,road sign,路标,NOUN,B2
-roadblock,roadblock,,NOUN,B2
-roadway,roadway,路面,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roar (noun),roar,词,NOUN,B2
 roast,roast,烤肉,NOUN,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
+to roast,to roast,煎烤,VERB,B2
+to roast lamb,to roast lamb,烤羊,VERB,B2
 robber,robber,强盗,NOUN,B2
-robe,robe,词,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotization,robotization,词,NOUN,C1
-robustness,robustness,词,NOUN,C1
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rock slab,rock slab,岩板,NOUN,B2
-rockery,rockery,假山,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rod,rod,词,NOUN,B1
-rodent,rodent,啮齿动物,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
 role model,role model,榜样,NOUN,B2
-rolled,rolled,词,ADJ,C1
-roller blind,roller blind,卷帘,NOUN,B2
-roller skate,roller skate,词,NOUN,B1
-rolling,rolling,词,NOUN,C1
+to roll,to roll,滚动,VERB,B2
 roman,roman,罗马人,NOUN,B2
-roman (adj),roman,罗马的,ADJ,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-roominess,roominess,词,NOUN,C1
-roots,roots,词,NOUN,C1
-rose bush,rose bush,词,NOUN,B1
-rot decomposition,rot decomposition,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
 roughness,roughness,粗糙,NOUN,B2
 round,round,轮 / 回合,NOUN,B2
-round (noun),round,一顿,NOUN,B1
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
 roundabout,roundabout,环岛,NOUN,B2
 router,router,路由器,NOUN,B2
 routine,routine,常规,NOUN,B2
-routing,routing,词,NOUN,C1
-row series,row series,词,NOUN,B1
-rowboat,rowboat,词,NOUN,B2
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal court,royal court,词,NOUN,C1
+to row,to row,划船,VERB,B2
 rubbing,rubbing,摩擦,NOUN,B2
-rubbish,rubbish,垃圾,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubble,rubble,瓦砾,NOUN,B2
-ruby,ruby,词,NOUN,C1
-ruckus,ruckus,词,NOUN,C1
-rudely,rudely,词,ADV,C1
 rudeness,rudeness,粗鲁,NOUN,B2
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
 ruin,ruin,废墟,NOUN,B2
-ruin (noun),ruin,词,NOUN,B2
-ruin relic,ruin relic,词,NOUN,B2
-ruined,ruined,词,ADJ,B2
 ruins,ruins,废墟,NOUN,B2
+to rule,to rule,统治,VERB,B2
 rule of law,rule of law,法治,NOUN,B2
-rulebook,rulebook,词,NOUN,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-rumination,rumination,词,NOUN,C1
-rummage,rummage,词,VERB,C1
-rumors,rumors,词,NOUN,B2
 run,run,跑步,NOUN,B2
-run (noun),run,跑来,NOUN,B2
-run away fled,run away fled,词,VERB,A1
-run over (adj),run over,词,ADJ,B2
-run-down,run-down,词,ADJ,C1
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,词,NOUN,B2
-rung,rung,词,NOUN,C1
+to run over,to run over,碾过,VERB,B2
 runner,runner,跑步者,NOUN,B2
-running,running,进行中的,NOUN,B2
 running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
 runny nose,runny nose,流鼻涕,NOUN,B2
-runway,runway,词,NOUN,C1
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-rush,rush,赶往,NOUN,B2
-rush (noun),rush,赶往,NOUN,B2
+to rush about,to rush about,奔波,VERB,B2
 rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
 russian,russian,俄罗斯的,ADJ,B2
 russian,russian,俄罗斯人,NOUN,B2
-russian (adj),russian,俄罗斯的,ADJ,B2
 rust,rust,铁锈,NOUN,B2
 rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rust-proof,rust-proof,防锈,ADJ,B2
-rusty,rusty,词,ADJ,C1
 ruthlessness,ruthlessness,无情,NOUN,B2
-sabbath,sabbath,安息日,NOUN,B2
-saber,saber,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sad sorrowful,sad sorrowful,悲伤,ADJ,B2
-saddening,saddening,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddle pad,saddle pad,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadly,sadly,词,ADV,B2
+to sacrifice,to sacrifice,牺牲,VERB,B2
 safe,safe,保险箱,NOUN,B2
-safe (noun),safe,保险箱,NOUN,B2
-safe container,safe container,词,NOUN,C1
 safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
 safety,safety,安全,NOUN,B2
 safety report,safety report,安全报告,NOUN,B2
 safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-sagacity,sagacity,词,NOUN,B2
-sagittarius,sagittarius,射手座,NOUN,B2
 sail,sail,帆,NOUN,B2
-sail (noun),sail,帆,NOUN,B2
-sailboat,sailboat,,NOUN,B2
 sailing,sailing,航行,NOUN,B2
-sailor,sailor,水手,NOUN,B2
-sailors,sailors,词,NOUN,B2
 saint,saint,圣人,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salaried,salaried,词,ADJ,B2
 sales,sales,打折,NOUN,B2
 salesperson,salesperson,销售人员,NOUN,B2
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-saliva,saliva,词,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salt shaker,salt shaker,词,NOUN,B2
-salted,salted,词,ADJ,B2
 salty,salty,咸的,ADJ,B2
-sama,sama,词,NOUN,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
+to sanctify,to sanctify,使神圣,VERB,B2
 sandal,sandal,凉鞋,NOUN,B2
-sands,sands,词,NOUN,B2
 sandstorm,sandstorm,沙尘暴,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
 sanity,sanity,理智,NOUN,B2
 santa claus,santa claus,圣诞老人,NOUN,B2
-santur,santur,词,NOUN,C1
-sap,sap,词,NOUN,C1
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sat,sat,词,NOUN,B1
-satchel,satchel,词,NOUN,C1
-sated,sated,词,ADJ,B2
 satisfactory,satisfactory,令人满意的,ADJ,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-saturated,saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
 saturday,saturday,星期六,NOUN,B2
 sauce,sauce,酱汁,NOUN,B2
-saucepan,saucepan,词,NOUN,B2
-saucy,saucy,词,ADJ,B2
-sauna,sauna,词,NOUN,B2
-savage,savage,savage,NOUN,B2
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
+to save seeds,to save seeds,留种,VERB,B2
 saving,saving,储蓄,NOUN,B2
-saving the root,saving the root,救本,NOUN,C1
-savior,savior,救星,NOUN,B2
 saw,saw,锯子,NOUN,B2
-sawdust,sawdust,词,NOUN,C1
-say he,say he,说他,NOUN,C1
+to say goodbye,to say goodbye,告别,VERB,B2
 saying,saying,格言,NOUN,B2
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,秤,NOUN,B2
-scallion,scallion,词,NOUN,B2
+to scald,to scald,烫伤,VERB,B2
 scalpel,scalpel,手术刀,NOUN,B2
-scaly,scaly,词,ADJ,C1
-scammer,scammer,词,NOUN,B2
-scan,scan,扫描件,NOUN,B2
-scan (noun),scan,扫描件,NOUN,B2
-scandalous,scandalous,可耻的,ADJ,B2
-scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
 scarcity,scarcity,短缺,NOUN,B2
-scarecrow,scarecrow,词,NOUN,C1
-scarf shawl,scarf shawl,词,NOUN,A1
-scatterbrained,scatterbrained,词,ADJ,B2
+to scare,to scare,惊吓,VERB,B2
 scattered,scattered,分散的,ADJ,B2
-scattering,scattering,词,NOUN,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
 scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
 scheduling,scheduling,调度；排序,NOUN,B2
-schema,schema,词,NOUN,B2
-schematic,schematic,概要的,ADJ,B2
 schizophrenia,schizophrenia,精神分裂症,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-scholar learned,scholar learned,词,NOUN,C1
-scholarship holder,scholarship holder,奖学金生,NOUN,B2
 scholastic,scholastic,经院哲学的,ADJ,B2
-scholing,scholing,词,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school,school,学校的,ADJ,B2
-school (adj),school,学校的,ADJ,B1
-school bag,school bag,词,NOUN,A2
-school bench,school bench,词,NOUN,A1
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-school year,school year,学年,NOUN,B2
-schoolbag,schoolbag,词,NOUN,A1
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schoolyard,schoolyard,词,NOUN,A1
-scientifically,scientifically,科学地,ADV,B2
-scientists,scientists,科学家,NOUN,B2
-scoff (noun),scoff,词,NOUN,C1
-scoop,scoop,词,NOUN,B2
+to scold,to scold,训斥,VERB,B2
 scooter,scooter,踏板摩托车,NOUN,B2
 scorching,scorching,灼热的,ADJ,B2
 score,score,比分,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scorpion,scorpion,词,NOUN,A1
-scottish,scottish,词,ADJ,B2
 scoundrel,scoundrel,恶棍,NOUN,B2
-scouting locating,scouting locating,定位 / 侦察,NOUN,B2
-scraps,scraps,屑,NOUN,C1
-scream (noun),scream,尖叫,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
+to scratch,to scratch,抓,VERB,B2
+to screen,to screen,筛选,VERB,B2
 screenplay,screenplay,剧本,NOUN,B2
-screenwriter,screenwriter,编剧,NOUN,B2
-screw (noun),screw,词,NOUN,C1
-screw up,screw up,词,VERB,C1
 screwdriver,screwdriver,螺丝刀,NOUN,B2
-scribal misreading,scribal misreading,词,NOUN,C1
-scribble (noun),scribble,词,NOUN,C1
-script for play,script for play,剧本,NOUN,B2
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulously,scrupulously,一丝不苟地,ADV,B2
-scrupulousness,scrupulousness,词,NOUN,C1
-scrutiny,scrutiny,明察,NOUN,B2
 scuba diving,scuba diving,潜水,NOUN,B2
 sculptor,sculptor,雕塑家,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-scumbag,scumbag,词,NOUN,C1
-scurvy,scurvy,词,NOUN,C1
-scythe,scythe,镰刀,NOUN,B2
 sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
 seagull,seagull,海鸥,NOUN,B2
-seal,seal,海豹,NOUN,B2
-seal (noun),seal,海豹,NOUN,C1
-seaplane,seaplane,水上飞机,NOUN,B2
-seaport,seaport,海港,NOUN,C1
 search,search,搜索,NOUN,B2
-search (noun),search,一搜,NOUN,A2
-search engine,search engine,搜索引擎,NOUN,B2
-search engine optimization,search engine optimization,词,NOUN,C1
-search warrant,search warrant,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
+to search for,to search for,寻找,VERB,B2
+to season,to season,调味,VERB,B2
 seasonal,seasonal,季节性的,ADJ,B2
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seated,seated,坐着的,ADJ,B2
-seats,seats,词,NOUN,C1
-seaweed,seaweed,词,NOUN,C1
-secession,secession,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-seclusion exit,seclusion exit,出关,NOUN,B2
 second,second,秒,NOUN,B2
-second (noun),second,词,NOUN,B2
-second (num),second,词,NUM,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
 second letter,second letter,再信,NOUN,B2
 second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second time,second time,再而,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
 secondly,secondly,其次,ADV,B2
-secondment,secondment,词,NOUN,C1
 secrecy,secrecy,保密,NOUN,B2
 secret,secret,秘密的,ADJ,B2
 secret,secret,诀,PART,B2
-secret (adj),secret,秘密的,ADJ,B2
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret meeting,secret meeting,密会,NOUN,B2
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
 secretariat,secretariat,秘书处,NOUN,B2
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-sectarianism,sectarianism,词,NOUN,C1
 section chief,section chief,课长,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
 secularism,secularism,世俗主义,NOUN,B2
-secularization,secularization,世俗化,NOUN,C1
-securitization,securitization,证券化,NOUN,B2
 security guard,security guard,保安,NOUN,B2
-security matter,security matter,词,NOUN,C1
-security service,security service,词,NOUN,C1
 security-related,security-related,安全的，安保的,ADJ,B2
-securocratic,securocratic,词,ADJ,C1
 sedan,sedan,轿车,NOUN,B2
-sedative,sedative,词,NOUN,C1
-sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
-sediment,sediment,词,NOUN,C1
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-seditious,seditious,词,ADJ,C1
-see off,see off,送走,NOUN,B2
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seedy,seedy,词,ADJ,C1
-seeker,seeker,寻求者,NOUN,B2
+to see corpse,to see corpse,见尸,VERB,B2
+to see through,to see through,看穿,VERB,B2
+to seek,to seek,寻找,VERB,B2
+to seek audience,to seek audience,求见,VERB,B2
+to seek peace,to seek peace,主和,VERB,B2
+to seek you,to seek you,寻你,VERB,B2
 seeking,seeking,寻求,NOUN,B2
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking instant benefit,seeking instant benefit,急功近利,ADJ,B2
-seeking intercession,seeking intercession,词,NOUN,C1
 seemingly,seemingly,表面上,ADV,B2
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-segregation,segregation,隔离，分离,NOUN,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-seizure,seizure,没收,NOUN,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
 selective,selective,选择的，挑选的,ADJ,B2
-selectively,selectively,有选择地,ADV,B2
-selector,selector,词,NOUN,C1
-self,self,自己,PRON,B2
-self (adv),self,词,ADV,B2
-self (pron),self,自己,PRON,A1
-self-abasement,self-abasement,词,NOUN,C1
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
 self-confidence,self-confidence,自信,NOUN,B2
 self-confident,self-confident,自信的,ADJ,B2
-self-deception,self-deception,词,NOUN,C1
-self-defense,self-defense,自卫,NOUN,B2
-self-denial,self-denial,自我牺牲,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-employed person,self-employed person,个体经营者,NOUN,B2
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-image,self-image,自我形象,NOUN,B2
-self-interest,self-interest,词,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-sacrifice,self-sacrifice,舍己,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-taught,self-taught,自学的,ADJ,B2
-self-worth,self-worth,词,NOUN,B2
 selfie,selfie,自拍,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfish (noun),selfish,selfish,NOUN,B2
 selfishness,selfishness,自私,NOUN,B2
-selfless,selfless,词,ADJ,B2
-selfless devotion,selfless devotion,词,NOUN,C1
 seller,seller,售货员,NOUN,B2
-sellou,sellou,塞卢能量膏,NOUN,B2
-semantic,semantic,词,ADJ,C1
 semantics,semantics,语义学,NOUN,B2
-semicolon,semicolon,分号,PUNCT,B2
 semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-semiology,semiology,符号学，症状学,NOUN,B2
-semiotics,semiotics,符号学,NOUN,B2
 semolina,semolina,粗面粉,NOUN,B2
-senate,senate,参议院,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-sending,sending,词,NOUN,B1
-senescence,senescence,词,NOUN,B2
+to send back,to send back,传回,VERB,B2
+to send mail,to send mail,寄件,VERB,B2
 senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
 seniority,seniority,资历,NOUN,B2
-seniors,seniors,词,NOUN,C1
-sensationalism,sensationalism,词,NOUN,C1
-sense of duty,sense of duty,词,NOUN,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
+to sense,to sense,隐约感到,VERB,B2
 senseless,senseless,无意义的,ADJ,B2
-sensibly,sensibly,词,ADV,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
 sensitivity,sensitivity,敏感性,NOUN,B2
-sensitization,sensitization,词,NOUN,B2
 sensor,sensor,传感器,NOUN,B2
-sensor donor,sensor donor,词,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentence verdict,sentence verdict,词,NOUN,B2
 sentenced,sentenced,被判刑的,ADJ,B2
-sentences,sentences,句子,NOUN,B2
-sentencing,sentencing,词,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentry post,sentry post,哨所,NOUN,C1
-separated,separated,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
-separatism,separatism,词,NOUN,C1
-separatist,separatist,词,NOUN,C1
 sequence,sequence,顺序，片段,NOUN,B2
-sequential,sequential,词,ADJ,C1
-serenely,serenely,词,ADV,C1
 sergeant,sergeant,中士,NOUN,B2
-serial,serial,词,NOUN,B1
-serial killer,serial killer,连环杀手,NOUN,B2
-serialized drama,serialized drama,连续剧,NOUN,B2
-series of conversations,series of conversations,系列对话,NOUN,B2
 sermon,sermon,布道,NOUN,B2
-serous,serous,词,ADJ,C1
-serum,serum,词,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
+to serve as,to serve as,充当,VERB,B2
 server,server,服务器,NOUN,B2
-service counter,service counter,词,NOUN,B1
-service favor,service favor,词,NOUN,A2
-service of process,service of process,词,NOUN,C1
 service provider,service provider,服务商,NOUN,B2
-service road,service road,辅路,NOUN,B2
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-service year,service year,,NOUN,B2
-services,services,词,NOUN,C1
-servilely,servilely,奴性地,ADV,B2
 servility,servility,奴性,NOUN,B2
-serving,serving,词,NOUN,B2
 sesame,sesame,芝麻,NOUN,B2
-set (noun),set,集合,NOUN,B1
-set of ideals,set of ideals,思想体系,NOUN,B2
-set square,set square,词,NOUN,B2
-set-off,set-off,词,NOUN,C1
+to set off,to set off,出发,VERB,B2
+to set up,to set up,建立,VERB,B2
 setback,setback,挫折,NOUN,B2
-setting splinting,setting splinting,词,NOUN,C1
-setting sun,setting sun,夕阳,NOUN,B2
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seven (adj),seven,词,ADJ,B2
-seventeen,seventeen,十七,NUM,B2
-seventh,seventh,第七,ADJ,B2
 seventy,seventy,七十,NUM,B2
-several,several,几个,ADJ,B2
-several (adj),several,词,ADJ,A2
-several (noun),several,若干,NOUN,B2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times,several times,几遍,NOUN,B2
-several times (adv),several times,词,ADV,C1
 severe,severe,严厉的,ADJ,B2
-severely,severely,严厉地,ADV,B2
 severity,severity,严厉,NOUN,B2
 sewing,sewing,缝纫,NOUN,B2
-sewing needle,sewing needle,词,NOUN,C1
 sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexily,sexily,性感地,ADV,B2
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
 sexual,sexual,性的,ADJ,B2
-sexually,sexually,在性方面,ADV,B2
-sfouf,sfouf,词,NOUN,B2
-sh,sh,词,INTJ,C1
 sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
 shack,shack,棚屋,NOUN,B2
 shading,shading,阴影,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shadows,shadows,词,NOUN,C1
-shady,shady,阴凉的,ADJ,B2
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,词,AUX,B2
-shame culture,shame culture,词,NOUN,B2
-shame disgrace,shame disgrace,词,NOUN,B2
-shame pity,shame pity,词,NOUN,B2
+to shame,to shame,使羞愧,VERB,B2
 shameless,shameless,无耻的,ADJ,B2
-shameless person,shameless person,厚颜无耻的人,NOUN,B2
-shamelessness,shamelessness,无耻,NOUN,B2
 shampoo,shampoo,洗发水,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shards,shards,词,NOUN,B2
-share (noun),share,份额,NOUN,B2
-shared boundary ownership,shared boundary ownership,词,NOUN,B2
+to shape,to shape,塑造,VERB,B2
 shareholder,shareholder,股东,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-shavings,shavings,刨花,NOUN,C1
+to shave,to shave,剃,VERB,B2
 she,she,可她,NOUN,B2
-she (noun),she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet of paper,sheet of paper,词,NOUN,B2
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-sheng,sheng,笙,NOUN,C1
 shh,shh,嘘,INTJ,B2
 shift,shift,轮班,NOUN,B2
-shift (noun),shift,轮班,NOUN,C1
-shift rotation,shift rotation,倒班,NOUN,B2
-shift swap,shift swap,换班,NOUN,B2
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
 shine,shine,光泽,NOUN,B2
-shine (noun),shine,词,NOUN,B1
-shining,shining,词,ADJ,C1
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
+to ship out,to ship out,出货,VERB,B2
 shipyard,shipyard,造船厂,NOUN,B2
-shit,shit,该死的,ADJ,B2
-shit (noun),shit,恐惧,NOUN,B2
-shit crap,shit crap,词,NOUN,B2
-shitty,shitty,词,ADJ,B2
-shiver,shiver,寒战,NOUN,B2
-shivers,shivers,词,NOUN,B2
-shockproof,shockproof,防震,ADJ,C1
-shoe polish,shoe polish,词,NOUN,B2
+to shock,to shock,震惊,VERB,B2
 shoe removal,shoe removal,鞋脱,NOUN,B2
-shoelace,shoelace,词,NOUN,C1
 shoes,shoes,鞋子,NOUN,B2
-shoot at,shoot at,词,VERB,C1
-shooter,shooter,射手,NOUN,B2
+to shoot down,to shoot down,击落,VERB,B2
 shooting,shooting,射击,NOUN,B2
-shooting down,shooting down,射落马下,NOUN,C1
 shooting star,shooting star,流星,NOUN,B2
-shootout,shootout,枪战,NOUN,B2
-shopkeeper,shopkeeper,词,NOUN,C1
+to shop,to shop,购物,VERB,B2
 shopping center,shopping center,购物中心,NOUN,B2
 shopping mall,shopping mall,商场,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short film,short film,短片,NOUN,B2
-short news item,short news item,词,NOUN,C1
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
 short-term,short-term,短期的,ADJ,B2
-shortcoming,shortcoming,缺点,NOUN,B2
-shortcomings,shortcomings,词,NOUN,C1
-shorter,shorter,更短的,ADJ,B2
-shortest,shortest,词,NOUN,B2
-shortly,shortly,不久,ADV,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-should not,should not,不该,AUX,B2
-should ought to,should ought to,应该,AUX,B2
+to shorten,to shorten,缩短,VERB,B2
+to shout,to shout,吼叫,VERB,B2
 shovel,shovel,铲子,NOUN,B2
-show,show,表演,NOUN,B2
-show (noun),show,表演,NOUN,A2
-show (part),show,秀,PART,C1
 show of hands,show of hands,举手,NOUN,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-showy,showy,词,ADJ,B2
-shred,shred,词,NOUN,B2
+to shower,to shower,淋浴,VERB,B2
 shrine,shrine,مشعر,NOUN,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrub,shrub,词,NOUN,C1
-shrunken,shrunken,词,ADJ,B2
 shudder,shudder,战栗,NOUN,B2
-shutdown,shutdown,词,NOUN,C1
+to shut up,to shut up,闭嘴,VERB,B2
 shyness,shyness,羞怯,NOUN,B2
 siblings,siblings,兄弟姐妹,NOUN,B2
-sibyl,sibyl,词,NOUN,C1
 sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickle,sickle,词,NOUN,B2
-sickly,sickly,词,ADJ,C1
-side,side,骄傲的,ADJ,B2
-side (adj),side,骄傲的,ADJ,B2
 side door,side door,侧门,NOUN,B2
 side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-sideburn,sideburn,词,NOUN,B1
 siege,siege,围攻,NOUN,B2
-siege time,siege time,攻城时,NOUN,C1
-sifted,sifted,词,ADJ,C1
-sighing,sighing,叹息的,ADJ,B2
-sign brand,sign brand,词,NOUN,C1
-signatory,signatory,词,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signed,signed,词,ADJ,B2
+to sift,to sift,筛选,VERB,B2
+to sigh,to sigh,叹气,VERB,B2
+to signal,to signal,示意,VERB,B2
 significance,significance,含义,NOUN,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silenced,silenced,词,ADJ,C1
-silencing,silencing,词,NOUN,C1
-silent quiet,silent quiet,词,ADJ,A1
-silk cloth,silk cloth,丝绸,NOUN,B2
-silk material,silk material,丝料,NOUN,C1
-silly girl,silly girl,傻丫头,NOUN,B2
-silly thing,silly thing,词,NOUN,C1
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
+to silence,to silence,خرس,VERB,B2
 silver,silver,银色,ADJ,B2
-silver (adj),silver,银色的,ADJ,B2
-silvery,silvery,词,ADJ,C1
-similarly,similarly,同样地,ADV,B2
-simony,simony,词,NOUN,C1
 simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
 simplicity,simplicity,简单,NOUN,B2
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplism,simplism,简单化,NOUN,C1
+to simplify,to simplify,简化,VERB,B2
 simply,simply,简单地,ADV,B2
-simulator,simulator,词,NOUN,C1
 simultaneous,simultaneous,同时的,ADJ,B2
-simultaneously,simultaneously,同时地,ADV,B2
-simultaneously with,simultaneously with,词,ADV,C1
 since,since,以来,PART,B2
 since,since,既然,SCONJ,B2
-since (part),since,以来,PART,B2
-since (sconj),since,既,SCONJ,A2
-since then,since then,从那以后,ADV,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerely,sincerely,真诚地,ADV,B2
 sincerity,sincerity,真诚,NOUN,B2
-sincerity devotion,sincerity devotion,词,NOUN,B2
 singing,singing,歌唱,NOUN,B2
-single,single,单曲,NOUN,B2
-single (noun),single,单曲,NOUN,B2
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-single thought,single thought,一念,NOUN,B2
-singular (noun),singular,词,NOUN,B2
 singularity,singularity,单一性,NOUN,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sir,sir,郎,PART,B2
-sir (part),sir,郎,PART,B2
+to sink,to sink,下沉,VERB,B2
+to sip,to sip,小口喝,VERB,B2
 sister yu,sister yu,俞姐,NOUN,B2
 sister-in-law,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姐妹,NOUN,B2
-sit,sit,坐坐,NOUN,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-situation circumstances,situation circumstances,情形,NOUN,B2
-six-line stanza,six-line stanza,词,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixteen,sixteen,十六,NUM,B2
+to sit down,to sit down,坐下,VERB,B2
 sixth,sixth,第六,ADJ,B2
-sixth (noun),sixth,sixth,NOUN,B2
 sixty,sixty,六十,NUM,B2
-size measure,size measure,尺寸 / 测量,NOUN,A2
-skate (noun),skate,词,NOUN,A2
-skater,skater,,NOUN,B2
-skating,skating,滑冰,NOUN,B2
-skeletal,skeletal,词,ADJ,C1
+to skate,to skate,滑冰,VERB,B2
 skepticism,skepticism,怀疑主义,NOUN,B2
-sketchiness,sketchiness,词,NOUN,C1
-ski (noun),ski,词,NOUN,C1
-ski resort,ski resort,滑雪场,NOUN,C1
-skid slip-up,skid slip-up,词,NOUN,C1
-skiff,skiff,词,NOUN,C1
 skiing,skiing,滑雪,NOUN,B2
-skilful,skilful,熟练的,ADJ,B2
 skillful,skillful,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skillfulness,skillfulness,词,NOUN,B2
-skin hide,skin hide,词,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-sky blue,sky blue,天蓝色,ADJ,B2
-skylight,skylight,天窗,NOUN,B2
-slack,slack,词,ADJ,B2
-slack off,slack off,词,VERB,C1
-slackening dip,slackening dip,词,NOUN,C1
-slackness,slackness,词,NOUN,C1
-slam,slam,,NOUN,B2
-slam (noun),slam,slam,NOUN,B2
-slammer jail,slammer jail,词,NOUN,C1
-slander,slander,诽谤,NOUN,B2
-slang,slang,俚语,NOUN,B2
 slanted,slanted,斜,ADJ,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
+to slap,to slap,打耳光,VERB,B2
+to slaughter,to slaughter,割喉,VERB,B2
 slavery,slavery,奴隶制,NOUN,B2
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleeper,sleeper,词,NOUN,C1
 sleeping pill,sleeping pill,安眠药,NOUN,B2
 sleeplessness,sleeplessness,失眠,NOUN,B2
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
 sleeve,sleeve,袖子,NOUN,B2
-sleigh,sleigh,雪橇,NOUN,C1
-slender,slender,纤细的,ADJ,B2
-slenderness,slenderness,纤细,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-sliding,sliding,滑动的,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
 slightly,slightly,轻微地,ADV,B2
-slim,slim,苗条,ADJ,B2
-slimy,slimy,词,ADJ,B2
-sling,sling,词,NOUN,C1
-slip (noun),slip,词,NOUN,C1
-slip in,slip in,塞入,VERB,B2
-slipper,slipper,拖鞋,NOUN,B2
-slit,slit,词,NOUN,C1
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
-slower,slower,更慢,ADJ,B2
+to slow down,to slow down,放慢,VERB,B2
 slowness,slowness,缓慢,NOUN,B2
-sluice,sluice,水闸,NOUN,C1
-slut,slut,荡妇,NOUN,B2
 sly,sly,狡猾的,ADJ,B2
-slyly,slyly,词,ADV,C1
 slyness,slyness,狡猾,NOUN,B2
-small bag,small bag,词,NOUN,C1
-small basket,small basket,词,NOUN,C1
-small boat,small boat,词,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small step,small step,词,NOUN,C1
-small sword,small sword,词,NOUN,C1
-small things,small things,词,NOUN,B2
-small window,small window,词,NOUN,A2
 smallest,smallest,最小的,ADJ,B2
 smallness,smallness,小小,NOUN,B2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
-smashing,smashing,砸过,NOUN,B2
-smear,smear,抹,NOUN,C1
-smell (noun),smell,还闻,NOUN,C1
-smelly,smelly,臭,ADJ,B2
-smelting,smelting,词,NOUN,C1
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoker,smoker,词,NOUN,C1
-smoking (adj),smoking,词,ADJ,C1
-smooth,smooth,能磨平,NOUN,B2
-smooth (noun),smooth,能磨平,NOUN,C1
+to smile,to smile,微笑,VERB,B2
+to smooth,to smooth,使光滑,VERB,B2
 smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smoothly,smoothly,顺利,ADV,B2
-smoothness,smoothness,词,NOUN,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
 smuggler,smuggler,走私者,NOUN,B2
 smuggling,smuggling,走私,NOUN,B2
-smugness,smugness,词,NOUN,C1
 snack,snack,小吃,NOUN,B2
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snap (verb),snap,词,VERB,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneaker,sneaker,词,NOUN,A1
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sneeze (noun),sneeze,词,NOUN,C1
-sneezing,sneezing,词,NOUN,C1
-sniffle,sniffle,词,VERB,C1
-snitch,snitch,告密者,NOUN,B2
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snooping,snooping,词,NOUN,C1
-snore,snore,打呼噜,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
+to sneeze,to sneeze,打喷嚏,VERB,B2
+to snore,to snore,打鼾,VERB,B2
 snout,snout,口鼻,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
 snow lotus,snow lotus,雪莲,NOUN,B2
-snow shadow,snow shadow,雪影姐姐,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowdrift,snowdrift,词,NOUN,B1
 snowflake,snowflake,雪花,NOUN,B2
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-so (sconj),so,遂,SCONJ,B2
 so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
 so far,so far,到目前为止,ADV,B2
 so much,so much,那么多,DET,B2
-so much (adv),so much,这么,ADV,A1
-so much so many,so much so many,词,ADV,C1
 so that,so that,以便,SCONJ,B2
-so thus,so thus,所以/如此,ADV,B2
-so to speak,so to speak,可以说,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-so-called,so-called,,NOUN,B2
-so-called (adj),so-called,所谓,ADJ,B2
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
+to soak,to soak,浸透,VERB,B2
 sobbing,sobbing,抽泣,NOUN,B2
 sociable,sociable,好交际的,ADJ,B2
-social action,social action,社会行动,NOUN,C1
 social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
 social appeal,social appeal,社会呼吁,NOUN,B2
-social arbitration,social arbitration,社会仲裁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
 social awakening,social awakening,社会觉醒,NOUN,B2
 social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
 social class,social class,社会阶层,NOUN,B2
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
 social compromise,social compromise,社会妥协,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
 social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social distancing,social distancing,社交距离,NOUN,B2
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
 social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
 social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social harmony,social harmony,社会和谐,NOUN,B2
 social hierarchy,social hierarchy,社会等级,NOUN,B2
-social identity,social identity,社会身份,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
 social interaction,social interaction,社会互动,NOUN,B2
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
 social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social mobilization,social mobilization,社会动员,NOUN,B2
 social morality,social morality,社会公德,NOUN,B2
 social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
 social order,social order,社会秩序,NOUN,B2
-social organization,social organization,社会组织,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
 social phenomenon,social phenomenon,社会现象,NOUN,B2
-social practice,social practice,社会实践,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social problem,social problem,社会问题,NOUN,B2
 social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reconciliation,social reconciliation,社会和解,NOUN,B2
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social stability,social stability,社会稳定,NOUN,B2
-social standard,social standard,社会标准,NOUN,C1
-social statistics,social statistics,社会统计,NOUN,B2
-social status,social status,社会地位,NOUN,C1
-social stratification,social stratification,社会分层,NOUN,B2
 social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social trend,social trend,社会趋势,NOUN,B2
 social trust,social trust,社会信任,NOUN,B2
-social turmoil,social turmoil,社会动荡,NOUN,C1
 social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义者,NOUN,B2
-socialist (adj),socialist,社会主义的,ADJ,C1
-socialization,socialization,社会化,NOUN,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,词,ADV,C1
-societal,societal,词,ADJ,B2
-sociological,sociological,词,ADJ,C1
+to socialize,to socialize,交往,VERB,B2
 sociologist,sociologist,社会学家,NOUN,B2
-socket,socket,词,NOUN,C1
-soda,soda,苏打,NOUN,B2
-softball,softball,垒球,NOUN,B2
-softness,softness,词,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software (adj),software,词,ADJ,C1
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-solar physics,solar physics,词,NOUN,C1
+to soften,to soften,使灵活,VERB,B2
 soldiers,soldiers,官兵,NOUN,B2
 sole,sole,鞋底,NOUN,B2
-solemn,solemn,,NOUN,B2
-solemn (adj),solemn,严肃,ADJ,B2
-solemnly,solemnly,词,ADV,C1
-solfege,solfege,词,NOUN,C1
-solicitation,solicitation,词,NOUN,C1
-solicitude,solicitude,词,NOUN,B2
 solid,solid,3D模型 / 实体,NOUN,B2
-solid (noun),solid,固体,NOUN,B2
-solid substantial,solid substantial,词,ADJ,B2
-solid-state drive,solid-state drive,固态硬盘,NOUN,B2
 solidarity,solidarity,团结,NOUN,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-soloist,soloist,词,NOUN,C1
-solute,solute,词,NOUN,C1
-solvency,solvency,偿付能力,NOUN,B2
 solvent,solvent,溶剂,NOUN,B2
 some,some,某些,ADJ,B2
-some (adj),some,某些,ADJ,A2
-some (noun),some,词,NOUN,B2
-some (pron),some,词,PRON,B2
-some many a,some many a,词,DET,A2
-some out,some out,出些,NOUN,B2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-someone stealing,someone stealing,有人偷,NOUN,C1
-someone's,someone's,某人的,PRON,B2
 something,something,شي,NOUN,B2
-something (noun),something,شي,NOUN,B2
-something better,something better,词,NOUN,C1
-something like that,something like that,词,PRON,B2
-somewhat,somewhat,词,ADV,C1
-somewhere,somewhere,,NOUN,B2
-somewhere (noun),somewhere,somewhere,NOUN,B2
-somewhere else,somewhere else,词,ADV,B1
-son of a bitch,son of a bitch,词,NOUN,B2
-son-in-law,son-in-law,词,NOUN,A2
-sonata,sonata,词,NOUN,C1
 song,song,歌,PART,B2
-song (part),song,歌,PART,B2
-song festival,song festival,音乐节,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
 soot,soot,烟灰,NOUN,B2
-soothsayer,soothsayer,词,NOUN,B2
-sophism,sophism,诡辩,NOUN,B2
-sophist,sophist,词,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sorcerer,sorcerer,巫师,NOUN,B2
 sorcery,sorcery,巫术,NOUN,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
 sorry,sorry,抱歉,INTJ,B2
-sorry (intj),sorry,对不起,INTJ,B2
-sorry (noun),sorry,词,NOUN,A1
 sorting,sorting,分类,NOUN,B2
-sought,sought,,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-soul spirit,soul spirit,词,NOUN,B2
+to sound,to sound,响起,VERB,B2
 sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,词,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound of activity,sound of activity,动静,NOUN,B2
 sound sleep,sound sleep,你踏实睡,NOUN,B2
 soundness,soundness,好端端,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-soundtrack,soundtrack,! 音轨,NOUN,B2
 sour,sour,酸的,ADJ,B2
-sour cherry,sour cherry,词,NOUN,C1
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
 south,south,南方,NOUN,B2
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern,southern,南方的,ADJ,B2
 southern army,southern army,南军,NOUN,B2
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southward,southward,词,ADV,B2
-southwest,southwest,西南的,ADJ,B2
 sovereign,sovereign,主权的,ADJ,B2
-sovereign (noun),sovereign,国主,NOUN,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-sow,sow,母猪,NOUN,B2
-sowing,sowing,播种,NOUN,B2
-soy,soy,词,NOUN,C1
 soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
 spacious,spacious,宽敞的,ADJ,B2
-spaciousness,spaciousness,词,NOUN,C1
-spadix,spadix,词,NOUN,C1
-spam (noun),spam,词,NOUN,B1
-span cleaner,span cleaner,词,NOUN,B2
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
 spanish,spanish,西班牙的,ADJ,B2
 spanish,spanish,西班牙语,NOUN,B2
-spanish (noun),spanish,词,NOUN,B2
-spanking,spanking,词,NOUN,B2
-spare (noun),spare,词,NOUN,C1
-spare time,spare time,业余,NOUN,B2
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
+to spare,to spare,节省,VERB,B2
 sparrow,sparrow,麻雀,NOUN,B2
-sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
-sparse forest,sparse forest,疏林,NOUN,C1
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spatial,spatial,空间的,ADJ,B2
-spatula,spatula,刮刀,NOUN,B2
 speaker,speaker,发言人,NOUN,B2
-speaking,speaking,说得,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
 spear,spear,长矛,NOUN,B2
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special topic,special topic,专题,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
 special-purpose trip,special-purpose trip,专程,ADV,B2
 specialization,specialization,专业化,NOUN,B2
 specialized,specialized,专业的,ADJ,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specifically,specifically,具体地,ADV,B2
 specification,specification,规格,NOUN,B2
-specifications,specifications,词,NOUN,C1
-specificity,specificity,词,NOUN,C1
-spectacle,spectacle,词,NOUN,B2
 spectacles,spectacles,眼镜,NOUN,B2
 spectator,spectator,观众,NOUN,B2
-spectrometer,spectrometer,词,NOUN,C1
 spectrum,spectrum,光谱,NOUN,B2
 speculation,speculation,推测,NOUN,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
 speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
 spell,spell,咒语,NOUN,B2
-spell (noun),spell,咒语,NOUN,B2
-spend the night,spend the night,词,VERB,B2
 spending,spending,行用,NOUN,B2
-spent,spent,词,ADJ,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
 spinning,spinning,纺纱,NOUN,B2
-spinning mill,spinning mill,纺纱厂,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spiral,spiral,词,NOUN,C1
 spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit training,spirit training,练神,NOUN,B2
-spirit world,spirit world,词,NOUN,B2
-spirited,spirited,词,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
 spirituality,spirituality,灵性,NOUN,B2
 spiteful,spiteful,怀恨的,ADJ,B2
-spittle,spittle,唾沫,NOUN,B2
-splash,splash,扑通,NOUN,B2
-spleen,spleen,词,NOUN,B2
 splint,splint,夹板,NOUN,B2
-splinter (noun),splinter,词,NOUN,B2
-split,split,分裂,NOUN,B2
-split (noun),split,词,NOUN,C1
-split secession,split secession,分裂,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoiled,spoiled,词,ADJ,B2
-spoiled child,spoiled child,词,NOUN,B1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-spokesperson,spokesperson,发言人,NOUN,B2
-spoliation,spoliation,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
 sponsorship,sponsorship,赞助,NOUN,B2
-spontaneity,spontaneity,词,NOUN,C1
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-sporadically,sporadically,词,ADV,B2
-sports,sports,体育,NOUN,B2
-sports car,sports car,跑车,NOUN,B2
 sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,运动公园,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot goods,spot goods,现货,NOUN,C1
 spouse,spouse,配偶,NOUN,B2
 sprain,sprain,扭伤,NOUN,B2
 spray,spray,喷雾,NOUN,B2
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
 spread,spread,传播,NOUN,B2
-spread (noun),spread,传遍,NOUN,B2
-spreading,spreading,词,NOUN,C1
-spree,spree,词,NOUN,C1
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-sputum,sputum,词,NOUN,C1
-squabble (noun),squabble,词,NOUN,B2
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squall,squall,骤雨,NOUN,B2
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
+to sprinkle,to sprinkle,撒,VERB,B2
 squandering,squandering,挥霍,NOUN,B2
 square,square,平方的,ADJ,B2
-square (adj),square,方,ADJ,B2
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak (noun),squeak,吱吱声,NOUN,B2
-squid,squid,鱿鱼,NOUN,B2
-squire,squire,词,NOUN,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-stab (noun),stab,捅,NOUN,C1
 stability,stability,稳定,NOUN,B2
-stabilization,stabilization,稳定化,NOUN,B2
 stable,stable,畜舍,NOUN,B2
-stable (noun),stable,马厩,NOUN,C1
-stably,stably,稳定地,ADV,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
 stage play,stage play,舞台剧,NOUN,B2
 staging,staging,上演,NOUN,B2
+to stagnate,to stagnate,停滞,VERB,B2
 stagnation,stagnation,停滞,NOUN,B2
-staircase,staircase,词,NOUN,B1
 stairs,stairs,楼梯,NOUN,B2
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalking,stalking,词,NOUN,C1
 stall,stall,包厢座位,NOUN,B2
-stalling,stalling,词,NOUN,B2
-stammering,stammering,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stampede,stampede,溃逃,NOUN,B2
-stand,stand,摊位,NOUN,B2
-stand (noun),stand,摊位,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
+to stall,to stall,拖延,VERB,B2
+to stand out,to stand out,引人注目,VERB,B2
+to stand side by side,to stand side by side,并列,VERB,B2
+to stand up,to stand up,站起来,VERB,B2
 standardization,standardization,标准化,NOUN,B2
-standby,standby,待机,VERB,C1
-standing,standing,站立的,ADJ,B2
-standing (adv),standing,词,ADV,A1
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-standpoint,standpoint,词,NOUN,B2
-stands,stands,词,NOUN,B2
-stanza,stanza,词,NOUN,B2
-stapler,stapler,词,NOUN,A2
-star anise,star anise,八角,NOUN,B2
-star celebrity,star celebrity,词,NOUN,B1
 star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-starling,starling,词,NOUN,B2
-starry sky,starry sky,星空,NOUN,B2
-start of school year,start of school year,词,NOUN,B1
-starter,starter,词,NOUN,C1
-starting point,starting point,出发点,NOUN,B2
-starting premise,starting premise,词,NOUN,C1
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-starved,starved,饥饿的,ADJ,B2
-state (adj),state,词,ADJ,B1
-state federal,state federal,词,NOUN,B2
-state of emergency,state of emergency,词,NOUN,C1
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
+to state,to state,说明,VERB,B2
 state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-statements,statements,词,NOUN,C1
 static,static,静态的,ADJ,B2
-static (adj),static,静态,ADJ,C1
-statics,statics,词,NOUN,C1
-stationery,stationery,文具,NOUN,B2
-stationery shop,stationery shop,词,NOUN,B2
-statism,statism,词,NOUN,C1
 statistical,statistical,统计的,ADJ,B2
 statistics,statistics,统计学,NOUN,B2
-statization,statization,词,NOUN,C1
-statute,statute,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-statutory rape,statutory rape,词,NOUN,C1
-stave,stave,词,NOUN,C1
+to statistics,to statistics,统计,VERB,B2
 stay,stay,停留,NOUN,B2
-stay (noun),stay,逗留,NOUN,C1
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfastness,steadfastness,词,NOUN,B2
-steadily,steadily,词,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
 steal sword,steal sword,盗剑,NOUN,B2
-stealthily,stealthily,词,ADV,B2
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steamed stuffed bun,steamed stuffed bun,包子,NOUN,B2
-steep,steep,陡峭的,ADJ,B2
-steering,steering,掌舵的,ADJ,B2
-steering (noun),steering,词,NOUN,C1
-steering control,steering control,词,NOUN,C1
+to steam,to steam,蒸,VERB,B2
 steering wheel,steering wheel,方向盘,NOUN,B2
 stellar,stellar,杰出的,ADJ,B2
 stem,stem,茎,NOUN,B2
-stem (adj),stem,词,ADJ,C1
-stem (noun),stem,茎,NOUN,B2
-stem cell,stem cell,干细胞,NOUN,C1
-stemming,stemming,词,ADJ,B1
 stenosis,stenosis,狭窄,NOUN,B2
-stent,stent,支架,NOUN,C1
-stepfather,stepfather,词,NOUN,A1
+to step,to step,踩,VERB,B2
 stepmother,stepmother,后母,NOUN,B2
-steppe,steppe,词,NOUN,C1
-steppes,steppes,草原,NOUN,B2
 steps,steps,台阶,NOUN,B2
-stepson,stepson,词,NOUN,A2
-stereotypical,stereotypical,词,ADJ,C1
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-sterility,sterility,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-stern (noun),stern,词,NOUN,C1
-stevedore,stevedore,词,NOUN,C1
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiff glove,stiff glove,词,NOUN,B2
+to stew,to stew,炖,VERB,B2
+to stick,to stick,插入,VERB,B2
 stiffness,stiffness,僵硬,NOUN,B2
-stifling,stifling,词,ADJ,B2
-stigmatization,stigmatization,词,NOUN,B2
-stiletto,stiletto,词,NOUN,C1
-still also,still also,还,ADV,A1
-stillness,stillness,静中,NOUN,B2
+to stigmatize,to stigmatize,污名化,VERB,B2
 stimulant,stimulant,兴奋剂,NOUN,B2
-stimulating,stimulating,词,ADJ,C1
-stimulus,stimulus,刺激,NOUN,B2
-sting,sting,刺,NOUN,B2
-sting (noun),sting,刺,NOUN,B2
-stinginess,stinginess,吝啬；小气,NOUN,B2
+to stimulate,to stimulate,激发,VERB,B2
 stingy,stingy,吝啬的,ADJ,B2
-stink (noun),stink,词,NOUN,B2
-stinking,stinking,发臭的,ADJ,B2
-stipulation,stipulation,词,NOUN,C1
 stir,stir,搅拌,NOUN,B2
-stir (noun),stir,掀不起,NOUN,C1
-stir-fry,stir-fry,炒,VERB,B1
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
 stock exchange,stock exchange,证券交易所,NOUN,B2
 stock market,stock market,股市,NOUN,B2
-stock-market,stock-market,词,ADJ,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stoically,stoically,词,ADV,C1
-stoicism,stoicism,斯多葛主义,NOUN,B2
-stolen,stolen,被偷的,ADJ,B2
-stolen one,stolen one,词,NOUN,B2
-stomach ache,stomach ache,词,NOUN,C1
-stomachache,stomachache,肚子痛,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
 stone,stone,石,PART,B2
-stone (part),stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stool,stool,词,NOUN,C1
 stop,stop,停止,NOUN,B2
-stop (noun),stop,词,NOUN,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-stopover,stopover,中途停留,NOUN,B2
 storage,storage,收纳,NOUN,B2
-storage room,storage room,储藏室,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-stork,stork,词,NOUN,B1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-storming,storming,词,NOUN,C1
+to store,to store,储存,VERB,B2
 stormy,stormy,有暴风雨的,ADJ,B2
-story history,story history,词,NOUN,A1
-stowage,stowage,词,NOUN,C1
-strabismus,strabismus,词,NOUN,B2
 straight,straight,径直地,ADV,B2
-straight (adv),straight,直接地,ADV,B1
-straight (noun),straight,直的,NOUN,B2
-straight ahead,straight ahead,词,ADV,B2
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
+to strain,to strain,努力,VERB,B2
 strait,strait,海峡,NOUN,B2
-straitened circumstances,straitened circumstances,词,NOUN,C1
-straitjacket,straitjacket,词,NOUN,C1
-strand,strand,词,NOUN,C1
-strange troops,strange troops,怪兵,NOUN,B2
-strangely,strangely,奇怪地,ADV,B2
 strangeness,strangeness,奇怪,NOUN,B2
-strangest,strangest,词,NOUN,C1
-strangulation,strangulation,词,NOUN,C1
-strapping,strapping,词,ADJ,C1
+to strangle,to strangle,扼杀,VERB,B2
 strategic,strategic,战略的,ADJ,B2
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratification,stratification,词,NOUN,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-stratum,stratum,阶层,NOUN,B2
 straw,straw,稻草,NOUN,B2
 strawberry,strawberry,草莓,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street kid,street kid,词,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-strengthening,strengthening,词,NOUN,C1
-stressful,stressful,有压力的,ADJ,B2
+to strengthen,to strengthen,加强,VERB,B2
 stretch,stretch,伸展,NOUN,B2
-stretch (noun),stretch,舒展,NOUN,B2
-stretch out,stretch out,词,VERB,B2
-stretched,stretched,词,ADJ,C1
 stretcher,stretcher,担架,NOUN,B2
-strictly,strictly,词,ADV,B2
-strictness,strictness,词,NOUN,B2
-stride (noun),stride,词,NOUN,C1
-strife,strife,词,NOUN,B2
-strike-related,strike-related,词,ADJ,C1
-strikebreaker,strikebreaker,词,NOUN,C1
-striker,striker,罢工者,NOUN,B2
-striking,striking,词,ADJ,B2
-string instruments,string instruments,词,NOUN,C1
-string music,string music,词,NOUN,C1
-stripe,stripe,条纹,NOUN,B2
-striped,striped,有条纹的,ADJ,B2
-stripping,stripping,词,ADJ,B2
-striving,striving,词,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
+to strike,to strike,打击,VERB,B2
+to strive,to strive,努力,VERB,B2
+to strive for,to strive for,争取,VERB,B2
 stroll,stroll,闲逛,NOUN,B2
-stroller,stroller,婴儿车,NOUN,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
+to stroll,to stroll,散步,VERB,B2
 structural,structural,结构的,ADJ,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structured,structured,词,ADJ,C1
-structuredness,structuredness,结构性,NOUN,B2
-structures,structures,词,NOUN,C1
-stubbornness,stubbornness,固执,NOUN,B2
+to struggle,to struggle,挣扎,VERB,B2
 stuck,stuck,卡住的,ADJ,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studies,studies,学业,NOUN,B2
-studious,studious,词,ADJ,C1
 study,study,研究,NOUN,B2
-study (noun),study,书斋,NOUN,A2
-study tour,study tour,游学,NOUN,C1
-stuffed,stuffed,词,ADJ,B1
+to study deeply,to study deeply,钻研,VERB,B2
+to study to learn,to study to learn,学习,VERB,B2
+to stuff,to stuff,填塞,VERB,B2
 stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stumble (noun),stumble,词,NOUN,C1
-stunner,stunner,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupefied,stupefied,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
+to stumble,to stumble,绊倒,VERB,B2
 stupidity,stupidity,愚蠢,NOUN,B2
-stuttering,stuttering,词,NOUN,C1
 stylish,stylish,雅致的,ADJ,B2
-stylist,stylist,词,NOUN,C1
-stylistics,stylistics,词,NOUN,C1
 su sha,su sha,我夙砂,NOUN,B2
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
 sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
 sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
 subcategory,subcategory,分目,NOUN,B2
-subconscious,subconscious,潜意识,NOUN,B2
 subcontracting,subcontracting,分包,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject field,subject field,科目 / 领域,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,受法律管辖的,ADJ,B2
-subject topic,subject topic,主题/话题,NOUN,B2
-subjection,subjection,词,NOUN,B2
 subjective,subjective,主观的,ADJ,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
-sublimation,sublimation,词,NOUN,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submarine,submarine,潜水艇,NOUN,B2
 submission,submission,顺从,NOUN,B2
-submit bid,submit bid,投标,VERB,C1
-subordination,subordination,隶属,NOUN,C1
-subpoena,subpoena,词,NOUN,B2
 subscription,subscription,订阅,NOUN,B2
-subsequently,subsequently,词,ADV,C1
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,辅助性原则,NOUN,B2
 subsistence,subsistence,生计,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantially,substantially,词,ADV,B2
 substantiation,substantiation,论证,NOUN,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-subtly,subtly,词,ADV,C1
-suburbs,suburbs,郊区,NOUN,B2
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
 successively,successively,连续地,ADV,B2
 successor,successor,继任者,NOUN,B2
-succinctly,succinctly,词,ADV,B2
 such,such,这样的,ADJ,B2
-such (adj),such,样,ADJ,A1
-such a,such a,这样的,DET,B2
-such a thing,such a thing,词,PRON,B1
-such an extent as to,such an extent as to,以致,SCONJ,B2
+to suck,to suck,吸,VERB,B2
 sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suffering (adj),suffering,词,ADJ,C1
 sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffocating,suffocating,词,ADJ,B2
+to suffocate,to suffocate,窒息,VERB,B2
 suffocation,suffocation,窒息,NOUN,B2
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestibility,suggestibility,词,NOUN,C1
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal,suicidal,自杀的,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
 suicide,suicide,自杀,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
+to suit,to suit,适合,VERB,B2
 suitability,suitability,适宜性,NOUN,B2
 suite,suite,套房,NOUN,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
-sulfide,sulfide,词,NOUN,C1
-sulfur,sulfur,硫,NOUN,B2
-sulfuric,sulfuric,词,NOUN,B2
-sullenness,sullenness,词,NOUN,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultriness,sultriness,词,NOUN,B2
 sum total,sum total,总而,NOUN,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer camp,summer camp,夏令营,NOUN,B2
 summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
 summons,summons,传票,NOUN,B2
-sumptuousness,sumptuousness,词,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
 sunday,sunday,星期日,NOUN,B2
-sundown,sundown,日暮,NOUN,C1
-sunflower,sunflower,向日葵,NOUN,B2
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
 sunny,sunny,晴朗的,ADJ,B2
-sunny day,sunny day,晴天,NOUN,C1
 sunshine,sunshine,阳光,NOUN,B2
-suona,suona,唢呐,NOUN,C1
-super (adv),super,词,ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
 super-comprehensive,super-comprehensive,超遍,NOUN,B2
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
 super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
 super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-grade,super-grade,超级,NOUN,B2
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
 super-number,super-number,超数,NOUN,B2
 super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
 super-principle,super-principle,超则,NOUN,B2
-super-proof,super-proof,超证,NOUN,B2
-super-quality,super-quality,超质,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
 super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-system,super-system,超制,NOUN,B2
-super-theory,super-theory,超论,NOUN,C1
-super-thought,super-thought,超思,NOUN,B2
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superficiality,superficiality,词,NOUN,C1
-superhero,superhero,词,NOUN,B2
 superior,superior,上级,NOUN,B2
-superior (noun),superior,上级,NOUN,B2
-superior upper,superior upper,词,ADJ,C1
-superiority,superiority,优越性/优势,NOUN,B2
 superstition,superstition,迷信,NOUN,B2
-superstitious,superstitious,迷信的,ADJ,B2
-supervision,supervision,监督,NOUN,B2
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplication,supplication,恳求,NOUN,B2
+to supplement,to supplement,补充,VERB,B2
 supplier,supplier,供应商,NOUN,B2
-supplies,supplies,词,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
+to supply,to supply,供货,VERB,B2
 supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
 support,support,支撑,NOUN,B2
-support (noun),support,撑住,NOUN,A2
-support medium,support medium,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supported,supported,词,ADJ,B2
 supporter,supporter,支持者,NOUN,B2
-supporter advocate,supporter advocate,词,NOUN,B1
-supporters,supporters,词,NOUN,B2
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,团结的,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-suppository,suppository,词,NOUN,C1
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
 suppression,suppression,抑,NOUN,B2
-suppression of us,suppression of us,压咱,NOUN,C1
-suppuration,suppuration,词,NOUN,C1
-supreme court,supreme court,最高法院,NOUN,C1
 supreme fate,supreme fate,上缘,NOUN,B2
-sure,sure,当然,ADV,B2
-sure (adv),sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-surety bond,surety bond,词,NOUN,C1
-suretyship,suretyship,保证,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surging effusive,surging effusive,词,ADJ,C1
 surname,surname,姓氏,NOUN,B2
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus,surplus,过剩的,ADJ,B2
-surplus (noun),surplus,结余,NOUN,C1
-surprise attack,surprise attack,偷袭,NOUN,C1
-surprised,surprised,惊讶的,ADJ,B2
-surrealism,surrealism,超现实主义,NOUN,B2
+to surpass,to surpass,超过,VERB,B2
+to surprise,to surprise,使惊讶,VERB,B2
 surrender,surrender,投降,NOUN,B2
-surrender (noun),surrender,就交,NOUN,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
 surroundings,surroundings,周围,NOUN,B2
+to surveil,to surveil,监视,VERB,B2
 surveyor,surveyor,测量员,NOUN,B2
 survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
 susha,susha,夙砂大,NOUN,B2
-suspect (noun),suspect,嫌犯,NOUN,B2
-suspended,suspended,悬浮的,ADJ,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspicions,suspicions,词,NOUN,C1
 sustainability,sustainability,可持续性,NOUN,B2
-sustainability policy,sustainability policy,词,NOUN,C1
 suture,suture,缝合,NOUN,B2
-swab,swab,词,NOUN,B2
-swagger (noun),swagger,词,NOUN,B2
 swan,swan,天鹅,NOUN,B2
-swarm (noun),swarm,词,NOUN,C1
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweatshirt,sweatshirt,词,NOUN,C1
-sweden,sweden,词,PROPN,B2
-swedish,swedish,瑞典语,NOUN,B2
+to sweat,to sweat,出汗,VERB,B2
 sweep,sweep,扫,NOUN,B2
-sweep (noun),sweep,词,NOUN,B2
-sweepings,sweepings,词,NOUN,B2
-sweet (noun),sweet,糖果,NOUN,C1
-sweet dream,sweet dream,美梦,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweetness,sweetness,,NOUN,B2
+to sweeten,to sweeten,使变甜,VERB,B2
 sweets,sweets,甜食,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swiftness,swiftness,词,NOUN,C1
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,词,NOUN,C1
 swimming,swimming,游泳,NOUN,B2
 swimming pool,swimming pool,游泳池,NOUN,B2
-swimwear,swimwear,词,NOUN,B2
-swindler,swindler,骗子,NOUN,B2
-swine,swine,猪,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swiss,swiss,瑞士的,ADJ,B2
-switch key,switch key,词,NOUN,C1
-switch room,switch room,配电室,NOUN,B2
-switchboard,switchboard,总机,NOUN,B2
-switchman,switchman,词,NOUN,C1
-swollen,swollen,肿胀的,ADJ,B2
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
+to swindle,to swindle,诈骗,VERB,B2
 sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
 sword strike,sword strike,看剑,NOUN,B2
-swordless,swordless,剑不,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
 swordsman,swordsman,剑客,NOUN,B2
 swordsmanship,swordsmanship,剑术,NOUN,B2
 sycophancy,sycophancy,阿谀奉承,NOUN,B2
-sycophantic,sycophantic,词,ADJ,B2
-syllabification,syllabification,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
 syllabus,syllabus,教学大纲,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbolic,symbolic,象征的,ADJ,B2
 symbolism,symbolism,象征主义,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symmetric,symmetric,词,ADJ,C1
-symmetrical,symmetrical,对称的,ADJ,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symphonic,symphonic,交响乐的,ADJ,B2
+to symbolize,to symbolize,象征,VERB,B2
+to sympathize,to sympathize,同情,VERB,B2
 symphony,symphony,交响乐,NOUN,B2
-symptom,symptom,症,PART,B2
-symptom (part),symptom,症,PART,B2
 symptomatic,symptomatic,症状的,ADJ,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-symptoms,symptoms,词,NOUN,B1
-synaptic,synaptic,词,ADJ,C1
-sync,sync,同步,NOUN,B2
 synchronization,synchronization,同步,NOUN,B2
-synchronized,synchronized,词,ADJ,C1
-synchrony,synchrony,词,NOUN,C1
-syncretism,syncretism,词,NOUN,C1
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,词,NOUN,B2
-synonym,synonym,词,NOUN,C1
 synonymy,synonymy,同义关系,NOUN,B2
-synoptic,synoptic,概要的,ADJ,B2
-syntactic,syntactic,词,ADJ,C1
 syntax,syntax,句法,NOUN,B2
 synthesis,synthesis,综合,NOUN,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-syrian,syrian,叙利亚的,ADJ,B2
 systematic,systematic,系统的,ADJ,B2
-systematically,systematically,系统地,ADV,B2
-systemless,systemless,无系统的,ADJ,B2
-t-shirt,t-shirt,词,NOUN,B1
-tab,tab,词,NOUN,C1
 table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tablecloth,tablecloth,词,NOUN,C1
-tablet,tablet,平板电脑,NOUN,B2
 taboo,taboo,禁忌,NOUN,B2
-taboo (adj),taboo,词,ADJ,C1
-tachometer,tachometer,转速表,NOUN,B2
-tacitly,tacitly,默不作声地,ADV,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-tackling,tackling,马具,NOUN,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,词,NOUN,B2
-tact,tact,词,NOUN,C1
 tactful,tactful,圆滑的,ADJ,B2
-tactful appeasement,tactful appeasement,词,NOUN,C1
 tactics,tactics,战术,NOUN,B2
 tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,词,ADJ,B2
 taekwondo,taekwondo,跆拳道,NOUN,B2
 taillight,taillight,尾灯,NOUN,B2
 tailor,tailor,裁缝,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
+to take along,to take along,带走,VERB,B2
+to take away,to take away,拿走,VERB,B2
+to take care,to take care,照顾,VERB,B2
+to take care of,to take care of,照顾,VERB,B2
+to take cuttings,to take cuttings,扦插,VERB,B2
+to take off,to take off,起飞,VERB,B2
+to take out,to take out,拿出,VERB,B2
+to take over,to take over,接管,VERB,B2
+to take place,to take place,举行,VERB,B2
+to take revenge,to take revenge,报复,VERB,B2
 takeoff,takeoff,起飞,NOUN,B2
-takeover,takeover,词,NOUN,C1
 taking,taking,拍摄,NOUN,B2
 taking command,taking command,挂帅,NOUN,B2
-tale,tale,词,NOUN,A1
-talisman,talisman,词,NOUN,B2
-talk show,talk show,脱口秀,NOUN,C1
-talkativeness,talkativeness,多嘴,NOUN,B2
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-tall and slender,tall and slender,词,ADJ,C1
-tamable,tamable,词,ADJ,C1
-tambourine,tambourine,词,NOUN,B2
-tame (adj),tame,词,ADJ,A1
-taming,taming,词,NOUN,C1
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tangle,tangle,混乱,NOUN,B2
-tank cistern,tank cistern,词,NOUN,C1
-tanned,tanned,词,ADJ,B2
+to talk,to talk,谈话,VERB,B2
+to talk nonsense,to talk nonsense,胡言乱语,VERB,B2
 tanner,tanner,制革工,NOUN,B2
-tannery,tannery,词,NOUN,B2
 tanning,tanning,晒黑,NOUN,B2
-tape,tape,词,NOUN,A2
-tapestry,tapestry,词,NOUN,C1
-tarab,tarab,词,NOUN,B2
-target group,target group,词,NOUN,C1
-targeted,targeted,有针对性的,ADJ,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
 targeting,targeting,定位,NOUN,B2
 tariff,tariff,费率,NOUN,B2
 taro,taro,芋头,NOUN,B2
-tarragon,tarragon,龙蒿,NOUN,B2
-tart pie,tart pie,词,NOUN,C1
-taste preference,taste preference,口味,NOUN,B2
-tasteless,tasteless,无味的,ADJ,B2
-tasting,tasting,词,NOUN,C1
-tasty,tasty,美味的,ADJ,B2
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tautology,tautology,词,NOUN,C1
+to taste,to taste,品尝,VERB,B2
 tavern,tavern,酒馆,NOUN,B2
-tax (adj),tax,词,ADJ,C1
-tax authorities,tax authorities,税务机关,NOUN,B2
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax rate,tax rate,词,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax return,tax return,词,NOUN,B2
+to tax,to tax,征税,VERB,B2
 tax revenue,tax revenue,税收,NOUN,B2
-tax-exempt,tax-exempt,免税,ADJ,B2
-taxable,taxable,应纳税的,ADJ,B2
 taxation,taxation,征税,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-taxpayer,taxpayer,纳税人,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-tea plantation,tea plantation,茶园,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching,teaching,教学的,ADJ,B2
-teaching (adj),teaching,教学的,ADJ,C1
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
 teammate,teammate,队友,NOUN,B2
-teapot,teapot,词,NOUN,C1
-tearing,tearing,tearing,NOUN,B2
+to tear up,to tear up,流泪,VERB,B2
 tears,tears,眼泪,NOUN,B2
-teasing playful,teasing playful,词,ADJ,C1
 technical,technical,技术的,ADJ,B2
-technically,technically,技术上地,ADV,B2
 technician,technician,技术员,NOUN,B2
-technocracy,technocracy,技术官僚主义,NOUN,B2
-technocrat,technocrat,词,NOUN,C1
-technocratic,technocratic,技术官僚的,ADJ,B2
 technological,technological,技术的,ADJ,B2
-tectonic,tectonic,词,ADJ,C1
-teddy bear,teddy bear,词,NOUN,B2
-tedious painful,tedious painful,词,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-telecommunications,telecommunications,词,NOUN,C1
 telegram,telegram,电报,NOUN,B2
-telegraph lightning,telegraph lightning,词,NOUN,C1
-teleological,teleological,词,ADJ,B2
 teleology,teleology,目的论,NOUN,B2
 telephone number,telephone number,电话号码,NOUN,B2
-telephone ringing,telephone ringing,词,NOUN,C1
-telephones,telephones,词,NOUN,B2
-telephony,telephony,电话学,NOUN,B2
 televised,televised,电视播出的,ADJ,B2
-television set,television set,词,NOUN,B1
-teller,teller,词,NOUN,B2
-telling-off,telling-off,词,NOUN,B1
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperamental,temperamental,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-template,template,词,NOUN,C1
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
 temporarily,temporarily,临时地,ADV,B2
-temporary refusal,temporary refusal,暂不,NOUN,B2
-temptation,temptation,词,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
 tender,tender,嫩的,ADJ,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tenderloin,tenderloin,里脊,NOUN,B2
 tenderness,tenderness,柔情,NOUN,B2
 tendon,tendon,肌腱,NOUN,B2
 tennis,tennis,网球,NOUN,B2
-tenor,tenor,男高音,NOUN,B2
-tens,tens,词,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
 tense,tense,紧张的,ADJ,B2
-tense (adj),tense,紧张的,ADJ,B2
-tense angry,tense angry,词,ADJ,A2
-tense excited,tense excited,词,ADJ,B2
-tenth,tenth,第十,ADJ,B2
-tenth (noun),tenth,词,NOUN,B2
-tenure,tenure,词,NOUN,B2
-teratogenic,teratogenic,词,ADJ,B2
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-terminal,terminal,终末的,ADJ,B2
-terminal (adj),terminal,终末的,ADJ,B2
 termination,termination,解除,NOUN,B2
 terminological,terminological,术语的,ADJ,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,词,NOUN,B2
-terribleness,terribleness,词,NOUN,B2
-terribly,terribly,可怕地/非常,ADV,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
 terrorist,terrorist,恐怖分子,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terseness,terseness,词,NOUN,C1
-test drive,test drive,,NOUN,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testator,testator,词,NOUN,C1
+to test,to test,测试,VERB,B2
 testicle,testicle,睾丸,NOUN,B2
-testicular,testicular,词,ADJ,C1
-testimony deposition,testimony deposition,词,NOUN,C1
 text message,text message,短信,NOUN,B2
-textbook,textbook,教科书,NOUN,B2
 textile,textile,纺织,NOUN,B2
 textual,textual,文本的,ADJ,B2
-textuality,textuality,词,NOUN,C1
-texture,texture,词,NOUN,C1
-than (adv),than,词,ADV,A1
-thank god,thank god,谢天谢地,INTJ,B2
+to thank,to thank,感谢,VERB,B2
 thank you,thank you,谢谢,INTJ,B2
 thanks,thanks,谢谢,INTJ,B2
-thanks (intj),thanks,谢谢,INTJ,A1
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
 thanks to,thanks to,多亏,ADP,B2
-tharid,tharid,词,NOUN,B2
 that,that,那个,DET,B2
 that,that,（引导从句）,SCONJ,B2
-that (det),that,那个,DET,A2
-that (noun),that,将那,NOUN,C1
-that (sconj),that,词,SCONJ,A1
-that arrow,that arrow,那一箭,NOUN,B2
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
 that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is,that is,即,ADV,B2
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
 that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
 that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that one,that one,那个,PRON,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way,that way,那样,PRON,B2
-that way (adv),that way,词,ADV,B2
 that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,词,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,词,NOUN,B2
-the chain,the chain,词,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,NOUN,B2
-the day after tomorrow (adv),the day after tomorrow,后天,ADV,B2
-the day before yesterday,the day before yesterday,词,ADV,C1
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the emperor,the emperor,词,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masculine,the masculine,词,DET,A2
-the masses,the masses,大众,NOUN,C1
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the more,the more,越,ADV,B2
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
+to thaw,to thaw,解冻,VERB,B2
 the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,词,DET,B1
-the one (pron),the one,那个人,PRON,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,词,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
 the rest,the rest,其余,NOUN,B2
-the rich,the rich,词,NOUN,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,相同的,ADJ,B2
-the same (det),the same,词,DET,A2
-the same (pron),the same,词,PRON,C1
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unseen,the unseen,词,NOUN,C1
-the unstellung,the unstellung,词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,词,NOUN,B2
-the urbewegung,the urbewegung,词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,词,NOUN,B2
-the urrechnung,the urrechnung,词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,词,NOUN,B2
-the verminderung,the verminderung,词,NOUN,B2
-the verstbindung,the verstbindung,词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,词,NOUN,B2
-the ververtiefung,the ververtiefung,词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the very,the very,正是,ADV,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,词,NOUN,B2
-the zerordnung,the zerordnung,词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-theatrical,theatrical,戏剧的,ADJ,B2
-their,their,他们的,DET,B2
-their (det),their,词,DET,B2
-them dative,them dative,词,PRON,A2
-thematic,thematic,主题的,ADJ,B2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
 then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then you,then you,那你,PRON,B2
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,词,ADJ,B2
-theodicy,theodicy,词,NOUN,C1
-theologian,theologian,神学家,NOUN,B2
-theological,theological,神学的,ADJ,B2
 theoretical,theoretical,理论的,ADJ,B2
 theoretically,theoretically,理论上,ADV,B2
-therapist,therapist,治疗师,NOUN,B2
 there,there,那儿,NOUN,B2
-there (noun),there,那儿,NOUN,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
 therefore,therefore,所以,SCONJ,B2
-therefore (sconj),therefore,所以,SCONJ,B2
 thereupon,thereupon,随后,ADV,B2
-thermal,thermal,热的,ADJ,B2
-thermal (noun),thermal,词,NOUN,B2
-thermodynamics,thermodynamics,词,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-thesaurus,thesaurus,词,NOUN,C1
 these,these,这些,DET,B2
-these (det),these,这些,DET,B2
-these three,these three,这三,NOUN,B2
 thesis,thesis,论文,NOUN,B2
-thetic,thetic,正题的,ADJ,B2
-they female,they female,她们,PRON,B2
-they things,they things,它们,PRON,B2
-they two,they two,词,PRON,A1
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thickets,thickets,词,NOUN,B2
 thickness,thickness,厚度,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thief presence,thief presence,有贼,NOUN,B2
 thigh,thigh,大腿,NOUN,B2
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-thinker,thinker,词,NOUN,C1
+to think to want,to think to want,想,VERB,B2
 thinking,thinking,思维,NOUN,B2
-thinner,thinner,更薄的,ADJ,B2
-thinness,thinness,瘦,NOUN,B2
 third,third,三分之一,NOUN,B2
-third (noun),third,三分之一,NOUN,B2
-third (num),third,词,NUM,B1
-third bestowal,third bestowal,三授,NOUN,B2
 third place,third place,季军,NOUN,B2
 thirteen,thirteen,十三,NUM,B2
 thirty,thirty,三十,NUM,B2
 this,this,这个,DET,B2
-this (det),this,此次,DET,A1
-this (noun),this,你这,NOUN,B2
-this afternoon,this afternoon,词,ADV,B2
-this battle,this battle,此战,NOUN,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
 this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this item,this item,这件,NOUN,B2
-this masculine,this masculine,词,DET,A1
 this matter,this matter,这事,NOUN,B2
-this morning,this morning,今天早上,ADV,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
 this way,this way,这样,PRON,B2
-this way (adv),this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-this-camp,this-camp,这营,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
 thorn,thorn,刺,NOUN,B2
-thorny,thorny,词,ADJ,C1
 thoroughness,thoroughness,彻底,NOUN,B2
 those,those,那些,DET,B2
-those (det),those,那些,DET,B2
 thoughtful,thoughtful,体贴的,ADJ,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
 thousand,thousand,千,NUM,B2
-thousand (noun),thousand,词,NOUN,B2
-thousands,thousands,数千,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thread (verb),thread,词,VERB,C1
-threads,threads,词,NOUN,B2
-threatened,threatened,词,ADJ,C1
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
 three-d printing,three-d printing,3D打印,NOUN,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-threshing floor,threshing floor,词,NOUN,B2
-thrifty,thrifty,节俭的,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throughout,throughout,词,ADP,B1
-throw,throw,投掷,NOUN,B2
-throw (noun),throw,投掷,NOUN,B2
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-throwing,throwing,词,NOUN,B2
-thrust toward,thrust toward,插向,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thunderstorm,thunderstorm,雷阵雨,NOUN,B2
-thursday,thursday,星期四,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,词,NOUN,B2
-ticket window,ticket window,售票窗口,NOUN,B2
-tickle,tickle,发痒,NOUN,B2
-tidal,tidal,潮汐,ADJ,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
-tidy (adj),tidy,词,ADJ,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tier,tier,分阶,NOUN,C1
-tiger,tiger,老虎,NOUN,B2
-tight grip,tight grip,手握紧,NOUN,B2
-tight narrow,tight narrow,词,ADJ,B1
-tight-fitting,tight-fitting,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightly,tightly,词,ADV,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-tights,tights,词,NOUN,C1
-tile,tile,瓦片,NOUN,B2
-tiling,tiling,铺瓷砖,NOUN,B2
-timbre,timbre,词,NOUN,C1
-time clock,time clock,词,NOUN,B2
-time era,time era,词,NOUN,A2
-time limit,time limit,词,NOUN,B1
-time occasion,time occasion,次,NOUN,B2
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time out,time out,词,NOUN,B2
-time to go to bed,time to go to bed,词,ADV,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
-times,times,倍,NOUN,B2
-timetable,timetable,时刻表,NOUN,B2
-timid,timid,词,ADJ,B2
-timidity,timidity,胆怯,NOUN,B2
-timing,timing,时机,NOUN,B2
-tingling,tingling,麻木感,NOUN,B2
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (noun),tint,词,NOUN,C1
-tiny minute,tiny minute,词,ADJ,C1
-tips,tips,词,NOUN,C1
-tire,tire,轮胎,NOUN,B2
-tire (noun),tire,词,NOUN,B1
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tiredness,tiredness,疲劳,NOUN,B2
-tirelessly,tirelessly,词,ADV,C1
-tiresome,tiresome,累人的,ADJ,B2
-tiring,tiring,词,ADJ,B2
-tissue,tissue,组织,NOUN,B2
-tissue (adj),tissue,词,ADJ,C1
-titling,titling,词,NOUN,C1
-tits,tits,词,NOUN,C1
-to,to,去,PART,B2
-to (part),to,去,PART,B2
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abort,to abort,流产,VERB,B2
-to abound,to abound,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,词,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abstract,to abstract,抽象,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abuse (verb),to abuse,词,VERB,B2
-to abwandeln,to abwandeln,词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to access,to access,进入,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act,to act,行动,VERB,B2
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address (verb),to address,处理,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adhere join,to adhere join,词,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to advance,to advance,前进,VERB,B2
-to advise against,to advise against,劝阻,VERB,B2
-to advocate,to advocate,提倡,VERB,B2
-to age,to age,变老,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to agree with,to agree with,词,VERB,B2
-to aim,to aim,瞄准,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alert,to alert,警告,VERB,B2
-to ally,to ally,结盟,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to amount to,to amount to,总计,VERB,B2
-to anathematize,to anathematize,词,VERB,C1
-to anchor,to anchor,抛锚,VERB,B2
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to anger,to anger,使生气,VERB,B2
-to animate,to animate,词,VERB,B2
-to annex (verb),to annex,吞并,VERB,B2
-to answer (verb),to answer,答,VERB,A1
-to answer reply,to answer reply,回答,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,叛教,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to appear in court,to appear in court,词,VERB,B2
-to appear to seem,to appear to seem,出现/显得,VERB,B2
-to apply a cast,to apply a cast,打石膏,VERB,B2
-to apply be valid,to apply be valid,词,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to apply makeup,to apply makeup,化妆,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to approach,to approach,靠近,VERB,B2
-to archive (verb),to archive,词,VERB,B2
-to arm,to arm,武装,VERB,B2
-to armor (verb),to armor,词,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to assault,to assault,袭击,VERB,B2
-to assume office,to assume office,就任,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attack (verb),to attack,发难,VERB,C1
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt,to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attribute,to attribute,归因于,VERB,B2
-to audit,to audit,审计,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await,to await,等待,VERB,B2
-to await orders,to await orders,待命,VERB,B2
-to award,to award,分配,VERB,B2
-to back up,to back up,后退,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to balance,to balance,平衡,VERB,B2
-to ban (verb),to ban,取缔,VERB,B2
-to bandage,to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to bare,to bare,暴露,VERB,B2
-to bargain (verb),to bargain,词,VERB,C1
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to barricade (verb),to barricade,词,VERB,B2
-to base,to base,基于,VERB,B2
-to battle,to battle,之战,VERB,B2
-to be (aux),to be,词,AUX,B2
-to be able,to be able,能,VERB,B2
-to be able (aux),to be able,能够,AUX,B1
-to be able to,to be able to,能够,VERB,B2
-to be absent,to be absent,缺席,VERB,B2
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be added,to be added,加入,VERB,B2
-to be addicted,to be addicted,上瘾,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be ashamed,to be ashamed,感到羞愧,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be based on,to be based on,基于,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be born,to be born,出生,VERB,B2
-to be brave,to be brave,勇善,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be called,to be called,叫做,VERB,B2
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be content,to be content,词,VERB,C1
-to be contradicted,to be contradicted,词,VERB,B2
-to be correct,to be correct,正确,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be damaged,to be damaged,受损,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defeated,to be defeated,会败,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be dissonant,to be dissonant,词,VERB,C1
-to be done,to be done,被做,VERB,B2
-to be driven,to be driven,被驱动,VERB,B2
-to be eager,to be eager,心切,VERB,B2
-to be eager for,to be eager for,巴不得,VERB,B2
-to be elected,to be elected,当选,VERB,B2
-to be enough,to be enough,足够,VERB,B2
-to be entranced,to be entranced,出神,VERB,B2
-to be equivalent,to be equivalent,词,VERB,C1
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be forbidden,to be forbidden,词,VERB,B2
-to be forced,to be forced,被迫,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be good at,to be good at,擅长,VERB,B2
-to be good for,to be good for,词,VERB,B2
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be grateful,to be grateful,感激,VERB,B2
-to be happy,to be happy,词,VERB,A2
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be hit,to be hit,中箭,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be jealous,to be jealous,嫉妒,VERB,B2
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be late,to be late,迟到,VERB,B2
-to be left over,to be left over,剩余,VERB,B2
-to be liable,to be liable,词,VERB,B2
-to be located,to be located,位于,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be missing,to be missing,缺少,VERB,B2
-to be moved,to be moved,感动,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be necessary must,to be necessary must,词,VERB,A2
-to be needed,to be needed,被需要,VERB,B2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticeable,to be noticeable,词,VERB,C1
-to be noticed,to be noticed,词,VERB,B2
-to be observed,to be observed,词,VERB,B2
-to be on duty,to be on duty,值班,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,词,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be related,to be related,词,VERB,C1
-to be released,to be released,词,VERB,B2
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be required,to be required,被要求,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be responsible,to be responsible,词,VERB,B2
-to be responsible for,to be responsible for,负责,VERB,B2
-to be right,to be right,正确,VERB,B2
-to be safe,to be safe,安好,VERB,B2
-to be said,to be said,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be silent,to be silent,沉默,VERB,B2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be so,to be so,然,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be stolen,to be stolen,失窃,VERB,B2
-to be struck,to be struck,词,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be surprised,to be surprised,感到惊讶,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,不知道,VERB,B2
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be useful,to be useful,有用,VERB,B2
-to be valid,to be valid,词,VERB,B2
-to be vigilant,to be vigilant,词,VERB,B2
-to be visible,to be visible,词,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worth,to be worth,值得,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to bear (verb),to bear,承受,VERB,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to bear to endure,to bear to endure,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to become (aux),to become,词,AUX,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become alert,to become alert,词,VERB,B2
-to become bold,to become bold,词,VERB,C1
-to become certain,to become certain,词,VERB,B2
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to begin to cut into,to begin to cut into,词,VERB,C1
-to begin to start,to begin to start,开始,VERB,B2
-to behave rudely,to behave rudely,词,VERB,C1
-to belong to,to belong to,属于,VERB,B2
-to benefit,to benefit,受益,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to bet invest,to bet invest,词,VERB,B2
-to betray one's country,to betray one's country,卖国,VERB,B2
-to betroth,to betroth,词,VERB,C1
-to bevriezen,to bevriezen,词,VERB,C1
-to bid farewell,to bid farewell,词,VERB,B1
-to blackmail (verb),to blackmail,敲诈,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to bleat,to bleat,哀叫,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to block (verb),to block,堵塞,VERB,B2
-to blockade,to blockade,封锁,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to blow up,to blow up,炸毁,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to board (verb),to board,词,VERB,C1
-to boil cook,to boil cook,词,VERB,B1
-to book (verb),to book,预订,VERB,B2
-to border,to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to bottle (verb),to bottle,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to box (verb),to box,词,VERB,B2
-to brake,to brake,刹车,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to breach contract,to breach contract,违约,VERB,B2
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break down,to break down,分解,VERB,B2
-to break in,to break in,词,VERB,B2
-to break into,to break into,撬开,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break open,to break open,撬开,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to break up,to break up,破裂,VERB,B2
-to breastfeed,to breastfeed,母乳喂养,VERB,B2
-to breathe again,to breathe again,松口气,VERB,B2
-to bribe,to bribe,贿赂,VERB,B2
-to bridle (verb),to bridle,词,VERB,C1
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring back,to bring back,带回,VERB,B2
-to bring closer,to bring closer,靠近,VERB,B2
-to bring here,to bring here,词,VERB,C1
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to bristle,to bristle,使竖起,VERB,B2
-to broadcast,to broadcast,播出,VERB,B2
-to brush,to brush,刷,VERB,B2
-to build up,to build up,构建,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump (verb),to bump,碰撞,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to call (noun),to call,号召,NOUN,B2
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call out,to call out,词,VERB,C1
-to call ring,to call ring,打电话,VERB,B2
-to call to contact,to call to contact,词,VERB,A2
-to calm,to calm,使平静,VERB,B2
-to calm down,to calm down,使平静,VERB,B2
-to camouflage,to camouflage,伪装,VERB,B2
-to camp,to camp,露营,VERB,B2
-to campaign,to campaign,积极参与活动,VERB,B2
-to can't believe,to can't believe,不敢相信,VERB,B2
-to cannot bear,to cannot bear,不堪,VERB,B2
-to cannot help,to cannot help,忍不住,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to capture,to capture,获取,VERB,B2
-to care about,to care about,关心,VERB,A1
-to care for,to care for,照顾,VERB,B2
-to carry forward,to carry forward,发扬,VERB,B2
-to carry on,to carry on,词,VERB,C1
-to carry out,to carry out,实施,VERB,B2
-to cash,to cash,兑现,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to cast (verb),to cast,词,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,瞥见,VERB,B2
-to catch up,to catch up,赶上,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to catechize,to catechize,词,VERB,B2
-to cause,to cause,引起,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to caw,to caw,呱呱叫,VERB,B2
-to cement,to cement,巩固,VERB,B2
-to center,to center,居中,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to chair (verb),to chair,词,VERB,C1
-to challenge,to challenge,质疑,VERB,B2
-to change clothes,to change clothes,更衣,VERB,B1
-to change tire,to change tire,换胎,VERB,B2
-to change trains,to change trains,词,VERB,A1
-to channel,to channel,疏导,VERB,B2
-to charge,to charge,充电,VERB,B2
-to charter,to charter,租船,VERB,B2
-to chatter (verb),to chatter,闲聊,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to cheer up,to cheer up,使高兴,VERB,B2
-to chill,to chill,使冰冻,VERB,B2
-to chirp,to chirp,啁啾,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,词,VERB,B2
-to clarify doubts,to clarify doubts,释疑,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clean (verb),to clean,打扫,VERB,A1
-to clean out,to clean out,词,VERB,C1
-to clean up,to clean up,清理,VERB,B2
-to clear,to clear,清理,VERB,B2
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close account,to close account,销户,VERB,B2
-to close eyes,to close eyes,闭眼,VERB,B2
-to close the door,to close the door,关门,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coach,to coach,辅导,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to color,to color,着色,VERB,B2
-to comb,to comb,梳头,VERB,B2
-to combat,to combat,对抗,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come along,to come along,一起来,VERB,B2
-to come back,to come back,回来,VERB,B2
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come from,to come from,来自,VERB,B2
-to come here,to come here,来到这里,VERB,B2
-to come in,to come in,进来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to come out,to come out,出来,VERB,B2
-to come over,to come over,顺道来访,VERB,B2
-to come true,to come true,词,VERB,B2
-to come up,to come up,出现,VERB,B2
-to command,to command,命令,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commission (verb),to commission,委托,VERB,B2
-to commit a crime,to commit a crime,犯罪,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,交融,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to complement (verb),to complement,补充,VERB,C1
-to complete (verb),to complete,完成,VERB,B1
-to complete finish,to complete finish,词,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to comply with,to comply with,遵守,VERB,B2
-to compose (noun),to compose,合成,NOUN,B2
-to compromise,to compromise,危及,VERB,B2
-to computerize,to computerize,词,VERB,C1
-to concern,to concern,涉及,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concretize,to concretize,词,VERB,C1
-to condition,to condition,制约,VERB,B2
-to condole,to condole,哀悼,VERB,B2
-to conduct,to conduct,أجرى,VERB,B2
-to conjecture,to conjecture,猜测,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to consent,to consent,同意,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to constipate,to constipate,词,VERB,C1
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consult reference,to consult reference,参考,VERB,B2
-to contact (verb),to contact,接触,VERB,B2
-to contest (verb),to contest,词,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to contract,to contract,收缩,VERB,B2
-to contrast,to contrast,对比,VERB,B2
-to cook (verb),to cook,做饭,VERB,C1
-to cook fix,to cook fix,做/修理,VERB,B2
-to cool,to cool,冷却,VERB,B2
-to cool down,to cool down,冷却,VERB,B2
-to coordinate,to coordinate,协调,VERB,B2
-to cope with,to cope with,应对,VERB,B2
-to copy,to copy,复制,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to correct,to correct,纠正,VERB,B2
-to correspond (! verb),to correspond,词,! VERB,C1
-to corrupt,to corrupt,腐败,VERB,B2
-to cost,to cost,花费,VERB,B2
-to cough,to cough,咳嗽,VERB,B2
-to count (verb),to count,计算,VERB,A2
-to count as,to count as,算,VERB,B2
-to counter,to counter,反击,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover (verb),to cover,掩,VERB,B2
-to cover a shift,to cover a shift,替班,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,词,VERB,C1
-to crack,to crack,破裂,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to crash,to crash,碰撞,VERB,B2
-to crash into,to crash into,撞击,VERB,B2
-to criminalize,to criminalize,定罪,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,挤在一起,VERB,B2
-to crown,to crown,加冕,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to curse (verb),to curse,词,VERB,B2
-to curve (verb),to curve,词,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut off,to cut off,切断,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut short,to cut short,截断,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to cycle,to cycle,骑自行车,VERB,B2
-to dam up,to dam up,词,VERB,C1
-to damage,to damage,损坏,VERB,B2
-to damn,to damn,诅咒,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to date,to date,注明日期,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daydream,to daydream,幻想,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deal (verb),to deal,处理,VERB,B2
-to deal with,to deal with,处理,VERB,B2
-to death (adv),to death,致死,ADV,B2
-to debate,to debate,辩论,VERB,B2
-to debut,to debut,首次亮相,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,词,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declare war,to declare war,宣战,VERB,B2
-to decline (verb),to decline,推辞,VERB,B2
-to decline politely,to decline politely,婉拒,VERB,B2
-to decontextualize,to decontextualize,词,VERB,C1
-to decrease (verb),to decrease,减少,VERB,B2
-to decree,to decree,颁布法令,VERB,B2
-to deep-fry,to deep-fry,油炸,VERB,B2
-to default,to default,赖账,VERB,B2
-to defeat,to defeat,击败,VERB,B2
-to defect,to defect,叛变,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend one's country,to defend one's country,卫国,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to dejta,to dejta,词,VERB,B2
-to delay (verb),to delay,耽搁,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delegate (verb),to delegate,委派,VERB,C1
-to delegitimize,to delegitimize,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to deliberate,to deliberate,深思熟虑,VERB,B2
-to delight,to delight,使高兴,VERB,B2
-to delimit,to delimit,词,VERB,C1
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to delude oneself,to delude oneself,词,VERB,B2
-to demand,to demand,要求,VERB,B2
-to densify,to densify,词,VERB,C1
-to depend on,to depend on,依赖,VERB,B2
-to depersonalize,to depersonalize,词,VERB,C1
-to deploy unfold,to deploy unfold,词,VERB,C1
-to deposit,to deposit,存放,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,词,VERB,B2
-to desert,to desert,擅离职守,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to design (verb),to design,词,VERB,B2
-to desire,to desire,渴望,VERB,B2
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to despise,to despise,鄙视,VERB,B2
-to destock,to destock,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to detail,to detail,详述,VERB,B2
-to determine (ver! b),to determine,确定,VER! B,B2
-to dialogue,to dialogue,对话,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to diffuse (verb),to diffuse,扩散,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to dimension (verb),to dimension,词,VERB,C1
-to direct,to direct,对准,VERB,B2
-to dirty (verb),to dirty,词,VERB,C1
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disarray (verb),to disarray,词,VERB,C1
-to discipline,to discipline,管教,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to discourse,to discourse,论述,VERB,B2
-to discredit (verb),to discredit,败坏名誉,VERB,C1
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disfavor,to disfavor,不利于,VERB,B2
-to disguise,to disguise,伪装,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to dishonor,to dishonor,使蒙羞,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dislike (verb),to dislike,嫌,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disoblige,to disoblige,词,VERB,C1
-to dispatch (verb),to dispatch,派遣,VERB,C1
-to dispense medicine,to dispense medicine,配药,VERB,B2
-to display,to display,显示,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to disproportion (verb),to disproportion,词,VERB,C1
-to disrespect (verb),to disrespect,词,VERB,C1
-to dissent (verb),to dissent,词,VERB,C1
-to dissipate,to dissipate,消散,VERB,B2
-to distance (verb),to distance,词,VERB,C1
-to distill,to distill,蒸馏,VERB,B2
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to diverge,to diverge,分歧,VERB,B2
-to divorce,to divorce,离婚,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do hair,to do hair,词,VERB,C1
-to do harm,to do harm,伤害,VERB,B2
-to do justice to,to do justice to,词,VERB,C1
-to do make,to do make,词,VERB,A1
-to do not know,to do not know,不知,VERB,B2
-to do one's best,to do one's best,尽力,VERB,B2
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do to make,to do to make,做,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to document,to document,记录,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to dote,to dote,词,VERB,B2
-to double,to double,加倍,VERB,B2
-to doubt,to doubt,怀疑,VERB,B2
-to download,to download,下载,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw blood,to draw blood,抽血,VERB,B2
-to draw on the experience of,to draw on the experience of,借鉴,VERB,B2
-to draw support from,to draw support from,借助,VERB,B2
-to draw up,to draw up,起草,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to dread (verb),to dread,惧怕,VERB,B2
-to dream (verb),to dream,做梦,VERB,B1
-to dress,to dress,给...穿衣,VERB,B2
-to dress up,to dress up,盛装打扮,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drive herd,to drive herd,词,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,驾驶,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry,to dry,弄干,VERB,B2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun,to dry in the sun,晾晒,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry out,to dry out,词,VERB,C1
-to dry up,to dry up,词,VERB,B2
-to duck (verb),to duck,词,VERB,C1
-to dull (verb),to dull,词,VERB,C1
-to dump,to dump,抛弃,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dust off,to dust off,词,VERB,C1
-to each other (adv),to each other,词,ADV,C1
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eavesdrop (verb),to eavesdrop,偷听,VERB,B2
-to eclipse,to eclipse,使失色,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to edit (verb),to edit,编辑,VERB,C1
-to elaborate,to elaborate,制定,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to email (verb),to email,词,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emphasize (verb),to emphasize,侧重,VERB,C1
-to empty,to empty,倒空,VERB,B2
-to encore (verb),to encore,词,VERB,C1
-to end (verb),to end,结束,VERB,B2
-to end up,to end up,最终到达,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to enter city,to enter city,进城,VERB,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to envy,to envy,羡慕,VERB,B2
-to equal,to equal,无异,VERB,B2
-to erect behave,to erect behave,词,VERB,B2
-to espy,to espy,窥探,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to estimate,to estimate,估计,VERB,B2
-to ever,to ever,里何尝,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to exchange,to exchange,交换,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to excuse,to excuse,原谅,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exercise (verb),to exercise,锻炼,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exile (verb),to exile,流放,VERB,C1
-to exist there is,to exist there is,存在/有,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to expatriate,to expatriate,使移居国外,VERB,B2
-to experience (verb),to experience,体验,VERB,B2
-to experiment,to experiment,实验,VERB,B2
-to export (verb),to export,出口,VERB,C1
-to express sympathy,to express sympathy,慰问,VERB,C1
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extract (verb),to extract,extract,VERB,C1
-to face (verb),to face,临,VERB,B2
-to fail to fulfill,to fail to fulfill,未履行,VERB,B2
-to faint,to faint,昏倒,VERB,B2
-to fake,to fake,伪造,VERB,B2
-to fall asleep,to fall asleep,入睡,VERB,B2
-to fall back,to fall back,回落,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall ill,to fall ill,患病,VERB,B2
-to fall in love,to fall in love,坠入爱河,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall silent,to fall silent,沉默,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to fart,to fart,放屁,VERB,B2
-to fast,to fast,禁食,VERB,B2
-to favor,to favor,偏袒,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to fear (verb),to fear,怕,VERB,B1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to ferret (verb),to ferret,搜寻,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight,to fight,对抗,VERB,B2
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file a case,to file a case,立案,VERB,B2
-to file expense,to file expense,报账,VERB,B2
-to file for record,to file for record,备案,VERB,B2
-to fill in,to fill in,填写,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to film (verb),to film,拍摄,VERB,B2
-to filter (verb),to filter,过滤,VERB,C1
-to finally,to finally,你可算,VERB,B2
-to finance,to finance,资助,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find out,to find out,找出,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fine,to fine,罚款,VERB,B2
-to fire,to fire,开火,VERB,B2
-to fire a gun,to fire a gun,开枪,VERB,B2
-to fish,to fish,钓鱼,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fit suit,to fit suit,适合,VERB,B2
-to fix to prepare,to fix to prepare,词,VERB,A2
-to fix to set,to fix to set,词,VERB,B1
-to flame (verb),to flame,词,VERB,B2
-to flash,to flash,闪烁,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flock (verb),to flock,群集,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flow,to flow,流动,VERB,B2
-to flow in,to flow in,词,VERB,C1
-to flow into,to flow into,词,VERB,C1
-to flush out,to flush out,词,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to focus,to focus,聚焦,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force,to force,强迫,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to form (verb),to form,形成,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to form to train,to form to train,词,VERB,B1
-to found a country,to found a country,建国,VERB,B2
-to fraction,to fraction,分割,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to frame,to frame,装框,VERB,B2
-to free (verb),to free,词,VERB,B1
-to frequent (verb),to frequent,常去,VERB,C1
-to frighten away,to frighten away,词,VERB,C1
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to function,to function,运作,VERB,B2
-to function to work,to function to work,词,VERB,B1
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse,to fuse,融合,VERB,B2
-to gain weight,to gain weight,变胖,VERB,B2
-to gallop (verb),to gallop,奔跑,VERB,C1
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to gaze (verb),to gaze,凝视,VERB,B2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquainted,to get acquainted,相互认识,VERB,B2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get along,to get along,词,VERB,B2
-to get angry,to get angry,生气,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get by,to get by,过得去,VERB,B2
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get fond of,to get fond of,词,VERB,C1
-to get into,to get into,陷入,VERB,B2
-to get into debt,to get into debt,词,VERB,C1
-to get lost,to get lost,迷路,VERB,B2
-to get off,to get off,词,VERB,B2
-to get off work,to get off work,下班,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get rid of,to get rid of,摆脱,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get stuck,to get stuck,词,VERB,B2
-to get tired,to get tired,疲劳,VERB,A2
-to get to know,to get to know,词,VERB,B1
-to get up,to get up,起床,VERB,B2
-to get used to,to get used to,习惯于,VERB,B2
-to gift (verb),to gift,词,VERB,B1
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give as a gift,to give as a gift,赠送,VERB,B2
-to give back,to give back,归还,VERB,B2
-to give birth,to give birth,分娩,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give to grant,to give to grant,予以,VERB,B2
-to give up,to give up,放弃,VERB,B2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glance,to glance,瞥,VERB,B2
-to glimpse,to glimpse,瞥见,VERB,B2
-to gloss,to gloss,注释,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back,to go back,回去,VERB,B2
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go bankrupt,to go bankrupt,破产,VERB,B2
-to go blind,to go blind,失明,VERB,B2
-to go crazy,to go crazy,发疯,VERB,B2
-to go deep into,to go deep into,深入,VERB,B2
-to go down,to go down,下去,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go first,to go first,先去,VERB,B2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in,to go in,进去,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,麻木,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go online,to go online,上网,VERB,B2
-to go out,to go out,出去,VERB,B2
-to go there,to go there,词,VERB,B1
-to go through,to go through,经历,VERB,B2
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up,to go up,上升,VERB,B2
-to go up again,to go up again,词,VERB,B1
-to go up in smoke,to go up in smoke,词,VERB,B2
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to gossip,to gossip,闲聊,VERB,B2
-to graduate,to graduate,毕业,VERB,B2
-to grant (verb),to grant,授予,VERB,B2
-to grasp firmly,to grasp firmly,抓紧,VERB,B2
-to graspen,to graspen,词,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to gray,to gray,变白,VERB,B2
-to grease,to grease,涂油,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to group,to group,分组,VERB,B2
-to grow fond of,to grow fond of,词,VERB,C1
-to grow old,to grow old,词,VERB,A1
-to grow up,to grow up,成长,VERB,B2
-to growl (verb),to growl,咆哮,VERB,B2
-to guarantee (verb),to guarantee,保证,VERB,B2
-to guard,to guard,看守,VERB,B2
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,猜中,VERB,B2
-to guide,to guide,引导,VERB,B2
-to guillotine,to guillotine,斩首,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to gurgle (verb),to gurgle,词,VERB,C1
-to hack,to hack,入侵；盗版,VERB,B2
-to haggle,to haggle,讨价还价,VERB,B2
-to hail,to hail,下冰雹,VERB,B2
-to hail inspect,to hail inspect,盘查,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to hand over,to hand over,交付,VERB,B2
-to handcuff,to handcuff,给…戴手铐,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,词,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to hang up,to hang up,挂断,VERB,B2
-to harangue (verb),to harangue,词,VERB,B2
-to harass,to harass,骚扰,VERB,B2
-to harbor,to harbor,怀有,VERB,B2
-to harden,to harden,使经受锻炼,VERB,B2
-to harm,to harm,损害,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,使和谐,VERB,B2
-to harvest,to harvest,收割,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have (aux),to have,词,AUX,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an accident,to have an accident,遭遇意外,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have breakfast,to have breakfast,吃早餐,VERB,B2
-to have dinner,to have dinner,吃晚餐,VERB,B2
-to have had enough,to have had enough,受够了,VERB,B2
-to have lunch,to have lunch,吃午餐,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have only,to have only,唯有,VERB,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to have to,to have to,必须,VERB,B2
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear a case,to hear a case,审理,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to heat,to heat,加热,VERB,B2
-to help assistance,to help assistance,帮助,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hide oneself,to hide oneself,躲藏,VERB,B2
-to hide to disappear,to hide to disappear,词,VERB,A2
-to highlight (verb),to highlight,突出,VERB,B2
-to hike,to hike,徒步旅行,VERB,B2
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold accountable,to hold accountable,问责,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold on,to hold on,抓住,VERB,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up,to hold up,词,VERB,B2
-to hold up stop,to hold up stop,词,VERB,A2
-to hollow out,to hollow out,词,VERB,C1
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to honk,to honk,按喇叭,VERB,B2
-to honor,to honor,尊敬,VERB,B2
-to hook (verb),to hook,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to hope to wish,to hope to wish,希望,VERB,B2
-to hospitalize,to hospitalize,使住院,VERB,B2
-to host,to host,接待,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to hug,to hug,拥抱,VERB,B2
-to hum,to hum,哼唱,VERB,B2
-to humanize,to humanize,使人性化,VERB,B2
-to humiliate,to humiliate,羞辱,VERB,B2
-to hunt,to hunt,打猎,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idealize,to idealize,理想化,VERB,B2
-to idolize,to idolize,崇拜,VERB,B2
-to ignite,to ignite,词,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to imbue,to imbue,词,VERB,C1
-to immigrate,to immigrate,移入,VERB,B2
-to immobilize,to immobilize,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to impart,to impart,传授,VERB,B2
-to impel,to impel,推动,VERB,B2
-to implant,to implant,植入,VERB,B2
-to implicate,to implicate,连累,VERB,B2
-to implore,to implore,恳求,VERB,B2
-to import (verb),to import,进口,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to imprint (verb),to imprint,词,VERB,C1
-to imprison,to imprison,监禁,VERB,B2
-to impute,to impute,归咎,VERB,B2
-to in spite of,to in spite of,不顾,VERB,B2
-to inaugurate,to inaugurate,启用,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incarcerate,to incarcerate,词,VERB,B2
-to incentivize,to incentivize,词,VERB,C1
-to incinerate,to incinerate,焚烧,VERB,B2
-to incite,to incite,煽动,VERB,B2
-to incline,to incline,使倾斜,VERB,B2
-to inconvenience,to inconvenience,使不便,VERB,B2
-to increase steadily,to increase steadily,与日俱增,VERB,B2
-to incur,to incur,招致,VERB,B2
-to indicate interpret,to indicate interpret,词,VERB,B2
-to indict,to indict,控告,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to indispose,to indispose,词,VERB,C1
-to indoctrinate,to indoctrinate,灌输,VERB,B2
-to induce to lead to,to induce to lead to,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to infest,to infest,滋生,VERB,B2
-to infiltrate,to infiltrate,渗透,VERB,B2
-to inflame,to inflame,使发炎,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict,to inflict,词,VERB,C1
-to inflict to impose,to inflict to impose,词,VERB,B2
-to influence,to influence,影响,VERB,B2
-to inform to reach,to inform to reach,词,VERB,A2
-to infringe,to infringe,侵犯,VERB,B2
-to infuse,to infuse,泡制,VERB,B2
-to ingest,to ingest,服用,VERB,B2
-to innovate,to innovate,词,VERB,C1
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insinuate,to insinuate,暗示,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to instill,to instill,灌输,VERB,B2
-to institute (verb),to institute,词,VERB,C1
-to institutionalize,to institutionalize,制度化,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to insure,to insure,保证,VERB,B2
-to intensify,to intensify,加剧,VERB,B2
-to interact,to interact,词,VERB,C1
-to intercede,to intercede,调停,VERB,B2
-to interest,to interest,使感兴趣,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to internalize,to internalize,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to intervene,to intervene,干预,VERB,B2
-to interview,to interview,采访,VERB,B2
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intoxicate,to intoxicate,使中毒,VERB,B2
-to intuit,to intuit,词,VERB,C1
-to invade,to invade,入侵,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoice,to invoice,开票,VERB,B2
-to invoke,to invoke,援引,VERB,B2
-to iron,to iron,熨烫,VERB,B2
-to ironize,to ironize,讽刺,VERB,B2
-to irrigate,to irrigate,灌溉,VERB,B2
-to issue,to issue,颁布,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to it (adv),to it,对此,ADV,B2
-to it is said that,to it is said that,据说,VERB,B2
-to itch,to itch,发痒,VERB,B2
-to jam (verb),to jam,词,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,词,VERB,B2
-to joke (verb),to joke,开玩笑,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to judge,to judge,判断,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to kiss,to kiss,亲吻,VERB,B2
-to knead,to knead,词,VERB,A1
-to kneel,to kneel,词,VERB,B1
-to knit,to knit,编织,VERB,B2
-to knock down,to knock down,词,VERB,B2
-to knock to pound,to knock to pound,词,VERB,A2
-to knot (verb),to knot,词,VERB,C1
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to know to recognize,to know to recognize,认识,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack,to lack,缺乏,VERB,B2
-to lack basis,to lack basis,无据,VERB,B2
-to land (verb),to land,降落,VERB,B1
-to languish,to languish,词,VERB,C1
-to last (verb),to last,持续,VERB,B1
-to last a period of time,to last a period of time,为期,VERB,B2
-to laugh smile,to laugh smile,笑,VERB,A1
-to lay down,to lay down,放下,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to lay put,to lay put,放,VERB,B2
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,使入歧途,VERB,B2
-to lead to,to lead to,通向,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to leaf through,to leaf through,翻阅,VERB,B2
-to leak,to leak,泄漏,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to lean out,to lean out,词,VERB,B2
-to leap,to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave behind,to leave behind,留下,VERB,B2
-to leave out,to leave out,省略,VERB,B2
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to,to leave to,词,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to lecture,to lecture,教导,VERB,B2
-to legislate,to legislate,词,VERB,C1
-to legitimize,to legitimize,使合法,VERB,B2
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lengthen,to lengthen,延长,VERB,B2
-to lessen,to lessen,词,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let go,to let go,放开,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to level,to level,夷平,VERB,B2
-to levy,to levy,征收,VERB,C1
-to license (verb),to license,词,VERB,B2
-to lie down,to lie down,躺,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,词,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to light,to light,照亮,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,词,VERB,B2
-to lighten,to lighten,减轻,VERB,B2
-to like (aux),to like,词,AUX,A2
-to limit,to limit,限制,VERB,B2
-to limp,to limp,跛行,VERB,B2
-to line up,to line up,排成一行,VERB,B2
-to link (verb),to link,词,VERB,C1
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to list,to list,列举,VERB,B2
-to listen attentively,to listen attentively,倾听,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live in,to live in,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to load,to load,装载,VERB,B2
-to load charge,to load charge,装载,VERB,B2
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lock,to lock,锁上,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lock up,to lock up,关押,VERB,B2
-to lockdown,to lockdown,封城,VERB,B2
-to lodge,to lodge,词,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to log in,to log in,登录,VERB,B2
-to loiter,to loiter,词,VERB,C1
-to long (verb),to long,词,VERB,B2
-to long for,to long for,渴望,VERB,B2
-to look after,to look after,照料,VERB,B2
-to look at,to look at,观看,VERB,B2
-to look down upon,to look down upon,看不起,VERB,B2
-to look for,to look for,寻找,VERB,B2
-to look for to find,to look for to find,找,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to look up,to look up,查阅,VERB,B2
-to loosen,to loosen,放松,VERB,B2
-to loot (verb),to loot,词,VERB,C1
-to lose (noun),to lose,上丢,NOUN,B2
-to lose bid,to lose bid,落标,VERB,B2
-to lose face,to lose face,丢脸,VERB,B2
-to lose heart,to lose heart,灰心,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to lose weight,to lose weight,减肥,VERB,B2
-to love,to love,爱,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower,to lower,降低,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lunge,to lunge,词,VERB,C1
-to lure (verb),to lure,词,VERB,B2
-to lurk,to lurk,词,VERB,B2
-to machine wash,to machine wash,机洗,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to magnify,to magnify,放大,VERB,B2
-to maim,to maim,词,VERB,C1
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a mistake,to make a mistake,弄错,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make a speech,to make a speech,发言,VERB,B2
-to make bland,to make bland,使乏味,VERB,B2
-to make do,to make do,做,VERB,B2
-to make drowsy,to make drowsy,词,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make heavier,to make heavier,加重,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,词,VERB,C1
-to make lasting,to make lasting,词,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make noise,to make noise,闹得,VERB,B2
-to make one's way,to make one's way,词,VERB,B2
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make proud,to make proud,使自豪,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make sure,to make sure,确保,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to make up for,to make up for,弥补,VERB,B2
-to make up for substitute,to make up for substitute,词,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manure (verb),to manure,词,VERB,C1
-to map out,to map out,摸清,VERB,B2
-to marinate,to marinate,腌制,VERB,B2
-to mark (verb),to mark,标记,VERB,B1
-to mark out,to mark out,标示,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to marvel,to marvel,使惊奇,VERB,B2
-to mash (verb),to mash,词,VERB,A2
-to massacre (verb),to massacre,词,VERB,C1
-to mast,to mast,降伏,VERB,B2
-to master,to master,掌握,VERB,B2
-to match,to match,相配,VERB,B2
-to matter,to matter,重要,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to maximize,to maximize,词,VERB,C1
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to head to,to mean to head to,词,VERB,A2
-to mean to think,to mean to think,词,VERB,C1
-to meant,to meant,意思是,VERB,B2
-to measure,to measure,测量,VERB,B2
-to meddle,to meddle,干涉,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mend,to mend,修补,VERB,B2
-to mention to remember,to mention to remember,词,VERB,A2
-to merge (verb),to merge,合并,VERB,C1
-to mess about,to mess about,胡搞,VERB,B2
-to mess around,to mess around,胡闹,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mime (verb),to mime,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to minimize,to minimize,最小化,VERB,B2
-to mirror,to mirror,反映,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to missed,to missed,错过,VERB,B2
-to mistake,to mistake,弄错,VERB,B2
-to mistreat,to mistreat,أساء,VERB,B2
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to moan,to moan,呻吟,VERB,B2
-to model (verb),to model,词,VERB,C1
-to modernize,to modernize,词,VERB,C1
-to monitor,to monitor,监控,VERB,B2
-to monopolize,to monopolize,垄断,VERB,B2
-to moon (verb),to moon,词,VERB,A2
-to moor (verb),to moor,词,VERB,B2
-to mop (verb),to mop,词,VERB,A2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to mortgage,to mortgage,抵押,VERB,B2
-to move aside,to move aside,移开,VERB,B2
-to move away,to move away,移开,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move house,to move house,搬家,VERB,B2
-to move in,to move in,搬入,VERB,B2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to move touch,to move touch,使感动,VERB,B2
-to mud (verb),to mud,词,VERB,C1
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to murder,to murder,谋杀,VERB,B2
-to mutiny,to mutiny,煽动叛乱,VERB,B2
-to mutter,to mutter,嘟囔,VERB,B2
-to mystify,to mystify,神秘化,VERB,B2
-to nag,to nag,唠叨,VERB,B2
-to nail,to nail,钉,VERB,B2
-to name,to name,命名,VERB,B2
-to narrow,to narrow,使变窄,VERB,B2
-to nationalize,to nationalize,国有化,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need (aux),to need,还要,AUX,B2
-to need must,to need must,词,VERB,A2
-to neglect,to neglect,忽视,VERB,B2
-to neigh,to neigh,嘶鸣,VERB,B2
-to neutralize,to neutralize,中和,VERB,B2
-to nibble,to nibble,啃,VERB,B2
-to nickname,to nickname,给...起绰号,VERB,B2
-to nod,to nod,点头,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not about,to not about,不关,VERB,B2
-to not come,to not come,不来,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not have,to not have,没,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note,to note,记录,VERB,B2
-to note down,to note down,词,VERB,B2
-to notice,to notice,注意到,VERB,B2
-to notify,to notify,通知,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to nuance,to nuance,使具有细微差别,VERB,B2
-to numb,to numb,使麻木,VERB,B2
-to number (verb),to number,词,VERB,C1
-to object,to object,反对,VERB,B2
-to objectify,to objectify,客观化,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to obstruct,to obstruct,阻碍,VERB,B2
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to occur to,to occur to,词,VERB,B2
-to ogle,to ogle,词,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to optimize,to optimize,优化,VERB,B2
-to order (verb),to order,下令,VERB,C1
-to orient,to orient,词,VERB,B2
-to orient to guide,to orient to guide,词,VERB,C1
-to ostracize,to ostracize,排斥,VERB,B2
-to oust,to oust,推翻,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to outline,to outline,勾勒,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overdraw,to overdraw,透支,VERB,B2
-to overestimate,to overestimate,词,VERB,C1
-to overflow,to overflow,溢出,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to overstep,to overstep,越权,VERB,B2
-to overthrow (verb),to overthrow,推翻,VERB,C1
-to overturn,to overturn,打翻,VERB,B2
-to own (verb),to own,词,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,词,VERB,C1
-to package (verb),to package,词,VERB,C1
-to paint,to paint,粉刷,VERB,B2
-to paint over,to paint over,重新粉刷,VERB,B2
-to pair (verb),to pair,词,VERB,C1
-to panic (verb),to panic,词,VERB,C1
-to pant,to pant,喘气,VERB,B2
-to parade,to parade,游行,VERB,B2
-to pardon,to pardon,赦免,VERB,B2
-to park,to park,停车,VERB,B2
-to part,to part,分离,VERB,B2
-to part by death,to part by death,死别,VERB,B2
-to part forever,to part forever,永别,VERB,B2
-to party,to party,狂欢,VERB,B2
-to pass,to pass,通过,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass away,to pass away,流逝,VERB,B2
-to pass by,to pass by,经过,VERB,B2
-to pass on,to pass on,转交,VERB,B2
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to pat,to pat,轻拍,VERB,B2
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pause,to pause,暂停,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention,to pay attention,注意,VERB,B2
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay respects,to pay respects,参见,VERB,B2
-to pay smilingly,to pay smilingly,笑付,VERB,B2
-to pay tax,to pay tax,纳税,VERB,B2
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to peel,to peel,削皮,VERB,B2
-to pension off,to pension off,词,VERB,C1
-to perfect,to perfect,精修,VERB,B2
-to perforate,to perforate,词,VERB,C1
-to perform umrah,to perform umrah,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to permit,to permit,允许,VERB,B2
-to perpetrate,to perpetrate,词,VERB,C1
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to personify,to personify,词,VERB,C1
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to phone (verb),to phone,词,VERB,B2
-to photocopy,to photocopy,复印,VERB,B2
-to photograph,to photograph,拍照,VERB,B2
-to pick out,to pick out,挑选,VERB,B2
-to pick up,to pick up,捡起,VERB,B2
-to pick up a car,to pick up a car,取车,VERB,B2
-to pickle,to pickle,腌渍,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pile up,to pile up,堆积,VERB,B2
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pin,to pin,别住,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to pity,to pity,同情,VERB,B2
-to place,to place,放置,VERB,B2
-to place put,to place put,放置,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plan,to plan,计划,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant (verb),to plant,种植,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant out,to plant out,定植,VERB,B2
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to please,to please,使高兴,VERB,B2
-to pledge mutually,to pledge mutually,词,VERB,C1
-to plot,to plot,密谋,VERB,B2
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plug in,to plug in,插入,VERB,B2
-to plunder,to plunder,掠夺,VERB,B2
-to point,to point,指向,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to point out,to point out,指出,VERB,B2
-to point to clock in,to point to clock in,词,VERB,B2
-to poison,to poison,毒害,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to polemicize,to polemicize,词,VERB,C1
-to pollute,to pollute,词,VERB,B2
-to popularize,to popularize,推广,VERB,B2
-to populate,to populate,居住,VERB,B2
-to portend,to portend,词,VERB,B2
-to position,to position,定位 / 安置,VERB,B2
-to post,to post,张贴,VERB,B2
-to postpone to carry over,to postpone to carry over,推迟,VERB,B2
-to pounce,to pounce,猛扑,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to powder,to powder,撒粉,VERB,B2
-to practice (verb),to practice,实践,VERB,C1
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to prepare a lesson,to prepare a lesson,预习,VERB,B2
-to present (verb),to present,呈现,VERB,B1
-to preserve to protect,to preserve to protect,词,VERB,C1
-to press,to press,按,VERB,B2
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to pretend to be,to pretend to be,冒充,VERB,B2
-to prick,to prick,扎,VERB,B2
-to prioritize,to prioritize,优先考虑,VERB,B2
-to privatize,to privatize,私有化,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to process,to process,处理,VERB,B2
-to proclaim,to proclaim,宣布,VERB,B2
-to procure,to procure,获取,VERB,B2
-to profile (verb),to profile,词,VERB,C1
-to program,to program,编程,VERB,B2
-to progress,to progress,进步,VERB,B2
-to project,to project,投射,VERB,B2
-to promise (verb),to promise,答应,VERB,C1
-to prop,to prop,撑,VERB,B2
-to prop up,to prop up,支撑,VERB,B2
-to prophesy,to prophesy,预言,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to protest,to protest,抗议,VERB,B2
-to provide evidence,to provide evidence,举证,VERB,B2
-to provide feedback,to provide feedback,反馈,VERB,B2
-to provide for,to provide for,供应,VERB,B2
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pucker,to pucker,噘,VERB,B2
-to pull out hair,to pull out hair,词,VERB,C1
-to pull through,to pull through,词,VERB,B2
-to pump (verb),to pump,词,VERB,C1
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purchase,to purchase,购买,VERB,B2
-to purge,to purge,清除,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push through,to push through,推动,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put away,to put away,词,VERB,B2
-to put back,to put back,放回,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put down,to put down,放下,VERB,B2
-to put in order,to put in order,收拾,VERB,B2
-to put on,to put on,穿上,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,使走上正轨,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to puzzle (verb),to puzzle,迷惑,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to quarrel,to quarrel,争吵,VERB,B2
-to question (verb),to question,提问,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to race (verb),to race,词,VERB,B1
-to race down,to race down,词,VERB,C1
-to radiate,to radiate,辐射,VERB,B2
-to rage,to rage,狂怒,VERB,B2
-to rain,to rain,下雨,VERB,B2
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise donations,to raise donations,募捐,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rape,to rape,强奸,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to reason (verb),to reason,推理,VERB,B2
-to rebel,to rebel,反叛,VERB,B2
-to rebuke,to rebuke,斥责,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive mail,to receive mail,收件,VERB,B2
-to receive orders,to receive orders,受命,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to receive worldwide attention,to receive worldwide attention,举世瞩目,VERB,B2
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record (verb),to record,备案,VERB,B1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to recreate,to recreate,重建,VERB,B2
-to recuperate,to recuperate,恢复,VERB,B2
-to redden,to redden,变红,VERB,B2
-to rediscover,to rediscover,重新发现,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to reform (verb),to reform,改革,VERB,B2
-to refrain (verb),to refrain,就别,VERB,B2
-to refuel,to refuel,加油,VERB,B2
-to regain,to regain,恢复,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to regret apologize,to regret apologize,词,VERB,B2
-to regulate,to regulate,调节,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to reimburse,to reimburse,偿还,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to reissue,to reissue,补办,VERB,B2
-to rejoice,to rejoice,欢欣,VERB,B2
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relate to narrate,to relate to narrate,叙述,VERB,B2
-to relativize,to relativize,词,VERB,C1
-to relaunch,to relaunch,重启,VERB,B2
-to release from prison,to release from prison,释放,VERB,B2
-to release let go,to release let go,词,VERB,B2
-to release me,to release me,放我,VERB,B2
-to relocate,to relocate,调动,VERB,B2
-to rely on,to rely on,依靠,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remove to pull out,to remove to pull out,词,VERB,A2
-to remunerate,to remunerate,词,VERB,C1
-to renew,to renew,更新,VERB,B2
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to rent (verb),to rent,租,VERB,A1
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,词,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repay,to repay,偿还,VERB,B2
-to repeal,to repeal,废除,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to reply,to reply,回复,VERB,B2
-to report (verb),to report,报,VERB,B2
-to report back,to report back,复命,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to reproach,to reproach,责备,VERB,B2
-to request,to request,请求,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to rescue,to rescue,拯救,VERB,B2
-to research,to research,研究,VERB,B2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resolve doubts,to resolve doubts,解惑,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to,to respond to,回应,VERB,B2
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to rest,to rest,休息,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to result,to result,产生,VERB,B2
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retell,to retell,转述,VERB,B2
-to retreat,to retreat,撤退,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return first,to return first,先回,VERB,B2
-to return home,to return home,词,VERB,B1
-to return something,to return something,词,VERB,A2
-to return to restore,to return to restore,词,VERB,C1
-to return visit,to return visit,回访,VERB,B2
-to revalue,to revalue,重新估值,VERB,B2
-to review,to review,复习,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revive,to revive,复兴,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to reward,to reward,奖励,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to riddle,to riddle,使布满孔洞,VERB,B2
-to ride along,to ride along,词,VERB,B1
-to ridicule (verb),to ridicule,词,VERB,C1
-to ring,to ring,鸣响,VERB,B2
-to rinse,to rinse,冲洗,VERB,B2
-to risk,to risk,冒险,VERB,B2
-to risk life,to risk life,拼命,VERB,B2
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to roast,to roast,煎烤,VERB,B2
-to roast lamb,to roast lamb,烤羊,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll,to roll,滚动,VERB,B2
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to roof,to roof,房顶,VERB,B2
-to root out,to root out,词,VERB,C1
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to rough-hew,to rough-hew,粗加工,VERB,B2
-to round (verb),to round,词,VERB,A2
-to row,to row,划船,VERB,B2
-to ruffle,to ruffle,词,VERB,C1
-to rule,to rule,统治,VERB,B2
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to run into,to run into,碰见,VERB,B2
-to run over,to run over,碾过,VERB,B2
-to run quickly,to run quickly,奔驰,VERB,B2
-to run to jog,to run to jog,跑步,VERB,B2
-to rush about,to rush about,奔波,VERB,B2
-to sabotage,to sabotage,破坏,VERB,B2
-to sacrifice,to sacrifice,牺牲,VERB,B2
-to sadden,to sadden,使悲伤,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanctify,to sanctify,使神圣,VERB,B2
-to sanction,to sanction,认可,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to saw,to saw,锯,VERB,B2
-to say goodbye,to say goodbye,告别,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scald,to scald,烫伤,VERB,B2
-to scamper,to scamper,词,VERB,B2
-to scare,to scare,惊吓,VERB,B2
-to scare away,to scare away,词,VERB,B2
-to scent,to scent,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scheme (verb),to scheme,词,VERB,C1
-to scold,to scold,训斥,VERB,B2
-to score (verb),to score,词,VERB,B2
-to scourge (verb),to scourge,词,VERB,C1
-to scout,to scout,侦察,VERB,B2
-to scram,to scram,词,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch,to scratch,抓,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to screen,to screen,筛选,VERB,B2
-to screw,to screw,拧,VERB,B2
-to scribble (verb),to scribble,词,VERB,C1
-to scrimp,to scrimp,词,VERB,C1
-to sculpt,to sculpt,词,VERB,C1
-to search apply,to search apply,词,VERB,B2
-to search for,to search for,寻找,VERB,B2
-to season,to season,调味,VERB,B2
-to seat,to seat,使坐下,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to secure (verb),to secure,获得,VERB,B2
-to see again,to see again,再见,VERB,B2
-to see corpse,to see corpse,见尸,VERB,B2
-to see emperor,to see emperor,面圣,VERB,C1
-to see through,to see through,看穿,VERB,B2
-to seek,to seek,寻找,VERB,B2
-to seek audience,to seek audience,求见,VERB,B2
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek truth from facts,to seek truth from facts,实事求是,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segment (verb),to segment,词,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sense,to sense,隐约感到,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to sentence (verb),to sentence,量刑,VERB,B2
-to separate (verb),to separate,分开,VERB,C1
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set a record,to set a record,创造纪录,VERB,B2
-to set aside,to set aside,移开,VERB,B2
-to set off,to set off,出发,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to set up,to set up,建立,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sew in,to sew in,词,VERB,C1
-to sexualize,to sexualize,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to shake hands,to shake hands,握手,VERB,B2
-to shame,to shame,使羞愧,VERB,B2
-to shape,to shape,塑造,VERB,B2
-to share divide,to share divide,分享,VERB,B2
-to sharpen,to sharpen,磨快,VERB,B2
-to shave,to shave,剃,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shelter,to shelter,庇护,VERB,B2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shift to an earlier date,to shift to an earlier date,提前,VERB,B2
-to ship out,to ship out,出货,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shock,to shock,震惊,VERB,B2
-to shoe (verb),to shoe,词,VERB,C1
-to shoot dead,to shoot dead,词,VERB,B2
-to shoot down,to shoot down,击落,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop,to shop,购物,VERB,B2
-to shop be about,to shop be about,购物,VERB,B2
-to shop for groceries,to shop for groceries,词,VERB,A2
-to shorten,to shorten,缩短,VERB,B2
-to shout,to shout,吼叫,VERB,B2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show favoritism,to show favoritism,徇私,VERB,B2
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shower,to shower,淋浴,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sidestep,to sidestep,词,VERB,C1
-to sift,to sift,筛选,VERB,B2
-to sigh,to sigh,叹气,VERB,B2
-to sigh with sorrow,to sigh with sorrow,感慨,VERB,B2
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign (verb),to sign,签字,VERB,B1
-to sign for,to sign for,签收,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to signal,to signal,示意,VERB,B2
-to signify,to signify,意味着,VERB,B2
-to silence,to silence,خرس,VERB,B2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to simplify,to simplify,简化,VERB,B2
-to singe,to singe,词,VERB,B2
-to sink,to sink,下沉,VERB,B2
-to sip,to sip,小口喝,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to sit down,to sit down,坐下,VERB,B2
-to situate,to situate,定位,VERB,B2
-to skate,to skate,滑冰,VERB,B2
-to skein,to skein,绕成线团,VERB,B2
-to sketch,to sketch,勾勒,VERB,B2
-to skewer,to skewer,串起,VERB,B2
-to skim,to skim,轻触,VERB,B2
-to skin,to skin,剥皮,VERB,B2
-to skip,to skip,词,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slander (verb),to slander,诽谤,VERB,B2
-to slap,to slap,打耳光,VERB,B2
-to slaughter,to slaughter,割喉,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slay,to slay,词,VERB,C1
-to sleep (verb),to sleep,睡,VERB,A1
-to slice (verb),to slice,词,VERB,C1
-to slide,to slide,滑动,VERB,B2
-to slight,to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to slope down,to slope down,词,VERB,B2
-to slow down,to slow down,放慢,VERB,B2
-to smile,to smile,微笑,VERB,B2
-to smoke (verb),to smoke,吸烟,VERB,A2
-to smooth,to smooth,使光滑,VERB,B2
-to snack (verb),to snack,词,VERB,C1
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to sneak away,to sneak away,溜走,VERB,B2
-to sneeze,to sneeze,打喷嚏,VERB,B2
-to snoop,to snoop,窥探,VERB,B2
-to snore,to snore,打鼾,VERB,B2
-to snort (verb),to snort,词,VERB,B2
-to snow,to snow,下雪,VERB,B2
-to soak,to soak,浸透,VERB,B2
-to socialize,to socialize,交往,VERB,B2
-to soften,to soften,使灵活,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solicit donations,to solicit donations,募捐,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to solve a case,to solve a case,破案,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort,to sort,分类,VERB,B2
-to sort out,to sort out,词,VERB,B2
-to sound,to sound,响起,VERB,B2
-to sour (verb),to sour,词,VERB,C1
-to sow (verb),to sow,播种,VERB,B2
-to spam,to spam,发垃圾信息,VERB,B2
-to spare,to spare,节省,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to spawn,to spawn,产卵,VERB,B2
-to specify,to specify,具体说明,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spend time,to spend time,词,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spirit away,to spirit away,变走,VERB,B2
-to splash (verb),to splash,溅,VERB,B2
-to splint,to splint,用夹板固定,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to sponsor,to sponsor,赞助,VERB,B2
-to spot,to spot,看见,VERB,B2
-to spout,to spout,喷射,VERB,B2
-to spray (verb),to spray,词,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to sprinkle,to sprinkle,撒,VERB,B2
-to spy,to spy,监视,VERB,B2
-to spy on,to spy on,词,VERB,C1
-to squeak (verb),to squeak,词,VERB,B2
-to stabilize,to stabilize,使稳定,VERB,B2
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stagnate,to stagnate,停滞,VERB,B2
-to stall,to stall,拖延,VERB,B2
-to stammer,to stammer,结巴,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to stand out,to stand out,引人注目,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to stand side by side,to stand side by side,并列,VERB,B2
-to stand up,to stand up,站起来,VERB,B2
-to standardize,to standardize,标准化,VERB,B2
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start (verb),to start,下手,VERB,A1
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to state,to state,说明,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steam,to steam,蒸,VERB,B2
-to steep (verb),to steep,词,VERB,C1
-to steer,to steer,引导,VERB,B2
-to steer control,to steer control,控制,VERB,B2
-to stem from,to stem from,源于,VERB,B2
-to step,to step,踩,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stew,to stew,炖,VERB,B2
-to stick,to stick,插入,VERB,B2
-to stick out,to stick out,伸出,VERB,B2
-to stiffen,to stiffen,词,VERB,C1
-to stifle smother,to stifle smother,词,VERB,B2
-to stigmatize,to stigmatize,污名化,VERB,B2
-to stimulate,to stimulate,激发,VERB,B2
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop bleeding,to stop bleeding,止血,VERB,B2
-to stop down,to stop down,词,VERB,C1
-to stop me,to stop me,拦我,VERB,B2
-to store,to store,储存,VERB,B2
-to straighten up,to straighten up,词,VERB,B2
-to strain,to strain,努力,VERB,B2
-to strangle,to strangle,扼杀,VERB,B2
-to strengthen,to strengthen,加强,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to strictly prohibit,to strictly prohibit,严禁,VERB,B2
-to stride (verb),to stride,词,VERB,B2
-to strike,to strike,打击,VERB,B2
-to strike down,to strike down,击倒,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip,to strip,裸露,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive,to strive,努力,VERB,B2
-to strive for,to strive for,争取,VERB,B2
-to stroll,to stroll,散步,VERB,B2
-to structure,to structure,构建,VERB,B2
-to struggle,to struggle,挣扎,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stuff,to stuff,填塞,VERB,B2
-to stumble,to stumble,绊倒,VERB,B2
-to stun,to stun,词,VERB,C1
-to stutter,to stutter,词,VERB,B2
-to stylize,to stylize,词,VERB,C1
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to submit to,to submit to,顺从,VERB,B2
-to subordinate (verb),to subordinate,从属,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to succeed to pass,to succeed to pass,词,VERB,A2
-to suck,to suck,吸,VERB,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer from insomnia,to suffer from insomnia,失眠,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to suffocate,to suffocate,窒息,VERB,B2
-to suit,to suit,适合,VERB,B2
-to suit agree,to suit agree,词,VERB,B2
-to sulk,to sulk,生闷气,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplement,to supplement,补充,VERB,B2
-to supply,to supply,供货,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surge (verb),to surge,词,VERB,B2
-to surname (verb),to surname,词,VERB,B2
-to surpass,to surpass,超过,VERB,B2
-to surprise,to surprise,使惊讶,VERB,B2
-to surveil,to surveil,监视,VERB,B2
-to survey,to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture,to suture,缝合,VERB,B2
-to swallow up,to swallow up,词,VERB,B2
-to swarm,to swarm,分群,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to sweat,to sweat,出汗,VERB,B2
-to sweeten,to sweeten,使变甜,VERB,B2
-to swell,to swell,使肿胀,VERB,B2
-to swindle,to swindle,诈骗,VERB,B2
-to swing,to swing,荡秋千,VERB,B2
-to swipe,to swipe,词,VERB,C1
-to switch,to switch,切换,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to symbolize,to symbolize,象征,VERB,B2
-to sympathize,to sympathize,同情,VERB,B2
-to synchronize,to synchronize,词,VERB,C1
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to tag (verb),to tag,词,VERB,C1
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a leave of absence,to take a leave of absence,休学,VERB,B2
-to take a photo,to take a photo,照相,VERB,B2
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take along,to take along,带走,VERB,B2
-to take amiss,to take amiss,词,VERB,C1
-to take away,to take away,拿走,VERB,B2
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care,to take care,照顾,VERB,B2
-to take care of,to take care of,照顾,VERB,B2
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take cuttings,to take cuttings,扦插,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,词,VERB,B2
-to take off,to take off,起飞,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take office,to take office,就职,VERB,B2
-to take on,to take on,词,VERB,C1
-to take one's time,to take one's time,词,VERB,B2
-to take out,to take out,拿出,VERB,B2
-to take over,to take over,接管,VERB,B2
-to take place,to take place,举行,VERB,B2
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take revenge,to take revenge,报复,VERB,B2
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to talk,to talk,谈话,VERB,B2
-to talk chat,to talk chat,词,VERB,B2
-to talk nonsense,to talk nonsense,胡言乱语,VERB,B2
-to tap to type,to tap to type,词,VERB,C1
-to target (verb),to target,针对,VERB,B2
-to tarnish,to tarnish,词,VERB,C1
-to task (verb),to task,词,VERB,C1
-to taste,to taste,品尝,VERB,B2
-to tax,to tax,征税,VERB,B2
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to teach reading,to teach reading,词,VERB,B2
-to tear (verb),to tear,撕,VERB,C1
-to tear down,to tear down,拆除,VERB,B2
-to tear out,to tear out,拔出,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to tear up,to tear up,流泪,VERB,B2
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to tell to narrate,to tell to narrate,词,VERB,A2
-to temper (verb),to temper,词,VERB,B2
-to tense (verb),to tense,词,VERB,B2
-to test,to test,测试,VERB,B2
-to text,to text,发短信,VERB,B2
-to thank,to thank,感谢,VERB,B2
-to thaw,to thaw,解冻,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to there's still time,to there's still time,来得及,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,词,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,认为,VERB,B2
-to think to want,to think to want,想,VERB,B2
-to think up,to think up,构思,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
 to thresh,to thresh,脱粒,VERB,B2
-to thrill,to thrill,使兴奋,VERB,B2
+thrifty,thrifty,节俭的,ADJ,B2
 to thrive,to thrive,茁壮成长,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrown,to thrown,词,VERB,B2
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy,to tidy,整理,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
+throw,throw,投掷,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+thursday,thursday,星期四,NOUN,B2
 to tidy up,to tidy up,整理,VERB,B2
 to tie,to tie,联结,VERB,B2
-to tie up,to tie up,绑,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+tiger,tiger,老虎,NOUN,B2
 to tighten,to tighten,紧握/收紧,VERB,B2
-to tinker,to tinker,词,VERB,B1
-to tip (verb),to tip,词,VERB,B2
-to tip over,to tip over,翻倒,VERB,B2
-to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
-to title,to title,命名,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toast (verb),to toast,词,VERB,B2
-to toil (verb),to toil,词,VERB,C1
-to topple,to topple,词,VERB,C1
-to torment,to torment,折磨,VERB,B2
-to torture,to torture,折磨,VERB,B2
-to total,to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to tow,to tow,词,VERB,C1
-to trace,to trace,描绘；标出,VERB,B2
-to track,to track,追踪,VERB,B2
-to train (verb),to train,培训,VERB,B2
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to trample,to trample,踩踏,VERB,B2
-to transfer,to transfer,转移,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transport,to transport,运输,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to tread,to tread,踏上,VERB,B2
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat guests,to treat guests,请客,VERB,B2
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to tremble,to tremble,颤抖,VERB,B2
-to trick (verb),to trick,欺骗,VERB,B2
-to trigger (verb),to trigger,引发,VERB,B2
-to trivialize,to trivialize,使平庸,VERB,B2
-to trouble,to trouble,有劳,VERB,B2
-to try hard to,to try hard to,力图,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tune,to tune,调谐,VERB,B2
-to turn around,to turn around,转身,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn off,to turn off,关闭,VERB,B2
-to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
-to turn on,to turn on,打开,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn out,to turn out,结果是,VERB,B2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to twinkle,to twinkle,词,VERB,B2
-to type,to type,打字,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbalance,to unbalance,词,VERB,C1
-to unbend,to unbend,词,VERB,B2
-to unblind,to unblind,词,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to unbutton,to unbutton,解开纽扣,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to uncover,to uncover,揭露,VERB,B2
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to undo,to undo,解开,VERB,B2
-to undress,to undress,脱衣,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unhook,to unhook,摘下,VERB,B2
-to unite,to unite,联合,VERB,B2
-to unload,to unload,卸货,VERB,B2
-to unmask,to unmask,揭穿,VERB,B2
-to unpack,to unpack,拆包,VERB,B2
-to unplug,to unplug,词,VERB,C1
-to unroll,to unroll,词,VERB,C1
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to untangle,to untangle,词,VERB,C1
-to untie,to untie,解开,VERB,B2
-to unwrap,to unwrap,词,VERB,B1
-to uproot,to uproot,根除,VERB,B2
-to upset,to upset,使生气,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use chopsticks,to use chopsticks,动筷,VERB,B2
-to use crutches,to use crutches,拄拐,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to use up,to use up,用完,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to vaccinate,to vaccinate,接种疫苗,VERB,B2
-to vacuum (verb),to vacuum,词,VERB,A2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to vent,to vent,倾诉,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to view (verb),to view,参观,VERB,B2
-to violate discipline,to violate discipline,违纪,VERB,B2
-to vote,to vote,表决,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wage war,to wage war,作战,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to wait long,to wait long,久等,VERB,B2
-to wake,to wake,唤醒,VERB,B2
-to wake up,to wake up,叫醒,VERB,B2
-to walk,to walk,走,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to want (aux),to want,欲,AUX,A2
-to want alive,to want alive,活要,VERB,C1
-to want to need will,to want to need will,要,VERB,B2
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to was,to was,是,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to waste,to waste,浪费,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch out,to watch out,小心,VERB,B2
-to watch tv,to watch tv,看电视,VERB,B2
-to water,to water,浇水,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wave,to wave,挥手,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to weaken,to weaken,削弱,VERB,B2
-to wear down,to wear down,词,VERB,B2
-to wear out,to wear out,磨损,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,使厌倦,VERB,B2
-to wed,to wed,词,VERB,C1
-to wedge,to wedge,卡住,VERB,B2
-to weed (verb),to weed,词,VERB,C1
-to weigh down,to weigh down,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whimper,to whimper,呜咽,VERB,B2
-to whine,to whine,哀叹,VERB,B2
-to whistle,to whistle,吹口哨,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to widen,to widen,加宽,VERB,B2
-to wilt,to wilt,枯萎,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wind,to wind,缠绕,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw a lawsuit,to withdraw a lawsuit,撤诉,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to wither,to wither,词,VERB,B2
-to witness,to witness,目击,VERB,B2
-to wobble,to wobble,摇晃,VERB,B2
-to won't do,to won't do,不成,VERB,B2
-to woo,to woo,词,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work,to work,工作,VERB,B2
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work hard for sth to strive for success,to work hard for sth to strive for success,争气,VERB,B2
-to work out,to work out,成功,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen,to worsen,恶化,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to worship,to worship,崇拜,VERB,B2
-to wound,to wound,使受伤,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wring,to wring,拧干,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn for,to yearn for,渴望,VERB,B2
-to yell,to yell,大吼,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-to zero out,to zero out,清零,VERB,B2
-toad,toad,蟾蜍,NOUN,B2
+tile,tile,瓦片,NOUN,B2
+timing,timing,时机,NOUN,B2
+tingling,tingling,麻木感,NOUN,B2
+tire,tire,轮胎,NOUN,B2
+tiredness,tiredness,疲劳,NOUN,B2
+tissue,tissue,组织,NOUN,B2
 toast,toast,你敬酒,NOUN,B2
 today,today,今天,NOUN,B2
-today (noun),today,今,NOUN,B2
-today's,today's,词,ADJ,C1
 tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
 together,together,共同的,ADJ,B2
-together (adj),together,共同的,ADJ,B2
-togetherness,togetherness,词,NOUN,C1
 toil,toil,苦工,NOUN,B2
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toiling,toiling,词,ADJ,C1
-told instructed,told instructed,被告知的,ADJ,B2
 tolerance,tolerance,宽容,NOUN,B2
-tolerance dependence,tolerance dependence,词,NOUN,C1
-tolerant,tolerant,宽容的,ADJ,B2
-tomb monument,tomb monument,词,NOUN,B2
-tombstone,tombstone,词,NOUN,C1
 tomorrow,tomorrow,غد,NOUN,B2
-tomorrow (noun),tomorrow,明天,NOUN,B2
-tomorrow night,tomorrow night,明晚,ADV,B2
-tonality,tonality,词,NOUN,C1
-tonic (adj),tonic,词,ADJ,C1
 tonight,tonight,今晚,NOUN,B2
-tonight (noun),tonight,词,NOUN,B2
-tonsil,tonsil,词,NOUN,B2
 too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
-too much,too much,太,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
 too small,too small,太小,ADJ,B2
-too soft,too soft,太软,NOUN,B2
-tool room,tool room,工具间,NOUN,B2
-tooling,tooling,词,NOUN,C1
 tools,tools,工具,NOUN,B2
-toothache,toothache,牙痛,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
-top,top,顶部的,ADJ,B2
-top (adj),top,顶部的,ADJ,C1
-top dressing,top dressing,追肥,NOUN,B2
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-topographical,topographical,词,ADJ,C1
-tormentor,tormentor,词,NOUN,B2
-torments,torments,词,NOUN,B2
-torque,torque,词,NOUN,C1
-torso,torso,躯干,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-torture ordeal,torture ordeal,词,NOUN,C1
+to torture,to torture,折磨,VERB,B2
 total,total,完全的,ADJ,B2
-total (adj),total,完全的,ADJ,B2
-totalitarianism,totalitarianism,词,NOUN,C1
-totality,totality,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
 touch,touch,接触,NOUN,B2
-touch (noun),touch,敢触摸,NOUN,A2
 touchability,touchability,能触摸,NOUN,B2
-touchy,touchy,易怒的,ADJ,B2
 tough,tough,艰难的,ADJ,B2
-tough guy,tough guy,硬汉,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
 tourism,tourism,旅游业,NOUN,B2
-tourist,tourist,旅游的,ADJ,B2
-tourist (adj),tourist,旅游的,ADJ,B2
 touristic,touristic,旅游的,ADJ,B2
-towards,towards,迎向,ADV,B2
-towards (adv),towards,迎向,ADV,B2
-towering,towering,词,ADJ,B2
-town hall,town hall,市政厅,NOUN,B2
 town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
-township head,township head,乡长,NOUN,B2
 township road,township road,乡道,NOUN,B2
-toxicity,toxicity,词,NOUN,C1
-toys,toys,玩具,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracking,tracking,词,NOUN,C1
-tracksuit,tracksuit,词,NOUN,C1
-tractor,tractor,拖拉机,NOUN,B2
-trade (noun),trade,行什么行,NOUN,B1
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
+to track,to track,追踪,VERB,B2
 trade union,trade union,工会,NOUN,B2
-trade unionist,trade unionist,词,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
 traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditionally,traditionally,传统地,ADV,B2
-traditions,traditions,词,NOUN,B1
 traffic jam,traffic jam,交通堵塞,NOUN,B2
 traffic light,traffic light,红绿灯,NOUN,B2
-traffic restriction,traffic restriction,限行,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficker,trafficker,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-tragically,tragically,词,ADV,B2
-tragicness,tragicness,词,NOUN,C1
 trailer,trailer,预告片,NOUN,B2
 train of thought,train of thought,思路,NOUN,B2
-train ride,train ride,词,NOUN,A1
 train station,train station,火车站,NOUN,B2
-train ticket,train ticket,词,NOUN,A1
-trained,trained,词,ADJ,C1
-trainer,trainer,教练,NOUN,B2
-trainer bastard,trainer bastard,词,NOUN,B2
-training center,training center,培训中心,NOUN,C1
-traits qualities,traits qualities,词,NOUN,C1
-tram,tram,有轨电车,NOUN,B2
-trance,trance,词,NOUN,C1
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-decision,trans-decision,超断,NOUN,B2
-trans-deduction,trans-deduction,超绎,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
+to trample,to trample,踩踏,VERB,B2
 trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-guest,trans-guest,超客,NOUN,B2
-trans-host,trans-host,超主,NOUN,C1
 trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
 trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-matter,trans-matter,超物,NOUN,B2
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
 transaction,transaction,交易,NOUN,B2
-transatlantic,transatlantic,词,ADJ,C1
 transcendence,transcendence,超越,NOUN,B2
 transcendental,transcendental,先验的,ADJ,B2
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferee,transferee,词,NOUN,C1
-transferor,transferor,词,NOUN,C1
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
+to transfer,to transfer,转移,VERB,B2
+to transfer schools,to transfer schools,转学,VERB,B2
 transformation,transformation,تحول,NOUN,B2
-transformer converter,transformer converter,词,NOUN,C1
-transhumance,transhumance,词,NOUN,B2
-transistor,transistor,词,NOUN,C1
 transitional,transitional,过渡的,ADJ,B2
-transitivity,transitivity,及物性,NOUN,C1
-translatology,translatology,词,NOUN,C1
 translator,translator,译者,NOUN,B2
 transmission,transmission,传输,NOUN,B2
 transmission to you,transmission to you,传你,NOUN,B2
 transmitter,transmitter,发射台,NOUN,B2
-transnational,transnational,跨国性,ADJ,C1
 transparency,transparency,透明度,NOUN,B2
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport (adj),transport,词,ADJ,C1
-transport service,transport service,词,NOUN,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transregional,transregional,词,ADJ,C1
-trapdoor,trapdoor,活板门,NOUN,B2
-trapped,trapped,词,ADJ,A2
-trapping,trapping,词,NOUN,C1
-trash bag,trash bag,垃圾袋,NOUN,B2
-trash can,trash can,词,NOUN,A2
-traumatic,traumatic,创伤的,ADJ,B2
+to transport,to transport,运输,VERB,B2
 travel,travel,出行,NOUN,B2
-travel (noun),travel,词,NOUN,B2
-travel fatigue,travel fatigue,车马劳顿,NOUN,B2
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
 traveler,traveler,旅行家,NOUN,B2
 tray,tray,托盘,NOUN,B2
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
 treacherousness,treacherousness,阴险,NOUN,B2
 treachery,treachery,背叛,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
 treasury,treasury,国库,NOUN,B2
-treat,treat,盛宴,NOUN,B2
-treat (noun),treat,盛宴,NOUN,B2
-trembling,trembling,颤抖的,ADJ,B2
-trench coat,trench coat,词,NOUN,C1
+to treat wound,to treat wound,治伤,VERB,B2
+to tremble,to tremble,颤抖,VERB,B2
 trend,trend,趋势,NOUN,B2
-trending,trending,词,ADJ,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trial run,trial run,词,NOUN,B2
 triangle,triangle,三角形,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
 tributary,tributary,支流,NOUN,B2
-tricolor,tricolor,词,ADJ,C1
-trigger (adj),trigger,词,ADJ,C1
-trigger imprint,trigger imprint,词,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-triggering,triggering,触发,NOUN,B2
-trigonometry,trigonometry,词,NOUN,C1
-trilemma,trilemma,三难困境,NOUN,B2
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trilogy,trilogy,词,NOUN,B2
 triviality,triviality,琐碎,NOUN,B2
-trivializable,trivializable,可轻描淡写的,ADJ,B2
 trivialization,trivialization,浅薄化,NOUN,B2
-trocar,trocar,词,NOUN,C1
 troop,troop,部队,NOUN,B2
-troop dispatch,troop dispatch,出兵,NOUN,B2
 troops,troops,部队,NOUN,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
 troublesome,troublesome,麻烦的,ADJ,B2
-troubling,troubling,词,ADJ,B2
-trout,trout,词,NOUN,C1
-trowel,trowel,词,NOUN,B2
 truce,truce,休战,NOUN,B2
-true concession,true concession,真让,NOUN,B2
-true form,true form,原形,NOUN,B2
-true heart,true heart,本心,NOUN,B2
-true qi,true qi,真气,NOUN,C1
-truly,truly,词,ADV,B2
 trumpet,trumpet,小号,NOUN,B2
 trust,trust,信托,NOUN,B2
-trust (noun),trust,我信你,NOUN,A2
-trust in God,trust in God,词,NOUN,C1
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
-try out,try out,词,VERB,C1
-tsunami,tsunami,海啸,NOUN,C1
+to try hard to,to try hard to,力图,VERB,B2
 tube,tube,أنبوب,NOUN,B2
-tuberculosis,tuberculosis,结核病,NOUN,B2
 tuesday,tuesday,星期二,NOUN,B2
-tumble (noun),tumble,词,NOUN,C1
-tumoral,tumoral,词,ADJ,C1
-tuna,tuna,金枪鱼,NOUN,B2
-tunic,tunic,束腰外衣,NOUN,B2
-tuning,tuning,词,NOUN,C1
-turban,turban,词,NOUN,B2
-turbine,turbine,词,NOUN,C1
-turkey,turkey,火鸡,NOUN,B2
-turkish,turkish,土耳其的,ADJ,B2
-turmeric,turmeric,词,NOUN,B2
 turn,turn,转弯,NOUN,B2
-turn (noun),turn,也轮,NOUN,B1
-turn of phrase,turn of phrase,词,NOUN,C1
-turn signal,turn signal,转向灯,NOUN,B2
-turnaround,turnaround,转胜,NOUN,C1
+to turn around,to turn around,转身,VERB,B2
+to turn off,to turn off,关闭,VERB,B2
+to turn out,to turn out,结果是,VERB,B2
 turning point,turning point,转折点,NOUN,B2
-turnip,turnip,芜菁,NOUN,B2
-turnoff,turnoff,词,NOUN,B2
 turnout,turnout,出席率,NOUN,B2
 turnover,turnover,营业额,NOUN,B2
-turntable,turntable,,NOUN,B2
-tutor,tutor,导师,NOUN,C1
-tutoring,tutoring,补习,NOUN,B2
-tv,tv,电视,NOUN,B2
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-tweezers,tweezers,词,NOUN,C1
 twenty,twenty,二十,NUM,B2
-twenty-five,twenty-five,词,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
-twist (noun),twist,词,NOUN,C1
 twisted,twisted,扭曲的,ADJ,B2
-twitching,twitching,抽搐的,ADJ,B2
 two animals,two animals,两只,NUM,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
 two people,two people,两名,NUM,B2
 two polite,two polite,两位,NUM,B2
 two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
-two-headed,two-headed,双头的,ADJ,B2
-two-way street,two-way street,双行道,NOUN,B2
-twofold,twofold,双重的,ADJ,B2
-tycoon,tycoon,词,NOUN,C1
-type like,type like,词,NOUN,B2
-typhoon,typhoon,台风,NOUN,B2
-typically,typically,词,ADV,C1
-typographical,typographical,词,ADJ,B2
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
 ugliness,ugliness,丑陋,NOUN,B2
-ukrainian,ukrainian,乌克兰的,ADJ,B2
-ulcer,ulcer,溃疡,NOUN,B2
 ulceration,ulceration,溃疡,NOUN,B2
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
 um,um,嗯,INTJ,B2
 unacceptable,unacceptable,不可接受的,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unambiguous,unambiguous,明确的,ADJ,B2
-unanimity,unanimity,词,NOUN,C1
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
 unattainable,unattainable,难以获得的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
-unbelieving,unbelieving,词,ADJ,C1
-unbridled,unbridled,肆无忌惮的,ADJ,B2
-unceasing,unceasing,不断,ADV,B2
-uncertain,uncertain,不确定的,ADJ,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
-uncompromising,uncompromising,词,ADJ,B2
-unconditional,unconditional,无条件的,ADJ,B2
-unconquerable,unconquerable,词,ADJ,C1
-unconscious (noun),unconscious,词,NOUN,C1
-unconsciousness,unconsciousness,词,NOUN,C1
 uncontrollable,uncontrollable,无法控制的,ADJ,B2
-uncooled,uncooled,未寒,NOUN,B2
-uncountable,uncountable,词,ADJ,C1
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,词,ADJ,B2
-uncultivated,uncultivated,词,ADJ,B2
-undaunted,undaunted,词,ADJ,C1
-undead,undead,词,NOUN,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+to uncover,to uncover,揭露,VERB,B2
 undeniable,undeniable,不可否认的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under below,under below,在...下方,ADP,A2
-under the,under the,词,ADP,B2
-underclass,underclass,底层,NOUN,B2
 undercover agent,undercover agent,卧底,NOUN,B2
-underestimation,underestimation,小看,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
 underground,underground,地铁,NOUN,B2
-underground (noun),underground,地下,NOUN,B2
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underlying,underlying,词,ADJ,B2
-undermining authority,undermining authority,削弱权威,NOUN,B2
 underneath,underneath,在下面,ADV,B2
-underneath (adv),underneath,下面,ADV,B2
-underneath (noun),underneath,底下,NOUN,C1
 underpants,underpants,内裤,NOUN,B2
-underpass,underpass,地下通道,NOUN,C1
-underside,underside,下方,NOUN,C1
-understanding,understanding,体贴的,ADJ,B2
-understanding (adj),understanding,体贴的,ADJ,B2
-understood,understood,词,ADJ,A1
-undervaluing,undervaluing,词,NOUN,C1
 underwear,underwear,内衣,NOUN,B2
-underworld,underworld,地下世界,NOUN,B2
-undeserved,undeserved,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undoubtedly,undoubtedly,无疑地,ADV,B2
-unearned,unearned,浪得,NOUN,C1
 unease,unease,不安,NOUN,B2
 unemployed,unemployed,失业的,ADJ,B2
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
 unequal,unequal,不平等的,ADJ,B2
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected event,unexpected event,变故,NOUN,B2
 unexpectedly,unexpectedly,出乎意料地,ADV,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful,unfaithful,不忠的,ADJ,B2
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
-unfolding,unfolding,词,NOUN,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfriendly,unfriendly,不友好的,ADJ,B2
-ungabe,ungabe,词,NOUN,C1
-ungestaltung,ungestaltung,词,NOUN,C1
-ungodliness,ungodliness,词,NOUN,C1
-ungrateful,ungrateful,忘恩负义的,ADJ,B2
-unhappiness,unhappiness,词,NOUN,C1
-unharmed,unharmed,未受伤的,ADJ,B2
-unhealthy,unhealthy,词,ADJ,C1
-unhurried patience,unhurried patience,词,NOUN,C1
-unicorn,unicorn,词,NOUN,C1
-unification,unification,词,NOUN,B2
 unified examination,unified examination,统考,NOUN,B2
-uniform,uniform,制服,NOUN,B2
-uniformity,uniformity,词,NOUN,B2
-unilateralism,unilateralism,词,NOUN,C1
 unimaginable,unimaginable,难以想象的,ADJ,B2
-unimpeded,unimpeded,词,ADJ,C1
 unimportant,unimportant,不重要的,ADJ,B2
-uninhabited,uninhabited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
-union (adj),union,词,ADJ,C1
 unionism,unionism,工会主义,NOUN,B2
-unionist,unionist,词,ADJ,B2
-unique (noun),unique,词,NOUN,B2
 uniqueness,uniqueness,独特,NOUN,B2
+to unite,to unite,联合,VERB,B2
 united,united,联合的,ADJ,B2
 unity,unity,团结,NOUN,B2
-universal,universal,普遍的,ADJ,B2
-universal applicability,universal applicability,普适性,NOUN,B2
-universal total,universal total,词,ADJ,C1
 universality,universality,普遍性,NOUN,B2
-universities,universities,大学,NOUN,B2
-university (adj),university,词,ADJ,C1
-university of applied sciences,university of applied sciences,词,NOUN,B2
-university student,university student,大学生,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
 unknown,unknown,未知数,NOUN,B2
-unknown (noun),unknown,未知数,NOUN,C1
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
-unleashed,unleashed,词,ADJ,C1
-unlike (verb),unlike,不像,VERB,B2
-unlimited,unlimited,无限的,ADJ,B2
-unlocked,unlocked,词,NOUN,B2
 unlucky,unlucky,倒霉的,ADJ,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unnatural,unnatural,词,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
+to unpack,to unpack,拆包,VERB,B2
 unpredictable,unpredictable,不可预测的,ADJ,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpublished,unpublished,词,ADJ,B2
-unpunished,unpunished,词,ADJ,C1
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreality,unreality,虚幻,NOUN,B2
 unreasonable,unreasonable,不合理的,ADJ,B2
 unreasonable,unreasonable,不情,NOUN,B2
-unreasonable (noun),unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unreflective,unreflective,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
 unrest,unrest,动荡,NOUN,B2
-unrichtung,unrichtung,词,NOUN,C1
-unruffled,unruffled,从容,ADJ,B2
-unsafe,unsafe,词,ADJ,B1
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unsecured,unsecured,词,NOUN,B2
-unseen realities,unseen realities,词,NOUN,C1
-unsetzung,unsetzung,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsociable,unsociable,词,ADJ,C1
 unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsprache,unsprache,词,NOUN,C1
 unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-unthinkable,unthinkable,不可想象的,ADJ,B2
-untidiness,untidiness,凌乱,NOUN,B2
-untidy,untidy,词,ADJ,C1
+to untie,to untie,解开,VERB,B2
 until,until,直到,ADP,B2
-until (adp),until,至,ADP,B2
-until to,until to,词,ADP,A2
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouchable,untouchable,不可触碰的,ADJ,B2
-untreibung,untreibung,词,NOUN,B2
-unveiling ceremony,unveiling ceremony,揭幕仪式,NOUN,B2
-unviable,unviable,词,ADJ,C1
-unwandel,unwandel,词,NOUN,B2
-unwanted,unwanted,词,ADJ,B2
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwillingness,unwillingness,不甘,NOUN,B2
 unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwise,unwise,词,ADJ,C1
-unworthy,unworthy,你不配,NOUN,B2
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to,up to,为止,ADP,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
 upbringing,upbringing,教养,NOUN,B2
 upcoming,upcoming,مقبل,ADJ,B2
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-upholding of rights,upholding of rights,词,NOUN,C1
-upload (noun),upload,词,NOUN,C1
 upper,upper,上面的,ADJ,B2
-upper class,upper class,词,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
 upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-upright,upright,直立地,ADV,B2
-upright (adj),upright,直立的,ADJ,C1
-uprightness,uprightness,词,NOUN,B2
 uproar,uproar,骚动,NOUN,B2
-uprooted,uprooted,词,ADJ,C1
 uprooting,uprooting,背井离乡,NOUN,B2
-ups and downs,ups and downs,词,NOUN,B2
-upstart (adj),upstart,词,ADJ,C1
-upturn,upturn,好转,NOUN,B2
-upward,upward,向上,ADV,B2
-upwards,upwards,向上,ADV,B2
-urban area,urban area,词,NOUN,C1
-urbanism,urbanism,词,NOUN,B2
+to upset,to upset,使生气,VERB,B2
 urbanity,urbanity,都市风度,NOUN,B2
 urbanization,urbanization,城市化,NOUN,B2
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
 urgency,urgency,紧急,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,C1
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
 us,us,你我,NOUN,B2
-us (noun),us,你我,NOUN,B2
 usable,usable,可用的,ADJ,B2
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
 usb flash drive,usb flash drive,U盘,NOUN,B2
 use,use,使用,NOUN,B2
-use (noun),use,分用,NOUN,A2
-used,used,词,ADJ,C1
-usefulness avail,usefulness avail,效用,NOUN,C1
-useless zero,useless zero,词,ADJ,A2
-uselessly,uselessly,词,ADV,C1
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
 user,user,用户,NOUN,B2
-using this,using this,用这,NOUN,C1
-usual thing,usual thing,惯例,NOUN,B2
 usufruct,usufruct,用益权,NOUN,B2
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-usurpation,usurpation,词,NOUN,C1
-usury,usury,词,NOUN,C1
-utensil,utensil,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
 utilitarianism,utilitarianism,功利主义,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
-utilization,utilization,利用,NOUN,B2
 utmost,utmost,你尽,NOUN,B2
-utmost extreme end,utmost extreme end,词,NOUN,C1
 utterance,utterance,话语,NOUN,B2
-utterance-related,utterance-related,词,ADJ,C1
 vacancy,vacancy,空缺,NOUN,B2
-vacant lot,vacant lot,空地,NOUN,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccinal,vaccinal,词,ADJ,C1
 vaccination,vaccination,疫苗接种,NOUN,B2
 vaccine,vaccine,疫苗,NOUN,B2
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (adj),vacuum,真空的,ADJ,B2
-vacuum cleaner,vacuum cleaner,词,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
 vague,vague,含糊的,ADJ,B2
-vaguely,vaguely,词,ADV,C1
-vagueness,vagueness,模糊,NOUN,C1
-vain,vain,白白,NOUN,B2
-vain (noun),vain,白白,NOUN,C1
-vainglory,vainglory,词,NOUN,C1
-vale of tears,vale of tears,词,NOUN,C1
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
 validity,validity,有效期,NOUN,B2
 valuation,valuation,估值,NOUN,B2
-value chain,value chain,价值链,NOUN,C1
 value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-valve,valve,词,NOUN,C1
-vanishing,vanishing,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
 variable,variable,变量,NOUN,B2
-variable (adj),variable,词,ADJ,C1
-variables,variables,词,NOUN,C1
-variance,variance,方差,NOUN,B2
-variant,variant,变体,NOUN,B2
-various departments,various departments,各部,NOUN,B2
-varnish,varnish,清漆,NOUN,B2
-varying,varying,词,ADJ,B2
-vassal,vassal,之臣,NOUN,C1
-vastness,vastness,词,NOUN,B2
-vat,vat,增值税,NOUN,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunted,vaunted,词,ADJ,B2
-vector,vector,词,NOUN,C1
 vegetable garden,vegetable garden,果园,NOUN,B2
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehicle registration,vehicle registration,行驶证,NOUN,B2
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiled,veiled,隐晦的,ADJ,B2
-velarization,velarization,词,NOUN,C1
-vending machine,vending machine,自动售货机,NOUN,B2
-venereal disease,venereal disease,性病,NOUN,B2
-venomous dragon,venomous dragon,毒龙,NOUN,C1
 ventilation,ventilation,通风,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-verbal,verbal,词,ADJ,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbosely,verbosely,词,ADV,C1
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-vergestaltung,vergestaltung,词,NOUN,C1
-verifiable,verifiable,词,ADJ,C1
-verification,verification,词,NOUN,C1
-verkunft,verkunft,词,NOUN,C1
-vermilion,vermilion,词,NOUN,B2
 vermin,vermin,害兽,NOUN,B2
-vernahme,vernahme,词,NOUN,C1
-vernier,vernier,词,NOUN,C1
-verpflegung,verpflegung,词,NOUN,C1
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
-versatility,versatility,词,NOUN,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versification,versification,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-versprache,versprache,词,NOUN,C1
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-vertebra,vertebra,词,NOUN,B2
-verteilung,verteilung,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertreibung,vertreibung,词,NOUN,C1
-verwandel,verwandel,词,NOUN,C1
-verweisung,verweisung,词,NOUN,C1
-verwirkung,verwirkung,词,NOUN,C1
-very best,very best,词,ADJ,B2
 very deep,very deep,很深,ADJ,B2
-very fine,very fine,词,ADJ,C1
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
 very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-veterinarian,veterinarian,词,NOUN,C1
-vial,vial,词,NOUN,C1
 vibration,vibration,振动,NOUN,B2
 vice,vice,恶习,NOUN,B2
 vice versa,vice versa,反之亦然,ADV,B2
-vice versa (adj),vice versa,词,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
 vicinity,vicinity,附近,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-video clip,video clip,词,NOUN,C1
-video disc,video disc,影碟,NOUN,B2
-video on demand,video on demand,点播,NOUN,C1
-video recording,video recording,录像,NOUN,B2
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigor of prime,vigor of prime,词,NOUN,C1
-vile (adv),vile,词,ADV,B2
-village head,village head,村长,NOUN,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-villainy,villainy,邪恶,NOUN,B2
 vine,vine,藤蔓,NOUN,B2
 vinegar,vinegar,醋,NOUN,B2
-vineyard,vineyard,葡萄园,NOUN,C1
-violate regulations,violate regulations,违规,VERB,C1
+to violate discipline,to violate discipline,违纪,VERB,B2
 violation,violation,侵越,NOUN,B2
-violations,violations,词,NOUN,C1
-violent act,violent act,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violet (adj),violet,词,ADJ,C1
-violet (noun),violet,词,NOUN,B2
 violin,violin,小提琴,NOUN,B2
-viper,viper,词,NOUN,B2
-virginal,virginal,处女的,ADJ,B2
 virtual reality,virtual reality,虚拟现实,NOUN,B2
 visa,visa,签证,NOUN,B2
-viscosity,viscosity,词,NOUN,C1
 visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
 visit,visit,拜访,NOUN,B2
-visit (noun),visit,去看,NOUN,A2
-visiting ban,visiting ban,,NOUN,B2
 visitor,visitor,访客,NOUN,B2
-visor,visor,词,NOUN,B2
 vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vocal range,vocal range,词,NOUN,C1
-vocalization,vocalization,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vodka,vodka,词,NOUN,C1
-voice command,voice command,声令,NOUN,B2
-voicing,voicing,词,NOUN,C1
 void,void,最无,NOUN,B2
-volatility,volatility,词,NOUN,C1
-volcanic,volcanic,词,ADJ,C1
-volleyball,volleyball,排球,NOUN,B2
-voltage,voltage,词,NOUN,C1
-volume measure,volume measure,词,NOUN,B2
-volumetric,volumetric,词,ADJ,C1
 voluntarily,voluntarily,自愿地,ADV,B2
-voluntariness,voluntariness,词,NOUN,C1
-voluntarist,voluntarist,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
 volunteering,volunteering,志愿服务,NOUN,B2
-vomit (noun),vomit,词,NOUN,B2
-vomiting,vomiting,词,NOUN,C1
-voracity,voracity,词,NOUN,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorkunft,vorkunft,词,NOUN,C1
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
+to vote,to vote,表决,VERB,B2
 voter,voter,选民,NOUN,B2
 voting,voting,投票,NOUN,B2
-votive offering,votive offering,词,NOUN,C1
 voucher,voucher,代金券,NOUN,B2
-vowel,vowel,词,NOUN,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-vs,vs,与...相对,ADP,B2
 vulgar,vulgar,粗俗的,ADJ,B2
 vulgarity,vulgarity,粗俗,NOUN,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulture,vulture,词,NOUN,B2
-wading,wading,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-wage earner,wage earner,词,NOUN,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage murder unit,wage murder unit,词,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-wager,wager,词,NOUN,C1
+to wage war,to wage war,作战,VERB,B2
 wages,wages,工资,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wailing,wailing,词,NOUN,B2
 waist token,waist token,腰牌,NOUN,B2
 wait,wait,等待,NOUN,B2
-wait (noun),wait,等,NOUN,B2
-wait for me,wait for me,等我,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
+to wait long,to wait long,久等,VERB,B2
 waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waiting room,waiting room,候诊室,NOUN,B2
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-walker,walker,词,NOUN,C1
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wall-mounted,wall-mounted,词,ADJ,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
+to wake,to wake,唤醒,VERB,B2
+to wake up,to wake up,叫醒,VERB,B2
+to walk,to walk,走,VERB,B2
 wandering,wandering,漫游,NOUN,B2
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
 want,want,想,AUX,B2
-want (adp),want,我要,ADP,A2
-want to lure,want to lure,想引,NOUN,B2
 wanted,wanted,故意的,ADJ,B2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
+to wanted,to wanted,通缉,VERB,B2
 wanting you,wanting you,要你,NOUN,B2
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
 war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warehouse store,warehouse store,词,NOUN,B1
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,词,ADJ,B2
 warming,warming,变暖,NOUN,B2
-warmly,warmly,热情地,ADV,B2
 warmth,warmth,温暖,NOUN,B2
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-washer,washer,词,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to wash with water,to wash with water,水洗,VERB,B2
 washing,washing,洗涤,NOUN,B2
 washing machine,washing machine,洗衣机,NOUN,B2
-waste disposal site,waste disposal site,词,NOUN,B1
-waste of time,waste of time,词,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
+to waste,to waste,浪费,VERB,B2
 wasteful,wasteful,浪费的,ADJ,B2
 wasteland,wasteland,荒地,NOUN,B2
-wastewater,wastewater,废水,NOUN,C1
 watch,watch,手表,NOUN,B2
-watch (noun),watch,你看好小,NOUN,B2
-watch of the night,watch of the night,词,NOUN,C1
-watch over,watch over,词,VERB,C1
-watched,watched,词,NOUN,B2
-watchmaking,watchmaking,词,NOUN,C1
-watchtower,watchtower,词,NOUN,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water falling,water falling,水落,NOUN,B2
-water garment,water garment,水衣,NOUN,C1
-water heater,water heater,热水器,NOUN,B2
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
+to water,to water,浇水,VERB,B2
 water spinach,water spinach,空心菜,NOUN,B2
 watercolor,watercolor,水彩画,NOUN,B2
-watercourse,watercourse,河道,NOUN,B1
 waterfall,waterfall,瀑布,NOUN,B2
-watering,watering,词,NOUN,B2
 watermelon,watermelon,西瓜,NOUN,B2
-watermelon seed,watermelon seed,西瓜子,NOUN,B2
 waterproof,waterproof,防水的,ADJ,B2
-waterproof (verb),waterproof,词,VERB,C1
-waterskin,waterskin,词,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
+to wave,to wave,挥手,VERB,B2
 way out,way out,出路,NOUN,B2
-we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
-we two,we two,我俩,PRON,B2
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weakened,weakened,词,ADJ,C1
-weakening,weakening,减弱,NOUN,B2
-weakly,weakly,词,ADV,C1
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
+to weaken,to weaken,削弱,VERB,B2
 weaning,weaning,断奶,NOUN,B2
-weapon arms,weapon arms,词,NOUN,A1
-wear,wear,磨损,NOUN,B2
-wear (noun),wear,磨损,NOUN,C1
-wear tear,wear tear,词,NOUN,C1
-wearily,wearily,词,ADV,C1
-weather forecast,weather forecast,词,NOUN,B1
-weather institute,weather institute,词,NOUN,B2
-weathering,weathering,词,NOUN,C1
-weaver,weaver,词,NOUN,B1
 weaving,weaving,编织,NOUN,B2
 webcam,webcam,网络摄像头,NOUN,B2
 website,website,网站,NOUN,B2
 wedding anniversary,wedding anniversary,结婚纪念日,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
 wedding photo,wedding photo,婚纱照,NOUN,B2
 wednesday,wednesday,星期三,NOUN,B2
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
-week number,week number,周次,NOUN,B2
 weekly,weekly,周刊,NOUN,B2
-weekly (adj),weekly,每周的,ADJ,B2
-weekly (adv),weekly,按周,ADV,C1
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weekly test,weekly test,周测,NOUN,B2
-weeping,weeping,痛哭,NOUN,C1
-weighing,weighing,词,NOUN,B2
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
-weirdo,weirdo,怪人,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
 welcome,welcome,受欢迎的,ADJ,B2
-welcome (adj),welcome,词,ADJ,B2
-welcome (intj),welcome,词,INTJ,A1
-welcome (noun),welcome,词,NOUN,A2
-welcome banquet,welcome banquet,欢迎宴,NOUN,B2
-welcome committee,welcome committee,,NOUN,B2
-welcoming,welcoming,舒适的,ADJ,B2
-welder,welder,词,NOUN,C1
 welding,welding,焊接,NOUN,B2
-welfare home,welfare home,福利院,NOUN,C1
 well,well,好吧,INTJ,B2
 well,well,井,NOUN,B2
-well (intj),well,好吧,INTJ,B2
-well (noun),well,水井,NOUN,B2
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
 well-being,well-being,健康,NOUN,B2
 well-considered,well-considered,深思熟虑的,ADJ,B2
-well-crafted,well-crafted,词,ADJ,B2
-well-disposed,well-disposed,词,ADJ,B2
 well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-known,well-known,众所周知的,ADJ,B2
-well-liked,well-liked,词,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-werewolf,werewolf,狼人,NOUN,B2
 west,west,西方,NOUN,B2
-western,western,西方的,ADJ,B2
-western regions,western regions,西域,NOUN,B2
-westerner,westerner,词,NOUN,B2
 westward,westward,往西,NOUN,B2
-westward (adv),westward,向西,ADV,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wetland,wetland,湿地,NOUN,B2
-wharf,wharf,码头,NOUN,B2
-what,what,什么,ADV,B2
-what (adv),what,词,ADV,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
 what extent,what extent,在何种程度上,ADV,B2
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
 wheat,wheat,小麦,NOUN,B2
-wheel hub,wheel hub,轮毂,NOUN,C1
 wheelchair,wheelchair,轮椅,NOUN,B2
 when,when,当...时,SCONJ,B2
-when (adp),when,之时,ADP,B2
-when (sconj),when,当,SCONJ,A1
-when than,when than,词,SCONJ,A2
 when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where,where,哪里,PRON,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (cconj),whereas,词,CCONJ,B2
-whereas since,whereas since,词,SCONJ,A2
 whereby,whereby,其中,ADV,B2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whether,whether,能否,NOUN,B2
-whether (noun),whether,能否,NOUN,B2
-whether (part),whether,词,PART,A1
-whether or not,whether or not,是否,SCONJ,B2
-whey,whey,词,NOUN,B2
 which,which,哪个,DET,B2
-which (det),which,哪个,DET,B2
 which one,which one,哪一个,PRON,B2
-which ones,which ones,哪些,PRON,B2
 which seat,which seat,哪座,NOUN,B2
 while,while,一会儿,NOUN,B2
-while (noun),while,会儿,NOUN,A1
-whiny,whiny,词,ADJ,C1
-whip,whip,鞭,NOUN,B2
-whip (noun),whip,鞭,NOUN,B2
+to whimper,to whimper,呜咽,VERB,B2
+to whine,to whine,哀叹,VERB,B2
 whirlwind,whirlwind,旋风；漩涡,NOUN,B2
-whirring,whirring,词,NOUN,C1
-whisk,whisk,打蛋器,NOUN,B2
-whisk whip,whisk whip,词,NOUN,B1
 whisper,whisper,低语,NOUN,B2
-whisper (noun),whisper,耳语,NOUN,B2
-whistleblower,whistleblower,词,NOUN,C1
-whistling,whistling,词,NOUN,C1
+to whistle,to whistle,吹口哨,VERB,B2
 white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whiting,whiting,词,NOUN,B2
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
 who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
 whole,whole,整体,NOUN,B2
-whole (noun),whole,整体,NOUN,B2
-whole body,whole body,连身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-whole world,whole world,全世界,NOUN,B2
 wholesale,wholesale,批发,NOUN,B2
-wholesale (adv),wholesale,词,ADV,B1
 whore,whore,妓女,NOUN,B2
-whose (det),whose,词,DET,B2
 why bother,why bother,何必,ADV,B2
 why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,加宽,NOUN,B2
-widower,widower,词,NOUN,C1
-widowhood,widowhood,词,NOUN,C1
 width,width,宽度,NOUN,B2
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wig,wig,假发,NOUN,B2
-wild beast,wild beast,猛兽,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
 wilderness,wilderness,荒野,NOUN,B2
 will,will,遗嘱,NOUN,B2
-will (adv),will,将,ADV,C1
-will (noun),will,咱要,NOUN,A2
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will shall,will shall,将要/会,AUX,B2
 will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
-willing,willing,肯,AUX,B2
-willing (aux),willing,肯,AUX,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willow,willow,词,NOUN,B2
-wimp,wimp,懦夫,NOUN,B2
-win,win,胜利,NOUN,B2
-win (noun),win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
+to wilt,to wilt,枯萎,VERB,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+to wind,to wind,缠绕,VERB,B2
 wind speed,wind speed,风速,NOUN,B2
-winding,winding,蜿蜒的,ADJ,B2
-windless,windless,无风的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
-window glass,window glass,窗玻璃,NOUN,B2
-windowsill,windowsill,窗台,NOUN,C1
 windproof,windproof,挡风的,ADJ,B2
-windy,windy,有风的,ADJ,B2
 windy day,windy day,风天,NOUN,B2
-wine cup,wine cup,这酒盏,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wintry,wintry,冬天的,ADJ,B2
-wiper,wiper,雨刷,NOUN,B2
-wired,wired,词,ADJ,C1
-wisely,wisely,明智地,ADV,B2
+to wiretap,to wiretap,监听,VERB,B2
 wish,wish,愿望,NOUN,B2
-wish (noun),wish,也想,NOUN,A1
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wit,wit,词,NOUN,C1
-witch hunt,witch hunt,词,NOUN,C1
-witchcraft,witchcraft,巫术,NOUN,B2
-with difficulty,with difficulty,困难地,ADV,B2
-with each other,with each other,词,ADV,A2
 with it,with it,在其中,ADV,B2
-with me,with me,词,PRON,A1
-with that,with that,以此,ADV,B2
-with the aim of,with the aim of,词,ADP,C1
-with this,with this,以此,ADV,B2
-with what,with what,用什么,ADV,B2
-with which,with which,词,PRON,A2
-with you,with you,词,PRON,A1
-withdrawal fold,withdrawal fold,词,NOUN,C1
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without exception,without exception,无例外的,ADV,B2
-without further ado,without further ado,词,ADV,B2
-witness examination,witness examination,证人询问,NOUN,B2
-witness female,witness female,词,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witness testimony,witness testimony,人证,NOUN,B2
-wits,wits,心眼,NOUN,B2
-wittiness,wittiness,风趣,NOUN,B2
+to witness,to witness,目击,VERB,B2
 witty,witty,机智的,ADJ,B2
-witty saying,witty saying,词,NOUN,C1
-woe (intj),woe,词,INTJ,B2
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do,won't do,不行,ADJ,B2
+to won't do,to won't do,不成,VERB,B2
 wonder,wonder,奇迹,NOUN,B2
-wonder (noun),wonder,太妙,NOUN,C1
-wonderful (adv),wonderful,词,ADV,B2
-wonton,wonton,馄饨,NOUN,C1
-wood ear mushroom,wood ear mushroom,木耳,NOUN,B2
-wooded,wooded,树木茂盛的,ADJ,B2
-wooden,wooden,木制的,ADJ,B2
-woodland,woodland,林地,NOUN,B2
 woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
 wool,wool,羊毛,NOUN,B2
-word choice,word choice,措辞,NOUN,B2
-wording,wording,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-workday,workday,词,NOUN,C1
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working,working,词,ADJ,C1
-working class,working class,工人阶级,NOUN,B2
-working day,working day,词,NOUN,B2
-working method,working method,词,NOUN,B2
+to work,to work,工作,VERB,B2
+to work out,to work out,成功,VERB,B2
+to work part-time,to work part-time,打工,VERB,B2
 workplace,workplace,工作场所,NOUN,B2
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world champion,world champion,世界冠军,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
 world war,world war,世界大战,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldliness,worldliness,词,NOUN,C1
-worldly,worldly,世俗的,ADJ,B2
 worldview,worldview,世界观,NOUN,B2
 worldwide,worldwide,全世界的,ADJ,B2
-wormwood,wormwood,词,NOUN,A2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
 worry,worry,担忧,NOUN,B2
-worry (noun),worry,多虑,NOUN,C1
 worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worse (noun),worse,词,NOUN,B2
-worsening,worsening,词,NOUN,C1
-worst (adv),worst,词,ADV,C1
-worst (noun),worst,词,NOUN,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthless,worthless,无价值的,ADJ,B2
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would like,would like,词,AUX,A2
-would rather,would rather,宁愿,SCONJ,B2
-would rather (adv),would rather,宁可,ADV,B1
-wounded,wounded,受伤的,ADJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
+to worsen,to worsen,恶化,VERB,B2
+to worship,to worship,崇拜,VERB,B2
+to wound,to wound,使受伤,VERB,B2
 wow,wow,哇,INTJ,B2
-wrapper,wrapper,词,NOUN,C1
 wrapping,wrapping,包装,NOUN,B2
-wrathful,wrathful,词,ADJ,C1
 wrestling,wrestling,摔跤,NOUN,B2
 wretch,wretch,令人厌恶的人,NOUN,B2
-wretchedness,wretchedness,悲惨,NOUN,C1
 wrinkle,wrinkle,皱纹,NOUN,B2
-wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
 writing,writing,文字,NOUN,B2
 written,written,书面的,ADJ,B2
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
 wrong,wrong,错误的事,NOUN,B2
-wrong (noun),wrong,错误的事,NOUN,C1
 wrong mistake,wrong mistake,错误,ADJ,B2
-wrongdoer,wrongdoer,罪犯,NOUN,B2
+to wrong someone,to wrong someone,冤枉,VERB,B2
 wrongful conviction,wrongful conviction,冤案,NOUN,B2
 wudang,wudang,武当,NOUN,B2
-x-ray,x-ray,X光片,NOUN,B2
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yarn,yarn,纱线,NOUN,B2
 yeah yeah,yeah yeah,是是是,INTJ,B2
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
 year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
+to yearn for,to yearn for,渴望,VERB,B2
 years,years,数年,NOUN,B2
 yeast,yeast,酵母,NOUN,B2
-yep,yep,词,INTJ,B2
-yes,yes,是啊,NOUN,B2
-yes (adv),yes,词,ADV,A2
-yes (noun),yes,是啊,NOUN,B2
-yes (part),yes,是的,PART,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yes indeed (adv),yes indeed,词,ADV,B2
+to yell,to yell,大吼,VERB,B2
 yesterday,yesterday,بارحة,NOUN,B2
-yesterday (noun),yesterday,昨天,NOUN,B2
-yesteryear,yesteryear,词,NOUN,C1
 yield,yield,产量,NOUN,B2
-yield (noun),yield,再让,NOUN,B2
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yo,yo,哟,PART,B2
-yoga practice,yoga practice,词,NOUN,B2
 yogurt,yogurt,酸奶,NOUN,B2
 yoke,yoke,枷锁,NOUN,B2
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and i,you and i,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you can,you can,您能,NOUN,B2
-you cannot live,you cannot live,你也活不,NOUN,B2
-you dative,you dative,词,PRON,A2
 you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you formal,you formal,您,PRON,B2
-you masculine,you masculine,词,PRON,A1
 you plural,you plural,你们,PRON,B2
-you polite,you polite,您,PRON,B2
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
 young lady,young lady,小姐,NOUN,B2
 young man,young man,年轻人,NOUN,B2
-young master,young master,少庄主,NOUN,B2
 young person,young person,年轻人,NOUN,B2
 young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
 younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,词,ADJ,B2
-youngster,youngster,年少者,NOUN,B2
 your,your,你的,DET,B2
-your (det),your,你的,DET,A1
 your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
 your head,your head,你头上,NOUN,B2
-your highness,your highness,殿下,NOUN,B2
 your laugh,your laugh,你笑,NOUN,B2
-your majesty,your majesty,陛下,NOUN,B2
 your parents,your parents,你爹娘,NOUN,B2
 your photo,your photo,照你,NOUN,B2
-your pl,your pl,词,DET,B2
-your plural,your plural,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
 your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,词,PRON,B2
-youth culture,youth culture,词,NOUN,C1
-youth people,youth people,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful,youthful,词,ADJ,C1
-youthful vigor,youthful vigor,词,NOUN,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
-yuanxiao,yuanxiao,元宵,NOUN,B2
 yuck,yuck,呸,INTJ,B2
-zajal,zajal,词,NOUN,B2
-zellige tiles,zellige tiles,词,NOUN,A2
 zen master,zen master,禅师,NOUN,B2
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
 zero,zero,零,NUM,B2
-zero (num),zero,零,NUM,A2
-zeroing,zeroing,词,NOUN,C1
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
 zhuang he,zhuang he,庄郃,NOUN,B2
-zhuang hun,zhuang hun,庄混,NOUN,B2
-zinc,zinc,锌,NOUN,B2
-zodiac sign,zodiac sign,属相,NOUN,B2
 zongzi,zongzi,粽子,NOUN,B2
 zucchini,zucchini,西葫芦,NOUN,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zukunft,zukunft,词,NOUN,C1
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
+township head,township head,乡长,NOUN,B2
+re-submission,re-submission,再上,NOUN,B2
+dune,dune,沙丘,NOUN,B2
+road sign,road sign,路标,NOUN,B2
+ringing,ringing,铃声,NOUN,B2
+to be stolen,to be stolen,失窃,VERB,B2
+to infiltrate,to infiltrate,渗透,VERB,B2
+wait for me,wait for me,等我,NOUN,B2
+-ly,-ly,地,PART,B2
+you polite,you polite,您,PRON,B2
+proletariat,proletariat,无产阶级,NOUN,B2
+fortune telling,fortune telling,算命,NOUN,B2
+to structure,to structure,构建,VERB,B2
+spokesperson,spokesperson,发言人,NOUN,B2
+slipper,slipper,拖鞋,NOUN,B2
+measure word for books,measure word for books,本,NUM,B2
+personal record,personal record,个人纪录,NOUN,B2
+purity,purity,纯洁,NOUN,B2
+to raise donations,to raise donations,募捐,VERB,B2
+hard to distinguish,hard to distinguish,难以区分,ADJ,B2
+bypass surgery,bypass surgery,搭桥手术,NOUN,B2
+monopolistic,monopolistic,垄断的,ADJ,B2
+gigolo,gigolo,面首,NOUN,B2
+retrieve qingming,retrieve qingming,拿回青冥,NOUN,B2
+known,known,已知的,ADJ,B2
+won't do,won't do,不行,ADJ,B2
+demanding,demanding,要求高的,ADJ,B2
+cash,cash,现金,ADJ,B2
+new year's day,new year's day,元旦,NOUN,B2
+centrifugal force,centrifugal force,离心力,NOUN,B2
+from childhood,from childhood,从小,ADV,B2
+payment all,payment all,付都,NOUN,B2
+melon groping,melon groping,摸瓜,NOUN,B2
+that way,that way,那样,PRON,B2
+not only,not only,不光,CCONJ,B2
+leniency,leniency,宽厚,NOUN,B2
+to shake hands,to shake hands,握手,VERB,B2
+plated,plated,镀层的,ADJ,B2
+to receive worldwide attention,to receive worldwide attention,举世瞩目,VERB,B2
+exegesis,exegesis,注释,NOUN,B2
+social arbitration,social arbitration,社会仲裁,NOUN,B2
+this battle,this battle,此战,NOUN,B2
+re-reason,re-reason,重理,NOUN,B2
+internal force,internal force,内力,NOUN,B2
+danmei,danmei,但没,NOUN,B2
+non-shadow,non-shadow,非影,NOUN,B2
+ice hockey,ice hockey,冰球,NOUN,B2
+annual report,annual report,年报,NOUN,B2
+respectful deferential,respectful deferential,恭敬,ADJ,B2
+typhoon,typhoon,台风,NOUN,B2
+memorandum,memorandum,备忘录,NOUN,B2
+pantheism,pantheism,泛神论,NOUN,B2
+to give to grant,to give to grant,予以,VERB,B2
+jianghu,jianghu,江湖,NOUN,B2
+shift swap,shift swap,换班,NOUN,B2
+cellar,cellar,地窖,NOUN,B2
+to plant out,to plant out,定植,VERB,B2
+dashboard,dashboard,仪表盘,NOUN,B2
+flask,flask,小瓶,NOUN,B2
+to look for to find,to look for to find,找,VERB,B2
+cold blood,cold blood,冷血,NOUN,B2
+person honorific,person honorific,位,NOUN,B2
+public order,public order,治安,NOUN,B2
+inconsistency,inconsistency,不一致,NOUN,B2
+past exam papers,past exam papers,真题,NOUN,B2
+my big one,my big one,我偌大,NOUN,B2
+maxim,maxim,格言,NOUN,B2
+water falling,water falling,水落,NOUN,B2
+command room,command room,指挥室,NOUN,B2
+austerity,austerity,紧缩,NOUN,B2
+redefinition,redefinition,改界,NOUN,B2
+video recording,video recording,录像,NOUN,B2
+want to lure,want to lure,想引,NOUN,B2
+ceremonial cap,ceremonial cap,爵弁,NOUN,B2
+decadence,decadence,衰落,NOUN,B2
+well-known,well-known,众所周知的,ADJ,B2
+quarreling,quarreling,再吵,NOUN,B2
+hard to maintain,hard to maintain,难以维持,ADJ,B2
+non-substance,non-substance,非质,NOUN,B2
+morals,morals,道德,NOUN,B2
+expropriation,expropriation,征用,NOUN,B2
+relatively speaking,relatively speaking,相对而言,ADV,B2
+zodiac sign,zodiac sign,属相,NOUN,B2
+family ruin,family ruin,家破,NOUN,B2
+mri,mri,核磁共振,NOUN,B2
+western regions,western regions,西域,NOUN,B2
+growl,growl,低吼,NOUN,B2
+night view,night view,夜景,NOUN,B2
+smoothly,smoothly,顺利,ADV,B2
+stoicism,stoicism,斯多葛主义,NOUN,B2
+chest pain,chest pain,胸痛,NOUN,B2
+mutual generation,mutual generation,相生,NOUN,B2
+green-eyed,green-eyed,让碧眼,NOUN,B2
+classifier for trees,classifier for trees,棵,NUM,B2
+guitarist,guitarist,吉他手,NOUN,B2
+to be entranced,to be entranced,出神,VERB,B2
+to haggle,to haggle,讨价还价,VERB,B2
+none,none,没有一个,DET,B2
+overseas chinese,overseas chinese,华侨,NOUN,B2
+paronomasia,paronomasia,近音词双关,NOUN,B2
+to signify,to signify,意味着,VERB,B2
+correspondence,correspondence,通信,NOUN,B2
+to not come,to not come,不来,VERB,B2
+stinking,stinking,发臭的,ADJ,B2
+remote-controlled car,remote-controlled car,遥控车,NOUN,B2
+numerous,numerous,众多的,ADJ,B2
+social reconciliation,social reconciliation,社会和解,NOUN,B2
+over-stroke,over-stroke,超程,NOUN,B2
+social statistics,social statistics,社会统计,NOUN,B2
+enjoyment,enjoyment,享受,NOUN,B2
+counterfeit,counterfeit,假冒,ADJ,B2
+cold wave,cold wave,寒潮,NOUN,B2
+underestimation,underestimation,小看,NOUN,B2
+but you,but you,但您,NOUN,B2
+tenderloin,tenderloin,里脊,NOUN,B2
+essential equipment,essential equipment,要置,NOUN,B2
+re-abruptness,re-abruptness,再骤,NOUN,B2
+crushing defeat,crushing defeat,惨败,NOUN,B2
+unveiling ceremony,unveiling ceremony,揭幕仪式,NOUN,B2
+every day,every day,天天,ADV,B2
+to sign for,to sign for,签收,VERB,B2
+pinch,pinch,捏,NOUN,B2
+to cool down,to cool down,冷却,VERB,B2
+bitterness,bitterness,苦涩,NOUN,B2
+designated driver,designated driver,代驾,NOUN,B2
+to do one's best,to do one's best,尽力,VERB,B2
+roller blind,roller blind,卷帘,NOUN,B2
+failed bid,failed bid,流标,NOUN,B2
+instead on the contrary,instead on the contrary,反而,ADV,B2
+municipal,municipal,市政的,ADJ,B2
+to look down upon,to look down upon,看不起,VERB,B2
+hot air balloon,hot air balloon,热气球,NOUN,B2
+wetland,wetland,湿地,NOUN,B2
+no need,no need,不用,AUX,B2
+might,might,威力,NOUN,B2
+vehicle registration,vehicle registration,行驶证,NOUN,B2
+callous,callous,冷酷,ADJ,B2
+repulse,repulse,击退,NOUN,B2
+steamed stuffed bun,steamed stuffed bun,包子,NOUN,B2
+falling out,falling out,反目,NOUN,B2
+you cannot live,you cannot live,你也活不,NOUN,B2
+hilt,hilt,剑柄,NOUN,B2
+nurturing,nurturing,养好,NOUN,B2
+only-me,only-me,只我,NOUN,B2
+to make noise,to make noise,闹得,VERB,B2
+puberty,puberty,青春期,NOUN,B2
+draw out,draw out,引出,NOUN,B2
+interlocutor,interlocutor,对话者,NOUN,B2
+dumpling,dumpling,丸子,NOUN,B2
+reformism,reformism,改唯,NOUN,B2
+solid-state drive,solid-state drive,固态硬盘,NOUN,B2
+youngster,youngster,年少者,NOUN,B2
+thief presence,thief presence,有贼,NOUN,B2
+to provide evidence,to provide evidence,举证,VERB,B2
+faction,faction,派,NOUN,B2
+to be safe,to be safe,安好,VERB,B2
+hysterical,hysterical,歇斯底里的,ADJ,B2
+re-logic,re-logic,再逻,NOUN,B2
+god of war,god of war,战神,NOUN,B2
+ethereum,ethereum,以太坊,NOUN,B2
+exile,exile,流亡,NOUN,B2
+plight,plight,处境,NOUN,B2
+license plate restriction,license plate restriction,限号,NOUN,B2
+destitution,destitution,贫困,NOUN,B2
+to be responsible for,to be responsible for,负责,VERB,B2
+to focus,to focus,聚焦,VERB,B2
+to take office,to take office,就职,VERB,B2
+to count as,to count as,算,VERB,B2
+no harm,no harm,没事吧,NOUN,B2
+paper cutting,paper cutting,剪纸,NOUN,B2
+genesis,genesis,起源,NOUN,B2
+hay,hay,干草,NOUN,B2
+pity,pity,可惜,ADJ,B2
+condensation,condensation,凝结,NOUN,B2
+to matter,to matter,重要,VERB,B2
+two-way street,two-way street,双行道,NOUN,B2
+true heart,true heart,本心,NOUN,B2
+easy to say,easy to say,好说,NOUN,B2
+pavilion,pavilion,亭子,NOUN,B2
+what,what,什么,ADV,B2
+re-routing,re-routing,改轨,NOUN,B2
+bridal chamber,bridal chamber,洞房,NOUN,B2
+green technology,green technology,绿色技术,NOUN,B2
+pad,pad,垫,NOUN,B2
+to steer,to steer,引导,VERB,B2
+digitization,digitization,数字化,NOUN,B2
+re-fruit,re-fruit,再果,NOUN,B2
+habituation,habituation,习惯化,NOUN,B2
+loot,loot,战利品,NOUN,B2
+impairment,impairment,左手废,NOUN,B2
+to deep-fry,to deep-fry,油炸,VERB,B2
+forbidden land,forbidden land,禁地,NOUN,B2
+bass,bass,贝斯,NOUN,B2
+to vaccinate,to vaccinate,接种疫苗,VERB,B2
+ba zi,ba zi,八字,NOUN,B2
+to cash,to cash,兑现,VERB,B2
+this-camp,this-camp,这营,NOUN,B2
+contrary,contrary,反而,NOUN,B2
+backflow,backflow,倒流,NOUN,B2
+counter-mechanism,counter-mechanism,反机,NOUN,B2
+to fall back,to fall back,回落,VERB,B2
+to glance,to glance,瞥,VERB,B2
+human capacity,human capacity,人会,NOUN,B2
+a pile,a pile,一堆,NUM,B2
+felony,felony,重罪,NOUN,B2
+to lockdown,to lockdown,封城,VERB,B2
+just as in the past,just as in the past,一如既往,ADV,B2
+social stratification,social stratification,社会分层,NOUN,B2
+futurism,futurism,未来主义,NOUN,B2
+softball,softball,垒球,NOUN,B2
+minor course,minor course,辅修课,NOUN,B2
+heat wave,heat wave,热浪,NOUN,B2
+to be so,to be so,然,VERB,B2
+colonization,colonization,殖民化,NOUN,B2
+to purchase,to purchase,购买,VERB,B2
+glorification,glorification,赞美,NOUN,B2
+proposition,proposition,主张,NOUN,B2
+rush,rush,赶往,NOUN,B2
+father,father,父,PART,B2
+handwriting practice,handwriting practice,练字,NOUN,B2
+to nibble,to nibble,啃,VERB,B2
+income and expense,income and expense,收支,NOUN,B2
+bad idea,bad idea,坏水,NOUN,B2
+overdue,overdue,逾期,ADJ,B2
+shift rotation,shift rotation,倒班,NOUN,B2
+please,please,请,ADV,B2
+liaison,liaison,联络,NOUN,B2
+various departments,various departments,各部,NOUN,B2
+star anise,star anise,八角,NOUN,B2
+social stability,social stability,社会稳定,NOUN,B2
+to retell,to retell,转述,VERB,B2
+artistic portrait,artistic portrait,艺术照,NOUN,B2
+point in time,point in time,时间点,NOUN,B2
+social organization,social organization,社会组织,NOUN,B2
+amended interior,amended interior,改内,NOUN,B2
+really want,really want,真要,NOUN,B2
+unwillingness,unwillingness,不甘,NOUN,B2
+enemy must,enemy must,仇必,NOUN,B2
+that is,that is,即,ADV,B2
+conventional,conventional,传统的,ADJ,B2
+dissatisfied,dissatisfied,不满的,ADJ,B2
+social practice,social practice,社会实践,NOUN,B2
+carbon tax,carbon tax,碳税,NOUN,B2
+village head,village head,村长,NOUN,B2
+irascibility,irascibility,易怒,NOUN,B2
+smashing,smashing,砸过,NOUN,B2
+full power,full power,全力,NOUN,B2
+over-strategy,over-strategy,超策,NOUN,B2
+mode,mode,方式,NOUN,B2
+herder,herder,牧民,NOUN,B2
+tractor,tractor,拖拉机,NOUN,B2
+to seek truth from facts,to seek truth from facts,实事求是,VERB,B2
+bid collusion,bid collusion,串标,NOUN,B2
+anti-integration,anti-integration,反合,NOUN,B2
+trans-decision,trans-decision,超断,NOUN,B2
+this item,this item,这件,NOUN,B2
+re-inner,re-inner,再内,NOUN,B2
+counter-form,counter-form,反式,NOUN,B2
+purple yin,purple yin,紫阴,NOUN,B2
+legality,legality,合法性,NOUN,B2
+young master,young master,少庄主,NOUN,B2
+to prepare a lesson,to prepare a lesson,预习,VERB,B2
+non-sound,non-sound,非响,NOUN,B2
+proofreading,proofreading,校对,NOUN,B2
+car insurance,car insurance,车险,NOUN,B2
+wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
+reachable,reachable,可到达的,ADJ,B2
+whether or not,whether or not,是否,SCONJ,B2
+immunotherapy,immunotherapy,免疫治疗,NOUN,B2
+demilitarization,demilitarization,去武,NOUN,B2
+wounded,wounded,受伤的,ADJ,B2
+incoming,incoming,进来的,ADJ,B2
+script for play,script for play,剧本,NOUN,B2
+brewery,brewery,啤酒厂,NOUN,B2
+to stop me,to stop me,拦我,VERB,B2
+to run into,to run into,碰见,VERB,B2
+novelistic,novelistic,小说般的,ADJ,B2
+that arrow,that arrow,那一箭,NOUN,B2
+in writing,in writing,书面,NOUN,B2
+idyll,idyll,田园诗,NOUN,B2
+forbidden,forbidden,被禁止的,ADJ,B2
+some out,some out,出些,NOUN,B2
+appreciation banquet,appreciation banquet,答谢宴,NOUN,B2
+to ever,to ever,里何尝,VERB,B2
+to lock,to lock,锁上,VERB,B2
+antioxidant,antioxidant,抗氧化剂,NOUN,B2
+entertainment center,entertainment center,娱乐中心,NOUN,B2
+rationalization,rationalization,合理化,NOUN,B2
+to receive orders,to receive orders,受命,VERB,B2
+rust-proof,rust-proof,防锈,ADJ,B2
+to be on duty,to be on duty,值班,VERB,B2
+to prop,to prop,撑,VERB,B2
+environmental report,environmental report,环境报告,NOUN,B2
+coming and going,coming and going,往来,NOUN,B2
+to hope to wish,to hope to wish,希望,VERB,B2
+polluted,polluted,受污染的,ADJ,B2
+see off,see off,送走,NOUN,B2
+sad sorrowful,sad sorrowful,悲伤,ADJ,B2
+to draw on the experience of,to draw on the experience of,借鉴,VERB,B2
+to be hit,to be hit,中箭,VERB,B2
+starry sky,starry sky,星空,NOUN,B2
+to was,to was,是,VERB,B2
+serial killer,serial killer,连环杀手,NOUN,B2
+beside next to,beside next to,旁边,NOUN,B2
+rhetorical question,rhetorical question,宁非,NOUN,B2
+burnt,burnt,烧焦的,ADJ,B2
+cooked rice,cooked rice,米饭,NOUN,B2
+social distancing,social distancing,社交距离,NOUN,B2
+to do to make,to do to make,做,VERB,B2
+matchmaker,matchmaker,媒,NOUN,B2
+whether,whether,能否,NOUN,B2
+ride break,ride break,骑破,NOUN,B2
+your majesty,your majesty,陛下,NOUN,B2
+narrator,narrator,叙述者,NOUN,B2
+to have only,to have only,唯有,VERB,B2
+imperial father's will,imperial father's will,父皇要,NOUN,B2
+math,math,数学,NOUN,B2
+eternal alliance,eternal alliance,永结,NOUN,B2
+wine cup,wine cup,这酒盏,NOUN,B2
+blood debt,blood debt,血债,NOUN,B2
+a well,a well,井,NOUN,B2
+considerate,considerate,体贴,ADJ,B2
+horse departure,horse departure,马去,NOUN,B2
+righteousness,righteousness,亦正,NOUN,B2
+partial cause,partial cause,分因,NOUN,B2
+promoter,promoter,推动者,NOUN,B2
+face recognition,face recognition,认人,NOUN,B2
+retype,retype,再型,NOUN,B2
+enrollment,enrollment,注册,NOUN,B2
+on head,on head,当头,NOUN,B2
+to channel,to channel,疏导,VERB,B2
+running,running,进行中的,NOUN,B2
+brocade,brocade,锦绣,NOUN,B2
+public welfare,public welfare,公益性,NOUN,B2
+myself,myself,我自,NOUN,B2
+thermal,thermal,热的,ADJ,B2
+to hike,to hike,徒步旅行,VERB,B2
+one family,one family,一家,NUM,B2
+to cannot help,to cannot help,忍不住,VERB,B2
+non-war,non-war,非战,NOUN,B2
+to base,to base,基于,VERB,B2
+accord with,accord with,合乎,NOUN,B2
+to be good at,to be good at,擅长,VERB,B2
+reconsideration,reconsideration,重思,NOUN,B2
+cleansing,cleansing,清洗,NOUN,B2
+to grasp firmly,to grasp firmly,抓紧,VERB,B2
+too soft,too soft,太软,NOUN,B2
+maximum,maximum,最大,ADJ,B2
+ring road,ring road,绕城,NOUN,B2
+malady,malady,弊病,NOUN,B2
+to overdraw,to overdraw,透支,VERB,B2
+door handle,door handle,门把手,NOUN,B2
+to carry forward,to carry forward,发扬,VERB,B2
+semiology,semiology,符号学，症状学,NOUN,B2
+re-sequencing,re-sequencing,改骤,NOUN,B2
+tool room,tool room,工具间,NOUN,B2
+its details,its details,其详,NOUN,B2
+empty fame,empty fame,虚名,NOUN,B2
+long-distance bus,long-distance bus,长途车,NOUN,B2
+older brother,older brother,大哥哥,NOUN,B2
+tutoring,tutoring,补习,NOUN,B2
+heavy machine,heavy machine,重机,NOUN,B2
+recusal,recusal,回避,NOUN,B2
+non-level,non-level,非级,NOUN,B2
+to charter,to charter,租船,VERB,B2
+to widen,to widen,加宽,VERB,B2
+to hospitalize,to hospitalize,使住院,VERB,B2
+early warning,early warning,预警,NOUN,B2
+to know to recognize,to know to recognize,认识,VERB,B2
+traffic restriction,traffic restriction,限行,NOUN,B2
+amputation,amputation,截肢,NOUN,B2
+ancient times,ancient times,古代,NOUN,B2
+him,him,他吧,NOUN,B2
+slander,slander,诽谤,NOUN,B2
+eldest son,eldest son,长子,NOUN,B2
+wits,wits,心眼,NOUN,B2
+housing,housing,住房,NOUN,B2
+scan,scan,扫描件,NOUN,B2
+fraction marker,fraction marker,分之,PART,B2
+spirit training,spirit training,练神,NOUN,B2
+reprice,reprice,再价,NOUN,B2
+grounds,grounds,论据,NOUN,B2
+non-orbit,non-orbit,非轨,NOUN,B2
+one's heart's content,one's heart's content,尽情,ADV,B2
+sweet dream,sweet dream,美梦,NOUN,B2
+business meeting,business meeting,洽谈会,NOUN,B2
+puncture,puncture,穿刺,NOUN,B2
+changed policy,changed policy,改策,NOUN,B2
+mobile payment,mobile payment,移动支付,NOUN,B2
+fourteen,fourteen,十四,NUM,B2
+favorable circumstances,favorable circumstances,顺境,NOUN,B2
+physical evidence,physical evidence,物证,NOUN,B2
+heavy type,heavy type,重型,NOUN,B2
+re-evidence,re-evidence,重据,NOUN,B2
+collateral,collateral,附属的,ADJ,B2
+feudal,feudal,封建,ADJ,B2
+solvency,solvency,偿付能力,NOUN,B2
+month moon,month moon,月,NOUN,B2
+memorization,memorization,记忆,NOUN,B2
+they things,they things,它们,PRON,B2
+zinc,zinc,锌,NOUN,B2
+art gallery,art gallery,美术馆,NOUN,B2
+id photo,id photo,证件照,NOUN,B2
+situation circumstances,situation circumstances,情形,NOUN,B2
+risking death,risking death,冒死,NOUN,B2
+uncertain,uncertain,不确定的,ADJ,B2
+difficult problem,difficult problem,难题,NOUN,B2
+noncompliant,noncompliant,违规,ADJ,B2
+switch room,switch room,配电室,NOUN,B2
+non-specific,non-specific,非殊,NOUN,B2
+pace-setter,pace-setter,标兵,NOUN,B2
+rebellious heart,rebellious heart,反心,NOUN,B2
+to dispense medicine,to dispense medicine,配药,VERB,B2
+one book,one book,一本,NUM,B2
+record player,record player,唱机,NOUN,B2
+inside story,inside story,内幕,NOUN,B2
+phoenix,phoenix,拿凤,NOUN,B2
+to make a speech,to make a speech,发言,VERB,B2
+englishman,englishman,英国人,NOUN,B2
+badminton,badminton,羽毛球,NOUN,B2
+lord yu,lord yu,玉大人,NOUN,B2
+partial meaning,partial meaning,分义,NOUN,B2
+moderate rain,moderate rain,中雨,NOUN,B2
+to apply a cast,to apply a cast,打石膏,VERB,B2
+character word,character word,字,NOUN,B2
+a married couple,a married couple,夫妇,NOUN,B2
+asexual,asexual,无性的,ADJ,B2
+granite,granite,花岗岩,NOUN,B2
+marriageable,marriageable,适婚,NOUN,B2
+stomachache,stomachache,肚子痛,NOUN,B2
+one head,one head,一头,NUM,B2
+to there's still time,to there's still time,来得及,VERB,B2
+amended judgment,amended judgment,改断,NOUN,B2
+with difficulty,with difficulty,困难地,ADV,B2
+to not have,to not have,没,VERB,B2
+philanthropy,philanthropy,慈善,NOUN,B2
+to get acquainted,to get acquainted,相互认识,VERB,B2
+do not,do not,莫,ADV,B2
+upturn,upturn,好转,NOUN,B2
+second time,second time,再而,NOUN,B2
+counter-quality,counter-quality,反质,NOUN,B2
+look at you,look at you,你看你,NOUN,B2
+imam,imam,伊玛目,NOUN,B2
+morphology,morphology,形态学,NOUN,B2
+standing,standing,站立的,ADJ,B2
+occupied,occupied,被占用的,ADJ,B2
+to come along,to come along,一起来,VERB,B2
+liberalism,liberalism,自由主义,NOUN,B2
+and so on,and so on,之类,NOUN,B2
+third bestowal,third bestowal,三授,NOUN,B2
+to balance,to balance,平衡,VERB,B2
+in the sky,in the sky,天上,NOUN,B2
+special topic,special topic,专题,NOUN,B2
+id card,id card,身份证,NOUN,B2
+old master,old master,老太爷,NOUN,B2
+intruder,intruder,入侵者,NOUN,B2
+monitoring,monitoring,监控,NOUN,B2
+to take a leave of absence,to take a leave of absence,休学,VERB,B2
+laundry room,laundry room,洗衣房,NOUN,B2
+individual assignment,individual assignment,个人作业,NOUN,B2
+stationery,stationery,文具,NOUN,B2
+dried tofu,dried tofu,豆干,NOUN,B2
+seeking instant benefit,seeking instant benefit,急功近利,ADJ,B2
+counter-trend,counter-trend,反势,NOUN,B2
+welcome banquet,welcome banquet,欢迎宴,NOUN,B2
+ordinary people,ordinary people,老百姓,NOUN,B2
+digestion,digestion,消化,NOUN,B2
+good reputation,good reputation,清誉,NOUN,B2
+quarterly magazine,quarterly magazine,季刊,NOUN,B2
+to run quickly,to run quickly,奔驰,VERB,B2
+locker room,locker room,更衣室,NOUN,B2
+higher,higher,更高的,ADJ,B2
+super-quality,super-quality,超质,NOUN,B2
+abrasion,abrasion,擦伤,NOUN,B2
+textbook,textbook,教科书,NOUN,B2
+carrier,carrier,承运人,NOUN,B2
+to not about,to not about,不关,VERB,B2
+backup light,backup light,倒车灯,NOUN,B2
+publishing house,publishing house,出版社,NOUN,B2
+tidal,tidal,潮汐,ADJ,B2
+personal enmity,personal enmity,私仇,NOUN,B2
+to look for,to look for,寻找,VERB,B2
+female relatives,female relatives,女眷,NOUN,B2
+rockery,rockery,假山,NOUN,B2
+habitually in the past,habitually in the past,往常,NOUN,B2
+switchboard,switchboard,总机,NOUN,B2
+recommendation by others,recommendation by others,他荐,NOUN,B2
+times,times,倍,NOUN,B2
+re-limit,re-limit,重限,NOUN,B2
+to last a period of time,to last a period of time,为期,VERB,B2
+to can't believe,to can't believe,不敢相信,VERB,B2
+both hands,both hands,双手,NOUN,B2
+to answer reply,to answer reply,回答,VERB,B2
+emancipation,emancipation,解放,NOUN,B2
+distinguished,distinguished,杰出,ADJ,B2
+to suffer from insomnia,to suffer from insomnia,失眠,VERB,B2
+non-construction,non-construction,非建,NOUN,B2
+eastern,eastern,东方的,ADJ,B2
+variance,variance,方差,NOUN,B2
+to part by death,to part by death,死别,VERB,B2
+experienced,experienced,老练的,ADJ,B2
+seclusion exit,seclusion exit,出关,NOUN,B2
+re-creation,re-creation,再作,NOUN,B2
+decommissioning,decommissioning,退役,NOUN,B2
+facsimile,facsimile,副本,NOUN,B2
+top dressing,top dressing,追肥,NOUN,B2
+watermelon seed,watermelon seed,西瓜子,NOUN,B2
+afterward,afterward,去后,NOUN,B2
+military order,military order,军令,NOUN,B2
+provincial highway,provincial highway,省道,NOUN,B2
+congregation,congregation,集会,NOUN,B2
+ulcer,ulcer,溃疡,NOUN,B2
+june,june,六月,NOUN,B2
+clear soup,clear soup,江瑶清羹,NOUN,B2
+pragmatism,pragmatism,实用主义,NOUN,B2
+to see again,to see again,再见,VERB,B2
+direction sign,direction sign,指示牌,NOUN,B2
+to make a mistake,to make a mistake,弄错,VERB,B2
+clientelism,clientelism,庇护主义,NOUN,B2
+to solicit donations,to solicit donations,募捐,VERB,B2
+unworthy,unworthy,你不配,NOUN,B2
+gravel,gravel,砾石,NOUN,B2
+let alone,let alone,别说,ADV,B2
+catch,catch,捕捉,NOUN,B2
+chestnut,chestnut,板栗,NOUN,B2
+non-order,non-order,非序,NOUN,B2
+inside city,inside city,城内,NOUN,B2
+cultural relic,cultural relic,文物,NOUN,B2
+increasingly,increasingly,越来越,ADV,B2
+my residence,my residence,我府,NOUN,B2
+department head,department head,厅长,NOUN,B2
+social harmony,social harmony,社会和谐,NOUN,B2
+we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
+tax-exempt,tax-exempt,免税,ADJ,B2
+to be elected,to be elected,当选,VERB,B2
+in detail,in detail,详细地,ADV,B2
+shootout,shootout,枪战,NOUN,B2
+thrust toward,thrust toward,插向,NOUN,B2
+stinginess,stinginess,吝啬；小气,NOUN,B2
+options,options,期权,NOUN,B2
+to ingest,to ingest,服用,VERB,B2
+to tie up,to tie up,绑,VERB,B2
+re-enactment,re-enactment,再演,NOUN,B2
+yes,yes,是啊,NOUN,B2
+re-quantity,re-quantity,再量,NOUN,B2
+weekly test,weekly test,周测,NOUN,B2
+woodland,woodland,林地,NOUN,B2
+jurisdiction area,jurisdiction area,辖区,NOUN,B2
+quarter of a year,quarter of a year,季度,NOUN,B2
+to be eager,to be eager,心切,VERB,B2
+international student,international student,留学生,NOUN,B2
+major course,major course,专业课,NOUN,B2
+counter-logic,counter-logic,反逻,NOUN,B2
+full name,full name,大名,NOUN,B2
+to provide feedback,to provide feedback,反馈,VERB,B2
+to use chopsticks,to use chopsticks,动筷,VERB,B2
+preschool,preschool,幼儿园,NOUN,B2
+biomass,biomass,生物质,NOUN,B2
+to increase steadily,to increase steadily,与日俱增,VERB,B2
+inner court,inner court,朝内,NOUN,B2
+swindler,swindler,骗子,NOUN,B2
+department store,department store,百货商店,NOUN,B2
+manufacturer,manufacturer,制造商,NOUN,B2
+disinterested,disinterested,公正的,ADJ,B2
+errata,errata,勘误,NOUN,B2
+powerful nation,powerful nation,强国,NOUN,B2
+military power,military power,兵权,NOUN,B2
+blood sea,blood sea,血海,NOUN,B2
+flattery,flattery,奉承,NOUN,B2
+one night,one night,一晚,NUM,B2
+to go first,to go first,先去,VERB,B2
+only just,only just,才,ADV,B2
+bad news,bad news,坏消息,NOUN,B2
+but i,but i,可我,ADV,B2
+to limp,to limp,跛行,VERB,B2
+counter-technique,counter-technique,反术,NOUN,B2
+among them,among them,其中,PRON,B2
+tiling,tiling,铺瓷砖,NOUN,B2
+sophism,sophism,诡辩,NOUN,B2
+elegy,elegy,挽歌,NOUN,B2
+to cannot bear,to cannot bear,不堪,VERB,B2
+much,much,多,DET,B2
+to use crutches,to use crutches,拄拐,VERB,B2
+semiotics,semiotics,符号学,NOUN,B2
+trans-matter,trans-matter,超物,NOUN,B2
+universal applicability,universal applicability,普适性,NOUN,B2
+counter-route,counter-route,反途,NOUN,B2
+swordless,swordless,剑不,NOUN,B2
+toothache,toothache,牙痛,NOUN,B2
+anti-generality,anti-generality,反般,NOUN,B2
+matching,matching,配套,ADJ,B2
+do not use,do not use,别用,NOUN,B2
+re-boundary,re-boundary,重界,NOUN,B2
+nazi,nazi,纳粹分子,NOUN,B2
+compensatory leave,compensatory leave,调休,NOUN,B2
+accelerator,accelerator,油门,NOUN,B2
+reversion,reversion,重归,NOUN,B2
+aggression,aggression,侵略,NOUN,B2
+haggling,haggling,计较,NOUN,B2
+to neigh,to neigh,嘶鸣,VERB,B2
+tunic,tunic,束腰外衣,NOUN,B2
+rear part,rear part,后部,NOUN,B2
+to suture,to suture,缝合,VERB,B2
+to pay respects,to pay respects,参见,VERB,B2
+final stage,final stage,末期,NOUN,B2
+thinness,thinness,瘦,NOUN,B2
+uncooled,uncooled,未寒,NOUN,B2
+re-meaning,re-meaning,再义,NOUN,B2
+witness testimony,witness testimony,人证,NOUN,B2
+wiper,wiper,雨刷,NOUN,B2
+in wind,in wind,临风,NOUN,B2
+then you,then you,那你,PRON,B2
+non-trace,non-trace,非迹,NOUN,B2
+establishment,establishment,机构,NOUN,B2
+modified effect,modified effect,改效,NOUN,B2
+reshaping,reshaping,改形,NOUN,B2
+non-merit,non-merit,非功,NOUN,B2
+dowry,dowry,嫁妆,NOUN,B2
+service road,service road,辅路,NOUN,B2
+to sort,to sort,分类,VERB,B2
+to work hard for sth to strive for success,to work hard for sth to strive for success,争气,VERB,B2
+make mistake,make mistake,犯错,NOUN,B2
+contradictory,contradictory,矛盾的,ADJ,B2
+sound of activity,sound of activity,动静,NOUN,B2
+checkout,checkout,收银台,NOUN,B2
+re-battle,re-battle,重战,NOUN,B2
+heavy knot,heavy knot,重结,NOUN,B2
+preaching,preaching,劝诫,NOUN,B2
+video disc,video disc,影碟,NOUN,B2
+mother's reassurance,mother's reassurance,娘放心,NOUN,B2
+to want to need will,to want to need will,要,VERB,B2
+to amount to,to amount to,总计,VERB,B2
+progress report,progress report,进度报告,NOUN,B2
+savior,savior,救星,NOUN,B2
+decadent,decadent,颓废,ADJ,B2
+turn signal,turn signal,转向灯,NOUN,B2
+to stabilize,to stabilize,使稳定,VERB,B2
+obsessed,obsessed,着迷的,ADJ,B2
+contrary intention,contrary intention,反意,NOUN,B2
+week number,week number,周次,NOUN,B2
+super-system,super-system,超制,NOUN,B2
+these three,these three,这三,NOUN,B2
+reply to your-highness,reply to your-highness,回殿下,NOUN,B2
+anti-war,anti-war,反战,NOUN,B2
+non-state,non-state,非态,NOUN,B2
+first merit,first merit,首功,NOUN,B2
+to in spite of,to in spite of,不顾,VERB,B2
+reuse,reuse,重用,NOUN,B2
+hehe,hehe,嘿嘿,INTJ,B2
+expulsion,expulsion,驱逐,NOUN,B2
+to help assistance,to help assistance,帮助,VERB,B2
+repeated,repeated,反复的,ADJ,B2
+not allowed,not allowed,不准,ADJ,B2
+coaxing,coaxing,哄得,NOUN,B2
+to trouble,to trouble,有劳,VERB,B2
+hyper-use,hyper-use,超用,NOUN,B2
+to be brave,to be brave,勇善,VERB,B2
+should not,should not,不该,AUX,B2
+affair hall,affair hall,事殿,NOUN,B2
+prolixity,prolixity,冗长,NOUN,B2
+in love,in love,恋爱中的,ADJ,B2
+trans-guest,trans-guest,超客,NOUN,B2
+papaya,papaya,木瓜,NOUN,B2
+propriety,propriety,分寸,NOUN,B2
+studies,studies,学业,NOUN,B2
+rabbi,rabbi,拉比,NOUN,B2
+non-evidence,non-evidence,非据,NOUN,B2
+tacitly,tacitly,默不作声地,ADV,B2
+exaggerated,exaggerated,夸张的,ADJ,B2
+non-management,non-management,管不,NOUN,B2
+to pay tax,to pay tax,纳税,VERB,B2
+pomelo,pomelo,柚子,NOUN,B2
+instability,instability,不稳定,NOUN,B2
+to implicate,to implicate,连累,VERB,B2
+to wobble,to wobble,摇晃,VERB,B2
+life and death,life and death,生死,NOUN,B2
+social mobilization,social mobilization,社会动员,NOUN,B2
+couplet,couplet,对联,NOUN,B2
+talkativeness,talkativeness,多嘴,NOUN,B2
+rat-proof,rat-proof,防鼠,ADJ,B2
+to belong to,to belong to,属于,VERB,B2
+electronic payment,electronic payment,电子支付,NOUN,B2
+debatable,debatable,有争议的,ADJ,B2
+institutionalization,institutionalization,制度化,NOUN,B2
+off-road vehicle,off-road vehicle,越野车,NOUN,B2
+bid opening,bid opening,开标,NOUN,B2
+heard beile,heard beile,听说贝勒,NOUN,B2
+to be grateful,to be grateful,感激,VERB,B2
+macroscopic,macroscopic,宏观的,ADJ,B2
+consort,consort,福晋,NOUN,B2
+military intelligence,military intelligence,军情,NOUN,B2
+push luck,push luck,太得寸,NOUN,B2
+inexperienced,inexperienced,生疏的,ADJ,B2
+bianzhong,bianzhong,编钟,NOUN,B2
+melancholy,melancholy,忧郁,ADJ,B2
+monetary,monetary,金钱的,ADJ,B2
+anti-abstraction,anti-abstraction,反抽,NOUN,B2
+super-grade,super-grade,超级,NOUN,B2
+modified model,modified model,改模,NOUN,B2
+to enter city,to enter city,进城,VERB,B2
+seizure,seizure,没收,NOUN,B2
+replanning,replanning,再策,NOUN,B2
+super-thought,super-thought,超思,NOUN,B2
+snow shadow,snow shadow,雪影姐姐,NOUN,B2
+to turn on,to turn on,打开,VERB,B2
+flock,flock,兽群,NOUN,B2
+altered mechanism,altered mechanism,改机,NOUN,B2
+drifting,drifting,漂泊,NOUN,B2
+certificate of merit,certificate of merit,奖状,NOUN,B2
+surrealism,surrealism,超现实主义,NOUN,B2
+counter-skill,counter-skill,反技,NOUN,B2
+consecutive cards,consecutive cards,连牌,NOUN,B2
+matching time,matching time,对时,NOUN,B2
+face reading,face reading,面相,NOUN,B2
+to be defeated,to be defeated,会败,VERB,B2
+project assignment,project assignment,项目作业,NOUN,B2
+submarine,submarine,潜水艇,NOUN,B2
+to loosen,to loosen,放松,VERB,B2
+police station,police station,警察局,NOUN,B2
+plantation,plantation,人工林,NOUN,B2
+representative,representative,有代表性的,ADJ,B2
+animated film,animated film,动画片,NOUN,B2
+for the sake of,for the sake of,为了,ADP,B2
+yuanxiao,yuanxiao,元宵,NOUN,B2
+grandeur,grandeur,宏伟,NOUN,B2
+to relate to narrate,to relate to narrate,叙述,VERB,B2
+to specify,to specify,具体说明,VERB,B2
+window glass,window glass,窗玻璃,NOUN,B2
+taste preference,taste preference,口味,NOUN,B2
+jiaolong,jiaolong,娇龙,NOUN,B2
+nervousness,nervousness,紧张,NOUN,B2
+act jointly,act jointly,合伙,NOUN,B2
+lose,lose,上丢,NOUN,B2
+old person,old person,老人,NOUN,B2
+barbecue,barbecue,烧烤,NOUN,B2
+true concession,true concession,真让,NOUN,B2
+rebuke,rebuke,责备,NOUN,B2
+air defense,air defense,防空,NOUN,B2
+one day,one day,一天,NUM,B2
+i don't deserve your praise,i don't deserve your praise,不敢当,INTJ,B2
+first capping,first capping,首加缁布冠,NOUN,B2
+whole world,whole world,全世界,NOUN,B2
+civilized,civilized,文明的,ADJ,B2
+re-layering,re-layering,改层,NOUN,B2
+playmate,playmate,玩伴,NOUN,B2
+catholicism,catholicism,天主教,NOUN,B2
+raven,raven,乌鸦,NOUN,B2
+ballpoint pen,ballpoint pen,圆珠笔,NOUN,B2
+non-belief,non-belief,非信,NOUN,B2
+sports car,sports car,跑车,NOUN,B2
+hiking,hiking,徒步,NOUN,B2
+split,split,分裂,NOUN,B2
+to breach contract,to breach contract,违约,VERB,B2
+filial,filial,孝顺,ADJ,B2
+to be eager for,to be eager for,巴不得,VERB,B2
+my place,my place,我处,NOUN,B2
+travel fatigue,travel fatigue,车马劳顿,NOUN,B2
+we two,we two,我俩,PRON,B2
+law enforcement,law enforcement,执法,NOUN,B2
+non-model,non-model,非模,NOUN,B2
+up to,up to,为止,ADP,B2
+civil servant,civil servant,公务员,NOUN,B2
+gigantic,gigantic,巨大的,ADJ,B2
+executioner,executioner,刽子手,NOUN,B2
+re-pace,re-pace,重骤,NOUN,B2
+dilation,dilation,扩张,NOUN,B2
+to leave out,to leave out,省略,VERB,B2
+strange troops,strange troops,怪兵,NOUN,B2
+to consult reference,to consult reference,参考,VERB,B2
+tuna,tuna,金枪鱼,NOUN,B2
+anti-omnipresence,anti-omnipresence,反遍,NOUN,B2
+imperial relatives,imperial relatives,皇亲,NOUN,B2
+true form,true form,原形,NOUN,B2
+foundry,foundry,铸造厂,NOUN,B2
+responsiveness,responsiveness,反应性,NOUN,B2
+life-and-death,life-and-death,决生,NOUN,B2
+july,july,七月,NOUN,B2
+recurrence,recurrence,往复,NOUN,B2
+self-sacrifice,self-sacrifice,舍己,NOUN,B2
+to have lunch,to have lunch,吃午餐,VERB,B2
+timidity,timidity,胆怯,NOUN,B2
+advanced study,advanced study,深造,NOUN,B2
+non-ability,non-ability,非能,NOUN,B2
+to treat guests,to treat guests,请客,VERB,B2
+functionality,functionality,功能性,NOUN,B2
+counter-sole,counter-sole,反唯,NOUN,B2
+classifier for paintings cloth etc.,classifier for paintings cloth etc.,幅,NUM,B2
+reverse reflection,reverse reflection,反影,NOUN,B2
+disorientation,disorientation,迷失方向,NOUN,B2
+creditor's right,creditor's right,债权,NOUN,B2
+to tread,to tread,踏上,VERB,B2
+badly,badly,坏地,ADV,B2
+secret meeting,secret meeting,密会,NOUN,B2
+mountain descent,mountain descent,下山,NOUN,B2
+homosexual,homosexual,同性恋的,ADJ,B2
+a pair,a pair,一对,NUM,B2
+conceited,conceited,自负的,ADJ,B2
+falling though,falling though,虽坠,NOUN,B2
+single thought,single thought,一念,NOUN,B2
+silly girl,silly girl,傻丫头,NOUN,B2
+non-action,non-action,非作,NOUN,B2
+bid evaluation,bid evaluation,评标,NOUN,B2
+for what,for what,为了什么,ADV,B2
+only then,only then,才,ADV,B2
+non-thought,non-thought,非念,NOUN,B2
+social identity,social identity,社会身份,NOUN,B2
+to change tire,to change tire,换胎,VERB,B2
+accounting,accounting,会计,NOUN,B2
+counter-model,counter-model,反模,NOUN,B2
+supervision,supervision,监督,NOUN,B2
+non-abstraction,non-abstraction,非抽,NOUN,B2
+anti-measure,anti-measure,反度,NOUN,B2
+to put in order,to put in order,收拾,VERB,B2
+customary,customary,习惯的,ADJ,B2
+weirdo,weirdo,怪人,NOUN,B2
+reoperation,reoperation,再术,NOUN,B2
+to defend one's country,to defend one's country,卫国,VERB,B2
+buckwheat,buckwheat,荞麦,NOUN,B2
+procession,procession,行列,NOUN,B2
+unruffled,unruffled,从容,ADJ,B2
+technocracy,technocracy,技术官僚主义,NOUN,B2
+lord's words,lord's words,主说,NOUN,B2
+coniferous forest,coniferous forest,针叶林,NOUN,B2
+anti-action,anti-action,反作,NOUN,B2
+paw,paw,爪子,NOUN,B2
+tea plantation,tea plantation,茶园,NOUN,B2
+current dynasty,current dynasty,当朝,NOUN,B2
+to go online,to go online,上网,VERB,B2
+righteous indignation,righteous indignation,义愤,NOUN,B2
+to decline politely,to decline politely,婉拒,VERB,B2
+counter-observation,counter-observation,反察,NOUN,B2
+to roof,to roof,房顶,VERB,B2
+to sigh with sorrow,to sigh with sorrow,感慨,VERB,B2
+given,given,给定,NOUN,B2
+wood ear mushroom,wood ear mushroom,木耳,NOUN,B2
+boulder,boulder,巨石,NOUN,B2
+clearly demarcated,clearly demarcated,分明,ADJ,B2
+temporary refusal,temporary refusal,暂不,NOUN,B2
+social trend,social trend,社会趋势,NOUN,B2
+ha,ha,哈,INTJ,B2
+can only,can only,只能,AUX,B2
+silk cloth,silk cloth,丝绸,NOUN,B2
+to run to jog,to run to jog,跑步,VERB,B2
+less,less,更少,ADV,B2
+tight grip,tight grip,手握紧,NOUN,B2
+shortcoming,shortcoming,缺点,NOUN,B2
+regarding this,regarding this,对此,ADV,B2
+sowing,sowing,播种,NOUN,B2
+fine skin,fine skin,细皮,NOUN,B2
+counter-system,counter-system,反系,NOUN,B2
+to shift to an earlier date,to shift to an earlier date,提前,VERB,B2
+reverse inclusion,reverse inclusion,反纳,NOUN,B2
+to think up,to think up,构思,VERB,B2
+utilization,utilization,利用,NOUN,B2
+dissolution,dissolution,溶解,NOUN,B2
+you can,you can,您能,NOUN,B2
+his departure,his departure,他走,NOUN,B2
+black market,black market,黑市,NOUN,B2
+waiting room,waiting room,候诊室,NOUN,B2
+outhouse,outhouse,茅房,NOUN,B2
+spare time,spare time,业余,NOUN,B2
+pedestrian bridge,pedestrian bridge,天桥,NOUN,B2
+cooling,cooling,冷却,NOUN,B2
+negligible not,negligible not,不可忽视,ADJ,B2
+clear knowledge,clear knowledge,明知,NOUN,B2
+too much,too much,太,ADV,B2
+eyewitness,eyewitness,目击,NOUN,B2
+antibiotics,antibiotics,抗生素,NOUN,B2
+injured,injured,受伤的,ADJ,B2
+commemoration,commemoration,纪念,NOUN,B2
+congratulations,congratulations,恭喜,INTJ,B2
+better,better,越好,NOUN,B2
+hiss,hiss,嘶嘶声,NOUN,B2
+grenade,grenade,手榴弹,NOUN,B2
+military,military,军队,NOUN,B2
+expansive,expansive,扩张的,ADJ,B2
+academic,academic,学者,NOUN,B2
+lost,lost,迷失的,ADJ,B2
+to date,to date,注明日期,VERB,B2
+february,february,二月,NOUN,B2
+divinity,divinity,神性,NOUN,B2
+condescending,condescending,屈尊的,ADJ,B2
+inferiority,inferiority,劣势,NOUN,B2
+clandestine,clandestine,秘密的,ADJ,B2
+intolerance,intolerance,不容忍,NOUN,B2
+to deposit,to deposit,存放,VERB,B2
+christian,christian,基督徒,NOUN,B2
+indication,indication,指示,NOUN,B2
+nearby,nearby,附近的,ADJ,B2
+rear,rear,后面的,ADJ,B2
+to condition,to condition,制约,VERB,B2
+last night,last night,昨晚,ADV,B2
+shady,shady,阴凉的,ADJ,B2
+deformed,deformed,畸形的,ADJ,B2
+striker,striker,罢工者,NOUN,B2
+to daydream,to daydream,幻想,VERB,B2
+minister,minister,臣,PART,B2
+disputed,disputed,有争议的,ADJ,B2
+to cool,to cool,冷却,VERB,B2
+older,older,年长的,ADJ,B2
+pop music,pop music,流行音乐,NOUN,B2
+detection,detection,检测,NOUN,B2
+guardianship,guardianship,监护,NOUN,B2
+securitization,securitization,证券化,NOUN,B2
+enchanting,enchanting,迷人的,ADJ,B2
+several,several,几个,ADJ,B2
+to level,to level,夷平,VERB,B2
+turnip,turnip,芜菁,NOUN,B2
+quote,quote,报价单,NOUN,B2
+muslim,muslim,مسلم,NOUN,B2
+to attribute,to attribute,归因于,VERB,B2
+cupboard,cupboard,橱柜,NOUN,B2
+conquest,conquest,征服,NOUN,B2
+dumping,dumping,倾销,NOUN,B2
+draw,draw,平局,NOUN,B2
+damn,damn,该死,INTJ,B2
+seventh,seventh,第七,ADJ,B2
+to swarm,to swarm,分群,VERB,B2
+senate,senate,参议院,NOUN,B2
+open-minded,open-minded,思想开明的,ADJ,B2
+unambiguous,unambiguous,明确的,ADJ,B2
+hurrah,hurrah,万岁,INTJ,B2
+ninth,ninth,第九,ADJ,B2
+metallic,metallic,金属的,ADJ,B2
+right,right,右边,ADV,B2
+law firm,law firm,律师事务所,NOUN,B2
+regularity,regularity,规律性,NOUN,B2
+pronounced,pronounced,显著的,ADJ,B2
+from where,from where,从哪里,ADV,B2
+bread roll,bread roll,小圆面包,NOUN,B2
+chieftain,chieftain,酋长,NOUN,B2
+thunderstorm,thunderstorm,雷阵雨,NOUN,B2
+become,become,成为,AUX,B2
+diffuse,diffuse,模糊的,ADJ,B2
+private life,private life,私生活,NOUN,B2
+to switch,to switch,切换,VERB,B2
+loved,loved,被爱的,ADJ,B2
+refreshing,refreshing,令人清爽的,ADJ,B2
+since then,since then,从那以后,ADV,B2
+to empty,to empty,倒空,VERB,B2
+to rinse,to rinse,冲洗,VERB,B2
+to blow up,to blow up,炸毁,VERB,B2
+report card,report card,成绩单,NOUN,B2
+to give birth,to give birth,分娩,VERB,B2
+the more,the more,越,ADV,B2
+broke,broke,破产的,ADJ,B2
+across,across,越过,ADV,B2
+firstly,firstly,首先,ADV,B2
+separated,separated,分开的,ADJ,B2
+excursion,excursion,郊游,NOUN,B2
+about it,about it,关于它,ADV,B2
+hiding place,hiding place,藏身处,NOUN,B2
+infinitive marker,infinitive marker,去,PART,B2
+holidays,holidays,假期,NOUN,B2
+targeted,targeted,有针对性的,ADJ,B2
+wimp,wimp,懦夫,NOUN,B2
+sting,sting,刺,NOUN,B2
+it,it,对此,ADV,B2
+guided tour,guided tour,导游,NOUN,B2
+last name,last name,姓,NOUN,B2
+timetable,timetable,时刻表,NOUN,B2
+grid,grid,网格,NOUN,B2
+cigarette butt,cigarette butt,烟头,NOUN,B2
+to give as a gift,to give as a gift,赠送,VERB,B2
+the ursammlung,the ursammlung,复合词,NOUN,B2
+the verststoff,the verststoff,复合词,NOUN,B2
+the aufwendung,the aufwendung,复合词,NOUN,B2
+wage labor,wage labor,雇佣劳动,NOUN,B2
+to abtrocken,to abtrocken,动词,VERB,B2
+the ausstellung,the ausstellung,复合词,NOUN,B2
+concerning,concerning,关于,ADP,B2
+to go blind,to go blind,失明,VERB,B2
+the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
+the hochbindung,the hochbindung,复合词,NOUN,B2
+tasteless,tasteless,无味的,ADJ,B2
+learning curve,learning curve,学习曲线,NOUN,B2
+hintersucht,hintersucht,词,NOUN,B2
+einwirkung,einwirkung,词,NOUN,B2
+she they,she they,她,PRON,B2
+the aktivist,the aktivist,名词,NOUN,B2
+vortheilung,vortheilung,词,NOUN,B2
+the zuwandlung,the zuwandlung,复合词,NOUN,B2
+the vorrechnung,the vorrechnung,复合词,NOUN,B2
+the antrag,the antrag,名词,NOUN,B2
+getreibung,getreibung,词,NOUN,B2
+the unbildung,the unbildung,复合词,NOUN,B2
+the verstwerk,the verstwerk,复合词,NOUN,B2
+sky blue,sky blue,天蓝色,ADJ,B2
+the vorstellung,the vorstellung,复合词,NOUN,B2
+the adressat,the adressat,名词,NOUN,B2
 zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
-zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
+the einmessung,the einmessung,复合词,NOUN,B2
+christmas tree,christmas tree,圣诞树,NOUN,B2
+geteilung,geteilung,词,NOUN,B2
+unfahrt,unfahrt,词,NOUN,B2
+the aufwandlung,the aufwandlung,复合词,NOUN,B2
+romanian,romanian,罗马尼亚人,NOUN,B2
+but rather,but rather,而是,CCONJ,B2
+lord god,lord god,上帝,NOUN,B2
+nahfahrt,nahfahrt,词,NOUN,B2
+twitching,twitching,抽搐的,ADJ,B2
+the tiefbindung,the tiefbindung,复合词,NOUN,B2
+fernrechnung,fernrechnung,词,NOUN,B2
+aufweisung,aufweisung,词,NOUN,B2
+hinterrechnung,hinterrechnung,词,NOUN,B2
+the erzkraft,the erzkraft,复合词,NOUN,B2
+vorderfassung,vorderfassung,词,NOUN,B2
+the aufheilung,the aufheilung,复合词,NOUN,B2
+vorwandel,vorwandel,词,NOUN,B2
+the unleitung,the unleitung,复合词,NOUN,B2
+to pressurize,to pressurize,逼迫,VERB,B2
+einnahme,einnahme,词,NOUN,B2
+emergency doctor,emergency doctor,急诊医生,NOUN,B2
+the aushandlung,the aushandlung,复合词,NOUN,B2
+yikes,yikes,哎呀,INTJ,B2
+misstreibung,misstreibung,词,NOUN,B2
+oddball,oddball,怪人,NOUN,B2
+grown,grown,长大的,ADJ,B2
+theme music,theme music,主题曲,NOUN,B2
+nachsuchung,nachsuchung,词,NOUN,B2
+university student,university student,大学生,NOUN,B2
+nachsinnung,nachsinnung,词,NOUN,B2
+bodily harm,bodily harm,人身伤害,NOUN,B2
+the ansage,the ansage,名词,NOUN,B2
+trash bag,trash bag,垃圾袋,NOUN,B2
+sow,sow,母猪,NOUN,B2
+in view of,in view of,鉴于,ADP,B2
+the andrang,the andrang,名词,NOUN,B2
+the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
+to break out,to break out,爆发,VERB,B2
+the verstleitung,the verstleitung,复合词,NOUN,B2
+unnahme,unnahme,词,NOUN,B2
+mortal fear,mortal fear,极度恐惧,NOUN,B2
+the berechnung,the berechnung,复合词,NOUN,B2
+to breathe again,to breathe again,松口气,VERB,B2
+hochweisung,hochweisung,词,NOUN,B2
+hinterrichtung,hinterrichtung,词,NOUN,B2
+the erzheilung,the erzheilung,复合词,NOUN,B2
+burdened,burdened,负担重的,ADJ,B2
+to make sense,to make sense,讲得通,VERB,B2
+sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
+to stint,to stint,吝啬,VERB,B2
+the grundstoff,the grundstoff,复合词,NOUN,B2
+the anwerk,the anwerk,复合词,NOUN,B2
+the abmessung,the abmessung,复合词,NOUN,B2
+the hochstoff,the hochstoff,复合词,NOUN,B2
+the untererweiterung,the untererweiterung,复合词,NOUN,B2
+the urheilung,the urheilung,复合词,NOUN,B2
+benahme,benahme,词,NOUN,B2
+zersucht,zersucht,词,NOUN,B2
+zufahrt,zufahrt,词,NOUN,B2
+hintertheilung,hintertheilung,词,NOUN,B2
+the verwandlung,the verwandlung,复合词,NOUN,B2
+the aufstoff,the aufstoff,复合词,NOUN,B2
+the anbeginn,the anbeginn,名词,NOUN,B2
+the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
+the alpinismus,the alpinismus,名词,NOUN,B2
+the missbildung,the missbildung,复合词,NOUN,B2
+the erzwendung,the erzwendung,复合词,NOUN,B2
+verschaft,verschaft,词,NOUN,B2
+the anform,the anform,复合词,NOUN,B2
+city map,city map,城市地图,NOUN,B2
+the nachbindung,the nachbindung,复合词,NOUN,B2
+resident,resident,定居的,ADJ,B2
+to queue,to queue,排队,VERB,B2
+erfahrt,erfahrt,词,NOUN,B2
+the aktnadel,the aktnadel,名词,NOUN,B2
+the weitstoff,the weitstoff,复合词,NOUN,B2
+fernsucht,fernsucht,词,NOUN,B2
+ausgestaltung,ausgestaltung,词,NOUN,B2
+erweisung,erweisung,词,NOUN,B2
+the zurechnung,the zurechnung,复合词,NOUN,B2
+urgabe,urgabe,词,NOUN,B2
+the abholung,the abholung,名词,NOUN,B2
+einsprache,einsprache,词,NOUN,B2
+the abkraft,the abkraft,复合词,NOUN,B2
+comma,comma,逗号,PUNCT,B2
+guards,guards,警卫,NOUN,B2
+unfassung,unfassung,词,NOUN,B2
+the mitheilung,the mitheilung,复合词,NOUN,B2
+the vorordnung,the vorordnung,复合词,NOUN,B2
+the auserweiterung,the auserweiterung,复合词,NOUN,B2
+semicolon,semicolon,分号,PUNCT,B2
+to share divide,to share divide,分享,VERB,B2
+getheilung,getheilung,词,NOUN,B2
+to pick out,to pick out,挑选,VERB,B2
+usual thing,usual thing,惯例,NOUN,B2
+host of angels,host of angels,天使群,NOUN,B2
+the abweisung,the abweisung,名词,NOUN,B2
+to anesthetize,to anesthetize,麻醉,VERB,B2
+oberleitung,oberleitung,词,NOUN,B2
+president female,president female,女总统,NOUN,B2
+beteilung,beteilung,词,NOUN,B2
+the beleitung,the beleitung,复合词,NOUN,B2
+to switch off,to switch off,关掉,VERB,B2
+unweisung,unweisung,词,NOUN,B2
+urwandel,urwandel,词,NOUN,B2
+investigated,investigated,被调查的,ADJ,B2
+drinking glass,drinking glass,水杯,NOUN,B2
+worst thing,worst thing,最坏的事,NOUN,B2
+eingabe,eingabe,词,NOUN,B2
+the hochleitung,the hochleitung,复合词,NOUN,B2
+weitweisung,weitweisung,词,NOUN,B2
+thousands,thousands,数千,NOUN,B2
+to keep secret,to keep secret,隐瞒,VERB,B2
+ausforderung,ausforderung,词,NOUN,B2
+hinterleitung,hinterleitung,词,NOUN,B2
+the weitminderung,the weitminderung,复合词,NOUN,B2
+groan,groan,呻吟,NOUN,B2
+so to speak,so to speak,可以说,ADV,B2
+wiedertreibung,wiedertreibung,词,NOUN,B2
+everyday life,everyday life,日常生活,NOUN,B2
+naherziehung,naherziehung,词,NOUN,B2
+vegetarian,vegetarian,素食者,NOUN,B2
+the tiefleitung,the tiefleitung,复合词,NOUN,B2
+hearts,hearts,心,NOUN,B2
+the missordnung,the missordnung,复合词,NOUN,B2
+motherfucker,motherfucker,混蛋,NOUN,B2
+crap,crap,屎,NOUN,B2
+thin-walled,thin-walled,隔音差的,ADJ,B2
+the aufleitung,the aufleitung,复合词,NOUN,B2
+the beminderung,the beminderung,复合词,NOUN,B2
+the anbruch,the anbruch,名词,NOUN,B2
+sagittarius,sagittarius,射手座,NOUN,B2
+the akademie,the akademie,名词,NOUN,B2
+the bewendung,the bewendung,复合词,NOUN,B2
+to abschweifen,to abschweifen,动词,VERB,B2
+at the,at the,在...时,ADP,B2
+the abwert,the abwert,复合词,NOUN,B2
+einteilung,einteilung,词,NOUN,B2
+urteilung,urteilung,词,NOUN,B2
+the zuhandlung,the zuhandlung,复合词,NOUN,B2
+the erzmischung,the erzmischung,复合词,NOUN,B2
+per,per,每,ADP,B2
+to lay down,to lay down,放下,VERB,B2
+to play along,to play along,配合,VERB,B2
+the ausbildung,the ausbildung,复合词,NOUN,B2
+auswandel,auswandel,词,NOUN,B2
+weitwandel,weitwandel,词,NOUN,B2
+the hochordnung,the hochordnung,复合词,NOUN,B2
+to step in,to step in,介入,VERB,B2
+anteilung,anteilung,词,NOUN,B2
+ursicht,ursicht,词,NOUN,B2
+to stay here,to stay here,留在这里,VERB,B2
+the nachleitung,the nachleitung,复合词,NOUN,B2
+the zerbildung,the zerbildung,复合词,NOUN,B2
+the gemischung,the gemischung,复合词,NOUN,B2
+the gebindung,the gebindung,复合词,NOUN,B2
+the anreiz,the anreiz,名词,NOUN,B2
+annual wage,annual wage,年薪,NOUN,B2
+untersinnung,untersinnung,词,NOUN,B2
+the aktion,the aktion,名词,NOUN,B2
+erzregelung,erzregelung,词,NOUN,B2
+the abhang,the abhang,名词,NOUN,B2
+unterpflegung,unterpflegung,词,NOUN,B2
+that yonder,that yonder,那个,DET,B2
+weitsuchung,weitsuchung,词,NOUN,B2
+the mitbildung,the mitbildung,复合词,NOUN,B2
+from it,from it,从中,ADV,B2
+the mitstellung,the mitstellung,复合词,NOUN,B2
+the gewendung,the gewendung,复合词,NOUN,B2
+einweisung,einweisung,词,NOUN,B2
+gerichtung,gerichtung,词,NOUN,B2
+einerziehung,einerziehung,词,NOUN,B2
+sacrificed,sacrificed,牺牲,ADJ,B2
+serve markup,serve markup,发球/加价,NOUN,B2
+chain mail,chain mail,锁子甲,NOUN,B2
+the erzwerk,the erzwerk,复合词,NOUN,B2
+the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
+agreed,agreed,一致的,ADJ,B2
+the weitmischung,the weitmischung,复合词,NOUN,B2
+urgestaltung,urgestaltung,词,NOUN,B2
+helper,helper,助手,NOUN,B2
+ausweisung,ausweisung,词,NOUN,B2
+distorted image,distorted image,扭曲的形象,NOUN,B2
+the bemessung,the bemessung,复合词,NOUN,B2
+german class,german class,德语课,NOUN,B2
+the erwendung,the erwendung,复合词,NOUN,B2
+the unmischung,the unmischung,复合词,NOUN,B2
+to get by,to get by,过得去,VERB,B2
+the adoption,the adoption,名词,NOUN,B2
+anrichtung,anrichtung,词,NOUN,B2
+the vorwert,the vorwert,复合词,NOUN,B2
+aussinnung,aussinnung,词,NOUN,B2
+of,of,之,PART,B2
+willing,willing,肯,AUX,B2
+pool,pool,池,PART,B2
+divine,divine,如神,NOUN,B2
+sir,sir,郎,PART,B2
+emigration,emigration,移民,NOUN,B2
+advanced,advanced,高级的,ADJ,B2
+swollen,swollen,肿胀的,ADJ,B2
+pathology,pathology,病理学,NOUN,B2
+to have to,to have to,必须,VERB,B2
+to infest,to infest,滋生,VERB,B2
+emblem,emblem,徽章,NOUN,B2
+dictator,dictator,独裁者,NOUN,B2
+illumination,illumination,照明,NOUN,B2
+to undress,to undress,脱衣,VERB,B2
+congruent,congruent,一致的,ADJ,B2
+to abort,to abort,流产,VERB,B2
+dignitary,dignitary,高官,NOUN,B2
+perplexed,perplexed,困惑的,ADJ,B2
+stimulus,stimulus,刺激,NOUN,B2
+grumpy,grumpy,脾气坏的,ADJ,B2
+homonymy,homonymy,同音异义,NOUN,B2
+redemption,redemption,救赎,NOUN,B2
+witchcraft,witchcraft,巫术,NOUN,B2
+to irrigate,to irrigate,灌溉,VERB,B2
+to eclipse,to eclipse,使失色,VERB,B2
+hepatic,hepatic,肝脏的,ADJ,B2
+partial,partial,部分的,ADJ,B2
+homogeneity,homogeneity,同质性,NOUN,B2
+muzzle,muzzle,口套,NOUN,B2
+philologist,philologist,语言学家,NOUN,B2
+fidelity,fidelity,忠诚,NOUN,B2
+insolvent,insolvent,无偿还能力的,ADJ,B2
+free of charge,free of charge,免费,NOUN,B2
+fatality,fatality,致命性,NOUN,B2
+inefficiency,inefficiency,低效,NOUN,B2
+to overflow,to overflow,溢出,VERB,B2
+endemic,endemic,地方性的,ADJ,B2
+shiver,shiver,寒战,NOUN,B2
+diminutive,diminutive,指小词,NOUN,B2
+laxity,laxity,松弛,NOUN,B2
+balloon,balloon,气球,NOUN,B2
+wear,wear,磨损,NOUN,B2
+desertion,desertion,逃亡,NOUN,B2
+elocution,elocution,演讲术,NOUN,B2
+duplicity,duplicity,口是心非,NOUN,B2
+extended,extended,广泛的,ADJ,B2
+fifteen,fifteen,十五,NUM,B2
+pharaoh,pharaoh,法老,NOUN,B2
+fiery,fiery,热烈的,ADJ,B2
+rubble,rubble,瓦砾,NOUN,B2
+babysitter,babysitter,保姆,NOUN,B2
+figurative,figurative,比喻的,ADJ,B2
+counterfeiting,counterfeiting,伪造,NOUN,B2
+erotic,erotic,色情的,ADJ,B2
+counterproductive,counterproductive,适得其反的,ADJ,B2
+gravely,gravely,严重地,ADV,B2
+to invoke,to invoke,援引,VERB,B2
+to gossip,to gossip,闲聊,VERB,B2
+cognition,cognition,认知,NOUN,B2
+historicity,historicity,历史性,NOUN,B2
+imperfect,imperfect,不完美的,ADJ,B2
+to implant,to implant,植入,VERB,B2
+to spot,to spot,看见,VERB,B2
+self-denial,self-denial,自我牺牲,NOUN,B2
+festive,festive,节日的,ADJ,B2
+greek,greek,希腊语,NOUN,B2
+discernment,discernment,洞察力,NOUN,B2
+tiresome,tiresome,累人的,ADJ,B2
+to move away,to move away,移开,VERB,B2
+snitch,snitch,告密者,NOUN,B2
+hotelier,hotelier,旅馆老板,NOUN,B2
+funereal,funereal,丧葬的,ADJ,B2
+welcoming,welcoming,舒适的,ADJ,B2
+to standardize,to standardize,标准化,VERB,B2
+curative,curative,有疗效的,ADJ,B2
+to plot,to plot,密谋,VERB,B2
+islamic,islamic,伊斯兰的,ADJ,B2
+combativeness,combativeness,好斗性,NOUN,B2
+impartiality,impartiality,公正,NOUN,B2
+fatuity,fatuity,愚昧,NOUN,B2
+to nickname,to nickname,给...起绰号,VERB,B2
+to gloss,to gloss,注释,VERB,B2
+to redden,to redden,变红,VERB,B2
+stratum,stratum,阶层,NOUN,B2
+disloyal,disloyal,不忠的,ADJ,B2
+illustration,illustration,插图,NOUN,B2
+explicitly,explicitly,明确地,ADV,B2
+to calm down,to calm down,使平静,VERB,B2
+wintry,wintry,冬天的,ADJ,B2
+flourishing,flourishing,繁荣的,ADJ,B2
+favoritism,favoritism,偏袒,NOUN,B2
+decal,decal,贴花,NOUN,B2
+to sulk,to sulk,生闷气,VERB,B2
+corollary,corollary,推论,NOUN,B2
+fragmentary,fragmentary,零碎的,ADJ,B2
+to ally,to ally,结盟,VERB,B2
+conception,conception,概念,NOUN,B2
+teaching,teaching,教学的,ADJ,B2
+contingent,contingent,偶然的,ADJ,B2
+deplorable,deplorable,可悲的,ADJ,B2
+cynicism,cynicism,犬儒主义,NOUN,B2
+inconceivable,inconceivable,不可想象的,ADJ,B2
+remote control,remote control,遥控器,NOUN,B2
+to tear out,to tear out,拔出,VERB,B2
+trembling,trembling,颤抖的,ADJ,B2
+dilatory,dilatory,拖延的,ADJ,B2
+entrails,entrails,内脏,NOUN,B2
+diffusion,diffusion,传播,NOUN,B2
+to set aside,to set aside,移开,VERB,B2
+grandiosity,grandiosity,宏伟,NOUN,B2
+fallibility,fallibility,易错性,NOUN,B2
+to gain weight,to gain weight,变胖,VERB,B2
+to undo,to undo,解开,VERB,B2
+philosophical,philosophical,哲学的,ADJ,B2
+taxpayer,taxpayer,纳税人,NOUN,B2
+deterioration,deterioration,恶化,NOUN,B2
+undoubtedly,undoubtedly,无疑地,ADV,B2
+to dissipate,to dissipate,消散,VERB,B2
+long-lasting,long-lasting,持久的,ADJ,B2
+disc,disc,光盘,NOUN,B2
+decidedly,decidedly,坚决地,ADV,B2
+complexion,complexion,肤色,NOUN,B2
+physiological,physiological,生理的,ADJ,B2
+ejection,ejection,喷射,NOUN,B2
+imaginative,imaginative,富有想象力的,ADJ,B2
+jubilation,jubilation,欢欣,NOUN,B2
+inclusion,inclusion,包含,NOUN,B2
+hinge,hinge,合页,NOUN,B2
+to detail,to detail,详述,VERB,B2
+to prop up,to prop up,支撑,VERB,B2
+enumeration,enumeration,列举,NOUN,B2
+gutter,gutter,路沟,NOUN,B2
+fictitious,fictitious,虚构的,ADJ,B2
+carefree,carefree,无忧无虑的,ADJ,B2
+on purpose,on purpose,故意地,ADV,B2
+inkling,inkling,预感,NOUN,B2
+infidelity,infidelity,不忠,NOUN,B2
+puddle,puddle,水坑,NOUN,B2
+exponential,exponential,指数的,ADJ,B2
+postage,postage,邮资,NOUN,B2
+kiosk,kiosk,亭子,NOUN,B2
+feminine,feminine,女性的,ADJ,B2
+to age,to age,变老,VERB,B2
+imposing,imposing,宏伟的,ADJ,B2
+comparable,comparable,可比较的,ADJ,B2
+cigar,cigar,雪茄,NOUN,B2
+to riddle,to riddle,使布满孔洞,VERB,B2
+eroticism,eroticism,色情,NOUN,B2
+defective,defective,有缺陷的,ADJ,B2
+hydraulic,hydraulic,液压的,ADJ,B2
+parsimony,parsimony,吝啬,NOUN,B2
+jurist,jurist,法学家,NOUN,B2
+extract,extract,摘录,NOUN,B2
+to intoxicate,to intoxicate,使中毒,VERB,B2
+two-headed,two-headed,双头的,ADJ,B2
+emblematic,emblematic,象征性的,ADJ,B2
+devaluation,devaluation,贬值,NOUN,B2
+railway,railway,铁路的,ADJ,B2
+ungrateful,ungrateful,忘恩负义的,ADJ,B2
+itinerary,itinerary,行程,NOUN,B2
+unreality,unreality,虚幻,NOUN,B2
+to inconvenience,to inconvenience,使不便,VERB,B2
+to snoop,to snoop,窥探,VERB,B2
+disarmament,disarmament,裁军,NOUN,B2
+to harden,to harden,使经受锻炼,VERB,B2
+to seat,to seat,使坐下,VERB,B2
+exegete,exegete,注释家,NOUN,B2
+unthinkable,unthinkable,不可想象的,ADJ,B2
+cosmetic,cosmetic,化妆品的,ADJ,B2
+barely,barely,几乎不,ADV,B2
+seal,seal,海豹,NOUN,B2
+devastating,devastating,毁灭性的,ADJ,B2
+to abstract,to abstract,抽象,VERB,B2
+hermit,hermit,隐士,NOUN,B2
+invader,invader,入侵者,NOUN,B2
+deference,deference,敬意,NOUN,B2
+supplication,supplication,恳求,NOUN,B2
+to spawn,to spawn,产卵,VERB,B2
+latin,latin,拉丁的,ADJ,B2
+generic,generic,通用的,ADJ,B2
+flammable,flammable,易燃的,ADJ,B2
+rebellious,rebellious,叛逆的,ADJ,B2
+to trivialize,to trivialize,使平庸,VERB,B2
+monarch,monarch,君主,NOUN,B2
+to debut,to debut,首次亮相,VERB,B2
+curly,curly,卷曲的,ADJ,B2
+unfaithful,unfaithful,不忠的,ADJ,B2
+casuistry,casuistry,决疑法,NOUN,B2
+eccentricity,eccentricity,古怪,NOUN,B2
+infirmary,infirmary,医务室,NOUN,B2
+tangle,tangle,混乱,NOUN,B2
+demarcation,demarcation,划界,NOUN,B2
+consultative,consultative,咨询的,ADJ,B2
+devilish,devilish,恶魔般的,ADJ,B2
+chosen,chosen,精选的,ADJ,B2
+jurisprudence,jurisprudence,法理学,NOUN,B2
+councilor,councilor,市议员,NOUN,B2
+sunflower,sunflower,向日葵,NOUN,B2
+frieze,frieze,檐壁,NOUN,B2
+nape,nape,后颈,NOUN,B2
+corrosive,corrosive,腐蚀性的,ADJ,B2
+paroxysm,paroxysm,发作,NOUN,B2
+graphology,graphology,笔迹学,NOUN,B2
+humanist,humanist,人文主义者,NOUN,B2
+erudition,erudition,博学,NOUN,B2
+conversion,conversion,转换,NOUN,B2
+precisely,precisely,确切地; 正好,ADV,B2
+manifesto,manifesto,宣言,NOUN,B2
+to inflame,to inflame,使发炎,VERB,B2
+to unmask,to unmask,揭穿,VERB,B2
+exuberant,exuberant,繁茂的,ADJ,B2
+spatial,spatial,空间的,ADJ,B2
+duvet,duvet,羽绒被,NOUN,B2
+time occasion,time occasion,次,NOUN,B2
+to flash,to flash,闪烁,VERB,B2
+unconditional,unconditional,无条件的,ADJ,B2
+inquisition,inquisition,宗教裁判所,NOUN,B2
+frigate,frigate,护卫舰,NOUN,B2
+dissident,dissident,异见者,NOUN,B2
+wooded,wooded,树木茂盛的,ADJ,B2
+to bring closer,to bring closer,靠近,VERB,B2
+choleric,choleric,易怒的,ADJ,B2
+scrupulously,scrupulously,一丝不苟地,ADV,B2
+to bristle,to bristle,使竖起,VERB,B2
+dependence,dependence,依赖,NOUN,B2
+yarn,yarn,纱线,NOUN,B2
+co-owner,co-owner,共有人,NOUN,B2
+exploration,exploration,探索,NOUN,B2
+fatalism,fatalism,宿命论,NOUN,B2
+inhuman,inhuman,不人道的,ADJ,B2
+scandalous,scandalous,可耻的,ADJ,B2
+descriptive,descriptive,描述性的,ADJ,B2
+confessional,confessional,宗派的,ADJ,B2
+to be moved,to be moved,感动,VERB,B2
+steep,steep,陡峭的,ADJ,B2
+desolation,desolation,荒凉,NOUN,B2
+fragility,fragility,脆弱,NOUN,B2
+to nail,to nail,钉,VERB,B2
+self-taught,self-taught,自学的,ADJ,B2
+to dishonor,to dishonor,使蒙羞,VERB,B2
+ordinance,ordinance,条例,NOUN,B2
+shamelessness,shamelessness,无耻,NOUN,B2
+fortuitous,fortuitous,偶然的,ADJ,B2
+gravitation,gravitation,引力,NOUN,B2
+to slide,to slide,滑动,VERB,B2
+to conjecture,to conjecture,猜测,VERB,B2
+nomad,nomad,游牧者,NOUN,B2
+epic,epic,史诗的,ADJ,B2
+complement,complement,补充物,NOUN,B2
+skylight,skylight,天窗,NOUN,B2
+insufficiency,insufficiency,不足,NOUN,B2
+evocation,evocation,唤起,NOUN,B2
+proselytism,proselytism,传教,NOUN,B2
+bragging,bragging,吹嘘,NOUN,B2
+flagrancy,flagrancy,现行,NOUN,B2
+to assault,to assault,袭击,VERB,B2
+detriment,detriment,损害,NOUN,B2
+to hail,to hail,下冰雹,VERB,B2
+restriction,restriction,限制,NOUN,B2
+impunity,impunity,逍遥法外,NOUN,B2
+to impute,to impute,归咎,VERB,B2
+to intercede,to intercede,调停,VERB,B2
+to knit,to knit,编织,VERB,B2
+conservatory,conservatory,音乐学院,NOUN,B2
+deposition,deposition,证词,NOUN,B2
+etymology,etymology,词源学,NOUN,B2
+to incur,to incur,招致,VERB,B2
+insecurity,insecurity,不安全感,NOUN,B2
+commiseration,commiseration,同情,NOUN,B2
+controllable,controllable,可控制的,ADJ,B2
+to shelter,to shelter,庇护,VERB,B2
+moving,moving,感人的,ADJ,B2
+to radiate,to radiate,辐射,VERB,B2
+humanitarian,humanitarian,人道主义的,ADJ,B2
+to repeal,to repeal,废除,VERB,B2
+reach,reach,范围,NOUN,B2
+to anger,to anger,使生气,VERB,B2
+conciliatory,conciliatory,调和的,ADJ,B2
+generality,generality,普遍性,NOUN,B2
+embolism,embolism,栓塞,NOUN,B2
+incoherent,incoherent,不连贯的,ADJ,B2
+lizard,lizard,蜥蜴,NOUN,B2
+propeller,propeller,螺旋桨,NOUN,B2
+embryo,embryo,胚胎,NOUN,B2
+to crash,to crash,碰撞,VERB,B2
+schematic,schematic,概要的,ADJ,B2
+express,express,明确的,ADJ,B2
+to rough-hew,to rough-hew,粗加工,VERB,B2
+infamy,infamy,恶名,NOUN,B2
+feminist,feminist,女权主义者,NOUN,B2
+desirable,desirable,可取的,ADJ,B2
+irritating,irritating,令人恼火的,ADJ,B2
+diaphragm,diaphragm,横膈膜,NOUN,B2
+failed,failed,失败的,ADJ,B2
+squall,squall,骤雨,NOUN,B2
+imprint,imprint,印记,NOUN,B2
+stopover,stopover,中途停留,NOUN,B2
+irregularity,irregularity,不规则,NOUN,B2
+homily,homily,布道,NOUN,B2
+looting,looting,掠夺,NOUN,B2
+deceased,deceased,已故的,ADJ,B2
+school,school,学校的,ADJ,B2
+to expatriate,to expatriate,使移居国外,VERB,B2
+daycare,daycare,托儿所,NOUN,B2
+to leaf through,to leaf through,翻阅,VERB,B2
+to swell,to swell,使肿胀,VERB,B2
+flowery,flowery,华丽的,ADJ,B2
+eminent,eminent,杰出的,ADJ,B2
+cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
+illustrious,illustrious,著名的,ADJ,B2
+to indoctrinate,to indoctrinate,灌输,VERB,B2
+consecutively,consecutively,连续地,ADV,B2
+carpet rug,carpet rug,地毯,NOUN,B2
+to border,to border,接壤,VERB,B2
+to wear out,to wear out,磨损,VERB,B2
+lowest,lowest,最低的,ADJ,B2
+rag,rag,破布,NOUN,B2
+immovable,immovable,不可移动的,ADJ,B2
+to consent,to consent,同意,VERB,B2
+impotence,impotence,无力,NOUN,B2
+fetish,fetish,恋物,NOUN,B2
+nor,nor,也不,CCONJ,B2
+to bleat,to bleat,哀叫,VERB,B2
+influx,influx,涌入,NOUN,B2
+to lighten,to lighten,减轻,VERB,B2
+idiosyncrasy,idiosyncrasy,特质,NOUN,B2
+to diverge,to diverge,分歧,VERB,B2
+educational,educational,教育的,ADJ,B2
+endowment,endowment,配备,NOUN,B2
+inadmissible,inadmissible,不可接受的,ADJ,B2
+divergence,divergence,分歧,NOUN,B2
+extremist,extremist,极端主义者,NOUN,B2
+floating,floating,漂浮的,ADJ,B2
+enviable,enviable,令人羡慕的,ADJ,B2
+to numb,to numb,使麻木,VERB,B2
+to make proud,to make proud,使自豪,VERB,B2
+to uproot,to uproot,根除,VERB,B2
+to torment,to torment,折磨,VERB,B2
+gastronomy,gastronomy,美食学,NOUN,B2
+grotto,grotto,洞穴,NOUN,B2
+spinning mill,spinning mill,纺纱厂,NOUN,B2
+coat of arms,coat of arms,纹章,NOUN,B2
+credulity,credulity,轻信,NOUN,B2
+census,census,人口普查,NOUN,B2
+disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
+self,self,自己,PRON,B2
+moratorium,moratorium,暂停,NOUN,B2
+insulin,insulin,胰岛素,NOUN,B2
+fang,fang,犬齿,NOUN,B2
+gaseous,gaseous,气态的,ADJ,B2
+unlimited,unlimited,无限的,ADJ,B2
+scholarship holder,scholarship holder,奖学金生,NOUN,B2
+contestable,contestable,可质疑的,ADJ,B2
+carbohydrate,carbohydrate,碳水化合物,NOUN,B2
+gymnast,gymnast,体操运动员,NOUN,B2
+calamitous,calamitous,灾难性的,ADJ,B2
+to distill,to distill,蒸馏,VERB,B2
+to spy,to spy,监视,VERB,B2
+to idealize,to idealize,理想化,VERB,B2
+congenital,congenital,先天的,ADJ,B2
+farmstead,farmstead,农庄,NOUN,B2
+mistreatment,mistreatment,虐待,NOUN,B2
+didactic,didactic,教学的,ADJ,B2
+motionless,motionless,静止的,ADJ,B2
+insensitive,insensitive,麻木的,ADJ,B2
+cashier,cashier,出纳员,NOUN,B2
+sorcerer,sorcerer,巫师,NOUN,B2
+gangrene,gangrene,坏疽,NOUN,B2
+superstitious,superstitious,迷信的,ADJ,B2
+cavity,cavity,腔,NOUN,B2
+finnish,finnish,芬兰的,ADJ,B2
+unharmed,unharmed,未受伤的,ADJ,B2
+to sadden,to sadden,使悲伤,VERB,B2
+fellow citizen,fellow citizen,同胞,NOUN,B2
+disproportion,disproportion,不成比例,NOUN,B2
+junk,junk,破烂货,NOUN,B2
+to ironize,to ironize,讽刺,VERB,B2
+to swing,to swing,荡秋千,VERB,B2
+cognitive,cognitive,认知的,ADJ,B2
+heterogeneity,heterogeneity,异质性,NOUN,B2
+frozen,frozen,冻僵的,ADJ,B2
+consanguinity,consanguinity,血缘,NOUN,B2
+to instill,to instill,灌输,VERB,B2
+duchess,duchess,公爵夫人,NOUN,B2
+condescension,condescension,屈尊,NOUN,B2
+blessed,blessed,受祝福的,ADJ,B2
+circumspect,circumspect,谨慎的,ADJ,B2
+incorrect,incorrect,不正确的,ADJ,B2
+to camouflage,to camouflage,伪装,VERB,B2
+magistrate,magistrate,法官,NOUN,B2
+to narrow,to narrow,使变窄,VERB,B2
+hundred,hundred,一百,NOUN,B2
+to stammer,to stammer,结巴,VERB,B2
+comic strip,comic strip,连环画,NOUN,B2
+coproduction,coproduction,联合制作,NOUN,B2
+gardening,gardening,园艺,NOUN,B2
+show,show,表演,NOUN,B2
+on top,on top,在上面,ADV,B2
+doubtful,doubtful,可疑的,ADJ,B2
+clemency,clemency,仁慈,NOUN,B2
+apostate,apostate,叛教者,NOUN,B2
+to desert,to desert,擅离职守,VERB,B2
+jewelry store,jewelry store,珠宝店,NOUN,B2
+cistern,cistern,蓄水池,NOUN,B2
+to parade,to parade,游行,VERB,B2
+gruff,gruff,阴沉的,ADJ,B2
+hypertrophy,hypertrophy,肥大,NOUN,B2
+novelty,novelty,新奇事物,NOUN,B2
+to overstep,to overstep,越权,VERB,B2
+instantaneous,instantaneous,瞬间的,ADJ,B2
+to sponsor,to sponsor,赞助,VERB,B2
+disagreeing,disagreeing,不同意的,ADJ,B2
+manufacture,manufacture,制造,NOUN,B2
+to delight,to delight,使高兴,VERB,B2
+inhibition,inhibition,抑制,NOUN,B2
+cardboard,cardboard,硬纸板,NOUN,B2
+diabolical,diabolical,恶魔般的,ADJ,B2
+guild,guild,行会,NOUN,B2
+to group,to group,分组,VERB,B2
+depravity,depravity,堕落,NOUN,B2
+incidence,incidence,发生率,NOUN,B2
+stabilization,stabilization,稳定化,NOUN,B2
+cardinal,cardinal,枢机主教,NOUN,B2
+hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
+drool,drool,口水,NOUN,B2
+circumlocution,circumlocution,迂回说法,NOUN,B2
+puff,puff,一口烟,NOUN,B2
+gerontocracy,gerontocracy,老人政治,NOUN,B2
+fascism,fascism,法西斯主义,NOUN,B2
+to strike down,to strike down,击倒,VERB,B2
+hedonism,hedonism,享乐主义,NOUN,B2
+to plug in,to plug in,插入,VERB,B2
+languor,languor,倦怠,NOUN,B2
+to sketch,to sketch,勾勒,VERB,B2
+indiscretion,indiscretion,轻率,NOUN,B2
+to access,to access,进入,VERB,B2
+to oust,to oust,推翻,VERB,B2
+him her,him her,他/她,PRON,B2
+reticent,reticent,沉默寡言的,ADJ,B2
+offspring,offspring,幼崽,NOUN,B2
+lapse,lapse,疏忽,NOUN,B2
+holocaust,holocaust,浩劫,NOUN,B2
+immodesty,immodesty,不贞,NOUN,B2
+to insinuate,to insinuate,暗示,VERB,B2
+canonical,canonical,规范的,ADJ,B2
+frugality,frugality,节俭,NOUN,B2
+marine,marine,海洋的,ADJ,B2
+formulation,formulation,配方,NOUN,B2
+ellipsis,ellipsis,省略,NOUN,B2
+to skin,to skin,剥皮,VERB,B2
+to gray,to gray,变白,VERB,B2
+gravid,gravid,怀孕的,ADJ,B2
+intolerant,intolerant,不容忍的,ADJ,B2
+stampede,stampede,溃逃,NOUN,B2
+exculpation,exculpation,开脱,NOUN,B2
+copious,copious,丰富的,ADJ,B2
+to meddle,to meddle,干涉,VERB,B2
+hooligan,hooligan,流氓,NOUN,B2
+colossal,colossal,巨大的,ADJ,B2
+to plunder,to plunder,掠夺,VERB,B2
+to mutiny,to mutiny,煽动叛乱,VERB,B2
+conic,conic,圆锥曲线,NOUN,B2
+centipede,centipede,蜈蚣,NOUN,B2
+falconry,falconry,猎鹰术,NOUN,B2
+babble,babble,结巴,NOUN,B2
+informative,informative,提供信息的,ADJ,B2
+unbridled,unbridled,肆无忌惮的,ADJ,B2
+wharf,wharf,码头,NOUN,B2
+inflection,inflection,词尾,NOUN,B2
+to idolize,to idolize,崇拜,VERB,B2
+flaccid,flaccid,松弛的,ADJ,B2
+revelry,revelry,狂欢,NOUN,B2
+generatrix,generatrix,母线,NOUN,B2
+shameless person,shameless person,厚颜无耻的人,NOUN,B2
+set of ideals,set of ideals,思想体系,NOUN,B2
+collusion,collusion,串通,NOUN,B2
+involuntary,involuntary,无意识的,ADJ,B2
+slender,slender,纤细的,ADJ,B2
+emulation,emulation,模仿,NOUN,B2
+illogical,illogical,不合逻辑的,ADJ,B2
+varnish,varnish,清漆,NOUN,B2
+suicidal,suicidal,自杀的,ADJ,B2
+doctrinaire,doctrinaire,教条主义的,ADJ,B2
+to harmonize,to harmonize,使和谐,VERB,B2
+to skein,to skein,绕成线团,VERB,B2
+to skewer,to skewer,串起,VERB,B2
+fanatic,fanatic,狂热的,ADJ,B2
+fruit tree,fruit tree,果树的,ADJ,B2
+to guillotine,to guillotine,斩首,VERB,B2
+to thrill,to thrill,使兴奋,VERB,B2
+insinuation,insinuation,暗示,NOUN,B2
+cove,cove,小海湾,NOUN,B2
+to go deep into,to go deep into,深入,VERB,B2
+contiguous,contiguous,相邻的,ADJ,B2
+celerity,celerity,迅速,NOUN,B2
+empirically,empirically,凭经验地,ADV,B2
+slenderness,slenderness,纤细,NOUN,B2
+to spirit away,to spirit away,变走,VERB,B2
+inclement,inclement,严酷的,ADJ,B2
+to release from prison,to release from prison,释放,VERB,B2
+galician,galician,加利西亚的,ADJ,B2
+horoscope,horoscope,星座运势,NOUN,B2
+squid,squid,鱿鱼,NOUN,B2
+epithet,epithet,绰号,NOUN,B2
+furtive,furtive,鬼鬼祟祟的,ADJ,B2
+to be unaware,to be unaware,不知道,VERB,B2
+condemned,condemned,被定罪的,ADJ,B2
+to apostatize,to apostatize,叛教,VERB,B2
+charitable,charitable,慈善的,ADJ,B2
+sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
+countercurrent,countercurrent,逆流,NOUN,B2
+confidant,confidant,知己,NOUN,B2
+fortune teller,fortune teller,占卜者,NOUN,B2
+deteriorated,deteriorated,恶化的,ADJ,B2
+tickle,tickle,发痒,NOUN,B2
+scythe,scythe,镰刀,NOUN,B2
+spatula,spatula,刮刀,NOUN,B2
+governability,governability,可治理性,NOUN,B2
+to humanize,to humanize,使人性化,VERB,B2
+idiot,idiot,傻瓜,ADJ,B2
+to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
+musk,musk,麝香,NOUN,B2
+to espy,to espy,窥探,VERB,B2
+justness,justness,公正,NOUN,B2
+narrowing,narrowing,变窄,NOUN,B2
+quotable,quotable,可估价的,ADJ,B2
+scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
+hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+disorganization,disorganization,无组织,NOUN,B2
+herbaceous,herbaceous,草本的,ADJ,B2
+incongruity,incongruity,不协调,NOUN,B2
+leafy,leafy,枝叶茂密的,ADJ,B2
+wild beast,wild beast,猛兽,NOUN,B2
+grotesque,grotesque,怪诞的,ADJ,B2
+disloyalty,disloyalty,不忠,NOUN,B2
+to vent,to vent,倾诉,VERB,B2
+confinement,confinement,禁闭,NOUN,B2
+pharisee,pharisee,法利赛人,NOUN,B2
+gatekeeper,gatekeeper,道口看守员,NOUN,B2
+disheveled,disheveled,蓬乱的,ADJ,B2
+inflamed,inflamed,激烈的,ADJ,B2
+widening,widening,加宽,NOUN,B2
+disenchantment,disenchantment,幻灭,NOUN,B2
+equestrian,equestrian,马术的,ADJ,B2
+long-distance runner,long-distance runner,长跑运动员,NOUN,B2
+excavator,excavator,挖掘机,NOUN,B2
+winding,winding,蜿蜒的,ADJ,B2
+delirious,delirious,谵妄的,ADJ,B2
+to splint,to splint,用夹板固定,VERB,B2
+to put on track,to put on track,使走上正轨,VERB,B2
+epitaph,epitaph,墓志铭,NOUN,B2
+untidiness,untidiness,凌乱,NOUN,B2
+cattle rancher,cattle rancher,牧场主,NOUN,B2
+to handcuff,to handcuff,给…戴手铐,VERB,B2
+every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
+to guess right,to guess right,猜中,VERB,B2
+horrified,horrified,惊骇的,ADJ,B2
+brute,brute,粗野的,ADJ,B2
+conformist,conformist,墨守成规者,NOUN,B2
+to fail to fulfill,to fail to fulfill,未履行,VERB,B2
+egalitarian,egalitarian,平等主义的,ADJ,B2
+tackling,tackling,马具,NOUN,B2
+duet,duet,二重奏,NOUN,B2
+concordat,concordat,政教协定,NOUN,B2
+hygienic,hygienic,卫生的,ADJ,B2
+compendium,compendium,纲要,NOUN,B2
+expeditious,expeditious,迅速的,ADJ,B2
+countenance,countenance,面容,NOUN,B2
+to go numb,to go numb,麻木,VERB,B2
+gamete,gamete,配子,NOUN,B2
+devourer,devourer,吞噬者,NOUN,B2
+out of place,out of place,格格不入的,ADJ,B2
+exalted,exalted,狂热的,ADJ,B2
+discredit,discredit,丧失信誉,NOUN,B2
+alien,alien,外星人的,ADJ,B2
+reclamation,reclamation,收复,NOUN,B2
+disadvantageous,disadvantageous,不利的,ADJ,B2
+flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
+home-loving,home-loving,顾家的,ADJ,B2
+to powder,to powder,撒粉,VERB,B2
+concordance,concordance,一致,NOUN,B2
+to unbutton,to unbutton,解开纽扣,VERB,B2
+disquisition,disquisition,论述,NOUN,B2
+fractional,fractional,分数的,ADJ,B2
+to lead astray,to lead astray,使入歧途,VERB,B2
+to crowd together,to crowd together,挤在一起,VERB,B2
+foliage,foliage,枝叶,NOUN,B2
+curator,curator,策展人,NOUN,B2
+seaplane,seaplane,水上飞机,NOUN,B2
+excitability,excitability,兴奋性,NOUN,B2
+to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
+indistinct,indistinct,模糊的,ADJ,B2
+land register,land register,地籍,NOUN,B2
+grandiloquent,grandiloquent,夸张的,ADJ,B2
+ferret,ferret,雪貂,NOUN,B2
+chinese language,chinese language,华文,NOUN,B2
+existing,existing,现有的,ADJ,B2
+tenth,tenth,第十,ADJ,B2
+asian,asian,亚洲的,ADJ,B2
+elsewhere,elsewhere,别处,ADV,B2
+western,western,西方的,ADJ,B2
+simultaneously,simultaneously,同时地,ADV,B2
+police officer,police officer,警察,NOUN,B2
+intensive,intensive,强化的,ADJ,B2
+october,october,十月,NOUN,B2
+democrat,democrat,民主主义者,NOUN,B2
+january,january,一月,NOUN,B2
+to sharpen,to sharpen,磨快,VERB,B2
+to light,to light,照亮,VERB,B2
+southern,southern,南方的,ADJ,B2
+barrel,barrel,桶,NOUN,B2
+to unload,to unload,卸货,VERB,B2
+alternative,alternative,替代的,ADJ,B2
+metropolis,metropolis,大都市,NOUN,B2
+shooter,shooter,射手,NOUN,B2
+eighth,eighth,第八,ADJ,B2
+frightening,frightening,令人恐惧的,ADJ,B2
+conceivable,conceivable,可设想的,ADJ,B2
+villainy,villainy,邪恶,NOUN,B2
+delighted,delighted,高兴的,ADJ,B2
+recognizable,recognizable,可辨认的,ADJ,B2
+to camp,to camp,露营,VERB,B2
+artillery,artillery,炮兵,NOUN,B2
+metaphorical,metaphorical,隐喻的,ADJ,B2
+alcoholic,alcoholic,酒精的,ADJ,B2
+technically,technically,技术上地,ADV,B2
+reunification,reunification,重新统一,NOUN,B2
+to perfect,to perfect,精修,VERB,B2
+to position,to position,定位 / 安置,VERB,B2
+pornography,pornography,色情,NOUN,B2
+turkey,turkey,火鸡,NOUN,B2
+to load charge,to load charge,装载,VERB,B2
+to program,to program,编程,VERB,B2
+brutality,brutality,残暴,NOUN,B2
+swedish,swedish,瑞典语,NOUN,B2
+mobility,mobility,流动性,NOUN,B2
+literal,literal,字面的,ADJ,B2
+mythical,mythical,神话般的,ADJ,B2
+paternal,paternal,父亲的,ADJ,B2
+canadian,canadian,加拿大的,ADJ,B2
+superiority,superiority,优越性/优势,NOUN,B2
+heavily,heavily,沉重地,ADV,B2
+minimal,minimal,微小的,ADJ,B2
+olympic,olympic,奥林匹克的,ADJ,B2
+marble,marble,大理石,NOUN,B2
+remarkably,remarkably,显著地,ADV,B2
+sulfur,sulfur,硫,NOUN,B2
+stroller,stroller,婴儿车,NOUN,B2
+to skim,to skim,轻触,VERB,B2
+to wedge,to wedge,卡住,VERB,B2
+regulatory,regulatory,监管的,ADJ,B2
+triggering,triggering,触发,NOUN,B2
+partially,partially,部分地,ADV,B2
+implicitly,implicitly,含蓄地,ADV,B2
+intentionally,intentionally,故意地,ADV,B2
+corporal,corporal,下士,NOUN,B2
+therapist,therapist,治疗师,NOUN,B2
+to privatize,to privatize,私有化,VERB,B2
+turkish,turkish,土耳其的,ADJ,B2
+located,located,位于,ADJ,B2
+warmly,warmly,热情地,ADV,B2
+scientifically,scientifically,科学地,ADV,B2
+self-employed person,self-employed person,个体经营者,NOUN,B2
+administrator,administrator,管理员,NOUN,B2
+to neutralize,to neutralize,中和,VERB,B2
+categorical,categorical,绝对的,ADJ,B2
+catholic,catholic,天主教的,ADJ,B2
+decorative,decorative,装饰性的,ADJ,B2
+mitten,mitten,连指手套,NOUN,B2
+rehabilitation,rehabilitation,康复,NOUN,B2
+infantry,infantry,步兵,NOUN,B2
+to trace,to trace,描绘；标出,VERB,B2
+meteorological,meteorological,气象的,ADJ,B2
+effectively,effectively,有效地,ADV,B2
+wisely,wisely,明智地,ADV,B2
+massively,massively,大量地,ADV,B2
+to move touch,to move touch,使感动,VERB,B2
+to prioritize,to prioritize,优先考虑,VERB,B2
+gifted,gifted,有天赋的,ADJ,B2
+water heater,water heater,热水器,NOUN,B2
+overview,overview,概览,NOUN,B2
+boxer,boxer,拳击手,NOUN,B2
+pedantry,pedantry,迂腐,NOUN,B2
+socialization,socialization,社会化,NOUN,B2
+that one,that one,那个,PRON,B2
+muscle ache,muscle ache,肌肉酸痛,NOUN,B2
+belgian,belgian,比利时的,ADJ,B2
+polish,polish,波兰的,ADJ,B2
+symbolic,symbolic,象征的,ADJ,B2
+to arm,to arm,武装,VERB,B2
+lyrical,lyrical,抒情的,ADJ,B2
+picturesque,picturesque,如画的；别致的,ADJ,B2
+their,their,他们的,DET,B2
+to wring,to wring,拧干,VERB,B2
+to back up,to back up,后退,VERB,B2
+revolt,revolt,叛乱,NOUN,B2
+metric,metric,公制的,ADJ,B2
+ashtray,ashtray,烟灰缸,NOUN,B2
+politically,politically,在政治上,ADV,B2
+cyclist,cyclist,骑自行车的人,NOUN,B2
+competitive,competitive,竞争的,ADJ,B2
+indoctrination,indoctrination,灌输,NOUN,B2
+adjustment,adjustment,调节,NOUN,B2
+tax authorities,tax authorities,税务机关,NOUN,B2
+press release,press release,公报,NOUN,B2
+concerned,concerned,担忧的,ADJ,B2
+to experiment,to experiment,实验,VERB,B2
+to title,to title,命名,VERB,B2
+mosquito net,mosquito net,蚊帐,NOUN,B2
+break-in,break-in,非法侵入,NOUN,B2
+campsite,campsite,露营地,NOUN,B2
+by chance,by chance,偶然地,ADV,B2
+listener,listener,听众,NOUN,B2
+mechanical,mechanical,机械的,ADJ,B2
+hanging,hanging,绞刑,NOUN,B2
+dying,dying,垂死的,ADJ,B2
+entropy,entropy,熵,NOUN,B2
+prestigious,prestigious,有声望的,ADJ,B2
+to benefit,to benefit,受益,VERB,B2
+to lower,to lower,降低,VERB,B2
+physically,physically,身体上地,ADV,B2
+generously,generously,慷慨地,ADV,B2
+political party,political party,政党,NOUN,B2
+presumably,presumably,据推测,ADV,B2
+rodent,rodent,啮齿动物,NOUN,B2
+universal,universal,普遍的,ADJ,B2
+precision,precision,精确,NOUN,B2
+english-speaking,english-speaking,讲英语的,ADJ,B2
+seated,seated,坐着的,ADJ,B2
+about,about,大约,ADV,B2
+to appear to seem,to appear to seem,出现/显得,VERB,B2
+thematic,thematic,主题的,ADJ,B2
+prophet,prophet,先知,NOUN,B2
+childbirth,childbirth,分娩,NOUN,B2
+counterargument,counterargument,反论点,NOUN,B2
+premeditation,premeditation,预谋,NOUN,B2
+profitability,profitability,盈利能力,NOUN,B2
+stripe,stripe,条纹,NOUN,B2
+theological,theological,神学的,ADJ,B2
+parliamentary,parliamentary,议会的/议员,ADJ,B2
+hold,hold,控制,NOUN,B2
+broadcaster,broadcaster,广播公司,NOUN,B2
+uniform,uniform,制服,NOUN,B2
+theatrical,theatrical,戏剧的,ADJ,B2
+to build up,to build up,构建,VERB,B2
+instructive,instructive,有教育意义的,ADJ,B2
+baton,baton,警棍,NOUN,B2
+fussy,fussy,挑剔的,ADJ,B2
+to post,to post,张贴,VERB,B2
+advent,advent,到来,NOUN,B2
+to result,to result,产生,VERB,B2
+town hall,town hall,市政厅,NOUN,B2
+lay,lay,叙事短诗,NOUN,B2
+wording,wording,措辞,NOUN,B2
+hood,hood,兜帽,NOUN,B2
+admirer,admirer,仰慕者,NOUN,B2
+to indict,to indict,控告,VERB,B2
+minority,minority,少数派的,ADJ,B2
+tv,tv,电视,NOUN,B2
+to relaunch,to relaunch,重启,VERB,B2
+to draw up,to draw up,起草,VERB,B2
+distributor,distributor,分销商,NOUN,B2
+to strip,to strip,裸露,VERB,B2
+to project,to project,投射,VERB,B2
+industrialization,industrialization,工业化,NOUN,B2
+subconscious,subconscious,潜意识,NOUN,B2
+to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
+general practitioner,general practitioner,全科医生,NOUN,B2
+to crash into,to crash into,撞击,VERB,B2
+to alert,to alert,警告,VERB,B2
+symmetrical,symmetrical,对称的,ADJ,B2
+of which,of which,关于哪个,PRON,B2
+monstrous,monstrous,怪异的,ADJ,B2
+damages,damages,损害赔偿,NOUN,B2
+soda,soda,苏打,NOUN,B2
+navel,navel,肚脐,NOUN,B2
+to put back,to put back,放回,VERB,B2
+condom,condom,避孕套,NOUN,B2
+relocation,relocation,搬家,NOUN,B2
+asphalt,asphalt,沥青,NOUN,B2
+sailor,sailor,水手,NOUN,B2
+mentally,mentally,精神上地,ADV,B2
+decor,decor,布景,NOUN,B2
+ribbon,ribbon,丝带,NOUN,B2
+narrow-minded,narrow-minded,狭隘的,ADJ,B2
+draftsman,draftsman,绘图员,NOUN,B2
+cylindrical,cylindrical,圆柱形的,ADJ,B2
+specifically,specifically,具体地,ADV,B2
+pajamas,pajamas,睡衣,NOUN,B2
+weakening,weakening,减弱,NOUN,B2
+x-ray,x-ray,X光片,NOUN,B2
+wig,wig,假发,NOUN,B2
+torso,torso,躯干,NOUN,B2
+tablet,tablet,平板电脑,NOUN,B2
+considerably,considerably,相当地,ADV,B2
+to lengthen,to lengthen,延长,VERB,B2
+sexually,sexually,在性方面,ADV,B2
+to move house,to move house,搬家,VERB,B2
+carefully,carefully,仔细地,ADV,B2
+to minimize,to minimize,最小化,VERB,B2
+to recreate,to recreate,重建,VERB,B2
+to infuse,to infuse,泡制,VERB,B2
+to snow,to snow,下雪,VERB,B2
+psychopath,psychopath,精神变态者,NOUN,B2
+masonry,masonry,砌体,NOUN,B2
+trapdoor,trapdoor,活板门,NOUN,B2
+not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
+separately,separately,分开地，单独地,ADV,B2
+tv movie,tv movie,电视电影,NOUN,B2
+to prosper,to prosper,繁荣,VERB,B2
+paper clip,paper clip,回形针,NOUN,B2
+granny,granny,奶奶,NOUN,B2
+overdraft,overdraft,透支,NOUN,B2
+neonatal,neonatal,新生儿的,ADJ,B2
+bicameral,bicameral,两院制的,ADJ,B2
+to break into,to break into,撬开,VERB,B2
+to gratinate,to gratinate,烤成焦皮,VERB,B2
+preferable,preferable,更可取的,ADJ,B2
+speculator,speculator,投机者,NOUN,B2
+braggadocio,braggadocio,吹牛,NOUN,B2
+facies,facies,面貌,NOUN,B2
+gently,gently,轻轻地,ADV,B2
+mascot,mascot,吉祥物,NOUN,B2
+philippic,philippic,猛烈的抨击,NOUN,B2
+deeply moving,deeply moving,令人感动的,ADJ,B2
+to meditate,to meditate,沉思,VERB,B2
+painstakingly,painstakingly,细致地,ADV,B2
+to purge,to purge,清除,VERB,B2
+catachresis,catachresis,词语误用,NOUN,B2
+renunciation,renunciation,放弃,NOUN,B2
+iatrogenic,iatrogenic,医源性的,ADJ,B2
+vaccine-related,vaccine-related,疫苗的,ADJ,B2
+punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
+to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
+prophylaxis,prophylaxis,预防,NOUN,B2
+resumption,resumption,恢复,NOUN,B2
+anaphora,anaphora,首语重复修辞,NOUN,B2
+aphasia,aphasia,失语症,NOUN,B2
+delicately,delicately,巧妙地,ADV,B2
+taxable,taxable,应纳税的,ADJ,B2
+to start again,to start again,重新开始,VERB,B2
+remote work,remote work,远程办公,NOUN,B2
+feature film,feature film,故事片,NOUN,B2
+except for,except for,除了,ADP,B2
+relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+personalized,personalized,个性化的,ADJ,B2
+pantheon,pantheon,先贤祠,NOUN,B2
+meticulously,meticulously,一丝不苟地,ADV,B2
+supporting document,supporting document,证明文件,NOUN,B2
+landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
+trusting,trusting,信任的,ADJ,B2
+locality,locality,地点,NOUN,B2
+decontamination,decontamination,去污,NOUN,B2
+hemp,hemp,大麻,NOUN,B2
+know-how,know-how,诀窍,NOUN,B2
+closing argument,closing argument,辩护词,NOUN,B2
+split secession,split secession,分裂,NOUN,B2
+hesitant,hesitant,犹豫的,ADJ,B2
+contaminated,contaminated,受污染的,ADJ,B2
+to buy back,to buy back,赎回,VERB,B2
+balm,balm,香脂,NOUN,B2
+to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
+respite,respite,喘息,NOUN,B2
+slowdown,slowdown,减速,NOUN,B2
+lucidity,lucidity,清醒 / 明晰,NOUN,B2
+syllable,syllable,音节,NOUN,B2
+sanitation,sanitation,卫生,NOUN,B2
+outcome ending,outcome ending,结局，解决,NOUN,B2
+to plane,to plane,刨,VERB,B2
+touchy,touchy,易怒的,ADJ,B2
+theologian,theologian,神学家,NOUN,B2
+public holiday,public holiday,公共假日,ADJ,B2
+historically,historically,历史上,ADV,B2
+screenwriter,screenwriter,编剧,NOUN,B2
+quiddity,quiddity,本质,NOUN,B2
+tenor,tenor,男高音,NOUN,B2
+precarization,precarization,不稳定化,NOUN,B2
+to recharge,to recharge,充电,VERB,B2
+factoring,factoring,保理,NOUN,B2
+grumbler,grumbler,爱抱怨的人,NOUN,B2
+tax exemption,tax exemption,免税,NOUN,B2
+to reopen,to reopen,重新开放,VERB,B2
+bailiff,bailiff,法警,NOUN,B2
+fit,fit,适合的,ADJ,B2
+to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
+peritoneum,peritoneum,腹膜,NOUN,B2
+e-reader,e-reader,电子阅读器,NOUN,B2
+deleveraging,deleveraging,去杠杆化,NOUN,B2
+damaging,damaging,有害的,ADJ,B2
+to rally,to rally,团结,VERB,B2
+ataxia,ataxia,共济失调,NOUN,B2
+larva,larva,幼虫,NOUN,B2
+lymphatic,lymphatic,淋巴的,ADJ,B2
+perceptibly,perceptibly,明显地,ADV,B2
+independently,independently,独立地,ADV,B2
+obtaining,obtaining,获得,NOUN,B2
+rain shower,rain shower,阵雨,NOUN,B2
+financing funding,financing funding,融资,NOUN,B2
+to make heavier,to make heavier,加重,VERB,B2
+to generate engender,to generate engender,产生,VERB,B2
+psychoanalysis,psychoanalysis,精神分析,NOUN,B2
+formally,formally,正式地,ADV,B2
+to hail inspect,to hail inspect,盘查,VERB,B2
+to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
+balance sheet,balance sheet,资产负债表,NOUN,B2
+implacably,implacably,毫不留情地,ADV,B2
+attractiveness,attractiveness,吸引力,NOUN,B2
+roadway,roadway,路面,NOUN,B2
+annexation,annexation,吞并,NOUN,B2
+antisemitism,antisemitism,反犹太主义,NOUN,B2
+choreographer,choreographer,编舞者,NOUN,B2
+prosecution service,prosecution service,检察院,NOUN,B2
+bulgarian,bulgarian,保加利亚的,ADJ,B2
+cooked,cooked,熟的,ADJ,B2
+traditionally,traditionally,传统地,ADV,B2
+probable likely,probable likely,可能的,ADJ,B2
+inexorably,inexorably,不可阻挡地,ADV,B2
+lubricity,lubricity,好色 / 淫荡,NOUN,B2
+unforeseen,unforeseen,意外的,ADJ,B2
+mash,mash,泥状食物,NOUN,B2
+severely,severely,严厉地,ADV,B2
+prosody,prosody,韵律学,NOUN,B2
+hair bun,hair bun,发髻,NOUN,B2
+tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
+flow rate,flow rate,流量,NOUN,B2
+invariably,invariably,不变地,ADV,B2
+to serve a route,to serve a route,为...提供交通服务,VERB,B2
+pleura,pleura,胸膜,NOUN,B2
+notch,notch,刻痕,NOUN,B2
+capital gain,capital gain,增值,NOUN,B2
+bookplate,bookplate,藏书票,NOUN,B2
+jointly,jointly,共同地,ADV,B2
+proliferation,proliferation,增殖,NOUN,B2
+multinational,multinational,跨国公司,NOUN,B2
+disdainfully,disdainfully,轻蔑地,ADV,B2
+malevolence,malevolence,恶意,NOUN,B2
+to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
+short film,short film,短片,NOUN,B2
+freely,freely,自由地,ADV,B2
+obliged,obliged,被迫的,ADJ,B2
+cohort,cohort,队列,NOUN,B2
+pickaxe,pickaxe,镐；锄,NOUN,B2
+doe,doe,雌鹿,NOUN,B2
+summer visitor,summer visitor,暑期游客,NOUN,B2
+to unbridle,to unbridle,解开,VERB,B2
+resourceful,resourceful,机灵的,ADJ,B2
+to make stupid,to make stupid,使愚蠢,VERB,B2
+layperson,layperson,外行,NOUN,B2
+detached house,detached house,独栋房屋,NOUN,B2
+calmly,calmly,平静地,ADV,B2
+pathogenic,pathogenic,致病的,ADJ,B2
+gallop,gallop,疾驰,NOUN,B2
+pusillanimous,pusillanimous,怯懦的,ADJ,B2
+to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
+to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
+abusive,abusive,滥用的,ADJ,B2
+to appal,to appal,使惊恐,VERB,B2
+to fraction,to fraction,分割,VERB,B2
+potentially,potentially,潜在地,ADV,B2
+bodywork,bodywork,车身,NOUN,B2
+notarized,notarized,经公证的,ADJ,B2
+lukewarm,lukewarm,微温的,ADJ,B2
+indirectly,indirectly,间接地,ADV,B2
+tv viewer,tv viewer,电视观众,NOUN,B2
+proportional,proportional,成比例的,ADJ,B2
+legatee,legatee,受遗赠人,NOUN,B2
+sexism,sexism,性别歧视,NOUN,B2
+to nuance,to nuance,使具有细微差别,VERB,B2
+bistro,bistro,小酒馆,NOUN,B2
+release of lien,release of lien,解除扣押,NOUN,B2
+irregular,irregular,不规则的,ADJ,B2
+picking,picking,采摘,NOUN,B2
+untouchable,untouchable,不可触碰的,ADJ,B2
+litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
+to fall to,to fall to,落到...身上,VERB,B2
+delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
+peroration,peroration,结语,NOUN,B2
+to pour out,to pour out,倾诉,VERB,B2
+lymph node,lymph node,淋巴结,NOUN,B2
+airfield,airfield,飞机场,NOUN,B2
+symphonic,symphonic,交响乐的,ADJ,B2
+to chill,to chill,使冰冻,VERB,B2
+penal,penal,刑事的,ADJ,B2
+freshly,freshly,新鲜地,ADV,B2
+moralism,moralism,道德主义,NOUN,B2
+typology,typology,类型学,NOUN,B2
+asphyxia,asphyxia,窒息,NOUN,B2
+pitchfork,pitchfork,叉子,NOUN,B2
+to subsist,to subsist,存在,VERB,B2
+street interview,street interview,街头采访,NOUN,B2
+food,food,食品的,ADJ,B2
+apodictic,apodictic,确证的,ADJ,B2
+checkbook,checkbook,支票簿,NOUN,B2
+media library,media library,多媒体图书馆,NOUN,B2
+carcass,carcass,骨架,NOUN,B2
+currant,currant,醋栗,NOUN,B2
+depressive,depressive,抑郁的，压抑的,ADJ,B2
+pictorial,pictorial,绘画的,ADJ,B2
+socialist,socialist,社会主义者,NOUN,B2
+pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
+segregation,segregation,隔离，分离,NOUN,B2
+eight-line stanza,eight-line stanza,八行诗,NOUN,B2
+caterpillar,caterpillar,毛毛虫,NOUN,B2
+stressful,stressful,有压力的,ADJ,B2
+quashing,quashing,撤销,NOUN,B2
+productivist,productivist,生产至上主义的,ADJ,B2
+to push to grow,to push to grow,推/生长,VERB,B2
+cordially,cordially,亲切地,ADV,B2
+symptomatology,symptomatology,症状学,NOUN,B2
+sincerely,sincerely,真诚地,ADV,B2
+sovereigntist,sovereigntist,主权主义者,NOUN,B2
+faithful loyal,faithful loyal,忠诚的,ADJ,B2
+undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+obsequiously,obsequiously,谄媚地,ADV,B2
+manifestly,manifestly,明显地,ADV,B2
+heroically,heroically,英勇地,ADV,B2
+stage fright,stage fright,怯场,NOUN,B2
+retiree,retiree,退休人员,NOUN,B2
+the blues,the blues,忧郁,NOUN,B2
+servilely,servilely,奴性地,ADV,B2
+hostess,hostess,女服务员,NOUN,B2
+obsequiousness,obsequiousness,谄媚,NOUN,B2
+worrying,worrying,令人担忧的,ADJ,B2
+to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
+registered mail,registered mail,挂号信,NOUN,B2
+jurisconsult,jurisconsult,法学专家,NOUN,B2
+parataxis,parataxis,意合,NOUN,B2
+to move to pity,to move to pity,使怜悯,VERB,B2
+oyster,oyster,牡蛎,NOUN,B2
+purely,purely,纯粹地,ADV,B2
+to resell,to resell,转售,VERB,B2
+flint,flint,燧石,NOUN,B2
+fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+lawnmower,lawnmower,割草机,NOUN,B2
+a lot,a lot,很多,ADV,B2
+diagonal,diagonal,对角线,NOUN,B2
+clumsiness,clumsiness,笨拙,NOUN,B2
+anarchist,anarchist,无政府主义者,NOUN,B2
+about sixty,about sixty,六十来个,NOUN,B2
+to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
+unofficially,unofficially,非正式地,ADV,B2
+marshal,marshal,元帅,NOUN,B2
+customs officer,customs officer,海关官员,NOUN,B2
+to maltreat,to maltreat,虐待,VERB,B2
+heatwave,heatwave,热浪,NOUN,B2
+magnesium,magnesium,镁,NOUN,B2
+to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
+pamphleteer,pamphleteer,小册子作者,NOUN,B2
+generational,generational,代际的,ADJ,B2
+alpine,alpine,高山的,ADJ,B2
+guru,guru,精神导师,NOUN,B2
+to strip bare,to strip bare,洗劫,VERB,B2
+manually,manually,手动地,ADV,B2
+juvenile,juvenile,青少年的,ADJ,B2
+toad,toad,蟾蜍,NOUN,B2
+treat,treat,盛宴,NOUN,B2
+populist,populist,民粹主义者,NOUN,B2
+rapper,rapper,说唱歌手,NOUN,B2
+telephony,telephony,电话学,NOUN,B2
+heartening,heartening,令人高兴的,ADJ,B2
+agitated,agitated,焦躁的,ADJ,B2
+marrow,marrow,骨髓,NOUN,B2
+indiscriminately,indiscriminately,不加区别地,ADV,B2
+recruiter,recruiter,招聘人员,NOUN,B2
+triangular,triangular,三角形的,ADJ,B2
+perfidy,perfidy,背信弃义,NOUN,B2
+dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
+to taint,to taint,玷污,VERB,B2
+case law,case law,判例法,NOUN,B2
+coastal,coastal,沿海的,ADJ,B2
+nationalist,nationalist,民族主义者,NOUN,B2
+alternatively,alternatively,交替地,ADV,B2
+setting sun,setting sun,夕阳,NOUN,B2
+obstetrics,obstetrics,产科学,NOUN,B2
+reproducibility,reproducibility,可重复性,NOUN,B2
+consecutive,consecutive,连续的,ADJ,B2
+indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+french-speaking,french-speaking,讲法语的,ADJ,B2
+productive,productive,多产的,ADJ,B2
+wrongdoer,wrongdoer,罪犯,NOUN,B2
+food-processing,food-processing,食品加工的,ADJ,B2
+to raise awareness,to raise awareness,提高意识,VERB,B2
+to make bland,to make bland,使乏味,VERB,B2
+slang,slang,俚语,NOUN,B2
+practicing believer,practicing believer,信徒,NOUN,B2
+anagram,anagram,字谜游戏,NOUN,B2
+accordion,accordion,手风琴,NOUN,B2
+trilemma,trilemma,三难困境,NOUN,B2
+to weary to tire,to weary to tire,使厌倦,VERB,B2
+hyperthermia,hyperthermia,体温过高,NOUN,B2
+about thirty,about thirty,三十左右,NOUN,B2
+droppings,droppings,粪便,NOUN,B2
+laundering,laundering,洗钱,NOUN,B2
+forfeiture,forfeiture,丧失,NOUN,B2
+fresco,fresco,壁画,NOUN,B2
+preacher,preacher,传教士,NOUN,B2
+recruit,recruit,新兵,NOUN,B2
+on upon,on upon,在...上,ADP,B2
+polysyndeton,polysyndeton,连词叠用,NOUN,B2
+patently,patently,显然地,ADV,B2
+indebted,indebted,负债的,ADJ,B2
+illuminator,illuminator,彩饰画家,NOUN,B2
+to mast,to mast,降伏,VERB,B2
+parable,parable,寓言,NOUN,B2
+malaria,malaria,疟疾,NOUN,B2
+to rediscover,to rediscover,重新发现,VERB,B2
+great-grandfather,great-grandfather,曾祖父,NOUN,B2
+to stem from,to stem from,源于,VERB,B2
+to unhook,to unhook,摘下,VERB,B2
+scales,scales,秤,NOUN,B2
+fishing,fishing,钓鱼,NOUN,B2
+bedsheet,bedsheet,床单,NOUN,B2
+geriatrics,geriatrics,老年医学,NOUN,B2
+computer specialist,computer specialist,计算机专家,NOUN,B2
+co-ownership,co-ownership,共有产权,NOUN,B2
+breathing,breathing,呼吸,NOUN,B2
+dish towel,dish towel,抹布,NOUN,B2
+naturalization,naturalization,入籍,NOUN,B2
+momentarily,momentarily,暂时地,ADV,B2
+systematically,systematically,系统地,ADV,B2
+to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
+cyst,cyst,囊肿,NOUN,B2
+suburbs,suburbs,郊区,NOUN,B2
+blender,blender,搅拌机,NOUN,B2
+to tip over,to tip over,翻倒,VERB,B2
+paralogism,paralogism,谬误推理,NOUN,B2
+skating,skating,滑冰,NOUN,B2
+boastfulness,boastfulness,吹嘘,NOUN,B2
+priority,priority,优先的,ADJ,B2
+footage,footage,镜头长度,NOUN,B2
+oligopoly,oligopoly,寡头垄断,NOUN,B2
+surplus,surplus,过剩的,ADJ,B2
+similarly,similarly,同样地,ADV,B2
+chauvinism,chauvinism,沙文主义,NOUN,B2
+degenerative,degenerative,退化的,ADJ,B2
+to commune,to commune,交融,VERB,B2
+subject to the law,subject to the law,受法律管辖的,ADJ,B2
+be tender,be tender,温柔的,ADJ,B2
+hematoma,hematoma,血肿,NOUN,B2
+artificially,artificially,人为地,ADV,B2
+scouting locating,scouting locating,定位 / 侦察,NOUN,B2
+foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
+to postpone to carry over,to postpone to carry over,推迟,VERB,B2
+community-related,community-related,社区的,ADJ,B2
+nitrogen,nitrogen,氮,NOUN,B2
+to mark out,to mark out,标示,VERB,B2
+supportive,supportive,团结的,ADJ,B2
+overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
+sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
+traumatic,traumatic,创伤的,ADJ,B2
+to spout,to spout,喷射,VERB,B2
+lily,lily,百合,NOUN,B2
+neuron,neuron,神经元,NOUN,B2
+playable,playable,可演奏的,ADJ,B2
+tarragon,tarragon,龙蒿,NOUN,B2
+fingernail,fingernail,指甲,NOUN,B2
+to drive lead,to drive lead,驾驶,VERB,B2
+lucky find,lucky find,意外发现,NOUN,B2
+to catch sight of,to catch sight of,瞥见,VERB,B2
+derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
+enslavement,enslavement,奴役,NOUN,B2
+fistula,fistula,瘘管,NOUN,B2
+biologist,biologist,生物学家,NOUN,B2
+malefic,malefic,邪恶的,ADJ,B2
+resection,resection,切除术,NOUN,B2
+deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
+acronym,acronym,首字母缩略词,NOUN,B2
+receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
+ticket window,ticket window,售票窗口,NOUN,B2
+remains spoils,remains spoils,遗体，战利品,NOUN,B2
+fake news,fake news,假新闻,NOUN,B2
+ignominy,ignominy,耻辱,NOUN,B2
+genetically,genetically,遗传地,ADV,B2
+recourse,recourse,求助,NOUN,B2
+marginally,marginally,边缘地,ADV,B2
+dynamism,dynamism,活力,NOUN,B2
+tuberculosis,tuberculosis,结核病,NOUN,B2
+cinematographic,cinematographic,电影的,ADJ,B2
+regeneration,regeneration,再生,NOUN,B2
+cruelly,cruelly,残酷地,ADV,B2
+cross-border,cross-border,边境的,ADJ,B2
+preterition,preterition,假托,NOUN,B2
+striped,striped,有条纹的,ADJ,B2
+selectively,selectively,有选择地,ADV,B2
+subsidiarity,subsidiarity,辅助性原则,NOUN,B2
+symptom,symptom,症,PART,B2
+few,few,几下,NOUN,B2
+rubbish,rubbish,垃圾,NOUN,B2
+vending machine,vending machine,自动售货机,NOUN,B2
+worthless,worthless,无价值的,ADJ,B2
+surprised,surprised,惊讶的,ADJ,B2
+fire brigade,fire brigade,消防队,NOUN,B2
+someone's,someone's,某人的,PRON,B2
+exactness,exactness,精确,NOUN,B2
+moreover,moreover,而且,CCONJ,B2
+vat,vat,增值税,NOUN,B2
+colored,colored,有色的,ADJ,B2
+henceforth,henceforth,从此以后,ADV,B2
+the same,the same,相同的,ADJ,B2
+daylight,daylight,日光,NOUN,B2
+understanding,understanding,体贴的,ADJ,B2
+favorite,favorite,最爱,NOUN,B2
+complex,complex,建筑群,NOUN,B2
+good morning,good morning,早上好,INTJ,B2
+focused,focused,专注的,ADJ,B2
+driven,driven,被驾驶的,ADJ,B2
+continued,continued,持续的,ADJ,B2
+nearest,nearest,最近的,ADJ,B2
+family life,family life,家庭生活,NOUN,B2
+suspended,suspended,悬浮的,ADJ,B2
+to sabotage,to sabotage,破坏,VERB,B2
+to dump,to dump,抛弃,VERB,B2
+dominance,dominance,威权,NOUN,B2
+including,including,包括,ADP,B2
+this morning,this morning,今天早上,ADV,B2
+sixteen,sixteen,十六,NUM,B2
+terribly,terribly,可怕地/非常,ADV,B2
+infected,infected,被感染的,ADJ,B2
+power grid,power grid,电网,NOUN,B2
+curbing,curbing,遏制,NOUN,B2
+asthmatic,asthmatic,哮喘的,ADJ,B2
+stand,stand,摊位,NOUN,B2
+old-fashioned,old-fashioned,老式的,ADJ,B2
+reporting,reporting,报道,NOUN,B2
+eighty,eighty,八十,NUM,B2
+eighteen,eighteen,十八,NUM,B2
+little sister,little sister,妹妹,NOUN,B2
+least,least,最少,ADV,B2
+to refuel,to refuel,加油,VERB,B2
+oh well,oh well,算了,INTJ,B2
+front page,front page,头版,NOUN,B2
+good night,good night,晚安,INTJ,B2
+to sanction,to sanction,认可,VERB,B2
+moral,moral,道德的,ADJ,B2
+halfway,halfway,半途,ADV,B2
+inspiring,inspiring,鼓舞人心的,ADJ,B2
+tasty,tasty,美味的,ADJ,B2
+dangerousness,dangerousness,危险性,NOUN,B2
+meaningless,meaningless,毫无意义的,ADJ,B2
+highest,highest,最高的,ADJ,B2
+on top of,on top of,在...上面,ADP,B2
+downfall,downfall,毁灭,NOUN,B2
+jewish,jewish,犹太的,ADJ,B2
+from there,from there,从那里,ADV,B2
+highlight,highlight,亮点,NOUN,B2
+air force,air force,空军,NOUN,B2
+loyalty to authority,loyalty to authority,服从权威,NOUN,B2
+to spam,to spam,发垃圾信息,VERB,B2
+member of parliament,member of parliament,议员,NOUN,B2
+declinable,declinable,可变格的,ADJ,B2
+many,many,许多,DET,B2
+dentition,dentition,牙齿,NOUN,B2
+retranslation,retranslation,重译,NOUN,B2
+timeline,timeline,时间线,NOUN,B2
+reproachable,reproachable,应受责备的,ADJ,B2
+contentious,contentious,有争议的,ADJ,B2
+film star,film star,,NOUN,B2
+emotional experience,emotional experience,情感体验,NOUN,B2
+to asphalt,to asphalt,铺沥青,VERB,B2
+demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
+on which,on which,在其上,PRON,B2
+class struggle,class struggle,阶级斗争,NOUN,B2
+mysticism,mysticism,神秘主义,NOUN,B2
+towards,towards,迎向,ADV,B2
+filipino,filipino,菲律宾的,ADJ,B2
+bicycle repairer,bicycle repairer,修车匠,NOUN,B2
+schooled person,schooled person,受过培训者,NOUN,B2
+unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
+museum piece,museum piece,博物馆藏品,NOUN,B2
+border arrangement,border arrangement,边境安排,NOUN,B2
+tourist,tourist,旅游的,ADJ,B2
+culture of greed,culture of greed,贪得无厌文化,NOUN,B2
+intended,intended,预定的,ADJ,B2
+parliamentary elections,parliamentary elections,议会选举,NOUN,B2
+communautarization,communautarization,社群化,NOUN,B2
+worldly,worldly,世俗的,ADJ,B2
+cheapness,cheapness,廉价,NOUN,B2
+asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
+misplaced,misplaced,不合时宜的,ADJ,B2
+to tune,to tune,调谐,VERB,B2
+member state,member state,成员国,NOUN,B2
+grammaticality,grammaticality,合语法性,NOUN,B2
+hence,hence,因此,ADV,B2
+basal,basal,基本的,ADJ,B2
+nauseous,nauseous,恶心的,ADJ,B2
+budgetable,budgetable,可预算的,ADJ,B2
+inheritance law,inheritance law,继承法,NOUN,B2
+composable,composable,可组合的,ADJ,B2
+data processing,data processing,数据处理,NOUN,B2
+life's work,life's work,毕生事业,NOUN,B2
+healing power,healing power,疗效,NOUN,B2
+attributive,attributive,定语的,ADJ,B2
+gratuity,gratuity,酬金,NOUN,B2
+orange,orange,橙色的,ADJ,B2
+little son,little son,小儿子,NOUN,B2
+radius,radius,半径,NOUN,B2
+shit,shit,该死的,ADJ,B2
+conference-based,conference-based,会议的,ADJ,B2
+to industrialize,to industrialize,工业化,VERB,B2
+to regionalize,to regionalize,区域化,VERB,B2
+bent,bent,弯的,ADJ,B2
+to commentate,to commentate,评论,VERB,B2
+daft,daft,傻的,ADJ,B2
+life-size,life-size,真人大小的,ADJ,B2
+australian,australian,澳大利亚的,ADJ,B2
+her,her,她的,DET,B2
+sighing,sighing,叹息的,ADJ,B2
+all-round,all-round,全面的,ADJ,B2
+megalomanic,megalomanic,狂妄自大的,ADJ,B2
+april,april,四月,NOUN,B2
+to lug,to lug,搬运,VERB,B2
+fictional character,fictional character,虚构角色,NOUN,B2
+youth trauma,youth trauma,童年创伤,NOUN,B2
+remaining,remaining,,NOUN,B2
+presidential election,presidential election,总统选举,NOUN,B2
+worth mentioning,worth mentioning,值得一提的,ADJ,B2
+well-groomed,well-groomed,整洁的,ADJ,B2
+family tension,family tension,家庭紧张,NOUN,B2
+knowledge transfer,knowledge transfer,知识传授,NOUN,B2
+power station,power station,发电厂,NOUN,B2
+school year,school year,学年,NOUN,B2
+to telework,to telework,远程办公,VERB,B2
+family composition,family composition,家庭构成,NOUN,B2
+trivializable,trivializable,可轻描淡写的,ADJ,B2
+from which,from which,从中,ADV,B2
+energy crisis,energy crisis,能源危机,NOUN,B2
+benignity,benignity,良性,NOUN,B2
+peat,peat,泥炭,NOUN,B2
+to plagiarize,to plagiarize,剽窃,VERB,B2
+for this purpose,for this purpose,为此,ADV,B2
+exclusionary,exclusionary,排他性的,ADJ,B2
+to objectify,to objectify,客观化,VERB,B2
+sporty,sporty,运动的,ADJ,B2
+nameable,nameable,可命名的,ADJ,B2
+tyrannical,tyrannical,专横的,ADJ,B2
+founding,founding,成立,NOUN,B2
+ceremonial,ceremonial,仪式的,ADJ,B2
+court fee,court fee,诉讼费,NOUN,B2
+emotional expression,emotional expression,! 情感表达,NOUN,B2
+irrelevance,irrelevance,无关,NOUN,B2
+line-up,line-up,阵容,NOUN,B2
+to ostracize,to ostracize,排斥,VERB,B2
+to set rates,to set rates,定价,VERB,B2
+the one,the one,,NOUN,B2
+grave desecration,grave desecration,亵渎坟墓,NOUN,B2
+whisk,whisk,打蛋器,NOUN,B2
+veiled,veiled,隐晦的,ADJ,B2
+place of residence,place of residence,居住地,NOUN,B2
+regardless,regardless,不管,ADP,B2
+to drop off,to drop off,放下,VERB,B2
+to do sports,to do sports,运动,VERB,B2
+atheistic,atheistic,无神论的,ADJ,B2
+fatty,fatty,脂肪的,ADJ,B2
+headscarf,headscarf,头巾,NOUN,B2
+genital,genital,生殖器,NOUN,B2
+proliferate,proliferate,扩散,! VERB,B2
+fossil fuel,fossil fuel,化石燃料,NOUN,B2
+feeble-minded,feeble-minded,弱智的,ADJ,B2
+truthful,truthful,忠于事实的,ADJ,B2
+constitutive,constitutive,构成的,ADJ,B2
+this evening,this evening,今晚,ADV,B2
+gay man,gay man,男同性恋者,NOUN,B2
+variant,variant,变体,NOUN,B2
+endowed,endowed,有天赋的,ADJ,B2
+full of life,full of life,充满活力的,ADJ,B2
+two-dimensional,two-dimensional,二维的,ADJ,B2
+schoolboy,schoolboy,学生,NOUN,B2
+new construction,new construction,新建建筑,NOUN,B2
+aghast,aghast,惊骇的,ADJ,B2
+little sun,little sun,小太阳,NOUN,B2
+national coach,national coach,国家队教练,NOUN,B2
+by now,by now,此时,ADV,B2
+side,side,骄傲的,ADJ,B2
+norwegian,norwegian,挪威的,ADJ,B2
+to invoice,to invoice,开票,VERB,B2
+consolidating,consolidating,巩固的,ADJ,B2
+gravitational,gravitational,引力的,ADJ,B2
+prayer room,prayer room,祈祷室,NOUN,B2
+moralizing,moralizing,说教的,ADJ,B2
+brazilian,brazilian,巴西的,ADJ,B2
+to draw water,to draw water,打水,VERB,B2
+connotative,connotative,内涵的,ADJ,B2
+desirability,desirability,可取性,NOUN,B2
+insightfulness,insightfulness,洞察,NOUN,B2
+leading role,leading role,主角,NOUN,B2
+methodological,methodological,方法论的,ADJ,B2
+dutchman,dutchman,荷兰人,NOUN,B2
+grand officer,grand officer,大官,NOUN,B2
+associated,associated,相关的,ADJ,B2
+upright,upright,直立地,ADV,B2
+guilt-ridden,guilt-ridden,内疚的,ADJ,B2
+constructivism,constructivism,建构主义,NOUN,B2
+contractual,contractual,合同的,ADJ,B2
+diction,diction,措辞,NOUN,B2
+group member,group member,群体成员,NOUN,B2
+bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
+mainstream,mainstream,主流的,ADJ,B2
+tired of,tired of,,NOUN,B2
+very hard,very hard,极硬的,ADJ,B2
+frictionless,frictionless,无摩擦的,ADJ,B2
+motor,motor,运动的,ADJ,B2
+paralysed,paralysed,瘫痪的,ADJ,B2
+florid,florid,辞藻华丽的,ADJ,B2
+southeast,southeast,东南,NOUN,B2
+to be correct,to be correct,正确,VERB,B2
+concave,concave,凹的,ADJ,B2
+customer service,customer service,客户服务,NOUN,B2
+entranced,entranced,痴迷的,ADJ,B2
+gracious,gracious,亲切的,ADJ,B2
+to tweet,to tweet,发推文,VERB,B2
+compulsiveness,compulsiveness,强迫性,NOUN,B2
+off,off,关,ADP,B2
+dislike,dislike,厌恶,NOUN,B2
+with this,with this,以此,ADV,B2
+inflexibility,inflexibility,僵化,NOUN,B2
+danish,danish,丹麦的,ADJ,B2
+legation,legation,公使馆,NOUN,B2
+group culture,group culture,群体文化,NOUN,B2
+guilder,guilder,盾,NOUN,B2
+reformulation,reformulation,重新表述,NOUN,B2
+syrian,syrian,叙利亚的,ADJ,B2
+skilful,skilful,熟练的,ADJ,B2
+ice cold,ice cold,冰冷的,ADJ,B2
+technocratic,technocratic,技术官僚的,ADJ,B2
+incorporation,incorporation,纳入,NOUN,B2
+universities,universities,大学,NOUN,B2
+to log in,to log in,登录,VERB,B2
+one hundred,one hundred,一百,NUM,B2
+cohort-based,cohort-based,队列的,ADJ,B2
+native american,native american,印第安人,NOUN,B2
+religiousness,religiousness,虔诚,NOUN,B2
+pregnant woman,pregnant woman,孕妇,NOUN,B2
+meek,meek,温顺的,ADJ,B2
+contractualization,contractualization,契约化,NOUN,B2
+court case,court case,诉讼,NOUN,B2
+final score,final score,最终比分,NOUN,B2
+explicable,explicable,可解释的,ADJ,B2
+health policy,health policy,健康政策,NOUN,B2
+border post,border post,边防哨所,NOUN,B2
+small gift,small gift,小礼物,NOUN,B2
+southwest,southwest,西南的,ADJ,B2
+purifying,purifying,净化的,ADJ,B2
+religious war,religious war,宗教战争,NOUN,B2
+crisis situation,crisis situation,危机局势,NOUN,B2
+synoptic,synoptic,概要的,ADJ,B2
+tolerant,tolerant,宽容的,ADJ,B2
+breach of contract,breach of contract,违约,NOUN,B2
+climate denial,climate denial,气候否认,NOUN,B2
+liquid,liquid,液态的,ADJ,B2
+decibel,decibel,分贝,NOUN,B2
+such a,such a,这样的,DET,B2
+splash,splash,扑通,NOUN,B2
+paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
+mp,mp,国会议员,NOUN,B2
+expertise center,expertise center,专业中心,NOUN,B2
+search engine,search engine,搜索引擎,NOUN,B2
+undermining authority,undermining authority,削弱权威,NOUN,B2
+kindred spirit,kindred spirit,志同道合者,NOUN,B2
+gynaecology,gynaecology,妇科,NOUN,B2
+toothless,toothless,无齿的,ADJ,B2
+increased,increased,增加的,ADJ,B2
+collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
+to tax to burden,to tax to burden,征税,VERB,B2
+soundtrack,soundtrack,! 音轨,NOUN,B2
+physiotherapy,physiotherapy,物理治疗,NOUN,B2
+volunteer work,volunteer work,志愿工作,NOUN,B2
+property right,property right,所有权,NOUN,B2
+every,every,每个,PRON,B2
+bumpy,bumpy,凹凸不平的,ADJ,B2
+to play football,to play football,踢足球,VERB,B2
+disco,disco,迪厅,NOUN,B2
+group individual,group individual,群体个体,NOUN,B2
+palestinian,palestinian,巴勒斯坦的,ADJ,B2
+directorship,directorship,董事职位,NOUN,B2
+to walk around,to walk around,四处走动,VERB,B2
+to pauperize,to pauperize,使贫困,VERB,B2
+minus,minus,减,NOUN,B2
+thetic,thetic,正题的,ADJ,B2
+toys,toys,玩具,NOUN,B2
+tidal movement,tidal movement,潮汐运动,NOUN,B2
+satisfying,satisfying,令人满意的,ADJ,B2
+duplicate,duplicate,! 副本,NOUN,B2
+federalization,federalization,联邦化,NOUN,B2
+how long,how long,多久,ADV,B2
+group solidarity,group solidarity,群体团结,NOUN,B2
+state of mind,state of mind,精神状态,NOUN,B2
+to situate,to situate,定位,VERB,B2
+amusement,amusement,娱乐,NOUN,B2
+domestic,domestic,国内,NOUN,B2
+dismal,dismal,令人失望的,ADJ,B2
+effortless,effortless,不费力的,ADJ,B2
+to keep silent,to keep silent,保持沉默,VERB,B2
+posh,posh,上流的,ADJ,B2
+gosh,gosh,天哪,INTJ,B2
+exemplary country,exemplary country,模范国家,NOUN,B2
+connective,connective,连接的,ADJ,B2
+noise nuisance,noise nuisance,噪音扰民,NOUN,B2
+colour,colour,颜色,NOUN,B2
+manual,manual,手工的,ADJ,B2
+fort,fort,堡垒,NOUN,B2
+grand duchy,grand duchy,大公国,NOUN,B2
+petrol,petrol,汽油,NOUN,B2
+to stitch,to stitch,缝,VERB,B2
+habitual behavior,habitual behavior,习惯行为,NOUN,B2
+border community,border community,边境社区,NOUN,B2
+eczema,eczema,湿疹,NOUN,B2
+irish,irish,爱尔兰的,ADJ,B2
+criminal law,criminal law,刑法,NOUN,B2
+bombardment,bombardment,轰炸,NOUN,B2
+vs,vs,与...相对,ADP,B2
+higher professional education,higher professional education,高等专业教育,NOUN,B2
+family circle,family circle,家庭圈子,NOUN,B2
+furnishing,furnishing,室内布置,NOUN,B2
+crystal clear,crystal clear,清澈的,ADJ,B2
+windless,windless,无风的,ADJ,B2
+about that,about that,关于那个,ADV,B2
+character assassination,character assassination,人格谋杀,NOUN,B2
+to bully,to bully,欺凌,VERB,B2
+to mystify,to mystify,神秘化,VERB,B2
+grand duke,grand duke,大公,NOUN,B2
+licentious,licentious,放荡的,ADJ,B2
+one-way traffic,one-way traffic,单向通行,NOUN,B2
+mannerly,mannerly,有礼貌的,ADJ,B2
+visible,visible,可见的,ADJ,B2
+to persevere,to persevere,坚持,VERB,B2
+systemless,systemless,无系统的,ADJ,B2
+little brother,little brother,小弟弟,NOUN,B2
+swiss,swiss,瑞士的,ADJ,B2
+paralympic,paralympic,残奥会的,ADJ,B2
+globalization process,globalization process,全球化进程,NOUN,B2
+to sublimate,to sublimate,升华,VERB,B2
+postal code,postal code,邮政编码,NOUN,B2
+labor market,labor market,劳动力市场,NOUN,B2
+egyptian,egyptian,埃及的,ADJ,B2
+dissociation,dissociation,解离,NOUN,B2
+gallows humor,gallows humor,绞刑架幽默,NOUN,B2
+unfriendly,unfriendly,不友好的,ADJ,B2
+email address,email address,电子邮件地址,NOUN,B2
+exceptionality,exceptionality,特殊性,NOUN,B2
+multipart,multipart,多部分的,ADJ,B2
+contact person,contact person,联系人,NOUN,B2
+to text,to text,发短信,VERB,B2
+to instrumentalize,to instrumentalize,工具化,VERB,B2
+liberalize,liberalize,自由化,! VERB,B2
+contaminating,contaminating,污染的,ADJ,B2
+conversional,conversional,转换的,ADJ,B2
+heath,heath,石楠荒原,NOUN,B2
+peddler,peddler,小贩,NOUN,B2
+dossier,dossier,档案,NOUN,B2
+neighbour,neighbour,邻居,NOUN,B2
+racist,racist,种族主义的,ADJ,B2
+comparative,comparative,比较的,ADJ,B2
+to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
+to use up,to use up,用完,VERB,B2
+lacunary,lacunary,残缺的,ADJ,B2
+factual,factual,事实的,ADJ,B2
+on behalf of,on behalf of,代表,ADP,B2
+photon,photon,光子,NOUN,B2
+heated,heated,激昂的,ADJ,B2
+to revalue,to revalue,重新估值,VERB,B2
+expressiveness,expressiveness,表现力,NOUN,B2
+one and a half,one and a half,一个半,NUM,B2
+enforcement policy,enforcement policy,执法政策,NOUN,B2
+catastrophic,catastrophic,灾难性的,ADJ,B2
+drinking water,drinking water,饮用水,NOUN,B2
+caring,caring,关怀的,ADJ,B2
+group mentality,group mentality,群体心态,NOUN,B2
+connecting,connecting,连接的,ADJ,B2
+to stick out,to stick out,伸出,VERB,B2
+trade barrier,trade barrier,贸易壁垒,NOUN,B2
+witness examination,witness examination,证人询问,NOUN,B2
+broadening,broadening,拓宽,NOUN,B2
+rest assured,rest assured,放心的,ADJ,B2
+depicting,depicting,描绘的,ADJ,B2
+informedness,informedness,知情度,NOUN,B2
+wooden,wooden,木制的,ADJ,B2
+to mess about,to mess about,胡搞,VERB,B2
+eclecticism,eclecticism,折衷主义,NOUN,B2
+upwards,upwards,向上,ADV,B2
+austrian,austrian,奥地利的,ADJ,B2
+to revitalize,to revitalize,使复苏,VERB,B2
+financier,financier,资助者,NOUN,B2
+collectomania,collectomania,收藏癖,NOUN,B2
+destined,destined,,NOUN,B2
+iranian,iranian,伊朗的,ADJ,B2
+in which,in which,在其中,PRON,B2
+maximal,maximal,最大的,ADJ,B2
+group norm,group norm,群体规范,NOUN,B2
+demagogy,demagogy,蛊惑,NOUN,B2
+venereal disease,venereal disease,性病,NOUN,B2
+depot,depot,仓库,NOUN,B2
+to sensitize,to sensitize,提高意识,VERB,B2
+for this,for this,为此,ADV,B2
+position of authority,position of authority,! 权威地位,NOUN,B2
+flemish,flemish,佛兰芒的,ADJ,B2
+steering,steering,掌舵的,ADJ,B2
+to type,to type,打字,VERB,B2
+religious strife,religious strife,宗教纷争,NOUN,B2
+wait-and-see,wait-and-see,观望的,ADJ,B2
+abolition,abolition,废除,NOUN,B2
+hassle,hassle,麻烦,NOUN,B2
+concessionary,concessionary,让步的,ADJ,B2
+to vegetate,to vegetate,苟活,VERB,B2
+gloriousness,gloriousness,光荣,NOUN,B2
+to vampirize,to vampirize,吸血,VERB,B2
+macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+line of conduct,line of conduct,行为方针,NOUN,B2
+hungarian,hungarian,匈牙利的,ADJ,B2
+mayoral,mayoral,市长的,ADJ,B2
+run-up,run-up,助跑,NOUN,B2
+damageable,damageable,易损的,ADJ,B2
+to localize,to localize,本地化,VERB,B2
+all kinds,all kinds,各种各样的,DET,B2
+little hand,little hand,小手,NOUN,B2
+to immunize,to immunize,免疫,VERB,B2
+at the top,at the top,在最上面,ADV,B2
+potential,potential,潜在的,ADJ,B2
+christianity,christianity,基督教,NOUN,B2
+humanities,humanities,人文学科,NOUN,B2
+inventorying,inventorying,清点,NOUN,B2
+basic income,basic income,基本收入,NOUN,B2
+ukrainian,ukrainian,乌克兰的,ADJ,B2
+to play sports,to play sports,做运动,VERB,B2
+family reunification,family reunification,家庭团聚,NOUN,B2
+factionalism,factionalism,派系主义,NOUN,B2
+holism,holism,整体论,NOUN,B2
+newsletter,newsletter,简报,NOUN,B2
+vacuum,vacuum,真空的,ADJ,B2
+further on,further on,更远处,ADV,B2
+heartfelt,heartfelt,衷心的,ADJ,B2
+front line,front line,前线,NOUN,B2
+cycle path,cycle path,自行车道,NOUN,B2
+bleak,bleak,无望的,ADJ,B2
+at the back,at the back,在后面,ADV,B2
+counterproductivity,counterproductivity,适得其反,NOUN,B2
+to rent out,to rent out,出租,VERB,B2
+convertible,convertible,可兑换的,ADJ,B2
+orderliness,orderliness,有序性,NOUN,B2
+to theatricalize,to theatricalize,戏剧化,VERB,B2
+villainous,villainous,恶棍的,ADJ,B2
+emaciating,emaciating,消耗的,ADJ,B2
+conceptual,conceptual,概念的,ADJ,B2
+correctness,correctness,正确性,NOUN,B2
+chauvinistic,chauvinistic,沙文主义的,ADJ,B2
+costs,costs,费用,NOUN,B2
+collegial,collegial,同事的,ADJ,B2
+grandparenthood,grandparenthood,祖父母身份,NOUN,B2
+to,to,去,PART,B2
+portuguese,portuguese,葡萄牙语,NOUN,B2
+terminal,terminal,终末的,ADJ,B2
+hatch,hatch,舱口,NOUN,B2
+continual,continual,持续的,ADJ,B2
+determine,determine,确定,VER! B,B2
+city centre,city centre,市中心,NOUN,B2
+milky,milky,乳白色的,ADJ,B2
+selfish,selfish,,NOUN,B2
+having a birthday,having a birthday,过生日的,ADJ,B2
+numismatic,numismatic,钱币学的,ADJ,B2
+to settle up,to settle up,结账,VERB,B2
+solemn,solemn,,NOUN,B2
+egocentrism,egocentrism,自我中心,NOUN,B2
+to technologize,to technologize,技术化,VERB,B2
+hollowed,hollowed,掏空的,ADJ,B2
+state secretary,state secretary,国务秘书,NOUN,B2
+light brown,light brown,浅棕色的,ADJ,B2
+national anthem,national anthem,国歌,NOUN,B2
+showing,showing,表现,NOUN,B2
+conspiratorial,conspiratorial,阴谋的,ADJ,B2
+fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
+hazard report,hazard report,危险报告,NOUN,B2
+workable,workable,可加工的,ADJ,B2
+virginal,virginal,处女的,ADJ,B2
+tens of thousands,tens of thousands,数万,NUM,B2
+arabic,arabic,阿拉伯的,ADJ,B2
+manipulable,manipulable,可操纵的,ADJ,B2
+largely,largely,主要地,ADV,B2
+redrawing,redrawing,重新绘制,NOUN,B2
+to break off,to break off,中断,VERB,B2
+structuredness,structuredness,结构性,NOUN,B2
+to pucker,to pucker,噘,VERB,B2
+berlijns,berlijns,柏林的,ADJ,B2
+source citation,source citation,出处注明,NOUN,B2
+ourselves,ourselves,我们自己,PRON,B2
+parish priest,parish priest,本堂神父,NOUN,B2
+balancing,balancing,平衡的,ADJ,B2
+dispirited,dispirited,沮丧的,ADJ,B2
+liberating,liberating,解放的,ADJ,B2
+documentation,documentation,文献,NOUN,B2
+depicted,depicted,描绘的,ADJ,B2
+to tidy,to tidy,整理,VERB,B2
+special offer,special offer,特价,NOUN,B2
+diplomatic relations,diplomatic relations,外交关系,NOUN,B2
+judgement,judgement,评估,NOUN,B2
+nuts,nuts,疯狂的,ADJ,B2
+provable,provable,可证明的,ADJ,B2
+traditional costume,traditional costume,传统服饰,NOUN,B2
+children's rights,children's rights,儿童权利,NOUN,B2
+with that,with that,以此,ADV,B2
+folksy,folksy,乡土的,ADJ,B2
+south african,south african,南非的,ADJ,B2
+solar panel,solar panel,太阳能电池板,NOUN,B2
+to contextualize,to contextualize,置于语境,VERB,B2
+tram,tram,有轨电车,NOUN,B2
+how come,how come,怎么会,INTJ,B2
+habitlessness,habitlessness,无习惯,NOUN,B2
+coloredness,coloredness,有色性,NOUN,B2
+owed,owed,欠下的,ADJ,B2
+increasing,increasing,增加的,ADJ,B2
+cosmetics,cosmetics,化妆品,NOUN,B2
+explanatory,explanatory,解释的,ADJ,B2
+church community,church community,教会,NOUN,B2
+to revolutionize,to revolutionize,革命化,VERB,B2
+editor-in-chief,editor-in-chief,主编,NOUN,B2
+for a moment,for a moment,片刻,ADV,B2
+midfielder,midfielder,中场球员,NOUN,B2
+demotion,demotion,降职,NOUN,B2
+to saw,to saw,锯,VERB,B2
+twofold,twofold,双重的,ADJ,B2
+world champion,world champion,世界冠军,NOUN,B2
+barbarization,barbarization,野蛮化,NOUN,B2
+rightly,rightly,正确地,ADV,B2
+hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
+tomorrow night,tomorrow night,明晚,ADV,B2
+disharmony,disharmony,不和谐,NOUN,B2
+primary school,primary school,小学,NOUN,B2
+fabulist,fabulist,幻想家,NOUN,B2
+brabant,brabant,布拉班特的,ADJ,B2
+paving,paving,铺路,NOUN,B2
+full-time,full-time,全职,ADJ,B2
+conviviality,conviviality,温馨,NOUN,B2
+lawless,lawless,无法的,ADJ,B2
+deputation,deputation,代表团,NOUN,B2
+song festival,song festival,音乐节,NOUN,B2
+border check,border check,边境检查,NOUN,B2
+sentences,sentences,句子,NOUN,B2
+lifelong,lifelong,终身,ADJ,B2
+series of conversations,series of conversations,系列对话,NOUN,B2
+plenty,plenty,充足地,ADV,B2
+meandering,meandering,蜿蜒的,ADJ,B2
+land policy,land policy,土地政策,NOUN,B2
+domineeringness,domineeringness,支配欲,NOUN,B2
+hem,hem,边缘,NOUN,B2
+just like that,just like that,随便地,ADV,B2
+inactivity,inactivity,不活跃,NOUN,B2
+figuration,figuration,群演,NOUN,B2
+group work,group work,群体工作,NOUN,B2
+removed,removed,移除的,ADJ,B2
+authority structure,authority structure,权威结构,NOUN,B2
+governable,governable,可管理的,ADJ,B2
+day after tomorrow,day after tomorrow,后天,NOUN,B2
+sports park,sports park,运动公园,NOUN,B2
+little heart,little heart,小心脏,NOUN,B2
+alternating,alternating,交替的,ADJ,B2
+subject field,subject field,科目 / 领域,NOUN,B2
+grand master,grand master,大师,NOUN,B2
+in the back,in the back,在后面,ADV,B2
+film industry,film industry,电影业,NOUN,B2
+healthcare,healthcare,医疗保健,NOUN,B2
+to harbor,to harbor,怀有,VERB,B2
+rash,rash,皮疹,NOUN,B2
+greetings,greetings,,NOUN,B2
+the guy,the guy,那个男人,NOUN,B2
+egg card,egg card,,NOUN,B2
+penance,penance,忏悔,NOUN,B2
+edging,edging,镶边,NOUN,B2
+your plural,your plural,你们的,DET,B2
+to rot,to rot,腐烂,VERB,B2
+milk tooth,milk tooth,,NOUN,B2
+darn,darn,哎呀,INTJ,B2
+from within,from within,从内部,ADV,B2
+law team,law team,法律/团队,NOUN,B2
+like that,like that,像那样,ADV,B2
+electric motor,electric motor,电动机,NOUN,B2
+to food give birth,to food give birth,食物/生育,VERB,B2
+values base,values base,价值基础,NOUN,B2
+here hither,here hither,这里/到这里,ADV,B2
+twenty-two-year-old,twenty-two-year-old,,NOUN,B2
+band tape,band tape,带子,NOUN,B2
+where i,where i,,NOUN,B2
+values,values,价值观,NOUN,B2
+fun joke,fun joke,乐趣/玩笑,NOUN,B2
+to call ring,to call ring,打电话,VERB,B2
+meaning content,meaning content,语义内容,NOUN,B2
+confusing,confusing,令人困惑的,ADJ,B2
+to account for,to account for,说明,VERB,B2
+based,based,基于,ADJ,B2
+limit border,limit border,界限,NOUN,B2
+girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
+sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
+shady suspicious,shady suspicious,可疑的,ADJ,B2
+intelligence service,intelligence service,情报机构,NOUN,B2
+dejt,dejt,约会,NOUN,B2
+substandard,substandard,,NOUN,B2
+evidence bag,evidence bag,,NOUN,B2
+to acquaint,to acquaint,使熟悉,VERB,B2
+one-way,one-way,单向的,ADJ,B2
+definite,definite,明确的,ADJ,B2
+seeker,seeker,寻求者,NOUN,B2
+diagonally,diagonally,对角地,ADV,B2
+upper floor,upper floor,楼上,NOUN,B2
+told instructed,told instructed,被告知的,ADJ,B2
+mapping,mapping,梳理,NOUN,B2
+self-care,self-care,自我护理,NOUN,B2
+doctor visit,doctor visit,,NOUN,B2
+deck tire,deck tire,甲板/轮胎,NOUN,B2
+irish person,irish person,爱尔兰人,NOUN,B2
+baptized,baptized,受洗的,ADJ,B2
+more important,more important,更重要的,ADJ,B2
+thank god,thank god,谢天谢地,INTJ,B2
+knowledge exchange,knowledge exchange,知识交流,NOUN,B2
+occupational pension,occupational pension,职业养老金,NOUN,B2
+in peace,in peace,不受打扰地,ADV,B2
+gender equality,gender equality,性别平等,NOUN,B2
+pavement,pavement,人行道,NOUN,B2
+top great,top great,顶部/极好,NOUN,B2
+to be felled,to be felled,被砍倒,VERB,B2
+effort bet,effort bet,努力/赌注,NOUN,B2
+loudly,loudly,大声地,ADV,B2
+middle class,middle class,中产阶层,NOUN,B2
+orange juice,orange juice,橙汁,NOUN,B2
+salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
+clock watch,clock watch,钟表,NOUN,B2
+single,single,单曲,NOUN,B2
+service year,service year,,NOUN,B2
+guest tester,guest tester,,NOUN,B2
+cellulose,cellulose,纤维素,NOUN,B2
+gay,gay,同性恋者,NOUN,B2
+word choice,word choice,措辞,NOUN,B2
+social problem,social problem,社会问题,NOUN,B2
+the casinos,the casinos,赌场,NOUN,B2
+yes indeed,yes indeed,正是,INTJ,B2
+outdoors,outdoors,户外,ADV,B2
+capable good,capable good,能干的/优秀的,ADJ,B2
+indigenous people,indigenous people,原住民,NOUN,B2
+to place put,to place put,放置,VERB,B2
+tough guy,tough guy,硬汉,NOUN,B2
+sure safe,sure safe,确定的,ADJ,B2
+good behavior,good behavior,,NOUN,B2
+the devil bastard,the devil bastard,混蛋,NOUN,B2
+to have strength,to have strength,有力气,VERB,B2
+suicide candidate,suicide candidate,,NOUN,B2
+nicely nice,nicely nice,美好地,ADV,B2
+like this,like this,,NOUN,B2
+arrived present,arrived present,到了,ADV,B2
+to disfavor,to disfavor,不利于,VERB,B2
+of by,of by,的/被,ADP,B2
+cancelled set,cancelled set,取消的/设定的,ADJ,B2
+to get acquire,to get acquire,获得/弄到,VERB,B2
+care home,care home,,NOUN,B2
+smart clever,smart clever,聪明的,ADJ,B2
+curfew,curfew,宵禁,NOUN,B2
+faster,faster,更快的,ADJ,B2
+to screw,to screw,拧,VERB,B2
+ride lift,ride lift,搭车,NOUN,B2
+stockholm,stockholm,斯德哥尔摩,PROPN,B2
+date fruit,date fruit,椰枣,NOUN,B2
+cheaper,cheaper,更便宜的,ADJ,B2
+quivering,quivering,颤抖的,ADJ,B2
+impressed,impressed,印象深刻的,ADJ,B2
+fired,fired,被解雇的,ADJ,B2
+clear,clear,当然,ADV,B2
+phrasing,phrasing,措辞,NOUN,B2
+werewolf,werewolf,狼人,NOUN,B2
+news reporting,news reporting,新闻报道,NOUN,B2
+lent,lent,大斋期,NOUN,B2
+seen,seen,被看见,ADJ,B2
+armorer,armorer,,NOUN,B2
+little one,little one,小家伙,NOUN,B2
+agree,agree,一致,ADJ,B2
+dozens,dozens,数十个,NOUN,B2
+sinner,sinner,罪人,NOUN,B2
+press freedom,press freedom,新闻自由,NOUN,B2
+fair decent,fair decent,公平的/正派的,ADJ,B2
+too late,too late,太迟,ADV,B2
+poison gas,poison gas,毒气,NOUN,B2
+starved,starved,饥饿的,ADJ,B2
+professionally active,professionally active,在职,NOUN,B2
+oh really,oh really,真的吗,INTJ,B2
+to exist there is,to exist there is,存在/有,VERB,B2
+to meant,to meant,意思是,VERB,B2
+unarmed,unarmed,手无寸铁的,ADJ,B2
+marine corps,marine corps,海军陆战队,NOUN,B2
+welcome committee,welcome committee,,NOUN,B2
+corpse alike,corpse alike,尸体/相似的,NOUN,B2
+to diet,to diet,减肥,VERB,B2
+history story,history story,历史/故事,NOUN,B2
+all-clear,all-clear,许可信号,NOUN,B2
+databas,databas,数据库,NOUN,B2
+to tear down,to tear down,拆除,VERB,B2
+eider hunter,eider hunter,,NOUN,B2
+ought,ought,应该,AUX,B2
+electric power,electric power,电力,NOUN,B2
+trigger mechanism,trigger mechanism,,NOUN,B2
+to find oneself,to find oneself,处于,VERB,B2
+to missed,to missed,错过,VERB,B2
+to furlough,to furlough,临时解雇,VERB,B2
+shedding,shedding,,NOUN,B2
+parent-friendly,parent-friendly,,NOUN,B2
+fast,fast,快地,ADV,B2
+brain activity,brain activity,,NOUN,B2
+itself,itself,它自己,PRON,B2
+equal treatment,equal treatment,平等待遇,NOUN,B2
+monkey ape,monkey ape,猿/猴,NOUN,B2
+half hour,half hour,半小时,NOUN,B2
+eating,eating,,NOUN,B2
+layer storage,layer storage,层/仓库,NOUN,B2
+concussion,concussion,脑震荡,NOUN,B2
+self-image,self-image,自我形象,NOUN,B2
+the very,the very,正是,ADV,B2
+green-clad,green-clad,,NOUN,B2
+angle of approach,angle of approach,切入点,NOUN,B2
+datum,datum,日期,NOUN,B2
+to close eyes,to close eyes,闭眼,VERB,B2
+down there,down there,在那下面,ADV,B2
+to drink binge,to drink binge,狂饮,VERB,B2
+cola,cola,可乐,NOUN,B2
+innocent,innocent,无辜地,ADV,B2
+language use,language use,语言使用,NOUN,B2
+the career,the career,职业生涯,NOUN,B2
+selected,selected,选中的,ADJ,B2
+freedom of speech,freedom of speech,言论自由,NOUN,B2
+top,top,顶部的,ADJ,B2
+for sale,for sale,待售,ADJ,B2
+mr master,mr master,先生/主人,NOUN,B2
+heroin vapor,heroin vapor,,NOUN,B2
+the sick,the sick,病人,NOUN,B2
+should ought to,should ought to,应该,AUX,B2
+find,find,发现物,NOUN,B2
+citizenship right,citizenship right,公民权,NOUN,B2
+alarm center,alarm center,报警中心,NOUN,B2
+prayer trap,prayer trap,,NOUN,B2
+underclass,underclass,底层,NOUN,B2
+other others,other others,其他,DET,B2
+more pl,more pl,更多,ADJ,B2
+to stay awake,to stay awake,守夜,VERB,B2
+sabbath,sabbath,安息日,NOUN,B2
+to zero out,to zero out,清零,VERB,B2
+older woman,older woman,老妇人,NOUN,B2
+its,its,它的,PRON,B2
+bank card,bank card,银行卡,NOUN,B2
+berkeley coach,berkeley coach,,NOUN,B2
+squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
+conifer,conifer,针叶树,NOUN,B2
+eidsvold,eidsvold,,NOUN,B2
+firearms,firearms,枪支,NOUN,B2
+healthcare worker,healthcare worker,医护人员,NOUN,B2
+medical help,medical help,,NOUN,B2
+to be saved,to be saved,获救,VERB,B2
+sought,sought,,NOUN,B2
+bang,bang,砰,INTJ,B2
+observation skill,observation skill,,NOUN,B2
+terrorists,terrorists,恐怖分子们,NOUN,B2
+ever,ever,,NOUN,B2
+to watch out,to watch out,小心,VERB,B2
+big brother,big brother,哥哥,NOUN,B2
+up there,up there,在那上面,ADV,B2
+retailer,retailer,零售商,NOUN,B2
+pre,pre,,NOUN,B2
+mighty very,mighty very,非常,ADJ,B2
+to map out,to map out,摸清,VERB,B2
+chief physician,chief physician,主任医师,NOUN,B2
+ribs,ribs,肋骨,NOUN,B2
+paternal grandmother,paternal grandmother,祖母,NOUN,B2
+english teacher,english teacher,,NOUN,B2
+to be punished,to be punished,受罚,VERB,B2
+drug dealer,drug dealer,毒贩,NOUN,B2
+phone number,phone number,电话号码,NOUN,B2
+colder,colder,更冷的,ADJ,B2
+hard,hard,努力地,ADV,B2
+painless,painless,,NOUN,B2
+to dismiss fire,to dismiss fire,解雇,VERB,B2
+cultural encounter,cultural encounter,文化交汇,NOUN,B2
+citrus,citrus,柑橘,NOUN,B2
+blood test,blood test,验血,NOUN,B2
+sense of shame,sense of shame,,NOUN,B2
+seventeen,seventeen,十七,NUM,B2
+advancement,advancement,晋升,NOUN,B2
+to be needed,to be needed,被需要,VERB,B2
+bump shock,bump shock,碰撞/震惊,NOUN,B2
+hallelujah,hallelujah,哈利路亚,INTJ,B2
+farm yard,farm yard,农场,NOUN,B2
+watertight,watertight,,NOUN,B2
+elite unit,elite unit,,NOUN,B2
+apart from,apart from,除了,ADP,B2
+bike basket,bike basket,车筐,NOUN,B2
+to be counted,to be counted,被算作,VERB,B2
+cats,cats,猫,NOUN,B2
+sure,sure,当然,ADV,B2
+experience exchange,experience exchange,经验交流,NOUN,B2
+to be created,to be created,被创造,VERB,B2
+sun sensitivity,sun sensitivity,,NOUN,B2
+surely safe,surely safe,肯定地,ADV,B2
+kidnapped,kidnapped,被绑架的,ADJ,B2
+detention center,detention center,拘留所,NOUN,B2
+chubby,chubby,胖子,NOUN,B2
+the other day,the other day,前几天,ADV,B2
+to shop be about,to shop be about,购物,VERB,B2
+his her its their,his her its their,他的/她的/它的/他们的,DET,B2
+fascinated,fascinated,着迷的,ADJ,B2
+entrance ticket,entrance ticket,门票,NOUN,B2
+shortly,shortly,不久,ADV,B2
+gothenburg,gothenburg,哥德堡,PROPN,B2
+to mess around,to mess around,胡闹,VERB,B2
+working class,working class,工人阶级,NOUN,B2
+to use to usually,to use to usually,通常/习惯于,VERB,B2
+leaf page,leaf page,叶子,NOUN,B2
+online dating profile,online dating profile,,NOUN,B2
+to step down,to step down,辞职,VERB,B2
+meatballs,meatballs,肉丸,NOUN,B2
+paralyzed,paralyzed,瘫痪的,ADJ,B2
+alive living,alive living,活着的,ADJ,B2
+so thus,so thus,所以/如此,ADV,B2
+to trap fell,to trap fell,困住/砍倒,VERB,B2
+younger,younger,较年轻的,ADJ,B2
+contacts,contacts,人脉,NOUN,B2
+to come loose,to come loose,松脱,VERB,B2
+field medic,field medic,战地医生,NOUN,B2
+following page,following page,,NOUN,B2
+managed,managed,,NOUN,B2
+broken,broken,破碎的,ADV,B2
+latest,latest,最新的,ADJ,B2
+to light a fire,to light a fire,生火,VERB,B2
+work environment,work environment,工作环境,NOUN,B2
+to occupy oneself,to occupy oneself,从事,VERB,B2
+hanged,hanged,被绞死的,ADJ,B2
+somewhere,somewhere,,NOUN,B2
+thicker,thicker,更厚的,ADJ,B2
+devil bastard,devil bastard,混蛋,NOUN,B2
+atm,atm,自动取款机,NOUN,B2
+side page,side page,侧面/页,NOUN,B2
+matter of time,matter of time,时间问题,NOUN,B2
+own,own,自己的,DET,B2
+filled,filled,充满的,ADJ,B2
+the guy's,the guy's,那个男人的,NOUN,B2
+burger stand,burger stand,,NOUN,B2
+degree exam,degree exam,学位/考试,NOUN,B2
+he this one,he this one,他/这位,PRON,B2
+pain relief,pain relief,,NOUN,B2
+film movie,film movie,电影,NOUN,B2
+so-called,so-called,,NOUN,B2
+although,although,尽管,CCONJ,B2
+nerd,nerd,书呆子,NOUN,B2
+best friend,best friend,最好的朋友,NOUN,B2
+lab,lab,实验室,NOUN,B2
+to party,to party,狂欢,VERB,B2
+balsam,balsam,香脂,NOUN,B2
+to center,to center,居中,VERB,B2
+special agent,special agent,特工,NOUN,B2
+more beautiful,more beautiful,更美的,ADJ,B2
+atomic nucleus,atomic nucleus,原子核,NOUN,B2
+attacked,attacked,被攻击的,ADJ,B2
+locked,locked,锁定的,ADJ,B2
+to cook fix,to cook fix,做/修理,VERB,B2
+insanely,insanely,疯狂地,ADV,B2
+central station,central station,中央车站,NOUN,B2
+ace,ace,王牌,NOUN,B2
+fjeld cleft,fjeld cleft,,NOUN,B2
+six-year-old,six-year-old,,NOUN,B2
+self-evident,self-evident,,NOUN,B2
+from behind,from behind,从后面,ADV,B2
+back side,back side,背面,NOUN,B2
+property owner,property owner,房主,NOUN,B2
+lower,lower,较低的,ADJ,B2
+underworld,underworld,地下世界,NOUN,B2
+the it,the it,那,DET,B2
+freedom of religion,freedom of religion,宗教自由,NOUN,B2
+bags,bags,包,NOUN,B2
+gaping,gaping,,NOUN,B2
+chips,chips,薯片,NOUN,B2
+locked in,locked in,被关在里面的,ADJ,B2
+load cargo,load cargo,货物/负荷,NOUN,B2
+indoors,indoors,在室内,ADV,B2
+to separate divorce,to separate divorce,分离/离婚,VERB,B2
+malmo,malmo,马尔默,PROPN,B2
+proposal suggestion,proposal suggestion,建议,NOUN,B2
+keen eager,keen eager,渴望的,ADJ,B2
+kind sort,kind sort,种类,NOUN,B2
+evenly,evenly,均匀地,ADV,B2
+stably,stably,稳定地,ADV,B2
+to wipe out,to wipe out,消灭,VERB,B2
+to fall crash,to fall crash,坠落/猛冲,VERB,B2
+student residence,student residence,学生宿舍,NOUN,B2
+dear,dear,,NOUN,B2
+free off,free off,空闲的/休假,ADJ,B2
+slut,slut,荡妇,NOUN,B2
+to puncture deflate,to puncture deflate,刺破,VERB,B2
+income tax,income tax,所得税,NOUN,B2
+civilian,civilian,平民的,ADJ,B2
+self-esteem,self-esteem,自尊,NOUN,B2
+bigwig,bigwig,大人物,NOUN,B2
+the day after tomorrow,the day after tomorrow,后天,NOUN,B2
+ace carcass,ace carcass,王牌/尸体,NOUN,B2
+wife mrs,wife mrs,妻子/夫人,NOUN,B2
+change exchange,change exchange,改变/交换,NOUN,B2
+goodbye kiss,goodbye kiss,,NOUN,B2
+registered,registered,注册的,ADJ,B2
+lifestyle,lifestyle,生活方式,NOUN,B2
+it neuter,it neuter,它 (中性),PRON,B2
+dissatisfaction,dissatisfaction,不满,NOUN,B2
+strangely,strangely,奇怪地,ADV,B2
+snot,snot,鼻涕,NOUN,B2
+terminus,terminus,,NOUN,B2
+freedom of assembly,freedom of assembly,集会自由,NOUN,B2
+inflammable,inflammable,易燃的,ADJ,B2
+ready finished,ready finished,准备好的/完成的,ADJ,B2
+suicidal thought,suicidal thought,,NOUN,B2
+nuclear war,nuclear war,核战争,NOUN,B2
+that to,that to,那/去,PART,B2
+guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
+bike helmet,bike helmet,自行车头盔,NOUN,B2
+loathing,loathing,,NOUN,B2
+one you,one you,人们,PRON,B2
+to sneak away,to sneak away,溜走,VERB,B2
+at once,at once,立刻,ADV,B2
+sexily,sexily,性感地,ADV,B2
+number one,number one,第一名,NOUN,B2
+arrested,arrested,被逮捕的,ADJ,B2
+to fit suit,to fit suit,适合,VERB,B2
+longer,longer,更长的,ADJ,B2
+furthest,furthest,最远,ADV,B2
+cultural heritage,cultural heritage,文化遗产,NOUN,B2
+computer program,computer program,电脑程序,NOUN,B2
+couple pair,couple pair,一对,NOUN,B2
+pine needle,pine needle,针叶,NOUN,B2
+stolen,stolen,被偷的,ADJ,B2
+win,win,胜利,NOUN,B2
+co-determination,co-determination,共同决定权,NOUN,B2
+creep,creep,令人厌恶的人,NOUN,B2
+matter of conscience,matter of conscience,良心问题,NOUN,B2
+epoch,epoch,时代,NOUN,B2
+to be tricked,to be tricked,被欺骗,VERB,B2
+in here,in here,在这里面,ADV,B2
+to bare,to bare,暴露,VERB,B2
+christmas present,christmas present,圣诞礼物,NOUN,B2
+enormously,enormously,巨大地,ADV,B2
+funeral home,funeral home,,NOUN,B2
+difficult flirt,difficult flirt,,NOUN,B2
+to be driven,to be driven,被驱动,VERB,B2
+lots,lots,大量,NOUN,B2
+mafia,mafia,黑手党,NOUN,B2
+odds,odds,赔率,NOUN,B2
+slam,slam,,NOUN,B2
+family relatives,family relatives,亲属,NOUN,B2
+magically,magically,魔法地,ADV,B2
+dal,dal,山谷,NOUN,B2
+inboard,inboard,船内的,ADV,B2
+fewer,fewer,较少的,ADJ,B2
+in two,in two,成两半,ADV,B2
+organically,organically,有机地,ADV,B2
+certainly,certainly,当然,INTJ,B2
+present time,present time,现在,NOUN,B2
+coworker,coworker,同事,NOUN,B2
+rock slab,rock slab,岩板,NOUN,B2
+sunglasses,sunglasses,太阳镜,NOUN,B2
+all everyone,all everyone,所有/大家,PRON,B2
+subject topic,subject topic,主题/话题,NOUN,B2
+personal integrity,personal integrity,个人隐私,NOUN,B2
+parcel,parcel,包裹,NOUN,B2
+violently,violently,暴力地,ADV,B2
+it common,it common,它 (通性),PRON,B2
+happily,happily,快乐地,ADV,B2
+what kind of,what kind of,什么样的,PRON,B2
+heart,heart,心,ADV,B2
+decimal,decimal,小数,NOUN,B2
+to be taken,to be taken,被拿走,VERB,B2
+junior jersey,junior jersey,,NOUN,B2
+explosives,explosives,炸药,NOUN,B2
+lesbian,lesbian,女同性恋的,ADJ,B2
+to kidnapped,to kidnapped,绑架,VERB,B2
+to bring lead,to bring lead,带来/引导,VERB,B2
+just over,just over,稍微超过,ADV,B2
+death,death,致死,ADV,B2
+cognac,cognac,干邑,NOUN,B2
+resistance movement,resistance movement,抵抗运动,NOUN,B2
+snazzy,snazzy,时髦的,ADJ,B2
+chill,chill,放松,ADJ,B2
+recall,recall,回忆,NOUN,B2
+to lay put,to lay put,放,VERB,B2
+out here,out here,这里外面,ADV,B2
+away gone,away gone,不在/离开,ADV,B2
+to know feel,to know feel,认识/感觉,VERB,B2
+away,away,避开,ADP,B2
+knock,knock,敲击,NOUN,B2
+to scout,to scout,侦察,VERB,B2
+action plan,action plan,行动方案,NOUN,B2
+thoughtfully,thoughtfully,体贴地,ADV,B2
+upward,upward,向上,ADV,B2
+full drunk,full drunk,满的/醉的,ADJ,B2
+to warm,to warm,加热,VERB,B2
+nah,nah,不,INTJ,B2
+freedom of opinion,freedom of opinion,意见自由,NOUN,B2
+funniness,funniness,,NOUN,B2
+super dead,super dead,,NOUN,B2
+test drive,test drive,,NOUN,B2
+beside,beside,在...旁边,ADP,B2
+last evening,last evening,,NOUN,B2
+hither,hither,到这里,ADV,B2
+fresh,fresh,,NOUN,B2
+high tall,high tall,高的,ADJ,B2
+to leave stick,to leave stick,离开/刺,VERB,B2
+more fun,more fun,更有趣的,ADJ,B2
+part-time worker,part-time worker,兼职工,NOUN,B2
+to consider think,to consider think,考虑/思考,VERB,B2
+before previously,before previously,以前,ADV,B2
+determined definite,determined definite,确定的,ADJ,B2
+swine,swine,猪,NOUN,B2
+roadblock,roadblock,,NOUN,B2
+play game,play game,游戏/玩耍,NOUN,B2
+grille,grille,格栅,NOUN,B2
+demonstrative,demonstrative,演示的,ADJ,B2
+alder,alder,桤木,NOUN,B2
+to paint over,to paint over,重新粉刷,VERB,B2
+nuclear weapon,nuclear weapon,核武器,NOUN,B2
+emotionally,emotionally,情感上,ADV,B2
+resource shortage,resource shortage,资源短缺,NOUN,B2
+ears,ears,耳朵,NOUN,B2
+minority group,minority group,少数群体,NOUN,B2
+to bump push,to bump push,推/碰撞,VERB,B2
+poorer,poorer,更穷的,ADJ,B2
+every other,every other,每隔一个,DET,B2
+for because,for because,因为,CCONJ,B2
+innermost,innermost,最里面的,ADV,B2
+student loan,student loan,助学贷款,NOUN,B2
+gastronomic,gastronomic,美食的,ADJ,B2
+moose,moose,驼鹿,NOUN,B2
+hag,hag,老妇,NOUN,B2
+bigger,bigger,更大的,ADJ,B2
+attempted murder,attempted murder,谋杀未遂,NOUN,B2
+much many,much many,许多,ADJ,B2
+witness protection,witness protection,,NOUN,B2
+to give a ride,to give a ride,载送一程,VERB,B2
+to push through,to push through,推动,VERB,B2
+pie,pie,派,NOUN,B2
+just precis,just precis,恰好,ADV,B2
+gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
+to object,to object,反对,VERB,B2
+cleanly,cleanly,干净地,ADV,B2
+kind species,kind species,种类/物种,NOUN,B2
+super high,super high,,NOUN,B2
+poor devil,poor devil,可怜虫,NOUN,B2
+from above,from above,从上方,ADV,B2
+confounded,confounded,该死的,ADJ,B2
+dator,dator,电脑,NOUN,B2
+fine pretty,fine pretty,美丽的,ADJ,B2
+civilisation,civilisation,文明,NOUN,B2
+preliminary investigation,preliminary investigation,,NOUN,B2
+to blunder,to blunder,犯大错,VERB,B2
+astray,astray,迷路,ADJ,B2
+hooray,hooray,万岁,INTJ,B2
+scientists,scientists,科学家,NOUN,B2
+known famous,known famous,著名的/熟悉的,ADJ,B2
+sync,sync,同步,NOUN,B2
+the chinese,the chinese,中国人,NOUN,B2
+freedom of the press,freedom of the press,出版自由,NOUN,B2
+nourishment,nourishment,营养,NOUN,B2
+swim training,swim training,,NOUN,B2
+will shall,will shall,将要/会,AUX,B2
+artistry,artistry,,NOUN,B2
+light-year,light-year,,NOUN,B2
+poor wretched,poor wretched,可怜的,ADJ,B2
+ground basis,ground basis,基础/理由,NOUN,B2
+to raise bring up,to raise bring up,抚养,VERB,B2
+good day,good day,你好,INTJ,B2
+director manager,director manager,主管/经理,NOUN,B2
+mental hospital,mental hospital,精神病院,NOUN,B2
+to steer control,to steer control,控制,VERB,B2
+safe secure,safe secure,安全的/可靠的,ADJ,B2
+to put set,to put set,放置,VERB,B2
+to mirror,to mirror,反映,VERB,B2
+good well,good well,好/很好,ADJ,B2
+good-looking person,good-looking person,帅哥/美女,NOUN,B2
+jews,jews,犹太人,NOUN,B2
+sailboat,sailboat,,NOUN,B2
+to train exercise,to train exercise,训练/锻炼,VERB,B2
+to flee escape,to flee escape,逃跑,VERB,B2
+to decide determine,to decide determine,决定/确定,VERB,B2
+salon,salon,沙龙,NOUN,B2
+hot dog stand,hot dog stand,小吃摊,NOUN,B2
+omelette,omelette,煎蛋卷,NOUN,B2
+fiancee,fiancee,未婚妻,NOUN,B2
+on board,on board,在船上,ADV,B2
+listen up,listen up,听着,INTJ,B2
+scene stage,scene stage,场景/舞台,NOUN,B2
+police chief,police chief,警察局长,NOUN,B2
+to bark scold,to bark scold,吠/责骂,VERB,B2
+sliding,sliding,滑动的,ADJ,B2
+to be included,to be included,包含,VERB,B2
+sweetness,sweetness,,NOUN,B2
+idiotic,idiotic,愚蠢的,ADJ,B2
+dans,dans,舞蹈,NOUN,B2
+cover blanket,cover blanket,覆盖物,NOUN,B2
+millions of,millions of,数百万的,NUM,B2
+legion unit,legion unit,,NOUN,B2
+caught,caught,被捕获的,ADJ,B2
+the safe,the safe,保险箱,NOUN,B2
+bro,bro,哥们,NOUN,B2
+morphine,morphine,吗啡,NOUN,B2
+nineteen,nineteen,十九,NUM,B2
+half-year,half-year,半年,NOUN,B2
+meeting hit,meeting hit,会面/击中,NOUN,B2
+long,long,,NOUN,B2
+to function work,to function work,运作/起作用,VERB,B2
+hamburger,hamburger,汉堡包,NOUN,B2
+skater,skater,,NOUN,B2
+to mean entail,to mean entail,意味着,VERB,B2
+dressed,dressed,穿着的,ADJ,B2
+deadly,deadly,致命地,ADV,B2
+delayed,delayed,延误的,ADJ,B2
+all of it,all of it,全部,PRON,B2
+slower,slower,更慢,ADJ,B2
+overfall,overfall,,NOUN,B2
+to make out,to make out,接吻,VERB,B2
+knocked out,knocked out,被淘汰的,ADJ,B2
+fair hair,fair hair,,NOUN,B2
+track trace,track trace,痕迹/轨道,NOUN,B2
+all of them,all of them,大家,PRON,B2
+rug,rug,地毯,NOUN,B2
+work task,work task,工作任务,NOUN,B2
+to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
+turntable,turntable,,NOUN,B2
+convicted,convicted,被判罪的,ADJ,B2
+competition bastard,competition bastard,,NOUN,B2
+self-defense,self-defense,自卫,NOUN,B2
+starting point,starting point,出发点,NOUN,B2
+evening meal,evening meal,晚餐,NOUN,B2
+shorter,shorter,更短的,ADJ,B2
+visiting ban,visiting ban,,NOUN,B2
+backward,backward,向后,ADV,B2
+closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
+calming,calming,令人平静的,ADJ,B2
+europe,europe,欧洲,PROPN,B2
+trainer,trainer,教练,NOUN,B2
+beaten,beaten,被打败的,ADJ,B2
+gas flame,gas flame,煤气火焰,NOUN,B2
+thinner,thinner,更薄的,ADJ,B2
+police report,police report,,NOUN,B2
+bigness,bigness,,NOUN,B2
+attitude setting,attitude setting,态度/设置,NOUN,B2
+outer,outer,外部的,ADJ,B2
+to think opine,to think opine,认为,VERB,B2
+retirement pension,retirement pension,退休金,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+sweet potato,sweet potato,红薯,NOUN,B2
+crosswalk,crosswalk,斑马线,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+voice command,voice command,声令,NOUN,B2
+from away from,from away from,离,ADP,B2
+morale,morale,士气,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+super-internal,super-internal,超内,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+to use force,to use force,动武,VERB,B2
+surfing,surfing,冲浪,NOUN,B2
+decision-making,decision-making,决策,NOUN,B2
+hard to adapt,hard to adapt,难以适应,ADJ,B2
+altogether,altogether,共,ADV,B2
+non-skill,non-skill,非技,NOUN,B2
+speed measurement,speed measurement,测速,NOUN,B2
+overthinking,overthinking,你想多,NOUN,B2
+mantra,mantra,心诀,NOUN,B2
+contrary to expectations,contrary to expectations,偏偏,ADV,B2
+knockout match,knockout match,淘汰赛,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to report to authorities,to report to authorities,举报,VERB,B2
+air pressure,air pressure,气压,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+non-work,non-work,非工,NOUN,B2
+architecture photo,architecture photo,建筑照,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+final account,final account,决算,NOUN,B2
+large amount,large amount,大量,NOUN,B2
+two days,two days,两天,NUM,B2
+all day,all day,整天,ADV,B2
+altered art,altered art,改艺,NOUN,B2
+moonlight,moonlight,月色,NOUN,B2
+comforted,comforted,宽慰,ADJ,B2
+from then on,from then on,从此,ADV,B2
+my taking,my taking,我拿,NOUN,B2
+push further,push further,进尺,NOUN,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+second unit of time,second unit of time,秒,NOUN,B2
+green blue,green blue,青,ADJ,B2
+snore,snore,打呼噜,NOUN,B2
+the human world,the human world,人间,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+too heavy,too heavy,太重,ADJ,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+to practice sword,to practice sword,练剑,VERB,B2
+shift work,shift work,轮班,NOUN,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+cold case,cold case,悬案,NOUN,B2
+emphasize,emphasize,着重,ADV,B2
+this sword,this sword,这剑,NOUN,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+super-root,super-root,超本,NOUN,B2
+he she,he she,伊,PRON,B2
+tendering,tendering,招标,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+foe,foe,敌友,NOUN,B2
+casual photo,casual photo,生活照,NOUN,B2
+that pair,that pair,那付,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+extreme height,extreme height,极高,NOUN,B2
+crude oil,crude oil,原油,NOUN,B2
+all with,all with,都与,NOUN,B2
+empress mother,empress mother,你母后,NOUN,B2
+major case,major case,大案,NOUN,B2
+to dry clean,to dry clean,干洗,VERB,B2
+not intentional,not intentional,不是故意,ADJ,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+anti-specificity,anti-specificity,反殊,NOUN,B2
+edit,edit,重辑,NOUN,B2
+to do what,to do what,干嘛,VERB,B2
+sticky note,sticky note,便签,NOUN,B2
+demeanor,demeanor,仪态,NOUN,B2
+this route,this route,这路,NOUN,B2
+divine fist,divine fist,神拳,NOUN,B2
+re-echo,re-echo,再响,NOUN,B2
+to release me,to release me,放我,VERB,B2
+non-possible,non-possible,非可,NOUN,B2
+re-popularization,re-popularization,再普,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+one year,one year,一年,NUM,B2
+entrapment,entrapment,身陷,NOUN,B2
+express car,express car,快车,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+foundation base,foundation base,基础,NOUN,B2
+over-surface,over-surface,超面,NOUN,B2
+timely,timely,适时,ADJ,B2
+walnut,walnut,核桃,NOUN,B2
+good faith,good faith,信义,NOUN,B2
+destroy,destroy,毁掉,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+to sum up,to sum up,总括,VERB,B2
+random posting,random posting,乱贴,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+cilantro,cilantro,香菜,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+to ambush,to ambush,埋伏,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+exchange goods,exchange goods,换货,NOUN,B2
+mix bar,mix bar,混吧,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+state relatives,state relatives,国戚,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+important case,important case,要案,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+senior male student,senior male student,学长,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+to donate blood,to donate blood,献血,VERB,B2
+doesn't work,doesn't work,不通,ADJ,B2
+super-quantity,super-quantity,超量,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+eyes,eyes,眼中,NOUN,B2
+in high spirits,in high spirits,兴高采烈,ADJ,B2
+to not sleep,to not sleep,睡不,VERB,B2
+number of people,number of people,人数,NOUN,B2
+sports,sports,体育,NOUN,B2
+counter-quantity,counter-quantity,反量,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+worry-free,worry-free,无忧,NOUN,B2
+re-face,re-face,重面,NOUN,B2
+equal size,equal size,等大,NOUN,B2
+re-verification,re-verification,改证,NOUN,B2
+good hall,good hall,好殿,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+air raid,air raid,空袭,NOUN,B2
+family portrait,family portrait,全家福,NOUN,B2
+that night,that night,那晚,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+bluntness,bluntness,直说,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+ten million,ten million,千万,NUM,B2
+later stage,later stage,后期,NOUN,B2
+several times,several times,几遍,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+printout,printout,打印件,NOUN,B2
+non-institution,non-institution,非制,NOUN,B2
+careful search,careful search,仔细搜,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+to linkage,to linkage,联动,VERB,B2
+what kind,what kind,什么样,PRON,B2
+larger,larger,再大,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+bumping,bumping,碰我,NOUN,B2
+re-staging,re-staging,改阶,NOUN,B2
+where,where,哪里,PRON,B2
+not very good,not very good,不太好,ADJ,B2
+for to,for to,为,ADP,B2
+main camp,main camp,大营,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
+to move sb emotionally,to move sb emotionally,感动,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+financial center,financial center,金融中心,NOUN,B2
+ghostly look,ghostly look,鬼样子,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+synthetic fiber,synthetic fiber,化纤,NOUN,B2
+modern dance,modern dance,现代舞,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+near-dry,near-dry,近干,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+no benefit,no benefit,无一利,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+to not lose,to not lose,别丢,VERB,B2
+partial basis,partial basis,分据,NOUN,B2
+military pay,military pay,军饷,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+hundred million,hundred million,亿,NUM,B2
+missile,missile,导弹,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+i,i,我连,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+hidden master,hidden master,江湖里卧虎,NOUN,B2
+township,township,乡镇,NOUN,B2
+interest rate,interest rate,利率,NOUN,B2
+carefulness,carefulness,细心,NOUN,B2
+your highness,your highness,殿下,NOUN,B2
+plantain,plantain,芭蕉,NOUN,B2
+slim,slim,苗条,ADJ,B2
+countability,countability,屈指可数,NOUN,B2
+territory expansion,territory expansion,开疆,NOUN,B2
+to go on stage,to go on stage,上场,VERB,B2
+crosstalk,crosstalk,相声,NOUN,B2
+soaking,soaking,等你泡,NOUN,B2
+fashionable,fashionable,时髦,ADJ,B2
+blowout,blowout,爆胎,NOUN,B2
+advance guard,advance guard,先遣,NOUN,B2
+reach position,reach position,及位,NOUN,B2
+to stare blankly,to stare blankly,发呆,VERB,B2
+world record,world record,世界纪录,NOUN,B2
+this poison,this poison,这毒,NOUN,B2
+re-suffering,re-suffering,再受,NOUN,B2
+mango,mango,芒果,NOUN,B2
+master's possession,master's possession,爷有,NOUN,B2
+social competition,social competition,社会竞争,NOUN,B2
+hydrogen energy,hydrogen energy,氢能,NOUN,B2
+return mansion first,return mansion first,先回府,NOUN,B2
+poor quality,poor quality,劣质,ADJ,B2
+vain,vain,白白,NOUN,B2
+tea party,tea party,茶话会,NOUN,B2
+social science,social science,社会科学,NOUN,B2
+trans-inference,trans-inference,超推,NOUN,B2
+county road,county road,县道,NOUN,B2
+round-robin tournament,round-robin tournament,循环赛,NOUN,B2
+to record sound,to record sound,录音,VERB,B2
+not necessarily,not necessarily,未必,ADV,B2
+non-form,non-form,非式,NOUN,B2
+to fart,to fart,放屁,VERB,B2
+saturated,saturated,饱和,ADJ,B2
+sisters,sisters,姐妹,NOUN,B2
+to apply for a job,to apply for a job,应聘,VERB,B2
+human need,human need,人要,NOUN,B2
+artificial intelligence,artificial intelligence,人工智能,NOUN,B2
+house arrest,house arrest,软禁,NOUN,B2
+to total,to total,共计,VERB,B2
+defeated soldier,defeated soldier,败兵,NOUN,B2
+not very,not very,不怎么,ADV,B2
+famous brand,famous brand,名牌,NOUN,B2
+hard to spread,hard to spread,难以推广,ADJ,B2
+to submit to,to submit to,顺从,VERB,B2
+pickup truck,pickup truck,皮卡,NOUN,B2
+by me,by me,以我,NOUN,B2
+the end,the end,尽头,NOUN,B2
+ling,ling,叫凌,NOUN,B2
+middle third of a month,middle third of a month,中旬,NOUN,B2
+ultimate art,ultimate art,绝学,NOUN,B2
+non-thing,non-thing,非物,NOUN,B2
+co-conspirator,co-conspirator,同谋,NOUN,B2
+death anniversary,death anniversary,忌日,NOUN,B2
+within one's power,within one's power,力所能及,ADJ,B2
+he him,he him,他,PRON,B2
+to found a country,to found a country,建国,VERB,B2
+to get rich,to get rich,发财,VERB,B2
+to resolve doubts,to resolve doubts,解惑,VERB,B2
+trans-deduction,trans-deduction,超绎,NOUN,B2
+winter vacation,winter vacation,寒假,NOUN,B2
+casualties,casualties,伤亡,NOUN,B2
+extremity,extremity,极为,NOUN,B2
+amended classification,amended classification,改归,NOUN,B2
+reining,reining,勒马,NOUN,B2
+genuine product,genuine product,正品,NOUN,B2
+to wish one could,to wish one could,恨不得,VERB,B2
+reason and justice common sense,reason and justice common sense,情理,NOUN,B2
+winning bid price,winning bid price,中标价,NOUN,B2
+secret alliance,secret alliance,暗通锦,NOUN,B2
+hyper-efficacy,hyper-efficacy,超效,NOUN,B2
+in case sth happens,in case sth happens,一旦,SCONJ,B2
+finished laughter,finished laughter,笑完,NOUN,B2
+open theft,open theft,明拿,NOUN,B2
+hard to satisfy,hard to satisfy,难以满足,ADJ,B2
+wait inside,wait inside,里候,NOUN,B2
+to stop bleeding,to stop bleeding,止血,VERB,B2
+crude,crude,简陋,ADJ,B2
+anti-inwardness,anti-inwardness,反内,NOUN,B2
+bayberry,bayberry,杨梅,NOUN,B2
+one handful,one handful,一把,NUM,B2
+you take,you take,你拿,NOUN,B2
+blade mountain,blade mountain,刀山,NOUN,B2
+to ask rhetorically,to ask rhetorically,反问,VERB,B2
+in order,in order,依次,ADV,B2
+non-step,non-step,非步,NOUN,B2
+porcelain,porcelain,瓷器,NOUN,B2
+river bank,river bank,河岸,NOUN,B2
+to not fear,to not fear,别怕,VERB,B2
+opening ceremony,opening ceremony,开幕仪式,NOUN,B2
+to give up halfway,to give up halfway,半途而废,VERB,B2
+modal particle,modal particle,啊,PART,B2
+potency,potency,药效,NOUN,B2
+chinese chess,chinese chess,象棋,NOUN,B2
+super-basis,super-basis,超据,NOUN,B2
+pacifier,pacifier,奶嘴,NOUN,B2
+to survey,to survey,调研,VERB,B2
+at the earliest possible time,at the earliest possible time,及早,ADV,B2
+bout,bout,阵,NOUN,B2
+numb powder,numb powder,五麻散,NOUN,B2
+mineral water,mineral water,矿泉水,NOUN,B2
+non-subject,non-subject,非主,NOUN,B2
+to bring to,to bring to,带到,VERB,B2
+scrutiny,scrutiny,明察,NOUN,B2
+bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
+to feel relieved,to feel relieved,放心,VERB,B2
+social news,social news,社会新闻,NOUN,B2
+bereavement leave,bereavement leave,丧假,NOUN,B2
+social tradition,social tradition,社会传统,NOUN,B2
+sit,sit,坐坐,NOUN,B2
+to default,to default,赖账,VERB,B2
+ten thousand years,ten thousand years,万年,NOUN,B2
+to return visit,to return visit,回访,VERB,B2
+tendering meeting,tendering meeting,招标会,NOUN,B2
+bitter decision,bitter decision,痛下,NOUN,B2
+dragon fruit,dragon fruit,火龙果,NOUN,B2
+i hate,i hate,我恨,NOUN,B2
+old jiang,old jiang,老江,NOUN,B2
+troop dispatch,troop dispatch,出兵,NOUN,B2
+to revolve around,to revolve around,围绕,VERB,B2
+tax evasion,tax evasion,逃税,NOUN,B2
+to cut robe,to cut robe,割袍,VERB,B2
+direct shot,direct shot,面射,NOUN,B2
+you and i,you and i,我和你,NOUN,B2
+social experiment,social experiment,社会实验,NOUN,B2
+pros and cons,pros and cons,利害,NOUN,B2
+to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
+cloud computing,cloud computing,云计算,NOUN,B2
+also,also,也要,AUX,B2
+plum rain season,plum rain season,梅雨,NOUN,B2
+how to do it,how to do it,办呢,ADV,B2
+to have a fever,to have a fever,发烧,VERB,B2
+middle stage,middle stage,中期,NOUN,B2
+to file expense,to file expense,报账,VERB,B2
+over-war,over-war,超战,NOUN,B2
+social role,social role,社会角色,NOUN,B2
+gong,gong,锣,NOUN,B2
+esteemed guest,esteemed guest,嘉宾,NOUN,B2
+light snow,light snow,小雪,NOUN,B2
+coconut,coconut,椰子,NOUN,B2
+non-machine,non-machine,非机,NOUN,B2
+unceasing,unceasing,不断,ADV,B2
+it can be seen,it can be seen,可见,ADV,B2
+speaking,speaking,说得,NOUN,B2
+master's grudge,master's grudge,师仇,NOUN,B2
+reverse compilation,reverse compilation,反辑,NOUN,B2
+special zone,special zone,特区,NOUN,B2
+counter-limit,counter-limit,反限,NOUN,B2
+dashing,dashing,潇洒,ADJ,B2
+to set a record,to set a record,创造纪录,VERB,B2
+contents,contents,内有,NOUN,B2
+social revolution,social revolution,社会革命,NOUN,B2
+to be in a state,to be in a state,处于,VERB,B2
+defense to death,defense to death,死守,NOUN,B2
+back-and-forth,back-and-forth,来来回回,NOUN,B2
+greenhouse gas,greenhouse gas,温室气体,NOUN,B2
+south gate,south gate,南关,NOUN,B2
+mass innovation,mass innovation,众创,NOUN,B2
+playground,playground,操场,NOUN,B2
+college entrance examination,college entrance examination,高考,NOUN,B2
+imperial family,imperial family,皇室,NOUN,B2
+to be open for business,to be open for business,营业,VERB,B2
+to show favoritism,to show favoritism,徇私,VERB,B2
+eldest sister,eldest sister,大姐,NOUN,B2
+rare earth,rare earth,稀土,NOUN,B2
+non-domain,non-domain,非畴,NOUN,B2
+one matter,one matter,一事,NOUN,B2
+to fire a gun,to fire a gun,开枪,VERB,B2
+would rather,would rather,宁愿,SCONJ,B2
+open tournament,open tournament,公开赛,NOUN,B2
+smooth,smooth,能磨平,NOUN,B2
+tasty delicious,tasty delicious,好吃,ADJ,B2
+to be unharmed,to be unharmed,无恙,VERB,B2
+to pick up a car,to pick up a car,取车,VERB,B2
+despite,despite,虽有,NOUN,B2
+devoted,devoted,尽心,ADV,B2
+new year's eve dinner,new year's eve dinner,年夜饭,NOUN,B2
+dispense ceremony,dispense ceremony,免礼,NOUN,B2
+air leak,air leak,漏气,NOUN,B2
+hard to implement,hard to implement,难以实施,ADJ,B2
+mr. sir,mr. sir,先生,NOUN,B2
+modified category,modified category,改类,NOUN,B2
+staying behind,staying behind,我留下,NOUN,B2
+swordplay,swordplay,剑走,NOUN,B2
+graphics card,graphics card,显卡,NOUN,B2
+to slight,to slight,怠慢,VERB,B2
+quite a few,quite a few,好些,ADJ,B2
+yo,yo,哟,PART,B2
+classifier for small round objects,classifier for small round objects,颗,NOUN,B2
+be worthy of,be worthy of,不愧,ADV,B2
+cash conversion,cash conversion,改现,NOUN,B2
+to it is said that,to it is said that,据说,VERB,B2
+to bandage,to bandage,包扎,VERB,B2
+middle part,middle part,中部,NOUN,B2
+hard to judge,hard to judge,难以判断,ADJ,B2
+frostbite,frostbite,冻伤,NOUN,B2
+letter paper,letter paper,信纸,NOUN,B2
+volleyball,volleyball,排球,NOUN,B2
+re-process,re-process,重程,NOUN,B2
+posture,posture,作势,NOUN,B2
+far away,far away,远远,ADV,B2
+body temperature,body temperature,体温,NOUN,B2
+in the final analysis,in the final analysis,归根结底,ADV,B2
+three-sided siege,three-sided siege,三面围,NOUN,B2
+prefectural registrar,prefectural registrar,府典,NOUN,B2
+if i,if i,我若,SCONJ,B2
+social inclusion,social inclusion,社会包容,NOUN,B2
+about to,about to,快要,ADV,B2
+weightlifting,weightlifting,举重,NOUN,B2
+to be in contact with,to be in contact with,相处,VERB,B2
+amended abstraction,amended abstraction,改抽,NOUN,B2
+o'clock,o'clock,点,NOUN,B2
+modder,modder,改客,NOUN,B2
+be willing,be willing,愿意,AUX,B2
+to lose heart,to lose heart,灰心,VERB,B2
+to harm you,to harm you,害你,VERB,B2
+trustworthiness,trustworthiness,讲信,NOUN,B2
+grasp,grasp,把及,NOUN,B2
+to cope with,to cope with,应对,VERB,B2
+sword placement,sword placement,剑放,NOUN,B2
+natural gas,natural gas,天然气,NOUN,B2
+garment,garment,衣,PART,B2
+super-necessity,super-necessity,超必,NOUN,B2
+sleep bar,sleep bar,睡吧,NOUN,B2
+hard and soft,hard and soft,刚柔,NOUN,B2
+rotating leave,rotating leave,轮休,NOUN,B2
+tachometer,tachometer,转速表,NOUN,B2
+heavy rain,heavy rain,大雨,NOUN,B2
+social consensus,social consensus,社会共识,NOUN,B2
+dispatch,dispatch,我派,NOUN,B2
+to earn money,to earn money,挣钱,VERB,B2
+spinach,spinach,菠菜,NOUN,B2
+to part forever,to part forever,永别,VERB,B2
+on time,on time,按时,ADV,B2
+serialized drama,serialized drama,连续剧,NOUN,B2
+mudslide,mudslide,泥石流,NOUN,B2
+waste residue,waste residue,废渣,NOUN,B2
+heavy class,heavy class,重类,NOUN,B2
+outsider,outsider,无亲无故,NOUN,B2
+imperial gaze,imperial gaze,朕看,NOUN,B2
+briefing,briefing,简报,NOUN,B2
+foreign exchange,foreign exchange,外汇,NOUN,B2
+lu ke,lu ke,陆珂,NOUN,B2
+to attain enlightenment,to attain enlightenment,得道,VERB,B2
+to find you,to find you,找你,VERB,B2
+to lose one's job,to lose one's job,失业,VERB,B2
+to machine wash,to machine wash,机洗,VERB,B2
+that place,that place,在那,NOUN,B2
+to support with the hand,to support with the hand,扶,VERB,B2
+social equality,social equality,社会平等,NOUN,B2
+pursuer,pursuer,追兵,NOUN,B2
+wedding ceremony,wedding ceremony,婚礼,NOUN,B2
+network card,network card,网卡,NOUN,B2
+individual specific,individual specific,个别,ADJ,B2
+ripeness,ripeness,该熟,NOUN,B2
+to battle,to battle,之战,VERB,B2
+my audience,my audience,我要见,NOUN,B2
+to solve a case,to solve a case,破案,VERB,B2
+wind force,wind force,风力,NOUN,B2
+to declare war,to declare war,宣战,VERB,B2
+nationwide,nationwide,全国,NOUN,B2
+misstep,misstep,失足,NOUN,B2
+empress dowager,empress dowager,母后,NOUN,B2
+to draw blood,to draw blood,抽血,VERB,B2
+hard to execute,hard to execute,难以执行,ADJ,B2
+inappropriateness,inappropriateness,不妥,NOUN,B2
+to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
+whole body,whole body,连身,NOUN,B2
+glass noodles,glass noodles,粉丝,NOUN,B2
+death trap,death trap,死地,NOUN,B2
+but on the contrary,but on the contrary,反倒,ADV,B2
+kindly,kindly,慈祥,ADJ,B2
+to report back,to report back,复命,VERB,B2
+change of faith,change of faith,改信,NOUN,B2
+memoir,memoir,回忆录,NOUN,B2
+buddies,buddies,哥们,NOUN,B2
+to feel sorry for,to feel sorry for,惋惜,VERB,B2
+to strictly prohibit,to strictly prohibit,严禁,VERB,B2
+desperately serious,desperately serious,不得了,ADJ,B2
+apology for disrespect,apology for disrespect,失敬失敬,NOUN,B2
+trans-dialectic,trans-dialectic,超辩,NOUN,B2
+you want sword,you want sword,你要剑……,NOUN,B2
+to feel wronged,to feel wronged,委屈,VERB,B2
+super-proof,super-proof,超证,NOUN,B2
+brother he,brother he,郃弟,NOUN,B2
+to understand by listening,to understand by listening,听懂,VERB,B2
+briskness,briskness,轻快,NOUN,B2
+to betray one's country,to betray one's country,卖国,VERB,B2
+to take a photo,to take a photo,照相,VERB,B2
+midterm exam,midterm exam,期中考,NOUN,B2
+my death,my death,我死,NOUN,B2
+sand and dust,sand and dust,沙尘,NOUN,B2
+stillness,stillness,静中,NOUN,B2
+wandering monk,wandering monk,游方,NOUN,B2
+acupoint strike,acupoint strike,点穴,NOUN,B2
+classifier for flowers,classifier for flowers,朵,NUM,B2
+non-reality,non-reality,非实,NOUN,B2
+quick arrival,quick arrival,赶紧到,NOUN,B2
+non-general,non-general,非般,NOUN,B2
+non-effect,non-effect,非效,NOUN,B2
+generally accepted,generally accepted,公认,ADJ,B2
+fastening,fastening,要扎紧,NOUN,B2
+storage room,storage room,储藏室,NOUN,B2
+anti-state,anti-state,反态,NOUN,B2
+chinese zodiac,chinese zodiac,生肖,NOUN,B2
+last time,last time,上次,NOUN,B2
+to withdraw a lawsuit,to withdraw a lawsuit,撤诉,VERB,B2
+signing ceremony,signing ceremony,签约仪式,NOUN,B2
+waiting hall,waiting hall,候车室,NOUN,B2
+snow fungus,snow fungus,银耳,NOUN,B2
+must listen,must listen,得听,NOUN,B2
+measure word general,measure word general,个,NUM,B2
+general course,general course,公共课,NOUN,B2
+non-origin,non-origin,非原,NOUN,B2
+to crossbreed,to crossbreed,杂交,VERB,B2
+victory banquet,victory banquet,庆功宴,NOUN,B2
+social pressure,social pressure,社会压力,NOUN,B2
+re-count,re-count,重数,NOUN,B2
+well-timed,well-timed,合时,ADJ,B2
+haha,haha,哈哈,INTJ,B2
+murong,murong,慕容,NOUN,B2
+in passing,in passing,顺便,ADV,B2
+to do not know,to do not know,不知,VERB,B2
+maternal grace,maternal grace,母恩难,NOUN,B2
+inpatient department,inpatient department,住院部,NOUN,B2
+to lose face,to lose face,丢脸,VERB,B2
+non-essential,non-essential,非本,NOUN,B2
+super-state,super-state,超态,NOUN,B2
+steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
+partial image,partial image,分象,NOUN,B2
+to deliver to give as gift,to deliver to give as gift,送,VERB,B2
+classwork,classwork,课堂作业,NOUN,B2
+mutual visit,mutual visit,互访,NOUN,B2
+to take care of oneself,to take care of oneself,保重,VERB,B2
+impressions,impressions,感想,NOUN,B2
+to fuse,to fuse,融合,VERB,B2
+not hard,not hard,不难,ADV,B2
+whip,whip,鞭,NOUN,B2
+counter-evidence,counter-evidence,反据,NOUN,B2
+anti-nature,anti-nature,反性,NOUN,B2
+zhuang hun,zhuang hun,庄混,NOUN,B2
+heart meridian,heart meridian,心脉……,NOUN,B2
+that stretch,that stretch,那片,NOUN,B2
+also come,also come,也来,NOUN,B2
+judicial,judicial,司法,NOUN,B2
+arrangement of ideas,arrangement of ideas,层次,NOUN,B2
+public security bureau,public security bureau,公安局,NOUN,B2
+very good,very good,很好,ADJ,B2
+entail strenuous effort,entail strenuous effort,吃力,NOUN,B2
+a chat,a chat,一聊,NOUN,B2
+to sightsee,to sightsee,游览,VERB,B2
+such an extent as to,such an extent as to,以致,SCONJ,B2
+holding,holding,抱有,NOUN,B2
+bitter cold,bitter cold,严寒,NOUN,B2
+counter-domain,counter-domain,反畴,NOUN,B2
+desire for release,desire for release,思放,NOUN,B2
+abdominal pain,abdominal pain,腹痛,NOUN,B2
+self-concern,self-concern,自顾,NOUN,B2
+southern part,southern part,南部,NOUN,B2
+hard to complete,hard to complete,难以完成,ADJ,B2
+pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
+motherland,motherland,祖国,NOUN,B2
+to have seen,to have seen,看过,VERB,B2
+sorghum,sorghum,高粱,NOUN,B2
+sword provocation,sword provocation,剑惹,NOUN,B2
+to clarify doubts,to clarify doubts,释疑,VERB,B2
+to cover a shift,to cover a shift,替班,VERB,B2
+respiration,respiration,呼吸作用,NOUN,B2
+bike lane,bike lane,自行车道,NOUN,B2
+your wound,your wound,你这伤,NOUN,B2
+to remediate,to remediate,整治,VERB,B2
+research topic,research topic,课题,NOUN,B2
+vice-minister,vice-minister,侍郎,NOUN,B2
+to let to allow,to let to allow,让,VERB,B2
+classifier for horses,classifier for horses,匹,NUM,B2
+non-sole,non-sole,非唯,NOUN,B2
+far from,far from,远非,NOUN,B2
+flustered,flustered,慌张,ADJ,B2
+to prick,to prick,扎,VERB,B2
+scripture,scripture,经,NOUN,B2
+trans-abstraction,trans-abstraction,超抽,NOUN,B2
+social justice,social justice,社会正义,NOUN,B2
+to step on,to step on,踩,VERB,B2
+piling up,piling up,堆砌,NOUN,B2
+books,books,书籍,NOUN,B2
+re-interpretation,re-interpretation,重绎,NOUN,B2
+heavy system,heavy system,重系,NOUN,B2
+frontier,frontier,前沿,NOUN,B2
+even you,even you,连你,PRON,B2
+ecosystem chain,ecosystem chain,生态链,NOUN,B2
+your trouble,your trouble,有劳你,NOUN,B2
+polaris,polaris,北极星,NOUN,B2
+original state,original state,本就,NOUN,B2

--- a/french/expansion.csv
+++ b/french/expansion.csv
@@ -1,19567 +1,8239 @@
 French_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
 -ment,-ly,地,PART,B2
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Alawi,Alawi,词,NOUN,C1
-Alice,Alice,词,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
-Amazigh,Amazigh,词,NOUN,C1
-Andalusian,Andalusian,词,ADJ,B2
-Anglais,englishman,英国人,NOUN,B2
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
-Balkanization,Balkanization,词,NOUN,C1
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Brother He,Brother He,郃弟,NOUN,B2
-Brussels,Brussels,词,ADJ,C1
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Calvinism,Calvinism,词,NOUN,C1
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese (noun),Chinese,中文,NOUN,C1
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Chinois d'outre-mer,overseas chinese,华侨,NOUN,B2
-Christian (adj),Christian,词,ADJ,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cretaceous,Cretaceous,词,ADJ,B2
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-Ed,Ed,词,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-England,England,词,PROPN,B1
-English language,English language,词,NOUN,A2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
-Eurasian,Eurasian,词,ADJ,C1
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Fauvism,Fauvism,词,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-Français,frenchman,法国人,NOUN,B2
-French (noun),French,词,NOUN,B2
-French language,French language,词,NOUN,A2
-Frenchification,Frenchification,词,NOUN,C1
-Friday evening,Friday evening,词,NOUN,C1
-Gallic,Gallic,词,ADJ,C1
-German (noun),German,词,NOUN,B2
-Gnawa,Gnawa,词,NOUN,B2
-Goyaesque,Goyaesque,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gypsy,Gypsy,词,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-Hurufiyya,Hurufiyya,词,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IRM,mri,核磁共振,NOUN,B2
-IT-related,IT-related,词,ADJ,C1
-Iberian,Iberian,词,ADJ,C1
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Irish (noun),Irish,词,NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
-Israeli,Israeli,词,ADJ,B2
-January evening,January evening,词,NOUN,B2
-Japanese person,Japanese person,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
-Kufic,Kufic,词,ADJ,C1
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Latin (noun),Latin,词,NOUN,C1
-Limburgish,Limburgish,词,ADJ,C1
-Ling,Ling,叫凌,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-Machiavellian,Machiavellian,词,ADJ,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Marxist,Marxist,词,ADJ,C1
-Mary,Mary,词,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Mon,Mon,词,NOUN,C1
-Moroccan,Moroccan,词,ADJ,B2
-Mr. sir,Mr. sir,先生,NOUN,B2
-Mrs.,Mrs.,词,NOUN,A1
-Ms.,Ms.,词,NOUN,C1
-Murong,Murong,慕容,NOUN,B2
-Natan,Natan,词,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-No.,No.,词,NOUN,C1
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
-Philippic (adj),Philippic,词,ADJ,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Polaris,Polaris,北极星,NOUN,B2
-Prophet birthday,Prophet birthday,词,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Quran,Quran,词,NOUN,B2
-Rotterdam,Rotterdam,词,ADJ,C1
-SIM card,SIM card,词,NOUN,B1
-Salafism,Salafism,词,NOUN,C1
-Saturday evening,Saturday evening,词,NOUN,C1
-Serbian,Serbian,词,ADJ,C1
-Shiism,Shiism,词,NOUN,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Su Sha,Su Sha,夙砂,NOUN,B2
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Surinamese,Surinamese,词,ADJ,C1
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-T-junction,T-junction,丁字路口,NOUN,C1
-TV series,TV series,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Tajwid,Tajwid,词,NOUN,C1
-Thai,Thai,词,ADJ,C1
-Tifinagh script,Tifinagh script,词,NOUN,C1
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-VIP room,VIP room,贵宾室,NOUN,C1
-Whistles,Whistles,词,NOUN,C1
-Wushk,Wushk,词,NOUN,B1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-YouTuber,YouTuber,词,NOUN,B2
-Your Highness,Your Highness,殿下,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang He,zhuang he,庄郃,NOUN,B2
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-a,a,一个,DET,B2
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
-a little,a little,一点儿,ADV,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
+un peu,a bit,一点,ADV,B2
+un peu,a little,一点,ADJ,B2
+couple marié,a married couple,夫妇,NOUN,B2
+paire,a pair,一对,NUM,B2
+pile,a pile,一堆,NUM,B2
+puits,a well,井,NOUN,B2
+moment,a while,一会儿,NOUN,B2
 abandon,abandonment,抛弃,NOUN,B2
-abate,abate,词,VERB,B2
-abattre,to shoot down,击落,VERB,B2
-abattu,dejected,沮丧的,ADJ,B2
-abbot,abbot,院长,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aberrant,aberrant,词,ADJ,B2
-aberziehung,aberziehung,词,NOUN,B2
-abet,abet,词,VERB,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abhorrent,abhorrent,词,ADJ,B2
 abhorrer,to abhor,憎恶,VERB,B2
-abject,abject,悲惨的,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkunft,abkunft,词,NOUN,C1
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
-able to play,able to play,能下,NOUN,B2
-ablution,ablution,词,NOUN,B2
-abolition,abolition,废除,NOUN,B2
-abominable,abominable,可憎的,ADJ,B2
-abominate,abominate,词,VERB,B2
-abomination,abomination,词,NOUN,B2
-abondant,abundant,丰富的,ADJ,B2
-about it,about it,关于它,ADV,B2
-about that,about that,关于那个,ADV,B2
-about this,about this,关于这个,ADV,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-about which,about which,关于什么,PRON,B2
-above,above,上面,ADV,B2
-above (noun),above,重上,NOUN,C1
-above all,above all,,NOUN,B2
-above average,above average,词,ADJ,C1
-above over,above over,词,ADP,A2
-above-mentioned,above-mentioned,上述的,ADJ,B2
-aboyer,to bark,吠叫,VERB,B2
-abpflegung,abpflegung,词,NOUN,C1
+aptitude,ability,能力,NOUN,B2
+capable,able,能够的,ADJ,B2
+à propos de,about,关于,ADP,B2
+au-dessus,above,在...之上,ADP,B2
 abrasion,abrasion,擦伤,NOUN,B2
-abrasive,abrasive,词,ADJ,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
-abroad,abroad,在国外,ADV,B2
-abrogate,abrogate,词,VERB,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
+étranger,abroad,国外,NOUN,B2
+se soustraire,to abscond,潜逃,VERB,B2
 absence,absence,缺席,NOUN,B2
-absent,absent,缺席的,ADJ,B2
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
-absolutely not,absolutely not,词,ADV,C1
-absolutist,absolutist,词,ADJ,C1
-absorbed,absorbed,全神贯注的,ADJ,B2
-absprache,absprache,词,NOUN,C1
-abstemious,abstemious,有节制的,ADJ,B2
-abstinence,abstinence,节制,NOUN,B2
-abstract (noun),abstract,词,NOUN,C1
+distraction,absent-mindedness,心不在焉,NOUN,B2
 abstraction,abstraction,抽象,NOUN,B2
-abstractionism,abstractionism,词,NOUN,C1
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-absurde,preposterous,荒谬的,ADJ,B2
-absurdism,absurdism,词,NOUN,C1
-abtheilung,abtheilung,词,NOUN,C1
-abuse case,abuse case,词,NOUN,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuser,abuser,滥用者,NOUN,B2
-abuses,abuses,词,NOUN,C1
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-abysmal,abysmal,词,ADJ,B2
-academic (noun),academic,学者,NOUN,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
-académie,academy,学院,NOUN,B2
+abondant,abundant,丰富的,ADJ,B2
 académique,academic,学者,NOUN,B2
-accede,accede,词,VERB,B2
+académie,academy,学院,NOUN,B2
+accélérateur,accelerator,油门,NOUN,B2
 accent,accent,口音,NOUN,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-acceptable,acceptable,可接受的,ADJ,B2
-accessibility features,accessibility features,词,NOUN,B2
-accessible,accessible,易接近的,ADJ,B2
-accessible,reachable,可到达的,ADJ,B2
 accession,accession,即位,NOUN,B2
 accident,accident,事故,NOUN,B2
-accident,car accident,车祸,NOUN,B2
 accidentel,accidental,偶然的,ADJ,B2
 accidentellement,accidentally,意外地,ADV,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompagner,to come along,一起来,VERB,B2
-accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
+complice,accomplice,同谋,NOUN,B2
 accord,accord with,合乎,NOUN,B2
-accord,deal,交易,NOUN,B2
-accorder,to bestow,授予,VERB,B2
-accorder,to give to grant,予以,VERB,B2
-according to,according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordingly consequently,accordingly consequently,词,ADV,C1
-accost,accost,词,VERB,B2
-accountable,accountable,负责任的,ADJ,B2
-accounting (adj),accounting,词,ADJ,C1
-accreditation,accreditation,词,NOUN,C1
-accroupir,to squat,蹲,VERB,B2
-acculturation,acculturation,文化涵化,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
+responsabilité,accountability,问责制,NOUN,B2
+s'accumuler,to accrue,积累,VERB,B2
 accurate,accurate,准确的,ADJ,B2
 accusation,accusation,指控,NOUN,B2
-accused,accused,词,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
 accustomed,accustomed,习惯的,ADJ,B2
-accélérateur,accelerator,油门,NOUN,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acerbate,acerbate,词,VERB,B2
-acerbic,acerbic,尖刻的,ADJ,B2
-acheter,purchase,购买,NOUN,B2
-acheter,to purchase,购买,VERB,B2
-acheter,to shop,购物,VERB,B2
-achieved,achieved,词,ADJ,B1
 acid,acid,酸,NOUN,B2
-acid (adj),acid,词,ADJ,B1
-acidic,acidic,词,ADJ,B2
 acoustics,acoustics,声学,NOUN,B2
 acquaintance,acquaintance,熟人,NOUN,B2
-acquired,acquired,词,ADJ,B2
 acquisition,acquisition,获得,NOUN,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
 acrobat,acrobat,杂技演员,NOUN,B2
-acrobatics,acrobatics,杂技,NOUN,B2
 across,across,穿过,ADP,B2
-across (adv),across,越过,ADV,C1
 act jointly,act jointly,合伙,NOUN,B2
-act of kneeling,act of kneeling,词,NOUN,C1
-acte,deed,行为,NOUN,B2
-actif,assets,资产,NOUN,B2
 acting,acting,行为,NOUN,B2
 action,action,行动,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
-activation,activation,词,NOUN,B2
-active population,active population,词,NOUN,C1
-activities,activities,词,NOUN,B2
-activité,busyness,事忙,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
 actual,actual,实际的,ADJ,B2
 actually,actually,实际上,ADV,B2
-actually (noun),actually,倒也,NOUN,C1
-actuate,actuate,词,VERB,B2
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
 acute,acute,剧烈的,ADJ,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
 adapt,to adapt,适应,VERB,B2
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
 adaptation,adaptation,适应,NOUN,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
 addict,addict,上瘾者,NOUN,B2
 addicted,addicted,上瘾的,ADJ,B2
 addiction,addiction,上瘾,NOUN,B2
-addictive,addictive,词,ADJ,B2
 additional,additional,额外的,ADJ,B2
-additionally,additionally,另外,ADV,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
 adequate,adequate,足够的,ADJ,B2
-adherence,adherence,词,NOUN,B2
 adjacency,adjacency,邻接,NOUN,B2
-adjacent,adjacent,邻近的,ADJ,B2
 adjective,adjective,形容词,NOUN,B2
-adjoin,adjoin,词,VERB,B2
-adjoint,deputy,副的,ADJ,B2
-adjourn,adjourn,词,VERB,B2
-adjournment,adjournment,词,NOUN,C1
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjure,adjure,词,VERB,B2
 adjust,to adjust,调整,VERB,B2
-adjustability,adjustability,词,NOUN,C1
 administration,administration,管理,NOUN,B2
-administrative offense,administrative offense,词,NOUN,C1
-admirable,admirable,词,ADJ,B2
-admiration,admiration,词,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible,admissible,词,ADJ,B2
-admission,admission,词,NOUN,B1
-admitted,admitted,词,ADJ,B2
 admittedly,admittedly,诚然,ADV,B2
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
 adoption,adoption,收养,NOUN,B2
-adorable,adorable,词,ADJ,B2
 adornment,adornment,装饰品,NOUN,B2
-adoul notaries,adoul notaries,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
-adulation,adulation,词,NOUN,C1
 adult,adult,成年的,ADJ,B2
 adulterate,to adulterate,掺杂,VERB,B2
 adulthood,adulthood,成年,NOUN,B2
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
-advance payment,advance payment,预付款,NOUN,B2
-advanced,advanced,高级的,ADJ,B2
 advanced study,advanced study,深造,NOUN,B2
 advanced technology,advanced technology,先进,ADJ,B2
-advancement,advancement,晋升,NOUN,B2
 adventure,adventure,冒险,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
 adversaire,adversary,对手,NOUN,B2
-adversarial,adversarial,词,ADJ,B2
-adverse,adverse,不利的,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
-advertiser,advertiser,词,NOUN,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advocacy,advocacy,词,NOUN,C1
-advocate (noun),advocate,词,NOUN,B2
-adéquat,fitting,合适的,ADJ,B2
-aerodynamics,aerodynamics,词,NOUN,C1
-aesthetic taste,aesthetic taste,词,NOUN,C1
+publiciser,to advertise,做广告,VERB,B2
+publicité,advertisement,广告,NOUN,B2
+déconseiller,to advise against,劝阻,VERB,B2
+conseiller,advisor,顾问,NOUN,B2
+esthétique,aesthetics,美学,NOUN,B2
 affable,affable,和蔼可亲的,ADJ,B2
 affaire,affair,事务,NOUN,B2
-affaires,belongings,所属物,NOUN,B2
-affectation individuelle,individual assignment,个人作业,NOUN,B2
-affected,affected,受影响的,ADJ,B2
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
+salle des fêtes,affair hall,事殿,NOUN,B2
 affection,affection,喜爱,NOUN,B2
 affectueux,affectionate,深情的,ADJ,B2
-affidavit,affidavit,词,NOUN,B2
-affiliation,affiliation,隶属关系,NOUN,B2
 affilié,affiliate,附属机构,NOUN,B2
-affirmative,affirmative,词,ADJ,B2
+affiliation,affiliation,隶属关系,NOUN,B2
 affirmer,to affirm,断言,VERB,B2
-affix,affix,词,NOUN,B2
-affliction,affliction,灾难,NOUN,C1
-affluence,turnout,出席率,NOUN,B2
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
-affront,affront,冒犯,NOUN,B2
-aforementioned,aforementioned,上述的,ADJ,B2
-afraid,afraid,害怕的,ADJ,B2
-afraid (noun),afraid,词,NOUN,B2
-after (adv),after,词,ADV,A1
-after (noun),after,以后,NOUN,B2
-after all just,after all just,毕竟刚,ADV,C1
-after the example of,after the example of,词,NOUN,C1
-after this,after this,词,ADV,B2
-after to,after to,词,ADP,A2
-after-class exercises,after-class exercises,课后题,NOUN,C1
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
-again (noun),again,你又,NOUN,B2
-against it,against it,词,ADV,A2
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-aged,aged,年老的,ADJ,B2
-agencement,layout,布局,NOUN,B2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
-agent de sécurité,security guard,保安,NOUN,B2
-agglomerate,agglomerate,词,NOUN,B2
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravated,aggravated,词,ADJ,C1
-aggravating,aggravating,词,ADJ,B2
-aggravation,aggravation,词,NOUN,C1
-aggravation,exacerbation,加剧,NOUN,B2
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
+reboisement,afforestation,植树造林,NOUN,B2
+après,after,تلو,NOUN,B2
+finalement,after all,毕竟,ADV,B2
+ensuite,after that,此后,ADV,B2
+après quoi,after which,之后,ADV,B2
+après-midi,afternoon,下午,NOUN,B2
+après,afterward,去后,NOUN,B2
+ensuite,afterwards,后来,ADV,B2
+encore,again,你又,NOUN,B2
+âge,age,年龄,NOUN,B2
 agile,agile,敏捷的,ADJ,B2
 agilité,agility,敏捷,NOUN,B2
-aging,aging,老化,NOUN,B2
-agitation,agitation,词,NOUN,B2
-agitation,unrest,动荡,NOUN,B2
-agiter,to wave,挥手,VERB,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (adj),agnostic,词,ADJ,B2
-agnostic (noun),agnostic,词,NOUN,B2
-agnosticism,agnosticism,词,NOUN,C1
-ago,ago,以前,ADV,B2
-agonize,agonize,词,VERB,B2
-agree,agree,一致,ADJ,B2
-agreeable,agreeable,词,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
 agriculture,agriculture,农业,NOUN,B2
-agriculture,farming,农业,NOUN,B2
-agripper,grip,握法,NOUN,B2
-agripper,to grip,紧握,VERB,B2
-agréable,nice,好的,ADJ,B2
 ah,ah,水 水,PART,B2
-ah (part),ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
+en avant,ahead,在前面,ADV,B2
 aide,aid,援助,NOUN,B2
-aider,to help assistance,帮助,VERB,B2
-aile,wing,翅膀,NOUN,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aimless,aimless,词,ADJ,C1
-aims,aims,词,NOUN,C1
-ainsi que,as well as,以及,CCONJ,B2
+viser,aim,目标,NOUN,B2
+viser,to aim,瞄准,VERB,B2
 air,air,空气,NOUN,B2
-air force,air force,空军,NOUN,B2
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airline,airline,词,NOUN,C1
-airs,airs,摆架子,NOUN,B2
-airtight,airtight,密封的,ADJ,B2
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-ajar,ajar,半开的,ADJ,B2
-ajuster,to fit,适合,VERB,B2
-akin,akin,相似的,ADJ,B2
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
+défense aérienne,air defense,防空,NOUN,B2
+aéroport,airport,机场,NOUN,B2
+réveil,alarm clock,闹钟,NOUN,B2
 alarmant,alarming,令人担忧的,ADJ,B2
-alarmism,alarmism,词,NOUN,C1
 album,album,相册,NOUN,B2
-alcoholic (adj),alcoholic,酒精的,ADJ,B2
 alcool,alcohol,酒精,NOUN,B2
 alcoolique,alcoholic,酗酒者,NOUN,B2
-alder,alder,桤木,NOUN,B2
-alderman,alderman,市议员,NOUN,B2
-alentours,nearby,在附近,ADV,B2
-alert (adj),alert,alert,ADJ,B1
 alerte,alert,警觉的,ADJ,B2
-alertness,alertness,机敏,NOUN,C1
-algae,algae,词,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
-alibi,alibi,不在场证明,NOUN,B2
 alien,alien,外星人,NOUN,B2
-alien (adj),alien,词,ADJ,B1
-alienable,alienable,可转让的,ADJ,B2
-alienating,alienating,使人疏远的,ADJ,B2
-aligner,to line up,排成一行,VERB,B2
-alike,alike,词,ADV,B1
-alive living,alive living,活着的,ADJ,B2
-alkalinity,alkalinity,词,NOUN,C1
-all,all,全部,DET,B2
-all (adj),all,全,ADJ,B2
-all (noun),all,全体,NOUN,B2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all everyone,all everyone,所有/大家,PRON,B2
-all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,诸圣节,NOUN,B2
-all the more,all the more,更加,ADV,B2
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allay,allay,词,VERB,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allemand,german,德国人,NOUN,B2
-alleys,alleys,词,NOUN,B2
+pension alimentaire,alimony,赡养费,NOUN,B2
+vivant,alive,活着的,ADJ,B2
+tout,all,全部,ADV,B2
+toute la journée,all day long,一整天,NOUN,B2
 alliance,alliance,联盟,NOUN,B2
-alliance matrimoniale,marriage alliance,联姻,NOUN,B2
-alliance éternelle,eternal alliance,永结,NOUN,B2
-allies,allies,盟友,NOUN,C1
-allocation,allocation,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
-allure,allure,词,NOUN,C1
-allure,bearing,轴承,NOUN,B2
-alluring,alluring,诱人的,ADJ,C1
+autorisation de masquage,allow hiding,许躲,NOUN,B2
+autorisé,allowed,被允许的,ADJ,B2
 allusion,allusion,暗示,NOUN,B2
-allusive,allusive,暗指的,ADJ,B2
-allée,driveway,车道,NOUN,B2
-allées et venues,coming and going,往来,NOUN,B2
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
-alone (adv),alone,单独,ADV,A1
-aloof,aloof,词,ADJ,C1
-aloofness,aloofness,冷漠,NOUN,B2
-alors,thereupon,随后,ADV,B2
-alors vous,then you,那你,PRON,B2
-aloud,aloud,出声地,ADV,B2
-alpha,alpha,阿尔法,NOUN,B2
-alphabet,alphabet,字母表,NOUN,B2
-alphabétisation,literacy,读写能力,NOUN,B2
-already may particle,already may particle,词,PART,A2
-alright (noun),alright,好吧,NOUN,B1
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-altar,altar,词,NOUN,B2
-alteration,alteration,改变,NOUN,B2
-altercation,altercation,争执,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternating,alternating,交替的,ADJ,B2
-alternative,alternative,替代方案,NOUN,B2
+seul,alone,独自,ADV,B2
+le long de,along,沿着,ADP,B2
+avec,along with,随着,ADP,B2
+bien,alright,好的,ADV,B2
+aussi,also too,也,ADV,B2
+sens altéré,altered meaning,改义,NOUN,B2
+mécanisme modifié,altered mechanism,改机,NOUN,B2
 alterner,to alternate,交替,VERB,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-altitude,altitude,海拔,NOUN,B2
-altogether,altogether,共,ADV,B2
-altruistic,altruistic,利他的,ADJ,B2
 aluminium,aluminum,铝,NOUN,B2
-alumnus,alumnus,校友,NOUN,B2
-always have,always have,总有,VERB,C1
 amateur,amateur,业余爱好者,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
-amber,amber,琥珀,NOUN,B2
-ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
-ambitieux,ambitious,有雄心的,ADJ,B2
+émerveillement,amazement,惊愕,NOUN,B2
+étonnant,amazing,令人惊叹的,ADJ,B2
 ambition,ambition,雄心,NOUN,B2
-ambivalent,ambivalent,矛盾的,ADJ,B2
+ambitieux,ambitious,有雄心的,ADJ,B2
 ambulance,ambulance,救护车,NOUN,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
-amendable,amendable,可修正的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
-amendement de surface,top dressing,追肥,NOUN,B2
-amender,fine,好的,ADJ,B2
 amender,to amend,修订,VERB,B2
-amender,to fine,罚款,VERB,B2
-amendments,amendments,词,NOUN,C1
-amends,amends,补偿,NOUN,B2
+intérieur modifié,amended interior,改内,NOUN,B2
+jugement modifié,amended judgment,改断,NOUN,B2
 american,american,美国人,NOUN,B2
 amiable,amiable,和蔼可亲的,ADJ,B2
-amicable,amicable,友好的,ADJ,B2
-amie,female friend,女性朋友,NOUN,B2
-amino acid,amino acid,氨基酸,NOUN,C1
 ammunition,ammunition,弹药,NOUN,B2
 among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amoral,amoral,词,ADJ,C1
-amorphous,amorphous,无定形的,ADJ,B2
-amortization,amortization,词,NOUN,C1
 amount to,to amount to,总计,VERB,B2
 ample,ample,充足的,ADJ,B2
-amplification,amplification,放大,NOUN,B2
 amplifier,amplifier,放大器,NOUN,B2
 amputation,amputation,截肢,NOUN,B2
 amulet,amulet,护身符,NOUN,B2
-amused,amused,词,ADJ,B2
-amusement,amusement,娱乐,NOUN,B2
-an,an,词,DET,A1
-an official standard,an official standard,标准,NOUN,B2
-anachronism,anachronism,时代错误,NOUN,B2
-anachronistic,anachronistic,时代错误的,ADJ,B2
-analogize,analogize,词,VERB,B2
-analogous,analogous,类似的,ADJ,B2
-analytical,analytical,分析的,ADJ,B2
-anarchical,anarchical,词,ADJ,C1
-anathema,anathema,深恶痛绝之物,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
 ancestors,ancestors,祖先,NOUN,B2
-ancestral,ancestral,词,ADJ,C1
-ancestry,ancestry,血统,NOUN,B2
 anchor,anchor,锚,NOUN,B2
 anchorage,anchorage,锚地,NOUN,B2
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
-ancien,former,以前的,ADJ,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
 ancient times,ancient times,古代,NOUN,B2
-ancillary,ancillary,辅助的,ADJ,B2
 and,and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
 and so forth,and so forth,依此类推,ADV,B2
 and so on,and so on,之类,NOUN,B2
-and you,and you,而你…,NOUN,C1
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
 anecdote,anecdote,轶事,NOUN,B2
-anemic,anemic,词,ADJ,C1
-anerziehung,anerziehung,词,NOUN,C1
 anesthetic,anesthetic,麻醉剂,NOUN,B2
-anfahrt,anfahrt,词,NOUN,C1
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angestaltung,angestaltung,词,NOUN,C1
-anglais,english,英国的,ADJ,B2
 angle,angle,角度,NOUN,B2
-angle of approach,angle of approach,切入点,NOUN,B2
 angry,angry,生气的,ADJ,B2
-anguished,anguished,词,ADJ,C1
 animal,animal,动物,NOUN,B2
-animal de compagnie,pet,宠物,NOUN,B2
-animal pen,animal pen,词,NOUN,B1
-animated,animated,词,ADJ,C1
 animated film,animated film,动画片,NOUN,B2
 animation,animation,动画,NOUN,B2
-anis étoilé,star anise,八角,NOUN,B2
-anise,anise,茴香,NOUN,B2
-annales,past exam papers,真题,NOUN,B2
 annex,annex,附件,NOUN,B2
-annexes,annexes,词,NOUN,C1
 annihilation,annihilation,寂灭,NOUN,B2
-anniversaire de mariage,wedding anniversary,结婚纪念日,NOUN,B2
 anniversary,anniversary,周年纪念,NOUN,B2
-annotation,annotation,注释,NOUN,B2
 annoyed,annoyed,恼火的,ADJ,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
 annual report,annual report,年报,NOUN,B2
-annual wage,annual wage,年薪,NOUN,B2
-annulation,cancellation,取消,NOUN,B2
-annulment,annulment,词,NOUN,C1
-année dernière,last year,去年,NOUN,B2
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
-anomalous,anomalous,词,ADJ,C1
-anomie,anomie,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anonymously,anonymously,词,ADV,B2
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansicht,ansicht,词,NOUN,C1
-ansinnung,ansinnung,词,NOUN,C1
-ansprache,ansprache,词,NOUN,C1
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-answer questions,answer questions,答疑,VERB,C1
 answer reply,to answer reply,回答,VERB,B2
 answering machine,answering machine,邮箱,NOUN,B2
-answers,answers,词,NOUN,C1
-antagonism,antagonism,对抗,NOUN,B2
-antagonistic,antagonistic,词,ADJ,C1
-antediluvian,antediluvian,词,ADJ,C1
-anteilung,anteilung,词,NOUN,B2
-antheilung,antheilung,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthill,anthill,词,NOUN,C1
-anthropological,anthropological,词,ADJ,C1
-anti-Semitic,anti-Semitic,词,ADJ,C1
 anti-abstraction,anti-abstraction,反抽,NOUN,B2
 anti-action,anti-action,反作,NOUN,B2
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
 anti-generality,anti-generality,反般,NOUN,B2
 anti-integration,anti-integration,反合,NOUN,B2
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
 anti-measure,anti-measure,反度,NOUN,B2
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
 anti-omniprésence,anti-omnipresence,反遍,NOUN,B2
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-work,anti-work,反功,NOUN,C1
-antibiotiques,antibiotics,抗生素,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
-anticipation,anticipation,预期,NOUN,B2
-anticipatory,anticipatory,词,ADJ,C1
-anticyclone,anticyclone,反气旋,NOUN,B2
-antidote,antidote,解毒剂,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
 antiguerre,anti-war,反战,NOUN,B2
+antibiotiques,antibiotics,抗生素,NOUN,B2
+anticipation,anticipation,预期,NOUN,B2
 antioxydant,antioxidant,抗氧化剂,NOUN,B2
-antipode,antipode,对跖点,NOUN,B2
 antique,antique,古老的,ADJ,B2
-antique (noun),antique,古董,NOUN,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
 antiseptique,antiseptic,防腐剂,NOUN,B2
-antisocial,antisocial,反社会的,ADJ,B2
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreibung,antreibung,词,NOUN,C1
-antsy,antsy,词,ADJ,C1
-anvil,anvil,词,NOUN,B2
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-anxious eager,anxious eager,词,ADJ,B1
-any,any,任何,PRON,B2
-any (adv),any,词,ADV,B2
-any (det),any,词,DET,A1
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-apart from,apart from,除了,ADP,B2
-apart from (verb),apart from,词,VERB,C1
-apartheid,apartheid,词,NOUN,C1
-apathetic,apathetic,冷漠的,ADJ,B2
-apathy,apathy,冷漠,NOUN,B2
-apex,apex,顶点,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apocalypse,apocalypse,词,NOUN,C1
-apolitical,apolitical,非政治的,ADJ,B2
-apologetic,apologetic,道歉的,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apologist,apologist,辩护者,NOUN,B2
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apoplexy,apoplexy,中风,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostrophize,apostrophize,词,VERB,C1
-apotheosis,apotheosis,神化,NOUN,B2
-apotheotic,apotheotic,神化的,ADJ,B2
-app,app,词,NOUN,B1
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
+quelconque,any,任何,DET,B2
+quiconque,anyone,任何人,PRON,B2
+quelque chose,anything,任何事,PRON,B2
+quand même,anyway,无论如何,ADV,B2
+à part,apart,分开,ADV,B2
+s'excuser,to apologize,道歉,VERB,B2
+excuse,apology,道歉,NOUN,B2
 appareil,apparatus,仪器,NOUN,B2
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-appartenance,belonging,归属感,NOUN,B2
-appartenir à,to belong to,属于,VERB,B2
-appeals,appeals,词,NOUN,C1
-appel téléphonique,phone call,通话,NOUN,B2
-appellate,appellate,词,ADJ,C1
-append,append,词,VERB,C1
-appertain,appertain,词,VERB,C1
-appetizers,appetizers,词,NOUN,B2
-applaudir,to clap,拍手,VERB,B2
-appliance,appliance,词,NOUN,B1
+faire appel,to appeal,呼吁,VERB,B2
 applicabilité,applicability,适用性,NOUN,B2
-applicabilité universelle,universal applicability,普适性,NOUN,B2
-applicable,applicable,适用的,ADJ,B2
-application,enforcement,执行,NOUN,B2
-application de la loi,law enforcement,执法,NOUN,B2
-appliquer,to enforce,执行,VERB,B2
-appointments,appointments,词,NOUN,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-appreciable,appreciable,可观的,ADJ,B2
-apprehensive,apprehensive,忧虑的,ADJ,B2
-apprentissage,apprenticeship,学徒期,NOUN,B2
-approachable,approachable,词,ADJ,C1
-approbation,approval,批准,NOUN,B2
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,挪用,NOUN,B2
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
-approximation,approximation,近似值,NOUN,B2
+plâtrer,to apply a cast,打石膏,VERB,B2
+se maquiller,to apply makeup,化妆,VERB,B2
+nommer,to appoint,任命,VERB,B2
+évaluer,to appraise,评估,VERB,B2
 appréciation,appreciation,欣赏,NOUN,B2
-april,april,四月,NOUN,B2
-après,after,تلو,NOUN,B2
-après,afterward,去后,NOUN,B2
-après quoi,after which,之后,ADV,B2
-après-midi,afternoon,下午,NOUN,B2
-apt,apt,词,ADJ,C1
-aptitude,ability,能力,NOUN,B2
-aptitude,aptitude,天资,NOUN,B2
-aptitude,fitness,健康,NOUN,B2
-aqueous,aqueous,词,ADJ,B2
+banquet d'appréciation,appreciation banquet,答谢宴,NOUN,B2
+apprentissage,apprenticeship,学徒期,NOUN,B2
+approbation,approval,批准,NOUN,B2
+environ,approximately,大约,ADV,B2
+approximation,approximation,近似值,NOUN,B2
 arabesque,arabesque,阿拉伯式花纹,NOUN,B2
-arabic,arabic,阿拉伯的,ADJ,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-araignée,spider,蜘蛛,NOUN,B2
-arbitrage,arbitrage,词,NOUN,C1
-arbitrage social,social arbitration,社会仲裁,NOUN,B2
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
-arbre,classifier for trees,棵,NUM,B2
 arc,arc,弧,NOUN,B2
-arcane,arcane,神秘的,ADJ,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
 architectural,architectural,建筑的,ADJ,B2
 architecture,architecture,建筑,NOUN,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-archival,archival,词,ADJ,C1
 archive,archive,档案,NOUN,B2
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-ardent,ardent,热情的,ADJ,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
 ardu,arduous,艰巨的,ADJ,B2
-argan,argan,词,NOUN,B1
-argent,silver,银色,ADJ,B2
-argentinian,argentinian,阿根廷的,ADJ,B2
-arguable,arguable,词,ADJ,C1
-argumentative,argumentative,词,ADJ,C1
-argumentativeness,argumentativeness,词,NOUN,C1
-arid,arid,干旱的,ADJ,B2
-aridity,aridity,干旱,NOUN,B2
 aristocrate,aristocrat,贵族,NOUN,B2
-aristocratic,aristocratic,词,ADJ,C1
-arithmetic (adj),arithmetic,词,ADJ,C1
-arme du crime,murder weapon,凶器,NOUN,B2
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armoire,closet,壁橱,NOUN,B2
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-armée du sud,southern army,南军,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arousal,arousal,词,NOUN,C1
-arraign,arraign,词,VERB,C1
-arranged,arranged,词,ADJ,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrested,arrested,被逮捕的,ADJ,B2
-arrived present,arrived present,到了,ADV,B2
-arriver,to happen,发生,VERB,B2
-arrivée,coming,مجيء,NOUN,B2
-arrière,rear,后部,NOUN,B2
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
-arrogant,arrogant,傲慢的,ADJ,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
-arrêt,standstill,停滞,NOUN,B2
+autour de,around,在周围,ADP,B2
 arrêter,to arrest,逮捕,VERB,B2
-arrêter,to halt,停止,VERB,B2
+arrogant,arrogant,傲慢的,ADJ,B2
 arsenal,arsenal,军火库,NOUN,B2
-arson,arson,纵火,NOUN,B2
 art,art,艺术,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
+galerie d'art,art gallery,美术馆,NOUN,B2
 article,article,文章,NOUN,B2
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
-articulation,articulation,清晰表达,NOUN,B2
 artifice,artifice,诡计,NOUN,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
 artificiel,artificial,人造的,ADJ,B2
-artisanat,craft,工艺,NOUN,B2
-artisanat,handicraft,工艺品,NOUN,B2
-artistry,artistry,,NOUN,B2
-artless,artless,词,ADJ,C1
-artwork,artwork,艺术品,NOUN,B2
-as,as,作为,SCONJ,B2
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as a precaution,as a precaution,词,ADV,C1
-as a result of which,as a result of which,由此,ADV,B2
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as far as,as far as,就……而言,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (part),as for,词,PART,B1
-as if,as if,好像,SCONJ,B2
-as long as,as long as,只要,SCONJ,B2
-as many,as many,一样多,NUM,B2
-as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,尽可能地,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
-as well as,as well as,以及,SCONJ,B2
-as when,as when,词,SCONJ,A1
-ascending,ascending,词,ADJ,C1
-ascenseur,elevator,电梯,NOUN,B2
+portrait artistique,artistic portrait,艺术照,NOUN,B2
+comme,as,像,ADP,B2
+comme si,as if,仿佛,ADV,B2
+tant que,as long as,طالما,CCONJ,B2
+dès que,as soon as,一...就,SCONJ,B2
+ainsi que,as well as,以及,CCONJ,B2
+monter,to ascend,上升,VERB,B2
 ascension,ascension,升天,NOUN,B2
 ascension,ascent,上升,NOUN,B2
-ascertain,ascertain,词,VERB,C1
-ascetic,ascetic,苦行的,ADJ,B2
-ascetic (noun),ascetic,词,NOUN,C1
 asexuel,asexual,无性的,ADJ,B2
-asharite school,asharite school,词,NOUN,C1
-ashen,ashen,灰白的,ADJ,B2
-ashes,ashes,词,NOUN,B2
-ashore,ashore,词,ADV,C1
-asinine,asinine,词,ADJ,C1
-asleep,asleep,词,ADJ,A2
-asp,asp,角蝰,NOUN,B2
-asparagus,asparagus,芦笋,NOUN,B2
+honteux,ashamed,羞愧的,ADJ,B2
+de côté,aside,在旁边,ADV,B2
 aspect,aspect,方面,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-aspirant,aspirant,词,NOUN,C1
 aspiration,aspiration,抱负,NOUN,B2
-assail,assail,词,VERB,C1
+fesse,ass,驴,NOUN,B2
 assassin,assassin,刺客,NOUN,B2
-assassiner,to murder,谋杀,VERB,B2
 assemblée,assembly,集会,NOUN,B2
-assent (noun),assent,词,NOUN,B2
-assertion,assertion,断言,NOUN,B2
-assertiveness,assertiveness,果断,NOUN,C1
-assez,enough,足够的,ADJ,B2
-assez,quite,非常,ADV,B2
-asshole,asshole,词,NOUN,A2
+évaluer,to assess,评估,VERB,B2
+actif,assets,资产,NOUN,B2
 assidu,assiduous,勤勉的,ADJ,B2
-assiduity,assiduity,词,NOUN,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduousness,assiduousness,词,NOUN,C1
-assigner,to sue,起诉,VERB,B2
 assimilation,assimilation,同化,NOUN,B2
 assistance,assistance,援助,NOUN,B2
 assistant,assistant,助手,NOUN,B2
-associate (noun),associate,词,NOUN,B2
-associated,associated,相关的,ADJ,B2
 association,association,协会,NOUN,B2
-associative,associative,协会性质的,ADJ,C1
-assombrir,to darken,变暗,VERB,B2
-assort,assort,词,VERB,C1
-assorti,matching,配套,ADJ,B2
-assortment,assortment,词,NOUN,C1
-assuage,assuage,词,VERB,C1
-assurance,assurance,保证,NOUN,B2
-assurance,car insurance,车险,NOUN,B2
+hypothèse,assumption,假设,NOUN,B2
 assurer,to assure,保证,VERB,B2
-assurer,to insure,保证,VERB,B2
-asthmatic,asthmatic,哮喘的,ADJ,B2
-astonished,astonished,惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astray,astray,迷路,ADJ,B2
-astride (adp),astride,词,ADP,C1
-astride (adv),astride,词,ADV,C1
-astringent (adj),astringent,词,ADJ,C1
-astringent (noun),astringent,词,NOUN,B2
-astronomer,astronomer,词,NOUN,B1
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
-asylum shelter,asylum shelter,词,NOUN,B2
+étonner,to astonish,使惊讶,VERB,B2
+étonnant,astonishing,令人惊讶的,ADJ,B2
+étonnement,astonishment,惊讶,NOUN,B2
+perspicace,astute,精明的,ADJ,B2
 asymétrique,asymmetrical,不对称的,ADJ,B2
-asynchronous,asynchronous,异步的,ADJ,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
-at home (noun),at home,家里,NOUN,C1
-at it,at it,靠近,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,夜间,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the bottom,at the bottom,在底部,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
-at the top,at the top,在最上面,ADV,B2
-at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
-at worst,at worst,大不了,ADV,B2
-atelier,tool room,工具间,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
-atm,atm,自动取款机,NOUN,B2
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atomic,atomic,原子的,ADJ,B2
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atonement,atonement,赎罪,NOUN,B2
-atrocious,atrocious,词,ADJ,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-atrocity,atrocity,暴行,NOUN,B2
-attache office,attache office,词,NOUN,C1
-attached,attached,词,ADJ,B2
-attacked,attacked,被攻击的,ADJ,B2
-attainable,attainable,可获得的,ADJ,B2
-attainment,attainment,词,NOUN,C1
-attaque difficile,difficult attack,难攻,NOUN,B2
-atteindre,to attain,达到,VERB,B2
-attelle,splint,夹板,NOUN,B2
-attempt at crime,attempt at crime,词,NOUN,C1
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
-attendre,to hold on,抓住,VERB,B2
-attendre longtemps,to wait long,久等,VERB,B2
-attends-moi,wait for me,等我,NOUN,B2
-attente,expectation,期望,NOUN,B2
-attention,attention,注意力,NOUN,B2
-attention (intj),attention,词,INTJ,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attenuation,attenuation,衰减,NOUN,C1
-attestation,attestation,词,NOUN,C1
-attitude,attitude,态度,NOUN,B2
-attitude setting,attitude setting,态度/设置,NOUN,B2
-attribution,attribution,归因,NOUN,B2
-attributists,attributists,词,NOUN,C1
-attributive,attributive,定语的,ADJ,B2
-au contraire,instead on the contrary,反而,ADV,B2
-au fait,by the way,顺便说一下,ADV,B2
+à,at,在,ADP,B2
+du tout,at all,根本,ADV,B2
+à tout moment,at any time,随时,ADV,B2
+à l'aise,at ease,安心,ADJ,B2
+à la maison,at home,在家,ADV,B2
 au moins,at least,至少,ADV,B2
-au moyen de,by means of,通过,ADP,B2
-au revoir,bye,再见,INTJ,B2
-au revoir,goodbye,再见,INTJ,B2
-au-delà,beyond,在...之外,ADP,B2
-au-dessus,above,在...之上,ADP,B2
-au-dessus,over,在...上方,ADP,B2
-aucun,none,没有一个,PRON,B2
-aucun mal,no harm,没事吧,NOUN,B2
-audace,push luck,太得寸,NOUN,B2
-audacious,audacious,大胆的,ADJ,B2
-audibility,audibility,词,NOUN,C1
-audible,audible,听得见的,ADJ,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
+à ce moment-là,at that time,当时/那时,ADV,B2
+en même temps,at the same time,同时,ADV,B2
+atteindre,to attain,达到,VERB,B2
+préposé,attendant,服务员,NOUN,B2
+attention,attention,注意力,NOUN,B2
+tenue,attire,服装,NOUN,B2
+attitude,attitude,态度,NOUN,B2
+avocat,attorney,律师,NOUN,B2
+enchère,auction,拍卖,NOUN,B2
 auditer,audit,审计,NOUN,B2
 auditer,to audit,审计,VERB,B2
 auditeur,auditor,审计员,NOUN,B2
-audition,audition,词,NOUN,B1
-auditory,auditory,词,ADJ,C1
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmentation quotidienne,daily increase,日渐,NOUN,B2
-augmented reality,augmented reality,增强现实,NOUN,C1
-augmenter régulièrement,to increase steadily,与日俱增,VERB,B2
-augury,augury,词,NOUN,C1
-aujourd'hui,today,今天,NOUN,B2
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspice,auspice,赞助,NOUN,B2
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussi,also too,也,ADV,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
-austheilung,austheilung,词,NOUN,C1
-australian,australian,澳大利亚的,ADJ,B2
-austreibung,austreibung,词,NOUN,C1
-austrian,austrian,奥地利的,ADJ,B2
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarchy,autarchy,词,NOUN,C1
-autarky,autarky,词,NOUN,B2
-auteur,perpetrator,肇事者,NOUN,B2
-authenticated,authenticated,词,ADJ,C1
-authentique,genuine,真正的,ADJ,B2
-authoritarianism,authoritarianism,词,NOUN,C1
-authoritative,authoritative,权威的,ADJ,B2
-authority figure,authority figure,权威人士,NOUN,B2
-authority structure,authority structure,权威结构,NOUN,B2
-autistic (adj),autistic,词,ADJ,C1
-autobiographical,autobiographical,词,ADJ,C1
-autobiographie,autobiography,自传,NOUN,B2
-autocar,long-distance bus,长途车,NOUN,B2
-autocracy,autocracy,专制,NOUN,B2
-autocratic,autocratic,专制的,ADJ,B2
-automatique,automatic,自动的,ADJ,B2
-automatisé,automated,自动化的,ADJ,B2
-autorisation de masquage,allow hiding,许躲,NOUN,B2
-autorisé,allowed,被允许的,ADJ,B2
 autorisé,authorized,有资格的,ADJ,B2
-autour de,around,在周围,ADP,B2
-autre,other,其他的,DET,B2
-autre côté,other side,对面,NOUN,B2
-autres,others,他人,NOUN,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-avail,avail,词,NOUN,C1
+autobiographie,autobiography,自传,NOUN,B2
+automatisé,automated,自动化的,ADJ,B2
+automatique,automatic,自动的,ADJ,B2
 avalanche,avalanche,雪崩,NOUN,B2
-avancer,to shift to an earlier date,提前,VERB,B2
-avant,before,之前,ADV,B2
-avant tout,first of all,首先,ADV,B2
-avant-garde,vanguard,先锋,NOUN,B2
 avant-gardiste,avant-garde,前卫的,ADJ,B2
-avarice,avarice,词,NOUN,C1
-avaricious,avaricious,词,ADJ,C1
-avec,along with,随着,ADP,B2
+venger,to avenge,复仇,VERB,B2
 avenue,avenue,大道,NOUN,B2
-aver,aver,词,VERB,C1
 average,average,平均,ADJ,B2
-average (noun),average,平均数,NOUN,B2
-averageness,averageness,平庸,NOUN,B2
-averse,averse,厌恶的,ADJ,B2
-averse,downpour,倾盆大雨,NOUN,B2
 aversion,aversion,厌恶,NOUN,B2
-avert,avert,词,VERB,C1
-avid,avid,热切的,ADJ,B2
-avion,plane,飞机,NOUN,B2
-avocado,avocado,牛油果,NOUN,C1
-avocat,attorney,律师,NOUN,B2
-avoidable,avoidable,可避免的,ADJ,B2
 avoidance,avoidance,避免,NOUN,B2
-avoir,have,有,AUX,B2
-avoir,to have only,唯有,VERB,B2
-avoir,to not have,没,VERB,B2
-avoir hâte,to be eager,心切,VERB,B2
-avoir hâte de,to be eager for,巴不得,VERB,B2
-avoir lieu,to take place,举行,VERB,B2
-avoir raison,to be right,正确,VERB,B2
-avoir un accident,to have an accident,遭遇意外,VERB,B2
-avow,avow,词,VERB,C1
 await,to await,等待,VERB,B2
 awake,awake,醒着的,ADJ,B2
 awaken,to awaken,唤醒,VERB,B2
 award,award,奖项,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
 awareness,awareness,意识,NOUN,B2
 away,away,离开,ADV,B2
-away (adj),away,外出,ADJ,C1
-away (adp),away,避开,ADP,B2
-away gone,away gone,不在/离开,ADV,B2
 awe,awe,敬畏,NOUN,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awesome,awesome,词,ADJ,A2
 awkward,awkward,尴尬的,ADJ,B2
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiomatic,axiomatic,公理的,ADJ,B2
-axioms,axioms,词,NOUN,C1
-axis axle,axis axle,词,NOUN,C1
-aéroport,airport,机场,NOUN,B2
-aérosol,spray,喷雾,NOUN,B2
-aïe,ouch,哎哟,INTJ,B2
 ba zi,ba zi,八字,NOUN,B2
-babble,babble,结巴,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-baby walker,baby walker,词,NOUN,B1
-babysitter,babysitter,保姆,NOUN,B2
-baccalaureate,baccalaureate,词,NOUN,B2
-bacchanal,bacchanal,狂欢,NOUN,B2
 bachelor,bachelor,单身汉,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
 bachelor's degree,bachelor's degree,学士学位,NOUN,B2
 back,back,回来,ADV,B2
 back door,back door,后门,NOUN,B2
-back mountain,back mountain,后山,NOUN,C1
 back seat,back seat,后座,NOUN,B2
-back side,back side,背面,NOUN,B2
-back then,back then,词,ADV,A1
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-backache,backache,背痛,NOUN,B2
 backbone,backbone,脊梁,NOUN,B2
-backdrop,backdrop,背景,NOUN,B2
-backfire,backfire,词,VERB,C1
 backflow,backflow,倒流,NOUN,B2
 background,background,背景,NOUN,B2
 backpack,backpack,背包,NOUN,B2
-backside,backside,臀部,NOUN,B2
-backslide,backslide,词,VERB,C1
 backstab,backstab,背刺,NOUN,B2
 backstage,backstage,幕后,NOUN,B2
 backup light,backup light,倒车灯,NOUN,B2
-backward,backward,向后,ADV,B2
 backwards,backwards,向后,ADV,B2
-backyard,backyard,后院,NOUN,B2
 bacon,bacon,培根,NOUN,B2
 bacteria,bacteria,细菌,NOUN,B2
-bactericide,bactericide,杀菌剂,NOUN,C1
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
 bad idea,bad idea,坏水,NOUN,B2
 bad news,bad news,坏消息,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
 bad thing,bad thing,坏事,NOUN,B2
-badge,badge,徽章,NOUN,B2
-badger,badger,词,NOUN,C1
 badminton,badminton,羽毛球,NOUN,B2
-baffle,baffle,词,VERB,C1
-bagatelle,trifle,琐事,NOUN,B2
-baggage,baggage,行李,NOUN,B2
-bagpiper,bagpiper,风笛手,NOUN,B2
-bags,bags,包,NOUN,B2
-baiser,kiss,吻,NOUN,B2
 bake,to bake,烘焙,VERB,B2
-bakery,bakery,词,NOUN,A2
-balance of power,balance of power,均势,NOUN,C1
 balanced,balanced,平衡的,ADJ,B2
-balancing,balancing,平衡的,ADJ,B2
-baldness,baldness,词,NOUN,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballast,ballast,压舱物,NOUN,B2
-balle,bullet,子弹,NOUN,B2
 ballet,ballet,芭蕾舞,NOUN,B2
-balloon,balloon,气球,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
 ballpoint pen,ballpoint pen,圆珠笔,NOUN,B2
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balsam,balsam,香脂,NOUN,B2
-balustrade,balustrade,栏杆,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+interdiction,ban,禁令,NOUN,B2
 banal,banal,陈腐的,ADJ,B2
-banalisation,trivialization,浅薄化,NOUN,B2
 banalité,banality,陈词滥调,NOUN,B2
-banalité,triviality,琐碎,NOUN,B2
-bananas,bananas,词,NOUN,A1
-band tape,band tape,带子,NOUN,B2
-band volume,band volume,词,NOUN,C1
-bandaging,bandaging,词,NOUN,C1
 bande,band,乐队,NOUN,B2
 bandit,bandit,强盗,NOUN,B2
-bandwidth,bandwidth,词,ADJ,C1
 bang,bang,巨响,NOUN,B2
-bang (intj),bang,砰,INTJ,B2
-banister,banister,词,NOUN,C1
-bank card,bank card,银行卡,NOUN,B2
-bankrupt,bankrupt,破产的,ADJ,B2
-banlieue,suburb,郊区,NOUN,B2
-banner headline,banner headline,词,NOUN,C1
 bannissement,banishment,流放,NOUN,B2
+billet de banque,banknote,钞票,NOUN,B2
 banquet,banquet,宴会,NOUN,B2
-banquet d'appréciation,appreciation banquet,答谢宴,NOUN,B2
-banquet de bienvenue,welcome banquet,欢迎宴,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
 bar,bar,酒吧,NOUN,B2
-bar,pub,酒吧,NOUN,B2
-barbarian,barbarian,词,NOUN,B2
-barbarization,barbarization,野蛮化,NOUN,B2
 barbecue,barbecue,烧烤,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
-bard,bard,吟游诗人,NOUN,B2
-bare,bare,赤裸的,ADJ,B2
-barefoot,barefoot,赤脚的,ADJ,B2
-bareheaded,bareheaded,词,ADJ,C1
-barely,barely,几乎不,ADV,B2
-bargain,bargain,便宜货,NOUN,B2
-bargaining,bargaining,词,NOUN,C1
-barge,barge,驳船,NOUN,B2
-bark (noun),bark,词,NOUN,B2
-barking,barking,词,NOUN,B2
-baron,baron,词,NOUN,B2
+aboyer,to bark,吠叫,VERB,B2
 baronne,baroness,女男爵,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barren,barren,词,ADJ,C1
-barrenness,barrenness,词,NOUN,C1
-barricade,barricade,路障,NOUN,B2
-barter (noun),barter,词,NOUN,C1
-barter (verb),barter,词,VERB,C1
-basal,basal,基本的,ADJ,B2
-base,basis,基础,NOUN,B2
-base de données,database,数据库,NOUN,B2
-base fertilizer,base fertilizer,基肥,NOUN,B2
 baseball,baseball,棒球,NOUN,B2
-based,based,基于,ADJ,B2
-bash,bash,词,VERB,C1
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic attitude,basic attitude,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
-basic income,basic income,基本收入,NOUN,B2
-basing,basing,词,NOUN,C1
+sous-sol,basement,地下室,NOUN,B2
 basique,basic,基本的,ADJ,B2
-bask,bask,词,VERB,C1
+essentiellement,basically,基本上,ADV,B2
+base,basis,基础,NOUN,B2
 basketball,basketball,篮球,NOUN,B2
 basse,bass,贝斯,NOUN,B2
-baste,baste,词,VERB,C1
-basting,basting,词,NOUN,C1
-bastion,bastion,堡垒,NOUN,B2
+bâtard,bastard,混蛋,NOUN,B2
+raquette,bat,蝙蝠,NOUN,B2
+salle de bain,bathroom,浴室,NOUN,B2
 bataille,battle,战斗,NOUN,B2
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-battement de cœur,heartbeat,心跳,NOUN,B2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
-battlement,battlement,城垛,NOUN,B2
-bavardage,talkativeness,多嘴,NOUN,B2
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
-be able to (aux),be able to,能够,AUX,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be crushed,be crushed,词,VERB,C1
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
-be rumored,be rumored,词,VERB,C1
-be shot,be shot,中弹,VERB,C1
-be sorry,be sorry,抱歉,ADJ,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beans,beans,词,NOUN,A1
-beaten,beaten,被打败的,ADJ,B2
-beau,good-looking,好看的,ADJ,B2
-beau,handsome,帅气的,ADJ,B2
-beau garçon,handsome guy,帅哥,NOUN,B2
-beaucoup,many,许多,ADJ,B2
-beaucoup,much,多,DET,B2
-beautification,beautification,词,NOUN,C1
-beautifully,beautifully,美丽地,ADV,B2
-because of this,because of this,词,ADV,A2
-beckon,beckon,词,VERB,C1
-become,become,成为,AUX,B2
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-beech grove,beech grove,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
-befahrt,befahrt,词,NOUN,C1
-befall,befall,词,VERB,C1
-befassung,befassung,词,NOUN,C1
-befit,befit,词,VERB,C1
-beforderung,beforderung,词,NOUN,C1
-before (adv),before,先前,ADV,A1
-before (noun),before,以前,NOUN,A1
-before one's eyes,before one's eyes,词,ADV,C1
-before previously,before previously,以前,ADV,B2
-before that,before that,词,ADV,B1
-befuddle,befuddle,词,VERB,C1
-beg for pity,beg for pity,乞怜,VERB,B2
-begabe,begabe,词,NOUN,C1
-begestaltung,begestaltung,词,NOUN,C1
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
-behavioral pattern,behavioral pattern,词,NOUN,C1
-behaviorist,behaviorist,行为主义者,NOUN,B2
-beheading,beheading,按律当斩,NOUN,C1
-behind (adv),behind,词,ADV,A1
-behind (noun),behind,词,NOUN,B2
-behind it,behind it,在后面,ADV,B2
-behoove,behoove,词,VERB,C1
-beile,heard beile,听说贝勒,NOUN,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-bejeweled,bejeweled,镶满宝石的,ADJ,B2
-bekunft,bekunft,词,NOUN,C1
-belabor,belabor,词,VERB,C1
-belated,belated,词,ADJ,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-beleaguered,beleaguered,受围困的,ADJ,B2
-belgian,belgian,比利时人,NOUN,B2
-belie,belie,词,VERB,C1
-belief creed,belief creed,词,NOUN,B2
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-believability,believability,词,NOUN,C1
-belittling,belittling,词,NOUN,C1
-belligerent,belligerent,好战的,ADJ,B2
-bellows,bellows,词,NOUN,C1
-beloved,beloved,心爱的,ADJ,B2
-below,below,下面,ADV,B2
-below (adj),below,下面的,ADJ,B1
-below (noun),below,词,NOUN,B2
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-benahme,benahme,词,NOUN,B2
-bending,bending,弯曲,NOUN,C1
-beneath,beneath,词,ADP,B2
-beneficence,beneficence,词,NOUN,C1
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-bepflegung,bepflegung,词,NOUN,B2
-berate,berate,词,VERB,C1
-bereave,bereave,词,VERB,C1
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-berger,herder,牧民,NOUN,B2
-berger,shepherd,牧羊人,NOUN,B2
-berichtung,berichtung,词,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beschaft,beschaft,词,NOUN,C1
-beschrift,beschrift,词,NOUN,C1
-beseech,beseech,词,VERB,C1
-beset,beset,词,VERB,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
-beside,beside,在...旁边,ADP,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
-besieged,besieged,被围困的,ADJ,B2
-besieging,besieging,词,NOUN,C1
-besinnung,besinnung,词,NOUN,C1
-besmirch,besmirch,词,VERB,C1
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-best possible,best possible,词,ADJ,C1
-bestial,bestial,词,ADJ,C1
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betray one's country,betray one's country,卖国,VERB,B2
-betreibung,betreibung,词,NOUN,C1
-betrothal,betrothal,订婚,NOUN,B2
-betrothal gift,betrothal gift,聘,NOUN,C1
-better (noun),better,越好,NOUN,B2
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-beverage,beverage,词,NOUN,B2
-bewail,bewail,词,VERB,C1
-bewandel,bewandel,词,NOUN,C1
-beware,beware,词,VERB,C1
-beweisung,beweisung,词,NOUN,C1
-bewilder,bewilder,词,VERB,C1
-bewirkung,bewirkung,词,NOUN,C1
+champ de bataille,battlefield,战场,NOUN,B2
+être,be,是,AUX,B2
+être absent,to be absent,缺席,VERB,B2
+être accro,to be addicted,上瘾,VERB,B2
+être autorisé,be allowed,允许,AUX,B2
+être honteux,to be ashamed,感到羞愧,VERB,B2
+être brave,to be brave,勇善,VERB,B2
+s'appeler,to be called,叫做,VERB,B2
+être endommagé,to be damaged,受损,VERB,B2
+être vaincu,to be defeated,会败,VERB,B2
+être fait,to be done,被做,VERB,B2
+avoir hâte,to be eager,心切,VERB,B2
+avoir hâte de,to be eager for,巴不得,VERB,B2
+être élu,to be elected,当选,VERB,B2
+suffire,to be enough,足够,VERB,B2
+être ensorcelé,to be entranced,出神,VERB,B2
+être contraint,to be forced,被迫,VERB,B2
+être bon en,to be good at,擅长,VERB,B2
+être reconnaissant,to be grateful,感激,VERB,B2
+être frappé,to be hit,中箭,VERB,B2
+être jaloux,to be jealous,嫉妒,VERB,B2
+être en retard,to be late,迟到,VERB,B2
+rester,to be left over,剩余,VERB,B2
+être situé,to be located,位于,VERB,B2
+manquer,to be missing,缺少,VERB,B2
+être de service,to be on duty,值班,VERB,B2
+être requis,to be required,被要求,VERB,B2
+être responsable de,to be responsible for,负责,VERB,B2
+avoir raison,to be right,正确,VERB,B2
+être en sécurité,to be safe,安好,VERB,B2
+être ainsi,to be so,然,VERB,B2
+être volé,to be stolen,失窃,VERB,B2
+être surpris,to be surprised,感到惊讶,VERB,B2
+être utile,to be useful,有用,VERB,B2
+supporter,to bear,忍受,VERB,B2
+supportable,bearable,可忍受的,ADJ,B2
+allure,bearing,轴承,NOUN,B2
+bête,beast,野兽,NOUN,B2
+parce que,because,因为,SCONJ,B2
+à cause de,because of,因为,ADP,B2
+chambre,bedroom,卧室,NOUN,B2
+bip,beep,吱吱声,NOUN,B2
+coléoptère,beetle,甲虫,NOUN,B2
+avant,before,之前,ADV,B2
+supplier,to beg,乞求,VERB,B2
+mendiant,beggar,乞丐,NOUN,B2
+commencer,to begin to start,开始,VERB,B2
+se comporter,to behave,表现,VERB,B2
+derrière,behind,在后面,ADV,B2
+être,being,存在,NOUN,B2
+croyance,belief,信念,NOUN,B2
+cloche,bell,铃,NOUN,B2
+ventre,belly,肚子,NOUN,B2
+appartenir à,to belong to,属于,VERB,B2
+appartenance,belonging,归属感,NOUN,B2
+affaires,belongings,所属物,NOUN,B2
+bien-aimé,beloved,爱人,NOUN,B2
+dessous,below,在...下面,ADP,B2
+courbure,bend,弯道,NOUN,B2
+bienfaiteur,benefactor,恩人,NOUN,B2
+bénéfice,benefit,利益,NOUN,B2
+côté,beside next to,旁边,NOUN,B2
+meilleur,best,最好的,ADJ,B2
+accorder,to bestow,授予,VERB,B2
+octroi,bestowal,授予,NOUN,B2
+meilleur,better,越好,NOUN,B2
+au-delà,beyond,在...之外,ADP,B2
 bianzhong,bianzhong,编钟,NOUN,B2
 bible,bible,圣经,NOUN,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bids,bids,词,NOUN,C1
-bien,alright,好的,ADV,B2
-bien,good,خير,NOUN,B2
-bien réfléchi,well-considered,深思熟虑的,ADJ,B2
-bien-aimé,beloved,爱人,NOUN,B2
-bien-être,welfare,福利,NOUN,B2
-bien-être public,public welfare,公益性,NOUN,B2
-bienfaiteur,benefactor,恩人,NOUN,B2
-bienvenu,welcome,受欢迎的,ADJ,B2
-bifurcation,bifurcation,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigger,bigger,更大的,ADJ,B2
-bigness,bigness,,NOUN,B2
-bigotry,bigotry,词,NOUN,C1
-bigwig,bigwig,大人物,NOUN,B2
-bijoux,jewelry,珠宝,NOUN,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
-bilateral,bilateral,双边的,ADJ,B2
+collusion d'enchères,bid collusion,串标,NOUN,B2
+évaluation des offres,bid evaluation,评标,NOUN,B2
+ouverture des offres,bid opening,开标,NOUN,B2
+grand,biggest,最大,ADJ,B2
 bile,bile,胆汁,NOUN,B2
-bilingualism,bilingualism,词,NOUN,C1
-bilious,bilious,易怒的,ADJ,B2
-bilk,bilk,词,VERB,C1
-bill of exchange,bill of exchange,词,NOUN,C1
-billet de banque,banknote,钞票,NOUN,B2
-billion,billion,十亿,NOUN,B2
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
-binding (adj),binding,词,ADJ,C1
-binge,binge,放纵,NOUN,B2
-bingo,bingo,词,NOUN,B2
-biographical,biographical,词,ADJ,C1
-biographies,biographies,词,NOUN,C1
-biology,biology,生物学,NOUN,B2
+lier,to bind,捆绑,VERB,B2
 biomasse,biomass,生物质,NOUN,B2
 biotechnologie,biotechnology,生物技术,NOUN,B2
-bip,beep,吱吱声,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-biscuit,biscuit,饼干,NOUN,A2
-biscuit,cookie,饼干,NOUN,B2
-bisexual,bisexual,双性恋的,ADJ,B2
-bit,bit,一点,NOUN,B2
-bitch,bitch,母狗,NOUN,B2
-biting,biting,咬人,NOUN,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
-biweekly,biweekly,双周的,ADJ,B2
+évêque,bishop,主教,NOUN,B2
+morsure,biting,尖刻的,ADJ,B2
 bizarre,bizarre,奇异的,ADJ,B2
-bizarre,weird,奇怪的,ADJ,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-blab,blab,词,VERB,C1
-black (noun),black,أسود,NOUN,C1
-black pepper,black pepper,词,NOUN,B2
-blackbird,blackbird,乌鸫,NOUN,B2
-blackout,blackout,词,NOUN,C1
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blah,blah,词,INTJ,C1
-blanch,blanch,词,VERB,C1
-blandish,blandish,词,VERB,C1
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blasphemy,blasphemy,亵渎,NOUN,B2
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blaze,blaze,火焰,NOUN,B2
-blazing,blazing,炽热的,ADJ,B2
-blazing ardor,blazing ardor,词,NOUN,C1
-bleak,bleak,无望的,ADJ,B2
-bleeding,bleeding,流血的,ADJ,B2
-blend,blend,词,VERB,B2
-blending,blending,词,NOUN,C1
-blessed,blessed,受祝福的,ADJ,B2
-blight,blight,词,NOUN,C1
-blind person,blind person,词,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
-blister,blister,词,NOUN,C1
-blizzard,blizzard,暴风雪,NOUN,B2
-bloat,bloat,词,VERB,C1
-bloc,bloc,阵营,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
-blockhead,blockhead,笨蛋,NOUN,B2
-blocking,blocking,词,NOUN,B2
-blog,blog,博客,NOUN,B2
-blog post,blog post,词,NOUN,C1
-blogger,blogger,词,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
-blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-bloodless,bloodless,不流血的,ADJ,B2
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,沾血,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-bloom of youth,bloom of youth,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
-bloquer,to blockade,封锁,VERB,B2
-blossoming ripening,blossoming ripening,词,NOUN,C1
-blouse,blouse,女衬衫,NOUN,B2
-blow beating,blow beating,殴打,NOUN,B2
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blue (noun),blue,词,NOUN,C1
-blueprint,blueprint,词,NOUN,C1
-blueprint diagram,blueprint diagram,词,NOUN,C1
-blunder,blunder,大错,NOUN,B2
-blunt,blunt,词,ADJ,B2
-bluntness,bluntness,直说,NOUN,B2
-blurred,blurred,词,ADJ,C1
-blurriness,blurriness,词,NOUN,C1
-blurt,blurt,词,VERB,C1
-bluster,bluster,词,VERB,C1
+marché noir,black market,黑市,NOUN,B2
+robe noire,black robe,黑衣,NOUN,B2
+tableau noir,blackboard,黑板,NOUN,B2
+faire chanter,to blackmail,勒索,VERB,B2
 blâme,blame,责备,NOUN,B2
-boarding pass,boarding pass,登机牌,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastful,boastful,自夸的,ADJ,B2
-boatman,boatman,船夫,NOUN,C1
-bode,bode,词,VERB,C1
-bodies,bodies,词,NOUN,C1
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bog,bog,沼泽,NOUN,B2
-boggle,boggle,词,VERB,C1
-bohemian,bohemian,放荡不羁的,ADJ,B2
-boil (noun),boil,词,NOUN,C1
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
-bois,woodland,林地,NOUN,B2
-bois de chauffage,firewood,木柴,NOUN,B2
-boisson,drink,饮料,NOUN,B2
-boisterous,boisterous,喧闹的,ADJ,B2
-boiteux,lame,跛的,ADJ,B2
-boldness daring,boldness daring,词,NOUN,B2
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolted,bolted,词,ADJ,C1
-bombardment,bombardment,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
-bon,voucher,代金券,NOUN,B2
-bondir,to pounce,猛扑,VERB,B2
-bonds,bonds,词,NOUN,C1
-bondé,packed,打包,ADJ,B2
-bone-setting,bone-setting,接骨,NOUN,C1
-bonfire,bonfire,篝火,NOUN,B2
-bonhomie,bonhomie,词,NOUN,C1
-bonne chance,good luck,好运,NOUN,B2
-bonne réputation,good reputation,清誉,NOUN,B2
-bonté,goodness,善良,NOUN,B2
-bookcase,bookcase,书柜,NOUN,B2
-booking,booking,词,NOUN,A2
-books,books,书籍,NOUN,B2
-bookshelf,bookshelf,书架,NOUN,B1
-boorish,boorish,词,ADJ,C1
-bordel,brothel,妓院,NOUN,B2
-border,border,边界,NOUN,B2
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,边境检查,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,边境立法,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,边境地区,NOUN,B2
-borders,borders,边界,NOUN,A1
+fade,bland,平淡的,ADJ,B2
+couverture,blanket,毯子,NOUN,B2
+eau de Javel,bleach,漂白剂,NOUN,B2
+saignement,bleeding,出血,NOUN,B2
+défaut,blemish,瑕疵,NOUN,B2
+bénir,to bless,祝福,VERB,B2
+béatitude,bliss,极乐,NOUN,B2
+blizzard,blizzard,暴风雪,NOUN,B2
+bloc,bloc,阵营,NOUN,B2
+bloquer,to blockade,封锁,VERB,B2
+blog,blog,博客,NOUN,B2
+dette de sang,blood debt,血债,NOUN,B2
+tension artérielle,blood pressure,血压,NOUN,B2
+mer de sang,blood sea,血海,NOUN,B2
+tache,blot,污点,NOUN,B2
+blouse,blouse,女衬衫,NOUN,B2
+brouiller,to blur,模糊,VERB,B2
+se vanter,to boast,吹嘘,VERB,B2
+vantardise,boasting,夸耀,NOUN,B2
+garde du corps,bodyguard,保镖,NOUN,B2
+bouillir,to boil,煮沸,VERB,B2
+ébullition,boiling,沸腾,NOUN,B2
+lien,bond,纽带,NOUN,B2
+os,bone,骨头,NOUN,B2
+réserver,to book,预订,VERB,B2
+cabine,booth,摊位,NOUN,B2
+frontière,border,边境的,ADJ,B2
+ennuyer,to bore,使厌烦,VERB,B2
 bored,bored,无聊的,ADJ,B2
 boring,boring,无聊的,ADJ,B2
-born,born,出生的,ADJ,B2
-born (noun),born,词,NOUN,B2
-born (verb),born,词,VERB,A1
-borrowed,borrowed,词,ADJ,C1
-borrowed knife,borrowed knife,借刀,NOUN,B2
 borrowing,borrowing,借贷,NOUN,B2
-bosom,bosom,词,NOUN,C1
-boss female,boss female,词,NOUN,B2
-boss manager,boss manager,词,NOUN,A1
-bossism,bossism,老板主义,NOUN,B2
-botanical,botanical,词,ADJ,C1
-botched job,botched job,粗劣的活儿,NOUN,B2
 both,both,两者都,CCONJ,B2
-both (adj),both,两者的,ADJ,B2
-both (det),both,两者都,DET,A1
-both (noun),both,词,NOUN,B2
-both (pron),both,两者,PRON,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
 both hands,both hands,双手,NOUN,B2
-both parties,both parties,双方,NOUN,B1
 bother,bother,麻烦,NOUN,B2
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
-bouillir,to boil,煮沸,VERB,B2
-bouillon,clear soup,江瑶清羹,NOUN,B2
 boulder,boulder,巨石,NOUN,B2
-boulette de viande cuite,cooked meatball,丸子熟,NOUN,B2
-bouleverser,to upset,使生气,VERB,B2
-bounce,bounce,词,VERB,B2
 bound,bound,一定的,ADJ,B2
-bound to,bound to,势必,ADV,B2
 boundary,boundary,边界,NOUN,B2
-boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bourgeois,bourgeois,资产阶级的,ADJ,B2
 bourgeoisie,bourgeoisie,资产阶级,NOUN,B2
-bout,bout,阵,NOUN,B2
-bouturer,to take cuttings,扦插,VERB,B2
-bow (verb),bow,词,VERB,B1
-bow tie,bow tie,领结,NOUN,B2
-bower,bower,凉亭,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
 boxing,boxing,拳击,NOUN,B2
-boyfriend,boyfriend,男朋友,NOUN,B2
-boîte aux lettres,mailbox,邮箱,NOUN,B2
-boîte de nuit,nightclub,夜总会,NOUN,B2
-brabant,brabant,布拉班特的,ADJ,B2
-brace,brace,词,NOUN,C1
 bracelet,bracelet,手镯,NOUN,B2
-bracket,bracket,括号,NOUN,B2
 brag,to brag,吹嘘,VERB,B2
-braid,braid,辫子,NOUN,C1
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,,NOUN,B2
-brainstorming,brainstorming,词,NOUN,C1
-brainwasher,brainwasher,洗脑者,NOUN,B2
-brainy,brainy,聪明的,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakeman,brakeman,刹车员,NOUN,B2
-brakes,brakes,词,NOUN,C1
-bran,bran,词,NOUN,B2
-brancard,stretcher,担架,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
 brand new,brand new,崭新的,ADJ,B2
-brass band,brass band,词,NOUN,B2
-brassware,brassware,词,NOUN,C1
 brave,brave,勇敢的,ADJ,B2
-bravo,bravo,词,NOUN,B2
-bravoure,valor,勇气,NOUN,B2
-bray,bray,词,VERB,C1
-brazen,brazen,厚颜无耻的,ADJ,B2
 brazenness,brazenness,厚颜无耻,NOUN,B2
-brazier,brazier,词,NOUN,B1
-brazilian,brazilian,巴西的,ADJ,B2
 breach contract,to breach contract,违约,VERB,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-bread roll,bread roll,小圆面包,NOUN,B2
-breadth,breadth,词,NOUN,C1
 break down,to break down,分解,VERB,B2
-break fraction,break fraction,词,NOUN,C1
 break open,to break open,撬开,VERB,B2
-break out of prison,break out of prison,越狱,VERB,C1
 break up,to break up,破裂,VERB,B2
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
 breakfast,breakfast,早餐,NOUN,B2
-breakthrough,breakthrough,突破性,ADJ,B2
 breastfeed,to breastfeed,母乳喂养,VERB,B2
-breath holding,breath holding,住气,NOUN,C1
-breathing space,breathing space,词,NOUN,C1
 breed,breed,品种,NOUN,B2
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
 brevity,brevity,简洁,NOUN,B2
 bribe,bribe,贿赂,NOUN,B2
 bribe,to bribe,贿赂,VERB,B2
-bribe-taker,bribe-taker,词,NOUN,C1
 bribery,bribery,贿赂,NOUN,B2
-bribes,bribes,词,NOUN,C1
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
 bridal chamber,bridal chamber,洞房,NOUN,B2
-bridal trousseau,bridal trousseau,词,NOUN,C1
 bride,bride,新娘,NOUN,B2
-bridegroom,bridegroom,词,NOUN,C1
 brief,brief,近点说,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brigade,brigade,词,NOUN,C1
-brigand poet,brigand poet,词,NOUN,C1
 bright,bright,明亮的,ADJ,B2
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightly,brightly,词,ADV,C1
-brillance,shine,光泽,NOUN,B2
 brilliance,brilliance,辉煌,NOUN,B2
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
-brim,brim,词,NOUN,C1
 bringing,bringing,جلب,NOUN,B2
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-briskness,briskness,轻快,NOUN,B2
-bristle (noun),bristle,词,NOUN,C1
 britannique,british,英国的,ADJ,B2
 britannique,briton,英国人,NOUN,B2
-brittle,brittle,易碎的,ADJ,B2
-brittleness,brittleness,词,NOUN,C1
-bro,bro,哥们,NOUN,B2
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
-broadcasting station,broadcasting station,词,NOUN,C1
-broaden,broaden,词,VERB,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade (part),brocade,锦,PART,A1
+diffusion,broadcast,广播,NOUN,B2
 brocart,brocade,锦绣,NOUN,B2
-broccoli,broccoli,西兰花,NOUN,C1
-brochure,brochure,小册子,NOUN,B2
-broder,to embroider,刺绣,VERB,B2
-broderie,embroidery,刺绣,NOUN,B2
-broil,broil,词,VERB,C1
-broke,broke,破产的,ADJ,B2
-broken,broken,破碎的,ADV,B2
-brokenness,brokenness,词,NOUN,C1
-bronze,bronze,青铜,NOUN,B2
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,青铜色的,ADJ,B2
-brooding,brooding,忧思,NOUN,B2
-brooding (adj),brooding,词,ADJ,B2
-brook no delay,brook no delay,刻不容缓,ADJ,B2
-broom blow,broom blow,词,NOUN,C1
-brother (part),brother,兄,PART,B1
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-brouille,estrangement,疏离,NOUN,B2
-brouille,falling out,反目,NOUN,B2
-brouiller,to blur,模糊,VERB,B2
-brow,brow,眉毛,NOUN,B2
-browbeat,browbeat,词,VERB,C1
-broyer,to grind,磨碎,VERB,B2
-bruises,bruises,词,NOUN,B2
-brusqueness,brusqueness,唐突,NOUN,B2
-brutal,brutal,词,ADJ,B2
-brutalizing,brutalizing,词,ADJ,C1
-brute,brute,粗野的,ADJ,B2
-brute,bully,欺凌者,NOUN,B2
-bruyant,loud,大声的,ADJ,B2
-bruyant,noisy,吵闹的,ADJ,B2
-brûlé,burnt,烧焦的,ADJ,B2
-buanderie,laundry room,洗衣房,NOUN,B2
-bubbling,bubbling,冒泡的,ADJ,B2
-buccaneer,buccaneer,海盗,NOUN,B2
-buckle,buckle,词,VERB,C1
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-budge,budge,词,VERB,C1
+cassé,broken,破碎的,ADJ,B2
+courtage,brokerage,经纪业,NOUN,B2
+bordel,brothel,妓院,NOUN,B2
+dollar,buck,美元,NOUN,B2
+sarrasin,buckwheat,荞麦,NOUN,B2
+copain,buddy,伙伴,NOUN,B2
 budget,budget,预算,NOUN,B2
-budgetable,budgetable,可预算的,ADJ,B2
-budgeting,budgeting,词,NOUN,C1
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-buffoon,buffoon,小丑,NOUN,B2
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-bulge,bulge,词,NOUN,C1
-bull,bull,词,NOUN,B1
-bulldog,bulldog,斗牛犬,NOUN,B2
-bulldoze,bulldoze,词,VERB,C1
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bullying,bullying,词,NOUN,B2
-bulwark,bulwark,壁垒,NOUN,B2
-bum,bum,流浪汉,NOUN,B2
-bumble,bumble,词,VERB,C1
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bunch,bunch,一群,NOUN,B2
-bundling,bundling,词,NOUN,C1
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bungler,bungler,笨手笨脚的人,NOUN,B2
-bunker,bunker,词,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-buoyant,buoyant,有浮力的,ADJ,B2
-burdened,burdened,负担重的,ADJ,B2
-burdensome,burdensome,繁重的,ADJ,B2
+vrac,bulk,主体,NOUN,B2
+balle,bullet,子弹,NOUN,B2
+brute,bully,欺凌者,NOUN,B2
+paquet,bundle,捆,NOUN,B2
 bureau,bureau,局,NOUN,B2
-bureau,desk,书桌,NOUN,B2
-bureau de poste,post office,邮局,NOUN,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-bureaucratic,bureaucratic,官僚的,ADJ,B2
-burger stand,burger stand,,NOUN,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque,burlesque,滑稽的,ADJ,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burned,burned,词,ADJ,B2
-burner,burner,燃烧器,NOUN,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burp (noun),burp,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-burst in,burst in,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
+cambrioleur,burglar,窃贼,NOUN,B2
+brûlé,burnt,烧焦的,ADJ,B2
+roter,to burp,打嗝,VERB,B2
 bus,bus,公共汽车,NOUN,B2
-bushy,bushy,词,ADJ,C1
-business card,business card,名片,NOUN,B1
-business sector,business sector,商业界,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-bust,bust,词,NOUN,B1
-bustle,bustle,喧闹,NOUN,B2
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-but,purpose,目的,NOUN,B2
-but (adv),but,却,ADV,A1
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but-for,but-for,词,NOUN,B2
-butler,butler,词,NOUN,C1
-butt,butt,臀部,NOUN,B2
-buttermilk,buttermilk,词,NOUN,A2
-buttress,buttress,扶壁,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buying and selling,buying and selling,词,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by heart,by heart,词,ADV,B2
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
-by means of,by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
-bypass (noun),bypass,词,NOUN,C1
-bypassing,bypassing,词,NOUN,C1
-byzantine,byzantine,错综复杂的,ADJ,B2
-bâtard,bastard,混蛋,NOUN,B2
-béatitude,bliss,极乐,NOUN,B2
-bénir,to bless,祝福,VERB,B2
-bénéfice,benefit,利益,NOUN,B2
-bête,dumb,愚蠢的,ADJ,B2
-bête,beast,野兽,NOUN,B2
-c'est-à-dire,that is,即,ADV,B2
-cabin boy,cabin boy,词,NOUN,C1
-cabine,booth,摊位,NOUN,B2
-cabinet,cabinet,内阁,NOUN,B2
-cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
-cable car,cable car,缆车,NOUN,B1
-cache,cache,词,NOUN,C1
-cachette,hideout,藏身处,NOUN,B2
-cachette,hiding,ٱختباء,NOUN,B2
-cackle,cackle,词,VERB,C1
-cacophony,cacophony,刺耳的声音,NOUN,B2
-cactus,cactus,词,NOUN,B1
-cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
-cadeau,gift,礼物,NOUN,B2
-cadence,cadence,词,NOUN,B2
-cadres,cadres,词,NOUN,C1
-cafeteria,cafeteria,词,NOUN,B1
-caftan,caftan,词,NOUN,A1
+commercial,business,商业的,ADJ,B2
+réunion d'affaires,business meeting,洽谈会,NOUN,B2
+homme d'affaires,businessman,商人,NOUN,B2
+occupé,busy,忙碌的,ADJ,B2
+activité,busyness,事忙,NOUN,B2
+mais,but,然而,ADV,B2
+mais je,but i,可我,ADV,B2
+mais vous,but you,但您,NOUN,B2
+fesses,buttocks,屁股,NOUN,B2
+par tous les moyens,by fair means or foul,不择手段,ADV,B2
+au moyen de,by means of,通过,ADP,B2
+au fait,by the way,顺便说一下,ADV,B2
+au revoir,bye,再见,INTJ,B2
+pontage,bypass surgery,搭桥手术,NOUN,B2
 café,cafe,咖啡馆,NOUN,B2
 cage,cage,笼子,NOUN,B2
-cage (verb),cage,词,VERB,C1
-cageot,crate,板条箱,NOUN,B2
-caid local governor,caid local governor,词,NOUN,C1
-caillot,clot,凝块,NOUN,B2
-cajole,cajole,词,VERB,C1
-calamitous,calamitous,灾难性的,ADJ,B2
 calamité,calamity,灾难,NOUN,B2
-calcareous,calcareous,词,ADJ,B2
 calculatrice,calculator,计算器,NOUN,B2
-calculer,to compute,计算,VERB,B2
-caliber,caliber,词,NOUN,C1
-calibrated,calibrated,词,ADJ,C1
 calibration,calibration,校准,NOUN,B2
-calibrator,calibrator,词,NOUN,C1
-caliph,caliph,词,NOUN,B2
-call to prayer,call to prayer,词,NOUN,B2
-caller,caller,词,NOUN,A2
-calligrapher,calligrapher,词,NOUN,C1
 calligraphie,calligraphy,书法,NOUN,B2
-calligraphie,handwriting practice,练字,NOUN,B2
-callus,callus,硬茧……,NOUN,C1
-calm (noun),calm,安安,NOUN,A2
+vocation,calling,使命,NOUN,B2
+insensible,callous,冷酷,ADJ,B2
 calme,calm,平静,NOUN,B2
 calme,calmness,平静,NOUN,B2
-calming,calming,令人平静的,ADJ,B2
-calorie,calorie,词,NOUN,C1
-calve,calve,词,VERB,C1
-camarade de classe,classmate,同学,NOUN,B2
-camarade de jeu,playmate,玩伴,NOUN,B2
-cambrioleur,burglar,窃贼,NOUN,B2
-camouflage (noun),camouflage,词,NOUN,C1
 camp,camp,营地,NOUN,B2
-camp (part),camp,营,PART,A2
 campagne,campaign,运动,NOUN,B2
-campfire,campfire,词,NOUN,C1
 camping,camping,露营,NOUN,B2
-campus,campus,词,NOUN,B2
-campus-like,campus-like,校园式的,ADJ,B2
-can (noun),can,词,NOUN,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,罐子,NOUN,B2
-can may,can may,可以,AUX,A1
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
+pouvoir,can,能够,AUX,B2
+pouvoir,can only,只能,AUX,B2
+croire,to can't believe,不敢相信,VERB,B2
+involontairement,can't help,不由得,ADV,B2
 canal,canal,运河,NOUN,B2
-canal belt,canal belt,词,NOUN,C1
-canal d'irrigation,irrigation canal,灌溉渠,NOUN,B2
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
+annulation,cancellation,取消,NOUN,B2
 cancer,cancer,癌症,NOUN,B2
-cancerous,cancerous,词,ADJ,C1
-candid,candid,词,ADJ,C1
 candidature,candidacy,候选资格,NOUN,B2
-candy shop,candy shop,词,NOUN,B2
-cane,cane,手杖,NOUN,B2
-canicule,heat wave,热浪,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
-canning,canning,词,NOUN,C1
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-canteen,canteen,食堂,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
-canvass,canvass,词,VERB,C1
+pouvoir,cannot,不能,AUX,B2
+supporter,to cannot bear,不堪,VERB,B2
+s'empêcher,to cannot help,忍不住,VERB,B2
 canyon,canyon,峡谷,NOUN,B2
-capable,able,能够的,ADJ,B2
-capable,capable,有能力的,ADJ,B2
-capable (noun),capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacitate,capacitate,词,VERB,C1
-capacitor condenser,capacitor condenser,词,NOUN,C1
 capacité,capability,能力,NOUN,B2
+capable,capable,有能力的,ADJ,B2
 cape,cape,海角,NOUN,B2
-cape,cloak,斗篷,NOUN,B2
-caper (noun),caper,词,NOUN,B2
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,资本外逃,NOUN,B2
-capitalization,capitalization,词,NOUN,C1
-capitulation,capitulation,词,NOUN,C1
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capsize,capsize,词,VERB,C1
-captious,captious,词,ADJ,B2
 captivant,captivating,迷人的,ADJ,B2
-captivated,captivated,词,ADJ,C1
-captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-captive bond,captive bond,词,NOUN,C1
 captivité,captivity,囚禁,NOUN,B2
 capture,capture,捕获,NOUN,B2
-car (part),car,车,PART,C1
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-caramelize,caramelize,词,VERB,C1
-carat,carat,克拉,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon trading,carbon trading,碳交易,NOUN,C1
-cardinal,cardinal,枢机主教,NOUN,B2
+accident,car accident,车祸,NOUN,B2
+assurance,car insurance,车险,NOUN,B2
+taxe,carbon tax,碳税,NOUN,B2
+carte,card,卡片,NOUN,B2
 care,to care,照顾,VERB,B2
 care for,to care for,照顾,VERB,B2
-care home,care home,,NOUN,B2
-care worker,care worker,护理人员,NOUN,B2
-careen,careen,词,VERB,C1
-career leap,career leap,词,NOUN,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-carefree,carefree,无忧无虑的,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefulness,carefulness,细心,NOUN,B2
 careless,careless,粗心的,ADJ,B2
-carelessness,carelessness,词,NOUN,C1
-carer,carer,词,NOUN,C1
-caress (noun),caress,词,NOUN,B2
 cargo,cargo,货物,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
 caricatural,caricatural,漫画的,ADJ,B2
 caricature,caricature,讽刺画,NOUN,B2
-caricature (verb),caricature,词,VERB,B2
-caring,caring,关怀的,ADJ,B2
-carnation,carnation,词,NOUN,B2
 carnival,carnival,狂欢节,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carp (verb),carp,词,VERB,C1
 carpentry,carpentry,木工,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carrefour,crossroads,十字路口,NOUN,B2
 carriage,carriage,马车,NOUN,B2
 carry forward,to carry forward,发扬,VERB,B2
 carry out,to carry out,实施,VERB,B2
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carré,square,平方的,ADJ,B2
-carte,card,卡片,NOUN,B2
-carte d'identité,id card,身份证,NOUN,B2
-carte de crédit,credit card,信用卡,NOUN,B2
-carte postale,postcard,明信片,NOUN,B2
-cartel,cartel,卡特尔,NOUN,B2
 cartilage,cartilage,软骨,NOUN,B2
-cartography,cartography,词,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
 cash,cash,现金,ADJ,B2
 cash,to cash,兑现,VERB,B2
-cash conversion,cash conversion,改现,NOUN,B2
 cashew,cashew,腰果,NOUN,B2
-casino,casino,词,NOUN,B2
-casket,casket,词,NOUN,C1
-casque audio,headphones,耳机,NOUN,B2
-cassation,cassation,词,NOUN,B2
 cassava,cassava,木薯,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cassé,broken,破碎的,ADJ,B2
-cast,cast,演员阵容,NOUN,B2
-cast (adj),cast,词,ADJ,C1
-castanets,castanets,词,NOUN,B1
-caste,caste,词,NOUN,B2
-casting,casting,词,NOUN,C1
 castle,castle,城堡,NOUN,B2
-castrate,castrate,词,VERB,C1
 casual,casual,随意的,ADJ,B2
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
 catalog,catalog,目录,NOUN,B2
-catalogue,catalogue,目录,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
-catapult,catapult,投石机,NOUN,B2
-cataract,cataract,词,NOUN,B2
 catastrophe,catastrophe,大灾难,NOUN,B2
-catastrophic,catastrophic,灾难性的,ADJ,B2
 catch,catch,捕捉,NOUN,B2
-catch thief,catch thief,抓贼,NOUN,C1
 catch up,to catch up,赶上,VERB,B2
-cater,cater,词,VERB,C1
 catharsis,catharsis,宣泄,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教徒,NOUN,B2
-cats,cats,猫,NOUN,B2
 cattle,cattle,牛,NOUN,B2
-cattle rancher,cattle rancher,牧场主,NOUN,B2
-cauchemar,nightmare,噩梦,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-caught,caught,被捕获的,ADJ,B2
-causal,causal,因果的,ADJ,B2
-causal link,causal link,因果关系,NOUN,B2
 causation,causation,因果关系,NOUN,B2
 cause,cause,原因,NOUN,B2
-cause of change,cause of change,改因,NOUN,B2
 cause of death,cause of death,死因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-cause partielle,partial cause,分因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-caustic,caustic,词,ADJ,B2
 caution,caution,谨慎,NOUN,B2
 cautious,cautious,小心的,ADJ,B2
 cautious and conscientious,cautious and conscientious,兢兢业业,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
-cavern,cavern,词,NOUN,B2
-cavil,cavil,词,VERB,C1
-cavort,cavort,词,VERB,C1
 caw,to caw,呱呱叫,VERB,B2
-caw (noun),caw,词,NOUN,C1
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-cede,cede,词,VERB,C1
-celebrant,celebrant,词,NOUN,B2
 celebrity,celebrity,名人,NOUN,B2
-celerity,celerity,迅速,NOUN,B2
 celery,celery,芹菜,NOUN,B2
-celestial (noun),celestial,词,NOUN,B2
-celibate,celibate,词,ADJ,B2
 cell phone,cell phone,手机,NOUN,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
-cellulose,cellulose,纤维素,NOUN,B2
 cement,to cement,巩固,VERB,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-censure (verb),censure,词,VERB,C1
-centenary,centenary,词,NOUN,C1
-centennial,centennial,词,ADJ,B2
 centimeter,centimeter,厘米,NOUN,B2
-centipede,centipede,蜈蚣,NOUN,B2
 central,central,中心的,ADJ,B2
-central station,central station,中央车站,NOUN,B2
-centrality,centrality,词,NOUN,C1
-centre,centre,词,NOUN,B2
-centre commercial,shopping center,购物中心,NOUN,B2
-centre de divertissement,entertainment center,娱乐中心,NOUN,B2
-centre-ville,inside city,城内,NOUN,B2
 centrifugal force,centrifugal force,离心力,NOUN,B2
 centrifuge,centrifuge,离心机,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-century-old,century-old,世纪的,ADJ,B2
-ceo,ceo,首席执行官,NOUN,B2
-cependant,meanwhile,同时,ADV,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
 ceremonial cap,ceremonial cap,爵弁,NOUN,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
 certain,certain,确定的,ADJ,B2
-certain (det),certain,某些,DET,B2
-certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
 certificate of merit,certificate of merit,奖状,NOUN,B2
-certification,certification,认证,NOUN,C1
 cessation,cessation,终止,NOUN,B2
-cessation passing,cessation passing,消亡,NOUN,C1
-cette flèche,that arrow,那一箭,NOUN,B2
-chacun,everyone,每个人,PRON,B2
-chagrin,grief,悲伤,NOUN,B2
-chain (adj),chain,词,ADJ,C1
-chain mail,chain mail,锁子甲,NOUN,B2
-chain of transmission,chain of transmission,词,NOUN,C1
 chairman,chairman,主席,NOUN,B2
 chairperson,chairperson,主席,NOUN,B2
-chalet,chalet,词,NOUN,B1
-chaleur,warmth,温暖,NOUN,B2
-challenges,challenges,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
 chamber,chamber,房间,NOUN,B2
-chamberlain,chamberlain,词,NOUN,C1
-chambre,bedroom,卧室,NOUN,B2
-chamois,chamois,词,NOUN,C1
-champ de bataille,battlefield,战场,NOUN,B2
 champagne,champagne,香槟,NOUN,B2
 champion,champion,冠军,NOUN,B2
-chance,lucky chance,虽侥,NOUN,B2
-chance opportunity,chance opportunity,词,NOUN,A2
-chancery,chancery,词,NOUN,C1
 chandelier,chandelier,吊灯,NOUN,B2
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
 change tire,to change tire,换胎,VERB,B2
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
 changed policy,changed policy,改策,NOUN,B2
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changement climatique,climate change,气候变化,NOUN,B2
-changer,shift,轮班,NOUN,B2
-changer,to shift,改变,VERB,B2
-changing clothes,changing clothes,换上,NOUN,C1
 channel,channel,频道,NOUN,B2
-chant,singing,歌唱,NOUN,B2
-chant,chant,词,VERB,C1
-chantier naval,shipyard,造船厂,NOUN,B2
-chants,chants,词,NOUN,B2
 chaos,chaos,混乱,NOUN,B2
-chaperon,chaperon,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-chaque,every,每个,DET,B2
-character assassination,character assassination,人格谋杀,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
 character word,character word,字,NOUN,B2
 characteristic,characteristic,典型的,ADJ,B2
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charade,charade,词,NOUN,B2
-charades,charades,打哑谜,NOUN,B2
 charcoal,charcoal,木炭,NOUN,B2
 charge,charge,收费,NOUN,B2
 charge,to charge,充电,VERB,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
 charisma,charisma,个人魅力,NOUN,B2
-charitable,charitable,慈善的,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
 charlatan,charlatan,江湖骗子,NOUN,B2
-charlatanisme,sham,假冒,NOUN,B2
-charmer,charmer,词,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
 chase,chase,追逐,NOUN,B2
 chase,to chase,追逐,VERB,B2
-chase (noun),chase,追他,NOUN,B2
-chase fast,chase fast,快追,NOUN,C1
-chasten,chasten,词,VERB,C1
-chastity,chastity,贞洁,NOUN,B2
-chastity probity,chastity probity,词,NOUN,C1
 chat,chat,聊天,NOUN,B2
-chatter (noun),chatter,词,NOUN,A2
-chauffeur,chauffeur,词,NOUN,C1
-chaussure,footwear,鞋穿,NOUN,B2
-chaussures,shoes,鞋子,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-chaîne de montagnes,mountain range,山脉,NOUN,B2
-chaîne industrielle,industry chain,产业链,NOUN,B2
 cheap,cheap,便宜的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheaper,cheaper,更便宜的,ADJ,B2
-cheapness,cheapness,廉价,NOUN,B2
 check,to check,检查,VERB,B2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checked,checked,词,ADJ,C1
-checkmark,checkmark,词,NOUN,C1
-checkmate,checkmate,词,NOUN,C1
 checkout,checkout,收银台,NOUN,B2
-checkup,checkup,体检,NOUN,B2
 cheek,cheek,脸颊,NOUN,B2
-cheekbone,cheekbone,词,NOUN,C1
 cheeky,cheeky,厚颜无耻的,ADJ,B2
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
 cheers,cheers,干杯,INTJ,B2
-cheers (noun),cheers,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
-chef de district,district head,区长,NOUN,B2
-chef de département,department head,厅长,NOUN,B2
-chef de village,village head,村长,NOUN,B2
-chef-d'œuvre,masterpiece,杰作,NOUN,B2
-chemical (adj),chemical,化学品,ADJ,B2
-chemicals,chemicals,词,NOUN,C1
-cheminée,chimney,烟囱,NOUN,B2
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-cher,dear,亲爱的,ADJ,B2
-chercher,to look for to find,找,VERB,B2
-chercher,to seek,寻找,VERB,B2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
-chest breast,chest breast,胸部/乳房,NOUN,B2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chevalerie,chivalry,骑士精神,NOUN,B2
-chevauchement,overlap,重叠,NOUN,B2
-chez moi,my place,我处,NOUN,B2
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chic (adj),chic,词,ADJ,C1
-chic (noun),chic,词,NOUN,C1
-chickpeas,chickpeas,词,NOUN,A2
-chide,chide,词,VERB,C1
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,主要地,ADV,B2
-chieftain,chieftain,酋长,NOUN,B2
-chiffonné,ragged,破烂的,ADJ,B2
-chiffre d'affaires,turnover,营业额,NOUN,B2
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childcare,childcare,词,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
-chili,chili,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (noun),chill,词,NOUN,B1
-chilling,chilling,词,ADJ,C1
-chime,chime,词,NOUN,C1
-chimera,chimera,词,NOUN,C1
-chimie,chemistry,化学,NOUN,B2
 chimique,chemical,化学品,NOUN,B2
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
+chimie,chemistry,化学,NOUN,B2
+échecs,chess,国际象棋,NOUN,B2
+douleur thoracique,chest pain,胸痛,NOUN,B2
+châtaigne,chestnut,板栗,NOUN,B2
+enfance,childhood,童年,NOUN,B2
+puéril,childish,幼稚的,ADJ,B2
+cheminée,chimney,烟囱,NOUN,B2
 chinois,chinese,中文,NOUN,B2
 chinois,chinese language,华文,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chitchat,chitchat,词,NOUN,B2
-chivalrous,chivalrous,词,ADJ,B2
-chive,chive,韭菜,NOUN,C1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,唱诗班男孩,NOUN,B2
-choke,choke,词,VERB,B2
-choleric,choleric,易怒的,ADJ,B2
-chomp,chomp,词,VERB,C1
-chop (noun),chop,砍了,NOUN,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-choreograph,choreograph,词,VERB,C1
-choreographic,choreographic,词,ADJ,C1
-choreography,choreography,词,NOUN,C1
-chortle,chortle,词,VERB,C1
-chosen,chosen,精选的,ADJ,B2
-christen,christen,词,VERB,C1
-christian,christian,基督徒,NOUN,B2
-christianity,christianity,基督教,NOUN,B2
-christianization,christianization,词,NOUN,C1
-christmas eve,christmas eve,平安夜,NOUN,B2
-christmas porridge,christmas porridge,,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
-chromosome,chromosome,染色体,NOUN,B2
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicle,chronicle,编年史,NOUN,B2
-chronicler,chronicler,词,NOUN,B2
-chronological,chronological,词,ADJ,C1
-chubby,chubby,胖子,NOUN,B2
-chuchotement,whisper,低语,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-church community,church community,教会,NOUN,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn,churn,词,VERB,C1
-churn skin,churn skin,词,NOUN,B2
-chute,scrap,碎屑,NOUN,B2
-chute d'eau,water falling,水落,NOUN,B2
-châtaigne,chestnut,板栗,NOUN,B2
-chéri,darling,亲爱的,NOUN,B2
-chômage,unemployment,失业,NOUN,B2
-chômeur,unemployed,失业的,ADJ,B2
-ciel,heaven,天堂,NOUN,B2
-ciel étoilé,starry sky,星空,NOUN,B2
-cigar,cigar,雪茄,NOUN,B2
-cigarette,cigarette,香烟,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinquante,fifty,五十,NUM,B2
-cinquième,fifth,خامس,ADJ,B2
-cinétique,kinetic,运动的,ADJ,B2
-circoncision,circumcision,割礼,NOUN,B2
-circonstances,situation circumstances,情形,NOUN,B2
-circonstances favorables,favorable circumstances,顺境,NOUN,B2
-circuit,circuit,电路,NOUN,B2
-circular (adj),circular,词,ADJ,C1
-circulating,circulating,词,ADJ,B2
-circulation,circulation,循环,NOUN,B2
-circumference,circumference,词,NOUN,C1
-circumscription,circumscription,词,NOUN,C1
-circumspection,circumspection,词,NOUN,B2
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circumvent,circumvent,词,VERB,C1
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
+puce,chip,碎片,NOUN,B2
 ciseau,chisel,凿子,NOUN,B2
-cistern,cistern,蓄水池,NOUN,B2
+chevalerie,chivalry,骑士精神,NOUN,B2
+hacher,chop,砍,NOUN,B2
+hacher,to chop,砍,VERB,B2
+noël,christmas,圣诞节,NOUN,B2
+chromosome,chromosome,染色体,NOUN,B2
+église,church,教堂,NOUN,B2
+cigarette,cigarette,香烟,NOUN,B2
+circuit,circuit,电路,NOUN,B2
+circulation,circulation,循环,NOUN,B2
+circoncision,circumcision,割礼,NOUN,B2
 citation,citation,引用,NOUN,B2
 citer,to cite,引用,VERB,B2
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city centre,city centre,市中心,NOUN,B2
-city council,city council,市议会,NOUN,B2
-city gate,city gate,城门,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic-mindedness,civic-mindedness,词,NOUN,B2
+hôtel de ville,city hall,市政厅,NOUN,B2
 civil,civil,民事的,ADJ,B2
 civil,civilian,平民,NOUN,B2
-civil war,civil war,内战,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairement délimité,clearly demarcated,分明,ADJ,B2
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,有洞察力的,ADJ,B2
-clamber,clamber,词,VERB,C1
 clameur,clamor,喧嚣,NOUN,B2
-clamorous,clamorous,词,ADJ,B2
-clampdown,clampdown,词,NOUN,C1
+pince,clamp,夹钳,NOUN,B2
 clan,clan,家族,NOUN,B2
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestineness,clandestineness,词,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clapping,clapping,词,NOUN,B2
+applaudir,to clap,拍手,VERB,B2
 clarification,clarification,澄清,NOUN,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarify doubts,clarify doubts,释疑,VERB,B2
-clarity evidentness,clarity evidentness,词,NOUN,C1
 clarté,clarity,清晰,NOUN,B2
-clash (noun),clash,词,NOUN,C1
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-class test,class test,词,NOUN,B1
-classe sociale,social class,社会阶层,NOUN,B2
-classic (noun),classic,经典,NOUN,C1
-classical poetry,classical poetry,词,NOUN,C1
-classicist,classicist,古典主义的,ADJ,B2
-classification,classification,分类,NOUN,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
-classique,classical,古典的,ADJ,B2
 classique,classic,经典作品,NOUN,B2
-classwork,classwork,课堂作业,NOUN,B2
-clatter,clatter,哗啦声,NOUN,C1
+classique,classical,古典的,ADJ,B2
+classification,classification,分类,NOUN,B2
+pièce,classifier for paintings cloth etc.,幅,NUM,B2
+arbre,classifier for trees,棵,NUM,B2
+camarade de classe,classmate,同学,NOUN,B2
+salle de classe,classroom,教室,NOUN,B2
 clause,clause,从句,NOUN,B2
-clauses,clauses,词,NOUN,C1
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner,cleaner,更干净的,ADJ,B2
-cleaner (noun),cleaner,清洁剂,NOUN,B2
-cleaning,cleaning,清洁,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanly,cleanly,干净地,ADV,B2
-cleanse,cleanse,词,VERB,C1
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
-clearing of the throat,clearing of the throat,词,NOUN,C1
-clench,clench,词,VERB,C1
-clerk,clerk,职员,NOUN,B2
-clickbait,clickbait,词,NOUN,C1
+propreté,cleanliness,清洁,NOUN,B2
+nettoyage,cleansing,清洗,NOUN,B2
+connaissance claire,clear knowledge,明知,NOUN,B2
+bouillon,clear soup,江瑶清羹,NOUN,B2
+clairement délimité,clearly demarcated,分明,ADJ,B2
 client,client,客户,NOUN,B2
-clientele,clientele,词,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-cligner,to wink,眨眼,VERB,B2
-clignotant,turn signal,转向灯,NOUN,B2
 climat,climate,气候,NOUN,B2
-climate denial,climate denial,气候否认,NOUN,B2
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
+changement climatique,climate change,气候变化,NOUN,B2
 climax,climax,高潮,NOUN,B2
-climbing,climbing,词,NOUN,B1
-clinch,clinch,词,VERB,C1
 clinique,clinical,临床的,ADJ,B2
-clink,clink,词,NOUN,C1
-clinking,clinking,词,NOUN,C1
 clip,clip,夹子,NOUN,B2
-clipping,clipping,词,NOUN,C1
-clobber,clobber,词,VERB,C1
-cloche,bell,铃,NOUN,B2
-clock watch,clock watch,钟表,NOUN,B2
-clog (verb),clog,词,VERB,C1
+cape,cloak,斗篷,NOUN,B2
+vestiaire,cloakroom,衣帽间,NOUN,B2
 clone,clone,克隆体,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
-close a case,close a case,结案,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
-close well,close well,关好,NOUN,C1
-closed,closed,关闭的,ADJ,B2
-closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
-closedness,closedness,封闭,NOUN,C1
-closely,closely,紧密地,ADV,B2
-closer,closer,更近的,ADJ,B2
-closer (adv),closer,词,ADV,B2
-closing,closing,词,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-clouds,clouds,云,NOUN,B1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clown,clown,小丑,NOUN,B2
-cloying,cloying,词,ADJ,C1
-club,club,俱乐部,NOUN,B2
-club blow,club blow,词,NOUN,C1
-cluck,cluck,词,NOUN,C1
-clueless,clueless,词,ADJ,C1
-clump,clump,词,NOUN,C1
-clunky,clunky,词,ADJ,C1
-clutter,clutter,词,NOUN,C1
 clôturer,to close account,销户,VERB,B2
-co-,co-,共同,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-occurrence,co-occurrence,词,NOUN,C1
-co-owner,co-owner,共有人,NOUN,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coalesce,coalesce,词,VERB,C1
+fermer,to close the door,关门,VERB,B2
+proximité,closeness,接近,NOUN,B2
+armoire,closet,壁橱,NOUN,B2
+cérémonie de clôture,closing ceremony,闭幕仪式,NOUN,B2
+caillot,clot,凝块,NOUN,B2
+tissu,cloth,布,NOUN,B2
+vêtements,clothes,衣服,NOUN,B2
+nuageux,cloudy,阴沉的,ADJ,B2
+clown,clown,小丑,NOUN,B2
+club,club,俱乐部,NOUN,B2
+grappe,cluster,簇,NOUN,B2
+embrayage,clutch,离合器,NOUN,B2
+entraîner,to coach,辅导,VERB,B2
 coalition,coalition,联盟,NOUN,B2
-coarse,coarse,粗糙的,ADJ,B2
-coarse rough,coarse rough,词,ADJ,C1
-coast road,coast road,词,NOUN,B2
-coastal (noun),coastal,词,NOUN,B2
-cobble,cobble,词,VERB,C1
-cobbler,cobbler,词,NOUN,B2
+persuasion,coaxing,哄得,NOUN,B2
 cocaïne,cocaine,可卡因,NOUN,B2
-cock,cock,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
 cocktail,cocktail,鸡尾酒,NOUN,B2
-cocky,cocky,傲慢的,ADJ,B2
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-coddle,coddle,词,VERB,C1
 code,code,代码,NOUN,B2
-code of conduct,code of conduct,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-coding,coding,词,NOUN,B2
 coefficient,coefficient,系数,NOUN,B2
+contrainte,coercion,胁迫,NOUN,B2
 coexistence,coexistence,共存,NOUN,B2
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cogito,cogito,词,NOUN,C1
-cognac,cognac,干邑,NOUN,B2
-cognate,cognate,词,NOUN,B2
-cognition,cognition,认知,NOUN,B2
-cognizance,cognizance,词,NOUN,C1
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-cohort-based,cohort-based,队列的,ADJ,B2
 cohérence,coherence,连贯性,NOUN,B2
-coil (noun),coil,词,NOUN,C1
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coitus,coitus,词,NOUN,B2
-coke,coke,可卡因,NOUN,B2
-cola,cola,可乐,NOUN,B2
-cold (noun),cold,cold,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
-coldness,coldness,词,NOUN,B2
-colic,colic,词,NOUN,C1
-coliseum,coliseum,词,NOUN,B2
+pièce,coin,硬币,NOUN,B2
+coïncider,to coincide,同时发生,VERB,B2
+froid,cold,寒冷,NOUN,B2
+sang-froid,cold blood,冷血,NOUN,B2
+vague de froid,cold wave,寒潮,NOUN,B2
 collaboration,collaboration,合作,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
-collation,collation,词,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,收集的,ADJ,B2
-collectie,collectie,收藏,NOUN,B2
-collections,collections,词,NOUN,C1
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-collectivization,collectivization,集体化,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
-college,college,学院,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiality,collegiality,词,NOUN,C1
-collegiate,collegiate,词,ADJ,B2
-colline,hills,丘陵,NOUN,B2
+percuter,to collide,碰撞,VERB,B2
 collision,collision,碰撞,NOUN,B2
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial,colloquial,词,ADJ,B2
-colloquial language,colloquial language,词,NOUN,C1
-colloquium,colloquium,词,NOUN,B2
-collusion,collusion,串通,NOUN,B2
-collusion d'enchères,bid collusion,串标,NOUN,B2
-colon,colon,冒号,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
+comploter,to collude,勾结,VERB,B2
 colonel,colonel,上校,NOUN,B2
-colonial,colonial,词,ADJ,C1
-colonial settlers,colonial settlers,词,NOUN,C1
-colonizing,colonizing,词,ADJ,C1
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colophon,colophon,词,NOUN,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-colored,colored,有色的,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
-coloring,coloring,词,NOUN,B2
-colorless,colorless,词,ADJ,C1
 coloré,colorful,五颜六色的,ADJ,B2
-colossal,colossal,巨大的,ADJ,B2
-colossus,colossus,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-columnar,columnar,词,ADJ,C1
-coléoptère,beetle,甲虫,NOUN,B2
 coma,coma,昏迷,NOUN,B2
-combat,combating,打击,NOUN,B2
-combatant,combatant,词,NOUN,B2
-combative,combative,词,ADJ,B2
+peigner,to comb,梳头,VERB,B2
 combattre,combat,战斗,NOUN,B2
 combattre,to combat,对抗,VERB,B2
-combinations,combinations,词,NOUN,C1
-combinatorial,combinatorial,组合的,ADJ,B2
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combining,combining,结合的,ADJ,B2
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come on,come on,词,INTJ,C1
-comer,comer,词,NOUN,C1
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comic strip,comic strip,连环画,NOUN,B2
-comicness,comicness,词,NOUN,C1
-coming,coming,即将到来的,ADJ,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comique,comic,喜剧的,ADJ,B2
-comma,comma,逗号,PUNCT,B2
-comma (noun),comma,词,NOUN,B1
-commandeer,commandeer,词,VERB,C1
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
-commandment,commandment,词,NOUN,C1
-comme,as,像,ADP,B2
-comme par le passé,just as in the past,一如既往,ADV,B2
-comme si,as if,仿佛,ADV,B2
-commence,commence,词,VERB,B2
-commencement,commencement,开始,NOUN,B2
-commencement,start,开始,NOUN,B2
-commencer,to begin to start,开始,VERB,B2
-commend,commend,词,VERB,C1
-commendable,commendable,词,ADJ,C1
-commendation,commendation,词,NOUN,C1
-commensalism,commensalism,词,NOUN,B2
-commensurability,commensurability,词,NOUN,C1
-commentaire,comment,评论,NOUN,B2
-commentaries,commentaries,词,NOUN,C1
-commerce,commerce,商业,NOUN,B2
-commercial,business,商业的,ADJ,B2
-commercial,commercial,商业的,ADJ,B2
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commettre un crime,to commit a crime,犯罪,VERB,B2
-commiserate,commiserate,词,VERB,C1
-commission,commission,委员会,NOUN,B2
-commitments,commitments,词,NOUN,C1
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commode,convenient,方便的,ADJ,B2
-commodification,commodification,词,NOUN,C1
-common good,common good,词,NOUN,B2
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
-commonplace,commonplace,词,ADJ,C1
-commotion,commotion,骚动,NOUN,B2
-communal work,communal work,词,NOUN,C1
-communautarization,communautarization,社群化,NOUN,B2
-communes,communes,词,NOUN,C1
-communication,communication,沟通,NOUN,B2
-communicativeness,communicativeness,词,NOUN,C1
-communion rail,communion rail,词,NOUN,B2
-communiquer,to communicate,交流,VERB,B2
-communiqué,communique,公报,NOUN,B2
-communist (adj),communist,共产主义的,ADJ,B2
-communiste,communist,شيوعي,ADJ,B2
-communitarian,communitarian,词,ADJ,C1
-commuter,commuter,词,NOUN,A2
-compact,compact,紧凑的,ADJ,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-compagnon,fellow,家伙,NOUN,B2
-compagnonnage,companionship,陪伴,NOUN,B2
-comparability,comparability,词,NOUN,C1
-comparable,comparable,可比较的,ADJ,B2
-comparative,comparative,比较的,ADJ,B2
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
-compartmental,compartmental,词,ADJ,C1
-compassion,compassion,同情,NOUN,B2
-compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
-compatibilité,compatibility,兼容性,NOUN,B2
-compatible,compatible,词,ADJ,C1
-compatissant,compassionate,有同情心的,ADJ,B2
-compelling,compelling,词,ADJ,C1
-compendious,compendious,词,ADJ,B2
-compendium,compendium,纲要,NOUN,B2
-compenser,to make up for,弥补,VERB,B2
-competencies,competencies,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competition bastard,competition bastard,,NOUN,B2
-competitive exam,competitive exam,词,NOUN,B2
-compilation,compilation,汇编,NOUN,B2
-complacency,complacency,词,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complet,complete,完整的,ADJ,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex,complex,建筑群,NOUN,B2
-complexe,complex,复杂的,ADJ,B2
-complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
-complice,complicit,共谋的,ADJ,B2
-complice,accomplice,同谋,NOUN,B2
-compliment,compliment,称赞,NOUN,B2
-comploter,to collude,勾结,VERB,B2
-complémentaire,complementary,互补的,ADJ,B2
-composable,composable,可组合的,ADJ,B2
-composition,composition,作文,NOUN,B2
-compositional,compositional,词,ADJ,C1
-compostable,compostable,可堆肥的,ADJ,B2
-composé,composed,稳重的,ADJ,B2
-composé,compound,复合性,ADJ,B2
-compound,compound,化合物,NOUN,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
-comprehensibility,comprehensibility,词,NOUN,C1
-comprendre,to comprehend,理解,VERB,B2
-compressed,compressed,词,ADJ,C1
-compressibility,compressibility,词,NOUN,C1
-compressible,compressible,词,ADJ,C1
-comprise,comprise,词,VERB,C1
-compromis social,social compromise,社会妥协,NOUN,B2
-compréhension,comprehension,理解,NOUN,B2
-compter comme,to count as,算,VERB,B2
-compulsif,compulsive,强迫性的,ADJ,B2
-compulsion,compulsion,词,NOUN,C1
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compunction,compunction,词,NOUN,B2
-compurgation oath,compurgation oath,词,NOUN,C1
-computability,computability,词,NOUN,C1
-computer mouse,computer mouse,词,NOUN,B1
-computer program,computer program,电脑程序,NOUN,B2
-computer science,computer science,词,NOUN,C1
-comtesse,countess,女伯爵,NOUN,B2
-comté,county,县,NOUN,B2
+combat,combating,打击,NOUN,B2
+accompagner,to come along,一起来,VERB,B2
+venir,to come here,来到这里,VERB,B2
+entrer,to come in,进来,VERB,B2
+sortir,to come out,出来,VERB,B2
+passer,to come over,顺道来访,VERB,B2
+monter,to come up,出现,VERB,B2
 comète,comet,彗星,NOUN,B2
-con artist,con artist,词,NOUN,B1
-concatenation,concatenation,词,NOUN,B2
-concave,concave,凹的,ADJ,B2
-concavity,concavity,词,NOUN,B2
-concealed,concealed,词,ADJ,C1
-conceit,conceit,词,NOUN,C1
-concentrated,concentrated,浓,ADJ,B1
+comique,comic,喜剧的,ADJ,B2
+arrivée,coming,مجيء,NOUN,B2
+allées et venues,coming and going,往来,NOUN,B2
+salle de commandement,command room,指挥室,NOUN,B2
+commentaire,comment,评论,NOUN,B2
+commerce,commerce,商业,NOUN,B2
+commercial,commercial,商业的,ADJ,B2
+commission,commission,委员会,NOUN,B2
+commettre un crime,to commit a crime,犯罪,VERB,B2
+engagé,committed,投入的,ADJ,B2
+marchandise,commodity,商品,NOUN,B2
+similitude,commonality,共同点,NOUN,B2
+roturier,commoner,平民,NOUN,B2
+commotion,commotion,骚动,NOUN,B2
+communiquer,to communicate,交流,VERB,B2
+communication,communication,沟通,NOUN,B2
+communiqué,communique,公报,NOUN,B2
+communiste,communist,شيوعي,ADJ,B2
+compagnonnage,companionship,陪伴,NOUN,B2
+compassion,compassion,同情,NOUN,B2
+compatissant,compassionate,有同情心的,ADJ,B2
+compatibilité,compatibility,兼容性,NOUN,B2
+congé compensateur,compensatory leave,调休,NOUN,B2
+compilation,compilation,汇编,NOUN,B2
+se plaindre,to complain,抱怨,VERB,B2
+complémentaire,complementary,互补的,ADJ,B2
+complet,complete,完整的,ADJ,B2
+complexe,complex,复杂的,ADJ,B2
+complice,complicit,共谋的,ADJ,B2
+compliment,compliment,称赞,NOUN,B2
+se conformer,to comply,遵守,VERB,B2
+se conformer à,to comply with,遵守,VERB,B2
+composé,composed,稳重的,ADJ,B2
+composition,composition,作文,NOUN,B2
+composé,compound,复合性,ADJ,B2
+comprendre,to comprehend,理解,VERB,B2
+compréhension,comprehension,理解,NOUN,B2
+exhaustif,comprehensive,全面的,ADJ,B2
+compulsif,compulsive,强迫性的,ADJ,B2
+calculer,to compute,计算,VERB,B2
+ordinateur,computer,电脑,NOUN,B2
+vaniteux,conceited,自负的,ADJ,B2
 concentration,concentration,专注,NOUN,B2
-concentric,concentric,词,ADJ,C1
 concept,concept,概念,NOUN,B2
-conception,conception,概念,NOUN,B2
-concepts,concepts,词,NOUN,C1
-conceptual,conceptual,概念的,ADJ,B2
-conceptualize,conceptualize,词,VERB,C1
-concernant,regarding,关于,ADP,B2
 concerner,to concern,涉及,VERB,B2
-concerner,to not about,不关,VERB,B2
-concerning,concerning,关于,ADP,B2
-concerning (adj),concerning,词,ADJ,B2
-concerns,concerns,词,NOUN,C1
 concert,concert,音乐会,NOUN,B2
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
 concession,concession,让步,NOUN,B2
-concessionary,concessionary,让步的,ADJ,B2
-concevoir,to devise,设计,VERB,B2
-conch,conch,海螺壳,NOUN,B2
-concierge,doorman,门卫,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
 concis,concise,简洁的,ADJ,B2
-conciseness,conciseness,简洁,NOUN,B2
-concision,concision,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,推断的,ADJ,B2
 conclusion,conclusion,结论,NOUN,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
-concord,concord,和谐,NOUN,B2
-concordance,concordance,一致,NOUN,B2
-concordat,concordat,政教协定,NOUN,B2
-concretization,concretization,词,NOUN,C1
 concubine,concubine,妾,NOUN,B2
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concur,concur,词,VERB,C1
-concurrence,concurrence,词,NOUN,B2
-concussion,concussion,脑震荡,NOUN,B2
 condamnation,condemnation,谴责,NOUN,B2
-condamner,to convict,定罪,VERB,B2
-condemned,condemned,被定罪的,ADJ,B2
 condensation,condensation,凝结,NOUN,B2
-condenser,condenser,词,NOUN,C1
 condenser,to condense,浓缩,VERB,B2
-condescending,condescending,屈尊的,ADJ,B2
 condition,condition,条件,NOUN,B2
-conditioning (adj),conditioning,词,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
 conditionnel,conditional,条件的,ADJ,B2
 condoler,to condole,哀悼,VERB,B2
 condoléance,condolence,哀悼,NOUN,B2
-conducive,conducive,词,ADJ,B2
-conduciveness,conduciveness,词,NOUN,C1
-conducteur désigné,designated driver,代驾,NOUN,B2
-conductor,conductor,词,NOUN,C1
 conduire,conduct,行为,NOUN,B2
 conduire,to conduct,أجرى,VERB,B2
-conduit,conduit,词,NOUN,B2
-confederal,confederal,词,ADJ,C1
-confederate,confederate,同盟者,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-confessional,confessional,宗派的,ADJ,B2
-confetti,confetti,词,NOUN,C1
+confédération,confederation,邦联,NOUN,B2
 confiance,confidence,信心,NOUN,B2
-confiance,reliance,信赖,NOUN,B2
 confiant,confident,自信的,ADJ,B2
-confidant,confidant,知己,NOUN,B2
-confidentialité,secrecy,保密,NOUN,B2
 confidentiel,confidential,机密的,ADJ,B2
-confiding,confiding,词,NOUN,C1
 configuration,configuration,配置,NOUN,B2
-configure,configure,词,VERB,C1
-configured,configured,词,ADJ,C1
-confinement,confinement,禁闭,NOUN,B2
-confiner,to lockdown,封城,VERB,B2
 confirmation,confirmation,确认,NOUN,B2
 confiscation,confiscation,没收,NOUN,B2
-conflictual,conflictual,词,ADJ,C1
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
-conforming,conforming,遵从的,ADJ,B2
-conformist,conformist,墨守成规者,NOUN,B2
-conformist (adj),conformist,词,ADJ,B2
-conformity,conformity,词,NOUN,B2
-confound,confound,词,VERB,C1
-confounded,confounded,该死的,ADJ,B2
-confronted,confronted,词,ADJ,B2
-confronting,confronting,对峙的,ADJ,B2
 confus,confused,困惑的,ADJ,B2
-confus,muddled,混乱的,ADJ,B2
-confused (adv),confused,词,ADV,B1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusing,confusing,令人困惑的,ADJ,B2
 confusion,confusion,困惑,NOUN,B2
-confédération,confederation,邦联,NOUN,B2
-conférencier,lecturer,演讲者,NOUN,B2
-congeal,congeal,词,VERB,C1
 congestion,congestion,拥堵,NOUN,B2
-conglomerate,conglomerate,词,NOUN,B2
-congratulations,congratulations,恭喜,INTJ,B2
-congratulations (noun),congratulations,祝贺,NOUN,B2
-congregate,congregate,词,VERB,C1
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-congruent,congruent,一致的,ADJ,B2
+félicitation,congratulation,祝贺,NOUN,B2
 congrès,congress,国会,NOUN,B2
-congé,see off,送走,NOUN,B2
-congé compensateur,compensatory leave,调休,NOUN,B2
-conic,conic,圆锥曲线,NOUN,B2
-conifer,conifer,针叶树,NOUN,B2
+forêt de conifères,coniferous forest,针叶林,NOUN,B2
 conjecture,conjecture,推测,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugal,conjugal,词,ADJ,B2
-conjunctural,conjunctural,词,ADJ,C1
 conjure,to conjure,变魔术,VERB,B2
-connaissance claire,clear knowledge,明知,NOUN,B2
 connected,connected,连接的,ADJ,B2
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connector,connector,词,NOUN,B2
-connivance,connivance,词,NOUN,B2
-connive,connive,词,VERB,C1
-conniving,conniving,词,ADJ,C1
 connotation,connotation,内涵,NOUN,B2
-connotative,connotative,内涵的,ADJ,B2
-connu,known,已知的,ADJ,B2
-connu,well-known,众所周知的,ADJ,B2
-conquests,conquests,征服,NOUN,C1
-consanguineous,consanguineous,词,ADJ,B2
 conscience,conscience,良知,NOUN,B2
 conscientious,conscientious,认真的,ADJ,B2
-conscientious objection,conscientious objection,良知抗拒,NOUN,B2
 conscious,conscious,有意识的,ADJ,B2
-consciously,consciously,有意识地,ADV,B2
 consciousness,consciousness,意识,NOUN,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
 consecrate,to consecrate,奉献,VERB,B2
-consecration,consecration,词,NOUN,C1
 consecutive cards,consecutive cards,连牌,NOUN,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-conseil,council,委员会,NOUN,B2
-conseil,counseling,咨询,NOUN,B2
-conseiller,advisor,顾问,NOUN,B2
-consensualism,consensualism,词,NOUN,C1
 consensus,consensus,共识,NOUN,B2
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,随之发生的,ADJ,B2
 conservation,conservation,保护,NOUN,B2
-conservatism,conservatism,词,NOUN,C1
-considerable (noun),considerable,不小,NOUN,C1
 considerate,considerate,体贴,ADJ,B2
-considered,considered,词,ADJ,B1
 consignment,consignment,托运,NOUN,B2
 consistency,consistency,一致性,NOUN,B2
 consistent,consistent,一致的,ADJ,B2
 consolation,consolation,安慰,NOUN,B2
-console (noun),console,词,NOUN,B2
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consolidation,consolidation,词,NOUN,C1
-consonance,consonance,词,NOUN,B2
 consort,consort,福晋,NOUN,B2
-consortium,consortium,词,NOUN,B2
 conspicuous,conspicuous,显著的,ADJ,B2
-conspirator,conspirator,词,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
 constable,constable,警官,NOUN,B2
 constant,constant,持续的,ADJ,B2
-constant (noun),constant,常量,NOUN,B2
 constantly,constantly,不断地,ADV,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
 constellation,constellation,星座,NOUN,B2
-consternation,consternation,词,NOUN,B2
 constipation,constipation,便秘,NOUN,B2
-constituencies,constituencies,词,NOUN,C1
-constituent,constituent,成分,NOUN,B2
 constitution,constitution,宪法,NOUN,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
 constitutionality,constitutionality,合宪性,NOUN,B2
-constitutionalization,constitutionalization,词,NOUN,B2
-constitutive,constitutive,构成的,ADJ,B2
-constraints,constraints,词,NOUN,C1
-constrict,constrict,词,VERB,C1
 construct,to construct,建造,VERB,B2
 construction,construction,建造,NOUN,B2
 constructive,constructive,建设性的,ADJ,B2
-constructiveness,constructiveness,词,NOUN,C1
-constructivism,constructivism,建构主义,NOUN,B2
-construe,construe,词,VERB,C1
 consul,consul,领事,NOUN,B2
 consult reference,to consult reference,参考,VERB,B2
 consultant,consultant,顾问,NOUN,B2
-consultations,consultations,磋商,NOUN,C1
-consultative,consultative,咨询的,ADJ,B2
-consulter,to look up,查阅,VERB,B2
-consummate,consummate,熟练的,ADJ,B2
-consummation,consummation,词,NOUN,B2
-consumptive,consumptive,消费的,ADJ,B2
 contact,contact,联系,NOUN,B2
-contact person,contact person,联系人,NOUN,B2
-contacts,contacts,人脉,NOUN,B2
-contactual,contactual,接触的,ADJ,B2
-contagion,contagion,词,NOUN,B2
-containment,containment,词,NOUN,C1
-contaminating,contaminating,污染的,ADJ,B2
-conte de fées,fairy tale,童话,NOUN,B2
-contemn,contemn,蔑视,VERB,C1
-contemplation,contemplation,沉思,NOUN,B2
 contemplative,contemplative,沉思的,ADJ,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contender,contender,词,NOUN,B2
-content (adj),content,词,ADJ,B2
-contentious,contentious,有争议的,ADJ,B2
-contents,contents,内有,NOUN,B2
 contest,contest,比赛,NOUN,B2
-contestable,contestable,可质疑的,ADJ,B2
-contestable,questionable,可疑的,ADJ,B2
-contested,contested,有争议的,ADJ,B2
-contesté,disputed,有争议的,ADJ,B2
 contexte,context,上下文,NOUN,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
 contextuel,contextual,语境的,ADJ,B2
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,相邻的,ADJ,B2
-continence,continence,词,NOUN,B2
 continent,continent,大陆,NOUN,B2
-continent,mainland,大陆,NOUN,B2
-continental,continental,词,ADJ,B2
-contingent,contingent,偶然的,ADJ,B2
-continual,continual,持续的,ADJ,B2
-continued,continued,持续的,ADJ,B2
-continuously,continuously,一直,ADV,A1
-contort,contort,词,VERB,C1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contraband,contraband,违禁品,NOUN,B2
-contracted,contracted,词,ADJ,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual,contractual,合同的,ADJ,B2
-contractual nature,contractual nature,词,NOUN,C1
-contractuality,contractuality,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
 contradiction,contradiction,矛盾,NOUN,B2
-contradictoriness,contradictoriness,词,NOUN,C1
-contraindicate,contraindicate,词,VERB,C1
-contrainte,coercion,胁迫,NOUN,B2
 contraire,contrary,反而,NOUN,B2
-contrary (adj),contrary,词,ADJ,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrastive,contrastive,词,ADJ,C1
-contre-attaque,counterattack,反击,NOUN,B2
-contre-compétence,counter-skill,反技,NOUN,B2
+intention contraire,contrary intention,反意,NOUN,B2
+salle de contrôle,control room,控制室,NOUN,B2
+commode,convenient,方便的,ADJ,B2
+convention,convention,惯例,NOUN,B2
+converger,to converge,汇聚,VERB,B2
+convergence,convergence,汇聚,NOUN,B2
+conversation,conversation,对话,NOUN,B2
+transmettre,to convey,传达,VERB,B2
+condamner,to convict,定罪,VERB,B2
+convaincu,convinced,确信的,ADJ,B2
+convulsion,convulsion,抽搐,NOUN,B2
+boulette de viande cuite,cooked meatball,丸子熟,NOUN,B2
+riz cuit,cooked rice,米饭,NOUN,B2
+biscuit,cookie,饼干,NOUN,B2
+frais,cool,凉爽的,ADJ,B2
+refroidir,to cool down,冷却,VERB,B2
+fraîcheur,coolness,凉爽,NOUN,B2
+coordonnée,coordinate,坐标,NOUN,B2
+flic,cop,警察,NOUN,B2
+droit d'auteur,copyright,版权,NOUN,B2
+corail,coral,珊瑚,NOUN,B2
+maïs,corn,玉米,NOUN,B2
+correct,correct,正确的,ADJ,B2
+correction,correction,纠正,NOUN,B2
+corrosion,corrosion,腐蚀,NOUN,B2
+corruption,corruption,腐败,NOUN,B2
+costume,costume,戏服,NOUN,B2
+conseil,council,委员会,NOUN,B2
+conseil,counseling,咨询,NOUN,B2
+compter comme,to count as,算,VERB,B2
 contre-forme,counter-form,反式,NOUN,B2
 contre-logique,counter-logic,反逻,NOUN,B2
 contre-matière,counter-matter,反物,NOUN,B2
-contre-modèle,counter-model,反模,NOUN,B2
 contre-mécanisme,counter-mechanism,反机,NOUN,B2
+contre-modèle,counter-model,反模,NOUN,B2
 contre-observation,counter-observation,反察,NOUN,B2
 contre-qualité,counter-quality,反质,NOUN,B2
+contre-voie,counter-route,反途,NOUN,B2
+contre-compétence,counter-skill,反技,NOUN,B2
 contre-semelle,counter-sole,反唯,NOUN,B2
 contre-structure,counter-structure,反结,NOUN,B2
 contre-système,counter-system,反系,NOUN,B2
 contre-technique,counter-technique,反术,NOUN,B2
 contre-tendance,counter-trend,反势,NOUN,B2
 contre-type,counter-type,反型,NOUN,B2
-contre-voie,counter-route,反途,NOUN,B2
+contre-attaque,counterattack,反击,NOUN,B2
 contrefait,counterfeit,假冒,ADJ,B2
-contrefaçon,forgery,伪造品,NOUN,B2
-contributions,contributions,词,NOUN,C1
-contrite,contrite,词,ADJ,B2
-contrition,contrition,悔罪,NOUN,B2
-contrive,contrive,词,VERB,C1
-controllability,controllability,词,NOUN,C1
-controllable,controllable,可控制的,ADJ,B2
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
-contusion,contusion,词,NOUN,B2
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convaincu,convinced,确信的,ADJ,B2
-convalesce,convalesce,词,VERB,B2
-convalescence,convalescence,词,NOUN,C1
-convalescent,convalescent,词,ADJ,B2
-convenant,convenant,词,NOUN,C1
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
-convening,convening,召集,NOUN,C1
-convent,convent,词,NOUN,B2
-convention,convention,惯例,NOUN,B2
-conventionality,conventionality,词,NOUN,C1
-convergence,convergence,汇聚,NOUN,B2
-convergent,convergent,词,ADJ,C1
-converger,to converge,汇聚,VERB,B2
-conversation,conversation,对话,NOUN,B2
-conversation technique,conversation technique,词,NOUN,C1
-conversion,conversion,转换,NOUN,B2
-conversional,conversional,转换的,ADJ,B2
-convert (noun),convert,词,NOUN,B2
-convertibility,convertibility,可兑换性,NOUN,B2
-convertible,convertible,可兑换的,ADJ,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
-conveyance,conveyance,词,NOUN,C1
-convict (adj),convict,词,ADJ,B2
-convict (noun),convict,词,NOUN,C1
-convicted,convicted,被判罪的,ADJ,B2
-conviviality,conviviality,温馨,NOUN,B2
-convoke,convoke,词,VERB,C1
-convoluted,convoluted,词,ADJ,B2
-convolutional,convolutional,卷积的,ADJ,B2
-convulse,convulse,词,VERB,C1
-convulsion,convulsion,抽搐,NOUN,B2
-convulsive,convulsive,词,ADJ,B2
-cookbook,cookbook,词,NOUN,C1
-cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,冷静的,ADJ,B2
-cooler,cooler,词,ADJ,C1
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
-coop,coop,词,VERB,C1
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
-coordonnée,coordinate,坐标,NOUN,B2
-copain,buddy,伙伴,NOUN,B2
-cope with,cope with,应对,VERB,B2
-copious,copious,丰富的,ADJ,B2
-coproduction,coproduction,联合制作,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
-coquin,scoundrel,恶棍,NOUN,B2
-corail,coral,珊瑚,NOUN,B2
-coral (adj),coral,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-corbeau,crow,乌鸦,NOUN,B2
-cord,cord,绳索,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordiality,cordiality,词,NOUN,C1
-cordoning,cordoning,词,NOUN,C1
-core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-corniche,corniche,词,NOUN,C1
-corporate,corporate,公司的,ADJ,B2
-corporation,corporation,公司,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpulent,corpulent,词,ADJ,B2
-corpuscle,corpuscle,词,NOUN,C1
-correct,correct,正确的,ADJ,B2
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correction,correction,纠正,NOUN,B2
-corrections,corrections,刑事司法,NOUN,B2
-correctness,correctness,正确性,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlative,correlative,词,ADJ,B2
-correspondence course,correspondence course,函授,NOUN,C1
-correspondents,correspondents,词,NOUN,C1
-corridors,corridors,词,NOUN,C1
-corrigible,corrigible,可改正的,ADJ,B2
-corroboration,corroboration,证实,NOUN,B2
-corrosion,corrosion,腐蚀,NOUN,B2
-corrosive,corrosive,腐蚀性的,ADJ,B2
-corrupted,corrupted,,NOUN,B2
-corruptibility,corruptibility,词,NOUN,C1
-corruption,corruption,腐败,NOUN,B2
-cortical,cortical,皮层的,ADJ,C1
-cosmetics,cosmetics,化妆品,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
-costs,costs,费用,NOUN,B2
-costumbrism,costumbrism,词,NOUN,B2
-costume,costume,戏服,NOUN,B2
-costumes,costumes,词,NOUN,B2
-cosy,cosy,舒适的,ADJ,B2
-cosy,cozy,舒适的,ADJ,B2
-cottage,cottage,小屋,NOUN,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couard,coward,懦夫,NOUN,B2
-couch,couch,词,NOUN,B1
-couche,diaper,尿布,NOUN,B2
-couette,quilt,被子,NOUN,B2
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-couloir,hallway,走廊,NOUN,B2
-council-related,council-related,词,ADJ,C1
-councilor,councilor,市议员,NOUN,B2
-councils,councils,委员会,NOUN,C1
-counsel,counsel,词,NOUN,B2
-counselor,counselor,词,NOUN,C1
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,面容,NOUN,B2
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,逆流,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterproductive,counterproductive,适得其反的,ADJ,B2
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-counterweight,counterweight,词,NOUN,B2
-country land,country land,词,NOUN,A1
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
+comtesse,countess,女伯爵,NOUN,B2
+comté,county,县,NOUN,B2
 coup,coup,政变,NOUN,B2
-coup,hit,击中,NOUN,B2
-coup,stroke,中风,NOUN,B2
-coup de poing,punch,拳击,NOUN,B2
-coupe à vin,wine cup,这酒盏,NOUN,B2
-coupe-vent,windproof,挡风的,ADJ,B2
-couper,to cut off,切断,VERB,B2
 couple,couple,一对,NOUN,B2
-couple marié,a married couple,夫妇,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
 couplet,couplet,对联,NOUN,B2
-cour intérieure,inner court,朝内,NOUN,B2
 courage,courage,勇气,NOUN,B2
-courageous,courageous,勇敢的,ADJ,B2
-courant,current,电流,NOUN,B2
-courant dominant,mainstream,主流,NOUN,B2
-courbure,bend,弯道,NOUN,B2
-courriel,email,电子邮件,NOUN,B2
-court and country,court and country,朝野,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court costs,court costs,词,NOUN,C1
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courtage,brokerage,经纪业,NOUN,B2
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cousin,cousin,表亲,NOUN,B2
-cousin female,cousin female,词,NOUN,B2
-coussin,pad,垫,NOUN,B2
-coutumier,customary,习惯的,ADJ,B2
-couvert,overcast,阴天的,ADJ,B2
-couverture,blanket,毯子,NOUN,B2
+renvoi,court dismissal,退朝,NOUN,B2
+pacte,covenant,契约,NOUN,B2
 couverture,coverage,报道,NOUN,B2
-cove,cove,小海湾,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-cover-up,cover-up,词,NOUN,C1
-coward (adj),coward,词,ADJ,A2
-cower,cower,词,VERB,C1
-coworker,coworker,同事,NOUN,B2
-cowpeas,cowpeas,词,NOUN,B2
-coïncider,to coincide,同时发生,VERB,B2
-crackdown,crackdown,词,NOUN,C1
-cracker,cracker,饼干,NOUN,B2
-cracking,cracking,词,NOUN,B2
-cradle,cradle,摇篮,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramp,cramp,抽筋,NOUN,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crap,crap,屎,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-crass,crass,词,ADJ,B2
-craving,craving,渴求,NOUN,B2
-crayon,crayon,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-creamy,creamy,词,ADJ,C1
-crease,crease,词,NOUN,C1
-credentials,credentials,国书,NOUN,B2
-credible,credible,词,ADJ,C1
-creditor's rights,creditor's rights,债权,NOUN,B2
-credulous,credulous,词,ADJ,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (verb),creep,词,VERB,B2
-creepy,creepy,令人毛骨悚然的,ADJ,B2
-cremate,cremate,词,VERB,C1
-cremation,cremation,火化,NOUN,B2
-crenelate,crenelate,词,VERB,C1
-crescendo,crescendo,词,NOUN,C1
-crescent,crescent,crescent,NOUN,B2
-creusement,digging,挖掘,NOUN,B2
-creux,hollow,洼地,NOUN,B2
-crevaison,puncture,穿刺,NOUN,B2
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-cricket,cricket,板球,NOUN,B2
-crier,scream,尖叫,NOUN,B2
-crier,to scream,尖叫,VERB,B2
-crime,crime,犯罪,NOUN,B2
-crime,felony,重罪,NOUN,B2
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
-criminal (adj),criminal,刑事,ADJ,C1
-criminal law,criminal law,刑法,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
-criminalization,criminalization,词,NOUN,C1
-criminel,criminal,罪犯,NOUN,B2
-crimson,crimson,词,ADJ,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisis-ridden,crisis-ridden,词,ADJ,C1
-crisp,crisp,词,ADJ,C1
-criticité,criticality,临界性,NOUN,B2
-criticizable,criticizable,词,ADJ,B2
-critique,critical,关键的,ADJ,B2
-critique,critic,评论家,NOUN,B2
-critique,critique,词,NOUN,C1
-crochet,crochet,钩针编织,NOUN,B2
-crocodile,crocodile,词,NOUN,A1
-croire,to can't believe,不敢相信,VERB,B2
-cronyism,cronyism,词,NOUN,C1
-crook,crook,骗子,NOUN,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crossing the border,crossing the border,越境,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-crouch (noun),crouch,词,NOUN,B2
-croup,croup,词,NOUN,C1
-crowbar,crowbar,词,NOUN,B2
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-croyance,belief,信念,NOUN,B2
-crucial,crucial,至关重要的,ADJ,B2
-crucible,crucible,词,NOUN,B2
-crucifixion,crucifixion,词,NOUN,C1
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruel,cruel,残忍的,ADJ,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-crumbs,crumbs,词,NOUN,B2
-crunching,crunching,词,NOUN,C1
-crunchy,crunchy,脆的,ADJ,B1
-crushing,crushing,词,NOUN,B2
-crustacé,crustacean,甲壳类动物,NOUN,B2
-crusty,crusty,词,ADJ,B2
-cry weep,cry weep,词,VERB,A1
-crying shouting,crying shouting,词,NOUN,B1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystal glass,crystal glass,词,NOUN,B1
-crystalline,crystalline,水晶般的,ADJ,B2
-crystallization,crystallization,词,NOUN,C1
-crystallize,crystallize,词,VERB,C1
-crâne,skull,头骨,NOUN,B2
-crème glacée,ice cream,冰淇淋,NOUN,B2
-créance,creditor's right,债权,NOUN,B2
-crédit,credit,信用,NOUN,B2
+vache,cow,奶牛,NOUN,B2
+couard,coward,懦夫,NOUN,B2
+cosy,cozy,舒适的,ADJ,B2
 crépiter,to crackle,噼啪作响,VERB,B2
+artisanat,craft,工艺,NOUN,B2
+grue,crane,起重机,NOUN,B2
+cageot,crate,板条箱,NOUN,B2
+désirer,to crave,渴望,VERB,B2
+rampiner,to crawl,爬行,VERB,B2
+crédit,credit,信用,NOUN,B2
+carte de crédit,credit card,信用卡,NOUN,B2
+créance,creditor's right,债权,NOUN,B2
+équipage,crew,全体船员,NOUN,B2
+crime,crime,犯罪,NOUN,B2
+scène de crime,crime scene,犯罪现场,NOUN,B2
+criminel,criminal,罪犯,NOUN,B2
+critique,critic,评论家,NOUN,B2
+critique,critical,关键的,ADJ,B2
+criticité,criticality,临界性,NOUN,B2
+tordu,crooked,弯曲的,ADJ,B2
+récolte,crop,庄稼,NOUN,B2
+carrefour,crossroads,十字路口,NOUN,B2
+s'accroupir,to crouch,蹲下,VERB,B2
+corbeau,crow,乌鸦,NOUN,B2
+crucial,crucial,至关重要的,ADJ,B2
+cruel,cruel,残忍的,ADJ,B2
+défaite écrasante,crushing defeat,惨败,NOUN,B2
+crustacé,crustacean,甲壳类动物,NOUN,B2
+pleurs,crying,,NOUN,B2
+petit,cub,幼兽,NOUN,B2
 cube,cube,立方体,NOUN,B2
-cubit,cubit,词,NOUN,B2
-cuckold,cuckold,词,VERB,C1
-cudgel,cudgel,棍棒,NOUN,B2
-cue,cue,词,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuire à la vapeur,steam,蒸汽,NOUN,B2
-cuire à la vapeur,to steam,蒸,VERB,B2
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culmination,culmination,词,NOUN,B2
-culotte,underpants,内裤,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cult,cult,邪教,NOUN,B2
-cultivation,cultivation,培养,NOUN,B2
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-culturalism,culturalism,词,NOUN,C1
+vestige culturel,cultural relic,文物,NOUN,B2
 culture,culture,文化,NOUN,B2
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cultured,cultured,词,ADJ,B2
-cumber,cumber,词,VERB,C1
-cumbersome,cumbersome,笨重的,ADJ,B2
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
-cunning,cunning,狡猾的,ADJ,B2
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupola,cupola,词,NOUN,C1
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curate,curate,词,VERB,C1
-curator,curator,策展人,NOUN,B2
-curbing,curbing,遏制,NOUN,B2
-curd,curd,词,NOUN,B2
-curdle,curdle,词,VERB,C1
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
+guérir,to cure,治愈,VERB,B2
 curiosité,curiosity,好奇心,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
-current times,current times,词,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
-curry,curry,词,NOUN,B2
-cursing,cursing,骂人,NOUN,C1
-curvature,curvature,词,NOUN,B2
-curved,curved,词,ADJ,B2
-cusp,cusp,词,NOUN,B2
-custodian,custodian,词,NOUN,B2
-customary law,customary law,词,NOUN,C1
-customer orientation,customer orientation,客户导向,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
-customs (adj),customs,词,ADJ,C1
-cut off,cut off,割下,NOUN,B2
-cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
+courant,current,电流,NOUN,B2
+dynastie actuelle,current dynasty,当朝,NOUN,B2
+maudire,to curse,诅咒,VERB,B2
+tringle à rideau,curtain rod,窗帘杆,NOUN,B2
+garde,custody,监护,NOUN,B2
+coutumier,customary,习惯的,ADJ,B2
+couper,to cut off,切断,VERB,B2
+interrompre,to cut short,截断,VERB,B2
 cyber,cyber,网络的,ADJ,B2
-cybernetics,cybernetics,词,NOUN,C1
-cyborg,cyborg,词,NOUN,C1
-cycle path,cycle path,自行车道,NOUN,B2
 cycliser,cycle,循环,NOUN,B2
 cycliser,to cycle,骑自行车,VERB,B2
 cyclone,cyclone,气旋,NOUN,B2
-cykel,cykel,自行车,NOUN,B2
 cymbale,cymbal,钹,NOUN,B2
-cynicism,cynicism,犬儒主义,NOUN,B2
-czech,czech,捷克的,ADJ,B2
-céphalée,headache,头痛,NOUN,B2
-cérémonie de clôture,closing ceremony,闭幕仪式,NOUN,B2
-cérémonie de dévoilement,unveiling ceremony,揭幕仪式,NOUN,B2
-côté,beside next to,旁边,NOUN,B2
-côté gauche,left side,左侧,NOUN,B2
-cœur rebelle,rebellious heart,反心,NOUN,B2
-d'abord,first,首先,ADV,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dachshund,dachshund,词,NOUN,A1
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
-daddy,daddy,爸爸,NOUN,B2
-daft,daft,傻的,ADJ,B2
-daglig,daglig,词,ADJ,C1
-daily (noun),daily,词,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
-daily wage,daily wage,词,NOUN,C1
-dal,dal,山谷,NOUN,B2
-dally,dally,词,VERB,C1
-damageable,damageable,易损的,ADJ,B2
-damask,damask,词,NOUN,B2
-damm,damm,池塘,NOUN,B2
-damn,damn,该死,INTJ,B2
-damn (adv),damn,该死的,ADV,B2
-damned,damned,词,ADJ,B2
-damping,damping,词,NOUN,C1
-dance (noun),dance,舞蹈,NOUN,A2
-dance floor,dance floor,舞池,NOUN,B2
-dandle,dandle,词,VERB,C1
-dandruff,dandruff,词,NOUN,B2
-danger,danger,危险,NOUN,B2
-dangereux,dangerous,危险的,ADJ,B2
-dangerousness,dangerousness,危险性,NOUN,B2
-dangle,dangle,词,VERB,C1
-danish,danish,丹麦的,ADJ,B2
-danmei,danmei,但没,NOUN,B2
-dans,within,在……之内,ADP,B2
-dans,dans,舞蹈,NOUN,B2
-dans le ciel,in the sky,天上,NOUN,B2
-dans le vent,in wind,临风,NOUN,B2
-dans quelle mesure,what extent,在何种程度上,ADV,B2
+augmentation quotidienne,daily increase,日渐,NOUN,B2
+quotidien,daily newspaper,日报,NOUN,B2
+dommage,damage,损害,NOUN,B2
+maudit,damn,该死的,ADJ,B2
 danser,dance,舞蹈,NOUN,B2
 danser,to dance,跳舞,VERB,B2
 danseur,dancer,舞者,NOUN,B2
-dapper,dapper,整洁的,ADJ,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-daring bold,daring bold,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
-darkness of night,darkness of night,词,NOUN,C1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (verb),darn,词,VERB,B2
-dart (noun),dart,词,NOUN,B2
-dart (verb),dart,词,VERB,C1
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data leak,data leak,词,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-data protection,data protection,数据保护,NOUN,B2
-databas,databas,数据库,NOUN,B2
+danger,danger,危险,NOUN,B2
+dangereux,dangerous,危险的,ADJ,B2
+danmei,danmei,但没,NOUN,B2
+assombrir,to darken,变暗,VERB,B2
+chéri,darling,亲爱的,NOUN,B2
+tableau de bord,dashboard,仪表盘,NOUN,B2
+base de données,database,数据库,NOUN,B2
 date,date,日期,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daub,daub,词,VERB,C1
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dawning,dawning,破晓,NOUN,B2
-day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,后天,NOUN,B2
-day by day,day by day,日日,ADV,B2
-day off,day off,词,NOUN,B2
-day out,day out,一日游,NOUN,B2
-day school,day school,词,NOUN,C1
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daydream (noun),daydream,词,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daylight,daylight,日光,NOUN,B2
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
-de,from,来自,ADP,B2
-de cette façon,that way,那样,PRON,B2
-de côté,aside,在旁边,ADV,B2
-de facto,de facto,词,ADJ,C1
-de force,forcibly,强制地,ADV,B2
-de nos jours,nowadays,如今,ADV,B2
-de plus en plus,increasingly,越来越,ADV,B2
-de préférence,preferably,更愿意,ADV,B2
-de-escalation,de-escalation,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-dead person,dead person,词,NOUN,B1
-deaden,deaden,词,VERB,C1
-deadlock,deadlock,词,NOUN,C1
-deadly,deadly,致命的,ADJ,B2
-deadly (adv),deadly,致命地,ADV,B2
-deaf person,deaf person,词,NOUN,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
-deals,deals,词,NOUN,C1
-deanship,deanship,词,NOUN,C1
-dear,dear,,NOUN,B2
-dearest,dearest,最爱的人,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
-deaths,deaths,词,NOUN,C1
-debasement,debasement,词,NOUN,C1
-debauch,debauch,词,VERB,C1
-debilitate,debilitate,词,VERB,C1
-debility,debility,虚弱,NOUN,C1
-debit,debit,词,VERB,C1
-debout,standing,站立的,ADJ,B2
-debrief,debrief,词,VERB,C1
-debris rubble,debris rubble,词,NOUN,C1
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
-debut,debut,初次登台,NOUN,B2
-decade,decade,十年,NOUN,B2
-decal,decal,贴花,NOUN,B2
-decalogue,decalogue,词,NOUN,B2
-decamp,decamp,词,VERB,C1
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
-deceased (adj),deceased,已故的,ADJ,B2
-deceived,deceived,词,ADJ,A2
-decelerate,decelerate,词,VERB,C1
-decentralized,decentralized,词,ADJ,C1
-deceptive,deceptive,欺骗性的,ADJ,B2
-decibel,decibel,分贝,NOUN,B2
-decimal,decimal,小数,NOUN,B2
-decimal (adj),decimal,词,ADJ,C1
-decision-making,decision-making,决策,NOUN,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck,deck,词,NOUN,B1
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declamatory style,declamatory style,词,NOUN,C1
-declarant,declarant,词,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declare war,declare war,宣战,VERB,B2
-declinable,declinable,可变格的,ADJ,B2
-decline setting,decline setting,词,NOUN,C1
-decoding,decoding,词,NOUN,B2
-decommission,decommission,词,VERB,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
-deconstructionist,deconstructionist,词,ADJ,C1
-decontaminate,decontaminate,词,VERB,C1
-decorated,decorated,词,ADJ,B1
-decorous,decorous,词,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
-decorum,decorum,礼仪,NOUN,B2
-decoy,decoy,词,NOUN,C1
-decreasing,decreasing,词,ADJ,B2
-decrepit,decrepit,词,ADJ,B2
-deduct points,deduct points,扣分,VERB,C1
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
-deem,deem,词,VERB,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
-deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply,deeply,深深地,ADV,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deer,deer,鹿,NOUN,B2
-deface,deface,词,VERB,C1
-defamiliarization,defamiliarization,词,NOUN,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
-defection,defection,词,NOUN,B2
-defectiveness,defectiveness,词,NOUN,C1
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,无防御的,ADJ,B2
-deferential,deferential,词,ADJ,C1
-deficitary,deficitary,词,ADJ,C1
-defile,defile,词,VERB,C1
-definable,definable,词,ADJ,C1
-definite,definite,明确的,ADJ,B2
-deflated,deflated,词,ADJ,B1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deformed,deformed,畸形的,ADJ,B2
-deformity,deformity,词,NOUN,C1
-defunct,defunct,词,ADJ,C1
-degrading,degrading,词,ADJ,C1
-degrease,degrease,词,VERB,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-dehors,out,在外面,ADV,B2
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
-dehydration dryness,dehydration dryness,词,NOUN,C1
-deice,deice,词,VERB,C1
-deification,deification,词,NOUN,C1
-dejt,dejt,约会,NOUN,B2
-del,del,部分,NOUN,B2
-delayed,delayed,延误的,ADJ,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
-deletion,deletion,词,NOUN,B2
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
-deliberateness,deliberateness,词,NOUN,C1
-deliberations,deliberations,词,NOUN,C1
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delightful,delightful,令人愉快的,ADJ,B2
-delimitation,delimitation,词,NOUN,C1
-deliquesce,deliquesce,词,VERB,C1
-delirious,delirious,谵妄的,ADJ,B2
-delivery van,delivery van,厢式送货车,NOUN,B2
-delouse,delouse,词,VERB,C1
-delta,delta,delta,NOUN,B2
-delude,delude,词,VERB,C1
-delve,delve,词,VERB,C1
-demagogic,demagogic,词,ADJ,C1
-demagogue,demagogue,词,NOUN,C1
-demagoguery,demagoguery,煽动性,NOUN,B2
-demagogy,demagogy,蛊惑,NOUN,B2
-demain,tomorrow,غد,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
-demande,demand,需求,NOUN,B2
-demarcation,demarcation,划界,NOUN,B2
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
-dement,dement,词,VERB,C1
-demented,demented,词,ADJ,C1
-demijohn,demijohn,词,NOUN,B2
-demobilize,demobilize,词,VERB,C1
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demonization,demonization,词,NOUN,C1
-demons,demons,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demonstrator,demonstrator,词,NOUN,C1
-demoralization,demoralization,词,NOUN,C1
-demote,demote,词,VERB,C1
-demotion,demotion,降职,NOUN,B2
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-den,den,兽穴,NOUN,B2
-denationalize,denationalize,词,VERB,C1
-denim jacket,denim jacket,词,NOUN,C1
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
-dense,dense,密集的,ADJ,B2
-dense forest,dense forest,密林,NOUN,B2
-dent,dent,凹痕,NOUN,B2
-dentiste,dentist,牙医,NOUN,B2
-dentition,dentition,牙齿,NOUN,B2
-denude,denude,词,VERB,C1
-deodorize,deodorize,词,VERB,C1
-deontology,deontology,词,NOUN,C1
-department director,department director,司长,NOUN,C1
-departure lounge,departure lounge,候机室,NOUN,B2
-dependency,dependency,词,NOUN,B2
-dependent passivity,dependent passivity,词,NOUN,C1
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-deplete,deplete,词,VERB,C1
-depletion,depletion,词,NOUN,C1
-depone,depone,词,VERB,C1
-deportation,deportation,驱逐出境,NOUN,B2
-deposition,deposition,证词,NOUN,B2
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depot,depot,仓库,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-deprecation,deprecation,词,NOUN,C1
-depredate,depredate,词,VERB,C1
-depredation,depredation,词,NOUN,C1
-depressing,depressing,令人沮丧的,ADJ,B2
-deputation,deputation,代表团,NOUN,B2
-depute,depute,词,VERB,C1
-deputy (adj),deputy,副,ADJ,B2
-deracinate,deracinate,词,VERB,C1
-derailment,derailment,词,NOUN,C1
-derange,derange,词,VERB,C1
-derby,derby,词,NOUN,B2
-deregulate,deregulate,词,VERB,C1
-deride,deride,词,VERB,C1
-derivation,derivation,词,NOUN,C1
-dermal,dermal,词,ADJ,C1
-dernièrement,last,最后,ADV,B2
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-derrière,behind,在后面,ADV,B2
-desalination,desalination,词,NOUN,C1
-descant,descant,词,VERB,C1
-descend go down,descend go down,词,VERB,A1
-descendant,descendant,后代,NOUN,B2
-descending,descending,词,ADJ,C1
-descendre,to descend,下降,VERB,B2
-descente,descent,下降,NOUN,B2
-descente de montagne,mountain descent,下山,NOUN,B2
-describable,describable,词,ADJ,C1
-description,description,描述,NOUN,B2
-descriptiveness,descriptiveness,词,NOUN,C1
-descry,descry,词,VERB,C1
-desecrate,desecrate,词,VERB,C1
-desecration,desecration,词,NOUN,C1
-desegregate,desegregate,词,VERB,C1
-deserter,deserter,逃兵,NOUN,B2
-desertion,desertion,逃亡,NOUN,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desiccation,desiccation,词,NOUN,C1
-desirability,desirability,可取性,NOUN,B2
-desirable,desirable,可取的,ADJ,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-despatch,despatch,词,VERB,C1
-desperately serious,desperately serious,不得了,ADJ,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despond,despond,词,VERB,C1
-despote,despot,暴君,NOUN,B2
-despotic,despotic,专制的,ADJ,B2
-despotisme,despotism,专制,NOUN,B2
-desquamation,desquamation,词,NOUN,C1
-desserrer,to loosen,放松,VERB,B2
-dessert,dessert,甜点,NOUN,B2
-dessous,below,在...下面,ADP,B2
-dessous,inside story,内幕,NOUN,B2
-destin,destiny,命运,NOUN,B2
-destination,destination,目的地,NOUN,B2
-destine,destine,词,VERB,C1
-destined,destined,,NOUN,B2
-destitute,destitute,词,ADJ,C1
-destroyed,destroyed,被毁坏的,ADJ,B2
-destroyer,destroyer,词,NOUN,C1
-destructeur,destructive,مدمر,ADJ,B2
-destruction,destruction,破坏,NOUN,B2
-destruction of property,destruction of property,毁坏财物,NOUN,C1
-detachable,detachable,词,ADJ,C1
-details,details,细细,NOUN,C1
-detective force,detective force,刑警,NOUN,B2
-detention center,detention center,拘留所,NOUN,B2
-deter,deter,词,VERB,C1
-detergent,detergent,洗涤剂,NOUN,B2
-deteriorated,deteriorated,恶化的,ADJ,B2
-determinant,determinant,词,NOUN,C1
-determine,determine,确定,VER! B,B2
-determined definite,determined definite,确定的,ADJ,B2
-determinist,determinist,词,ADJ,C1
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
-detritus,detritus,词,NOUN,C1
+fille,daughter,女儿,NOUN,B2
+jour et nuit,day and night,昼夜,NOUN,B2
+journalier,day laborer,日工,NOUN,B2
+éblouissant,dazzling,耀眼的,ADJ,B2
+mort,dead,死的,ADJ,B2
+échéance,deadline,截止日期,NOUN,B2
+accord,deal,交易,NOUN,B2
+traiter,to deal with,处理,VERB,B2
+cher,dear,亲爱的,ADJ,B2
+peine de mort,death penalty,死刑,NOUN,B2
+désir de mort,death wish,找死,NOUN,B2
 dette,debts,债务,NOUN,B2
-dette de sang,blood debt,血债,NOUN,B2
-deux,two animals,两只,NUM,B2
-deux fois,twice,两次,ADV,B2
-devastated,devastated,崩溃的,ADJ,B2
-devastating,devastating,毁灭性的,ADJ,B2
-devastation,devastation,破坏,NOUN,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-devenir fou,to go crazy,发疯,VERB,B2
-deviance,deviance,词,NOUN,B2
-devices,devices,设备,NOUN,B2
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devilish,devilish,恶魔般的,ADJ,B2
-devious,devious,词,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid,devoid,词,ADJ,C1
-devoir,must,必须,AUX,B2
-devoir,should,应该,AUX,B2
-devoir,have to,还得,NOUN,B2
-devoir,to owe,欠,VERB,B2
-devoirs,homework,家庭作业,NOUN,B2
-devolution,devolution,词,NOUN,C1
-devolve,devolve,词,VERB,C1
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devourer,devourer,吞噬者,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-dexterity,dexterity,灵巧,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
-diabetic,diabetic,词,ADJ,C1
-diachrony,diachrony,词,NOUN,C1
-diagonally,diagonally,对角地,ADV,B2
-dial (verb),dial,词,VERB,B2
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialogism,dialogism,词,NOUN,C1
-dialogue,dialogue,对话,NOUN,B2
-diamant,diamond,钻石,NOUN,B2
-diameter,diameter,词,NOUN,C1
-diapers,diapers,词,NOUN,B1
-diaphanous,diaphanous,词,ADJ,C1
-diaphragm,diaphragm,横膈膜,NOUN,B2
-diarrhée,diarrhea,腹泻,NOUN,B2
-diaspora,diaspora,流散,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-diatribe,diatribe,词,NOUN,C1
-dichotomy,dichotomy,二分法,NOUN,B2
-dictation,dictation,dictation,NOUN,B2
-dictature,dictatorship,独裁统治,NOUN,B2
-diction,diction,措辞,NOUN,B2
-dictionnaire,dictionary,词典,NOUN,B2
-didactics,didactics,词,NOUN,C1
-die,die,骰子,NOUN,B2
-dietary,dietary,词,ADJ,C1
-dieu de la guerre,god of war,战神,NOUN,B2
-different,different,不同地,ADV,B2
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
-difficile à aborder,hard to speak of,难以启齿,ADJ,B2
-difficile à choisir,hard to choose,难以抉择,ADJ,B2
-difficile à distinguer,hard to distinguish,难以区分,ADJ,B2
-difficile à maintenir,hard to maintain,难以维持,ADJ,B2
-difficult flirt,difficult flirt,,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-difficulté,difficulty,困难,NOUN,B2
-diffuse,diffuse,模糊的,ADJ,B2
-diffuser,to diffuse,扩散,VERB,B2
-diffusion,broadcast,广播,NOUN,B2
-diffusion,diffusion,传播,NOUN,B2
-diffusion spread,diffusion spread,词,NOUN,C1
-dig up,dig up,词,VERB,B2
-digestible,digestible,词,ADJ,C1
-digestion,digestion,消化,NOUN,B2
-digital currency,digital currency,数字货币,NOUN,C1
-digitized,digitized,词,ADJ,C1
-dignified,dignified,词,ADJ,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignify,dignify,词,VERB,C1
-dignitaries,dignitaries,词,NOUN,C1
-digression,digression,词,NOUN,C1
-dike,dike,词,NOUN,B2
-dilatation,dilation,扩张,NOUN,B2
-dilated,dilated,词,ADJ,C1
-diligence,diligence,勤勉,NOUN,B2
-dilution,dilution,词,NOUN,C1
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-dimension,dimension,维度,NOUN,B2
-diminutive,diminutive,指小词,NOUN,B2
-dimmed,dimmed,词,ADJ,C1
-dimple,dimple,词,NOUN,C1
-din,din,喧嚣,NOUN,B2
-dine,dine,词,VERB,C1
-dining hall,dining hall,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
-dinosaure,dinosaur,恐龙,NOUN,B2
-diocesan,diocesan,词,ADJ,C1
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-dipsomaniac,dipsomaniac,词,NOUN,C1
-dire au revoir,to say goodbye,告别,VERB,B2
-dire des bêtises,to talk nonsense,胡言乱语,VERB,B2
-direct,direct,直接的,ADJ,B2
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directing,directing,导演,NOUN,B2
-direction,direction,方向,NOUN,B2
-directionality,directionality,词,NOUN,C1
-directive,directive,指令,NOUN,B2
-directive (adj),directive,词,ADJ,C1
-directness,directness,词,NOUN,C1
-director manager,director manager,主管/经理,NOUN,B2
-directorate,directorate,局,NOUN,C1
-directorship,directorship,董事职位,NOUN,B2
-dirham,dirham,词,NOUN,A1
-diriger,to steer,引导,VERB,B2
-dirt soil,dirt soil,词,NOUN,A1
-dirtier,dirtier,更脏的,ADJ,B2
-dirty bastard,dirty bastard,词,NOUN,C1
-dirty trick,dirty trick,词,NOUN,B2
-disable,disable,词,VERB,C1
-disadvantageous,disadvantageous,不利的,ADJ,B2
-disaffect,disaffect,词,VERB,C1
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disagreeing,disagreeing,不同意的,ADJ,B2
-disallow,disallow,词,VERB,C1
-disapproval,disapproval,词,NOUN,C1
-disarray (noun),disarray,词,NOUN,C1
-disassembly,disassembly,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-disbursement,disbursement,词,NOUN,C1
-disciple,disciple,门徒,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
-disciplined,disciplined,词,ADJ,C1
-discipliner,discipline,纪律,NOUN,B2
-discipliner,to discipline,管教,VERB,B2
-disclaim,disclaim,词,VERB,C1
-disclosure,disclosure,泄露,NOUN,C1
-disco,disco,迪厅,NOUN,B2
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
-disconnection,disconnection,词,NOUN,C1
-disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
-disconsolation,disconsolation,词,NOUN,C1
-discontinuer,to discontinue,停止,VERB,B2
-discontinuity,discontinuity,词,NOUN,B2
-discordance,discordance,不一致,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discounts,discounts,折扣,NOUN,B2
-discouragement,discouragement,词,NOUN,C1
-discours,discourse,论述,NOUN,B2
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit,discredit,丧失信誉,NOUN,B2
-discrediting,discrediting,词,NOUN,C1
-discrepancy,discrepancy,差异,NOUN,B2
-discrete,discrete,词,ADJ,C1
-discretionary,discretionary,自由裁量的,ADJ,B2
-discretionary punishment,discretionary punishment,词,NOUN,C1
-discrimination,discrimination,歧视,NOUN,B2
-discursive,discursive,词,ADJ,C1
-discussion,discussion,讨论,NOUN,B2
-discuter,to discuss,讨论,VERB,B2
-disdainful,disdainful,词,ADJ,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenchantment,disenchantment,幻灭,NOUN,B2
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
-disengagement,disengagement,词,NOUN,B2
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disgorge,disgorge,词,VERB,C1
-disgruntle,disgruntle,词,VERB,C1
-disharmony,disharmony,不和谐,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-dishes,dishes,词,NOUN,C1
-disheveled,disheveled,蓬乱的,ADJ,B2
-dishonor,dishonor,耻辱,NOUN,B2
-dishonorable,dishonorable,词,ADJ,C1
-dishwasher,dishwasher,洗碗机,NOUN,B2
-disillusion,disillusion,词,VERB,C1
-disillusionment,disillusionment,词,NOUN,C1
-disincline,disincline,词,VERB,C1
-disinhibited,disinhibited,词,ADJ,C1
-disintegration,disintegration,词,NOUN,B2
-disinter,disinter,词,VERB,C1
-disinterest,disinterest,公正;不感兴趣,NOUN,B2
-disjoint,disjoint,不相交的,ADJ,B2
-disjointed,disjointed,词,ADJ,C1
-dislike,dislike,厌恶,NOUN,B2
-disloyal,disloyal,不忠的,ADJ,B2
-disloyalty,disloyalty,不忠,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
-dismember,dismember,词,VERB,C1
-disobedient,disobedient,不服从的,ADJ,B2
-disorganization,disorganization,无组织,NOUN,B2
-disorganize,disorganize,词,VERB,C1
-disoriented,disoriented,词,ADJ,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparagement,disparagement,词,NOUN,C1
-disparate,disparate,截然不同的,ADJ,B2
-disparaître,to vanish,消失,VERB,B2
-dispassionate,dispassionate,词,ADJ,C1
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displace,displace,词,VERB,C1
-displaced person,displaced person,词,NOUN,C1
-displacement,displacement,位移,NOUN,B2
-displeased,displeased,词,ADJ,C1
-disport,disport,词,VERB,C1
-disposable,disposable,一次性的,ADJ,B2
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposed,disposed,词,ADJ,C1
-disposition,disposition,性情,NOUN,B2
-dispossessed,dispossessed,词,ADJ,C1
-disproportion,disproportion,不成比例,NOUN,B2
-disproportionate,disproportionate,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-disputation,disputation,词,NOUN,C1
-disputed case,disputed case,词,NOUN,C1
-disqualification,disqualification,词,NOUN,C1
-disque,disk,唱片,NOUN,B2
-disquiet,disquiet,词,NOUN,C1
-disquisition,disquisition,论述,NOUN,B2
-disrepair,disrepair,词,NOUN,C1
-disrepute,disrepute,坏名声,NOUN,B2
-disrespect,disrespect,不敬,NOUN,B2
-disrespectful,disrespectful,无礼的,ADJ,B2
-disrobe,disrobe,词,VERB,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfy,dissatisfy,词,VERB,C1
-dissemble,dissemble,词,VERB,C1
-dissembling,dissembling,词,ADJ,C1
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
-dissert,dissert,词,VERB,C1
-dissertation,dissertation,论文,NOUN,B2
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissidence,dissent,异议,NOUN,B2
-dissident,dissident,异见者,NOUN,B2
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
-dissipation,dissipation,挥霍,NOUN,B2
-dissociate,dissociate,词,VERB,C1
-dissociation,dissociation,解离,NOUN,B2
-dissolute,dissolute,放荡的,ADJ,B2
-dissolution,dissolution,溶解,NOUN,B2
-dissonance,dissonance,不和谐,NOUN,B2
-dissonant,dissonant,词,ADJ,C1
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-disséminer,to disseminate,传播,VERB,B2
-distance,distance,距离,NOUN,B2
-distanciation sociale,social distancing,社交距离,NOUN,B2
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distil,distil,词,VERB,C1
-distillation,distillation,词,NOUN,C1
-distinct,distinct,明显的,ADJ,B2
-distinction,distinction,区别,NOUN,B2
-distinctive,distinctive,独特的,ADJ,B2
-distinguishable,distinguishable,词,ADJ,C1
-distingué,distinguished,杰出,ADJ,B2
-distorted,distorted,歪曲的,ADJ,B2
-distorted image,distorted image,扭曲的形象,NOUN,B2
-distraction,absent-mindedness,心不在焉,NOUN,B2
-distraction,distraction,分心,NOUN,B2
-distrain,distrain,词,VERB,C1
-distrait,distracted,分心的,ADJ,B2
-distrait,forgetful,健忘的,ADJ,B2
-distributed,distributed,词,ADJ,C1
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
-distrustful,distrustful,词,ADJ,C1
-disturbance,disturbance,干扰,NOUN,B2
-disturbed,disturbed,不安的,ADJ,B2
-disuse,disuse,废弃,NOUN,B2
-dive appear,dive appear,词,VERB,B2
-diver,diver,词,NOUN,B2
-divergence,divergence,分歧,NOUN,B2
-divergent,divergent,分歧的,ADJ,B2
-diverging,diverging,词,ADJ,C1
-diverse,diverse,多样的,ADJ,B2
-diversification,diversification,多样化,NOUN,B2
-divestment,divestment,词,NOUN,C1
-divider,divider,词,NOUN,C1
-divin,divine,如神,NOUN,B2
-divination,divination,占卜,NOUN,B2
-divinatory,divinatory,词,ADJ,C1
-divine (noun),divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
-divinité,deity,神,NOUN,B2
-divisibility,divisibility,词,NOUN,C1
-divisible,divisible,可分的,ADJ,B2
-division,division,分开,NOUN,B2
-divisive,divisive,词,ADJ,C1
-divisor,divisor,词,NOUN,C1
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
-divorcer,divorce,离婚,NOUN,B2
-divorcer,to divorce,离婚,VERB,B2
-divulguer,to disclose,揭露,VERB,B2
-djellaba,djellaba,词,NOUN,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
-do not want,do not want,不想,VERB,B2
-do one's best (adv),do one's best,竭力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-docile,docile,温顺的,ADJ,B2
-docilité,docility,温顺,NOUN,B2
-doctor visit,doctor visit,,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
-doctrinaire,doctrinaire,教条主义的,ADJ,B2
-doctrine,doctrine,词,NOUN,B2
-document original,original document,原件,NOUN,B2
-documentaire,documentary,纪录片的,ADJ,B2
-documentary (adj),documentary,纪录的,ADJ,B2
-documentation,documentation,文献,NOUN,B2
-documented,documented,词,ADJ,C1
-documenter,document,文件,NOUN,B2
-documenter,to document,记录,VERB,B2
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-dollar,buck,美元,NOUN,B2
-dollar,dollar,词,NOUN,C1
-domain,domain,领域,NOUN,B2
-domaine,estate,地产,NOUN,B2
-domestic,domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
-domesticate,domesticate,词,VERB,C1
-domestication,domestication,驯化,NOUN,B2
-dominance,dominance,威权,NOUN,B2
-dominant,dominant,占主导地位的,ADJ,B2
-domineering,domineering,词,ADJ,C1
-domineeringness,domineeringness,支配欲,NOUN,B2
-dommage,damage,损害,NOUN,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
-donation,donation,捐款,NOUN,B2
-donation of goods,donation of goods,捐物,NOUN,C1
-donkey foal,donkey foal,词,NOUN,B2
-donner,to donate,捐赠,VERB,B2
-donner une conférence,lecture,讲座,NOUN,B2
-donner une conférence,to lecture,教导,VERB,B2
-donnée,given,给定,NOUN,B2
-doom,doom,词,VERB,C1
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door lock,door lock,门锁,NOUN,C1
-doorbell button,doorbell button,门铃按钮,NOUN,B2
-doorkeeper,doorkeeper,词,NOUN,B1
-doorway,doorway,门口,NOUN,C1
-dope (noun),dope,词,NOUN,B2
-doping agents,doping agents,词,NOUN,B2
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
-dose,dose,剂量,NOUN,B2
-dossier,dossier,档案,NOUN,B2
-dossier,folder,文件夹,NOUN,B2
-dossier médical,medical record,病历,NOUN,B2
-dot,dot,点,NOUN,B2
-dot,dowry,嫁妆,NOUN,B2
-dotting,dotting,词,NOUN,C1
-double,double,两倍的,ADJ,B2
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubtful,doubtful,可疑的,ADJ,B2
-doughy,doughy,面团状的,ADJ,B2
-douleur,pain,疼痛,NOUN,B2
-douleur musculaire,muscle pain,肌肉痛,NOUN,B2
-douleur thoracique,chest pain,胸痛,NOUN,B2
-douse,douse,词,VERB,C1
-douzaine,dozen,一打,NOUN,B2
-douze,twelve,十二,NUM,B2
-down,down,向下,ADV,B2
-down (noun),down,下…,NOUN,C1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downfall,downfall,毁灭,NOUN,B2
-downgrade,downgrade,词,VERB,C1
-downplay,downplay,词,VERB,C1
-downplaying,downplaying,词,NOUN,C1
-downsize,downsize,词,VERB,C1
-downstairs,downstairs,词,ADV,B1
-doze (noun),doze,词,NOUN,C1
-doze (verb),doze,词,VERB,C1
-doze off,doze off,词,VERB,B2
-dozens,dozens,数十个,NOUN,B2
-draconian,draconian,词,ADJ,C1
-drag,drag,拖曳,NOUN,B2
-dragon,dragon,龙,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-dragoon,dragoon,词,VERB,C1
-drainage,drainage,词,NOUN,C1
-drainage sewage,drainage sewage,词,NOUN,C1
-dramatization,dramatization,词,NOUN,C1
-drastic,drastic,词,ADJ,C1
-draught,draught,词,NOUN,C1
-draw,draw,平局,NOUN,B2
-draw blood,draw blood,抽血,VERB,B2
-drawl,drawl,词,VERB,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge,dredge,,NOUN,B2
-dredge (verb),dredge,词,VERB,C1
-drench,drench,词,VERB,C1
-dressed,dressed,穿着的,ADJ,B2
-dribble,dribble,词,VERB,C1
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
-drift (verb),drift,词,VERB,B2
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinking water,drinking water,饮用水,NOUN,B2
-drinks,drinks,词,NOUN,C1
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-drive,drive,动力,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-drivel,drivel,词,NOUN,C1
-driven,driven,被驾驶的,ADJ,B2
-driving,driving,你来驾车,NOUN,C1
-drizzly,drizzly,词,ADJ,C1
-droit,upright,正直的,ADJ,B2
-droit d'auteur,copyright,版权,NOUN,B2
-droits,rights,权利,NOUN,B2
-droiture,righteousness,亦正,NOUN,B2
-drone,drone,无人机,NOUN,B2
-droop,droop,词,VERB,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
-dropper,dropper,词,NOUN,C1
-drops,drops,词,NOUN,B1
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drug medication,drug medication,词,NOUN,C1
-drugs,drugs,毒品,NOUN,B2
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
-drunkenness,drunkenness,醉酒,NOUN,B2
-dry land,dry land,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-du jour au lendemain,overnight,一夜之间,ADV,B2
-du tout,at all,根本,ADV,B2
-dual,dual,词,ADJ,C1
-dual form,dual form,词,NOUN,C1
-dualisme,dualism,二元论,NOUN,B2
-dub,dub,词,VERB,C1
-duc,duke,公爵,NOUN,B2
-ductile,ductile,词,ADJ,C1
-dude,dude,词,NOUN,A2
-due date maturity,due date maturity,词,NOUN,B2
-duel,duel,词,NOUN,C1
-duet,duet,二重奏,NOUN,B2
-dull-witted,dull-witted,词,ADJ,B2
-dumbfound,dumbfound,词,VERB,C1
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dump site,dump site,词,NOUN,B2
-dumping,dumping,倾销,NOUN,B2
-dune,dune,沙丘,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-dungeon,dungeon,地牢,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicate,duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
-dupliquer,to duplicate,复制,VERB,B2
-dur,tough,艰难的,ADJ,B2
-durable,durable,词,ADJ,C1
-durer,to last a period of time,为期,VERB,B2
-dureté,hardness,硬度,NOUN,B2
-durian,durian,榴莲,NOUN,C1
-during the day,during the day,在白天,ADV,B2
-durée de vie,lifetime,一生,NOUN,B2
-dusk,dusk,黄昏,NOUN,B2
-dust coat,dust coat,词,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-dutch,dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty,duty,责任,NOUN,B2
-duty of care,duty of care,词,NOUN,C1
-duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
-dwell,dwell,词,VERB,C1
-dwindle,dwindle,词,VERB,C1
-dwindling,dwindling,词,NOUN,C1
-dyed,dyed,词,ADJ,B1
-dying,dying,,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamics,dynamics,词,NOUN,C1
-dynamite,dynamite,炸药,NOUN,B2
-dynastie actuelle,current dynasty,当朝,NOUN,B2
-dysfunction,dysfunction,功能障碍,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
-dystopia,dystopia,反乌托邦,NOUN,B2
-dès l'enfance,from childhood,从小,ADV,B2
-dès que,as soon as,一...就,SCONJ,B2
-dès à présent,hereby,特此,ADV,B2
 décadent,decadent,颓废,ADJ,B2
-décharge,discharge,放电,NOUN,B2
-déchirer,to tear up,流泪,VERB,B2
+défunt,deceased,死者,NOUN,B2
+trompeur,deceitful,欺诈的,ADJ,B2
+défi de tromperie,deception dare,你敢骗我,NOUN,B2
 déclaration,declaration,宣言,NOUN,B2
-déclaration,statement,声明,NOUN,B2
-déclarer,state,国家,NOUN,B2
-déclarer,to state,说明,VERB,B2
 déclin,decline,衰退,NOUN,B2
+refuser poliment,to decline politely,婉拒,VERB,B2
 décommissionnement,decommissioning,退役,NOUN,B2
 décomposer,to decompose,分解,VERB,B2
-déconnecter,to disconnect,断开,VERB,B2
-déconseiller,to advise against,劝阻,VERB,B2
-déconstruction,deconstruction,解构主义,NOUN,B2
 déconstruire,to deconstruct,解构,VERB,B2
-découpe de papier,paper cutting,剪纸,NOUN,B2
-découvrir,to find out,找出,VERB,B2
-découvrir,to uncover,揭露,VERB,B2
-décret oral,oral decree,口谕,NOUN,B2
-décryptage,decryption,解密,NOUN,B2
+déconstruction,deconstruction,解构主义,NOUN,B2
 décréter,to decree,颁布法令,VERB,B2
-décéder,to part by death,死别,VERB,B2
+décryptage,decryption,解密,NOUN,B2
 déduire,to deduct,扣除,VERB,B2
-défaite écrasante,crushing defeat,惨败,NOUN,B2
-défaitisme,defeatism,失败主义,NOUN,B2
-défaut,blemish,瑕疵,NOUN,B2
+acte,deed,行为,NOUN,B2
+frire,to deep-fry,油炸,VERB,B2
 défaut,default,违约,NOUN,B2
-défaut,shortcoming,缺点,NOUN,B2
+défaitisme,defeatism,失败主义,NOUN,B2
 défectionner,defect,缺陷,NOUN,B2
 défectionner,to defect,叛变,VERB,B2
 défendre son pays,to defend one's country,卫国,VERB,B2
-défense aérienne,air defense,防空,NOUN,B2
 défenseur,defender,防守者,NOUN,B2
 défi,defiance,挑衅,NOUN,B2
-défi de tromperie,deception dare,你敢骗我,NOUN,B2
 défiant,defiant,挑衅的,ADJ,B2
 déficient,deficient,有缺陷的,ADJ,B2
-déficit,impairment,左手废,NOUN,B2
-défier,to defy,违抗,VERB,B2
-définitif,definitive,决定性的,ADJ,B2
-définition,definition,定义,NOUN,B2
 définitivement,definitely,肯定地,ADV,B2
+définition,definition,定义,NOUN,B2
+définitif,definitive,决定性的,ADJ,B2
 déformation,deformation,变形,NOUN,B2
-défunt,late,晚的,ADJ,B2
-défunt,deceased,死者,NOUN,B2
-dégeler,to thaw,解冻,VERB,B2
+escroquer,to defraud,诈骗,VERB,B2
+défier,to defy,违抗,VERB,B2
 dégenerer,to degenerate,退化,VERB,B2
-dégoût,disgust,厌恶,NOUN,B2
-dégoûtant,disgusting,令人厌恶的,ADJ,B2
-déjeuner,lunch,午餐,NOUN,B2
+divinité,deity,神,NOUN,B2
+abattu,dejected,沮丧的,ADJ,B2
+supprimer,to delete,删除,VERB,B2
 délicieux,delicious,美味的,ADJ,B2
 délinquant,delinquent,罪犯,NOUN,B2
-délire,delusion,幻想,NOUN,B2
-délivrer,to dispense medicine,配药,VERB,B2
+livrer,to deliver,递送,VERB,B2
 déluge,deluge,洪水,NOUN,B2
-démanger,to itch,发痒,VERB,B2
+délire,delusion,幻想,NOUN,B2
+demande,demand,需求,NOUN,B2
 démence,dementia,痴呆,NOUN,B2
 démilitarisation,demilitarization,去武,NOUN,B2
 démocratie,democracy,民主,NOUN,B2
 démographie,demography,人口学,NOUN,B2
-démonter,to disassemble,拆卸,VERB,B2
-déménagement,move,搬家,NOUN,B2
 dénotation,denotation,外延,NOUN,B2
-dénouer,to untie,解开,VERB,B2
-départ,his departure,他走,NOUN,B2
-départements divers,various departments,各部,NOUN,B2
-dépasser,to overdraw,透支,VERB,B2
-dépasser,to overtake,超过,VERB,B2
-dépeindre,to depict,描绘,VERB,B2
-dépeindre,to portray,描绘,VERB,B2
+dense,dense,密集的,ADJ,B2
+dentiste,dentist,牙医,NOUN,B2
+partir,to depart,离开,VERB,B2
+chef de département,department head,厅长,NOUN,B2
+grand magasin,department store,百货商店,NOUN,B2
 dépendre de,to depend on,依赖,VERB,B2
-dépense,expenditure,支出,NOUN,B2
-dépense,expenses,费用,NOUN,B2
-dépenser,to expend,花费,VERB,B2
+dépeindre,to depict,描绘,VERB,B2
 déployer,to deploy,部署,VERB,B2
 dépression,depression,抑郁,NOUN,B2
-déracinement,uprooting,背井离乡,NOUN,B2
-déraisonnable,unreasonable,不合理的,ADJ,B2
-dérive,drift,漂移,NOUN,B2
-dérive,drifting,漂泊,NOUN,B2
+adjoint,deputy,副的,ADJ,B2
 dériver,to derive,源于,VERB,B2
+descendre,to descend,下降,VERB,B2
+descendant,descendant,后代,NOUN,B2
+descente,descent,下降,NOUN,B2
+description,description,描述,NOUN,B2
+conducteur désigné,designated driver,代驾,NOUN,B2
+bureau,desk,书桌,NOUN,B2
+désolé,desolate,荒凉的,ADJ,B2
+méprisable,despicable,可鄙的,ADJ,B2
+despote,despot,暴君,NOUN,B2
+despotisme,despotism,专制,NOUN,B2
+dessert,dessert,甜点,NOUN,B2
+déstabilisation,destabilization,动摇,NOUN,B2
+destination,destination,目的地,NOUN,B2
+destin,destiny,命运,NOUN,B2
+destruction,destruction,破坏,NOUN,B2
+destructeur,destructive,مدمر,ADJ,B2
+détenir,to detain,拘留,VERB,B2
+détective,detective,侦探,NOUN,B2
+détente,detente,缓和,NOUN,B2
+détériorer,to deteriorate,恶化,VERB,B2
+déterminé,determined,下定决心的,ADJ,B2
+détoner,to detonate,引爆,VERB,B2
+détonation,detonation,爆炸,NOUN,B2
+détoxifier,to detoxify,解毒,VERB,B2
+développé,developed,发达的,ADJ,B2
+concevoir,to devise,设计,VERB,B2
+dialogue,dialogue,对话,NOUN,B2
+diamant,diamond,钻石,NOUN,B2
+couche,diaper,尿布,NOUN,B2
+diarrhée,diarrhea,腹泻,NOUN,B2
+diaspora,diaspora,流散,NOUN,B2
+dictature,dictatorship,独裁统治,NOUN,B2
+dictionnaire,dictionary,词典,NOUN,B2
+attaque difficile,difficult attack,难攻,NOUN,B2
+problème difficile,difficult problem,难题,NOUN,B2
+difficulté,difficulty,困难,NOUN,B2
+diffuser,to diffuse,扩散,VERB,B2
+digestion,digestion,消化,NOUN,B2
+creusement,digging,挖掘,NOUN,B2
+numérisation,digitization,数字化,NOUN,B2
+dilatation,dilation,扩张,NOUN,B2
+diligence,diligence,勤勉,NOUN,B2
+dimension,dimension,维度,NOUN,B2
+dîner,dinner,晚餐,NOUN,B2
+dinosaure,dinosaur,恐龙,NOUN,B2
+plonger,to dip,蘸,VERB,B2
+direct,direct,直接的,ADJ,B2
+direction,direction,方向,NOUN,B2
+panneau de direction,direction sign,指示牌,NOUN,B2
+directive,directive,指令,NOUN,B2
+saleté,dirt,污垢,NOUN,B2
+sale,dirty,脏的,ADJ,B2
 désapprouver,to disagree,不同意,VERB,B2
 désapprouver,to disapprove,不赞成,VERB,B2
+démonter,to disassemble,拆卸,VERB,B2
+incrédulité,disbelief,不信,NOUN,B2
+jeter,to discard,丢弃,VERB,B2
+décharge,discharge,放电,NOUN,B2
+disciple,disciple,门徒,NOUN,B2
+discipliner,discipline,纪律,NOUN,B2
+discipliner,to discipline,管教,VERB,B2
+divulguer,to disclose,揭露,VERB,B2
+déconnecter,to disconnect,断开,VERB,B2
+discontinuer,to discontinue,停止,VERB,B2
+discordance,discordance,不一致,NOUN,B2
+discours,discourse,论述,NOUN,B2
+discrimination,discrimination,歧视,NOUN,B2
+discuter,to discuss,讨论,VERB,B2
+discussion,discussion,讨论,NOUN,B2
+maladie,disease,疾病,NOUN,B2
 déshonneur,disgrace,耻辱,NOUN,B2
+dégoût,disgust,厌恶,NOUN,B2
+dégoûtant,disgusting,令人厌恶的,ADJ,B2
 désinfectant,disinfectant,消毒剂,NOUN,B2
-désir,longing,渴望,NOUN,B2
-désir ardent,really want,真要,NOUN,B2
-désir de mort,death wish,找死,NOUN,B2
-désir de séduire,want to lure,想引,NOUN,B2
-désirer,to crave,渴望,VERB,B2
-désolé,desolate,荒凉的,ADJ,B2
-désordonné,disorderly,杂乱的,ADJ,B2
-désordonné,messy,混乱的,ADJ,B2
-désordre,mess,混乱,NOUN,B2
-désorientation,disorientation,迷失方向,NOUN,B2
-déstabilisation,destabilization,动摇,NOUN,B2
-détail,retail,零售,NOUN,B2
-détails,its details,其详,NOUN,B2
-détective,detective,侦探,NOUN,B2
-détenir,to detain,拘留,VERB,B2
-détente,detente,缓和,NOUN,B2
-déterminé,determined,下定决心的,ADJ,B2
+disque,disk,唱片,NOUN,B2
 détester,to dislike,不喜欢,VERB,B2
-détonation,detonation,爆炸,NOUN,B2
-détoner,to detonate,引爆,VERB,B2
-détourner,to embezzle,贪污,VERB,B2
-détoxifier,to detoxify,解毒,VERB,B2
-détériorer,to deteriorate,恶化,VERB,B2
-développé,developed,发达的,ADJ,B2
-dîme,tithe,什一税,NOUN,B2
-dîner,dinner,晚餐,NOUN,B2
+désordonné,disorderly,杂乱的,ADJ,B2
+désorientation,disorientation,迷失方向,NOUN,B2
+délivrer,to dispense medicine,配药,VERB,B2
+mécontentement,displeasure,不悦,NOUN,B2
+élimination,disposal,处理,NOUN,B2
+contesté,disputed,有争议的,ADJ,B2
+négliger,to disregard,忽视,VERB,B2
+disséminer,to disseminate,传播,VERB,B2
+dissidence,dissent,异议,NOUN,B2
+dissertation,dissertation,论文,NOUN,B2
+dissipation,dissipation,挥霍,NOUN,B2
+dissolution,dissolution,溶解,NOUN,B2
+dissonance,dissonance,不和谐,NOUN,B2
+distance,distance,距离,NOUN,B2
+distinct,distinct,明显的,ADJ,B2
+distinction,distinction,区别,NOUN,B2
+distingué,distinguished,杰出,ADJ,B2
+distrait,distracted,分心的,ADJ,B2
+distraction,distraction,分心,NOUN,B2
+chef de district,district head,区长,NOUN,B2
+disturbance,disturbance,干扰,NOUN,B2
+divergent,divergent,分歧的,ADJ,B2
+diversification,diversification,多样化,NOUN,B2
+divination,divination,占卜,NOUN,B2
+divin,divine,如神,NOUN,B2
+division,division,分开,NOUN,B2
+divorcer,divorce,离婚,NOUN,B2
+divorcer,to divorce,离婚,VERB,B2
+vertige,dizziness,眩晕,NOUN,B2
+étourdi,dizzy,头晕的,ADJ,B2
+ne pas,do not,莫,ADV,B2
+non-utilisation,do not use,别用,NOUN,B2
+s'efforcer,to do one's best,尽力,VERB,B2
+réaliser,to do to make,做,VERB,B2
+docilité,docility,温顺,NOUN,B2
+quai,dock,码头,NOUN,B2
+documenter,document,文件,NOUN,B2
+documenter,to document,记录,VERB,B2
+documentaire,documentary,纪录片的,ADJ,B2
+domestication,domestication,驯化,NOUN,B2
+dominant,dominant,占主导地位的,ADJ,B2
+donner,to donate,捐赠,VERB,B2
+donation,donation,捐款,NOUN,B2
+fait,done,事已,NOUN,B2
+âne,donkey,驴,NOUN,B2
+poignée de porte,door handle,门把手,NOUN,B2
+concierge,doorman,门卫,NOUN,B2
+dose,dose,剂量,NOUN,B2
+double,double,两倍的,ADJ,B2
+en bas,down,顺...而下,ADP,B2
+télécharger,to download,下载,VERB,B2
+averse,downpour,倾盆大雨,NOUN,B2
+vers le bas,downwards,向下,ADV,B2
+dot,dowry,嫁妆,NOUN,B2
+douzaine,dozen,一打,NOUN,B2
+dragon,dragon,龙,NOUN,B2
+égout,drain,排水沟,NOUN,B2
+s'appuyer,to draw on the experience of,借鉴,VERB,B2
+tirage,draw out,引出,NOUN,B2
+rêver,to dream,做梦,VERB,B2
+marc,dregs,渣滓,NOUN,B2
+se déguiser,to dress up,盛装打扮,VERB,B2
+tofu séché,dried tofu,豆干,NOUN,B2
+dérive,drift,漂移,NOUN,B2
+dérive,drifting,漂泊,NOUN,B2
+boisson,drink,饮料,NOUN,B2
+permis de conduire,driver's license,驾驶证,NOUN,B2
+allée,driveway,车道,NOUN,B2
+drone,drone,无人机,NOUN,B2
+tomber,to drop,掉落,VERB,B2
+somnolence,drowsiness,昏睡,NOUN,B2
+dualisme,dualism,二元论,NOUN,B2
 dû,due,到期的,ADJ,B2
+en raison de,due to,由于,ADP,B2
+duc,duke,公爵,NOUN,B2
+ennui,dullness,迟钝,NOUN,B2
+bête,dumb,愚蠢的,ADJ,B2
+ravioli,dumpling,丸子,NOUN,B2
+dune,dune,沙丘,NOUN,B2
+dupliquer,to duplicate,复制,VERB,B2
+during the day,during the day,在白天,ADV,B2
+dusk,dusk,黄昏,NOUN,B2
+duty,duty,责任,NOUN,B2
+dysfunction,dysfunction,功能障碍,NOUN,B2
+dystopia,dystopia,反乌托邦,NOUN,B2
 each,each,每个,PRON,B2
-each (noun),each,一一,NOUN,C1
-each every,each every,每,DET,A1
 each other,each other,互相,PRON,B2
 eager,eager,渴望的,ADJ,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-eagerness,eagerness,词,NOUN,B2
 earlier,earlier,刚才,ADV,B2
-earlier (adj),earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
 early,early,早的,ADJ,B2
-early (noun),early,词,NOUN,B2
 early morning,early morning,凌晨,NOUN,B2
-early morning (adv),early morning,词,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
 early warning,early warning,预警,NOUN,B2
 earn,to earn,赚取,VERB,B2
-earnest,earnest,词,ADJ,B1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears,ears,耳朵,NOUN,B2
-ears of wheat,ears of wheat,词,NOUN,B2
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easier,easier,更容易的,ADJ,B2
-easing,easing,词,NOUN,C1
 east,east,东方,NOUN,B2
-east bank,east bank,东岸,NOUN,C1
-eastward,eastward,向东,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
 easy to say,easy to say,好说,NOUN,B2
-eating,eating,,NOUN,B2
-eating habit,eating habit,词,NOUN,C1
-eau de Javel,bleach,漂白剂,NOUN,B2
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-ebb tide,ebb tide,词,NOUN,B1
-eccentric person,eccentric person,词,NOUN,C1
-eccentricity,eccentricity,古怪,NOUN,B2
-ecclesial,ecclesial,词,ADJ,C1
 echo,echo,回声,NOUN,B2
-echoes,echoes,词,NOUN,C1
-eclectic,eclectic,折衷的,ADJ,B2
-eclecticism,eclecticism,折衷主义,NOUN,B2
 eclipse,eclipse,日食,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
 ecological,ecological,生态的,ADJ,B2
-ecology,ecology,生态学,NOUN,B2
 economic,economic,经济的,ADJ,B2
-economic cycle,economic cycle,经济周期,NOUN,B2
-economical,economical,词,ADJ,A1
-economically,economically,词,ADV,B1
-economize,economize,词,VERB,C1
 economy,economy,经济,NOUN,B2
 ecosystem,ecosystem,生态系统,NOUN,B2
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eczema,eczema,湿疹,NOUN,B2
-edging,edging,镶边,NOUN,B2
-edible,edible,词,ADJ,C1
 edict,edict,法令,NOUN,B2
-edifying,edifying,词,ADJ,C1
 edit,to edit,编辑,VERB,B2
-edit (noun),edit,重辑,NOUN,B2
 edition,edition,版本,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
 editorial,editorial,社论,NOUN,B2
-editorial office,editorial office,编辑部,NOUN,B2
 education,education,教育,NOUN,B2
-educational background,educational background,学历,NOUN,C1
 eeg,eeg,脑电图,NOUN,B2
-efface,efface,词,VERB,C1
-effect and traces,effect and traces,词,NOUN,C1
-effect-seeking,effect-seeking,词,NOUN,C1
 effectiveness,effectiveness,功效,NOUN,B2
-effects,effects,词,NOUN,B2
-effectuate,effectuate,词,VERB,C1
-effervesce,effervesce,词,VERB,C1
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,沸腾的,ADJ,B2
 efficacy,efficacy,功效,NOUN,B2
-effigy,effigy,词,NOUN,C1
 effort,effort,努力,NOUN,B2
-effort bet,effort bet,努力/赌注,NOUN,B2
-effortless,effortless,不费力的,ADJ,B2
-effrayer,to scare,惊吓,VERB,B2
-effrayé,scared,害怕的,ADJ,B2
-effuse,effuse,词,VERB,C1
-egalitarian,egalitarian,平等主义的,ADJ,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-ego,ego,词,NOUN,C1
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egyptian,egyptian,埃及的,ADJ,B2
-eh,eh,词,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eight (noun),eight,词,NOUN,B2
-eighteen,eighteen,十八,NUM,B2
-eighty,eighty,八十,NUM,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
 either,either,或者,CCONJ,B2
-either (adv),either,词,ADV,B2
-ejection,ejection,喷射,NOUN,B2
-elaborate,elaborate,详尽的,ADJ,B2
-elaboration,elaboration,词,NOUN,C1
 elasticity,elasticity,弹性,NOUN,B2
 elated,elated,兴高采烈的,ADJ,B2
 elbow,elbow,手肘,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
-elderly,elderly,老年人,NOUN,B2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective,elective,词,ADJ,C1
-elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
-electric (noun),electric,词,NOUN,B2
-electric guitar,electric guitar,电吉他,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electric power,electric power,电力,NOUN,B2
-electrical engineering,electrical engineering,词,NOUN,C1
-electrical theory,electrical theory,电学,NOUN,B2
-electrician,electrician,电工,NOUN,B2
-electrification,electrification,词,NOUN,C1
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
-electronics,electronics,电子学,NOUN,B2
-elegance,elegance,词,NOUN,C1
-elemental,elemental,词,ADJ,B2
-elementary,elementary,基本的,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
-elevated,elevated,词,ADJ,C1
-eleven,eleven,十一,NOUN,B2
-eleventh,eleventh,词,NUM,B1
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,词,NOUN,C1
-ellipsis (part),ellipsis,…,PART,C1
-elocution,elocution,演讲术,NOUN,B2
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
-else,else,词,ADV,A1
-elucidation,elucidation,词,NOUN,C1
-elusive,elusive,难以捉摸的,ADJ,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciated,emaciated,词,ADJ,C1
-emaciating,emaciating,消耗的,ADJ,B2
-emaciation,emaciation,词,NOUN,C1
-email address,email address,电子邮件地址,NOUN,B2
-emballer,to pack,打包,VERB,B2
-embalm,embalm,词,VERB,C1
-embargo,embargo,禁运,NOUN,B2
-embarras,predicament,困境,NOUN,B2
-embattle,embattle,词,VERB,C1
-embers,embers,词,NOUN,B1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-embodiment,embodiment,词,NOUN,B2
-emboss,emboss,词,VERB,C1
-embrace each other,embrace each other,词,VERB,B2
-embrayage,clutch,离合器,NOUN,B2
-embroil,embroil,词,VERB,C1
-embryonic,embryonic,词,ADJ,C1
-emend,emend,词,VERB,B2
-emerald,emerald,祖母绿,NOUN,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
-emerging,emerging,词,ADJ,C1
-emigration,emigration,移民,NOUN,B2
-eminence,eminence,词,NOUN,C1
-eminent,eminent,杰出的,ADJ,B2
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emitter,emitter,词,NOUN,C1
-emmener,to take along,带走,VERB,B2
-emolument,emolument,词,NOUN,C1
-emote,emote,词,VERB,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
-emotional life,emotional life,情感生活,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emotionally,emotionally,情感上,ADV,B2
-empathetic,empathetic,词,ADJ,B1
-empathiser,to empathize,共情,VERB,B2
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-empiler,to pile up,堆积,VERB,B2
-empire,empire,帝国,NOUN,B2
-empirically,empirically,凭经验地,ADV,B2
-emploi,employment,就业,NOUN,B2
-emporium,emporium,词,NOUN,C1
-empowerment,empowerment,词,NOUN,C1
-empreinte digitale,fingerprint,指纹,NOUN,B2
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-emulation,emulation,模仿,NOUN,B2
-emulator,emulator,词,NOUN,C1
-emulsify,emulsify,词,VERB,C1
-emulsion,emulsion,词,NOUN,C1
-en avant,ahead,在前面,ADV,B2
-en avant,forth,向前,ADV,B2
-en avant,forward,向前,ADV,B2
-en bas,down,顺...而下,ADP,B2
-en bref,in short,简而言之,ADV,B2
-en danger,endangered,濒危的,ADJ,B2
-en fer,iron,铁的,ADJ,B2
-en haut,up,向上,ADV,B2
-en même temps,at the same time,同时,ADV,B2
-en personne,in person,亲自地,ADV,B2
-en raison de,due to,由于,ADP,B2
-en vain,in vain,徒劳,ADV,B2
-enamel,enamel,珐琅,NOUN,B2
-enamel (verb),enamel,词,VERB,C1
-enamor,enamor,词,VERB,C1
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampments,encampments,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-encens,incense,香,NOUN,B2
-encephalic,encephalic,词,ADJ,C1
-enchain,enchain,词,VERB,C1
-enchanter,to enchant,使着迷,VERB,B2
-enchanting,enchanting,迷人的,ADJ,B2
-enchère,auction,拍卖,NOUN,B2
-encirclement,encirclement,环绕,NOUN,B2
-encoding,encoding,编码,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore,again,你又,NOUN,B2
-encore (noun),encore,词,NOUN,C1
-encore moins,let alone,别说,ADV,B2
-encounter (noun),encounter,遇上,NOUN,B2
-encre,ink,墨水,NOUN,B2
-encroachment,encroachment,词,NOUN,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encrypted,encrypted,词,ADJ,B2
-encumber,encumber,词,VERB,C1
-encyclopédique,encyclopedic,百科全书式的,ADJ,B2
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
-endear,endear,词,VERB,C1
-endeavor,endeavor,努力,NOUN,B2
-endeavor (verb),endeavor,词,VERB,C1
-ending,ending,了头,NOUN,C1
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,内生的,ADJ,B2
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowed,endowed,有天赋的,ADJ,B2
-endue,endue,词,VERB,C1
-endurance,endurance,坚忍,NOUN,B2
-enduring hardship,enduring hardship,词,NOUN,C1
-enemy army,enemy army,敌军,NOUN,C1
-enemy of the state,enemy of the state,词,NOUN,C1
-energize,energize,词,VERB,C1
-energy crisis,energy crisis,能源危机,NOUN,B2
-energy saving,energy saving,节能,NOUN,B2
-enfance,childhood,童年,NOUN,B2
-enfant trouvé,foundling,弃婴,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfold,enfold,词,VERB,C1
-enforceability,enforceability,词,NOUN,C1
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-enfranchise,enfranchise,词,VERB,C1
-enfreindre la discipline,to violate discipline,违纪,VERB,B2
-engagé,committed,投入的,ADJ,B2
-engagé,engaged,订婚的,ADJ,B2
-engender,engender,词,VERB,C1
-engine motor,engine motor,词,NOUN,C1
-english (adj),english,英语,ADJ,B2
-english teacher,english teacher,,NOUN,B2
-engouement,infatuation,迷恋,NOUN,B2
-engourdissement,numbness,麻木,NOUN,B2
-engraft,engraft,词,VERB,C1
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
-engrossing,engrossing,引人入胜的,ADJ,B2
-engulf,engulf,词,VERB,C1
-enigma,enigma,词,NOUN,C1
-enigmatic,enigmatic,神秘的,ADJ,B2
-enjoin,enjoin,词,VERB,C1
-enjoyable,enjoyable,词,ADJ,B1
-enjoyed,enjoyed,词,ADJ,C1
-enkindle,enkindle,词,VERB,C1
-enlargement,enlargement,词,NOUN,C1
-enlightening,enlightening,词,ADJ,C1
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enmesh,enmesh,词,VERB,C1
-ennemi,enemy must,仇必,NOUN,B2
-ennui,dullness,迟钝,NOUN,B2
-ennuyer,to bore,使厌烦,VERB,B2
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
-enough (adj),enough,足够,ADJ,A1
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enquire,enquire,词,VERB,C1
-enquête,inquiry,调查,NOUN,B2
-enquêter,to inquire,询问,VERB,B2
-enraged,enraged,词,ADJ,C1
-enregistrement,record,记录,NOUN,B2
-enregistrement vidéo,video recording,录像,NOUN,B2
-enriching,enriching,词,ADJ,C1
-enrolled,enrolled,词,ADJ,B2
-enrouler,to wind,缠绕,VERB,B2
-ensconce,ensconce,词,VERB,C1
-enseignement,teaching,教学,NOUN,B2
-enshrine,enshrine,词,VERB,C1
-enshrinement,enshrinement,词,NOUN,C1
-enshroud,enshroud,词,VERB,C1
-ensign,ensign,词,NOUN,C1
-enslavement by love,enslavement by love,词,NOUN,C1
-ensue,ensue,词,VERB,B2
-ensuite,after that,此后,ADV,B2
-ensuite,afterwards,后来,ADV,B2
-entanglement,entanglement,缠,NOUN,C1
-entelechy,entelechy,词,NOUN,C1
-entendre,to hear a case,审理,VERB,B2
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertainer,entertainer,词,NOUN,B2
-entertaining,entertaining,有趣的,ADJ,B2
-enthousiaste,enthusiast,爱好者,NOUN,B2
-enticement,enticement,词,NOUN,C1
-entirely,entirely,完全地,ADV,B2
-entitle,entitle,词,VERB,C1
-entitled to exist,entitled to exist,词,ADJ,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
-entomb,entomb,词,VERB,C1
-entomology,entomology,词,NOUN,C1
-entourage,entourage,随从,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrant,incoming,进来的,ADJ,B2
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entrave,hindrance,障碍,NOUN,B2
-entraînement spirituel,spirit training,练神,NOUN,B2
-entraîner,to coach,辅导,VERB,B2
-entreat,entreat,词,VERB,C1
-entremetteur,matchmaker,媒,NOUN,B2
-entrenchment,entrenchment,词,NOUN,C1
-entrepreneur,entrepreneur,企业家,NOUN,B2
-entrepreneurship,entrepreneurship,词,NOUN,C1
-entreprise,enterprise,企业,NOUN,B2
-entreprise,undertaking,事业,NOUN,B2
-entrer,to come in,进来,VERB,B2
-entrer,to go in,进去,VERB,B2
-entrer en fonction,to take office,就职,VERB,B2
-entrer en ville,to enter city,进城,VERB,B2
-entry,entry,入口,NOUN,B2
-entwine,entwine,词,VERB,C1
-enumeration,enumeration,列举,NOUN,B2
-enunciation,enunciation,发音,NOUN,B2
-enunciative,enunciative,词,ADJ,C1
-envelop,envelop,词,VERB,C1
-envenom,envenom,词,VERB,C1
-enviable,enviable,令人羡慕的,ADJ,B2
-envious,envious,嫉妒的,ADJ,B2
-envious jealous,envious jealous,嫉妒的,ADJ,B2
-environ,approximately,大约,ADV,B2
-environ,environ,词,VERB,C1
-environmental protection,environmental protection,环境保护,NOUN,B2
-environmental report,environmental report,环境报告,NOUN,B2
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
-envision,to envision,展望,VERB,B2
-envoy,envoy,词,NOUN,B2
-envy,envy,嫉妒,NOUN,B2
-envy,to envy,羡慕,VERB,B2
-enwetens,enwetens,词,ADV,C1
-enzyme,enzyme,酶,NOUN,B2
-eon age,eon age,词,NOUN,C1
-ephemeral,ephemeral,短暂的,ADJ,B2
-epic,epic,史诗,NOUN,B2
-epic (adj),epic,史诗的,ADJ,C1
-epic quality,epic quality,词,NOUN,C1
-epicurean,epicurean,享乐主义的,ADJ,B2
-epidemic,epidemic,流行病,NOUN,B2
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epilepsy,epilepsy,词,NOUN,C1
-epilogue,epilogue,词,NOUN,C1
-episode,episode,集,NOUN,B2
-episodic,episodic,词,ADJ,C1
-epistemology,epistemology,认识论,NOUN,B2
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,墓志铭,NOUN,B2
-epithet,epithet,绰号,NOUN,B2
-epitome,epitome,化身,NOUN,B2
-epitomize,epitomize,词,VERB,C1
-epoch,epoch,时代,NOUN,B2
-eponymous,eponymous,词,ADJ,C1
-equal,equal,相等的,ADJ,B2
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equality,equality,平等,NOUN,B2
-equally,equally,同样地,ADV,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equation,equation,方程,NOUN,B2
-equatorial,equatorial,词,ADJ,C1
-equestrian,equestrian,马术的,ADJ,B2
-equestrianism,equestrianism,马术,NOUN,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,等边的,ADJ,B2
-equilibrate,equilibrate,词,VERB,C1
-equilibrium,equilibrium,平衡,NOUN,B2
-equipment,equipment,设备,NOUN,B2
-equipped,equipped,配备的,ADJ,B2
-equity,equity,公平,NOUN,B2
-equivalent,equivalent,等价物,NOUN,B2
-equivalent (adj),equivalent,相等的,ADJ,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
-equivocate,equivocate,词,VERB,C1
-era,era,时代,NOUN,B2
-eradicate,to eradicate,根除,VERB,B2
-eradication,eradication,根除,NOUN,B2
-erect,to erect,建立,VERB,B2
-erection,erection,词,NOUN,C1
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergestaltung,ergestaltung,词,NOUN,C1
-ergonomics,ergonomics,词,NOUN,C1
-erhu,erhu,二胡,NOUN,B2
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
-erosion,erosion,侵蚀,NOUN,B2
-erotic,erotic,色情的,ADJ,B2
-eroticism,eroticism,色情,NOUN,B2
-erpflegung,erpflegung,词,NOUN,C1
-err,to err,犯错,VERB,B2
-errance,wandering,漫游,NOUN,B2
-errand,errand,差事,NOUN,B2
-errant,errant,词,ADJ,C1
-errata,errata,勘误,NOUN,B2
-erratic,erratic,不稳定的,ADJ,B2
-erregelung,erregelung,词,NOUN,C1
-errer,to roam,漫游,VERB,B2
-erreur,make mistake,犯错,NOUN,B2
-erroneous,erroneous,词,ADJ,C1
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
-erudite,erudite,博学的,ADJ,B2
-erudition,erudition,博学,NOUN,B2
-erupt,erupt,词,VERB,C1
-eruption,eruption,爆发,NOUN,B2
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
-escalate,to escalate,升级,VERB,B2
-escalator,escalator,自动扶梯,NOUN,B2
-escalier,stairs,楼梯,NOUN,B2
-escaping,escaping,词,NOUN,C1
-eschatological,eschatological,词,ADJ,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escort (noun),escort,你带人,NOUN,B2
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-escorter,escort,护卫,NOUN,B2
-escorter,to escort,护送,VERB,B2
-escroquer,to defraud,诈骗,VERB,B2
-esophagus,esophagus,词,NOUN,B2
-esoteric,esoteric,词,ADJ,C1
-esotericism,esotericism,秘教,NOUN,B2
-espagnol,spanish,西班牙语,NOUN,B2
-espresso,espresso,浓缩咖啡,NOUN,B2
-esprit,spirit,精神,NOUN,B2
-esprit,wits,心眼,NOUN,B2
-espèce,species,物种,NOUN,B2
-espérer,to hope to wish,希望,VERB,B2
-esquisser,to outline,勾勒,VERB,B2
-esquiver,to evade,逃避,VERB,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-essayistic quality,essayistic quality,词,NOUN,C1
-essence,essence,本质,NOUN,B2
-essence core,essence core,词,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
-essentiellement,basically,基本上,ADV,B2
-essuie-glace,wiper,雨刷,NOUN,B2
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-esthétique,aesthetics,美学,NOUN,B2
-estimation,estimation,词,NOUN,C1
-estime,esteem,尊重,NOUN,B2
-estrange,estrange,词,VERB,C1
-estuaire,estuary,河口,NOUN,B2
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
-ethereal,ethereal,飘渺的,ADJ,B2
-ethereum,ethereum,以太坊,NOUN,B2
-ethical,ethical,道德的,ADJ,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnicité,ethnicity,种族,NOUN,B2
-ethnographie,ethnography,人种学,NOUN,B2
-ethnologie,ethnology,民族学,NOUN,B2
-etymology,etymology,词源学,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-eunuch,eunuch,词,NOUN,C1
-euphemistic,euphemistic,委婉的,ADJ,B2
-euphonic,euphonic,悦耳的,ADJ,B2
-euphoric,euphoric,词,ADJ,C1
-europe,europe,欧洲,PROPN,B2
-euthanasia,euthanasia,词,NOUN,C1
-evanesce,evanesce,词,VERB,C1
-evangelical,evangelical,词,ADJ,C1
-evangelist,evangelist,词,NOUN,C1
-evangelization,evangelization,词,NOUN,C1
-evaporating,evaporating,词,ADJ,C1
-evasion,evasion,逃避,NOUN,B2
-eve,eve,前夕,NOUN,C1
-even,even,甚至,ADV,B2
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening meal,evening meal,晚餐,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-evenly,evenly,均匀地,ADV,B2
-events,events,事件,NOUN,C1
-eventual,eventual,词,ADJ,C1
-eventual outcome,eventual outcome,词,NOUN,C1
-eventuate,eventuate,词,VERB,C1
-ever,ever,,NOUN,B2
-everlasting,everlasting,词,ADJ,C1
-everlastingness,everlastingness,词,NOUN,C1
-every,every,每个,PRON,B2
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
-everydayness,everydayness,词,NOUN,B2
-everyone,everyone,各位,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
-evil,evil,邪,PART,B2
-evil (adj),evil,词,ADJ,B1
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evocation,evocation,唤起,NOUN,B2
-evocative,evocative,引起回忆的,ADJ,B2
-evolutionary,evolutionary,词,ADJ,C1
-exact,exact,精确的,ADJ,B2
-exactitude,exactitude,词,NOUN,C1
-exactly just,exactly just,恰好,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exactness,exactness,精确,NOUN,B2
-exagéré,exaggerated,夸张的,ADJ,B2
-exaltation,exaltation,狂热,NOUN,B2
-exalted,exalted,狂热的,ADJ,B2
-exam evening,exam evening,,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-examen,exam,考试,NOUN,B2
-examen,examination,考试,NOUN,B2
-examiner,review,回顾,NOUN,B2
-examiner,screen,屏幕,NOUN,B2
-examiner,to review,复习,VERB,B2
-examiner,to screen,筛选,VERB,B2
-exaspération,exasperation,恼怒,NOUN,B2
-excavated,excavated,词,ADJ,B1
-excavator,excavator,挖掘机,NOUN,B2
-excellence,excellence,卓越,NOUN,B2
-excellent,excellent,优秀的,ADJ,B2
-exceller,to excel,擅长,VERB,B2
-excentrique,weirdo,怪人,NOUN,B2
-except unless,except unless,词,ADP,A2
-exception,exception,例外,NOUN,B2
-exceptionality,exceptionality,特殊性,NOUN,B2
-excessiveness,excessiveness,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excitability,excitability,兴奋性,NOUN,B2
-excitant,exciting,令人兴奋的,ADJ,B2
-excité,excited,兴奋的,ADJ,B2
-exclamation,exclamation,感叹,NOUN,B2
-exclamation (punct),exclamation,词,PUNCT,A2
-exclu,excluded,排除在外的,ADJ,B2
-exclusion,exclusion,排除,NOUN,B2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusive dedication,exclusive dedication,词,NOUN,C1
-exclusivism,exclusivism,词,NOUN,C1
-exclusivité,exclusivity,排他性,NOUN,B2
-excommunication,excommunication,绝罚,NOUN,B2
-excrement,excrement,排泄物,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,开脱,NOUN,B2
-excursion,excursion,郊游,NOUN,B2
-excuse,apology,道歉,NOUN,B2
-excuse,excuse,借口,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-excès,excess,过量,NOUN,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executory,executory,词,ADJ,C1
-exemplar,exemplar,楷模,NOUN,C1
-exemplary country,exemplary country,模范国家,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercice,exercise,锻炼,NOUN,B2
-exercise book,exercise book,词,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exercises,exercises,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhalation,exhalation,呼气,NOUN,B2
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhaustif,comprehensive,全面的,ADJ,B2
-exhausting,exhausting,词,ADJ,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exhortation,exhortation,劝诫,NOUN,B2
-exhorter,to urge,强烈要求,VERB,B2
-exhumation,exhumation,掘墓,NOUN,B2
-exigent,exigent,词,ADJ,C1
-exiled,exiled,词,ADJ,C1
-existence,existence,存在,NOUN,B2
-existential,existential,存在主义的,ADJ,B2
-exit (verb),exit,词,VERB,A1
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,过高的,ADJ,B2
-exorcism,exorcism,词,NOUN,C1
-exotic,exotic,异国情调的,ADJ,B2
-exoticism,exoticism,异国情调,NOUN,B2
-expanse,expanse,词,NOUN,B2
-expansion,expansion,扩张,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expansive,expansive,扩张的,ADJ,B2
-expatiate,expatiate,词,VERB,C1
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expedite,expedite,词,VERB,C1
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,迅速的,ADJ,B2
-expenditures,expenditures,支出,NOUN,C1
-expensiveness,expensiveness,词,NOUN,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
-experimentation,experimentation,词,NOUN,C1
-expert,expert,专家,NOUN,B2
-expert opinion,expert opinion,专家意见,NOUN,B2
-expertise,expertise,专业知识,NOUN,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiate,expiate,词,VERB,C1
-expiration,expiration,词,NOUN,C1
-expirer,to expire,到期,VERB,B2
-explanatory,explanatory,解释的,ADJ,B2
-expletive,expletive,词,NOUN,C1
-explicable,explicable,可解释的,ADJ,B2
-explicate,explicate,词,VERB,C1
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
-exploitation,exploitation,利用,NOUN,B2
-exploits,exploits,词,NOUN,C1
-exploration,exploration,探索,NOUN,B2
-exploratory,exploratory,词,ADJ,C1
-explosif,explosive,爆炸性的,ADJ,B2
-explosion,explosion,爆炸,NOUN,B2
-explosion-proof,explosion-proof,防爆,ADJ,B2
-explosive (noun),explosive,词,NOUN,B2
-explosives,explosives,炸药,NOUN,B2
-exponent,exponent,指数,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exports,exports,词,NOUN,C1
-exposer,to expound,阐述,VERB,B2
-exposition,exposition,阐述,NOUN,B2
-exposition,exposure,暴露,NOUN,B2
-expostulate,expostulate,词,VERB,C1
-express,express,明确的,ADJ,B2
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expression,expression,表达,NOUN,B2
-expression of opinion,expression of opinion,意见表达,NOUN,B2
-expressionism,expressionism,词,NOUN,C1
-expressiveness,expressiveness,表现力,NOUN,B2
-expropriation,expropriation,征用,NOUN,B2
-expulsion,eviction,驱逐,NOUN,B2
-expulsion,expulsion,驱逐,NOUN,B2
-expunge,expunge,词,VERB,C1
-expédier,to ship out,出货,VERB,B2
-expérience,experiment,实验,NOUN,B2
-expérimenter,to experience,经历,VERB,B2
-exquisiteness,exquisiteness,词,NOUN,C1
-extemporize,extemporize,词,VERB,C1
-extended,extended,广泛的,ADJ,B2
-extended reality,extended reality,扩展现实,NOUN,C1
-extension,extension,延伸,NOUN,B2
-extension,spread,传播,NOUN,B2
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,在外,NOUN,B2
-extermination,extermination,灭绝,NOUN,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinct,extinct,灭绝的,ADJ,B2
-extinction,extinction,灭绝,NOUN,B2
-extinguishable,extinguishable,词,ADJ,C1
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extirpation,extirpation,切除,NOUN,B2
-extolling,extolling,词,NOUN,C1
-extorquer,to extort,敲诈,VERB,B2
-extort a confession,extort a confession,逼供,VERB,C1
-extra,extra,额外的,ADJ,B2
-extra (adv),extra,词,ADV,A1
-extra drink,extra drink,多喝,NOUN,C1
-extraction,extraction,提取,NOUN,B2
-extradition,extradition,引渡,NOUN,B2
-extrait,excerpt,摘录,NOUN,B2
-extramarital,extramarital,词,ADJ,C1
-extrapolation,extrapolation,词,NOUN,C1
-extraterrestrial,extraterrestrial,外星的,ADJ,B2
-extravagant,extravagant,奢侈的,ADJ,B2
-extraversion,extraversion,词,NOUN,C1
-extraversion,extroversion,外向,NOUN,B2
-extreme (noun),extreme,至极,NOUN,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-extrême,extreme,أقصى,NOUN,B2
-extrêmement,extremely,极其,ADV,B2
-exuberance,exuberance,繁茂,NOUN,B2
-exuberant,exuberant,繁茂的,ADJ,B2
-exudation,exudation,词,NOUN,C1
-exultation,exultation,欢腾,NOUN,B2
-exécuteur,executor,遗嘱执行人,NOUN,B2
-exécutif,executive,行政主管,NOUN,B2
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyebrows,eyebrows,词,NOUN,A1
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
-fable,fable,寓言,NOUN,B2
-fabricant,maker,制造者,NOUN,B2
-fabricated,fabricated,词,ADJ,B2
-fabrication,fabrication,捏造,NOUN,B2
-fabulist,fabulist,幻想家,NOUN,B2
-fabulous,fabulous,极好的,ADJ,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facilitation,facilitation,词,NOUN,C1
-facticity,facticity,词,NOUN,C1
-faction,faction,派,NOUN,B2
-factionalism,factionalism,派系主义,NOUN,B2
-factious,factious,词,ADJ,C1
-factotum,factotum,词,NOUN,C1
-factual,factual,事实的,ADJ,B2
-fad,fad,词,NOUN,C1
-fade,bland,平淡的,ADJ,B2
-fade away,fade away,词,VERB,C1
-fading away,fading away,词,NOUN,C1
-fag,fag,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failed,failed,失败的,ADJ,B2
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-faille,loophole,漏洞,NOUN,B2
-failure to act,failure to act,词,NOUN,C1
-faint,faint,微弱的,ADJ,B2
-faint (noun),faint,词,NOUN,C1
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,词,ADJ,B1
-faire,to make,制作,VERB,B2
-faire appel,to appeal,呼吁,VERB,B2
-faire attention,to pay attention,注意,VERB,B2
-faire attention,to take care,照顾,VERB,B2
-faire chanter,to blackmail,勒索,VERB,B2
-faire connaissance,to get acquainted,相互认识,VERB,B2
-faire d'une pierre deux coups,kill two birds with one stone,一举两得,ADJ,B2
-faire du bruit,to make noise,闹得,VERB,B2
-faire faillite,to go bankrupt,破产,VERB,B2
-faire un discours,to make a speech,发言,VERB,B2
-fairness,fairness,词,NOUN,B2
-faisable,feasible,可行的,ADJ,B2
-fait,done,事已,NOUN,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-falconry,falconry,猎鹰术,NOUN,B2
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallibility,fallibility,易错性,NOUN,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-fallout,fallout,词,NOUN,C1
-fallow land,fallow land,词,NOUN,B2
-false oath,false oath,词,NOUN,C1
-falsification,falsification,词,NOUN,C1
-falsifier,to falsify,伪造,VERB,B2
-falsity,falsity,虚假,NOUN,B2
-falter,falter,词,VERB,C1
-faltering,faltering,词,ADJ,C1
-familial,familial,词,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
-familiarité,familiarity,مألوف,NOUN,B2
-family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family life,family life,家庭生活,NOUN,B2
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,家庭纽带,NOUN,B2
-famine,famine,饥荒,NOUN,B2
-famish,famish,词,VERB,C1
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fanatic,fanatic,狂热的,ADJ,B2
-fanatical,fanatical,词,ADJ,C1
-fanatisme,fanaticism,狂热,NOUN,B2
-fancy,fancy,词,ADJ,B1
-fancy decoration,fancy decoration,词,NOUN,C1
-fantasize,fantasize,词,VERB,C1
-fantasizing,fantasizing,词,NOUN,C1
-fantastique,fantastic,极好的,ADJ,B2
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-farce,farce,闹剧,NOUN,B2
-fare,fare,车费,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farmland,farmland,农田,NOUN,C1
-farmstead,farmstead,农庄,NOUN,B2
-farrow,farrow,词,VERB,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascination,fascination,魅力,NOUN,B2
-fascism,fascism,法西斯主义,NOUN,B2
-fascist (noun),fascist,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast forward,fast forward,快进,VERB,C1
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
-fatal,fatal,致命的,ADJ,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatalist (noun),fatalist,词,NOUN,C1
-fatality,fatality,致命性,NOUN,B2
-fateful,fateful,词,ADJ,C1
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatigue,fatigue,疲劳,NOUN,B2
-fatigue,tiredness,疲劳,NOUN,B2
-fatness,fatness,词,NOUN,C1
-fats,fats,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatuous,fatuous,词,ADJ,C1
-fatwa,fatwa,词,NOUN,B2
-faucet,faucet,词,NOUN,C1
-faucon,falcon,猎鹰,NOUN,B2
-faulty,faulty,词,ADJ,C1
-faute,fault,错误,NOUN,B2
-fauteuil roulant,wheelchair,轮椅,NOUN,B2
-faux,fake,假的,ADJ,B2
-faveur,favor,恩惠,NOUN,B2
-favor kindness,favor kindness,恩,NOUN,C1
-favorite,favorite,最爱,NOUN,B2
-favoritism,favoritism,偏袒,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawn,fawn,词,VERB,C1
-fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
-façonner,to shape,塑造,VERB,B2
-fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
-feast,feast,盛宴,NOUN,B2
-february,february,二月,NOUN,B2
-feces,feces,屎,NOUN,C1
-fecundate,fecundate,词,VERB,C1
-fecundity,fecundity,词,NOUN,C1
-fed up (adj),fed up,词,ADJ,B1
-federalization,federalization,联邦化,NOUN,B2
-federalize,federalize,词,VERB,C1
-feeble,feeble,虚弱的,ADJ,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
-feeding,feeding,词,NOUN,C1
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-felicitate,felicitate,词,VERB,C1
-feline,feline,词,ADJ,C1
-felt,felt,词,NOUN,C1
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
-feminization,feminization,词,NOUN,C1
-femme,wife,妻子,NOUN,B2
-fend,fend,词,VERB,C1
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-fennec fox,fennec fox,词,NOUN,B2
-fenouil,fennel,茴香,NOUN,B2
-fente,split,分裂,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-fenêtre,window,窗户,NOUN,B2
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
-ferme,firm,坚固的,ADJ,B2
-fermentation,fermentation,发酵,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fermenter,to ferment,发酵,VERB,B2
-fermer,to close the door,关门,VERB,B2
-fern,fern,蕨类植物,NOUN,B2
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferret,ferret,雪貂,NOUN,B2
-ferrule,ferrule,箍,NOUN,B2
-ferry,ferry,渡轮,NOUN,B2
-fertile,fertile,肥沃的,ADJ,B2
-fertilisation,fertilization,施肥,NOUN,B2
-fervent,fervent,词,ADJ,C1
-fesse,ass,驴,NOUN,B2
-fesses,buttocks,屁股,NOUN,B2
-festival,festival,节日,NOUN,B2
-festivals,festivals,词,NOUN,C1
-festive,festive,节日的,ADJ,B2
-festivity,festivity,词,NOUN,C1
-fete,fete,词,VERB,C1
-fetid,fetid,词,ADJ,C1
-fetishism,fetishism,词,NOUN,B2
-fetter,fetter,词,VERB,C1
-feud end,feud end,仇终,NOUN,C1
-feudal ethics,feudal ethics,礼教,NOUN,B2
-feuille,sheet,床单,NOUN,B2
-feux d'artifice,fireworks,烟花,NOUN,B2
-feverish,feverish,词,ADJ,C1
-few,few,几下,NOUN,B2
-fewer,fewer,较少的,ADJ,B2
-fez,fez,词,NOUN,B2
-fiable,trustworthy,值得信赖的,ADJ,B2
-fiancee,fiancee,未婚妻,NOUN,B2
-fiancé,fiance,未婚夫,NOUN,B2
-fib,fib,词,VERB,C1
-fibrous,fibrous,词,ADJ,C1
-fickleness,fickleness,反复无常,NOUN,B2
-fiction,fiction,小说,NOUN,B2
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictionalize,fictionalize,词,VERB,C1
-fictionnel,fictional,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fiddle (verb),fiddle,词,VERB,C1
-fidget,fidget,词,VERB,C1
-fiduciary,fiduciary,词,ADJ,C1
-fidèle,faithful,忠诚的,ADJ,B2
-fief,fief,封地,NOUN,B2
-field (adj),field,词,ADJ,C1
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fiend,fiend,词,NOUN,C1
-fierce one,fierce one,词,NOUN,B2
-fiery,fiery,热烈的,ADJ,B2
-fifteen,fifteen,十五,NUM,B2
-fifth,fifth,第五,NUM,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figuration,figuration,群演,NOUN,B2
-figurative language,figurative language,词,NOUN,C1
-figuratively,figuratively,比喻地,ADV,B2
-figure,figure,图形,NOUN,B2
-figure skating,figure skating,花样滑冰,NOUN,C1
-fil,wire,电线,NOUN,B2
-filament,filament,词,NOUN,C1
-filch,filch,词,VERB,C1
-file,queue,队列,NOUN,B2
-file a case,file a case,立案,VERB,B2
-file expense,file expense,报账,VERB,B2
-filet,tenderloin,里脊,NOUN,B2
-filial,filial,孝顺,ADJ,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filings,filings,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
-fill pack,fill pack,装满,VERB,B2
-fille,daughter,女儿,NOUN,B2
-filled,filled,充满的,ADJ,B2
-fillet (noun),fillet,词,NOUN,C1
-fillet (verb),fillet,词,VERB,C1
-filling,filling,词,NOUN,B2
-film,movie,电影,NOUN,B2
-film art,film art,词,NOUN,C1
-film industry,film industry,电影业,NOUN,B2
-film movie,film movie,电影,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,电影制片厂,NOUN,B2
-fils aîné,eldest son,长子,NOUN,B2
-filthy,filthy,肮脏的,ADJ,B2
-fin,fin,词,NOUN,B2
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
-finalement,after all,毕竟,ADV,B2
-finalement,eventually,最终,ADV,B2
-finalement,ultimately,最终,ADV,B2
-finality,finality,词,NOUN,C1
-finals,finals,决赛,NOUN,B1
-finance,finance,金融,NOUN,B2
-financement,financing,融资,NOUN,B2
-financer,to finance,资助,VERB,B2
-finances,finances,财政,NOUN,B2
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financier,financier,资助者,NOUN,B2
-find,find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine print,fine print,词,NOUN,C1
-fine well,fine well,词,ADJ,A1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fini,finite,有限的,ADJ,B2
-finial,finial,词,NOUN,C1
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
-finition,finishing,装修,NOUN,B2
-finnish,finnish,芬兰的,ADJ,B2
-fir forest,fir forest,杉林,NOUN,C1
-fire a gun,fire a gun,开枪,VERB,B2
-fire brigade,fire brigade,消防队,NOUN,B2
-fire department,fire department,词,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire kick,fire kick,词,VERB,A2
-fire station,fire station,词,NOUN,C1
-firearms,firearms,枪支,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firedamp,firedamp,词,NOUN,C1
-firework,firework,词,NOUN,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firm fixed,firm fixed,词,ADJ,B1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first aid,first aid,词,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
-first-class,first-class,一流,ADJ,B2
-firstly,firstly,首先,ADV,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fisheries,fisheries,词,NOUN,B2
-fishery,fishery,渔业,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing rod,fishing rod,钓竿,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
-fission,fission,裂变,NOUN,B2
-fissure,fissure,裂缝,NOUN,B2
-fissure,rift,裂痕,NOUN,B2
-fit (noun),fit,词,NOUN,B2
-fitting out,fitting out,词,NOUN,B2
-fittings,fittings,水龙头配件,NOUN,B2
-five (adj),five,词,ADJ,C1
-five organs,five organs,五脏,NOUN,B2
-fixation,fixation,词,NOUN,C1
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fixer,gaze,目视,NOUN,B2
-fixer,to gaze,凝视,VERB,B2
-fixer,to stare,凝视,VERB,B2
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flabby,flabby,词,ADJ,B2
-flaccid,flaccid,松弛的,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-flacon,flask,小瓶,NOUN,B2
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrant,flagrant,词,ADJ,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable,flammable,易燃的,ADJ,B2
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
-flank (verb),flank,词,VERB,C1
-flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashback,flashback,词,NOUN,C1
-flashlight,flashlight,手电筒,NOUN,B2
-flat (noun),flat,词,NOUN,B1
-flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
-flatter,to flatter,奉承,VERB,B2
-flatterie,flattery,奉承,NOUN,B2
-flattering,flattering,词,ADJ,C1
-flaunt,flaunt,词,VERB,C1
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flegme,phlegm,痰,NOUN,B2
-flemish,flemish,佛兰芒的,ADJ,B2
-fleurir,to flourish,繁荣,VERB,B2
-flex,flex,词,VERB,C1
-flexion,flexion,词,NOUN,C1
-flic,cop,警察,NOUN,B2
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flinch,flinch,词,VERB,C1
-fling (noun),fling,词,NOUN,C1
-fling (verb),fling,词,VERB,C1
-flip,flip,词,VERB,B2
-flirt,flirt,调情者,NOUN,B2
-flirt (verb),flirt,词,VERB,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-flit,flit,词,VERB,C1
-float (noun),float,词,NOUN,B2
-floating (noun),floating,词,NOUN,C1
-floating dust,floating dust,浮尘,NOUN,B2
-flocon,snowflake,雪花,NOUN,B2
-flogging,flogging,词,NOUN,C1
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floor story,floor story,词,NOUN,A2
-floorboard,floorboard,木地板,NOUN,B2
-flop,flop,词,VERB,C1
-floral,floral,词,ADJ,C1
-florid,florid,辞藻华丽的,ADJ,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-flotter,to float,漂浮,VERB,B2
-flou,unclear,不清楚的,ADJ,B2
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-floundering,floundering,词,NOUN,C1
-flourishing,flourishing,繁荣的,ADJ,B2
-flourishing (noun),flourishing,词,NOUN,C1
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-fluctuation,fluctuation,波动,NOUN,B2
-fluency,fluency,流利,NOUN,B2
-fluff,fluff,词,NOUN,C1
-fluid,fluid,液体,NOUN,B2
-fluide,fluent,流利的,ADJ,B2
-fluidity,fluidity,流畅,NOUN,B2
-fluidize,fluidize,词,VERB,C1
-fluids,fluids,词,NOUN,C1
-fluke,fluke,词,NOUN,B2
-flunk,flunk,词,VERB,C1
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flutist,flutist,词,NOUN,C1
-flutter (noun),flutter,词,NOUN,B2
-flux,flux,变迁,NOUN,B2
-flying,flying,飞行的,ADJ,B2
-flyting poems,flyting poems,词,NOUN,C1
-fob,fob,词,NOUN,C1
-focalization,focalization,词,NOUN,C1
-focused,focused,专注的,ADJ,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-foin,hay,干草,NOUN,B2
-fois,times,倍,NOUN,B2
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,枝叶,NOUN,B2
-foliar,foliar,词,ADJ,C1
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
-folklore,folklore,民俗,NOUN,B2
-folkloric,folkloric,词,ADJ,C1
-folksy,folksy,乡土的,ADJ,B2
-followers,followers,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-foment,foment,词,VERB,C1
-fonctionner,to work out,成功,VERB,B2
-fondle,fondle,词,VERB,C1
-fondness,fondness,词,NOUN,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
-foot-warming,foot-warming,捂脚,NOUN,B2
-football,football,足球,NOUN,B2
-football camp,football camp,词,NOUN,B2
-football player,football player,词,NOUN,C1
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footprint,footprint,足迹,NOUN,B2
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
-for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for each other,for each other,相互,ADV,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for hours,for hours,词,ADJ,B2
-for my sake,for my sake,词,ADV,C1
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,为此,ADV,B2
-for the,for the,词,ADP,A2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what purpose,for what purpose,为了什么目的,ADV,B2
-for your sake,for your sake,词,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearing,forbearing,词,ADJ,C1
-force,force,力量,NOUN,B2
-force interne,internal force,内力,NOUN,B2
-forced labor,forced labor,词,NOUN,C1
-forceful,forceful,词,ADJ,B2
-forcing submission,forcing submission,词,NOUN,C1
-forcé,forced,强迫的,ADJ,B2
-ford,ford,词,NOUN,B2
-forearm,forearm,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,外国的/陌生的,ADJ,B2
-foreknow,foreknow,词,VERB,C1
-foreman,foreman,词,NOUN,B2
-forenoon,forenoon,词,NOUN,A1
-forensic,forensic,法医的,ADJ,B2
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forest-related,forest-related,词,ADJ,B2
-forestall,forestall,词,VERB,C1
-foretell,foretell,词,VERB,C1
-forewarn,forewarn,词,VERB,C1
-forfeit,forfeit,词,VERB,C1
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forger,forger,词,NOUN,C1
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-forgo,forgo,词,VERB,C1
-formal notice,formal notice,词,NOUN,C1
-formalisme,formalism,形式主义,NOUN,B2
-formalist (adj),formalist,词,ADJ,C1
-formalist (noun),formalist,词,NOUN,C1
-format,format,格式,NOUN,B2
-formation,formation,组建,NOUN,B2
-former,to form,形成,VERB,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-formulation,formulation,配方,NOUN,B2
-formule,formula,公式,NOUN,B2
-fornicate,fornicate,词,VERB,C1
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-fort,fort,堡垒,NOUN,B2
-forthcoming,forthcoming,词,ADJ,C1
-fortification,fortification,词,NOUN,C1
-fortlet,fortlet,词,NOUN,C1
-fortune,fortune,运气,NOUN,B2
-fortune teller,fortune teller,占卜者,NOUN,B2
-forum,forum,论坛,NOUN,B2
-forums,forums,词,NOUN,C1
-forward (verb),forward,词,VERB,B2
-forêt de conifères,coniferous forest,针叶林,NOUN,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-fossils,fossils,化石,NOUN,C1
-foster,foster,词,VERB,B2
-fou,fool,傻瓜,NOUN,B2
-fou,madman,疯子,NOUN,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
-founding,founding,成立,NOUN,B2
-four,oven,烤箱,NOUN,B2
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fournir des preuves,to provide evidence,举证,VERB,B2
-fournir des retours,to provide feedback,反馈,VERB,B2
-fournisseur,provider,提供者,NOUN,B2
-fourrage,fodder,饲料,NOUN,B2
-fourth (num),fourth,词,NUM,B1
-fowl,fowl,词,NOUN,C1
-foyer,focus,焦点,NOUN,B2
-foyer,foyer,词,NOUN,C1
-foyer,home family,家,NOUN,B2
-fractal,fractal,分形,NOUN,B2
-fraction,fraction,分数,NOUN,B2
-fractional,fractional,分数的,ADJ,B2
-fracture,fracture,骨折,NOUN,B2
-fractured,fractured,词,ADJ,C1
-fragile,flimsy,脆弱的,ADJ,B2
-fragile,fragile,易碎的,ADJ,B2
-fragment,fragment,碎片,NOUN,B2
-fragmentation,fragmentation,碎片化,NOUN,B2
-fragrance,fragrance,香味,NOUN,B2
-frais,cool,凉爽的,ADJ,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework-related,framework-related,词,ADJ,C1
-framing,framing,词,NOUN,C1
-franchise,franchise,特许经营权,NOUN,B2
-franciscan,franciscan,方济各会的,ADJ,B2
-frantic,frantic,狂乱的,ADJ,B2
-français,french,法语,NOUN,B2
-frapper,kick,踢,NOUN,B2
-frapper,to kick,踢,VERB,B2
-frapper,to strike,打击,VERB,B2
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fratricide,fratricide,杀兄弟,NOUN,B2
-fratrie,siblings,兄弟姐妹,NOUN,B2
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudster,fraudster,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-fray,fray,词,VERB,C1
-frayed,frayed,词,ADJ,C1
-frazzle,frazzle,词,VERB,C1
-fraîcheur,coolness,凉爽,NOUN,B2
-freak,freak,怪人,NOUN,B2
-freckles,freckles,词,NOUN,B2
-free association,free association,词,NOUN,C1
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
-free off,free off,空闲的/休假,ADJ,B2
-free will,free will,词,NOUN,B2
-freedmen clients,freedmen clients,词,NOUN,C1
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,选择自由,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freezing,freezing,极冷的,ADJ,B2
-freight,freight,货物,NOUN,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
-fresh,fresh,,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-fret,fret,词,VERB,C1
-friar,friar,词,NOUN,C1
-friche,wasteland,荒地,NOUN,B2
-friction,friction,摩擦,NOUN,B2
-frictionless,frictionless,无摩擦的,ADJ,B2
-fried,fried,词,ADJ,B1
-fried food,fried food,词,NOUN,C1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-friends with,friends with,词,ADJ,B2
-frightful,frightful,词,ADJ,B1
-frigid,frigid,寒冷的,ADJ,B2
-frill,frill,词,NOUN,C1
-frire,to deep-fry,油炸,VERB,B2
-frisian,frisian,弗里斯兰的,ADJ,B2
-frisk,frisk,词,VERB,C1
-frisson,shudder,战栗,NOUN,B2
-frites,fries,炸薯条,NOUN,B2
-fritter,fritter,词,VERB,C1
-frivol,frivol,词,VERB,C1
-frivolous,frivolous,轻浮的,ADJ,B2
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-froid,cold,寒冷,NOUN,B2
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from above,from above,从上方,ADV,B2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
-from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from here,from here,从这里,ADV,B2
-from home,from home,从家里,ADV,B2
-from it,from it,从中,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from there,from there,从那里,ADV,B2
-from this,from this,由此,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from where,from where,从哪里,ADV,B2
-from which,from which,从中,ADV,B2
-from within,from within,从内部,ADV,B2
-front,front,前面,NOUN,B2
-front door,front door,正门,NOUN,B2
-front line,front line,前线,NOUN,B2
-front page,front page,头版,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontière,border,边境的,ADJ,B2
-frontrunner,frontrunner,词,NOUN,C1
-frost,frost,霜,NOUN,B2
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-frosty,frosty,词,ADJ,A1
-froth,froth,泡沫,NOUN,B2
-frown (noun),frown,frown,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frowning,frowning,词,NOUN,C1
-frozen,frozen,冻僵的,ADJ,B2
-frozen (noun),frozen,词,NOUN,B2
-fructify,fructify,词,VERB,C1
-frugal,frugal,节俭的,ADJ,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,果树的,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruiting,fruiting,词,ADJ,C1
-fruitless,fruitless,词,ADJ,C1
-frustrated,frustrated,沮丧的,ADJ,B2
-frustration,frustration,挫折,NOUN,B2
-fry,to fry,油炸,VERB,B2
-fryer,fryer,词,NOUN,C1
-frénésie,frenzy,疯狂,NOUN,B2
-fuchsia,fuchsia,词,NOUN,C1
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fuir,leak,泄漏,NOUN,B2
-fuir,to leak,泄漏,VERB,B2
-fulcrum,fulcrum,词,NOUN,C1
-fulfil,fulfil,词,VERB,C1
-fulfill,to fulfill,履行,VERB,B2
-fulfillment,fulfillment,满足,NOUN,B2
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full fed up,full fed up,词,ADJ,B1
-full moon,full moon,满月,NOUN,B2
-full moon banquet,full moon banquet,满月酒,NOUN,C1
-full name,full name,大名,NOUN,B2
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full power,full power,全力,NOUN,B2
-full satiated,full satiated,词,ADJ,A2
-full stop,full stop,词,NOUN,B2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,全职,ADJ,B2
-fullness,fullness,词,NOUN,C1
-fulminate,fulminate,词,VERB,C1
-fumarole,fumarole,词,NOUN,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
-fun,fun,有趣的,ADJ,B2
-fun (noun),fun,乐趣,NOUN,A1
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
-function,to function,运作,VERB,B2
-functionalism,functionalism,功能主义,NOUN,B2
-fund,fund,基金,NOUN,B2
-fundamental,fundamental,基本的,ADJ,B2
-fundamental rights,fundamental rights,词,NOUN,C1
-fundamentalism,fundamentalism,原教旨主义,NOUN,B2
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,词,NOUN,C1
-fungal,fungal,词,ADJ,C1
-fungi,fungi,词,NOUN,B2
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funnel,funnel,漏斗,NOUN,B2
-funniness,funniness,,NOUN,B2
-furbish,furbish,词,VERB,C1
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnish,to furnish,提供,VERB,B2
-furnished,furnished,词,ADJ,B2
-furnishing,furnishing,室内布置,NOUN,B2
-further,further,进一步的,ADJ,B2
-further (adv),further,词,ADV,B2
-further additional,further additional,词,ADJ,B2
-further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
-furthermore,furthermore,此外,ADV,B2
-furthest,furthest,最远,ADV,B2
-furtive,furtive,鬼鬼祟祟的,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
-fuse,fuse,保险丝,NOUN,B2
-fuselage,fuselage,机身,NOUN,B2
-fusillade,shootout,枪战,NOUN,B2
-fusion,fusion,融合,NOUN,B2
-fusion,merge,合并,NOUN,B2
-fuss,fuss,大惊小怪,NOUN,B2
-futile,futile,词,ADJ,C1
-futility,futility,无用,NOUN,B2
-future,future,未来的,ADJ,B2
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurism,futurism,未来主义,NOUN,B2
-futurist,futurist,词,NOUN,C1
-fuzzy,fuzzy,词,ADJ,C1
-fédération,federation,联邦,NOUN,B2
-fée,fairy,仙女,NOUN,B2
-félicitation,congratulation,祝贺,NOUN,B2
-féminin,female,女性的,ADJ,B2
-féminisme,feminism,女权主义,NOUN,B2
-féodal,feudal,封建,ADJ,B2
-féodalisme,feudalism,封建主义,NOUN,B2
-férocity,ferocity,凶猛,NOUN,B2
-férocity,fierceness,凶猛,NOUN,B2
-fête,feud,世仇,NOUN,B2
-gad,gad,词,VERB,C1
-gadget,gadget,小装置,NOUN,B2
-gag,gag,词,NOUN,C1
-gain,gain,收益,NOUN,B2
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
-galerie d'art,art gallery,美术馆,NOUN,B2
-galician,galician,加利西亚的,ADJ,B2
-gallantry,gallantry,英勇,NOUN,B2
-gallbladder,gallbladder,词,NOUN,C1
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
-galvanization,galvanization,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
-gamble,gamble,赌博,NOUN,B2
-gamble,to gamble,赌博,VERB,B2
-gamble (noun),gamble,就赌,NOUN,C1
-gambling,gambling,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game play,game play,游戏/比赛,NOUN,B2
-game rule,game rule,游戏规则,NOUN,B2
-gamete,gamete,配子,NOUN,B2
-gang,gang,帮派,NOUN,B2
-gangster,gangster,黑帮成员,NOUN,B2
-gaol,gaol,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garage,garage,车库,NOUN,B2
-garantie,warranty,保修单,NOUN,B2
-garb,garb,词,NOUN,C1
-garbage,garbage,词,NOUN,B2
-garble,garble,词,VERB,C1
-garde,custody,监护,NOUN,B2
-garde d'escorte,escort guard,镖师,NOUN,B2
-garde du corps,bodyguard,保镖,NOUN,B2
-garder,to guard,看守,VERB,B2
-gardien,warden,看守人,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
-gargle (verb),gargle,词,VERB,C1
-gargoyle,gargoyle,滴水嘴兽,NOUN,B2
-garland,garland,花环,NOUN,B2
-garment (part),garment,衣,PART,B2
-garner,garner,词,VERB,C1
-garrison towns,garrison towns,词,NOUN,C1
-garrulous,garrulous,喋喋不休的,ADJ,B2
-gars,guy,家伙,NOUN,B2
-gas flame,gas flame,煤气火焰,NOUN,B2
-gas meter,gas meter,,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
-gaseous,gaseous,气态的,ADJ,B2
-gash,gash,词,NOUN,C1
-gasket,gasket,词,NOUN,B1
-gasp (noun),gasp,词,NOUN,B2
-gasp (verb),gasp,词,VERB,B2
-gaspilleur,wasteful,浪费的,ADJ,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomic,gastronomic,美食的,ADJ,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatekeeper,gatekeeper,道口看守员,NOUN,B2
-gateway,gateway,词,NOUN,C1
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauche,left,左边,ADV,B2
-gauge (noun),gauge,词,NOUN,C1
-gauge meter,gauge meter,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,快乐的,ADJ,B2
-gay (noun),gay,同性恋者,NOUN,B2
-gay man,gay man,男同性恋者,NOUN,B2
-gaze (noun),gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gazette,gazette,词,NOUN,C1
-gearbox,gearbox,变速箱,NOUN,B2
-geek,geek,极客,NOUN,C1
-geerziehung,geerziehung,词,NOUN,C1
-gefahrt,gefahrt,词,NOUN,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gekunft,gekunft,词,NOUN,C1
-gel,freezing,冻结,NOUN,B2
-gel,gel,词,NOUN,C1
-gelatin,gelatin,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-geld,geld,词,VERB,C1
-gem,gem,宝石,NOUN,B2
-gemstone,gemstone,词,NOUN,C1
-genahme,genahme,词,NOUN,C1
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
-gender equality,gender equality,性别平等,NOUN,B2
-gender parity,gender parity,词,NOUN,C1
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
-general (noun),general,将军,NOUN,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generations,generations,词,NOUN,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
-generatrix,generatrix,母线,NOUN,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetic modification,genetic modification,基因改造,NOUN,B2
-genetics,genetics,遗传学,NOUN,B2
-genial,genial,词,ADJ,C1
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,种族灭绝,NOUN,B2
-genou,knee,膝盖,NOUN,B2
-genoux,lap,大腿部,NOUN,B2
-genre,gender,性别,NOUN,B2
-genre,genre,类型,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gens ordinaires,ordinary people,老百姓,NOUN,B2
-gentle reproach,gentle reproach,词,NOUN,C1
-gentlemen,gentlemen,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gentrification,gentrification,词,NOUN,C1
-genuflect,genuflect,词,VERB,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geocentric,geocentric,词,ADJ,C1
-geographer,geographer,词,NOUN,C1
-geometer,geometer,几何学家,NOUN,B2
-geometry,geometry,几何学,NOUN,B2
-geophysics,geophysics,词,NOUN,C1
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gepflegung,gepflegung,词,NOUN,C1
-geregelung,geregelung,词,NOUN,C1
-geriatric,geriatric,词,ADJ,C1
-gerichtung,gerichtung,词,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,德国人,NOUN,B2
-germanic,germanic,日耳曼的,ADJ,B2
-germe,germ,病菌,NOUN,B2
-germicidal,germicidal,杀菌的,ADJ,B2
-germination,germination,发芽,NOUN,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-gesprache,gesprache,词,NOUN,C1
-gestation,gestation,词,NOUN,C1
-gestion,management,管理,NOUN,B2
-gestural,gestural,手势的,ADJ,B2
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-getting rich,getting rich,词,NOUN,C1
-gewandel,gewandel,词,NOUN,C1
-geweisung,geweisung,词,NOUN,C1
-gewirkung,gewirkung,词,NOUN,C1
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
-gibber,gibber,词,VERB,C1
-gibberish,gibberish,词,NOUN,C1
-gibe,gibe,词,VERB,C1
-giddy,giddy,头晕的,ADJ,B2
-giftedness,giftedness,词,NOUN,C1
-gigantesque,giant,巨大的,ADJ,B2
-gigolo,gigolo,面首,NOUN,B2
-gilding,gilding,词,NOUN,C1
-gills,gills,词,NOUN,B2
-gin,gin,金酒,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-girafe,giraffe,长颈鹿,NOUN,B2
-girdle,girdle,词,NOUN,C1
-girl daughter,girl daughter,词,NOUN,A1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give you (noun),give you,送你,NOUN,C1
-given,given,给定的,ADJ,B2
-given datum,given datum,词,NOUN,C1
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-glacial,glacial,词,ADJ,C1
-glacial,ice-cold,冰冷的,ADJ,B2
-glacier,glacier,冰川,NOUN,B2
-gladden,gladden,词,VERB,C1
-gladiator,gladiator,词,NOUN,C1
-gladly,gladly,乐意地,ADV,B2
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glamour,glamour,词,NOUN,C1
-glance,glance,一瞥,NOUN,B2
-glare,glare,词,VERB,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-glebe,glebe,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-glib,glib,伶牙俐齿的,ADJ,B2
-gliding,gliding,滑翔,NOUN,B2
-glimmer,glimmer,词,NOUN,C1
-glimpse,glimpse,一瞥,NOUN,B2
-glint,glint,词,NOUN,C1
-glissement de terrain,landslide,滑坡,NOUN,B2
-glisten,glisten,词,VERB,C1
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-gloating,gloating,词,NOUN,C1
-global (noun),global,全球,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-gloire vaine,empty fame,虚名,NOUN,B2
-glomerulus,glomerulus,词,NOUN,C1
-glorifier,to glorify,赞美,VERB,B2
-gloriously,gloriously,词,ADV,C1
-gloriousness,gloriousness,光荣,NOUN,B2
-glossary,glossary,词汇表,NOUN,B2
-glossator,glossator,词,NOUN,C1
-gloves,gloves,词,NOUN,B2
-glow (verb),glow,词,VERB,B2
-glower,glower,词,VERB,C1
-glucose,glucose,词,NOUN,C1
-glut,glut,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
-glyph,glyph,词,NOUN,C1
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-go away,go away,词,VERB,C1
-go wrong,go wrong,词,VERB,C1
-goalkeeper,goalkeeper,守门员,NOUN,B2
-gobble,gobble,词,VERB,C1
-goblin,goblin,词,NOUN,C1
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-godliness,godliness,词,NOUN,C1
-goggle,goggle,词,VERB,C1
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good day,good day,你好,INTJ,B2
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good heavens,good heavens,天哪,INTJ,B2
-good lord,good lord,词,INTJ,B2
-good medicine,good medicine,好药,NOUN,B2
-good morning,good morning,早上好,INTJ,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good night,good night,晚安,INTJ,B2
-good offices,good offices,词,NOUN,C1
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-good-naturedness,good-naturedness,温和,NOUN,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gosh,gosh,天哪,INTJ,B2
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,爱传流言的,ADJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-gouge,gouge,词,VERB,C1
-gourmandise,gluttony,暴食,NOUN,B2
-gourmet,gourmet,美食家,NOUN,B2
-govern a country,govern a country,治国,VERB,C1
-governability,governability,可治理性,NOUN,B2
-governable,governable,可管理的,ADJ,B2
-governess,governess,词,NOUN,C1
-governorate,governorate,词,NOUN,C1
-grab,grab,揪,NOUN,B2
-gracefulness,gracefulness,词,NOUN,C1
-gracieux,graceful,优雅的,ADJ,B2
-gracious,gracious,亲切的,ADJ,B2
-gradation,gradation,渐变,NOUN,B2
-grade,grade,等级,NOUN,B2
-grade (verb),grade,分级,VERB,C1
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation,graduation,毕业,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-graffiti,graffiti,涂鸦,NOUN,C1
-grail,grail,圣杯,NOUN,B2
-grain,grain,谷物,NOUN,B2
-graine de pastèque,watermelon seed,西瓜子,NOUN,B2
-graisser,to grease,涂油,VERB,B2
-grammatical,grammatical,词,ADJ,C1
-grammaticality,grammaticality,合语法性,NOUN,B2
-gramophone,gramophone,词,NOUN,C1
-granary,granary,词,NOUN,C1
-grand,biggest,最大,ADJ,B2
-grand,grand,宏伟的,ADJ,B2
-grand,tall,高的,ADJ,B2
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand livre,ledger,总账,NOUN,B2
-grand magasin,department store,百货商店,NOUN,B2
-grand master,grand master,大师,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand pouvoir,great power,大国,NOUN,B2
-grand service,great favor,大恩,NOUN,B2
-grand theater,grand theater,大剧院,NOUN,B2
-grand-mère,grandma,奶奶,NOUN,B2
-grand-mère,grandmother,祖母,NOUN,B2
-grand-père,grandfather,祖父,NOUN,B2
-grande distance,grand distance,雄远,NOUN,B2
-grande offense,great offense,冒犯大,NOUN,B2
-grande puissance,powerful nation,强国,NOUN,B2
-grandeur,grandeur,宏伟,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,夸张的,ADJ,B2
-grandiose,grandiose,浮夸的,ADJ,B2
-grandiosity,grandiosity,宏伟,NOUN,B2
-grandpa,grandpa,爷爷,NOUN,B2
-grandparent,grandparent,词,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granitic,granitic,词,ADJ,C1
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-granule,granule,词,NOUN,C1
-grapes,grapes,词,NOUN,A1
-graph,graph,词,NOUN,C1
-graphic artist,graphic artist,词,NOUN,C1
-graphic designer,graphic designer,图形设计师,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-graphique,graphic,图形的,ADJ,B2
-graphology,graphology,笔迹学,NOUN,B2
-grappe,cluster,簇,NOUN,B2
-grapple,grapple,词,VERB,C1
-gras,greasy,油腻的,ADJ,B2
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grasshopper,grasshopper,词,NOUN,B1
-grassroots,grassroots,词,ADJ,C1
-grate,grate,词,VERB,C1
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratitude,gratitude,感激,NOUN,B2
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-graveyard,graveyard,墓地,NOUN,B2
-gravid,gravid,怀孕的,ADJ,B2
-gravitas,gravitas,词,NOUN,C1
-gravitation,gravitation,引力,NOUN,B2
-gravitational,gravitational,引力的,ADJ,B2
-gravity of loss,gravity of loss,词,NOUN,C1
-gray hair,gray hair,词,NOUN,B2
-grayish,grayish,词,ADJ,C1
-grease (noun),grease,词,NOUN,C1
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-greaten,greaten,词,VERB,C1
-greatest,greatest,词,NOUN,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊语,NOUN,B2
-green blue,green blue,青,ADJ,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green-clad,green-clad,,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-greetings,greetings,,NOUN,B2
-greffe,graft,嫁接,NOUN,B2
-gregarious,gregarious,爱社交的,ADJ,B2
-grenade,grenade,手榴弹,NOUN,B2
-grenadier,grenadier,词,NOUN,C1
-grenouille,frog,青蛙,NOUN,B2
-grey area,grey area,灰色地带,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
-grieve,grieve,词,VERB,C1
-grieved,grieved,词,ADJ,B2
-grievously unjust,grievously unjust,词,ADJ,C1
-grill (noun),grill,词,NOUN,B2
-grille,grille,格栅,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grimace,grimace,词,NOUN,C1
-grimness,grimness,词,NOUN,C1
-grinder,grinder,词,NOUN,C1
-grip (noun),grip,握呀,NOUN,C1
-gripe,gripe,词,VERB,C1
-gris,gray,灰色的,ADJ,B2
-grit,grit,词,NOUN,C1
-groan,groan,呻吟,NOUN,B2
-grocer,grocer,词,NOUN,A2
-grocery,grocery,词,NOUN,B2
-grognement,growl,低吼,NOUN,B2
-gronder,to scold,训斥,VERB,B2
-grooved,grooved,词,ADJ,C1
-grope,grope,词,VERB,C1
-gros,wholesale,批发,NOUN,B2
-grossier,gross,总的,ADJ,B2
-grotesque,grotesque,怪诞的,ADJ,B2
-grotto,grotto,洞穴,NOUN,B2
-ground (adj),ground,磨碎的,ADJ,B1
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds of judgment,grounds of judgment,词,NOUN,C1
-groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,群体工作,NOUN,B2
-grouse,grouse,词,VERB,C1
-grovel,grovel,词,VERB,C1
-grown,grown,长大的,ADJ,B2
-growth rate,growth rate,词,NOUN,C1
-grub,grub,词,NOUN,C1
-grue,crane,起重机,NOUN,B2
-grueling,grueling,词,ADJ,C1
-gruff,gruff,阴沉的,ADJ,B2
-grumpy,grumpy,脾气坏的,ADJ,B2
-grunt,grunt,词,VERB,B2
-grâce à,thanks to,多亏,ADP,B2
-guarantees,guarantees,词,NOUN,C1
-guarding,guarding,守住,NOUN,C1
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-guerre mondiale,world war,世界大战,NOUN,B2
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guffaw,guffaw,哄笑,NOUN,B2
-guidance,guidance,指导,NOUN,B2
-guide,guide,导游,NOUN,B2
-guidebook,guidebook,词,NOUN,B1
-guided tour,guided tour,导游,NOUN,B2
-guideline,guideline,指导方针,NOUN,B2
-guiding light,guiding light,词,NOUN,C1
-guild,guild,行会,NOUN,B2
-guild (adj),guild,词,ADJ,C1
-guilder,guilder,盾,NOUN,B2
-guillotine,guillotine,断头台,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-gunshot,gunshot,枪声,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
-guérir,to cure,治愈,VERB,B2
-gymnast,gymnast,体操运动员,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gymnastique,gymnastics,体操,NOUN,B2
-gynaecology,gynaecology,妇科,NOUN,B2
-gynecologist,gynecologist,词,NOUN,C1
-gyroscope,gyroscope,词,NOUN,C1
-gémir,to wail,哀号,VERB,B2
-gémir,to whine,哀叹,VERB,B2
-génie,genius,天才,NOUN,B2
-généalogie,genealogy,家谱学,NOUN,B2
-général,general,将军,NOUN,B2
-génération mutuelle,mutual generation,相生,NOUN,B2
-géologique,geological,地质的,ADJ,B2
-géopolitique,geopolitics,地缘政治,NOUN,B2
-gênant,troublesome,麻烦的,ADJ,B2
-ha,ha,哈,INTJ,B2
-habiliter,to empower,授权,VERB,B2
-habit formation,habit formation,词,NOUN,C1
-habitability,habitability,词,NOUN,C1
-habitat,habitat,栖息地,NOUN,B2
-habiter,to inhabit,居住,VERB,B2
-habitlessness,habitlessness,无习惯,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-habituation,habituation,习惯化,NOUN,B2
-habitude,habitually in the past,往常,NOUN,B2
-habituellement,usually,通常,ADV,B2
-habitus,habitus,词,NOUN,C1
-habous endowments,habous endowments,词,NOUN,C1
-hacher,chop,砍,NOUN,B2
-hacher,to chop,砍,VERB,B2
-hacker,hacker,黑客,NOUN,C1
-hackneyed,hackneyed,词,ADJ,C1
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hag,hag,老妇,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-haine,hate,仇恨,NOUN,B2
-haine,hatred,仇恨,NOUN,B2
-hair-raising,hair-raising,词,ADJ,B2
-haircut,haircut,词,NOUN,C1
-hakawati,hakawati,词,NOUN,B2
-half (num),half,半,NUM,A1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
-half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway,halfway,半途,ADV,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall,hall,大厅,NOUN,B2
-hall (part),hall,殿,PART,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
-hallowed,hallowed,词,ADJ,C1
-hallucination,hallucination,幻觉,NOUN,B2
-halo,halo,词,NOUN,B2
-haléter,to pant,喘气,VERB,B2
-hamburger,hamburger,汉堡包,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
-handbrake,handbrake,手刹,NOUN,C1
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-handyman,handyman,工匠,NOUN,B2
-hanged,hanged,被绞死的,ADJ,B2
-hangover,hangover,词,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy cheerful,happy cheerful,词,ADJ,B1
-happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-harbour,harbour,港口,NOUN,B2
-harceler,to nag,唠叨,VERB,B2
-hard,hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-harder,harder,词,ADJ,A2
-hardship,hardship,艰难,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
-hare,hare,野兔,NOUN,B2
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
-harmonie sociale,social harmony,社会和谐,NOUN,B2
-harried,harried,词,ADJ,C1
-harshness,harshness,词,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hassle,hassle,麻烦,NOUN,B2
-hastily,hastily,急忙,ADV,B2
-hatch,hatch,舱口,NOUN,B2
-hatching,hatching,词,NOUN,C1
-haughty,haughty,傲慢的,ADJ,B2
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have time,have time,词,VERB,B2
-have to (adv),have to,不得不,ADV,A1
-have to (aux),have to,必须,AUX,B2
-have to (noun),have to,还得,NOUN,B2
-having a birthday,having a birthday,过生日的,ADJ,B2
-having a cold,having a cold,感冒的,ADJ,B2
-having item,having item,有件,NOUN,C1
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-heading,heading,标题,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headline,headline,标题,NOUN,B2
-headlines,headlines,词,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healer,healer,词,NOUN,B2
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,医疗保健,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-hearing aid,hearing aid,词,NOUN,B2
-hearsay,hearsay,词,NOUN,C1
-heart,heart,心,ADV,B2
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartfelt,heartfelt,衷心的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-hearth,hearth,壁炉,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartlessness,heartlessness,无情,NOUN,B2
-heartrending,heartrending,词,ADJ,C1
-hearts,hearts,心,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hectic,hectic,忙乱,NOUN,B2
-hectic (adj),hectic,词,ADJ,C1
-hedonist,hedonist,词,NOUN,C1
-hedonistic,hedonistic,享乐主义的,ADJ,B2
-heedlessness,heedlessness,词,NOUN,C1
-hefen,hefen,河粉,NOUN,C1
-heinous,heinous,词,ADJ,C1
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello bye,hello bye,词,INTJ,B2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-hem,hem,边缘,NOUN,B2
-hemiplegia,hemiplegia,词,NOUN,C1
-hemisphere,hemisphere,半球,NOUN,B2
-hemistich,hemistich,词,NOUN,C1
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hence,hence,因此,ADV,B2
-henceforth,henceforth,从此以后,ADV,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hennir,to neigh,嘶鸣,VERB,B2
-hepatic,hepatic,肝脏的,ADJ,B2
-her,her,她的,DET,B2
-her (pron),her,词,PRON,A1
-her their,her their,词,DET,A1
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
-herbaceous,herbaceous,草本的,ADJ,B2
-herbalism,herbalism,词,NOUN,C1
-herbalist,herbalist,词,NOUN,B1
-herbarium,herbarium,词,NOUN,C1
-herbe,herb,草药,NOUN,B2
-herbicide,herbicide,除草剂,NOUN,B2
-herbs,herbs,词,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
-here (noun),here,此地,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here you go,here you go,请,INTJ,B2
-hereafter,hereafter,词,NOUN,C1
-herein,herein,词,ADV,B1
-heresiarch,heresiarch,词,NOUN,C1
-heretical,heretical,词,ADJ,C1
-heretical innovation,heretical innovation,词,NOUN,C1
-hermeneutics,hermeneutics,词,NOUN,C1
-hermetic,hermetic,词,ADJ,C1
-hermitage,hermitage,词,NOUN,B2
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,词,NOUN,B1
-heron,heron,词,NOUN,C1
-heterodox,heterodox,异端的,ADJ,B2
-heterodoxy,heterodoxy,词,NOUN,C1
-heterogeneity,heterogeneity,异质性,NOUN,B2
-heterosexual,heterosexual,词,ADJ,C1
-heures supplémentaires,overtime,加班,NOUN,B2
-heureusement,fortunately,幸运地,ADV,B2
-heureux,fortunate,幸运的,ADJ,B2
-heureux,glad,高兴的,ADJ,B2
-hexadecimal,hexadecimal,词,ADJ,C1
-hexagon,hexagon,六边形,NOUN,B2
-heyday,heyday,词,NOUN,C1
-hidden,hidden,隐藏的,ADJ,B2
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
-hideous,hideous,丑陋的,ADJ,B2
-hider,hider,词,NOUN,B2
-hiding place,hiding place,藏身处,NOUN,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,高中毕业生,NOUN,B2
-high tall,high tall,高的,ADJ,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highest,highest,最高的,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
-highlight,highlight,亮点,NOUN,B2
-hijack,hijack,词,VERB,C1
-hijacking,hijacking,词,NOUN,C1
-hilarious,hilarious,滑稽的,ADJ,B2
-him,him,他,PRON,B2
-him dative,him dative,词,PRON,A2
-himself herself,himself herself,词,PRON,A1
-hint,hint,暗示,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
-hirsute,hirsute,词,ADJ,C1
-his certainty,his certainty,他定,NOUN,C1
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,他/她自己的,DET,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,西班牙的,ADJ,B2
-hiss,hiss,嘶嘶声,NOUN,B2
-histoire,history,历史,NOUN,B2
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historicism,historicism,历史主义,NOUN,B2
-historicist,historicist,历史主义者,NOUN,B2
-historicity,historicity,历史性,NOUN,B2
-historicization,historicization,词,NOUN,C1
-historiographie,historiography,史学,NOUN,B2
-historique,historic,历史性的,ADJ,B2
-history education,history education,词,NOUN,C1
-history story,history story,历史/故事,NOUN,B2
-histrionic,histrionic,词,ADJ,C1
-hit beat,hit beat,词,VERB,A2
-hither,hither,到这里,ADV,B2
-hmm,hmm,嗯,INTJ,B2
-hocher,to nod,点头,VERB,B2
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hockey sur glace,ice hockey,冰球,NOUN,B2
-hold catch,hold catch,词,VERB,A1
-hold together,hold together,词,VERB,C1
-holding,holding,别放,NOUN,B2
-holdup,holdup,词,NOUN,B2
-holiday feast,holiday feast,词,NOUN,A2
-holism,holism,整体论,NOUN,B2
-holistique,holistic,整体的,ADJ,B2
-hollowed,hollowed,掏空的,ADJ,B2
-holm oak,holm oak,词,NOUN,C1
-hologram,hologram,词,NOUN,C1
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home (adv),home,词,ADV,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,顾家的,ADJ,B2
-homelessness,homelessness,词,NOUN,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,,NOUN,B2
-homework duty,homework duty,词,NOUN,A2
-homicide,homicide,杀人,NOUN,B2
-homiletic,homiletic,词,ADJ,C1
-hominization,hominization,词,NOUN,C1
-homme d'affaires,businessman,商人,NOUN,B2
-homogeneity,homogeneity,同质性,NOUN,B2
-homonym,homonym,词,NOUN,C1
-homosexuel,homosexual,同性恋的,ADJ,B2
-homothety,homothety,位似,NOUN,C1
-honor culture,honor culture,荣誉文化,NOUN,B2
-honorability,honorability,词,NOUN,C1
-honorable,honorable,可敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-honoré,honored,尊敬的,ADJ,B2
-honte,shame,羞愧,NOUN,B2
-honte,to shame,使羞愧,VERB,B2
-honteux,ashamed,羞愧的,ADJ,B2
-hooligan,hooligan,流氓,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
-hoped-for,hoped-for,词,ADJ,C1
-hopeful,hopeful,词,ADJ,C1
-hopefully,hopefully,希望,ADV,B2
-hopeless,hopeless,绝望的,ADJ,B2
-hopelessly,hopelessly,绝望地,ADV,B2
-hopelessness,hopelessness,词,NOUN,C1
-horde,horde,词,NOUN,B2
-horizon,horizon,地平线,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
-hormone,hormone,激素,NOUN,B2
-horny,horny,性欲的,ADJ,B2
-horoscope,horoscope,星座运势,NOUN,B2
-horrible,horrible,可怕的,ADJ,B2
-horrified,horrified,惊骇的,ADJ,B2
-horrifying,horrifying,令人毛骨悚然的,ADJ,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-hors de,out of,从...出来,ADP,B2
-horse departure,horse departure,马去,NOUN,B2
-horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hose,hose,软管,NOUN,B2
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
-hospitalization,hospitalization,词,NOUN,C1
-host of angels,host of angels,天使群,NOUN,B2
-hostel,hostel,词,NOUN,C1
-hostile,hostile,敌对的,ADJ,B2
-hosting,hosting,托管,NOUN,C1
-hot air balloon,hot air balloon,热气球,NOUN,B2
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
-hotbed,hotbed,词,NOUN,C1
-hotel room,hotel room,酒店房间,NOUN,B2
-hothead,hothead,急性子的人,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-house search,house search,词,NOUN,B2
-household,household,家庭的,ADJ,B2
-household income,household income,家庭收入,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
-hover,to hover,盘旋,VERB,B2
-how,how,又怎会,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
-how many,how many,多少,NUM,B2
-how many (pron),how many,多少,PRON,A1
-how much,how much,多少,PRON,B2
-how to do it,how to do it,办呢,ADV,B2
-however,however,然而,CCONJ,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hubris,hubris,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
-hug,hug,拥抱,NOUN,B2
-hug,to hug,拥抱,VERB,B2
-huge,huge,巨大的,ADJ,B2
-huh,huh,哈,INTJ,B2
-human,human,人类,NOUN,B2
-human being,human being,词,NOUN,B1
-human capacity,human capacity,人会,NOUN,B2
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
-human nature,human nature,人性,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humane,humane,人道的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
-humanity,humanity,人类,NOUN,B2
-humanization,humanization,人性化,NOUN,B2
-humble,humble,谦逊的,ADJ,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humid,humid,潮湿的,ADJ,B2
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
-humide,wet,湿的,ADJ,B2
-humidity,humidity,湿度,NOUN,B2
-humiliating,humiliating,令人羞辱的,ADJ,B2
-humming,humming,词,NOUN,B2
-hummingbird,hummingbird,词,NOUN,B2
-humorist,humorist,词,NOUN,C1
-humorous,humorous,幽默的,ADJ,B2
-hump,hump,驼峰,NOUN,B2
-hunch,hunch,词,NOUN,B2
-hunchbacked,hunchbacked,驼背的,ADJ,B2
-hundred,hundred,百,NUM,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hundreds (num),hundreds,词,NUM,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
-hungry,hungry,饥饿的,ADJ,B2
-hunt,hunt,狩猎,NOUN,B2
-hurrah,hurrah,万岁,INTJ,B2
-hurricane,hurricane,飓风,NOUN,B2
-hurriedly,hurriedly,赶紧,ADV,B2
-hurry,hurry,匆忙,NOUN,B2
-hurry,to hurry,赶快,VERB,B2
-hurry (noun),hurry,快些,NOUN,A1
-hurt,to hurt,受伤,VERB,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hyaline,hyaline,词,ADJ,C1
-hybridism,hybridism,词,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
-hybridization,hybridization,杂交,NOUN,B2
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrology,hydrology,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
-hygienic,hygienic,卫生的,ADJ,B2
-hymnal,hymnal,词,NOUN,C1
-hymne,hymn,赞美诗,NOUN,B2
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
-hyper-utilisation,hyper-use,超用,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbole,hyperbole,夸张,NOUN,B2
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hypnose,hypnosis,催眠,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
-hypocrite,hypocrite,伪君子,NOUN,B2
-hypotension,hypotension,词,NOUN,C1
-hypotensive,hypotensive,词,ADJ,C1
-hypothesize,hypothesize,词,VERB,B2
-hypothetically,hypothetically,词,ADV,C1
-hypothèse,assumption,假设,NOUN,B2
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
-hâtif,hasty,仓促的,ADJ,B2
-hé,hey,嘿,INTJ,B2
-héhé,hehe,嘿嘿,INTJ,B2
-hémoglobine,hemoglobin,血红蛋白,NOUN,B2
-hérisson,hedgehog,刺猬,NOUN,B2
-héritage,legacy,遗产,NOUN,B2
-héros,hero,英雄,NOUN,B2
-héroïque,heroic,英勇的,ADJ,B2
-héroïsme,heroism,英雄主义,NOUN,B2
-hérédité,heredity,遗传,NOUN,B2
-hérétique,heretic,异端,NOUN,B2
-hôtel de ville,city hall,市政厅,NOUN,B2
-i,i,我连,NOUN,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-ice cold,ice cold,冰冷的,ADJ,B2
-ice pick,ice pick,,NOUN,B2
-ici,here,此地,NOUN,B2
-icicle,icicle,词,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconicity,iconicity,词,NOUN,C1
-iconoclast,iconoclast,偶像破坏者,NOUN,B2
-iconoclastic,iconoclastic,词,ADJ,C1
-iconographic,iconographic,词,ADJ,C1
-ideal (noun),ideal,理想,NOUN,B2
-idealization,idealization,理想化,NOUN,B2
-ideational,ideational,词,ADJ,C1
-identification,identification,身份证明,NOUN,B2
-identitarianism,identitarianism,词,NOUN,C1
-identité,id,证件,NOUN,B2
-identité sociale,social identity,社会身份,NOUN,B2
-ideologization,ideologization,词,NOUN,C1
-idiomatic,idiomatic,词,ADJ,C1
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiot,idiot,傻瓜,ADJ,B2
-idiotic,idiotic,愚蠢的,ADJ,B2
-idiotie,idiocy,愚蠢,NOUN,B2
-idolatry,idolatry,词,NOUN,B2
-idyllic,idyllic,词,ADJ,C1
-idéal,ideal,理想,NOUN,B2
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
-igneous,igneous,火成的,ADJ,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominious,ignominious,词,ADJ,C1
-ignorance,ignorance,无知,NOUN,B2
-ignorant,ignorant,无知的,ADJ,B2
-il,it,它,PRON,B2
-il y a encore du temps,to there's still time,来得及,VERB,B2
-il y a longtemps,long ago,早已,ADV,B2
-iliac,iliac,词,ADJ,C1
-illiteracy,illiteracy,词,NOUN,C1
-illiterate,illiterate,词,ADJ,B2
-illogical,illogical,不合逻辑的,ADJ,B2
-illumination,enlightenment,澄清,NOUN,B2
-illuminationism,illuminationism,照明主义,NOUN,C1
-illusion,illusion,幻觉,NOUN,B2
-illustration,illustration,插图,NOUN,B2
-illustrative,illustrative,词,ADJ,C1
-illégalité,illegality,非法,NOUN,B2
-image,image,形象,NOUN,B2
-image,picture,图画,NOUN,B2
-image formation,image formation,形象塑造,NOUN,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imagination,imagination,想象力,NOUN,B2
-imaginative,imaginative,富有想象力的,ADJ,B2
-imagined,imagined,想象的,ADJ,C1
-imaging,imaging,词,NOUN,C1
-imam,imam,伊玛目,NOUN,B2
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecility,imbecility,愚蠢,NOUN,B2
-imitatif,imitative,模仿性,ADJ,B2
-imitation,imitation,模仿,NOUN,B2
-immaculate,immaculate,词,ADJ,C1
-immanence,immanence,内在性,NOUN,B2
-immanent,immanent,词,ADJ,C1
-immatriculation,vehicle registration,行驶证,NOUN,B2
-immature,immature,不成熟的,ADJ,B2
-immediacy,immediacy,词,NOUN,C1
-immemorial,immemorial,词,ADJ,C1
-immense,immense,巨大的,ADJ,B2
-immensely,immensely,词,ADV,B2
-immensity,immensity,词,NOUN,C1
-immerse,immerse,词,VERB,C1
-immersed,immersed,词,ADJ,C1
-immersion,immersion,沉浸,NOUN,B2
-immigration,immigration,移民,NOUN,B2
-immigrer,to immigrate,移入,VERB,B2
-imminence,imminence,就将,NOUN,C1
-imminent,imminent,即将来临的,ADJ,B2
-immobilier,real estate,不动产,NOUN,B2
-immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immoral,immoral,不道德的,ADJ,B2
-immorality,immorality,词,NOUN,C1
-immortal,immortal,不朽的,ADJ,B2
-immovable,immovable,不可移动的,ADJ,B2
-immunothérapie,immunotherapy,免疫治疗,NOUN,B2
-immédiatement,immediately,立即,ADV,B2
-impartial,impartial,词,ADJ,C1
-impasse,impasse,词,NOUN,C1
-impassive,impassive,词,ADJ,C1
-impatience,impatience,词,NOUN,C1
-impatient,impatient,不耐烦的,ADJ,B2
-impeccable,impeccable,无瑕疵的,ADJ,B2
-impediment,impediment,障碍,NOUN,B2
-impel,to impel,推动,VERB,B2
-impenetrable,impenetrable,不可穿透的,ADJ,B2
-imperceptible,imperceptible,词,ADJ,C1
-imperfection,imperfection,词,NOUN,C1
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
-imperial court,imperial court,朝廷,NOUN,B2
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
-imperial father's will,imperial father's will,父皇要,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
-imperial guard,imperial guard,御林,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,太医,NOUN,B2
-imperial relatives,imperial relatives,皇亲,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
-imperialist,imperialist,帝国主义的,ADJ,B2
-imperious,imperious,词,ADJ,C1
-impersonal,impersonal,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbable,unruffled,从容,ADJ,B2
-impetuosity,impetuosity,词,NOUN,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implantation,implantation,词,NOUN,C1
-implausible,implausible,词,ADJ,C1
-implement,to implement,实施,VERB,B2
-implementation,implementation,实施,NOUN,B2
-implicate,to implicate,连累,VERB,B2
-implicated,implicated,牵连的,ADJ,C1
-implication,implication,含义,NOUN,B2
-impliqué,involved,涉及的,ADJ,B2
-implore,to implore,恳求,VERB,B2
-impolite,impolite,不礼貌的,ADJ,B2
-impoliteness,impoliteness,词,NOUN,C1
-import,import,进口,NOUN,B2
-import,to import,进口,VERB,B2
-import (noun),import,词,NOUN,B2
-importance,importance,重要性,NOUN,B2
-important,important,重要的,ADJ,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
-importation,importation,进口,NOUN,B2
-imports,imports,词,NOUN,C1
-imposition,imposition,词,NOUN,C1
-impossibility,impossibility,不可能,NOUN,B2
-impossible,impossible,不可能的,ADJ,B2
-imposture,imposture,词,NOUN,C1
-impotence,impotence,无力,NOUN,B2
-impotent,impotent,词,ADJ,C1
-impoverished,impoverished,贫困的,ADJ,B2
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
-impressed,impressed,印象深刻的,ADJ,B2
-impression,impression,印象,NOUN,B2
-impressions,impressions,感想,NOUN,B2
-impressive,impressive,令人印象深刻的,ADJ,B2
-imprison,to imprison,监禁,VERB,B2
-imprisoned,imprisoned,被监禁的,ADJ,B2
-improbable,unlikely,不太可能的,ADJ,B2
-impromptu,impromptu,即兴的,ADJ,B2
-improper,improper,不合适的,ADJ,B2
-improvidence,improvidence,词,NOUN,C1
-improvisation,improvisation,即兴创作,NOUN,B2
-improvised,improvised,即兴的,ADJ,B2
-imprudence,imprudence,词,NOUN,C1
-imprudence,recklessness,轻率,NOUN,B2
-imprudent,imprudent,词,ADJ,C1
-impudence,impudence,厚颜无耻,NOUN,B2
-impudent,impudent,无礼的,ADJ,B2
-impudent,shameless,无耻的,ADJ,B2
-impuissant,helpless,无助的,ADJ,B2
-impulsive,impulsive,冲动的,ADJ,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-impure,impure,词,ADJ,C1
-impurity,impurity,不纯,NOUN,B2
-imputation,imputation,词,NOUN,C1
-in,in,进来,ADV,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in addition,in addition,此外,ADV,B2
-in addition to,in addition to,除...之外,ADP,B2
-in advance,in advance,事先,ADV,B2
-in agreement,in agreement,词,ADV,C1
-in anticipation of,in anticipation of,词,ADV,C1
-in between,in between,在中间,ADV,B2
-in book,in book,书里,NOUN,C1
-in case,in case,如果,SCONJ,B2
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in detail,in detail,详细地,ADV,B2
-in every detail,in every detail,词,ADV,C1
-in fact,in fact,事实上,ADV,B2
-in front,in front,在前面,ADV,B2
-in front of before,in front of before,在...前,ADP,B2
-in here,in here,在这里面,ADV,B2
-in high spirits,in high spirits,兴致勃勃,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
-in it,in it,在里面,ADV,B2
-in its entirety,in its entirety,词,ADV,C1
-in me,in me,我中,NOUN,C1
-in mind,in mind,记住,ADV,B2
-in need,in need,词,ADJ,A2
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
-in order to,in order to,以期,SCONJ,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in private,in private,私下地,ADV,B2
-in question,in question,词,ADV,C1
-in return,in return,作为回报,NOUN,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,在后面,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,在那里面,ADV,B2
-in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
-in time (adj),in time,词,ADJ,B1
-in two,in two,成两半,ADV,B2
-in unison,in unison,齐声,ADV,B2
-in vain,in vain,徒劳,NOUN,B2
-in view of,in view of,鉴于,ADP,B2
-in which,in which,在其中,PRON,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccessible,inaccessible,词,ADJ,C1
-inaccurate,inaccurate,词,ADJ,C1
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inactivity,inactivity,不活跃,NOUN,B2
-inadequate,inadequate,不足的,ADJ,B2
-inadvertent,inadvertent,词,ADJ,C1
-inadvertently,inadvertently,词,ADV,B2
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inapproprié,inappropriate,不恰当的,ADJ,B2
-inaptitude,non-ability,非能,NOUN,B2
-inatteignable,unattainable,难以获得的,ADJ,B2
-inattentive,inattentive,词,ADJ,C1
-inaudible,inaudible,词,ADJ,B2
-inauguration,inauguration,开幕,NOUN,B2
-inboard,inboard,船内的,ADV,B2
-inborn nature,inborn nature,词,NOUN,C1
-incandescence,incandescence,词,NOUN,C1
-incandescent,incandescent,白炽的,ADJ,B2
-incantation,incantation,咒语,NOUN,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incapacité,inability,无能,NOUN,B2
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
-incentivization,incentivization,词,NOUN,C1
-inceptive,inceptive,词,ADJ,C1
-incessant,incessant,持续的,ADJ,B2
-inchoative,inchoative,词,ADJ,C1
-incidence,incidence,发生率,NOUN,B2
-incident,incident,事件,NOUN,B2
-incidental,incidental,偶然的,ADJ,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
-incinérer,to incinerate,焚烧,VERB,B2
-incipient,incipient,初期的,ADJ,B2
-incision,incision,切口,NOUN,B2
-incisive,incisive,深刻的,ADJ,B2
-incitation,incitement,煽动,NOUN,B2
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,严酷的,ADJ,B2
-inclinaison,reclining,躺下,NOUN,B2
-including,including,包括,ADP,B2
-including (adv),including,词,ADV,A2
-inclusion,inclusion,包含,NOUN,B2
-inclusion inverse,reverse inclusion,反纳,NOUN,B2
-incognito,incognito,词,ADJ,C1
-incoherence,incoherence,不连贯,NOUN,B2
-incohérent,inconsistent,不一致的,ADJ,B2
-incombustible,fireproof,防火的,ADJ,B2
-income tax,income tax,所得税,NOUN,B2
-incommensurable,immeasurable,不可估量的,ADJ,B2
-incommunicado,incommunicado,词,ADJ,C1
-incompatibilité,incompatibility,不兼容,NOUN,B2
-incompatible,incompatible,词,ADJ,C1
-incompetence,incompetence,词,NOUN,C1
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,不完整,NOUN,B2
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,不协调,NOUN,B2
-incongruous,incongruous,不协调的,ADJ,B2
-inconsiderate,inconsiderate,词,ADJ,C1
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontrôlable,uncontrollable,无法控制的,ADJ,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorporation,incorporation,纳入,NOUN,B2
-incorrect,incorrect,不正确的,ADJ,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increased,increased,增加的,ADJ,B2
-increases,increases,增加,NOUN,C1
-increasing,increasing,增加的,ADJ,B2
-incredible,incredible,难以置信的,ADJ,B2
-incredible,unbelievable,难以置信的,ADJ,B2
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
-incremental,incremental,渐进性,ADJ,B2
-incrédulité,disbelief,不信,NOUN,B2
-incubateur,incubator,孵化器,NOUN,B2
-incubation,incubation,孵化,NOUN,B2
-inculcate,inculcate,词,VERB,C1
-incumbent,incumbent,词,ADJ,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-indecent,indecent,词,ADJ,C1
-indecipherable,indecipherable,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
-indescriptible,indescribable,难以形容的,ADJ,B2
-indeterminate,indeterminate,词,ADJ,C1
-index,index,索引,NOUN,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
-indian,indian,印度的,ADJ,B2
-indication,indication,指示,NOUN,B2
-indifférent,indifferent,冷漠的,ADJ,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indigent,indigent,词,ADJ,C1
-indigestion,indigestion,消化不良,NOUN,B2
-indignation,indignation,愤慨,NOUN,B2
-indignation juste,righteous indignation,义愤,NOUN,B2
-indigne,unworthy,你不配,NOUN,B2
-indignity,indignity,词,NOUN,C1
-indigné,indignant,愤慨的,ADJ,B2
-indirect,indirect,词,ADJ,C1
-indiscreet,indiscreet,词,ADJ,C1
-indispensable,indispensable,不可或缺的,ADJ,B2
-indistinct,indistinct,模糊的,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualité,individuality,个性,NOUN,B2
-individualization,individualization,词,NOUN,C1
-indolent,indolent,词,ADJ,C1
-indomitable,indomitable,词,ADJ,C1
-indonesian,indonesian,印度尼西亚的,ADJ,B2
-indoors,indoors,在室内,ADV,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-induire,to induce,引起,VERB,B2
-indulge,indulge,词,VERB,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrious,industrious,勤劳的,ADJ,B2
-indécis,indecisive,犹豫不决的,ADJ,B2
-indélébile,indelible,不可磨灭的,ADJ,B2
-indéniable,undeniable,不可否认的,ADJ,B2
-indépendance,independence,独立,NOUN,B2
-inedible,inedible,词,ADJ,C1
-ineffable,ineffable,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-ineffectiveness,ineffectiveness,! 无效,NOUN,B2
-inefficace,inefficient,低效的,ADJ,B2
-inefficiency,inefficiency,低效,NOUN,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inequity,inequity,词,NOUN,C1
-inert,inert,惰性的,ADJ,B2
-inertness,inertness,词,NOUN,B2
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable,inevitable,,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-inexpérimenté,inexperienced,生疏的,ADJ,B2
-infamous,infamous,声名狼藉的,ADJ,B2
-infantilism,infantilism,词,NOUN,C1
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-infected,infected,被感染的,ADJ,B2
-infecter,to infect,感染,VERB,B2
-infection,infection,感染,NOUN,B2
-inferential,inferential,词,ADJ,C1
-infertility,infertility,词,NOUN,C1
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infinitive marker,infinitive marker,去,PART,B2
-infinity,infinity,词,NOUN,C1
-inflamed,inflamed,激烈的,ADJ,B2
-inflammable,inflammable,易燃的,ADJ,B2
-inflammation,inflammation,炎症,NOUN,B2
-inflated,inflated,膨胀的,ADJ,B1
-inflation,inflation,通货膨胀,NOUN,B2
-inflection,inflection,词尾,NOUN,B2
-inflexibility,inflexibility,僵化,NOUN,B2
-influenceur,influencer,网红,NOUN,B2
-influential,influential,词,ADJ,C1
-influential person,influential person,词,NOUN,C1
-informateur,informant,线人,NOUN,B2
-informatics,informatics,词,NOUN,B2
-information,information,信息,NOUN,B2
-information desk,information desk,词,NOUN,B1
-information exchange,information exchange,词,NOUN,B2
-informative,informative,提供信息的,ADJ,B2
-informed,informed,见多识广的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informel,informal,非正式的,ADJ,B2
-informer,informer,词,NOUN,C1
-informers,informers,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrastructural,infrastructural,词,ADJ,C1
-infrastructure,infrastructure,基础设施,NOUN,B2
-infringement,infringement,侵犯,NOUN,C1
-inférer,to infer,推断,VERB,B2
-ingratitude,ingratitude,词,NOUN,C1
-ingredients,ingredients,词,NOUN,B1
-ingérer,to ingest,服用,VERB,B2
-inhabited,inhabited,词,ADJ,C1
-inharmonious,inharmonious,词,ADJ,C1
-inherence,inherence,固有,NOUN,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inherited,inherited,词,ADJ,C1
-inhibited,inhibited,词,ADJ,B2
-inhibition,inhibition,抑制,NOUN,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhumanity,inhumanity,词,NOUN,C1
-inimitability,inimitability,词,NOUN,C1
-inimitié personnelle,personal enmity,私仇,NOUN,B2
-initial,initial,最初的,ADJ,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
-initiation,initiation,词,NOUN,C1
-initiative,initiative,主动权,NOUN,B2
-initier,to initiate,发起,VERB,B2
-injured,injured,受伤的,ADJ,B2
-injury recovery,injury recovery,好伤,NOUN,C1
-injuste,unjust,不公正的,ADJ,B2
-injustice,injustice,不公,NOUN,B2
-inkling,inkling,预感,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inmate,inmate,词,NOUN,C1
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
-inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
-inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
-innermost,innermost,最里面的,ADV,B2
-innocence,innocence,无辜,NOUN,B2
-innocent,innocent,无辜的,ADJ,B2
-innocent (adv),innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
-innovation,innovation,创新,NOUN,B2
-innuendo,innuendo,词,NOUN,C1
-inné,innate,天生的,ADJ,B2
-inoffensif,harmless,无害的,ADJ,B2
-inopportune,inopportune,词,ADJ,C1
-inorganic,inorganic,词,ADJ,C1
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
-inquiet,uneasy,不安的,ADJ,B2
-inquisition,inquisition,宗教裁判所,NOUN,B2
-inquisitive,inquisitive,好奇的,ADJ,B2
-insane,insane,疯狂的,ADJ,B2
-insanely,insanely,疯狂地,ADV,B2
-insatiable,insatiable,不知足的,ADJ,B2
-inscription,enrollment,注册,NOUN,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect-proof,insect-proof,防虫,ADJ,C1
-insecticide,insecticide,杀虫剂,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensible,callous,冷酷,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
-insertion,insertion,词,NOUN,B2
-inside,inside,内部,NOUN,B2
-inside in,inside in,里,NOUN,B2
-inside of,inside of,在...里面,ADP,B2
-insightfulness,insightfulness,洞察,NOUN,B2
-insincere,insincere,词,ADJ,C1
-insinuation,insinuation,暗示,NOUN,B2
-insipid,insipid,词,ADJ,C1
-insistence persistence,insistence persistence,词,NOUN,B2
-insolence,insolence,无礼,NOUN,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
-insolent,insolent,傲慢的,ADJ,B2
-insolent conceit,insolent conceit,词,NOUN,C1
-insomnie,sleeplessness,失眠,NOUN,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
-inspection,inspection,检查,NOUN,B2
-inspectorate,inspectorate,词,NOUN,C1
-inspiration,inspiration,灵感,NOUN,B2
-inspired,inspired,受启发的,ADJ,B2
-inspiring,inspiring,鼓舞人心的,ADJ,B2
-installation,facility,设施,NOUN,B2
-installation,installation,安装,NOUN,B2
-installation assembly,installation assembly,词,NOUN,C1
-installations,facilities,设施,NOUN,B2
-installed,installed,词,ADJ,C1
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
-instance,instance,例子,NOUN,B2
-instant,instant,فور,NOUN,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinct,instinct,本能,NOUN,B2
-instinctuality,instinctuality,词,NOUN,C1
-institution,institution,机构,NOUN,B2
-institutionalized,institutionalized,词,ADJ,C1
-institutionnalisation,institutionalization,制度化,NOUN,B2
-instruction,instruction,指示,NOUN,B2
-instrument,instrument,乐器,NOUN,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insulator,insulator,词,NOUN,B2
-insurances,insurances,词,NOUN,C1
-insured,insured,词,NOUN,B2
-insurgency,insurgency,词,NOUN,C1
-insurmontable,insurmountable,不可逾越的,ADJ,B2
-insurrection,insurrection,起义,NOUN,B2
-intact,intact,完好无损的,ADJ,B2
-intake,intake,词,NOUN,C1
-intangible,intangible,无形的,ADJ,B2
-integer,integer,词,NOUN,C1
-integral,integral,不可或缺的,ADJ,B2
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-intellect,intellect,智力,NOUN,B2
-intellectual,intellectual,知识的,ADJ,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intellectual life,intellectual life,精神生活,NOUN,B2
-intelligence,intelligence,智力,NOUN,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
-intelligent,intelligent,聪明的,ADJ,B2
-intelligent,smart,聪明的,ADJ,B2
-intelligible,intelligible,词,ADJ,C1
-intemperate,intemperate,词,ADJ,C1
-intended,intended,预定的,ADJ,B2
-intended (noun),intended,intended,NOUN,B2
-intended meaning,intended meaning,词,NOUN,C1
-intense,intense,强烈的,ADJ,B2
-intensification,intensification,词,NOUN,C1
-intensive care,intensive care,重症监护,NOUN,B2
-intention,intent,意图,NOUN,B2
-intention contraire,contrary intention,反意,NOUN,B2
-intentionality,intentionality,词,NOUN,C1
-intentionnel,intentional,故意的,ADJ,B2
-intentions,intentions,词,NOUN,C1
-interaction,interaction,互动,NOUN,B2
-interaction sociale,social interaction,社会互动,NOUN,B2
-interactivity,interactivity,词,NOUN,C1
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,ban,禁令,NOUN,B2
-interdiction,interdiction,词,NOUN,C1
-interdit,forbidden,被禁止的,ADJ,B2
-interest rate,interest rate,利率,NOUN,B2
-interesting things,interesting things,词,NOUN,C1
-interface,interface,接口,NOUN,B2
-interférence,interference,干扰,NOUN,B2
-interférer,to interfere,干涉,VERB,B2
-interim (adj),interim,词,ADJ,C1
-interjection,interjection,词,NOUN,C1
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
-interlocuteur,interlocutor,对话者,NOUN,B2
-intermediate,intermediate,中级的,ADJ,B2
-intermission,intermission,词,NOUN,C1
-intermittent,intermittent,间歇的,ADJ,B2
-internal affairs,internal affairs,内政,NOUN,C1
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
-international,international,国际的,ADJ,B2
-internationalization,internationalization,词,NOUN,C1
-interne,internal,内部的,ADJ,B2
-internet,internet,互联网,NOUN,B2
-interpellation,interpellation,词,NOUN,C1
-interpersonal,interpersonal,人际的,ADJ,B2
-interpretive,interpretive,词,ADJ,C1
-interrogation room,interrogation room,审讯室,NOUN,B2
-interrompre,to cut short,截断,VERB,B2
-interrupted,interrupted,词,ADJ,B2
-intersection,intersection,交叉点,NOUN,B2
-intertextuality,intertextuality,词,NOUN,C1
-intertwined,intertwined,词,ADJ,C1
-interval,interval,词,NOUN,C1
-intervalle,meantime,同时,NOUN,B2
-intervention,intervention,干预,NOUN,B2
-interviewer,interviewer,词,NOUN,C1
-interviewer,to interview,采访,VERB,B2
-intestines,intestines,词,NOUN,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimidation,intimidation,恐吓,NOUN,B2
-intimider,to intimidate,恐吓,VERB,B2
-into (adp),into,词,ADP,A1
-into (adv),into,词,ADV,B1
-intolerant,intolerant,不容忍的,ADJ,B2
-intonation,intonation,语调,NOUN,B2
-intonational quality,intonational quality,词,NOUN,C1
-intoxication,intoxication,词,NOUN,C1
-intraitable,intractable,难处理的,ADJ,B2
-intransigence,intransigence,词,NOUN,C1
-intransigent,intransigent,不妥协的,ADJ,B2
-intravenous drip,intravenous drip,输液,NOUN,B2
-intricacy,intricacy,词,NOUN,C1
-intricate,intricate,错综复杂的,ADJ,B2
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
-introduction,introduction,介绍,NOUN,B2
-introspection,introspection,内省,NOUN,B2
-introversion,introversion,词,NOUN,B2
-introverti,introverted,内向的,ADJ,B2
-intrusion,intrusion,闯入,NOUN,B2
-intrusive,intrusive,词,ADJ,C1
-intrépide,intrepid,无畏的,ADJ,B2
-intrônisation,enthronement,登基,NOUN,B2
-intuition,intuition,直觉,NOUN,B2
-intuitionist,intuitionist,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-intérieur,inner,内部的,ADJ,B2
-intérieur,inside,在内部,ADP,B2
-intérieur modifié,amended interior,改内,NOUN,B2
-inure,inure,词,VERB,C1
-inutile,unnecessary,不必要的,ADJ,B2
-inutile,no need,不用,AUX,B2
-invalidated,invalidated,词,ADJ,C1
-invalidity,invalidity,词,NOUN,C1
-invariable,invariable,词,ADJ,C1
-invasion,invasion,入侵,NOUN,B2
-invention,invention,发明,NOUN,B2
-inventorying,inventorying,清点,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigated,investigated,被调查的,ADJ,B2
-investigative,investigative,词,ADJ,C1
-investment (adj),investment,词,ADJ,C1
-invincibility,invincibility,不胜,NOUN,C1
-invincible,invincible,无敌的,ADJ,B2
-inviolate,inviolate,词,ADJ,C1
-invisible,invisible,看不见的,ADJ,B2
-invitation,invitation,邀请,NOUN,B2
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite offer,invite offer,词,VERB,A2
-invited,invited,词,ADJ,C1
-invocation,invocation,词,NOUN,C1
-invocations,invocations,词,NOUN,C1
-invoicing,invoicing,开票,NOUN,B2
-involontairement,can't help,不由得,ADV,B2
-involuntary,involuntary,无意识的,ADJ,B2
-involved party,involved party,词,NOUN,C1
-invulnerability,invulnerability,词,NOUN,C1
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-inégal,unequal,不平等的,ADJ,B2
-iodine deficiency,iodine deficiency,词,NOUN,C1
-ion,ion,词,NOUN,C1
-iranian,iranian,伊朗的,ADJ,B2
-irascible,irascible,易怒的,ADJ,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰的,ADJ,B2
-irish person,irish person,爱尔兰人,NOUN,B2
-irksome,irksome,词,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
-irrational,irrational,非理性的,ADJ,B2
-irrationalité,irrationality,非理性,NOUN,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irreligious,irreligious,词,ADJ,C1
-irremplaçable,irreplaceable,不可替代的,ADJ,B2
-irretrievable,irretrievable,词,ADJ,C1
-irreversibility,irreversibility,词,NOUN,C1
-irrigation,irrigation,词,NOUN,B2
-irritability,irritability,词,NOUN,C1
-irritable,irritable,易怒的,ADJ,B2
-irritable boredom,irritable boredom,词,NOUN,C1
-irritating,irritating,令人恼火的,ADJ,B2
-irritation,irritation,刺激,NOUN,B2
-irréconciliable,irreconcilable,不可调和的,ADJ,B2
-irrésistible,irresistible,不可抗拒的,ADJ,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamic,islamic,伊斯兰的,ADJ,B2
-islamization,islamization,词,NOUN,C1
-islander,islander,词,NOUN,C1
-isolated reports,isolated reports,词,NOUN,C1
-isolation,insulation,绝缘,NOUN,B2
-isotope,isotope,同位素,NOUN,B2
-isthmus,isthmus,词,NOUN,C1
-it,it,对此,ADV,B2
-it (noun),it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
-it neuter,it neuter,它 (中性),PRON,B2
-italian (noun),italian,意大利人,NOUN,B2
-italien,italian,意大利人,NOUN,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-itinerant,itinerant,巡回的,ADJ,B2
-its,its,它的,PRON,B2
-its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-jack plug,jack plug,词,NOUN,C1
-jackal,jackal,词,NOUN,B2
-jade,jade,这玉,NOUN,B2
-jade,jade ware,玉器,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
-jaded,jaded,厌倦的,ADJ,B2
-jadeite,jadeite,翡翠,NOUN,C1
-jailer,jailer,词,NOUN,B2
-jalousie,jealousy,嫉妒,NOUN,B2
-janitor,janitor,词,NOUN,B2
-japanese (noun),japanese,日本人,NOUN,B2
-japonais,japanese,日本人,NOUN,B2
-jargon,jargon,行话,NOUN,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jarring,jarring,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jasmine tea,jasmine tea,词,NOUN,C1
-jaws,jaws,词,NOUN,C1
-je ne mérite pas ton éloge,i don't deserve your praise,不敢当,INTJ,B2
-jeans,jeans,牛仔裤,NOUN,B2
-jest,jest,词,NOUN,C1
-jet,jet,喷气式飞机,NOUN,B2
-jet-black,jet-black,乌黑,ADJ,B2
-jeter,to discard,丢弃,VERB,B2
-jeter un coup d'œil,to glance,瞥,VERB,B2
-jeu,play,剧本,NOUN,B2
-jeune fille,maiden,少女,NOUN,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jeweler,jeweler,词,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewish,jewish,犹太的,ADJ,B2
-jews,jews,犹太人,NOUN,B2
-jeûner,to fast,禁食,VERB,B2
-jianghu,jianghu,江湖,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
-jiaolong,jiaolong,娇龙,NOUN,B2
-jin,jin,斤,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocular,jocular,词,ADJ,C1
-jocularity,jocularity,词,NOUN,B2
-jog,jog,词,VERB,A1
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,生活乐趣,NOUN,B2
-joint,joint,关节,NOUN,B2
-joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
-joint pain,joint pain,关节痛,NOUN,C1
-jointness,jointness,词,NOUN,C1
-joker,joker,词,NOUN,C1
-joking,joking,词,NOUN,B2
-jour de l'an,new year's day,元旦,NOUN,B2
-jour et nuit,day and night,昼夜,NOUN,B2
-jour ordinaire,ordinary day,平日,NOUN,B2
-jour ouvrable,weekday,工作日,NOUN,B2
-journal,journal,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
-journalier,day laborer,日工,NOUN,B2
-journalism,journalism,新闻业,NOUN,B2
-journeying,journeying,词,NOUN,C1
-joust,joust,词,NOUN,B1
-jubilant,jubilant,词,ADJ,C1
-jubilé,jubilee,禧年,NOUN,B2
-judge sentence,judge sentence,词,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judo,judo,柔道,NOUN,C1
-jugement modifié,amended judgment,改断,NOUN,B2
-juif,jew,犹太人,NOUN,B2
-jujube,jujube,枣子,NOUN,B2
-jumble,jumble,词,NOUN,B2
-junction,junction,词,NOUN,C1
-juncture,juncture,词,NOUN,B2
-jungle,jungle,丛林,NOUN,B2
-jungles,jungles,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junk,junk,破烂货,NOUN,B2
-junkie,junkie,词,NOUN,C1
-juridiction,jurisdiction area,辖区,NOUN,B2
-jurisprudence,jurisprudence,法理学,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
-jury,jury,陪审团,NOUN,B2
-jury service,jury service,陪审,NOUN,C1
-jusqu'ici,so far,到目前为止,ADV,B2
-jusqu'à,up to,为止,ADP,B2
-just,just,公正,ADJ,B2
-just as,just as,词,ADV,A2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,随便地,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-juste,fair,公平的,ADJ,B2
-juste,righteous,正直的,ADJ,B2
-juste,just right,恰到好处,ADV,B2
-justice,justice,正义,NOUN,B2
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
-justification,justification,理由,NOUN,B2
-justified,justified,有根据的,ADJ,B2
-justness,justness,公正,NOUN,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
-juxtapose,juxtapose,词,VERB,C1
-kaleidoscope,kaleidoscope,词,NOUN,B2
-karaté,karate,空手道,NOUN,B2
-kasbah,kasbah,词,NOUN,B1
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenly,keenly,词,ADV,C1
-keenness,keenness,词,NOUN,B2
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kept,kept,词,ADJ,B2
-kerosene,kerosene,火油,NOUN,C1
-key point,key point,要点,NOUN,C1
-khul',khul',女方离婚,NOUN,C1
-kick (noun),kick,词,NOUN,B1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kidnapper,kidnapper,绑架者,NOUN,B2
-kidnapper,to kidnap,绑架,VERB,B2
-kids,kids,孩子,NOUN,B2
-killed,killed,,NOUN,B2
-killing,killing,词,NOUN,B2
-kilogramme,kilogram,千克,NOUN,B2
-kilomètre,kilometer,公里,NOUN,B2
-kin,kin,宗族,NOUN,B2
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
-king,king,王,PART,B2
-kiss (noun),kiss,词,NOUN,A2
-kit,kit,词,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
-kitten,kitten,小猫,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-klaxonner,to honk,按喇叭,VERB,B2
-knack,knack,窍,NOUN,C1
-kneader,kneader,词,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knock,knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-known famous,known famous,著名的/熟悉的,ADJ,B2
-kohl,kohl,词,NOUN,A1
-laazima,laazima,词,NOUN,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,不稳定的,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-labor-related,labor-related,词,ADJ,C1
-laboratory (adj),laboratory,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laborieux,laborious,费力的,ADJ,B2
-laborious striving,laborious striving,词,NOUN,C1
-laboriously,laboriously,词,ADV,C1
-labour market,labour market,词,NOUN,B1
-labyrinth,labyrinth,词,NOUN,C1
-labyrinthine,labyrinthine,词,ADJ,C1
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-lacunary,lacunary,残缺的,ADJ,B2
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-ladle,ladle,词,NOUN,A2
-lagoon,lagoon,词,NOUN,C1
-laideur,ugliness,丑陋,NOUN,B2
-laisser,let,让,AUX,B2
-laisser,to leave behind,留下,VERB,B2
-laitue,lettuce,生菜,NOUN,B2
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lament (noun),lament,词,NOUN,C1
-lamentable,lamentable,词,ADJ,C1
-lamp niche,lamp niche,词,NOUN,C1
-lampe,lamp,灯,NOUN,B2
-lance,spear,长矛,NOUN,B2
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
-land (adj),land,بري,ADJ,B2
-land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,土地政策,NOUN,B2
-land register,land register,地籍,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land use,land use,土地利用,NOUN,B2
-landfill,landfill,填埋,NOUN,C1
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmine,landmine,词,NOUN,C1
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
-language use,language use,语言使用,NOUN,B2
-langue,tongue,舌头,NOUN,B2
-languid,languid,词,ADJ,C1
-lantern,lantern,灯笼,NOUN,B2
-lapidary,lapidary,简略的,ADJ,B2
-laptop,laptop,笔记本电脑,NOUN,B2
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large estate,large estate,词,NOUN,C1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larme,tears,眼泪,NOUN,B2
-larynx,larynx,喉,NOUN,B2
-lassitude,lassitude,词,NOUN,C1
-last (num),last,词,NUM,A2
-last evening,last evening,,NOUN,B2
-last name,last name,姓,NOUN,B2
-last night,last night,昨晚,ADV,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
-lasting,lasting,词,ADJ,C1
-late,late,晚才,NOUN,B2
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-latent,latent,潜在的,ADJ,B2
-later stage,later stage,后期,NOUN,B2
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin,latin,拉丁的,ADJ,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latrine,outhouse,茅房,NOUN,B2
-latéral,lateral,侧面的,ADJ,B2
-laudable,laudable,词,ADJ,C1
-laugh,laugh,笑,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-lave,lava,熔岩,NOUN,B2
-lave-linge,washing machine,洗衣机,NOUN,B2
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
-law firm,law firm,律师事务所,NOUN,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
-lawless,lawless,无法的,ADJ,B2
-lawlessness,lawlessness,词,NOUN,C1
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lawyer female,lawyer female,词,NOUN,B2
-laxative,laxative,词,NOUN,C1
-lay (adj),lay,词,ADJ,C1
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
-layer storage,layer storage,层/仓库,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
-le long de,along,沿着,ADP,B2
-le reste,the rest,其余,NOUN,B2
-lead actor,lead actor,主演,NOUN,B2
-leader,pace-setter,标兵,NOUN,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
-leadership,leadership,领导能力,NOUN,B2
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf litter,leaf litter,词,NOUN,C1
-leaf page,leaf page,叶子,NOUN,B2
-leafiness,leafiness,词,NOUN,C1
-leafy,leafy,枝叶茂密的,ADJ,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learning curve,learning curve,学习曲线,NOUN,B2
-leash,leash,词,NOUN,B2
-least,least,最少,ADV,B2
-least (adj),least,词,ADJ,A1
-leather goods,leather goods,词,NOUN,C1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
-led astray,led astray,词,ADJ,C1
-left,left,左,NOUN,B2
-left (adv),left,左边,ADV,B2
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leftovers,leftovers,剩菜,NOUN,B2
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
-legal representative,legal representative,词,NOUN,C1
-legation,legation,公使馆,NOUN,B2
-legible,legible,词,ADJ,C1
-legion unit,legion unit,,NOUN,B2
-legislative elections,legislative elections,词,NOUN,C1
-legislator,legislator,词,NOUN,C1
-legitimization,legitimization,词,NOUN,B2
-leisurely,leisurely,词,ADJ,C1
-lemon verbena,lemon verbena,词,NOUN,B2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-lengthy,lengthy,词,ADJ,C1
-lens,lens,词,NOUN,C1
-lent,slow,慢的,ADJ,B2
-lent,lent,大斋期,NOUN,B2
-lentement,slowly,缓慢地,ADV,B2
-lentils,lentils,词,NOUN,A2
-lesbian,lesbian,女同性恋的,ADJ,B2
-less,less,较少的,ADJ,B2
-less starch,less starch,粉少,NOUN,C1
-let alone (cconj),let alone,何况,CCONJ,B1
-lethargic,lethargic,昏睡的,ADJ,B2
-lethargy,lethargy,词,NOUN,C1
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
-leurre,lure,诱惑,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-leverage,leverage,词,NOUN,B2
-levity,levity,词,NOUN,C1
-lexical,lexical,词,ADJ,C1
-liabilities,liabilities,词,NOUN,C1
-liaison,liaison,联络,NOUN,B2
-libel,libel,词,NOUN,C1
-liberalize,liberalize,自由化,! VERB,B2
-liberating,liberating,解放的,ADJ,B2
-liberty,liberty,词,NOUN,B2
-libération,release,释放,NOUN,B2
-libérer,to liberate,解放,VERB,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licensor,licensor,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
-lichen,lichen,词,NOUN,B2
-lien,bond,纽带,NOUN,B2
-lier,to bind,捆绑,VERB,B2
-lieu,location,地点,NOUN,B2
-lieu,venue,场地,NOUN,B2
-lieu de travail,workplace,工作场所,NOUN,B2
-lieutenant,lieutenant,中尉,NOUN,B2
-life (part),life,生,PART,A2
-life connection,life connection,连命,NOUN,C1
-life sentence,life sentence,无期徒刑,NOUN,B2
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifeguard,lifeguard,词,NOUN,B2
-lifeless,lifeless,无生命的,ADJ,B2
-lifelong,lifelong,终身,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
-light blue,light blue,词,ADJ,A1
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb,light bulb,词,NOUN,B2
-light grey,light grey,浅灰色的,ADJ,B2
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,词,NOUN,A1
-lightest,lightest,最轻,NOUN,C1
-lighting,lighting,词,NOUN,B2
-like,like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like as,like as,如同/好像,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,词,ADV,B1
-likeable,likeable,词,ADJ,C1
-likely (adj),likely,词,ADJ,A1
-likely (adv),likely,词,ADV,A1
-likely source,likely source,词,NOUN,C1
-limb,limb,肢体,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
-liminal,liminal,阈限的,ADJ,B2
-limit border,limit border,界限,NOUN,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limité,limited,有限的,ADJ,B2
-limpidity,limpidity,词,NOUN,C1
-lin,linen,线麻,NOUN,B2
-line of conduct,line of conduct,行为方针,NOUN,B2
-line-up,line-up,阵容,NOUN,B2
-lineages,lineages,词,NOUN,C1
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-linge,laundry,洗衣,NOUN,B2
-lingerie,underwear,内衣,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,语言的,ADJ,B2
-linguist,linguist,词,NOUN,C1
-linguistic intuition,linguistic intuition,词,NOUN,C1
-linguistique,linguistics,语言学,NOUN,B2
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linkage (noun),linkage,词,NOUN,C1
-linking,linking,词,NOUN,C1
-linéaire,linear,线性的,ADJ,B2
-lion,lion,狮子,NOUN,B2
-lip service,lip service,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
-liqueur,liquor,烈酒,NOUN,B2
-liquid,liquid,液态的,ADJ,B2
-liquidation,liquidation,清算,NOUN,B2
-lisp (noun),lisp,词,NOUN,C1
-lissément,smoothly,顺利,ADV,B2
-listen (intj),listen,词,INTJ,B2
-listen up,listen up,听着,INTJ,B2
-listening,listening,也听,NOUN,B2
-listing,listing,词,NOUN,C1
-listless,listless,词,ADJ,C1
-litanies,litanies,词,NOUN,C1
-literalism,literalism,词,NOUN,C1
-literally,literally,字面上地,ADV,B2
-literariness,literariness,词,NOUN,C1
-literary thefts,literary thefts,词,NOUN,C1
-lithe,lithe,词,ADJ,C1
-lithography,lithography,词,NOUN,C1
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litre,litre,升,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
-little,little,少,DET,B2
-little (adj),little,词,ADJ,A1
-little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,小男孩,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
-little finger,little finger,小指,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,小心脏,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little sister,little sister,妹妹,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little thing,little thing,词,NOUN,B2
-little town,little town,词,NOUN,C1
-littérature,literature,文学,NOUN,B2
-liturgical,liturgical,词,ADJ,C1
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
-livre,pound,磅,NOUN,B2
-livrer,to deliver,递送,VERB,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loanword,loanword,外来词,NOUN,C1
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,词,ADJ,C1
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
-local,local,当地的,ADJ,B2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
-local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locomotive,locomotive,词,NOUN,C1
-lodges,lodges,道堂,NOUN,C1
-loft,loft,词,NOUN,C1
-loftiness,loftiness,高尚,NOUN,C1
-logarithm,logarithm,词,NOUN,C1
-logic modification,logic modification,改逻,NOUN,B2
-logique,logical,合乎逻辑的,ADJ,B2
-logique,logic,逻辑,NOUN,B2
-logistical,logistical,词,ADJ,C1
-logistics (adj),logistics,词,ADJ,C1
-logo,logo,标识,NOUN,C1
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,长的,ADJ,B2
-long (noun),long,long,NOUN,B2
-long absence,long absence,久违,NOUN,C1
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance runner,long-distance runner,长跑运动员,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-lasting,long-lasting,持久的,ADJ,B2
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longest,longest,أطول,NOUN,B1
-longevity,longevity,词,NOUN,C1
-longtemps,long time,长时间,ADV,B2
-longueur,length,长度,NOUN,B2
-loofah,loofah,丝瓜,NOUN,C1
-look around,look around,词,VERB,C1
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loopholes,loopholes,词,NOUN,C1
-loose,loose,松的,ADJ,B2
-loose thread,loose thread,线头,NOUN,B2
-looseness,looseness,词,NOUN,C1
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
-lord god,lord god,上帝,NOUN,B2
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
-losses,losses,词,NOUN,B1
-lost,lost,迷失的,ADJ,B2
-lost tradition,lost tradition,失传,NOUN,C1
-lot,lot,许多,NOUN,B2
-lotar,lotar,词,NOUN,C1
-lots,lots,大量,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
-loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
-louer,to praise,赞扬,VERB,B2
-lourd,sluggish,迟钝的,ADJ,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-loved,loved,被爱的,ADJ,B2
-lovely,lovely,美好的,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowest,lowest,最低的,ADJ,B2
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyal,loyal,忠诚的,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lucid,lucid,词,ADJ,C1
-luck turn,luck turn,词,NOUN,A2
-lucky (noun),lucky,吉祥,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-lueur,glow,光芒,NOUN,B2
-lui,him,他吧,NOUN,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-lullaby,lullaby,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-lump in throat,lump in throat,词,NOUN,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunatic,lunatic,疯子,NOUN,B2
-lunch break,lunch break,午休,NOUN,B2
-lune de miel,honeymoon,蜜月,NOUN,B2
-lupini beans,lupini beans,词,NOUN,B2
-lurid,lurid,词,ADJ,C1
-lute,lute,词,NOUN,C1
-lutte,struggle,斗争,NOUN,B2
-lutter,to vie,竞争,VERB,B2
-lychee,lychee,荔枝,NOUN,C1
-lymphe,lymph,淋巴,NOUN,B2
-lyre,lyre,词,NOUN,B2
-lyricism,lyricism,词,NOUN,C1
-là,there,那儿,NOUN,B2
-là-bas,over there,在那边,ADV,B2
-lâcher,to let go,放开,VERB,B2
-légal,lawful,合法的,ADJ,B2
-légitimer,to legitimize,使合法,VERB,B2
-légume,vegetable,蔬菜,NOUN,B2
-ma résidence,my residence,我府,NOUN,B2
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machination,machination,词,NOUN,C1
-machine,machine,机器,NOUN,B2
-machine (adj),machine,词,ADJ,B2
-machine learning,machine learning,机器学习,NOUN,B2
-machine lourde,heavy machine,重机,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-machinery,machinery,词,NOUN,C1
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
-macroscopique,macroscopic,宏观的,ADJ,B2
-mad,mad,词,ADJ,A1
-made,made,制成的,ADJ,B2
-maelstrom,maelstrom,词,NOUN,C1
-mafia,mafia,黑手党,NOUN,B2
-magazine,magazine,杂志,NOUN,B2
-magically,magically,魔法地,ADV,B2
-magnanimous,magnanimous,宽宏大量的,ADJ,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
-magnifique,gorgeous,华丽的,ADJ,B2
-magnitude,magnitude,词,NOUN,C1
-mai,may,五月,NOUN,B2
-maigre,lean,瘦的,ADJ,B2
-mail (verb),mail,寄送,VERB,C1
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-main thing,main thing,词,NOUN,B2
-mainstream,mainstream,主流的,ADJ,B2
-mais,but,然而,ADV,B2
-mais je,but i,可我,ADV,B2
-mais vous,but you,但您,NOUN,B2
-maison,home,家,NOUN,B2
-maison d'édition,publishing house,出版社,NOUN,B2
-majeur,major,少校,NOUN,B2
-major (noun),major,主修,NOUN,B2
-major case,major case,大案,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-make amends,make amends,词,VERB,C1
-make flexible,make flexible,词,VERB,C1
-makeover,makeover,改容,NOUN,C1
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-making,making,词,NOUN,B2
-mal,evil,恶行,NOUN,B2
-malade,ill,生病的,ADJ,B2
-maladie,disease,疾病,NOUN,B2
-maladie,malady,弊病,NOUN,B2
-maladjusted,maladjusted,适应不良的,ADJ,B2
-maladjustment,maladjustment,词,NOUN,C1
-malchanceux,unlucky,倒霉的,ADJ,B2
-male,male,男性,NOUN,B2
-male goat,male goat,词,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malgré,to in spite of,不顾,VERB,B2
-malheureusement,unfortunately,不幸地,ADV,B2
-malheureux,unfortunate,不幸的,ADJ,B2
-malhun,malhun,词,NOUN,B2
-malice,malice,恶意,NOUN,B2
-malicious,malicious,恶意的,ADJ,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
-maliki school,maliki school,词,NOUN,C1
-malin,malignant,恶性的,ADJ,B2
-mall,mall,词,NOUN,B2
-malleability,malleability,词,NOUN,C1
-malleable,malleable,词,ADJ,C1
-mallow greens,mallow greens,词,NOUN,B2
-malmo,malmo,马尔默,PROPN,B2
-malnutrition,malnutrition,营养不良,NOUN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mammalian,mammalian,词,ADJ,C1
-managed,managed,,NOUN,B2
-management pipe,management pipe,管理层/管道,NOUN,B2
-managing director,managing director,总经理,NOUN,B2
-mandataire,proxy,代理人,NOUN,B2
-mane,mane,词,NOUN,C1
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-mania,mania,狂躁症,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifesto,manifesto,宣言,NOUN,B2
-manifold,manifold,多方面的,ADJ,B2
-manipulable,manipulable,可操纵的,ADJ,B2
-manipulation,handling,处理,NOUN,B2
-manipulation,manipulation,操纵,NOUN,B2
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
-mannerly,mannerly,有礼貌的,ADJ,B2
-manners,manners,词,NOUN,B2
-mannish,mannish,像男人的,ADJ,B2
-manoir,mansion,豪宅,NOUN,B2
-manor (part),manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
-manquer,lack,缺乏,NOUN,B2
-manquer,to be missing,缺少,VERB,B2
-manquer,to lack,缺乏,VERB,B2
-manslaughter,manslaughter,词,NOUN,C1
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manufacture,manufacture,制造,NOUN,B2
-manumission,manumission,词,NOUN,C1
-manure (noun),manure,词,NOUN,C1
-many,many,许多,DET,B2
-many (noun),many,多……,NOUN,B2
-many (pron),many,词,PRON,B1
-many things,many things,许多事物,PRON,B2
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapping,mapping,梳理,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
-marathon,marathon,马拉松,NOUN,B2
-marbly,marbly,大理石般的,ADJ,B2
-marc,dregs,渣滓,NOUN,B2
-marchandage,haggling,计较,NOUN,B2
-marchandise,commodity,商品,NOUN,B2
-marchandises,goods,商品,NOUN,B2
-marché noir,black market,黑市,NOUN,B2
-mare,mare,词,NOUN,B2
-marginal,marginal,边缘的,ADJ,B2
-mariable,marriageable,适婚,NOUN,B2
-marinade,marinade,词,NOUN,B2
-marine,marine,海洋的,ADJ,B2
-marine,navy,海军,NOUN,B2
-marine (noun),marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
-mariner,to pickle,腌渍,VERB,B2
-maritime,maritime,海事的,ADJ,B2
-marié,married,已婚的,ADJ,B2
-marié,groom,新郎,NOUN,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
-markets,markets,词,NOUN,C1
-maroon,maroon,深红色,ADJ,B2
-marque,mark,标记,NOUN,B2
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshy,marshy,沼泽般的,ADJ,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martyr,martyr,词,NOUN,C1
-marée basse,low tide,退潮,NOUN,B2
-marée haute,high tide,涨潮,NOUN,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-mask (verb),mask,词,VERB,C1
-masochism,masochism,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,大众媒体,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massacre,massacre,大屠杀,NOUN,B2
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,按摩师,NOUN,B2
-mast (noun),mast,词,NOUN,C1
-master,master's degree,硕士学位,NOUN,B2
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
-mastermind,mastermind,词,NOUN,C1
-mat,mat,词,NOUN,B2
-matches,matches,词,NOUN,C1
-matching use,matching use,配用,NOUN,C1
-mate,mate,词,NOUN,A2
-material (adj),material,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-maths,math,数学,NOUN,B2
-mathématiques,mathematics,数学,NOUN,B2
-matière,matter,事情,NOUN,B2
-matière,stuff,东西,NOUN,B2
-matière principale,major course,专业课,NOUN,B2
-matriarch,matriarch,女家长,NOUN,B2
-matriarchy,matriarchy,词,NOUN,C1
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
-mature,mature,成熟的,ADJ,B2
-maudire,to curse,诅咒,VERB,B2
-maudit,damn,该死的,ADJ,B2
-mausoleum,mausoleum,词,NOUN,B1
-mauvaise herbe,weed,杂草,NOUN,B2
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawwal,mawwal,词,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
-maxime,maxim,格言,NOUN,B2
-maximization,maximization,词,NOUN,C1
-maximum,utmost,你尽,NOUN,B2
-maximum (noun),maximum,词,NOUN,B2
-may (aux),may,词,AUX,A1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe possible,maybe possible,可能,ADV,A1
-mayoral,mayoral,市长的,ADJ,B2
-maze,maze,词,NOUN,C1
-maze labyrinth,maze labyrinth,词,NOUN,C1
-maîtriser,to master,掌握,VERB,B2
-maïs,corn,玉米,NOUN,B2
-me (noun),me,我?,NOUN,B2
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-mead,mead,词,NOUN,C1
-meager,meager,词,ADJ,C1
-mean (noun),mean,词,NOUN,C1
-meander,meander,词,NOUN,C1
-meandering,meandering,蜿蜒的,ADJ,B2
-meaning content,meaning content,语义内容,NOUN,B2
-meaningful,meaningful,有意义的,ADJ,B2
-meaningless,meaningless,毫无意义的,ADJ,B2
-meanness,meanness,词,NOUN,C1
-measurable,measurable,词,ADJ,C1
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word general,measure word general,个,NUM,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mechanics,mechanics,词,NOUN,C1
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
-medal awarding,medal awarding,授勋,NOUN,B2
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-media (adj),media,词,ADJ,C1
-media professionals,media professionals,词,NOUN,C1
-mediator,mediator,调解人,NOUN,C1
-medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical examiner,medical examiner,法医,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,词,NOUN,C1
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-meek,meek,温顺的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-megabyte,megabyte,词,NOUN,C1
-megalomania,megalomania,狂妄自大,NOUN,B2
-megalomaniac,megalomaniac,词,ADJ,C1
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
-meilleur,best,最好的,ADJ,B2
-meilleur,better,越好,NOUN,B2
-mellifluous,mellifluous,词,ADJ,C1
-mellifluousness,mellifluousness,词,NOUN,C1
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
-melon,melon,香瓜,NOUN,C1
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
-membrane,membrane,词,NOUN,C1
-membre de la famille,family member,家庭成员,NOUN,B2
-memoir,memoir,回忆录,NOUN,B2
-memorable,memorable,难忘的,ADJ,B2
-memorial (adj),memorial,词,ADJ,C1
-memorizer,memorizer,词,NOUN,C1
-memory loss,memory loss,词,NOUN,C1
-men,men,词,NOUN,C1
-menace,menace,词,NOUN,C1
-mendacious,mendacious,词,ADJ,C1
-mendiant,beggar,乞丐,NOUN,B2
-mener la guerre,to wage war,作战,VERB,B2
-menotte,handcuff,手铐,NOUN,B2
-menses,menses,词,NOUN,B2
-mensonge,falsehood,谎言,NOUN,B2
-mental,mental,精神的,ADJ,B2
-mental hospital,mental hospital,精神病院,NOUN,B2
-mention,mention,提及,NOUN,B2
-mentioned,mentioned,词,ADJ,B2
-mentor,mentor,导师,NOUN,B2
-mentoring,mentoring,词,NOUN,B2
-menu,menu,菜单,NOUN,B2
-mer de sang,blood sea,血海,NOUN,B2
-mercantile,mercantile,词,ADJ,C1
-mercenaries,mercenaries,词,NOUN,C1
-mercenary (adj),mercenary,词,ADJ,C1
-merchant ship,merchant ship,商船,NOUN,C1
-merci,thanks,谢谢,INTJ,B2
-merciful,merciful,词,ADJ,B2
-mercredi,wednesday,星期三,NOUN,B2
-mercurial,mercurial,词,ADJ,C1
-mercy blow,mercy blow,致命一击,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
-merged,merged,词,ADJ,C1
-merger,merger,合并,NOUN,B2
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
-merits,merits,词,NOUN,C1
-merriment,merriment,词,NOUN,C1
-merveilleux,wonderful,极好的,ADJ,B2
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-message,message,信息,NOUN,B2
-message errand,message errand,消息/差事,NOUN,B2
-metabolic,metabolic,代谢的,ADJ,B2
-metalinguistic,metalinguistic,词,ADJ,C1
-metamorphic,metamorphic,变质的,ADJ,B2
-metaverse,metaverse,元宇宙,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological observations,meteorological observations,词,NOUN,C1
-metering,metering,词,ADJ,C1
-methodical,methodical,词,ADJ,C1
-methodological,methodological,方法论的,ADJ,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolises,metropolises,词,NOUN,C1
-mettle,mettle,词,NOUN,C1
-mettre en danger,to endanger,危及,VERB,B2
-mettre à jour,to update,更新,VERB,B2
-mettre à niveau,to upgrade,升级,VERB,B2
-mexicain,mexican,墨西哥的,ADJ,B2
-mezzanine,mezzanine,夹层,NOUN,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
-microeconomic,microeconomic,微观经济学的,ADJ,B2
-microscope,microscope,显微镜,NOUN,B2
-microscopic,microscopic,微观的,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-mid-morning,mid-morning,词,NOUN,C1
-midday heat,midday heat,词,NOUN,B1
-middle,middle,中间,ADV,B2
-middle (adj),middle,词,ADJ,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
-midpoint,midpoint,词,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
-might as well,might as well,不妨,ADV,B2
-mighty,mighty,词,ADJ,B1
-mighty man,mighty man,强人,NOUN,B2
-mighty very,mighty very,非常,ADJ,B2
-migraine,migraine,偏头痛,NOUN,B2
-migrant,migrant,词,NOUN,B2
-migrate,to migrate,迁移,VERB,B2
-migration,migration,移民,NOUN,B2
-mild,mild,温和的,ADJ,B2
-mildew,mildew,词,VERB,C1
-mile,mile,英里,NOUN,B2
-milestone,milestone,里程碑,NOUN,B2
-milieu,midst,中间,NOUN,B2
-militant,militant,词,ADJ,C1
-militaristic,militaristic,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
-military,military,军队,NOUN,B2
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
-military intelligence,military intelligence,军情,NOUN,B2
-military merit,military merit,军功,NOUN,C1
-military order,military order,军令,NOUN,B2
-military pay,military pay,军饷,NOUN,B2
-military power,military power,兵权,NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,词,NOUN,C1
-milkman,milkman,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millier de plomb,lead thousand,率千,NOUN,B2
-million,million,百万,NOUN,B2
-million (num),million,词,NUM,A1
-millions of,millions of,数百万的,NUM,B2
-mime (noun),mime,词,NOUN,C1
-minaret,minaret,词,NOUN,B1
-minatory,minatory,词,ADJ,C1
-minced meat,minced meat,词,NOUN,A2
-mind,to mind,介意,VERB,B2
-mindfulness,mindfulness,从正念,NOUN,C1
-mindset,mindset,词,NOUN,B2
-mine,mine,矿井,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
-mineral,mineral,矿物,NOUN,B2
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
-minibus,minibus,中巴,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimization,minimization,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minister,minister,臣,PART,B2
-ministerial,ministerial,部长的,ADJ,B2
-minivan,minivan,小型货车,NOUN,B2
-minor,minor,未成年人,NOUN,B2
-minor (adj),minor,较小的,ADJ,B2
-minor course,minor course,辅修课,NOUN,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
-minority group,minority group,少数群体,NOUN,B2
-mint,mint,薄荷,NOUN,B2
-minuit,midnight,午夜,NOUN,B2
-minus,minus,减,NOUN,B2
-minuscule,minuscule,极小的,ADJ,B2
-minutage,timing,时机,NOUN,B2
-minute,minute,分钟,NOUN,B2
-minutes,minutes,词,NOUN,B2
-miracle,miracle,奇迹,NOUN,B2
-miraculous,miraculous,词,ADJ,C1
-mirage,mirage,词,NOUN,C1
-mirthful,mirthful,词,ADJ,C1
-misanthrope,misanthrope,厌世者,NOUN,B2
-misanthropic,misanthropic,词,ADJ,C1
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misconception,misconception,误解,NOUN,B2
-misdemeanor,misdemeanor,词,NOUN,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-miserly,miserly,吝啬的,ADJ,B2
-misery,misery,痛苦,NOUN,B2
-misfortune,misfortune,不幸,NOUN,B2
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
-misjudge,misjudge,词,VERB,C1
-mislead,to mislead,误导,VERB,B2
-mismatch,mismatch,词,NOUN,C1
-misplaced,misplaced,不合时宜的,ADJ,B2
-miss teacher,miss teacher,小姐/老师,NOUN,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-missile,missile,导弹,NOUN,B2
-mission,mission,任务,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missionizing,missionizing,词,ADJ,C1
-missions,missions,词,NOUN,C1
-missive,missive,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-missnahme,missnahme,词,NOUN,C1
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
-mistake,to mistake,弄错,VERB,B2
-mistaken,mistaken,错误的,ADJ,B2
-mistreat,to mistreat,أساء,VERB,B2
-misunderstand,to misunderstand,误解,VERB,B2
-misunderstood,misunderstood,词,ADJ,C1
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
-mitigating,mitigating,词,ADJ,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitigation,mitigation,词,NOUN,C1
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixer,mixer,词,NOUN,C1
-moan,moan,呻吟,NOUN,B2
-moan,to moan,呻吟,VERB,B2
-mob,mob,词,NOUN,B2
-mobile,mobile,移动的,ADJ,B2
-mobile (noun),mobile,词,NOUN,B2
-mobile payment,mobile payment,移动支付,NOUN,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-mockery,mockery,词,NOUN,C1
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modder,modder,改客,NOUN,B2
-mode,mode,方式,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
-modem,modem,词,NOUN,C1
-moderate rain,moderate rain,中雨,NOUN,B2
-moderate snow,moderate snow,中雪,NOUN,C1
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,现代,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
-modification,modification,修改,NOUN,B2
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified effect,modified effect,改效,NOUN,B2
-modified model,modified model,改模,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified sound,modified sound,改响,NOUN,B2
-modified structure,modified structure,改结,NOUN,C1
-modified system,modified system,改系,NOUN,B2
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
-modular,modular,模块化的,ADJ,B2
-modulation,modulation,词,NOUN,C1
-module,module,词,NOUN,C1
-modèle,role model,榜样,NOUN,B2
-moi,me,لي,NOUN,B2
-moi-même,myself,我自,NOUN,B2
-moineau,sparrow,麻雀,NOUN,B2
-moist,moist,潮湿的,ADJ,B2
-moisten,moisten,词,VERB,C1
-moisture,moisture,湿气,NOUN,B2
-moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
-mollesse,too soft,太软,NOUN,B2
-mollify,mollify,词,VERB,C1
-molten,molten,词,ADJ,C1
-mom mother,mom mother,妈妈,NOUN,A1
-moment,a while,一会儿,NOUN,B2
-moment,moment,时刻,NOUN,B2
-moment,point in time,时间点,NOUN,B2
-momentous,momentous,词,ADJ,C1
-momentum,momentum,势头,NOUN,B2
-mommy,mommy,词,NOUN,B1
-mon grand,my big one,我偌大,NOUN,B2
-monarchy,monarchy,君主制,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monasticism,monasticism,词,NOUN,C1
-monde entier,whole world,全世界,NOUN,B2
-mondial,worldwide,全世界的,ADJ,B2
-monetization,monetization,词,NOUN,C1
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
-monitor,monitor,显示器,NOUN,B2
-monitor,to monitor,监控,VERB,B2
-monitoring,monitoring,监控,NOUN,B2
-monitoring room,monitoring room,监控室,NOUN,B2
-monkey ape,monkey ape,猿/猴,NOUN,B2
-monolithic,monolithic,单一的,ADJ,B2
-monologue,monologue,词,NOUN,B2
-monopolistic,monopolistic,垄断的,ADJ,B2
-monopolize,to monopolize,垄断,VERB,B2
-monotheism,monotheism,词,NOUN,C1
-monotonic,monotonic,词,ADJ,C1
-monotonous,monotonous,单调的,ADJ,B2
-monotony,monotony,词,NOUN,C1
-monsieur,mr.,先生,NOUN,B2
-monsieur,sir,郎,PART,B2
-montagne,mountain,山,NOUN,B2
-monter,to ascend,上升,VERB,B2
-monter,to come up,出现,VERB,B2
-monter,to rise,上升,VERB,B2
-month ago,month ago,月前,NOUN,B2
-month moon,month moon,月,NOUN,B2
-monthly,monthly,每月的,ADV,B2
-monthly exam,monthly exam,月考,NOUN,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-monument,monument,纪念碑,NOUN,B2
-monumental,monumental,词,ADJ,C1
-moodiness,moodiness,词,NOUN,B2
-mooncake,mooncake,月饼,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-moor,moor,荒野,NOUN,B2
-mooring,mooring,词,NOUN,C1
-moose,moose,驼鹿,NOUN,B2
-moral,moral,道德,NOUN,B2
-moral (adj),moral,道德的,ADJ,C1
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral portrait,moral portrait,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,人心,NOUN,B2
-moralization,moralization,词,NOUN,C1
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morals,morals,道德,NOUN,B2
-morass,morass,词,NOUN,C1
-morceau,lump,块,NOUN,B2
-more,more,更多,ADJ,B2
-more (noun),more,你越,NOUN,B2
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,更贵的,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
-more often,more often,更频繁,ADV,B2
-more personal,more personal,词,ADJ,C1
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover,moreover,此外,ADV,B2
-moreover (cconj),moreover,而且,CCONJ,B2
-morgue,morgue,词,NOUN,B1
-morning newspaper,morning newspaper,晨报,NOUN,B2
-moroccanization,moroccanization,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morpheme,morpheme,语素,NOUN,C1
-morphine,morphine,吗啡,NOUN,B2
-morphological,morphological,形态的,ADJ,B2
-morsure,biting,尖刻的,ADJ,B2
-mort,dead,死的,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortar,mortar,词,NOUN,C1
-mortuary,mortuary,词,NOUN,B2
-moslem,moslem,词,NOUN,C1
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-moss,moss,苔藓,NOUN,B2
-most,most,大多数,ADJ,B2
-most (adv),most,最,ADV,B2
-most (det),most,词,DET,B2
-most (noun),most,大部分,NOUN,B2
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-mot de maître,master's word,爷说,NOUN,B2
-mot de passe,password,密码,NOUN,B2
-motel,motel,汽车旅馆,NOUN,B2
-moth,moth,词,NOUN,B2
-mother,mother,娘,PART,B2
-mother's reassurance,mother's reassurance,娘放心,NOUN,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
-motif,motif,主题,NOUN,B2
-motif,pattern,模式,NOUN,B2
-motion,motion,运动,NOUN,B2
-motion picture,motion picture,电影,NOUN,B2
-motivation,motivation,动机,NOUN,B2
-motive for murder,motive for murder,词,NOUN,C1
-motor,motor,发动机,NOUN,B2
-motor (adj),motor,运动的,ADJ,C1
-motorway,motorway,高速公路,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mouette,seagull,海鸥,NOUN,B2
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mousseux,foamy,多泡沫的,ADJ,B2
-mouth animal,mouth animal,词,NOUN,B1
-mouton,mutton,羊肉,NOUN,B2
-move fast,move fast,快搬,NOUN,C1
-moving,moving,感人的,ADJ,B2
-mow,mow,词,VERB,B2
-mp,mp,国会议员,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-much,much,很多,ADV,B2
-much (adj),much,词,ADJ,A1
-much many,much many,许多,ADJ,B2
-mucus,mucus,黏液,NOUN,B2
-muddied,muddied,词,ADJ,C1
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-muezzin,muezzin,词,NOUN,B2
-muffin,muffin,玛芬蛋糕,NOUN,B2
-mufti,mufti,词,NOUN,C1
-mug (noun),mug,词,NOUN,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiple,multiple,词,ADJ,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
-munificence,munificence,慷慨,NOUN,B2
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder case,murder case,词,NOUN,B2
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
-murderer female,murderer female,词,NOUN,B2
-murk of dawn,murk of dawn,词,NOUN,C1
-murky,murky,词,ADJ,C1
-murmuring,murmuring,词,NOUN,C1
-muscle,muscle,肌肉,NOUN,B2
-muse,muse,词,VERB,B2
-museau,snout,口鼻,NOUN,B2
-museum piece,museum piece,博物馆藏品,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
-musical,musical,موسيقي,ADJ,B2
-musical (noun),musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
-musicality,musicality,词,NOUN,C1
-musique pop,pop music,流行音乐,NOUN,B2
-musk,musk,麝香,NOUN,B2
-muslim,muslim,مسلم,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustache,mustache,胡子,NOUN,B2
-mutable,mutable,词,ADJ,C1
-mutagenic,mutagenic,词,ADJ,C1
-mutation,mutation,突变,NOUN,B2
-mutazilites,mutazilites,词,NOUN,C1
-mute person,mute person,词,NOUN,B2
-mutilate,mutilate,词,VERB,C1
-mutiny (noun),mutiny,兵变,NOUN,B2
-muttering,muttering,念叨,NOUN,C1
-mutual affection,mutual affection,词,NOUN,C1
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
-mutual pulling,mutual pulling,词,NOUN,C1
-mutual support,mutual support,互助,NOUN,C1
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myriad,myriad,词,ADJ,C1
-myself,myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
-mécanisme modifié,altered mechanism,改机,NOUN,B2
-mécaniste,mechanistic,机制性,ADJ,B2
-méchant,nasty,令人不快的,ADJ,B2
-mécontentement,displeasure,不悦,NOUN,B2
-médecin,physician,内科医生,NOUN,B2
-médicament,medication,药物,NOUN,B2
-médier,to mediate,调解,VERB,B2
-méditation,meditation,冥想,NOUN,B2
-mélancolique,melancholy,忧郁,ADJ,B2
-mémorandum,memorandum,备忘录,NOUN,B2
-mémorial,memorial,纪念碑,NOUN,B2
-méprisable,despicable,可鄙的,ADJ,B2
-mépriser,to look down upon,看不起,VERB,B2
-métaphysique,metaphysics,形而上学,NOUN,B2
-métro,subway,地铁,NOUN,B2
-même,even,偶数的,ADJ,B2
-même si,even if,即使,SCONJ,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-nadir,nadir,最低点,NOUN,B2
-nah,nah,不,INTJ,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
-name-calling,name-calling,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-named,named,词,ADP,C1
-nanotechnologie,nanotechnology,纳米技术,NOUN,B2
-narcotics,narcotics,词,NOUN,C1
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
-narrators,narrators,词,NOUN,C1
-narrowing,narrowing,变窄,NOUN,B2
-nascent,nascent,词,ADJ,C1
-nation,nation,国家,NOUN,B2
-national,national,国家的,ADJ,B2
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
-nationalité,nationality,国籍,NOUN,B2
-nationwide,nationwide,全国,NOUN,B2
-native (noun),native,词,NOUN,C1
-native american,native american,印第安人,NOUN,B2
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-nature,nature,本性,NOUN,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-naval,naval,词,ADJ,C1
-navigation,navigation,导航；航行,NOUN,B2
-navigational,navigational,词,ADJ,C1
-nazi,nazi,纳粹分子,NOUN,B2
-ne,not,不,PART,B2
-ne pas,do not,莫,ADV,B2
-ne pas devoir,should not,不该,AUX,B2
-ne pas faire,won't do,不行,ADJ,B2
-ne pas faire,to won't do,不成,VERB,B2
-near,near,在附近,ADP,B2
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,附近的,ADJ,B2
-nearby (noun),nearby,附近,NOUN,B2
-nearest,nearest,最近的,ADJ,B2
-nearest (noun),nearest,词,NOUN,B2
-nearness,nearness,词,NOUN,B2
-neat,neat,整洁的,ADJ,B2
-neatly,neatly,整洁地,ADV,B2
-nebulous,nebulous,词,ADJ,C1
-necessarily incumbent,necessarily incumbent,词,ADV,C1
-necklace chain,necklace chain,词,NOUN,A1
-neckline,neckline,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-nefarious,nefarious,词,ADJ,C1
-negativity,negativity,消极,NOUN,B2
-neglect (noun),neglect,词,NOUN,C1
-negotiator,negotiator,词,NOUN,C1
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
-neighbors,neighbors,词,NOUN,B1
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,社区,NOUN,B2
-neither (adv),neither,词,ADV,A1
-neither (det),neither,词,DET,A2
-nemesis,nemesis,词,NOUN,C1
-neophyte,neophyte,新手；初学者,NOUN,B2
-nephews,nephews,子侄,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
-nerve pain,nerve pain,神经痛,NOUN,C1
-nervosité,nervousness,紧张,NOUN,B2
-nettle,nettle,词,NOUN,C1
-nettoyage,cleansing,清洗,NOUN,B2
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neuf,nine,九,NUM,B2
-neural,neural,词,ADJ,C1
-neurological,neurological,词,ADJ,C1
-neuroscience,neuroscience,词,NOUN,C1
-neuroticism,neuroticism,词,NOUN,C1
-neutron,neutron,词,NOUN,C1
-new beginning,new beginning,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
-news bulletin,news bulletin,词,NOUN,B2
-news reporting,news reporting,新闻报道,NOUN,B2
-newsletter,newsletter,简报,NOUN,B2
-next (adv),next,其次,ADV,B2
-next door,next door,在隔壁,ADV,B2
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
-next to (adv),next to,词,ADV,B2
-next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
-ni,neither,也不,CCONJ,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,,NOUN,B2
-niche,niche,词,NOUN,C1
-nickel,nickel,镍,NOUN,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
-nihilistic,nihilistic,词,ADJ,C1
-nimble,nimble,敏捷的,ADJ,B2
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-no,no,不,INTJ,B2
-no (det),no,毫无,DET,A2
-no (part),no,词,PART,B2
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no heaven,no heaven,无天,NOUN,C1
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-nobility of character,nobility of character,词,NOUN,C1
-noble,noble,高尚的,ADJ,B2
-noble,nobleman,贵族,NOUN,B2
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
-node,node,词,NOUN,C1
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noises,noises,噪音,NOUN,B2
-noisome,noisome,词,ADJ,C1
-nomads,nomads,词,NOUN,B2
-nominal,nominal,词,ADJ,C1
-nomination,nomination,提名,NOUN,B2
-nominee,nominee,词,NOUN,C1
-nommer,to appoint,任命,VERB,B2
-nommer,to nominate,提名,VERB,B2
-non,no,毫无,DET,B2
-non,nope,不,INTJ,B2
-non autorisé,not allowed,不准,ADJ,B2
-non conforme,noncompliant,违规,ADJ,B2
-non imposable,tax-exempt,免税,ADJ,B2
-non négligeable,negligible not,不可忽视,ADJ,B2
-non pertinent,irrelevant,不相关的,ADJ,B2
-non refroidi,uncooled,未寒,NOUN,B2
-non seulement,not only,不光,CCONJ,B2
-non-above,non-above,非上,NOUN,C1
-non-abstraction,non-abstraction,非抽,NOUN,B2
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-action,non-action,非作,NOUN,B2
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-assistance,non-assistance,勿助,NOUN,B2
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
-non-concept,non-concept,非概,NOUN,B2
-non-concrete,non-concrete,非具,NOUN,C1
-non-construction,non-construction,非建,NOUN,B2
-non-contingent,non-contingent,非偶,NOUN,B2
-non-criterion,non-criterion,非准,NOUN,C1
-non-croyance,non-belief,非信,NOUN,B2
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-esprit,non-mind,非心,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-gestion,non-management,管不,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-guerre,non-war,非战,NOUN,B2
-non-image,non-image,非象,NOUN,C1
-non-induction,non-induction,非归,NOUN,B2
-non-inférence,non-inference,非推,NOUN,B2
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-modèle,non-model,非模,NOUN,B2
-non-momentum,non-momentum,非势,NOUN,C1
-non-mérite,non-merit,非功,NOUN,B2
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-niveau,non-level,非级,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-ombre,non-shadow,非影,NOUN,B2
-non-orbite,non-orbit,非轨,NOUN,B2
-non-ordre,non-order,非序,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-pensée,non-thought,非念,NOUN,B2
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-preuve,non-evidence,非据,NOUN,B2
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-sens,nonsense,胡说,NOUN,B2
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-son,non-sound,非响,NOUN,B2
-non-spécifique,non-specific,非殊,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-stratégie,non-strategy,非略,NOUN,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-substance,non-substance,非质,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-trace,non-trace,非迹,NOUN,B2
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-utilisation,do not use,别用,NOUN,B2
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-non-état,non-state,非态,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
-nonconformist,nonconformist,词,NOUN,C1
-none (pron),none,没有一个,PRON,A2
-nonexistent,nonexistent,词,ADJ,C1
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonviolence,nonviolence,非暴力,NOUN,B2
-noodles,noodles,面条,NOUN,A1
-nor,nor,也不,CCONJ,B2
-nordique,northern,北方的,ADJ,B2
-normal,normal,正常的,ADJ,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalization,normalization,词,NOUN,C1
-normativity,normativity,词,NOUN,C1
-norme,norm,规范,NOUN,B2
-northeast,northeast,词,NOUN,C1
-northward,northward,向北,ADV,B2
-norwegian,norwegian,挪威的,ADJ,B2
-nosy,nosy,爱打听的,ADJ,B2
-not (part),not,不,PART,A1
-not afraid,not afraid,不怕,VERB,B2
-not as good as,not as good as,不如,VERB,B1
-not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
-not catch up,not catch up,非赶,NOUN,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
-notable,notable,显著的,ADJ,B2
-notables,notables,词,NOUN,B2
-notarisation,notarization,公证,NOUN,B2
-note,note,笔记,NOUN,B2
-note patch,note patch,词,NOUN,C1
-notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
-notification,notification,通知,NOUN,B2
-notifications,notifications,词,NOUN,C1
-notifier,to notify,通知,VERB,B2
-notion,notion,词,NOUN,B2
-notions,smattering,少量,NOUN,B2
-nounou,nanny,保姆,NOUN,B2
-nourishment,nourishment,营养,NOUN,B2
-nourrir,to nurture,养育,VERB,B2
-nourrissement,nurturing,养好,NOUN,B2
-nourriture,feed,饲料,NOUN,B2
-nous,us,你我,NOUN,B2
-nous,we,我们,PRON,B2
-nous,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
-nous deux,we two,我俩,PRON,B2
-novice,novice,词,NOUN,C1
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
-noël,christmas,圣诞节,NOUN,B2
-nuageux,cloudy,阴沉的,ADJ,B2
-nuance,nuance,细微差别,NOUN,B2
-nuclear (noun),nuclear,词,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,核能,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nuisance,nuisance,麻烦事,NOUN,B2
-null and void,null and void,无效的,ADJ,C1
-nulle part,nowhere,无处,ADV,B2
-nullify,nullify,词,VERB,C1
-numb,numb,麻木的,ADJ,B2
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
-numbering,numbering,词,NOUN,C1
-numeral,numeral,词,NOUN,C1
-numerical,numerical,词,ADJ,C1
-numismatic,numismatic,钱币学的,ADJ,B2
-numérisation,digitization,数字化,NOUN,B2
-numéro de semaine,week number,周次,NOUN,B2
-numéro deux,number two,二号,NOUN,B2
-nunation,nunation,词,NOUN,C1
-nursing home,nursing home,养老院,NOUN,C1
-nutrition,nutrition,营养,NOUN,B2
-nutritional,nutritional,词,ADJ,C1
-nuts,nuts,疯狂的,ADJ,B2
-nylon,nylon,尼龙,NOUN,C1
-nécessiter,need,需要,AUX,B2
-nécessiter,to need,需要,VERB,B2
-négater,to negate,否定,VERB,B2
-négation,negation,否定,NOUN,B2
-négligent,negligent,疏忽的,ADJ,B2
-négliger,to disregard,忽视,VERB,B2
-négliger,to neglect,忽视,VERB,B2
-nœud serré,heavy knot,重结,NOUN,B2
-o,o,词,PART,B1
-o'clock (adv),o'clock,词,ADV,B2
-o'clock (noun),o'clock,点,NOUN,B2
-oak,oak,词,NOUN,B1
-oasis,oasis,绿洲,NOUN,B2
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
-obdurate,obdurate,词,ADJ,C1
-obelisk,obelisk,词,NOUN,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
-objection,objection,异议,NOUN,B2
-objective,objective,客观的,ADJ,B2
-objective (noun),objective,宗旨,NOUN,B2
-objectivism,objectivism,词,NOUN,C1
-obligation,obligation,义务,NOUN,B2
-obligatoire,mandatory,强制的,ADJ,B2
-obligatory,obligatory,词,ADJ,C1
-obliging,obliging,词,ADJ,B2
-oblique,oblique,斜的,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-obliteration,obliteration,词,NOUN,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
-obscene,obscene,淫秽的,ADJ,B2
-obscenity,obscenity,词,NOUN,C1
-obscurantist,obscurantist,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-observable,observable,可观测的,ADJ,B2
-observation,observation,观察,NOUN,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,词,ADJ,C1
-observe,to observe,观察,VERB,B2
-observers,observers,词,NOUN,C1
-obsess,obsess,词,VERB,B2
-obsessed,obsessed,着迷的,ADJ,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle,obstacle,障碍,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstreperous,obstreperous,词,ADJ,C1
-obstruct,to obstruct,阻碍,VERB,B2
-obstruction,obstruction,阻塞,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious,obvious,明显的,ADJ,B2
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-obviously,obviously,显然,ADV,B2
-obéir,to obey,服从,VERB,B2
-obéissant,obedient,顺从的,ADJ,B2
-occasion,occasion,场合,NOUN,B2
-occasional,occasional,词,ADJ,C1
-occupation,occupation,职业,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
-occupied,occupied,被占用的,ADJ,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-occupé,busy,忙碌的,ADJ,B2
-occurrence,occurrence,发生,NOUN,B2
-octave,octave,词,NOUN,C1
-octopus,octopus,词,NOUN,B2
-octroi,bestowal,授予,NOUN,B2
-odd,odd,奇怪的,ADJ,B2
-oddball,oddball,怪人,NOUN,B2
-odds,odds,赔率,NOUN,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-of,of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of by,of by,的/被,ADP,B2
-of course,of course,理所当然的,ADJ,B2
-of course (adv),of course,当然,ADV,B2
-of course (intj),of course,词,INTJ,C1
-of first instance,of first instance,词,ADJ,C1
-of it,of it,其中,ADV,B2
-of old,of old,词,ADV,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,乌得勒支的,ADJ,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
-off-center,off-center,词,ADJ,C1
-off-road vehicle,off-road vehicle,越野车,NOUN,B2
-off-track,off-track,词,ADJ,C1
-offcuts,offcuts,词,NOUN,C1
-offence,offence,罪行,NOUN,B2
-offend,to offend,冒犯,VERB,B2
-offensive,offensive,冒犯的,ADJ,B2
-offensive (noun),offensive,词,NOUN,C1
-office work,office work,办公室工作,NOUN,B2
-official,official,官员,NOUN,B2
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
-officials,officials,官员,NOUN,B2
-officious,officious,词,ADJ,C1
-oh,oh,哇,PART,B2
-oh (part),oh,呀,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
-oh my god,oh my god,我的天,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oh well,oh well,算了,INTJ,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oilfield,oilfield,词,NOUN,C1
-oisif,idle,懒惰的,ADJ,B2
-okay,okay,好的,INTJ,B2
-okay (adj),okay,词,ADJ,A1
-okay (noun),okay,好啊,NOUN,C1
-old (noun),old,夙,NOUN,B1
-old age,old age,老年,NOUN,B2
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old man,old man,老人,NOUN,B2
-old master,old master,老太爷,NOUN,B2
-old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
-old person,old person,老人,NOUN,B2
-old servant,old servant,老奴,NOUN,B2
-old thief,old thief,老贼,NOUN,C1
-old woman,old woman,老妇人,NOUN,B2
-old-age,old-age,晚年,NOUN,C1
-old-fashioned,old-fashioned,老式的,ADJ,B2
-older,older,年长的,ADJ,B2
-older brother,older brother,大哥哥,NOUN,B2
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oldest,oldest,词,ADJ,C1
-oleander,oleander,词,NOUN,B2
-olfactory,olfactory,词,ADJ,C1
-olives,olives,词,NOUN,A2
-ombre de neige,snow shadow,雪影姐姐,NOUN,B2
-omelette,omelette,煎蛋卷,NOUN,B2
-omettre,to leave out,省略,VERB,B2
-ominous,ominous,不祥的,ADJ,B2
-omit,to omit,省略,VERB,B2
-omnipotent,omnipotent,词,ADJ,C1
-omniscient,omniscient,词,ADJ,C1
-on,on,在...上,ADP,B2
-on (adv),on,进行中,ADV,A2
-on (noun),on,on,NOUN,B2
-on behalf of,on behalf of,代表,ADP,B2
-on board,on board,在船上,ADV,B2
-on condition,on condition,词,SCONJ,C1
-on head,on head,当头,NOUN,B2
-on it,on it,在上面,ADV,B2
-on one hand,on one hand,一方面,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on that day,on that day,词,ADV,C1
-on the contrary,on the contrary,相反,ADV,B2
-on the one hand,on the one hand,一方面,ADV,B2
-on the other hand,on the other hand,另一方面,ADV,B2
-on the spot,on the spot,当场,ADV,B2
-on the way,on the way,在路上,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,准时,ADV,B2
-on top of,on top of,在...上面,ADP,B2
-on what,on what,在什么上面,ADV,B2
-on which,on which,在其上,PRON,B2
-once,once,一次,ADV,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
-once more,once more,再次,ADV,B2
-oncle maternel,maternal uncle,舅舅,NOUN,B2
-oncology,oncology,词,NOUN,C1
-one (adj),one,词,ADJ,A2
-one (noun),one,one,NOUN,B2
-one after another,one after another,接连地,ADV,B2
-one and a half,one and a half,一个半,NUM,B2
-one book,one book,一本,NUM,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day,one day,一天,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one family,one family,一家,NUM,B2
-one flat,one flat,一张,NUM,B2
-one handful,one handful,一把,NUM,B2
-one head,one head,一头,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one night,one night,一晚,NUM,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
-one set,one set,一套,NUM,B2
-one shot,one shot,一枪,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
-one's heart's content,one's heart's content,尽情,ADV,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
-one-sided,one-sided,单方面的,ADJ,B2
-one-sidedness,one-sidedness,片面性,NOUN,B2
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
-onerous,onerous,词,ADJ,C1
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-ongoing,ongoing,进行中的,ADJ,B2
-ongoing (noun),ongoing,词,NOUN,B2
-online,online,词,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,词,NOUN,C1
-only,only,唯一的,ADJ,B2
-only (det),only,词,DET,B2
-only (sconj),only,而已,SCONJ,B2
-only bringing,only bringing,只带,NOUN,C1
-only just,only just,才,ADV,B2
-only son,only son,独子,NOUN,C1
-only then,only then,才,ADV,B2
-only-me,only-me,只我,NOUN,B2
-oops,oops,词,INTJ,C1
-oozing,oozing,词,NOUN,B2
-opaque,opaque,词,ADJ,C1
-open,open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-minded,open-minded,思想开明的,ADJ,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-opening,opening,开口,NOUN,B2
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
-openness,openness,开放,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
-operetta,operetta,词,NOUN,C1
-opium den,opium den,词,NOUN,B2
-opportune,opportune,词,ADJ,C1
-opportunism,opportunism,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opposite,opposite,对立面,NOUN,B2
-opposite (adp),opposite,对面,ADP,B2
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
-opposition,opposition,对立,NOUN,B2
-oppress,to oppress,压迫,VERB,B2
-oppressed,oppressed,词,ADJ,B1
-oppression,oppression,压迫,NOUN,B2
-oppressive,oppressive,压迫的,ADJ,B2
-oppressive weight,oppressive weight,词,NOUN,C1
-opt,opt,词,VERB,C1
-optical,optical,光学的,ADJ,B2
-optical illusion,optical illusion,词,NOUN,C1
-optician,optician,词,NOUN,C1
-optics,optics,光学,NOUN,B2
-optimal,optimal,最佳的,ADJ,B2
-optimum,optimum,词,NOUN,C1
-option,option,选择,NOUN,B2
-optional,optional,可选的,ADJ,B2
-options,options,期权,NOUN,B2
-opulence,opulence,词,NOUN,C1
-opulent,opulent,豪华的,ADJ,B2
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
-or something,or something,词,ADV,C1
-oracle,oracle,神谕,NOUN,B2
-oracular,oracular,词,ADJ,C1
-oral,oral,口头的,ADJ,B2
-oral cavity,oral cavity,口腔,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange,orange,橙色,NOUN,B2
-orange (adj),orange,橙色的,ADJ,B2
-orange color,orange color,词,ADJ,A1
-orange juice,orange juice,橙汁,NOUN,B2
-oratory,oratory,词,NOUN,C1
-orbital,orbital,词,ADJ,C1
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-order mission,order mission,词,NOUN,A2
-orderliness,orderliness,有序性,NOUN,B2
-ordinairement,ordinarily,通常,ADV,B2
-ordinance,ordinance,条例,NOUN,B2
-ordinateur,computer,电脑,NOUN,B2
-ordonné,orderly,有序的,ADJ,B2
-ordre public,public order,治安,NOUN,B2
-oreille de bois,wood ear mushroom,木耳,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organism,organism,词,NOUN,C1
-organisé,organized,有组织的,ADJ,B2
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
-orientation,orientation,取向,NOUN,B2
-original,original,最初的,ADJ,B2
-original (noun),original,正本,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
-originally (part),originally,原,PART,B2
-originating,originating,词,ADJ,B1
-originator,originator,词,NOUN,C1
-originer,to originate,发源,VERB,B2
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,无父母的,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
-os,bone,骨头,NOUN,B2
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-oscillator,oscillator,振荡器,NOUN,C1
-osseous,osseous,词,ADJ,C1
-ostensible,ostensible,词,ADJ,C1
-ostentation,ostentation,词,NOUN,C1
-ostentatious,ostentatious,词,ADJ,C1
-ostracism,ostracism,词,NOUN,C1
-ostrich,ostrich,词,NOUN,B2
-other,other,其他,NOUN,B2
-other (det),other,词,DET,B2
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
-other people,other people,人家,NOUN,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherworldly,otherworldly,词,ADJ,C1
-ought,ought,应该,AUX,B2
-ought to,ought to,词,AUX,A2
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out,out,出,ADP,B2
-out here,out here,这里外面,ADV,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,格格不入的,ADJ,B2
-out there,out there,词,ADV,B2
-outbreak,outbreak,爆发,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoor pool,outdoor pool,词,NOUN,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,外部的,ADJ,B2
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outfit,outfit,服装,NOUN,B2
-outgoing,outgoing,外向的,ADJ,C1
-outil,tools,工具,NOUN,B2
-outlandish,outlandish,古怪的,ADJ,B2
-outlast,outlast,词,VERB,B2
-outlaw,outlaw,歹徒,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outrage,outrage,愤怒,NOUN,B2
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outset,outset,词,NOUN,C1
-outside,outside,在外面,ADP,B2
-outside of,outside of,在...之外,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,外界,NOUN,B2
-outsider,outsider,外人,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward,outward,向外,ADV,B2
-outward (adj),outward,词,ADJ,C1
-outward journey,outward journey,词,NOUN,C1
-ouverture des offres,bid opening,开标,NOUN,B2
-ovarian,ovarian,词,ADJ,C1
-over,over,过去,ADV,B2
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
-overdose,overdose,过量,NOUN,B2
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overhead,overhead,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overlapping,overlapping,重叠的,ADJ,C1
-overly familiar,overly familiar,词,ADJ,B2
-overreach,overreach,词,NOUN,C1
-overrule,overrule,词,VERB,C1
-overseas,overseas,词,ADV,B2
-oversight,oversight,疏忽,NOUN,B2
-overt,overt,词,ADJ,C1
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overweight,overweight,词,ADJ,C1
-overwhelming,overwhelming,压倒性的,ADJ,B2
-ow,ow,词,INTJ,C1
-owed,owed,欠下的,ADJ,B2
-own,own,自己的,DET,B2
-owned,owned,被拥有的,ADJ,A1
-ox,ox,词,NOUN,C1
-oxidation,oxidation,词,NOUN,C1
-oxidized,oxidized,词,ADJ,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-packet,packet,小包裹,NOUN,B2
-pacte,covenant,契约,NOUN,B2
-pacts,pacts,词,NOUN,C1
-padding,padding,词,NOUN,C1
-paddle,paddle,词,VERB,C1
-padlock,padlock,词,NOUN,B2
-page,page,页,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paiement intégral,payment all,付都,NOUN,B2
-paiement électronique,electronic payment,电子支付,NOUN,B2
-pain,loaf,一条面包,NOUN,B2
-pain farci à la vapeur,steamed stuffed bun,包子,NOUN,B2
-pain hurt,pain hurt,疼痛,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,词,ADJ,C1
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-paint dye,paint dye,词,VERB,A1
-pair,peer,同龄人,NOUN,B2
-paire,a pair,一对,NUM,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-palatable,palatable,词,ADJ,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palisade,palisade,词,NOUN,C1
-pallid,pallid,词,ADJ,C1
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
-palpable,palpable,词,ADJ,C1
-palpage de melon,melon groping,摸瓜,NOUN,B2
-paltriness,paltriness,词,NOUN,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
-panda,panda,熊猫,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-panneau de direction,direction sign,指示牌,NOUN,B2
-panneau routier,road sign,路标,NOUN,B2
-panties,panties,词,NOUN,C1
-pants,pants,裤子,NOUN,B2
-pants trousers,pants trousers,词,NOUN,A1
-papal bull,papal bull,词,NOUN,B2
-papaye,papaya,木瓜,NOUN,B2
-pape,pope,教皇,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-papeterie,stationery,文具,NOUN,B2
-paquet,bundle,捆,NOUN,B2
-par exemple,for example,例如,ADV,B2
-par lequel,whereby,其中,ADV,B2
-par là,thereby,从而,ADV,B2
-par tous les moyens,by fair means or foul,不择手段,ADV,B2
-par écrit,in writing,书面,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-paradis,paradise,天堂,NOUN,B2
-parage,whereabouts,行踪,NOUN,B2
-paragraph heel,paragraph heel,词,NOUN,C1
-parallelism,parallelism,词,NOUN,C1
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
-paralyser,to paralyze,使瘫痪,VERB,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
-paramount,paramount,词,ADJ,C1
-parangon,paragon,典范,NOUN,B2
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parce que,because,因为,SCONJ,B2
-parcel,parcel,包裹,NOUN,B2
-parch,parch,词,VERB,C1
-pardon (noun),pardon,莫怪,NOUN,B2
-pardoning,pardoning,词,NOUN,C1
-pardonner,pardon,赦免,NOUN,B2
-pardonner,to pardon,赦免,VERB,B2
-parent,parent,父母,NOUN,B2
-parent-friendly,parent-friendly,,NOUN,B2
-parentes,female relatives,女眷,NOUN,B2
-parenthesis,parenthesis,词,NOUN,C1
-parents,parents,父母,NOUN,B2
-parfum céleste,heavenly fragrance,天香,NOUN,B2
-parfumé,fragrant,芬芳的,ADJ,B2
-paria,outcast,被遗弃者,NOUN,B2
-pariah,pariah,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parishioner,parishioner,教区居民,NOUN,B2
-parishioners,parishioners,词,NOUN,C1
-parking space,parking space,停车位,NOUN,C1
-parlement,parliament,议会,NOUN,B2
-parler,talk,谈话,NOUN,B2
-parler,to talk,谈话,VERB,B2
-parley,parley,词,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
-parlor,parlor,词,NOUN,C1
-parole,parole,假释,NOUN,B2
-paroles,lyrics,歌词,NOUN,B2
-paroles du seigneur,lord's words,主说,NOUN,B2
-parquet,parquet,词,NOUN,C1
-parse,parse,解析,VERB,B2
-part,share,股份,NOUN,B2
-part forever,part forever,永别,VERB,B2
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-participant,participant,参与者,NOUN,B2
-participation,participation,参与,NOUN,B2
-particle (part),particle,么,PART,B2
-particularize,particularize,词,VERB,B2
-partie arrière,rear part,后部,NOUN,B2
-partiellement,partly,部分地,ADV,B2
-partir,to depart,离开,VERB,B2
-partir,to part,分离,VERB,B2
-partisan (adj),partisan,词,ADJ,C1
-partisan (noun),partisan,词,NOUN,C1
-partisanship,partisanship,党派性,NOUN,C1
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
-partner female,partner female,词,NOUN,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-party to the contract,party to the contract,词,NOUN,B2
-pashalik,pashalik,词,NOUN,C1
-pass (noun),pass,过得,NOUN,C1
-passable,passable,词,ADJ,C1
-passage,passage,段落,NOUN,B2
-passage,passing,过世,NOUN,B2
-passe-temps,hobby,爱好,NOUN,B2
-passed,passed,递,ADJ,B2
-passer,to come over,顺道来访,VERB,B2
-passer,to pass by,经过,VERB,B2
-passer en premier,to go first,先去,VERB,B2
-passerelle,pedestrian bridge,天桥,NOUN,B2
-passion,passion,激情,NOUN,B2
-passionate love,passionate love,词,NOUN,C1
-passive reliance on others,passive reliance on others,词,NOUN,C1
-passé,past,过去的,ADJ,B2
-past,past,经过,ADV,B2
-past (adj),past,past,ADJ,A1
-past (adp),past,词,ADP,B2
-past events,past events,往事,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
-pastime,pastime,爱好,NOUN,B2
-pastoral (adj),pastoral,词,ADJ,C1
-patch,patch,补丁,NOUN,B2
-patch tire,patch tire,补胎,VERB,C1
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
-patience,patience,耐心,NOUN,B2
-patient,patient,耐心的,ADJ,B2
-patient (noun),patient,病人,NOUN,A2
-patient female,patient female,词,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patriarch,patriarch,词,NOUN,C1
-patricide,patricide,弑父,NOUN,B2
-patrie,homeland,家乡,NOUN,B2
-patriotique,patriotic,爱国的,ADJ,B2
-patriotisme,patriotism,爱国主义,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
-paucity,paucity,词,NOUN,C1
-pauper,pauper,词,NOUN,B2
-pave,pave,词,VERB,C1
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-pavillon,pavilion,亭子,NOUN,B2
-paving,paving,铺路,NOUN,B2
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-payer des impôts,to pay tax,纳税,VERB,B2
-payer en souriant,to pay smilingly,笑付,VERB,B2
-payments,payments,词,NOUN,C1
-paysage,scenery,风景,NOUN,B2
-pea,pea,词,NOUN,C1
-peach tree,peach tree,词,NOUN,C1
-peanut field,peanut field,词,NOUN,B2
-peat,peat,泥炭,NOUN,B2
-peau fine,fine skin,细皮,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
-peculiarity,peculiarity,词,NOUN,B2
-pecuniary,pecuniary,词,ADJ,C1
-pedantic,pedantic,词,ADJ,C1
-peddler,peddler,小贩,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediment,pediment,词,NOUN,C1
-peek,peek,词,VERB,C1
-peel (noun),peel,词,NOUN,B2
-peephole,peephole,门镜,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-peg,peg,词,NOUN,C1
-peigner,to comb,梳头,VERB,B2
-peine de mort,death penalty,死刑,NOUN,B2
-peinture,paint,油漆,NOUN,B2
-pejorative,pejorative,词,ADJ,C1
-peler,peel,皮,NOUN,B2
-peler,to peel,削皮,VERB,B2
-pellucid,pellucid,词,ADJ,C1
-pelvis,pelvis,词,NOUN,B2
-pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
-penalties,penalties,处罚,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-penchant,penchant,词,NOUN,C1
-pendant des années,for years,多年,ADV,B2
-pending,pending,词,ADJ,B1
-penguin,penguin,词,NOUN,A1
-penis,penis,词,NOUN,B2
-penitent,penitent,词,ADJ,C1
-pennant,pennant,词,NOUN,C1
-penniless,penniless,词,ADJ,B1
-pension,pension,养老金,NOUN,B2
-pension alimentaire,alimony,赡养费,NOUN,B2
-pensive,pensive,沉思的,ADJ,B2
-pensée unique,single thought,一念,NOUN,B2
-penury,penury,词,NOUN,C1
-people,people,人们,PRON,B2
-people nation,people nation,人民 / 民族,NOUN,B2
-peppermint,peppermint,词,NOUN,C1
-per,per,每,ADP,B2
-perception,perception,感知,NOUN,B2
-perception opinion,perception opinion,看法,NOUN,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-percuter,to collide,碰撞,VERB,B2
-perfection,perfection,完美,NOUN,B2
-perfidious,perfidious,词,ADJ,C1
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-performer,performer,词,NOUN,C1
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-perilla,perilla,紫苏,NOUN,B2
-period,period,句号,PUNCT,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodical,periodical,词,NOUN,C1
-periodization,periodization,分期,NOUN,C1
-periphery,periphery,边缘,NOUN,B2
-perishing,perishing,,NOUN,B2
-perks,perks,词,NOUN,C1
-permanence,permanence,持久,NOUN,B2
-permanent,permanent,永久的,ADJ,B2
-permanently,permanently,词,ADV,C1
-permeability,permeability,词,NOUN,C1
-permettre,not allow,不许,AUX,B2
-permettre,to enable,使能够,VERB,B2
-permis,permit,许可证,NOUN,B2
-permis de conduire,driver's license,驾驶证,NOUN,B2
-permissible,permissible,词,ADJ,C1
-permission,permission,许可,NOUN,B2
-permutations,permutations,词,NOUN,C1
-perméable,permeable,可渗透的,ADJ,B2
-perpendiculaire,perpendicular,垂直的,ADJ,B2
-perplex,perplex,词,VERB,C1
-perplexer,puzzle,谜题,NOUN,B2
-perplexer,to puzzle,使困惑,VERB,B2
-persimmon,persimmon,柿子,NOUN,C1
-person involved,person involved,当事人,NOUN,C1
-personable,personable,词,ADJ,C1
-personal,personal,私事,NOUN,B2
-personal best,personal best,,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
-personalization,personalization,词,NOUN,C1
-personally experience,personally experience,亲历,VERB,C1
-personne,nobody,没有人,PRON,B2
 personne âgée,elderly,年长的,ADJ,B2
-personnel,personal,个人的,ADJ,B2
-personnel,personnel,人员,NOUN,B2
-perspective,outlook,前景,NOUN,B2
-perspective,perspective,视角,NOUN,B2
-perspective,prospect,前景,NOUN,B2
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicace,astute,精明的,ADJ,B2
-perspicacious,perspicacious,词,ADJ,C1
-perspicacité,insight,洞察力,NOUN,B2
-persuasion,coaxing,哄得,NOUN,B2
-persuasion,persuasion,说服,NOUN,B2
-perte,lose,上丢,NOUN,B2
-pertinent,pertinent,词,ADJ,C1
-pervasive,pervasive,词,ADJ,C1
-pest,pest,词,NOUN,C1
-pesticide,pesticide,杀虫剂,NOUN,B2
-pesticides,pesticides,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-petal,petal,词,NOUN,C1
-petit,smallest,最小的,ADJ,B2
-petit,cub,幼兽,NOUN,B2
-petit neuf,little nine,小九,NOUN,B2
-petit onze,little eleven,小十一,NOUN,B2
-petit-enfant,grandchild,孙辈,NOUN,B2
-petite amie,girlfriend,女朋友,NOUN,B2
-petitesse,smallness,小小,NOUN,B2
-petition for review,petition for review,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-peu,few,很少的,ADJ,B2
-peu important,unimportant,不重要的,ADJ,B2
-peu importe,no matter,不论,CCONJ,B2
-peu profond,shallow,浅的,ADJ,B2
-peu sûr,insecure,不安全的,ADJ,B2
-peuple,folk,民间的,ADJ,B2
-peut-être,maybe,也许,ADV,B2
-peut-être,perhaps,也许,ADV,B2
-phantasmagorical,phantasmagorical,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharisee,pharisee,法利赛人,NOUN,B2
-pharmacie,pharmacy,药房,NOUN,B2
-pharynx,pharynx,词,NOUN,B2
-phase,phase,阶段,NOUN,B2
-phased (adv),phased,词,ADV,B1
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-pheasant,pheasant,词,NOUN,C1
-phenomenal,phenomenal,非凡的,ADJ,B2
-phenomenological,phenomenological,词,ADJ,C1
-phew,phew,词,INTJ,C1
-philanthropic,philanthropic,词,ADJ,C1
-philanthropist,philanthropist,慈善家,NOUN,B2
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philosophizing,philosophizing,词,NOUN,C1
-philosophy of life,philosophy of life,词,NOUN,B2
-phishing,phishing,词,NOUN,B2
-phlebitis,phlebitis,静脉炎,NOUN,B2
-phlegmatic,phlegmatic,冷静的,ADJ,B2
-phloem,phloem,词,ADJ,C1
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
-phone credit,phone credit,词,NOUN,B1
-phone number,phone number,电话号码,NOUN,B2
-phoneme,phoneme,词,NOUN,C1
-phonologie,phonology,音系学,NOUN,B2
-phony,phony,假的,ADJ,B2
-phosphate,phosphate,词,NOUN,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-photo,photo,照片,NOUN,B2
-photo album,photo album,影集,NOUN,C1
-photo d'identité,id photo,证件照,NOUN,B2
-photo de mariage,wedding photo,婚纱照,NOUN,B2
-photo model,photo model,模特,NOUN,B2
-photocopier,photocopy,复印件,NOUN,B2
-photocopier,to photocopy,复印,VERB,B2
-photogenic,photogenic,词,ADJ,C1
-photographe,photographer,摄影师,NOUN,B2
-photographie,photography,摄影,NOUN,B2
-photographier,photograph,照片,NOUN,B2
-photographier,to photograph,拍照,VERB,B2
-photogravure,photogravure,词,NOUN,C1
-photon,photon,光子,NOUN,B2
-photophobia,photophobia,词,NOUN,C1
-phototypy,phototypy,词,NOUN,C1
-phrase,phrase,短语,NOUN,B2
-phraseology,phraseology,词,NOUN,C1
-phrasing,phrasing,措辞,NOUN,B2
-physiognomonie,face reading,面相,NOUN,B2
-physiognomonie,physiognomy,面相,NOUN,B2
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-physique,physics,物理,NOUN,B2
-phénix,phoenix,拿凤,NOUN,B2
-piano,piano,钢琴,NOUN,B2
-piano music,piano music,词,NOUN,B2
-picaresque,picaresque,词,ADJ,C1
-pick up a car,pick up a car,取车,VERB,B2
-pickle (noun),pickle,词,NOUN,C1
-pickles,pickles,词,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
-picotement,tingling,麻木感,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-picture photo,picture photo,词,NOUN,A2
-pie,pie,派,NOUN,B2
-piece of bread,piece of bread,词,NOUN,B2
-piecework,piecework,词,NOUN,C1
-pier,pier,码头,NOUN,B2
-piety pity,piety pity,词,NOUN,B2
-pigeon,pigeon,鸽子,NOUN,B2
-pile,a pile,一堆,NUM,B2
-piling up,piling up,堆砌,NOUN,B2
-pillage,plunder,掠夺,NOUN,B2
-pills,pills,词,NOUN,B2
-pimp,pimp,词,NOUN,C1
-pimple,pimple,词,NOUN,B2
-pince,clamp,夹钳,NOUN,B2
-pincer,pinch,捏,NOUN,B2
-pincer,to pinch,捏,VERB,B2
-pinch (noun),pinch,词,NOUN,C1
-pine,pine,松树,NOUN,B2
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
-pious,pious,虔诚的,ADJ,B2
-pipa,pipa,琵琶,NOUN,B2
-pipe dream,pipe dream,词,NOUN,C1
-piquant,piquant,词,ADJ,C1
-pique-nique,picnic,野餐,NOUN,B2
-pirate,pirate,海盗,NOUN,B2
-pirated,pirated,词,ADJ,B2
-piscine,pool,池,PART,B2
-pisser,to pee,小便,VERB,B2
-pistache,pistachio,开心果,NOUN,B2
-piston,piston,词,NOUN,C1
-pitch,pitch,词,NOUN,B1
-pitch darkness,pitch darkness,词,NOUN,C1
-piteous,piteous,可怜的,ADJ,B2
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pitoyable,pitiful,可怜的,ADJ,B2
-pitoyable,pity,可惜,ADJ,B2
-pittance,pittance,词,NOUN,C1
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,hold the balance of power,举足轻重,ADJ,B2
-pivotal,pivotal,词,ADJ,C1
-pizza,pizza,词,NOUN,B1
-pièce,coin,硬币,NOUN,B2
-pièce,classifier for paintings cloth etc.,幅,NUM,B2
-pièce de théâtre,stage play,舞台剧,NOUN,B2
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-place value,place value,位值,NOUN,C1
-placed before,placed before,词,ADJ,B2
-placement,placement,放置,NOUN,B2
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
-placid,placid,词,ADJ,C1
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plainte,grievance,弊端,NOUN,B2
-plaintive,plaintive,哀伤的,ADJ,C1
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
-plan,plan,计划,NOUN,B2
-plantain,plantain,芭蕉,NOUN,B2
-plantation,plantation,人工林,NOUN,B2
-plantation,planting,种植,NOUN,B2
-plantation de thé,tea plantation,茶园,NOUN,B2
-plaque d'immatriculation,license plate,车牌,NOUN,B2
-plaquette,platelet,血小板,NOUN,B2
-plaqué,plated,镀层的,ADJ,B2
-plasma,plasma,血浆,NOUN,B2
-plastic (adj),plastic,塑料,ADJ,B1
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
-plastique,plastic,塑料的,ADJ,B2
-plat,flat,扁平的,ADJ,B2
-plateau,plateau,高原,NOUN,B2
-platforms,platforms,词,NOUN,C1
-platitude,platitude,词,NOUN,C1
-plausibility,plausibility,词,NOUN,B2
-plausible,plausible,似是而非的,ADJ,B2
-play game,play game,游戏/玩耍,NOUN,B2
-playback,playback,回放,NOUN,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
-plays,plays,词,NOUN,C1
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-please,please,请,INTJ,B2
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plenary,plenary,词,ADJ,C1
-plentiful,plentiful,词,ADJ,B2
-plenty,plenty,充足地,ADV,B2
-plenty (noun),plenty,大量,NOUN,A2
-pleurer,to weep,哭泣,VERB,B2
-pleurs,crying,,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
-plomberie,plumbing,管道工程,NOUN,B2
-plonger,to dip,蘸,VERB,B2
-plongée sous-marine,scuba diving,潜水,NOUN,B2
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plow,plow,词,NOUN,B2
-plow handle,plow handle,词,NOUN,C1
-plucky,plucky,勇敢的,ADJ,B2
-pluie verglacée,freezing rain,冻雨,NOUN,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-plumb,plumb,词,NOUN,C1
-plump,plump,词,ADJ,C1
-plundering,plundering,掠夺,NOUN,B2
-plunge,plunge,词,VERB,C1
-plural (part),plural,们,PART,A1
-pluralisme,pluralism,多元主义,NOUN,B2
-plus,no longer,不再,ADV,B2
-plus,plus,加上,VERB,B2
-plus tard,later,后来,ADV,B2
-plutôt,instead,代替,ADV,B2
-plutôt,or rather,或者,ADV,B2
-plâtrer,to apply a cast,打石膏,VERB,B2
-poach,poach,词,VERB,C1
-podcast,podcast,播客,NOUN,B2
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
-poignant,poignant,词,ADJ,C1
-poignarder,to stab,刺,VERB,B2
-poignée,hilt,剑柄,NOUN,B2
-poignée de porte,door handle,门把手,NOUN,B2
-point de vue,viewpoint,观点,NOUN,B2
-point grade,point grade,词,NOUN,A2
-point of view,point of view,词,NOUN,C1
-pointer,point,点,NOUN,B2
-pointer,to point,指向,VERB,B2
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,徒劳地,ADV,B2
-pointwise,pointwise,词,ADJ,C1
-poison,poison,毒药,NOUN,B2
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,,NOUN,B2
-poke,poke,词,VERB,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polarity,polarity,极性,NOUN,C1
-polemic,polemic,词,NOUN,C1
-police,police,警察,NOUN,B2
-police chief,police chief,警察局长,NOUN,B2
-police officer female,police officer female,词,NOUN,B2
-police report,police report,,NOUN,B2
-policier,policeman,警察,NOUN,B2
-policy-related,policy-related,词,ADJ,C1
-polish,polish,精炼,NOUN,B2
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politic,politic,词,ADJ,C1
-politicization,politicization,词,NOUN,C1
-politique,policy,政策,NOUN,B2
-politique,politics,政治,NOUN,B2
-pollinic,pollinic,词,ADJ,C1
-pollinisation,pollination,授粉,NOUN,B2
-pollster,pollster,词,NOUN,C1
-pollution,pollution,污染,NOUN,B2
-pollué,polluted,受污染的,ADJ,B2
-polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polytunnel,polytunnel,大棚,NOUN,B2
-polémique,polemical,论战的,ADJ,B2
-pomp,pomp,词,NOUN,C1
-pompous,pompous,浮夸的,ADJ,B2
-pomélo,pomelo,柚子,NOUN,B2
-ponctuel,punctual,准时的,ADJ,B2
-ponderous,ponderous,词,ADJ,C1
-pontage,bypass surgery,搭桥手术,NOUN,B2
-pool,pool,水池,NOUN,B2
-pooled,pooled,词,ADJ,C1
-poor devil,poor devil,可怜虫,NOUN,B2
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,最穷的,ADJ,B2
-pop,pop,词,NOUN,B1
-popcorn,popcorn,词,ADJ,C1
-pops,pops,词,NOUN,C1
-populariser,to popularize,推广,VERB,B2
-population,population,人口,NOUN,B2
-populism,populism,民粹主义,NOUN,C1
-populous,populous,词,ADJ,C1
-porcelain,porcelain,瓷器,NOUN,B2
-pornographie,porn,色情,NOUN,B2
-porosity,porosity,词,NOUN,C1
-porous,porous,词,ADJ,C1
-port,port,港口,NOUN,B2
-port harbor,port harbor,词,NOUN,A1
-portable,portable,词,ADJ,C1
-porte latérale,side door,侧门,NOUN,B2
-portentous,portentous,词,ADJ,C1
-porter,to wear,穿,VERB,B2
-porteur,porter,搬运工,NOUN,B2
-portfolios,portfolios,词,NOUN,C1
-portico,portico,词,NOUN,C1
-portion,portion,部分,NOUN,B2
-portrait,portrait,肖像,NOUN,B2
-portrait artistique,artistic portrait,艺术照,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portrayal,portrayal,词,NOUN,B2
-portuguese,portuguese,葡萄牙语,NOUN,B2
-poser,to lay,放置,VERB,B2
-posh,posh,上流的,ADJ,B2
-posit,posit,词,VERB,B2
-position,position,位置,NOUN,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-possession,possession,财产,NOUN,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-possible,possible,可能的,ADJ,B2
-possible future,possible future,词,ADJ,C1
-posséder,to possess,拥有,VERB,B2
-postage,postage,邮资,NOUN,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postal code,postal code,邮政编码,NOUN,B2
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
-postponement,postponement,延期,NOUN,B2
-postscript,postscript,词,NOUN,C1
-posture,posture,作势,NOUN,B2
-posture,stance,立场,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-pot,pot,锅,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
-potential,potential,潜在的,ADJ,B2
-potion,potion,词,NOUN,B2
-potter,potter,词,NOUN,B2
-pouce,inch,بوصة,NOUN,B2
-pouch,pouch,词,NOUN,C1
-poudre,powder,粉末,NOUN,B2
-pouilleux,lousy,糟糕的,ADJ,B2
-pouls,pulse,脉搏,NOUN,B2
-poultice,poultice,词,NOUN,B2
-pounding,pounding,捶,NOUN,B2
-pour,for the sake of,为了,ADP,B2
-pour,for it,为此,ADV,B2
-pour into,pour into,倾注,VERB,B2
-pour l'instant,for now,暂时,ADV,B2
-pour toujours,forever,永远,ADV,B2
-pourcent,percent,百分比,NOUN,B2
-pourquoi,for what,为了什么,ADV,B2
-poursuite,prosecution,起诉,NOUN,B2
-poursuite,pursuit,追求,NOUN,B2
-poursuivre,to pursue,追求,VERB,B2
-pousser,to push,推,VERB,B2
-pouvoir,can,能够,AUX,B2
-pouvoir,can only,只能,AUX,B2
-pouvoir,cannot,不能,AUX,B2
-power grid,power grid,电网,NOUN,B2
-power outlet,power outlet,插座,NOUN,B1
-power plant,power plant,发电厂,NOUN,B2
-power station,power station,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powers,powers,词,NOUN,C1
-poêle,pan,平底锅,NOUN,B2
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatist,pragmatist,词,NOUN,C1
-prairie,grassland,草地,NOUN,B2
-prairie,prairie,词,NOUN,C1
-praise singer,praise singer,词,NOUN,C1
-prank,prank,恶作剧,NOUN,B2
-pratique,practice,练习,NOUN,B2
-prawn,prawn,词,NOUN,C1
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer room,prayer room,祈祷室,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
-precinct,precinct,辖区,NOUN,B2
-precipice,precipice,词,NOUN,C1
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-preclude,preclude,词,VERB,C1
-precocious talent,precocious talent,词,NOUN,C1
-preconception,preconception,,NOUN,B2
-predisposition,predisposition,天赋,NOUN,B2
-predominantly,predominantly,词,ADV,C1
-preeminent,preeminent,词,ADJ,C1
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-prejudiced,prejudiced,有偏见的,ADJ,B2
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature baby,premature baby,词,NOUN,B2
-prematurity,prematurity,词,NOUN,C1
-premeditate,premeditate,词,VERB,C1
-premier,premier,总理,NOUN,B2
-premier bouchage,first capping,首加缁布冠,NOUN,B2
-premier jet,first draft,初稿,NOUN,B2
-premier mérite,first merit,首功,NOUN,B2
-premiere,premiere,首演,NOUN,B2
-premium,premium,溢价,NOUN,B2
-premonition,premonition,预感,NOUN,B2
-prendre le petit-déjeuner,to have breakfast,吃早餐,VERB,B2
-prendre le relais,to take over,接管,VERB,B2
-prendre sa retraite,to retire,退休,VERB,B2
-prendre soin de,to take care of,照顾,VERB,B2
-prendre un congé,to take a leave of absence,休学,VERB,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
-prepared,prepared,准备好的,ADJ,B2
-preparedness,preparedness,词,NOUN,B1
-preponderance,preponderance,词,NOUN,C1
-prerequisite,prerequisite,前提,NOUN,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-preschool,preschool,幼儿园,NOUN,B2
-prescient,prescient,词,ADJ,C1
-present,present,礼物,NOUN,B2
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
-presentation,presentation,展示,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-preserve,to preserve,保护,VERB,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidential election,presidential election,总统选举,NOUN,B2
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
-presque,nearly,几乎,ADV,B2
-press conference,press conference,新闻发布会,NOUN,B2
-press freedom,press freedom,新闻自由,NOUN,B2
-pressing,pressing,紧迫的,ADJ,B2
-prestige,prestige,声望,NOUN,B2
-presume,to presume,假定,VERB,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-presumptuous,presumptuous,词,ADJ,C1
-pretend,to pretend,假装,VERB,B2
-pretend to be,to pretend to be,冒充,VERB,B2
-pretending to forget,pretending to forget,词,VERB,C1
-pretext,pretext,借口,NOUN,B2
-preuve,evidence,证据,NOUN,B2
-preuve matérielle,physical evidence,物证,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalence,prevalence,词,NOUN,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
-prevent,to prevent,阻止,VERB,B2
-preventive,preventive,词,ADJ,B2
-preview,preview,词,NOUN,C1
-previous,previous,,NOUN,B2
-prey,prey,猎物,NOUN,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-prices,prices,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
-primary school,primary school,小学,NOUN,B2
-primate,primate,词,NOUN,C1
-prime,prime,首要的,ADJ,B1
-prime matter,prime matter,词,NOUN,C1
-prime minister,prime minister,总理,NOUN,B2
-primeval forest,primeval forest,原始森林,NOUN,C1
-primordial chaos,primordial chaos,词,NOUN,C1
-prince,prince,王子,NOUN,B2
-principal,leading,领先的,ADJ,B2
-principal (adj),principal,词,ADJ,B2
-printed,printed,词,ADJ,C1
-printed form,printed form,词,NOUN,B1
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-prise,plug,插头,NOUN,B2
-prise,taking,拍摄,NOUN,B2
-prison,jail,监狱,NOUN,B2
-prison,prison,监狱,NOUN,B2
-pristine,pristine,词,ADJ,C1
-privacy,privacy,隐私,NOUN,B2
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-private life,private life,私生活,NOUN,B2
-privatization,privatization,词,NOUN,B2
-prize,prize,奖品,NOUN,B2
-pro-war,pro-war,主战,NOUN,C1
-proactive,proactive,积极主动的,ADJ,B2
-probability,probability,概率,NOUN,B2
-probable,probable,可能的,ADJ,B2
-probation,probation,缓刑,NOUN,B2
-probative,probative,词,ADJ,C1
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-problematic issue,problematic issue,词,NOUN,C1
-problème difficile,difficult problem,难题,NOUN,B2
-procedural,procedural,程序的,ADJ,B2
-procedure,procedure,程序,NOUN,B2
-procedures,procedures,词,NOUN,C1
-process,process,过程,NOUN,B2
-process,to process,处理,VERB,B2
-processable,processable,词,ADJ,C1
-processing,processing,处理,NOUN,B2
-processing (adj),processing,词,ADJ,C1
-prochain,next,接下来,ADV,B2
-proche,near,近,ADJ,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
-procès,lawsuit,诉讼,NOUN,B2
-prodigal,prodigal,词,ADJ,C1
-prodigality,prodigality,挥霍,NOUN,C1
-prodigious,prodigious,词,ADJ,C1
-production,production,生产,NOUN,B2
-profane,profane,词,ADJ,C1
-profane,layman,外行,NOUN,B2
-profess,profess,词,VERB,B2
-profession juridique,legal profession,律师业,NOUN,B2
-professional,professional,专业人士,NOUN,B2
-professional formation,professional formation,职业养成,NOUN,B2
-professionalism,professionalism,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professor,professor,教授,NOUN,B2
-professorship,professorship,词,NOUN,C1
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
-proficient,proficient,熟练的,ADJ,B2
-profit-making,profit-making,营利性,ADJ,B2
-profits,profits,词,NOUN,B2
-profligate,profligate,词,ADJ,C1
-profound,profound,深刻的,ADJ,B2
-profuse,profuse,词,ADJ,C1
-profusion,profusion,词,NOUN,C1
-program schedule,program schedule,词,NOUN,A2
-programmed,programmed,词,ADJ,C1
-programmer,programmer,程序员,NOUN,B2
-progress report,progress report,进度报告,NOUN,B2
-progressif,gradual,逐渐的,ADJ,B2
-prohibit,to prohibit,禁止,VERB,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
-project assignment,project assignment,项目作业,NOUN,B2
-project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projection,projection,词,NOUN,C1
-projections,projections,词,NOUN,C1
-proliferate,proliferate,扩散,! VERB,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolific,prolific,多产的,ADJ,B2
-prolix,prolix,冗长的,ADJ,B2
-promenade,ride,行程,NOUN,B2
-promenade,walk,行走,NOUN,B2
-promettre,to pledge,保证,VERB,B2
-prominence,prominence,词,NOUN,B2
-prominent,prominent,突出的,ADJ,B2
-prominent family,prominent family,望族,NOUN,C1
-promiscuous,promiscuous,滥交的,ADJ,B2
-promising,promising,有前途的,ADJ,B2
-promissory note,promissory note,本票,NOUN,B2
-promoted,promoted,词,ADJ,B1
-promoter,promoter,推动者,NOUN,B2
-promotion,promotion,晋升,NOUN,B2
-prompt,prompt,词,ADJ,C1
-promptement,promptly,迅速地,ADV,B2
-promptness,promptness,词,NOUN,C1
-promulguer,to enact,颁布,VERB,B2
-prone,prone,词,ADJ,C1
-pronounced,pronounced,显著的,ADJ,B2
-proofread,proofread,校对,VERB,C1
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-property owner,property owner,房主,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
-prophétiser,to prophesy,预言,VERB,B2
-propitious,propitious,词,ADJ,C1
-proportion,proportion,比例,NOUN,B2
-proportionality,proportionality,词,NOUN,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proposition,proposition,主张,NOUN,B2
-propre,own,自己的,ADJ,B2
-propre,proper,适当的,ADJ,B2
-propreté,cleanliness,清洁,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-propriétaire,landlord,房东,NOUN,B2
-propriété,ownership,,NOUN,B2
-propriété,propriety,分寸,NOUN,B2
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
-prosaïque,prosaic,平淡无奇的,ADJ,B2
-prose,prose,散文,NOUN,B2
-prose writer,prose writer,词,NOUN,C1
-prosecutions,prosecutions,词,NOUN,C1
-prosecutor's office,prosecutor's office,词,NOUN,B2
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prostitution,prostitution,词,NOUN,B2
-prostituée,prostitute,妓女,NOUN,B2
-protection,protection,保护,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protector,protector,保护者,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
-proton,proton,词,NOUN,C1
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-provable,provable,可证明的,ADJ,B2
-proverbs,proverbs,词,NOUN,C1
-providential,providential,词,ADJ,C1
-province,province,省,NOUN,B2
-provinces,provinces,词,NOUN,C1
-provincial,provincial,地方的,ADJ,B2
-provision,provision,词,NOUN,C1
-provisional,provisional,临时的,ADJ,B2
-provisions,provisions,储备,NOUN,B2
-provocation,provocation,挑衅,NOUN,B2
-provocative,provocative,挑衅的,ADJ,B2
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-proximité,closeness,接近,NOUN,B2
-proximité,proximity,邻近,NOUN,B2
-prudence,prudence,谨慎,NOUN,B2
-prudent,prudent,谨慎的,ADJ,B2
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-précieux,valuable,有价值的,ADJ,B2
-préciosité,preciousness,珍贵,NOUN,B2
-précipitation,precipitation,降水,NOUN,B2
-précédent,precedent,先例,NOUN,B2
-prédateur,predatory,掠夺的,ADJ,B2
-prédication,preaching,劝诫,NOUN,B2
-préférence gustative,taste preference,口味,NOUN,B2
-préparer,to prepare,准备,VERB,B2
-préparer une leçon,to prepare a lesson,预习,VERB,B2
-préposé,attendant,服务员,NOUN,B2
-psoriasis,psoriasis,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychiatre,psychiatrist,精神科医生,NOUN,B2
-psychopathy,psychopathy,词,NOUN,C1
-public,public,公共的,ADJ,B2
-public (noun),public,公众,NOUN,B1
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publiciser,to advertise,做广告,VERB,B2
-publicity,publicity,宣传,NOUN,B2
-publicité,advertisement,广告,NOUN,B2
-puce,chip,碎片,NOUN,B2
-puddle,puddle,水坑,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puff pastry,puff pastry,词,NOUN,C1
-pugnacious,pugnacious,词,ADJ,C1
-puissance,might,威力,NOUN,B2
-puissant,puissant,词,ADJ,C1
-puits,a well,井,NOUN,B2
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
-pulling,pulling,拔,NOUN,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-punch (verb),punch,词,VERB,B2
-punch drink,punch drink,词,NOUN,C1
-punctilious,punctilious,词,ADJ,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
-punishable,punishable,可处罚的,ADJ,B2
-punitive,punitive,惩罚性的,ADJ,B2
-puny,puny,瘦弱的,ADJ,B2
-pupil female,pupil female,词,NOUN,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-puppy,puppy,小狗,NOUN,B2
-purchase price,purchase price,购买价,NOUN,B2
-purification,purification,净化,NOUN,B2
-purifying,purifying,净化的,ADJ,B2
-puritanical,puritanical,词,ADJ,C1
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-purse,purse,词,NOUN,B1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-pus,pus,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-putrid,putrid,词,ADJ,C1
-puéril,childish,幼稚的,ADJ,B2
-pâte,paste,酱,NOUN,B2
-pâtes,pasta,意大利面,NOUN,B2
-pâturage,grazing,放牧,NOUN,B2
-père,father,父,PART,B2
-père Noël,santa claus,圣诞老人,NOUN,B2
-pédagogique,pedagogical,教学的,ADJ,B2
-périphérique,ring road,绕城,NOUN,B2
-pétrole,petroleum,石油,NOUN,B2
-pêche,peach,桃子,NOUN,B2
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quackery,quackery,词,NOUN,B2
-quai,dock,码头,NOUN,B2
-quai,quay,码头,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualification,qualification,资格,NOUN,B2
-qualifications,qualifications,资格,NOUN,B2
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifié,qualified,合格的,ADJ,B2
-qualifying,qualifying,词,ADJ,C1
-qualitatif,qualitative,定性的,ADJ,B2
-quand,when,当...时,ADV,B2
-quand même,anyway,无论如何,ADV,B2
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,可量化的,ADJ,B2
-quantité,quantity,数量,NOUN,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarry,quarry,词,NOUN,B1
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quasi,quasi,词,ADV,B2
-quaternary,quaternary,第四的,ADJ,B2
-quatre-vingt-dix,ninety,九十,NUM,B2
-que,than,比,ADP,B2
-que,what,什么,ADV,B2
-que,whether or not,是否,SCONJ,B2
-queer,queer,词,ADJ,C1
-quelconque,any,任何,DET,B2
-quelque chose,anything,任何事,PRON,B2
-quench,quench,词,VERB,C1
-querelle,quarreling,再吵,NOUN,B2
-querulous,querulous,词,ADJ,C1
-question,question,问题,NOUN,B2
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
-question rhétorique,rhetorical question,宁非,NOUN,B2
-questioning (adj),questioning,词,ADJ,C1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-queue,tail,尾巴,NOUN,B2
-qui,whom,谁,PRON,B2
-quibble,quibble,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiconque,anyone,任何人,PRON,B2
-quiescent,quiescent,词,ADJ,C1
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
-quill,quill,词,NOUN,C1
-quint,quint,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quitter le travail,to get off work,下班,VERB,B2
-quivering,quivering,颤抖的,ADJ,B2
-quixotic,quixotic,词,ADJ,C1
-quota sharing,quota sharing,配额分享,NOUN,C1
-quotable,quotable,可估价的,ADJ,B2
-quotidian,quotidian,词,ADJ,C1
-quotidien,every day,天天,ADV,B2
-quotidien,daily newspaper,日报,NOUN,B2
-quotient,quotient,词,NOUN,B2
-quête,quest,探索,NOUN,B2
-rabble,rabble,词,NOUN,C1
-raccourcir,to shorten,缩短,VERB,B2
-racist,racist,种族主义的,ADJ,B2
-raconter,to narrate,叙述,VERB,B2
-raconter,to relate to narrate,叙述,VERB,B2
-radar,radar,词,NOUN,B2
-radiant,radiant,容光焕发的,ADJ,B2
-radiation,radiation,辐射,NOUN,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radical,radical,激进的,ADJ,B2
-radicalism,radicalism,词,NOUN,C1
-radio,radio,收音机,NOUN,B2
-radio silence,radio silence,词,NOUN,C1
-radiography rays,radiography rays,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
-radiotherapy,radiotherapy,放疗,NOUN,B2
-radius,radius,半径,NOUN,B2
-raffinage,refining,提炼,NOUN,B2
-raffinement,refinement,修养,NOUN,B2
-rage,rage,愤怒,NOUN,B2
-rage de dents,toothache,牙痛,NOUN,B2
-rags,rags,词,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-rai,rai,词,NOUN,B2
-raid,raid,突袭,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
-railing,railing,栏杆,NOUN,B2
-railroad,railroad,词,NOUN,B2
-rails,rails,词,NOUN,C1
-railway,railway,铁路,NOUN,B2
-rain clouds,rain clouds,词,NOUN,C1
-rainforest,rainforest,雨林,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise,to raise,举起,VERB,B2
-raise (noun),raise,词,NOUN,B1
-raise donations,to raise donations,募捐,VERB,B2
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-raisonnable,reasonable,合理的,ADJ,B2
-raisonnement,reasoning,论证,NOUN,B2
-rajaz poem,rajaz poem,词,NOUN,C1
-rake,rake,耙子,NOUN,B2
-rally (noun),rally,词,NOUN,B2
-rambunctious,rambunctious,词,ADJ,C1
-rampant tyranny,rampant tyranny,横行,NOUN,B2
-rampiner,to crawl,爬行,VERB,B2
-ramshackle,ramshackle,词,ADJ,C1
-ran,ran,跑,ADJ,B2
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancor,rancor,怨恨,NOUN,B2
-rancorous,rancorous,词,ADJ,C1
-rancunier,spiteful,怀恨的,ADJ,B2
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-randonner,to hike,徒步旅行,VERB,B2
-randonnée,hiking,徒步,NOUN,B2
-range zone,range zone,词,NOUN,C1
-ranger,ranger,词,NOUN,B2
-ranger,to put in order,收拾,VERB,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-rapacious,rapacious,词,ADJ,C1
-rape,rape,强奸,NOUN,B2
-rape,to rape,强奸,VERB,B2
-rapid,rapid,迅速的,ADJ,B2
-rapide,fast quick,快的,ADJ,B2
-rapidly,rapidly,词,ADV,B2
-rapier,rapier,词,NOUN,C1
-rapport,intercourse,性交,NOUN,B2
-rapporter,to fetch,取来,VERB,B2
-rapporteur,rapporteur,词,NOUN,C1
-rapprochement,rapprochement,和解,NOUN,B2
-rapturous,rapturous,词,ADJ,C1
-raquette,bat,蝙蝠,NOUN,B2
-rare,rare,稀有的,ADJ,B2
-rare,scarce,稀少的,ADJ,B2
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,稀薄,NOUN,B2
-rarity,rarity,希罕,NOUN,C1
-rascal,rascal,无赖,NOUN,B2
-rash,rash,轻率的,ADJ,B2
-rash (noun),rash,词,NOUN,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-raspy,raspy,词,ADJ,C1
-rassemblement,gathering,聚集,NOUN,B2
-rassurance,reassurance,安抚,NOUN,B2
-rat,rat,老鼠,NOUN,B2
-rat-proof,rat-proof,防鼠,ADJ,B2
-rate percentage,rate percentage,词,NOUN,B2
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
-rating,rating,评分,NOUN,B2
-ratio,ratio,比率,NOUN,B2
-ration,ration,配给,NOUN,B2
-rational,rational,词,ADJ,B2
-rationalist,rationalist,词,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
-rattling,rattling,词,NOUN,C1
-raucous,raucous,词,ADJ,C1
-ravage (noun),ravage,词,NOUN,C1
-raven,raven,乌鸦,NOUN,B2
-ravenous,ravenous,词,ADJ,C1
-ravioli,dumpling,丸子,NOUN,B2
-raw material,raw material,原材料,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-raw ore,raw ore,词,ADJ,C1
-ray,ray,光线,NOUN,B2
-rayonnement,radiance,光辉,NOUN,B2
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-raze,raze,词,VERB,C1
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-abruptness,re-abruptness,再骤,NOUN,B2
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-battle,re-battle,重战,NOUN,B2
-re-boundary,re-boundary,重界,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-course,re-course,重途,NOUN,B2
-re-creation,re-creation,再作,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-enactment,re-enactment,再演,NOUN,B2
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-evidence,re-evidence,重据,NOUN,B2
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-fruit,re-fruit,再果,NOUN,B2
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-inner,re-inner,再内,NOUN,B2
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,再判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-layering,re-layering,改层,NOUN,B2
-re-limit,re-limit,重限,NOUN,B2
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-logic,re-logic,再逻,NOUN,B2
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-reality,re-reality,再实,NOUN,C1
-re-route,re-route,重路,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-shape,re-shape,重形,NOUN,C1
-re-signification,re-meaning,再义,NOUN,B2
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,再综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach,reach,范围,NOUN,B2
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reactionary,reactionary,反动,ADJ,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
-readiness,readiness,准备就绪,NOUN,B2
-readiness to help,readiness to help,词,NOUN,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
-reaffirm,reaffirm,词,VERB,B2
-real estate (noun),real estate,不动产,NOUN,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
-realist,realist,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rear,rear,后面的,ADJ,B2
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasoned,reasoned,经过推理的,ADJ,B2
-rebab,rebab,列巴布琴,NOUN,B2
-reboisement,afforestation,植树造林,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recede,recede,词,VERB,C1
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-recent past,recent past,前些,NOUN,C1
-recess,recess,词,NOUN,C1
-recevoir des ordres,to receive orders,受命,VERB,B2
-recevoir du courrier,to receive mail,收件,VERB,B2
-recevoir une attention mondiale,to receive worldwide attention,举世瞩目,VERB,B2
-recharge (noun),recharge,词,NOUN,B2
-recherche,search,搜索,NOUN,B2
-rechercher,to research,研究,VERB,B2
-recidivism,recidivism,词,NOUN,B2
-reciprocate,reciprocate,词,VERB,C1
-recitation,recitation,词,NOUN,C1
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,收复,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-recognized,recognized,词,NOUN,B2
-recombination,recombination,再结,NOUN,C1
-recommandation d'autrui,recommendation by others,他荐,NOUN,B2
-recommended,recommended,词,ADJ,C1
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconnaissance,reconnaissance,侦察,NOUN,B2
-reconnaissance faciale,face recognition,认人,NOUN,B2
-reconnaissant,grateful,感激的,ADJ,B2
-reconnoiter,reconnoiter,词,VERB,C1
-reconsidération,reconsideration,重思,NOUN,B2
-reconsidérer,to reconsider,重新考虑,VERB,B2
-reconstruire,to rebuild,重建,VERB,B2
-reconstruire,to reconstruct,重建,VERB,B2
-record personnel,personal record,个人纪录,NOUN,B2
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recours,resort,度假胜地,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-recueil de poésie,poetry collection,诗集,NOUN,B2
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
-recursive,recursive,词,ADJ,C1
-recycled item,recycled item,再物,NOUN,B2
-recycler,to recycle,回收利用,VERB,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-redact,redact,词,VERB,C1
-redesign,redesign,词,NOUN,C1
-redire,to retell,转述,VERB,B2
-redolent,redolent,词,ADJ,C1
-redoubtable,redoubtable,词,ADJ,C1
-redrawing,redrawing,重新绘制,NOUN,B2
-redress,redress,词,VERB,B2
-reductionism,reductionism,词,NOUN,C1
-redundant,redundant,多余的,ADJ,B2
-redéfinition,redefinition,改界,NOUN,B2
-reed bed,reed bed,词,NOUN,B2
-reed pen,reed pen,词,NOUN,C1
-reef,reef,词,NOUN,B2
-reefs,reefs,词,NOUN,B2
-refereed,refereed,词,ADJ,C1
-references,references,词,NOUN,C1
-referral,referral,词,NOUN,C1
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
-reflective,reflective,词,ADJ,C1
-reformatory,reformatory,词,NOUN,C1
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-reformulation,reformulation,重新表述,NOUN,B2
-refractory,refractory,词,ADJ,C1
-refreshing,refreshing,令人清爽的,ADJ,B2
-refrigeration,refrigeration,词,NOUN,C1
-refroidir,to cool down,冷却,VERB,B2
-refuge,refuge,避难所,NOUN,B2
-refulgent,refulgent,词,ADJ,C1
-refurbish,refurbish,词,VERB,C1
-refus temporaire,temporary refusal,暂不,NOUN,B2
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refuser poliment,to decline politely,婉拒,VERB,B2
-regal,regal,词,ADJ,C1
-regard,look,看,NOUN,B2
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regarder,to look at,观看,VERB,B2
-regardless,regardless,不管,ADP,B2
-regardless (adv),regardless,不管,ADV,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regenerate,regenerate,再生,VERB,C1
-regimen,regimen,词,NOUN,C1
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-registered,registered,注册的,ADJ,B2
-regret,regret,后悔,NOUN,B2
-regrettable,regrettable,词,ADJ,B2
-regularly,regularly,定期地,ADV,B2
-regulated,regulated,词,ADJ,C1
-regulator,regulator,词,NOUN,C1
-rehabilitative,rehabilitative,词,ADJ,B2
-rehearsal,rehearsal,排练,NOUN,B2
-reification,reification,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
-reinforced,reinforced,词,ADJ,C1
-reining,reining,勒马,NOUN,B2
-reins,reins,词,NOUN,B2
-rejustification,re-reason,重理,NOUN,B2
-relapse (verb),relapse,词,VERB,B2
-relation,relation,词,NOUN,B1
-relativement,relatively,相对地,ADV,B2
-relativement parlant,relatively speaking,相对而言,ADV,B2
-relativist,relativist,词,ADJ,C1
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
-relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-released,released,获释的,ADJ,B2
-religieuse,nun,修女,NOUN,B2
-religion,religion,宗教,NOUN,B2
-religiosity,religiosity,笃信宗教,NOUN,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiousness,religiousness,虔诚,NOUN,B2
-relinquish,relinquish,词,VERB,C1
-relinquishment,relinquishment,词,NOUN,C1
-relique,relic,圣物,NOUN,B2
-relocaliser,to relocate,调动,VERB,B2
-reluctant,reluctant,不情愿的,ADJ,B2
-remainder,remainder,剩余部分,NOUN,B2
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
-remains,remains,残骸,NOUN,B2
-remand,remand,词,NOUN,B2
-remaniement,reshaping,改形,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
-remark (verb),remark,词,VERB,B2
-remarkable,remarkable,非凡的,ADJ,B2
-remarks,remarks,说些,NOUN,C1
-remarquable,outstanding,杰出的,ADJ,B2
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
-remediation,remediation,词,NOUN,B2
-remedy,remedy,补救措施,NOUN,B2
-remember,to remember,记得,VERB,B2
-remembrance,remembrance,纪念,NOUN,B2
-remettre,to hand over,交付,VERB,B2
-remind,to remind,提醒,VERB,B2
-reminisce,reminisce,词,VERB,C1
-reminiscence,reminiscence,词,NOUN,C1
-reminiscent,reminiscent,词,ADJ,C1
-remise,handover,拿给,NOUN,B2
-remiss,remiss,词,ADJ,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remnant,remnant,词,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse,remorse,悔恨,NOUN,B2
-remorse regret,remorse regret,悔恨,NOUN,C1
-remorseful,remorseful,悔恨的,ADJ,B2
-remote,remote,遥远的,ADJ,B2
-remote-controlled car,remote-controlled car,遥控车,NOUN,B2
-removal,removal,移除,NOUN,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,移除的,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
-remplir,to fill in,填写,VERB,B2
-renaissance,renaissance,复兴,NOUN,B2
-renascent,renascent,词,ADJ,C1
-rencontrer,encounter,相遇,NOUN,B2
-rencontrer,to encounter,遭遇,VERB,B2
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
-rendezvous,rendezvous,约会,NOUN,B2
-rendition,rendition,词,NOUN,C1
-rendre hommage,to pay respects,参见,VERB,B2
-renegade,renegade,词,NOUN,C1
-renege,to renege,食言,VERB,B2
-renewable energy,renewable energy,可再生能源,NOUN,C1
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
-renminbi,renminbi,人民币,NOUN,B2
-renounce,renounce,词,VERB,C1
-rent a car,rent a car,租车,VERB,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renvoi,court dismissal,退朝,NOUN,B2
-reoperation,reoperation,再术,NOUN,B2
-reordering,reordering,改序,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-reparable,reparable,词,ADJ,C1
-reparation,reparation,赔偿,NOUN,B2
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repay,to repay,偿还,VERB,B2
-repayment,repayment,偿还,NOUN,B2
-repayment time,repayment time,还时,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
-repeated,repeated,反复的,ADJ,B2
-repeatedly,repeatedly,反复地,ADV,B2
-repelling,repelling,词,VERB,C1
-repent,to repent,悔改,VERB,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-repiquer,to plant out,定植,VERB,B2
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
-replanning,replanning,再策,NOUN,B2
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
-reply,reply,回复,NOUN,B2
-reply,to reply,回复,VERB,B2
-reply to your-highness,reply to your-highness,回殿下,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
-reporter,reporter,记者,NOUN,B2
-reporter,to postpone,推迟,VERB,B2
-reporting,reporting,报道,NOUN,B2
-repositioning,repositioning,重新定位,NOUN,B2
-reprehensible,reprehensible,应受谴责的,ADJ,B2
-representation,representation,代表,NOUN,B2
-representational,representational,词,ADJ,C1
-repressed,repressed,词,ADJ,C1
-repressive,repressive,压制的,ADJ,B2
-reprice,reprice,再价,NOUN,B2
-reprint,reprint,词,NOUN,C1
-reprisal,reprisal,词,NOUN,C1
-reproachable,reproachable,应受责备的,ADJ,B2
-reprobate,reprobate,词,NOUN,C1
-reproduction,reproduction,繁殖,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
-reprogramming,reprogramming,改程,NOUN,B2
-reptiles,reptiles,词,NOUN,B2
-republicanism,republicanism,词,NOUN,C1
-repudiate,repudiate,词,VERB,C1
-repudiation,repudiation,词,NOUN,C1
-repugnant,repugnant,词,ADJ,C1
-repulse,repulse,击退,NOUN,B2
-repulsive,repulsive,令人反感的,ADJ,B2
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
-requantification,re-quantity,再量,NOUN,B2
-request,to request,请求,VERB,B2
-request to rest,request to rest,请息,NOUN,C1
-required,required,必需的,ADJ,B2
-required course,required course,必修课,NOUN,C1
-requirements,requirements,词,NOUN,C1
-requisite,requisite,词,NOUN,C1
-reroutage,re-path,重径,NOUN,B2
-reroutage,re-routing,改轨,NOUN,B2
-resaisie,retype,再型,NOUN,B2
-rescind,rescind,词,VERB,C1
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resent,resent,词,VERB,C1
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
-reserves,reserves,储备,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
-residence housing,residence housing,词,NOUN,A2
-resident,resident,定居的,ADJ,B2
-residential,residential,词,ADJ,B2
-residue,residue,词,NOUN,C1
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
-resigned submission,resigned submission,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistor,resistor,词,NOUN,C1
-resolve doubts,resolve doubts,解惑,VERB,B2
-resoumission,re-submission,再上,NOUN,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respect,respect,尊重,NOUN,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectively,respectively,词,ADV,C1
-respectueux,respectful deferential,恭敬,ADJ,B2
-respiration,respiration,呼吸作用,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
-responsabilité,accountability,问责制,NOUN,B2
-responsabilité,liability,责任,NOUN,B2
-responsable,person in charge,负责人,NOUN,B2
-ressemblance,likeness,就象,NOUN,B2
-ressource,resource,资源,NOUN,B2
-rest assured,rest assured,放心的,ADJ,B2
-rest stop,rest stop,词,NOUN,B1
-restate,restate,词,VERB,B2
-restaurant,restaurant,餐厅,NOUN,B2
-restauration,restoration,恢复,NOUN,B2
-rester,to be left over,剩余,VERB,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-restock,restock,补货,VERB,C1
-restrain,restrain,词,VERB,C1
-restriction,restriction,限制,NOUN,B2
-restriction de plaque d'immatriculation,license plate restriction,限号,NOUN,B2
-restriction mutuelle,mutual restriction,相克,NOUN,B2
-restructuration,restructuring,重组,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
-resurgent,resurgent,词,ADJ,C1
-resuscitate,resuscitate,词,VERB,C1
-reséquencement,re-sequencing,改骤,NOUN,B2
-retailer,retailer,零售商,NOUN,B2
-retaliate,retaliate,词,VERB,C1
-retaliation,retaliation,词,NOUN,C1
-retarded,retarded,词,ADJ,C1
-retenir,to withhold,扣留,VERB,B2
-retention,retention,我留,NOUN,B2
-retenue,restraint,隐忍,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-reticent,reticent,沉默寡言的,ADJ,B2
-retina,retina,词,NOUN,B2
-retinue,retinue,词,NOUN,B2
-retirement pension,retirement pension,退休金,NOUN,B2
-retourner d'abord,to return first,先回,VERB,B2
-retrait de chaussures,shoe removal,鞋脱,NOUN,B2
-retraité,retired,退休的,ADJ,B2
-retranslation,retranslation,重译,NOUN,B2
-retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retroactive,retroactive,词,ADJ,C1
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-revealing,revealing,现出,NOUN,B2
-revel,revel,词,VERB,C1
-revelry,revelry,狂欢,NOUN,B2
-revenir,to go back,回去,VERB,B2
-revenue,revenue,收入,NOUN,C1
-revenues,revenues,词,NOUN,C1
-revenus et dépenses,income and expense,收支,NOUN,B2
-reverberation,reverberation,词,NOUN,C1
-reverent,reverent,虔诚的,ADJ,B2
-reverie,reverie,词,NOUN,C1
-revers,reverse side,反面,NOUN,B2
-reverse (adj),reverse,反,ADJ,B2
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
-revile,revile,词,VERB,C1
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revivalism,revivalism,词,NOUN,C1
-revolver,revolver,词,NOUN,C1
-revue trimestrielle,quarterly magazine,季刊,NOUN,B2
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-rhétorique,rhetorical,修辞的,ADJ,B2
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald,ribald,词,ADJ,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribs,ribs,肋骨,NOUN,B2
-ricaner,to giggle,咯咯笑,VERB,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-richement doté par la nature,richly endowed by nature,得天独厚,ADJ,B2
-richer,richer,更富的,ADJ,B2
-rickety,rickety,词,ADJ,C1
-ricochet,ricochet,词,NOUN,C1
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridicule (noun),ridicule,词,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
-rife,rife,词,ADJ,C1
-riffraff,riffraff,词,NOUN,C1
-right (intj),right,词,INTJ,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rightly,rightly,正确地,ADV,B2
-rights and interests,rights and interests,权益,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rile,rile,词,VERB,C1
-rim,rim,词,NOUN,C1
-rings,rings,词,NOUN,B2
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-rire,laughter,笑声,NOUN,B2
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
-risks,risks,词,NOUN,C1
-risque,risque,有伤风化的,ADJ,B2
-risque de mort,risking death,冒死,NOUN,B2
-risquer sa vie,to risk life,拼命,VERB,B2
-risqué,risky,危险的,ADJ,B2
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
-rival,rival,对手,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river-gauging,river-gauging,词,ADJ,C1
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-riz cuit,cooked rice,米饭,NOUN,B2
-roadblock,roadblock,,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roar (noun),roar,词,NOUN,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
-robe,robe,词,NOUN,B2
-robe noire,black robe,黑衣,NOUN,B2
-robot,robot,机器人,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotics,robotics,词,NOUN,C1
-robotization,robotization,词,NOUN,C1
-robustness,robustness,词,NOUN,C1
-rocaille,rockery,假山,NOUN,B2
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rock slab,rock slab,岩板,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rod,rod,词,NOUN,B1
-rogue,rogue,词,NOUN,B2
-rolled,rolled,词,ADJ,C1
-rolling,rolling,词,NOUN,C1
-roman,novel,小说,NOUN,B2
-roman,roman,罗马人,NOUN,B2
-romance,romance,浪漫,NOUN,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-rondin,log,日志,NOUN,B2
-ronger,to gnaw,啃,VERB,B2
-roof,to roof,房顶,VERB,B2
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-roominess,roominess,词,NOUN,C1
-roommate,roommate,室友,NOUN,B2
-rooster,rooster,公鸡,NOUN,B2
-roots,roots,词,NOUN,C1
-rose,rose,玫瑰,NOUN,B2
-roster,roster,词,NOUN,C1
-rot decomposition,rot decomposition,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation de poste,shift rotation,倒班,NOUN,B2
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
-roter,to burp,打嗝,VERB,B2
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
-roturier,commoner,平民,NOUN,B2
-rouge à lèvres,lipstick,口红,NOUN,B2
-rough,rough,粗糙的,ADJ,B2
-roughly,roughly,大约,ADV,B2
-round,round,轮 / 回合,NOUN,B2
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
-route provinciale,provincial highway,省道,NOUN,B2
-router,router,路由器,NOUN,B2
-routine,routine,常规,NOUN,B2
-routing,routing,词,NOUN,C1
-rove,rove,词,VERB,C1
-row series,row series,词,NOUN,B1
-rowboat,rowboat,词,NOUN,B2
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal,royal,皇家的,ADJ,B2
-royal court,royal court,词,NOUN,C1
-royaume,kingdom,王国,NOUN,B2
-royaume,realm,领域,NOUN,B2
-rubber,rubber,橡胶,NOUN,B2
-rubbing,rubbing,摩擦,NOUN,B2
-rubbish,rubbish,垃圾,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubicund,rubicund,词,ADJ,C1
-ruckus,ruckus,词,NOUN,C1
-rudeness,rudeness,粗鲁,NOUN,B2
-rudimentary,rudimentary,词,ADJ,C1
-rue à double sens,two-way street,双行道,NOUN,B2
-rueful,rueful,词,ADJ,C1
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
-rugir,to roar,咆哮,VERB,B2
-ruin relic,ruin relic,词,NOUN,B2
-ruine familiale,family ruin,家破,NOUN,B2
-ruined,ruined,词,ADJ,B2
-ruins,ruins,废墟,NOUN,B2
-rule of law,rule of law,法治,NOUN,B2
-rulebook,rulebook,规则体系,NOUN,B2
-ruler,ruler,统治者,NOUN,B2
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-rumination,rumination,词,NOUN,C1
-ruminative,ruminative,词,ADJ,C1
-rummage,rummage,词,VERB,C1
-rumors,rumors,词,NOUN,B2
-run,run,跑步,NOUN,B2
-run away fled,run away fled,词,VERB,A1
-run into,to run into,碰见,VERB,B2
-run over,run over,被碾过的,ADJ,B2
-run over,to run over,碾过,VERB,B2
-run over (adj),run over,词,ADJ,B2
-run quickly,to run quickly,奔驰,VERB,B2
-run to jog,to run to jog,跑步,VERB,B2
-run-down,run-down,词,ADJ,C1
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,,NOUN,B2
-running,running,进行中的,NOUN,B2
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
-runny nose,runny nose,流鼻涕,NOUN,B2
-runway,runway,词,NOUN,C1
-rupture,rupture,破裂,NOUN,B2
-rural,rural,乡村的,ADJ,B2
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-ruse,ruse,词,NOUN,C1
-rush,rush,赶往,NOUN,B2
-rush about,to rush about,奔波,VERB,B2
-rushing,rushing,居赶,NOUN,B2
-russian,russian,俄罗斯人,NOUN,B2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rust-proof,rust-proof,防锈,ADJ,B2
-rusty,rusty,词,ADJ,C1
-ruthless,ruthless,无情的,ADJ,B2
-ruthlessness,ruthlessness,无情,NOUN,B2
-rythme,re-pace,重骤,NOUN,B2
-règlements,regulations,法规,NOUN,B2
-réaliser,to do to make,做,VERB,B2
-réaliser,to realize,意识到,VERB,B2
-récemment,recently,最近,ADV,B2
-réchauffement climatique,global warming,气候变暖,NOUN,B2
-récit,narrative,叙述；故事,NOUN,B2
-réciter,to recite,背诵,VERB,B2
-réclamer,to reclaim,收回,VERB,B2
-réclusion à perpétuité,life imprisonment,无期徒刑,NOUN,B2
-récolte,crop,庄稼,NOUN,B2
-récompense,reward,奖励,NOUN,B2
-récupération,retrieval,检索,NOUN,B2
-récupération,retrieve qingming,拿回青冥,NOUN,B2
-récupérer,to recuperate,恢复,VERB,B2
-récupérer,to retrieve,取回,VERB,B2
-récurrence,recurrence,往复,NOUN,B2
-réflexion inverse,reverse reflection,反影,NOUN,B2
-réfléchir,to ponder,沉思,VERB,B2
-réforme,reform,改革,NOUN,B2
-réformisme,reformism,改唯,NOUN,B2
-réfrigérateur,fridge,冰箱,NOUN,B2
-réfutation,rebuttal,反驳,NOUN,B2
-réfuter,to rebut,反驳,VERB,B2
-référer,to refer,参考,VERB,B2
-régions occidentales,western regions,西域,NOUN,B2
-régresser,to regress,倒退,VERB,B2
-régressif,regressive,退步的,ADJ,B2
-réitérer,to reiterate,重申,VERB,B2
-réorganisation,re-order,重序,NOUN,B2
-répandu,widespread,广泛的,ADJ,B2
-réparer,to mend,修补,VERB,B2
-répondre,to respond,回应,VERB,B2
-répondre à,to respond to,回应,VERB,B2
-réponse,response,回应,NOUN,B2
-réprimande,rebuke,责备,NOUN,B2
-réserve,reserve,预备,NOUN,B2
-réserve naturelle,nature reserve,自然保护区,NOUN,B2
-réserver,to book,预订,VERB,B2
-résumé,resume,简历,NOUN,B2
-réticence,unwillingness,不甘,NOUN,B2
-rétribution à vie,life retribution,偿命,NOUN,B2
-rétroaction,feedback,反馈,NOUN,B2
-rétrécir,to shrink,收缩,VERB,B2
-réunion d'affaires,business meeting,洽谈会,NOUN,B2
-réunion secrète,secret meeting,密会,NOUN,B2
-réussi,successful,成功的,ADJ,B2
-réutilisation,reuse,重用,NOUN,B2
-réveil,alarm clock,闹钟,NOUN,B2
-réversion,reversion,重归,NOUN,B2
-révoquer,to revoke,撤销,VERB,B2
-rééditer,to reissue,补办,VERB,B2
-rêver,to dream,做梦,VERB,B2
-rôtir l'agneau,to roast lamb,烤羊,VERB,B2
-s'abstenir,to refrain,克制,VERB,B2
-s'accroupir,to crouch,蹲下,VERB,B2
-s'accumuler,to accrue,积累,VERB,B2
-s'allonger,to lie down,躺,VERB,B2
-s'apaiser,to subside,平息,VERB,B2
-s'appeler,to be called,叫做,VERB,B2
-s'appuyer,to draw on the experience of,借鉴,VERB,B2
-s'arrêter,pause,暂停,NOUN,B2
-s'arrêter,to pause,暂停,VERB,B2
-s'asseoir,to sit down,坐下,VERB,B2
-s'assurer,to make sure,确保,VERB,B2
-s'efforcer,to do one's best,尽力,VERB,B2
-s'efforcer,to work hard for sth to strive for success,争气,VERB,B2
-s'efforcer de,to try hard to,力图,VERB,B2
-s'empêcher,to cannot help,忍不住,VERB,B2
-s'endormir,to fall asleep,入睡,VERB,B2
-s'enflammer,to fester,溃烂,VERB,B2
-s'entrencher,to entrench,巩固,VERB,B2
-s'estomper,to fade,褪色,VERB,B2
-s'excuser,to apologize,道歉,VERB,B2
-s'habituer,to get used to,习惯于,VERB,B2
-s'il vous plaît,please,请,ADV,B2
-s'occuper de,to look after,照料,VERB,B2
-s'étonner,wonder,奇迹,NOUN,B2
-s'étonner,to wonder,觉得奇怪,VERB,B2
-s'évanouir,to faint,昏倒,VERB,B2
-sabbath,sabbath,安息日,NOUN,B2
-sabbatical,sabbatical,词,NOUN,C1
-saber,saber,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-sac à main,handbag,手提包,NOUN,B2
-saccharine,saccharine,词,ADJ,C1
-sack,sack,麻袋,NOUN,B2
-sacrifice,sacrifice,牺牲,NOUN,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrilege,sacrilege,亵渎,NOUN,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
-sad,sad,悲伤的,ADJ,B2
-sad sorrowful,sad sorrowful,悲伤,ADJ,B2
-saddening,saddening,词,ADJ,C1
-saddle pad,saddle pad,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadly,sadly,词,ADV,B2
-safe,safe,安全的,ADJ,B2
-safe (noun),safe,保险箱,NOUN,B2
-safe container,safe container,词,NOUN,C1
-safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
-safety report,safety report,安全报告,NOUN,B2
-safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-sage,wise,明智的,ADJ,B2
-sage,sage,词,NOUN,C1
-sagittarius,sagittarius,射手座,NOUN,B2
-saignement,bleeding,出血,NOUN,B2
-sail,sail,帆,NOUN,B2
-sail,to sail,航行,VERB,B2
-sail (noun),sail,帆,NOUN,B2
-sailboat,sailboat,,NOUN,B2
-sailors,sailors,词,NOUN,B2
-saint,holy,神圣的,ADJ,B2
-saint,saint,圣人,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-saisir,to grab,抓,VERB,B2
-saisir,to grasp,抓住,VERB,B2
-saisir fermement,to grasp firmly,抓紧,VERB,B2
-sake,sake,缘故,NOUN,B2
-salacious,salacious,词,ADJ,C1
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salaire,wage,工资,NOUN,B2
-salaires,wages,工资,NOUN,B2
-salaried,salaried,词,ADJ,B2
-sale,dirty,脏的,ADJ,B2
-salesman,salesman,词,NOUN,B2
-saleté,dirt,污垢,NOUN,B2
-salient,salient,词,ADJ,C1
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-saliva,saliva,词,NOUN,B2
-salle d'attente,waiting room,候诊室,NOUN,B2
-salle de bain,bathroom,浴室,NOUN,B2
-salle de classe,classroom,教室,NOUN,B2
-salle de commandement,command room,指挥室,NOUN,B2
-salle de contrôle,control room,控制室,NOUN,B2
-salle de sport,gym,健身房,NOUN,B2
-salle des fêtes,affair hall,事殿,NOUN,B2
-salon,lounge,休息室,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salt shaker,salt shaker,,NOUN,B2
-salted,salted,词,ADJ,B2
-salubrious,salubrious,词,ADJ,C1
-salut,hi,嗨,INTJ,B2
-salut,salvation,拯救,NOUN,B2
-salutary,salutary,词,ADJ,C1
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-salé,salty,咸的,ADJ,B2
-sama,sama,词,NOUN,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimonious,sanctimonious,伪善的,ADJ,B2
-sanction,sanction,制裁,NOUN,B2
-sanctity,sanctity,词,NOUN,C1
-sanctuaire,shrine,مشعر,NOUN,B2
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
-sands,sands,词,NOUN,B2
-sandwich,sandwich,三明治,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sane,sane,神志正常的,ADJ,B2
-sang-froid,cold blood,冷血,NOUN,B2
-sanglot,sobbing,抽泣,NOUN,B2
-sangloter,to sob,啜泣,VERB,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sans fil,wireless,无线的,ADJ,B2
-sans-abri,homeless,无家可归的,ADJ,B2
-santur,santur,词,NOUN,C1
-santé mentale,sanity,理智,NOUN,B2
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sardonic,sardonic,词,ADJ,C1
-sarrasin,buckwheat,荞麦,NOUN,B2
-sat,sat,词,NOUN,B1
-sated,sated,词,ADJ,B2
-satellite,satellite,卫星,NOUN,B2
-satire,satire,讽刺,NOUN,B2
-satisfaction,satisfaction,满意,NOUN,B2
-satisfait,satisfied,满意的,ADJ,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-satiété,satiety,饱足,NOUN,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-sauce,sauce,酱汁,NOUN,B2
-saucy,saucy,下流的,ADJ,B2
-sauna,sauna,桑拿,NOUN,B2
-saunter,saunter,词,VERB,C1
-sauvetage,rescue,救援,NOUN,B2
-sauvetage,rescue a-fang,救阿方,NOUN,B2
-sauveur,savior,救星,NOUN,B2
-savage,savage,savage,NOUN,B2
-savant,savant,词,NOUN,C1
-savant,scholar,学者,NOUN,B2
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
-saving,saving,储蓄,NOUN,B2
-saving the root,saving the root,救本,NOUN,C1
-savoir reconnaître,to know to recognize,认识,VERB,B2
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-sawdust,sawdust,词,NOUN,C1
-say he,say he,说他,NOUN,C1
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
-scald (noun),scald,烫伤,NOUN,C1
-scallion,scallion,词,NOUN,B2
-scalpel,scalpel,手术刀,NOUN,B2
-scaly,scaly,有鳞的,ADJ,B2
-scammer,scammer,词,NOUN,B2
-scan,scan,扫描件,NOUN,B2
-scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
-scarcely,scarcely,几乎不,ADV,B2
-scarecrow,scarecrow,词,NOUN,C1
-scarf shawl,scarf shawl,词,NOUN,A1
-scathing,scathing,词,ADJ,C1
-scatterbrained,scatterbrained,词,ADJ,B2
-scattering,scattering,词,NOUN,B2
-sceller,to seal,密封,VERB,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
-sceptical,sceptical,词,ADJ,C1
-sceptique,skeptical,怀疑的,ADJ,B2
-schematic,schematic,概要的,ADJ,B2
-schism,schism,分裂,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-schizophrénie,schizophrenia,精神分裂症,NOUN,B2
-scholing,scholing,受过训练,NOUN,B2
-school bench,school bench,词,NOUN,A1
-school year,school year,学年,NOUN,B2
-schoolbag,schoolbag,词,NOUN,A1
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schoolyard,schoolyard,词,NOUN,A1
-schéma,scheme,计划,NOUN,B2
-science,science,科学,NOUN,B2
-scientifique,scientist,科学家,NOUN,B2
-scientists,scientists,科学家,NOUN,B2
-scintillate,scintillate,词,VERB,C1
-scoff (noun),scoff,词,NOUN,C1
-scoff (verb),scoff,词,VERB,C1
-scolder,to scald,烫伤,VERB,B2
-scoop,scoop,词,NOUN,B2
-scorching,scorching,灼热的,ADJ,B2
-score,score,比分,NOUN,B2
-scorn,scorn,轻蔑,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scorpion,scorpion,词,NOUN,A1
-scottish,scottish,苏格兰的,ADJ,B2
-scour,scour,词,VERB,C1
-scout,scout,侦察员,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-scratch,scratch,抓痕,NOUN,B2
-scream (noun),scream,尖叫,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screw (noun),screw,词,NOUN,C1
-screw up,screw up,词,VERB,C1
-scribal misreading,scribal misreading,词,NOUN,C1
-scribble (noun),scribble,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-script,script,剧本,NOUN,B2
-scripture,scripture,经,NOUN,B2
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulousness,scrupulousness,词,NOUN,C1
-scruter,to scrutinize,仔细检查,VERB,B2
-scrutiny,scrutiny,明察,NOUN,B2
-sculpteur,sculptor,雕塑家,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-sculpture,sculpture,雕塑,NOUN,B2
-scumbag,scumbag,词,NOUN,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scurvy,scurvy,词,NOUN,C1
-scuttle,scuttle,词,VERB,C1
-scythe,scythe,镰刀,NOUN,B2
-scène,stage,阶段,NOUN,B2
-scène de crime,crime scene,犯罪现场,NOUN,B2
-scélérat,villain,反派,NOUN,B2
-scénario,script for play,剧本,NOUN,B2
-se cacher,to hide oneself,躲藏,VERB,B2
-se comporter,to behave,表现,VERB,B2
-se conformer,to comply,遵守,VERB,B2
-se conformer à,to comply with,遵守,VERB,B2
-se connecter,to go online,上网,VERB,B2
-se doucher,shower,淋浴,NOUN,B2
-se doucher,to shower,淋浴,VERB,B2
-se débrouiller,to make do,做,VERB,B2
-se déguiser,to dress up,盛装打扮,VERB,B2
-se faufiler,to sneak,潜行,VERB,B2
-se fier,to rely,依赖,VERB,B2
-se fier,to trust,信任,VERB,B2
-se fier à,to rely on,依靠,VERB,B2
-se fâcher,to get angry,生气,VERB,B2
-se lever,to get up,起床,VERB,B2
-se lever,to stand up,站起来,VERB,B2
-se maquiller,to apply makeup,化妆,VERB,B2
-se perdre,to get lost,迷路,VERB,B2
-se plaindre,to complain,抱怨,VERB,B2
-se quereller,to quarrel,争吵,VERB,B2
-se retirer,retreat,撤退,NOUN,B2
-se retirer,to retreat,撤退,VERB,B2
-se retourner,to turn around,转身,VERB,B2
-se soustraire,to abscond,潜逃,VERB,B2
-se séparer,to secede,脱离,VERB,B2
-se taire,silence,沉默,NOUN,B2
-se taire,to silence,خرس,VERB,B2
-se tenir côte à côte,to stand side by side,并列,VERB,B2
-se tenir debout,to stand,站立,VERB,B2
-se terminer,to end up,最终到达,VERB,B2
-se tromper,to make a mistake,弄错,VERB,B2
-se vanter,to boast,吹嘘,VERB,B2
-se venger,to take revenge,报复,VERB,B2
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seam,seam,词,NOUN,C1
-seamless,seamless,无缝的,ADJ,B2
-seaplane,seaplane,水上飞机,NOUN,B2
-seaport,seaport,海港,NOUN,C1
-search engine,search engine,搜索引擎,NOUN,B2
-search warrant,search warrant,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seats,seats,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-second (num),second,词,NUM,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
-seconde fois,second time,再而,NOUN,B2
-secondment,secondment,词,NOUN,C1
-secouriste,paramedic,急救人员,NOUN,B2
-secours,go help,去帮,NOUN,B2
-secret,secret,秘密的,ADJ,B2
-secret (noun),secret,奥秘,NOUN,A2
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-sectaire,sectarian,宗派的,ADJ,B2
-sectarianism,sectarianism,词,NOUN,C1
-section chief,section chief,课长,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secular,secular,词,ADJ,C1
-secularization,secularization,世俗化,NOUN,C1
-secure (adj),secure,词,ADJ,B1
-security matter,security matter,词,NOUN,C1
-security service,security service,词,NOUN,C1
-securocratic,securocratic,词,ADJ,C1
-sedate,sedate,词,ADJ,C1
-sedative,sedative,词,NOUN,C1
-sedentary,sedentary,久坐的,ADJ,B2
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-sedulous,sedulous,词,ADJ,C1
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seek truth from facts,to seek truth from facts,实事求是,VERB,B2
-seeker,seeker,寻求者,NOUN,B2
-seeking,seeking,寻求,NOUN,B2
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking instant benefit,seeking instant benefit,急功近利,ADJ,B2
-seeking intercession,seeking intercession,词,NOUN,C1
-seemingly,seemingly,表面上,ADV,B2
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-seigneur Yu,lord yu,玉大人,NOUN,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-seldom,seldom,很少,ADV,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
-self,self,自我,NOUN,B2
-self (adv),self,词,ADV,B2
-self (pron),self,自己,PRON,A1
-self-abasement,self-abasement,词,NOUN,C1
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
-self-confidence,self-confidence,自信,NOUN,B2
-self-confident,self-confident,自信的,ADJ,B2
-self-deception,self-deception,词,NOUN,C1
-self-defense,self-defense,自卫,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-image,self-image,自我形象,NOUN,B2
-self-interest,self-interest,私利,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-sacrifice,self-sacrifice,舍己,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-worth,self-worth,自我价值,NOUN,B2
-selfie,selfie,自拍,NOUN,B2
-selfish,selfish,自私的,ADJ,B2
-selfish (noun),selfish,selfish,NOUN,B2
-selfishness,selfishness,自私,NOUN,B2
-selfless,selfless,词,ADJ,B2
-selfless devotion,selfless devotion,词,NOUN,C1
-seller,seller,售货员,NOUN,B2
-sellou,sellou,塞卢能量膏,NOUN,B2
-semantic,semantic,词,ADJ,C1
-semblance,semblance,词,NOUN,C1
-semester,semester,学期,NOUN,B2
-semicolon,semicolon,分号,PUNCT,B2
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
-seminary,seminary,词,NOUN,C1
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
-seniors,seniors,词,NOUN,C1
-sens altéré,altered meaning,改义,NOUN,B2
-sens partiel,partial meaning,分义,NOUN,B2
-sensation,sensation,感觉,NOUN,B2
-sensationalism,sensationalism,词,NOUN,C1
-sense of duty,sense of duty,责任感,NOUN,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
-senseless,senseless,无意义的,ADJ,B2
-sensibly,sensibly,明智地,ADV,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
-sensitization,sensitization,词,NOUN,B2
-sensor donor,sensor donor,传感器/捐献者,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sentence,sentence,句子,NOUN,B2
-sentence,to sentence,判决,VERB,B2
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentence verdict,sentence verdict,词,NOUN,B2
-sentenced,sentenced,被判刑的,ADJ,B2
-sentences,sentences,句子,NOUN,B2
-sentencing,sentencing,量刑,NOUN,B2
-sentient,sentient,词,ADJ,C1
-sentiment,sentiment,情感,NOUN,B2
-sentir,to smell,闻,VERB,B2
-sentry,sentry,卫兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separate,separate,分开的,ADJ,B2
-separated,separated,分开的,ADJ,B2
-separatism,separatism,词,NOUN,C1
-sequential,sequential,词,ADJ,C1
-seraphic,seraphic,词,ADJ,C1
-serendipity,serendipity,词,NOUN,C1
-serene,serene,宁静的,ADJ,B2
-serial killer,serial killer,连环杀手,NOUN,B2
-serialized drama,serialized drama,连续剧,NOUN,B2
-series of conversations,series of conversations,系列对话,NOUN,B2
-seriousness,seriousness,严肃,NOUN,B2
-sermon,sermon,布道,NOUN,B2
-serpentine,serpentine,词,ADJ,C1
-serrer,to squeeze,挤压,VERB,B2
-serum,serum,词,NOUN,B2
-servante,maid,女仆,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
-server,server,服务器,NOUN,B2
-serveuse,waitress,女服务员,NOUN,B2
-service,ward,病房,NOUN,B2
-service counter,service counter,词,NOUN,B1
-service favor,service favor,词,NOUN,A2
-service of process,service of process,词,NOUN,C1
-service road,service road,辅路,NOUN,B2
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-service year,service year,,NOUN,B2
-services,services,词,NOUN,C1
-serviette,napkin,餐巾,NOUN,B2
-servile,servile,词,ADJ,C1
-serving,serving,词,NOUN,B2
-servitude,servitude,奴役,NOUN,C1
-sesame,sesame,芝麻,NOUN,B2
-session,session,会议,NOUN,B2
-set,set,一套,NOUN,B2
-set,to set,设置,VERB,B2
-set (noun),set,集合,NOUN,B1
-set a record,set a record,创造纪录,VERB,B2
-set of ideals,set of ideals,思想体系,NOUN,B2
-set off,to set off,出发,VERB,B2
-set square,set square,词,NOUN,B2
-set up,to set up,建立,VERB,B2
-set-off,set-off,词,NOUN,C1
-setting,setting,词,NOUN,B1
-setting splinting,setting splinting,词,NOUN,C1
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seul,alone,独自,ADV,B2
-seulement,merely,仅仅,ADV,B2
-seven (adj),seven,词,ADJ,B2
-seventeen,seventeen,十七,NUM,B2
-seventy,seventy,七十,NUM,B2
-sever,sever,词,VERB,C1
-several,several,若干,NOUN,B2
-several (adj),several,词,ADJ,A2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times (adv),several times,词,ADV,C1
-several times (noun),several times,几遍,NOUN,B2
-severance,severance,词,NOUN,C1
-sevrer,to wean,断奶,VERB,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
-sewing needle,sewing needle,词,NOUN,C1
-sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexily,sexily,性感地,ADV,B2
-sexy,sexy,性感的,ADJ,B2
-sfouf,sfouf,词,NOUN,B2
-sh,sh,词,INTJ,C1
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
-shackle,shackle,镣铐,NOUN,B2
-shading,shading,阴影,NOUN,B2
-shadow,shadow,影子,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadows,shadows,词,NOUN,C1
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shaft,shaft,词,NOUN,B2
-shake hands,to shake hands,握手,VERB,B2
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,将要,AUX,B2
-shambles,shambles,词,NOUN,C1
-shame culture,shame culture,羞耻文化,NOUN,B2
-shame disgrace,shame disgrace,词,NOUN,B2
-shame pity,shame pity,遗憾,NOUN,B2
-shameless person,shameless person,厚颜无耻的人,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shards,shards,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-sharply,sharply,词,ADV,B2
-shavings,shavings,刨花,NOUN,C1
-she (noun),she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet of paper,sheet of paper,词,NOUN,B2
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift (noun),shift,轮班,NOUN,C1
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shining,shining,词,ADJ,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
-shipment,shipment,货物,NOUN,B2
-shirk,shirk,词,VERB,C1
-shit,shit,恐惧,NOUN,B2
-shit (adj),shit,该死的,ADJ,B2
-shit crap,shit crap,废话,NOUN,B2
-shitty,shitty,词,ADJ,B2
-shivers,shivers,词,NOUN,B2
-shocked,shocked,震惊的,ADJ,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoe polish,shoe polish,词,NOUN,B2
-shoot at,shoot at,词,VERB,C1
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shopping,shopping,购物,NOUN,B2
-shopping mall,shopping mall,商场,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short news item,short news item,短新闻,NOUN,B2
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-shortcomings,shortcomings,词,NOUN,C1
-shorter,shorter,更短的,ADJ,B2
-shortest,shortest,词,NOUN,B2
-shortly,shortly,不久,ADV,B2
-shotgun,shotgun,猎枪,NOUN,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-should ought to,should ought to,应该,AUX,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-showy,showy,词,ADJ,B2
-shred,shred,词,NOUN,B2
-shriek,shriek,词,VERB,C1
-shrill,shrill,尖锐的,ADJ,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrivel,shrivel,词,VERB,C1
-shrug,shrug,词,VERB,C1
-shrunken,shrunken,词,ADJ,B2
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shutdown,shutdown,词,NOUN,C1
-si,whether,能否,NOUN,B2
-si quand,if when,如果,SCONJ,B2
-sibilant,sibilant,词,ADJ,C1
-sibling,sibling,兄弟姐妹,NOUN,B2
-sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickle,sickle,词,NOUN,B2
-sickly,sickly,词,ADJ,C1
-sickness,sickness,词,NOUN,B2
-side,side,骄傲的,ADJ,B2
-side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideburn,sideburn,词,NOUN,B1
-siege time,siege time,攻城时,NOUN,C1
-sifflet,whistle,口哨,NOUN,B2
-sifted,sifted,词,ADJ,C1
-sighing,sighing,叹息的,ADJ,B2
-sightseeing,sightseeing,词,NOUN,C1
-signaler,signal,信号,NOUN,B2
-signaler,to signal,示意,VERB,B2
-signboard,signboard,招牌,NOUN,B2
-signe du zodiaque,zodiac sign,属相,NOUN,B2
-signed,signed,词,ADJ,B2
-signer pour,to sign for,签收,VERB,B2
-signification,significance,含义,NOUN,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signifier,to signify,意味着,VERB,B2
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silenced,silenced,词,ADJ,C1
-silencing,silencing,词,NOUN,C1
-silent quiet,silent quiet,词,ADJ,A1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-silly thing,silly thing,词,NOUN,C1
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
-silver,silver,银,NOUN,B2
-simian,simian,词,ADJ,C1
-simile,simile,明喻,NOUN,B2
-similitude,commonality,共同点,NOUN,B2
-simple,simple,简单的,ADJ,B2
-simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplism,simplism,简单化,NOUN,C1
-simulation,simulation,模拟,NOUN,B2
-simultaneously with,simultaneously with,词,ADV,C1
-since (part),since,以来,PART,B2
-since then,since then,从那以后,ADV,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerity devotion,sincerity devotion,词,NOUN,B2
-sinecure,sinecure,词,NOUN,C1
-sinew,sinew,词,NOUN,C1
-single,single,单曲,NOUN,B2
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-singular (adj),singular,词,ADJ,C1
-singular (noun),singular,词,NOUN,B2
-singularity,singularity,单一性,NOUN,B2
-sinister,sinister,不祥的,ADJ,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sinuous,sinuous,词,ADJ,C1
-sir (part),sir,郎,PART,B2
-sirène,mermaid,美人鱼,NOUN,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-site,site,词,NOUN,B1
-site web,website,网站,NOUN,B2
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-situation,plight,处境,NOUN,B2
-situation,situation,情况,NOUN,B2
-six,six,六,NUM,B2
-six-year-old,six-year-old,,NOUN,B2
-sixième,sixth,第六,ADJ,B2
-sixteen,sixteen,十六,NUM,B2
-sixth,sixth,,NOUN,B2
-size measure,size measure,尺寸 / 测量,NOUN,A2
-siège,headquarters,总部,NOUN,B2
-siège,siege,围攻,NOUN,B2
-skater,skater,,NOUN,B2
-skeletal,skeletal,词,ADJ,C1
-skeptic,skeptic,词,NOUN,C1
-sketchiness,sketchiness,词,NOUN,C1
-ski,ski,滑雪板,NOUN,B2
-ski,skiing,滑雪,NOUN,B2
-ski resort,ski resort,滑雪场,NOUN,C1
-skiff,skiff,词,NOUN,C1
-skilful,skilful,熟练的,ADJ,B2
-skillful,skillful,熟练的,ADJ,B2
-skillfulness,skillfulness,词,NOUN,B2
-skin hide,skin hide,皮肤/皮革,NOUN,B2
-skip a grade,skip a grade,跳级,VERB,C1
-skirmish,skirmish,小规模战斗,NOUN,B2
-sky blue,sky blue,天蓝色,ADJ,B2
-slack,slack,词,ADJ,B2
-slack off,slack off,词,VERB,C1
-slackness,slackness,词,NOUN,C1
-slake,slake,词,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slanted,slanted,斜,ADJ,B2
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleek,sleek,词,ADJ,C1
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleeper,sleeper,词,NOUN,C1
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
-sleigh,sleigh,雪橇,NOUN,C1
-slender,slender,纤细的,ADJ,B2
-slenderness,slenderness,纤细,NOUN,B2
-slick,slick,词,ADJ,C1
-sliding,sliding,滑动的,ADJ,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
-slim,slim,苗条,ADJ,B2
-slimy,slimy,粘滑的,ADJ,B2
-sling,sling,词,NOUN,C1
-slip (noun),slip,词,NOUN,C1
-slip in,slip in,塞入,VERB,B2
-slither,slither,词,VERB,C1
-slogan,slogan,口号,NOUN,B2
-slothful,slothful,懒惰的,ADJ,B2
-slovenly,slovenly,词,ADJ,C1
-slow pace,slow pace,你慢点,NOUN,C1
-slower,slower,更慢,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slur,slur,词,VERB,C1
-slut,slut,荡妇,NOUN,B2
-small basket,small basket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small step,small step,词,NOUN,C1
-small sword,small sword,词,NOUN,C1
-small things,small things,琐事,NOUN,B2
-small window,small window,词,NOUN,A2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
-smear,smear,抹,NOUN,C1
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smelting,smelting,词,NOUN,C1
-smile (noun),smile,似笑,NOUN,A2
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoking (adj),smoking,词,ADJ,C1
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smoothness,smoothness,词,NOUN,C1
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snap (verb),snap,词,VERB,C1
-snare,snare,词,NOUN,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sneer,sneer,词,VERB,C1
-sneeze (noun),sneeze,词,NOUN,C1
-sneezing,sneezing,词,NOUN,C1
-sniffle,sniffle,词,VERB,C1
-sniper,sniper,狙击手,NOUN,B2
-snippet,snippet,词,NOUN,C1
-snitch,snitch,告密者,NOUN,B2
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snooping,snooping,词,NOUN,C1
-snore (noun),snore,打呼,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so thus,so thus,所以/如此,ADV,B2
-so to speak,so to speak,可以说,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-so-called,so-called,,NOUN,B2
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
-sobriquet,sobriquet,词,NOUN,C1
-soccer,soccer,足球,NOUN,B2
-sociable,sociable,好交际的,ADJ,B2
-social,social,社会的,ADJ,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social mobilization,social mobilization,社会动员,NOUN,B2
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social organization,social organization,社会组织,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social practice,social practice,社会实践,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social problem,social problem,社会问题,NOUN,B2
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reconciliation,social reconciliation,社会和解,NOUN,B2
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social stability,social stability,社会稳定,NOUN,B2
-social standard,social standard,社会标准,NOUN,C1
-social statistics,social statistics,社会统计,NOUN,B2
-social status,social status,社会地位,NOUN,C1
-social stratification,social stratification,社会分层,NOUN,B2
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social trend,social trend,社会趋势,NOUN,B2
-social trust,social trust,社会信任,NOUN,B2
-social turmoil,social turmoil,社会动荡,NOUN,C1
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义的,ADJ,B2
-socialize,to socialize,交往,VERB,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,在社会上,ADV,B2
-societal,societal,社会的,ADJ,B2
-sociology,sociology,社会学,NOUN,B2
-softball,softball,垒球,NOUN,B2
-softness,softness,词,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software (adj),software,词,ADJ,C1
-soil,soil,土壤,NOUN,B2
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-soir,tonight,今晚,NOUN,B2
-sojourn,sojourn,逗留,NOUN,B2
-sol,floor,地板,NOUN,B2
-solace,solace,安慰,NOUN,B2
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-solar physics,solar physics,词,NOUN,C1
-soldiers,soldiers,官兵,NOUN,B2
-solely,solely,词,ADV,C1
-solemn,solemn,,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solfege,solfege,词,NOUN,C1
-solicit donations,to solicit donations,募捐,VERB,B2
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solid,solid,3D模型 / 实体,NOUN,B2
-solid substantial,solid substantial,结实的/大量的,ADJ,B2
-solid-state drive,solid-state drive,固态硬盘,NOUN,B2
-solide,sturdy,坚固的,ADJ,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-solitaire,lonely,孤独的,ADJ,B2
-solitude,loneliness,孤独,NOUN,B2
-solitude,solitude,孤独,NOUN,B2
-solliciter une audience,to seek audience,求见,VERB,B2
-soloist,soloist,词,NOUN,C1
-solstice,solstice,词,NOUN,C1
-solute,solute,词,NOUN,C1
-solution,solution,解决方案,NOUN,B2
-solve a case,solve a case,破案,VERB,B2
-solvent,solvent,溶剂,NOUN,B2
-somber,somber,词,ADJ,B2
-sombre,gloomy,阴郁的,ADJ,B2
-sombre,grim,严酷的,ADJ,B2
-some,some,一些,PRON,B2
-some (adj),some,某些,ADJ,A2
-some (noun),some,词,NOUN,B2
-some many a,some many a,词,DET,A2
-some out,some out,出些,NOUN,B2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-somebody,somebody,词,PRON,A1
-somehow,somehow,以某种方式,ADV,B2
-someone stealing,someone stealing,有人偷,NOUN,C1
-someone's,someone's,某人的,PRON,B2
-something,something,某事,PRON,B2
-something (noun),something,شي,NOUN,B2
-something better,something better,词,NOUN,C1
-something like that,something like that,类似的事物,PRON,B2
-sometime,sometime,在某个时候,ADV,B2
-somewhat,somewhat,词,ADV,C1
-somewhere,somewhere,某处,ADV,B2
-somewhere (noun),somewhere,somewhere,NOUN,B2
-somewhere else,somewhere else,词,ADV,B1
-sommet,top,顶部,NOUN,B2
-somnolence,drowsiness,昏睡,NOUN,B2
-somnolent,somnolent,词,ADJ,C1
-son of a bitch,son of a bitch,词,NOUN,B2
-sonata,sonata,词,NOUN,C1
-song (part),song,歌,PART,B2
-song festival,song festival,音乐节,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sonnerie,ringing,铃声,NOUN,B2
-sonorous,sonorous,词,ADJ,C1
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soot,soot,烟灰,NOUN,B2
-soothing,soothing,词,ADJ,C1
-soothsayer,soothsayer,词,NOUN,B2
-sophisme,fallacy,谬误,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sophistry,sophistry,诡辩,NOUN,B2
-sophomoric,sophomoric,词,ADJ,C1
-soporific,soporific,词,ADJ,C1
-sorcery,sorcery,巫术,NOUN,B2
-sorcier,wizard,巫师,NOUN,B2
-sorcière,witch,女巫,NOUN,B2
-sore,sore,疼痛的,ADJ,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry,sorry,抱歉,INTJ,B2
-sorry (noun),sorry,词,NOUN,A1
-sort,sort,种类,NOUN,B2
-sortie,outing,郊游,NOUN,B2
-sortie,sortie,词,NOUN,C1
-sortie,way out,出路,NOUN,B2
-sortie de retrait,seclusion exit,出关,NOUN,B2
-sortilège,spell,咒语,NOUN,B2
-sortir,to come out,出来,VERB,B2
-sot,silly,愚蠢的,ADJ,B2
-sotte fille,silly girl,傻丫头,NOUN,B2
-soudain,sudden,突然的,ADJ,B2
-souffrir d'insomnie,to suffer from insomnia,失眠,VERB,B2
-sought,sought,,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-souhait,wish,愿望,NOUN,B2
-soul,soul,灵魂,NOUN,B2
-soul spirit,soul spirit,词,NOUN,B2
-souligner,to highlight,强调,VERB,B2
-souligner,to point out,指出,VERB,B2
-soulmate,soulmate,词,NOUN,C1
-soulèvement,uprising,起义,NOUN,B2
-soumettre,to subdue,制服,VERB,B2
-sound,sound,声音,NOUN,B2
-sound,to sound,响起,VERB,B2
-sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,音频片段,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound of activity,sound of activity,动静,NOUN,B2
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundness,soundness,好端端,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-soundtrack,soundtrack,! 音轨,NOUN,B2
-soupirer,sigh,叹息,NOUN,B2
-soupirer,to sigh,叹气,VERB,B2
-soupirer de chagrin,to sigh with sorrow,感慨,VERB,B2
-sour,sour,酸的,ADJ,B2
-sour cherry,sour cherry,词,NOUN,C1
-source,source,来源,NOUN,B2
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
-sourire,smile,微笑,NOUN,B2
-sourire,to grin,咧嘴笑,VERB,B2
-sous-estimation,underestimation,小看,NOUN,B2
-sous-estimer,to underestimate,低估,VERB,B2
-sous-marin,submarine,潜水艇,NOUN,B2
-sous-sol,basement,地下室,NOUN,B2
-sous-sol,underground,地铁,NOUN,B2
-souscrire,to underwrite,承保,VERB,B2
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southward,southward,向南,ADV,B2
-southwest,southwest,西南的,ADJ,B2
-soutien,endorsement,背书,NOUN,B2
-souvenir,souvenir,纪念品,NOUN,B2
-souvent,many times,多次,ADV,B2
-souverain,sovereign,君主,NOUN,B2
-souveraineté,sovereignty,主权,NOUN,B2
-sovereign (adj),sovereign,主权,ADJ,B2
-sow,sow,母猪,NOUN,B2
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
-spacieux,spacious,宽敞的,ADJ,B2
-spaciousness,spaciousness,词,NOUN,C1
-spadix,spadix,词,NOUN,C1
-span cleaner,span cleaner,词,NOUN,B2
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
-spanish (noun),spanish,词,NOUN,B2
-spanking,spanking,词,NOUN,B2
-spar,spar,词,VERB,C1
-spare (adj),spare,词,ADJ,B1
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
-sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spate,spate,词,NOUN,C1
-spatial,spatial,空间的,ADJ,B2
-spatula,spatula,刮刀,NOUN,B2
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specifications,specifications,词,NOUN,C1
-spectacle,spectacle,词,NOUN,B2
-spectacles,spectacles,眼镜,NOUN,B2
-specter,specter,词,NOUN,C1
-spectral,spectral,幽灵般的,ADJ,B2
-spectrometer,spectrometer,词,NOUN,C1
-speculative,speculative,词,ADJ,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-spelling,spelling,拼写,NOUN,B2
-spend the night,spend the night,词,VERB,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-spent,spent,词,ADJ,B2
-sperm,sperm,精子,NOUN,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-sphère,sphere,领域,NOUN,B2
-spice,spice,香料,NOUN,B2
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
-spine,spine,脊柱,NOUN,B2
-spinning,spinning,纺纱,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit world,spirit world,灵界,NOUN,B2
-spirited,spirited,活泼的,ADJ,B2
-spiritual,spiritual,精神的,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
-spiritualité,spirituality,灵性,NOUN,B2
-spite,spite,恶意,NOUN,B2
-spittle,spittle,唾沫,NOUN,B2
-splash,splash,扑通,NOUN,B2
-splay,splay,词,VERB,C1
-spleen,spleen,词,NOUN,B2
-splendeur,splendor,辉煌,NOUN,B2
-splinter (noun),splinter,词,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoiled,spoiled,词,ADJ,B2
-spoiled child,spoiled child,词,NOUN,B1
-spoiler,spoiler,词,NOUN,C1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-spoliation,spoliation,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
-sponsor (noun),sponsor,词,NOUN,B2
-spontaneity,spontaneity,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-sporadic,sporadic,词,ADJ,C1
-sport,sport,运动,NOUN,B2
-sports,sports,体育,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,运动公园,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot,spot,地点,NOUN,B2
-spot goods,spot goods,现货,NOUN,C1
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
-spreading,spreading,词,NOUN,C1
-spree,spree,词,NOUN,C1
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-spry,spry,词,ADJ,C1
-spurious,spurious,虚假的,ADJ,B2
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-sputum,sputum,词,NOUN,C1
-spécial,special,特别的,ADJ,B2
-spécialité,specialty,专业,NOUN,B2
-spéculer,to speculate,推测,VERB,B2
-squabble (noun),squabble,词,NOUN,B2
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
-squandering,squandering,挥霍,NOUN,B2
-square (adj),square,方,ADJ,B2
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak,squeak,吱吱声,NOUN,B2
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squid,squid,鱿鱼,NOUN,B2
-squire,squire,词,NOUN,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-stab (noun),stab,捅,NOUN,C1
-stabilité,stability,稳定,NOUN,B2
-stable,steady,稳定的,ADJ,B2
-stable,stable,畜舍,NOUN,B2
-stably,stably,稳定地,ADV,B2
-stack (noun),stack,词,NOUN,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-staging,staging,上演,NOUN,B2
-stagnant,stagnant,停滞的,ADJ,B2
-stagnation,stagnation,停滞,NOUN,B2
-staid,staid,词,ADJ,C1
-staircase,staircase,词,NOUN,B1
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalemate,stalemate,词,NOUN,C1
-stalking,stalking,词,NOUN,C1
-stalling,stalling,词,NOUN,B2
-stalwart,stalwart,词,ADJ,C1
-stamina,stamina,词,NOUN,C1
-stammering,stammering,词,NOUN,C1
-stampede,stampede,溃逃,NOUN,B2
-stanch,stanch,词,VERB,C1
-stand,stand,摊位,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
-standby,standby,待机,VERB,C1
-standing (adj),standing,持久的,ADJ,B2
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-standpoint,standpoint,立场,NOUN,B2
-stands,stands,词,NOUN,B2
-staple,staple,词,NOUN,C1
-star celebrity,star celebrity,词,NOUN,B1
-star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-stark,stark,词,ADJ,B2
-starling,starling,词,NOUN,B2
-starter,starter,词,NOUN,C1
-starting point,starting point,出发点,NOUN,B2
-starting premise,starting premise,词,NOUN,C1
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-starved,starved,饥饿的,ADJ,B2
-state (adj),state,词,ADJ,B1
-state federal,state federal,州,NOUN,B2
-state of emergency,state of emergency,词,NOUN,C1
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-statements,statements,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-statics,statics,词,NOUN,C1
-station de radio,radio station,广播电台,NOUN,B2
-statism,statism,词,NOUN,C1
-statistic,statistic,统计数据,NOUN,B2
-statistical,statistical,统计的,ADJ,B2
-statistiques,statistics,统计学,NOUN,B2
-statization,statization,词,NOUN,C1
-statue,statue,雕像,NOUN,B2
-statut,status,地位,NOUN,B2
-statute,statute,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-statutory rape,statutory rape,词,NOUN,C1
-staunch,staunch,坚定的,ADJ,B2
-stave,stave,词,NOUN,C1
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadfastness,steadfastness,词,NOUN,B2
-steadily,steadily,稳定地,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
-steak,steak,牛排,NOUN,B2
-stealthily,stealthily,词,ADV,B2
-stealthy,stealthy,词,ADJ,C1
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steep,steep,陡峭的,ADJ,B2
-steering,steering,掌舵的,ADJ,B2
-steering control,steering control,词,NOUN,C1
-steering wheel,steering wheel,方向盘,NOUN,B2
-stellar,stellar,杰出的,ADJ,B2
-stem (adj),stem,词,ADJ,C1
-stem cell,stem cell,干细胞,NOUN,C1
-stench,stench,恶臭,NOUN,B2
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-step,step,步骤,NOUN,B2
-step,to step,踩,VERB,B2
-stepfather,stepfather,词,NOUN,A1
-stepmother,stepmother,后母,NOUN,B2
-steppe,steppe,词,NOUN,C1
-steppes,steppes,草原,NOUN,B2
-steps,steps,台阶,NOUN,B2
-stereotypical,stereotypical,词,ADJ,C1
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-sterility,sterility,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-stern (adj),stern,词,ADJ,C1
-stevedore,stevedore,词,NOUN,C1
-stew,stew,炖菜,NOUN,B2
-stew,to stew,炖,VERB,B2
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiff glove,stiff glove,,NOUN,B2
-stiffness,stiffness,僵硬,NOUN,B2
-stifle,stifle,词,VERB,C1
-stifling,stifling,词,ADJ,B2
-stigma,stigma,耻辱,NOUN,B2
-stiletto,stiletto,词,NOUN,C1
-still,still,仍然,ADV,B2
-still also,still also,还,ADV,A1
-stillness,stillness,静中,NOUN,B2
-stilted,stilted,词,ADJ,C1
-stimulant,stimulant,兴奋剂,NOUN,B2
-stimulating,stimulating,词,ADJ,C1
-sting,sting,刺,NOUN,B2
-stink,stink,恶臭,NOUN,B2
-stinking,stinking,发臭的,ADJ,B2
-stipend,stipend,津贴,NOUN,B2
-stipulation,stipulation,词,NOUN,C1
-stir,stir,搅拌,NOUN,B2
-stir-fry,stir-fry,炒,VERB,B1
-stitch,stitch,针脚,NOUN,B2
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stock,stock,库存,NOUN,B2
-stock exchange,stock exchange,证券交易所,NOUN,B2
-stock market,stock market,股市,NOUN,B2
-stock-market,stock-market,词,ADJ,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stocking,stocking,词,NOUN,C1
-stockpile,stockpile,储备,NOUN,B2
-stodgy,stodgy,词,ADJ,C1
-stoic,stoic,坚忍的,ADJ,B2
-stolen,stolen,被偷的,ADJ,B2
-stolen one,stolen one,词,NOUN,B2
-stolid,stolid,冷漠的,ADJ,B2
-stomach,stomach,胃,NOUN,B2
-stomach ache,stomach ache,词,NOUN,C1
-stomachache,stomachache,肚子痛,NOUN,B2
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stop bleeding,stop bleeding,止血,VERB,B2
-stop me,to stop me,拦我,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-storage room,storage room,储藏室,NOUN,B2
-store,store,商店,NOUN,B2
-store enrouleur,roller blind,卷帘,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-stork,stork,词,NOUN,B1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-storming,storming,词,NOUN,C1
-stormy,stormy,有暴风雨的,ADJ,B2
-story history,story history,词,NOUN,A1
-stout,stout,词,ADJ,C1
-stove,stove,炉灶,NOUN,B2
-stowage,stowage,词,NOUN,C1
-strabismus,strabismus,词,NOUN,B2
-straight,straight,笔直的,ADJ,B2
-straight (adv),straight,直接地,ADV,B1
-straight (noun),straight,直的,NOUN,B2
-straight ahead,straight ahead,词,ADV,B2
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
-straightforward,straightforward,直率的,ADJ,B2
-strain,strain,压力,NOUN,B2
-strain,to strain,努力,VERB,B2
-straitened circumstances,straitened circumstances,词,NOUN,C1
-straitjacket,straitjacket,词,NOUN,C1
-strange,strange,奇怪的,ADJ,B2
-strange troops,strange troops,怪兵,NOUN,B2
-strangely,strangely,奇怪地,ADV,B2
-strangeness,strangeness,奇怪,NOUN,B2
-stranger,stranger,陌生人,NOUN,B2
-strangest,strangest,词,NOUN,C1
-strangulation,strangulation,词,NOUN,C1
-strapping,strapping,词,ADJ,C1
-stratagem,stratagem,策略,NOUN,B2
-strategize,strategize,运筹,VERB,C1
-strategy,strategy,策略,NOUN,B2
-stratification,stratification,词,NOUN,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-stratum,stratum,阶层,NOUN,B2
-strawberry,strawberry,草莓,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-street dance,street dance,街舞,NOUN,C1
-street kid,street kid,词,NOUN,B2
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-strengthening,strengthening,词,NOUN,C1
-strenuous,strenuous,费力的,ADJ,B2
-stress (noun),stress,压力,NOUN,B1
-stressed,stressed,焦虑的,ADJ,B2
-stretch (noun),stretch,舒展,NOUN,B2
-stretch out,stretch out,词,VERB,B2
-stretched,stretched,词,ADJ,C1
-strict,strict,严格的,ADJ,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-strictness,strictness,词,NOUN,B2
-strident,strident,刺耳的,ADJ,B2
-strife,strife,词,NOUN,B2
-strike-related,strike-related,词,ADJ,C1
-strikebreaker,strikebreaker,词,NOUN,C1
-string instruments,string instruments,词,NOUN,C1
-string music,string music,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-stripping,stripping,剥离的,ADJ,B2
-striving,striving,追求,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structure,structure,结构,NOUN,B2
-structured,structured,词,ADJ,C1
-structuredness,structuredness,结构性,NOUN,B2
-structures,structures,词,NOUN,C1
-stubbornness,stubbornness,固执,NOUN,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studio,studio,工作室,NOUN,B2
-studious,studious,词,ADJ,C1
-study tour,study tour,游学,NOUN,C1
-stuffed,stuffed,词,ADJ,B1
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stumble (noun),stumble,词,NOUN,C1
-stunner,stunner,词,NOUN,B2
-stunt,stunt,词,NOUN,B2
-stupefied,stupefied,词,ADJ,C1
-stupendous,stupendous,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
-stupide,foolish,愚蠢的,ADJ,B2
-stuttering,stuttering,词,NOUN,C1
-style,style,风格,NOUN,B2
-stylistics,stylistics,词,NOUN,C1
-stylo,pen,钢笔,NOUN,B2
-stymie,stymie,词,VERB,C1
-suave,suave,词,ADJ,C1
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject field,subject field,科目 / 领域,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject topic,subject topic,主题/话题,NOUN,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
-sublimation,sublimation,词,NOUN,C1
-sublime,sublime,崇高的,ADJ,B2
-subliminal,subliminal,词,ADJ,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submerger,to overwhelm,使不知所措,VERB,B2
-submerger,to submerge,淹没,VERB,B2
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordination,subordination,隶属,NOUN,C1
-subordonné,subordinate,下属,NOUN,B2
-subpoena,subpoena,词,NOUN,B2
-subservient,subservient,词,ADJ,C1
-substance,substance,物质,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantiation,substantiation,论证,NOUN,B2
-substantive,substantive,实质性的,ADJ,B2
-substitute (verb),substitute,代换,VERB,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-suburban,suburban,词,ADJ,C1
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
-succer,to suck,吸,VERB,B2
-succession,succession,连续,NOUN,B2
-successive generations,successive generations,历代,NOUN,B2
-succinct,succinct,简明的,ADJ,B2
-succomber,to succumb,屈服,VERB,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-such (adj),such,样,ADJ,A1
-such a,such a,这样的,DET,B2
-such a thing,such a thing,词,PRON,B1
-sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-suffering (adj),suffering,词,ADJ,C1
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-suffire,to be enough,足够,VERB,B2
-suffisance,sufficiency,充足,NOUN,B2
-suffocating,suffocating,词,ADJ,B2
-suffocation,suffocation,窒息,NOUN,B2
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestion,suggestion,建议,NOUN,B2
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal,suicidal,自杀的,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
-suicide,suicide,自杀,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-suit,suit,西装,NOUN,B2
-suitcase,suitcase,手提箱,NOUN,B2
-suite,suite,套房,NOUN,B2
-suiveur,follower,追随者,NOUN,B2
-suivi,follow-up,跟进,NOUN,B2
-sujet,topic,话题,NOUN,B2
-sujet spécial,special topic,专题,NOUN,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
-sulfide,sulfide,词,NOUN,C1
-sulfuric,sulfuric,词,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sullenness,sullenness,词,NOUN,C1
-sully,sully,词,VERB,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultriness,sultriness,词,NOUN,B2
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer,summer,夏天,NOUN,B2
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-sumptuousness,sumptuousness,词,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
-sunny day,sunny day,晴天,NOUN,C1
-sunrise,sunrise,日出,NOUN,B2
-sunset,sunset,日落,NOUN,B2
-sunshine,sunshine,阳光,NOUN,B2
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super (adv),super,词,ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-comprehensive,super-comprehensive,超遍,NOUN,B2
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-grade,super-grade,超级,NOUN,B2
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-principle,super-principle,超则,NOUN,B2
-super-proof,super-proof,超证,NOUN,B2
-super-quality,super-quality,超质,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-system,super-system,超制,NOUN,B2
-super-theory,super-theory,超论,NOUN,C1
-super-thought,super-thought,超思,NOUN,B2
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-supercilious,supercilious,词,ADJ,C1
-superficiality,superficiality,词,NOUN,C1
-superfluous,superfluous,多余的,ADJ,B2
-superhero,superhero,超级英雄,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior,superior,更好的,ADJ,B2
-superior (noun),superior,上级,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supernumerary,supernumerary,词,ADJ,C1
-supersede,supersede,词,VERB,C1
-superstition,superstition,迷信,NOUN,B2
-superstitious,superstitious,迷信的,ADJ,B2
-supervision,supervision,监督,NOUN,B2
-supine,supine,词,ADJ,C1
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement,supplement,补充,NOUN,B2
-supplement,to supplement,补充,VERB,B2
-supplication,supplication,恳求,NOUN,B2
-supplier,to beg,乞求,VERB,B2
-supplies,supplies,必需品,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supportable,bearable,可忍受的,ADJ,B2
-supported,supported,词,ADJ,B2
-supporter,supporter,支持者,NOUN,B2
-supporter,to bear,忍受,VERB,B2
-supporter,to cannot bear,不堪,VERB,B2
-supporters,supporters,词,NOUN,B2
-supposition,guess,猜测,NOUN,B2
-supposition,supposition,词,NOUN,C1
-suppository,suppository,词,NOUN,C1
-suppress,to suppress,压制,VERB,B2
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
-suppression,suppression,抑,NOUN,B2
-suppression of us,suppression of us,压咱,NOUN,C1
-supprimer,to delete,删除,VERB,B2
-suppuration,suppuration,词,NOUN,C1
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-supérieur,higher,更高的,ADJ,B2
-supérieur,upper,上面的,ADJ,B2
-sur-domaine,over-domain,超畴,NOUN,B2
-surcoup,over-stroke,超程,NOUN,B2
-sure,sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-suretyship,suretyship,保证,NOUN,C1
-surface,surface,表面,NOUN,B2
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surgical,surgical,外科的,ADJ,B2
-surging effusive,surging effusive,词,ADJ,C1
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname,surname,姓氏,NOUN,B2
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surprise,surprise,惊喜,NOUN,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
-surprised,surprised,惊讶的,ADJ,B2
-surrender,to surrender,投降,VERB,B2
-surreptitious,surreptitious,秘密的,ADJ,B2
-surrogate,surrogate,词,NOUN,C1
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
-surstratégie,over-strategy,超策,NOUN,B2
-surveil,to surveil,监视,VERB,B2
-surveillance,surveillance,监视,NOUN,B2
-survey,survey,调查,NOUN,B2
-survival,survival,生存,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
-susha,susha,夙砂大,NOUN,B2
-suspect,suspect,嫌疑人,NOUN,B2
-suspended,suspended,悬浮的,ADJ,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspense,suspense,悬念,NOUN,B2
-suspension,suspension,暂停,NOUN,B2
-suspicions,suspicions,词,NOUN,C1
-suspicious,suspicious,可疑的,ADJ,B2
-sustain,sustain,词,VERB,C1
-sustainability policy,sustainability policy,词,NOUN,C1
-sustenance,sustenance,食物,NOUN,B2
-suture,suture,缝合,NOUN,B2
-suture,to suture,缝合,VERB,B2
-svelte,svelte,词,ADJ,C1
-swab,swab,词,NOUN,B2
-swagger (noun),swagger,词,NOUN,B2
-swamp,swamp,沼泽,NOUN,B2
-swap,swap,词,VERB,B2
-swarm,swarm,蜂群,NOUN,B2
-swarthy,swarthy,词,ADJ,C1
-sway,to sway,摇摆,VERB,B2
-sweat,sweat,汗水,NOUN,B2
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweden,sweden,瑞典,PROPN,B2
-swedish,swedish,瑞典的,ADJ,B2
-sweep,sweep,扫,NOUN,B2
-sweepings,sweepings,扫出的垃圾,NOUN,B2
-sweet,sweet,甜的,ADJ,B2
-sweet (noun),sweet,糖果,NOUN,C1
-sweet dream,sweet dream,美梦,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweeten,to sweeten,使变甜,VERB,B2
-sweetheart,sweetheart,爱人,NOUN,B2
-sweetie,sweetie,亲爱的,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-sweets,sweets,甜食,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swiftness,swiftness,词,NOUN,C1
-swim training,swim training,,NOUN,B2
-swimwear,swimwear,,NOUN,B2
-swindle,to swindle,诈骗,VERB,B2
-swine,swine,猪,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swirl,swirl,词,VERB,C1
-swiss,swiss,瑞士的,ADJ,B2
-switch key,switch key,词,NOUN,C1
-switch room,switch room,配电室,NOUN,B2
-switchboard,switchboard,总机,NOUN,B2
-switchman,switchman,词,NOUN,C1
-swollen,swollen,肿胀的,ADJ,B2
-sword,sword,剑,NOUN,B2
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordless,swordless,剑不,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsman,swordsman,剑客,NOUN,B2
-swordsmanship,swordsmanship,剑术,NOUN,B2
-sycophant,sycophant,词,NOUN,C1
-sycophantic,sycophantic,词,ADJ,B2
-syllabification,syllabification,词,NOUN,C1
-syllabus,syllabus,教学大纲,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symbolize,to symbolize,象征,VERB,B2
-symmetric,symmetric,词,ADJ,C1
-sympathetic,sympathetic,同情的,ADJ,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symptom,symptom,症状,NOUN,B2
-symptom (part),symptom,症,PART,B2
-symptoms,symptoms,词,NOUN,B1
-sync,sync,同步,NOUN,B2
-synchronized,synchronized,词,ADJ,C1
-synchronous,synchronous,同步的,ADJ,B2
-synchrony,synchrony,词,NOUN,C1
-syncopate,syncopate,词,VERB,C1
-syndicat,union,工会,NOUN,B2
-syndicate,syndicate,词,NOUN,C1
-syndrome,syndrome,综合征,NOUN,B2
-synergy,synergy,协同效应,NOUN,B2
-synopsis,synopsis,词,NOUN,C1
-synoptic,synoptic,概要的,ADJ,B2
-syntactic,syntactic,词,ADJ,C1
-synthesize,to synthesize,合成,VERB,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-syrian,syrian,叙利亚的,ADJ,B2
-syringe,syringe,注射器,NOUN,B2
-systemless,systemless,无系统的,ADJ,B2
-t-shirt,t-shirt,T 恤衫,NOUN,B2
-tabernacle,tabernacle,词,NOUN,C1
-table,table,桌子,NOUN,B2
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tableau de bord,dashboard,仪表盘,NOUN,B2
-tableau noir,blackboard,黑板,NOUN,B2
-taboo (adj),taboo,词,ADJ,C1
-tache,blot,污点,NOUN,B2
-tachometer,tachometer,转速表,NOUN,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-taciturn,taciturn,沉默寡言的,ADJ,B2
-tackle,to tackle,处理,VERB,B2
-tackling,tackling,马具,NOUN,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,俗气的事,NOUN,B2
-tact,tact,词,NOUN,C1
-tactful,tactful,圆滑的,ADJ,B2
-tactful appeasement,tactful appeasement,词,NOUN,C1
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactics,tactics,战术,NOUN,B2
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,不得体的,ADJ,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-taille,waist,腰,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
-takeover,takeover,词,NOUN,C1
-taking command,taking command,挂帅,NOUN,B2
-talent,talent,天赋,NOUN,B2
-talisman,talisman,词,NOUN,B2
-talk show,talk show,脱口秀,NOUN,C1
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-tall and slender,tall and slender,词,ADJ,C1
-tally,tally,词,VERB,C1
-tamable,tamable,词,ADJ,C1
-tambourine,tambourine,词,NOUN,B2
-tame (adj),tame,词,ADJ,A1
-taming,taming,词,NOUN,C1
-tamis,sieve,筛子,NOUN,B2
-tamiser,to sift,筛选,VERB,B2
-tamper,tamper,词,VERB,C1
-tandis que,while,一会儿,NOUN,B2
-tangente,tangent,切线,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible,tangible,有形的,ADJ,B2
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tangle,tangle,混乱,NOUN,B2
-tanned,tanned,词,ADJ,B2
-tannery,tannery,词,NOUN,B2
-tanneur,tanner,制革工,NOUN,B2
-tant,so much,那么多,DET,B2
-tant que,as long as,طالما,CCONJ,B2
-tantamount,tantamount,词,ADJ,C1
-tante maternelle,maternal aunt,姨母,NOUN,B2
-tante paternelle,paternal aunt,姑母,NOUN,B2
-tantrum,tantrum,词,NOUN,C1
-tape,tape,词,NOUN,A2
-tapoter,to pat,轻拍,VERB,B2
-tarab,tarab,词,NOUN,B2
-target group,target group,词,NOUN,C1
-targeted,targeted,有针对性的,ADJ,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
-tarif,tariff,费率,NOUN,B2
-taro,taro,芋头,NOUN,B2
-tarry,tarry,词,VERB,C1
-tas,heap,堆,NOUN,B2
-tas,pile,堆,NOUN,B2
-tasteless,tasteless,无味的,ADJ,B2
-tasting,tasting,词,NOUN,C1
-tasty,tasty,美味的,ADJ,B2
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tatter,tatter,词,NOUN,C1
-tawdry,tawdry,词,ADJ,C1
-tax (adj),tax,词,ADJ,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax rate,tax rate,税率,NOUN,B2
-tax return,tax return,报税,NOUN,B2
-tax revenue,tax revenue,税收,NOUN,B2
-taxe,carbon tax,碳税,NOUN,B2
-taxer,to tax,征税,VERB,B2
-taxi,taxi,出租车,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-te voilà,look at you,你看你,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching,teaching,教学的,ADJ,B2
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
-tearing,tearing,tearing,NOUN,B2
-technique,technical,技术的,ADJ,B2
-technique,technique,技巧,NOUN,B2
-technocrat,technocrat,词,NOUN,C1
-technocratic,technocratic,技术官僚的,ADJ,B2
-technologie verte,green technology,绿色技术,NOUN,B2
-teddy bear,teddy bear,词,NOUN,B2
-tedious,tedious,乏味的,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-teetotal,teetotal,词,ADJ,C1
-tel,such,如此,DET,B2
-telecommunications,telecommunications,词,NOUN,C1
-telegram,telegram,电报,NOUN,B2
-telegraph lightning,telegraph lightning,词,NOUN,C1
-teleological,teleological,目的论的,ADJ,B2
-telepathy,telepathy,词,NOUN,C1
-telephone number,telephone number,电话号码,NOUN,B2
-telephone ringing,telephone ringing,词,NOUN,C1
-telephones,telephones,电话,NOUN,B2
-television set,television set,词,NOUN,B1
-teller,teller,词,NOUN,B2
-telltale,telltale,词,ADJ,C1
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperamental,temperamental,词,ADJ,C1
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-temple,temple,寺庙,NOUN,B2
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
-temps,weather,天气,NOUN,B2
-temps de correspondance,matching time,对时,NOUN,B2
-temps libre,free time,业余时间,NOUN,B2
-temps libre,spare time,业余,NOUN,B2
-temptation,temptation,词,NOUN,B2
-tempérament,temper,脾气,NOUN,B2
-température,temperature,温度,NOUN,B2
-tempête de sable,sandstorm,沙尘暴,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-tenable,tenable,词,ADJ,C1
-tend,tend,词,VERB,B2
-tendance,tendency,趋势,NOUN,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tendon,tendon,肌腱,NOUN,B2
-tendre,tender,嫩的,ADJ,B2
-tendu,taut,绷紧的,ADJ,B2
-tenement,tenement,词,NOUN,C1
-tenet,tenet,词,NOUN,C1
-tennis,tennis,网球,NOUN,B2
-tens,tens,词,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
-tense (noun),tense,词,NOUN,B1
-tense angry,tense angry,词,ADJ,A2
-tense excited,tense excited,词,ADJ,B2
-tensile,tensile,词,ADJ,C1
-tension,tension,紧张,NOUN,B2
-tension artérielle,blood pressure,血压,NOUN,B2
-tentatif,tentative,暂定的,ADJ,B2
-tentative échouée,failed bid,流标,NOUN,B2
-tenth (noun),tenth,词,NOUN,B2
-tenue,attire,服装,NOUN,B2
-tenuous,tenuous,词,ADJ,C1
-tenure,tenure,词,NOUN,B2
-tepid,tepid,词,ADJ,C1
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-terminal,terminal,终点站,NOUN,B2
-terminal (adj),terminal,终末的,ADJ,B2
-terminer,end,端,PART,B2
-terminer,to end,结束,VERB,B2
-terminologique,terminological,术语的,ADJ,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,,NOUN,B2
-terrain,grounds,论据,NOUN,B2
-terrain,terrain,地形,NOUN,B2
-terre interdite,forbidden land,禁地,NOUN,B2
-terrible,terrible,可怕的,ADJ,B2
-terribleness,terribleness,,NOUN,B2
-terribly,terribly,可怕地/非常,ADV,B2
-terrified,terrified,极度恐惧的,ADJ,B2
-terrifier,to terrify,使恐惧,VERB,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
-territorial,territorial,领土的,ADJ,B2
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terse,terse,简练的,ADJ,B2
-terseness,terseness,词,NOUN,C1
-test,test,测试,NOUN,B2
-test drive,test drive,,NOUN,B2
-test hebdomadaire,weekly test,周测,NOUN,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testicular,testicular,词,ADJ,C1
-tether,tether,词,NOUN,C1
-textile,textile,纺织,NOUN,B2
-textuality,textuality,词,NOUN,C1
-textuel,textual,文本的,ADJ,B2
-texture,texture,词,NOUN,C1
-than (adv),than,词,ADV,A1
-thank god,thank god,谢天谢地,INTJ,B2
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-tharid,tharid,词,NOUN,B2
-that,that,那个,DET,B2
-that (noun),that,将那,NOUN,C1
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
-that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way,that way,往那边,ADV,B2
-that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,复合词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,复合词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,复合词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,名词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,名词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,名词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,名词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,复合词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,复合词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,复合词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,复合词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,收银台,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,骑兵,NOUN,B2
-the chain,the chain,链条,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,ADV,B2
-the day after tomorrow (noun),the day after tomorrow,词,NOUN,B2
-the day before yesterday,the day before yesterday,前天,ADV,B2
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the emperor,the emperor,皇帝,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,复合词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,复合词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,复合词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masculine,the masculine,词,DET,A2
-the masses,the masses,大众,NOUN,C1
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,复合词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the more,the more,越,ADV,B2
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,复合词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
-the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,词,DET,B1
-the one (pron),the one,那个人,PRON,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,前几天晚上,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the rich,the rich,富人,NOUN,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,相同的,ADJ,B2
-the same (det),the same,词,DET,A2
-the same (pron),the same,词,PRON,C1
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unseen,the unseen,词,NOUN,C1
-the unstellung,the unstellung,复合词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,复合词,NOUN,B2
-the urbewegung,the urbewegung,复合词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,复合词,NOUN,B2
-the urrechnung,the urrechnung,复合词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,复合词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,复合词,NOUN,B2
-the verminderung,the verminderung,复合词,NOUN,B2
-the verstbindung,the verstbindung,复合词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,复合词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,复合词,NOUN,B2
-the ververtiefung,the ververtiefung,复合词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the very,the very,正是,ADV,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,复合词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,复合词,NOUN,B2
-the zerordnung,the zerordnung,复合词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-their,their,他们的,PRON,B2
-them dative,them dative,词,PRON,A2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,神权的,ADJ,B2
-theodicy,theodicy,词,NOUN,C1
-theorize,theorize,词,VERB,B2
-there (noun),there,那儿,NOUN,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-thereafter,thereafter,此后,ADV,B2
-therefore (sconj),therefore,所以,SCONJ,B2
-thermal,thermal,热的,ADJ,B2
-thermal (noun),thermal,词,NOUN,B2
-thesaurus,thesaurus,词,NOUN,C1
-these,these,这些,DET,B2
-these (pron),these,词,PRON,A1
-these three,these three,这三,NOUN,B2
-thespian,thespian,词,NOUN,C1
-thetic,thetic,正题的,ADJ,B2
-they female,they female,她们,PRON,B2
-they things,they things,它们,PRON,B2
-they two,they two,词,PRON,A1
-thick,thick,厚的,ADJ,B2
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thicket,thicket,灌木丛,NOUN,B2
-thickets,thickets,词,NOUN,B2
-thickness,thickness,厚度,NOUN,B2
-thief,thief,小偷,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thief presence,thief presence,有贼,NOUN,B2
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-think to want,to think to want,想,VERB,B2
-think up,to think up,构思,VERB,B2
-thinking,thinking,思维,NOUN,B2
-thinner,thinner,更薄的,ADJ,B2
-thinness,thinness,瘦,NOUN,B2
-third,third,三分之一,NOUN,B2
-third (num),third,词,NUM,B1
-third bestowal,third bestowal,三授,NOUN,B2
-third place,third place,季军,NOUN,B2
-thirsty,thirsty,口渴的,ADJ,B2
-this,this,您这,NOUN,B2
-this afternoon,this afternoon,词,ADV,B2
-this battle,this battle,此战,NOUN,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this item,this item,这件,NOUN,B2
-this masculine,this masculine,词,DET,A1
-this matter,this matter,这事,NOUN,B2
-this morning,this morning,今天早上,ADV,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
-this way,this way,这样,PRON,B2
-this way (adv),this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-this-camp,this-camp,这营,NOUN,B2
-thorn,thorn,刺,NOUN,B2
-thorny,thorny,词,ADJ,C1
-thoroughly,thoroughly,词,ADV,B2
-thoroughness,thoroughness,彻底,NOUN,B2
-those,those,那些,DET,B2
-those (pron),those,词,PRON,A1
-thoughtful,thoughtful,体贴的,ADJ,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thousand (noun),thousand,词,NOUN,B2
-thousands,thousands,数千,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thrall,thrall,词,NOUN,C1
-thread (verb),thread,词,VERB,C1
-threadbare,threadbare,词,ADJ,C1
-threads,threads,词,NOUN,B2
-threat,threat,威胁,NOUN,B2
-threatened,threatened,词,ADJ,C1
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
-three-d printing,three-d printing,3D打印,NOUN,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threshing floor,threshing floor,词,NOUN,B2
-thrifty,thrifty,节俭的,ADJ,B2
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throne,throne,王座,NOUN,B2
-throng,throng,词,NOUN,C1
-through,through,通过,ADP,B2
-throughout,throughout,词,ADP,B1
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-throwing,throwing,词,NOUN,B2
-thrust,thrust,猛推,NOUN,B2
-thrust toward,thrust toward,插向,NOUN,B2
-thug,thug,暴徒,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-théocratie,theocracy,神权政治,NOUN,B2
-tick,tick,滴答声,NOUN,B2
-tickle,tickle,发痒,NOUN,B2
-tidal,tidal,潮汐,ADJ,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
-tidy (adj),tidy,词,ADJ,B2
-tie,to tie,联结,VERB,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tier,tier,分阶,NOUN,C1
-tight grip,tight grip,手握紧,NOUN,B2
-tight narrow,tight narrow,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightly,tightly,词,ADV,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-timber,timber,词,NOUN,C1
-timbre,timbre,词,NOUN,C1
-time era,time era,词,NOUN,A2
-time occasion,time occasion,次,NOUN,B2
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time out,time out,词,NOUN,B2
-time to go to bed,time to go to bed,该睡觉了,ADV,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timetable,timetable,时刻表,NOUN,B2
-timid,timid,词,ADJ,B2
-timidité,timidity,胆怯,NOUN,B2
-timorous,timorous,词,ADJ,C1
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (adj),tint,词,ADJ,C1
-tips,tips,词,NOUN,C1
-tir,shot,射击,NOUN,B2
-tirage,draw out,引出,NOUN,B2
-tirage de sort,fortune telling,算命,NOUN,B2
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tireless,tireless,不知疲倦的,ADJ,B2
-tirer,to fire,开火,VERB,B2
-tirer,to shoot,射击,VERB,B2
-tiresome,tiresome,累人的,ADJ,B2
-tiring,tiring,令人疲倦的,ADJ,B2
-tissu,cloth,布,NOUN,B2
-tissu,tissue,组织,NOUN,B2
-tissu de soie,silk cloth,丝绸,NOUN,B2
-tissue (adj),tissue,词,ADJ,C1
-titanic,titanic,词,ADJ,C1
-titillate,titillate,词,VERB,C1
-titling,titling,词,NOUN,C1
-titre honorifique,person honorific,位,NOUN,B2
-tits,tits,词,NOUN,C1
-titular,titular,词,ADJ,C1
-to,to,去,PART,B2
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,动词,VERB,B2
-to absolve,to absolve,赦免,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abstract,to abstract,抽象,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,动词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abwandeln,to abwandeln,动词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to acclaim,to acclaim,称赞,VERB,B2
-to accommodate,to accommodate,容纳,VERB,B2
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to accredit,to accredit,认可,VERB,B2
-to acknowledge,to acknowledge,承认,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to adduce,to adduce,引证,VERB,B2
-to adhere,to adhere,坚持,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to adore,to adore,爱慕,VERB,B2
-to afforest,to afforest,造林,VERB,B2
-to age,to age,变老,VERB,B2
-to aggravate,to aggravate,加重,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agitate,to agitate,鼓动,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to agree with,to agree with,词,VERB,B2
-to ail,to ail,使苦恼,VERB,B2
-to aim (verb),to aim,词,VERB,B2
-to alienate,to alienate,使疏远,VERB,B2
-to align,to align,使一致,VERB,B2
-to allege,to allege,宣称,VERB,B2
-to alleviate,to alleviate,缓解,VERB,B2
-to allocate,to allocate,分配,VERB,B2
-to allude,to allude,暗指,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter,to alter,改变,VERB,B2
-to amalgamate,to amalgamate,合并,VERB,B2
-to amaze,to amaze,使吃惊,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to anathematize,to anathematize,词,VERB,C1
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to annul,to annul,废除,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antagonize,to antagonize,使对立,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,叛教,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to apply be valid,to apply be valid,适用/有效,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to archive,to archive,归档,VERB,B2
-to armor,to armor,装甲,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
-to ascribe,to ascribe,归因于,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to asphyxiate,to asphyxiate,使窒息,VERB,B2
-to assent,to assent,同意,VERB,B2
-to assume office,to assume office,就任,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt (verb),to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attenuate,to attenuate,减弱,VERB,B2
-to audit (verb),to audit,审核,VERB,B2
-to augur,to augur,预言,VERB,B2
-to auscultate,to auscultate,听诊,VERB,B2
-to authenticate,to authenticate,认证,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await orders,to await orders,待命,VERB,B2
-to bandage (verb),to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to bare,to bare,暴露,VERB,B2
-to bargain (verb),to bargain,词,VERB,C1
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be (aux),to be,词,AUX,B2
-to be able (aux),to be able,能够,AUX,B1
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be added,to be added,加入,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be based on,to be based on,基于,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be content,to be content,词,VERB,C1
-to be contradicted,to be contradicted,词,VERB,B2
-to be correct,to be correct,正确,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be dissonant,to be dissonant,词,VERB,C1
-to be driven,to be driven,被驱动,VERB,B2
-to be equivalent,to be equivalent,词,VERB,C1
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be forbidden,to be forbidden,词,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be good for,to be good for,词,VERB,B2
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be happy,to be happy,词,VERB,A2
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be liable,to be liable,负责,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be moved,to be moved,感动,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary must,to be necessary must,词,VERB,A2
-to be needed,to be needed,被需要,VERB,B2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticeable,to be noticeable,词,VERB,C1
-to be noticed,to be noticed,被注意到,VERB,B2
-to be observed,to be observed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,进行中,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be related,to be related,词,VERB,C1
-to be released,to be released,词,VERB,B2
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be responsible,to be responsible,负责,VERB,B2
-to be said,to be said,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be struck,to be struck,被打击,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,不知道,VERB,B2
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be valid,to be valid,有效,VERB,B2
-to be vigilant,to be vigilant,词,VERB,B2
-to be visible,to be visible,可见,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to beatify,to beatify,宣福,VERB,B2
-to beautify,to beautify,美化,VERB,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become alert,to become alert,词,VERB,B2
-to become bold,to become bold,词,VERB,C1
-to become certain,to become certain,词,VERB,B2
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to befriend,to befriend,与...交朋友,VERB,B2
-to beget,to beget,引起,VERB,B2
-to behave rudely,to behave rudely,词,VERB,C1
-to behold,to behold,注视,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to bet invest,to bet invest,下注/投资,VERB,B2
-to bevriezen,to bevriezen,词,VERB,C1
-to bewitch,to bewitch,迷住,VERB,B2
-to bicker,to bicker,争吵,VERB,B2
-to bid farewell,to bid farewell,词,VERB,B1
-to bide,to bide,等待,VERB,B2
-to bifurcate,to bifurcate,分叉,VERB,B2
-to bisect,to bisect,平分,VERB,B2
-to blaspheme,to blaspheme,亵渎,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to blink,to blink,眨眼,VERB,B2
-to blow up,to blow up,炸毁,VERB,B2
-to bluff,to bluff,虚张声势,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to boil cook,to boil cook,词,VERB,B1
-to boost,to boost,促进,VERB,B2
-to border (verb),to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to botch,to botch,搞砸,VERB,B2
-to bottle (verb),to bottle,词,VERB,C1
-to box,to box,拳击,VERB,B2
-to brandish,to brandish,挥舞,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break in,to break in,词,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to breathe again,to breathe again,松口气,VERB,B2
-to bribe (verb),to bribe,行贿,VERB,B2
-to bridle,to bridle,给...上笼头,VERB,B2
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring here,to bring here,词,VERB,C1
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to brood,to brood,沉思,VERB,B2
-to bullshit,to bullshit,胡扯,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump,to bump,碰撞,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to bungle,to bungle,搞砸,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to calibrate,to calibrate,校准,VERB,B2
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call ring,to call ring,打电话,VERB,B2
-to call to contact,to call to contact,词,VERB,A2
-to calm down,to calm down,使平静,VERB,B2
-to camouflage,to camouflage,伪装,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to capitalize,to capitalize,利用,VERB,B2
-to capitulate,to capitulate,投降,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to captivate,to captivate,迷住,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carry on,to carry on,词,VERB,C1
-to cash (verb),to cash,兑现,VERB,B2
-to cast (verb),to cast,词,VERB,B2
-to catalyze,to catalyze,催化,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catechize,to catechize,词,VERB,B2
-to categorize,to categorize,分类,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to cauterize,to cauterize,烧灼,VERB,B2
-to center,to center,居中,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chair (verb),to chair,词,VERB,C1
-to change clothes,to change clothes,更衣,VERB,B1
-to change trains,to change trains,词,VERB,A1
-to charge (verb),to charge,充电,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chirp,to chirp,啁啾,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,割礼,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close eyes,to close eyes,闭眼,VERB,B2
-to cloy,to cloy,使厌烦,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coax,to coax,哄骗,VERB,B2
-to codify,to codify,编纂,VERB,B2
-to coerce,to coerce,强迫,VERB,B2
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to collate,to collate,核对,VERB,B2
-to combat (verb),to combat,战斗,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to come true,to come true,词,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commercialize,to commercialize,商业化,VERB,B2
-to commission,to commission,委托,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to compile,to compile,编译,VERB,B2
-to complement,to complement,补充,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to compose (noun),to compose,合成,NOUN,B2
-to computerize,to computerize,词,VERB,C1
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concretize,to concretize,词,VERB,C1
-to condescend,to condescend,屈尊,VERB,B2
-to condone,to condone,宽恕,VERB,B2
-to conduct (verb),to conduct,指挥,VERB,B2
-to confine,to confine,限制,VERB,B2
-to connote,to connote,暗示,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to consign,to consign,移交,VERB,B2
-to constipate,to constipate,词,VERB,C1
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consummate,to consummate,完成,VERB,B2
-to contend,to contend,主张,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to cook fix,to cook fix,做/修理,VERB,B2
-to cope,to cope,应付,VERB,B2
-to correspond (! verb),to correspond,词,! VERB,C1
-to corrode,to corrode,腐蚀,VERB,B2
-to countersign,to countersign,副署,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,掩盖,VERB,B2
-to covet,to covet,觊觎,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to cram,to cram,填鸭式学习,VERB,B2
-to crash,to crash,碰撞,VERB,B2
-to creak,to creak,嘎吱作响,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,挤在一起,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to culminate,to culminate,达到顶点,VERB,B2
-to curtail,to curtail,削减,VERB,B2
-to curve,to curve,弯曲,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cycle (verb),to cycle,循环,VERB,B2
-to dampen,to dampen,使潮湿,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to date,to date,注明日期,VERB,B2
-to daunt,to daunt,使气馁,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daydream,to daydream,幻想,VERB,B2
-to daze,to daze,使茫然,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deafen,to deafen,使聋,VERB,B2
-to deal,to deal,处理,VERB,B2
-to debut,to debut,首次亮相,VERB,B2
-to decant,to decant,倾析,VERB,B2
-to decentralize,to decentralize,去中心化,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,大量削减,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declassify,to declassify,解密,VERB,B2
-to decode,to decode,解码,VERB,B2
-to decompress,to decompress,解压,VERB,B2
-to decontextualize,to decontextualize,词,VERB,C1
-to defame,to defame,诽谤,VERB,B2
-to default (verb),to default,拖欠,VERB,B2
-to defect (verb),to defect,叛变,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to defer,to defer,推迟,VERB,B2
-to deflate,to deflate,使泄气,VERB,B2
-to deform,to deform,使变形,VERB,B2
-to deify,to deify,神化,VERB,B2
-to deign,to deign,屈尊,VERB,B2
-to dejta,to dejta,约会,VERB,B2
-to delegitimize,to delegitimize,词,VERB,C1
-to delimit,to delimit,词,VERB,C1
-to delineate,to delineate,描绘,VERB,B2
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to delude oneself,to delude oneself,词,VERB,B2
-to demarcate,to demarcate,划定界限,VERB,B2
-to demilitarize,to demilitarize,非军事化,VERB,B2
-to democratize,to democratize,民主化,VERB,B2
-to denature,to denature,使变性,VERB,B2
-to denigrate,to denigrate,诋毁,VERB,B2
-to denominate,to denominate,命名,VERB,B2
-to denote,to denote,表示,VERB,B2
-to densify,to densify,词,VERB,C1
-to depersonalize,to depersonalize,词,VERB,C1
-to depilate,to depilate,脱毛,VERB,B2
-to depopulate,to depopulate,使人口减少,VERB,B2
-to deport,to deport,驱逐出境,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deprave,to deprave,使堕落,VERB,B2
-to depreciate,to depreciate,贬值,VERB,B2
-to depress,to depress,使沮丧,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,起源于,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to detest,to detest,厌恶,VERB,B2
-to dethrone,to dethrone,废黜,VERB,B2
-to detract,to detract,贬低,VERB,B2
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to digitize,to digitize,数字化,VERB,B2
-to dilute,to dilute,稀释,VERB,B2
-to dirty (verb),to dirty,词,VERB,C1
-to disabuse,to disabuse,纠正错误想法,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disarrange,to disarrange,弄乱,VERB,B2
-to disarray (verb),to disarray,词,VERB,C1
-to discern,to discern,辨别,VERB,B2
-to discipline (verb),to discipline,处分,VERB,B2
-to disconcert,to disconcert,使惊慌,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to discriminate,to discriminate,歧视,VERB,B2
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disentangle,to disentangle,解开,VERB,B2
-to disfavor,to disfavor,不利于,VERB,B2
-to disfigure,to disfigure,毁容,VERB,B2
-to dishearten,to dishearten,使沮丧,VERB,B2
-to dishevel,to dishevel,弄乱,VERB,B2
-to disinherit,to disinherit,剥夺继承权,VERB,B2
-to disintegrate,to disintegrate,瓦解,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dismay,to dismay,使沮丧,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disperse,to disperse,分散,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to dispose,to dispose,处理,VERB,B2
-to dispossess,to dispossess,剥夺,VERB,B2
-to disproportion (verb),to disproportion,词,VERB,C1
-to disqualify,to disqualify,取消资格,VERB,B2
-to disrespect (verb),to disrespect,词,VERB,C1
-to dissent (verb),to dissent,词,VERB,C1
-to distance (verb),to distance,词,VERB,C1
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to disunite,to disunite,使分裂,VERB,B2
-to divest,to divest,剥夺,VERB,B2
-to divorce (verb),to divorce,离婚,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do harm,to do harm,伤害,VERB,B2
-to do justice to,to do justice to,词,VERB,C1
-to do make,to do make,词,VERB,A1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to document (verb),to document,记录,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dote,to dote,词,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw support from,to draw support from,借助,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drip,to drip,滴,VERB,B2
-to drive herd,to drive herd,驱赶/推动,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry in the sun (verb),to dry in the sun,晾晒,VERB,B2
-to dry out,to dry out,词,VERB,C1
-to duck,to duck,躲避,VERB,B2
-to dump,to dump,抛弃,VERB,B2
-to dust off,to dust off,词,VERB,C1
-to each other (adv),to each other,词,ADV,C1
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eavesdrop,to eavesdrop,偷听,VERB,B2
-to edify,to edify,启发,VERB,B2
-to eject,to eject,弹出,VERB,B2
-to elapse,to elapse,流逝,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to elevate,to elevate,提升,VERB,B2
-to elide,to elide,省略,VERB,B2
-to elucidate,to elucidate,阐明,VERB,B2
-to elude,to elude,逃避,VERB,B2
-to email,to email,发邮件,VERB,B2
-to embark,to embark,上船,VERB,B2
-to embarrass,to embarrass,使尴尬,VERB,B2
-to embolden,to embolden,使大胆,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emigrate,to emigrate,移居国外,VERB,B2
-to empty,to empty,倒空,VERB,B2
-to encircle,to encircle,环绕,VERB,B2
-to encode,to encode,编码,VERB,B2
-to enervate,to enervate,使衰弱,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engross,to engross,使全神贯注,VERB,B2
-to enhance,to enhance,增强,VERB,B2
-to enrage,to enrage,激怒,VERB,B2
-to enrapture,to enrapture,使狂喜,VERB,B2
-to enrol,to enrol,注册,VERB,B2
-to enslave,to enslave,奴役,VERB,B2
-to ensnare,to ensnare,诱捕,VERB,B2
-to entail,to entail,牵涉,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthrall,to enthrall,迷住,VERB,B2
-to enthrone,to enthrone,立为王,VERB,B2
-to enthuse,to enthuse,使热情,VERB,B2
-to enunciate,to enunciate,阐明,VERB,B2
-to envy (verb),to envy,羡慕,VERB,B2
-to equal (verb),to equal,无异,VERB,B2
-to equalize,to equalize,使相等,VERB,B2
-to equate,to equate,等同,VERB,B2
-to erect behave,to erect behave,建造,VERB,B2
-to erode,to erode,侵蚀,VERB,B2
-to espy,to espy,窥探,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to eternalize,to eternalize,使永恒,VERB,B2
-to ever (verb),to ever,何尝,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to exalt,to exalt,颂扬,VERB,B2
-to exchange (verb),to exchange,交换,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to exclaim,to exclaim,呼喊,VERB,B2
-to exculpate,to exculpate,开脱,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exemplify,to exemplify,举例说明,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exfoliate,to exfoliate,去角质,VERB,B2
-to exist there is,to exist there is,存在/有,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to exorcise,to exorcise,驱魔,VERB,B2
-to expectorate,to expectorate,吐痰,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to expurgate,to expurgate,删节,VERB,B2
-to externalize,to externalize,使外在化,VERB,B2
-to extirpate,to extirpate,根除,VERB,B2
-to extol,to extol,赞美,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extricate,to extricate,使摆脱,VERB,B2
-to exude,to exude,散发,VERB,B2
-to fabricate,to fabricate,捏造,VERB,B2
-to fail to fulfill,to fail to fulfill,未履行,VERB,B2
-to fake,to fake,伪造,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall silent,to fall silent,沉默,VERB,B2
-to familiarize,to familiarize,使熟悉,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fasten,to fasten,系紧,VERB,B2
-to fatten,to fatten,养肥,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to fell,to fell,砍倒,VERB,B2
-to fertilize,to fertilize,施肥,VERB,B2
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to finally,to finally,你可算,VERB,B2
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fine (verb),to fine,罚款,VERB,B2
-to fit suit,to fit suit,适合,VERB,B2
-to fix to prepare,to fix to prepare,词,VERB,A2
-to flap,to flap,拍打,VERB,B2
-to flatten,to flatten,使平坦,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flog,to flog,鞭打,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flow in,to flow in,词,VERB,C1
-to flow into,to flow into,词,VERB,C1
-to fluctuate,to fluctuate,波动,VERB,B2
-to flush,to flush,冲洗,VERB,B2
-to fluster,to fluster,使慌乱,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to foist,to foist,强加,VERB,B2
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to forebode,to forebode,预兆,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to formalize,to formalize,使正式化,VERB,B2
-to fortify,to fortify,加强,VERB,B2
-to fossilize,to fossilize,石化,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to fraternize,to fraternize,勾结,VERB,B2
-to frighten away,to frighten away,词,VERB,C1
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to fumigate,to fumigate,熏蒸,VERB,B2
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse (verb),to fuse,融合,VERB,B2
-to gain,to gain,获得,VERB,B2
-to gallop,to gallop,飞奔,VERB,B2
-to galvanize,to galvanize,激励,VERB,B2
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to gauge,to gauge,测量,VERB,B2
-to germinate,to germinate,发芽,VERB,B2
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get along,to get along,词,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get by,to get by,过得去,VERB,B2
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get fond of,to get fond of,词,VERB,C1
-to get into,to get into,陷入,VERB,B2
-to get into debt,to get into debt,词,VERB,C1
-to get off,to get off,词,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get stuck,to get stuck,卡住,VERB,B2
-to get tired,to get tired,疲劳,VERB,A2
-to get to know,to get to know,词,VERB,B1
-to gift (verb),to gift,词,VERB,B1
-to gird,to gird,束紧,VERB,B2
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give as a gift,to give as a gift,赠送,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glean,to glean,搜集,VERB,B2
-to globalize,to globalize,使全球化,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go blind,to go blind,失明,VERB,B2
-to go deep into,to go deep into,深入,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,麻木,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go there,to go there,词,VERB,B1
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up in smoke,to go up in smoke,化为乌有,VERB,B2
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to goad,to goad,刺激,VERB,B2
-to gossip,to gossip,闲聊,VERB,B2
-to graspen,to graspen,抓住,VERB,B2
-to gratify,to gratify,使满足,VERB,B2
-to gravitate,to gravitate,受吸引,VERB,B2
-to gray,to gray,变白,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to grow fond of,to grow fond of,词,VERB,C1
-to growl,to growl,咆哮,VERB,B2
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,猜中,VERB,B2
-to guillotine,to guillotine,斩首,VERB,B2
-to gurgle (verb),to gurgle,词,VERB,C1
-to gush,to gush,涌出,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to handcuff,to handcuff,给…戴手铐,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harangue (verb),to harangue,词,VERB,B2
-to harbor,to harbor,怀有,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,使和谐,VERB,B2
-to have (aux),to have,词,AUX,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hide to disappear,to hide to disappear,词,VERB,A2
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold accountable,to hold accountable,问责,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up,to hold up,词,VERB,B2
-to hold up stop,to hold up stop,词,VERB,A2
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to hook (verb),to hook,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to hug (verb),to hug,词,VERB,B2
-to humanize,to humanize,使人性化,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idealize,to idealize,理想化,VERB,B2
-to idolize,to idolize,崇拜,VERB,B2
-to ignite,to ignite,点燃,VERB,B2
-to imbue,to imbue,词,VERB,C1
-to immobilize,to immobilize,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to improvise,to improvise,即兴创作,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incentivize,to incentivize,词,VERB,C1
-to incorporate,to incorporate,包含,VERB,B2
-to incriminate,to incriminate,归罪,VERB,B2
-to incur,to incur,招致,VERB,B2
-to indicate interpret,to indicate interpret,表明/解释,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict,to inflict,词,VERB,C1
-to inform to reach,to inform to reach,词,VERB,A2
-to innovate,to innovate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to institute (verb),to institute,词,VERB,C1
-to institutionalize,to institutionalize,制度化,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to internalize,to internalize,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intuit,to intuit,词,VERB,C1
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoice,to invoice,开票,VERB,B2
-to ironize,to ironize,讽刺,VERB,B2
-to issue (verb),to issue,发行,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to jam,to jam,堵塞,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to knead,to knead,词,VERB,A1
-to kneel,to kneel,词,VERB,B1
-to knock down,to knock down,词,VERB,B2
-to knock to pound,to knock to pound,词,VERB,A2
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack (verb),to lack,无凭,VERB,B2
-to lack basis,to lack basis,无据,VERB,B2
-to languish,to languish,词,VERB,C1
-to laugh smile,to laugh smile,笑,VERB,A1
-to lay down,to lay down,放下,VERB,B2
-to lay put,to lay put,放,VERB,B2
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,使入歧途,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to leaf through,to leaf through,翻阅,VERB,B2
-to leak (verb),to leak,泄密,VERB,B2
-to lean out,to lean out,探出身体,VERB,B2
-to leap (verb),to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to,to leave to,词,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to lecture (verb),to lecture,宣讲,VERB,B2
-to legislate,to legislate,词,VERB,C1
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lessen,to lessen,词,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to level,to level,夷平,VERB,B2
-to levy,to levy,征收,VERB,C1
-to license,to license,许可,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,对...说谎,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,点燃,VERB,B2
-to like (aux),to like,词,AUX,A2
-to linger,to linger,徘徊,VERB,B2
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lodge,to lodge,借宿,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to log in,to log in,登录,VERB,B2
-to loiter,to loiter,词,VERB,C1
-to long,to long,渴望,VERB,B2
-to long for,to long for,渴望,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lunge,to lunge,词,VERB,C1
-to lure (verb),to lure,词,VERB,B2
-to lurk,to lurk,词,VERB,B2
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make drowsy,to make drowsy,词,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,使独立,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to manure (verb),to manure,词,VERB,C1
-to map out,to map out,摸清,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to mash (verb),to mash,词,VERB,A2
-to maximize,to maximize,词,VERB,C1
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to head to,to mean to head to,词,VERB,A2
-to mean to think,to mean to think,词,VERB,C1
-to meant,to meant,意思是,VERB,B2
-to meddle,to meddle,干涉,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mention to remember,to mention to remember,词,VERB,A2
-to mess about,to mess about,胡搞,VERB,B2
-to mess around,to mess around,胡闹,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to mirror,to mirror,反映,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to missed,to missed,错过,VERB,B2
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to moan (verb),to moan,词,VERB,B2
-to model (verb),to model,词,VERB,C1
-to modernize,to modernize,词,VERB,C1
-to modulate,to modulate,调节,VERB,B2
-to monitor (verb),to monitor,监察,VERB,B2
-to moon (verb),to moon,词,VERB,A2
-to moor (verb),to moor,词,VERB,B2
-to mop (verb),to mop,词,VERB,A2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to mourn,to mourn,哀悼,VERB,B2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to mud,to mud,弄脏,VERB,B2
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to must (aux),to must,必,AUX,A1
-to mutiny,to mutiny,煽动叛乱,VERB,B2
-to mystify,to mystify,神秘化,VERB,B2
-to navigate,to navigate,导航；航行,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need (aux),to need,还要,AUX,B2
-to need must,to need must,词,VERB,A2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note down,to note down,词,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to number (verb),to number,词,VERB,C1
-to object,to object,反对,VERB,B2
-to objectify,to objectify,客观化,VERB,B2
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to occur to,to occur to,词,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to orient,to orient,定向,VERB,B2
-to ostracize,to ostracize,排斥,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overestimate,to overestimate,词,VERB,C1
-to overlook,to overlook,忽视,VERB,B2
-to overshadow,to overshadow,使黯然失色,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to overthrow,to overthrow,推翻,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,平息,VERB,B2
-to package (verb),to package,词,VERB,C1
-to paint over,to paint over,重新粉刷,VERB,B2
-to pair,to pair,配对,VERB,B2
-to party,to party,狂欢,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pause (verb),to pause,……,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to pension off,to pension off,词,VERB,C1
-to perforate,to perforate,词,VERB,C1
-to perform umrah,to perform umrah,词,VERB,C1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to perpetrate,to perpetrate,词,VERB,C1
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to persist,to persist,坚持,VERB,B2
-to personify,to personify,词,VERB,C1
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to phone (verb),to phone,词,VERB,B2
-to photocopy (verb),to photocopy,复印,VERB,B2
-to photograph (verb),to photograph,拍照,VERB,B2
-to pick out,to pick out,挑选,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to placate,to placate,安抚,VERB,B2
-to place put,to place put,放置,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to pledge mutually,to pledge mutually,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plunder,to plunder,掠夺,VERB,B2
-to point (verb),to point,指,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to polarize,to polarize,使两极分化,VERB,B2
-to polemicize,to polemicize,词,VERB,C1
-to polish,to polish,擦亮,VERB,B2
-to pollute,to pollute,词,VERB,B2
-to postulate,to postulate,假定,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to powder,to powder,撒粉,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to prick,to prick,扎,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to process (verb),to process,加工,VERB,B2
-to profile (verb),to profile,词,VERB,C1
-to propagate,to propagate,传播,VERB,B2
-to prosecute,to prosecute,起诉,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to publicize,to publicize,宣传,VERB,B1
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pucker,to pucker,噘,VERB,B2
-to pull out hair,to pull out hair,词,VERB,C1
-to pull through,to pull through,词,VERB,B2
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purchase (verb),to purchase,词,VERB,B2
-to purify,to purify,净化,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to push through,to push through,推动,VERB,B2
-to put away,to put away,收拾,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,使走上正轨,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to puzzle (verb),to puzzle,迷惑,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to quiver,to quiver,颤抖,VERB,B2
-to race (verb),to race,词,VERB,B1
-to radiate,to radiate,辐射,VERB,B2
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rant,to rant,咆哮,VERB,B2
-to rape (verb),to rape,词,VERB,B2
-to rationalize,to rationalize,合理化,VERB,B2
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to rebuke,to rebuke,斥责,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to redeem,to redeem,赎回,VERB,B2
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to refuel,to refuel,加油,VERB,B2
-to regain,to regain,恢复,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
-to rehabilitate,to rehabilitate,使康复,VERB,B2
-to rehearse,to rehearse,排练,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate,to relate,联系,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to release from prison,to release from prison,释放,VERB,B2
-to release let go,to release let go,释放/放手,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove to pull out,to remove to pull out,词,VERB,A2
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,重犯,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to repel,to repel,击退,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to replicate,to replicate,复制,VERB,B2
-to reply (verb),to reply,答辩,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to resemble (adj),to resemble,相似,ADJ,B1
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to retort,to retort,反驳,VERB,B2
-to retract,to retract,撤回,VERB,B2
-to retreat (verb),to retreat,后退,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return something,to return something,词,VERB,A2
-to revalue,to revalue,重新估值,VERB,B2
-to review (verb),to review,回顾,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to ride along,to ride along,词,VERB,B1
-to rinse,to rinse,冲洗,VERB,B2
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to root out,to root out,词,VERB,C1
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to round (verb),to round,词,VERB,A2
-to ruffle,to ruffle,词,VERB,C1
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to sabotage,to sabotage,破坏,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanctify,to sanctify,使神圣,VERB,B2
-to sanction,to sanction,认可,VERB,B2
-to satiate,to satiate,使饱足,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to saw,to saw,锯,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scamper,to scamper,词,VERB,B2
-to scan,to scan,扫描,VERB,B2
-to scent,to scent,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scorch,to scorch,烧焦,VERB,B2
-to score (verb),to score,词,VERB,B2
-to scourge (verb),to scourge,词,VERB,C1
-to scout,to scout,侦察,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to screen (verb),to screen,筛选,VERB,B2
-to screw,to screw,拧,VERB,B2
-to scribble (verb),to scribble,词,VERB,C1
-to scrub,to scrub,擦洗,VERB,B2
-to search apply,to search apply,寻找/申请,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to see emperor,to see emperor,面圣,VERB,C1
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segment,to segment,细分,VERB,B2
-to segregate,to segregate,隔离,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to sentence (verb),to sentence,量刑,VERB,B2
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew in,to sew in,词,VERB,C1
-to sexualize,to sexualize,词,VERB,C1
-to shame (verb),to shame,羞辱,VERB,B2
-to share divide,to share divide,分享,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shield (verb),to shield,包庇,VERB,B2
-to shoe (verb),to shoe,词,VERB,C1
-to shoot dead,to shoot dead,击毙,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop be about,to shop be about,购物,VERB,B2
-to shop for groceries,to shop for groceries,词,VERB,A2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shower (verb),to shower,淋浴,VERB,B2
-to shroud,to shroud,覆盖,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shunt,to shunt,分流,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sidestep,to sidestep,词,VERB,C1
-to sigh (verb),to sigh,词,VERB,B2
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to signal (verb),to signal,暗讯,VERB,B2
-to silence (verb),to silence,灭口,VERB,B2
-to singe,to singe,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to situate,to situate,定位,VERB,B2
-to skein,to skein,绕成线团,VERB,B2
-to skewer,to skewer,串起,VERB,B2
-to ski,to ski,滑雪,VERB,B2
-to skip,to skip,跳过,VERB,B2
-to slay,to slay,词,VERB,C1
-to slide,to slide,滑动,VERB,B2
-to slight (verb),to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to slope down,to slope down,词,VERB,B2
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to sneak away,to sneak away,溜走,VERB,B2
-to sniff,to sniff,嗅,VERB,B2
-to snoop,to snoop,窥探,VERB,B2
-to snort (verb),to snort,词,VERB,B2
-to snub,to snub,冷落,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solder,to solder,焊接,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort out,to sort out,词,VERB,B2
-to sound (verb),to sound,响,VERB,B2
-to sour (verb),to sour,词,VERB,C1
-to spam,to spam,发垃圾信息,VERB,B2
-to sparkle,to sparkle,闪耀,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to specialize,to specialize,专攻,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spell,to spell,拼写,VERB,B2
-to spend time,to spend time,词,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spill,to spill,溢出,VERB,B2
-to spirit away,to spirit away,变走,VERB,B2
-to splash,to splash,溅,VERB,B2
-to splint,to splint,用夹板固定,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to sponsor,to sponsor,赞助,VERB,B2
-to spray,to spray,喷洒,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to sprout,to sprout,发芽,VERB,B2
-to spy,to spy,监视,VERB,B2
-to squeak,to squeak,吱吱叫,VERB,B2
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stalk,to stalk,跟踪,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to standardize,to standardize,标准化,VERB,B2
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to state (verb),to state,陈述,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steal sword,to steal sword,偷剑,NOUN,B2
-to steam (verb),to steam,蒸煮,VERB,B2
-to steer control,to steer control,控制,VERB,B2
-to step (verb),to step,步,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stew (verb),to stew,炖煮,VERB,B2
-to stick out,to stick out,伸出,VERB,B2
-to stiffen,to stiffen,词,VERB,C1
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to straighten up,to straighten up,词,VERB,B2
-to strain (verb),to strain,词,VERB,B2
-to stratify,to stratify,分层,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to stride (verb),to stride,词,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive for,to strive for,争取,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stutter,to stutter,词,VERB,B2
-to stylize,to stylize,风格化,VERB,B2
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to subordinate,to subordinate,从属,VERB,B2
-to substantiate,to substantiate,证实,VERB,B2
-to succeed to pass,to succeed to pass,词,VERB,A2
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplement (verb),to supplement,补充,VERB,B2
-to supplicate,to supplicate,恳求,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surge (verb),to surge,词,VERB,B2
-to surname (verb),to surname,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture (verb),to suture,缝合,VERB,B2
-to swagger,to swagger,大摇大摆,VERB,B2
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to swing,to swing,荡秋千,VERB,B2
-to swipe,to swipe,词,VERB,C1
-to switch,to switch,切换,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to synchronize,to synchronize,词,VERB,C1
-to tag (verb),to tag,词,VERB,C1
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take amiss,to take amiss,词,VERB,C1
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,记录,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take one's time,to take one's time,词,VERB,B2
-to take out,to take out,拿出,VERB,B2
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to talk (verb),to talk,谈,VERB,B2
-to talk chat,to talk chat,聊天/谈论,VERB,B2
-to tarnish,to tarnish,词,VERB,C1
-to task (verb),to task,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to teach reading,to teach reading,词,VERB,B2
-to tear down,to tear down,拆除,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to tell to narrate,to tell to narrate,词,VERB,A2
-to temper (verb),to temper,词,VERB,B2
-to temporize,to temporize,拖延,VERB,B2
-to tense (verb),to tense,词,VERB,B2
-to text,to text,发短信,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,思考,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,认为,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrill,to thrill,使兴奋,VERB,B2
-to thrive,to thrive,茁壮成长,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrown,to thrown,扔,VERB,B2
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy,to tidy,整理,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
-to tip,to tip,透露,VERB,B2
-to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
-to toast (verb),to toast,词,VERB,B2
-to toil (verb),to toil,词,VERB,C1
-to topple,to topple,词,VERB,C1
-to torment,to torment,折磨,VERB,B2
-to total (verb),to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to touch (verb),to touch,摸,VERB,A1
-to tow,to tow,词,VERB,C1
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transport (verb),to transport,输送,VERB,B2
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trivialize,to trivialize,使平庸,VERB,B2
-to trouble (verb),to trouble,困扰,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tune,to tune,调谐,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to twinkle,to twinkle,词,VERB,B2
-to type,to type,打字,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbalance,to unbalance,词,VERB,C1
-to unbutton,to unbutton,解开纽扣,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to underline,to underline,强调,VERB,B2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to unearth,to unearth,发掘,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unplug,to unplug,词,VERB,C1
-to unravel,to unravel,解开,VERB,B2
-to unroll,to unroll,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to untangle,to untangle,词,VERB,C1
-to unwrap,to unwrap,词,VERB,B1
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to use up,to use up,用完,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to vacuum (verb),to vacuum,词,VERB,A2
-to validate,to validate,验证,VERB,B2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vary,to vary,改变,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to venerate,to venerate,崇敬,VERB,B2
-to vent,to vent,倾诉,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to vibrate,to vibrate,振动,VERB,B2
-to view,to view,参观,VERB,B2
-to vilify,to vilify,诽谤,VERB,B2
-to vote (verb),to vote,表决,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wane,to wane,减弱,VERB,B2
-to want (aux),to want,欲,AUX,A2
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch out,to watch out,小心,VERB,B2
-to watch tv,to watch tv,看电视,VERB,B2
-to wear down,to wear down,词,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to wed,to wed,词,VERB,C1
-to weed (verb),to weed,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whimper,to whimper,呜咽,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to wield,to wield,行使,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to wither,to wither,,VERB,B2
-to woo,to woo,词,VERB,B2
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn,to yearn,渴望,VERB,B2
-to zero out,to zero out,清零,VERB,B2
-toast,toast,你敬酒,NOUN,B2
-tobacco,tobacco,烟草,NOUN,B2
-today (noun),today,今,NOUN,B2
-today's,today's,词,ADJ,C1
-tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-tofu séché,dried tofu,豆干,NOUN,B2
-together,together,共同的,ADJ,B2
-togetherness,togetherness,词,NOUN,C1
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toilettes,toilet,厕所,NOUN,B2
-toiling,toiling,词,ADJ,C1
-told instructed,told instructed,被告知的,ADJ,B2
-tolerant,tolerant,宽容的,ADJ,B2
-tomb monument,tomb monument,墓碑,NOUN,B2
-tombe,grave,坟墓,NOUN,B2
-tomber,to drop,掉落,VERB,B2
-tomber malade,to fall ill,患病,VERB,B2
-tombstone,tombstone,词,NOUN,C1
-tome,tome,词,NOUN,C1
-tomorrow (noun),tomorrow,明天,NOUN,B2
-tomorrow night,tomorrow night,明晚,ADV,B2
-ton,tone,语气,NOUN,B2
-tonality,tonality,词,NOUN,C1
-tonic (noun),tonic,词,NOUN,C1
-tonight,tonight,今晚,ADV,B2
-tonsil,tonsil,词,NOUN,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
-toothbrush,toothbrush,牙刷,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
-top,top,顶部的,ADJ,B2
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-topographical,topographical,词,ADJ,C1
-tordu,crooked,弯曲的,ADJ,B2
-torment (noun),torment,词,NOUN,C1
-tormentor,tormentor,词,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torque,torque,词,NOUN,C1
-torrent,torrent,激流,NOUN,B2
-torrid,torrid,词,ADJ,C1
-torsion,torsion,扭转,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-tortue,turtle,海龟,NOUN,B2
-tortuous,tortuous,词,ADJ,C1
-torture,torture,酷刑,NOUN,B2
-toss,toss,词,VERB,B2
-total,total,完全的,ADJ,B2
-total (noun),total,都加,NOUN,A2
-totalitarianism,totalitarianism,词,NOUN,C1
-totem,totem,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
-touchabilité,touchability,能触摸,NOUN,B2
-toucher,touch,接触,NOUN,B2
-touching,touching,动人的,ADJ,B2
-touchstone,touchstone,词,NOUN,C1
-tough guy,tough guy,硬汉,NOUN,B2
-toujours,ever,曾经,ADV,B2
-toujours,to ever,里何尝,VERB,B2
-tour,turn,转弯,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
-tourist,tourist,旅游的,ADJ,B2
-touriste,tourist,游客,NOUN,B2
-tourne-disque,record player,唱机,NOUN,B2
-tout,whole,整个的,ADJ,B2
-tout,all,全部,ADV,B2
-tout,everything,一切,PRON,B2
-tout,tout,词,VERB,C1
-toute la journée,all day long,一整天,NOUN,B2
-towards,towards,迎向,ADV,B2
-towering,towering,词,ADJ,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
-township head,township head,乡长,NOUN,B2
-township road,township road,乡道,NOUN,B2
-toxicity,toxicity,词,NOUN,C1
-toxin,toxin,词,NOUN,C1
-toxique,poisonous,有毒的,ADJ,B2
-toys,toys,玩具,NOUN,B2
-trace,trace,痕迹,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracking,tracking,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
-trade (verb),trade,词,VERB,A2
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
-tradition,tradition,传统,NOUN,B2
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditions,traditions,词,NOUN,B1
-traduce,traduce,词,VERB,C1
-traffic light,traffic light,红绿灯,NOUN,B2
-traffic restriction,traffic restriction,限行,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-tragically,tragically,悲剧地,ADV,B2
-tragicness,tragicness,词,NOUN,C1
-trail,trail,词,NOUN,B1
-train,train,火车,NOUN,B2
-train of thought,train of thought,思路,NOUN,B2
-train ride,train ride,词,NOUN,A1
-train station,train station,火车站,NOUN,B2
-train ticket,train ticket,词,NOUN,A1
-trained,trained,词,ADJ,C1
-trainee,trainee,实习生,NOUN,B2
-trainer,trainer,教练,NOUN,B2
-trainer bastard,trainer bastard,,NOUN,B2
-training center,training center,培训中心,NOUN,C1
-trait,trait,特征,NOUN,B2
-traiter,to deal with,处理,VERB,B2
-traits qualities,traits qualities,词,NOUN,C1
-tram,tram,有轨电车,NOUN,B2
-trample,to trample,踩踏,VERB,B2
-tranquil,tranquil,宁静的,ADJ,B2
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-decision,trans-decision,超断,NOUN,B2
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-guest,trans-guest,超客,NOUN,B2
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-matter,trans-matter,超物,NOUN,B2
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transaction,transaction,交易,NOUN,B2
-transcend,transcend,词,VERB,C1
-transcendent,transcendent,卓越的,ADJ,B2
-transcendental,transcendental,先验的,ADJ,B2
-transcript,transcript,词,NOUN,C1
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
-transfix,transfix,词,VERB,C1
-transformation,transformation,تحول,NOUN,B2
-transformer converter,transformer converter,词,NOUN,C1
-transgression,transgression,违犯,NOUN,B2
-transhumance,transhumance,词,NOUN,B2
-transient,transient,词,ADJ,C1
-transistor,transistor,词,NOUN,C1
-transit,transit,运输,NOUN,C1
-transition,transition,过渡,NOUN,B2
-transitivity,transitivity,及物性,NOUN,C1
-transitory,transitory,词,ADJ,C1
-translation,translation,翻译,NOUN,B2
-translatology,translatology,词,NOUN,C1
-translucent,translucent,词,ADJ,C1
-transmettre,to convey,传达,VERB,B2
-transmettre,to impart,传授,VERB,B2
-transmettre,to pass on,转交,VERB,B2
-transmission,transmission,传输,NOUN,B2
-transmission to you,transmission to you,传你,NOUN,B2
-transmitter,transmitter,发射台,NOUN,B2
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
-transparent,transparent,透明的,ADJ,B2
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport,transport,运输,NOUN,B2
-transport,to transport,运输,VERB,B2
-transport (adj),transport,词,ADJ,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transpose,transpose,词,VERB,C1
-transregional,transregional,词,ADJ,C1
-trapped,trapped,词,ADJ,A2
-trapping,trapping,词,NOUN,C1
-trash,trash,垃圾,NOUN,B2
-trash bag,trash bag,垃圾袋,NOUN,B2
-travail,labor,劳动,NOUN,B2
-travail,travail,词,NOUN,C1
-travail lourd,heavy work,重功,NOUN,B2
-travailleur,hardworking,勤奋的,ADJ,B2
-travaux administratifs,paperwork,文书工作,NOUN,B2
-travel,to travel,旅行,VERB,B2
-travel fatigue,travel fatigue,车马劳顿,NOUN,B2
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
-traveler,traveler,旅行家,NOUN,B2
-traverser,to go through,经历,VERB,B2
-travesty,travesty,词,NOUN,C1
-treacherous,treacherous,背叛的,ADJ,B2
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherousness,treacherousness,阴险,NOUN,B2
-tread,to tread,踏上,VERB,B2
-treason,treason,叛国罪,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
-treat guests,to treat guests,请客,VERB,B2
-treatise,treatise,词,NOUN,C1
-treaty,treaty,条约,NOUN,B2
-trek (noun),trek,词,NOUN,C1
-tremendous,tremendous,词,ADJ,B2
-tremulous,tremulous,颤抖的,ADJ,B2
-trench coat,trench coat,词,NOUN,C1
-trenchant,trenchant,词,ADJ,C1
-trending,trending,词,ADJ,C1
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-trial,trial,试验,NOUN,B2
-trial run,trial run,词,NOUN,B2
-triangle,triangle,三角形,NOUN,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tricky,tricky,词,ADJ,B2
-trifling,trifling,微不足道的,ADJ,B2
-trigger (adj),trigger,词,ADJ,C1
-trigger imprint,trigger imprint,印记,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-trigonometry,trigonometry,词,NOUN,C1
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trim,trim,词,VERB,C1
-trimestre,quarter of a year,季度,NOUN,B2
-tringle à rideau,curtain rod,窗帘杆,NOUN,B2
-trinket,trinket,小饰品,NOUN,B2
-triple,triple,三倍的,ADJ,B2
-trite,trite,陈腐的,ADJ,B2
-triumph,triumph,胜利,NOUN,B2
-trivia,trivia,词,NOUN,C1
-trivializable,trivializable,可轻描淡写的,ADJ,B2
-trocar,trocar,词,NOUN,C1
-troglodyte,troglodyte,词,NOUN,C1
-tromper,to trick,欺骗,VERB,B2
-trompeur,deceitful,欺诈的,ADJ,B2
-troop dispatch,troop dispatch,出兵,NOUN,B2
-trop,too,太,ADV,B2
-tropic,tropic,词,NOUN,C1
-tropical,tropical,热带的,ADJ,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
-troubler,trouble,麻烦,NOUN,B2
-troubler,to trouble,有劳,VERB,B2
-troubling,troubling,令人担忧的,ADJ,B2
-troupe,troop,部队,NOUN,B2
-troupe,troupe,剧团,NOUN,B2
-troupeau,flock,兽群,NOUN,B2
-troupes,troops,部队,NOUN,B2
-trowel,trowel,词,NOUN,B2
-truculent,truculent,词,ADJ,C1
-true qi,true qi,真气,NOUN,C1
-truly,truly,确实,ADV,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trust in God,trust in God,词,NOUN,C1
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
-try out,try out,词,VERB,C1
-tsunami,tsunami,海啸,NOUN,C1
-tube,tube,أنبوب,NOUN,B2
-tug,tug,词,VERB,C1
-tumoral,tumoral,词,ADJ,C1
-tumult,tumult,词,NOUN,C1
-tumulte,uproar,骚动,NOUN,B2
-tumultuous,tumultuous,词,ADJ,C1
-tuning,tuning,词,NOUN,C1
-tunnel,tunnel,隧道,NOUN,B2
-turban,turban,词,NOUN,B2
-turbid,turbid,词,ADJ,C1
-turbine,turbine,词,NOUN,C1
-turbulence,turbulence,词,NOUN,C1
-turbulent,turbulent,动荡的,ADJ,B2
-turgid,turgid,词,ADJ,C1
-turmeric,turmeric,词,NOUN,B2
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
-turnoff,turnoff,词,NOUN,B2
-turntable,turntable,,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
-tutelary,tutelary,词,ADJ,C1
-tutelle,tutelage,监护,NOUN,B2
-tutor,tutor,导师,NOUN,C1
-tutorat,tutoring,补习,NOUN,B2
-tweezers,tweezers,词,NOUN,C1
-twenty-five,twenty-five,词,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
-twitching,twitching,抽搐的,ADJ,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
-two-headed,two-headed,双头的,ADJ,B2
-twofold,twofold,双重的,ADJ,B2
-tycoon,tycoon,词,NOUN,C1
-type,type,类型,NOUN,B2
-type like,type like,类型/比如,NOUN,B2
-type lourd,heavy type,重型,NOUN,B2
-typhon,typhoon,台风,NOUN,B2
-typographical,typographical,排版的,ADJ,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
-tyrannie,tyranny,暴政,NOUN,B2
-télescope,telescope,望远镜,NOUN,B2
-télécharger,to download,下载,VERB,B2
-téléphoner,phone,电话,NOUN,B2
-téléphoner,to phone,打电话,VERB,B2
-téléverser,to upload,上传,VERB,B2
-télévision,television,电视,NOUN,B2
-témoignage,witness testimony,人证,NOUN,B2
-témoigner,to witness,目击,VERB,B2
-témoin,eyewitness,目击,NOUN,B2
-ubiquitous,ubiquitous,词,ADJ,C1
-ukrainian,ukrainian,乌克兰的,ADJ,B2
-ulcération,ulceration,溃疡,NOUN,B2
-ulterior,ulterior,词,ADJ,C1
-ultimate,ultimate,最终的,ADJ,B2
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
-um,um,嗯,INTJ,B2
-umbrage,umbrage,词,NOUN,C1
-un peu,a little,一点,ADJ,B2
-un peu,a bit,一点,ADV,B2
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unanimity,unanimity,词,NOUN,C1
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
-unbelieving,unbelieving,词,ADJ,C1
-unbridled,unbridled,肆无忌惮的,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
-unconquerable,unconquerable,词,ADJ,C1
-unconscious (noun),unconscious,词,NOUN,C1
-unconsciousness,unconsciousness,词,NOUN,C1
-uncountable,uncountable,词,ADJ,C1
-uncouth,uncouth,粗俗的,ADJ,B2
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,不加批判的,ADJ,B2
-unctuous,unctuous,谄媚的,ADJ,B2
-uncultivated,uncultivated,词,ADJ,B2
-undaunted,undaunted,词,ADJ,C1
-undead,undead,词,NOUN,C1
-under below,under below,在...下方,ADP,A2
-under the,under the,词,ADP,B2
-underclass,underclass,底层,NOUN,B2
-undercover agent,undercover agent,卧底,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underling,underling,词,NOUN,C1
-undermining authority,undermining authority,削弱权威,NOUN,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-understanding,understanding,体贴的,ADJ,B2
-understood,understood,词,ADJ,A1
-undervaluing,undervaluing,词,NOUN,C1
-underwater,underwater,词,ADJ,B2
-underworld,underworld,地下世界,NOUN,B2
-undeserved,undeserved,词,ADJ,C1
-undisturbed,undisturbed,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undoubtedly,undoubtedly,无疑地,ADV,B2
-undulate,undulate,词,VERB,C1
-unearned,unearned,浪得,NOUN,C1
-unending flow,unending flow,川流不息,ADJ,C1
-unequivocal,unequivocal,词,ADJ,C1
-unerring,unerring,词,ADJ,C1
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected event,unexpected event,变故,NOUN,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful,unfaithful,不忠的,ADJ,B2
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfettered,unfettered,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
-unfolding,unfolding,词,NOUN,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable,unforgivable,不可原谅的,ADJ,B2
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfounded,unfounded,词,ADJ,C1
-unfriendly,unfriendly,不友好的,ADJ,B2
-ungabe,ungabe,词,NOUN,C1
-ungainly,ungainly,笨拙的,ADJ,B2
-ungestaltung,ungestaltung,词,NOUN,C1
-ungodliness,ungodliness,词,NOUN,C1
-unhappiness,unhappiness,词,NOUN,C1
-unharmed,unharmed,未受伤的,ADJ,B2
-unhurried patience,unhurried patience,词,NOUN,C1
-unicité,uniqueness,独特,NOUN,B2
-unification,unification,统一,NOUN,B2
-unified examination,unified examination,统考,NOUN,B2
-unifier,to unify,统一,VERB,B2
-uniformity,uniformity,统一性,NOUN,B2
-unilateralism,unilateralism,词,NOUN,C1
-unimpeachable,unimpeachable,词,ADJ,C1
-unimpeded,unimpeded,词,ADJ,C1
-uninhabited,uninhabited,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
-unionist,unionist,词,ADJ,B2
-unique,unique,独特的,ADJ,B2
-unique (noun),unique,词,NOUN,B2
-unité,unit,单元,NOUN,B2
-universal total,universal total,词,ADJ,C1
-universalité,universality,普遍性,NOUN,B2
-universities,universities,大学,NOUN,B2
-university (adj),university,词,ADJ,C1
-university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
-university student,university student,大学生,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unknown,unknown,未知数,NOUN,B2
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
-unleashed,unleashed,词,ADJ,C1
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlocked,unlocked,词,NOUN,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unmitigated,unmitigated,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unnatural,unnatural,不自然的,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unobtrusive,unobtrusive,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
-unprecedented,unprecedented,史无前例的,ADJ,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpunished,unpunished,未受惩罚的,ADJ,B2
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreality,unreality,虚幻,NOUN,B2
-unreasonable,unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unreflective,unreflective,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
-unrichtung,unrichtung,词,NOUN,C1
-unsafe,unsafe,词,ADJ,B1
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unsecured,unsecured,,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unseen realities,unseen realities,词,NOUN,C1
-unsetzung,unsetzung,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsociable,unsociable,词,ADJ,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsprache,unsprache,词,NOUN,C1
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsuccessful,unsuccessful,词,ADJ,C1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untenable,untenable,词,ADJ,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-untidiness,untidiness,凌乱,NOUN,B2
-untidy,untidy,词,ADJ,C1
-until to,until to,词,ADP,A2
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untreibung,untreibung,词,NOUN,B2
-unviable,unviable,词,ADJ,C1
-unwandel,unwandel,词,NOUN,B2
-unwanted,unwanted,不受欢迎的,ADJ,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwise,unwise,词,ADJ,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
-upbraid,upbraid,词,VERB,C1
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-uphold,uphold,词,VERB,C1
-upholding of rights,upholding of rights,词,NOUN,C1
-upload (noun),upload,词,NOUN,C1
-upper class,upper class,上层,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-upright,upright,直立地,ADV,B2
-uprightness,uprightness,词,NOUN,B2
-uprooted,uprooted,词,ADJ,C1
-ups and downs,ups and downs,词,NOUN,B2
-upset,upset,心烦的,ADJ,B2
-upshot,upshot,词,NOUN,C1
-upstart,upstart,暴发户,NOUN,B2
-upstart (adj),upstart,词,ADJ,C1
-upward,upward,向上,ADV,B2
-upwards,upwards,向上,ADV,B2
-urbane,urbane,词,ADJ,C1
-urbanism,urbanism,词,NOUN,B2
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
-urgence,urgency,紧急,NOUN,B2
-urgent,urgent,紧急的,ADJ,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,B2
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
-us,us,我们,PRON,B2
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
-usb flash drive,usb flash drive,U盘,NOUN,B2
-used,used,词,ADJ,C1
-usefulness avail,usefulness avail,效用,NOUN,C1
-uselessly,uselessly,词,ADV,C1
-using this,using this,用这,NOUN,C1
-usual thing,usual thing,惯例,NOUN,B2
-usurpation,usurpation,词,NOUN,C1
-usury,usury,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
-utilisation,utilization,利用,NOUN,B2
-utiliser,to utilize,利用,VERB,B2
-utiliser des baguettes,to use chopsticks,动筷,VERB,B2
-utiliser des béquilles,to use crutches,拄拐,VERB,B2
-utility,utility,效用,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
-utmost extreme end,utmost extreme end,词,NOUN,C1
-utopie,utopia,乌托邦,NOUN,B2
-utopique,utopian,乌托邦式的,ADJ,B2
-utter,utter,词,ADJ,C1
-utterance-related,utterance-related,词,ADJ,C1
-vacances,holiday,假期,NOUN,B2
-vacances,vacation,假期,NOUN,B2
-vacant,vacant,空缺的,ADJ,B2
-vacant lot,vacant lot,空地,NOUN,C1
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccinal,vaccinal,词,ADJ,C1
-vaccination,vaccination,疫苗接种,NOUN,B2
-vache,cow,奶牛,NOUN,B2
-vacillate,vacillate,词,VERB,C1
-vacuous,vacuous,词,ADJ,C1
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vagabond,vagabond,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
-vagary,vagary,词,NOUN,C1
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vague,vague,含糊的,ADJ,B2
-vague de froid,cold wave,寒潮,NOUN,B2
-vagueness,vagueness,模糊,NOUN,C1
-vaillant,valiant,英勇的,ADJ,B2
-vain,vain,徒劳的,ADJ,B2
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vainglory,vainglory,词,NOUN,C1
-vaisseau spatial,spaceship,宇宙飞船,NOUN,B2
-vale of tears,vale of tears,词,NOUN,C1
-valedictory,valedictory,词,ADJ,C1
-valeur,value,价值,NOUN,B2
-valiance,valiance,骁勇,NOUN,C1
-valid,valid,有效的,ADJ,B2
-validité,validity,有效期,NOUN,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-valve,valve,词,NOUN,C1
-vampire,vampire,吸血鬼,NOUN,B2
-vanilla,vanilla,词,NOUN,C1
-vanishing,vanishing,词,NOUN,C1
-vaniteux,conceited,自负的,ADJ,B2
-vanité,vanity,虚荣,NOUN,B2
-vanner,to winnow,筛选,VERB,B2
-vanquish,vanquish,词,VERB,C1
-vantardise,boasting,夸耀,NOUN,B2
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
-variable,variable,变量,NOUN,B2
-variable (adj),variable,词,ADJ,C1
-variables,variables,词,NOUN,C1
-variance,variance,方差,NOUN,B2
-variant,variant,变体,NOUN,B2
-variation,variation,变化,NOUN,B2
-variegate,variegate,词,VERB,C1
-variété,variety,种类,NOUN,B2
-varnish,varnish,清漆,NOUN,B2
-varying,varying,词,ADJ,B2
-vase,vase,花瓶,NOUN,B2
-vassal,vassal,之臣,NOUN,C1
-vaste,vast,巨大的,ADJ,B2
-vastness,vastness,词,NOUN,B2
-vat,vat,增值税,NOUN,B2
-vault,vault,金库,NOUN,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunt,vaunt,词,VERB,C1
-vaunted,vaunted,词,ADJ,B2
-vector,vector,词,NOUN,C1
-veer,veer,词,VERB,C1
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehemence,vehemence,词,NOUN,C1
-vehement,vehement,激烈的,ADJ,B2
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiled,veiled,隐晦的,ADJ,B2
-veille,vigil,守夜,NOUN,B2
-veine,vein,静脉,NOUN,B2
-velarization,velarization,词,NOUN,C1
-vendeur,salesperson,销售人员,NOUN,B2
-vending machine,vending machine,自动售货机,NOUN,B2
-vendredi,friday,星期五,NOUN,B2
-veneer,veneer,词,NOUN,C1
-venereal disease,venereal disease,性病,NOUN,B2
-vengeance,vengeance,报复,NOUN,B2
-venger,to avenge,复仇,VERB,B2
-venial,venial,词,ADJ,C1
-venir,to come here,来到这里,VERB,B2
-venir,to not come,不来,VERB,B2
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-vente,sale,出售,NOUN,B2
-ventilateur,fan,粉丝,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-ventre,belly,肚子,NOUN,B2
-venture (noun),venture,词,NOUN,B2
-veracity,veracity,词,NOUN,C1
-verbal,verbal,言语的,ADJ,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbalize,verbalize,词,VERB,B2
-verbatim,verbatim,词,ADV,C1
-verbosité,verbosity,冗长,NOUN,B2
-verdant,verdant,词,ADJ,C1
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-verge,verge,词,NOUN,C1
-verger,orchard,果园,NOUN,B2
-vergestaltung,vergestaltung,词,NOUN,C1
-verifiable,verifiable,词,ADJ,C1
-verification,verification,词,NOUN,C1
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkunft,verkunft,词,NOUN,C1
-vermilion,vermilion,词,NOUN,B2
-vermine,vermin,害兽,NOUN,B2
-vernacular,vernacular,词,NOUN,C1
-vernahme,vernahme,词,NOUN,C1
-vernal,vernal,春季的,ADJ,B2
-vernier,vernier,词,NOUN,C1
-verpflegung,verpflegung,词,NOUN,C1
-verre,glass,玻璃,NOUN,B2
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
-verrouiller,to lock,锁上,VERB,B2
-vers,toward,朝向,ADP,B2
-vers,towards,朝向,ADP,B2
-vers le bas,downwards,向下,ADV,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verse,verse,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versement,installment,分期付款,NOUN,B2
-verser,to pour,倾倒,VERB,B2
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versification,versification,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-version,version,版本,NOUN,B2
-versprache,versprache,词,NOUN,C1
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-versus,versus,对,ADP,B2
-versé,versed,精通的,ADJ,B2
-vert,green,绿色的,ADJ,B2
-vertebra,vertebra,词,NOUN,B2
-verteilung,verteilung,词,NOUN,C1
-vertex,vertex,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
-vertical,vertical,垂直的,ADJ,B2
-vertige,dizziness,眩晕,NOUN,B2
-vertigo,vertigo,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertreibung,vertreibung,词,NOUN,C1
-vertu,virtue,美德,NOUN,B2
-verwandel,verwandel,词,NOUN,C1
-verweisung,verweisung,词,NOUN,C1
-verwirkung,verwirkung,词,NOUN,C1
-very best,very best,最好的,ADJ,B2
-very deep,very deep,很深,ADJ,B2
-very fine,very fine,极细的,ADJ,B2
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-vessel,vessel,船,NOUN,B2
-vestiaire,cloakroom,衣帽间,NOUN,B2
-vestiaire,locker room,更衣室,NOUN,B2
-vestige,vestige,词,NOUN,C1
-vestige culturel,cultural relic,文物,NOUN,B2
-veterinarian,veterinarian,词,NOUN,C1
-veto,veto,否决,NOUN,B2
-veuve,widow,寡妇,NOUN,B2
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-viable,viable,可行的,ADJ,B2
-vibrant,vibrant,词,ADJ,C1
-vibration,vibration,振动,NOUN,B2
-vicarious,vicarious,词,ADJ,C1
-vice,vice,恶习,NOUN,B2
-vice versa,vice versa,反之亦然,ADV,B2
-vice versa (adj),vice versa,词,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
-vicious,vicious,词,ADJ,B2
-vicissitude,vicissitude,变迁,NOUN,B2
-victime,victim,受害者,NOUN,B2
-victoire,victory,胜利,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-vide,empty,空的,ADJ,B2
-vide,emptiness,空虚,NOUN,B2
-video clip,video clip,视频片段,NOUN,B2
-video on demand,video on demand,点播,NOUN,C1
-videotape,videotape,词,NOUN,C1
-vidéo,video,视频,NOUN,B2
-vidéodisque,video disc,影碟,NOUN,B2
-vie,life,生命,NOUN,B2
-vie et mort,life and death,生死,NOUN,B2
-vie ou mort,life-and-death,决生,NOUN,B2
-vierge,virgin,处女,NOUN,B2
-viewer,viewer,观众,NOUN,B2
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigie,lookout,瞭望,NOUN,B2
-vigilance,vigilance,警惕,NOUN,B2
-vigilant,vigilant,警惕的,ADJ,B2
-vigne,vine,藤蔓,NOUN,B2
-vignette,vignette,词,NOUN,C1
-vigor of prime,vigor of prime,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
-vigueur,vigor,活力,NOUN,B2
-vil,vile,卑鄙的,ADJ,B2
-vile,vile,可憎地,ADV,B2
-villa,villa,别墅,NOUN,B2
-village,village,村庄,NOUN,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-vin,wine,葡萄酒,NOUN,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vineyard,vineyard,葡萄园,NOUN,C1
-vingt,twenty,二十,NUM,B2
-violate regulations,violate regulations,违规,VERB,C1
-violation,violation,侵越,NOUN,B2
-violations,violations,词,NOUN,C1
-violence,violence,暴力,NOUN,B2
-violent,violent,暴力的,ADJ,B2
-violent act,violent act,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violer,to violate,违反,VERB,B2
-violet (adj),violet,词,ADJ,C1
-violet (noun),violet,词,NOUN,B2
-violon,violin,小提琴,NOUN,B2
-viper,viper,词,NOUN,B2
-viral,viral,病毒性的,ADJ,C1
-virginal,virginal,处女的,ADJ,B2
-virgule,fraction marker,分之,PART,B2
-virtual reality,virtual reality,虚拟现实,NOUN,B2
-virtuel,virtual,虚拟的,ADJ,B2
-virtuellement,virtually,几乎,ADV,B2
-virtuoso,virtuoso,词,NOUN,C1
-virtuous,virtuous,有德行的,ADJ,B2
-virulent,virulent,恶性的,ADJ,B2
-virus,virus,病毒,NOUN,B2
-visa,visa,签证,NOUN,B2
-visage,face,脸,NOUN,B2
-viscosity,viscosity,词,NOUN,C1
-viscount,viscount,词,NOUN,C1
-viser,aim,目标,NOUN,B2
-viser,to aim,瞄准,VERB,B2
-visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
-vision,vision,远见,NOUN,B2
-vision du monde,worldview,世界观,NOUN,B2
-visionary,visionary,词,NOUN,C1
-visit (noun),visit,去看,NOUN,A2
-visiter,visit,拜访,NOUN,B2
-visiter,to visit,参观,VERB,B2
-visiteur,visitor,访客,NOUN,B2
-visiting ban,visiting ban,,NOUN,B2
-visor,visor,词,NOUN,B2
-visqueux,viscous,黏稠的,ADJ,B2
-visualize,visualize,词,VERB,C1
-visuel,visual,视觉的,ADJ,B2
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vitamine,vitamin,维生素,NOUN,B2
-vitiate,vitiate,词,VERB,C1
-vitre,window glass,窗玻璃,NOUN,B2
-vitriolic,vitriolic,词,ADJ,C1
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
-vivant,alive,活着的,ADJ,B2
-vive,long live,万岁,INTJ,B2
-vivid,vivid,生动的,ADJ,B2
-vocabulary,vocabulary,词,NOUN,C1
-vocal,vocal,直言的,ADJ,B2
-vocalization,vocalization,词,NOUN,C1
-vocation,calling,使命,NOUN,B2
-vocation,vocation,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vociferous,vociferous,词,ADJ,C1
-vodka,vodka,词,NOUN,C1
-vogue,vogue,流行,NOUN,B2
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-voicing,voicing,词,NOUN,C1
-void,void,最无,NOUN,B2
-voie,lane,小巷,NOUN,B2
-voile,sailing,航行,NOUN,B2
-voir un cadavre,to see corpse,见尸,VERB,B2
-voir à travers,to see through,看穿,VERB,B2
-voisin,neighboring,邻近的,ADJ,B2
-voisin,next door,隔壁,NOUN,B2
-voiture de sport,sports car,跑车,NOUN,B2
-voix,voice,声音,NOUN,B2
-vol,flight,航班,NOUN,B2
-vol,robbery,抢劫案,NOUN,B2
-vol,theft,盗窃,NOUN,B2
-volaille,poultry,家禽,NOUN,B2
-volatil,volatile,易变的,ADJ,B2
-volatility,volatility,词,NOUN,C1
-volcan,volcano,火山,NOUN,B2
-volcanic,volcanic,词,ADJ,C1
-voler,to rob,抢劫,VERB,B2
-voler,to steal,偷,VERB,B2
-voleur,robber,强盗,NOUN,B2
-volition,volition,词,NOUN,C1
-volleyball,volleyball,排球,NOUN,B2
-volontaire,voluntary,自愿的,ADJ,B2
-volontaire,willful,任性的,ADJ,B2
-volonté,willingness,乐意,NOUN,B2
-voltage,voltage,词,NOUN,C1
-voltiger,to flutter,飘动,VERB,B2
-voluble,voluble,词,ADJ,C1
-volume,measure word for books,本,NUM,B2
-volume measure,volume measure,词,NOUN,B2
-volumetric,volumetric,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-voluntarily,voluntarily,自愿地,ADV,B2
-voluntariness,voluntariness,词,NOUN,C1
-voluntarist,voluntarist,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-vomir,to vomit,呕吐,VERB,B2
-vomit (noun),vomit,词,NOUN,B2
-vomiting,vomiting,词,NOUN,C1
-voracious,voracious,词,ADJ,C1
-voracity,voracity,词,NOUN,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorkunft,vorkunft,词,NOUN,C1
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortex,vortex,漩涡,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-votant,voter,选民,NOUN,B2
-votary,votary,词,NOUN,C1
-vote,voting,投票,NOUN,B2
-voter,vote,投票,NOUN,B2
-voter,to vote,表决,VERB,B2
-votive offering,votive offering,词,NOUN,C1
-vouch,vouch,词,VERB,C1
-vouchsafe,vouchsafe,词,VERB,C1
-vouloir,want,想,AUX,B2
-vouloir,will,将要,AUX,B2
-vouloir,willing,肯,AUX,B2
-vouloir,to want to need will,要,VERB,B2
-voulu,wanted,故意的,ADJ,B2
-vowel,vowel,词,NOUN,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-voyage,trip,旅行,NOUN,B2
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vrac,bulk,主体,NOUN,B2
-vrai,true,真实的,ADJ,B2
-vrai cœur,true heart,本心,NOUN,B2
-vraie concession,true concession,真让,NOUN,B2
-vraie forme,true form,原形,NOUN,B2
-vraiment,really,真正地,ADV,B2
-vs,vs,与...相对,ADP,B2
-vue,sight,视力,NOUN,B2
-vue,view,观点,NOUN,B2
-vue nocturne,night view,夜景,NOUN,B2
-vulgaire,vulgar,粗俗的,ADJ,B2
-vulgarité,vulgarity,粗俗,NOUN,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulnerable,vulnerable,易受伤害的,ADJ,B2
-vulture,vulture,词,NOUN,B2
-véhicule,vehicle,车辆,NOUN,B2
-vénérable,venerable,值得尊敬的,ADJ,B2
-vénération,veneration,崇敬,NOUN,B2
-vénérer,to revere,尊敬,VERB,B2
-vérifier,to verify,核实,VERB,B2
-vérité,truth,真相,NOUN,B2
-vétéran,veteran,老手,NOUN,B2
-vêtements,clothes,衣服,NOUN,B2
-vœu,vow,誓言,NOUN,B2
-wading,wading,词,NOUN,B2
-waft,waft,词,VERB,C1
-wage earner,wage earner,词,NOUN,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage murder unit,wage murder unit,词,NOUN,B2
-wager,wager,词,NOUN,C1
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wailing,wailing,词,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waive,waive,词,VERB,C1
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
-wan,wan,词,ADJ,B2
-wanderer,wanderer,词,NOUN,C1
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
-want (adp),want,我要,ADP,A2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warble (verb),warble,词,VERB,C1
-warehouse store,warehouse store,词,NOUN,B1
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,更暖的,ADJ,B2
-warmonger,warmonger,词,NOUN,C1
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrant,warrant,令状,NOUN,B2
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wary,wary,谨慎的,ADJ,B2
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-washer,washer,词,NOUN,B2
-waste of time,waste of time,浪费时间,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wastewater,wastewater,废水,NOUN,C1
-watch of the night,watch of the night,词,NOUN,C1
-watch over,watch over,词,VERB,C1
-watched,watched,词,NOUN,B2
-watchtower,watchtower,词,NOUN,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water garment,water garment,水衣,NOUN,C1
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-watercourse,watercourse,河道,NOUN,B1
-watering,watering,词,NOUN,B2
-waterproof (verb),waterproof,词,VERB,C1
-watershed,watershed,词,NOUN,C1
-waterskin,waterskin,词,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-wax,wax,蜡,NOUN,B2
-waxen,waxen,词,ADJ,C1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
-waylay,waylay,词,VERB,C1
-we two (noun),we two,们俩,NOUN,C1
-weak point,weak point,弱点,NOUN,C1
-weakened,weakened,词,ADJ,C1
-weal,weal,词,NOUN,C1
-wealthy,wealthy,富有的,ADJ,B2
-wealthy nation,wealthy nation,富国,NOUN,C1
-weapon arms,weapon arms,词,NOUN,A1
-wear tear,wear tear,词,NOUN,C1
-wearily,wearily,词,ADV,C1
-wearisome,wearisome,词,ADJ,C1
-weary,weary,疲倦的,ADJ,B2
-weather institute,weather institute,词,NOUN,B2
-weathering,weathering,词,NOUN,C1
-weaver,weaver,词,NOUN,B1
-webcam,webcam,网络摄像头,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
-week-end,weekend,周末,NOUN,B2
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weeping,weeping,痛哭,NOUN,C1
-weighing,weighing,词,NOUN,B2
-weightlifting,weightlifting,举重,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
-welcome (intj),welcome,词,INTJ,A1
-welcome committee,welcome committee,,NOUN,B2
-weld,weld,词,VERB,C1
-welder,welder,词,NOUN,C1
-welfare home,welfare home,福利院,NOUN,C1
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
-well-crafted,well-crafted,词,ADJ,B2
-well-disposed,well-disposed,善意的,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-liked,well-liked,词,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welter,welter,词,NOUN,C1
-wend,wend,词,VERB,C1
-werewolf,werewolf,狼人,NOUN,B2
-westerner,westerner,词,NOUN,B2
-westward,westward,向西,ADV,B2
-westward (noun),westward,往西,NOUN,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wharf,wharf,码头,NOUN,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
-when (adp),when,之时,ADP,B2
-when (adv),when,何时,ADV,A1
-when than,when than,词,SCONJ,A2
-when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (cconj),whereas,词,CCONJ,B2
-whereas (sconj),whereas,词,SCONJ,C1
-whereas since,whereas since,词,SCONJ,A2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whet,whet,词,VERB,C1
-whether,whether,是否,SCONJ,B2
-whether (part),whether,词,PART,A1
-whey,whey,乳清,NOUN,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-while,while,当...时,SCONJ,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
-whiny,whiny,词,ADJ,C1
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
-whirring,whirring,词,NOUN,C1
-whisk,whisk,打蛋器,NOUN,B2
-whistleblower,whistleblower,词,NOUN,C1
-whistling,whistling,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whiting,whiting,词,NOUN,B2
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whole,whole,整体,NOUN,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-wholehearted,wholehearted,词,ADJ,C1
-wholesale (adv),wholesale,词,ADV,B1
-wholesome,wholesome,词,ADJ,C1
-whore,whore,妓女,NOUN,B2
-whose (det),whose,词,DET,B2
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wicked,wicked,邪恶的,ADJ,B2
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,加宽,NOUN,B2
-widower,widower,词,NOUN,C1
-widowhood,widowhood,词,NOUN,C1
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wild beast,wild beast,猛兽,NOUN,B2
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
-wilderness,wilderness,荒野,NOUN,B2
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will shall,will shall,将要/会,AUX,B2
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willow,willow,词,NOUN,B2
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-wimp,wimp,懦夫,NOUN,B2
-win,win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-winding,winding,蜿蜒的,ADJ,B2
-windless,windless,无风的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
-windowsill,windowsill,窗台,NOUN,C1
-windy,windy,有风的,ADJ,B2
-windy day,windy day,风天,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
-winsome,winsome,词,ADJ,C1
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wired,wired,词,ADJ,C1
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wistful,wistful,词,ADJ,C1
-wit,wit,词,NOUN,C1
-witch hunt,witch hunt,词,NOUN,C1
-with each other,with each other,词,ADV,A2
-with it,with it,在其中,ADV,B2
-with me,with me,词,PRON,A1
-with that,with that,以此,ADV,B2
-with the aim of,with the aim of,词,ADP,C1
-with this,with this,以此,ADV,B2
-with what,with what,用什么,ADV,B2
-with which,with which,词,PRON,A2
-with you,with you,词,PRON,A1
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without exception,without exception,无例外的,ADV,B2
-without further ado,without further ado,毫不犹豫地,ADV,B2
-withstand,withstand,词,VERB,C1
-witness examination,witness examination,证人询问,NOUN,B2
-witness female,witness female,词,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,词,NOUN,C1
-wittiness,wittiness,风趣,NOUN,B2
-witty saying,witty saying,词,NOUN,C1
-wizened,wizened,词,ADJ,C1
-woe (intj),woe,词,INTJ,B2
-woe (noun),woe,词,NOUN,C1
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wonder (noun),wonder,太妙,NOUN,C1
-wonderful,wonderful,极好地,ADV,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-wooded,wooded,树木茂盛的,ADJ,B2
-wooden,wooden,木制的,ADJ,B2
-woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
-word choice,word choice,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-workday,workday,词,NOUN,C1
-working,working,词,ADJ,C1
-working class,working class,工人阶级,NOUN,B2
-working day,working day,工作日,NOUN,B2
-working method,working method,工作方式,NOUN,B2
-workout,workout,词,NOUN,C1
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world champion,world champion,世界冠军,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldliness,worldliness,词,NOUN,C1
-worldly,worldly,世俗的,ADJ,B2
-worm,worm,虫,NOUN,B2
-wormwood,wormwood,词,NOUN,A2
-worn,worn,磨损的,ADJ,B2
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worse,worse,更糟的事,NOUN,B2
-worship,to worship,崇拜,VERB,B2
-worst,worst,最坏的,ADJ,B2
-worst (adv),worst,词,ADV,C1
-worst (noun),worst,词,NOUN,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-worth,worth,值得的,ADJ,B2
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthless,worthless,无价值的,ADJ,B2
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would,would,将要,AUX,B2
-would like,would like,词,AUX,A2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wound,to wound,使受伤,VERB,B2
-wounded,wounded,受伤的,ADJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
-wow,wow,哇,INTJ,B2
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wrapper,wrapper,词,NOUN,C1
-wrapping,wrapping,包装,NOUN,B2
-wrathful,wrathful,词,ADJ,C1
-wreck,wreck,残骸,NOUN,B2
-wreckage,wreckage,词,NOUN,C1
-wrench,wrench,词,NOUN,C1
-wrest,to wrest,强行夺取,VERB,B2
-wrestling,wrestling,摔跤,NOUN,B2
-wretch,wretch,令人厌恶的人,NOUN,B2
-wretched,wretched,词,ADJ,C1
-wretchedness,wretchedness,悲惨,NOUN,C1
-wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
-writ,writ,词,NOUN,C1
-writer,writer,作家,NOUN,B2
-writhe,writhe,词,VERB,C1
-written,written,书面的,ADJ,B2
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
-wrong,wrong,错误的,ADJ,B2
-wrong mistake,wrong mistake,错误,ADJ,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
-wudang,wudang,武当,NOUN,B2
-xenophobia,xenophobia,排外心理,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
-yard,yard,院子,NOUN,B2
-yarn,yarn,纱线,NOUN,B2
-yeah,yeah,词,INTJ,A1
-yeah yeah,yeah yeah,是是是,INTJ,B2
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
-yearn for,to yearn for,渴望,VERB,B2
-yearning,yearning,向往,NOUN,B2
-years,years,数年,NOUN,B2
-yeoman,yeoman,词,NOUN,C1
-yep,yep,是的,INTJ,B2
-yes,yes,是啊,NOUN,B2
-yes (adv),yes,词,ADV,A2
-yes (part),yes,是的,PART,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yes indeed (adv),yes indeed,词,ADV,B2
-yesterday,yesterday,بارحة,NOUN,B2
-yet,yet,还,ADV,B2
-yeux verts,green eyes,想碧眼,NOUN,B2
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yin pourpre,purple yin,紫阴,NOUN,B2
-yo,yo,哟,PART,B2
-yoga,yoga,瑜伽,NOUN,B2
-yoga practice,yoga practice,瑜伽练习,NOUN,B2
-yogurt,yogurt,酸奶,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you can,you can,您能,NOUN,B2
-you cannot live,you cannot live,你也活不,NOUN,B2
-you dative,you dative,词,PRON,A2
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you formal,you formal,您,PRON,B2
-you masculine,you masculine,词,PRON,A1
-you plural,you plural,你们,PRON,B2
-you polite,you polite,您,PRON,B2
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
-young man,young man,年轻人,NOUN,B2
-young master,young master,少庄主,NOUN,B2
-young person,young person,年轻人,NOUN,B2
-young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,最年轻的,ADJ,B2
-youngster,youngster,年少者,NOUN,B2
-your,your,你的,PRON,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
-your laugh,your laugh,你笑,NOUN,B2
-your majesty,your majesty,陛下,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your pl,your pl,你们的,DET,B2
-your plural,your plural,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,你的,PRON,B2
-yourself,yourself,你自己,PRON,B2
-youth,youth,青年,NOUN,B2
-youth culture,youth culture,词,NOUN,C1
-youth people,youth people,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful,youthful,词,ADJ,C1
-youthful vigor,youthful vigor,词,NOUN,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
-yuanxiao,yuanxiao,元宵,NOUN,B2
-yuck,yuck,呸,INTJ,B2
-zajal,zajal,词,NOUN,B2
-zany,zany,词,ADJ,C1
-zeal,zeal,热情,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zellige tiles,zellige tiles,词,NOUN,A2
-zen master,zen master,禅师,NOUN,B2
-zephyr,zephyr,词,NOUN,C1
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
-zero,zero,零,NOUN,B2
-zeroing,zeroing,词,NOUN,C1
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
-zinc,zinc,锌,NOUN,B2
-zombie,zombie,僵尸,NOUN,B2
-zone,zone,区域,NOUN,B2
-zone humide,wetland,湿地,NOUN,B2
-zongzi,zongzi,粽子,NOUN,B2
-zoo,zoo,动物园,NOUN,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zukunft,zukunft,词,NOUN,C1
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
-zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
-zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
-zénith,zenith,顶点,NOUN,B2
-zéro,zero,零,NUM,B2
-État ennemi,enemy state,敌国,NOUN,B2
-à,at,在,ADP,B2
-à,to,到,ADP,B2
-à cause de,because of,因为,ADP,B2
-à ce moment-là,at that time,当时/那时,ADV,B2
-à ce sujet,regarding this,对此,ADV,B2
-à contrecœur,reluctantly,不情愿地,ADV,B2
-à court terme,short-term,短期的,ADJ,B2
-à côté de,next to,在...旁边,ADP,B2
-à droite,right,右边,ADV,B2
-à grande échelle,large-scale,大规模的,ADJ,B2
-à l'aise,at ease,安心,ADJ,B2
-à l'instant,just now,刚刚,ADV,B2
-à l'origine,originally,最初,ADV,B2
-à la maison,at home,在家,ADV,B2
-à part,apart,分开,ADV,B2
-à propos de,about,关于,ADP,B2
-à temps,in time,及时地,ADV,B2
-à tout moment,at any time,随时,ADV,B2
-à venir,upcoming,مقبل,ADJ,B2
-âge,age,年龄,NOUN,B2
-âne,donkey,驴,NOUN,B2
-éblouissant,dazzling,耀眼的,ADJ,B2
-ébullition,boiling,沸腾,NOUN,B2
-échafaudage,scaffold,脚手架,NOUN,B2
-échange de poste,shift swap,换班,NOUN,B2
-échanger,exchange,交换,NOUN,B2
-échanger,to exchange,交换,VERB,B2
-échantillon,sample,样本,NOUN,B2
-échappée,ride break,骑破,NOUN,B2
-écharpe,scarf,围巾,NOUN,B2
-échec,falling though,虽坠,NOUN,B2
-échecs,chess,国际象棋,NOUN,B2
-échelle,ladder,梯子,NOUN,B2
-échelonné,phased,阶段性,ADJ,B2
-échu,overdue,逾期,ADJ,B2
-échéance,deadline,截止日期,NOUN,B2
-éclairer,to enlighten,启发,VERB,B2
-éclairé,enlightened,开明的,ADJ,B2
-éclat,luster,光泽,NOUN,B2
-école,school,学校,NOUN,B2
-écouter attentivement,to listen attentively,倾听,VERB,B2
-écrasement,smashing,砸过,NOUN,B2
-écraser,to smash,粉碎,VERB,B2
-écriture,handwriting,笔迹,NOUN,B2
-écureuil,squirrel,松鼠,NOUN,B2
-écurie,stable,稳定的,ADJ,B2
-éditeur,publisher,出版商,NOUN,B2
-éducation,upbringing,教养,NOUN,B2
-église,church,教堂,NOUN,B2
-égout,drain,排水沟,NOUN,B2
+fils aîné,eldest son,长子,NOUN,B2
 élection,election,选举,NOUN,B2
 électorat,electorate,选民,NOUN,B2
-électricité,electricity,电,NOUN,B2
 électrique,electric,电动的,ADJ,B2
+électricité,electricity,电,NOUN,B2
 électronique,electronic,电子的,ADJ,B2
-élevé,lofty,崇高的,ADJ,B2
-élimination,disposal,处理,NOUN,B2
-élimination,elimination,消除,NOUN,B2
-éliminer,to eliminate,消除,VERB,B2
-éloge,eulogy,赞辞,NOUN,B2
-éloigné,far,远的,ADJ,B2
-éloquent,eloquent,雄辩的,ADJ,B2
-élève,pupil,学生,NOUN,B2
+paiement électronique,electronic payment,电子支付,NOUN,B2
 élégant,elegant,优雅的,ADJ,B2
 élégie,elegy,挽歌,NOUN,B2
 élément,element,元素,NOUN,B2
 éléphant,elephant,大象,NOUN,B2
 élévation,elevation,提升,NOUN,B2
+ascenseur,elevator,电梯,NOUN,B2
+éliminer,to eliminate,消除,VERB,B2
+élimination,elimination,消除,NOUN,B2
+éloquent,eloquent,雄辩的,ADJ,B2
+courriel,email,电子邮件,NOUN,B2
 émanation,emanation,散发物,NOUN,B2
+détourner,to embezzle,贪污,VERB,B2
+étreinte,embrace,拥抱,NOUN,B2
+broder,to embroider,刺绣,VERB,B2
+broderie,embroidery,刺绣,NOUN,B2
 émergence,emergence,涌现,NOUN,B2
-émerveillement,amazement,惊愕,NOUN,B2
-émettre,issue,问题,NOUN,B2
-émettre,to issue,颁布,VERB,B2
-émeute,riot,骚乱,NOUN,B2
 émission,emission,排放,NOUN,B2
 émotion,emotion,情感,NOUN,B2
 émotivité,emotionality,感性/情绪化,NOUN,B2
-énergie,energy,能量,NOUN,B2
-énergie hydraulique,hydro energy,水能,NOUN,B2
+empathiser,to empathize,共情,VERB,B2
+empire,empire,帝国,NOUN,B2
+emploi,employment,就业,NOUN,B2
+habiliter,to empower,授权,VERB,B2
+vide,emptiness,空虚,NOUN,B2
+vide,empty,空的,ADJ,B2
+gloire vaine,empty fame,虚名,NOUN,B2
+permettre,to enable,使能够,VERB,B2
+promulguer,to enact,颁布,VERB,B2
+enchanter,to enchant,使着迷,VERB,B2
+rencontrer,encounter,相遇,NOUN,B2
+rencontrer,to encounter,遭遇,VERB,B2
+encyclopédique,encyclopedic,百科全书式的,ADJ,B2
+terminer,end,端,PART,B2
+terminer,to end,结束,VERB,B2
+se terminer,to end up,最终到达,VERB,B2
+mettre en danger,to endanger,危及,VERB,B2
+en danger,endangered,濒危的,ADJ,B2
+soutien,endorsement,背书,NOUN,B2
+endurance,endurance,坚忍,NOUN,B2
+ennemi,enemy must,仇必,NOUN,B2
+État ennemi,enemy state,敌国,NOUN,B2
 énergique,energetic,精力充沛的,ADJ,B2
-énigme,riddle,谜语,NOUN,B2
-énonciation,utterance,话语,NOUN,B2
-énorme,enormous,巨大的,ADJ,B2
+énergie,energy,能量,NOUN,B2
+appliquer,to enforce,执行,VERB,B2
+application,enforcement,执行,NOUN,B2
+engagé,engaged,订婚的,ADJ,B2
+anglais,english,英国的,ADJ,B2
+Anglais,englishman,英国人,NOUN,B2
+éclairer,to enlighten,启发,VERB,B2
+éclairé,enlightened,开明的,ADJ,B2
+illumination,enlightenment,澄清,NOUN,B2
 énormité,enormity,极恶,NOUN,B2
-éparpiller,to scatter,分散,VERB,B2
-éparpillé,scattered,分散的,ADJ,B2
-épaule,shoulder,肩膀,NOUN,B2
-éphémère,fleeting,短暂的,ADJ,B2
-épinard d'eau,water spinach,空心菜,NOUN,B2
-époustouflant,stunning,极好的,ADJ,B2
-épuisement,exhaustion,疲惫,NOUN,B2
-épuisé,exhausted,筋疲力尽的,ADJ,B2
-équipage,crew,全体船员,NOUN,B2
-équipe,team,团队,NOUN,B2
+énorme,enormous,巨大的,ADJ,B2
+assez,enough,足够的,ADJ,B2
+inscription,enrollment,注册,NOUN,B2
+entrer en ville,to enter city,进城,VERB,B2
+entreprise,enterprise,企业,NOUN,B2
+centre de divertissement,entertainment center,娱乐中心,NOUN,B2
+intrônisation,enthronement,登基,NOUN,B2
+enthousiaste,enthusiast,爱好者,NOUN,B2
+entourage,entourage,随从,NOUN,B2
+s'entrencher,to entrench,巩固,VERB,B2
+entry,entry,入口,NOUN,B2
+enunciation,enunciation,发音,NOUN,B2
+envious,envious,嫉妒的,ADJ,B2
+environmental protection,environmental protection,环境保护,NOUN,B2
+environmental report,environmental report,环境报告,NOUN,B2
+envision,to envision,展望,VERB,B2
+envy,envy,嫉妒,NOUN,B2
+envy,to envy,羡慕,VERB,B2
+enzyme,enzyme,酶,NOUN,B2
+epic,epic,史诗,NOUN,B2
+epicurean,epicurean,享乐主义的,ADJ,B2
+epidemic,epidemic,流行病,NOUN,B2
+episode,episode,集,NOUN,B2
+epistemology,epistemology,认识论,NOUN,B2
+epitome,epitome,化身,NOUN,B2
+equal,equal,相等的,ADJ,B2
+equality,equality,平等,NOUN,B2
+equation,equation,方程,NOUN,B2
+equestrianism,equestrianism,马术,NOUN,B2
+equilibrium,equilibrium,平衡,NOUN,B2
+equipment,equipment,设备,NOUN,B2
+equipped,equipped,配备的,ADJ,B2
+equivalent,equivalent,等价物,NOUN,B2
+era,era,时代,NOUN,B2
+eradicate,to eradicate,根除,VERB,B2
+eradication,eradication,根除,NOUN,B2
+erect,to erect,建立,VERB,B2
+erhu,erhu,二胡,NOUN,B2
+erosion,erosion,侵蚀,NOUN,B2
+err,to err,犯错,VERB,B2
+errand,errand,差事,NOUN,B2
+errata,errata,勘误,NOUN,B2
+escalate,to escalate,升级,VERB,B2
+escalator,escalator,自动扶梯,NOUN,B2
+escorter,escort,护卫,NOUN,B2
+escorter,to escort,护送,VERB,B2
+garde d'escorte,escort guard,镖师,NOUN,B2
+essence,essence,本质,NOUN,B2
 équipement essentiel,essential equipment,要置,NOUN,B2
 établi,established,既定的,ADJ,B2
-étagère,shelf,架子,NOUN,B2
-étain,tin,锡,NOUN,B2
-étanche,waterproof,防水的,ADJ,B2
-étape finale,final stage,末期,NOUN,B2
-étayer,to prop,撑,VERB,B2
-éteindre,to turn off,关闭,VERB,B2
-étendre,to expand,扩大,VERB,B2
-étendre,to extend,延伸,VERB,B2
-étendu,extensive,广泛的,ADJ,B2
-étendue,extent,程度,NOUN,B2
+domaine,estate,地产,NOUN,B2
+estime,esteem,尊重,NOUN,B2
+brouille,estrangement,疏离,NOUN,B2
+estuaire,estuary,河口,NOUN,B2
 éternel,eternal,永恒的,ADJ,B2
+alliance éternelle,eternal alliance,永结,NOUN,B2
 éternité,eternity,永恒,NOUN,B2
+ethereum,ethereum,以太坊,NOUN,B2
 éthique,ethics,伦理学,NOUN,B2
-étincelle,spark,火花,NOUN,B2
-étiquette,label,标签,NOUN,B2
-étiquette lourde,heavy etiquette,礼太重,NOUN,B2
-étirer,stretch,伸展,NOUN,B2
-étirer,to stretch,伸展,VERB,B2
-étoile,star,星星,NOUN,B2
-étonnant,amazing,令人惊叹的,ADJ,B2
-étonnant,astonishing,令人惊讶的,ADJ,B2
-étonnement,astonishment,惊讶,NOUN,B2
-étonner,to astonish,使惊讶,VERB,B2
-étourdi,dizzy,头晕的,ADJ,B2
-étranger,foreign,外国的,ADJ,B2
-étranger,abroad,国外,NOUN,B2
-étranger,foreigner,外国人,NOUN,B2
-étreinte,embrace,拥抱,NOUN,B2
-étroit,narrow,狭窄的,ADJ,B2
-étroitesse,narrowness,狭窄,NOUN,B2
-étude,study,研究,NOUN,B2
-études,studies,学业,NOUN,B2
-étudiant,student,学生,NOUN,B2
-étudiant,undergraduate,本科生,NOUN,B2
-étudiant international,international student,留学生,NOUN,B2
-évacuation,evacuation,疏散,NOUN,B2
+ethnicité,ethnicity,种族,NOUN,B2
+ethnographie,ethnography,人种学,NOUN,B2
+ethnologie,ethnology,民族学,NOUN,B2
+éloge,eulogy,赞辞,NOUN,B2
 évacuer,to evacuate,疏散,VERB,B2
+évacuation,evacuation,疏散,NOUN,B2
+esquiver,to evade,逃避,VERB,B2
 évaluation,evaluation,评估,NOUN,B2
-évaluation,valuation,估值,NOUN,B2
-évaluation des offres,bid evaluation,评标,NOUN,B2
-évaluer,to appraise,评估,VERB,B2
-évaluer,to assess,评估,VERB,B2
 évaporation,evaporation,蒸发,NOUN,B2
 évasif,evasive,回避的,ADJ,B2
-éveil social,social awakening,社会觉醒,NOUN,B2
-évident,evident,明显的,ADJ,B2
-évolution,evolution,进化,NOUN,B2
+même,even,偶数的,ADJ,B2
+même si,even if,即使,SCONJ,B2
 événement,event,事件,NOUN,B2
-évêque,bishop,主教,NOUN,B2
-être,be,是,AUX,B2
-être,being,存在,NOUN,B2
-être,to was,是,VERB,B2
-être absent,to be absent,缺席,VERB,B2
-être accro,to be addicted,上瘾,VERB,B2
-être ainsi,to be so,然,VERB,B2
-être autorisé,be allowed,允许,AUX,B2
-être bon en,to be good at,擅长,VERB,B2
-être brave,to be brave,勇善,VERB,B2
-être contraint,to be forced,被迫,VERB,B2
-être de service,to be on duty,值班,VERB,B2
-être en retard,to be late,迟到,VERB,B2
-être en sécurité,to be safe,安好,VERB,B2
-être endommagé,to be damaged,受损,VERB,B2
-être ensorcelé,to be entranced,出神,VERB,B2
-être fait,to be done,被做,VERB,B2
-être frappé,to be hit,中箭,VERB,B2
-être honteux,to be ashamed,感到羞愧,VERB,B2
-être jaloux,to be jealous,嫉妒,VERB,B2
-être reconnaissant,to be grateful,感激,VERB,B2
-être requis,to be required,被要求,VERB,B2
-être responsable de,to be responsible for,负责,VERB,B2
-être situé,to be located,位于,VERB,B2
-être surpris,to be surprised,感到惊讶,VERB,B2
-être utile,to be useful,有用,VERB,B2
-être vaincu,to be defeated,会败,VERB,B2
-être volé,to be stolen,失窃,VERB,B2
-être élu,to be elected,当选,VERB,B2
-île,island,岛屿,NOUN,B2
+finalement,eventually,最终,ADV,B2
+toujours,ever,曾经,ADV,B2
+toujours,to ever,里何尝,VERB,B2
+chaque,every,每个,DET,B2
+quotidien,every day,天天,ADV,B2
+chacun,everyone,每个人,PRON,B2
+tout,everything,一切,PRON,B2
+expulsion,eviction,驱逐,NOUN,B2
+preuve,evidence,证据,NOUN,B2
+évident,evident,明显的,ADJ,B2
+mal,evil,恶行,NOUN,B2
+évolution,evolution,进化,NOUN,B2
+aggravation,exacerbation,加剧,NOUN,B2
+exact,exact,精确的,ADJ,B2
+exagéré,exaggerated,夸张的,ADJ,B2
+examen,exam,考试,NOUN,B2
+examen,examination,考试,NOUN,B2
+exaspération,exasperation,恼怒,NOUN,B2
+exceller,to excel,擅长,VERB,B2
+excellence,excellence,卓越,NOUN,B2
+excellent,excellent,优秀的,ADJ,B2
+exception,exception,例外,NOUN,B2
+extrait,excerpt,摘录,NOUN,B2
+excès,excess,过量,NOUN,B2
+échanger,exchange,交换,NOUN,B2
+échanger,to exchange,交换,VERB,B2
+excité,excited,兴奋的,ADJ,B2
+excitant,exciting,令人兴奋的,ADJ,B2
+exclamation,exclamation,感叹,NOUN,B2
+exclu,excluded,排除在外的,ADJ,B2
+exclusion,exclusion,排除,NOUN,B2
+exclusivité,exclusivity,排他性,NOUN,B2
+excommunication,excommunication,绝罚,NOUN,B2
+excuse,excuse,借口,NOUN,B2
+exécutif,executive,行政主管,NOUN,B2
+exécuteur,executor,遗嘱执行人,NOUN,B2
+exercice,exercise,锻炼,NOUN,B2
+épuisé,exhausted,筋疲力尽的,ADJ,B2
+épuisement,exhaustion,疲惫,NOUN,B2
+existence,existence,存在,NOUN,B2
+étendre,to expand,扩大,VERB,B2
+expansion,expansion,扩张,NOUN,B2
+attente,expectation,期望,NOUN,B2
+dépenser,to expend,花费,VERB,B2
+dépense,expenditure,支出,NOUN,B2
+dépense,expenses,费用,NOUN,B2
+expérimenter,to experience,经历,VERB,B2
+expérience,experiment,实验,NOUN,B2
+expert,expert,专家,NOUN,B2
+expirer,to expire,到期,VERB,B2
+exploitation,exploitation,利用,NOUN,B2
+explosion,explosion,爆炸,NOUN,B2
+explosif,explosive,爆炸性的,ADJ,B2
+exposition,exposition,阐述,NOUN,B2
+exposition,exposure,暴露,NOUN,B2
+exposer,to expound,阐述,VERB,B2
+expression,expression,表达,NOUN,B2
+expropriation,expropriation,征用,NOUN,B2
+expulsion,expulsion,驱逐,NOUN,B2
+étendre,to extend,延伸,VERB,B2
+extension,extension,延伸,NOUN,B2
+étendu,extensive,广泛的,ADJ,B2
+étendue,extent,程度,NOUN,B2
+extermination,extermination,灭绝,NOUN,B2
+extinction,extinction,灭绝,NOUN,B2
+extorquer,to extort,敲诈,VERB,B2
+extra,extra,额外的,ADJ,B2
+extraction,extraction,提取,NOUN,B2
+extrême,extreme,أقصى,NOUN,B2
+extrêmement,extremely,极其,ADV,B2
+extraversion,extroversion,外向,NOUN,B2
+exultation,exultation,欢腾,NOUN,B2
 œil,eye,眼睛,NOUN,B2
+témoin,eyewitness,目击,NOUN,B2
+fable,fable,寓言,NOUN,B2
+fabrication,fabrication,捏造,NOUN,B2
+visage,face,脸,NOUN,B2
+physiognomonie,face reading,面相,NOUN,B2
+reconnaissance faciale,face recognition,认人,NOUN,B2
+installations,facilities,设施,NOUN,B2
+installation,facility,设施,NOUN,B2
+faction,faction,派,NOUN,B2
+s'estomper,to fade,褪色,VERB,B2
+tentative échouée,failed bid,流标,NOUN,B2
+s'évanouir,to faint,昏倒,VERB,B2
+juste,fair,公平的,ADJ,B2
+fée,fairy,仙女,NOUN,B2
+conte de fées,fairy tale,童话,NOUN,B2
+fidèle,faithful,忠诚的,ADJ,B2
+faux,fake,假的,ADJ,B2
+faucon,falcon,猎鹰,NOUN,B2
+s'endormir,to fall asleep,入睡,VERB,B2
+tomber malade,to fall ill,患病,VERB,B2
+sophisme,fallacy,谬误,NOUN,B2
+brouille,falling out,反目,NOUN,B2
+échec,falling though,虽坠,NOUN,B2
+mensonge,falsehood,谎言,NOUN,B2
+falsifier,to falsify,伪造,VERB,B2
+familiarité,familiarity,مألوف,NOUN,B2
+membre de la famille,family member,家庭成员,NOUN,B2
+ruine familiale,family ruin,家破,NOUN,B2
+ventilateur,fan,粉丝,NOUN,B2
+fanatisme,fanaticism,狂热,NOUN,B2
+fantastique,fantastic,极好的,ADJ,B2
+éloigné,far,远的,ADJ,B2
+agriculture,farming,农业,NOUN,B2
+jeûner,to fast,禁食,VERB,B2
+rapide,fast quick,快的,ADJ,B2
+fatal,fatal,致命的,ADJ,B2
+père,father,父,PART,B2
+fatigue,fatigue,疲劳,NOUN,B2
+faute,fault,错误,NOUN,B2
+faveur,favor,恩惠,NOUN,B2
+circonstances favorables,favorable circumstances,顺境,NOUN,B2
+faisable,feasible,可行的,ADJ,B2
+fédération,federation,联邦,NOUN,B2
+nourriture,feed,饲料,NOUN,B2
+rétroaction,feedback,反馈,NOUN,B2
+compagnon,fellow,家伙,NOUN,B2
+crime,felony,重罪,NOUN,B2
+féminin,female,女性的,ADJ,B2
+amie,female friend,女性朋友,NOUN,B2
+parentes,female relatives,女眷,NOUN,B2
+féminisme,feminism,女权主义,NOUN,B2
+fenouil,fennel,茴香,NOUN,B2
+fermenter,to ferment,发酵,VERB,B2
+fermentation,fermentation,发酵,NOUN,B2
+férocity,ferocity,凶猛,NOUN,B2
+fertilisation,fertilization,施肥,NOUN,B2
+s'enflammer,to fester,溃烂,VERB,B2
+festival,festival,节日,NOUN,B2
+rapporter,to fetch,取来,VERB,B2
+fête,feud,世仇,NOUN,B2
+féodal,feudal,封建,ADJ,B2
+féodalisme,feudalism,封建主义,NOUN,B2
+peu,few,很少的,ADJ,B2
+fiancé,fiance,未婚夫,NOUN,B2
+fiction,fiction,小说,NOUN,B2
+fictionnel,fictional,虚构的,ADJ,B2
+férocity,fierceness,凶猛,NOUN,B2
+cinquième,fifth,خامس,ADJ,B2
+cinquante,fifty,五十,NUM,B2
+figure,figure,图形,NOUN,B2
+filial,filial,孝顺,ADJ,B2
+remplir,to fill in,填写,VERB,B2
+étape finale,final stage,末期,NOUN,B2
+financer,to finance,资助,VERB,B2
+finances,finances,财政,NOUN,B2
+financement,financing,融资,NOUN,B2
+découvrir,to find out,找出,VERB,B2
+amender,fine,好的,ADJ,B2
+amender,to fine,罚款,VERB,B2
+peau fine,fine skin,细皮,NOUN,B2
+empreinte digitale,fingerprint,指纹,NOUN,B2
+finition,finishing,装修,NOUN,B2
+fini,finite,有限的,ADJ,B2
+tirer,to fire,开火,VERB,B2
+incombustible,fireproof,防火的,ADJ,B2
+bois de chauffage,firewood,木柴,NOUN,B2
+feux d'artifice,fireworks,烟花,NOUN,B2
+ferme,firm,坚固的,ADJ,B2
+d'abord,first,首先,ADV,B2
+premier bouchage,first capping,首加缁布冠,NOUN,B2
+premier jet,first draft,初稿,NOUN,B2
+premier mérite,first merit,首功,NOUN,B2
+avant tout,first of all,首先,ADV,B2
+fission,fission,裂变,NOUN,B2
+ajuster,to fit,适合,VERB,B2
+aptitude,fitness,健康,NOUN,B2
+adéquat,fitting,合适的,ADJ,B2
+flacon,flask,小瓶,NOUN,B2
+plat,flat,扁平的,ADJ,B2
+flatter,to flatter,奉承,VERB,B2
+flatterie,flattery,奉承,NOUN,B2
+éphémère,fleeting,短暂的,ADJ,B2
+vol,flight,航班,NOUN,B2
+fragile,flimsy,脆弱的,ADJ,B2
+flotter,to float,漂浮,VERB,B2
+troupeau,flock,兽群,NOUN,B2
+sol,floor,地板,NOUN,B2
+fleurir,to flourish,繁荣,VERB,B2
+fluctuation,fluctuation,波动,NOUN,B2
+fluide,fluent,流利的,ADJ,B2
+voltiger,to flutter,飘动,VERB,B2
+mousseux,foamy,多泡沫的,ADJ,B2
+foyer,focus,焦点,NOUN,B2
+fourrage,fodder,饲料,NOUN,B2
+dossier,folder,文件夹,NOUN,B2
+peuple,folk,民间的,ADJ,B2
+folklore,folklore,民俗,NOUN,B2
+suivi,follow-up,跟进,NOUN,B2
+suiveur,follower,追随者,NOUN,B2
+fou,fool,傻瓜,NOUN,B2
+stupide,foolish,愚蠢的,ADJ,B2
+football,football,足球,NOUN,B2
+chaussure,footwear,鞋穿,NOUN,B2
+par exemple,for example,例如,ADV,B2
+pour,for it,为此,ADV,B2
+pour l'instant,for now,暂时,ADV,B2
+pour,for the sake of,为了,ADP,B2
+pourquoi,for what,为了什么,ADV,B2
+pendant des années,for years,多年,ADV,B2
+interdit,forbidden,被禁止的,ADJ,B2
+terre interdite,forbidden land,禁地,NOUN,B2
+force,force,力量,NOUN,B2
+forcé,forced,强迫的,ADJ,B2
+de force,forcibly,强制地,ADV,B2
+étranger,foreign,外国的,ADJ,B2
+étranger,foreigner,外国人,NOUN,B2
+pour toujours,forever,永远,ADV,B2
+contrefaçon,forgery,伪造品,NOUN,B2
+distrait,forgetful,健忘的,ADJ,B2
+former,to form,形成,VERB,B2
+formalisme,formalism,形式主义,NOUN,B2
+formation,formation,组建,NOUN,B2
+ancien,former,以前的,ADJ,B2
+formule,formula,公式,NOUN,B2
+en avant,forth,向前,ADV,B2
+heureux,fortunate,幸运的,ADJ,B2
+heureusement,fortunately,幸运地,ADV,B2
+fortune,fortune,运气,NOUN,B2
+tirage de sort,fortune telling,算命,NOUN,B2
+forum,forum,论坛,NOUN,B2
+en avant,forward,向前,ADV,B2
+enfant trouvé,foundling,弃婴,NOUN,B2
+fraction,fraction,分数,NOUN,B2
+virgule,fraction marker,分之,PART,B2
+fracture,fracture,骨折,NOUN,B2
+fragile,fragile,易碎的,ADJ,B2
+fragmentation,fragmentation,碎片化,NOUN,B2
+fragrance,fragrance,香味,NOUN,B2
+parfumé,fragrant,芬芳的,ADJ,B2
+franchise,franchise,特许经营权,NOUN,B2
+freak,freak,怪人,NOUN,B2
+temps libre,free time,业余时间,NOUN,B2
+gel,freezing,冻结,NOUN,B2
+pluie verglacée,freezing rain,冻雨,NOUN,B2
+français,french,法语,NOUN,B2
+Français,frenchman,法国人,NOUN,B2
+frénésie,frenzy,疯狂,NOUN,B2
+friction,friction,摩擦,NOUN,B2
+vendredi,friday,星期五,NOUN,B2
+réfrigérateur,fridge,冰箱,NOUN,B2
+frites,fries,炸薯条,NOUN,B2
+grenouille,frog,青蛙,NOUN,B2
+de,from,来自,ADP,B2
+dès l'enfance,from childhood,从小,ADV,B2
+front,front,前面,NOUN,B2
+front door,front door,正门,NOUN,B2
+frost,frost,霜,NOUN,B2
+frugal,frugal,节俭的,ADJ,B2
+frustrated,frustrated,沮丧的,ADJ,B2
+frustration,frustration,挫折,NOUN,B2
+fry,to fry,油炸,VERB,B2
+fulfill,to fulfill,履行,VERB,B2
+full moon,full moon,满月,NOUN,B2
+full name,full name,大名,NOUN,B2
+full power,full power,全力,NOUN,B2
+fun,fun,有趣的,ADJ,B2
+function,to function,运作,VERB,B2
+functionalism,functionalism,功能主义,NOUN,B2
+fund,fund,基金,NOUN,B2
+fundamental,fundamental,基本的,ADJ,B2
+fundamentalism,fundamentalism,原教旨主义,NOUN,B2
+furnish,to furnish,提供,VERB,B2
+further,further,进一步的,ADJ,B2
+furthermore,furthermore,此外,ADV,B2
+fuse,fuse,保险丝,NOUN,B2
+fuselage,fuselage,机身,NOUN,B2
+fusion,fusion,融合,NOUN,B2
+fuss,fuss,大惊小怪,NOUN,B2
+futility,futility,无用,NOUN,B2
+future,future,未来的,ADJ,B2
+futurism,futurism,未来主义,NOUN,B2
+gain,gain,收益,NOUN,B2
+gallantry,gallantry,英勇,NOUN,B2
+gamble,gamble,赌博,NOUN,B2
+gamble,to gamble,赌博,VERB,B2
+gang,gang,帮派,NOUN,B2
+garage,garage,车库,NOUN,B2
+garrulous,garrulous,喋喋不休的,ADJ,B2
+rassemblement,gathering,聚集,NOUN,B2
+fixer,gaze,目视,NOUN,B2
+fixer,to gaze,凝视,VERB,B2
+genre,gender,性别,NOUN,B2
+généalogie,genealogy,家谱学,NOUN,B2
+général,general,将军,NOUN,B2
+génie,genius,天才,NOUN,B2
+authentique,genuine,真正的,ADJ,B2
+géologique,geological,地质的,ADJ,B2
+géopolitique,geopolitics,地缘政治,NOUN,B2
+germe,germ,病菌,NOUN,B2
+allemand,german,德国人,NOUN,B2
+germination,germination,发芽,NOUN,B2
+faire connaissance,to get acquainted,相互认识,VERB,B2
+se fâcher,to get angry,生气,VERB,B2
+se perdre,to get lost,迷路,VERB,B2
+quitter le travail,to get off work,下班,VERB,B2
+se lever,to get up,起床,VERB,B2
+s'habituer,to get used to,习惯于,VERB,B2
+gigantesque,giant,巨大的,ADJ,B2
+cadeau,gift,礼物,NOUN,B2
+ricaner,to giggle,咯咯笑,VERB,B2
+gigolo,gigolo,面首,NOUN,B2
+girafe,giraffe,长颈鹿,NOUN,B2
+petite amie,girlfriend,女朋友,NOUN,B2
+accorder,to give to grant,予以,VERB,B2
+donnée,given,给定,NOUN,B2
+glacier,glacier,冰川,NOUN,B2
+heureux,glad,高兴的,ADJ,B2
+jeter un coup d'œil,to glance,瞥,VERB,B2
+verre,glass,玻璃,NOUN,B2
+réchauffement climatique,global warming,气候变暖,NOUN,B2
+sombre,gloomy,阴郁的,ADJ,B2
+glorifier,to glorify,赞美,VERB,B2
+lueur,glow,光芒,NOUN,B2
+gourmandise,gluttony,暴食,NOUN,B2
+ronger,to gnaw,啃,VERB,B2
+revenir,to go back,回去,VERB,B2
+faire faillite,to go bankrupt,破产,VERB,B2
+devenir fou,to go crazy,发疯,VERB,B2
+passer en premier,to go first,先去,VERB,B2
+secours,go help,去帮,NOUN,B2
+entrer,to go in,进去,VERB,B2
+se connecter,to go online,上网,VERB,B2
+traverser,to go through,经历,VERB,B2
+dieu de la guerre,god of war,战神,NOUN,B2
+bien,good,خير,NOUN,B2
+bonne chance,good luck,好运,NOUN,B2
+bonne réputation,good reputation,清誉,NOUN,B2
+beau,good-looking,好看的,ADJ,B2
+au revoir,goodbye,再见,INTJ,B2
+bonté,goodness,善良,NOUN,B2
+marchandises,goods,商品,NOUN,B2
+magnifique,gorgeous,华丽的,ADJ,B2
+gourmet,gourmet,美食家,NOUN,B2
+saisir,to grab,抓,VERB,B2
+gracieux,graceful,优雅的,ADJ,B2
+gradation,gradation,渐变,NOUN,B2
+grade,grade,等级,NOUN,B2
+progressif,gradual,逐渐的,ADJ,B2
+greffe,graft,嫁接,NOUN,B2
+grain,grain,谷物,NOUN,B2
+grand,grand,宏伟的,ADJ,B2
+grande distance,grand distance,雄远,NOUN,B2
+petit-enfant,grandchild,孙辈,NOUN,B2
+grandeur,grandeur,宏伟,NOUN,B2
+grand-père,grandfather,祖父,NOUN,B2
+grandiose,grandiose,浮夸的,ADJ,B2
+grand-mère,grandma,奶奶,NOUN,B2
+grand-mère,grandmother,祖母,NOUN,B2
+graphique,graphic,图形的,ADJ,B2
+saisir,to grasp,抓住,VERB,B2
+saisir fermement,to grasp firmly,抓紧,VERB,B2
+prairie,grassland,草地,NOUN,B2
+reconnaissant,grateful,感激的,ADJ,B2
+gratitude,gratitude,感激,NOUN,B2
+tombe,grave,坟墓,NOUN,B2
+gris,gray,灰色的,ADJ,B2
+pâturage,grazing,放牧,NOUN,B2
+graisser,to grease,涂油,VERB,B2
+gras,greasy,油腻的,ADJ,B2
+grand service,great favor,大恩,NOUN,B2
+grande offense,great offense,冒犯大,NOUN,B2
+grand pouvoir,great power,大国,NOUN,B2
+vert,green,绿色的,ADJ,B2
 œil vert,green eye,碧眼,NOUN,B2
+yeux verts,green eyes,想碧眼,NOUN,B2
+technologie verte,green technology,绿色技术,NOUN,B2
 œil vert,green-eyed,让碧眼,NOUN,B2
+chagrin,grief,悲伤,NOUN,B2
+plainte,grievance,弊端,NOUN,B2
+sombre,grim,严酷的,ADJ,B2
+sourire,to grin,咧嘴笑,VERB,B2
+broyer,to grind,磨碎,VERB,B2
+agripper,grip,握法,NOUN,B2
+agripper,to grip,紧握,VERB,B2
+marié,groom,新郎,NOUN,B2
+grossier,gross,总的,ADJ,B2
+terrain,grounds,论据,NOUN,B2
+grognement,growl,低吼,NOUN,B2
+garder,to guard,看守,VERB,B2
+supposition,guess,猜测,NOUN,B2
+guide,guide,导游,NOUN,B2
+gars,guy,家伙,NOUN,B2
+salle de sport,gym,健身房,NOUN,B2
+gymnastique,gymnastics,体操,NOUN,B2
+ha,ha,哈,INTJ,B2
+habitat,habitat,栖息地,NOUN,B2
+habitude,habitually in the past,往常,NOUN,B2
+habituation,habituation,习惯化,NOUN,B2
+marchandage,haggling,计较,NOUN,B2
+hall,hall,大厅,NOUN,B2
+hallucination,hallucination,幻觉,NOUN,B2
+couloir,hallway,走廊,NOUN,B2
+arrêter,to halt,停止,VERB,B2
+remettre,to hand over,交付,VERB,B2
+sac à main,handbag,手提包,NOUN,B2
+menotte,handcuff,手铐,NOUN,B2
+artisanat,handicraft,工艺品,NOUN,B2
+manipulation,handling,处理,NOUN,B2
+remise,handover,拿给,NOUN,B2
+beau,handsome,帅气的,ADJ,B2
+beau garçon,handsome guy,帅哥,NOUN,B2
+écriture,handwriting,笔迹,NOUN,B2
+calligraphie,handwriting practice,练字,NOUN,B2
+arriver,to happen,发生,VERB,B2
+difficile à choisir,hard to choose,难以抉择,ADJ,B2
+difficile à distinguer,hard to distinguish,难以区分,ADJ,B2
+difficile à maintenir,hard to maintain,难以维持,ADJ,B2
+difficile à aborder,hard to speak of,难以启齿,ADJ,B2
+dureté,hardness,硬度,NOUN,B2
+travailleur,hardworking,勤奋的,ADJ,B2
+inoffensif,harmless,无害的,ADJ,B2
+hâtif,hasty,仓促的,ADJ,B2
+haine,hate,仇恨,NOUN,B2
+haine,hatred,仇恨,NOUN,B2
+avoir,have,有,AUX,B2
+avoir un accident,to have an accident,遭遇意外,VERB,B2
+prendre le petit-déjeuner,to have breakfast,吃早餐,VERB,B2
+avoir,to have only,唯有,VERB,B2
+devoir,have to,还得,NOUN,B2
+foin,hay,干草,NOUN,B2
+céphalée,headache,头痛,NOUN,B2
+casque audio,headphones,耳机,NOUN,B2
+siège,headquarters,总部,NOUN,B2
+tas,heap,堆,NOUN,B2
+entendre,to hear a case,审理,VERB,B2
+beile,heard beile,听说贝勒,NOUN,B2
+battement de cœur,heartbeat,心跳,NOUN,B2
+canicule,heat wave,热浪,NOUN,B2
+ciel,heaven,天堂,NOUN,B2
+parfum céleste,heavenly fragrance,天香,NOUN,B2
+étiquette lourde,heavy etiquette,礼太重,NOUN,B2
+nœud serré,heavy knot,重结,NOUN,B2
+machine lourde,heavy machine,重机,NOUN,B2
+type lourd,heavy type,重型,NOUN,B2
+travail lourd,heavy work,重功,NOUN,B2
+hérisson,hedgehog,刺猬,NOUN,B2
+héhé,hehe,嘿嘿,INTJ,B2
+aider,to help assistance,帮助,VERB,B2
+impuissant,helpless,无助的,ADJ,B2
+hémoglobine,hemoglobin,血红蛋白,NOUN,B2
+herbe,herb,草药,NOUN,B2
+berger,herder,牧民,NOUN,B2
+ici,here,此地,NOUN,B2
+dès à présent,hereby,特此,ADV,B2
+hérédité,heredity,遗传,NOUN,B2
+hérétique,heretic,异端,NOUN,B2
+héros,hero,英雄,NOUN,B2
+héroïque,heroic,英勇的,ADJ,B2
+héroïsme,heroism,英雄主义,NOUN,B2
+hé,hey,嘿,INTJ,B2
+salut,hi,嗨,INTJ,B2
+se cacher,to hide oneself,躲藏,VERB,B2
+cachette,hideout,藏身处,NOUN,B2
+cachette,hiding,ٱختباء,NOUN,B2
+marée haute,high tide,涨潮,NOUN,B2
+supérieur,higher,更高的,ADJ,B2
+souligner,to highlight,强调,VERB,B2
+randonner,to hike,徒步旅行,VERB,B2
+randonnée,hiking,徒步,NOUN,B2
+colline,hills,丘陵,NOUN,B2
+poignée,hilt,剑柄,NOUN,B2
+lui,him,他吧,NOUN,B2
+entrave,hindrance,障碍,NOUN,B2
+départ,his departure,他走,NOUN,B2
+historique,historic,历史性的,ADJ,B2
+historiographie,historiography,史学,NOUN,B2
+histoire,history,历史,NOUN,B2
+coup,hit,击中,NOUN,B2
+hmm,hmm,嗯,INTJ,B2
+passe-temps,hobby,爱好,NOUN,B2
+attendre,to hold on,抓住,VERB,B2
+pivotal,hold the balance of power,举足轻重,ADJ,B2
+vacances,holiday,假期,NOUN,B2
+holistique,holistic,整体的,ADJ,B2
+creux,hollow,洼地,NOUN,B2
+saint,holy,神圣的,ADJ,B2
+maison,home,家,NOUN,B2
+foyer,home family,家,NOUN,B2
+patrie,homeland,家乡,NOUN,B2
+sans-abri,homeless,无家可归的,ADJ,B2
+devoirs,homework,家庭作业,NOUN,B2
+homicide,homicide,杀人,NOUN,B2
+homosexuel,homosexual,同性恋的,ADJ,B2
+lune de miel,honeymoon,蜜月,NOUN,B2
+klaxonner,to honk,按喇叭,VERB,B2
+honoré,honored,尊敬的,ADJ,B2
+espérer,to hope to wish,希望,VERB,B2
+hopefully,hopefully,希望,ADV,B2
+hopeless,hopeless,绝望的,ADJ,B2
+horizon,horizon,地平线,NOUN,B2
+hormone,hormone,激素,NOUN,B2
+horrifying,horrifying,令人毛骨悚然的,ADJ,B2
+horse departure,horse departure,马去,NOUN,B2
+hose,hose,软管,NOUN,B2
+hostile,hostile,敌对的,ADJ,B2
+hot air balloon,hot air balloon,热气球,NOUN,B2
+hotel room,hotel room,酒店房间,NOUN,B2
+hover,to hover,盘旋,VERB,B2
+how,how,又怎会,NOUN,B2
+how many,how many,多少,NUM,B2
+how much,how much,多少,PRON,B2
+however,however,然而,CCONJ,B2
+hug,hug,拥抱,NOUN,B2
+hug,to hug,拥抱,VERB,B2
+huge,huge,巨大的,ADJ,B2
+huh,huh,哈,INTJ,B2
+human,human,人类,NOUN,B2
+human capacity,human capacity,人会,NOUN,B2
+human nature,human nature,人性,NOUN,B2
+humanity,humanity,人类,NOUN,B2
+humanization,humanization,人性化,NOUN,B2
+humidity,humidity,湿度,NOUN,B2
+hunchbacked,hunchbacked,驼背的,ADJ,B2
+hundred,hundred,百,NUM,B2
+hungry,hungry,饥饿的,ADJ,B2
+hunt,hunt,狩猎,NOUN,B2
+hurrah,hurrah,万岁,INTJ,B2
+hurricane,hurricane,飓风,NOUN,B2
+hurry,hurry,匆忙,NOUN,B2
+hurry,to hurry,赶快,VERB,B2
+hurt,to hurt,受伤,VERB,B2
+hybridization,hybridization,杂交,NOUN,B2
+énergie hydraulique,hydro energy,水能,NOUN,B2
+hymne,hymn,赞美诗,NOUN,B2
+hyper-utilisation,hyper-use,超用,NOUN,B2
+hypnose,hypnosis,催眠,NOUN,B2
+je ne mérite pas ton éloge,i don't deserve your praise,不敢当,INTJ,B2
+crème glacée,ice cream,冰淇淋,NOUN,B2
+hockey sur glace,ice hockey,冰球,NOUN,B2
+glacial,ice-cold,冰冷的,ADJ,B2
+identité,id,证件,NOUN,B2
+carte d'identité,id card,身份证,NOUN,B2
+photo d'identité,id photo,证件照,NOUN,B2
+idéal,ideal,理想,NOUN,B2
+identification,identification,身份证明,NOUN,B2
+idiotie,idiocy,愚蠢,NOUN,B2
+oisif,idle,懒惰的,ADJ,B2
+si quand,if when,如果,SCONJ,B2
+ignorance,ignorance,无知,NOUN,B2
+ignorant,ignorant,无知的,ADJ,B2
+malade,ill,生病的,ADJ,B2
+illégalité,illegality,非法,NOUN,B2
+illusion,illusion,幻觉,NOUN,B2
+image,image,形象,NOUN,B2
+imagination,imagination,想象力,NOUN,B2
+imam,imam,伊玛目,NOUN,B2
+imitation,imitation,模仿,NOUN,B2
+imitatif,imitative,模仿性,ADJ,B2
+incommensurable,immeasurable,不可估量的,ADJ,B2
+immédiatement,immediately,立即,ADV,B2
+immersion,immersion,沉浸,NOUN,B2
+immigrer,to immigrate,移入,VERB,B2
+imminent,imminent,即将来临的,ADJ,B2
+immunothérapie,immunotherapy,免疫治疗,NOUN,B2
+déficit,impairment,左手废,NOUN,B2
+transmettre,to impart,传授,VERB,B2
+impatient,impatient,不耐烦的,ADJ,B2
+impediment,impediment,障碍,NOUN,B2
+impel,to impel,推动,VERB,B2
+impenetrable,impenetrable,不可穿透的,ADJ,B2
+imperial court,imperial court,朝廷,NOUN,B2
+imperial father's will,imperial father's will,父皇要,NOUN,B2
+imperial guard,imperial guard,御林,NOUN,B2
+imperial relatives,imperial relatives,皇亲,NOUN,B2
+implement,to implement,实施,VERB,B2
+implementation,implementation,实施,NOUN,B2
+implicate,to implicate,连累,VERB,B2
+implication,implication,含义,NOUN,B2
+implore,to implore,恳求,VERB,B2
+impolite,impolite,不礼貌的,ADJ,B2
+import,to import,进口,VERB,B2
+importance,importance,重要性,NOUN,B2
+important,important,重要的,ADJ,B2
+importation,importation,进口,NOUN,B2
+impossibility,impossibility,不可能,NOUN,B2
+impossible,impossible,不可能的,ADJ,B2
+impression,impression,印象,NOUN,B2
+impressive,impressive,令人印象深刻的,ADJ,B2
+imprison,to imprison,监禁,VERB,B2
+improper,improper,不合适的,ADJ,B2
+improvisation,improvisation,即兴创作,NOUN,B2
+impudence,impudence,厚颜无耻,NOUN,B2
+impudent,impudent,无礼的,ADJ,B2
+impulsive,impulsive,冲动的,ADJ,B2
+in addition,in addition,此外,ADV,B2
+in advance,in advance,事先,ADV,B2
+in between,in between,在中间,ADV,B2
+in case,in case,如果,SCONJ,B2
+in detail,in detail,详细地,ADV,B2
+in front,in front,在前面,ADV,B2
+in it,in it,在里面,ADV,B2
+in order to,in order to,以期,SCONJ,B2
+en personne,in person,亲自地,ADV,B2
+en bref,in short,简而言之,ADV,B2
+malgré,to in spite of,不顾,VERB,B2
+dans le ciel,in the sky,天上,NOUN,B2
+à temps,in time,及时地,ADV,B2
+en vain,in vain,徒劳,ADV,B2
+dans le vent,in wind,临风,NOUN,B2
+par écrit,in writing,书面,NOUN,B2
+incapacité,inability,无能,NOUN,B2
+inapproprié,inappropriate,不恰当的,ADJ,B2
+inauguration,inauguration,开幕,NOUN,B2
+encens,incense,香,NOUN,B2
+pouce,inch,بوصة,NOUN,B2
+incident,incident,事件,NOUN,B2
+incinérer,to incinerate,焚烧,VERB,B2
+incitation,incitement,煽动,NOUN,B2
+revenus et dépenses,income and expense,收支,NOUN,B2
+entrant,incoming,进来的,ADJ,B2
+incompatibilité,incompatibility,不兼容,NOUN,B2
+incohérent,inconsistent,不一致的,ADJ,B2
+augmenter régulièrement,to increase steadily,与日俱增,VERB,B2
+de plus en plus,increasingly,越来越,ADV,B2
+incubation,incubation,孵化,NOUN,B2
+incubateur,incubator,孵化器,NOUN,B2
+indécis,indecisive,犹豫不决的,ADJ,B2
+indélébile,indelible,不可磨灭的,ADJ,B2
+indépendance,independence,独立,NOUN,B2
+indescriptible,indescribable,难以形容的,ADJ,B2
+index,index,索引,NOUN,B2
+indifférent,indifferent,冷漠的,ADJ,B2
+indigestion,indigestion,消化不良,NOUN,B2
+indigné,indignant,愤慨的,ADJ,B2
+indignation,indignation,愤慨,NOUN,B2
+indispensable,indispensable,不可或缺的,ADJ,B2
+affectation individuelle,individual assignment,个人作业,NOUN,B2
+individualité,individuality,个性,NOUN,B2
+induire,to induce,引起,VERB,B2
+chaîne industrielle,industry chain,产业链,NOUN,B2
+inefficace,inefficient,低效的,ADJ,B2
+inexpérimenté,inexperienced,生疏的,ADJ,B2
+engouement,infatuation,迷恋,NOUN,B2
+infecter,to infect,感染,VERB,B2
+infection,infection,感染,NOUN,B2
+inférer,to infer,推断,VERB,B2
+inflation,inflation,通货膨胀,NOUN,B2
+influenceur,influencer,网红,NOUN,B2
+informel,informal,非正式的,ADJ,B2
+informateur,informant,线人,NOUN,B2
+information,information,信息,NOUN,B2
+ingérer,to ingest,服用,VERB,B2
+habiter,to inhabit,居住,VERB,B2
+initial,initial,最初的,ADJ,B2
+initier,to initiate,发起,VERB,B2
+initiative,initiative,主动权,NOUN,B2
+injustice,injustice,不公,NOUN,B2
+encre,ink,墨水,NOUN,B2
+inné,innate,天生的,ADJ,B2
+intérieur,inner,内部的,ADJ,B2
+cour intérieure,inner court,朝内,NOUN,B2
+innocence,innocence,无辜,NOUN,B2
+innocent,innocent,无辜的,ADJ,B2
+innovation,innovation,创新,NOUN,B2
+enquêter,to inquire,询问,VERB,B2
+enquête,inquiry,调查,NOUN,B2
+insecticide,insecticide,杀虫剂,NOUN,B2
+peu sûr,insecure,不安全的,ADJ,B2
+intérieur,inside,在内部,ADP,B2
+centre-ville,inside city,城内,NOUN,B2
+dessous,inside story,内幕,NOUN,B2
+perspicacité,insight,洞察力,NOUN,B2
+insolence,insolence,无礼,NOUN,B2
+insolent,insolent,傲慢的,ADJ,B2
+inspection,inspection,检查,NOUN,B2
+inspiration,inspiration,灵感,NOUN,B2
+installation,installation,安装,NOUN,B2
+versement,installment,分期付款,NOUN,B2
+instant,instant,فور,NOUN,B2
+plutôt,instead,代替,ADV,B2
+au contraire,instead on the contrary,反而,ADV,B2
+instinct,instinct,本能,NOUN,B2
+institution,institution,机构,NOUN,B2
+institutionnalisation,institutionalization,制度化,NOUN,B2
+instruction,instruction,指示,NOUN,B2
+instrument,instrument,乐器,NOUN,B2
+isolation,insulation,绝缘,NOUN,B2
+assurer,to insure,保证,VERB,B2
+insurmontable,insurmountable,不可逾越的,ADJ,B2
+insurrection,insurrection,起义,NOUN,B2
+intelligence,intelligence,智力,NOUN,B2
+intelligent,intelligent,聪明的,ADJ,B2
+intense,intense,强烈的,ADJ,B2
+intention,intent,意图,NOUN,B2
+intentionnel,intentional,故意的,ADJ,B2
+interaction,interaction,互动,NOUN,B2
+rapport,intercourse,性交,NOUN,B2
+interface,interface,接口,NOUN,B2
+interférer,to interfere,干涉,VERB,B2
+interférence,interference,干扰,NOUN,B2
+interlocuteur,interlocutor,对话者,NOUN,B2
+intermittent,intermittent,间歇的,ADJ,B2
+interne,internal,内部的,ADJ,B2
+force interne,internal force,内力,NOUN,B2
+international,international,国际的,ADJ,B2
+étudiant international,international student,留学生,NOUN,B2
+internet,internet,互联网,NOUN,B2
+intersection,intersection,交叉点,NOUN,B2
+intervention,intervention,干预,NOUN,B2
+interviewer,to interview,采访,VERB,B2
+intimider,to intimidate,恐吓,VERB,B2
+intimidation,intimidation,恐吓,NOUN,B2
+intonation,intonation,语调,NOUN,B2
+intraitable,intractable,难处理的,ADJ,B2
+intrépide,intrepid,无畏的,ADJ,B2
+introduction,introduction,介绍,NOUN,B2
+introspection,introspection,内省,NOUN,B2
+introverti,introverted,内向的,ADJ,B2
+intrusion,intrusion,闯入,NOUN,B2
+intuition,intuition,直觉,NOUN,B2
+invasion,invasion,入侵,NOUN,B2
+invention,invention,发明,NOUN,B2
+invisible,invisible,看不见的,ADJ,B2
+invitation,invitation,邀请,NOUN,B2
+impliqué,involved,涉及的,ADJ,B2
+irascible,irascible,易怒的,ADJ,B2
+en fer,iron,铁的,ADJ,B2
+irrationalité,irrationality,非理性,NOUN,B2
+irréconciliable,irreconcilable,不可调和的,ADJ,B2
+non pertinent,irrelevant,不相关的,ADJ,B2
+irremplaçable,irreplaceable,不可替代的,ADJ,B2
+irrésistible,irresistible,不可抗拒的,ADJ,B2
+canal d'irrigation,irrigation canal,灌溉渠,NOUN,B2
+irritable,irritable,易怒的,ADJ,B2
+irritation,irritation,刺激,NOUN,B2
+île,island,岛屿,NOUN,B2
+isotope,isotope,同位素,NOUN,B2
+émettre,issue,问题,NOUN,B2
+émettre,to issue,颁布,VERB,B2
+il,it,它,PRON,B2
+italien,italian,意大利人,NOUN,B2
+démanger,to itch,发痒,VERB,B2
+détails,its details,其详,NOUN,B2
+jade,jade,这玉,NOUN,B2
+jade,jade ware,玉器,NOUN,B2
+prison,jail,监狱,NOUN,B2
+japonais,japanese,日本人,NOUN,B2
+jargon,jargon,行话,NOUN,B2
+jalousie,jealousy,嫉妒,NOUN,B2
+juif,jew,犹太人,NOUN,B2
+bijoux,jewelry,珠宝,NOUN,B2
+jianghu,jianghu,江湖,NOUN,B2
+jiaolong,jiaolong,娇龙,NOUN,B2
+jin,jin,斤,NOUN,B2
+joint,joint,关节,NOUN,B2
+jubilé,jubilee,禧年,NOUN,B2
+jungle,jungle,丛林,NOUN,B2
+juridiction,jurisdiction area,辖区,NOUN,B2
+comme par le passé,just as in the past,一如既往,ADV,B2
+à l'instant,just now,刚刚,ADV,B2
+juste,just right,恰到好处,ADV,B2
+justice,justice,正义,NOUN,B2
+justification,justification,理由,NOUN,B2
+karaté,karate,空手道,NOUN,B2
+frapper,kick,踢,NOUN,B2
+frapper,to kick,踢,VERB,B2
+kidnapper,to kidnap,绑架,VERB,B2
+faire d'une pierre deux coups,kill two birds with one stone,一举两得,ADJ,B2
+kilogramme,kilogram,千克,NOUN,B2
+kilomètre,kilometer,公里,NOUN,B2
+cinétique,kinetic,运动的,ADJ,B2
+royaume,kingdom,王国,NOUN,B2
+baiser,kiss,吻,NOUN,B2
+genou,knee,膝盖,NOUN,B2
+savoir reconnaître,to know to recognize,认识,VERB,B2
+connu,known,已知的,ADJ,B2
+étiquette,label,标签,NOUN,B2
+travail,labor,劳动,NOUN,B2
+laborieux,laborious,费力的,ADJ,B2
+manquer,lack,缺乏,NOUN,B2
+manquer,to lack,缺乏,VERB,B2
+échelle,ladder,梯子,NOUN,B2
+boiteux,lame,跛的,ADJ,B2
+lampe,lamp,灯,NOUN,B2
+propriétaire,landlord,房东,NOUN,B2
+glissement de terrain,landslide,滑坡,NOUN,B2
+voie,lane,小巷,NOUN,B2
+genoux,lap,大腿部,NOUN,B2
+à grande échelle,large-scale,大规模的,ADJ,B2
+larynx,larynx,喉,NOUN,B2
+dernièrement,last,最后,ADV,B2
+durer,to last a period of time,为期,VERB,B2
+année dernière,last year,去年,NOUN,B2
+défunt,late,晚的,ADJ,B2
+plus tard,later,后来,ADV,B2
+latéral,lateral,侧面的,ADJ,B2
+rire,laughter,笑声,NOUN,B2
+linge,laundry,洗衣,NOUN,B2
+buanderie,laundry room,洗衣房,NOUN,B2
+lave,lava,熔岩,NOUN,B2
+application de la loi,law enforcement,执法,NOUN,B2
+légal,lawful,合法的,ADJ,B2
+procès,lawsuit,诉讼,NOUN,B2
+poser,to lay,放置,VERB,B2
+profane,layman,外行,NOUN,B2
+agencement,layout,布局,NOUN,B2
+millier de plomb,lead thousand,率千,NOUN,B2
+leadership,leadership,领导能力,NOUN,B2
+principal,leading,领先的,ADJ,B2
+fuir,leak,泄漏,NOUN,B2
+fuir,to leak,泄漏,VERB,B2
+maigre,lean,瘦的,ADJ,B2
+laisser,to leave behind,留下,VERB,B2
+omettre,to leave out,省略,VERB,B2
+donner une conférence,lecture,讲座,NOUN,B2
+donner une conférence,to lecture,教导,VERB,B2
+conférencier,lecturer,演讲者,NOUN,B2
+grand livre,ledger,总账,NOUN,B2
+gauche,left,左边,ADV,B2
+côté gauche,left side,左侧,NOUN,B2
+héritage,legacy,遗产,NOUN,B2
+profession juridique,legal profession,律师业,NOUN,B2
+légitimer,to legitimize,使合法,VERB,B2
+longueur,length,长度,NOUN,B2
+laisser,let,让,AUX,B2
+encore moins,let alone,别说,ADV,B2
+lâcher,to let go,放开,VERB,B2
+laitue,lettuce,生菜,NOUN,B2
+responsabilité,liability,责任,NOUN,B2
+liaison,liaison,联络,NOUN,B2
+libérer,to liberate,解放,VERB,B2
+plaque d'immatriculation,license plate,车牌,NOUN,B2
+restriction de plaque d'immatriculation,license plate restriction,限号,NOUN,B2
+s'allonger,to lie down,躺,VERB,B2
+lieutenant,lieutenant,中尉,NOUN,B2
+vie,life,生命,NOUN,B2
+vie et mort,life and death,生死,NOUN,B2
+réclusion à perpétuité,life imprisonment,无期徒刑,NOUN,B2
+rétribution à vie,life retribution,偿命,NOUN,B2
+vie ou mort,life-and-death,决生,NOUN,B2
+durée de vie,lifetime,一生,NOUN,B2
+ressemblance,likeness,就象,NOUN,B2
+limité,limited,有限的,ADJ,B2
+aligner,to line up,排成一行,VERB,B2
+linéaire,linear,线性的,ADJ,B2
+lin,linen,线麻,NOUN,B2
+linguistique,linguistics,语言学,NOUN,B2
+lion,lion,狮子,NOUN,B2
+rouge à lèvres,lipstick,口红,NOUN,B2
+liquidation,liquidation,清算,NOUN,B2
+liqueur,liquor,烈酒,NOUN,B2
+écouter attentivement,to listen attentively,倾听,VERB,B2
+alphabétisation,literacy,读写能力,NOUN,B2
+littérature,literature,文学,NOUN,B2
+litre,litre,升,NOUN,B2
+petit onze,little eleven,小十一,NOUN,B2
+petit neuf,little nine,小九,NOUN,B2
+pain,loaf,一条面包,NOUN,B2
+local,local,当地的,ADJ,B2
+lieu,location,地点,NOUN,B2
+verrouiller,to lock,锁上,VERB,B2
+confiner,to lockdown,封城,VERB,B2
+vestiaire,locker room,更衣室,NOUN,B2
+élevé,lofty,崇高的,ADJ,B2
+rondin,log,日志,NOUN,B2
+logique,logic,逻辑,NOUN,B2
+logique,logical,合乎逻辑的,ADJ,B2
+solitude,loneliness,孤独,NOUN,B2
+solitaire,lonely,孤独的,ADJ,B2
+long,long,长的,ADJ,B2
+il y a longtemps,long ago,早已,ADV,B2
+vive,long live,万岁,INTJ,B2
+longtemps,long time,长时间,ADV,B2
+autocar,long-distance bus,长途车,NOUN,B2
+désir,longing,渴望,NOUN,B2
+regard,look,看,NOUN,B2
+s'occuper de,to look after,照料,VERB,B2
+regarder,to look at,观看,VERB,B2
+te voilà,look at you,你看你,NOUN,B2
+mépriser,to look down upon,看不起,VERB,B2
+chercher,to look for to find,找,VERB,B2
+consulter,to look up,查阅,VERB,B2
+vigie,lookout,瞭望,NOUN,B2
+faille,loophole,漏洞,NOUN,B2
+desserrer,to loosen,放松,VERB,B2
+seigneur Yu,lord yu,玉大人,NOUN,B2
+paroles du seigneur,lord's words,主说,NOUN,B2
+perte,lose,上丢,NOUN,B2
+bruyant,loud,大声的,ADJ,B2
+salon,lounge,休息室,NOUN,B2
+pouilleux,lousy,糟糕的,ADJ,B2
+marée basse,low tide,退潮,NOUN,B2
+loyal,loyal,忠诚的,ADJ,B2
+chance,lucky chance,虽侥,NOUN,B2
+morceau,lump,块,NOUN,B2
+déjeuner,lunch,午餐,NOUN,B2
+leurre,lure,诱惑,NOUN,B2
+éclat,luster,光泽,NOUN,B2
+lymphe,lymph,淋巴,NOUN,B2
+paroles,lyrics,歌词,NOUN,B2
+machine,machine,机器,NOUN,B2
+macroscopique,macroscopic,宏观的,ADJ,B2
+fou,madman,疯子,NOUN,B2
+magazine,magazine,杂志,NOUN,B2
+servante,maid,女仆,NOUN,B2
+jeune fille,maiden,少女,NOUN,B2
+boîte aux lettres,mailbox,邮箱,NOUN,B2
+continent,mainland,大陆,NOUN,B2
+courant dominant,mainstream,主流,NOUN,B2
+majeur,major,少校,NOUN,B2
+matière principale,major course,专业课,NOUN,B2
+faire,to make,制作,VERB,B2
+se tromper,to make a mistake,弄错,VERB,B2
+faire un discours,to make a speech,发言,VERB,B2
+se débrouiller,to make do,做,VERB,B2
+erreur,make mistake,犯错,NOUN,B2
+faire du bruit,to make noise,闹得,VERB,B2
+s'assurer,to make sure,确保,VERB,B2
+compenser,to make up for,弥补,VERB,B2
+fabricant,maker,制造者,NOUN,B2
+maladie,malady,弊病,NOUN,B2
+malice,malice,恶意,NOUN,B2
+malin,malignant,恶性的,ADJ,B2
+gestion,management,管理,NOUN,B2
+obligatoire,mandatory,强制的,ADJ,B2
+manipulation,manipulation,操纵,NOUN,B2
+manoir,mansion,豪宅,NOUN,B2
+beaucoup,many,许多,ADJ,B2
+souvent,many times,多次,ADV,B2
+marathon,marathon,马拉松,NOUN,B2
+maritime,maritime,海事的,ADJ,B2
+marque,mark,标记,NOUN,B2
+alliance matrimoniale,marriage alliance,联姻,NOUN,B2
+mariable,marriageable,适婚,NOUN,B2
+marié,married,已婚的,ADJ,B2
+massacre,massacre,大屠杀,NOUN,B2
+maîtriser,to master,掌握,VERB,B2
+master,master's degree,硕士学位,NOUN,B2
+mot de maître,master's word,爷说,NOUN,B2
+chef-d'œuvre,masterpiece,杰作,NOUN,B2
+assorti,matching,配套,ADJ,B2
+temps de correspondance,matching time,对时,NOUN,B2
+entremetteur,matchmaker,媒,NOUN,B2
+tante maternelle,maternal aunt,姨母,NOUN,B2
+oncle maternel,maternal uncle,舅舅,NOUN,B2
+maths,math,数学,NOUN,B2
+mathématiques,mathematics,数学,NOUN,B2
+matière,matter,事情,NOUN,B2
+mature,mature,成熟的,ADJ,B2
+maxime,maxim,格言,NOUN,B2
+mai,may,五月,NOUN,B2
+peut-être,maybe,也许,ADV,B2
+moi,me,لي,NOUN,B2
+intervalle,meantime,同时,NOUN,B2
+cependant,meanwhile,同时,ADV,B2
+volume,measure word for books,本,NUM,B2
+mécaniste,mechanistic,机制性,ADJ,B2
+médier,to mediate,调解,VERB,B2
+dossier médical,medical record,病历,NOUN,B2
+médicament,medication,药物,NOUN,B2
+méditation,meditation,冥想,NOUN,B2
+mélancolique,melancholy,忧郁,ADJ,B2
+palpage de melon,melon groping,摸瓜,NOUN,B2
+mémorandum,memorandum,备忘录,NOUN,B2
+mémorial,memorial,纪念碑,NOUN,B2
+réparer,to mend,修补,VERB,B2
+mental,mental,精神的,ADJ,B2
+mention,mention,提及,NOUN,B2
+mentor,mentor,导师,NOUN,B2
+menu,menu,菜单,NOUN,B2
+seulement,merely,仅仅,ADV,B2
+fusion,merge,合并,NOUN,B2
+sirène,mermaid,美人鱼,NOUN,B2
+désordre,mess,混乱,NOUN,B2
+message,message,信息,NOUN,B2
+désordonné,messy,混乱的,ADJ,B2
+métaphysique,metaphysics,形而上学,NOUN,B2
+mexicain,mexican,墨西哥的,ADJ,B2
+microscope,microscope,显微镜,NOUN,B2
+minuit,midnight,午夜,NOUN,B2
+milieu,midst,中间,NOUN,B2
+puissance,might,威力,NOUN,B2
+migraine,migraine,偏头痛,NOUN,B2
+migrate,to migrate,迁移,VERB,B2
+migration,migration,移民,NOUN,B2
+mild,mild,温和的,ADJ,B2
+mile,mile,英里,NOUN,B2
+milestone,milestone,里程碑,NOUN,B2
+military,military,军队,NOUN,B2
+military intelligence,military intelligence,军情,NOUN,B2
+military order,military order,军令,NOUN,B2
+military power,military power,兵权,NOUN,B2
+million,million,百万,NOUN,B2
+mind,to mind,介意,VERB,B2
+mine,mine,矿井,NOUN,B2
+mineral,mineral,矿物,NOUN,B2
+minister,minister,臣,PART,B2
+ministerial,ministerial,部长的,ADJ,B2
+minor course,minor course,辅修课,NOUN,B2
+mint,mint,薄荷,NOUN,B2
+minute,minute,分钟,NOUN,B2
+miracle,miracle,奇迹,NOUN,B2
+misery,misery,痛苦,NOUN,B2
+misfortune,misfortune,不幸,NOUN,B2
+mislead,to mislead,误导,VERB,B2
+mission,mission,任务,NOUN,B2
+mistake,to mistake,弄错,VERB,B2
+mistreat,to mistreat,أساء,VERB,B2
+misunderstand,to misunderstand,误解,VERB,B2
+moan,moan,呻吟,NOUN,B2
+moan,to moan,呻吟,VERB,B2
+mobile,mobile,移动的,ADJ,B2
+mobile payment,mobile payment,移动支付,NOUN,B2
+mode,mode,方式,NOUN,B2
+moderate rain,moderate rain,中雨,NOUN,B2
+modification,modification,修改,NOUN,B2
+modified effect,modified effect,改效,NOUN,B2
+modified model,modified model,改模,NOUN,B2
+modified sound,modified sound,改响,NOUN,B2
+modified system,modified system,改系,NOUN,B2
+modular,modular,模块化的,ADJ,B2
+moist,moist,潮湿的,ADJ,B2
+moment,moment,时刻,NOUN,B2
+momentum,momentum,势头,NOUN,B2
+monitor,monitor,显示器,NOUN,B2
+monitor,to monitor,监控,VERB,B2
+monitoring,monitoring,监控,NOUN,B2
+monitoring room,monitoring room,监控室,NOUN,B2
+monopolistic,monopolistic,垄断的,ADJ,B2
+monopolize,to monopolize,垄断,VERB,B2
+monotonous,monotonous,单调的,ADJ,B2
+month moon,month moon,月,NOUN,B2
+monthly,monthly,每月的,ADV,B2
+monthly exam,monthly exam,月考,NOUN,B2
+mooncake,mooncake,月饼,NOUN,B2
+moral,moral,道德,NOUN,B2
+morals,morals,道德,NOUN,B2
+more,more,更多,ADJ,B2
+more often,more often,更频繁,ADV,B2
+moreover,moreover,此外,ADV,B2
+morning newspaper,morning newspaper,晨报,NOUN,B2
+morphological,morphological,形态的,ADJ,B2
+moss,moss,苔藓,NOUN,B2
+most,most,大多数,ADJ,B2
+mother,mother,娘,PART,B2
+mother's reassurance,mother's reassurance,娘放心,NOUN,B2
+motion,motion,运动,NOUN,B2
+motivation,motivation,动机,NOUN,B2
+motor,motor,发动机,NOUN,B2
+montagne,mountain,山,NOUN,B2
+descente de montagne,mountain descent,下山,NOUN,B2
+chaîne de montagnes,mountain range,山脉,NOUN,B2
+déménagement,move,搬家,NOUN,B2
+film,movie,电影,NOUN,B2
+monsieur,mr.,先生,NOUN,B2
+IRM,mri,核磁共振,NOUN,B2
+beaucoup,much,多,DET,B2
+mucus,mucus,黏液,NOUN,B2
+confus,muddled,混乱的,ADJ,B2
+munificence,munificence,慷慨,NOUN,B2
+assassiner,to murder,谋杀,VERB,B2
+arme du crime,murder weapon,凶器,NOUN,B2
+muscle,muscle,肌肉,NOUN,B2
+douleur musculaire,muscle pain,肌肉痛,NOUN,B2
+musical,musical,موسيقي,ADJ,B2
+devoir,must,必须,AUX,B2
+mutation,mutation,突变,NOUN,B2
+mouton,mutton,羊肉,NOUN,B2
+génération mutuelle,mutual generation,相生,NOUN,B2
+restriction mutuelle,mutual restriction,相克,NOUN,B2
+mon grand,my big one,我偌大,NOUN,B2
+chez moi,my place,我处,NOUN,B2
+ma résidence,my residence,我府,NOUN,B2
+moi-même,myself,我自,NOUN,B2
+harceler,to nag,唠叨,VERB,B2
+nounou,nanny,保姆,NOUN,B2
+nanotechnologie,nanotechnology,纳米技术,NOUN,B2
+serviette,napkin,餐巾,NOUN,B2
+raconter,to narrate,叙述,VERB,B2
+récit,narrative,叙述；故事,NOUN,B2
+étroit,narrow,狭窄的,ADJ,B2
+étroitesse,narrowness,狭窄,NOUN,B2
+méchant,nasty,令人不快的,ADJ,B2
+nation,nation,国家,NOUN,B2
+national,national,国家的,ADJ,B2
+nationalité,nationality,国籍,NOUN,B2
+nature,nature,本性,NOUN,B2
+réserve naturelle,nature reserve,自然保护区,NOUN,B2
+navigation,navigation,导航；航行,NOUN,B2
+marine,navy,海军,NOUN,B2
+nazi,nazi,纳粹分子,NOUN,B2
+proche,near,近,ADJ,B2
+alentours,nearby,在附近,ADV,B2
+presque,nearly,几乎,ADV,B2
+nécessiter,need,需要,AUX,B2
+nécessiter,to need,需要,VERB,B2
+négater,to negate,否定,VERB,B2
+négation,negation,否定,NOUN,B2
+négliger,to neglect,忽视,VERB,B2
+négligent,negligent,疏忽的,ADJ,B2
+non négligeable,negligible not,不可忽视,ADJ,B2
+hennir,to neigh,嘶鸣,VERB,B2
+voisin,neighboring,邻近的,ADJ,B2
+ni,neither,也不,CCONJ,B2
+nervosité,nervousness,紧张,NOUN,B2
+jour de l'an,new year's day,元旦,NOUN,B2
+prochain,next,接下来,ADV,B2
+voisin,next door,隔壁,NOUN,B2
+à côté de,next to,在...旁边,ADP,B2
+agréable,nice,好的,ADJ,B2
+vue nocturne,night view,夜景,NOUN,B2
+boîte de nuit,nightclub,夜总会,NOUN,B2
+cauchemar,nightmare,噩梦,NOUN,B2
+neuf,nine,九,NUM,B2
+quatre-vingt-dix,ninety,九十,NUM,B2
+non,no,毫无,DET,B2
+aucun mal,no harm,没事吧,NOUN,B2
+plus,no longer,不再,ADV,B2
+peu importe,no matter,不论,CCONJ,B2
+inutile,no need,不用,AUX,B2
+noble,noble,高尚的,ADJ,B2
+noble,nobleman,贵族,NOUN,B2
+personne,nobody,没有人,PRON,B2
+hocher,to nod,点头,VERB,B2
+bruyant,noisy,吵闹的,ADJ,B2
+nommer,to nominate,提名,VERB,B2
+nomination,nomination,提名,NOUN,B2
+inaptitude,non-ability,非能,NOUN,B2
+non-abstraction,non-abstraction,非抽,NOUN,B2
+non-action,non-action,非作,NOUN,B2
+non-assistance,non-assistance,勿助,NOUN,B2
+non-croyance,non-belief,非信,NOUN,B2
+non-concept,non-concept,非概,NOUN,B2
+non-construction,non-construction,非建,NOUN,B2
+non-contingent,non-contingent,非偶,NOUN,B2
+non-preuve,non-evidence,非据,NOUN,B2
+non-induction,non-induction,非归,NOUN,B2
+non-inférence,non-inference,非推,NOUN,B2
+non-niveau,non-level,非级,NOUN,B2
+non-gestion,non-management,管不,NOUN,B2
+non-mérite,non-merit,非功,NOUN,B2
+non-esprit,non-mind,非心,NOUN,B2
+non-modèle,non-model,非模,NOUN,B2
+non-orbite,non-orbit,非轨,NOUN,B2
+non-ordre,non-order,非序,NOUN,B2
+non-ombre,non-shadow,非影,NOUN,B2
+non-son,non-sound,非响,NOUN,B2
+non-spécifique,non-specific,非殊,NOUN,B2
+non-état,non-state,非态,NOUN,B2
+non-stratégie,non-strategy,非略,NOUN,B2
+non-substance,non-substance,非质,NOUN,B2
+non-pensée,non-thought,非念,NOUN,B2
+non-trace,non-trace,非迹,NOUN,B2
+non-guerre,non-war,非战,NOUN,B2
+non conforme,noncompliant,违规,ADJ,B2
+aucun,none,没有一个,PRON,B2
+non-sens,nonsense,胡说,NOUN,B2
+non,nope,不,INTJ,B2
+norme,norm,规范,NOUN,B2
+normal,normal,正常的,ADJ,B2
+nordique,northern,北方的,ADJ,B2
+ne,not,不,PART,B2
+concerner,to not about,不关,VERB,B2
+permettre,not allow,不许,AUX,B2
+non autorisé,not allowed,不准,ADJ,B2
+venir,to not come,不来,VERB,B2
+avoir,to not have,没,VERB,B2
+non seulement,not only,不光,CCONJ,B2
+notable,notable,显著的,ADJ,B2
+notarisation,notarization,公证,NOUN,B2
+note,note,笔记,NOUN,B2
+notification,notification,通知,NOUN,B2
+notifier,to notify,通知,VERB,B2
+roman,novel,小说,NOUN,B2
+de nos jours,nowadays,如今,ADV,B2
+nulle part,nowhere,无处,ADV,B2
+nuisance,nuisance,麻烦事,NOUN,B2
+numéro deux,number two,二号,NOUN,B2
+engourdissement,numbness,麻木,NOUN,B2
+religieuse,nun,修女,NOUN,B2
+nourrir,to nurture,养育,VERB,B2
+nourrissement,nurturing,养好,NOUN,B2
+nutrition,nutrition,营养,NOUN,B2
+oasis,oasis,绿洲,NOUN,B2
+obéissant,obedient,顺从的,ADJ,B2
+obéir,to obey,服从,VERB,B2
+objection,objection,异议,NOUN,B2
+objective,objective,客观的,ADJ,B2
+obligation,obligation,义务,NOUN,B2
+obscene,obscene,淫秽的,ADJ,B2
+observation,observation,观察,NOUN,B2
+observe,to observe,观察,VERB,B2
+obsessed,obsessed,着迷的,ADJ,B2
+obstacle,obstacle,障碍,NOUN,B2
+obstruct,to obstruct,阻碍,VERB,B2
+obstruction,obstruction,阻塞,NOUN,B2
+obvious,obvious,明显的,ADJ,B2
+obviously,obviously,显然,ADV,B2
+occasion,occasion,场合,NOUN,B2
+occupation,occupation,职业,NOUN,B2
+occupied,occupied,被占用的,ADJ,B2
+occurrence,occurrence,发生,NOUN,B2
+odd,odd,奇怪的,ADJ,B2
+of,of,之,PART,B2
+of course,of course,理所当然的,ADJ,B2
+off-road vehicle,off-road vehicle,越野车,NOUN,B2
+offend,to offend,冒犯,VERB,B2
+official,official,官员,NOUN,B2
+officials,officials,官员,NOUN,B2
+oh,oh,哇,PART,B2
+oh my god,oh my god,我的天,INTJ,B2
+okay,okay,好的,INTJ,B2
+old age,old age,老年,NOUN,B2
+old man,old man,老人,NOUN,B2
+old master,old master,老太爷,NOUN,B2
+old person,old person,老人,NOUN,B2
+old servant,old servant,老奴,NOUN,B2
+old woman,old woman,老妇人,NOUN,B2
+older brother,older brother,大哥哥,NOUN,B2
+ominous,ominous,不祥的,ADJ,B2
+omit,to omit,省略,VERB,B2
+on,on,在...上,ADP,B2
+on head,on head,当头,NOUN,B2
+on it,on it,在上面,ADV,B2
+on the contrary,on the contrary,相反,ADV,B2
+on the other hand,on the other hand,另一方面,ADV,B2
+on the way,on the way,在路上,ADV,B2
+once,once,一次,ADV,B2
+once more,once more,再次,ADV,B2
+one after another,one after another,接连地,ADV,B2
+one book,one book,一本,NUM,B2
+one day,one day,一天,NUM,B2
+one family,one family,一家,NUM,B2
+one flat,one flat,一张,NUM,B2
+one head,one head,一头,NUM,B2
+one night,one night,一晚,NUM,B2
+one set,one set,一套,NUM,B2
+one shot,one shot,一枪,NUM,B2
+one's heart's content,one's heart's content,尽情,ADV,B2
+one-sided,one-sided,单方面的,ADJ,B2
+only,only,唯一的,ADJ,B2
+only just,only just,才,ADV,B2
+only then,only then,才,ADV,B2
+only-me,only-me,只我,NOUN,B2
+opening,opening,开口,NOUN,B2
+opposite,opposite,对立面,NOUN,B2
+opposition,opposition,对立,NOUN,B2
+oppress,to oppress,压迫,VERB,B2
+oppression,oppression,压迫,NOUN,B2
+optical,optical,光学的,ADJ,B2
+optics,optics,光学,NOUN,B2
+optional,optional,可选的,ADJ,B2
+options,options,期权,NOUN,B2
+plutôt,or rather,或者,ADV,B2
+oral,oral,口头的,ADJ,B2
+décret oral,oral decree,口谕,NOUN,B2
+orange,orange,橙色,NOUN,B2
+verger,orchard,果园,NOUN,B2
+ordonné,orderly,有序的,ADJ,B2
+ordinairement,ordinarily,通常,ADV,B2
+jour ordinaire,ordinary day,平日,NOUN,B2
+gens ordinaires,ordinary people,老百姓,NOUN,B2
+organisé,organized,有组织的,ADJ,B2
+orientation,orientation,取向,NOUN,B2
+original,original,最初的,ADJ,B2
+document original,original document,原件,NOUN,B2
+à l'origine,originally,最初,ADV,B2
+originer,to originate,发源,VERB,B2
+autre,other,其他的,DET,B2
+autre côté,other side,对面,NOUN,B2
+autres,others,他人,NOUN,B2
+aïe,ouch,哎哟,INTJ,B2
+dehors,out,在外面,ADV,B2
+hors de,out of,从...出来,ADP,B2
+paria,outcast,被遗弃者,NOUN,B2
+latrine,outhouse,茅房,NOUN,B2
+sortie,outing,郊游,NOUN,B2
+esquisser,to outline,勾勒,VERB,B2
+perspective,outlook,前景,NOUN,B2
+outrage,outrage,愤怒,NOUN,B2
+remarquable,outstanding,杰出的,ADJ,B2
+four,oven,烤箱,NOUN,B2
+au-dessus,over,在...上方,ADP,B2
+là-bas,over there,在那边,ADV,B2
+sur-domaine,over-domain,超畴,NOUN,B2
+surstratégie,over-strategy,超策,NOUN,B2
+surcoup,over-stroke,超程,NOUN,B2
+couvert,overcast,阴天的,ADJ,B2
+dépasser,to overdraw,透支,VERB,B2
+échu,overdue,逾期,ADJ,B2
+chevauchement,overlap,重叠,NOUN,B2
+du jour au lendemain,overnight,一夜之间,ADV,B2
+Chinois d'outre-mer,overseas chinese,华侨,NOUN,B2
+dépasser,to overtake,超过,VERB,B2
+heures supplémentaires,overtime,加班,NOUN,B2
+submerger,to overwhelm,使不知所措,VERB,B2
+devoir,to owe,欠,VERB,B2
+propre,own,自己的,ADJ,B2
+propriété,ownership,,NOUN,B2
+leader,pace-setter,标兵,NOUN,B2
+emballer,to pack,打包,VERB,B2
+bondé,packed,打包,ADJ,B2
+coussin,pad,垫,NOUN,B2
+page,page,页,NOUN,B2
+douleur,pain,疼痛,NOUN,B2
+peinture,paint,油漆,NOUN,B2
+poêle,pan,平底锅,NOUN,B2
+haléter,to pant,喘气,VERB,B2
+papaye,papaya,木瓜,NOUN,B2
+découpe de papier,paper cutting,剪纸,NOUN,B2
+travaux administratifs,paperwork,文书工作,NOUN,B2
+paradis,paradise,天堂,NOUN,B2
+parangon,paragon,典范,NOUN,B2
+paralyser,to paralyze,使瘫痪,VERB,B2
+secouriste,paramedic,急救人员,NOUN,B2
+pardonner,pardon,赦免,NOUN,B2
+pardonner,to pardon,赦免,VERB,B2
+parent,parent,父母,NOUN,B2
+parents,parents,父母,NOUN,B2
+parlement,parliament,议会,NOUN,B2
+parole,parole,假释,NOUN,B2
+partir,to part,分离,VERB,B2
+décéder,to part by death,死别,VERB,B2
+cause partielle,partial cause,分因,NOUN,B2
+sens partiel,partial meaning,分义,NOUN,B2
+participant,participant,参与者,NOUN,B2
+participation,participation,参与,NOUN,B2
+partiellement,partly,部分地,ADV,B2
+passer,to pass by,经过,VERB,B2
+transmettre,to pass on,转交,VERB,B2
+passage,passage,段落,NOUN,B2
+passage,passing,过世,NOUN,B2
+passion,passion,激情,NOUN,B2
+mot de passe,password,密码,NOUN,B2
+passé,past,过去的,ADJ,B2
+annales,past exam papers,真题,NOUN,B2
+pâtes,pasta,意大利面,NOUN,B2
+pâte,paste,酱,NOUN,B2
+tapoter,to pat,轻拍,VERB,B2
+patch,patch,补丁,NOUN,B2
+tante paternelle,paternal aunt,姑母,NOUN,B2
+patience,patience,耐心,NOUN,B2
+patient,patient,耐心的,ADJ,B2
+patriotique,patriotic,爱国的,ADJ,B2
+patriotisme,patriotism,爱国主义,NOUN,B2
+motif,pattern,模式,NOUN,B2
+s'arrêter,pause,暂停,NOUN,B2
+s'arrêter,to pause,暂停,VERB,B2
+pavillon,pavilion,亭子,NOUN,B2
+faire attention,to pay attention,注意,VERB,B2
+rendre hommage,to pay respects,参见,VERB,B2
+payer en souriant,to pay smilingly,笑付,VERB,B2
+payer des impôts,to pay tax,纳税,VERB,B2
+paiement intégral,payment all,付都,NOUN,B2
+pêche,peach,桃子,NOUN,B2
+pédagogique,pedagogical,教学的,ADJ,B2
+passerelle,pedestrian bridge,天桥,NOUN,B2
+pisser,to pee,小便,VERB,B2
+peler,peel,皮,NOUN,B2
+peler,to peel,削皮,VERB,B2
+pair,peer,同龄人,NOUN,B2
+stylo,pen,钢笔,NOUN,B2
+pension,pension,养老金,NOUN,B2
+pourcent,percent,百分比,NOUN,B2
+perception,perception,感知,NOUN,B2
+perfection,perfection,完美,NOUN,B2
+peut-être,perhaps,也许,ADV,B2
+permanence,permanence,持久,NOUN,B2
+permanent,permanent,永久的,ADJ,B2
+perméable,permeable,可渗透的,ADJ,B2
+permission,permission,许可,NOUN,B2
+permis,permit,许可证,NOUN,B2
+perpendiculaire,perpendicular,垂直的,ADJ,B2
+auteur,perpetrator,肇事者,NOUN,B2
+titre honorifique,person honorific,位,NOUN,B2
+responsable,person in charge,负责人,NOUN,B2
+personnel,personal,个人的,ADJ,B2
+inimitié personnelle,personal enmity,私仇,NOUN,B2
+record personnel,personal record,个人纪录,NOUN,B2
+personnel,personnel,人员,NOUN,B2
+perspective,perspective,视角,NOUN,B2
+persuasion,persuasion,说服,NOUN,B2
+pesticide,pesticide,杀虫剂,NOUN,B2
+animal de compagnie,pet,宠物,NOUN,B2
+pétrole,petroleum,石油,NOUN,B2
+pharmacie,pharmacy,药房,NOUN,B2
+échelonné,phased,阶段性,ADJ,B2
+flegme,phlegm,痰,NOUN,B2
+phénix,phoenix,拿凤,NOUN,B2
+téléphoner,phone,电话,NOUN,B2
+téléphoner,to phone,打电话,VERB,B2
+appel téléphonique,phone call,通话,NOUN,B2
+phonologie,phonology,音系学,NOUN,B2
+photo,photo,照片,NOUN,B2
+photocopier,photocopy,复印件,NOUN,B2
+photocopier,to photocopy,复印,VERB,B2
+photographier,photograph,照片,NOUN,B2
+photographier,to photograph,拍照,VERB,B2
+photographe,photographer,摄影师,NOUN,B2
+photographie,photography,摄影,NOUN,B2
+preuve matérielle,physical evidence,物证,NOUN,B2
+médecin,physician,内科医生,NOUN,B2
+physique,physics,物理,NOUN,B2
+physiognomonie,physiognomy,面相,NOUN,B2
+piano,piano,钢琴,NOUN,B2
+mariner,to pickle,腌渍,VERB,B2
+pique-nique,picnic,野餐,NOUN,B2
+image,picture,图画,NOUN,B2
+pigeon,pigeon,鸽子,NOUN,B2
+tas,pile,堆,NOUN,B2
+empiler,to pile up,堆积,VERB,B2
+pincer,pinch,捏,NOUN,B2
+pincer,to pinch,捏,VERB,B2
+pirate,pirate,海盗,NOUN,B2
+pistache,pistachio,开心果,NOUN,B2
+pitoyable,pitiful,可怜的,ADJ,B2
+pitoyable,pity,可惜,ADJ,B2
+placement,placement,放置,NOUN,B2
+plan,plan,计划,NOUN,B2
+avion,plane,飞机,NOUN,B2
+repiquer,to plant out,定植,VERB,B2
+plantation,plantation,人工林,NOUN,B2
+plantation,planting,种植,NOUN,B2
+plastique,plastic,塑料的,ADJ,B2
+plateau,plateau,高原,NOUN,B2
+plaqué,plated,镀层的,ADJ,B2
+plaquette,platelet,血小板,NOUN,B2
+jeu,play,剧本,NOUN,B2
+camarade de jeu,playmate,玩伴,NOUN,B2
+s'il vous plaît,please,请,ADV,B2
+promettre,to pledge,保证,VERB,B2
+situation,plight,处境,NOUN,B2
+prise,plug,插头,NOUN,B2
+plomberie,plumbing,管道工程,NOUN,B2
+pillage,plunder,掠夺,NOUN,B2
+pluralisme,pluralism,多元主义,NOUN,B2
+podcast,podcast,播客,NOUN,B2
+recueil de poésie,poetry collection,诗集,NOUN,B2
+pointer,point,点,NOUN,B2
+pointer,to point,指向,VERB,B2
+moment,point in time,时间点,NOUN,B2
+souligner,to point out,指出,VERB,B2
+poison,poison,毒药,NOUN,B2
+toxique,poisonous,有毒的,ADJ,B2
+polémique,polemical,论战的,ADJ,B2
+police,police,警察,NOUN,B2
+policier,policeman,警察,NOUN,B2
+politique,policy,政策,NOUN,B2
+politique,politics,政治,NOUN,B2
+pollinisation,pollination,授粉,NOUN,B2
+pollué,polluted,受污染的,ADJ,B2
+pollution,pollution,污染,NOUN,B2
+pomélo,pomelo,柚子,NOUN,B2
+réfléchir,to ponder,沉思,VERB,B2
+piscine,pool,池,PART,B2
+musique pop,pop music,流行音乐,NOUN,B2
+pape,pope,教皇,NOUN,B2
+populariser,to popularize,推广,VERB,B2
+population,population,人口,NOUN,B2
+pornographie,porn,色情,NOUN,B2
+port,port,港口,NOUN,B2
+porteur,porter,搬运工,NOUN,B2
+portion,portion,部分,NOUN,B2
+portrait,portrait,肖像,NOUN,B2
+dépeindre,to portray,描绘,VERB,B2
+position,position,位置,NOUN,B2
+posséder,to possess,拥有,VERB,B2
+possession,possession,财产,NOUN,B2
+possible,possible,可能的,ADJ,B2
+bureau de poste,post office,邮局,NOUN,B2
+carte postale,postcard,明信片,NOUN,B2
+reporter,to postpone,推迟,VERB,B2
+pot,pot,锅,NOUN,B2
+volaille,poultry,家禽,NOUN,B2
+bondir,to pounce,猛扑,VERB,B2
+livre,pound,磅,NOUN,B2
+verser,to pour,倾倒,VERB,B2
+poudre,powder,粉末,NOUN,B2
+grande puissance,powerful nation,强国,NOUN,B2
+pratique,practice,练习,NOUN,B2
+louer,to praise,赞扬,VERB,B2
+prédication,preaching,劝诫,NOUN,B2
+précédent,precedent,先例,NOUN,B2
+préciosité,preciousness,珍贵,NOUN,B2
+précipitation,precipitation,降水,NOUN,B2
+prédateur,predatory,掠夺的,ADJ,B2
+embarras,predicament,困境,NOUN,B2
+de préférence,preferably,更愿意,ADV,B2
+premier,premier,总理,NOUN,B2
+préparer,to prepare,准备,VERB,B2
+préparer une leçon,to prepare a lesson,预习,VERB,B2
+absurde,preposterous,荒谬的,ADJ,B2
+prerequisite,prerequisite,前提,NOUN,B2
+preschool,preschool,幼儿园,NOUN,B2
+present,present,礼物,NOUN,B2
+presentation,presentation,展示,NOUN,B2
+preserve,to preserve,保护,VERB,B2
+press conference,press conference,新闻发布会,NOUN,B2
+pressing,pressing,紧迫的,ADJ,B2
+prestige,prestige,声望,NOUN,B2
+presume,to presume,假定,VERB,B2
+pretend,to pretend,假装,VERB,B2
+pretend to be,to pretend to be,冒充,VERB,B2
+pretext,pretext,借口,NOUN,B2
+prevent,to prevent,阻止,VERB,B2
+prime minister,prime minister,总理,NOUN,B2
+prince,prince,王子,NOUN,B2
+prison,prison,监狱,NOUN,B2
+privacy,privacy,隐私,NOUN,B2
+probability,probability,概率,NOUN,B2
+procedure,procedure,程序,NOUN,B2
+process,process,过程,NOUN,B2
+process,to process,处理,VERB,B2
+production,production,生产,NOUN,B2
+professional,professional,专业人士,NOUN,B2
+professor,professor,教授,NOUN,B2
+proficient,proficient,熟练的,ADJ,B2
+profit-making,profit-making,营利性,ADJ,B2
+profound,profound,深刻的,ADJ,B2
+programmer,programmer,程序员,NOUN,B2
+progress report,progress report,进度报告,NOUN,B2
+prohibit,to prohibit,禁止,VERB,B2
+project assignment,project assignment,项目作业,NOUN,B2
+promising,promising,有前途的,ADJ,B2
+promissory note,promissory note,本票,NOUN,B2
+promoter,promoter,推动者,NOUN,B2
+promotion,promotion,晋升,NOUN,B2
+promptement,promptly,迅速地,ADV,B2
+étayer,to prop,撑,VERB,B2
+propre,proper,适当的,ADJ,B2
+prophétiser,to prophesy,预言,VERB,B2
+proportion,proportion,比例,NOUN,B2
+proposition,proposition,主张,NOUN,B2
+propriété,propriety,分寸,NOUN,B2
+prosaïque,prosaic,平淡无奇的,ADJ,B2
+prose,prose,散文,NOUN,B2
+poursuite,prosecution,起诉,NOUN,B2
+perspective,prospect,前景,NOUN,B2
+prostituée,prostitute,妓女,NOUN,B2
+protection,protection,保护,NOUN,B2
+fournir des preuves,to provide evidence,举证,VERB,B2
+fournir des retours,to provide feedback,反馈,VERB,B2
+fournisseur,provider,提供者,NOUN,B2
+province,province,省,NOUN,B2
+route provinciale,provincial highway,省道,NOUN,B2
+provisions,provisions,储备,NOUN,B2
+provocation,provocation,挑衅,NOUN,B2
+proximité,proximity,邻近,NOUN,B2
+mandataire,proxy,代理人,NOUN,B2
+prudence,prudence,谨慎,NOUN,B2
+psychiatre,psychiatrist,精神科医生,NOUN,B2
+bar,pub,酒吧,NOUN,B2
+public,public,公共的,ADJ,B2
+ordre public,public order,治安,NOUN,B2
+bien-être public,public welfare,公益性,NOUN,B2
+éditeur,publisher,出版商,NOUN,B2
+maison d'édition,publishing house,出版社,NOUN,B2
+pouls,pulse,脉搏,NOUN,B2
+coup de poing,punch,拳击,NOUN,B2
+ponctuel,punctual,准时的,ADJ,B2
+crevaison,puncture,穿刺,NOUN,B2
+élève,pupil,学生,NOUN,B2
+acheter,purchase,购买,NOUN,B2
+acheter,to purchase,购买,VERB,B2
+yin pourpre,purple yin,紫阴,NOUN,B2
+but,purpose,目的,NOUN,B2
+poursuivre,to pursue,追求,VERB,B2
+poursuite,pursuit,追求,NOUN,B2
+pousser,to push,推,VERB,B2
+audace,push luck,太得寸,NOUN,B2
+ranger,to put in order,收拾,VERB,B2
+perplexer,puzzle,谜题,NOUN,B2
+perplexer,to puzzle,使困惑,VERB,B2
+qualification,qualification,资格,NOUN,B2
+qualifications,qualifications,资格,NOUN,B2
+qualifié,qualified,合格的,ADJ,B2
+qualitatif,qualitative,定性的,ADJ,B2
+quantité,quantity,数量,NOUN,B2
+se quereller,to quarrel,争吵,VERB,B2
+querelle,quarreling,再吵,NOUN,B2
+trimestre,quarter of a year,季度,NOUN,B2
+revue trimestrielle,quarterly magazine,季刊,NOUN,B2
+quai,quay,码头,NOUN,B2
+quête,quest,探索,NOUN,B2
+question,question,问题,NOUN,B2
+contestable,questionable,可疑的,ADJ,B2
+file,queue,队列,NOUN,B2
+couette,quilt,被子,NOUN,B2
+assez,quite,非常,ADV,B2
+rayonnement,radiance,光辉,NOUN,B2
+radiation,radiation,辐射,NOUN,B2
+radical,radical,激进的,ADJ,B2
+radio,radio,收音机,NOUN,B2
+station de radio,radio station,广播电台,NOUN,B2
+rage,rage,愤怒,NOUN,B2
+chiffonné,ragged,破烂的,ADJ,B2
+raid,raid,突袭,NOUN,B2
+railing,railing,栏杆,NOUN,B2
+railway,railway,铁路,NOUN,B2
+rainforest,rainforest,雨林,NOUN,B2
+raise,to raise,举起,VERB,B2
+raise donations,to raise donations,募捐,VERB,B2
+rampant tyranny,rampant tyranny,横行,NOUN,B2
+rancor,rancor,怨恨,NOUN,B2
+rape,rape,强奸,NOUN,B2
+rape,to rape,强奸,VERB,B2
+rapid,rapid,迅速的,ADJ,B2
+rapprochement,rapprochement,和解,NOUN,B2
+rare,rare,稀有的,ADJ,B2
+rascal,rascal,无赖,NOUN,B2
+rash,rash,轻率的,ADJ,B2
+rat,rat,老鼠,NOUN,B2
+rat-proof,rat-proof,防鼠,ADJ,B2
+rating,rating,评分,NOUN,B2
+ration,ration,配给,NOUN,B2
+raven,raven,乌鸦,NOUN,B2
+raw material,raw material,原材料,NOUN,B2
+ray,ray,光线,NOUN,B2
+re-abruptness,re-abruptness,再骤,NOUN,B2
+re-battle,re-battle,重战,NOUN,B2
+re-boundary,re-boundary,重界,NOUN,B2
+re-course,re-course,重途,NOUN,B2
+re-creation,re-creation,再作,NOUN,B2
+re-enactment,re-enactment,再演,NOUN,B2
+re-evidence,re-evidence,重据,NOUN,B2
+re-fruit,re-fruit,再果,NOUN,B2
+re-inner,re-inner,再内,NOUN,B2
+re-layering,re-layering,改层,NOUN,B2
+re-limit,re-limit,重限,NOUN,B2
+re-logic,re-logic,再逻,NOUN,B2
+re-signification,re-meaning,再义,NOUN,B2
+réorganisation,re-order,重序,NOUN,B2
+rythme,re-pace,重骤,NOUN,B2
+reroutage,re-path,重径,NOUN,B2
+requantification,re-quantity,再量,NOUN,B2
+rejustification,re-reason,重理,NOUN,B2
+reroutage,re-routing,改轨,NOUN,B2
+reséquencement,re-sequencing,改骤,NOUN,B2
+resoumission,re-submission,再上,NOUN,B2
+accessible,reachable,可到达的,ADJ,B2
+immobilier,real estate,不动产,NOUN,B2
+réaliser,to realize,意识到,VERB,B2
+vraiment,really,真正地,ADV,B2
+désir ardent,really want,真要,NOUN,B2
+royaume,realm,领域,NOUN,B2
+arrière,rear,后部,NOUN,B2
+partie arrière,rear part,后部,NOUN,B2
+raisonnable,reasonable,合理的,ADJ,B2
+raisonnement,reasoning,论证,NOUN,B2
+rassurance,reassurance,安抚,NOUN,B2
+cœur rebelle,rebellious heart,反心,NOUN,B2
+reconstruire,to rebuild,重建,VERB,B2
+réprimande,rebuke,责备,NOUN,B2
+réfuter,to rebut,反驳,VERB,B2
+réfutation,rebuttal,反驳,NOUN,B2
+recevoir du courrier,to receive mail,收件,VERB,B2
+recevoir des ordres,to receive orders,受命,VERB,B2
+recevoir une attention mondiale,to receive worldwide attention,举世瞩目,VERB,B2
+récemment,recently,最近,ADV,B2
+réciter,to recite,背诵,VERB,B2
+imprudence,recklessness,轻率,NOUN,B2
+réclamer,to reclaim,收回,VERB,B2
+inclinaison,reclining,躺下,NOUN,B2
+recommandation d'autrui,recommendation by others,他荐,NOUN,B2
+reconnaissance,reconnaissance,侦察,NOUN,B2
+reconsidérer,to reconsider,重新考虑,VERB,B2
+reconsidération,reconsideration,重思,NOUN,B2
+reconstruire,to reconstruct,重建,VERB,B2
+enregistrement,record,记录,NOUN,B2
+tourne-disque,record player,唱机,NOUN,B2
+récupérer,to recuperate,恢复,VERB,B2
+récurrence,recurrence,往复,NOUN,B2
+recycler,to recycle,回收利用,VERB,B2
+redéfinition,redefinition,改界,NOUN,B2
+référer,to refer,参考,VERB,B2
+raffinement,refinement,修养,NOUN,B2
+raffinage,refining,提炼,NOUN,B2
+réforme,reform,改革,NOUN,B2
+réformisme,reformism,改唯,NOUN,B2
+s'abstenir,to refrain,克制,VERB,B2
+refuge,refuge,避难所,NOUN,B2
+concernant,regarding,关于,ADP,B2
+à ce sujet,regarding this,对此,ADV,B2
+régresser,to regress,倒退,VERB,B2
+régressif,regressive,退步的,ADJ,B2
+regret,regret,后悔,NOUN,B2
+règlements,regulations,法规,NOUN,B2
+rééditer,to reissue,补办,VERB,B2
+réitérer,to reiterate,重申,VERB,B2
+raconter,to relate to narrate,叙述,VERB,B2
+relativement,relatively,相对地,ADV,B2
+relativement parlant,relatively speaking,相对而言,ADV,B2
+libération,release,释放,NOUN,B2
+confiance,reliance,信赖,NOUN,B2
+relique,relic,圣物,NOUN,B2
+religion,religion,宗教,NOUN,B2
+relocaliser,to relocate,调动,VERB,B2
+à contrecœur,reluctantly,不情愿地,ADV,B2
+se fier,to rely,依赖,VERB,B2
+se fier à,to rely on,依靠,VERB,B2
+remainder,remainder,剩余部分,NOUN,B2
+remains,remains,残骸,NOUN,B2
+remedy,remedy,补救措施,NOUN,B2
+remember,to remember,记得,VERB,B2
+remembrance,remembrance,纪念,NOUN,B2
+remind,to remind,提醒,VERB,B2
+remorse,remorse,悔恨,NOUN,B2
+remote,remote,遥远的,ADJ,B2
+remote-controlled car,remote-controlled car,遥控车,NOUN,B2
+removal,removal,移除,NOUN,B2
+renaissance,renaissance,复兴,NOUN,B2
+rendezvous,rendezvous,约会,NOUN,B2
+renege,to renege,食言,VERB,B2
+renminbi,renminbi,人民币,NOUN,B2
+reoperation,reoperation,再术,NOUN,B2
+reparation,reparation,赔偿,NOUN,B2
+repay,to repay,偿还,VERB,B2
+repayment,repayment,偿还,NOUN,B2
+repeated,repeated,反复的,ADJ,B2
+repeatedly,repeatedly,反复地,ADV,B2
+repent,to repent,悔改,VERB,B2
+replanning,replanning,再策,NOUN,B2
+reply,to reply,回复,VERB,B2
+reply to your-highness,reply to your-highness,回殿下,NOUN,B2
+reporter,reporter,记者,NOUN,B2
+repositioning,repositioning,重新定位,NOUN,B2
+reprehensible,reprehensible,应受谴责的,ADJ,B2
+representation,representation,代表,NOUN,B2
+repressive,repressive,压制的,ADJ,B2
+reprice,reprice,再价,NOUN,B2
+reproduction,reproduction,繁殖,NOUN,B2
+repulse,repulse,击退,NOUN,B2
+repulsive,repulsive,令人反感的,ADJ,B2
+request,to request,请求,VERB,B2
+required,required,必需的,ADJ,B2
+sauvetage,rescue,救援,NOUN,B2
+sauvetage,rescue a-fang,救阿方,NOUN,B2
+rechercher,to research,研究,VERB,B2
+réserve,reserve,预备,NOUN,B2
+remaniement,reshaping,改形,NOUN,B2
+recours,resort,度假胜地,NOUN,B2
+ressource,resource,资源,NOUN,B2
+respect,respect,尊重,NOUN,B2
+respectueux,respectful deferential,恭敬,ADJ,B2
+répondre,to respond,回应,VERB,B2
+répondre à,to respond to,回应,VERB,B2
+réponse,response,回应,NOUN,B2
+restaurant,restaurant,餐厅,NOUN,B2
+restauration,restoration,恢复,NOUN,B2
+retenue,restraint,隐忍,NOUN,B2
+restructuration,restructuring,重组,NOUN,B2
+résumé,resume,简历,NOUN,B2
+détail,retail,零售,NOUN,B2
+redire,to retell,转述,VERB,B2
+prendre sa retraite,to retire,退休,VERB,B2
+retraité,retired,退休的,ADJ,B2
+se retirer,retreat,撤退,NOUN,B2
+se retirer,to retreat,撤退,VERB,B2
+récupération,retrieval,检索,NOUN,B2
+récupérer,to retrieve,取回,VERB,B2
+récupération,retrieve qingming,拿回青冥,NOUN,B2
+retourner d'abord,to return first,先回,VERB,B2
+resaisie,retype,再型,NOUN,B2
+réutilisation,reuse,重用,NOUN,B2
+vénérer,to revere,尊敬,VERB,B2
+inclusion inverse,reverse inclusion,反纳,NOUN,B2
+réflexion inverse,reverse reflection,反影,NOUN,B2
+revers,reverse side,反面,NOUN,B2
+réversion,reversion,重归,NOUN,B2
+examiner,review,回顾,NOUN,B2
+examiner,to review,复习,VERB,B2
+révoquer,to revoke,撤销,VERB,B2
+récompense,reward,奖励,NOUN,B2
+rhétorique,rhetorical,修辞的,ADJ,B2
+question rhétorique,rhetorical question,宁非,NOUN,B2
+richement doté par la nature,richly endowed by nature,得天独厚,ADJ,B2
+énigme,riddle,谜语,NOUN,B2
+promenade,ride,行程,NOUN,B2
+échappée,ride break,骑破,NOUN,B2
+fissure,rift,裂痕,NOUN,B2
+à droite,right,右边,ADV,B2
+juste,righteous,正直的,ADJ,B2
+indignation juste,righteous indignation,义愤,NOUN,B2
+droiture,righteousness,亦正,NOUN,B2
+droits,rights,权利,NOUN,B2
+périphérique,ring road,绕城,NOUN,B2
+sonnerie,ringing,铃声,NOUN,B2
+émeute,riot,骚乱,NOUN,B2
+monter,to rise,上升,VERB,B2
+risquer sa vie,to risk life,拼命,VERB,B2
+risque de mort,risking death,冒死,NOUN,B2
+risqué,risky,危险的,ADJ,B2
+panneau routier,road sign,路标,NOUN,B2
+errer,to roam,漫游,VERB,B2
+rugir,to roar,咆哮,VERB,B2
+rôtir l'agneau,to roast lamb,烤羊,VERB,B2
+voler,to rob,抢劫,VERB,B2
+voleur,robber,强盗,NOUN,B2
+vol,robbery,抢劫案,NOUN,B2
+robot,robot,机器人,NOUN,B2
+rocaille,rockery,假山,NOUN,B2
+modèle,role model,榜样,NOUN,B2
+store enrouleur,roller blind,卷帘,NOUN,B2
+roman,roman,罗马人,NOUN,B2
+romance,romance,浪漫,NOUN,B2
+roof,to roof,房顶,VERB,B2
+roommate,roommate,室友,NOUN,B2
+rooster,rooster,公鸡,NOUN,B2
+rose,rose,玫瑰,NOUN,B2
+rough,rough,粗糙的,ADJ,B2
+roughly,roughly,大约,ADV,B2
+round,round,轮 / 回合,NOUN,B2
+router,router,路由器,NOUN,B2
+routine,routine,常规,NOUN,B2
+royal,royal,皇家的,ADJ,B2
+rubbing,rubbing,摩擦,NOUN,B2
+rudeness,rudeness,粗鲁,NOUN,B2
+ruins,ruins,废墟,NOUN,B2
+rule of law,rule of law,法治,NOUN,B2
+ruler,ruler,统治者,NOUN,B2
+run,run,跑步,NOUN,B2
+run into,to run into,碰见,VERB,B2
+run over,to run over,碾过,VERB,B2
+run quickly,to run quickly,奔驰,VERB,B2
+run to jog,to run to jog,跑步,VERB,B2
+running,running,进行中的,NOUN,B2
+runny nose,runny nose,流鼻涕,NOUN,B2
+rupture,rupture,破裂,NOUN,B2
+rural,rural,乡村的,ADJ,B2
+rush,rush,赶往,NOUN,B2
+rush about,to rush about,奔波,VERB,B2
+russian,russian,俄罗斯人,NOUN,B2
+rust-proof,rust-proof,防锈,ADJ,B2
+ruthlessness,ruthlessness,无情,NOUN,B2
+sad,sad,悲伤的,ADJ,B2
+sad sorrowful,sad sorrowful,悲伤,ADJ,B2
+safe,safe,安全的,ADJ,B2
+safety report,safety report,安全报告,NOUN,B2
+sail,to sail,航行,VERB,B2
+voile,sailing,航行,NOUN,B2
+saint,saint,圣人,NOUN,B2
+sake,sake,缘故,NOUN,B2
+vente,sale,出售,NOUN,B2
+vendeur,salesperson,销售人员,NOUN,B2
+salé,salty,咸的,ADJ,B2
+salut,salvation,拯救,NOUN,B2
+échantillon,sample,样本,NOUN,B2
+sanction,sanction,制裁,NOUN,B2
+tempête de sable,sandstorm,沙尘暴,NOUN,B2
+sandwich,sandwich,三明治,NOUN,B2
+santé mentale,sanity,理智,NOUN,B2
+père Noël,santa claus,圣诞老人,NOUN,B2
+satellite,satellite,卫星,NOUN,B2
+satiété,satiety,饱足,NOUN,B2
+satire,satire,讽刺,NOUN,B2
+satisfaction,satisfaction,满意,NOUN,B2
+satisfait,satisfied,满意的,ADJ,B2
+sauce,sauce,酱汁,NOUN,B2
+sauveur,savior,救星,NOUN,B2
+dire au revoir,to say goodbye,告别,VERB,B2
+échafaudage,scaffold,脚手架,NOUN,B2
+scolder,to scald,烫伤,VERB,B2
+scalpel,scalpel,手术刀,NOUN,B2
+scan,scan,扫描件,NOUN,B2
+rare,scarce,稀少的,ADJ,B2
+effrayer,to scare,惊吓,VERB,B2
+effrayé,scared,害怕的,ADJ,B2
+écharpe,scarf,围巾,NOUN,B2
+éparpiller,to scatter,分散,VERB,B2
+éparpillé,scattered,分散的,ADJ,B2
+paysage,scenery,风景,NOUN,B2
+schéma,scheme,计划,NOUN,B2
+schizophrénie,schizophrenia,精神分裂症,NOUN,B2
+savant,scholar,学者,NOUN,B2
+école,school,学校,NOUN,B2
+science,science,科学,NOUN,B2
+scientifique,scientist,科学家,NOUN,B2
+gronder,to scold,训斥,VERB,B2
+score,score,比分,NOUN,B2
+coquin,scoundrel,恶棍,NOUN,B2
+scout,scout,侦察员,NOUN,B2
+chute,scrap,碎屑,NOUN,B2
+crier,scream,尖叫,NOUN,B2
+crier,to scream,尖叫,VERB,B2
+examiner,screen,屏幕,NOUN,B2
+examiner,to screen,筛选,VERB,B2
+script,script,剧本,NOUN,B2
+scénario,script for play,剧本,NOUN,B2
+scruter,to scrutinize,仔细检查,VERB,B2
+plongée sous-marine,scuba diving,潜水,NOUN,B2
+sculpteur,sculptor,雕塑家,NOUN,B2
+sculpture,sculpture,雕塑,NOUN,B2
+mouette,seagull,海鸥,NOUN,B2
+sceller,to seal,密封,VERB,B2
+recherche,search,搜索,NOUN,B2
+se séparer,to secede,脱离,VERB,B2
+sortie de retrait,seclusion exit,出关,NOUN,B2
+seconde fois,second time,再而,NOUN,B2
+confidentialité,secrecy,保密,NOUN,B2
+secret,secret,秘密的,ADJ,B2
+réunion secrète,secret meeting,密会,NOUN,B2
+sectaire,sectarian,宗派的,ADJ,B2
+agent de sécurité,security guard,保安,NOUN,B2
+voir un cadavre,to see corpse,见尸,VERB,B2
+congé,see off,送走,NOUN,B2
+voir à travers,to see through,看穿,VERB,B2
+chercher,to seek,寻找,VERB,B2
+solliciter une audience,to seek audience,求见,VERB,B2
+seek truth from facts,to seek truth from facts,实事求是,VERB,B2
+seeking,seeking,寻求,NOUN,B2
+seeking instant benefit,seeking instant benefit,急功近利,ADJ,B2
+seemingly,seemingly,表面上,ADV,B2
+self,self,自我,NOUN,B2
+self-confidence,self-confidence,自信,NOUN,B2
+self-confident,self-confident,自信的,ADJ,B2
+self-sacrifice,self-sacrifice,舍己,NOUN,B2
+selfish,selfish,自私的,ADJ,B2
+selfishness,selfishness,自私,NOUN,B2
+seller,seller,售货员,NOUN,B2
+semester,semester,学期,NOUN,B2
+sensation,sensation,感觉,NOUN,B2
+senseless,senseless,无意义的,ADJ,B2
+sentence,sentence,句子,NOUN,B2
+sentence,to sentence,判决,VERB,B2
+sentiment,sentiment,情感,NOUN,B2
+sentry,sentry,卫兵,NOUN,B2
+serene,serene,宁静的,ADJ,B2
+serial killer,serial killer,连环杀手,NOUN,B2
+seriousness,seriousness,严肃,NOUN,B2
+sermon,sermon,布道,NOUN,B2
+server,server,服务器,NOUN,B2
+service road,service road,辅路,NOUN,B2
+sesame,sesame,芝麻,NOUN,B2
+session,session,会议,NOUN,B2
+set,set,一套,NOUN,B2
+set,to set,设置,VERB,B2
+set off,to set off,出发,VERB,B2
+set up,to set up,建立,VERB,B2
+seventy,seventy,七十,NUM,B2
+several,several,若干,NOUN,B2
+shackle,shackle,镣铐,NOUN,B2
+shadow,shadow,影子,NOUN,B2
+shake hands,to shake hands,握手,VERB,B2
+peu profond,shallow,浅的,ADJ,B2
+charlatanisme,sham,假冒,NOUN,B2
+honte,shame,羞愧,NOUN,B2
+honte,to shame,使羞愧,VERB,B2
+impudent,shameless,无耻的,ADJ,B2
+façonner,to shape,塑造,VERB,B2
+part,share,股份,NOUN,B2
+feuille,sheet,床单,NOUN,B2
+étagère,shelf,架子,NOUN,B2
+berger,shepherd,牧羊人,NOUN,B2
+changer,shift,轮班,NOUN,B2
+changer,to shift,改变,VERB,B2
+rotation de poste,shift rotation,倒班,NOUN,B2
+échange de poste,shift swap,换班,NOUN,B2
+avancer,to shift to an earlier date,提前,VERB,B2
+brillance,shine,光泽,NOUN,B2
+expédier,to ship out,出货,VERB,B2
+chantier naval,shipyard,造船厂,NOUN,B2
+retrait de chaussures,shoe removal,鞋脱,NOUN,B2
+chaussures,shoes,鞋子,NOUN,B2
+tirer,to shoot,射击,VERB,B2
+abattre,to shoot down,击落,VERB,B2
+fusillade,shootout,枪战,NOUN,B2
+acheter,to shop,购物,VERB,B2
+shopping,shopping,购物,NOUN,B2
+centre commercial,shopping center,购物中心,NOUN,B2
+à court terme,short-term,短期的,ADJ,B2
+défaut,shortcoming,缺点,NOUN,B2
+raccourcir,to shorten,缩短,VERB,B2
+tir,shot,射击,NOUN,B2
+devoir,should,应该,AUX,B2
+ne pas devoir,should not,不该,AUX,B2
+épaule,shoulder,肩膀,NOUN,B2
+se doucher,shower,淋浴,NOUN,B2
+se doucher,to shower,淋浴,VERB,B2
+sanctuaire,shrine,مشعر,NOUN,B2
+rétrécir,to shrink,收缩,VERB,B2
+frisson,shudder,战栗,NOUN,B2
+fratrie,siblings,兄弟姐妹,NOUN,B2
+porte latérale,side door,侧门,NOUN,B2
+siège,siege,围攻,NOUN,B2
+tamis,sieve,筛子,NOUN,B2
+tamiser,to sift,筛选,VERB,B2
+soupirer,sigh,叹息,NOUN,B2
+soupirer,to sigh,叹气,VERB,B2
+soupirer de chagrin,to sigh with sorrow,感慨,VERB,B2
+vue,sight,视力,NOUN,B2
+signer pour,to sign for,签收,VERB,B2
+signaler,signal,信号,NOUN,B2
+signaler,to signal,示意,VERB,B2
+signification,significance,含义,NOUN,B2
+signifier,to signify,意味着,VERB,B2
+se taire,silence,沉默,NOUN,B2
+se taire,to silence,خرس,VERB,B2
+tissu de soie,silk cloth,丝绸,NOUN,B2
+sot,silly,愚蠢的,ADJ,B2
+sotte fille,silly girl,傻丫头,NOUN,B2
+argent,silver,银色,ADJ,B2
+simile,simile,明喻,NOUN,B2
+simple,simple,简单的,ADJ,B2
+simulation,simulation,模拟,NOUN,B2
+chant,singing,歌唱,NOUN,B2
+pensée unique,single thought,一念,NOUN,B2
+monsieur,sir,郎,PART,B2
+s'asseoir,to sit down,坐下,VERB,B2
+situation,situation,情况,NOUN,B2
+circonstances,situation circumstances,情形,NOUN,B2
+six,six,六,NUM,B2
+sixième,sixth,第六,ADJ,B2
+sceptique,skeptical,怀疑的,ADJ,B2
+ski,skiing,滑雪,NOUN,B2
+crâne,skull,头骨,NOUN,B2
+insomnie,sleeplessness,失眠,NOUN,B2
+slogan,slogan,口号,NOUN,B2
+lent,slow,慢的,ADJ,B2
+lentement,slowly,缓慢地,ADV,B2
+lourd,sluggish,迟钝的,ADJ,B2
+petit,smallest,最小的,ADJ,B2
+petitesse,smallness,小小,NOUN,B2
+intelligent,smart,聪明的,ADJ,B2
+écraser,to smash,粉碎,VERB,B2
+écrasement,smashing,砸过,NOUN,B2
+notions,smattering,少量,NOUN,B2
+sentir,to smell,闻,VERB,B2
+sourire,smile,微笑,NOUN,B2
+lissément,smoothly,顺利,ADV,B2
+se faufiler,to sneak,潜行,VERB,B2
+museau,snout,口鼻,NOUN,B2
+ombre de neige,snow shadow,雪影姐姐,NOUN,B2
+flocon,snowflake,雪花,NOUN,B2
+jusqu'ici,so far,到目前为止,ADV,B2
+tant,so much,那么多,DET,B2
+sangloter,to sob,啜泣,VERB,B2
+sanglot,sobbing,抽泣,NOUN,B2
+sociable,sociable,好交际的,ADJ,B2
+social,social,社会的,ADJ,B2
+arbitrage social,social arbitration,社会仲裁,NOUN,B2
+éveil social,social awakening,社会觉醒,NOUN,B2
+classe sociale,social class,社会阶层,NOUN,B2
+compromis social,social compromise,社会妥协,NOUN,B2
+distanciation sociale,social distancing,社交距离,NOUN,B2
+harmonie sociale,social harmony,社会和谐,NOUN,B2
+identité sociale,social identity,社会身份,NOUN,B2
+interaction sociale,social interaction,社会互动,NOUN,B2
+social mobilization,social mobilization,社会动员,NOUN,B2
+social organization,social organization,社会组织,NOUN,B2
+social practice,social practice,社会实践,NOUN,B2
+social reconciliation,social reconciliation,社会和解,NOUN,B2
+social stability,social stability,社会稳定,NOUN,B2
+social statistics,social statistics,社会统计,NOUN,B2
+social stratification,social stratification,社会分层,NOUN,B2
+social trend,social trend,社会趋势,NOUN,B2
+social trust,social trust,社会信任,NOUN,B2
+socialize,to socialize,交往,VERB,B2
+sociology,sociology,社会学,NOUN,B2
+softball,softball,垒球,NOUN,B2
+soil,soil,土壤,NOUN,B2
+sojourn,sojourn,逗留,NOUN,B2
+solace,solace,安慰,NOUN,B2
+soldiers,soldiers,官兵,NOUN,B2
+solicit donations,to solicit donations,募捐,VERB,B2
+solid,solid,3D模型 / 实体,NOUN,B2
+solid-state drive,solid-state drive,固态硬盘,NOUN,B2
+solitude,solitude,孤独,NOUN,B2
+solution,solution,解决方案,NOUN,B2
+some out,some out,出些,NOUN,B2
+somehow,somehow,以某种方式,ADV,B2
+something,something,某事,PRON,B2
+sometime,sometime,在某个时候,ADV,B2
+somewhere,somewhere,某处,ADV,B2
+soot,soot,烟灰,NOUN,B2
+sophistry,sophistry,诡辩,NOUN,B2
+sorry,sorry,抱歉,INTJ,B2
+soul,soul,灵魂,NOUN,B2
+sound,sound,声音,NOUN,B2
+sound,to sound,响起,VERB,B2
+sound of activity,sound of activity,动静,NOUN,B2
+soundness,soundness,好端端,NOUN,B2
+sour,sour,酸的,ADJ,B2
+source,source,来源,NOUN,B2
+armée du sud,southern army,南军,NOUN,B2
+souvenir,souvenir,纪念品,NOUN,B2
+souverain,sovereign,君主,NOUN,B2
+souveraineté,sovereignty,主权,NOUN,B2
+vaisseau spatial,spaceship,宇宙飞船,NOUN,B2
+spacieux,spacious,宽敞的,ADJ,B2
+espagnol,spanish,西班牙语,NOUN,B2
+temps libre,spare time,业余,NOUN,B2
+étincelle,spark,火花,NOUN,B2
+moineau,sparrow,麻雀,NOUN,B2
+lance,spear,长矛,NOUN,B2
+spécial,special,特别的,ADJ,B2
+sujet spécial,special topic,专题,NOUN,B2
+spécialité,specialty,专业,NOUN,B2
+espèce,species,物种,NOUN,B2
+spectacles,spectacles,眼镜,NOUN,B2
+spectral,spectral,幽灵般的,ADJ,B2
+spéculer,to speculate,推测,VERB,B2
+sortilège,spell,咒语,NOUN,B2
+sphère,sphere,领域,NOUN,B2
+araignée,spider,蜘蛛,NOUN,B2
+esprit,spirit,精神,NOUN,B2
+entraînement spirituel,spirit training,练神,NOUN,B2
+spiritualité,spirituality,灵性,NOUN,B2
+rancunier,spiteful,怀恨的,ADJ,B2
+splendeur,splendor,辉煌,NOUN,B2
+attelle,splint,夹板,NOUN,B2
+fente,split,分裂,NOUN,B2
+sport,sport,运动,NOUN,B2
+voiture de sport,sports car,跑车,NOUN,B2
+aérosol,spray,喷雾,NOUN,B2
+extension,spread,传播,NOUN,B2
+squandering,squandering,挥霍,NOUN,B2
+carré,square,平方的,ADJ,B2
+accroupir,to squat,蹲,VERB,B2
+serrer,to squeeze,挤压,VERB,B2
+écureuil,squirrel,松鼠,NOUN,B2
+poignarder,to stab,刺,VERB,B2
+stabilité,stability,稳定,NOUN,B2
+écurie,stable,稳定的,ADJ,B2
+scène,stage,阶段,NOUN,B2
+pièce de théâtre,stage play,舞台剧,NOUN,B2
+stagnation,stagnation,停滞,NOUN,B2
+escalier,stairs,楼梯,NOUN,B2
+posture,stance,立场,NOUN,B2
+se tenir debout,to stand,站立,VERB,B2
+se tenir côte à côte,to stand side by side,并列,VERB,B2
+se lever,to stand up,站起来,VERB,B2
+debout,standing,站立的,ADJ,B2
+arrêt,standstill,停滞,NOUN,B2
+étoile,star,星星,NOUN,B2
+anis étoilé,star anise,八角,NOUN,B2
+fixer,to stare,凝视,VERB,B2
+ciel étoilé,starry sky,星空,NOUN,B2
+commencement,start,开始,NOUN,B2
+déclarer,state,国家,NOUN,B2
+déclarer,to state,说明,VERB,B2
+déclaration,statement,声明,NOUN,B2
+papeterie,stationery,文具,NOUN,B2
+statistiques,statistics,统计学,NOUN,B2
+statue,statue,雕像,NOUN,B2
+statut,status,地位,NOUN,B2
+stable,steady,稳定的,ADJ,B2
+voler,to steal,偷,VERB,B2
+cuire à la vapeur,steam,蒸汽,NOUN,B2
+cuire à la vapeur,to steam,蒸,VERB,B2
+pain farci à la vapeur,steamed stuffed bun,包子,NOUN,B2
+diriger,to steer,引导,VERB,B2
+steering wheel,steering wheel,方向盘,NOUN,B2
+stellar,stellar,杰出的,ADJ,B2
+stench,stench,恶臭,NOUN,B2
+step,step,步骤,NOUN,B2
+step,to step,踩,VERB,B2
+stepmother,stepmother,后母,NOUN,B2
+steps,steps,台阶,NOUN,B2
+stew,to stew,炖,VERB,B2
+stigma,stigma,耻辱,NOUN,B2
+still,still,仍然,ADV,B2
+stinking,stinking,发臭的,ADJ,B2
+stir,stir,搅拌,NOUN,B2
+stitch,stitch,针脚,NOUN,B2
+stock,stock,库存,NOUN,B2
+stock exchange,stock exchange,证券交易所,NOUN,B2
+stock market,stock market,股市,NOUN,B2
+stockpile,stockpile,储备,NOUN,B2
+stomach,stomach,胃,NOUN,B2
+stomachache,stomachache,肚子痛,NOUN,B2
+stop me,to stop me,拦我,VERB,B2
+store,store,商店,NOUN,B2
+stormy,stormy,有暴风雨的,ADJ,B2
+stove,stove,炉灶,NOUN,B2
+straight,straight,笔直的,ADJ,B2
+straightforward,straightforward,直率的,ADJ,B2
+strain,strain,压力,NOUN,B2
+strain,to strain,努力,VERB,B2
+strange,strange,奇怪的,ADJ,B2
+strange troops,strange troops,怪兵,NOUN,B2
+strangeness,strangeness,奇怪,NOUN,B2
+stranger,stranger,陌生人,NOUN,B2
+strategy,strategy,策略,NOUN,B2
+strawberry,strawberry,草莓,NOUN,B2
+stressed,stressed,焦虑的,ADJ,B2
+étirer,stretch,伸展,NOUN,B2
+étirer,to stretch,伸展,VERB,B2
+brancard,stretcher,担架,NOUN,B2
+strict,strict,严格的,ADJ,B2
+frapper,to strike,打击,VERB,B2
+coup,stroke,中风,NOUN,B2
+structure,structure,结构,NOUN,B2
+lutte,struggle,斗争,NOUN,B2
+étudiant,student,学生,NOUN,B2
+études,studies,学业,NOUN,B2
+studio,studio,工作室,NOUN,B2
+étude,study,研究,NOUN,B2
+matière,stuff,东西,NOUN,B2
+époustouflant,stunning,极好的,ADJ,B2
+solide,sturdy,坚固的,ADJ,B2
+style,style,风格,NOUN,B2
+soumettre,to subdue,制服,VERB,B2
+sous-marin,submarine,潜水艇,NOUN,B2
+submerger,to submerge,淹没,VERB,B2
+subordonné,subordinate,下属,NOUN,B2
+s'apaiser,to subside,平息,VERB,B2
+substance,substance,物质,NOUN,B2
+substantiation,substantiation,论证,NOUN,B2
+banlieue,suburb,郊区,NOUN,B2
+métro,subway,地铁,NOUN,B2
+réussi,successful,成功的,ADJ,B2
+succession,succession,连续,NOUN,B2
+succomber,to succumb,屈服,VERB,B2
+tel,such,如此,DET,B2
+succer,to suck,吸,VERB,B2
+soudain,sudden,突然的,ADJ,B2
+assigner,to sue,起诉,VERB,B2
+souffrir d'insomnie,to suffer from insomnia,失眠,VERB,B2
+suffisance,sufficiency,充足,NOUN,B2
+suffocation,suffocation,窒息,NOUN,B2
+suggestion,suggestion,建议,NOUN,B2
+suicide,suicide,自杀,NOUN,B2
+suit,suit,西装,NOUN,B2
+suitcase,suitcase,手提箱,NOUN,B2
+summer,summer,夏天,NOUN,B2
+sunrise,sunrise,日出,NOUN,B2
+sunset,sunset,日落,NOUN,B2
+sunshine,sunshine,阳光,NOUN,B2
+super-comprehensive,super-comprehensive,超遍,NOUN,B2
+super-grade,super-grade,超级,NOUN,B2
+super-principle,super-principle,超则,NOUN,B2
+super-quality,super-quality,超质,NOUN,B2
+super-system,super-system,超制,NOUN,B2
+super-thought,super-thought,超思,NOUN,B2
+superfluous,superfluous,多余的,ADJ,B2
+superior,superior,更好的,ADJ,B2
+superstition,superstition,迷信,NOUN,B2
+supervision,supervision,监督,NOUN,B2
+supplement,supplement,补充,NOUN,B2
+supplement,to supplement,补充,VERB,B2
+supporter,supporter,支持者,NOUN,B2
+suppress,to suppress,压制,VERB,B2
+suppression,suppression,抑,NOUN,B2
+surface,surface,表面,NOUN,B2
+surname,surname,姓氏,NOUN,B2
+surprise,surprise,惊喜,NOUN,B2
+surrender,to surrender,投降,VERB,B2
+surveil,to surveil,监视,VERB,B2
+surveillance,surveillance,监视,NOUN,B2
+survey,survey,调查,NOUN,B2
+survival,survival,生存,NOUN,B2
+susha,susha,夙砂大,NOUN,B2
+suspect,suspect,嫌疑人,NOUN,B2
+suspense,suspense,悬念,NOUN,B2
+suspension,suspension,暂停,NOUN,B2
+suspicious,suspicious,可疑的,ADJ,B2
+sustenance,sustenance,食物,NOUN,B2
+suture,suture,缝合,NOUN,B2
+suture,to suture,缝合,VERB,B2
+swamp,swamp,沼泽,NOUN,B2
+sway,to sway,摇摆,VERB,B2
+sweat,sweat,汗水,NOUN,B2
+sweep,sweep,扫,NOUN,B2
+sweet,sweet,甜的,ADJ,B2
+sweet dream,sweet dream,美梦,NOUN,B2
+sweeten,to sweeten,使变甜,VERB,B2
+sweetheart,sweetheart,爱人,NOUN,B2
+sweetie,sweetie,亲爱的,NOUN,B2
+sweets,sweets,甜食,NOUN,B2
+swindle,to swindle,诈骗,VERB,B2
+switch room,switch room,配电室,NOUN,B2
+switchboard,switchboard,总机,NOUN,B2
+sword,sword,剑,NOUN,B2
+swordless,swordless,剑不,NOUN,B2
+swordsman,swordsman,剑客,NOUN,B2
+syllabus,syllabus,教学大纲,NOUN,B2
+symbolize,to symbolize,象征,VERB,B2
+symptom,symptom,症状,NOUN,B2
+synchronous,synchronous,同步的,ADJ,B2
+synergy,synergy,协同效应,NOUN,B2
+synthesize,to synthesize,合成,VERB,B2
+syringe,syringe,注射器,NOUN,B2
+table,table,桌子,NOUN,B2
+taciturn,taciturn,沉默寡言的,ADJ,B2
+tackle,to tackle,处理,VERB,B2
+tactful,tactful,圆滑的,ADJ,B2
+tactics,tactics,战术,NOUN,B2
+queue,tail,尾巴,NOUN,B2
+prendre un congé,to take a leave of absence,休学,VERB,B2
+emmener,to take along,带走,VERB,B2
+faire attention,to take care,照顾,VERB,B2
+prendre soin de,to take care of,照顾,VERB,B2
+bouturer,to take cuttings,扦插,VERB,B2
+entrer en fonction,to take office,就职,VERB,B2
+prendre le relais,to take over,接管,VERB,B2
+avoir lieu,to take place,举行,VERB,B2
+se venger,to take revenge,报复,VERB,B2
+prise,taking,拍摄,NOUN,B2
+talent,talent,天赋,NOUN,B2
+parler,talk,谈话,NOUN,B2
+parler,to talk,谈话,VERB,B2
+dire des bêtises,to talk nonsense,胡言乱语,VERB,B2
+bavardage,talkativeness,多嘴,NOUN,B2
+grand,tall,高的,ADJ,B2
+tangente,tangent,切线,NOUN,B2
+tangible,tangible,有形的,ADJ,B2
+tanneur,tanner,制革工,NOUN,B2
+tarif,tariff,费率,NOUN,B2
+préférence gustative,taste preference,口味,NOUN,B2
+tendu,taut,绷紧的,ADJ,B2
+taxer,to tax,征税,VERB,B2
+non imposable,tax-exempt,免税,ADJ,B2
+taxi,taxi,出租车,NOUN,B2
+plantation de thé,tea plantation,茶园,NOUN,B2
+enseignement,teaching,教学,NOUN,B2
+équipe,team,团队,NOUN,B2
+déchirer,to tear up,流泪,VERB,B2
+larme,tears,眼泪,NOUN,B2
+technique,technical,技术的,ADJ,B2
+technique,technique,技巧,NOUN,B2
+télescope,telescope,望远镜,NOUN,B2
+télévision,television,电视,NOUN,B2
+tempérament,temper,脾气,NOUN,B2
+température,temperature,温度,NOUN,B2
+temple,temple,寺庙,NOUN,B2
+refus temporaire,temporary refusal,暂不,NOUN,B2
+tendance,tendency,趋势,NOUN,B2
+tendre,tender,嫩的,ADJ,B2
+filet,tenderloin,里脊,NOUN,B2
+tendon,tendon,肌腱,NOUN,B2
+tennis,tennis,网球,NOUN,B2
+tension,tension,紧张,NOUN,B2
+tentatif,tentative,暂定的,ADJ,B2
+terminal,terminal,终点站,NOUN,B2
+terminologique,terminological,术语的,ADJ,B2
+terrain,terrain,地形,NOUN,B2
+terrible,terrible,可怕的,ADJ,B2
+terrifier,to terrify,使恐惧,VERB,B2
+territorial,territorial,领土的,ADJ,B2
+test,test,测试,NOUN,B2
+textile,textile,纺织,NOUN,B2
+textuel,textual,文本的,ADJ,B2
+que,than,比,ADP,B2
+merci,thanks,谢谢,INTJ,B2
+grâce à,thanks to,多亏,ADP,B2
+cette flèche,that arrow,那一箭,NOUN,B2
+c'est-à-dire,that is,即,ADV,B2
+de cette façon,that way,那样,PRON,B2
+dégeler,to thaw,解冻,VERB,B2
+le reste,the rest,其余,NOUN,B2
+vol,theft,盗窃,NOUN,B2
+alors vous,then you,那你,PRON,B2
+théocratie,theocracy,神权政治,NOUN,B2
+là,there,那儿,NOUN,B2
+il y a encore du temps,to there's still time,来得及,VERB,B2
+par là,thereby,从而,ADV,B2
+alors,thereupon,随后,ADV,B2
+thermal,thermal,热的,ADJ,B2
+these,these,这些,DET,B2
+these three,these three,这三,NOUN,B2
+they things,they things,它们,PRON,B2
+thick,thick,厚的,ADJ,B2
+thickness,thickness,厚度,NOUN,B2
+thief,thief,小偷,NOUN,B2
+thief presence,thief presence,有贼,NOUN,B2
+think to want,to think to want,想,VERB,B2
+think up,to think up,构思,VERB,B2
+thinking,thinking,思维,NOUN,B2
+thinness,thinness,瘦,NOUN,B2
+third bestowal,third bestowal,三授,NOUN,B2
+thirsty,thirsty,口渴的,ADJ,B2
+this,this,您这,NOUN,B2
+this battle,this battle,此战,NOUN,B2
+this item,this item,这件,NOUN,B2
+this way,this way,这样,PRON,B2
+this-camp,this-camp,这营,NOUN,B2
+thorn,thorn,刺,NOUN,B2
+thoroughness,thoroughness,彻底,NOUN,B2
+those,those,那些,DET,B2
+thoughtful,thoughtful,体贴的,ADJ,B2
+threat,threat,威胁,NOUN,B2
+three-d printing,three-d printing,3D打印,NOUN,B2
+thrifty,thrifty,节俭的,ADJ,B2
+throne,throne,王座,NOUN,B2
+through,through,通过,ADP,B2
+thrust,thrust,猛推,NOUN,B2
+thrust toward,thrust toward,插向,NOUN,B2
+thug,thug,暴徒,NOUN,B2
+tidal,tidal,潮汐,ADJ,B2
+tie,to tie,联结,VERB,B2
+tight grip,tight grip,手握紧,NOUN,B2
+fois,times,倍,NOUN,B2
+timidité,timidity,胆怯,NOUN,B2
+minutage,timing,时机,NOUN,B2
+étain,tin,锡,NOUN,B2
+picotement,tingling,麻木感,NOUN,B2
+fatigue,tiredness,疲劳,NOUN,B2
+tissu,tissue,组织,NOUN,B2
+dîme,tithe,什一税,NOUN,B2
+à,to,到,ADP,B2
+aujourd'hui,today,今天,NOUN,B2
+tofu,tofu,豆腐,NOUN,B2
+toilettes,toilet,厕所,NOUN,B2
+demain,tomorrow,غد,NOUN,B2
+ton,tone,语气,NOUN,B2
+langue,tongue,舌头,NOUN,B2
+soir,tonight,今晚,NOUN,B2
+trop,too,太,ADV,B2
+mollesse,too soft,太软,NOUN,B2
+atelier,tool room,工具间,NOUN,B2
+outil,tools,工具,NOUN,B2
+rage de dents,toothache,牙痛,NOUN,B2
+sommet,top,顶部,NOUN,B2
+amendement de surface,top dressing,追肥,NOUN,B2
+sujet,topic,话题,NOUN,B2
+torrent,torrent,激流,NOUN,B2
+torsion,torsion,扭转,NOUN,B2
+torture,torture,酷刑,NOUN,B2
+total,total,完全的,ADJ,B2
+toucher,touch,接触,NOUN,B2
+touchabilité,touchability,能触摸,NOUN,B2
+dur,tough,艰难的,ADJ,B2
+touriste,tourist,游客,NOUN,B2
+vers,toward,朝向,ADP,B2
+vers,towards,朝向,ADP,B2
+township head,township head,乡长,NOUN,B2
+trace,trace,痕迹,NOUN,B2
+tradition,tradition,传统,NOUN,B2
+traffic restriction,traffic restriction,限行,NOUN,B2
+train,train,火车,NOUN,B2
+train of thought,train of thought,思路,NOUN,B2
+train station,train station,火车站,NOUN,B2
+trait,trait,特征,NOUN,B2
+trample,to trample,踩踏,VERB,B2
+tranquil,tranquil,宁静的,ADJ,B2
+trans-decision,trans-decision,超断,NOUN,B2
+trans-guest,trans-guest,超客,NOUN,B2
+trans-matter,trans-matter,超物,NOUN,B2
+transaction,transaction,交易,NOUN,B2
+transcendent,transcendent,卓越的,ADJ,B2
+transcendental,transcendental,先验的,ADJ,B2
+transformation,transformation,تحول,NOUN,B2
+transgression,transgression,违犯,NOUN,B2
+translation,translation,翻译,NOUN,B2
+transmission,transmission,传输,NOUN,B2
+transmission to you,transmission to you,传你,NOUN,B2
+transmitter,transmitter,发射台,NOUN,B2
+transparent,transparent,透明的,ADJ,B2
+transport,transport,运输,NOUN,B2
+transport,to transport,运输,VERB,B2
+trash,trash,垃圾,NOUN,B2
+travel,to travel,旅行,VERB,B2
+travel fatigue,travel fatigue,车马劳顿,NOUN,B2
+traveler,traveler,旅行家,NOUN,B2
+treacherous,treacherous,背叛的,ADJ,B2
+tread,to tread,踏上,VERB,B2
+treason,treason,叛国罪,NOUN,B2
+treat guests,to treat guests,请客,VERB,B2
+treaty,treaty,条约,NOUN,B2
+trial,trial,试验,NOUN,B2
+triangle,triangle,三角形,NOUN,B2
+tromper,to trick,欺骗,VERB,B2
+bagatelle,trifle,琐事,NOUN,B2
+voyage,trip,旅行,NOUN,B2
+triple,triple,三倍的,ADJ,B2
+banalité,triviality,琐碎,NOUN,B2
+banalisation,trivialization,浅薄化,NOUN,B2
+troupe,troop,部队,NOUN,B2
+troupes,troops,部队,NOUN,B2
+troubler,trouble,麻烦,NOUN,B2
+troubler,to trouble,有劳,VERB,B2
+gênant,troublesome,麻烦的,ADJ,B2
+troupe,troupe,剧团,NOUN,B2
+vrai,true,真实的,ADJ,B2
+vraie concession,true concession,真让,NOUN,B2
+vraie forme,true form,原形,NOUN,B2
+vrai cœur,true heart,本心,NOUN,B2
+se fier,to trust,信任,VERB,B2
+fiable,trustworthy,值得信赖的,ADJ,B2
+vérité,truth,真相,NOUN,B2
+s'efforcer de,to try hard to,力图,VERB,B2
+tube,tube,أنبوب,NOUN,B2
+tunnel,tunnel,隧道,NOUN,B2
+tour,turn,转弯,NOUN,B2
+se retourner,to turn around,转身,VERB,B2
+éteindre,to turn off,关闭,VERB,B2
+clignotant,turn signal,转向灯,NOUN,B2
+affluence,turnout,出席率,NOUN,B2
+chiffre d'affaires,turnover,营业额,NOUN,B2
+tortue,turtle,海龟,NOUN,B2
+tutelle,tutelage,监护,NOUN,B2
+tutorat,tutoring,补习,NOUN,B2
+douze,twelve,十二,NUM,B2
+vingt,twenty,二十,NUM,B2
+deux fois,twice,两次,ADV,B2
+deux,two animals,两只,NUM,B2
+rue à double sens,two-way street,双行道,NOUN,B2
+type,type,类型,NOUN,B2
+typhon,typhoon,台风,NOUN,B2
+tyrannie,tyranny,暴政,NOUN,B2
+laideur,ugliness,丑陋,NOUN,B2
+ulcération,ulceration,溃疡,NOUN,B2
+finalement,ultimately,最终,ADV,B2
+inatteignable,unattainable,难以获得的,ADJ,B2
+incredible,unbelievable,难以置信的,ADJ,B2
+flou,unclear,不清楚的,ADJ,B2
+incontrôlable,uncontrollable,无法控制的,ADJ,B2
+non refroidi,uncooled,未寒,NOUN,B2
+découvrir,to uncover,揭露,VERB,B2
+indéniable,undeniable,不可否认的,ADJ,B2
+sous-estimer,to underestimate,低估,VERB,B2
+sous-estimation,underestimation,小看,NOUN,B2
+étudiant,undergraduate,本科生,NOUN,B2
+sous-sol,underground,地铁,NOUN,B2
+culotte,underpants,内裤,NOUN,B2
+entreprise,undertaking,事业,NOUN,B2
+lingerie,underwear,内衣,NOUN,B2
+souscrire,to underwrite,承保,VERB,B2
+inquiet,uneasy,不安的,ADJ,B2
+chômeur,unemployed,失业的,ADJ,B2
+chômage,unemployment,失业,NOUN,B2
+inégal,unequal,不平等的,ADJ,B2
+malheureux,unfortunate,不幸的,ADJ,B2
+malheureusement,unfortunately,不幸地,ADV,B2
+unifier,to unify,统一,VERB,B2
+peu important,unimportant,不重要的,ADJ,B2
+syndicat,union,工会,NOUN,B2
+unique,unique,独特的,ADJ,B2
+unicité,uniqueness,独特,NOUN,B2
+unité,unit,单元,NOUN,B2
+applicabilité universelle,universal applicability,普适性,NOUN,B2
+universalité,universality,普遍性,NOUN,B2
+injuste,unjust,不公正的,ADJ,B2
+improbable,unlikely,不太可能的,ADJ,B2
+malchanceux,unlucky,倒霉的,ADJ,B2
+inutile,unnecessary,不必要的,ADJ,B2
+déraisonnable,unreasonable,不合理的,ADJ,B2
+agitation,unrest,动荡,NOUN,B2
+imperturbable,unruffled,从容,ADJ,B2
+dénouer,to untie,解开,VERB,B2
+cérémonie de dévoilement,unveiling ceremony,揭幕仪式,NOUN,B2
+réticence,unwillingness,不甘,NOUN,B2
+indigne,unworthy,你不配,NOUN,B2
+en haut,up,向上,ADV,B2
+jusqu'à,up to,为止,ADP,B2
+éducation,upbringing,教养,NOUN,B2
+à venir,upcoming,مقبل,ADJ,B2
+mettre à jour,to update,更新,VERB,B2
+mettre à niveau,to upgrade,升级,VERB,B2
+téléverser,to upload,上传,VERB,B2
+supérieur,upper,上面的,ADJ,B2
+droit,upright,正直的,ADJ,B2
+soulèvement,uprising,起义,NOUN,B2
+tumulte,uproar,骚动,NOUN,B2
+déracinement,uprooting,背井离乡,NOUN,B2
+bouleverser,to upset,使生气,VERB,B2
+exhorter,to urge,强烈要求,VERB,B2
+urgence,urgency,紧急,NOUN,B2
+urgent,urgent,紧急的,ADJ,B2
+nous,us,你我,NOUN,B2
+utiliser des baguettes,to use chopsticks,动筷,VERB,B2
+utiliser des béquilles,to use crutches,拄拐,VERB,B2
+habituellement,usually,通常,ADV,B2
+utilisation,utilization,利用,NOUN,B2
+utiliser,to utilize,利用,VERB,B2
+maximum,utmost,你尽,NOUN,B2
+utopie,utopia,乌托邦,NOUN,B2
+utopique,utopian,乌托邦式的,ADJ,B2
+énonciation,utterance,话语,NOUN,B2
+vacances,vacation,假期,NOUN,B2
+vaccination,vaccination,疫苗接种,NOUN,B2
+vague,vague,含糊的,ADJ,B2
+vaillant,valiant,英勇的,ADJ,B2
+validité,validity,有效期,NOUN,B2
+bravoure,valor,勇气,NOUN,B2
+précieux,valuable,有价值的,ADJ,B2
+évaluation,valuation,估值,NOUN,B2
+valeur,value,价值,NOUN,B2
+vampire,vampire,吸血鬼,NOUN,B2
+avant-garde,vanguard,先锋,NOUN,B2
+disparaître,to vanish,消失,VERB,B2
+vanité,vanity,虚荣,NOUN,B2
+variable,variable,变量,NOUN,B2
+variance,variance,方差,NOUN,B2
+variété,variety,种类,NOUN,B2
+départements divers,various departments,各部,NOUN,B2
+vaste,vast,巨大的,ADJ,B2
+légume,vegetable,蔬菜,NOUN,B2
+véhicule,vehicle,车辆,NOUN,B2
+immatriculation,vehicle registration,行驶证,NOUN,B2
+veine,vein,静脉,NOUN,B2
+vénérable,venerable,值得尊敬的,ADJ,B2
+vénération,veneration,崇敬,NOUN,B2
+vengeance,vengeance,报复,NOUN,B2
+lieu,venue,场地,NOUN,B2
+verbosité,verbosity,冗长,NOUN,B2
+vérifier,to verify,核实,VERB,B2
+vermine,vermin,害兽,NOUN,B2
+versé,versed,精通的,ADJ,B2
+version,version,版本,NOUN,B2
+vertical,vertical,垂直的,ADJ,B2
+vétéran,veteran,老手,NOUN,B2
+veto,veto,否决,NOUN,B2
+vibration,vibration,振动,NOUN,B2
+vice,vice,恶习,NOUN,B2
+vice versa,vice versa,反之亦然,ADV,B2
+victime,victim,受害者,NOUN,B2
+victoire,victory,胜利,NOUN,B2
+vidéo,video,视频,NOUN,B2
+vidéodisque,video disc,影碟,NOUN,B2
+enregistrement vidéo,video recording,录像,NOUN,B2
+lutter,to vie,竞争,VERB,B2
+vue,view,观点,NOUN,B2
+point de vue,viewpoint,观点,NOUN,B2
+veille,vigil,守夜,NOUN,B2
+vigilance,vigilance,警惕,NOUN,B2
+vigueur,vigor,活力,NOUN,B2
+vil,vile,卑鄙的,ADJ,B2
+villa,villa,别墅,NOUN,B2
+village,village,村庄,NOUN,B2
+chef de village,village head,村长,NOUN,B2
+scélérat,villain,反派,NOUN,B2
+vigne,vine,藤蔓,NOUN,B2
+violer,to violate,违反,VERB,B2
+enfreindre la discipline,to violate discipline,违纪,VERB,B2
+violation,violation,侵越,NOUN,B2
+violence,violence,暴力,NOUN,B2
+violent,violent,暴力的,ADJ,B2
+violon,violin,小提琴,NOUN,B2
+vierge,virgin,处女,NOUN,B2
+virtuel,virtual,虚拟的,ADJ,B2
+virtuellement,virtually,几乎,ADV,B2
+vertu,virtue,美德,NOUN,B2
+virus,virus,病毒,NOUN,B2
+visa,visa,签证,NOUN,B2
+visqueux,viscous,黏稠的,ADJ,B2
+vision,vision,远见,NOUN,B2
+visiter,visit,拜访,NOUN,B2
+visiter,to visit,参观,VERB,B2
+visiteur,visitor,访客,NOUN,B2
+visuel,visual,视觉的,ADJ,B2
+vitamine,vitamin,维生素,NOUN,B2
+vivid,vivid,生动的,ADJ,B2
+vocal,vocal,直言的,ADJ,B2
+voix,voice,声音,NOUN,B2
+volatil,volatile,易变的,ADJ,B2
+volcan,volcano,火山,NOUN,B2
+volontaire,voluntary,自愿的,ADJ,B2
+vomir,to vomit,呕吐,VERB,B2
+vortex,vortex,漩涡,NOUN,B2
+voter,vote,投票,NOUN,B2
+voter,to vote,表决,VERB,B2
+votant,voter,选民,NOUN,B2
+vote,voting,投票,NOUN,B2
+bon,voucher,代金券,NOUN,B2
+vœu,vow,誓言,NOUN,B2
+vulgaire,vulgar,粗俗的,ADJ,B2
+vulgarité,vulgarity,粗俗,NOUN,B2
+salaire,wage,工资,NOUN,B2
+mener la guerre,to wage war,作战,VERB,B2
+salaires,wages,工资,NOUN,B2
+gémir,to wail,哀号,VERB,B2
+taille,waist,腰,NOUN,B2
+attends-moi,wait for me,等我,NOUN,B2
+attendre longtemps,to wait long,久等,VERB,B2
+salle d'attente,waiting room,候诊室,NOUN,B2
+serveuse,waitress,女服务员,NOUN,B2
+promenade,walk,行走,NOUN,B2
+errance,wandering,漫游,NOUN,B2
+vouloir,want,想,AUX,B2
+désir de séduire,want to lure,想引,NOUN,B2
+vouloir,to want to need will,要,VERB,B2
+voulu,wanted,故意的,ADJ,B2
+service,ward,病房,NOUN,B2
+gardien,warden,看守人,NOUN,B2
+chaleur,warmth,温暖,NOUN,B2
+garantie,warranty,保修单,NOUN,B2
+être,to was,是,VERB,B2
+lave-linge,washing machine,洗衣机,NOUN,B2
+gaspilleur,wasteful,浪费的,ADJ,B2
+friche,wasteland,荒地,NOUN,B2
+chute d'eau,water falling,水落,NOUN,B2
+épinard d'eau,water spinach,空心菜,NOUN,B2
+graine de pastèque,watermelon seed,西瓜子,NOUN,B2
+étanche,waterproof,防水的,ADJ,B2
+agiter,to wave,挥手,VERB,B2
+sortie,way out,出路,NOUN,B2
+nous,we,我们,PRON,B2
+nous,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
+nous deux,we two,我俩,PRON,B2
+sevrer,to wean,断奶,VERB,B2
+porter,to wear,穿,VERB,B2
+temps,weather,天气,NOUN,B2
+webcam,webcam,网络摄像头,NOUN,B2
+site web,website,网站,NOUN,B2
+anniversaire de mariage,wedding anniversary,结婚纪念日,NOUN,B2
+photo de mariage,wedding photo,婚纱照,NOUN,B2
+mercredi,wednesday,星期三,NOUN,B2
+mauvaise herbe,weed,杂草,NOUN,B2
+numéro de semaine,week number,周次,NOUN,B2
+jour ouvrable,weekday,工作日,NOUN,B2
+week-end,weekend,周末,NOUN,B2
+test hebdomadaire,weekly test,周测,NOUN,B2
+pleurer,to weep,哭泣,VERB,B2
+bizarre,weird,奇怪的,ADJ,B2
+excentrique,weirdo,怪人,NOUN,B2
+bienvenu,welcome,受欢迎的,ADJ,B2
+banquet de bienvenue,welcome banquet,欢迎宴,NOUN,B2
+bien-être,welfare,福利,NOUN,B2
+bien réfléchi,well-considered,深思熟虑的,ADJ,B2
+connu,well-known,众所周知的,ADJ,B2
+régions occidentales,western regions,西域,NOUN,B2
+humide,wet,湿的,ADJ,B2
+zone humide,wetland,湿地,NOUN,B2
+que,what,什么,ADV,B2
+dans quelle mesure,what extent,在何种程度上,ADV,B2
+fauteuil roulant,wheelchair,轮椅,NOUN,B2
+quand,when,当...时,ADV,B2
+parage,whereabouts,行踪,NOUN,B2
+par lequel,whereby,其中,ADV,B2
+si,whether,能否,NOUN,B2
+que,whether or not,是否,SCONJ,B2
+tandis que,while,一会儿,NOUN,B2
+gémir,to whine,哀叹,VERB,B2
+chuchotement,whisper,低语,NOUN,B2
+sifflet,whistle,口哨,NOUN,B2
+tout,whole,整个的,ADJ,B2
+monde entier,whole world,全世界,NOUN,B2
+gros,wholesale,批发,NOUN,B2
+qui,whom,谁,PRON,B2
+répandu,widespread,广泛的,ADJ,B2
+veuve,widow,寡妇,NOUN,B2
+femme,wife,妻子,NOUN,B2
+vouloir,will,将要,AUX,B2
+volontaire,willful,任性的,ADJ,B2
+vouloir,willing,肯,AUX,B2
+volonté,willingness,乐意,NOUN,B2
+enrouler,to wind,缠绕,VERB,B2
+fenêtre,window,窗户,NOUN,B2
+vitre,window glass,窗玻璃,NOUN,B2
+coupe-vent,windproof,挡风的,ADJ,B2
+vin,wine,葡萄酒,NOUN,B2
+coupe à vin,wine cup,这酒盏,NOUN,B2
+aile,wing,翅膀,NOUN,B2
+cligner,to wink,眨眼,VERB,B2
+vanner,to winnow,筛选,VERB,B2
+essuie-glace,wiper,雨刷,NOUN,B2
+fil,wire,电线,NOUN,B2
+sans fil,wireless,无线的,ADJ,B2
+sage,wise,明智的,ADJ,B2
+souhait,wish,愿望,NOUN,B2
+sorcière,witch,女巫,NOUN,B2
+retenir,to withhold,扣留,VERB,B2
+dans,within,在……之内,ADP,B2
+témoigner,to witness,目击,VERB,B2
+témoignage,witness testimony,人证,NOUN,B2
+esprit,wits,心眼,NOUN,B2
+sorcier,wizard,巫师,NOUN,B2
+ne pas faire,won't do,不行,ADJ,B2
+ne pas faire,to won't do,不成,VERB,B2
+s'étonner,wonder,奇迹,NOUN,B2
+s'étonner,to wonder,觉得奇怪,VERB,B2
+merveilleux,wonderful,极好的,ADJ,B2
+oreille de bois,wood ear mushroom,木耳,NOUN,B2
+bois,woodland,林地,NOUN,B2
+s'efforcer,to work hard for sth to strive for success,争气,VERB,B2
+fonctionner,to work out,成功,VERB,B2
+lieu de travail,workplace,工作场所,NOUN,B2
+guerre mondiale,world war,世界大战,NOUN,B2
+vision du monde,worldview,世界观,NOUN,B2
+mondial,worldwide,全世界的,ADJ,B2
+worm,worm,虫,NOUN,B2
+worship,to worship,崇拜,VERB,B2
+worth,worth,值得的,ADJ,B2
+wound,to wound,使受伤,VERB,B2
+wounded,wounded,受伤的,ADJ,B2
+wrapping,wrapping,包装,NOUN,B2
+wreck,wreck,残骸,NOUN,B2
+wrest,to wrest,强行夺取,VERB,B2
+wrestling,wrestling,摔跤,NOUN,B2
+wretch,wretch,令人厌恶的人,NOUN,B2
+wrinkle-resistant,wrinkle-resistant,防皱,ADJ,B2
+writer,writer,作家,NOUN,B2
+written,written,书面的,ADJ,B2
+wrong,wrong,错误的,ADJ,B2
+wrong mistake,wrong mistake,错误,ADJ,B2
+wudang,wudang,武当,NOUN,B2
+yard,yard,院子,NOUN,B2
+yearn for,to yearn for,渴望,VERB,B2
+yearning,yearning,向往,NOUN,B2
+years,years,数年,NOUN,B2
+yes,yes,是啊,NOUN,B2
+yesterday,yesterday,بارحة,NOUN,B2
+yoga,yoga,瑜伽,NOUN,B2
+yogurt,yogurt,酸奶,NOUN,B2
+you can,you can,您能,NOUN,B2
+you cannot live,you cannot live,你也活不,NOUN,B2
+you plural,you plural,你们,PRON,B2
+you polite,you polite,您,PRON,B2
+young man,young man,年轻人,NOUN,B2
+young master,young master,少庄主,NOUN,B2
+young person,young person,年轻人,NOUN,B2
+youngster,youngster,年少者,NOUN,B2
+your laugh,your laugh,你笑,NOUN,B2
+your majesty,your majesty,陛下,NOUN,B2
+youth,youth,青年,NOUN,B2
+yuanxiao,yuanxiao,元宵,NOUN,B2
+zénith,zenith,顶点,NOUN,B2
+zéro,zero,零,NUM,B2
+Zhuang He,zhuang he,庄郃,NOUN,B2
+zinc,zinc,锌,NOUN,B2
+signe du zodiaque,zodiac sign,属相,NOUN,B2
+zombie,zombie,僵尸,NOUN,B2
+vessel,vessel,船,NOUN,B2
+even,even,甚至,ADV,B2
+gadget,gadget,小装置,NOUN,B2
+pine,pine,松树,NOUN,B2
+to polish,to polish,擦亮,VERB,B2
+stable,stable,畜舍,NOUN,B2
+option,option,选择,NOUN,B2
+enchanting,enchanting,迷人的,ADJ,B2
+to take out,to take out,拿出,VERB,B2
+fertile,fertile,肥沃的,ADJ,B2
+fascination,fascination,魅力,NOUN,B2
+deformed,deformed,畸形的,ADJ,B2
+barefoot,barefoot,赤脚的,ADJ,B2
+philanthropist,philanthropist,慈善家,NOUN,B2
+statistical,statistical,统计的,ADJ,B2
+zone,zone,区域,NOUN,B2
+blasphemy,blasphemy,亵渎,NOUN,B2
+to daydream,to daydream,幻想,VERB,B2
+cousin,cousin,表亲,NOUN,B2
+ancestry,ancestry,血统,NOUN,B2
+elaborate,elaborate,详尽的,ADJ,B2
+coarse,coarse,粗糙的,ADJ,B2
+immigration,immigration,移民,NOUN,B2
+to compile,to compile,编译,VERB,B2
+border,border,边界,NOUN,B2
+atomic,atomic,原子的,ADJ,B2
+solvent,solvent,溶剂,NOUN,B2
+to ski,to ski,滑雪,VERB,B2
+to authenticate,to authenticate,认证,VERB,B2
+cunning,cunning,狡猾的,ADJ,B2
+genetics,genetics,遗传学,NOUN,B2
+grenade,grenade,手榴弹,NOUN,B2
+falsity,falsity,虚假,NOUN,B2
+pool,pool,水池,NOUN,B2
+devastation,devastation,破坏,NOUN,B2
+compact,compact,紧凑的,ADJ,B2
+hidden,hidden,隐藏的,ADJ,B2
+to formalize,to formalize,使正式化,VERB,B2
+analogous,analogous,类似的,ADJ,B2
+ambivalent,ambivalent,矛盾的,ADJ,B2
+intact,intact,完好无损的,ADJ,B2
+to categorize,to categorize,分类,VERB,B2
+farce,farce,闹剧,NOUN,B2
+closed,closed,关闭的,ADJ,B2
+eruption,eruption,爆发,NOUN,B2
+scorching,scorching,灼热的,ADJ,B2
+to sniff,to sniff,嗅,VERB,B2
+injured,injured,受伤的,ADJ,B2
+to deform,to deform,使变形,VERB,B2
+vernal,vernal,春季的,ADJ,B2
+horrible,horrible,可怕的,ADJ,B2
+chastity,chastity,贞洁,NOUN,B2
+impurity,impurity,不纯,NOUN,B2
+fragment,fragment,碎片,NOUN,B2
+expertise,expertise,专业知识,NOUN,B2
+puppy,puppy,小狗,NOUN,B2
+boyfriend,boyfriend,男朋友,NOUN,B2
+cabinet,cabinet,内阁,NOUN,B2
+alternative,alternative,替代方案,NOUN,B2
+voluntarily,voluntarily,自愿地,ADV,B2
+to fabricate,to fabricate,捏造,VERB,B2
+stiffness,stiffness,僵硬,NOUN,B2
+blaze,blaze,火焰,NOUN,B2
+minor,minor,未成年人,NOUN,B2
+neat,neat,整洁的,ADJ,B2
+biology,biology,生物学,NOUN,B2
+condescending,condescending,屈尊的,ADJ,B2
+prolix,prolix,冗长的,ADJ,B2
+to level,to level,夷平,VERB,B2
+stimulant,stimulant,兴奋剂,NOUN,B2
+to accommodate,to accommodate,容纳,VERB,B2
+allusive,allusive,暗指的,ADJ,B2
+extradition,extradition,引渡,NOUN,B2
+deer,deer,鹿,NOUN,B2
+expansive,expansive,扩张的,ADJ,B2
+adjacent,adjacent,邻近的,ADJ,B2
+readiness,readiness,准备就绪,NOUN,B2
+a,a,一个,DET,B2
+vacant,vacant,空缺的,ADJ,B2
+geometry,geometry,几何学,NOUN,B2
+damn,damn,该死,INTJ,B2
+congratulations,congratulations,恭喜,INTJ,B2
+to discriminate,to discriminate,歧视,VERB,B2
+heading,heading,标题,NOUN,B2
+guillotine,guillotine,断头台,NOUN,B2
+electrician,electrician,电工,NOUN,B2
+to accredit,to accredit,认可,VERB,B2
+nearby,nearby,附近的,ADJ,B2
+hiss,hiss,嘶嘶声,NOUN,B2
+hilarious,hilarious,滑稽的,ADJ,B2
+trainee,trainee,实习生,NOUN,B2
+older,older,年长的,ADJ,B2
+bustle,bustle,喧闹,NOUN,B2
+bronze,bronze,青铜,NOUN,B2
+to entail,to entail,牵涉,VERB,B2
+christian,christian,基督徒,NOUN,B2
+to detest,to detest,厌恶,VERB,B2
+monument,monument,纪念碑,NOUN,B2
+lost,lost,迷失的,ADJ,B2
+ecology,ecology,生态学,NOUN,B2
+prominent,prominent,突出的,ADJ,B2
+loose,loose,松的,ADJ,B2
+sack,sack,麻袋,NOUN,B2
+to gallop,to gallop,飞奔,VERB,B2
+all,all,全部,DET,B2
+to date,to date,注明日期,VERB,B2
+intellectual,intellectual,知识的,ADJ,B2
+premiere,premiere,首演,NOUN,B2
+while,while,当...时,SCONJ,B2
+flux,flux,变迁,NOUN,B2
+to scorch,to scorch,烧焦,VERB,B2
+february,february,二月,NOUN,B2
+decade,decade,十年,NOUN,B2
+whole,whole,整体,NOUN,B2
+to incorporate,to incorporate,包含,VERB,B2
+entirely,entirely,完全地,ADV,B2
+to rehearse,to rehearse,排练,VERB,B2
+last night,last night,昨晚,ADV,B2
+lantern,lantern,灯笼,NOUN,B2
+lot,lot,许多,NOUN,B2
+packet,packet,小包裹,NOUN,B2
+rear,rear,后面的,ADJ,B2
+down,down,向下,ADV,B2
+indication,indication,指示,NOUN,B2
+entrepreneur,entrepreneur,企业家,NOUN,B2
+advance payment,advance payment,预付款,NOUN,B2
+to assume office,to assume office,就任,VERB,B2
+clerk,clerk,职员,NOUN,B2
+deadly,deadly,致命的,ADJ,B2
+disinterest,disinterest,公正;不感兴趣,NOUN,B2
+to improvise,to improvise,即兴创作,VERB,B2
+to capitalize,to capitalize,利用,VERB,B2
+us,us,我们,PRON,B2
+amplification,amplification,放大,NOUN,B2
+genre,genre,类型,NOUN,B2
+dishwasher,dishwasher,洗碗机,NOUN,B2
+delightful,delightful,令人愉快的,ADJ,B2
+absent,absent,缺席的,ADJ,B2
+colon,colon,冒号,NOUN,B2
+asynchronous,asynchronous,异步的,ADJ,B2
+insane,insane,疯狂的,ADJ,B2
+third,third,三分之一,NOUN,B2
+above,above,上面,ADV,B2
+silver,silver,银,NOUN,B2
+muslim,muslim,مسلم,NOUN,B2
+dumping,dumping,倾销,NOUN,B2
+cottage,cottage,小屋,NOUN,B2
+hypocrite,hypocrite,伪君子,NOUN,B2
+bankrupt,bankrupt,破产的,ADJ,B2
+worst,worst,最坏的,ADJ,B2
+ethical,ethical,道德的,ADJ,B2
+disjoint,disjoint,不相交的,ADJ,B2
+to depress,to depress,使沮丧,VERB,B2
+to globalize,to globalize,使全球化,VERB,B2
+left,left,左,NOUN,B2
+afraid,afraid,害怕的,ADJ,B2
+dynamite,dynamite,炸药,NOUN,B2
+incantation,incantation,咒语,NOUN,B2
+emigration,emigration,移民,NOUN,B2
+to enthuse,to enthuse,使热情,VERB,B2
+debut,debut,初次登台,NOUN,B2
+vault,vault,金库,NOUN,B2
+overwhelming,overwhelming,压倒性的,ADJ,B2
+deeply,deeply,深深地,ADV,B2
+draw,draw,平局,NOUN,B2
+to chirp,to chirp,啁啾,VERB,B2
+their,their,他们的,PRON,B2
+as,as,作为,SCONJ,B2
+please,please,请,INTJ,B2
+cocky,cocky,傲慢的,ADJ,B2
+immortal,immortal,不朽的,ADJ,B2
+advanced,advanced,高级的,ADJ,B2
+phrase,phrase,短语,NOUN,B2
+open-minded,open-minded,思想开明的,ADJ,B2
+footprint,footprint,足迹,NOUN,B2
+improvised,improvised,即兴的,ADJ,B2
+yet,yet,还,ADV,B2
+tedious,tedious,乏味的,ADJ,B2
+instance,instance,例子,NOUN,B2
+henceforth,henceforth,从此以后,ADV,B2
+puddle,puddle,水坑,NOUN,B2
+incidence,incidence,发生率,NOUN,B2
+gaseous,gaseous,气态的,ADJ,B2
+worthless,worthless,无价值的,ADJ,B2
+spatial,spatial,空间的,ADJ,B2
+power grid,power grid,电网,NOUN,B2
+power plant,power plant,发电厂,NOUN,B2
+divergence,divergence,分歧,NOUN,B2
+unharmed,unharmed,未受伤的,ADJ,B2
+focused,focused,专注的,ADJ,B2
+to incur,to incur,招致,VERB,B2
+to slide,to slide,滑动,VERB,B2
+eighteen,eighteen,十八,NUM,B2
+erudition,erudition,博学,NOUN,B2
+terribly,terribly,可怕地/非常,ADV,B2
+infinitive marker,infinitive marker,去,PART,B2
+nor,nor,也不,CCONJ,B2
+fallibility,fallibility,易错性,NOUN,B2
+air force,air force,空军,NOUN,B2
+to sponsor,to sponsor,赞助,VERB,B2
+daddy,daddy,爸爸,NOUN,B2
+least,least,最少,ADV,B2
+to radiate,to radiate,辐射,VERB,B2
+restriction,restriction,限制,NOUN,B2
+flourishing,flourishing,繁荣的,ADJ,B2
+inefficiency,inefficiency,低效,NOUN,B2
+to refuel,to refuel,加油,VERB,B2
+decal,decal,贴花,NOUN,B2
+yeah yeah,yeah yeah,是是是,INTJ,B2
+snitch,snitch,告密者,NOUN,B2
+manifesto,manifesto,宣言,NOUN,B2
+family life,family life,家庭生活,NOUN,B2
+wimp,wimp,懦夫,NOUN,B2
+complex,complex,建筑群,NOUN,B2
+purification,purification,净化,NOUN,B2
+guild,guild,行会,NOUN,B2
+frozen,frozen,冻僵的,ADJ,B2
+schematic,schematic,概要的,ADJ,B2
+good heavens,good heavens,天哪,INTJ,B2
+stand,stand,摊位,NOUN,B2
+little,little,少,DET,B2
+fire brigade,fire brigade,消防队,NOUN,B2
+balloon,balloon,气球,NOUN,B2
+horny,horny,性欲的,ADJ,B2
+cardinal,cardinal,枢机主教,NOUN,B2
+to spy,to spy,监视,VERB,B2
+together,together,共同的,ADJ,B2
+eccentricity,eccentricity,古怪,NOUN,B2
+gruff,gruff,阴沉的,ADJ,B2
+front page,front page,头版,NOUN,B2
+comparable,comparable,可比较的,ADJ,B2
+sacrifice,sacrifice,牺牲,NOUN,B2
+to snoop,to snoop,窥探,VERB,B2
+law firm,law firm,律师事务所,NOUN,B2
+elocution,elocution,演讲术,NOUN,B2
+devilish,devilish,恶魔般的,ADJ,B2
+graphology,graphology,笔迹学,NOUN,B2
+colored,colored,有色的,ADJ,B2
+vulnerable,vulnerable,易受伤害的,ADJ,B2
+infected,infected,被感染的,ADJ,B2
+grumpy,grumpy,脾气坏的,ADJ,B2
+carefree,carefree,无忧无虑的,ADJ,B2
+desirable,desirable,可取的,ADJ,B2
+fifteen,fifteen,十五,NUM,B2
+cigar,cigar,雪茄,NOUN,B2
+to whimper,to whimper,呜咽,VERB,B2
+latin,latin,拉丁的,ADJ,B2
+private life,private life,私生活,NOUN,B2
+chieftain,chieftain,酋长,NOUN,B2
+past,past,经过,ADV,B2
+favorite,favorite,最爱,NOUN,B2
+tonight,tonight,今晚,ADV,B2
+diffusion,diffusion,传播,NOUN,B2
+broke,broke,破产的,ADJ,B2
+it,it,对此,ADV,B2
+asthmatic,asthmatic,哮喘的,ADJ,B2
+to camouflage,to camouflage,伪装,VERB,B2
+exuberant,exuberant,繁茂的,ADJ,B2
+to abstract,to abstract,抽象,VERB,B2
+time occasion,time occasion,次,NOUN,B2
+pronounced,pronounced,显著的,ADJ,B2
+to empty,to empty,倒空,VERB,B2
+babysitter,babysitter,保姆,NOUN,B2
+since then,since then,从那以后,ADV,B2
+coproduction,coproduction,联合制作,NOUN,B2
+reticent,reticent,沉默寡言的,ADJ,B2
+other,other,其他,NOUN,B2
+farmstead,farmstead,农庄,NOUN,B2
+yuck,yuck,呸,INTJ,B2
+guided tour,guided tour,导游,NOUN,B2
+in,in,进来,ADV,B2
+to gossip,to gossip,闲聊,VERB,B2
+to debut,to debut,首次亮相,VERB,B2
+jewish,jewish,犹太的,ADJ,B2
+to fake,to fake,伪造,VERB,B2
+incredible,incredible,难以置信的,ADJ,B2
+stratum,stratum,阶层,NOUN,B2
+old-fashioned,old-fashioned,老式的,ADJ,B2
+targeted,targeted,有针对性的,ADJ,B2
+reporting,reporting,报道,NOUN,B2
+to long for,to long for,渴望,VERB,B2
+unfaithful,unfaithful,不忠的,ADJ,B2
+erotic,erotic,色情的,ADJ,B2
+a little,a little,一点儿,ADV,B2
+cognition,cognition,认知,NOUN,B2
+last name,last name,姓,NOUN,B2
+eroticism,eroticism,色情,NOUN,B2
+understanding,understanding,体贴的,ADJ,B2
+highlight,highlight,亮点,NOUN,B2
+become,become,成为,AUX,B2
+bread roll,bread roll,小圆面包,NOUN,B2
+to thrive,to thrive,茁壮成长,VERB,B2
+bare,bare,赤裸的,ADJ,B2
+with it,with it,在其中,ADV,B2
+the same,the same,相同的,ADJ,B2
+cynicism,cynicism,犬儒主义,NOUN,B2
+to standardize,to standardize,标准化,VERB,B2
+demarcation,demarcation,划界,NOUN,B2
+undoubtedly,undoubtedly,无疑地,ADV,B2
+him,him,他,PRON,B2
+on top of,on top of,在...上面,ADP,B2
+to be based on,to be based on,基于,VERB,B2
+gravitation,gravitation,引力,NOUN,B2
+disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
+good morning,good morning,早上好,INTJ,B2
+conversion,conversion,转换,NOUN,B2
+blessed,blessed,受祝福的,ADJ,B2
+vending machine,vending machine,自动售货机,NOUN,B2
+corrosive,corrosive,腐蚀性的,ADJ,B2
+someone's,someone's,某人的,PRON,B2
+co-owner,co-owner,共有人,NOUN,B2
+incorrect,incorrect,不正确的,ADJ,B2
+conception,conception,概念,NOUN,B2
+desertion,desertion,逃亡,NOUN,B2
+about it,about it,关于它,ADV,B2
+tasty,tasty,美味的,ADJ,B2
+festive,festive,节日的,ADJ,B2
+impotence,impotence,无力,NOUN,B2
+to dump,to dump,抛弃,VERB,B2
+steep,steep,陡峭的,ADJ,B2
+little sister,little sister,妹妹,NOUN,B2
+marine,marine,海洋的,ADJ,B2
+this morning,this morning,今天早上,ADV,B2
+exploration,exploration,探索,NOUN,B2
+alphabet,alphabet,字母表,NOUN,B2
+over,over,过去,ADV,B2
+formulation,formulation,配方,NOUN,B2
+irritating,irritating,令人恼火的,ADJ,B2
+historicity,historicity,历史性,NOUN,B2
+congruent,congruent,一致的,ADJ,B2
+to age,to age,变老,VERB,B2
+eighty,eighty,八十,NUM,B2
+failed,failed,失败的,ADJ,B2
+inspiring,inspiring,鼓舞人心的,ADJ,B2
+inkling,inkling,预感,NOUN,B2
+finnish,finnish,芬兰的,ADJ,B2
+overdose,overdose,过量,NOUN,B2
+superstitious,superstitious,迷信的,ADJ,B2
+rubbish,rubbish,垃圾,NOUN,B2
+lowest,lowest,最低的,ADJ,B2
+grotto,grotto,洞穴,NOUN,B2
+prey,prey,猎物,NOUN,B2
+ejection,ejection,喷射,NOUN,B2
+meaningless,meaningless,毫无意义的,ADJ,B2
+wooded,wooded,树木茂盛的,ADJ,B2
+deposition,deposition,证词,NOUN,B2
+sperm,sperm,精子,NOUN,B2
+inside,inside,内部,NOUN,B2
+to idealize,to idealize,理想化,VERB,B2
+ultimate,ultimate,最终的,ADJ,B2
+city council,city council,市议会,NOUN,B2
+separate,separate,分开的,ADJ,B2
+reach,reach,范围,NOUN,B2
+greek,greek,希腊语,NOUN,B2
+choleric,choleric,易怒的,ADJ,B2
+wilderness,wilderness,荒野,NOUN,B2
+teaching,teaching,教学的,ADJ,B2
+ordinance,ordinance,条例,NOUN,B2
+evocation,evocation,唤起,NOUN,B2
+controllable,controllable,可控制的,ADJ,B2
+excursion,excursion,郊游,NOUN,B2
+homogeneity,homogeneity,同质性,NOUN,B2
+near,near,在附近,ADP,B2
+die,die,骰子,NOUN,B2
+daylight,daylight,日光,NOUN,B2
+sixteen,sixteen,十六,NUM,B2
+disloyal,disloyal,不忠的,ADJ,B2
+flammable,flammable,易燃的,ADJ,B2
+diffuse,diffuse,模糊的,ADJ,B2
+councilor,councilor,市议员,NOUN,B2
+fascism,fascism,法西斯主义,NOUN,B2
+inquisition,inquisition,宗教裁判所,NOUN,B2
+long-lasting,long-lasting,持久的,ADJ,B2
+exactness,exactness,精确,NOUN,B2
+contestable,contestable,可质疑的,ADJ,B2
+calamitous,calamitous,灾难性的,ADJ,B2
+prepared,prepared,准备好的,ADJ,B2
+to crash,to crash,碰撞,VERB,B2
+unreality,unreality,虚幻,NOUN,B2
+loved,loved,被爱的,ADJ,B2
+confessional,confessional,宗派的,ADJ,B2
+continued,continued,持续的,ADJ,B2
+the more,the more,越,ADV,B2
+to sanctify,to sanctify,使神圣,VERB,B2
+grandpa,grandpa,爷爷,NOUN,B2
+devastating,devastating,毁灭性的,ADJ,B2
+dangerousness,dangerousness,危险性,NOUN,B2
+hiding place,hiding place,藏身处,NOUN,B2
+illustration,illustration,插图,NOUN,B2
+immovable,immovable,不可移动的,ADJ,B2
+barely,barely,几乎不,ADV,B2
+fiery,fiery,热烈的,ADJ,B2
+eminent,eminent,杰出的,ADJ,B2
+halfway,halfway,半途,ADV,B2
+express,express,明确的,ADJ,B2
+oh well,oh well,算了,INTJ,B2
+to trivialize,to trivialize,使平庸,VERB,B2
+behind it,behind it,在后面,ADV,B2
+islamic,islamic,伊斯兰的,ADJ,B2
+to blow up,to blow up,炸毁,VERB,B2
+including,including,包括,ADP,B2
+that,that,那个,DET,B2
+yarn,yarn,纱线,NOUN,B2
+to torment,to torment,折磨,VERB,B2
+hare,hare,野兔,NOUN,B2
+to sabotage,to sabotage,破坏,VERB,B2
+to swing,to swing,荡秋千,VERB,B2
+to rinse,to rinse,冲洗,VERB,B2
+nearest,nearest,最近的,ADJ,B2
+to be moved,to be moved,感动,VERB,B2
+driven,driven,被驾驶的,ADJ,B2
+moving,moving,感人的,ADJ,B2
+two-headed,two-headed,双头的,ADJ,B2
+tiresome,tiresome,累人的,ADJ,B2
+comic strip,comic strip,连环画,NOUN,B2
+dissident,dissident,异见者,NOUN,B2
+contingent,contingent,偶然的,ADJ,B2
+manufacture,manufacture,制造,NOUN,B2
+surprised,surprised,惊讶的,ADJ,B2
+premonition,premonition,预感,NOUN,B2
+from there,from there,从那里,ADV,B2
+to switch,to switch,切换,VERB,B2
+phase,phase,阶段,NOUN,B2
+doubtful,doubtful,可疑的,ADJ,B2
+chosen,chosen,精选的,ADJ,B2
+gymnast,gymnast,体操运动员,NOUN,B2
+imaginative,imaginative,富有想象力的,ADJ,B2
+to fall silent,to fall silent,沉默,VERB,B2
+glance,glance,一瞥,NOUN,B2
+counterproductive,counterproductive,适得其反的,ADJ,B2
+to ironize,to ironize,讽刺,VERB,B2
+tangle,tangle,混乱,NOUN,B2
+diminutive,diminutive,指小词,NOUN,B2
+jurisprudence,jurisprudence,法理学,NOUN,B2
+gladly,gladly,乐意地,ADV,B2
+to leaf through,to leaf through,翻阅,VERB,B2
+grandiosity,grandiosity,宏伟,NOUN,B2
+whore,whore,妓女,NOUN,B2
+postage,postage,邮资,NOUN,B2
+disproportion,disproportion,不成比例,NOUN,B2
+fatality,fatality,致命性,NOUN,B2
+telephone number,telephone number,电话号码,NOUN,B2
+enviable,enviable,令人羡慕的,ADJ,B2
+vat,vat,增值税,NOUN,B2
+heterogeneity,heterogeneity,异质性,NOUN,B2
+extended,extended,广泛的,ADJ,B2
+wow,wow,哇,INTJ,B2
+junk,junk,破烂货,NOUN,B2
+swollen,swollen,肿胀的,ADJ,B2
+inclusion,inclusion,包含,NOUN,B2
+consultative,consultative,咨询的,ADJ,B2
+good night,good night,晚安,INTJ,B2
+disagreeing,disagreeing,不同意的,ADJ,B2
+canteen,canteen,食堂,NOUN,B2
+enumeration,enumeration,列举,NOUN,B2
+to give as a gift,to give as a gift,赠送,VERB,B2
+downfall,downfall,毁灭,NOUN,B2
+to relate,to relate,联系,VERB,B2
+from where,from where,从哪里,ADV,B2
+highest,highest,最高的,ADJ,B2
+to sanction,to sanction,认可,VERB,B2
+terrified,terrified,极度恐惧的,ADJ,B2
+as long as,as long as,只要,SCONJ,B2
+etymology,etymology,词源学,NOUN,B2
+regularly,regularly,定期地,ADV,B2
+skillful,skillful,熟练的,ADJ,B2
+electronics,electronics,电子学,NOUN,B2
+offensive,offensive,冒犯的,ADJ,B2
+fort,fort,堡垒,NOUN,B2
+to center,to center,居中,VERB,B2
+find,find,发现物,NOUN,B2
+to mirror,to mirror,反映,VERB,B2
+apathetic,apathetic,冷漠的,ADJ,B2
+the anform,the anform,复合词,NOUN,B2
+in view of,in view of,鉴于,ADP,B2
+to collate,to collate,核对,VERB,B2
+bump shock,bump shock,碰撞/震惊,NOUN,B2
+peat,peat,泥炭,NOUN,B2
+student loan,student loan,助学贷款,NOUN,B2
+terminus,terminus,,NOUN,B2
+strident,strident,刺耳的,ADJ,B2
+further on,further on,更远处,ADV,B2
+staunch,staunch,坚定的,ADJ,B2
+contractualization,contractualization,契约化,NOUN,B2
+the anbruch,the anbruch,名词,NOUN,B2
+watertight,watertight,,NOUN,B2
+inert,inert,惰性的,ADJ,B2
+limit border,limit border,界限,NOUN,B2
+brittle,brittle,易碎的,ADJ,B2
+nameable,nameable,可命名的,ADJ,B2
+getheilung,getheilung,词,NOUN,B2
+tourist,tourist,旅游的,ADJ,B2
+where i,where i,,NOUN,B2
+on which,on which,在其上,PRON,B2
+tidal movement,tidal movement,潮汐运动,NOUN,B2
+ground basis,ground basis,基础/理由,NOUN,B2
+fernsucht,fernsucht,词,NOUN,B2
+existential,existential,存在主义的,ADJ,B2
+national coach,national coach,国家队教练,NOUN,B2
+humble,humble,谦逊的,ADJ,B2
+burger stand,burger stand,,NOUN,B2
+neophyte,neophyte,新手；初学者,NOUN,B2
+swine,swine,猪,NOUN,B2
+domestic,domestic,国内,NOUN,B2
+to place put,to place put,放置,VERB,B2
+here hither,here hither,这里/到这里,ADV,B2
+at the top,at the top,在最上面,ADV,B2
+forensic,forensic,法医的,ADJ,B2
+to cope,to cope,应付,VERB,B2
+the missbildung,the missbildung,复合词,NOUN,B2
+matter of time,matter of time,时间问题,NOUN,B2
+cover blanket,cover blanket,覆盖物,NOUN,B2
+to complement,to complement,补充,VERB,B2
+grown,grown,长大的,ADJ,B2
+sync,sync,同步,NOUN,B2
+religiosity,religiosity,笃信宗教,NOUN,B2
+ready finished,ready finished,准备好的/完成的,ADJ,B2
+self-care,self-care,自我护理,NOUN,B2
+reformulation,reformulation,重新表述,NOUN,B2
+counterproductivity,counterproductivity,适得其反,NOUN,B2
+disrespect,disrespect,不敬,NOUN,B2
+mighty very,mighty very,非常,ADJ,B2
+unterpflegung,unterpflegung,词,NOUN,B2
+to incriminate,to incriminate,归罪,VERB,B2
+spice,spice,香料,NOUN,B2
+to vary,to vary,改变,VERB,B2
+more pl,more pl,更多,ADJ,B2
+to spill,to spill,溢出,VERB,B2
+upset,upset,心烦的,ADJ,B2
+listen up,listen up,听着,INTJ,B2
+airs,airs,摆架子,NOUN,B2
+trade barrier,trade barrier,贸易壁垒,NOUN,B2
+feeble-minded,feeble-minded,弱智的,ADJ,B2
+to deprave,to deprave,使堕落,VERB,B2
+surely safe,surely safe,肯定地,ADV,B2
+caring,caring,关怀的,ADJ,B2
+viable,viable,可行的,ADJ,B2
+one-way,one-way,单向的,ADJ,B2
+anathema,anathema,深恶痛绝之物,NOUN,B2
+ascetic,ascetic,苦行的,ADJ,B2
+paralympic,paralympic,残奥会的,ADJ,B2
+colder,colder,更冷的,ADJ,B2
+demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
+fjeld cleft,fjeld cleft,,NOUN,B2
+lethargic,lethargic,昏睡的,ADJ,B2
+getreibung,getreibung,词,NOUN,B2
+six-year-old,six-year-old,,NOUN,B2
+emergency doctor,emergency doctor,急诊医生,NOUN,B2
+unknown,unknown,未知数,NOUN,B2
+to auscultate,to auscultate,听诊,VERB,B2
+hard,hard,努力地,ADV,B2
+bumpy,bumpy,凹凸不平的,ADJ,B2
+intended,intended,预定的,ADJ,B2
+minority group,minority group,少数群体,NOUN,B2
+proposal suggestion,proposal suggestion,建议,NOUN,B2
+all everyone,all everyone,所有/大家,PRON,B2
+habitual behavior,habitual behavior,习惯行为,NOUN,B2
+play game,play game,游戏/玩耍,NOUN,B2
+painless,painless,,NOUN,B2
+bulwark,bulwark,壁垒,NOUN,B2
+distorted,distorted,歪曲的,ADJ,B2
+humane,humane,人道的,ADJ,B2
+to substantiate,to substantiate,证实,VERB,B2
+methodological,methodological,方法论的,ADJ,B2
+connective,connective,连接的,ADJ,B2
+eczema,eczema,湿疹,NOUN,B2
+buffoon,buffoon,小丑,NOUN,B2
+triumph,triumph,胜利,NOUN,B2
+nineteen,nineteen,十九,NUM,B2
+disposable,disposable,一次性的,ADJ,B2
+cats,cats,猫,NOUN,B2
+bike basket,bike basket,车筐,NOUN,B2
+einteilung,einteilung,词,NOUN,B2
+the abmessung,the abmessung,复合词,NOUN,B2
+untersinnung,untersinnung,词,NOUN,B2
+lord god,lord god,上帝,NOUN,B2
+hintersucht,hintersucht,词,NOUN,B2
+gerichtung,gerichtung,词,NOUN,B2
+the adressat,the adressat,名词,NOUN,B2
+the weitmischung,the weitmischung,复合词,NOUN,B2
+nimble,nimble,敏捷的,ADJ,B2
+scratch,scratch,抓痕,NOUN,B2
+the verwandlung,the verwandlung,复合词,NOUN,B2
+creepy,creepy,令人毛骨悚然的,ADJ,B2
+the verstleitung,the verstleitung,复合词,NOUN,B2
+the tiefbindung,the tiefbindung,复合词,NOUN,B2
+einweisung,einweisung,词,NOUN,B2
+the aktnadel,the aktnadel,名词,NOUN,B2
+the auserweiterung,the auserweiterung,复合词,NOUN,B2
+college,college,学院,NOUN,B2
+sting,sting,刺,NOUN,B2
+to anesthetize,to anesthetize,麻醉,VERB,B2
+emerald,emerald,祖母绿,NOUN,B2
+to fell,to fell,砍倒,VERB,B2
+zersucht,zersucht,词,NOUN,B2
+the berechnung,the berechnung,复合词,NOUN,B2
+the anreiz,the anreiz,名词,NOUN,B2
+the erzheilung,the erzheilung,复合词,NOUN,B2
+the akademie,the akademie,名词,NOUN,B2
+guards,guards,警卫,NOUN,B2
+to switch off,to switch off,关掉,VERB,B2
+telegram,telegram,电报,NOUN,B2
+firstly,firstly,首先,ADV,B2
+beteilung,beteilung,词,NOUN,B2
+the anwerk,the anwerk,复合词,NOUN,B2
+concerning,concerning,关于,ADP,B2
+mania,mania,狂躁症,NOUN,B2
+the hochleitung,the hochleitung,复合词,NOUN,B2
+the weitstoff,the weitstoff,复合词,NOUN,B2
+einsprache,einsprache,词,NOUN,B2
+the hochordnung,the hochordnung,复合词,NOUN,B2
+no,no,不,INTJ,B2
+erfahrt,erfahrt,词,NOUN,B2
+eingabe,eingabe,词,NOUN,B2
+the beminderung,the beminderung,复合词,NOUN,B2
+nahfahrt,nahfahrt,词,NOUN,B2
+burdened,burdened,负担重的,ADJ,B2
+the nachleitung,the nachleitung,复合词,NOUN,B2
+oddball,oddball,怪人,NOUN,B2
+to breathe again,to breathe again,松口气,VERB,B2
+the gewendung,the gewendung,复合词,NOUN,B2
+fickleness,fickleness,反复无常,NOUN,B2
+aussinnung,aussinnung,词,NOUN,B2
+the grundstoff,the grundstoff,复合词,NOUN,B2
+to countersign,to countersign,副署,VERB,B2
+bum,bum,流浪汉,NOUN,B2
+aufweisung,aufweisung,词,NOUN,B2
+but rather,but rather,而是,CCONJ,B2
+the erzwendung,the erzwendung,复合词,NOUN,B2
+the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
+the unleitung,the unleitung,复合词,NOUN,B2
+oberleitung,oberleitung,词,NOUN,B2
+whether,whether,是否,SCONJ,B2
+the aushandlung,the aushandlung,复合词,NOUN,B2
+einerziehung,einerziehung,词,NOUN,B2
+so to speak,so to speak,可以说,ADV,B2
+the ausstellung,the ausstellung,复合词,NOUN,B2
+the ansage,the ansage,名词,NOUN,B2
+to share divide,to share divide,分享,VERB,B2
+theme music,theme music,主题曲,NOUN,B2
+nachsuchung,nachsuchung,词,NOUN,B2
+christmas tree,christmas tree,圣诞树,NOUN,B2
+thin-walled,thin-walled,隔音差的,ADJ,B2
+the vorrechnung,the vorrechnung,复合词,NOUN,B2
+the mitstellung,the mitstellung,复合词,NOUN,B2
+the tiefleitung,the tiefleitung,复合词,NOUN,B2
+crap,crap,屎,NOUN,B2
+to vibrate,to vibrate,振动,VERB,B2
+einwirkung,einwirkung,词,NOUN,B2
+the untererweiterung,the untererweiterung,复合词,NOUN,B2
+the abweisung,the abweisung,名词,NOUN,B2
+nachsinnung,nachsinnung,词,NOUN,B2
+unfassung,unfassung,词,NOUN,B2
+to break out,to break out,爆发,VERB,B2
+the ursammlung,the ursammlung,复合词,NOUN,B2
+to bump,to bump,碰撞,VERB,B2
+fishing rod,fishing rod,钓竿,NOUN,B2
+the nachbindung,the nachbindung,复合词,NOUN,B2
+from it,from it,从中,ADV,B2
+weitweisung,weitweisung,词,NOUN,B2
+the abkraft,the abkraft,复合词,NOUN,B2
+the aufleitung,the aufleitung,复合词,NOUN,B2
+to queue,to queue,排队,VERB,B2
+annual wage,annual wage,年薪,NOUN,B2
+erzregelung,erzregelung,词,NOUN,B2
+people nation,people nation,人民 / 民族,NOUN,B2
+prank,prank,恶作剧,NOUN,B2
+learning curve,learning curve,学习曲线,NOUN,B2
+the erwendung,the erwendung,复合词,NOUN,B2
+moor,moor,荒野,NOUN,B2
+benahme,benahme,词,NOUN,B2
+to stint,to stint,吝啬,VERB,B2
+the erzwerk,the erzwerk,复合词,NOUN,B2
+thousands,thousands,数千,NOUN,B2
+the erzmischung,the erzmischung,复合词,NOUN,B2
+to lay down,to lay down,放下,VERB,B2
+vorderfassung,vorderfassung,词,NOUN,B2
+everyday life,everyday life,日常生活,NOUN,B2
+city map,city map,城市地图,NOUN,B2
+host of angels,host of angels,天使群,NOUN,B2
+wage labor,wage labor,雇佣劳动,NOUN,B2
+to step in,to step in,介入,VERB,B2
+sort,sort,种类,NOUN,B2
+ausweisung,ausweisung,词,NOUN,B2
+vorwandel,vorwandel,词,NOUN,B2
+the abwert,the abwert,复合词,NOUN,B2
+the vorwert,the vorwert,复合词,NOUN,B2
+german class,german class,德语课,NOUN,B2
+the adoption,the adoption,名词,NOUN,B2
+hearts,hearts,心,NOUN,B2
+crook,crook,骗子,NOUN,B2
+hochweisung,hochweisung,词,NOUN,B2
+to make sense,to make sense,讲得通,VERB,B2
+to keep secret,to keep secret,隐瞒,VERB,B2
+bitch,bitch,母狗,NOUN,B2
+the zurechnung,the zurechnung,复合词,NOUN,B2
+semicolon,semicolon,分号,PUNCT,B2
+resident,resident,定居的,ADJ,B2
+the gebindung,the gebindung,复合词,NOUN,B2
+evil,evil,邪,PART,B2
+sky blue,sky blue,天蓝色,ADJ,B2
+vegetarian,vegetarian,素食者,NOUN,B2
+she they,she they,她,PRON,B2
+chain mail,chain mail,锁子甲,NOUN,B2
+the missordnung,the missordnung,复合词,NOUN,B2
+the verstwerk,the verstwerk,复合词,NOUN,B2
+twitching,twitching,抽搐的,ADJ,B2
+zusicht,zusicht,词,NOUN,B2
+urgestaltung,urgestaltung,词,NOUN,B2
+to overlook,to overlook,忽视,VERB,B2
+the mitbildung,the mitbildung,复合词,NOUN,B2
+motherfucker,motherfucker,混蛋,NOUN,B2
+the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
+the alpinismus,the alpinismus,名词,NOUN,B2
+yikes,yikes,哎呀,INTJ,B2
+sow,sow,母猪,NOUN,B2
+urgabe,urgabe,词,NOUN,B2
+erweisung,erweisung,词,NOUN,B2
+virtuous,virtuous,有德行的,ADJ,B2
+to go blind,to go blind,失明,VERB,B2
+zufahrt,zufahrt,词,NOUN,B2
+backdrop,backdrop,背景,NOUN,B2
+probation,probation,缓刑,NOUN,B2
+comma,comma,逗号,PUNCT,B2
+seamless,seamless,无缝的,ADJ,B2
+distorted image,distorted image,扭曲的形象,NOUN,B2
+sagittarius,sagittarius,射手座,NOUN,B2
+to stay here,to stay here,留在这里,VERB,B2
+verschaft,verschaft,词,NOUN,B2
+unweisung,unweisung,词,NOUN,B2
+the abholung,the abholung,名词,NOUN,B2
+gay,gay,快乐的,ADJ,B2
+ausgestaltung,ausgestaltung,词,NOUN,B2
+hinterleitung,hinterleitung,词,NOUN,B2
+to pick out,to pick out,挑选,VERB,B2
+president female,president female,女总统,NOUN,B2
+below,below,下面,ADV,B2
+to abschweifen,to abschweifen,动词,VERB,B2
+the aufwandlung,the aufwandlung,复合词,NOUN,B2
+the erzkraft,the erzkraft,复合词,NOUN,B2
+cleaning,cleaning,清洁,NOUN,B2
+timetable,timetable,时刻表,NOUN,B2
+einnahme,einnahme,词,NOUN,B2
+the zerbildung,the zerbildung,复合词,NOUN,B2
+drinking glass,drinking glass,水杯,NOUN,B2
+weitsuchung,weitsuchung,词,NOUN,B2
+the hochstoff,the hochstoff,复合词,NOUN,B2
+to brood,to brood,沉思,VERB,B2
+the antrag,the antrag,名词,NOUN,B2
+tasteless,tasteless,无味的,ADJ,B2
+sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
+to bullshit,to bullshit,胡扯,VERB,B2
+any,any,任何,PRON,B2
+university student,university student,大学生,NOUN,B2
+to growl,to growl,咆哮,VERB,B2
+the aufwendung,the aufwendung,复合词,NOUN,B2
+serve markup,serve markup,发球/加价,NOUN,B2
+the weitminderung,the weitminderung,复合词,NOUN,B2
+the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
+the einmessung,the einmessung,复合词,NOUN,B2
+the urheilung,the urheilung,复合词,NOUN,B2
+rake,rake,耙子,NOUN,B2
+to spell,to spell,拼写,VERB,B2
+sacrificed,sacrificed,牺牲,ADJ,B2
+to get by,to get by,过得去,VERB,B2
+hintertheilung,hintertheilung,词,NOUN,B2
+the vorordnung,the vorordnung,复合词,NOUN,B2
+to align,to align,使一致,VERB,B2
+geteilung,geteilung,词,NOUN,B2
+urwandel,urwandel,词,NOUN,B2
+the mitheilung,the mitheilung,复合词,NOUN,B2
+precinct,precinct,辖区,NOUN,B2
+the verststoff,the verststoff,复合词,NOUN,B2
+romanian,romanian,罗马尼亚人,NOUN,B2
+the vorstellung,the vorstellung,复合词,NOUN,B2
+helper,helper,助手,NOUN,B2
+the andrang,the andrang,名词,NOUN,B2
+hinterrechnung,hinterrechnung,词,NOUN,B2
+the abhang,the abhang,名词,NOUN,B2
+weitwandel,weitwandel,词,NOUN,B2
+investigated,investigated,被调查的,ADJ,B2
+auswandel,auswandel,词,NOUN,B2
+unnahme,unnahme,词,NOUN,B2
+the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
+hinterrichtung,hinterrichtung,词,NOUN,B2
+the bemessung,the bemessung,复合词,NOUN,B2
+misstreibung,misstreibung,词,NOUN,B2
+bodily harm,bodily harm,人身伤害,NOUN,B2
+that yonder,that yonder,那个,DET,B2
+vortheilung,vortheilung,词,NOUN,B2
+the aktivist,the aktivist,名词,NOUN,B2
+naherziehung,naherziehung,词,NOUN,B2
+pastime,pastime,爱好,NOUN,B2
+the aufstoff,the aufstoff,复合词,NOUN,B2
+refreshing,refreshing,令人清爽的,ADJ,B2
+ausforderung,ausforderung,词,NOUN,B2
+the unmischung,the unmischung,复合词,NOUN,B2
+the beleitung,the beleitung,复合词,NOUN,B2
+the bewendung,the bewendung,复合词,NOUN,B2
+the aufheilung,the aufheilung,复合词,NOUN,B2
+to elapse,to elapse,流逝,VERB,B2
+mortal fear,mortal fear,极度恐惧,NOUN,B2
+the aktion,the aktion,名词,NOUN,B2
+trash bag,trash bag,垃圾袋,NOUN,B2
+the anbeginn,the anbeginn,名词,NOUN,B2
+worst thing,worst thing,最坏的事,NOUN,B2
+usual thing,usual thing,惯例,NOUN,B2
+per,per,每,ADP,B2
+the hochbindung,the hochbindung,复合词,NOUN,B2
+to abtrocken,to abtrocken,动词,VERB,B2
+to pressurize,to pressurize,逼迫,VERB,B2
+at the,at the,在...时,ADP,B2
+the zuwandlung,the zuwandlung,复合词,NOUN,B2
+groan,groan,呻吟,NOUN,B2
+to shunt,to shunt,分流,VERB,B2
+bulldog,bulldog,斗牛犬,NOUN,B2
+to play along,to play along,配合,VERB,B2
+agreed,agreed,一致的,ADJ,B2
+ursicht,ursicht,词,NOUN,B2
+hideous,hideous,丑陋的,ADJ,B2
+the ausbildung,the ausbildung,复合词,NOUN,B2
+the gemischung,the gemischung,复合词,NOUN,B2
+drive,drive,动力,NOUN,B2
+wiedertreibung,wiedertreibung,词,NOUN,B2
+urteilung,urteilung,词,NOUN,B2
+fernrechnung,fernrechnung,词,NOUN,B2
+unfahrt,unfahrt,词,NOUN,B2
+separated,separated,分开的,ADJ,B2
+the unbildung,the unbildung,复合词,NOUN,B2
+the zuhandlung,the zuhandlung,复合词,NOUN,B2
+anteilung,anteilung,词,NOUN,B2
+anrichtung,anrichtung,词,NOUN,B2
+erschaft,erschaft,词,NOUN,B2
+interpersonal,interpersonal,人际的,ADJ,B2
+the allianz,the allianz,名词,NOUN,B2
+the anteil,the anteil,名词,NOUN,B2
+hothead,hothead,急性子的人,NOUN,B2
+tiefsuchung,tiefsuchung,词,NOUN,B2
+the zererweiterung,the zererweiterung,复合词,NOUN,B2
+the aktuar,the aktuar,名词,NOUN,B2
+nahfassung,nahfassung,词,NOUN,B2
+the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
+billion,billion,十亿,NOUN,B2
+the anheilung,the anheilung,复合词,NOUN,B2
+to turn away,to turn away,转开,VERB,B2
+to get into,to get into,陷入,VERB,B2
+the abheilung,the abheilung,复合词,NOUN,B2
+without exception,without exception,无例外的,ADV,B2
+to view,to view,参观,VERB,B2
+vordersinnung,vordersinnung,词,NOUN,B2
+to deregister,to deregister,注销,VERB,B2
+ran,ran,跑,ADJ,B2
+the day after tomorrow,the day after tomorrow,后天,ADV,B2
+the absteigerung,the absteigerung,复合词,NOUN,B2
+ausschrift,ausschrift,词,NOUN,B2
+the abgrund,the abgrund,名词,NOUN,B2
+to subordinate,to subordinate,从属,VERB,B2
+zersicht,zersicht,词,NOUN,B2
+the urvertiefung,the urvertiefung,复合词,NOUN,B2
+the mitkraft,the mitkraft,复合词,NOUN,B2
+the urverbesserung,the urverbesserung,复合词,NOUN,B2
+deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
+causal,causal,因果的,ADJ,B2
+windy,windy,有风的,ADJ,B2
+office work,office work,办公室工作,NOUN,B2
+zusprache,zusprache,词,NOUN,B2
+the nachbildung,the nachbildung,复合词,NOUN,B2
+untreibung,untreibung,词,NOUN,B2
+besprache,besprache,词,NOUN,B2
+many things,many things,许多事物,PRON,B2
+the bevertiefung,the bevertiefung,复合词,NOUN,B2
+the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
+the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
+unwandel,unwandel,词,NOUN,B2
+hinterfassung,hinterfassung,词,NOUN,B2
+to watch tv,to watch tv,看电视,VERB,B2
+to wait and see,to wait and see,等待观望,VERB,B2
+noises,noises,噪音,NOUN,B2
+grandparents,grandparents,祖父母,NOUN,B2
+to move out,to move out,搬出,VERB,B2
+next door,next door,在隔壁,ADV,B2
+the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
+the aktpunkt,the aktpunkt,名词,NOUN,B2
+the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
+the akkumulator,the akkumulator,名词,NOUN,B2
+the ererweiterung,the ererweiterung,复合词,NOUN,B2
+mitsetzung,mitsetzung,词,NOUN,B2
+bullshitted,bullshitted,被愚弄的,ADJ,B2
+upbeat,upbeat,轻快的,ADJ,B2
+the einwerk,the einwerk,复合词,NOUN,B2
+vorderweisung,vorderweisung,词,NOUN,B2
+nachrichtung,nachrichtung,词,NOUN,B2
+to abdanken,to abdanken,动词,VERB,B2
+scarce commodity,scarce commodity,紧缺商品,NOUN,B2
+lunch break,lunch break,午休,NOUN,B2
+wiedersprache,wiedersprache,词,NOUN,B2
+the erleitung,the erleitung,复合词,NOUN,B2
+to absagen,to absagen,动词,VERB,B2
+vordersetzung,vordersetzung,词,NOUN,B2
+in front of before,in front of before,在...前,ADP,B2
+misstheilung,misstheilung,词,NOUN,B2
+test of courage,test of courage,勇气测试,NOUN,B2
+the unwandlung,the unwandlung,复合词,NOUN,B2
+gesinnung,gesinnung,词,NOUN,B2
+shit,shit,恐惧,NOUN,B2
+hinterwandel,hinterwandel,词,NOUN,B2
+the anschlag,the anschlag,名词,NOUN,B2
+the altruismus,the altruismus,名词,NOUN,B2
+the verhandlung,the verhandlung,复合词,NOUN,B2
+song of praise,song of praise,赞歌,NOUN,B2
+aufforderung,aufforderung,词,NOUN,B2
+the urstoff,the urstoff,复合词,NOUN,B2
+the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
+on what,on what,在什么上面,ADV,B2
+unpflegung,unpflegung,词,NOUN,B2
+stupid things,stupid things,蠢事,NOUN,B2
+itching powder,itching powder,痒痒粉,NOUN,B2
+to be delayed,to be delayed,迟到,VERB,B2
+urschrift,urschrift,词,NOUN,B2
+to abschlafen,to abschlafen,动词,VERB,B2
+affected,affected,受影响的,ADJ,B2
+hintersuchung,hintersuchung,词,NOUN,B2
+zernahme,zernahme,词,NOUN,B2
+glib,glib,伶牙俐齿的,ADJ,B2
+wiedersucht,wiedersucht,词,NOUN,B2
+to abzwecken,to abzwecken,动词,VERB,B2
+the bekraft,the bekraft,复合词,NOUN,B2
+the alpen,the alpen,名词,NOUN,B2
+like,like,点赞,NOUN,B2
+besuchung,besuchung,词,NOUN,B2
+interrogation room,interrogation room,审讯室,NOUN,B2
+aussetzung,aussetzung,词,NOUN,B2
+hinterwendung,hinterwendung,词,NOUN,B2
+fernschaft,fernschaft,词,NOUN,B2
+obersuchung,obersuchung,词,NOUN,B2
+the unterordnung,the unterordnung,复合词,NOUN,B2
+most important thing,most important thing,最重要的事,NOUN,B2
+the aufordnung,the aufordnung,复合词,NOUN,B2
+main reason,main reason,主要原因,NOUN,B2
+to play down,to play down,淡化,VERB,B2
+the geverbesserung,the geverbesserung,复合词,NOUN,B2
+oberbildung,oberbildung,词,NOUN,B2
+the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
+weitsicht,weitsicht,词,NOUN,B2
+the aufwert,the aufwert,复合词,NOUN,B2
+to run away,to run away,逃跑,VERB,B2
+delivery van,delivery van,厢式送货车,NOUN,B2
+the amboss,the amboss,名词,NOUN,B2
+einschaft,einschaft,词,NOUN,B2
+the gebildung,the gebildung,复合词,NOUN,B2
+antheilung,antheilung,词,NOUN,B2
+the beerweiterung,the beerweiterung,复合词,NOUN,B2
+the missstoff,the missstoff,复合词,NOUN,B2
+the weitordnung,the weitordnung,复合词,NOUN,B2
+to commission,to commission,委托,VERB,B2
+zersuchung,zersuchung,词,NOUN,B2
+wiedersicht,wiedersicht,词,NOUN,B2
+hochkunft,hochkunft,词,NOUN,B2
+the aufbewegung,the aufbewegung,复合词,NOUN,B2
+of all things,of all things,偏偏,ADV,B2
+the unterleitung,the unterleitung,复合词,NOUN,B2
+nachtheilung,nachtheilung,词,NOUN,B2
+untertreibung,untertreibung,词,NOUN,B2
+the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
+personal,personal,私事,NOUN,B2
+missschrift,missschrift,词,NOUN,B2
+the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
+vorderrichtung,vorderrichtung,词,NOUN,B2
+to abstimmen,to abstimmen,动词,VERB,B2
+wiederordnung,wiederordnung,词,NOUN,B2
+the missbewegung,the missbewegung,复合词,NOUN,B2
+vorteilung,vorteilung,词,NOUN,B2
+unerziehung,unerziehung,词,NOUN,B2
+to do harm,to do harm,伤害,VERB,B2
+the weitheilung,the weitheilung,复合词,NOUN,B2
+the akkord,the akkord,名词,NOUN,B2
+unlawful,unlawful,非法的,ADJ,B2
+oberwandlung,oberwandlung,词,NOUN,B2
+kidnapper,kidnapper,绑架者,NOUN,B2
+the weitwendung,the weitwendung,复合词,NOUN,B2
+clear as day,clear as day,一清二楚的,ADJ,B2
+the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
+to abteilen,to abteilen,动词,VERB,B2
+the ackerbau,the ackerbau,名词,NOUN,B2
+the missvertiefung,the missvertiefung,复合词,NOUN,B2
+geforderung,geforderung,词,NOUN,B2
+to oversleep,to oversleep,睡过头,VERB,B2
+the gestoff,the gestoff,复合词,NOUN,B2
+loudspeaker,loudspeaker,扬声器,NOUN,B2
+the mitordnung,the mitordnung,复合词,NOUN,B2
+goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
+the tiefstoff,the tiefstoff,复合词,NOUN,B2
+erforderung,erforderung,词,NOUN,B2
+missschaft,missschaft,词,NOUN,B2
+wiederkunft,wiederkunft,词,NOUN,B2
+the unminderung,the unminderung,复合词,NOUN,B2
+ausfahrt,ausfahrt,词,NOUN,B2
+oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
+the nachmessung,the nachmessung,复合词,NOUN,B2
+game rule,game rule,游戏规则,NOUN,B2
+aufrichtung,aufrichtung,词,NOUN,B2
+mitfahrt,mitfahrt,词,NOUN,B2
+obererziehung,obererziehung,词,NOUN,B2
+the anbindung,the anbindung,复合词,NOUN,B2
+with what,with what,用什么,ADV,B2
+handyman,handyman,工匠,NOUN,B2
+urnahme,urnahme,词,NOUN,B2
+devices,devices,设备,NOUN,B2
+detective force,detective force,刑警,NOUN,B2
+the alphabet,the alphabet,名词,NOUN,B2
+the vorbindung,the vorbindung,复合词,NOUN,B2
+wiedersinnung,wiedersinnung,词,NOUN,B2
+weitregelung,weitregelung,词,NOUN,B2
+the hochsammlung,the hochsammlung,复合词,NOUN,B2
+zuschaft,zuschaft,词,NOUN,B2
+the anbieter,the anbieter,名词,NOUN,B2
+the albatros,the albatros,名词,NOUN,B2
+letter mail,letter mail,信,NOUN,B2
+once again,once again,再次,ADV,B2
+the abwurf,the abwurf,名词,NOUN,B2
+wiedererziehung,wiedererziehung,词,NOUN,B2
+the verform,the verform,复合词,NOUN,B2
+the nachstoff,the nachstoff,复合词,NOUN,B2
+the misskraft,the misskraft,复合词,NOUN,B2
+ferntheilung,ferntheilung,词,NOUN,B2
+emergency call,emergency call,紧急呼叫,NOUN,B2
+eleven,eleven,十一,NOUN,B2
+german person,german person,德国人,NOUN,B2
+hectic,hectic,忙乱,NOUN,B2
+to be added,to be added,加入,VERB,B2
+hintersicht,hintersicht,词,NOUN,B2
+to switch on,to switch on,开启,VERB,B2
+the zerrechnung,the zerrechnung,复合词,NOUN,B2
+the verstellung,the verstellung,复合词,NOUN,B2
+wiedersuchung,wiedersuchung,词,NOUN,B2
+sick nauseous,sick nauseous,恶心的,ADJ,B2
+you formal,you formal,您,PRON,B2
+zurichtung,zurichtung,词,NOUN,B2
+bepflegung,bepflegung,词,NOUN,B2
+hinterregelung,hinterregelung,词,NOUN,B2
+gesucht,gesucht,词,NOUN,B2
+zerteilung,zerteilung,词,NOUN,B2
+vorderleitung,vorderleitung,词,NOUN,B2
+nachweisung,nachweisung,词,NOUN,B2
+nachwirkung,nachwirkung,词,NOUN,B2
+the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
+the zerhandlung,the zerhandlung,复合词,NOUN,B2
+the abstoff,the abstoff,复合词,NOUN,B2
+over about,over about,在...上方,ADP,B2
+squeak,squeak,吱吱声,NOUN,B2
+the unterheilung,the unterheilung,复合词,NOUN,B2
+some things,some things,一些事情,PRON,B2
+no not any,no not any,没有,DET,B2
+ursetzung,ursetzung,词,NOUN,B2
+at it,at it,靠近,ADV,B2
+the ausleitung,the ausleitung,复合词,NOUN,B2
+expert opinion,expert opinion,专家意见,NOUN,B2
+the auswendung,the auswendung,复合词,NOUN,B2
+to descend from,to descend from,起源于,VERB,B2
+the hochminderung,the hochminderung,复合词,NOUN,B2
+your pl,your pl,你们的,DET,B2
+yours,yours,你的,PRON,B2
+pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
+erwirkung,erwirkung,词,NOUN,B2
+abfassung,abfassung,词,NOUN,B2
+the abhandlung,the abhandlung,复合词,NOUN,B2
+the alias,the alias,名词,NOUN,B2
+yoga practice,yoga practice,瑜伽练习,NOUN,B2
+the urmischung,the urmischung,复合词,NOUN,B2
+aussuchung,aussuchung,词,NOUN,B2
+nachfassung,nachfassung,词,NOUN,B2
+unschaft,unschaft,词,NOUN,B2
+anschrift,anschrift,词,NOUN,B2
+erztheilung,erztheilung,词,NOUN,B2
+at night,at night,夜间,ADV,B2
+the anordnung,the anordnung,复合词,NOUN,B2
+untersetzung,untersetzung,词,NOUN,B2
+the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
+the nachheilung,the nachheilung,复合词,NOUN,B2
+the missrechnung,the missrechnung,复合词,NOUN,B2
+the unwendung,the unwendung,复合词,NOUN,B2
+hochforderung,hochforderung,词,NOUN,B2
+the beordnung,the beordnung,复合词,NOUN,B2
+to abtun,to abtun,动词,VERB,B2
+vorderwandel,vorderwandel,词,NOUN,B2
+the zerordnung,the zerordnung,复合词,NOUN,B2
+aussucht,aussucht,词,NOUN,B2
+the anbettlung,the anbettlung,名词,NOUN,B2
+wiederleitung,wiederleitung,词,NOUN,B2
+to circumcise,to circumcise,割礼,VERB,B2
+the vermacht,the vermacht,复合词,NOUN,B2
+justified,justified,有根据的,ADJ,B2
+the geform,the geform,复合词,NOUN,B2
+hinterweisung,hinterweisung,词,NOUN,B2
+mitsicht,mitsicht,词,NOUN,B2
+nachsucht,nachsucht,词,NOUN,B2
+passed,passed,递,ADJ,B2
+nachschaft,nachschaft,词,NOUN,B2
+the ververbesserung,the ververbesserung,复合词,NOUN,B2
+vorerziehung,vorerziehung,词,NOUN,B2
+weitteilung,weitteilung,词,NOUN,B2
+the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
+the urrechnung,the urrechnung,复合词,NOUN,B2
+different,different,不同地,ADV,B2
+period,period,句号,PUNCT,B2
+the zerkraft,the zerkraft,复合词,NOUN,B2
+misssicht,misssicht,词,NOUN,B2
+joie de vivre,joie de vivre,生活乐趣,NOUN,B2
+the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
+the urstellung,the urstellung,复合词,NOUN,B2
+for each other,for each other,相互,ADV,B2
+hochgabe,hochgabe,词,NOUN,B2
+kitten,kitten,小猫,NOUN,B2
+outside of,outside of,在...之外,ADP,B2
+fernkunft,fernkunft,词,NOUN,B2
+to be valid,to be valid,有效,VERB,B2
+wiederfahrt,wiederfahrt,词,NOUN,B2
+to be liable,to be liable,负责,VERB,B2
+the vorkraft,the vorkraft,复合词,NOUN,B2
+the verminderung,the verminderung,复合词,NOUN,B2
+to abwandeln,to abwandeln,动词,VERB,B2
+the urbewegung,the urbewegung,复合词,NOUN,B2
+to absichern,to absichern,动词,VERB,B2
+the grundbildung,the grundbildung,复合词,NOUN,B2
+the ververtiefung,the ververtiefung,复合词,NOUN,B2
+ersetzung,ersetzung,词,NOUN,B2
+all the more,all the more,更加,ADV,B2
+to squeak,to squeak,吱吱叫,VERB,B2
+aberziehung,aberziehung,词,NOUN,B2
+mittheilung,mittheilung,词,NOUN,B2
+the altertum,the altertum,名词,NOUN,B2
+zerregelung,zerregelung,词,NOUN,B2
+mitpflegung,mitpflegung,词,NOUN,B2
+worse,worse,更糟的事,NOUN,B2
+the versthandlung,the versthandlung,复合词,NOUN,B2
+gefahrt,gefahrt,词,NOUN,B2
+managing director,managing director,总经理,NOUN,B2
+erzfahrt,erzfahrt,词,NOUN,B2
+coke,coke,可卡因,NOUN,B2
+as possible,as possible,尽可能地,ADV,B2
+waste of time,waste of time,浪费时间,NOUN,B2
+the unstellung,the unstellung,复合词,NOUN,B2
+aufgestaltung,aufgestaltung,词,NOUN,B2
+versinnung,versinnung,词,NOUN,B2
+missfassung,missfassung,词,NOUN,B2
+the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
+the abbindung,the abbindung,复合词,NOUN,B2
+masseur,masseur,按摩师,NOUN,B2
+all saints' day,all saints' day,诸圣节,NOUN,B2
+the angriff,the angriff,名词,NOUN,B2
+doorbell button,doorbell button,门铃按钮,NOUN,B2
+endeavor,endeavor,努力,NOUN,B2
+dearest,dearest,最爱的人,NOUN,B2
+relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
+nachwandel,nachwandel,词,NOUN,B2
+the verstbindung,the verstbindung,复合词,NOUN,B2
+the abordnung,the abordnung,复合词,NOUN,B2
+to lie to,to lie to,对...说谎,VERB,B2
+to ignite,to ignite,点燃,VERB,B2
+the day before yesterday,the day before yesterday,前天,ADV,B2
+motion picture,motion picture,电影,NOUN,B2
+ursprache,ursprache,词,NOUN,B2
+lifeless,lifeless,无生命的,ADJ,B2
+buoyant,buoyant,有浮力的,ADJ,B2
+to disfavor,to disfavor,不利于,VERB,B2
+fissure,fissure,裂缝,NOUN,B2
+to deafen,to deafen,使聋,VERB,B2
+the career,the career,职业生涯,NOUN,B2
+supplication,supplication,恳求,NOUN,B2
+drag,drag,拖曳,NOUN,B2
+line of conduct,line of conduct,行为方针,NOUN,B2
+locked,locked,锁定的,ADJ,B2
+layer storage,layer storage,层/仓库,NOUN,B2
+to vegetate,to vegetate,苟活,VERB,B2
+beautifully,beautifully,美丽地,ADV,B2
+fare,fare,车费,NOUN,B2
+to consummate,to consummate,完成,VERB,B2
+to allege,to allege,宣称,VERB,B2
+numb,numb,麻木的,ADJ,B2
+outlaw,outlaw,歹徒,NOUN,B2
+every,every,每个,PRON,B2
+compound,compound,化合物,NOUN,B2
+to dishevel,to dishevel,弄乱,VERB,B2
+to depilate,to depilate,脱毛,VERB,B2
+tyrannical,tyrannical,专横的,ADJ,B2
+seldom,seldom,很少,ADV,B2
+to situate,to situate,定位,VERB,B2
+equal treatment,equal treatment,平等待遇,NOUN,B2
+guilt-ridden,guilt-ridden,内疚的,ADJ,B2
+to deal,to deal,处理,VERB,B2
+to specialize,to specialize,专攻,VERB,B2
+to vampirize,to vampirize,吸血,VERB,B2
+chief physician,chief physician,主任医师,NOUN,B2
+professionally active,professionally active,在职,NOUN,B2
+idiotic,idiotic,愚蠢的,ADJ,B2
+soundtrack,soundtrack,! 音轨,NOUN,B2
+the casinos,the casinos,赌场,NOUN,B2
+buccaneer,buccaneer,海盗,NOUN,B2
+hatch,hatch,舱口,NOUN,B2
+fictional character,fictional character,虚构角色,NOUN,B2
+like that,like that,像那样,ADV,B2
+vain,vain,徒劳的,ADJ,B2
+motif,motif,主题,NOUN,B2
+to absolve,to absolve,赦免,VERB,B2
+to bump push,to bump push,推/碰撞,VERB,B2
+trinket,trinket,小饰品,NOUN,B2
+costs,costs,费用,NOUN,B2
+junior jersey,junior jersey,,NOUN,B2
+to be felled,to be felled,被砍倒,VERB,B2
+variant,variant,变体,NOUN,B2
+news reporting,news reporting,新闻报道,NOUN,B2
+would,would,将要,AUX,B2
+culture of greed,culture of greed,贪得无厌文化,NOUN,B2
+outdoors,outdoors,户外,ADV,B2
+meaning content,meaning content,语义内容,NOUN,B2
+chauvinistic,chauvinistic,沙文主义的,ADJ,B2
+to adore,to adore,爱慕,VERB,B2
+one you,one you,人们,PRON,B2
+latent,latent,潜在的,ADJ,B2
+co-determination,co-determination,共同决定权,NOUN,B2
+elementary,elementary,基本的,ADJ,B2
+ace carcass,ace carcass,王牌/尸体,NOUN,B2
+curfew,curfew,宵禁,NOUN,B2
+surreptitious,surreptitious,秘密的,ADJ,B2
+to allude,to allude,暗指,VERB,B2
+from behind,from behind,从后面,ADV,B2
+resource shortage,resource shortage,资源短缺,NOUN,B2
+damageable,damageable,易损的,ADJ,B2
+lunatic,lunatic,疯子,NOUN,B2
+to extirpate,to extirpate,根除,VERB,B2
+to eternalize,to eternalize,使永恒,VERB,B2
+ferry,ferry,渡轮,NOUN,B2
+fulfillment,fulfillment,满足,NOUN,B2
+nuclear war,nuclear war,核战争,NOUN,B2
+insanely,insanely,疯狂地,ADV,B2
+to dismay,to dismay,使沮丧,VERB,B2
+occupational pension,occupational pension,职业养老金,NOUN,B2
+mp,mp,国会议员,NOUN,B2
+cudgel,cudgel,棍棒,NOUN,B2
+his her its their,his her its their,他的/她的/它的/他们的,DET,B2
+to decant,to decant,倾析,VERB,B2
+incorporation,incorporation,纳入,NOUN,B2
+airtight,airtight,密封的,ADJ,B2
+group member,group member,群体成员,NOUN,B2
+acerbic,acerbic,尖刻的,ADJ,B2
+to bluff,to bluff,虚张声势,VERB,B2
+domain,domain,领域,NOUN,B2
+to put set,to put set,放置,VERB,B2
+selected,selected,选中的,ADJ,B2
+disturbed,disturbed,不安的,ADJ,B2
+veiled,veiled,隐晦的,ADJ,B2
+vigilant,vigilant,警惕的,ADJ,B2
+thetic,thetic,正题的,ADJ,B2
+to disfigure,to disfigure,毁容,VERB,B2
+attributive,attributive,定语的,ADJ,B2
+to meant,to meant,意思是,VERB,B2
+should ought to,should ought to,应该,AUX,B2
+from within,from within,从内部,ADV,B2
+thicker,thicker,更厚的,ADJ,B2
+shady suspicious,shady suspicious,可疑的,ADJ,B2
+villainous,villainous,恶棍的,ADJ,B2
+sexy,sexy,性感的,ADJ,B2
+upright,upright,直立地,ADV,B2
+values base,values base,价值基础,NOUN,B2
+acculturation,acculturation,文化涵化,NOUN,B2
+jews,jews,犹太人,NOUN,B2
+cradle,cradle,摇篮,NOUN,B2
+sail,sail,帆,NOUN,B2
+irish person,irish person,爱尔兰人,NOUN,B2
+photon,photon,光子,NOUN,B2
+cheapness,cheapness,廉价,NOUN,B2
+dator,dator,电脑,NOUN,B2
+to bungle,to bungle,搞砸,VERB,B2
+slut,slut,荡妇,NOUN,B2
+numismatic,numismatic,钱币学的,ADJ,B2
+faint,faint,微弱的,ADJ,B2
+demagogy,demagogy,蛊惑,NOUN,B2
+enamel,enamel,珐琅,NOUN,B2
+to map out,to map out,摸清,VERB,B2
+phlegmatic,phlegmatic,冷静的,ADJ,B2
+to do sports,to do sports,运动,VERB,B2
+side,side,骄傲的,ADJ,B2
+to log in,to log in,登录,VERB,B2
+iranian,iranian,伊朗的,ADJ,B2
+doctor visit,doctor visit,,NOUN,B2
+dans,dans,舞蹈,NOUN,B2
+to navigate,to navigate,导航；航行,VERB,B2
+family circle,family circle,家庭圈子,NOUN,B2
+ago,ago,以前,ADV,B2
+super dead,super dead,,NOUN,B2
+thicket,thicket,灌木丛,NOUN,B2
+emotional experience,emotional experience,情感体验,NOUN,B2
+film movie,film movie,电影,NOUN,B2
+to fasten,to fasten,系紧,VERB,B2
+depot,depot,仓库,NOUN,B2
+tropical,tropical,热带的,ADJ,B2
+to stitch,to stitch,缝,VERB,B2
+asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
+historicism,historicism,历史主义,NOUN,B2
+detention center,detention center,拘留所,NOUN,B2
+full of life,full of life,充满活力的,ADJ,B2
+sinister,sinister,不祥的,ADJ,B2
+to digitize,to digitize,数字化,VERB,B2
+dissatisfaction,dissatisfaction,不满,NOUN,B2
+city centre,city centre,市中心,NOUN,B2
+skilful,skilful,熟练的,ADJ,B2
+phone number,phone number,电话号码,NOUN,B2
+splash,splash,扑通,NOUN,B2
+on behalf of,on behalf of,代表,ADP,B2
+lent,lent,大斋期,NOUN,B2
+win,win,胜利,NOUN,B2
+shocked,shocked,震惊的,ADJ,B2
+bog,bog,沼泽,NOUN,B2
+filthy,filthy,肮脏的,ADJ,B2
+to overshadow,to overshadow,使黯然失色,VERB,B2
+clock watch,clock watch,钟表,NOUN,B2
+to familiarize,to familiarize,使熟悉,VERB,B2
+corporate,corporate,公司的,ADJ,B2
+wait-and-see,wait-and-see,观望的,ADJ,B2
+authoritative,authoritative,权威的,ADJ,B2
+band tape,band tape,带子,NOUN,B2
+dent,dent,凹痕,NOUN,B2
+impromptu,impromptu,即兴的,ADJ,B2
+orange juice,orange juice,橙汁,NOUN,B2
+periphery,periphery,边缘,NOUN,B2
+gastronomic,gastronomic,美食的,ADJ,B2
+genital,genital,生殖器,NOUN,B2
+to beget,to beget,引起,VERB,B2
+breach of contract,breach of contract,违约,NOUN,B2
+to purify,to purify,净化,VERB,B2
+spinning,spinning,纺纱,NOUN,B2
+to postulate,to postulate,假定,VERB,B2
+guffaw,guffaw,哄笑,NOUN,B2
+to venerate,to venerate,崇敬,VERB,B2
+cellulose,cellulose,纤维素,NOUN,B2
+by now,by now,此时,ADV,B2
+basal,basal,基本的,ADJ,B2
+averse,averse,厌恶的,ADJ,B2
+tremulous,tremulous,颤抖的,ADJ,B2
+checkup,checkup,体检,NOUN,B2
+unfriendly,unfriendly,不友好的,ADJ,B2
+graveyard,graveyard,墓地,NOUN,B2
+fresh,fresh,,NOUN,B2
+increased,increased,增加的,ADJ,B2
+arson,arson,纵火,NOUN,B2
+cleanly,cleanly,干净地,ADV,B2
+comparative,comparative,比较的,ADJ,B2
+to know feel,to know feel,认识/感觉,VERB,B2
+evidence bag,evidence bag,,NOUN,B2
+to placate,to placate,安抚,VERB,B2
+how long,how long,多久,ADV,B2
+steak,steak,牛排,NOUN,B2
+little one,little one,小家伙,NOUN,B2
+to type,to type,打字,VERB,B2
+advancement,advancement,晋升,NOUN,B2
+suicide candidate,suicide candidate,,NOUN,B2
+slam,slam,,NOUN,B2
+dossier,dossier,档案,NOUN,B2
+journalism,journalism,新闻业,NOUN,B2
+monolithic,monolithic,单一的,ADJ,B2
+duplicate,duplicate,! 副本,NOUN,B2
+extraterrestrial,extraterrestrial,外星的,ADJ,B2
+all kinds,all kinds,各种各样的,DET,B2
+hallelujah,hallelujah,哈利路亚,INTJ,B2
+extravagant,extravagant,奢侈的,ADJ,B2
+declinable,declinable,可变格的,ADJ,B2
+to rant,to rant,咆哮,VERB,B2
+to fatten,to fatten,养肥,VERB,B2
+antagonism,antagonism,对抗,NOUN,B2
+snot,snot,鼻涕,NOUN,B2
+volunteer work,volunteer work,志愿工作,NOUN,B2
+gender equality,gender equality,性别平等,NOUN,B2
+optimal,optimal,最佳的,ADJ,B2
+will shall,will shall,将要/会,AUX,B2
+told instructed,told instructed,被告知的,ADJ,B2
+state secretary,state secretary,国务秘书,NOUN,B2
+articulation,articulation,清晰表达,NOUN,B2
+about that,about that,关于那个,ADV,B2
+grand duke,grand duke,大公,NOUN,B2
+aloofness,aloofness,冷漠,NOUN,B2
+wooden,wooden,木制的,ADJ,B2
+tired of,tired of,,NOUN,B2
+up there,up there,在那上面,ADV,B2
+retailer,retailer,零售商,NOUN,B2
+longer,longer,更长的,ADJ,B2
+fewer,fewer,较少的,ADJ,B2
+just precis,just precis,恰好,ADV,B2
+determine,determine,确定,VER! B,B2
+to disqualify,to disqualify,取消资格,VERB,B2
+to elide,to elide,省略,VERB,B2
+substandard,substandard,,NOUN,B2
+ratio,ratio,比率,NOUN,B2
+infrastructure,infrastructure,基础设施,NOUN,B2
+to missed,to missed,错过,VERB,B2
+to extol,to extol,赞美,VERB,B2
+in here,in here,在这里面,ADV,B2
+little son,little son,小儿子,NOUN,B2
+antidote,antidote,解毒剂,NOUN,B2
+exceptionality,exceptionality,特殊性,NOUN,B2
+as if,as if,好像,SCONJ,B2
+present time,present time,现在,NOUN,B2
+nuclear weapon,nuclear weapon,核武器,NOUN,B2
+christianity,christianity,基督教,NOUN,B2
+freedom of assembly,freedom of assembly,集会自由,NOUN,B2
+having a birthday,having a birthday,过生日的,ADJ,B2
+to exorcise,to exorcise,驱魔,VERB,B2
+field medic,field medic,战地医生,NOUN,B2
+synoptic,synoptic,概要的,ADJ,B2
+to asphalt,to asphalt,铺沥青,VERB,B2
+beleaguered,beleaguered,受围困的,ADJ,B2
+humid,humid,潮湿的,ADJ,B2
+salon,salon,沙龙,NOUN,B2
+satisfying,satisfying,令人满意的,ADJ,B2
+to blaspheme,to blaspheme,亵渎,VERB,B2
+to consider think,to consider think,考虑/思考,VERB,B2
+conceptual,conceptual,概念的,ADJ,B2
+honorable,honorable,可敬的,ADJ,B2
+to be taken,to be taken,被拿走,VERB,B2
+bejeweled,bejeweled,镶满宝石的,ADJ,B2
+snazzy,snazzy,时髦的,ADJ,B2
+intricate,intricate,错综复杂的,ADJ,B2
+remaining,remaining,,NOUN,B2
+fired,fired,被解雇的,ADJ,B2
+danish,danish,丹麦的,ADJ,B2
+grand duchy,grand duchy,大公国,NOUN,B2
+norwegian,norwegian,挪威的,ADJ,B2
+online dating profile,online dating profile,,NOUN,B2
+sibling,sibling,兄弟姐妹,NOUN,B2
+to flee escape,to flee escape,逃跑,VERB,B2
+kidnapped,kidnapped,被绑架的,ADJ,B2
+basic income,basic income,基本收入,NOUN,B2
+exclusionary,exclusionary,排他性的,ADJ,B2
+disrepute,disrepute,坏名声,NOUN,B2
+concessionary,concessionary,让步的,ADJ,B2
+to flush,to flush,冲洗,VERB,B2
+to culminate,to culminate,达到顶点,VERB,B2
+press freedom,press freedom,新闻自由,NOUN,B2
+demonstrative,demonstrative,演示的,ADJ,B2
+continual,continual,持续的,ADJ,B2
+underclass,underclass,底层,NOUN,B2
+effort bet,effort bet,努力/赌注,NOUN,B2
+prayer room,prayer room,祈祷室,NOUN,B2
+rubber,rubber,橡胶,NOUN,B2
+observation skill,observation skill,,NOUN,B2
+egyptian,egyptian,埃及的,ADJ,B2
+to wane,to wane,减弱,VERB,B2
+diverse,diverse,多样的,ADJ,B2
+asp,asp,角蝰,NOUN,B2
+gay man,gay man,男同性恋者,NOUN,B2
+gaping,gaping,,NOUN,B2
+depicting,depicting,描绘的,ADJ,B2
+fluid,fluid,液体,NOUN,B2
+meeting hit,meeting hit,会面/击中,NOUN,B2
+religiousness,religiousness,虔诚,NOUN,B2
+freedom of speech,freedom of speech,言论自由,NOUN,B2
+dissociation,dissociation,解离,NOUN,B2
+ribs,ribs,肋骨,NOUN,B2
+timeline,timeline,时间线,NOUN,B2
+to object,to object,反对,VERB,B2
+much many,much many,许多,ADJ,B2
+of by,of by,的/被,ADP,B2
+nourishment,nourishment,营养,NOUN,B2
+corporation,corporation,公司,NOUN,B2
+the safe,the safe,保险箱,NOUN,B2
+directorship,directorship,董事职位,NOUN,B2
+cricket,cricket,板球,NOUN,B2
+bleak,bleak,无望的,ADJ,B2
+din,din,喧嚣,NOUN,B2
+to captivate,to captivate,迷住,VERB,B2
+slothful,slothful,懒惰的,ADJ,B2
+millions of,millions of,数百万的,NUM,B2
+baggage,baggage,行李,NOUN,B2
+self-esteem,self-esteem,自尊,NOUN,B2
+orderliness,orderliness,有序性,NOUN,B2
+mapping,mapping,梳理,NOUN,B2
+strangely,strangely,奇怪地,ADV,B2
+to embolden,to embolden,使大胆,VERB,B2
+freedom of opinion,freedom of opinion,意见自由,NOUN,B2
+terrorists,terrorists,恐怖分子们,NOUN,B2
+nah,nah,不,INTJ,B2
+to creak,to creak,嘎吱作响,VERB,B2
+fluency,fluency,流利,NOUN,B2
+bro,bro,哥们,NOUN,B2
+retranslation,retranslation,重译,NOUN,B2
+to coerce,to coerce,强迫,VERB,B2
+fascinated,fascinated,着迷的,ADJ,B2
+moose,moose,驼鹿,NOUN,B2
+truthful,truthful,忠于事实的,ADJ,B2
+to tweet,to tweet,发推文,VERB,B2
+citrus,citrus,柑橘,NOUN,B2
+member state,member state,成员国,NOUN,B2
+youth trauma,youth trauma,童年创伤,NOUN,B2
+concave,concave,凹的,ADJ,B2
+attempted murder,attempted murder,谋杀未遂,NOUN,B2
+provincial,provincial,地方的,ADJ,B2
+to enunciate,to enunciate,阐明,VERB,B2
+to bisect,to bisect,平分,VERB,B2
+compulsiveness,compulsiveness,强迫性,NOUN,B2
+to calibrate,to calibrate,校准,VERB,B2
+windless,windless,无风的,ADJ,B2
+furnishing,furnishing,室内布置,NOUN,B2
+good day,good day,你好,INTJ,B2
+to discern,to discern,辨别,VERB,B2
+oppressive,oppressive,压迫的,ADJ,B2
+extinct,extinct,灭绝的,ADJ,B2
+assurance,assurance,保证,NOUN,B2
+kind sort,kind sort,种类,NOUN,B2
+liquid,liquid,液态的,ADJ,B2
+itinerant,itinerant,巡回的,ADJ,B2
+to flog,to flog,鞭打,VERB,B2
+position of authority,position of authority,! 权威地位,NOUN,B2
+rock slab,rock slab,岩板,NOUN,B2
+to sparkle,to sparkle,闪耀,VERB,B2
+care home,care home,,NOUN,B2
+to keep silent,to keep silent,保持沉默,VERB,B2
+miserly,miserly,吝啬的,ADJ,B2
+in which,in which,在其中,PRON,B2
+outlandish,outlandish,古怪的,ADJ,B2
+arid,arid,干旱的,ADJ,B2
+dismal,dismal,令人失望的,ADJ,B2
+gloriousness,gloriousness,光荣,NOUN,B2
+valid,valid,有效的,ADJ,B2
+keen eager,keen eager,渴望的,ADJ,B2
+witness protection,witness protection,,NOUN,B2
+to warm,to warm,加热,VERB,B2
+to demarcate,to demarcate,划定界限,VERB,B2
+to diet,to diet,减肥,VERB,B2
+to stay awake,to stay awake,守夜,VERB,B2
+male,male,男性,NOUN,B2
+to connote,to connote,暗示,VERB,B2
+grandparenthood,grandparenthood,祖父母身份,NOUN,B2
+tobacco,tobacco,烟草,NOUN,B2
+explicable,explicable,可解释的,ADJ,B2
+disrespectful,disrespectful,无礼的,ADJ,B2
+one hundred,one hundred,一百,NUM,B2
+to function work,to function work,运作/起作用,VERB,B2
+to externalize,to externalize,使外在化,VERB,B2
+couple pair,couple pair,一对,NOUN,B2
+group culture,group culture,群体文化,NOUN,B2
+civilisation,civilisation,文明,NOUN,B2
+constructivism,constructivism,建构主义,NOUN,B2
+minuscule,minuscule,极小的,ADJ,B2
+deck tire,deck tire,甲板/轮胎,NOUN,B2
+catalogue,catalogue,目录,NOUN,B2
+gosh,gosh,天哪,INTJ,B2
+abroad,abroad,在国外,ADV,B2
+unctuous,unctuous,谄媚的,ADJ,B2
+underworld,underworld,地下世界,NOUN,B2
+to enthrone,to enthrone,立为王,VERB,B2
+insatiable,insatiable,不知足的,ADJ,B2
+for sale,for sale,待售,ADJ,B2
+to bring lead,to bring lead,带来/引导,VERB,B2
+to set rates,to set rates,定价,VERB,B2
+to bully,to bully,欺凌,VERB,B2
+suite,suite,套房,NOUN,B2
+recall,recall,回忆,NOUN,B2
+thoughtfully,thoughtfully,体贴地,ADV,B2
+ajar,ajar,半开的,ADJ,B2
+brain activity,brain activity,,NOUN,B2
+abominable,abominable,可憎的,ADJ,B2
+motel,motel,汽车旅馆,NOUN,B2
+spelling,spelling,拼写,NOUN,B2
+informedness,informedness,知情度,NOUN,B2
+parcel,parcel,包裹,NOUN,B2
+dungeon,dungeon,地牢,NOUN,B2
+little hand,little hand,小手,NOUN,B2
+cultural heritage,cultural heritage,文化遗产,NOUN,B2
+kind species,kind species,种类/物种,NOUN,B2
+to be created,to be created,被创造,VERB,B2
+arrived present,arrived present,到了,ADV,B2
+to dethrone,to dethrone,废黜,VERB,B2
+to drip,to drip,滴,VERB,B2
+enormously,enormously,巨大地,ADV,B2
+light-year,light-year,,NOUN,B2
+metabolic,metabolic,代谢的,ADJ,B2
+to amaze,to amaze,使吃惊,VERB,B2
+inboard,inboard,船内的,ADV,B2
+filled,filled,充满的,ADJ,B2
+younger,younger,较年轻的,ADJ,B2
+southeast,southeast,东南,NOUN,B2
+to commentate,to commentate,评论,VERB,B2
+to come loose,to come loose,松脱,VERB,B2
+gracious,gracious,亲切的,ADJ,B2
+to calm down,to calm down,使平静,VERB,B2
+gratuity,gratuity,酬金,NOUN,B2
+balsam,balsam,香脂,NOUN,B2
+to supplicate,to supplicate,恳求,VERB,B2
+limb,limb,肢体,NOUN,B2
+audacious,audacious,大胆的,ADJ,B2
+aged,aged,年老的,ADJ,B2
+student residence,student residence,学生宿舍,NOUN,B2
+mainstream,mainstream,主流的,ADJ,B2
+to fossilize,to fossilize,石化,VERB,B2
+steering,steering,掌舵的,ADJ,B2
+roadblock,roadblock,,NOUN,B2
+dozens,dozens,数十个,NOUN,B2
+decimal,decimal,小数,NOUN,B2
+to mess about,to mess about,胡搞,VERB,B2
+to denigrate,to denigrate,诋毁,VERB,B2
+integral,integral,不可或缺的,ADJ,B2
+intangible,intangible,无形的,ADJ,B2
+bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
+famine,famine,饥荒,NOUN,B2
+maximal,maximal,最大的,ADJ,B2
+guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
+so-called,so-called,,NOUN,B2
+that to,that to,那/去,PART,B2
+tolerant,tolerant,宽容的,ADJ,B2
+bubbling,bubbling,冒泡的,ADJ,B2
+all-clear,all-clear,许可信号,NOUN,B2
+sporty,sporty,运动的,ADJ,B2
+service year,service year,,NOUN,B2
+to contend,to contend,主张,VERB,B2
+drunkenness,drunkenness,醉酒,NOUN,B2
+enforcement policy,enforcement policy,执法政策,NOUN,B2
+australian,australian,澳大利亚的,ADJ,B2
+for this purpose,for this purpose,为此,ADV,B2
+finance,finance,金融,NOUN,B2
+to democratize,to democratize,民主化,VERB,B2
+preliminary investigation,preliminary investigation,,NOUN,B2
+shading,shading,阴影,NOUN,B2
+anachronistic,anachronistic,时代错误的,ADJ,B2
+igneous,igneous,火成的,ADJ,B2
+to disabuse,to disabuse,纠正错误想法,VERB,B2
+chili,chili,辣椒,NOUN,B2
+databas,databas,数据库,NOUN,B2
+to objectify,to objectify,客观化,VERB,B2
+systemless,systemless,无系统的,ADJ,B2
+jet,jet,喷气式飞机,NOUN,B2
+to theatricalize,to theatricalize,戏剧化,VERB,B2
+spot,spot,地点,NOUN,B2
+to goad,to goad,刺激,VERB,B2
+showing,showing,表现,NOUN,B2
+to equate,to equate,等同,VERB,B2
+wicked,wicked,邪恶的,ADJ,B2
+bookcase,bookcase,书柜,NOUN,B2
+malmo,malmo,马尔默,PROPN,B2
+virginal,virginal,处女的,ADJ,B2
+line-up,line-up,阵容,NOUN,B2
+to yearn,to yearn,渴望,VERB,B2
+kindred spirit,kindred spirit,志同道合者,NOUN,B2
+cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
+loathing,loathing,,NOUN,B2
+to use up,to use up,用完,VERB,B2
+redundant,redundant,多余的,ADJ,B2
+amendable,amendable,可修正的,ADJ,B2
+to segregate,to segregate,隔离,VERB,B2
+incision,incision,切口,NOUN,B2
+to annul,to annul,废除,VERB,B2
+incandescent,incandescent,白炽的,ADJ,B2
+to embark,to embark,上船,VERB,B2
+altercation,altercation,争执,NOUN,B2
+glimpse,glimpse,一瞥,NOUN,B2
+budgetable,budgetable,可预算的,ADJ,B2
+darn,darn,哎呀,INTJ,B2
+phenomenal,phenomenal,非凡的,ADJ,B2
+colour,colour,颜色,NOUN,B2
+higher professional education,higher professional education,高等专业教育,NOUN,B2
+best friend,best friend,最好的朋友,NOUN,B2
+to decode,to decode,解码,VERB,B2
+reproachable,reproachable,应受责备的,ADJ,B2
+drugs,drugs,毒品,NOUN,B2
+light brown,light brown,浅棕色的,ADJ,B2
+minus,minus,减,NOUN,B2
+boastful,boastful,自夸的,ADJ,B2
+lower,lower,较低的,ADJ,B2
+to raise bring up,to raise bring up,抚养,VERB,B2
+accessible,accessible,易接近的,ADJ,B2
+leading role,leading role,主角,NOUN,B2
+viewer,viewer,观众,NOUN,B2
+to revitalize,to revitalize,使复苏,VERB,B2
+to leave stick,to leave stick,离开/刺,VERB,B2
+drug dealer,drug dealer,毒贩,NOUN,B2
+invincible,invincible,无敌的,ADJ,B2
+bard,bard,吟游诗人,NOUN,B2
+hint,hint,暗示,NOUN,B2
+disobedient,disobedient,不服从的,ADJ,B2
+to play football,to play football,踢足球,VERB,B2
+scorn,scorn,轻蔑,NOUN,B2
+the guy,the guy,那个男人,NOUN,B2
+last evening,last evening,,NOUN,B2
+strenuous,strenuous,费力的,ADJ,B2
+to encircle,to encircle,环绕,VERB,B2
+correctness,correctness,正确性,NOUN,B2
+audible,audible,听得见的,ADJ,B2
+to use to usually,to use to usually,通常/习惯于,VERB,B2
+too late,too late,太迟,ADV,B2
+collegial,collegial,同事的,ADJ,B2
+to demilitarize,to demilitarize,非军事化,VERB,B2
+prayer trap,prayer trap,,NOUN,B2
+mannerly,mannerly,有礼貌的,ADJ,B2
+to splash,to splash,溅,VERB,B2
+hollowed,hollowed,掏空的,ADJ,B2
+nerd,nerd,书呆子,NOUN,B2
+crystal clear,crystal clear,清澈的,ADJ,B2
+zoo,zoo,动物园,NOUN,B2
+syndrome,syndrome,综合征,NOUN,B2
+to daunt,to daunt,使气馁,VERB,B2
+bastion,bastion,堡垒,NOUN,B2
+berkeley coach,berkeley coach,,NOUN,B2
+in two,in two,成两半,ADV,B2
+schism,schism,分裂,NOUN,B2
+gynaecology,gynaecology,妇科,NOUN,B2
+border post,border post,边防哨所,NOUN,B2
+paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
+to alleviate,to alleviate,缓解,VERB,B2
+explosives,explosives,炸药,NOUN,B2
+jury,jury,陪审团,NOUN,B2
+from above,from above,从上方,ADV,B2
+curbing,curbing,遏制,NOUN,B2
+remarkable,remarkable,非凡的,ADJ,B2
+to train exercise,to train exercise,训练/锻炼,VERB,B2
+embargo,embargo,禁运,NOUN,B2
+rival,rival,对手,NOUN,B2
+technocratic,technocratic,技术官僚的,ADJ,B2
+middle class,middle class,中产阶层,NOUN,B2
+resistance movement,resistance movement,抵抗运动,NOUN,B2
+to expurgate,to expurgate,删节,VERB,B2
+moralizing,moralizing,说教的,ADJ,B2
+expressiveness,expressiveness,表现力,NOUN,B2
+matter of conscience,matter of conscience,良心问题,NOUN,B2
+ethereal,ethereal,飘渺的,ADJ,B2
+sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
+to bifurcate,to bifurcate,分叉,VERB,B2
+ride lift,ride lift,搭车,NOUN,B2
+mafia,mafia,黑手党,NOUN,B2
+plundering,plundering,掠夺,NOUN,B2
+versus,versus,对,ADP,B2
+to play sports,to play sports,做运动,VERB,B2
+sure safe,sure safe,确定的,ADJ,B2
+to capitulate,to capitulate,投降,VERB,B2
+greetings,greetings,,NOUN,B2
+border community,border community,边境社区,NOUN,B2
+entrance ticket,entrance ticket,门票,NOUN,B2
+life's work,life's work,毕生事业,NOUN,B2
+virulent,virulent,恶性的,ADJ,B2
+ears,ears,耳朵,NOUN,B2
+stew,stew,炖菜,NOUN,B2
+yourself,yourself,你自己,PRON,B2
+inadequate,inadequate,不足的,ADJ,B2
+malnutrition,malnutrition,营养不良,NOUN,B2
+parent-friendly,parent-friendly,,NOUN,B2
+certainly,certainly,当然,INTJ,B2
+sliding,sliding,滑动的,ADJ,B2
+lab,lab,实验室,NOUN,B2
+morphine,morphine,吗啡,NOUN,B2
+alibi,alibi,不在场证明,NOUN,B2
+fine pretty,fine pretty,美丽的,ADJ,B2
+gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
+clear,clear,当然,ADV,B2
+top great,top great,顶部/极好,NOUN,B2
+twenty-two-year-old,twenty-two-year-old,,NOUN,B2
+feeble,feeble,虚弱的,ADJ,B2
+malicious,malicious,恶意的,ADJ,B2
+to revalue,to revalue,重新估值,VERB,B2
+pier,pier,码头,NOUN,B2
+in peace,in peace,不受打扰地,ADV,B2
+displacement,displacement,位移,NOUN,B2
+byzantine,byzantine,错综复杂的,ADJ,B2
+to depreciate,to depreciate,贬值,VERB,B2
+intransigent,intransigent,不妥协的,ADJ,B2
+apologist,apologist,辩护者,NOUN,B2
+inflammation,inflammation,炎症,NOUN,B2
+ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
+to enervate,to enervate,使衰弱,VERB,B2
+to vilify,to vilify,诽谤,VERB,B2
+to fluster,to fluster,使慌乱,VERB,B2
+to disarrange,to disarrange,弄乱,VERB,B2
+incongruous,incongruous,不协调的,ADJ,B2
+to fraternize,to fraternize,勾结,VERB,B2
+to edify,to edify,启发,VERB,B2
+abstemious,abstemious,有节制的,ADJ,B2
+prize,prize,奖品,NOUN,B2
+to augur,to augur,预言,VERB,B2
+hepatic,hepatic,肝脏的,ADJ,B2
+postponement,postponement,延期,NOUN,B2
+humiliating,humiliating,令人羞辱的,ADJ,B2
+pious,pious,虔诚的,ADJ,B2
+freight,freight,货物,NOUN,B2
+to daze,to daze,使茫然,VERB,B2
+incessant,incessant,持续的,ADJ,B2
+spurious,spurious,虚假的,ADJ,B2
+abject,abject,悲惨的,ADJ,B2
+nosy,nosy,爱打听的,ADJ,B2
+promiscuous,promiscuous,滥交的,ADJ,B2
+to denote,to denote,表示,VERB,B2
+to exculpate,to exculpate,开脱,VERB,B2
+import,import,进口,NOUN,B2
+to scrub,to scrub,擦洗,VERB,B2
+to disconcert,to disconcert,使惊慌,VERB,B2
+dexterity,dexterity,灵巧,NOUN,B2
+corroboration,corroboration,证实,NOUN,B2
+to ascribe,to ascribe,归因于,VERB,B2
+stagnant,stagnant,停滞的,ADJ,B2
+format,format,格式,NOUN,B2
+craving,craving,渴求,NOUN,B2
+bonfire,bonfire,篝火,NOUN,B2
+gargoyle,gargoyle,滴水嘴兽,NOUN,B2
+gunshot,gunshot,枪声,NOUN,B2
+to acclaim,to acclaim,称赞,VERB,B2
+stoic,stoic,坚忍的,ADJ,B2
+tick,tick,滴答声,NOUN,B2
+sane,sane,神志正常的,ADJ,B2
+to rebuke,to rebuke,斥责,VERB,B2
+to ail,to ail,使苦恼,VERB,B2
+atrocity,atrocity,暴行,NOUN,B2
+oracle,oracle,神谕,NOUN,B2
+wealthy,wealthy,富有的,ADJ,B2
+irrational,irrational,非理性的,ADJ,B2
+deportation,deportation,驱逐出境,NOUN,B2
+bracket,bracket,括号,NOUN,B2
+terse,terse,简练的,ADJ,B2
+to enslave,to enslave,奴役,VERB,B2
+given,given,给定的,ADJ,B2
+to flap,to flap,拍打,VERB,B2
+inhibition,inhibition,抑制,NOUN,B2
+to snub,to snub,冷落,VERB,B2
+to extricate,to extricate,使摆脱,VERB,B2
+frigid,frigid,寒冷的,ADJ,B2
+evocative,evocative,引起回忆的,ADJ,B2
+impeccable,impeccable,无瑕疵的,ADJ,B2
+to commercialize,to commercialize,商业化,VERB,B2
+to enrapture,to enrapture,使狂喜,VERB,B2
+apologetic,apologetic,道歉的,ADJ,B2
+opulent,opulent,豪华的,ADJ,B2
+barge,barge,驳船,NOUN,B2
+cultivation,cultivation,培养,NOUN,B2
+infamous,infamous,声名狼藉的,ADJ,B2
+to fortify,to fortify,加强,VERB,B2
+reverent,reverent,虔诚的,ADJ,B2
+to divest,to divest,剥夺,VERB,B2
+to disinherit,to disinherit,剥夺继承权,VERB,B2
+hyperbole,hyperbole,夸张,NOUN,B2
+to boost,to boost,促进,VERB,B2
+to fertilize,to fertilize,施肥,VERB,B2
+to satiate,to satiate,使饱足,VERB,B2
+arcane,arcane,神秘的,ADJ,B2
+discrepancy,discrepancy,差异,NOUN,B2
+to deport,to deport,驱逐出境,VERB,B2
+to cram,to cram,填鸭式学习,VERB,B2
+to fumigate,to fumigate,熏蒸,VERB,B2
+cramp,cramp,抽筋,NOUN,B2
+touching,touching,动人的,ADJ,B2
+immature,immature,不成熟的,ADJ,B2
+bacchanal,bacchanal,狂欢,NOUN,B2
+feast,feast,盛宴,NOUN,B2
+to botch,to botch,搞砸,VERB,B2
+scarcely,scarcely,几乎不,ADV,B2
+evasion,evasion,逃避,NOUN,B2
+to disperse,to disperse,分散,VERB,B2
+behaviorist,behaviorist,行为主义者,NOUN,B2
+beloved,beloved,心爱的,ADJ,B2
+to elude,to elude,逃避,VERB,B2
+bohemian,bohemian,放荡不羁的,ADJ,B2
+akin,akin,相似的,ADJ,B2
+brainwasher,brainwasher,洗脑者,NOUN,B2
+bossism,bossism,老板主义,NOUN,B2
+weary,weary,疲倦的,ADJ,B2
+apathy,apathy,冷漠,NOUN,B2
+skirmish,skirmish,小规模战斗,NOUN,B2
+shrill,shrill,尖锐的,ADJ,B2
+affront,affront,冒犯,NOUN,B2
+to deify,to deify,神化,VERB,B2
+garland,garland,花环,NOUN,B2
+brow,brow,眉毛,NOUN,B2
+to covet,to covet,觊觎,VERB,B2
+to sprout,to sprout,发芽,VERB,B2
+funnel,funnel,漏斗,NOUN,B2
+to gravitate,to gravitate,受吸引,VERB,B2
+to disintegrate,to disintegrate,瓦解,VERB,B2
+incoherence,incoherence,不连贯,NOUN,B2
+to ensnare,to ensnare,诱捕,VERB,B2
+constituent,constituent,成分,NOUN,B2
+fratricide,fratricide,杀兄弟,NOUN,B2
+ardent,ardent,热情的,ADJ,B2
+to forebode,to forebode,预兆,VERB,B2
+acceptable,acceptable,可接受的,ADJ,B2
+exotic,exotic,异国情调的,ADJ,B2
+to dilute,to dilute,稀释,VERB,B2
+cistern,cistern,蓄水池,NOUN,B2
+badge,badge,徽章,NOUN,B2
+to enrage,to enrage,激怒,VERB,B2
+ashen,ashen,灰白的,ADJ,B2
+aging,aging,老化,NOUN,B2
+diaphragm,diaphragm,横膈膜,NOUN,B2
+magnanimous,magnanimous,宽宏大量的,ADJ,B2
+sorcery,sorcery,巫术,NOUN,B2
+excrement,excrement,排泄物,NOUN,B2
+belligerent,belligerent,好战的,ADJ,B2
+detergent,detergent,洗涤剂,NOUN,B2
+sniper,sniper,狙击手,NOUN,B2
+bourgeois,bourgeois,资产阶级的,ADJ,B2
+to shroud,to shroud,覆盖,VERB,B2
+demagoguery,demagoguery,煽动性,NOUN,B2
+to erode,to erode,侵蚀,VERB,B2
+to denature,to denature,使变性,VERB,B2
+to alter,to alter,改变,VERB,B2
+to exude,to exude,散发,VERB,B2
+betrothal,betrothal,订婚,NOUN,B2
+to adhere,to adhere,坚持,VERB,B2
+to deign,to deign,屈尊,VERB,B2
+to allocate,to allocate,分配,VERB,B2
+antipode,antipode,对跖点,NOUN,B2
+anachronism,anachronism,时代错误,NOUN,B2
+docile,docile,温顺的,ADJ,B2
+to cloy,to cloy,使厌烦,VERB,B2
+to delineate,to delineate,描绘,VERB,B2
+to flatten,to flatten,使平坦,VERB,B2
+stipend,stipend,津贴,NOUN,B2
+to dispose,to dispose,处理,VERB,B2
+worn,worn,磨损的,ADJ,B2
+to gratify,to gratify,使满足,VERB,B2
+uncouth,uncouth,粗俗的,ADJ,B2
+disuse,disuse,废弃,NOUN,B2
+to galvanize,to galvanize,激励,VERB,B2
+freezing,freezing,极冷的,ADJ,B2
+to retract,to retract,撤回,VERB,B2
+aforementioned,aforementioned,上述的,ADJ,B2
+convertibility,convertibility,可兑换性,NOUN,B2
+absorbed,absorbed,全神贯注的,ADJ,B2
+to beautify,to beautify,美化,VERB,B2
+sore,sore,疼痛的,ADJ,B2
+vogue,vogue,流行,NOUN,B2
+elusive,elusive,难以捉摸的,ADJ,B2
+to confine,to confine,限制,VERB,B2
+to cauterize,to cauterize,烧灼,VERB,B2
+to unearth,to unearth,发掘,VERB,B2
+to dishearten,to dishearten,使沮丧,VERB,B2
+unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
+amorphous,amorphous,无定形的,ADJ,B2
+attribution,attribution,归因,NOUN,B2
+to stratify,to stratify,分层,VERB,B2
+frivolous,frivolous,轻浮的,ADJ,B2
+wax,wax,蜡,NOUN,B2
+soccer,soccer,足球,NOUN,B2
+mezzanine,mezzanine,夹层,NOUN,B2
+saving,saving,储蓄,NOUN,B2
+apprehensive,apprehensive,忧虑的,ADJ,B2
+to unravel,to unravel,解开,VERB,B2
+to overthrow,to overthrow,推翻,VERB,B2
+buttress,buttress,扶壁,NOUN,B2
+assertion,assertion,断言,NOUN,B2
+to germinate,to germinate,发芽,VERB,B2
+unprecedented,unprecedented,史无前例的,ADJ,B2
+bloodless,bloodless,不流血的,ADJ,B2
+remorseful,remorseful,悔恨的,ADJ,B2
+shipment,shipment,货物,NOUN,B2
+to engross,to engross,使全神贯注,VERB,B2
+chronicle,chronicle,编年史,NOUN,B2
+phony,phony,假的,ADJ,B2
+oblique,oblique,斜的,ADJ,B2
+to glean,to glean,搜集,VERB,B2
+to eject,to eject,弹出,VERB,B2
+vase,vase,花瓶,NOUN,B2
+vicissitude,vicissitude,变迁,NOUN,B2
+burner,burner,燃烧器,NOUN,B2
+stratagem,stratagem,策略,NOUN,B2
+to bewitch,to bewitch,迷住,VERB,B2
+shotgun,shotgun,猎枪,NOUN,B2
+adverse,adverse,不利的,ADJ,B2
+mistaken,mistaken,错误的,ADJ,B2
+bower,bower,凉亭,NOUN,B2
+unforgivable,unforgivable,不可原谅的,ADJ,B2
+ancillary,ancillary,辅助的,ADJ,B2
+bagpiper,bagpiper,风笛手,NOUN,B2
+to amalgamate,to amalgamate,合并,VERB,B2
+den,den,兽穴,NOUN,B2
+reluctant,reluctant,不情愿的,ADJ,B2
+spine,spine,脊柱,NOUN,B2
+to exclaim,to exclaim,呼喊,VERB,B2
+to condescend,to condescend,屈尊,VERB,B2
+ephemeral,ephemeral,短暂的,ADJ,B2
+immoral,immoral,不道德的,ADJ,B2
+inspired,inspired,受启发的,ADJ,B2
+to deflate,to deflate,使泄气,VERB,B2
+wary,wary,谨慎的,ADJ,B2
+abstinence,abstinence,节制,NOUN,B2
+sacrilege,sacrilege,亵渎,NOUN,B2
+to gauge,to gauge,测量,VERB,B2
+erudite,erudite,博学的,ADJ,B2
+spite,spite,恶意,NOUN,B2
+to depopulate,to depopulate,使人口减少,VERB,B2
+favoritism,favoritism,偏袒,NOUN,B2
+auspice,auspice,赞助,NOUN,B2
+confederate,confederate,同盟者,NOUN,B2
+sublime,sublime,崇高的,ADJ,B2
+misanthrope,misanthrope,厌世者,NOUN,B2
+equity,equity,公平,NOUN,B2
+hemisphere,hemisphere,半球,NOUN,B2
+deceptive,deceptive,欺骗性的,ADJ,B2
+exponent,exponent,指数,NOUN,B2
+cacophony,cacophony,刺耳的声音,NOUN,B2
+battlement,battlement,城垛,NOUN,B2
+enigmatic,enigmatic,神秘的,ADJ,B2
+froth,froth,泡沫,NOUN,B2
+aptitude,aptitude,天资,NOUN,B2
+to enthrall,to enthrall,迷住,VERB,B2
+balustrade,balustrade,栏杆,NOUN,B2
+barricade,barricade,路障,NOUN,B2
+to gain,to gain,获得,VERB,B2
+to assent,to assent,同意,VERB,B2
+concord,concord,和谐,NOUN,B2
+avid,avid,热切的,ADJ,B2
+zeal,zeal,热情,NOUN,B2
+to elucidate,to elucidate,阐明,VERB,B2
+decorum,decorum,礼仪,NOUN,B2
+to embarrass,to embarrass,使尴尬,VERB,B2
+asparagus,asparagus,芦笋,NOUN,B2
+dapper,dapper,整洁的,ADJ,B2
+alienable,alienable,可转让的,ADJ,B2
+fabulous,fabulous,极好的,ADJ,B2
+to equalize,to equalize,使相等,VERB,B2
+cast,cast,演员阵容,NOUN,B2
+to attenuate,to attenuate,减弱,VERB,B2
+gregarious,gregarious,爱社交的,ADJ,B2
+apotheotic,apotheotic,神化的,ADJ,B2
+apex,apex,顶点,NOUN,B2
+contrition,contrition,悔罪,NOUN,B2
+ruthless,ruthless,无情的,ADJ,B2
+crystalline,crystalline,水晶般的,ADJ,B2
+burdensome,burdensome,繁重的,ADJ,B2
+to disunite,to disunite,使分裂,VERB,B2
+to exfoliate,to exfoliate,去角质,VERB,B2
+risque,risque,有伤风化的,ADJ,B2
+cumbersome,cumbersome,笨重的,ADJ,B2
+bilious,bilious,易怒的,ADJ,B2
+gin,gin,金酒,NOUN,B2
+biweekly,biweekly,双周的,ADJ,B2
+brooding,brooding,忧思,NOUN,B2
+to decompress,to decompress,解压,VERB,B2
+intellect,intellect,智力,NOUN,B2
+contraband,contraband,违禁品,NOUN,B2
+autocratic,autocratic,专制的,ADJ,B2
+to condone,to condone,宽恕,VERB,B2
+stolid,stolid,冷漠的,ADJ,B2
+to swagger,to swagger,大摇大摆,VERB,B2
+to declassify,to declassify,解密,VERB,B2
+binge,binge,放纵,NOUN,B2
+trifling,trifling,微不足道的,ADJ,B2
+frantic,frantic,狂乱的,ADJ,B2
+to asphyxiate,to asphyxiate,使窒息,VERB,B2
+to foist,to foist,强加,VERB,B2
+sedentary,sedentary,久坐的,ADJ,B2
+dishonor,dishonor,耻辱,NOUN,B2
+humorous,humorous,幽默的,ADJ,B2
+to consign,to consign,移交,VERB,B2
+immense,immense,巨大的,ADJ,B2
+erratic,erratic,不稳定的,ADJ,B2
+haughty,haughty,傲慢的,ADJ,B2
+cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
+to beatify,to beatify,宣福,VERB,B2
+to redeem,to redeem,赎回,VERB,B2
+inquisitive,inquisitive,好奇的,ADJ,B2
+incisive,incisive,深刻的,ADJ,B2
+conciseness,conciseness,简洁,NOUN,B2
+brazen,brazen,厚颜无耻的,ADJ,B2
+to adduce,to adduce,引证,VERB,B2
+to temporize,to temporize,拖延,VERB,B2
+brochure,brochure,小册子,NOUN,B2
+tireless,tireless,不知疲倦的,ADJ,B2
+matriarch,matriarch,女家长,NOUN,B2
+vehement,vehement,激烈的,ADJ,B2
+to curtail,to curtail,削减,VERB,B2
+to expectorate,to expectorate,吐痰,VERB,B2
+to stalk,to stalk,跟踪,VERB,B2
+astonished,astonished,惊讶的,ADJ,B2
+catapult,catapult,投石机,NOUN,B2
+disparate,disparate,截然不同的,ADJ,B2
+brusqueness,brusqueness,唐突,NOUN,B2
+entertaining,entertaining,有趣的,ADJ,B2
+to alienate,to alienate,使疏远,VERB,B2
+pensive,pensive,沉思的,ADJ,B2
+atonement,atonement,赎罪,NOUN,B2
+to corrode,to corrode,腐蚀,VERB,B2
+to afforest,to afforest,造林,VERB,B2
+altitude,altitude,海拔,NOUN,B2
+plausible,plausible,似是而非的,ADJ,B2
+to brandish,to brandish,挥舞,VERB,B2
+sanctimonious,sanctimonious,伪善的,ADJ,B2
+boisterous,boisterous,喧闹的,ADJ,B2
+iconoclast,iconoclast,偶像破坏者,NOUN,B2
+blunder,blunder,大错,NOUN,B2
+ungainly,ungainly,笨拙的,ADJ,B2
+upstart,upstart,暴发户,NOUN,B2
+to defame,to defame,诽谤,VERB,B2
+biting,biting,咬人,NOUN,B2
+to exalt,to exalt,颂扬,VERB,B2
+dichotomy,dichotomy,二分法,NOUN,B2
+bargain,bargain,便宜货,NOUN,B2
+attainable,attainable,可获得的,ADJ,B2
+oversight,oversight,疏忽,NOUN,B2
+gem,gem,宝石,NOUN,B2
+to detract,to detract,贬低,VERB,B2
+contemplation,contemplation,沉思,NOUN,B2
+graduation,graduation,毕业,NOUN,B2
+to skein,to skein,绕成线团,VERB,B2
+slenderness,slenderness,纤细,NOUN,B2
+hygienic,hygienic,卫生的,ADJ,B2
+curator,curator,策展人,NOUN,B2
+horrified,horrified,惊骇的,ADJ,B2
+scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
+reclamation,reclamation,收复,NOUN,B2
+bungler,bungler,笨手笨脚的人,NOUN,B2
+to lead astray,to lead astray,使入歧途,VERB,B2
+to spirit away,to spirit away,变走,VERB,B2
+appreciable,appreciable,可观的,ADJ,B2
+deteriorated,deteriorated,恶化的,ADJ,B2
+cove,cove,小海湾,NOUN,B2
+intermediate,intermediate,中级的,ADJ,B2
+gamete,gamete,配子,NOUN,B2
+scythe,scythe,镰刀,NOUN,B2
+idiot,idiot,傻瓜,ADJ,B2
+to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
+to humanize,to humanize,使人性化,VERB,B2
+fractional,fractional,分数的,ADJ,B2
+centipede,centipede,蜈蚣,NOUN,B2
+to idolize,to idolize,崇拜,VERB,B2
+set of ideals,set of ideals,思想体系,NOUN,B2
+epithet,epithet,绰号,NOUN,B2
+autocracy,autocracy,专制,NOUN,B2
+to plunder,to plunder,掠夺,VERB,B2
+equestrian,equestrian,马术的,ADJ,B2
+celerity,celerity,迅速,NOUN,B2
+musk,musk,麝香,NOUN,B2
+to splint,to splint,用夹板固定,VERB,B2
+seaplane,seaplane,水上飞机,NOUN,B2
+to go numb,to go numb,麻木,VERB,B2
+to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
+insinuation,insinuation,暗示,NOUN,B2
+cane,cane,手杖,NOUN,B2
+shameless person,shameless person,厚颜无耻的人,NOUN,B2
+excitability,excitability,兴奋性,NOUN,B2
+inflection,inflection,词尾,NOUN,B2
+hooligan,hooligan,流氓,NOUN,B2
+disquisition,disquisition,论述,NOUN,B2
+to fail to fulfill,to fail to fulfill,未履行,VERB,B2
+to gush,to gush,涌出,VERB,B2
+annotation,annotation,注释,NOUN,B2
+fanatic,fanatic,狂热的,ADJ,B2
+gatekeeper,gatekeeper,道口看守员,NOUN,B2
+emulation,emulation,模仿,NOUN,B2
+charitable,charitable,慈善的,ADJ,B2
+cattle rancher,cattle rancher,牧场主,NOUN,B2
+to codify,to codify,编纂,VERB,B2
+narrowing,narrowing,变窄,NOUN,B2
+countercurrent,countercurrent,逆流,NOUN,B2
+inclement,inclement,严酷的,ADJ,B2
+every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
+confinement,confinement,禁闭,NOUN,B2
+sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
+to put on track,to put on track,使走上正轨,VERB,B2
+stampede,stampede,溃逃,NOUN,B2
+to gray,to gray,变白,VERB,B2
+confidant,confidant,知己,NOUN,B2
+wharf,wharf,码头,NOUN,B2
+brute,brute,粗野的,ADJ,B2
+to elevate,to elevate,提升,VERB,B2
+babble,babble,结巴,NOUN,B2
+to dispossess,to dispossess,剥夺,VERB,B2
+to crowd together,to crowd together,挤在一起,VERB,B2
+to guess right,to guess right,猜中,VERB,B2
+to espy,to espy,窥探,VERB,B2
+collusion,collusion,串通,NOUN,B2
+concordance,concordance,一致,NOUN,B2
+colossal,colossal,巨大的,ADJ,B2
+fortune teller,fortune teller,占卜者,NOUN,B2
+devourer,devourer,吞噬者,NOUN,B2
+flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
+contiguous,contiguous,相邻的,ADJ,B2
+widening,widening,加宽,NOUN,B2
+to unbutton,to unbutton,解开纽扣,VERB,B2
+to defer,to defer,推迟,VERB,B2
+spatula,spatula,刮刀,NOUN,B2
+to disentangle,to disentangle,解开,VERB,B2
+to apostatize,to apostatize,叛教,VERB,B2
+untidiness,untidiness,凌乱,NOUN,B2
+governability,governability,可治理性,NOUN,B2
+discredit,discredit,丧失信誉,NOUN,B2
+to handcuff,to handcuff,给…戴手铐,VERB,B2
+to fluctuate,to fluctuate,波动,VERB,B2
+generatrix,generatrix,母线,NOUN,B2
+long-distance runner,long-distance runner,长跑运动员,NOUN,B2
+prolific,prolific,多产的,ADJ,B2
+galician,galician,加利西亚的,ADJ,B2
+to meddle,to meddle,干涉,VERB,B2
+exalted,exalted,狂热的,ADJ,B2
+involuntary,involuntary,无意识的,ADJ,B2
+ferret,ferret,雪貂,NOUN,B2
+ballast,ballast,压舱物,NOUN,B2
+illogical,illogical,不合逻辑的,ADJ,B2
+to guillotine,to guillotine,斩首,VERB,B2
+bunch,bunch,一群,NOUN,B2
+justness,justness,公正,NOUN,B2
+disenchantment,disenchantment,幻灭,NOUN,B2
+grandiloquent,grandiloquent,夸张的,ADJ,B2
+fruit tree,fruit tree,果树的,ADJ,B2
+hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+suicidal,suicidal,自杀的,ADJ,B2
+doctrinaire,doctrinaire,教条主义的,ADJ,B2
+quotable,quotable,可估价的,ADJ,B2
+tickle,tickle,发痒,NOUN,B2
+compendium,compendium,纲要,NOUN,B2
+tackling,tackling,马具,NOUN,B2
+leafy,leafy,枝叶茂密的,ADJ,B2
+to vent,to vent,倾诉,VERB,B2
+to gird,to gird,束紧,VERB,B2
+furtive,furtive,鬼鬼祟祟的,ADJ,B2
+exculpation,exculpation,开脱,NOUN,B2
+countenance,countenance,面容,NOUN,B2
+falconry,falconry,猎鹰术,NOUN,B2
+conic,conic,圆锥曲线,NOUN,B2
+disloyalty,disloyalty,不忠,NOUN,B2
+to thrill,to thrill,使兴奋,VERB,B2
+herbaceous,herbaceous,草本的,ADJ,B2
+inflamed,inflamed,激烈的,ADJ,B2
+informative,informative,提供信息的,ADJ,B2
+aridity,aridity,干旱,NOUN,B2
+to encode,to encode,编码,VERB,B2
+epitaph,epitaph,墓志铭,NOUN,B2
+indistinct,indistinct,模糊的,ADJ,B2
+expeditious,expeditious,迅速的,ADJ,B2
+varnish,varnish,清漆,NOUN,B2
+to go deep into,to go deep into,深入,VERB,B2
+duet,duet,二重奏,NOUN,B2
+home-loving,home-loving,顾家的,ADJ,B2
+to coax,to coax,哄骗,VERB,B2
+pharisee,pharisee,法利赛人,NOUN,B2
+gravid,gravid,怀孕的,ADJ,B2
+condemned,condemned,被定罪的,ADJ,B2
+delirious,delirious,谵妄的,ADJ,B2
+apotheosis,apotheosis,神化,NOUN,B2
+squid,squid,鱿鱼,NOUN,B2
+unbridled,unbridled,肆无忌惮的,ADJ,B2
+grotesque,grotesque,怪诞的,ADJ,B2
+blazing,blazing,炽热的,ADJ,B2
+to be unaware,to be unaware,不知道,VERB,B2
+out of place,out of place,格格不入的,ADJ,B2
+revelry,revelry,狂欢,NOUN,B2
+to wield,to wield,行使,VERB,B2
+excavator,excavator,挖掘机,NOUN,B2
+to powder,to powder,撒粉,VERB,B2
+flaccid,flaccid,松弛的,ADJ,B2
+egalitarian,egalitarian,平等主义的,ADJ,B2
+cord,cord,绳索,NOUN,B2
+disadvantageous,disadvantageous,不利的,ADJ,B2
+foliage,foliage,枝叶,NOUN,B2
+winding,winding,蜿蜒的,ADJ,B2
+to antagonize,to antagonize,使对立,VERB,B2
+apoplexy,apoplexy,中风,NOUN,B2
+land register,land register,地籍,NOUN,B2
+intolerant,intolerant,不容忍的,ADJ,B2
+to release from prison,to release from prison,释放,VERB,B2
+conformist,conformist,墨守成规者,NOUN,B2
+empirically,empirically,凭经验地,ADV,B2
+incongruity,incongruity,不协调,NOUN,B2
+slender,slender,纤细的,ADJ,B2
+to harmonize,to harmonize,使和谐,VERB,B2
+wild beast,wild beast,猛兽,NOUN,B2
+to mutiny,to mutiny,煽动叛乱,VERB,B2
+brakeman,brakeman,刹车员,NOUN,B2
+bureaucratic,bureaucratic,官僚的,ADJ,B2
+disorganization,disorganization,无组织,NOUN,B2
+horoscope,horoscope,星座运势,NOUN,B2
+copious,copious,丰富的,ADJ,B2
+dissolute,dissolute,放荡的,ADJ,B2
+disheveled,disheveled,蓬乱的,ADJ,B2
+to skewer,to skewer,串起,VERB,B2
+concordat,concordat,政教协定,NOUN,B2
+to mud,to mud,弄脏,VERB,B2
+incipient,incipient,初期的,ADJ,B2
+corrigible,corrigible,可改正的,ADJ,B2
+germicidal,germicidal,杀菌的,ADJ,B2
+effervescent,effervescent,沸腾的,ADJ,B2
+high school graduate,high school graduate,高中毕业生,NOUN,B2
+phlebitis,phlebitis,静脉炎,NOUN,B2
+ferrule,ferrule,箍,NOUN,B2
+unnatural,unnatural,不自然的,ADJ,B2
+heterodox,heterodox,异端的,ADJ,B2
+burlesque,burlesque,滑稽的,ADJ,B2
+exaltation,exaltation,狂热,NOUN,B2
+mannish,mannish,像男人的,ADJ,B2
+exuberance,exuberance,繁茂,NOUN,B2
+to armor,to armor,装甲,VERB,B2
+slimy,slimy,粘滑的,ADJ,B2
+ski,ski,滑雪板,NOUN,B2
+consummate,consummate,熟练的,ADJ,B2
+choirboy,choirboy,唱诗班男孩,NOUN,B2
+to lean out,to lean out,探出身体,VERB,B2
+maroon,maroon,深红色,ADJ,B2
+industrious,industrious,勤劳的,ADJ,B2
+geometer,geometer,几何学家,NOUN,B2
+exorbitant,exorbitant,过高的,ADJ,B2
+consequent,consequent,随之发生的,ADJ,B2
+sweepings,sweepings,扫出的垃圾,NOUN,B2
+to curve,to curve,弯曲,VERB,B2
+discretionary,discretionary,自由裁量的,ADJ,B2
+to pacify,to pacify,平息,VERB,B2
+very fine,very fine,极细的,ADJ,B2
+to jam,to jam,堵塞,VERB,B2
+tacky thing,tacky thing,俗气的事,NOUN,B2
+deserter,deserter,逃兵,NOUN,B2
+extirpation,extirpation,切除,NOUN,B2
+amends,amends,补偿,NOUN,B2
+defenseless,defenseless,无防御的,ADJ,B2
+imperialist,imperialist,帝国主义的,ADJ,B2
+germanic,germanic,日耳曼的,ADJ,B2
+scaly,scaly,有鳞的,ADJ,B2
+short news item,short news item,短新闻,NOUN,B2
+hispanic,hispanic,西班牙的,ADJ,B2
+flashlight,flashlight,手电筒,NOUN,B2
+endogenous,endogenous,内生的,ADJ,B2
+to stylize,to stylize,风格化,VERB,B2
+swarm,swarm,蜂群,NOUN,B2
+loose thread,loose thread,线头,NOUN,B2
+imbecility,imbecility,愚蠢,NOUN,B2
+conch,conch,海螺壳,NOUN,B2
+maladjusted,maladjusted,适应不良的,ADJ,B2
+historicist,historicist,历史主义者,NOUN,B2
+gossipy,gossipy,爱传流言的,ADJ,B2
+t-shirt,t-shirt,T 恤衫,NOUN,B2
+hexagon,hexagon,六边形,NOUN,B2
+floorboard,floorboard,木地板,NOUN,B2
+exhumation,exhumation,掘墓,NOUN,B2
+parishioner,parishioner,教区居民,NOUN,B2
+to make independent,to make independent,使独立,VERB,B2
+to pair,to pair,配对,VERB,B2
+unpunished,unpunished,未受惩罚的,ADJ,B2
+figuratively,figuratively,比喻地,ADV,B2
+distinctive,distinctive,独特的,ADJ,B2
+fittings,fittings,水龙头配件,NOUN,B2
+pompous,pompous,浮夸的,ADJ,B2
+euphonic,euphonic,悦耳的,ADJ,B2
+equilateral,equilateral,等边的,ADJ,B2
+puny,puny,瘦弱的,ADJ,B2
+bronze-colored,bronze-colored,青铜色的,ADJ,B2
+despotic,despotic,专制的,ADJ,B2
+spirited,spirited,活泼的,ADJ,B2
+rarefaction,rarefaction,稀薄,NOUN,B2
+fluidity,fluidity,流畅,NOUN,B2
+exhortation,exhortation,劝诫,NOUN,B2
+crochet,crochet,钩针编织,NOUN,B2
+clairvoyant,clairvoyant,有洞察力的,ADJ,B2
+gestural,gestural,手势的,ADJ,B2
+quantifiable,quantifiable,可量化的,ADJ,B2
+flirt,flirt,调情者,NOUN,B2
+exhalation,exhalation,呼气,NOUN,B2
+to cover up,to cover up,掩盖,VERB,B2
+franciscan,franciscan,方济各会的,ADJ,B2
+eclectic,eclectic,折衷的,ADJ,B2
+abbot,abbot,院长,NOUN,B2
+besieged,besieged,被围困的,ADJ,B2
+botched job,botched job,粗劣的活儿,NOUN,B2
+to bridle,to bridle,给...上笼头,VERB,B2
+hump,hump,驼峰,NOUN,B2
+closer,closer,更近的,ADJ,B2
+conspiratorial,conspiratorial,阴谋的,ADJ,B2
+guidance,guidance,指导,NOUN,B2
+benignity,benignity,良性,NOUN,B2
+class struggle,class struggle,阶级斗争,NOUN,B2
+desirability,desirability,可取性,NOUN,B2
+liberalize,liberalize,自由化,! VERB,B2
+group mentality,group mentality,群体心态,NOUN,B2
+member of parliament,member of parliament,议员,NOUN,B2
+grammaticality,grammaticality,合语法性,NOUN,B2
+alienating,alienating,使人疏远的,ADJ,B2
+avoidable,avoidable,可避免的,ADJ,B2
+criminal law,criminal law,刑法,NOUN,B2
+group solidarity,group solidarity,群体团结,NOUN,B2
+surgical,surgical,外科的,ADJ,B2
+to solder,to solder,焊接,VERB,B2
+irish,irish,爱尔兰的,ADJ,B2
+universities,universities,大学,NOUN,B2
+entranced,entranced,痴迷的,ADJ,B2
+aghast,aghast,惊骇的,ADJ,B2
+diction,diction,措辞,NOUN,B2
+to technologize,to technologize,技术化,VERB,B2
+gallows humor,gallows humor,绞刑架幽默,NOUN,B2
+cycle path,cycle path,自行车道,NOUN,B2
+misplaced,misplaced,不合时宜的,ADJ,B2
+presidential election,presidential election,总统选举,NOUN,B2
+marginal,marginal,边缘的,ADJ,B2
+place of residence,place of residence,居住地,NOUN,B2
+to pauperize,to pauperize,使贫困,VERB,B2
+healing power,healing power,疗效,NOUN,B2
+to draw water,to draw water,打水,VERB,B2
+cohort-based,cohort-based,队列的,ADJ,B2
+publicity,publicity,宣传,NOUN,B2
+to walk around,to walk around,四处走动,VERB,B2
+spiritual,spiritual,精神的,ADJ,B2
+towards,towards,迎向,ADV,B2
+physiotherapy,physiotherapy,物理治疗,NOUN,B2
+founding,founding,成立,NOUN,B2
+family reunification,family reunification,家庭团聚,NOUN,B2
+to validate,to validate,验证,VERB,B2
+unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
+exemplary country,exemplary country,模范国家,NOUN,B2
+consolidating,consolidating,巩固的,ADJ,B2
+eclecticism,eclecticism,折衷主义,NOUN,B2
+statistic,statistic,统计数据,NOUN,B2
+hazard report,hazard report,危险报告,NOUN,B2
+dentition,dentition,牙齿,NOUN,B2
+front line,front line,前线,NOUN,B2
+conference-based,conference-based,会议的,ADJ,B2
+court case,court case,诉讼,NOUN,B2
+plucky,plucky,勇敢的,ADJ,B2
+two-dimensional,two-dimensional,二维的,ADJ,B2
+purifying,purifying,净化的,ADJ,B2
+to be correct,to be correct,正确,VERB,B2
+to rehabilitate,to rehabilitate,使康复,VERB,B2
+factual,factual,事实的,ADJ,B2
+sighing,sighing,叹息的,ADJ,B2
+to tune,to tune,调谐,VERB,B2
+collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
+little brother,little brother,小弟弟,NOUN,B2
+one-way traffic,one-way traffic,单向通行,NOUN,B2
+national anthem,national anthem,国歌,NOUN,B2
+to replicate,to replicate,复制,VERB,B2
+to catalyze,to catalyze,催化,VERB,B2
+nauseous,nauseous,恶心的,ADJ,B2
+to modulate,to modulate,调节,VERB,B2
+cult,cult,邪教,NOUN,B2
+grave desecration,grave desecration,亵渎坟墓,NOUN,B2
+effortless,effortless,不费力的,ADJ,B2
+worth mentioning,worth mentioning,值得一提的,ADJ,B2
+to settle up,to settle up,结账,VERB,B2
+portuguese,portuguese,葡萄牙语,NOUN,B2
+meaningful,meaningful,有意义的,ADJ,B2
+contested,contested,有争议的,ADJ,B2
+to instrumentalize,to instrumentalize,工具化,VERB,B2
+labor market,labor market,劳动力市场,NOUN,B2
+to lug,to lug,搬运,VERB,B2
+convertible,convertible,可兑换的,ADJ,B2
+upwards,upwards,向上,ADV,B2
+altruistic,altruistic,利他的,ADJ,B2
+hence,hence,因此,ADV,B2
+new construction,new construction,新建建筑,NOUN,B2
+jaded,jaded,厌倦的,ADJ,B2
+dominance,dominance,威权,NOUN,B2
+immanence,immanence,内在性,NOUN,B2
+coming,coming,即将到来的,ADJ,B2
+well-groomed,well-groomed,整洁的,ADJ,B2
+hassle,hassle,麻烦,NOUN,B2
+to text,to text,发短信,VERB,B2
+headscarf,headscarf,头巾,NOUN,B2
+courageous,courageous,勇敢的,ADJ,B2
+posh,posh,上流的,ADJ,B2
+daft,daft,傻的,ADJ,B2
+abolition,abolition,废除,NOUN,B2
+knowledge transfer,knowledge transfer,知识传授,NOUN,B2
+merger,merger,合并,NOUN,B2
+to stick out,to stick out,伸出,VERB,B2
+emaciating,emaciating,消耗的,ADJ,B2
+bisexual,bisexual,双性恋的,ADJ,B2
+with this,with this,以此,ADV,B2
+to decentralize,to decentralize,去中心化,VERB,B2
+contact person,contact person,联系人,NOUN,B2
+connecting,connecting,连接的,ADJ,B2
+proliferate,proliferate,扩散,! VERB,B2
+milky,milky,乳白色的,ADJ,B2
+to rent out,to rent out,出租,VERB,B2
+to retort,to retort,反驳,VERB,B2
+variation,variation,变化,NOUN,B2
+april,april,四月,NOUN,B2
+mysticism,mysticism,神秘主义,NOUN,B2
+humanities,humanities,人文学科,NOUN,B2
+power station,power station,发电厂,NOUN,B2
+bit,bit,一点,NOUN,B2
+peddler,peddler,小贩,NOUN,B2
+broadening,broadening,拓宽,NOUN,B2
+this evening,this evening,今晚,ADV,B2
+pregnant woman,pregnant woman,孕妇,NOUN,B2
+rest assured,rest assured,放心的,ADJ,B2
+to tax to burden,to tax to burden,征税,VERB,B2
+radius,radius,半径,NOUN,B2
+decibel,decibel,分贝,NOUN,B2
+small gift,small gift,小礼物,NOUN,B2
+museum piece,museum piece,博物馆藏品,NOUN,B2
+florid,florid,辞藻华丽的,ADJ,B2
+crisis situation,crisis situation,危机局势,NOUN,B2
+to ostracize,to ostracize,排斥,VERB,B2
+dislike,dislike,厌恶,NOUN,B2
+syrian,syrian,叙利亚的,ADJ,B2
+to scan,to scan,扫描,VERB,B2
+worldly,worldly,世俗的,ADJ,B2
+contentious,contentious,有争议的,ADJ,B2
+communautarization,communautarization,社群化,NOUN,B2
+connotative,connotative,内涵的,ADJ,B2
+to spam,to spam,发垃圾信息,VERB,B2
+macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+at the back,at the back,在后面,ADV,B2
+neighbour,neighbour,邻居,NOUN,B2
+schoolboy,schoolboy,学生,NOUN,B2
+to sublimate,to sublimate,升华,VERB,B2
+for this,for this,为此,ADV,B2
+witness examination,witness examination,证人询问,NOUN,B2
+climate denial,climate denial,气候否认,NOUN,B2
+turbulent,turbulent,动荡的,ADJ,B2
+to sensitize,to sensitize,提高意识,VERB,B2
+microscopic,microscopic,微观的,ADJ,B2
+toothless,toothless,无齿的,ADJ,B2
+to telework,to telework,远程办公,VERB,B2
+venereal disease,venereal disease,性病,NOUN,B2
+to persevere,to persevere,坚持,VERB,B2
+to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
+heath,heath,石楠荒原,NOUN,B2
+guilder,guilder,盾,NOUN,B2
+financier,financier,资助者,NOUN,B2
+filipino,filipino,菲律宾的,ADJ,B2
+to agitate,to agitate,鼓动,VERB,B2
+multipart,multipart,多部分的,ADJ,B2
+all-round,all-round,全面的,ADJ,B2
+her,her,她的,DET,B2
+vacuum,vacuum,真空的,ADJ,B2
+newsletter,newsletter,简报,NOUN,B2
+whisk,whisk,打蛋器,NOUN,B2
+very hard,very hard,极硬的,ADJ,B2
+to regionalize,to regionalize,区域化,VERB,B2
+suspended,suspended,悬浮的,ADJ,B2
+to plagiarize,to plagiarize,剽窃,VERB,B2
+axiomatic,axiomatic,公理的,ADJ,B2
+antisocial,antisocial,反社会的,ADJ,B2
+transition,transition,过渡,NOUN,B2
+to drop off,to drop off,放下,VERB,B2
+such a,such a,这样的,DET,B2
+noise nuisance,noise nuisance,噪音扰民,NOUN,B2
+amicable,amicable,友好的,ADJ,B2
+fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
+vs,vs,与...相对,ADP,B2
+mayoral,mayoral,市长的,ADJ,B2
+health policy,health policy,健康政策,NOUN,B2
+inheritance law,inheritance law,继承法,NOUN,B2
+bent,bent,弯的,ADJ,B2
+inventorying,inventorying,清点,NOUN,B2
+religious war,religious war,宗教战争,NOUN,B2
+to immunize,to immunize,免疫,VERB,B2
+analytical,analytical,分析的,ADJ,B2
+to invoice,to invoice,开票,VERB,B2
+life-size,life-size,真人大小的,ADJ,B2
+bilateral,bilateral,双边的,ADJ,B2
+little sun,little sun,小太阳,NOUN,B2
+collectomania,collectomania,收藏癖,NOUN,B2
+workable,workable,可加工的,ADJ,B2
+composable,composable,可组合的,ADJ,B2
+disco,disco,迪厅,NOUN,B2
+laptop,laptop,笔记本电脑,NOUN,B2
+legation,legation,公使馆,NOUN,B2
+group norm,group norm,群体规范,NOUN,B2
+inflexibility,inflexibility,僵化,NOUN,B2
+to enrol,to enrol,注册,VERB,B2
+insightfulness,insightfulness,洞察,NOUN,B2
+catastrophic,catastrophic,灾难性的,ADJ,B2
+to industrialize,to industrialize,工业化,VERB,B2
+fossil fuel,fossil fuel,化石燃料,NOUN,B2
+megalomanic,megalomanic,狂妄自大的,ADJ,B2
+contractual,contractual,合同的,ADJ,B2
+school year,school year,学年,NOUN,B2
+to persist,to persist,坚持,VERB,B2
+postal code,postal code,邮政编码,NOUN,B2
+property right,property right,所有权,NOUN,B2
+customer service,customer service,客户服务,NOUN,B2
+aloud,aloud,出声地,ADV,B2
+court fee,court fee,诉讼费,NOUN,B2
+globalization process,globalization process,全球化进程,NOUN,B2
+film star,film star,,NOUN,B2
+memorable,memorable,难忘的,ADJ,B2
+factionalism,factionalism,派系主义,NOUN,B2
+austrian,austrian,奥地利的,ADJ,B2
+family composition,family composition,家庭构成,NOUN,B2
+frictionless,frictionless,无摩擦的,ADJ,B2
+off,off,关,ADP,B2
+fatty,fatty,脂肪的,ADJ,B2
+ceremonial,ceremonial,仪式的,ADJ,B2
+ice cold,ice cold,冰冷的,ADJ,B2
+heated,heated,激昂的,ADJ,B2
+constitutive,constitutive,构成的,ADJ,B2
+character assassination,character assassination,人格谋杀,NOUN,B2
+meek,meek,温顺的,ADJ,B2
+contaminating,contaminating,污染的,ADJ,B2
+conversional,conversional,转换的,ADJ,B2
+federalization,federalization,联邦化,NOUN,B2
+gravitational,gravitational,引力的,ADJ,B2
+amusement,amusement,娱乐,NOUN,B2
+paralysed,paralysed,瘫痪的,ADJ,B2
+energy crisis,energy crisis,能源危机,NOUN,B2
+search engine,search engine,搜索引擎,NOUN,B2
+parliamentary elections,parliamentary elections,议会选举,NOUN,B2
+petrol,petrol,汽油,NOUN,B2
+final score,final score,最终比分,NOUN,B2
+holism,holism,整体论,NOUN,B2
+from which,from which,从中,ADV,B2
+family tension,family tension,家庭紧张,NOUN,B2
+drinking water,drinking water,饮用水,NOUN,B2
+state of mind,state of mind,精神状态,NOUN,B2
+destined,destined,,NOUN,B2
+tens of thousands,tens of thousands,数万,NUM,B2
+licentious,licentious,放荡的,ADJ,B2
+visible,visible,可见的,ADJ,B2
+few,few,几下,NOUN,B2
+schooled person,schooled person,受过培训者,NOUN,B2
+swiss,swiss,瑞士的,ADJ,B2
+to polarize,to polarize,使两极分化,VERB,B2
+atheistic,atheistic,无神论的,ADJ,B2
+accountable,accountable,负责任的,ADJ,B2
+guideline,guideline,指导方针,NOUN,B2
+native american,native american,印第安人,NOUN,B2
+provisional,provisional,临时的,ADJ,B2
+lacunary,lacunary,残缺的,ADJ,B2
+to hold accountable,to hold accountable,问责,VERB,B2
+utility,utility,效用,NOUN,B2
+data processing,data processing,数据处理,NOUN,B2
+irrelevance,irrelevance,无关,NOUN,B2
+to repel,to repel,击退,VERB,B2
+one and a half,one and a half,一个半,NUM,B2
+loyalty to authority,loyalty to authority,服从权威,NOUN,B2
+associated,associated,相关的,ADJ,B2
+southwest,southwest,西南的,ADJ,B2
+emotional expression,emotional expression,! 情感表达,NOUN,B2
+commencement,commencement,开始,NOUN,B2
+to propagate,to propagate,传播,VERB,B2
+religious strife,religious strife,宗教纷争,NOUN,B2
+heartfelt,heartfelt,衷心的,ADJ,B2
+trivializable,trivializable,可轻描淡写的,ADJ,B2
+bombardment,bombardment,轰炸,NOUN,B2
+to mystify,to mystify,神秘化,VERB,B2
+dutchman,dutchman,荷兰人,NOUN,B2
+bicycle repairer,bicycle repairer,修车匠,NOUN,B2
+to,to,去,PART,B2
+egocentrism,egocentrism,自我中心,NOUN,B2
+palestinian,palestinian,巴勒斯坦的,ADJ,B2
+toys,toys,玩具,NOUN,B2
+endowed,endowed,有天赋的,ADJ,B2
+hungarian,hungarian,匈牙利的,ADJ,B2
+expertise center,expertise center,专业中心,NOUN,B2
+sympathetic,sympathetic,同情的,ADJ,B2
+run-up,run-up,助跑,NOUN,B2
+to aggravate,to aggravate,加重,VERB,B2
+manual,manual,手工的,ADJ,B2
+flemish,flemish,佛兰芒的,ADJ,B2
+toothbrush,toothbrush,牙刷,NOUN,B2
+to emigrate,to emigrate,移居国外,VERB,B2
+email address,email address,电子邮件地址,NOUN,B2
+the one,the one,,NOUN,B2
+grand officer,grand officer,大官,NOUN,B2
+ukrainian,ukrainian,乌克兰的,ADJ,B2
+border arrangement,border arrangement,边境安排,NOUN,B2
+metamorphic,metamorphic,变质的,ADJ,B2
+to localize,to localize,本地化,VERB,B2
+undermining authority,undermining authority,削弱权威,NOUN,B2
+group individual,group individual,群体个体,NOUN,B2
+elderly,elderly,老年人,NOUN,B2
+brazilian,brazilian,巴西的,ADJ,B2
+nuts,nuts,疯狂的,ADJ,B2
+coloredness,coloredness,有色性,NOUN,B2
+berlijns,berlijns,柏林的,ADJ,B2
+judgement,judgement,评估,NOUN,B2
+manipulable,manipulable,可操纵的,ADJ,B2
+depicted,depicted,描绘的,ADJ,B2
+many,many,许多,DET,B2
+cosmetics,cosmetics,化妆品,NOUN,B2
+diplomatic relations,diplomatic relations,外交关系,NOUN,B2
+to pucker,to pucker,噘,VERB,B2
+how come,how come,怎么会,INTJ,B2
+structuredness,structuredness,结构性,NOUN,B2
+to break off,to break off,中断,VERB,B2
+to tidy,to tidy,整理,VERB,B2
+solemn,solemn,,NOUN,B2
+habitlessness,habitlessness,无习惯,NOUN,B2
+racist,racist,种族主义的,ADJ,B2
+increasing,increasing,增加的,ADJ,B2
+south african,south african,南非的,ADJ,B2
+your,your,你的,PRON,B2
+folksy,folksy,乡土的,ADJ,B2
+redrawing,redrawing,重新绘制,NOUN,B2
+largely,largely,主要地,ADV,B2
+to contextualize,to contextualize,置于语境,VERB,B2
+editor-in-chief,editor-in-chief,主编,NOUN,B2
+documentation,documentation,文献,NOUN,B2
+outside,outside,在外面,ADP,B2
+traditional costume,traditional costume,传统服饰,NOUN,B2
+special offer,special offer,特价,NOUN,B2
+balancing,balancing,平衡的,ADJ,B2
+dispirited,dispirited,沮丧的,ADJ,B2
+potential,potential,潜在的,ADJ,B2
+ourselves,ourselves,我们自己,PRON,B2
+explanatory,explanatory,解释的,ADJ,B2
+source citation,source citation,出处注明,NOUN,B2
+socialist,socialist,社会主义的,ADJ,B2
+swedish,swedish,瑞典的,ADJ,B2
+bleeding,bleeding,流血的,ADJ,B2
+children's rights,children's rights,儿童权利,NOUN,B2
+arabic,arabic,阿拉伯的,ADJ,B2
+demotion,demotion,降职,NOUN,B2
+to revolutionize,to revolutionize,革命化,VERB,B2
+with that,with that,以此,ADV,B2
+parish priest,parish priest,本堂神父,NOUN,B2
+tram,tram,有轨电车,NOUN,B2
+for a moment,for a moment,片刻,ADV,B2
+provable,provable,可证明的,ADJ,B2
+some,some,一些,PRON,B2
+owed,owed,欠下的,ADJ,B2
+midfielder,midfielder,中场球员,NOUN,B2
+solar panel,solar panel,太阳能电池板,NOUN,B2
+church community,church community,教会,NOUN,B2
+liberating,liberating,解放的,ADJ,B2
+healthcare,healthcare,医疗保健,NOUN,B2
+figuration,figuration,群演,NOUN,B2
+inactivity,inactivity,不活跃,NOUN,B2
+by means of,by means of,凭借,NOUN,B2
+in the back,in the back,在后面,ADV,B2
+series of conversations,series of conversations,系列对话,NOUN,B2
+day after tomorrow,day after tomorrow,后天,NOUN,B2
+plenty,plenty,充足地,ADV,B2
+myself,myself,我自己,PRON,B2
+disharmony,disharmony,不和谐,NOUN,B2
+barbarization,barbarization,野蛮化,NOUN,B2
+land policy,land policy,土地政策,NOUN,B2
+governable,governable,可管理的,ADJ,B2
+just like that,just like that,随便地,ADV,B2
+paving,paving,铺路,NOUN,B2
+belgian,belgian,比利时人,NOUN,B2
+fabulist,fabulist,幻想家,NOUN,B2
+regardless,regardless,不管,ADP,B2
+hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
+twofold,twofold,双重的,ADJ,B2
+sentences,sentences,句子,NOUN,B2
+alternating,alternating,交替的,ADJ,B2
+sports park,sports park,运动公园,NOUN,B2
+removed,removed,移除的,ADJ,B2
+world champion,world champion,世界冠军,NOUN,B2
+hem,hem,边缘,NOUN,B2
+border check,border check,边境检查,NOUN,B2
+rightly,rightly,正确地,ADV,B2
+brabant,brabant,布拉班特的,ADJ,B2
+group work,group work,群体工作,NOUN,B2
+domineeringness,domineeringness,支配欲,NOUN,B2
+lifelong,lifelong,终身,ADJ,B2
+authority structure,authority structure,权威结构,NOUN,B2
+deputation,deputation,代表团,NOUN,B2
+people,people,人们,PRON,B2
+meandering,meandering,蜿蜒的,ADJ,B2
+dutch,dutch,荷兰语,NOUN,B2
+tomorrow night,tomorrow night,明晚,ADV,B2
+polish,polish,精炼,NOUN,B2
+grand master,grand master,大师,NOUN,B2
+to saw,to saw,锯,VERB,B2
+full-time,full-time,全职,ADJ,B2
+subject field,subject field,科目 / 领域,NOUN,B2
+conviviality,conviviality,温馨,NOUN,B2
+film industry,film industry,电影业,NOUN,B2
+primary school,primary school,小学,NOUN,B2
+song festival,song festival,音乐节,NOUN,B2
+little heart,little heart,小心脏,NOUN,B2
+lawless,lawless,无法的,ADJ,B2
+in unison,in unison,齐声,ADV,B2
+neatly,neatly,整洁地,ADV,B2
+contactual,contactual,接触的,ADJ,B2
+compostable,compostable,可堆肥的,ADJ,B2
+as many,as many,一样多,NUM,B2
+century-old,century-old,世纪的,ADJ,B2
+self-interest,self-interest,私利,NOUN,B2
+collectivization,collectivization,集体化,NOUN,B2
+fishery,fishery,渔业,NOUN,B2
+liminal,liminal,阈限的,ADJ,B2
+tactless,tactless,不得体的,ADJ,B2
+without further ado,without further ado,毫不犹豫地,ADV,B2
+as a result of which,as a result of which,由此,ADV,B2
+euphemistic,euphemistic,委婉的,ADJ,B2
+to reoffend,to reoffend,重犯,VERB,B2
+border region,border region,边境地区,NOUN,B2
+patricide,patricide,弑父,NOUN,B2
+on the one hand,on the one hand,一方面,ADV,B2
+duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
+graphic designer,graphic designer,图形设计师,NOUN,B2
+megalomania,megalomania,狂妄自大,NOUN,B2
+to shoot dead,to shoot dead,击毙,VERB,B2
+lingual,lingual,语言的,ADJ,B2
+light grey,light grey,浅灰色的,ADJ,B2
+classicist,classicist,古典主义的,ADJ,B2
+tiring,tiring,令人疲倦的,ADJ,B2
+intellectual life,intellectual life,精神生活,NOUN,B2
+middle,middle,中间,ADV,B2
+nonviolence,nonviolence,非暴力,NOUN,B2
+inherence,inherence,固有,NOUN,B2
+conscientious objection,conscientious objection,良知抗拒,NOUN,B2
+spirit world,spirit world,灵界,NOUN,B2
+convolutional,convolutional,卷积的,ADJ,B2
+argentinian,argentinian,阿根廷的,ADJ,B2
+predisposition,predisposition,天赋,NOUN,B2
+authority figure,authority figure,权威人士,NOUN,B2
+marshy,marshy,沼泽般的,ADJ,B2
+whey,whey,乳清,NOUN,B2
+for that purpose,for that purpose,为此,ADV,B2
+brainy,brainy,聪明的,ADJ,B2
+to archive,to archive,归档,VERB,B2
+collectie,collectie,收藏,NOUN,B2
+unwanted,unwanted,不受欢迎的,ADJ,B2
+good-naturedness,good-naturedness,温和,NOUN,B2
+for what purpose,for what purpose,为了什么目的,ADV,B2
+labile,labile,不稳定的,ADJ,B2
+consumptive,consumptive,消费的,ADJ,B2
+incompleteness,incompleteness,不完整,NOUN,B2
+to take minutes,to take minutes,记录,VERB,B2
+czech,czech,捷克的,ADJ,B2
+backyard,backyard,后院,NOUN,B2
+indonesian,indonesian,印度尼西亚的,ADJ,B2
+processing,processing,处理,NOUN,B2
+outside world,outside world,外界,NOUN,B2
+tomb monument,tomb monument,墓碑,NOUN,B2
+care worker,care worker,护理人员,NOUN,B2
+to email,to email,发邮件,VERB,B2
+mercy blow,mercy blow,致命一击,NOUN,B2
+co-,co-,共同,ADV,B2
+purchase price,purchase price,购买价,NOUN,B2
+campus-like,campus-like,校园式的,ADJ,B2
+well-disposed,well-disposed,善意的,ADJ,B2
+offence,offence,罪行,NOUN,B2
+lapidary,lapidary,简略的,ADJ,B2
+uniformity,uniformity,统一性,NOUN,B2
+to graspen,to graspen,抓住,VERB,B2
+editorial office,editorial office,编辑部,NOUN,B2
+quaternary,quaternary,第四的,ADJ,B2
+marbly,marbly,大理石般的,ADJ,B2
+reasoned,reasoned,经过推理的,ADJ,B2
+out,out,出,ADP,B2
+little finger,little finger,小指,NOUN,B2
+uncritical,uncritical,不加批判的,ADJ,B2
+very best,very best,最好的,ADJ,B2
+family tie,family tie,家庭纽带,NOUN,B2
+impoverished,impoverished,贫困的,ADJ,B2
+little boy,little boy,小男孩,NOUN,B2
+to lodge,to lodge,借宿,VERB,B2
+expression of opinion,expression of opinion,意见表达,NOUN,B2
+cool-headed,cool-headed,冷静的,ADJ,B2
+tax rate,tax rate,税率,NOUN,B2
+genetic modification,genetic modification,基因改造,NOUN,B2
+engrossing,engrossing,引人入胜的,ADJ,B2
+image formation,image formation,形象塑造,NOUN,B2
+sound clip,sound clip,音频片段,NOUN,B2
+film studio,film studio,电影制片厂,NOUN,B2
+manifold,manifold,多方面的,ADJ,B2
+to think it over,to think it over,思考,VERB,B2
+esotericism,esotericism,秘教,NOUN,B2
+averageness,averageness,平庸,NOUN,B2
+microeconomic,microeconomic,微观经济学的,ADJ,B2
+above-mentioned,above-mentioned,上述的,ADJ,B2
+combining,combining,结合的,ADJ,B2
+artwork,artwork,艺术品,NOUN,B2
+unification,unification,统一,NOUN,B2
+household,household,家庭的,ADJ,B2
+heartlessness,heartlessness,无情,NOUN,B2
+of it,of it,其中,ADV,B2
+punishable,punishable,可处罚的,ADJ,B2
+to put away,to put away,收拾,VERB,B2
+troubling,troubling,令人担忧的,ADJ,B2
+laugh,laugh,笑,NOUN,B2
+photo model,photo model,模特,NOUN,B2
+exoticism,exoticism,异国情调,NOUN,B2
+as well as,as well as,以及,SCONJ,B2
+apolitical,apolitical,非政治的,ADJ,B2
+groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
+indian,indian,印度的,ADJ,B2
+cremation,cremation,火化,NOUN,B2
+confronting,confronting,对峙的,ADJ,B2
+appropriation,appropriation,挪用,NOUN,B2
+motorway,motorway,高速公路,NOUN,B2
+border legislation,border legislation,边境立法,NOUN,B2
+blackbird,blackbird,乌鸫,NOUN,B2
+telephones,telephones,电话,NOUN,B2
+divisible,divisible,可分的,ADJ,B2
+professional formation,professional formation,职业养成,NOUN,B2
+scholing,scholing,受过训练,NOUN,B2
+moisture,moisture,湿气,NOUN,B2
+teleological,teleological,目的论的,ADJ,B2
+about which,about which,关于什么,PRON,B2
+economic cycle,economic cycle,经济周期,NOUN,B2
+ineffectiveness,ineffectiveness,! 无效,NOUN,B2
+capital flight,capital flight,资本外逃,NOUN,B2
+scottish,scottish,苏格兰的,ADJ,B2
+alteration,alteration,改变,NOUN,B2
+prejudiced,prejudiced,有偏见的,ADJ,B2
+shall will,shall will,将要,AUX,B2
+one-sidedness,one-sidedness,片面性,NOUN,B2
+to orient,to orient,定向,VERB,B2
+land use,land use,土地利用,NOUN,B2
+university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
+observable,observable,可观测的,ADJ,B2
+crossing the border,crossing the border,越境,NOUN,B2
+working day,working day,工作日,NOUN,B2
+day out,day out,一日游,NOUN,B2
+misconception,misconception,误解,NOUN,B2
+minivan,minivan,小型货车,NOUN,B2
+conforming,conforming,遵从的,ADJ,B2
+of utrecht,of utrecht,乌得勒支的,ADJ,B2
+about this,about this,关于这个,ADV,B2
+something like that,something like that,类似的事物,PRON,B2
+fief,fief,封地,NOUN,B2
+at the bottom,at the bottom,在底部,ADV,B2
+customer orientation,customer orientation,客户导向,NOUN,B2
+to license,to license,许可,VERB,B2
+the rich,the rich,富人,NOUN,B2
+runaway,runaway,,NOUN,B2
+frisian,frisian,弗里斯兰的,ADJ,B2
+to wither,to wither,,VERB,B2
+collected,collected,收集的,ADJ,B2
+civil war,civil war,内战,NOUN,B2
+grey area,grey area,灰色地带,NOUN,B2
+combinatorial,combinatorial,组合的,ADJ,B2
+from this,from this,由此,ADV,B2
+typographical,typographical,排版的,ADJ,B2
+to segment,to segment,细分,VERB,B2
+closely,closely,紧密地,ADV,B2
+mighty man,mighty man,强人,NOUN,B2
+theocratic,theocratic,神权的,ADJ,B2
+goalkeeper,goalkeeper,守门员,NOUN,B2
+harbour,harbour,港口,NOUN,B2
+invoicing,invoicing,开票,NOUN,B2
+societal,societal,社会的,ADJ,B2
+flying,flying,飞行的,ADJ,B2
+genocide,genocide,种族灭绝,NOUN,B2
+verbal,verbal,言语的,ADJ,B2
+self-worth,self-worth,自我价值,NOUN,B2
+household income,household income,家庭收入,NOUN,B2
+incidental,incidental,偶然的,ADJ,B2
+neighbourhood,neighbourhood,社区,NOUN,B2
+idealization,idealization,理想化,NOUN,B2
+cosy,cosy,舒适的,ADJ,B2
+inevitable,inevitable,,NOUN,B2
+stripping,stripping,剥离的,ADJ,B2
+grail,grail,圣杯,NOUN,B2
+concluding,concluding,推断的,ADJ,B2
+alderman,alderman,市议员,NOUN,B2
+piteous,piteous,可怜的,ADJ,B2
+video clip,video clip,视频片段,NOUN,B2
+knowledge exchange,knowledge exchange,知识交流,NOUN,B2
+penance,penance,忏悔,NOUN,B2
+to be needed,to be needed,被需要,VERB,B2
+bike helmet,bike helmet,自行车头盔,NOUN,B2
+sailboat,sailboat,,NOUN,B2
+suicidal thought,suicidal thought,,NOUN,B2
+electric motor,electric motor,电动机,NOUN,B2
+family relatives,family relatives,亲属,NOUN,B2
+fast,fast,快地,ADV,B2
+monarchy,monarchy,君主制,NOUN,B2
+pain relief,pain relief,,NOUN,B2
+fair decent,fair decent,公平的/正派的,ADJ,B2
+to zero out,to zero out,清零,VERB,B2
+swim training,swim training,,NOUN,B2
+mental hospital,mental hospital,精神病院,NOUN,B2
+sense of shame,sense of shame,,NOUN,B2
+locked in,locked in,被关在里面的,ADJ,B2
+pants,pants,裤子,NOUN,B2
+stolen,stolen,被偷的,ADJ,B2
+to be included,to be included,包含,VERB,B2
+funniness,funniness,,NOUN,B2
+outbreak,outbreak,爆发,NOUN,B2
+premium,premium,溢价,NOUN,B2
+grille,grille,格栅,NOUN,B2
+single,single,单曲,NOUN,B2
+medical help,medical help,,NOUN,B2
+gothenburg,gothenburg,哥德堡,PROPN,B2
+managed,managed,,NOUN,B2
+english teacher,english teacher,,NOUN,B2
+literally,literally,字面上地,ADV,B2
+leaf page,leaf page,叶子,NOUN,B2
+to light a fire,to light a fire,生火,VERB,B2
+mr master,mr master,先生/主人,NOUN,B2
+pine needle,pine needle,针叶,NOUN,B2
+funeral home,funeral home,,NOUN,B2
+sweetness,sweetness,,NOUN,B2
+hooray,hooray,万岁,INTJ,B2
+angle of approach,angle of approach,切入点,NOUN,B2
+thereafter,thereafter,此后,ADV,B2
+although,although,尽管,CCONJ,B2
+latest,latest,最新的,ADJ,B2
+change exchange,change exchange,改变/交换,NOUN,B2
+work environment,work environment,工作环境,NOUN,B2
+to fit suit,to fit suit,适合,VERB,B2
+to be driven,to be driven,被驱动,VERB,B2
+to be counted,to be counted,被算作,VERB,B2
+its,its,它的,PRON,B2
+social problem,social problem,社会问题,NOUN,B2
+indigenous people,indigenous people,原住民,NOUN,B2
+bigwig,bigwig,大人物,NOUN,B2
+magically,magically,魔法地,ADV,B2
+number one,number one,第一名,NOUN,B2
+he this one,he this one,他/这位,PRON,B2
+concussion,concussion,脑震荡,NOUN,B2
+bank card,bank card,银行卡,NOUN,B2
+known famous,known famous,著名的/熟悉的,ADJ,B2
+bigger,bigger,更大的,ADJ,B2
+alive living,alive living,活着的,ADJ,B2
+following page,following page,,NOUN,B2
+more important,more important,更重要的,ADJ,B2
+to screw,to screw,拧,VERB,B2
+fun joke,fun joke,乐趣/玩笑,NOUN,B2
+agree,agree,一致,ADJ,B2
+to step down,to step down,辞职,VERB,B2
+monkey ape,monkey ape,猿/猴,NOUN,B2
+conifer,conifer,针叶树,NOUN,B2
+sure,sure,当然,ADV,B2
+to steer control,to steer control,控制,VERB,B2
+starved,starved,饥饿的,ADJ,B2
+artistry,artistry,,NOUN,B2
+to trap fell,to trap fell,困住/砍倒,VERB,B2
+half-year,half-year,半年,NOUN,B2
+hither,hither,到这里,ADV,B2
+guest tester,guest tester,,NOUN,B2
+contacts,contacts,人脉,NOUN,B2
+computer program,computer program,电脑程序,NOUN,B2
+hanged,hanged,被绞死的,ADJ,B2
+butt,butt,臀部,NOUN,B2
+to bicker,to bicker,争吵,VERB,B2
+violently,violently,暴力地,ADV,B2
+to decide determine,to decide determine,决定/确定,VERB,B2
+so thus,so thus,所以/如此,ADV,B2
+to wipe out,to wipe out,消灭,VERB,B2
+citizenship right,citizenship right,公民权,NOUN,B2
+at once,at once,立刻,ADV,B2
+to drink binge,to drink binge,狂饮,VERB,B2
+to dampen,to dampen,使潮湿,VERB,B2
+to denominate,to denominate,命名,VERB,B2
+test drive,test drive,,NOUN,B2
+disposition,disposition,性情,NOUN,B2
+itself,itself,它自己,PRON,B2
+the sick,the sick,病人,NOUN,B2
+more beautiful,more beautiful,更美的,ADJ,B2
+atomic nucleus,atomic nucleus,原子核,NOUN,B2
+to paint over,to paint over,重新粉刷,VERB,B2
+working class,working class,工人阶级,NOUN,B2
+to harbor,to harbor,怀有,VERB,B2
+sentenced,sentenced,被判刑的,ADJ,B2
+upper floor,upper floor,楼上,NOUN,B2
+salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
+scientists,scientists,科学家,NOUN,B2
+lots,lots,大量,NOUN,B2
+poor wretched,poor wretched,可怜的,ADJ,B2
+welcome committee,welcome committee,,NOUN,B2
+self-image,self-image,自我形象,NOUN,B2
+to find oneself,to find oneself,处于,VERB,B2
+ace,ace,王牌,NOUN,B2
+your plural,your plural,你们的,DET,B2
+values,values,价值观,NOUN,B2
+goodbye kiss,goodbye kiss,,NOUN,B2
+atm,atm,自动取款机,NOUN,B2
+sun sensitivity,sun sensitivity,,NOUN,B2
+load cargo,load cargo,货物/负荷,NOUN,B2
+egg card,egg card,,NOUN,B2
+wife mrs,wife mrs,妻子/夫人,NOUN,B2
+definite,definite,明确的,ADJ,B2
+evenly,evenly,均匀地,ADV,B2
+determined definite,determined definite,确定的,ADJ,B2
+healthcare worker,healthcare worker,医护人员,NOUN,B2
+to behold,to behold,注视,VERB,B2
+freedom of the press,freedom of the press,出版自由,NOUN,B2
+heroin vapor,heroin vapor,,NOUN,B2
+nuance,nuance,细微差别,NOUN,B2
+bags,bags,包,NOUN,B2
+other others,other others,其他,DET,B2
+degree exam,degree exam,学位/考试,NOUN,B2
+oh really,oh really,真的吗,INTJ,B2
+back side,back side,背面,NOUN,B2
+to quiver,to quiver,颤抖,VERB,B2
+scene stage,scene stage,场景/舞台,NOUN,B2
+director manager,director manager,主管/经理,NOUN,B2
+hag,hag,老妇,NOUN,B2
+stably,stably,稳定地,ADV,B2
+electric power,electric power,电力,NOUN,B2
+to rot,to rot,腐烂,VERB,B2
+income tax,income tax,所得税,NOUN,B2
+eating,eating,,NOUN,B2
+mustache,mustache,胡子,NOUN,B2
+safe secure,safe secure,安全的/可靠的,ADJ,B2
+squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
+sinner,sinner,罪人,NOUN,B2
+shortly,shortly,不久,ADV,B2
+to enhance,to enhance,增强,VERB,B2
+attacked,attacked,被攻击的,ADJ,B2
+chubby,chubby,胖子,NOUN,B2
+every other,every other,每隔一个,DET,B2
+caught,caught,被捕获的,ADJ,B2
+arrested,arrested,被逮捕的,ADJ,B2
+firearms,firearms,枪支,NOUN,B2
+to food give birth,to food give birth,食物/生育,VERB,B2
+diagonally,diagonally,对角地,ADV,B2
+to occupy oneself,to occupy oneself,从事,VERB,B2
+the guy's,the guy's,那个男人的,NOUN,B2
+good well,good well,好/很好,ADJ,B2
+impressed,impressed,印象深刻的,ADJ,B2
+emotionally,emotionally,情感上,ADV,B2
+experience exchange,experience exchange,经验交流,NOUN,B2
+good behavior,good behavior,,NOUN,B2
+green-clad,green-clad,,NOUN,B2
+broken,broken,破碎的,ADV,B2
+chips,chips,薯片,NOUN,B2
+difficult flirt,difficult flirt,,NOUN,B2
+cognac,cognac,干邑,NOUN,B2
+hot dog stand,hot dog stand,小吃摊,NOUN,B2
+corpse alike,corpse alike,尸体/相似的,NOUN,B2
+big brother,big brother,哥哥,NOUN,B2
+what kind of,what kind of,什么样的,PRON,B2
+ceo,ceo,首席执行官,NOUN,B2
+to call ring,to call ring,打电话,VERB,B2
+confusing,confusing,令人困惑的,ADJ,B2
+loudly,loudly,大声地,ADV,B2
+to be punished,to be punished,受罚,VERB,B2
+like this,like this,,NOUN,B2
+armorer,armorer,,NOUN,B2
+to account for,to account for,说明,VERB,B2
+dejt,dejt,约会,NOUN,B2
+to prosecute,to prosecute,起诉,VERB,B2
+it common,it common,它 (通性),PRON,B2
+self-evident,self-evident,,NOUN,B2
+informed,informed,见多识广的,ADJ,B2
+faster,faster,更快的,ADJ,B2
+action plan,action plan,行动方案,NOUN,B2
+seen,seen,被看见,ADJ,B2
+chill,chill,放松,ADJ,B2
+to mourn,to mourn,哀悼,VERB,B2
+to tear down,to tear down,拆除,VERB,B2
+to furlough,to furlough,临时解雇,VERB,B2
+subject topic,subject topic,主题/话题,NOUN,B2
+out here,out here,这里外面,ADV,B2
+pavement,pavement,人行道,NOUN,B2
+astray,astray,迷路,ADJ,B2
+epoch,epoch,时代,NOUN,B2
+phrasing,phrasing,措辞,NOUN,B2
+older woman,older woman,老妇人,NOUN,B2
+registered,registered,注册的,ADJ,B2
+elite unit,elite unit,,NOUN,B2
+zero,zero,零,NOUN,B2
+to be tricked,to be tricked,被欺骗,VERB,B2
+pre,pre,,NOUN,B2
+upward,upward,向上,ADV,B2
+lifestyle,lifestyle,生活方式,NOUN,B2
+christmas present,christmas present,圣诞礼物,NOUN,B2
+apart from,apart from,除了,ADP,B2
+part-time worker,part-time worker,兼职工,NOUN,B2
+central station,central station,中央车站,NOUN,B2
+based,based,基于,ADJ,B2
+cola,cola,可乐,NOUN,B2
+to be saved,to be saved,获救,VERB,B2
+smart clever,smart clever,聪明的,ADJ,B2
+to underline,to underline,强调,VERB,B2
+date fruit,date fruit,椰枣,NOUN,B2
+civilian,civilian,平民的,ADJ,B2
+trigger mechanism,trigger mechanism,,NOUN,B2
+sought,sought,,NOUN,B2
+to exist there is,to exist there is,存在/有,VERB,B2
+personal integrity,personal integrity,个人隐私,NOUN,B2
+to separate divorce,to separate divorce,分离/离婚,VERB,B2
+history story,history story,历史/故事,NOUN,B2
+away gone,away gone,不在/离开,ADV,B2
+legion unit,legion unit,,NOUN,B2
+the other day,the other day,前几天,ADV,B2
+dear,dear,,NOUN,B2
+xenophobia,xenophobia,排外心理,NOUN,B2
+stockholm,stockholm,斯德哥尔摩,PROPN,B2
+word choice,word choice,措辞,NOUN,B2
+ever,ever,,NOUN,B2
+indoors,indoors,在室内,ADV,B2
+omelette,omelette,煎蛋卷,NOUN,B2
+the it,the it,那,DET,B2
+to blink,to blink,眨眼,VERB,B2
+to acknowledge,to acknowledge,承认,VERB,B2
+cultural encounter,cultural encounter,文化交汇,NOUN,B2
+own,own,自己的,DET,B2
+the very,the very,正是,ADV,B2
+heart,heart,心,ADV,B2
+to mess around,to mess around,胡闹,VERB,B2
+cancelled set,cancelled set,取消的/设定的,ADJ,B2
+innermost,innermost,最里面的,ADV,B2
+sunglasses,sunglasses,太阳镜,NOUN,B2
+furthest,furthest,最远,ADV,B2
+to cook fix,to cook fix,做/修理,VERB,B2
+for because,for because,因为,CCONJ,B2
+pie,pie,派,NOUN,B2
+before previously,before previously,以前,ADV,B2
+beside,beside,在...旁边,ADP,B2
+coworker,coworker,同事,NOUN,B2
+yes indeed,yes indeed,正是,INTJ,B2
+to sneak away,to sneak away,溜走,VERB,B2
+headline,headline,标题,NOUN,B2
+farm yard,farm yard,农场,NOUN,B2
+to shop be about,to shop be about,购物,VERB,B2
+to kidnapped,to kidnapped,绑架,VERB,B2
+language use,language use,语言使用,NOUN,B2
+to watch out,to watch out,小心,VERB,B2
+eidsvold,eidsvold,,NOUN,B2
+to exemplify,to exemplify,举例说明,VERB,B2
+alarm center,alarm center,报警中心,NOUN,B2
+alder,alder,桤木,NOUN,B2
+blood test,blood test,验血,NOUN,B2
+dal,dal,山谷,NOUN,B2
+odds,odds,赔率,NOUN,B2
+to close eyes,to close eyes,闭眼,VERB,B2
+happily,happily,快乐地,ADV,B2
+devil bastard,devil bastard,混蛋,NOUN,B2
+cheaper,cheaper,更便宜的,ADJ,B2
+to bide,to bide,等待,VERB,B2
+capable good,capable good,能干的/优秀的,ADJ,B2
+property owner,property owner,房主,NOUN,B2
+dot,dot,点,NOUN,B2
+to acquaint,to acquaint,使熟悉,VERB,B2
+edging,edging,镶边,NOUN,B2
+the devil bastard,the devil bastard,混蛋,NOUN,B2
+alpha,alpha,阿尔法,NOUN,B2
+super high,super high,,NOUN,B2
+poor devil,poor devil,可怜虫,NOUN,B2
+to puncture deflate,to puncture deflate,刺破,VERB,B2
+sexily,sexily,性感地,ADV,B2
+more fun,more fun,更有趣的,ADJ,B2
+side page,side page,侧面/页,NOUN,B2
+to push through,to push through,推动,VERB,B2
+organically,organically,有机地,ADV,B2
+paralyzed,paralyzed,瘫痪的,ADJ,B2
+to regain,to regain,恢复,VERB,B2
+paternal grandmother,paternal grandmother,祖母,NOUN,B2
+to bark scold,to bark scold,吠/责骂,VERB,B2
+on board,on board,在船上,ADV,B2
+reply,reply,回复,NOUN,B2
+to get acquire,to get acquire,获得/弄到,VERB,B2
+ongoing,ongoing,进行中的,ADJ,B2
+ought,ought,应该,AUX,B2
+baptized,baptized,受洗的,ADJ,B2
+the chinese,the chinese,中国人,NOUN,B2
+free off,free off,空闲的/休假,ADJ,B2
+intelligence service,intelligence service,情报机构,NOUN,B2
+half hour,half hour,半小时,NOUN,B2
+to dismiss fire,to dismiss fire,解雇,VERB,B2
+seventeen,seventeen,十七,NUM,B2
+freedom of religion,freedom of religion,宗教自由,NOUN,B2
+police chief,police chief,警察局长,NOUN,B2
+lesbian,lesbian,女同性恋的,ADJ,B2
+knock,knock,敲击,NOUN,B2
+down there,down there,在那下面,ADV,B2
+high tall,high tall,高的,ADJ,B2
+death,death,致死,ADV,B2
+radiant,radiant,容光焕发的,ADJ,B2
+to have strength,to have strength,有力气,VERB,B2
+sabbath,sabbath,安息日,NOUN,B2
+marine corps,marine corps,海军陆战队,NOUN,B2
+seeker,seeker,寻求者,NOUN,B2
+to fall crash,to fall crash,坠落/猛冲,VERB,B2
+it neuter,it neuter,它 (中性),PRON,B2
+milk tooth,milk tooth,,NOUN,B2
+poison gas,poison gas,毒气,NOUN,B2
+full drunk,full drunk,满的/醉的,ADJ,B2
+tough guy,tough guy,硬汉,NOUN,B2
+to party,to party,狂欢,VERB,B2
+nicely nice,nicely nice,美好地,ADV,B2
+to lay put,to lay put,放,VERB,B2
+werewolf,werewolf,狼人,NOUN,B2
+to scout,to scout,侦察,VERB,B2
+good-looking person,good-looking person,帅哥/美女,NOUN,B2
+gangster,gangster,黑帮成员,NOUN,B2
+girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
+creep,creep,令人厌恶的人,NOUN,B2
+eider hunter,eider hunter,,NOUN,B2
+just over,just over,稍微超过,ADV,B2
+to give a ride,to give a ride,载送一程,VERB,B2
+fiancee,fiancee,未婚妻,NOUN,B2
+law team,law team,法律/团队,NOUN,B2
+quivering,quivering,颤抖的,ADJ,B2
+unarmed,unarmed,手无寸铁的,ADJ,B2
+meatballs,meatballs,肉丸,NOUN,B2
+datum,datum,日期,NOUN,B2
+inflammable,inflammable,易燃的,ADJ,B2
+confounded,confounded,该死的,ADJ,B2
+shedding,shedding,,NOUN,B2
+to blunder,to blunder,犯大错,VERB,B2
+to linger,to linger,徘徊,VERB,B2
+special agent,special agent,特工,NOUN,B2
+to bare,to bare,暴露,VERB,B2
+poorer,poorer,更穷的,ADJ,B2
+thank god,thank god,谢天谢地,INTJ,B2
+sixth,sixth,,NOUN,B2
+late,late,晚才,NOUN,B2
+delayed,delayed,延误的,ADJ,B2
+hamburger,hamburger,汉堡包,NOUN,B2
+rug,rug,地毯,NOUN,B2
+less,less,较少的,ADJ,B2
+dressed,dressed,穿着的,ADJ,B2
+top,top,顶部的,ADJ,B2
+knocked out,knocked out,被淘汰的,ADJ,B2
+all of it,all of it,全部,PRON,B2
+overfall,overfall,,NOUN,B2
+work task,work task,工作任务,NOUN,B2
+to mean entail,to mean entail,意味着,VERB,B2
+slower,slower,更慢,ADJ,B2
+all of them,all of them,大家,PRON,B2
+track trace,track trace,痕迹/轨道,NOUN,B2
+fair hair,fair hair,,NOUN,B2
+to make out,to make out,接吻,VERB,B2
+skater,skater,,NOUN,B2
+trainer,trainer,教练,NOUN,B2
+backward,backward,向后,ADV,B2
+to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
+retirement pension,retirement pension,退休金,NOUN,B2
+gas flame,gas flame,煤气火焰,NOUN,B2
+europe,europe,欧洲,PROPN,B2
+self-defense,self-defense,自卫,NOUN,B2
+closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
+visiting ban,visiting ban,,NOUN,B2
+to think opine,to think opine,认为,VERB,B2
+evening meal,evening meal,晚餐,NOUN,B2
+thinner,thinner,更薄的,ADJ,B2
+westward,westward,向西,ADV,B2
+calming,calming,令人平静的,ADJ,B2
+competition bastard,competition bastard,,NOUN,B2
+dying,dying,,NOUN,B2
+attitude setting,attitude setting,态度/设置,NOUN,B2
+turntable,turntable,,NOUN,B2
+convicted,convicted,被判罪的,ADJ,B2
+fifth,fifth,第五,NUM,B2
+shorter,shorter,更短的,ADJ,B2
+bigness,bigness,,NOUN,B2
+starting point,starting point,出发点,NOUN,B2
+beaten,beaten,被打败的,ADJ,B2
+open,open,开放地,ADV,B2
+outer,outer,外部的,ADJ,B2
+police report,police report,,NOUN,B2
+catholic,catholic,天主教徒,NOUN,B2
+steadily,steadily,稳定地,ADV,B2
+superhero,superhero,超级英雄,NOUN,B2
+to dejta,to dejta,约会,VERB,B2
+the cash register,the cash register,收银台,NOUN,B2
+protector,protector,保护者,NOUN,B2
+outward,outward,向外,ADV,B2
+born,born,出生的,ADJ,B2
+cleaner,cleaner,更干净的,ADJ,B2
+cykel,cykel,自行车,NOUN,B2
+destroyed,destroyed,被毁坏的,ADJ,B2
+ice pick,ice pick,,NOUN,B2
+tax return,tax return,报税,NOUN,B2
+dirtier,dirtier,更脏的,ADJ,B2
+sensibly,sensibly,明智地,ADV,B2
+to release let go,to release let go,释放/放手,VERB,B2
+tragically,tragically,悲剧地,ADV,B2
+lovely,lovely,美好的,ADJ,B2
+kids,kids,孩子,NOUN,B2
+sensor donor,sensor donor,传感器/捐献者,NOUN,B2
+sauna,sauna,桑拿,NOUN,B2
+to search apply,to search apply,寻找/申请,VERB,B2
+bow tie,bow tie,领结,NOUN,B2
+here you go,here you go,请,INTJ,B2
+to apply be valid,to apply be valid,适用/有效,VERB,B2
+in vain,in vain,徒劳,NOUN,B2
+shit crap,shit crap,废话,NOUN,B2
+like as,like as,如同/好像,ADV,B2
+upper class,upper class,上层,NOUN,B2
+poorest,poorest,最穷的,ADJ,B2
+sweden,sweden,瑞典,PROPN,B2
+salt shaker,salt shaker,,NOUN,B2
+state federal,state federal,州,NOUN,B2
+del,del,部分,NOUN,B2
+vile,vile,可憎地,ADV,B2
+inside of,inside of,在...里面,ADP,B2
+doughy,doughy,面团状的,ADJ,B2
+exactly just,exactly just,恰好,ADV,B2
+his her own,his her own,他/她自己的,DET,B2
+sentencing,sentencing,量刑,NOUN,B2
+christmas eve,christmas eve,平安夜,NOUN,B2
+time to go to bed,time to go to bed,该睡觉了,ADV,B2
+sense of duty,sense of duty,责任感,NOUN,B2
+that way,that way,往那边,ADV,B2
+giddy,giddy,头晕的,ADJ,B2
+rulebook,rulebook,规则体系,NOUN,B2
+electric guitar,electric guitar,电吉他,NOUN,B2
+richer,richer,更富的,ADJ,B2
+pain hurt,pain hurt,疼痛,ADJ,B2
+corrections,corrections,刑事司法,NOUN,B2
+to erect behave,to erect behave,建造,VERB,B2
+to tip,to tip,透露,VERB,B2
+trigger imprint,trigger imprint,印记,NOUN,B2
+yep,yep,是的,INTJ,B2
+compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
+dance floor,dance floor,舞池,NOUN,B2
+to be struck,to be struck,被打击,VERB,B2
+gas meter,gas meter,,NOUN,B2
+cracker,cracker,饼干,NOUN,B2
+corrupted,corrupted,,NOUN,B2
+to thrown,to thrown,扔,VERB,B2
+orphaned,orphaned,无父母的,ADJ,B2
+honor culture,honor culture,荣誉文化,NOUN,B2
+shame culture,shame culture,羞耻文化,NOUN,B2
+muffin,muffin,玛芬蛋糕,NOUN,B2
+saucy,saucy,下流的,ADJ,B2
+wonderful,wonderful,极好地,ADV,B2
+youngest,youngest,最年轻的,ADJ,B2
+personal best,personal best,,NOUN,B2
+life sentence,life sentence,无期徒刑,NOUN,B2
+warmer,warmer,更暖的,ADJ,B2
+pointlessly,pointlessly,徒劳地,ADV,B2
+devastated,devastated,崩溃的,ADJ,B2
+run over,run over,被碾过的,ADJ,B2
+supplies,supplies,必需品,NOUN,B2
+probable,probable,可能的,ADJ,B2
+stink,stink,恶臭,NOUN,B2
+to decimate,to decimate,大量削减,VERB,B2
+to light ignite,to light ignite,点燃,VERB,B2
+equally,equally,同样地,ADV,B2
+chest breast,chest breast,胸部/乳房,NOUN,B2
+terribleness,terribleness,,NOUN,B2
+game play,game play,游戏/比赛,NOUN,B2
+to be responsible,to be responsible,负责,VERB,B2
+in return,in return,作为回报,NOUN,B2
+to be ongoing,to be ongoing,进行中,VERB,B2
+mass media,mass media,大众媒体,NOUN,B2
+imprisoned,imprisoned,被监禁的,ADJ,B2
+swimwear,swimwear,,NOUN,B2
+in addition to,in addition to,除...之外,ADP,B2
+stiff glove,stiff glove,,NOUN,B2
+small things,small things,琐事,NOUN,B2
+message errand,message errand,消息/差事,NOUN,B2
+unsecured,unsecured,,NOUN,B2
+to be noticed,to be noticed,被注意到,VERB,B2
+above all,above all,,NOUN,B2
+hopelessly,hopelessly,绝望地,ADV,B2
+dredge,dredge,,NOUN,B2
+nuclear power,nuclear power,核能,NOUN,B2
+to get stuck,to get stuck,卡住,VERB,B2
+shame pity,shame pity,遗憾,NOUN,B2
+foreign strange,foreign strange,外国的/陌生的,ADJ,B2
+much,much,很多,ADV,B2
+business sector,business sector,商业界,NOUN,B2
+eastward,eastward,向东,ADV,B2
+cartel,cartel,卡特尔,NOUN,B2
+poisoned,poisoned,,NOUN,B2
+trainer bastard,trainer bastard,,NOUN,B2
+chiefly,chiefly,主要地,ADV,B2
+miss teacher,miss teacher,小姐/老师,NOUN,B2
+more expensive,more expensive,更贵的,ADJ,B2
+made,made,制成的,ADJ,B2
+brain damage,brain damage,,NOUN,B2
+the other evening,the other evening,前几天晚上,ADV,B2
+applicable,applicable,适用的,ADJ,B2
+to spray,to spray,喷洒,VERB,B2
+having a cold,having a cold,感冒的,ADJ,B2
+the cavalry,the cavalry,骑兵,NOUN,B2
+easier,easier,更容易的,ADJ,B2
+envious jealous,envious jealous,嫉妒的,ADJ,B2
+northward,northward,向北,ADV,B2
+in there,in there,在那里面,ADV,B2
+working method,working method,工作方式,NOUN,B2
+to box,to box,拳击,VERB,B2
+medical examiner,medical examiner,法医,NOUN,B2
+homeward,homeward,,NOUN,B2
+to be visible,to be visible,可见,VERB,B2
+from here,from here,从这里,ADV,B2
+blockhead,blockhead,笨蛋,NOUN,B2
+damm,damm,池塘,NOUN,B2
+to skip,to skip,跳过,VERB,B2
+backside,backside,臀部,NOUN,B2
+in private,in private,私下地,ADV,B2
+freedom of choice,freedom of choice,选择自由,NOUN,B2
+the emperor,the emperor,皇帝,NOUN,B2
+espresso,espresso,浓缩咖啡,NOUN,B2
+management pipe,management pipe,管理层/管道,NOUN,B2
+type like,type like,类型/比如,NOUN,B2
+southward,southward,向南,ADV,B2
+previous,previous,,NOUN,B2
+christmas porridge,christmas porridge,,NOUN,B2
+skin hide,skin hide,皮肤/皮革,NOUN,B2
+can jar,can jar,罐子,NOUN,B2
+to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
+exam evening,exam evening,,NOUN,B2
+consciously,consciously,有意识地,ADV,B2
+in mind,in mind,记住,ADV,B2
+to indicate interpret,to indicate interpret,表明/解释,VERB,B2
+emotional life,emotional life,情感生活,NOUN,B2
+to long,to long,渴望,VERB,B2
+perception opinion,perception opinion,看法,NOUN,B2
+released,released,获释的,ADJ,B2
+causal link,causal link,因果关系,NOUN,B2
+depressing,depressing,令人沮丧的,ADJ,B2
+standpoint,standpoint,立场,NOUN,B2
+truly,truly,确实,ADV,B2
+perishing,perishing,,NOUN,B2
+abuser,abuser,滥用者,NOUN,B2
+leftovers,leftovers,剩菜,NOUN,B2
+niceness,niceness,,NOUN,B2
+as far as,as far as,就……而言,ADV,B2
+to talk chat,to talk chat,聊天/谈论,VERB,B2
+from home,from home,从家里,ADV,B2
+tern path,tern path,,NOUN,B2
+striving,striving,追求,NOUN,B2
+blow beating,blow beating,殴打,NOUN,B2
+to bet invest,to bet invest,下注/投资,VERB,B2
+killed,killed,,NOUN,B2
+electrical theory,electrical theory,电学,NOUN,B2
+to go up in smoke,to go up in smoke,化为乌有,VERB,B2
+the chain,the chain,链条,NOUN,B2
+to drive herd,to drive herd,驱赶/推动,VERB,B2
+solid substantial,solid substantial,结实的/大量的,ADJ,B2
+data protection,data protection,数据保护,NOUN,B2
+to duck,to duck,躲避,VERB,B2
+kin,kin,宗族,NOUN,B2
+preconception,preconception,,NOUN,B2
+socially,socially,在社会上,ADV,B2
+partial norm,partial norm,分范,NOUN,B2
+one machine,one machine,一架,NUM,B2
+proactive,proactive,积极主动的,ADJ,B2
+domestic debt,domestic debt,内债,NOUN,B2
+sufficient flight,sufficient flight,飞够,NOUN,B2
+he she,he she,伊,PRON,B2
+mangosteen,mangosteen,山竹,NOUN,B2
+meridian,meridian,经脉,NOUN,B2
+toast,toast,你敬酒,NOUN,B2
+just,just,公正,ADJ,B2
+social custom,social custom,社会习俗,NOUN,B2
+amended generality,amended generality,改般,NOUN,B2
+jeans,jeans,牛仔裤,NOUN,B2
+crafty,crafty,狡猾,ADJ,B2
+trite,trite,陈腐的,ADJ,B2
+to wash with water,to wash with water,水洗,VERB,B2
+half-day,half-day,半天,NOUN,B2
+to extort a bribe,to extort a bribe,索贿,VERB,B2
+sub-reality,sub-reality,分实,NOUN,B2
+hard to measure,hard to measure,难以衡量,ADJ,B2
+to for example,to for example,比如,VERB,B2
+rethinking,rethinking,重想,NOUN,B2
+warrant,warrant,令状,NOUN,B2
+recounting,recounting,再叙,NOUN,B2
+to concern all,to concern all,凡事,VERB,B2
+timely,timely,适时,ADJ,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+foul smell,foul smell,骚味,NOUN,B2
+human life,human life,人命,NOUN,B2
+social value,social value,社会价值,NOUN,B2
+to donate blood,to donate blood,献血,VERB,B2
+hardship,hardship,艰难,NOUN,B2
+rehearsal,rehearsal,排练,NOUN,B2
+otherwise,otherwise,要不,PART,B2
+shooting star,shooting star,流星,NOUN,B2
+changed work,changed work,改工,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+your arrow,your arrow,若非你一箭,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
+amended synthesis,amended synthesis,改综,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+feudal ethics,feudal ethics,礼教,NOUN,B2
+very deep,very deep,很深,ADJ,B2
+bungee jumping,bungee jumping,蹦极,NOUN,B2
+non-knot,non-knot,非结,NOUN,B2
+bizarre case,bizarre case,奇案,NOUN,B2
+provocative,provocative,挑衅的,ADJ,B2
+non-possible,non-possible,非可,NOUN,B2
+main camp,main camp,大营,NOUN,B2
+imperial father,imperial father,父皇,NOUN,B2
+tendering,tendering,招标,NOUN,B2
+characteristic feature,characteristic feature,特点,NOUN,B2
+adversity,adversity,逆境,NOUN,B2
+partial basis,partial basis,分据,NOUN,B2
+waist token,waist token,腰牌,NOUN,B2
+sister yu,sister yu,俞姐,NOUN,B2
+no matter what,no matter what,无论,ADV,B2
+one building,one building,一座,NUM,B2
+to finally,to finally,你可算,VERB,B2
+how enough,how enough,哪够,NOUN,B2
+which seat,which seat,哪座,NOUN,B2
+succinct,succinct,简明的,ADJ,B2
+to seek peace,to seek peace,主和,VERB,B2
+case details,case details,案情,NOUN,B2
+motto,motto,座右铭,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+social activity,social activity,社会活动,NOUN,B2
+survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
+malicious words,malicious words,恶言,NOUN,B2
+social mediation,social mediation,社会调解,NOUN,B2
+gearbox,gearbox,变速箱,NOUN,B2
+hyper-target,hyper-target,超的,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+departure lounge,departure lounge,候机室,NOUN,B2
+social fairness,social fairness,社会公平,NOUN,B2
+to hope for,to hope for,盼望,VERB,B2
+great victory,great victory,大胜,NOUN,B2
+not bad,not bad,不错,ADJ,B2
+amended particular,amended particular,改特,NOUN,B2
+shopping mall,shopping mall,商场,NOUN,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
+wanting you,wanting you,要你,NOUN,B2
+to be afraid,to be afraid,害怕,VERB,B2
+re-criterion,re-criterion,重准,NOUN,B2
+non-technique,non-technique,非术,NOUN,B2
+cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
+earnest sincere,earnest sincere,恳切,ADJ,B2
+town mayor,town mayor,镇长,NOUN,B2
+traditional chinese painting,traditional chinese painting,国画,NOUN,B2
+acrobatics,acrobatics,杂技,NOUN,B2
+disposable diaper,disposable diaper,纸尿裤,NOUN,B2
+prudent,prudent,谨慎的,ADJ,B2
+inner heart,inner heart,内心,NOUN,B2
+walnut,walnut,核桃,NOUN,B2
+affordability,affordability,得起,NOUN,B2
+how dare,how dare,岂敢,NOUN,B2
+non-iron,non-iron,免烫,ADJ,B2
+to do what,to do what,干嘛,VERB,B2
+virtual reality,virtual reality,虚拟现实,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+kneeling,kneeling,跪,NOUN,B2
+reverse result,reverse result,反果,NOUN,B2
+dense forest,dense forest,密林,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+changed route,changed route,改路,NOUN,B2
+to thresh,to thresh,脱粒,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+overthinking,overthinking,你想多,NOUN,B2
+non-necessary,non-necessary,非必,NOUN,B2
+incremental,incremental,渐进性,ADJ,B2
+outer-gate,outer-gate,外门,NOUN,B2
+star search,star search,找星,NOUN,B2
+reverse origin,reverse origin,反原,NOUN,B2
+adequacy,adequacy,也不错,NOUN,B2
+inversion,inversion,反演,NOUN,B2
+from away from,from away from,离,ADP,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+that evening,that evening,当晚,NOUN,B2
+film roll,film roll,胶卷,NOUN,B2
+upper part,upper part,上部,NOUN,B2
+to shut up,to shut up,闭嘴,VERB,B2
+not good,not good,不好,ADJ,B2
+social progress,social progress,社会进步,NOUN,B2
+altogether,altogether,共,ADV,B2
+modified ability,modified ability,改能,NOUN,B2
+sucking,sucking,嗦,NOUN,B2
+not very good,not very good,不太好,ADJ,B2
+spiral pattern,spiral pattern,旋纹,NOUN,B2
+sticky note,sticky note,便签,NOUN,B2
+could it be,could it be,难不成,ADJ,B2
+outfit,outfit,服装,NOUN,B2
+meridians,meridians,筋脉,NOUN,B2
+re-grading,re-grading,改级,NOUN,B2
+my scrutiny,my scrutiny,我看你,NOUN,B2
+it is a pity,it is a pity,可惜,ADJ,B2
+polytunnel,polytunnel,大棚,NOUN,B2
+summer grass,summer grass,夏草,NOUN,B2
+now,now,此刻,NOUN,B2
+brook no delay,brook no delay,刻不容缓,ADJ,B2
+cilantro,cilantro,香菜,NOUN,B2
+further debate,further debate,再辩,NOUN,B2
+to act rashly,to act rashly,妄动,VERB,B2
+will surely,will surely,定会,AUX,B2
+heavy snow,heavy snow,大雪,NOUN,B2
+foot-warming,foot-warming,捂脚,NOUN,B2
+floating dust,floating dust,浮尘,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+cut off,cut off,割下,NOUN,B2
+surfing,surfing,冲浪,NOUN,B2
+well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
+not intentional,not intentional,不是故意,ADJ,B2
+all day,all day,整天,ADV,B2
+modern dance,modern dance,现代舞,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+to ambush,to ambush,埋伏,VERB,B2
+alumnus,alumnus,校友,NOUN,B2
+to transfer schools,to transfer schools,转学,VERB,B2
+um,um,嗯,INTJ,B2
+altered art,altered art,改艺,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+heart disease,heart disease,心脏病,NOUN,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+singularity,singularity,单一性,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+big data,big data,大数据,NOUN,B2
+charades,charades,打哑谜,NOUN,B2
+this matter,this matter,这事,NOUN,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+bloodshed,bloodshed,血腥,NOUN,B2
+re-argument,re-argument,重论,NOUN,B2
+foreign debt,foreign debt,外债,NOUN,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+side effect,side effect,副作用,NOUN,B2
+measure word flat objects,measure word flat objects,张,NOUN,B2
+hyper-origin,hyper-origin,超原,NOUN,B2
+but also,but also,但也,NOUN,B2
+captive,captive,俘虏,NOUN,B2
+cannot stay,cannot stay,不住,PART,B2
+moisture-proof,moisture-proof,防潮,ADJ,B2
+taking command,taking command,挂帅,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+re-concretization,re-concretization,再具,NOUN,B2
+jianghu world,jianghu world,江湖上,NOUN,B2
+as expected,as expected,果然,ADV,B2
+to return a car,to return a car,送车,VERB,B2
+for to,for to,为,ADP,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+entrapment,entrapment,身陷,NOUN,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+running around,running around,跑遍,NOUN,B2
+this indeed,this indeed,这倒,NOUN,B2
+quick lie-down,quick lie-down,快躺,NOUN,B2
+notepad,notepad,记事本,NOUN,B2
+courtyard guard,courtyard guard,护院,NOUN,B2
+major case,major case,大案,NOUN,B2
+elective course,elective course,选修课,NOUN,B2
+tactile paving,tactile paving,盲道,NOUN,B2
+to befriend,to befriend,与...交朋友,VERB,B2
+to not run,to not run,别跑,VERB,B2
+to raise funds,to raise funds,筹资,VERB,B2
+anti-universality,anti-universality,反普,NOUN,B2
+credentials,credentials,国书,NOUN,B2
+enoki mushroom,enoki mushroom,金针菇,NOUN,B2
+gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
+shh,shh,嘘,INTJ,B2
+to file for record,to file for record,备案,VERB,B2
+bound to,bound to,势必,ADV,B2
+grab,grab,揪,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
+sports exercise,sports exercise,运动,NOUN,B2
+red robe,red robe,红衣,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+borrowed knife,borrowed knife,借刀,NOUN,B2
+sound sleep,sound sleep,你踏实睡,NOUN,B2
+reincarnation,reincarnation,再体,NOUN,B2
+express car,express car,快车,NOUN,B2
+non-view,non-view,非观,NOUN,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to lose bid,to lose bid,落标,VERB,B2
+super-form,super-form,超形,NOUN,B2
+car wash,car wash,洗车,NOUN,B2
+can be at,can be at,可在,NOUN,B2
+to fall behind,to fall behind,落后,VERB,B2
+void,void,最无,NOUN,B2
+older sister,older sister,姐姐,NOUN,B2
+fax,fax,传真,NOUN,B2
+sha dynasty,sha dynasty,砂朝,NOUN,B2
+multi-level garage,multi-level garage,立体车库,NOUN,B2
+heaven and earth,heaven and earth,天地,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+to statistics,to statistics,统计,VERB,B2
+dignified manner,dignified manner,威仪,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+emphasize,emphasize,着重,ADV,B2
+to reflect on,to reflect on,思考,VERB,B2
+that pair,that pair,那付,NOUN,B2
+your photo,your photo,照你,NOUN,B2
+loud and clear,loud and clear,响亮,ADJ,B2
+unreasonable,unreasonable,不情,NOUN,B2
+cause of defeat,cause of defeat,败因,NOUN,B2
+good medicine,good medicine,好药,NOUN,B2
+that which,that which,所,PART,B2
+counter-boundary,counter-boundary,反界,NOUN,B2
+classifier for documents portions,classifier for documents portions,份,NOUN,B2
+plain and simple,plain and simple,朴素,ADJ,B2
+too small,too small,太小,ADJ,B2
+all night,all night,通宵,NOUN,B2
+plasma,plasma,血浆,NOUN,B2
+subcategory,subcategory,分目,NOUN,B2
+year by year,year by year,逐年,ADV,B2
+i,i,我连,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+to lack basis,to lack basis,无据,VERB,B2
+cantaloupe,cantaloupe,哈密瓜,NOUN,B2
+to not lose,to not lose,别丢,VERB,B2
+worry-free,worry-free,无忧,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+breakthrough,breakthrough,突破性,ADJ,B2
+lover sweetheart,lover sweetheart,情人,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
+traffic light,traffic light,红绿灯,NOUN,B2
+audio equipment,audio equipment,音响,NOUN,B2
+neighborhood head,neighborhood head,里长,NOUN,B2
+paternity leave,paternity leave,陪产假,NOUN,B2
+exchange goods,exchange goods,换货,NOUN,B2
+next week,next week,下周,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+to linkage,to linkage,联动,VERB,B2
+eyes,eyes,眼中,NOUN,B2
+nadir,nadir,最低点,NOUN,B2
+social morality,social morality,社会公德,NOUN,B2
+to die for,to die for,死要,VERB,B2
+quick removal,quick removal,赶快脱,NOUN,B2
+i'm afraid,i'm afraid,恐怕,ADV,B2
+extreme height,extreme height,极高,NOUN,B2
+marriage leave,marriage leave,婚假,NOUN,B2
+special-purpose trip,special-purpose trip,专程,ADV,B2
+housework,housework,家务,NOUN,B2
+i-than,i-than,我比,NOUN,B2
+mulberry,mulberry,桑葚,NOUN,B2
+inner side,inner side,内侧,NOUN,B2
+sex appeal,sex appeal,性感,NOUN,B2
+trans-idealism,trans-idealism,超唯,NOUN,B2
+to recommend for admission,to recommend for admission,保送,VERB,B2
+usb flash drive,usb flash drive,U盘,NOUN,B2
+holy decree,holy decree,圣令,NOUN,B2
+to study deeply,to study deeply,钻研,VERB,B2
+why not,why not,何不,ADV,B2
+super-distinction,super-distinction,超殊,NOUN,B2
+my taking,my taking,我拿,NOUN,B2
+foe,foe,敌友,NOUN,B2
+explosion-proof,explosion-proof,防爆,ADJ,B2
+this route,this route,这路,NOUN,B2
+birthmark,birthmark,胎记,NOUN,B2
+financial center,financial center,金融中心,NOUN,B2
+pounding,pounding,捶,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+be sorry,be sorry,抱歉,ADJ,B2
+trans-induction,trans-induction,超归,NOUN,B2
+to seek you,to seek you,寻你,VERB,B2
+eldest brother,eldest brother,做大哥,NOUN,B2
+second letter,second letter,再信,NOUN,B2
+counter-belief,counter-belief,反信,NOUN,B2
+past events,past events,往事,NOUN,B2
+swordsmanship,swordsmanship,剑术,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+logic modification,logic modification,改逻,NOUN,B2
+crowded,crowded,拥挤,ADJ,B2
+super-internal,super-internal,超内,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+nuclear energy,nuclear energy,核能,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+law,law,法,PART,B2
+zen master,zen master,禅师,NOUN,B2
+bluntness,bluntness,直说,NOUN,B2
+intravenous drip,intravenous drip,输液,NOUN,B2
+for a time,for a time,一度,ADV,B2
+cause of change,cause of change,改因,NOUN,B2
+equally matched,equally matched,不相上下,ADJ,B2
+external hard drive,external hard drive,移动硬盘,NOUN,B2
+immobility,immobility,都无动,NOUN,B2
+land expansion,land expansion,拓土,NOUN,B2
+pushover,pushover,善茬,NOUN,B2
+family background,family background,出身,NOUN,B2
+on the spot,on the spot,当场,ADV,B2
+sea level rise,sea level rise,海平面上升,NOUN,B2
+no not,no not,不,ADV,B2
+nephews,nephews,子侄,NOUN,B2
+common sense,common sense,常识,NOUN,B2
+revised image,revised image,改影,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+according to,according to,要照,NOUN,B2
+spending,spending,行用,NOUN,B2
+re-analysis,re-analysis,重析,NOUN,B2
+homestay,homestay,民宿,NOUN,B2
+at worst,at worst,大不了,ADV,B2
+stuffed crab,stuffed crab,蟹酿,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+creditor's rights,creditor's rights,债权,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+sick leave,sick leave,病假,NOUN,B2
+month ago,month ago,月前,NOUN,B2
+altered path,altered path,改径,NOUN,B2
+to pay off,to pay off,清偿,VERB,B2
+medal awarding,medal awarding,授勋,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+in those days,in those days,当年,NOUN,B2
+cutting grass,cutting grass,斩草,NOUN,B2
+main street,main street,大街,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+exchange meeting,exchange meeting,交流会,NOUN,B2
+high-speed,high-speed,高速,ADJ,B2
+senior male student,senior male student,学长,NOUN,B2
+trans-er,trans-er,超而,NOUN,B2
+over-skill,over-skill,超技,NOUN,B2
+can-exit,can-exit,还出得来,NOUN,B2
+polyester,polyester,涤纶,NOUN,B2
+retrial,retrial,再审,NOUN,B2
+then he,then he,那他,NOUN,B2
+to eavesdrop,to eavesdrop,偷听,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+not catch up,not catch up,非赶,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+good faith,good faith,信义,NOUN,B2
+recycled item,recycled item,再物,NOUN,B2
+non-number,non-number,非数,NOUN,B2
+amended possibility,amended possibility,改可,NOUN,B2
+initial stage,initial stage,初期,NOUN,B2
+social awareness,social awareness,社会觉悟,NOUN,B2
+coral reef,coral reef,珊瑚礁,NOUN,B2
+to send mail,to send mail,寄件,VERB,B2
+death news,death news,死讯,NOUN,B2
+able to play,able to play,能下,NOUN,B2
+supreme fate,supreme fate,上缘,NOUN,B2
+re-tolerance,re-tolerance,再容,NOUN,B2
+white blood cell,white blood cell,白细胞,NOUN,B2
+mock exam,mock exam,模拟考,NOUN,B2
+heavy effect,heavy effect,重效,NOUN,B2
+hearth,hearth,壁炉,NOUN,B2
+to wanted,to wanted,通缉,VERB,B2
+to dry clean,to dry clean,干洗,VERB,B2
+return destination,return destination,回哪,NOUN,B2
+historical site,historical site,古迹,NOUN,B2
+patient sufferer,patient sufferer,患者,NOUN,B2
+simple pure,simple pure,单纯,ADJ,B2
+re-basis,re-basis,再据,NOUN,B2
+taro,taro,芋头,NOUN,B2
+re-route,re-route,重路,NOUN,B2
+listening,listening,也听,NOUN,B2
+stone,stone,石,PART,B2
+main road,main road,主路,NOUN,B2
+sub-method,sub-method,分法,NOUN,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+moonlight,moonlight,月色,NOUN,B2
+your word,your word,听你,NOUN,B2
+happy event,happy event,喜事,NOUN,B2
+this sword,this sword,这剑,NOUN,B2
+jujube,jujube,枣子,NOUN,B2
+proclamation,proclamation,宣大,NOUN,B2
+eavesdropping,eavesdropping,偷听,NOUN,B2
+procedural,procedural,程序的,ADJ,B2
+medical care,medical care,医疗,NOUN,B2
+missile,missile,导弹,NOUN,B2
+inside in,inside in,里,NOUN,B2
+great joy,great joy,大喜,NOUN,B2
+direct sales,direct sales,直销,NOUN,B2
+radiotherapy,radiotherapy,放疗,NOUN,B2
+you except,you except,你除,NOUN,B2
+herbicide,herbicide,除草剂,NOUN,B2
+over-degree,over-degree,超阶,NOUN,B2
+core course,core course,核心课,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+non-theory,non-theory,非论,NOUN,B2
+to not seen,to not seen,不见,VERB,B2
+all at once,all at once,一下子,ADV,B2
+re-verification,re-verification,改证,NOUN,B2
+mutual treatment,mutual treatment,相待,NOUN,B2
+too big,too big,太大,ADJ,B2
+to break a record,to break a record,打破纪录,VERB,B2
+final exam,final exam,期末考,NOUN,B2
+anti-static,anti-static,防静电,ADJ,B2
+boundless,boundless,无疆,NOUN,B2
+to serve as,to serve as,充当,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+re-substance,re-substance,再质,NOUN,B2
+light rain,light rain,小雨,NOUN,B2
+undercover agent,undercover agent,卧底,NOUN,B2
+little bitch,little bitch,小婊子,NOUN,B2
+who polite,who polite,哪位,PRON,B2
+to pioneer,to pioneer,首创,VERB,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+over-model,over-model,超模,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+certain fall,certain fall,必倒,NOUN,B2
+anticyclone,anticyclone,反气旋,NOUN,B2
+safe haven,safe haven,避风港,NOUN,B2
+supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
+reordering,reordering,改序,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+air raid,air raid,空袭,NOUN,B2
+to fall down,to fall down,倒下,VERB,B2
+historical record,historical record,历史纪录,NOUN,B2
+re-possibility,re-possibility,重可,NOUN,B2
+larger,larger,再大,NOUN,B2
+wind speed,wind speed,风速,NOUN,B2
+award ceremony,award ceremony,颁奖典礼,NOUN,B2
+super-special,super-special,超特,NOUN,B2
+graduate student,graduate student,研究生,NOUN,B2
+machine learning,machine learning,机器学习,NOUN,B2
+random posting,random posting,乱贴,NOUN,B2
+unwinnable,unwinnable,打不赢,NOUN,B2
+postwar,postwar,战后,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+third place,third place,季军,NOUN,B2
+family happiness,family happiness,天伦之乐,NOUN,B2
+hot water,hot water,热水,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+two days,two days,两天,NUM,B2
+guqin,guqin,古琴,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
+table grape,table grape,提子,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+over-order,over-order,超序,NOUN,B2
+everyone,everyone,各位,NOUN,B2
+heavy capacity,heavy capacity,重容,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+pipa,pipa,琵琶,NOUN,B2
+so as not to,so as not to,免得,SCONJ,B2
+war cessation,war cessation,战息,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
+perilla,perilla,紫苏,NOUN,B2
+re-specialization,re-specialization,重特,NOUN,B2
+panda,panda,熊猫,NOUN,B2
+sum total,sum total,总而,NOUN,B2
+adolescent,adolescent,青少年,NOUN,B2
+rights and interests,rights and interests,权益,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+unstoppable,unstoppable,不可阻挡,ADJ,B2
+why bother,why bother,何必,ADV,B2
+overthrow,overthrow,扳倒,NOUN,B2
+chest stab,chest stab,胸刺,NOUN,B2
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
+rashly,rashly,轻举,ADV,B2
+social structure,social structure,社会结构,NOUN,B2
+revealing,revealing,现出,NOUN,B2
+amended unity,amended unity,改一,NOUN,B2
+hedonistic,hedonistic,享乐主义的,ADJ,B2
+to strive for,to strive for,争取,VERB,B2
+two people,two people,两名,NUM,B2
+social movement,social movement,社会运动,NOUN,B2
+dare gamble,dare gamble,敢赌,NOUN,B2
+change of mind,change of mind,改念,NOUN,B2
+push further,push further,进尺,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+hyper-intent,hyper-intent,超意,NOUN,B2
+to send back,to send back,传回,VERB,B2
+social ethos,social ethos,社会风气,NOUN,B2
+non-observation,non-observation,非察,NOUN,B2
+ceramic art,ceramic art,陶艺,NOUN,B2
+re-observation,re-observation,再观,NOUN,B2
+young wife,young wife,小媳,NOUN,B2
+visibility,visibility,能见度,NOUN,B2
+excretion,excretion,排泄,NOUN,B2
+eavesdrop,eavesdrop,营听,NOUN,B2
+senior,senior,前辈,NOUN,B2
+to wiretap,to wiretap,监听,VERB,B2
+entering home,entering home,进家,NOUN,B2
+hundred million,hundred million,亿,NUM,B2
+ginseng,ginseng,人参,NOUN,B2
+non-sudden,non-sudden,非骤,NOUN,B2
+later stage,later stage,后期,NOUN,B2
+windy day,windy day,风天,NOUN,B2
+nickel,nickel,镍,NOUN,B2
+scenic spot,scenic spot,名胜,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+super-observation,super-observation,超察,NOUN,B2
+big dipper,big dipper,北斗七星,NOUN,B2
+quite good,quite good,挺好,NOUN,B2
+limbs,limbs,手脚,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+unsolved case,unsolved case,疑案,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to love dearly,to love dearly,心疼,VERB,B2
+military pay,military pay,军饷,NOUN,B2
+over-side,over-side,超方,NOUN,B2
+annual leave,annual leave,年假,NOUN,B2
+to be far from,to be far from,绝非,VERB,B2
+substantive,substantive,实质性的,ADJ,B2
+empress mother,empress mother,你母后,NOUN,B2
+both eyes,both eyes,双眼,NOUN,B2
+rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
+waiter attendant,waiter attendant,服务员,NOUN,B2
+your head,your head,你头上,NOUN,B2
+but majesty,but majesty,可陛,NOUN,B2
+energy saving,energy saving,节能,NOUN,B2
+to use force,to use force,动武,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+national record,national record,全国纪录,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
+to work part-time,to work part-time,打工,VERB,B2
+social phenomenon,social phenomenon,社会现象,NOUN,B2
+super-number,super-number,超数,NOUN,B2
+king,king,王,PART,B2
+flanking,flanking,包抄,NOUN,B2
+coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
+snow lotus,snow lotus,雪莲,NOUN,B2
+personal effort,personal effort,亲力,NOUN,B2
+at the instant sth happens,at the instant sth happens,临时,ADV,B2
+next meeting,next meeting,下回遇,NOUN,B2
+to await orders,to await orders,待命,VERB,B2
+equal size,equal size,等大,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+re-generalization,re-generalization,重般,NOUN,B2
+project report,project report,项目报告,NOUN,B2
+local tyrant,local tyrant,豪强,NOUN,B2
+chinese cabbage,chinese cabbage,白菜,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+peephole,peephole,门镜,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+army morale,army morale,军心,NOUN,B2
+social hierarchy,social hierarchy,社会等级,NOUN,B2
+that is to say,that is to say,也就是说,SCONJ,B2
+value change,value change,改值,NOUN,B2
+what kind,what kind,什么样,PRON,B2
+punitive,punitive,惩罚性的,ADJ,B2
+mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+to follow up,to follow up,追问,VERB,B2
+non-righteousness,non-righteousness,非义,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+your parents,your parents,你爹娘,NOUN,B2
+two sons,two sons,儿俩,NOUN,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+over-form,over-form,超式,NOUN,B2
+hard to determine,hard to determine,难以确定,ADJ,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+don't,don't,可别,AUX,B2
+to be located at,to be located at,位于,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
+amber,amber,琥珀,NOUN,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
+architecture photo,architecture photo,建筑照,NOUN,B2

--- a/german/expansion.csv
+++ b/german/expansion.csv
@@ -1,101 +1,199 @@
 German_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
 -lich,-ly,地,PART,B2
-Abdeckung,cover,封面,NOUN,B2
-Abenteurer,adventurer,冒险家,NOUN,B2
-Aberglaube,superstition,迷信,NOUN,B2
-Abfall,waste,浪费,NOUN,B2
-Abfluss,drain,排水沟,NOUN,B2
-Abgrund,abyss,深渊,NOUN,B2
-Abkommando,detachment,脱落,NOUN,B2
-Ablauf,expiry,失效,NOUN,B2
-Ablehnung,recusal,回避,NOUN,B2
-Ablehnung,rejection,拒绝,NOUN,B2
-Ableitung,derivative,衍生物,NOUN,B2
-Abonnement,subscription,订阅,NOUN,B2
-Abonnent,subscriber,订阅者,NOUN,B2
-Abrieb,abrasion,擦伤,NOUN,B2
-Abriss,demolition,拆除,NOUN,B2
-Abritt,horse departure,马去,NOUN,B2
-Abschreibung,depreciation,贬值,NOUN,B2
-Absicht,intent,意图,NOUN,B2
-Abstammung,ancestry,血统,NOUN,B2
-Abstieg,descent,下降,NOUN,B2
-Abstimmung,voting,投票,NOUN,B2
-Abstufung,gradation,渐变,NOUN,B2
-Abszess,abscess,脓肿,NOUN,B2
-Abteilungsleiter,department head,厅长,NOUN,B2
+der,a,一个,DET,B2
+wenig,a little,一点,ADJ,B2
+Paar,a married couple,夫妇,NOUN,B2
+Paar,a pair,一对,NUM,B2
+Haufen,a pile,一堆,NUM,B2
+Brunnen,a well,井,NOUN,B2
+verlassen,to abandon,放弃,VERB,B2
+Verlassen,abandonment,抛弃,NOUN,B2
+abtreten,to abdicate,退位,VERB,B2
+verabscheuen,to abhor,憎恶,VERB,B2
 Abtreibung,abortion,流产,NOUN,B2
-Abwehr,repulse,击退,NOUN,B2
-Abweichung,deviation,偏离,NOUN,B2
-Achse,axis,轴,NOUN,B2
-Achtung,esteem,尊重,NOUN,B2
-Adipositas,obesity,肥胖,NOUN,B2
+über,about,关于,ADP,B2
+über,above,在...之上,ADP,B2
+Abrieb,abrasion,擦伤,NOUN,B2
+abrupt,abrupt,突然的,ADJ,B2
+Abszess,abscess,脓肿,NOUN,B2
+fliehen,to abscond,潜逃,VERB,B2
+abwesend,absent,缺席的,ADJ,B2
+Zerstreutheit,absent-mindedness,心不在焉,NOUN,B2
+absolut,absolute,绝对的,ADJ,B2
+absorbieren,to absorb,吸收,VERB,B2
+abstrus,abstruse,深奥的,ADJ,B2
+absurd,absurd,荒谬的,ADJ,B2
+Abgrund,abyss,深渊,NOUN,B2
+akademisch,academic,学术的,ADJ,B2
+Beschleunigung,acceleration,加速,NOUN,B2
+Beschleuniger,accelerator,油门,NOUN,B2
+Beitritt,accession,即位,NOUN,B2
+zufällig,accidental,偶然的,ADJ,B2
+unterbringen,to accommodate,容纳,VERB,B2
+Übereinstimmung,accord with,合乎,NOUN,B2
+Rechenschaftspflicht,accountability,问责制,NOUN,B2
+Buchhalter,accountant,会计师,NOUN,B2
+Buchhaltung,accounting,会计,NOUN,B2
+accredit,to accredit,认可,VERB,B2
+accredited,accredited,认可的,ADJ,B2
+accumulate,to accumulate,积累,VERB,B2
+accumulation,accumulation,积累,NOUN,B2
+accurate,accurate,准确的,ADJ,B2
+accustom,to accustom,使习惯,VERB,B2
+accustomed,accustomed,习惯的,ADJ,B2
+achieve,to achieve,实现,VERB,B2
+acid,acid,酸,NOUN,B2
+acidity,acidity,酸度,NOUN,B2
+acquire,to acquire,获得,VERB,B2
+acquisition,acquisition,获得,NOUN,B2
+acquit,to acquit,宣告无罪,VERB,B2
+acquittal,acquittal,无罪释放,NOUN,B2
+acrimony,acrimony,尖刻,NOUN,B2
+acrobat,acrobat,杂技演员,NOUN,B2
+across,across,穿过,ADP,B2
+act jointly,act jointly,合伙,NOUN,B2
+acting,acting,行为,NOUN,B2
+actual,actual,实际的,ADJ,B2
+acute,acute,剧烈的,ADJ,B2
+adaptation,adaptation,适应,NOUN,B2
+addict,addict,上瘾者,NOUN,B2
+addiction,addiction,上瘾,NOUN,B2
+addition,addition,增加,NOUN,B2
+additional,additional,额外的,ADJ,B2
+adequate,adequate,足够的,ADJ,B2
+adjacency,adjacency,邻接,NOUN,B2
+adjacent,adjacent,邻近的,ADJ,B2
+adjust,to adjust,调整,VERB,B2
+administration,administration,管理,NOUN,B2
+administrative,administrative,行政的,ADJ,B2
+admiral,admiral,海军上将,NOUN,B2
+adoption,adoption,收养,NOUN,B2
+adornment,adornment,装饰品,NOUN,B2
+verfälschen,to adulterate,掺杂,VERB,B2
+Erwachsenenalter,adulthood,成年,NOUN,B2
+vorrücken,advance,进展,NOUN,B2
+vorrücken,to advance,前进,VERB,B2
+Vorauszahlung,advance payment,预付款,NOUN,B2
+Aufbaustudium,advanced study,深造,NOUN,B2
+fortschrittlich,advanced technology,先进,ADJ,B2
+vorteilhaft,advantageous,有利的,ADJ,B2
+Abenteurer,adventurer,冒险家,NOUN,B2
+befürworten,to advocate,提倡,VERB,B2
+luftgestützt,aerial,航空的,ADJ,B2
+ästhetisch,aesthetic,审美的,ADJ,B2
+Ästhetik,aesthetics,美学,NOUN,B2
+umgänglich,affable,和蔼可亲的,ADJ,B2
+Festsaal,affair hall,事殿,NOUN,B2
+beeinflussen,to affect,影响,VERB,B2
 Affektiertheit,affectation,做作,NOUN,B2
-African,African,词,ADJ,B1
+Zugehörigkeit,affiliation,隶属关系,NOUN,B2
+bestätigen,to affirm,断言,VERB,B2
+plagen,to afflict,折磨,VERB,B2
+erschwinglich,affordable,负担得起的,ADJ,B2
+Aufforstung,afforestation,植树造林,NOUN,B2
+ängstlich,afraid,害怕的,ADJ,B2
+Nachher,after,تلو,NOUN,B2
+Nachwirkung,aftereffect,后遗症，后果,NOUN,B2
+Nachher,afterward,去后,NOUN,B2
+Wiederholung,again,你又,NOUN,B2
 Agent,agent,代理人,NOUN,B2
 Aggression,aggression,侵略,NOUN,B2
 Aggressivität,aggressiveness,攻击性,NOUN,B2
+agil,agile,敏捷的,ADJ,B2
 Agilität,agility,敏捷,NOUN,B2
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Aktienmarkt,stock market,股市,NOUN,B2
-Aktionär,shareholder,股东,NOUN,B2
+Qual,agony,极度痛苦,NOUN,B2
+landwirtschaftlich,agricultural,农业的,ADJ,B2
+ah,ah,啊,INTJ,B2
+Ziel,aim,目标,NOUN,B2
+Klimaanlage,air conditioning,空调,NOUN,B2
+Luftabwehr,air defense,防空,NOUN,B2
 Alarm,alarm,警报,NOUN,B2
-Alawi,Alawi,词,NOUN,C1
+ach,alas,唉,INTJ,B2
 Album,album,相册,NOUN,B2
+Warnung,alert,警觉的,ADJ,B2
 Algebra,algebra,代数,NOUN,B2
 Algorithmus,algorithm,算法,NOUN,B2
-Alice,Alice,词,NOUN,B2
+Entfremdung,alienation,异化,NOUN,B2
+Ausrichtung,alignment,结盟,NOUN,B2
+Unterhalt,alimony,赡养费,NOUN,B2
+Gesamtheit,all,全部,ADV,B2
+Ganztags,all day long,一整天,NOUN,B2
+vermeintlich,alleged,所谓的,ADJ,B2
 Allergie,allergy,过敏,NOUN,B2
-Alter,old age,老年,NOUN,B2
+Bündnis,alliance,联盟,NOUN,B2
+Versteckmöglichkeit,allow hiding,许躲,NOUN,B2
+Zulage,allowance,津贴,NOUN,B2
+Legierung,alloy,合金,NOUN,B2
+Anspielung,allusion,暗示,NOUN,B2
+anspielend,allusive,暗指的,ADJ,B2
+Verbündeter,ally,盟友,NOUN,B2
+Mandel,almond,杏仁,NOUN,B2
+zusammen mit,along with,随着,ADP,B2
+auch,also too,也,ADV,B2
+Bedeutungsänderung,altered meaning,改义,NOUN,B2
+veränderter Mechanismus,altered mechanism,改机,NOUN,B2
+wechseln,to alternate,交替,VERB,B2
+Wechsel,alternation,轮流,NOUN,B2
 Alternative,alternative,替代方案,NOUN,B2
-Altertum,ancient times,古代,NOUN,B2
 Altruismus,altruism,利他主义,NOUN,B2
 Aluminium,aluminum,铝,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
 Amateur,amateur,业余爱好者,NOUN,B2
-Amazigh,Amazigh,词,NOUN,C1
+Erstaunen,amazement,惊愕,NOUN,B2
+erstaunlich,amazing,令人惊叹的,ADJ,B2
+Mehrdeutigkeit,ambiguity,歧义,NOUN,B2
+mehrdeutig,ambiguous,模棱两可的,ADJ,B2
+ambivalent,ambivalent,矛盾的,ADJ,B2
+Hinterhalt,ambush,伏击,NOUN,B2
+ändern,to amend,修订,VERB,B2
+geänderter Innenraum,amended interior,改内,NOUN,B2
+abgeändertes Urteil,amended judgment,改断,NOUN,B2
+Änderung,amendment,修正案,NOUN,B2
+liebenswürdig,amiable,和蔼可亲的,ADJ,B2
 Amnestie,amnesty,大赦,NOUN,B2
+unter,among,在……之中,ADP,B2
+darunter,among them,其中,PRON,B2
+amortisieren,to amortize,摊销,VERB,B2
+reichlich,ample,充足的,ADJ,B2
+Verstärkung,amplification,放大,NOUN,B2
+Verstärker,amplifier,放大器,NOUN,B2
+verstärken,to amplify,放大,VERB,B2
+amputieren,to amputate,截肢,VERB,B2
 Amputation,amputation,截肢,NOUN,B2
-Amtseinführung,inauguration,开幕,NOUN,B2
 Amulett,amulet,护身符,NOUN,B2
+amüsant,amusing,有趣的,ADJ,B2
+analog,analog,模拟的,ADJ,B2
+analog,analogous,类似的,ADJ,B2
 Analogie,analogy,类比,NOUN,B2
 Analyst,analyst,分析师,NOUN,B2
-Ananas,pineapple,菠萝,NOUN,B2
 Anarchie,anarchy,无政府状态,NOUN,B2
 Anatomie,anatomy,解剖学,NOUN,B2
-Anbetung,worship,崇拜,NOUN,B2
-Anbieter,provider,提供者,NOUN,B2
-Andalusian,Andalusian,词,ADJ,B2
-Andere,other,其他,NOUN,B2
-Andersartigkeit,otherness,相异性,NOUN,B2
-Anekdote,anecdote,轶事,NOUN,B2
-Anfall,seizure,没收,NOUN,B2
-Anforderung,requirement,要求,NOUN,B2
-Anfrage,inquiry,调查,NOUN,B2
-Anfrage,request,请求,NOUN,B2
-Angebot,offering,祭品,NOUN,B2
-Angebotsbewertung,bid evaluation,评标,NOUN,B2
-Angebotsöffnung,bid opening,开标,NOUN,B2
-Angemessenheit,propriety,分寸,NOUN,B2
-Angst,anxiety,焦虑,NOUN,B2
-Anhang,appendix,附录,NOUN,B2
-Anhang,attachment,附件,NOUN,B2
-Anhänger,follower,追随者,NOUN,B2
-Animation,animation,动画,NOUN,B2
-Animationsfilm,animated film,动画片,NOUN,B2
+Abstammung,ancestry,血统,NOUN,B2
+ankern,anchor,锚,NOUN,B2
+ankern,to anchor,抛锚,VERB,B2
 Ankerplatz,anchorage,锚地,NOUN,B2
-Anklage,indictment,起诉,NOUN,B2
-Anklage,prosecution,起诉,NOUN,B2
-Anleihe,bond,纽带,NOUN,B2
-Anliegen,concern,担忧,NOUN,B2
-Anliegerstraße,service road,辅路,NOUN,B2
-Annäherung,approach,方法,NOUN,B2
-Annäherung,rapprochement,和解,NOUN,B2
+alt,ancient,古老的,ADJ,B2
+Altertum,ancient times,古代,NOUN,B2
+Und,and,重而,NOUN,B2
+und so weiter,and so forth,依此类推,ADV,B2
+Und so weiter,and so on,之类,NOUN,B2
+Anekdote,anecdote,轶事,NOUN,B2
+Anästhesie,anesthesia,麻醉,NOUN,B2
+Anästhetikum,anesthetic,麻醉剂,NOUN,B2
+Qual,anguish,痛苦,NOUN,B2
+Animationsfilm,animated film,动画片,NOUN,B2
+Animation,animation,动画,NOUN,B2
+Feindseligkeit,animosity,敌意,NOUN,B2
+annektieren,annex,附件,NOUN,B2
+annektieren,to annex,兼并,VERB,B2
+vernichten,to annihilate,消灭,VERB,B2
+Vernichtung,annihilation,寂灭,NOUN,B2
+Jahrestag,anniversary,周年纪念,NOUN,B2
+annotieren,to annotate,注释,VERB,B2
+Ärger,annoyance,烦恼,NOUN,B2
+Jahresbericht,annual report,年报,NOUN,B2
+jährlich,annually,每年,ADV,B2
 Anomalie,anomaly,异常,NOUN,B2
-Anrede,person honorific,位,NOUN,B2
-Anreiz,incentive,激励,NOUN,B2
-Anspielung,allusion,暗示,NOUN,B2
-Anstieg,surge,激增,NOUN,B2
+antworten,to answer reply,回答,VERB,B2
 Antenne,antenna,天线,NOUN,B2
 Anthologie,anthology,选集,NOUN,B2
 Anthropologie,anthropology,人类学,NOUN,B2
@@ -104,15602 +202,3988 @@ Anti-Abstraktion,anti-abstraction,反抽,NOUN,B2
 Anti-Aktion,anti-action,反作,NOUN,B2
 Anti-Allgemeinheit,anti-generality,反般,NOUN,B2
 Anti-Integration,anti-integration,反合,NOUN,B2
-Anti-Krieg,anti-war,反战,NOUN,B2
 Anti-Maßnahme,anti-measure,反度,NOUN,B2
 Anti-Omnipräsenz,anti-omnipresence,反遍,NOUN,B2
+Anti-Krieg,anti-war,反战,NOUN,B2
 Antibiotika,antibiotics,抗生素,NOUN,B2
-Antigen,antigen,抗原,NOUN,B2
 Antikörper,antibody,抗体,NOUN,B2
-Antimaterie,counter-matter,反物,NOUN,B2
+erwarten,to anticipate,预期,VERB,B2
+Erwartung,anticipation,预期,NOUN,B2
+Antigen,antigen,抗原,NOUN,B2
 Antioxidans,antioxidant,抗氧化剂,NOUN,B2
 Antiquität,antique,古董,NOUN,B2
 Antiseptikum,antiseptic,防腐剂,NOUN,B2
 Antithese,antithesis,对立面,NOUN,B2
 Antonym,antonym,反义词,NOUN,B2
-Antwort,response,回应,NOUN,B2
-Antwort an Eure Hoheit,reply to your-highness,回殿下,NOUN,B2
-Anwendbarkeit,applicability,适用性,NOUN,B2
-Anwesenheit,attendance,出席,NOUN,B2
-Anzeige,display,展示,NOUN,B2
-Anzeige,indication,指示,NOUN,B2
-Anziehung,attraction,吸引力,NOUN,B2
-Anästhesie,anesthesia,麻醉,NOUN,B2
-Anästhetikum,anesthetic,麻醉剂,NOUN,B2
+Angst,anxiety,焦虑,NOUN,B2
+irgendein,any,任何,PRON,B2
+apokryph,apocryphal,杜撰的,ADJ,B2
+sich entschuldigen,to apologize,道歉,VERB,B2
 Apostasie,apostasy,叛教,NOUN,B2
-Apotheker,pharmacist,药剂师,NOUN,B2
+appellieren,to appeal,呼吁,VERB,B2
+besänftigen,to appease,安抚,VERB,B2
+Berufungskläger,appellant,上诉人,NOUN,B2
+Anhang,appendix,附录,NOUN,B2
+applaudieren,to applaud,鼓掌,VERB,B2
+Anwendbarkeit,applicability,适用性,NOUN,B2
+Bewerber,applicant,申请人,NOUN,B2
+gipsen,to apply a cast,打石膏,VERB,B2
+bewerten,to appraise,评估,VERB,B2
+Wertschätzung,appreciation,欣赏,NOUN,B2
+Dankesfest,appreciation banquet,答谢宴,NOUN,B2
+festnehmen,to apprehend,逮捕,VERB,B2
+Festnahme,apprehension,忧虑,NOUN,B2
+Lehrling,apprentice,学徒,NOUN,B2
+Lehre,apprenticeship,学徒期,NOUN,B2
+Annäherung,approach,方法,NOUN,B2
+Näherung,approximation,近似值,NOUN,B2
 Aprikose,apricot,杏,NOUN,B2
-Aquarell,watercolor,水彩画,NOUN,B2
+Schürze,apron,围裙,NOUN,B2
 Arabeske,arabesque,阿拉伯式花纹,NOUN,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Arbeit,labor,劳动,NOUN,B2
-Arbeitslosigkeit,unemployment,失业,NOUN,B2
+willkürlich,arbitrary,任意的,ADJ,B2
+schlichten,to arbitrate,仲裁,VERB,B2
+Schlichtung,arbitration,仲裁,NOUN,B2
+Bogen,arc,弧,NOUN,B2
+Bogen,arch,拱门,NOUN,B2
+archäologisch,archaeological,考古的,ADJ,B2
+Archäologie,archaeology,考古学,NOUN,B2
+archaisch,archaic,古老的,ADJ,B2
 Archaismus,archaism,古语,NOUN,B2
 Archetyp,archetype,原型,NOUN,B2
 Archipel,archipelago,群岛,NOUN,B2
 Architekt,architect,建筑师,NOUN,B2
+architektonisch,architectural,建筑的,ADJ,B2
 Architektur,architecture,建筑,NOUN,B2
 Archiv,archive,档案,NOUN,B2
-Archäologie,archaeology,考古学,NOUN,B2
+Eifer,ardor,热情,NOUN,B2
+mühsam,arduous,艰巨的,ADJ,B2
 Arena,arena,竞技场,NOUN,B2
 Argumentation,argumentation,论证体系,NOUN,B2
-Aristokrat,aristocrat,贵族,NOUN,B2
 Aristokratie,aristocracy,贵族阶层,NOUN,B2
-Armaturenbrett,dashboard,仪表盘,NOUN,B2
+Aristokrat,aristocrat,贵族,NOUN,B2
+Rüstung,armor,盔甲,NOUN,B2
+Rückstand,arrears,欠款,NOUN,B2
 Arsenal,arsenal,军火库,NOUN,B2
-Art,kind,仁慈的,ADJ,B2
+Kunstgalerie,art gallery,美术馆,NOUN,B2
 Arterie,artery,动脉,NOUN,B2
-Artikulation,enunciation,发音,NOUN,B2
-Arzt,physician,内科医生,NOUN,B2
-Asche,ash,灰烬,NOUN,B2
+articulieren,to articulate,清晰表达,VERB,B2
+künstlich,artificial,人造的,ADJ,B2
+künstlerisch,artistic,艺术的,ADJ,B2
+Kunstporträt,artistic portrait,艺术照,NOUN,B2
+wie,as,像,ADP,B2
+als ob,as if,仿佛,ADV,B2
+solange,as long as,طالما,CCONJ,B2
+aufsteigen,to ascend,上升,VERB,B2
+Aufstieg,ascension,升天,NOUN,B2
+Aufstieg,ascent,上升,NOUN,B2
 Askese,asceticism,苦行主义,NOUN,B2
+asexuell,asexual,无性的,ADJ,B2
+Asche,ash,灰烬,NOUN,B2
+beschämt,ashamed,羞愧的,ADJ,B2
 Aspekt,aspect,方面,NOUN,B2
+Streben,aspiration,抱负,NOUN,B2
+streben,to aspire,渴望,VERB,B2
+Attentäter,assassin,刺客,NOUN,B2
+ermorden,to assassinate,暗杀,VERB,B2
+Attentat,assassination,暗杀,NOUN,B2
+Überfall,assault,袭击,NOUN,B2
+behaupten,to assert,断言,VERB,B2
+Vermögenswert,asset,资产,NOUN,B2
+Vermögenswerte,assets,资产,NOUN,B2
+fleißig,assiduous,勤勉的,ADJ,B2
+zuweisen,to assign,分配,VERB,B2
+Zuweisung,assignment,任务,NOUN,B2
+assimilieren,to assimilate,同化,VERB,B2
 Assimilation,assimilation,同化,NOUN,B2
+helfen,to assist,协助,VERB,B2
+assoziieren,to associate,联想,VERB,B2
 Assoziation,association,协会,NOUN,B2
+annehmen,to assume,假定,VERB,B2
+antreten,to assume office,就任,VERB,B2
 Asteroid,asteroid,小行星,NOUN,B2
 Asthma,asthma,哮喘,NOUN,B2
+Erstaunen,astonishment,惊讶,NOUN,B2
 Astrologie,astrology,占星术,NOUN,B2
 Astronaut,astronaut,宇航员,NOUN,B2
+astronomisch,astronomical,天文学的,ADJ,B2
 Astronomie,astronomy,天文学,NOUN,B2
+scharfsinnig,astute,精明的,ADJ,B2
 Asyl,asylum,庇护,NOUN,B2
+asymmetrisch,asymmetrical,不对称的,ADJ,B2
+asynchron,asynchronous,异步的,ADJ,B2
+entspannt,at ease,安心,ADJ,B2
+damals,at that time,当时/那时,ADV,B2
 Atheismus,atheism,无神论,NOUN,B2
 Atheist,atheist,无神论者,NOUN,B2
 Athlet,athlete,运动员,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
 Atom,atom,原子,NOUN,B2
-Attentat,assassination,暗杀,NOUN,B2
-Attentäter,assassin,刺客,NOUN,B2
-Aubergine,eggplant,茄子,NOUN,B2
-Audienz erbitten,to seek audience,求见,VERB,B2
-Auf Wiedersehen,goodbye,再见,INTJ,B2
-Aufbaustudium,advanced study,深造,NOUN,B2
-Aufenthalt,sojourn,逗留,NOUN,B2
-Aufenthaltsort,whereabouts,行踪,NOUN,B2
-Auferstehung,resurrection,复活,NOUN,B2
-Aufforstung,afforestation,植树造林,NOUN,B2
-Aufklärung,reconnaissance,侦察,NOUN,B2
-Auflösung,dissolution,溶解,NOUN,B2
-Auflösung,resolution,决心,NOUN,B2
-Aufrichtigkeit,sincerity,真诚,NOUN,B2
-Aufruhr,commotion,骚动,NOUN,B2
-Aufruhr,riot,骚乱,NOUN,B2
-Aufruhr,turmoil,混乱,NOUN,B2
-Aufsicht,supervision,监督,NOUN,B2
-Aufstachelung,incitement,煽动,NOUN,B2
-Aufstand,insurrection,起义,NOUN,B2
-Aufstieg,ascension,升天,NOUN,B2
-Aufstieg,ascent,上升,NOUN,B2
-Augenblick,instant,فور,NOUN,B2
-Augenbraue,eyebrow,眉毛,NOUN,B2
-Augenlid,eyelid,眼皮,NOUN,B2
-Augenzeuge,eyewitness,目击,NOUN,B2
+atomar,atomic,原子的,ADJ,B2
+Anhang,attachment,附件,NOUN,B2
+erreichen,to attain,达到,VERB,B2
+Anwesenheit,attendance,出席,NOUN,B2
+Bediener,attendant,服务员,NOUN,B2
+Kleidung,attire,服装,NOUN,B2
+anziehen,to attract,吸引,VERB,B2
+Anziehung,attraction,吸引力,NOUN,B2
+zuschreiben,attribute,属性,NOUN,B2
+zuschreiben,to attribute,归因于,VERB,B2
+atypisch,atypical,非典型的,ADJ,B2
 Auktion,auction,拍卖,NOUN,B2
-Aurikel,wood ear mushroom,木耳,NOUN,B2
-Ausblick,outlook,前景,NOUN,B2
-Ausbreitung,spread,传播,NOUN,B2
-Ausbruch,outburst,迸发,NOUN,B2
-Ausdauer,endurance,坚忍,NOUN,B2
-Ausdauer,perseverance,毅力,NOUN,B2
-Ausflug,outing,郊游,NOUN,B2
-Ausgabe,edition,版本,NOUN,B2
-Ausgabe,expenditure,支出,NOUN,B2
-Ausgabe,issue,问题,NOUN,B2
-Ausgaben,expenses,费用,NOUN,B2
-Ausgestoßener,outcast,被遗弃者,NOUN,B2
-Ausgleichsurlaub,compensatory leave,调休,NOUN,B2
-Auslandschinese,overseas chinese,华侨,NOUN,B2
-Auslieferung,extradition,引渡,NOUN,B2
-Auslöser,trigger,触发器,NOUN,B2
-Ausrichtung,alignment,结盟,NOUN,B2
-Ausrottung,eradication,根除,NOUN,B2
-Ausrottung,extermination,灭绝,NOUN,B2
-Ausschluss,expulsion,驱逐,NOUN,B2
-Ausschuss,committee,委员会,NOUN,B2
-Aussetzung,exposure,暴露,NOUN,B2
-Aussicht,prospect,前景,NOUN,B2
-Ausstellung,exposition,阐述,NOUN,B2
-Aussterben,extinction,灭绝,NOUN,B2
+Wagemut,audacity,大胆,NOUN,B2
+audiovisuell,audiovisual,视听的,ADJ,B2
+prüfen,audit,审计,NOUN,B2
+prüfen,to audit,审计,VERB,B2
+Prüfer,auditor,审计员,NOUN,B2
+asketisch,austere,严厉的,ADJ,B2
 Austerität,austerity,紧缩,NOUN,B2
-Auswurf,some out,出些,NOUN,B2
-Auszeichnung,award,奖项,NOUN,B2
+authentisch,authentic,真实的,ADJ,B2
+authentifizieren,to authenticate,认证,VERB,B2
 Authentifizierung,authentication,认证,NOUN,B2
 Authentizität,authenticity,真实性,NOUN,B2
+autoritär,authoritarian,独裁的,ADJ,B2
+Genehmigung,authorization,授权,NOUN,B2
+genehmigen,to authorize,授权,VERB,B2
 Autobiografie,autobiography,自传,NOUN,B2
+automatisieren,to automate,使自动化,VERB,B2
+automatisiert,automated,自动化的,ADJ,B2
+automatisch,automatically,自动地,ADV,B2
 Automatisierung,automation,自动化,NOUN,B2
-Außen,outside,外部,NOUN,B2
+autonom,autonomous,自治的,ADJ,B2
+Verfügbarkeit,availability,可用性,NOUN,B2
+Lawine,avalanche,雪崩,NOUN,B2
+avantgardistisch,avant-garde,前卫的,ADJ,B2
+Durchschnitt,average,平均,ADJ,B2
+Vermeidung,avoidance,避免,NOUN,B2
+erwarten,to await,等待,VERB,B2
+Erwachen,awakening,觉醒,NOUN,B2
+Auszeichnung,award,奖项,NOUN,B2
+Bewusstsein,awareness,意识,NOUN,B2
+Ehrfurcht,awe,敬畏,NOUN,B2
+peinlich,awkward,尴尬的,ADJ,B2
 Axiom,axiom,公理,NOUN,B2
-Bach,stream,溪流,NOUN,B2
+Achse,axis,轴,NOUN,B2
+Bazi,ba zi,八字,NOUN,B2
 Bachelor,bachelor's degree,学士学位,NOUN,B2
+Rückfluss,backflow,倒流,NOUN,B2
+Rückenstich,backstab,背刺,NOUN,B2
 Backstage,backstage,幕后,NOUN,B2
 Backup,backup,备份,NOUN,B2
-Bad,bath,洗澡,NOUN,B2
-Badminton,badminton,羽毛球,NOUN,B2
+Rückfahrlicht,backup light,倒车灯,NOUN,B2
 Bakterien,bacteria,细菌,NOUN,B2
 Bakterium,bacterium,细菌,NOUN,B2
-Balkanization,Balkanization,词,NOUN,C1
+schlechte Idee,bad idea,坏水,NOUN,B2
+schlechte Nachricht,bad news,坏消息,NOUN,B2
+schlecht,badly,坏地,ADV,B2
+Badminton,badminton,羽毛球,NOUN,B2
+Kaution,bail,保释,NOUN,B2
+ausgleichen,to balance,平衡,VERB,B2
+kahl,bald,秃头的,ADJ,B2
 Ball,ball,球,NOUN,B2
 Ballett,ballet,芭蕾舞,NOUN,B2
+verbieten,ban,禁令,NOUN,B2
+verbieten,to ban,禁止,VERB,B2
+banal,banal,陈腐的,ADJ,B2
 Banalität,banality,陈词滥调,NOUN,B2
 Band,band,乐队,NOUN,B2
+Verband,bandage,绷带,NOUN,B2
 Bandit,bandit,强盗,NOUN,B2
+verbannen,to banish,流放,VERB,B2
+Verbannung,banishment,流放,NOUN,B2
 Bank,bank,银行,NOUN,B2
-Bank,bench,长凳,NOUN,B2
-Bankett,banquet,宴会,NOUN,B2
+bankwirtschaftlich,banking,银行的,ADJ,B2
 Banknote,banknote,钞票,NOUN,B2
+bankrott,bankrupt,破产的,ADJ,B2
 Bankrott,bankruptcy,破产,NOUN,B2
 Banner,banner,横幅,NOUN,B2
-Barbarei,barbarity,残暴,NOUN,B2
+Bankett,banquet,宴会,NOUN,B2
+Wortwitz,banter,戏谑,NOUN,B2
+taufen,to baptize,施洗,VERB,B2
+barbarisch,barbaric,野蛮的,ADJ,B2
 Barbarismus,barbarism,野蛮,NOUN,B2
+Barbarei,barbarity,残暴,NOUN,B2
 Barbecue,barbecue,烧烤,NOUN,B2
+barfuß,barefoot,赤脚的,ADJ,B2
+Gerste,barley,大麦,NOUN,B2
 Barriere,barrier,障碍,NOUN,B2
-Basar,bazaar,集市,NOUN,B2
+basieren,to base,基于,VERB,B2
 Baseball,baseball,棒球,NOUN,B2
-Basilika,basilica,大教堂,NOUN,B2
+Niedertracht,baseness,卑鄙,NOUN,B2
+grundlegend,basic,基本的,ADJ,B2
+grundsätzlich,basically,基本上,ADV,B2
 Basilikum,basil,罗勒,NOUN,B2
+Basilika,basilica,大教堂,NOUN,B2
+Becken,basin,盆,NOUN,B2
 Basketball,basketball,篮球,NOUN,B2
 Bass,bass,贝斯,NOUN,B2
+Charge,batch,一批,NOUN,B2
+Bad,bath,洗澡,NOUN,B2
 Bataillon,battalion,营,NOUN,B2
-Bauchschmerzen,stomachache,肚子痛,NOUN,B2
-Bauchspeicheldrüse,pancreas,胰腺,NOUN,B2
-Baumwolle,cotton,棉花,NOUN,B2
-Bazi,ba zi,八字,NOUN,B2
-Beamter,civil servant,公务员,NOUN,B2
-Beamter,officials,官员,NOUN,B2
-Becken,basin,盆,NOUN,B2
-Bedauern,regret,后悔,NOUN,B2
-Bedeutung,significance,含义,NOUN,B2
-Bedeutungsänderung,altered meaning,改义,NOUN,B2
-Bediener,attendant,服务员,NOUN,B2
-Beeinträchtigung,impairment,左手废,NOUN,B2
-Beendigung,termination,解除,NOUN,B2
-Beerdigung,burial,埋葬,NOUN,B2
-Befehle erhalten,to receive orders,受命,VERB,B2
-Befreiung,exemption,豁免,NOUN,B2
-Befruchtung,fertilization,施肥,NOUN,B2
-Befürworter,promoter,推动者,NOUN,B2
-Begeisterung,enthusiasm,热情,NOUN,B2
-Begriff,term,学期,NOUN,B2
-Begünstigter,beneficiary,受益人,NOUN,B2
-Beharrlichkeit,insistence,坚持,NOUN,B2
-Behinderung,disability,残疾,NOUN,B2
-Behinderung,obstruction,阻塞,NOUN,B2
-Behälter,container,容器,NOUN,B2
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Beileid,condolence,哀悼,NOUN,B2
-Beitritt,accession,即位,NOUN,B2
-Beklagter,defendant,被告,NOUN,B2
-Bekämpfung,combating,打击,NOUN,B2
-Belagerung,siege,围攻,NOUN,B2
-Belastung,strain,压力,NOUN,B2
-Beleidigung,insult,辱骂,NOUN,B2
-Beliebtheit,popularity,流行,NOUN,B2
-Belästigung,harassment,骚扰,NOUN,B2
-Belüftung,ventilation,通风,NOUN,B2
-Benachrichtigung,notification,通知,NOUN,B2
-Benutzer,user,用户,NOUN,B2
-Beobachter,observer,观察者,NOUN,B2
-Berater,consultant,顾问,NOUN,B2
-Beratung,counseling,咨询,NOUN,B2
-Beratung,deliberation,深思熟虑,NOUN,B2
-Berechnung,calculation,计算,NOUN,B2
-Beredsamkeit,eloquence,口才,NOUN,B2
-Bereicherung,enrichment,丰富,NOUN,B2
-Bereitschaft,willingness,乐意,NOUN,B2
-Bergabfahrt,mountain descent,下山,NOUN,B2
-Berufungskläger,appellant,上诉人,NOUN,B2
-Beruhigung,reassurance,安抚,NOUN,B2
-Berühmtheit,celebrity,名人,NOUN,B2
-Bescheidenheit,modesty,谦虚,NOUN,B2
-Beschleuniger,accelerator,油门,NOUN,B2
-Beschleunigung,acceleration,加速,NOUN,B2
-Beschneidung,circumcision,割礼,NOUN,B2
-Beschäftigung,occupation,职业,NOUN,B2
-Besen,broom,扫帚,NOUN,B2
-Besitz,possession,财产,NOUN,B2
-Besonderheit,particularity,特点,NOUN,B2
-Besorgung,errand,差事,NOUN,B2
-Besserer,better,越好,NOUN,B2
-Bestechung,bribery,贿赂,NOUN,B2
-Bestechungsgeld,bribe,贿赂,NOUN,B2
-Bestellfahrer,designated driver,代驾,NOUN,B2
-Bestleistung,personal record,个人纪录,NOUN,B2
-Beständigkeit,permanence,持久,NOUN,B2
-Bestäubung,pollination,授粉,NOUN,B2
-Beteiligung,involvement,参与,NOUN,B2
-Beteiligung,turnout,出席率,NOUN,B2
-Beton,concrete,具体的,ADJ,B2
-Betreuung,tutelage,监护,NOUN,B2
-Betriebsamkeit,sound of activity,动静,NOUN,B2
-Betrug,scam,骗局,NOUN,B2
-Betrüger,swindler,骗子,NOUN,B2
-Betteln,begging,乞讨,NOUN,B2
+Schlachtfeld,battlefield,战场,NOUN,B2
+Bucht,bay,海湾,NOUN,B2
+Basar,bazaar,集市,NOUN,B2
+können,to be able,能,VERB,B2
+können,to be able to,能够,VERB,B2
+fehlen,to be absent,缺席,VERB,B2
+süchtig sein,to be addicted,上瘾,VERB,B2
+geboren werden,to be born,出生,VERB,B2
+mutig sein,to be brave,勇善,VERB,B2
+beschädigt sein,to be damaged,受损,VERB,B2
+besiegt werden,to be defeated,会败,VERB,B2
+fertig sein,to be done,被做,VERB,B2
+begierig sein,to be eager,心切,VERB,B2
+begehren,to be eager for,巴不得,VERB,B2
+gewählt werden,to be elected,当选,VERB,B2
+verzaubert sein,to be entranced,出神,VERB,B2
+gezwungen werden,to be forced,被迫,VERB,B2
+gut sein in,to be good at,擅长,VERB,B2
+dankbar sein,to be grateful,感激,VERB,B2
+getroffen werden,to be hit,中箭,VERB,B2
+eifersüchtig sein,to be jealous,嫉妒,VERB,B2
+sich verspäten,to be late,迟到,VERB,B2
+übrig bleiben,to be left over,剩余,VERB,B2
+Dienst haben,to be on duty,值班,VERB,B2
+benötigt werden,to be required,被要求,VERB,B2
+verantwortlich sein für,to be responsible for,负责,VERB,B2
+sicher sein,to be safe,安好,VERB,B2
+so sein,to be so,然,VERB,B2
+gestohlen werden,to be stolen,失窃,VERB,B2
+überrascht sein,to be surprised,感到惊讶,VERB,B2
+Leuchtturm,beacon,灯塔,NOUN,B2
+Richtung,bearing,轴承,NOUN,B2
+Schlag,beating,跳动,NOUN,B2
 Bettler,beggar,乞丐,NOUN,B2
-Bewegung,motion,运动,NOUN,B2
-Beweise liefern,to provide evidence,举证,VERB,B2
-Beweismittel,physical evidence,物证,NOUN,B2
-Bewerber,applicant,申请人,NOUN,B2
-Bewertung,grading,评分；记号,NOUN,B2
-Bewertung,rating,评分,NOUN,B2
-Bewertung,valuation,估值,NOUN,B2
-Bewusstsein,awareness,意识,NOUN,B2
-Bewährung,parole,假释,NOUN,B2
-Bewährungsprobe,ordeal,苦难,NOUN,B2
-Bewässerungskanal,irrigation canal,灌溉渠,NOUN,B2
-Bezeichnung,designation,指定,NOUN,B2
-Bezirksleiter,district head,区长,NOUN,B2
-Bibliographie,bibliography,参考书目,NOUN,B2
+Betteln,begging,乞讨,NOUN,B2
+beginnen,to begin to start,开始,VERB,B2
+Gläubiger,believer,信徒,NOUN,B2
+geringschätzen,to belittle,轻视,VERB,B2
+Paprika,bell pepper,甜椒,NOUN,B2
+kriegerisch,bellicose,好战的,ADJ,B2
+brüllen,to bellow,吼叫,VERB,B2
+gehören,to belong to,属于,VERB,B2
+Zugehörigkeit,belonging,归属感,NOUN,B2
+Habseligkeiten,belongings,所属物,NOUN,B2
+Unten,below,在...下面,ADP,B2
+Bank,bench,长凳,NOUN,B2
 Biegung,bend,弯道,NOUN,B2
+Begünstigter,beneficiary,受益人,NOUN,B2
+Nutzen,benefit,利益,NOUN,B2
+Wohltätigkeit,benevolence,仁慈,NOUN,B2
+wohlwollend,benevolent,仁慈的,ADJ,B2
+Nähe,beside next to,旁边,NOUN,B2
+belagern,to besiege,包围,VERB,B2
+verleihen,to bestow,授予,VERB,B2
+Verleihung,bestowal,授予,NOUN,B2
+Verrat,betrayal,背叛,NOUN,B2
+Besserer,better,越好,NOUN,B2
+Verwirrung,bewilderment,困惑,NOUN,B2
+Glocke,bianzhong,编钟,NOUN,B2
+Voreingenommenheit,bias,偏见,NOUN,B2
+voreingenommen,biased,有偏见的,ADJ,B2
+Bibliographie,bibliography,参考书目,NOUN,B2
+Gebot,bid,出价,NOUN,B2
 Bieterkartell,bid collusion,串标,NOUN,B2
-Bildhauer,sculptor,雕塑家,NOUN,B2
-Bildplatte,video disc,影碟,NOUN,B2
+Angebotsbewertung,bid evaluation,评标,NOUN,B2
+Angebotsöffnung,bid opening,开标,NOUN,B2
+groß,biggest,最大,ADJ,B2
+Galle,bile,胆汁,NOUN,B2
+Rechnung,bill,账单,NOUN,B2
 Billard,billiards,台球,NOUN,B2
+Milliarde,billion,十亿,NUM,B2
+binär,binary,二进制的,ADJ,B2
 Bindung,binding,装订,NOUN,B2
 Biodiversität,biodiversity,生物多样性,NOUN,B2
 Biografie,biography,传记,NOUN,B2
+biologisch,biological,生物的,ADJ,B2
 Biologie,biology,生物学,NOUN,B2
 Biomasse,biomass,生物质,NOUN,B2
 Biopsie,biopsy,活检,NOUN,B2
 Biotechnologie,biotechnology,生物技术,NOUN,B2
 Biss,biting,尖刻的,ADJ,B2
-Bitcoin,Bitcoin,比特币,NOUN,C1
 Bitterkeit,bitterness,苦涩,NOUN,B2
-Blase,bubble,气泡,NOUN,B2
-Blaubeere,blueberry,蓝莓,NOUN,B2
+Talar,black robe,黑衣,NOUN,B2
+Brombeere,blackberry,黑莓,NOUN,B2
+schwärzen,to blacken,变黑,VERB,B2
+Schmied,blacksmith,铁匠,NOUN,B2
+beschuldigen,blame,责备,NOUN,B2
+beschuldigen,to blame,责备,VERB,B2
+Gotteslästerung,blasphemy,亵渎,NOUN,B2
+Brand,blaze,火焰,NOUN,B2
 Bleichmittel,bleach,漂白剂,NOUN,B2
-Blick,look at you,你看你,NOUN,B2
-Blinker,turn signal,转向灯,NOUN,B2
+blind,blind,盲的,ADJ,B2
+Seligkeit,bliss,极乐,NOUN,B2
+Schneesturm,blizzard,暴风雪,NOUN,B2
 Block,bloc,阵营,NOUN,B2
 Block,block,街区,NOUN,B2
+blockieren,blockade,封锁,NOUN,B2
+blockieren,to blockade,封锁,VERB,B2
 Blog,blog,博客,NOUN,B2
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Blumenkohl,cauliflower,花椰菜,NOUN,B2
-Blut,cold blood,冷血,NOUN,B2
-Blutmeer,blood sea,血海,NOUN,B2
 Blutschuld,blood debt,血债,NOUN,B2
-Boden,bottom,底部,NOUN,B2
-Boden,soil,土壤,NOUN,B2
-Bogen,arc,弧,NOUN,B2
-Bogen,arch,拱门,NOUN,B2
-Bogen,bow,蝴蝶结,NOUN,B2
+Blutmeer,blood sea,血海,NOUN,B2
+blutig,bloody,血淋淋的,ADJ,B2
+Flecken,blot,污点,NOUN,B2
+Blaubeere,blueberry,蓝莓,NOUN,B2
+unverblümt,bluntly,直率地,ADV,B2
+Prahlen,boasting,夸耀,NOUN,B2
+körperlich,bodily,身体上的,ADJ,B2
+Leibwächter,bodyguard,保镖,NOUN,B2
+kochen,to boil,煮沸,VERB,B2
+Kessel,boiler,锅炉,NOUN,B2
+Sieden,boiling,沸腾,NOUN,B2
+mutig,bold,大胆的,ADJ,B2
+Mut,boldness,大胆,NOUN,B2
+bombardieren,to bombard,轰炸,VERB,B2
 Bombardierung,bombing,轰炸,NOUN,B2
-Bonbon,candy,糖果,NOUN,B2
+Anleihe,bond,纽带,NOUN,B2
 Bonus,bonus,奖金,NOUN,B2
+knochig,bony,瘦骨嶙峋的,ADJ,B2
+Heft,booklet,小册子,NOUN,B2
 Boom,boom,繁荣,NOUN,B2
-Bordell,brothel,妓院,NOUN,B2
-Bosheit,malice,恶意,NOUN,B2
-Botschaft,embassy,大使馆,NOUN,B2
-Brand,blaze,火焰,NOUN,B2
-Brand,burn,烧伤,NOUN,B2
-Braten,roast,烤肉,NOUN,B2
-Brauch,custom,习俗,NOUN,B2
-Brautkammer,bridal chamber,洞房,NOUN,B2
-Breite,width,宽度,NOUN,B2
-Brief,brief,简短的,ADJ,B2
-Briefmarke,stamp,邮票,NOUN,B2
-Brillanz,brilliance,辉煌,NOUN,B2
-Brille,spectacles,眼镜,NOUN,B2
-Bringen,bringing,جلب,NOUN,B2
-Brise,breeze,微风,NOUN,B2
-Brokat,brocade,锦绣,NOUN,B2
-Brombeere,blackberry,黑莓,NOUN,B2
-Bronze,bronze,青铜,NOUN,B2
-Brother He,Brother He,郃弟,NOUN,B2
-Browser,browser,浏览器,NOUN,B2
-Bruch,breach,违反,NOUN,B2
-Bruch,rupture,破裂,NOUN,B2
-Bruderschaft,brotherhood,兄弟情谊,NOUN,B2
-Brunnen,a well,井,NOUN,B2
-Brunnen,well,井,NOUN,B2
-Brussels,Brussels,词,ADJ,C1
-Brustschmerz,chest pain,胸痛,NOUN,B2
-Brühe,broth,肉汤,NOUN,B2
-Buchhalter,accountant,会计师,NOUN,B2
-Buchhaltung,accounting,会计,NOUN,B2
-Bucht,bay,海湾,NOUN,B2
-Buchweizen,buckwheat,荞麦,NOUN,B2
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Budget,budget,预算,NOUN,B2
-Bund,covenant,契约,NOUN,B2
-Bus,bus,公共汽车,NOUN,B2
-Buße,repentance,悔恨,NOUN,B2
-Bypass-Operation,bypass surgery,搭桥手术,NOUN,B2
-Bände,measure word for books,本,NUM,B2
-Bö,gust,阵风,NOUN,B2
-Börse,stock exchange,证券交易所,NOUN,B2
-Bühnenstück,stage play,舞台剧,NOUN,B2
-Bündel,bundle,捆,NOUN,B2
-Bündnis,alliance,联盟,NOUN,B2
-Bürgersteig,sidewalk,人行道,NOUN,B2
+grenznah,border,边境的,ADJ,B2
+langweilig,bored,无聊的,ADJ,B2
+Kreditnehmer,borrower,借款人,NOUN,B2
+Leihe,borrowing,借贷,NOUN,B2
+beide Hände,both hands,双手,NOUN,B2
+stören,bother,麻烦,NOUN,B2
+stören,to bother,打扰,VERB,B2
+Boden,bottom,底部,NOUN,B2
+Felsbrocken,boulder,巨石,NOUN,B2
+gebunden,bound,一定的,ADJ,B2
+Grenze,boundary,边界,NOUN,B2
 Bürgertum,bourgeoisie,资产阶级,NOUN,B2
+Bogen,bow,蝴蝶结,NOUN,B2
+boycottieren,to boycott,抵制,VERB,B2
+Freund,boyfriend,男朋友,NOUN,B2
+prahlen,to brag,吹嘘,VERB,B2
+bremsen,to brake,刹车,VERB,B2
+brandneu,brand new,崭新的,ADJ,B2
+Mut,bravery,勇敢,NOUN,B2
+Frechheit,brazenness,厚颜无耻,NOUN,B2
+Bruch,breach,违反,NOUN,B2
+Vertrag brechen,to breach contract,违约,VERB,B2
+kaputtgehen,to break down,分解,VERB,B2
+aufbrechen,to break open,撬开,VERB,B2
+stillen,to breastfeed,母乳喂养,VERB,B2
+Stillen,breastfeeding,母乳喂养,NOUN,B2
+Brise,breeze,微风,NOUN,B2
+Bestechungsgeld,bribe,贿赂,NOUN,B2
+Bestechung,bribery,贿赂,NOUN,B2
+Ziegel,brick,砖,NOUN,B2
+Brautkammer,bridal chamber,洞房,NOUN,B2
+Brief,brief,简短的,ADJ,B2
+Brillanz,brilliance,辉煌,NOUN,B2
+Bringen,bringing,جلب,NOUN,B2
+Sendung,broadcasting,广播,NOUN,B2
+Brokat,brocade,锦绣,NOUN,B2
+Makler,broker,经纪人,NOUN,B2
+Maklergeschäft,brokerage,经纪业,NOUN,B2
+Bronze,bronze,青铜,NOUN,B2
+Besen,broom,扫帚,NOUN,B2
+Brühe,broth,肉汤,NOUN,B2
+Bordell,brothel,妓院,NOUN,B2
+Bruderschaft,brotherhood,兄弟情谊,NOUN,B2
+braun,brown,棕色,ADJ,B2
+stöbern,to browse,浏览,VERB,B2
+Browser,browser,浏览器,NOUN,B2
+Prellung,bruise,瘀伤,NOUN,B2
+bürsten,brush,刷子,NOUN,B2
+bürsten,to brush,刷,VERB,B2
+brutalisieren,to brutalize,使变得残忍,VERB,B2
+Blase,bubble,气泡,NOUN,B2
+Buchweizen,buckwheat,荞麦,NOUN,B2
+Budget,budget,预算,NOUN,B2
+budgetär,budgetary,预算的,ADJ,B2
+Wanze,bug,虫子,NOUN,B2
+Masse,bulk,主体,NOUN,B2
+Tyrann,bully,欺凌者,NOUN,B2
+Bündel,bundle,捆,NOUN,B2
 Büro,bureau,局,NOUN,B2
 Bürokratie,bureaucracy,官僚主义,NOUN,B2
-CO2-Steuer,carbon tax,碳税,NOUN,B2
-Calvinism,Calvinism,词,NOUN,C1
+Beerdigung,burial,埋葬,NOUN,B2
+Brand,burn,烧伤,NOUN,B2
+brennend,burning,灼热的,ADJ,B2
+verbrannt,burnt,烧焦的,ADJ,B2
+rülpsen,to burp,打嗝,VERB,B2
+Bus,bus,公共汽车,NOUN,B2
+Geschäft,business,商业,NOUN,B2
+Geschäftstreffen,business meeting,洽谈会,NOUN,B2
+Trubel,bustle,喧闹,NOUN,B2
+Geschäftigkeit,busyness,事忙,NOUN,B2
+aber ich,but i,可我,ADV,B2
+aber du,but you,但您,NOUN,B2
+Metzger,butcher,屠夫,NOUN,B2
+bei,by,通过,ADP,B2
+mit allen Mitteln,by fair means or foul,不择手段,ADV,B2
+mittels,by means of,通过,ADP,B2
+vergangen,bygone,过去的,ADJ,B2
+Bypass-Operation,bypass surgery,搭桥手术,NOUN,B2
+Kohl,cabbage,卷心菜,NOUN,B2
+Schrank,cabinet,内阁,NOUN,B2
+Katastrophe,calamity,灾难,NOUN,B2
+Berechnung,calculation,计算,NOUN,B2
+Kalibrierung,calibration,校准,NOUN,B2
+Kalligrafie,calligraphy,书法,NOUN,B2
+gefühllos,callous,冷酷,ADJ,B2
+Ruhe,calm,冷静的,ADJ,B2
+Gelassenheit,calmness,平静,NOUN,B2
+Kamel,camel,骆驼,NOUN,B2
+kampagnieren,to campaign,积极参与活动,VERB,B2
 Camping,camping,露营,NOUN,B2
+nur können,can only,只能,AUX,B2
+nicht glauben,to can't believe,不敢相信,VERB,B2
+nicht umhin können,can't help,不由得,ADV,B2
+Kanal,canal,运河,NOUN,B2
+Stornierung,cancellation,取消,NOUN,B2
+Kandidatur,candidacy,候选资格,NOUN,B2
+Bonbon,candy,糖果,NOUN,B2
+Konserve,canned food,罐头食品,NOUN,B2
+nicht können,cannot,不能,AUX,B2
+nicht ertragen,to cannot bear,不堪,VERB,B2
+nicht umhin können,to cannot help,忍不住,VERB,B2
 Canyon,canyon,峡谷,NOUN,B2
+Fähigkeit,capability,能力,NOUN,B2
+Kapazität,capacity,容量,NOUN,B2
+Kap,cape,海角,NOUN,B2
+Kapitalismus,capitalism,资本主义,NOUN,B2
+kapitalisieren,to capitalize,利用,VERB,B2
+fesselnd,captivating,迷人的,ADJ,B2
+festnehmen,capture,捕获,NOUN,B2
+festnehmen,to capture,获取,VERB,B2
+Kfz-Versicherung,car insurance,车险,NOUN,B2
+Kohlenstoff,carbon,碳,NOUN,B2
+CO2-Steuer,carbon tax,碳税,NOUN,B2
+kardial,cardiac,心脏的,ADJ,B2
+Pflegeperson,caregiver,护理人员,NOUN,B2
+nachlässig,careless,粗心的,ADJ,B2
+streicheln,to caress,爱抚,VERB,B2
+karikaturhaft,caricatural,漫画的,ADJ,B2
+Schreiner,carpenter,木匠,NOUN,B2
+Schreinerei,carpentry,木工,NOUN,B2
+Träger,carrier,承运人,NOUN,B2
+Karotte,carrot,胡萝卜,NOUN,B2
+vortragen,to carry forward,发扬,VERB,B2
+Knorpel,cartilage,软骨,NOUN,B2
+einlösen,to cash,兑现,VERB,B2
+Kasse,cash register,收银机,NOUN,B2
 Cashew,cashew,腰果,NOUN,B2
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Cent,cent,分,NOUN,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chaos,chaos,混乱,NOUN,B2
-Charge,batch,一批,NOUN,B2
-Charisma,charisma,个人魅力,NOUN,B2
-Chengyang,Chengyang,承阳,NOUN,C1
-Chilischote,chili pepper,辣椒,NOUN,B2
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Chip,chip,碎片,NOUN,B2
-Cholesterin,cholesterol,胆固醇,NOUN,B2
-Christ,christian,基督徒,NOUN,B2
-Christian (adj),Christian,词,ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chromosom,chromosome,染色体,NOUN,B2
-Chu,Chu,楚,NOUN,C1
-Clip,clip,夹子,NOUN,B2
-Clown,clown,小丑,NOUN,B2
-Cluster,cluster,簇,NOUN,B2
-Cocktail,cocktail,鸡尾酒,NOUN,B2
-Code,code,代码,NOUN,B2
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Communiqué,communique,公报,NOUN,B2
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cousin,cousin,表亲,NOUN,B2
-Crash,crash,碰撞,NOUN,B2
-Cretaceous,Cretaceous,词,ADJ,B2
-Cybersicherheit,cybersecurity,网络安全,NOUN,B2
-DIY,DIY,词,NOUN,C1
-Damm,dam,水坝,NOUN,B2
-Dankesfest,appreciation banquet,答谢宴,NOUN,B2
-Danmei,danmei,但没,NOUN,B2
-Darlehen,loan,贷款,NOUN,B2
-Darm,intestine,肠,NOUN,B2
-Datenverarbeitung,computing,计算机科学,NOUN,B2
-Dating,dating,年代测定,NOUN,B2
-Deal,deal,交易,NOUN,B2
-Debüt,debut,初次登台,NOUN,B2
+Kaschmir,cashmere,羊绒,NOUN,B2
+Maniok,cassava,木薯,NOUN,B2
+zufällig,casual,随意的,ADJ,B2
+Katalog,catalog,目录,NOUN,B2
+Katalysator,catalyst,催化剂,NOUN,B2
+aufholen,to catch up,赶上,VERB,B2
+Kategorisierung,categorization,分类,NOUN,B2
+kategorisieren,to categorize,分类,VERB,B2
+Kategorie,category,类别,NOUN,B2
+Katharsis,catharsis,宣泄,NOUN,B2
+Katholizismus,catholicism,天主教,NOUN,B2
+Blumenkohl,cauliflower,花椰菜,NOUN,B2
+Kausalität,causality,因果关系,NOUN,B2
+Verursachung,causation,因果关系,NOUN,B2
+vorsichtig,cautious,小心的,ADJ,B2
+vorsichtig und gewissenhaft,cautious and conscientious,兢兢业业,ADJ,B2
+Kavallerie,cavalry,骑兵,NOUN,B2
+krähen,to caw,呱呱叫,VERB,B2
+aufhören,to cease,停止,VERB,B2
 Decke,ceiling,天花板,NOUN,B2
-Definition,definition,定义,NOUN,B2
-Defizit,deficit,赤字,NOUN,B2
-Deflation,deflation,通货紧缩,NOUN,B2
-Defätismus,defeatism,失败主义,NOUN,B2
-Degeneration,degeneration,退化,NOUN,B2
-Degradierung,degradation,降级,NOUN,B2
-Dehydratation,dehydration,脱水,NOUN,B2
-Deismus,deism,自然神论,NOUN,B2
-Dekadenz,decadence,衰落,NOUN,B2
+Berühmtheit,celebrity,名人,NOUN,B2
+Sellerie,celery,芹菜,NOUN,B2
+Zölibat,celibacy,独身,NOUN,B2
+Handy,cell phone,手机,NOUN,B2
+Keller,cellar,地窖,NOUN,B2
+zellulär,cellular,细胞的,ADJ,B2
+zementieren,cement,水泥,NOUN,B2
+zementieren,to cement,巩固,VERB,B2
+zensieren,to censor,审查,VERB,B2
+Zensur,censorship,审查制度,NOUN,B2
+Cent,cent,分,NOUN,B2
+zentral,central,中心的,ADJ,B2
+Zentralisierung,centralization,集中化,NOUN,B2
+zentralisieren,to centralize,集中,VERB,B2
+Zentrifugalkraft,centrifugal force,离心力,NOUN,B2
+Zentrifuge,centrifuge,离心机,NOUN,B2
+Keramik,ceramics,陶瓷,NOUN,B2
+Zeremonienkappe,ceremonial cap,爵弁,NOUN,B2
+gewiss,certain,某些,DET,B2
+Gewissheit,certainty,确定性,NOUN,B2
+Verdiensturkunde,certificate of merit,奖状,NOUN,B2
+Einstellung,cessation,终止,NOUN,B2
+Kreide,chalk,粉笔,NOUN,B2
+Meister,champion,冠军,NOUN,B2
+Meisterschaft,championship,锦标赛,NOUN,B2
+Kanzler,chancellor,总理,NOUN,B2
+Reifen wechseln,to change tire,换胎,VERB,B2
+geänderte Politik,changed policy,改策,NOUN,B2
+kanalisieren,to channel,疏导,VERB,B2
+Chaos,chaos,混乱,NOUN,B2
+chaotisch,chaotic,混乱的,ADJ,B2
+Wortzeichen,character word,字,NOUN,B2
+Merkmal,characteristic,典型的,ADJ,B2
+charakterisieren,to characterize,描绘,VERB,B2
+Holzkohle,charcoal,木炭,NOUN,B2
+Ladung,charge,收费,NOUN,B2
+Ladegerät,charger,充电器,NOUN,B2
+Charisma,charisma,个人魅力,NOUN,B2
+Wohltätigkeit,charity,慈善,NOUN,B2
+Scharlatan,charlatan,江湖骗子,NOUN,B2
+Diagramm,chart,图表,NOUN,B2
+chartern,charter,宪章,NOUN,B2
+chartern,to charter,租船,VERB,B2
+verfolgen,chase,追逐,NOUN,B2
+verfolgen,to chase,追逐,VERB,B2
+Keuschheit,chastity,贞洁,NOUN,B2
+Gespräch,chat,聊天,NOUN,B2
+plaudern,to chatter,喋喋不休,VERB,B2
+aufmuntern,to cheer up,使高兴,VERB,B2
+chemisch,chemical,化学的,ADJ,B2
+hegen,to cherish,珍爱,VERB,B2
+Kirsche,cherry,樱桃,NOUN,B2
+Brustschmerz,chest pain,胸痛,NOUN,B2
+Kastanie,chestnut,板栗,NOUN,B2
+kindisch,childish,幼稚的,ADJ,B2
+Chilischote,chili pepper,辣椒,NOUN,B2
+Chip,chip,碎片,NOUN,B2
+Meißel,chisel,凿子,NOUN,B2
+Ritterlichkeit,chivalry,骑士精神,NOUN,B2
+Cholesterin,cholesterol,胆固醇,NOUN,B2
+hacken,chop,砍,NOUN,B2
+hacken,to chop,砍,VERB,B2
+Christ,christian,基督徒,NOUN,B2
+Chromosom,chromosome,染色体,NOUN,B2
+chronisch,chronic,慢性的,ADJ,B2
+Schaltkreis,circuit,电路,NOUN,B2
+zirkulieren,to circulate,循环,VERB,B2
+Beschneidung,circumcision,割礼,NOUN,B2
+umschreiben,to circumscribe,限制,VERB,B2
+Zitat,citation,引用,NOUN,B2
+zitieren,to cite,引用,VERB,B2
+Staatsbürgerschaft,citizenship,公民身份,NOUN,B2
+zivil,civil,民事的,ADJ,B2
+Beamter,civil servant,公务员,NOUN,B2
+zivilisiert,civilized,文明的,ADJ,B2
+Lärm,clamor,喧嚣,NOUN,B2
+Klan,clan,家族,NOUN,B2
+heimlich,clandestine,秘密的,ADJ,B2
+Klärung,clarification,澄清,NOUN,B2
+klassisch,classic,经典的,ADJ,B2
+Klassizismus,classicism,古典主义,NOUN,B2
+Klassifikation,classification,分类,NOUN,B2
+Klassifikator,classifier for paintings cloth etc.,幅,NUM,B2
+Klassifikator,classifier for trees,棵,NUM,B2
+klassifizieren,to classify,分类,VERB,B2
+Klasskamerad,classmate,同学,NOUN,B2
+Klausel,clause,从句,NOUN,B2
+Kralle,claw,爪子,NOUN,B2
+Ton,clay,黏土,NOUN,B2
+Sauberkeit,cleanliness,清洁,NOUN,B2
+Reinigung,cleansing,清洗,NOUN,B2
+Erkenntnis,clear knowledge,明知,NOUN,B2
+Klarsuppe,clear soup,江瑶清羹,NOUN,B2
+eindeutig,clear-cut,明确的,ADJ,B2
+deutlich,clearly,清楚地,ADV,B2
+abgegrenzt,clearly demarcated,分明,ADJ,B2
+spalten,to cleave,劈开,VERB,B2
+Klerus,clergy,神职人员,NOUN,B2
+Schreiber,clerk,职员,NOUN,B2
+Klischee,cliche,陈词滥调,NOUN,B2
+klicken,to click,点击,VERB,B2
+Klientelismus,clientelism,庇护主义,NOUN,B2
+Klippe,cliff,悬崖,NOUN,B2
+Klima,climate,气候,NOUN,B2
+Klimawandel,climate change,气候变化,NOUN,B2
+klinisch,clinical,临床的,ADJ,B2
+Clip,clip,夹子,NOUN,B2
+Garderobe,cloakroom,衣帽间,NOUN,B2
+Klon,clone,克隆体,NOUN,B2
+schließen,to close account,销户,VERB,B2
+schließen,to close the door,关门,VERB,B2
+geschlossen,closed,关闭的,ADJ,B2
+Nähe,closeness,接近,NOUN,B2
+Kleiderschrank,closet,壁橱,NOUN,B2
+Schlussfeier,closing ceremony,闭幕仪式,NOUN,B2
+Clown,clown,小丑,NOUN,B2
+ungeschickt,clumsy,笨拙的,ADJ,B2
+Cluster,cluster,簇,NOUN,B2
+Kupplung,clutch,离合器,NOUN,B2
+trainieren,coach,教练,NOUN,B2
+trainieren,to coach,辅导,VERB,B2
+grob,coarse,粗糙的,ADJ,B2
+Überredung,coaxing,哄得,NOUN,B2
+Cocktail,cocktail,鸡尾酒,NOUN,B2
+übermütig,cocky,傲慢的,ADJ,B2
+Code,code,代码,NOUN,B2
+Koeffizient,coefficient,系数,NOUN,B2
+Zwang,coercion,胁迫,NOUN,B2
+koexistieren,to coexist,共存,VERB,B2
+Koexistenz,coexistence,共存,NOUN,B2
+Kohärenz,coherence,连贯性,NOUN,B2
+kohärent,coherent,连贯的,ADJ,B2
+Kohäsion,cohesion,凝聚力,NOUN,B2
+zusammenfallen,to coincide,同时发生,VERB,B2
+Sieb,colander,漏勺,NOUN,B2
+Blut,cold blood,冷血,NOUN,B2
+Kältewelle,cold wave,寒潮,NOUN,B2
+kalt,coldly,冷淡地,ADV,B2
+zusammenarbeiten,to collaborate,合作,VERB,B2
+Zusammenarbeit,collaboration,合作,NOUN,B2
+Kollaborateur,collaborator,合作者,NOUN,B2
+Zusammenbruch,collapse,倒塌,NOUN,B2
+zusätzlich,collateral,附属的,ADJ,B2
+kollektiv,collective,集体的,ADJ,B2
+Sammler,collector,收藏家,NOUN,B2
+verschwören,to collude,勾结,VERB,B2
+Kolonialismus,colonialism,殖民主义,NOUN,B2
+Kolonisierung,colonization,殖民化,NOUN,B2
+kolonisieren,to colonize,殖民,VERB,B2
+Kolonie,colony,殖民地,NOUN,B2
+färben,to color,着色,VERB,B2
+Kamm,comb,梳子,NOUN,B2
+bekämpfen,combat,战斗,NOUN,B2
+bekämpfen,to combat,对抗,VERB,B2
+Bekämpfung,combating,打击,NOUN,B2
+stammen,to come from,来自,VERB,B2
+auftauchen,to come up,出现,VERB,B2
+Komiker,comedian,喜剧演员,NOUN,B2
+Komödie,comedy,喜剧,NOUN,B2
+Komet,comet,彗星,NOUN,B2
+komisch,comic,喜剧的,ADJ,B2
+Kommen,coming,مجيء,NOUN,B2
+Kommen und Gehen,coming and going,往来,NOUN,B2
+Kommandoraum,command room,指挥室,NOUN,B2
+gedenken,to commemorate,纪念,VERB,B2
+Gedenkfeier,commemoration,纪念,NOUN,B2
+Kommentator,commentator,评论员,NOUN,B2
+Handel,commerce,商业,NOUN,B2
+kommerziell,commercial,商业的,ADJ,B2
+Kommission,commission,委员会,NOUN,B2
+begehen,to commit a crime,犯罪,VERB,B2
+Ausschuss,committee,委员会,NOUN,B2
+Ware,commodity,商品,NOUN,B2
+gemein,common,常见的,ADJ,B2
+Gemeiner,commoner,平民,NOUN,B2
+Aufruhr,commotion,骚动,NOUN,B2
+Communiqué,communique,公报,NOUN,B2
+Kommunismus,communism,共产主义,NOUN,B2
+kommunistisch,communist,شيوعي,ADJ,B2
+Kommunitarismus,communitarianism,社群主义,NOUN,B2
+kompakt,compact,紧凑的,ADJ,B2
+Freundschaft,companionship,陪伴,NOUN,B2
+Mitgefühl,compassion,同情,NOUN,B2
+mitfühlend,compassionate,有同情心的,ADJ,B2
+Kompatibilität,compatibility,兼容性,NOUN,B2
+Landsmann,compatriot,同胞,NOUN,B2
+Entschädigung,compensation,补偿,NOUN,B2
+Ausgleichsurlaub,compensatory leave,调休,NOUN,B2
+Kompetenz,competence,能力,NOUN,B2
+Wettbewerbsfähigkeit,competitiveness,竞争力,NOUN,B2
+Wettbewerber,competitor,竞争者,NOUN,B2
+Zusammenstellung,compilation,汇编,NOUN,B2
+kompilieren,to compile,编译,VERB,B2
+ergänzend,complementary,互补的,ADJ,B2
+Vollendung,completion,完成,NOUN,B2
+komplex,complex,复杂的,ADJ,B2
+Komplexität,complexity,复杂性,NOUN,B2
+Einhaltung,compliance,合规,NOUN,B2
+konform,compliant,符合的,ADJ,B2
+komplizieren,to complicate,使复杂化,VERB,B2
+mitschuldig,complicit,共谋的,ADJ,B2
+befolgen,to comply,遵守,VERB,B2
+einhalten,to comply with,遵守,VERB,B2
+Komponente,component,组成部分,NOUN,B2
+gelassen,composed,稳重的,ADJ,B2
+Zusammensetzung,composition,作文,NOUN,B2
+Kompost,compost,堆肥,NOUN,B2
+Verbindung,compound,复合性,ADJ,B2
+verstehen,to comprehend,理解,VERB,B2
+Verständnis,comprehension,理解,NOUN,B2
+umfassend,comprehensive,全面的,ADJ,B2
+komprimieren,to compress,压缩,VERB,B2
+Kompressor,compressor,压缩机,NOUN,B2
+sich einigen,to compromise,危及,VERB,B2
+zwanghaft,compulsive,强迫性的,ADJ,B2
+Datenverarbeitung,computing,计算机科学,NOUN,B2
+Verheimlichung,concealment,隐瞒,NOUN,B2
+eingebildet,conceited,自负的,ADJ,B2
+konzipieren,to conceive,构想,VERB,B2
+Anliegen,concern,担忧,NOUN,B2
+Zugeständnis,concession,让步,NOUN,B2
+prägnant,concise,简洁的,ADJ,B2
+Schluss,conclusion,结论,NOUN,B2
+schlüssig,conclusive,决定性的,ADJ,B2
+Beton,concrete,具体的,ADJ,B2
+Konkubine,concubine,妾,NOUN,B2
+Verurteilung,condemnation,谴责,NOUN,B2
+Kondensation,condensation,凝结,NOUN,B2
+kondensieren,to condense,浓缩,VERB,B2
+herablassend,condescending,屈尊的,ADJ,B2
+bedingen,to condition,制约,VERB,B2
+bedingt,conditional,条件的,ADJ,B2
+kondolieren,to condole,哀悼,VERB,B2
+Beileid,condolence,哀悼,NOUN,B2
+leiten,conduct,行为,NOUN,B2
+leiten,to conduct,أجرى,VERB,B2
+Kegel,cone,圆锥体,NOUN,B2
+Konföderation,confederation,邦联,NOUN,B2
+anvertrauen,to confide,吐露,VERB,B2
+zuversichtlich,confident,自信的,ADJ,B2
+Vertraulichkeit,confidentiality,保密性,NOUN,B2
+Konfiguration,configuration,配置,NOUN,B2
+beschlagnahmen,to confiscate,没收,VERB,B2
+Konfiszierung,confiscation,没收,NOUN,B2
+Konflikt,conflict,冲突,NOUN,B2
+Konformismus,conformism,因循守旧,NOUN,B2
+konfrontieren,to confront,面对,VERB,B2
+Konfrontation,confrontation,对抗,NOUN,B2
+verwirrt,confused,困惑的,ADJ,B2
+Verwirrung,confusion,困惑,NOUN,B2
+Stauung,congestion,拥堵,NOUN,B2
+Glückwunsch,congratulation,祝贺,NOUN,B2
+Glückwunsch,congratulations,恭喜,INTJ,B2
+Gemeinde,congregation,集会,NOUN,B2
+Nadelwald,coniferous forest,针叶林,NOUN,B2
+Vermutung,conjecture,推测,NOUN,B2
+Konjugation,conjugation,变位,NOUN,B2
+Konjunktion,conjunction,连词,NOUN,B2
+Konnotation,connotation,内涵,NOUN,B2
+Eroberung,conquest,征服,NOUN,B2
+gewissenhaft,conscientious,认真的,ADJ,B2
+aufeinanderfolgende Karten,consecutive cards,连牌,NOUN,B2
+Konsens,consensus,共识,NOUN,B2
+Einwilligung,consent,同意,NOUN,B2
+Erhaltung,conservation,保护,NOUN,B2
+rücksichtsvoll,considerate,体贴,ADJ,B2
+Sendung,consignment,托运,NOUN,B2
+bestehen,to consist,组成,VERB,B2
+Konsistenz,consistency,一致性,NOUN,B2
+Trost,consolation,安慰,NOUN,B2
+trösten,to console,安慰,VERB,B2
+Gatte,consort,福晋,NOUN,B2
+auffällig,conspicuous,显著的,ADJ,B2
+Polizist,constable,警官,NOUN,B2
+Konstante,constant,常数,NOUN,B2
+Sternbild,constellation,星座,NOUN,B2
+Verstopfung,constipation,便秘,NOUN,B2
+Wahlkreis,constituency,选区,NOUN,B2
+konstituieren,to constitute,构成,VERB,B2
+verfassungsmäßig,constitutional,宪法的,ADJ,B2
+Verfassungsmäßigkeit,constitutionality,合宪性,NOUN,B2
+einschränken,to constrain,限制,VERB,B2
+Einschränkung,constraint,约束,NOUN,B2
+konstruieren,to construct,建造,VERB,B2
+konstruktiv,constructive,建设性的,ADJ,B2
+Konsul,consul,领事,NOUN,B2
+konsularisch,consular,领事的,ADJ,B2
+Konsulat,consulate,领事馆,NOUN,B2
+konsultieren,to consult,咨询,VERB,B2
+nachschlagen,to consult reference,参考,VERB,B2
+Berater,consultant,顾问,NOUN,B2
+verbrauchen,to consume,消费,VERB,B2
+Verbraucher,consumer,消费者,NOUN,B2
+ansteckend,contagious,传染性的,ADJ,B2
+Behälter,container,容器,NOUN,B2
+kontemplieren,to contemplate,沉思,VERB,B2
+kontemplativ,contemplative,沉思的,ADJ,B2
+zeitgenössisch,contemporary,当代的,ADJ,B2
+Verachtung,contempt,轻视,NOUN,B2
+Zufriedenheit,contentment,满足,NOUN,B2
+Wettbewerb,contest,比赛,NOUN,B2
+kontextuell,contextual,语境的,ADJ,B2
+Kontingenz,contingency,偶然性,NOUN,B2
+Fortsetzung,continuation,延续,NOUN,B2
+Kontinuität,continuity,连续性,NOUN,B2
+kontinuierlich,continuous,连续的,ADJ,B2
+Widerspruch,contradiction,矛盾,NOUN,B2
+widersprüchlich,contradictory,矛盾的,ADJ,B2
+Gegenteil,contrary,反而,NOUN,B2
+Gegenteilige Absicht,contrary intention,反意,NOUN,B2
+kontrastieren,to contrast,对比,VERB,B2
+verstoßen,to contravene,违反,VERB,B2
+Kontrollraum,control room,控制室,NOUN,B2
+Kontroverse,controversy,争议,NOUN,B2
+einberufen,to convene,召集,VERB,B2
+praktisch,convenient,方便的,ADJ,B2
+Konvention,convention,惯例,NOUN,B2
+konventionell,conventional,传统的,ADJ,B2
+konvergieren,to converge,汇聚,VERB,B2
+Konvergenz,convergence,汇聚,NOUN,B2
+konversieren,to converse,交谈,VERB,B2
+umgekehrt,conversely,相反地,ADV,B2
+umwandeln,to convert,转换,VERB,B2
+übermitteln,to convey,传达,VERB,B2
+verurteilen,to convict,定罪,VERB,B2
+Überzeugung,conviction,定罪,NOUN,B2
+überzeugt,convinced,确信的,ADJ,B2
+Konvulsion,convulsion,抽搐,NOUN,B2
+Fleischkloß,cooked meatball,丸子熟,NOUN,B2
+gekochter Reis,cooked rice,米饭,NOUN,B2
+Kochtopf,cooking pot,炖锅,NOUN,B2
+kühlen,to cool,冷却,VERB,B2
+abkühlen,to cool down,冷却,VERB,B2
+Kühlung,cooling,冷却,NOUN,B2
+Kühle,coolness,凉爽,NOUN,B2
+koordinieren,to coordinate,协调,VERB,B2
+Koordinator,coordinator,协调员,NOUN,B2
+Kupfer,copper,铜,NOUN,B2
+Kopist,copyist,抄写员,NOUN,B2
+Koralle,coral,珊瑚,NOUN,B2
+Korken,cork,软木塞,NOUN,B2
+Krönung,coronation,加冕,NOUN,B2
+korrigieren,to correct,纠正,VERB,B2
+Korrelation,correlation,相关性,NOUN,B2
+Korrespondenz,correspondence,通信,NOUN,B2
+Korrespondent,correspondent,记者,NOUN,B2
+Korrosion,corrosion,腐蚀,NOUN,B2
+korruptieren,corrupt,腐败的,ADJ,B2
+korruptieren,to corrupt,腐败,VERB,B2
+Korruption,corruption,腐败,NOUN,B2
+kosmisch,cosmic,宇宙的,ADJ,B2
+Kosten,cost,费用,NOUN,B2
+Landhaus,cottage,小屋,NOUN,B2
+Baumwolle,cotton,棉花,NOUN,B2
+Rat,council,委员会,NOUN,B2
+Beratung,counseling,咨询,NOUN,B2
+zählen,to count as,算,VERB,B2
+gegensteuern,counter,柜台,NOUN,B2
+gegensteuern,to counter,反击,VERB,B2
+Gegenform,counter-form,反式,NOUN,B2
+Gegenlogik,counter-logic,反逻,NOUN,B2
+Antimaterie,counter-matter,反物,NOUN,B2
+Gegenmechanismus,counter-mechanism,反机,NOUN,B2
+Gegenmodell,counter-model,反模,NOUN,B2
+Gegenbeobachtung,counter-observation,反察,NOUN,B2
+Gegenqualität,counter-quality,反质,NOUN,B2
+Gegenroute,counter-route,反途,NOUN,B2
+Gegenfertigkeit,counter-skill,反技,NOUN,B2
+Gegensohle,counter-sole,反唯,NOUN,B2
+Gegenstruktur,counter-structure,反结,NOUN,B2
+Gegensystem,counter-system,反系,NOUN,B2
+Gegentechnik,counter-technique,反术,NOUN,B2
+Gegentrend,counter-trend,反势,NOUN,B2
+Gegentyp,counter-type,反型,NOUN,B2
+Gegenangriff,counterattack,反击,NOUN,B2
+gefälscht,counterfeit,假冒,ADJ,B2
+Gegenstück,counterpart,对应的人或物,NOUN,B2
+zähllos,countless,无数的,ADJ,B2
+Land,countryside,乡村,NOUN,B2
+Putsch,coup,政变,NOUN,B2
+Paarreim,couplet,对联,NOUN,B2
+Gerichtsausschluss,court dismissal,退朝,NOUN,B2
+Höflichkeit,courtesy,礼貌,NOUN,B2
+Hof,courtyard,庭院,NOUN,B2
+Cousin,cousin,表亲,NOUN,B2
+Bund,covenant,契约,NOUN,B2
+Abdeckung,cover,封面,NOUN,B2
+Habsucht,covetousness,贪欲,NOUN,B2
+Feigheit,cowardice,懦弱,NOUN,B2
+Krabbe,crab,螃蟹,NOUN,B2
+Riss,crack,裂缝,NOUN,B2
+knistern,to crackle,噼啪作响,VERB,B2
+Handwerk,craft,工艺,NOUN,B2
+Handwerker,craftsman,工匠,NOUN,B2
+Handwerkskunst,craftsmanship,手工艺,NOUN,B2
+Crash,crash,碰撞,NOUN,B2
+Krater,crater,火山口,NOUN,B2
+begehren,to crave,渴望,VERB,B2
+Schöpfung,creation,创造,NOUN,B2
+kreativ,creative,有创造力的,ADJ,B2
+Kreativität,creativity,创造力,NOUN,B2
+Schöpfer,creator,创造者,NOUN,B2
+Glaubwürdigkeit,credibility,可信度,NOUN,B2
+Gläubiger,creditor,债权人,NOUN,B2
+Gläubigerrecht,creditor's right,债权,NOUN,B2
+Glaubensbekenntnis,creed,信条,NOUN,B2
+Kamm,crest,顶峰,NOUN,B2
+kriminell,criminal,犯罪的,ADJ,B2
+Kriminalität,criminality,犯罪,NOUN,B2
+kriminalisieren,to criminalize,定罪,VERB,B2
+Kriterium,criterion,标准,NOUN,B2
+Kritiker,critic,评论家,NOUN,B2
+kritisch,critical,关键的,ADJ,B2
+Kritikalität,criticality,临界性,NOUN,B2
+kritisieren,to criticize,批评,VERB,B2
+Ernte,crop,庄稼,NOUN,B2
+Übergang,crossing,交叉口,NOUN,B2
+Kreuzung,crossroads,十字路口,NOUN,B2
+Krähe,crow,乌鸦,NOUN,B2
+Menge,crowd,人群,NOUN,B2
+krönen,to crown,加冕,VERB,B2
+entscheidend,crucial,至关重要的,ADJ,B2
+Grausamkeit,cruelty,残忍,NOUN,B2
+Kreuzfahrt,cruise,巡航,NOUN,B2
+knirschen,to crunch,嘎吱作响,VERB,B2
+zerdrücken,to crush,压碎,VERB,B2
+vernichtende Niederlage,crushing defeat,惨败,NOUN,B2
+Kruste,crust,外壳,NOUN,B2
+Krebstier,crustacean,甲壳类动物,NOUN,B2
+Weinen,crying,,NOUN,B2
+Jungtier,cub,幼兽,NOUN,B2
+Würfel,cube,立方体,NOUN,B2
+Kubismus,cubism,立体主义,NOUN,B2
+kulturell,cultural,文化的,ADJ,B2
+Kulturgut,cultural relic,文物,NOUN,B2
+List,cunning,狡猾的,ADJ,B2
+Schrank,cupboard,橱柜,NOUN,B2
+eindämmen,to curb,抑制,VERB,B2
+Währung,currency,货币,NOUN,B2
+Strom,current,当前的,ADJ,B2
+amtierende Dynastie,current dynasty,当朝,NOUN,B2
+Lehrplan,curriculum,课程,NOUN,B2
+Vorhangstange,curtain rod,窗帘杆,NOUN,B2
+Kissen,cushion,垫子,NOUN,B2
+Brauch,custom,习俗,NOUN,B2
+üblich,customary,习惯的,ADJ,B2
+abkürzen,to cut short,截断,VERB,B2
+Zyanose,cyanosis,发绀,NOUN,B2
+cyber,cyber,网络的,ADJ,B2
+Cybersicherheit,cybersecurity,网络安全,NOUN,B2
+zyklen,cycle,循环,NOUN,B2
+zyklen,to cycle,骑自行车,VERB,B2
+zyklisch,cyclical,周期的,ADJ,B2
+Zyklone,cyclone,气旋,NOUN,B2
+Zylinder,cylinder,圆柱体,NOUN,B2
+Zymbel,cymbal,钹,NOUN,B2
+zynisch,cynical,愤世嫉俗的,ADJ,B2
+Dolch,dagger,匕首,NOUN,B2
+täglich,daily,每天,ADV,B2
+Tageszuwachs,daily increase,日渐,NOUN,B2
+Tageszeitung,daily newspaper,日报,NOUN,B2
+Damm,dam,水坝,NOUN,B2
+verdammt,damn,该死,INTJ,B2
+feucht,damp,潮湿,ADJ,B2
+Danmei,danmei,但没,NOUN,B2
+Armaturenbrett,dashboard,仪表盘,NOUN,B2
+datieren,to date,注明日期,VERB,B2
+Dating,dating,年代测定,NOUN,B2
+Morgendämmerung,dawn,黎明,NOUN,B2
+Tag und Nacht,day and night,昼夜,NOUN,B2
+Tagesarbeiter,day laborer,日工,NOUN,B2
+schwärmen,to daydream,幻想,VERB,B2
+blendend,dazzling,耀眼的,ADJ,B2
+Sackgasse,dead end,死胡同,NOUN,B2
+Frist,deadline,截止日期,NOUN,B2
+tödlich,deadly,致命的,ADJ,B2
+Deal,deal,交易,NOUN,B2
 Dekan,dean,院长,NOUN,B2
+Todesstrafe,death penalty,死刑,NOUN,B2
+Todeswunsch,death wish,找死,NOUN,B2
+entwerten,to debase,贬低,VERB,B2
+diskutabel,debatable,有争议的,ADJ,B2
+debattieren,debate,辩论,NOUN,B2
+debattieren,to debate,辩论,VERB,B2
+Lüsternheit,debauchery,放荡,NOUN,B2
+Schuld,debt,债务,NOUN,B2
+Schuldner,debtor,债务人,NOUN,B2
+Debüt,debut,初次登台,NOUN,B2
+Jahrzehnt,decade,十年,NOUN,B2
+Dekadenz,decadence,衰落,NOUN,B2
+dekadent,decadent,颓废,ADJ,B2
+Verstorbene,deceased,死者,NOUN,B2
+betrügerisch,deceitful,欺诈的,ADJ,B2
+Dezentralisierung,decentralization,权力下放,NOUN,B2
+Täuschung,deception,欺骗,NOUN,B2
+Täuschungswette,deception dare,你敢骗我,NOUN,B2
+entziffern,to decipher,破译,VERB,B2
+Entscheider,decision-maker,决策者,NOUN,B2
+Erklärung,declaration,宣言,NOUN,B2
+erklären,to declare,宣布,VERB,B2
+zurückgehen,decline,衰退,NOUN,B2
+zurückgehen,to decline,下降,VERB,B2
+höflich ablehnen,to decline politely,婉拒,VERB,B2
+Stilllegung,decommissioning,退役,NOUN,B2
+zerfallen,to decompose,分解,VERB,B2
+dekonstruieren,to deconstruct,解构,VERB,B2
 Dekonstruktion,deconstruction,解构主义,NOUN,B2
 Dekoration,decoration,装饰品,NOUN,B2
+abnehmen,decrease,减少,NOUN,B2
+abnehmen,to decrease,减少,VERB,B2
+erlassen,decree,法令,NOUN,B2
+erlassen,to decree,颁布法令,VERB,B2
+Entschlüsselung,decryption,解密,NOUN,B2
+widmen,to dedicate,致力于,VERB,B2
+Widmung,dedication,奉献,NOUN,B2
+ableiten,to deduce,推断,VERB,B2
+frittieren,to deep-fry,油炸,VERB,B2
+vertiefen,to deepen,加深,VERB,B2
+tief,deeply,深深地,ADV,B2
+Hirsch,deer,鹿,NOUN,B2
+Verleumdung,defamation,诽谤,NOUN,B2
+Verzug,default,违约,NOUN,B2
+Defätismus,defeatism,失败主义,NOUN,B2
+defektieren,defect,缺陷,NOUN,B2
+defektieren,to defect,叛变,VERB,B2
+verteidigen,to defend one's country,卫国,VERB,B2
+Beklagter,defendant,被告,NOUN,B2
+Trotz,defiance,挑衅,NOUN,B2
+Defizit,deficit,赤字,NOUN,B2
+definieren,to define,定义,VERB,B2
+Definition,definition,定义,NOUN,B2
+definitiv,definitive,决定性的,ADJ,B2
+Deflation,deflation,通货紧缩,NOUN,B2
+Entwaldung,deforestation,森林砍伐,NOUN,B2
+verformen,to deform,使变形,VERB,B2
+Verformung,deformation,变形,NOUN,B2
+verformt,deformed,畸形的,ADJ,B2
+betrügen,to defraud,诈骗,VERB,B2
+degenerieren,to degenerate,退化,VERB,B2
+Degeneration,degeneration,退化,NOUN,B2
+Degradierung,degradation,降级,NOUN,B2
+degradieren,to degrade,贬低,VERB,B2
+Dehydratation,dehydration,脱水,NOUN,B2
+Deismus,deism,自然神论,NOUN,B2
+Gottheit,deity,神,NOUN,B2
+niedergeschlagen,dejected,沮丧的,ADJ,B2
+Niedergeschlagenheit,dejection,沮丧,NOUN,B2
+delegieren,delegate,代表,NOUN,B2
+delegieren,to delegate,委派,VERB,B2
 Delegation,delegation,代表团,NOUN,B2
-Delinquent,delinquent,罪犯,NOUN,B2
+beraten,deliberate,深思熟虑的,ADJ,B2
+beraten,to deliberate,深思熟虑,VERB,B2
+absichtlich,deliberately,故意地,ADV,B2
+Beratung,deliberation,深思熟虑,NOUN,B2
+Feinheit,delicacy,美食,NOUN,B2
+zart,delicate,精致的,ADJ,B2
+Freude,delight,高兴,NOUN,B2
+entzückend,delightful,令人愉快的,ADJ,B2
 Delinquenz,delinquency,违法行为,NOUN,B2
+Delinquent,delinquent,罪犯,NOUN,B2
 Delirium,delirium,精神错乱,NOUN,B2
+Flut,deluge,洪水,NOUN,B2
 Demenz,dementia,痴呆,NOUN,B2
-Demografie,demography,人口学,NOUN,B2
+Entmilitarisierung,demilitarization,去武,NOUN,B2
+demokratisch,democratic,民主的,ADJ,B2
 Demokratisierung,democratization,民主化,NOUN,B2
-Demonstrant,protester,示威者,NOUN,B2
+Demografie,demography,人口学,NOUN,B2
+demolieren,to demolish,拆除,VERB,B2
+Abriss,demolition,拆除,NOUN,B2
+demonstrieren,to demonstrate,证明,VERB,B2
 Demonstration,demonstration,演示,NOUN,B2
-Demontage,dismantling,拆除，瓦解,NOUN,B2
-Demut,humility,谦逊,NOUN,B2
-Demütigung,humiliation,羞辱,NOUN,B2
-Denken,thinking,思维,NOUN,B2
-Denkmal,monument,纪念碑,NOUN,B2
+demoralisieren,to demoralize,使士气低落,VERB,B2
+Verleugnung,denial,否认,NOUN,B2
 Denotation,denotation,外延,NOUN,B2
+verurteilen,to denounce,谴责,VERB,B2
+Dichte,density,密度,NOUN,B2
 Denunziation,denunciation,告发,NOUN,B2
+Abteilungsleiter,department head,厅长,NOUN,B2
+Kaufhaus,department store,百货商店,NOUN,B2
+abhängen,to depend,依赖,VERB,B2
+darstellen,to depict,描绘,VERB,B2
+bedauern,to deplore,谴责,VERB,B2
+absetzen,to depose,废黜,VERB,B2
+hinterlegen,to deposit,存放,VERB,B2
+Abschreibung,depreciation,贬值,NOUN,B2
+deprimieren,to depress,使沮丧,VERB,B2
 Depression,depression,抑郁,NOUN,B2
-Desinfektionsmittel,disinfectant,消毒剂,NOUN,B2
-Desinformation,disinformation,虚假信息,NOUN,B2
-Desinteresse,disinterest,公正;不感兴趣,NOUN,B2
-Desorientierung,disorientation,迷失方向,NOUN,B2
+Entbehrung,deprivation,剥夺,NOUN,B2
+berauben,to deprive,剥夺,VERB,B2
+Stellvertreter,deputy,副的,ADJ,B2
+entgleisen,to derail,使脱轨,VERB,B2
+Ableitung,derivative,衍生物,NOUN,B2
+abschwächen,to derogate,贬损,VERB,B2
+herabsteigen,to descend,下降,VERB,B2
+Nachkomme,descendant,后代,NOUN,B2
+Abstieg,descent,下降,NOUN,B2
+Wüstenbildung,desertification,荒漠化,NOUN,B2
+verdienen,to deserve,值得,VERB,B2
+Gestaltung,design,设计,NOUN,B2
+Bestellfahrer,designated driver,代驾,NOUN,B2
+Bezeichnung,designation,指定,NOUN,B2
+Gestalter,designer,设计者,NOUN,B2
+unterlassen,to desist,停止,VERB,B2
+wüst,desolate,荒凉的,ADJ,B2
+verachtenswert,despicable,可鄙的,ADJ,B2
+plündern,to despoil,掠夺,VERB,B2
 Despot,despot,暴君,NOUN,B2
 Despotismus,despotism,专制,NOUN,B2
 Destabilisierung,destabilization,动摇,NOUN,B2
-Details,its details,其详,NOUN,B2
+destabilisieren,to destabilize,使不稳定,VERB,B2
+Verarmung,destitution,贫困,NOUN,B2
+zerstörerisch,destructive,مدمر,ADJ,B2
+abtrennen,to detach,分离,VERB,B2
+Abkommando,detachment,脱落,NOUN,B2
+festhalten,to detain,拘留,VERB,B2
+erkennen,to detect,探测,VERB,B2
+Erkennung,detection,检测,NOUN,B2
+Entspannung,detente,缓和,NOUN,B2
+verschlechtern,to deteriorate,恶化,VERB,B2
 Determinismus,determinism,决定论,NOUN,B2
+deterministisch,deterministic,决定论的,ADJ,B2
+verabscheuen,to detest,厌恶,VERB,B2
+verabscheuungswürdig,detestable,可恶的,ADJ,B2
+detonieren,to detonate,引爆,VERB,B2
 Detonation,detonation,爆炸,NOUN,B2
-Dezentralisierung,decentralization,权力下放,NOUN,B2
+Umweg,detour,绕道,NOUN,B2
+entgiften,to detoxify,解毒,VERB,B2
+entwerten,to devalue,贬值,VERB,B2
+verwüsten,to devastate,摧毁,VERB,B2
+Verwüstung,devastation,破坏,NOUN,B2
+entwickelt,developed,发达的,ADJ,B2
+Entwickler,developer,开发商,NOUN,B2
+Abweichung,deviation,偏离,NOUN,B2
+widmen,to devote,奉献,VERB,B2
+gewidmet,devoted,忠诚的,ADJ,B2
+verschlingen,to devour,吞食,VERB,B2
+Tau,dew,露水,NOUN,B2
 Diabetes,diabetes,糖尿病,NOUN,B2
-Diagramm,chart,图表,NOUN,B2
+diagnostizieren,to diagnose,诊断,VERB,B2
 Diagramm,diagram,图表,NOUN,B2
 Dialekt,dialect,方言,NOUN,B2
+dialogisieren,dialogue,对话,NOUN,B2
+dialogisieren,to dialogue,对话,VERB,B2
+Durchfall,diarrhea,腹泻,NOUN,B2
 Diaspora,diaspora,流散,NOUN,B2
-Dichte,density,密度,NOUN,B2
-Dicke,thickness,厚度,NOUN,B2
-Diebesanwesenheit,thief presence,有贼,NOUN,B2
-Dienst haben,to be on duty,值班,VERB,B2
-Dienstleister,service provider,服务商,NOUN,B2
-Differenzierung,differentiation,区分,NOUN,B2
-Digitalisierung,digitization,数字化,NOUN,B2
+Würfel,dice,骰子,NOUN,B2
+diktieren,to dictate,口述,VERB,B2
 Diktatur,dictatorship,独裁统治,NOUN,B2
+sich unterscheiden,to differ,不同,VERB,B2
+differenzieren,to differentiate,区分,VERB,B2
+Differenzierung,differentiation,区分,NOUN,B2
+schwieriger Angriff,difficult attack,难攻,NOUN,B2
+schwieriges Problem,difficult problem,难题,NOUN,B2
+diffundieren,to diffuse,扩散,VERB,B2
+Verdauung,digestion,消化,NOUN,B2
+verdauend,digestive,消化的,ADJ,B2
+Graben,digging,挖掘,NOUN,B2
+Ziffer,digit,数字,NOUN,B2
+digital,digital,数字的,ADJ,B2
+Digitalisierung,digitization,数字化,NOUN,B2
+Würde,dignity,尊严,NOUN,B2
+abschweifen,to digress,离题,VERB,B2
+dilatieren,to dilate,膨胀,VERB,B2
 Dilatation,dilation,扩张,NOUN,B2
 Dilemma,dilemma,困境,NOUN,B2
-Dilemma,predicament,困境,NOUN,B2
+Gewissenhaftigkeit,diligence,勤勉,NOUN,B2
 Dimension,dimension,维度,NOUN,B2
+verringern,to diminish,减少,VERB,B2
+eintauchen,to dip,蘸,VERB,B2
 Diplomatie,diplomacy,外交,NOUN,B2
-Disk,disk,唱片,NOUN,B2
+Richtungsschild,direction sign,指示牌,NOUN,B2
+Richtlinie,directive,指令,NOUN,B2
+direkt,directly,直接地,ADV,B2
+Behinderung,disability,残疾,NOUN,B2
+behindert,disabled,残疾的,ADJ,B2
+widersprechen,to disagree,不同意,VERB,B2
+Uneinigkeit,disagreement,不和,NOUN,B2
+Verschwinden,disappearance,消失,NOUN,B2
+enttäuscht,disappointed,失望的,ADJ,B2
+enttäuschend,disappointing,令人失望的,ADJ,B2
+entwaffnen,to disarm,解除武装,VERB,B2
+zerlegen,to disassemble,拆卸,VERB,B2
+katastrophal,disastrous,灾难性的,ADJ,B2
+ablehnen,to disavow,否认,VERB,B2
+Unglaube,disbelief,不信,NOUN,B2
+verwerfen,to discard,丢弃,VERB,B2
+Entlassung,discharge,放电,NOUN,B2
+Jünger,disciple,门徒,NOUN,B2
+disziplinieren,to discipline,管教,VERB,B2
+offenlegen,to disclose,揭露,VERB,B2
+Unbehagen,discomfort,不适,NOUN,B2
+trennen,to disconnect,断开,VERB,B2
+Unzufriedenheit,discontent,不满,NOUN,B2
+Zwist,discord,不和,NOUN,B2
+Unstimmigkeit,discordance,不一致,NOUN,B2
+entmutigen,to discourage,使气馁,VERB,B2
+diskutieren,discourse,论述,NOUN,B2
+diskutieren,to discourse,论述,VERB,B2
+diskreditieren,to discredit,败坏名声,VERB,B2
 Diskretion,discretion,谨慎,NOUN,B2
+diskriminieren,to discriminate,歧视,VERB,B2
 Diskriminierung,discrimination,歧视,NOUN,B2
+Verachtung,disdain,蔑视,NOUN,B2
+aussteigen,to disembark,下船,VERB,B2
+sich lösen,to disengage,脱离,VERB,B2
+Geschirrspüler,dishwasher,洗碗机,NOUN,B2
+desinfizieren,to disinfect,消毒,VERB,B2
+Desinfektionsmittel,disinfectant,消毒剂,NOUN,B2
+Desinformation,disinformation,虚假信息,NOUN,B2
+Desinteresse,disinterest,公正;不感兴趣,NOUN,B2
+unparteiisch,disinterested,公正的,ADJ,B2
+disjunkt,disjoint,不相交的,ADJ,B2
+Disk,disk,唱片,NOUN,B2
+nicht mögen,to dislike,不喜欢,VERB,B2
+ausrenken,to dislocate,使脱臼,VERB,B2
+Luxation,dislocation,脱臼,NOUN,B2
+zerlegen,to dismantle,拆除,VERB,B2
+Demontage,dismantling,拆除，瓦解,NOUN,B2
+absteigen,to dismount,下马,VERB,B2
+Ungehorsam,disobedience,不服从,NOUN,B2
+missachten,to disobey,违抗,VERB,B2
+Unordnung,disorder,混乱,NOUN,B2
+unordentlich,disorderly,杂乱的,ADJ,B2
+desorientieren,to disorient,使迷失方向,VERB,B2
+Desorientierung,disorientation,迷失方向,NOUN,B2
+Ungleichheit,disparity,差异,NOUN,B2
+absenden,to dispatch,派遣,VERB,B2
+verabreichen,to dispense medicine,配药,VERB,B2
+Anzeige,display,展示,NOUN,B2
+missfallen,to displease,使不快,VERB,B2
+Unzufriedenheit,displeasure,不悦,NOUN,B2
+Streit,dispute,争论,NOUN,B2
+unzufrieden,dissatisfied,不满的,ADJ,B2
+sezieren,to dissect,解剖,VERB,B2
+verbreiten,to disseminate,传播,VERB,B2
 Dissens,dissent,异议,NOUN,B2
 Dissertation,dissertation,论文,NOUN,B2
+Verschwendung,dissipation,挥霍,NOUN,B2
+Auflösung,dissolution,溶解,NOUN,B2
 Dissonanz,dissonance,不和谐,NOUN,B2
+abraten,to dissuade,劝阻,VERB,B2
+deutlich,distinct,明显的,ADJ,B2
+Unterscheidung,distinction,区别,NOUN,B2
+ausgezeichnet,distinguished,杰出,ADJ,B2
+Verzerrung,distortion,扭曲,NOUN,B2
+abgelenkt,distracted,分心的,ADJ,B2
+Verteilung,distribution,分布,NOUN,B2
+Bezirksleiter,district head,区长,NOUN,B2
+Misstrauen,distrust,不信任,NOUN,B2
+störend,disturbing,令人不安的,ADJ,B2
+Graben,ditch,沟渠,NOUN,B2
+Tauchgang,dive,跳水,NOUN,B2
+abweichend,divergent,分歧的,ADJ,B2
 Diversifikation,diversification,多样化,NOUN,B2
+diversifizieren,to diversify,使多样化,VERB,B2
+Vielfalt,diversity,多样性,NOUN,B2
+umleiten,to divert,转移,VERB,B2
 Dividende,dividend,红利,NOUN,B2
+Wahrsagung,divination,占卜,NOUN,B2
+Gott,divine,神圣的,ADJ,B2
+Tauchen,diving,潜水,NOUN,B2
+Gottheit,divinity,神性,NOUN,B2
+Teilung,division,分开,NOUN,B2
+Schwindel,dizziness,眩晕,NOUN,B2
+schwindelig,dizzy,头晕的,ADJ,B2
+nicht,do not,莫,ADV,B2
+Nichtverwendung,do not use,别用,NOUN,B2
+sich bestmöglich anstrengen,to do one's best,尽力,VERB,B2
+tun,to do to make,做,VERB,B2
+Sanftmut,docility,温顺,NOUN,B2
 Dock,dock,码头,NOUN,B2
-Dogma,dogma,教条,NOUN,B2
-Dogmatismus,dogmatism,教条主义,NOUN,B2
 Dokumentarfilm,documentary,纪录片的,ADJ,B2
-Dolch,dagger,匕首,NOUN,B2
+ausweichen,to dodge,躲避,VERB,B2
+Dogma,dogma,教条,NOUN,B2
+dogmatisch,dogmatic,教条的,ADJ,B2
+Dogmatismus,dogmatism,教条主义,NOUN,B2
+Kuppel,dome,圆顶,NOUN,B2
+domestisch,domestic,国内的,ADJ,B2
 Domestizierung,domestication,驯化,NOUN,B2
-Dorfvorsteher,village head,村长,NOUN,B2
-Dorn,thorn,刺,NOUN,B2
+dominant,dominant,占主导地位的,ADJ,B2
+dominieren,to dominate,支配,VERB,B2
+Erledigung,done,事已,NOUN,B2
+Spender,donor,捐赠者,NOUN,B2
+Türgriff,door handle,门把手,NOUN,B2
+Türmatte,doormat,门垫,NOUN,B2
+Schlafsaal,dormitory,宿舍,NOUN,B2
 Dosierung,dosage,剂量,NOUN,B2
+hinunter,down,顺...而下,ADP,B2
 Download,download,下载,NOUN,B2
-Dozent,lecturer,演讲者,NOUN,B2
+Regenguss,downpour,倾盆大雨,NOUN,B2
+Unterkurs,downstream,下游,NOUN,B2
+Mitgift,dowry,嫁妆,NOUN,B2
+Entwurf,draft,草稿,NOUN,B2
+schleppen,to drag,拖,VERB,B2
+Abfluss,drain,排水沟,NOUN,B2
 Drama,drama,戏剧,NOUN,B2
+dramatisieren,to dramatize,戏剧化,VERB,B2
 Dramaturgie,dramaturgy,戏剧艺术,NOUN,B2
-Drehbuch,script,剧本,NOUN,B2
-Dumpling,steamed stuffed bun,包子,NOUN,B2
-Durchfall,diarrhea,腹泻,NOUN,B2
-Durchschnitt,average,平均,ADJ,B2
-Durchsetzung,enforcement,执行,NOUN,B2
-Dünger,fertilizer,肥料,NOUN,B2
-Dünne,thinness,瘦,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-EEG,eeg,脑电图,NOUN,B2
-Ebene,plain,平原,NOUN,B2
+draw,draw,平局,NOUN,B2
+draw on the experience of,to draw on the experience of,借鉴,VERB,B2
+draw out,draw out,引出,NOUN,B2
+dread,dread,恐惧,NOUN,B2
+dregs,dregs,渣滓,NOUN,B2
+dress up,to dress up,盛装打扮,VERB,B2
+dried tofu,dried tofu,豆干,NOUN,B2
+drift,drift,漂移,NOUN,B2
+drifting,drifting,漂泊,NOUN,B2
+drill,drill,钻头,NOUN,B2
+drizzle,drizzle,毛毛雨,NOUN,B2
+drop,to drop,掉落,VERB,B2
+drowsiness,drowsiness,昏睡,NOUN,B2
+drum,drum,鼓,NOUN,B2
+dualism,dualism,二元论,NOUN,B2
+duality,duality,二元性,NOUN,B2
+dubbing,dubbing,配音,NOUN,B2
+dull,dull,枯燥的,ADJ,B2
+dullness,dullness,迟钝,NOUN,B2
+dumping,dumping,倾销,NOUN,B2
+dumpling,dumpling,丸子,NOUN,B2
+dune,dune,沙丘,NOUN,B2
+duplicate,to duplicate,复制,VERB,B2
+durability,durability,耐用性,NOUN,B2
+dusk,dusk,黄昏,NOUN,B2
+dwelling,dwelling,住宅,NOUN,B2
+dynamite,dynamite,炸药,NOUN,B2
+dynasty,dynasty,王朝,NOUN,B2
+dysfunction,dysfunction,功能障碍,NOUN,B2
+dystopia,dystopia,反乌托邦,NOUN,B2
+each,each,每个,DET,B2
+eager,eager,渴望的,ADJ,B2
+early,early,早,ADV,B2
+early morning,early morning,凌晨,NOUN,B2
+Frühwarnung,early warning,预警,NOUN,B2
+Leichtigkeit,ease,轻松,NOUN,B2
+östlich,eastern,东方的,ADJ,B2
+Leichtes Sagen,easy to say,好说,NOUN,B2
+exzentrisch,eccentric,古怪的,ADJ,B2
+kirchlich,ecclesiastical,教会的,ADJ,B2
 Echo,echo,回声,NOUN,B2
-Ed,Ed,词,NOUN,B2
+Finsternis,eclipse,日食,NOUN,B2
+ökologisch,ecological,生态的,ADJ,B2
+Ökologie,ecology,生态学,NOUN,B2
+wirtschaftlich,economic,经济的,ADJ,B2
+Ökosystem,ecosystem,生态系统,NOUN,B2
 Edikt,edict,法令,NOUN,B2
+bearbeiten,to edit,编辑,VERB,B2
+Ausgabe,edition,版本,NOUN,B2
 Editorial,editorial,社论,NOUN,B2
+gebildet,educated,受过教育的,ADJ,B2
+EEG,eeg,脑电图,NOUN,B2
 Effektivität,effective,有效的,ADJ,B2
 Effektivität,effectiveness,功效,NOUN,B2
+Wirksamkeit,efficacy,功效,NOUN,B2
 Effizienz,efficiency,效率,NOUN,B2
-Ego,only-me,只我,NOUN,B2
-Egoismus,selfishness,自私,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-Ehefähigkeit,marriageable,适婚,NOUN,B2
-Eheverbindung,marriage alliance,联姻,NOUN,B2
-Ehrfurcht,awe,敬畏,NOUN,B2
-Ehrfurcht,reverence,尊敬,NOUN,B2
-Eifer,ardor,热情,NOUN,B2
-Eigentum,ownership,,NOUN,B2
-Eignung,suitability,适宜性,NOUN,B2
-Eile,rush,赶往,NOUN,B2
-Eindringen,intrusion,闯入,NOUN,B2
-Eindringling,intruder,入侵者,NOUN,B2
-Einfachheit,simplicity,简单,NOUN,B2
-Einfuhr,importation,进口,NOUN,B2
-Einhaltung,compliance,合规,NOUN,B2
-Einkaufen,shopping,购物,NOUN,B2
-Einkaufszentrum,shopping center,购物中心,NOUN,B2
-Einkommen,income,收入,NOUN,B2
-Einmischung,interference,干扰,NOUN,B2
-Einnahme,taking,拍摄,NOUN,B2
-Einnahmen und Ausgaben,income and expense,收支,NOUN,B2
-Einrichtung,establishment,机构,NOUN,B2
-Einsamkeit,solitude,孤独,NOUN,B2
-Einschreibung,enrollment,注册,NOUN,B2
-Einschränkung,constraint,约束,NOUN,B2
-Einschüchterung,intimidation,恐吓,NOUN,B2
-Einstellung,cessation,终止,NOUN,B2
-Eintrag,entry,入口,NOUN,B2
-Einwilligung,consent,同意,NOUN,B2
-Einzelarbeit,individual assignment,个人作业,NOUN,B2
-Einzelgedanke,single thought,一念,NOUN,B2
-Einzelhandel,retail,零售,NOUN,B2
-Einzigartigkeit,uniqueness,独特,NOUN,B2
-Eis,ice cream,冰淇淋,NOUN,B2
-Eisbahn,ice rink,溜冰场,NOUN,B2
-Eishockey,ice hockey,冰球,NOUN,B2
-Eitelkeit,vanity,虚荣,NOUN,B2
+effizient,efficient,高效的,ADJ,B2
+Aubergine,eggplant,茄子,NOUN,B2
+ausarbeiten,elaborate,详尽的,ADJ,B2
+ausarbeiten,to elaborate,制定,VERB,B2
 Elastizität,elasticity,弹性,NOUN,B2
-Elegie,elegy,挽歌,NOUN,B2
+begeistert,elated,兴高采烈的,ADJ,B2
+Ältere,elderly,年长的,ADJ,B2
+Erstgeborener,eldest son,长子,NOUN,B2
+wählen,to elect,选举,VERB,B2
+Wahl,election,选举,NOUN,B2
+Wählerschaft,electorate,选民,NOUN,B2
 Elektriker,electrician,电工,NOUN,B2
+elektronisch,electronic,电子的,ADJ,B2
 Elektronische Zahlung,electronic payment,电子支付,NOUN,B2
+elegant,elegant,优雅的,ADJ,B2
+Elegie,elegy,挽歌,NOUN,B2
 Element,element,元素,NOUN,B2
-Elend,misery,痛苦,NOUN,B2
-Elend,wretch,令人厌恶的人,NOUN,B2
+Erhebung,elevation,提升,NOUN,B2
 Eliminierung,elimination,消除,NOUN,B2
 Elite,elite,精英,NOUN,B2
+Beredsamkeit,eloquence,口才,NOUN,B2
+emanieren,to emanate,散发,VERB,B2
 Emanation,emanation,散发物,NOUN,B2
+emanzipieren,to emancipate,解放,VERB,B2
 Emanzipation,emancipation,解放,NOUN,B2
+Botschaft,embassy,大使馆,NOUN,B2
+einbetten,to embed,嵌入,VERB,B2
+verschönern,to embellish,装饰,VERB,B2
+Unterschlagung,embezzlement,贪污,NOUN,B2
+verkörpern,to embody,体现,VERB,B2
+umarmen,embrace,拥抱,NOUN,B2
+umarmen,to embrace,拥抱,VERB,B2
+besticken,to embroider,刺绣,VERB,B2
+Stickerei,embroidery,刺绣,NOUN,B2
+hervortreten,to emerge,出现,VERB,B2
+Entstehung,emergence,涌现,NOUN,B2
 Emission,emission,排放,NOUN,B2
+emittieren,to emit,发出,VERB,B2
 Emotion,emotion,情感,NOUN,B2
 Emotionalität,emotionality,感性/情绪化,NOUN,B2
+mitfühlen,to empathize,共情,VERB,B2
 Empathie,empathy,共情,NOUN,B2
-Empfehlung durch Dritte,recommendation by others,他荐,NOUN,B2
-Empfindung,sentiment,情感,NOUN,B2
-Empfänger,receiver,接收器,NOUN,B2
-Empfänger,recipient,接受者,NOUN,B2
+empirisch,empirical,经验的,ADJ,B2
 Empirismus,empiricism,经验主义,NOUN,B2
-Empörung,indignation,愤慨,NOUN,B2
-Endstufe,final stage,末期,NOUN,B2
-Enge,narrowness,狭窄,NOUN,B2
-England,England,词,PROPN,B1
-Englisch,english,英语,NOUN,B2
-English language,English language,词,NOUN,A2
-Enkel,grandchild,孙辈,NOUN,B2
-Entbehrung,deprivation,剥夺,NOUN,B2
-Entdecker,explorer,探险家,NOUN,B2
-Enteignung,expropriation,征用,NOUN,B2
-Entfremdung,alienation,异化,NOUN,B2
-Entfremdung,estrangement,疏离,NOUN,B2
-Enthusiast,enthusiast,爱好者,NOUN,B2
-Enthüllungsfeier,unveiling ceremony,揭幕仪式,NOUN,B2
-Entität,entity,实体,NOUN,B2
-Entlassung,discharge,放电,NOUN,B2
-Entmilitarisierung,demilitarization,去武,NOUN,B2
-Entourage,entourage,随从,NOUN,B2
-Entscheider,decision-maker,决策者,NOUN,B2
-Entschlüsselung,decryption,解密,NOUN,B2
-Entschädigung,compensation,补偿,NOUN,B2
-Entspannung,detente,缓和,NOUN,B2
-Entstehung,emergence,涌现,NOUN,B2
-Entthronung,enthronement,登基,NOUN,B2
-Entwaldung,deforestation,森林砍伐,NOUN,B2
-Entwickler,developer,开发商,NOUN,B2
-Entwurf,draft,草稿,NOUN,B2
-Entwurzelung,uprooting,背井离乡,NOUN,B2
-Entwöhnung,weaning,断奶,NOUN,B2
+ermächtigen,to empower,授权,VERB,B2
+Kaiserin,empress,女皇,NOUN,B2
+Hohler Ruhm,empty fame,虚名,NOUN,B2
+emulieren,to emulate,效仿,VERB,B2
+erlassen,to enact,颁布,VERB,B2
+bezaubernd,enchanting,迷人的,ADJ,B2
+umfassen,to encompass,包含,VERB,B2
+ermutigen,to encourage,鼓励,VERB,B2
+Verschlüsselung,encryption,加密,NOUN,B2
 Enzyklopädie,encyclopedia,百科全书,NOUN,B2
+enzyklopädisch,encyclopedic,百科全书式的,ADJ,B2
+schließlich,end,端,PART,B2
+landen,to end up,最终到达,VERB,B2
+unterstützen,to endorse,支持,VERB,B2
+Unterstützung,endorsement,背书,NOUN,B2
+ausstatten,to endow,赋予,VERB,B2
+Ausdauer,endurance,坚忍,NOUN,B2
+Feind,enemy must,仇必,NOUN,B2
+Feindstaat,enemy state,敌国,NOUN,B2
+energetisch,energetic,精力充沛的,ADJ,B2
+Durchsetzung,enforcement,执行,NOUN,B2
+Ingenieurwesen,engineering,工程学,NOUN,B2
+Englisch,english,英语,NOUN,B2
+Gravur,engraving,版画,NOUN,B2
+Genuss,enjoyment,享受,NOUN,B2
+aufklären,to enlighten,启发,VERB,B2
+aufgeklärt,enlightened,开明的,ADJ,B2
+anwerben,to enlist,征募,VERB,B2
+Feindschaft,enmity,敌意,NOUN,B2
+adeln,to ennoble,使高贵,VERB,B2
+Ungeheuerlichkeit,enormity,极恶,NOUN,B2
+bereichern,to enrich,使丰富,VERB,B2
+Bereicherung,enrichment,丰富,NOUN,B2
+einschreiben,to enroll,注册,VERB,B2
+Einschreibung,enrollment,注册,NOUN,B2
+bedingen,to entail,牵涉,VERB,B2
+verstricken,to entangle,使纠缠,VERB,B2
+eintreten,to enter city,进城,VERB,B2
+Unternehmen,enterprise,企业,NOUN,B2
+Unterhaltungszentrum,entertainment center,娱乐中心,NOUN,B2
+Entthronung,enthronement,登基,NOUN,B2
+begeistern,to enthuse,使热情,VERB,B2
+Begeisterung,enthusiasm,热情,NOUN,B2
+Enthusiast,enthusiast,爱好者,NOUN,B2
+verlocken,to entice,引诱,VERB,B2
+vollständig,entirely,完全地,ADV,B2
+Gesamtheit,entirety,全部,NOUN,B2
+Entität,entity,实体,NOUN,B2
+Entourage,entourage,随从,NOUN,B2
+verfestigen,to entrench,巩固,VERB,B2
+Unternehmer,entrepreneur,企业家,NOUN,B2
+Eintrag,entry,入口,NOUN,B2
+aufzählen,to enumerate,列举,VERB,B2
+Artikulation,enunciation,发音,NOUN,B2
+umweltbezogen,environmental,环境的,ADJ,B2
+Umweltbericht,environmental report,环境报告,NOUN,B2
+vorstellen,to envision,展望,VERB,B2
 Enzym,enzyme,酶,NOUN,B2
+Epos,epic,史诗,NOUN,B2
+epikureisch,epicurean,享乐主义的,ADJ,B2
 Epidemie,epidemic,流行病,NOUN,B2
 Epistemologie,epistemology,认识论,NOUN,B2
-Epos,epic,史诗,NOUN,B2
-Erbe,legacy,遗产,NOUN,B2
-Erdrutsch,landslide,滑坡,NOUN,B2
-Erdöl,petroleum,石油,NOUN,B2
-Ergebnis,outcome,结果,NOUN,B2
-Ergänzung,supplement,补充,NOUN,B2
-Erhaltung,conservation,保护,NOUN,B2
-Erhaltung,preservation,保护,NOUN,B2
-Erhebung,elevation,提升,NOUN,B2
-Erholung,recovery,恢复,NOUN,B2
+Gleichung,equation,方程,NOUN,B2
+Reitsport,equestrianism,马术,NOUN,B2
+Gleichgewicht,equilibrium,平衡,NOUN,B2
+ausgestattet,equipped,配备的,ADJ,B2
+Äquivalent,equivalent,等价物,NOUN,B2
+Ära,era,时代,NOUN,B2
+ausrotten,to eradicate,根除,VERB,B2
+Ausrottung,eradication,根除,NOUN,B2
+Löschung,erasure,擦除,NOUN,B2
 Erhu,erhu,二胡,NOUN,B2
-Erkenntnis,clear knowledge,明知,NOUN,B2
-Erkennung,detection,检测,NOUN,B2
-Erklärung,declaration,宣言,NOUN,B2
-Erledigung,done,事已,NOUN,B2
-Ernsthaftigkeit,seriousness,严肃,NOUN,B2
-Ernte,crop,庄稼,NOUN,B2
-Ernährung,nutrition,营养,NOUN,B2
-Eroberung,conquest,征服,NOUN,B2
 Erosion,erosion,侵蚀,NOUN,B2
-Erpressung,extortion,勒索,NOUN,B2
+Besorgung,errand,差事,NOUN,B2
 Errata,errata,勘误,NOUN,B2
-Ersatz,substitute,替代品,NOUN,B2
-Erschöpfung,exhaustion,疲惫,NOUN,B2
-Erstaunen,amazement,惊愕,NOUN,B2
-Erstaunen,astonishment,惊讶,NOUN,B2
-Erstentwurf,first draft,初稿,NOUN,B2
-Erstgeborener,eldest son,长子,NOUN,B2
-Erstickung,suffocation,窒息,NOUN,B2
-Erstkappe,first capping,首加缁布冠,NOUN,B2
-Erstverdienst,first merit,首功,NOUN,B2
-Ertrag,yield,产量,NOUN,B2
 Eruption,eruption,爆发,NOUN,B2
-Erwachen,awakening,觉醒,NOUN,B2
-Erwachsenenalter,adulthood,成年,NOUN,B2
-Erwartung,anticipation,预期,NOUN,B2
-Erweiterung,extension,延伸,NOUN,B2
-Erwärmung,warming,变暖,NOUN,B2
-Erziehung,nurturing,养好,NOUN,B2
-Erziehung,upbringing,教养,NOUN,B2
-Erzähler,narrator,叙述者,NOUN,B2
-Erzählung,narrative,叙述；故事,NOUN,B2
-Es lebe,long live,万岁,INTJ,B2
 Eskalation,escalation,升级,NOUN,B2
+Rolltreppe,escalator,自动扶梯,NOUN,B2
+begleiten,escort,护卫,NOUN,B2
+begleiten,to escort,护送,VERB,B2
+Wachposten,escort guard,镖师,NOUN,B2
+Spionage,espionage,间谍活动,NOUN,B2
 Essay,essay,散文,NOUN,B2
 Essenz,essence,本质,NOUN,B2
+Grundausstattung,essential equipment,要置,NOUN,B2
+im Wesentlichen,essentially,主要地,ADV,B2
+etabliert,established,既定的,ADJ,B2
+Einrichtung,establishment,机构,NOUN,B2
+Achtung,esteem,尊重,NOUN,B2
+Schätzung,estimate,估计,NOUN,B2
+Entfremdung,estrangement,疏离,NOUN,B2
+Mündung,estuary,河口,NOUN,B2
+ewiger Bund,eternal alliance,永结,NOUN,B2
 Ethereum,ethereum,以太坊,NOUN,B2
+ethisch,ethical,道德的,ADJ,B2
 Ethik,ethics,伦理学,NOUN,B2
+ethnisch,ethnic,种族的,ADJ,B2
 Ethnie,ethnicity,种族,NOUN,B2
 Ethnografie,ethnography,人种学,NOUN,B2
 Ethnologie,ethnology,民族学,NOUN,B2
-Etikett,label,标签,NOUN,B2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
+Trauerrede,eulogy,赞辞,NOUN,B2
 Euphemismus,euphemism,委婉语,NOUN,B2
 Euphorie,euphoria,欣快感,NOUN,B2
-Eurasian,Eurasian,词,ADJ,C1
+europäisch,european,欧洲的,ADJ,B2
+evakuieren,to evacuate,疏散,VERB,B2
 Evakuierung,evacuation,疏散,NOUN,B2
-Exegese,exegesis,注释,NOUN,B2
-Exemplar,specimen,标本,NOUN,B2
+umgehen,to evade,逃避,VERB,B2
+evangelisieren,to evangelize,传福音,VERB,B2
+evaporate,to evaporate,蒸发,VERB,B2
+evaporation,evaporation,蒸发,NOUN,B2
+evasive,evasive,回避的,ADJ,B2
+even,even,偶数的,ADJ,B2
+even if,even if,即使,SCONJ,B2
+eventually,eventually,最终,ADV,B2
+ever,to ever,里何尝,VERB,B2
+every day,every day,天天,ADV,B2
+evict,to evict,驱逐,VERB,B2
+eviction,eviction,驱逐,NOUN,B2
+evidence,evidence,证据,NOUN,B2
+evident,evident,明显的,ADJ,B2
+evil,evil,邪,PART,B2
+evoke,to evoke,唤起,VERB,B2
+evolution,evolution,进化,NOUN,B2
+evolve,to evolve,进化,VERB,B2
+exacerbate,to exacerbate,加剧,VERB,B2
+exacerbation,exacerbation,加剧,NOUN,B2
+exaggerate,to exaggerate,夸大,VERB,B2
+exaggeration,exaggeration,夸张,NOUN,B2
+examination,examination,考试,NOUN,B2
+exasperate,to exasperate,激怒,VERB,B2
+exasperation,exasperation,恼怒,NOUN,B2
+excavate,to excavate,挖掘,VERB,B2
+exceed,to exceed,超过,VERB,B2
+excel,to excel,擅长,VERB,B2
+exceptional,exceptional,杰出的,ADJ,B2
+excerpt,excerpt,摘录,NOUN,B2
+excess,excess,过量,NOUN,B2
+excite,to excite,使兴奋,VERB,B2
+exclamation,exclamation,感叹,NOUN,B2
+exclusion,exclusion,排除,NOUN,B2
+exclusive,exclusive,独有的,ADJ,B2
+exclusively,exclusively,专门地,ADV,B2
 Exklusivität,exclusivity,排他性,NOUN,B2
+exkommunizieren,to excommunicate,开除教籍,VERB,B2
 Exkommunikation,excommunication,绝罚,NOUN,B2
+exkoriarieren,to excoriate,严厉批评,VERB,B2
+Testamentsvollstrecker,executor,遗嘱执行人,NOUN,B2
+Exegese,exegesis,注释,NOUN,B2
+befreien,to exempt,免除,VERB,B2
+Befreiung,exemption,豁免,NOUN,B2
+üben,to exercise,锻炼,VERB,B2
+Erschöpfung,exhaustion,疲惫,NOUN,B2
+erschöpfend,exhaustive,详尽的,ADJ,B2
+ausstellen,to exhibit,展览,VERB,B2
+ermahnen,to exhort,劝告,VERB,B2
+exhumieren,to exhume,掘出,VERB,B2
+verbannen,exile,流亡,NOUN,B2
+verbannen,to exile,流放,VERB,B2
+entlasten,to exonerate,使无罪,VERB,B2
+expansiv,expansive,扩张的,ADJ,B2
 Expedition,expedition,探险,NOUN,B2
+vertreiben,to expel,开除,VERB,B2
+Ausgabe,expenditure,支出,NOUN,B2
+Kosten,expense,费用,NOUN,B2
+Ausgaben,expenses,费用,NOUN,B2
+erfahren,experienced,老练的,ADJ,B2
 Experiment,experiment,实验,NOUN,B2
+experimentell,experimental,实验的,ADJ,B2
 Expertise,expertise,专业知识,NOUN,B2
+Ablauf,expiry,失效,NOUN,B2
+Entdecker,explorer,探险家,NOUN,B2
 Explosion,explosion,爆炸,NOUN,B2
+explosiv,explosive,爆炸性的,ADJ,B2
+exportieren,export,出口,NOUN,B2
+exportieren,to export,出口,VERB,B2
+Ausstellung,exposition,阐述,NOUN,B2
+Aussetzung,exposure,暴露,NOUN,B2
+erläutern,to expound,阐述,VERB,B2
+ausdrücklich,expressly,明确地,ADV,B2
+enteignen,to expropriate,征用,VERB,B2
+Enteignung,expropriation,征用,NOUN,B2
+Ausschluss,expulsion,驱逐,NOUN,B2
+exquisit,exquisite,精致的,ADJ,B2
+ausdehnen,to extend,延伸,VERB,B2
+Erweiterung,extension,延伸,NOUN,B2
+Umfang,extent,程度,NOUN,B2
+ausrotten,to exterminate,消灭,VERB,B2
+Ausrottung,extermination,灭绝,NOUN,B2
+extern,external,外部的,ADJ,B2
+Aussterben,extinction,灭绝,NOUN,B2
+löschen,to extinguish,熄灭,VERB,B2
+erpressen,to extort,敲诈,VERB,B2
+Erpressung,extortion,勒索,NOUN,B2
 Extra,extra,群众演员,NOUN,B2
+extrahieren,to extract,提取,VERB,B2
 Extraktion,extraction,提取,NOUN,B2
+ausliefern,to extradite,引渡,VERB,B2
+Auslieferung,extradition,引渡,NOUN,B2
+extrapolieren,to extrapolate,推断,VERB,B2
 Extravaganz,extravagance,奢侈,NOUN,B2
 Extrem,extreme,أقصى,NOUN,B2
 Extrovertiertheit,extroversion,外向,NOUN,B2
+jubeln,to exult,狂喜,VERB,B2
+Jubel,exultation,欢腾,NOUN,B2
+Augenbraue,eyebrow,眉毛,NOUN,B2
+Wimper,eyelash,睫毛,NOUN,B2
+Augenlid,eyelid,眼皮,NOUN,B2
+Augenzeuge,eyewitness,目击,NOUN,B2
 Fabel,fable,寓言,NOUN,B2
+fabrizieren,to fabricate,捏造,VERB,B2
 Fabrikation,fabrication,捏造,NOUN,B2
-Fahrzeugzulassung,vehicle registration,行驶证,NOUN,B2
-Falschaussage,perjury,伪证,NOUN,B2
-Familie,home family,家,NOUN,B2
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Farbe,paint,油漆,NOUN,B2
 Fassade,facade,正面,NOUN,B2
-Faulheit,laziness,懒惰,NOUN,B2
-Faustschlag,punch,拳击,NOUN,B2
-Fauvism,Fauvism,词,NOUN,C1
+face,to face,面对,VERB,B2
+face reading,face reading,面相,NOUN,B2
+face recognition,face recognition,认人,NOUN,B2
+facet,facet,方面,NOUN,B2
+facilitate,to facilitate,促进,VERB,B2
+facilities,facilities,设施,NOUN,B2
+facsimile,facsimile,副本,NOUN,B2
+faction,faction,派,NOUN,B2
+faculty,faculty,学院,NOUN,B2
+fade,to fade,褪色,VERB,B2
+faded,faded,褪色的,ADJ,B2
+failed bid,failed bid,流标,NOUN,B2
+failure,failure,失败,NOUN,B2
+faint,to faint,昏倒,VERB,B2
+fainting,fainting,晕厥,NOUN,B2
+faith,faith,信仰,NOUN,B2
+fake,fake,假的,ADJ,B2
+falcon,falcon,猎鹰,NOUN,B2
+fall back,to fall back,回落,VERB,B2
+falling out,falling out,反目,NOUN,B2
+falling though,falling though,虽坠,NOUN,B2
+false,false,错误的,ADJ,B2
+falsehood,falsehood,谎言,NOUN,B2
+falsity,falsity,虚假,NOUN,B2
+familiarity,familiarity,مألوف,NOUN,B2
+family ruin,family ruin,家破,NOUN,B2
+fan,fan,粉丝,NOUN,B2
+fanaticism,fanaticism,狂热,NOUN,B2
+farce,farce,闹剧,NOUN,B2
+farming,farming,农业,NOUN,B2
+fascination,fascination,魅力,NOUN,B2
+fast,to fast,禁食,VERB,B2
+fast quick,fast quick,快的,ADJ,B2
+fasting,fasting,禁食,NOUN,B2
+father,father,父,PART,B2
+Müdigkeit,fatigue,疲劳,NOUN,B2
+bevorzugen,to favor,偏袒,VERB,B2
+günstige Umstände,favorable circumstances,顺境,NOUN,B2
+Machbarkeit,feasibility,可行性,NOUN,B2
+Leistung,feat,功绩,NOUN,B2
+Merkmal,feature,特征,NOUN,B2
 Februar,february,二月,NOUN,B2
+föderal,federal,联邦的,ADJ,B2
+Föderalismus,federalism,联邦主义,NOUN,B2
+Gebühr,fee,费用,NOUN,B2
+Rückmeldung,feedback,反馈,NOUN,B2
+Gebühren,fees,酬金,NOUN,B2
+Verbrechen,felony,重罪,NOUN,B2
+Frau,female,雌性,NOUN,B2
+weibliche Verwandte,female relatives,女眷,NOUN,B2
+Weiblichkeit,femininity,女性气质,NOUN,B2
 Fechten,fencing,击剑,NOUN,B2
-Feedback geben,to provide feedback,反馈,VERB,B2
-Feger,sweep,扫,NOUN,B2
-Fehde,feud,世仇,NOUN,B2
-Fehler,make mistake,犯错,NOUN,B2
-Fehler machen,to make a mistake,弄错,VERB,B2
-Fehlfunktion,malfunction,故障,NOUN,B2
-Fehltreffer,miss,小姐,NOUN,B2
-Feigheit,cowardice,懦弱,NOUN,B2
-Feilschen,haggling,计较,NOUN,B2
-Feind,enemy must,仇必,NOUN,B2
-Feindschaft,enmity,敌意,NOUN,B2
-Feindschaft,personal enmity,私仇,NOUN,B2
-Feindseligkeit,animosity,敌意,NOUN,B2
-Feindseligkeit,hostility,敌意,NOUN,B2
-Feindstaat,enemy state,敌国,NOUN,B2
-Feinhaut,fine skin,细皮,NOUN,B2
-Feinheit,delicacy,美食,NOUN,B2
-Felsbrocken,boulder,巨石,NOUN,B2
 Fenchel,fennel,茴香,NOUN,B2
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-Fensterglas,window glass,窗玻璃,NOUN,B2
-Fernbus,long-distance bus,长途车,NOUN,B2
-Fertigstellung,finishing,装修,NOUN,B2
-Fessel,shackle,镣铐,NOUN,B2
+Gärung,fermentation,发酵,NOUN,B2
+Wildheit,ferocity,凶猛,NOUN,B2
+fruchtbar,fertile,肥沃的,ADJ,B2
+Fruchtbarkeit,fertility,肥沃,NOUN,B2
+Befruchtung,fertilization,施肥,NOUN,B2
+Dünger,fertilizer,肥料,NOUN,B2
+eitern,to fester,溃烂,VERB,B2
 Fest,festival,节日,NOUN,B2
-Festigkeit,firmness,坚定,NOUN,B2
-Festkörper,solid,固体的,ADJ,B2
-Festland,mainland,大陆,NOUN,B2
-Festnahme,apprehension,忧虑,NOUN,B2
-Festsaal,affair hall,事殿,NOUN,B2
-Feuchtgebiet,wetland,湿地,NOUN,B2
-Feuchtigkeit,humidity,湿度,NOUN,B2
+Fötus,fetus,胎儿,NOUN,B2
+Fehde,feud,世仇,NOUN,B2
+feudal,feudal,封建,ADJ,B2
 Feudalismus,feudalism,封建主义,NOUN,B2
-Feuerholz,firewood,木柴,NOUN,B2
-Feuerwehrmann,firefighter,消防员,NOUN,B2
+wenige,few,很少的,ADJ,B2
 Fibrose,fibrosis,纤维化,NOUN,B2
-Filet,tenderloin,里脊,NOUN,B2
+fiktiv,fictional,虚构的,ADJ,B2
+wild,fierce,凶猛的,ADJ,B2
+Wildheit,fierceness,凶猛,NOUN,B2
+fünfte,fifth,خامس,ADJ,B2
+fünfzig,fifty,五十,NUM,B2
+kindlich,filial,孝顺,ADJ,B2
+ausfüllen,to fill in,填写,VERB,B2
 Film,film,电影,NOUN,B2
-Film,movie,电影,NOUN,B2
 Filter,filter,过滤器,NOUN,B2
+Endstufe,final stage,末期,NOUN,B2
+abschließen,to finalize,完成,VERB,B2
 Finanzierung,financing,融资,NOUN,B2
-Finsternis,eclipse,日食,NOUN,B2
+Fund,finding,发现,NOUN,B2
+bestrafen,fine,罚款,NOUN,B2
+bestrafen,to fine,罚款,VERB,B2
+Feinhaut,fine skin,细皮,NOUN,B2
+Fertigstellung,finishing,装修,NOUN,B2
+endlich,finite,有限的,ADJ,B2
+Knallkörper,firecracker,鞭炮,NOUN,B2
+Feuerwehrmann,firefighter,消防员,NOUN,B2
+feuerfest,fireproof,防火的,ADJ,B2
+Feuerholz,firewood,木柴,NOUN,B2
 Firma,firm,公司,NOUN,B2
+Festigkeit,firmness,坚定,NOUN,B2
+Erstkappe,first capping,首加缁布冠,NOUN,B2
+Erstentwurf,first draft,初稿,NOUN,B2
+Erstverdienst,first merit,首功,NOUN,B2
+Spaltung,fission,裂变,NOUN,B2
 Fitness,fitness,健康,NOUN,B2
-Fitnessstudio,gym,健身房,NOUN,B2
+fest,fixed,固定的,ADJ,B2
 Flanke,flank,侧翼,NOUN,B2
-Flecken,blot,污点,NOUN,B2
-Fleischkloß,cooked meatball,丸子熟,NOUN,B2
+Kolben,flask,小瓶,NOUN,B2
+schmeicheln,to flatter,奉承,VERB,B2
+Schmeichelei,flattery,奉承,NOUN,B2
+Geschmack,flavor,味道,NOUN,B2
+Makel,flaw,缺陷,NOUN,B2
+flüchtig,fleeting,短暂的,ADJ,B2
 Flexibilität,flexibility,灵活性,NOUN,B2
-Flora,flora,植物群,NOUN,B2
-Flugblatt,leaflet,传单,NOUN,B2
-Flugzeug,plane,飞机,NOUN,B2
-Flussufer,riverbank,河岸,NOUN,B2
-Flut,deluge,洪水,NOUN,B2
+flexibel,flexible,灵活的,ADJ,B2
+wackelig,flimsy,脆弱的,ADJ,B2
+schweben,to float,漂浮,VERB,B2
 Flut,flood,洪水,NOUN,B2
-Flux,flux,变迁,NOUN,B2
+Flora,flora,植物群,NOUN,B2
+Mehl,flour,面粉,NOUN,B2
+florieren,to flourish,繁荣,VERB,B2
+Strömung,flow,流动,NOUN,B2
+Grippe,flu,流感,NOUN,B2
+Schwankung,fluctuation,波动,NOUN,B2
 Flöte,flute,长笛,NOUN,B2
-Flüchtling,refugee,难民,NOUN,B2
-Flüstern,whisper,低语,NOUN,B2
+flattern,to flutter,飘动,VERB,B2
+Flux,flux,变迁,NOUN,B2
+Schaum,foam,泡沫,NOUN,B2
+schaumig,foamy,多泡沫的,ADJ,B2
+fokussieren,focus,焦点,NOUN,B2
+fokussieren,to focus,聚焦,VERB,B2
+Futter,fodder,饲料,NOUN,B2
+falten,to fold,折叠,VERB,B2
+Ordner,folder,文件夹,NOUN,B2
+Volk,folk,民间的,ADJ,B2
 Folklore,folklore,民俗,NOUN,B2
 Follow-up,follow-up,跟进,NOUN,B2
-Fonds,fund,基金,NOUN,B2
-Forscher,researcher,研究员,NOUN,B2
-Fortsetzung,continuation,延续,NOUN,B2
-Foto,photograph,照片,NOUN,B2
-Fotograf,photographer,摄影师,NOUN,B2
-Fotografie,photography,摄影,NOUN,B2
-Franciscan,Franciscan,词,ADJ,C1
-Fransen,fringe,边缘,NOUN,B2
-Frau,female,雌性,NOUN,B2
+Anhänger,follower,追随者,NOUN,B2
+Lebensmittel,foodstuff,食品,NOUN,B2
+töricht,foolish,愚蠢的,ADJ,B2
+Fußgängerbrücke,footbridge,人行天桥,NOUN,B2
+Fußabdruck,footprint,足迹,NOUN,B2
+Schuhe,footwear,鞋穿,NOUN,B2
+zum Beispiel,for example,例如,ADV,B2
+verboten,forbidden,被禁止的,ADJ,B2
+verbotenes Land,forbidden land,禁地,NOUN,B2
+Kraft,force,力量,NOUN,B2
+forced,forced,强迫的,ADJ,B2
+forcibly,forcibly,强制地,ADV,B2
+forecast,forecast,预测,NOUN,B2
+foresee,to foresee,预见,VERB,B2
+foresight,foresight,远见,NOUN,B2
+forever,forever,永远,ADV,B2
+forge,to forge,伪造,VERB,B2
+forgery,forgery,伪造品,NOUN,B2
+forgetful,forgetful,健忘的,ADJ,B2
+formal,formal,正式的,ADJ,B2
+formalism,formalism,形式主义,NOUN,B2
+formality,formality,礼节,NOUN,B2
+formalize,to formalize,使正式化,VERB,B2
+formation,formation,组建,NOUN,B2
+formulate,to formulate,制定,VERB,B2
+fortunate,fortunate,幸运的,ADJ,B2
+fortunately,fortunately,幸运地,ADV,B2
+fortune telling,fortune telling,算命,NOUN,B2
+forty,forty,四十,NUM,B2
+forum,forum,论坛,NOUN,B2
+fossil,fossil,化石,NOUN,B2
+foundling,foundling,弃婴,NOUN,B2
+foundry,foundry,铸造厂,NOUN,B2
+fourteen,fourteen,十四,NUM,B2
+fraction,fraction,分数,NOUN,B2
+fraction marker,fraction marker,分之,PART,B2
+fracture,fracture,骨折,NOUN,B2
+fragile,fragile,易碎的,ADJ,B2
+fragment,fragment,碎片,NOUN,B2
+fragmentation,fragmentation,碎片化,NOUN,B2
+fragrant,fragrant,芬芳的,ADJ,B2
+frame,to frame,装框,VERB,B2
+framework,framework,框架,NOUN,B2
+franchise,franchise,特许经营权,NOUN,B2
+frank,frank,坦率的,ADJ,B2
+Offenheit,frankness,坦率,NOUN,B2
 Freak,freak,怪人,NOUN,B2
-Frechheit,brazenness,厚颜无耻,NOUN,B2
-Freiwilliger,volunteer,志愿者,NOUN,B2
-Freizeit,leisure,闲暇,NOUN,B2
-Freizeit,spare time,业余,NOUN,B2
-Fremdheit,strangeness,奇怪,NOUN,B2
-French language,French language,词,NOUN,A2
-French-speaking world,French-speaking world,词,NOUN,B2
-Frenchification,Frenchification,词,NOUN,C1
+Gefrierschrank,freezer,冰柜,NOUN,B2
+Gefrieren,freezing,冻结,NOUN,B2
+Glatteisregen,freezing rain,冻雨,NOUN,B2
+Raserei,frenzy,疯狂,NOUN,B2
 Frequenz,frequency,频率,NOUN,B2
-Freude,delight,高兴,NOUN,B2
-Freund,boyfriend,男朋友,NOUN,B2
-Freundschaft,companionship,陪伴,NOUN,B2
-Friday evening,Friday evening,词,NOUN,C1
-Frist,deadline,截止日期,NOUN,B2
-Frommigkeit,piety,虔诚,NOUN,B2
-Fruchtbarkeit,fertility,肥沃,NOUN,B2
+frequentieren,to frequent,常去,VERB,B2
+Reibung,friction,摩擦,NOUN,B2
+Schrecken,fright,惊吓,NOUN,B2
+Fransen,fringe,边缘,NOUN,B2
+von Kindheit an,from childhood,从小,ADV,B2
+von nun an,from now on,今后,ADV,B2
+sparsam,frugal,节俭的,ADJ,B2
+frustrieren,to frustrate,挫败,VERB,B2
+frustrierend,frustrating,令人沮丧的,ADJ,B2
 Frustration,frustration,挫折,NOUN,B2
-Frühwarnung,early warning,预警,NOUN,B2
-Fund,finding,发现,NOUN,B2
-Fundamentalismus,fundamentalism,原教旨主义,NOUN,B2
+braten,to fry,油炸,VERB,B2
+Pfanne,frying pan,平底锅,NOUN,B2
+Kraftstoff,fuel,燃料,NOUN,B2
+Vollmond,full moon,满月,NOUN,B2
+voller Name,full name,大名,NOUN,B2
+volle Leistung,full power,全力,NOUN,B2
+lustig,fun,有趣的,ADJ,B2
 Funktionalismus,functionalism,功能主义,NOUN,B2
 Funktionalität,functionality,功能性,NOUN,B2
+Fonds,fund,基金,NOUN,B2
+fundamental,fundamental,基本的,ADJ,B2
+Fundamentalismus,fundamentalism,原教旨主义,NOUN,B2
+wütend,furious,愤怒的,ADJ,B2
+Wut,fury,狂怒,NOUN,B2
+Sicherung,fuse,保险丝,NOUN,B2
 Fusion,fusion,融合,NOUN,B2
-Futter,fodder,饲料,NOUN,B2
+Wirbel,fuss,大惊小怪,NOUN,B2
+Sinnlosigkeit,futility,无用,NOUN,B2
 Futurismus,futurism,未来主义,NOUN,B2
-Fußabdruck,footprint,足迹,NOUN,B2
-Fußgängerbrücke,footbridge,人行天桥,NOUN,B2
-Fähigkeit,capability,能力,NOUN,B2
-Föderalismus,federalism,联邦主义,NOUN,B2
-Fötus,fetus,胎儿,NOUN,B2
-Führung,leadership,领导能力,NOUN,B2
 Gadget,gadget,小装置,NOUN,B2
+Gewinn,gain,收益,NOUN,B2
+gallant,gallant,英勇的,ADJ,B2
 Gallanterie,gallantry,英勇,NOUN,B2
-Galle,bile,胆汁,NOUN,B2
-Gallic,Gallic,词,ADJ,C1
-Ganzes,whole,整体,NOUN,B2
-Ganztags,all day long,一整天,NOUN,B2
+galoppieren,to gallop,飞奔,VERB,B2
+wetten,gamble,赌博,NOUN,B2
+wetten,to gamble,赌博,VERB,B2
 Garage,garage,车库,NOUN,B2
-Garantie,warranty,保修单,NOUN,B2
-Garderobe,cloakroom,衣帽间,NOUN,B2
+Knoblauch,garlic,大蒜,NOUN,B2
+Kleidungsstück,garment,服装,NOUN,B2
+garnieren,to garnish,装饰,VERB,B2
 Garnison,garrison,驻军,NOUN,B2
+geschwätzig,garrulous,喋喋不休的,ADJ,B2
 Gas,gas,气体,NOUN,B2
-Gastfreundschaft,hospitality,好客,NOUN,B2
-Gatte,consort,福晋,NOUN,B2
-Gebirge,mountain range,山脉,NOUN,B2
-Gebot,bid,出价,NOUN,B2
-Gebühr,fee,费用,NOUN,B2
-Gebühren,fees,酬金,NOUN,B2
-Gedenkfeier,commemoration,纪念,NOUN,B2
-Gefahr,peril,危险,NOUN,B2
-Geflügel,poultry,家禽,NOUN,B2
-Gefrieren,freezing,冻结,NOUN,B2
-Gefrierschrank,freezer,冰柜,NOUN,B2
-Gefäß,vessel,船,NOUN,B2
-Gegenangriff,counterattack,反击,NOUN,B2
-Gegenbeobachtung,counter-observation,反察,NOUN,B2
-Gegenfertigkeit,counter-skill,反技,NOUN,B2
-Gegenform,counter-form,反式,NOUN,B2
-Gegenlogik,counter-logic,反逻,NOUN,B2
-Gegenmechanismus,counter-mechanism,反机,NOUN,B2
-Gegenmodell,counter-model,反模,NOUN,B2
-Gegenqualität,counter-quality,反质,NOUN,B2
-Gegenroute,counter-route,反途,NOUN,B2
-Gegenseitigkeitsversicherung,mutual insurance,互助保险,NOUN,B2
-Gegensohle,counter-sole,反唯,NOUN,B2
-Gegenstruktur,counter-structure,反结,NOUN,B2
-Gegenstück,counterpart,对应的人或物,NOUN,B2
-Gegensystem,counter-system,反系,NOUN,B2
-Gegentechnik,counter-technique,反术,NOUN,B2
-Gegenteil,contrary,反而,NOUN,B2
-Gegenteilige Absicht,contrary intention,反意,NOUN,B2
-Gegentrend,counter-trend,反势,NOUN,B2
-Gegentyp,counter-type,反型,NOUN,B2
-Geheimhaltung,secrecy,保密,NOUN,B2
-Geheimnis,mystery,谜,NOUN,B2
-Geheimtreffen,secret meeting,密会,NOUN,B2
-Gehhilfe,go help,去帮,NOUN,B2
-Geistestraining,spirit training,练神,NOUN,B2
-Geiz,stinginess,吝啬；小气,NOUN,B2
-Geißel,scourge,灾祸,NOUN,B2
-Gelassenheit,calmness,平静,NOUN,B2
-Gelassenheit,serenity,宁静,NOUN,B2
-Gelbsucht,jaundice,黄疸,NOUN,B2
-Gelehrter,scholar,学者,NOUN,B2
-Geländewagen,off-road vehicle,越野车,NOUN,B2
-Gelübde,vow,誓言,NOUN,B2
-Gemeinde,congregation,集会,NOUN,B2
-Gemeinde,municipality,市镇,NOUN,B2
-Gemeiner,commoner,平民,NOUN,B2
-Gemüsegarten,vegetable garden,果园,NOUN,B2
+Versammlung,gathering,聚集,NOUN,B2
+starren,gaze,目视,NOUN,B2
+starren,to gaze,凝视,VERB,B2
+Getriebe,gear,齿轮,NOUN,B2
 Genealogie,genealogy,家谱学,NOUN,B2
-Genehmigung,authorization,授权,NOUN,B2
-Genehmigung,permit,许可证,NOUN,B2
 General,general,将军,NOUN,B2
 Generalisierung,generalization,概括,NOUN,B2
+generalisieren,to generalize,概括,VERB,B2
+generell,generally,通常,ADV,B2
+generieren,to generate,产生,VERB,B2
 Generation,generation,一代人,NOUN,B2
 Generator,generator,发电机,NOUN,B2
+Großzügigkeit,generosity,慷慨,NOUN,B2
 Genese,genesis,起源,NOUN,B2
+genetisch,genetic,基因的,ADJ,B2
 Genetik,genetics,遗传学,NOUN,B2
 Genom,genome,基因组,NOUN,B2
 Genre,genre,类型,NOUN,B2
 Gentleman,gentleman,绅士,NOUN,B2
-Genuss,enjoyment,享受,NOUN,B2
-Gerechtigkeit,righteousness,亦正,NOUN,B2
-Gerichtsausschluss,court dismissal,退朝,NOUN,B2
-Gerichtsbarkeit,jurisdiction,管辖权,NOUN,B2
-Gerichtsbezirk,jurisdiction area,辖区,NOUN,B2
-Gerste,barley,大麦,NOUN,B2
-Gerüst,scaffold,脚手架,NOUN,B2
-Gesamtheit,all,全部,ADV,B2
-Gesamtheit,entirety,全部,NOUN,B2
-Geschichte,history,历史,NOUN,B2
-Geschirrspüler,dishwasher,洗碗机,NOUN,B2
-Geschmack,flavor,味道,NOUN,B2
-Geschwür,ulcer,溃疡,NOUN,B2
-Geschäft,business,商业,NOUN,B2
-Geschäftigkeit,busyness,事忙,NOUN,B2
-Geschäftstreffen,business meeting,洽谈会,NOUN,B2
-Gesellschaftsschicht,social class,社会阶层,NOUN,B2
-Gesetzgebung,legislation,立法,NOUN,B2
-Gespräch,chat,聊天,NOUN,B2
-Gespräch,talk,谈话,NOUN,B2
-Gesprächspartner,interlocutor,对话者,NOUN,B2
-Gestalter,designer,设计者,NOUN,B2
-Gestaltung,design,设计,NOUN,B2
-Gestern,yesterday,بارحة,NOUN,B2
-Getriebe,gear,齿轮,NOUN,B2
-Gewerkschaft,union,工会,NOUN,B2
-Gewinn,gain,收益,NOUN,B2
-Gewissenhaftigkeit,diligence,勤勉,NOUN,B2
-Gewissheit,certainty,确定性,NOUN,B2
-Gewohnheit,habitually in the past,往常,NOUN,B2
-Gewöhnung,habituation,习惯化,NOUN,B2
-Gewölbe,vault,金库,NOUN,B2
-Glatteisregen,freezing rain,冻雨,NOUN,B2
-Glaubensbekenntnis,creed,信条,NOUN,B2
-Glaubwürdigkeit,credibility,可信度,NOUN,B2
-Gleichgewicht,equilibrium,平衡,NOUN,B2
-Gleichgültigkeit,indifference,冷漠,NOUN,B2
-Gleichnis,simile,明喻,NOUN,B2
-Gleichung,equation,方程,NOUN,B2
-Glocke,bianzhong,编钟,NOUN,B2
-Gläubiger,believer,信徒,NOUN,B2
-Gläubiger,creditor,债权人,NOUN,B2
-Gläubigerrecht,creditor's right,债权,NOUN,B2
-Glück,good luck,好运,NOUN,B2
-Glück,happiness,幸福,NOUN,B2
-Glückwunsch,congratulations,恭喜,INTJ,B2
-Glückwunsch,congratulation,祝贺,NOUN,B2
-Gnawa,Gnawa,词,NOUN,B2
+echt,genuine,真正的,ADJ,B2
+geographical,geographical,地理的,ADJ,B2
+geological,geological,地质的,ADJ,B2
+geology,geology,地质学,NOUN,B2
+geometric,geometric,几何的,ADJ,B2
+geometry,geometry,几何学,NOUN,B2
+geopolitical,geopolitical,地缘政治的,ADJ,B2
+geopolitics,geopolitics,地缘政治,NOUN,B2
+germination,germination,发芽,NOUN,B2
+gesticulate,to gesticulate,做手势,VERB,B2
+get acquainted,to get acquainted,相互认识,VERB,B2
+get angry,to get angry,生气,VERB,B2
+get off work,to get off work,下班,VERB,B2
+ghost,ghost,鬼魂,NOUN,B2
+giant,giant,巨大的,ADJ,B2
+gigantic,gigantic,巨大的,ADJ,B2
+gigolo,gigolo,面首,NOUN,B2
+gild,to gild,镀金,VERB,B2
+giraffe,giraffe,长颈鹿,NOUN,B2
+give to grant,to give to grant,予以,VERB,B2
+given,given,给定,NOUN,B2
+glance,to glance,瞥,VERB,B2
+gland,gland,腺体,NOUN,B2
+glide,to glide,滑行,VERB,B2
+glimpse,to glimpse,瞥见,VERB,B2
+global,global,全球的,ADJ,B2
+global warming,global warming,气候变暖,NOUN,B2
+globalization,globalization,全球化,NOUN,B2
+globalize,to globalize,使全球化,VERB,B2
+gloominess,gloominess,忧郁,NOUN,B2
+glorification,glorification,赞美,NOUN,B2
+glory,glory,荣耀,NOUN,B2
+gloss,gloss,光泽,NOUN,B2
+glue,glue,胶水,NOUN,B2
+gluttony,gluttony,暴食,NOUN,B2
+gnosis,gnosis,灵知,NOUN,B2
+bankrottgehen,to go bankrupt,破产,VERB,B2
+absteigen,to go down,下去,VERB,B2
+vorangehen,to go first,先去,VERB,B2
+Gehhilfe,go help,去帮,NOUN,B2
+onlinegehen,to go online,上网,VERB,B2
+aufsteigen,to go up,上升,VERB,B2
+Ziel,goal,目标,NOUN,B2
+Kriegsgott,god of war,战神,NOUN,B2
 Gold,gold,金子,NOUN,B2
-Golf,gulf,海湾,NOUN,B2
-Gothic,Gothic,词,ADJ,C1
-Gott,divine,神圣的,ADJ,B2
-Gotteslästerung,blasphemy,亵渎,NOUN,B2
-Gottheit,deity,神,NOUN,B2
-Gottheit,divinity,神性,NOUN,B2
-Gourmet,gourmet,美食家,NOUN,B2
-Goyaesque,Goyaesque,词,ADJ,C1
-Graben,digging,挖掘,NOUN,B2
-Graben,ditch,沟渠,NOUN,B2
-Graben,trench,沟渠,NOUN,B2
-Granatapfel,pomegranate,石榴,NOUN,B2
-Granit,granite,花岗岩,NOUN,B2
-Grasland,grassland,草地,NOUN,B2
-Grausamkeit,cruelty,残忍,NOUN,B2
-Gravur,engraving,版画,NOUN,B2
-Grenze,boundary,边界,NOUN,B2
-Grippe,flu,流感,NOUN,B2
-Groll,rancor,怨恨,NOUN,B2
-Groll,resentment,愤恨,NOUN,B2
-Großhandel,wholesale,批发,NOUN,B2
-Großmacht,powerful nation,强国,NOUN,B2
-Großzügigkeit,generosity,慷慨,NOUN,B2
-Großzügigkeit,munificence,慷慨,NOUN,B2
-Grube,pit,坑,NOUN,B2
-Grundausstattung,essential equipment,要置,NOUN,B2
-Grundkenntnisse,smattering,少量,NOUN,B2
-Gründlichkeit,thoroughness,彻底,NOUN,B2
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gummi,gum,牙龈,NOUN,B2
 Gut,good,خير,NOUN,B2
-Gut,manor,庄园,NOUN,B2
+Glück,good luck,好运,NOUN,B2
+guter Ruf,good reputation,清誉,NOUN,B2
+gutaussehend,good-looking,好看的,ADJ,B2
+Auf Wiedersehen,goodbye,再见,INTJ,B2
+wunderschön,gorgeous,华丽的,ADJ,B2
+Gourmet,gourmet,美食家,NOUN,B2
+regieren,to govern,统治,VERB,B2
+Regierung,governance,治理,NOUN,B2
+staatlich,governmental,政府的,ADJ,B2
+graziös,graceful,优雅的,ADJ,B2
+Abstufung,gradation,渐变,NOUN,B2
+Bewertung,grading,评分；记号,NOUN,B2
+allmählich,gradually,逐渐地,ADV,B2
+absolvieren,graduate,毕业生,NOUN,B2
+absolvieren,to graduate,毕业,VERB,B2
+Transplantat,graft,嫁接,NOUN,B2
+Korn,grain,谷物,NOUN,B2
+großartig,grand,宏伟的,ADJ,B2
+große Entfernung,grand distance,雄远,NOUN,B2
+Enkel,grandchild,孙辈,NOUN,B2
+Pracht,grandeur,宏伟,NOUN,B2
+Granit,granite,花岗岩,NOUN,B2
+Zuschuss,grant,拨款,NOUN,B2
+fest greifen,to grasp firmly,抓紧,VERB,B2
+Grasland,grassland,草地,NOUN,B2
+gravel,gravel,砾石,NOUN,B2
+gravity,gravity,重力,NOUN,B2
+grazing,grazing,放牧,NOUN,B2
+great favor,great favor,大恩,NOUN,B2
+great offense,great offense,冒犯大,NOUN,B2
+great power,great power,大国,NOUN,B2
+greatness,greatness,伟大,NOUN,B2
+greed,greed,贪婪,NOUN,B2
+greedy,greedy,贪婪的,ADJ,B2
+green eye,green eye,碧眼,NOUN,B2
+green eyes,green eyes,想碧眼,NOUN,B2
+green technology,green technology,绿色技术,NOUN,B2
+green-eyed,green-eyed,让碧眼,NOUN,B2
+greenhouse,greenhouse,温室,NOUN,B2
+grenade,grenade,手榴弹,NOUN,B2
+grey,grey,灰色的,ADJ,B2
+grim,grim,严酷的,ADJ,B2
+grime,grime,污垢,NOUN,B2
+grin,to grin,咧嘴笑,VERB,B2
+grip,grip,握法,NOUN,B2
+grip,to grip,紧握,VERB,B2
+gross,gross,总的,ADJ,B2
+grounds,grounds,论据,NOUN,B2
+growth,growth,增长,NOUN,B2
+grumble,to grumble,抱怨,VERB,B2
+grumbling,grumbling,抱怨,NOUN,B2
+guarantee,guarantee,保证,NOUN,B2
+guarantor,guarantor,担保人,NOUN,B2
+guardian,guardian,守卫,NOUN,B2
+guardianship,guardianship,监护,NOUN,B2
+guess,guess,猜测,NOUN,B2
+guide,to guide,引导,VERB,B2
+guillotine,guillotine,断头台,NOUN,B2
+guilt,guilt,内疚,NOUN,B2
+guitarist,guitarist,吉他手,NOUN,B2
+Golf,gulf,海湾,NOUN,B2
+leichtgläubig,gullible,易受骗的,ADJ,B2
+schlucken,to gulp,吞咽,VERB,B2
+Gummi,gum,牙龈,NOUN,B2
+Bö,gust,阵风,NOUN,B2
+Fitnessstudio,gym,健身房,NOUN,B2
 Gymnasium,gymnasium,体育馆,NOUN,B2
 Gymnastik,gymnastics,体操,NOUN,B2
-Gypsy,Gypsy,词,NOUN,C1
-Gärung,fermentation,发酵,NOUN,B2
-Gültigkeit,validity,有效期,NOUN,B2
-Güte,kindness,仁慈,NOUN,B2
-Habseligkeiten,belongings,所属物,NOUN,B2
-Habsucht,covetousness,贪欲,NOUN,B2
-Hafen,harbor,港口,NOUN,B2
-Haferbrei,porridge,粥,NOUN,B2
+ha,ha,哈,INTJ,B2
+Lebensraum,habitat,栖息地,NOUN,B2
+Gewohnheit,habitually in the past,往常,NOUN,B2
+Gewöhnung,habituation,习惯化,NOUN,B2
+hacken,to hack,入侵；盗版,VERB,B2
+Feilschen,haggling,计较,NOUN,B2
 Halle,hall,殿,PART,B2
 Halluzination,hallucination,幻觉,NOUN,B2
-Halskette,necklace,项链,NOUN,B2
-Haltung,stance,立场,NOUN,B2
-Hammelfleisch,mutton,羊肉,NOUN,B2
+anhalten,to halt,停止,VERB,B2
 Hammer,hammer,锤子,NOUN,B2
-Handel,commerce,商业,NOUN,B2
-Handschrift,handwriting,笔迹,NOUN,B2
-Handwerk,craft,工艺,NOUN,B2
 Handwerk,handicraft,工艺品,NOUN,B2
-Handwerker,craftsman,工匠,NOUN,B2
-Handwerkskunst,craftsmanship,手工艺,NOUN,B2
-Handy,cell phone,手机,NOUN,B2
-Hang,slope,斜坡,NOUN,B2
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-Hast,rash,轻率的,ADJ,B2
-Haufen,a pile,一堆,NUM,B2
-Hauptbuch,ledger,总账,NOUN,B2
-Hauptfach,major course,专业课,NOUN,B2
-Hauptstrom,mainstream,主流,NOUN,B2
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hefe,yeast,酵母,NOUN,B2
-Heft,booklet,小册子,NOUN,B2
-Heiligkeit,holiness,神圣,NOUN,B2
-Heiligtum,sanctuary,避难所,NOUN,B2
-Heiratsvermittler,matchmaker,媒,NOUN,B2
-Heißluftballon,hot air balloon,热气球,NOUN,B2
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Herr,sir,先生,NOUN,B2
-Herrschaft,reign,统治,NOUN,B2
-Hersteller,maker,制造者,NOUN,B2
-Hersteller,manufacturer,制造商,NOUN,B2
-Heuchelei,hypocrisy,虚伪,NOUN,B2
-Heuchler,hypocrite,伪君子,NOUN,B2
-Himbeere,raspberry,覆盆子,NOUN,B2
-Himmel,in the sky,天上,NOUN,B2
-Hindernis,impediment,障碍,NOUN,B2
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hintergrundgeschichte,inside story,内幕,NOUN,B2
-Hinterhalt,ambush,伏击,NOUN,B2
-Hinterseite,rear,后面的,ADJ,B2
-Hinterteil,rear part,后部,NOUN,B2
-Hirsch,deer,鹿,NOUN,B2
-Hirte,shepherd,牧羊人,NOUN,B2
+Taschentuch,handkerchief,手帕,NOUN,B2
+Übergabe,handover,拿给,NOUN,B2
+hübsch,handsome,帅气的,ADJ,B2
+Schönling,handsome guy,帅哥,NOUN,B2
+Handschrift,handwriting,笔迹,NOUN,B2
+Schreibübung,handwriting practice,练字,NOUN,B2
+Glück,happiness,幸福,NOUN,B2
+Belästigung,harassment,骚扰,NOUN,B2
+Hafen,harbor,港口,NOUN,B2
+schwer zu wählen,hard to choose,难以抉择,ADJ,B2
+schwer zu unterscheiden,hard to distinguish,难以区分,ADJ,B2
+schwer zu erhalten,hard to maintain,难以维持,ADJ,B2
+schwer zu sagen,hard to speak of,难以启齿,ADJ,B2
+Härte,hardness,硬度,NOUN,B2
+fleißig,hardworking,勤奋的,ADJ,B2
+Schaden,harm,伤害,NOUN,B2
+harmonious,harmonious,和谐的,ADJ,B2
+harmonization,harmonization,协调,NOUN,B2
+haste,haste,匆忙,NOUN,B2
+hasty,hasty,仓促的,ADJ,B2
+hate,hate,仇恨,NOUN,B2
+haughtiness,haughtiness,傲慢,NOUN,B2
+have dinner,to have dinner,吃晚餐,VERB,B2
+have lunch,to have lunch,吃午餐,VERB,B2
+have only,to have only,唯有,VERB,B2
+have to,have to,还得,NOUN,B2
+hay,hay,干草,NOUN,B2
+hazelnut,hazelnut,榛子,NOUN,B2
+heading,heading,标题,NOUN,B2
+headphones,headphones,耳机,NOUN,B2
+heap,heap,堆,NOUN,B2
+hear a case,to hear a case,审理,VERB,B2
+heard beile,heard beile,听说贝勒,NOUN,B2
+heat wave,heat wave,热浪,NOUN,B2
+heating,heating,供暖,NOUN,B2
+heaven,heaven,天堂,NOUN,B2
+heavenly fragrance,heavenly fragrance,天香,NOUN,B2
+heaviness,heaviness,沉重 / 笨重,NOUN,B2
+heavy,heavy,重的,ADJ,B2
+heavy etiquette,heavy etiquette,礼太重,NOUN,B2
+heavy knot,heavy knot,重结,NOUN,B2
+heavy machine,heavy machine,重机,NOUN,B2
+heavy type,heavy type,重型,NOUN,B2
+heavy work,heavy work,重功,NOUN,B2
+hedge,hedge,树篱,NOUN,B2
+heel,heel,脚后跟,NOUN,B2
+hegemony,hegemony,霸权,NOUN,B2
+hehe,hehe,嘿嘿,INTJ,B2
+heir,heir,继承人,NOUN,B2
+help assistance,to help assistance,帮助,VERB,B2
+hemoglobin,hemoglobin,血红蛋白,NOUN,B2
+hemorrhage,hemorrhage,出血,NOUN,B2
+hen,hen,母鸡,NOUN,B2
+herd,herd,兽群,NOUN,B2
+herder,herder,牧民,NOUN,B2
+here,here,此地,NOUN,B2
+hereditary,hereditary,遗传的,ADJ,B2
+heredity,heredity,遗传,NOUN,B2
+heresy,heresy,异端,NOUN,B2
+heretic,heretic,异端,NOUN,B2
+heritage,heritage,遗产,NOUN,B2
+hermeneutic,hermeneutic,诠释学的,ADJ,B2
+heroic,heroic,英勇的,ADJ,B2
+heroism,heroism,英雄主义,NOUN,B2
+hesitation,hesitation,犹豫,NOUN,B2
+heterogeneous,heterogeneous,异质的,ADJ,B2
+hidden,hidden,隐藏的,ADJ,B2
+hide oneself,to hide oneself,躲藏,VERB,B2
+hideout,hideout,藏身处,NOUN,B2
+hiding,hiding,ٱختباء,NOUN,B2
+hierarchical,hierarchical,等级的,ADJ,B2
+high tide,high tide,涨潮,NOUN,B2
+higher,higher,更高的,ADJ,B2
+highlight,to highlight,强调,VERB,B2
+hiking,hiking,徒步,NOUN,B2
+hilarious,hilarious,滑稽的,ADJ,B2
+hills,hills,丘陵,NOUN,B2
+hilt,hilt,剑柄,NOUN,B2
+him,him,他吧,NOUN,B2
+hindrance,hindrance,障碍,NOUN,B2
+hiring,hiring,招聘,NOUN,B2
+his,his,他的,PRON,B2
+his departure,his departure,他走,NOUN,B2
+historical,historical,历史的,ADJ,B2
+historiography,historiography,史学,NOUN,B2
+Geschichte,history,历史,NOUN,B2
 Hobby,hobby,爱好,NOUN,B2
-Hochzeitsfoto,wedding photo,婚纱照,NOUN,B2
-Hoden,testicle,睾丸,NOUN,B2
-Hof,courtyard,庭院,NOUN,B2
-Hohler Ruhm,empty fame,虚名,NOUN,B2
+ausschlaggebend,hold the balance of power,举足轻重,ADJ,B2
+Heiligkeit,holiness,神圣,NOUN,B2
 Hohlraum,hollow,洼地,NOUN,B2
-Holzkohle,charcoal,木炭,NOUN,B2
+Familie,home family,家,NOUN,B2
+Tötung,homicide,杀人,NOUN,B2
+homogen,homogeneous,同质的,ADJ,B2
+homosexuell,homosexual,同性恋的,ADJ,B2
 Homosexualität,homosexuality,同性恋,NOUN,B2
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
+ehrlich,honestly,诚实地,ADV,B2
+ehrenamtlich,honorary,名誉的,ADJ,B2
+hoffen,to hope to wish,希望,VERB,B2
 Hormon,hormone,激素,NOUN,B2
 Horn,horn,号角,NOUN,B2
+schrecklich,horrible,可怕的,ADJ,B2
+entsetzen,to horrify,使惊骇,VERB,B2
+entsetzlich,horrifying,令人毛骨悚然的,ADJ,B2
 Horror,horror,恐怖,NOUN,B2
+Abritt,horse departure,马去,NOUN,B2
+Gastfreundschaft,hospitality,好客,NOUN,B2
+hospitalisieren,to hospitalize,使住院,VERB,B2
+Feindseligkeit,hostility,敌意,NOUN,B2
+Heißluftballon,hot air balloon,热气球,NOUN,B2
 Hotel,hotel,酒店,NOUN,B2
-Humanisierung,humanization,人性化,NOUN,B2
+Wohnraum,housing,住房,NOUN,B2
+schweben,to hover,盘旋,VERB,B2
+Wie,how,又怎会,NOUN,B2
+wie viele,how many,多少,NUM,B2
+wie viel,how much,多少,PRON,B2
+jedoch,however,然而,CCONJ,B2
+heulen,to howl,嚎叫,VERB,B2
+Mensch,human,人类,NOUN,B2
+Leistungsfähigkeit,human capacity,人会,NOUN,B2
+Menschennatur,human nature,人性,NOUN,B2
 Humanismus,humanism,人文主义,NOUN,B2
-Hummer,lobster,龙虾,NOUN,B2
+Humanisierung,humanization,人性化,NOUN,B2
+Feuchtigkeit,humidity,湿度,NOUN,B2
+demütigen,to humiliate,羞辱,VERB,B2
+Demütigung,humiliation,羞辱,NOUN,B2
+Demut,humility,谦逊,NOUN,B2
 Humor,humor,幽默,NOUN,B2
+krummrückig,hunchbacked,驼背的,ADJ,B2
 Hunger,hunger,饥饿,NOUN,B2
+Jagd,hunting,狩猎,NOUN,B2
 Hurrikan,hurricane,飓风,NOUN,B2
-Hurufiyya,Hurufiyya,词,NOUN,C1
+hybrid,hybrid,杂交的,ADJ,B2
 Hybridisierung,hybridization,杂交,NOUN,B2
+Wasserkraft,hydro energy,水能,NOUN,B2
+Wasserstoff,hydrogen,氢,NOUN,B2
 Hygiene,hygiene,卫生,NOUN,B2
 Hymne,hymn,赞美诗,NOUN,B2
+Übernutzung,hyper-use,超用,NOUN,B2
 Hypnose,hypnosis,催眠,NOUN,B2
+Heuchelei,hypocrisy,虚伪,NOUN,B2
+Heuchler,hypocrite,伪君子,NOUN,B2
 Hypothermie,hypothermia,体温过低,NOUN,B2
 Hypothese,hypothesis,假设,NOUN,B2
-Hände schütteln,to shake hands,握手,VERB,B2
-Härte,hardness,硬度,NOUN,B2
-Hässlichkeit,ugliness,丑陋,NOUN,B2
-Höflichkeit,courtesy,礼貌,NOUN,B2
-Hütte,shack,棚屋,NOUN,B2
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IT-related,IT-related,词,ADJ,C1
-Iberian,Iberian,词,ADJ,C1
+hypothetisch,hypothetical,假设的,ADJ,B2
+hysterisch,hysterical,歇斯底里的,ADJ,B2
 Ich verdiene dein Lob nicht,i don't deserve your praise,不敢当,INTJ,B2
+Eis,ice cream,冰淇淋,NOUN,B2
+Eishockey,ice hockey,冰球,NOUN,B2
+Eisbahn,ice rink,溜冰场,NOUN,B2
+Ikone,icon,偶像,NOUN,B2
+Passfoto,id photo,证件照,NOUN,B2
 Ideal,ideal,理想的,ADJ,B2
 Idealismus,idealism,理想主义,NOUN,B2
 Idealist,idealist,理想主义者,NOUN,B2
-Ikone,icon,偶像,NOUN,B2
-Immobilie,real estate,房地产,ADJ,B2
+identical,identical,完全相同的,ADJ,B2
+identification,identification,身份证明,NOUN,B2
+ideological,ideological,意识形态的,ADJ,B2
+idiocy,idiocy,愚蠢,NOUN,B2
+idiom,idiom,习语,NOUN,B2
+idle,idle,懒惰的,ADJ,B2
+idol,idol,偶像,NOUN,B2
+idyll,idyll,田园诗,NOUN,B2
+ignition,ignition,点火,NOUN,B2
+ignorance,ignorance,无知,NOUN,B2
+illegal,illegal,非法的,ADJ,B2
+illegality,illegality,非法,NOUN,B2
+illegitimate,illegitimate,非法的,ADJ,B2
+illicit,illicit,违禁的,ADJ,B2
+illness,illness,疾病,NOUN,B2
+illuminate,to illuminate,照亮,VERB,B2
+illustrate,to illustrate,说明,VERB,B2
+image,image,形象,NOUN,B2
+imagery,imagery,意象,NOUN,B2
+imagination,imagination,想象力,NOUN,B2
+imam,imam,伊玛目,NOUN,B2
+imitative,imitative,模仿性,ADJ,B2
+immeasurable,immeasurable,不可估量的,ADJ,B2
+immersion,immersion,沉浸,NOUN,B2
+immigrant,immigrant,移民,NOUN,B2
+immigrate,to immigrate,移入,VERB,B2
+immigration,immigration,移民,NOUN,B2
+imminent,imminent,即将来临的,ADJ,B2
+immortal,immortal,不朽的,ADJ,B2
+immortality,immortality,不朽,NOUN,B2
+immune,immune,免疫的,ADJ,B2
+immunity,immunity,免疫力,NOUN,B2
+immunization,immunization,免疫,NOUN,B2
+immunotherapy,immunotherapy,免疫治疗,NOUN,B2
+impact,impact,影响,NOUN,B2
+Beeinträchtigung,impairment,左手废,NOUN,B2
+erteilen,to impart,传授,VERB,B2
+ungeduldig,impatient,不耐烦的,ADJ,B2
+Hindernis,impediment,障碍,NOUN,B2
+antreiben,to impel,推动,VERB,B2
+undurchdringlich,impenetrable,不可穿透的,ADJ,B2
+imperativ,imperative,必要的,ADJ,B2
+kaiserlich,imperial,帝国的,ADJ,B2
+kaiserlicher Hof,imperial court,朝廷,NOUN,B2
+Wille des kaiserlichen Vaters,imperial father's will,父皇要,NOUN,B2
+kaiserliche Garde,imperial guard,御林,NOUN,B2
+kaiserliche Verwandte,imperial relatives,皇亲,NOUN,B2
 Imperialismus,imperialism,帝国主义,NOUN,B2
-Impfstoff,vaccine,疫苗,NOUN,B2
+Umsetzung,implementation,实施,NOUN,B2
+einbeziehen,to implicate,连累,VERB,B2
 Implikation,implication,含义,NOUN,B2
+implizit,implicit,含蓄的,ADJ,B2
+flehen,to implore,恳求,VERB,B2
+andienen,to imply,暗示,VERB,B2
+importieren,to import,进口,VERB,B2
+Wichtigkeit,importance,重要性,NOUN,B2
+Einfuhr,importation,进口,NOUN,B2
+Unmöglichkeit,impossibility,不可能,NOUN,B2
 Impressionismus,impressionism,印象主义,NOUN,B2
-Improvisation,improvisation,即兴创作,NOUN,B2
-Impuls,impulse,冲动,NOUN,B2
-Index,index,索引,NOUN,B2
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indikator,indicator,指标,NOUN,B2
-Individualismus,individualism,个人主义,NOUN,B2
-Individualität,individuality,个性,NOUN,B2
-Individuum,individual,个人,NOUN,B2
-Industriekette,industry chain,产业链,NOUN,B2
-Inflation,inflation,通货膨胀,NOUN,B2
-Influencer,influencer,网红,NOUN,B2
-Informant,informant,线人,NOUN,B2
-Ingenieurwesen,engineering,工程学,NOUN,B2
+einsperren,to imprison,监禁,VERB,B2
 Inhaftierung,imprisonment,监禁,NOUN,B2
-Initiative,initiative,主动权,NOUN,B2
+unangemessen,improper,不合适的,ADJ,B2
+Improvisation,improvisation,即兴创作,NOUN,B2
+improvisieren,to improvise,即兴创作,VERB,B2
+improvisiert,improvised,即兴的,ADJ,B2
+Unverschämtheit,impudence,厚颜无耻,NOUN,B2
+unverschämt,impudent,无礼的,ADJ,B2
+Impuls,impulse,冲动,NOUN,B2
+impulsiv,impulsive,冲动的,ADJ,B2
+Unreinheit,impurity,不纯,NOUN,B2
+im Voraus,in advance,事先,ADV,B2
+im Detail,in detail,详细地,ADV,B2
+vor,in front of,在……前面,ADP,B2
+verliebt,in love,恋爱中的,ADJ,B2
+um zu,in order to,以期,SCONJ,B2
+persönlich,in person,亲自地,ADV,B2
+kurz gesagt,in short,简而言之,ADV,B2
+trotz,to in spite of,不顾,VERB,B2
+Himmel,in the sky,天上,NOUN,B2
+Wind,in wind,临风,NOUN,B2
+Schrift,in writing,书面,NOUN,B2
+Unfähigkeit,inability,无能,NOUN,B2
+unangemessen,inappropriate,不恰当的,ADJ,B2
+Amtseinführung,inauguration,开幕,NOUN,B2
+Weihrauch,incense,香,NOUN,B2
+Anreiz,incentive,激励,NOUN,B2
+Zoll,inch,بوصة,NOUN,B2
+verbrennen,to incinerate,焚烧,VERB,B2
+aufstacheln,to incite,煽动,VERB,B2
+Aufstachelung,incitement,煽动,NOUN,B2
+Neigung,inclination,倾向,NOUN,B2
+neigen,to incline,使倾斜,VERB,B2
+einschließen,to include,包括,VERB,B2
+Einkommen,income,收入,NOUN,B2
+Einnahmen und Ausgaben,income and expense,收支,NOUN,B2
+eingehend,incoming,进来的,ADJ,B2
+Unvereinbarkeit,incompatibility,不兼容,NOUN,B2
+unvollständig,incomplete,不完整的,ADJ,B2
+Widersprüchlichkeit,inconsistency,不一致,NOUN,B2
+widersprüchlich,inconsistent,不一致的,ADJ,B2
+einverleiben,to incorporate,包含,VERB,B2
+stetig zunehmen,to increase steadily,与日俱增,VERB,B2
+zunehmend,increasingly,越来越,ADV,B2
 Inkubation,incubation,孵化,NOUN,B2
 Inkubator,incubator,孵化器,NOUN,B2
+Verschuldung,indebtedness,负债,NOUN,B2
+tatsächlich,indeed,确实,ADV,B2
+unverwischbar,indelible,不可磨灭的,ADJ,B2
+Unabhängigkeit,independence,独立,NOUN,B2
+Index,index,索引,NOUN,B2
+Anzeige,indication,指示,NOUN,B2
+Indikator,indicator,指标,NOUN,B2
+Anklage,indictment,起诉,NOUN,B2
+Gleichgültigkeit,indifference,冷漠,NOUN,B2
+gleichgültig,indifferent,冷漠的,ADJ,B2
+einheimisch,indigenous,本土的,ADJ,B2
+Verdauungsstörung,indigestion,消化不良,NOUN,B2
+empört,indignant,愤慨的,ADJ,B2
+Empörung,indignation,愤慨,NOUN,B2
+unentbehrlich,indispensable,不可或缺的,ADJ,B2
+Individuum,individual,个人,NOUN,B2
+Einzelarbeit,individual assignment,个人作业,NOUN,B2
+Individualismus,individualism,个人主义,NOUN,B2
+Individualität,individuality,个性,NOUN,B2
+herbeiführen,to induce,引起,VERB,B2
+industriell,industrial,工业的,ADJ,B2
+Industriekette,industry chain,产业链,NOUN,B2
+ineffizient,inefficient,低效的,ADJ,B2
+Ungleichheit,inequality,不平等,NOUN,B2
+Trägheit,inertia,惯性,NOUN,B2
+unvermeidlich,inevitable,不可避免的,ADJ,B2
+unerfahren,inexperienced,生疏的,ADJ,B2
+Verliebtheit,infatuation,迷恋,NOUN,B2
+ableiten,to infer,推断,VERB,B2
+Schlussfolgerung,inference,推断,NOUN,B2
+unterlegen,inferior,低等的,ADJ,B2
+Unterlegenheit,inferiority,劣势,NOUN,B2
+infiltrieren,to infiltrate,渗透,VERB,B2
+aufblähen,to inflate,使膨胀,VERB,B2
+Inflation,inflation,通货膨胀,NOUN,B2
+Influencer,influencer,网红,NOUN,B2
+informell,informal,非正式的,ADJ,B2
+Informant,informant,线人,NOUN,B2
+verletzen,to infringe,侵犯,VERB,B2
+genial,ingenious,灵巧的,ADJ,B2
+einatmen,to inhale,吸入,VERB,B2
+inhärent,inherent,固有的,ADJ,B2
+hemmen,to inhibit,抑制,VERB,B2
+anfänglich,initial,最初的,ADJ,B2
+Initiative,initiative,主动权,NOUN,B2
+injizieren,to inject,注射,VERB,B2
+Verfügung,injunction,禁令,NOUN,B2
+verletzt,injured,受伤的,ADJ,B2
+Tinte,ink,墨水,NOUN,B2
+angeboren,innate,天生的,ADJ,B2
+inner,inner,内部的,ADJ,B2
 Innenhof,inner court,朝内,NOUN,B2
-Innenstadt,inside city,城内,NOUN,B2
-Inneres,inside,在内部,ADP,B2
 Innovation,innovation,创新,NOUN,B2
+innovativ,innovative,创新的,ADJ,B2
+Anfrage,inquiry,调查,NOUN,B2
+verrückt,insane,疯狂的,ADJ,B2
+untrennbar,inseparable,不可分割的,ADJ,B2
+Inneres,inside,在内部,ADP,B2
+Innenstadt,inside city,城内,NOUN,B2
+Hintergrundgeschichte,inside story,内幕,NOUN,B2
 Insider,insider,知情者,NOUN,B2
+heimtückisch,insidious,潜伏的,ADJ,B2
+bestehen,to insist,坚持,VERB,B2
+Beharrlichkeit,insistence,坚持,NOUN,B2
+Unverschämtheit,insolence,无礼,NOUN,B2
+unverschämt,insolent,傲慢的,ADJ,B2
 Insolvenz,insolvency,无偿付能力,NOUN,B2
+Schlaflosigkeit,insomnia,失眠,NOUN,B2
+inspizieren,to inspect,检查,VERB,B2
 Inspektion,inspection,检查,NOUN,B2
 Instabilität,instability,不稳定,NOUN,B2
 Installation,installation,安装,NOUN,B2
+Ratenzahlung,installment,分期付款,NOUN,B2
 Instanz,instance,例子,NOUN,B2
+Augenblick,instant,فور,NOUN,B2
+im Gegenteil,instead on the contrary,反而,ADV,B2
 Institution,institution,机构,NOUN,B2
+institutionell,institutional,机构的,ADJ,B2
 Institutionalisierung,institutionalization,制度化,NOUN,B2
 Instrument,instrument,乐器,NOUN,B2
+unzureichend,insufficient,不足的,ADJ,B2
+Isolierung,insulation,绝缘,NOUN,B2
+Beleidigung,insult,辱骂,NOUN,B2
+unüberwindlich,insurmountable,不可逾越的,ADJ,B2
+Aufstand,insurrection,起义,NOUN,B2
+unversehrt,intact,完好无损的,ADJ,B2
+integrieren,to integrate,整合,VERB,B2
 Integration,integration,融合,NOUN,B2
 Integrität,integrity,正直,NOUN,B2
+intellektuell,intellectual,知识的,ADJ,B2
+intelligent,intelligent,聪明的,ADJ,B2
+beabsichtigen,to intend,打算,VERB,B2
+intensivieren,to intensify,加剧,VERB,B2
 Intensität,intensity,强度,NOUN,B2
+Absicht,intent,意图,NOUN,B2
 Interaktion,interaction,互动,NOUN,B2
+abfangen,to intercept,拦截,VERB,B2
+Verkehr,intercourse,性交,NOUN,B2
+Schnittstelle,interface,接口,NOUN,B2
+Einmischung,interference,干扰,NOUN,B2
+Gesprächspartner,interlocutor,对话者,NOUN,B2
+Vermittler,intermediary,中间人,NOUN,B2
+intermittierend,intermittent,间歇的,ADJ,B2
+intern,internal,内部的,ADJ,B2
+innere Kraft,internal force,内力,NOUN,B2
+international,international,国际的,ADJ,B2
+internationaler Student,international student,留学生,NOUN,B2
 Internet,internet,互联网,NOUN,B2
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Interpunktion,punctuation,标点符号,NOUN,B2
+interpretieren,to interpret,解释,VERB,B2
+Schnittpunkt,intersection,交叉点,NOUN,B2
+interviewen,interview,面试,NOUN,B2
+interviewen,to interview,采访,VERB,B2
+Darm,intestine,肠,NOUN,B2
 Intimität,intimacy,亲密,NOUN,B2
+intim,intimate,亲密的,ADJ,B2
+Einschüchterung,intimidation,恐吓,NOUN,B2
 Intoleranz,intolerance,不容忍,NOUN,B2
 Intonation,intonation,语调,NOUN,B2
+unbeugsam,intractable,难处理的,ADJ,B2
+furchtlos,intrepid,无畏的,ADJ,B2
+intrigieren,to intrigue,激起兴趣,VERB,B2
+immanent,intrinsic,固有的,ADJ,B2
 Introspektion,introspection,内省,NOUN,B2
+introvertiert,introverted,内向的,ADJ,B2
+Eindringling,intruder,入侵者,NOUN,B2
+Eindringen,intrusion,闯入,NOUN,B2
 Intuition,intuition,直觉,NOUN,B2
+invasieren,to invade,入侵,VERB,B2
 Invasion,invasion,入侵,NOUN,B2
 Inventar,inventory,库存,NOUN,B2
 Investor,investor,投资者,NOUN,B2
-Irish (noun),Irish,词,NOUN,C1
+Beteiligung,involvement,参与,NOUN,B2
+Zornmütigkeit,irascibility,易怒,NOUN,B2
+eisern,iron,铁的,ADJ,B2
 Ironie,irony,讽刺,NOUN,B2
 Irrationalität,irrationality,非理性,NOUN,B2
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
+unvereinbar,irreconcilable,不可调和的,ADJ,B2
+unwiderlegbar,irrefutable,无可辩驳的,ADJ,B2
+irrelevant,irrelevant,不相关的,ADJ,B2
+unersetzlich,irreplaceable,不可替代的,ADJ,B2
+tadellos,irreproachable,无可指责的,ADJ,B2
+verantwortungslos,irresponsible,不负责任的,ADJ,B2
+irreversibel,irreversible,不可逆转的,ADJ,B2
+Bewässerungskanal,irrigation canal,灌溉渠,NOUN,B2
+reizbar,irritable,易怒的,ADJ,B2
+reizen,to irritate,激怒,VERB,B2
+Reizung,irritation,刺激,NOUN,B2
+isolieren,to isolate,隔离,VERB,B2
+isoliert,isolated,孤立的,ADJ,B2
 Isolation,isolation,隔绝,NOUN,B2
-Isolierung,insulation,绝缘,NOUN,B2
 Isotop,isotope,同位素,NOUN,B2
-Israeli,Israeli,词,ADJ,B2
-Ja,yes,是啊,NOUN,B2
+Ausgabe,issue,问题,NOUN,B2
+Juckreiz,itch,痒,NOUN,B2
+Jucken,itching,瘙痒,NOUN,B2
+Details,its details,其详,NOUN,B2
 Jade,jade,这玉,NOUN,B2
 Jadekunst,jade ware,玉器,NOUN,B2
-Jagd,hunting,狩猎,NOUN,B2
-Jahr,years,数年,NOUN,B2
-Jahresbericht,annual report,年报,NOUN,B2
-Jahrestag,anniversary,周年纪念,NOUN,B2
-Jahrtausend,millennium,千年,NOUN,B2
-Jahrzehnt,decade,十年,NOUN,B2
-Japanese person,Japanese person,词,NOUN,C1
+Krug,jar,广口瓶,NOUN,B2
 Jargon,jargon,行话,NOUN,B2
-Jesuit,Jesuit,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
+Gelbsucht,jaundice,黄疸,NOUN,B2
+Kiefer,jaw,下巴,NOUN,B2
 Jianghu,jianghu,江湖,NOUN,B2
 Jiaolong,jiaolong,娇龙,NOUN,B2
 Jin,jin,斤,NOUN,B2
+beitreten,to join,加入,VERB,B2
+gemeinsam,joint,平等的,ADJ,B2
+Miteigentum,joint ownership,共有,NOUN,B2
+späßen,to joke,开玩笑,VERB,B2
 Journalist,journalist,记者,NOUN,B2
-Jubel,exultation,欢腾,NOUN,B2
+froh,joyful,快乐的,ADJ,B2
 Jubiläum,jubilee,禧年,NOUN,B2
-Jucken,itching,瘙痒,NOUN,B2
-Juckreiz,itch,痒,NOUN,B2
-Jugendlicher,young person,年轻人,NOUN,B2
-Juli,july,七月,NOUN,B2
-Jungtier,cub,幼兽,NOUN,B2
-Juni,june,六月,NOUN,B2
 Justiz,judiciary,司法官,NOUN,B2
-Jünger,disciple,门徒,NOUN,B2
-Kaiserin,empress,女皇,NOUN,B2
-Kalenderwoche,week number,周次,NOUN,B2
-Kalibrierung,calibration,校准,NOUN,B2
-Kalligrafie,calligraphy,书法,NOUN,B2
-Kamel,camel,骆驼,NOUN,B2
-Kamm,comb,梳子,NOUN,B2
-Kamm,crest,顶峰,NOUN,B2
-Kanal,canal,运河,NOUN,B2
-Kandidatur,candidacy,候选资格,NOUN,B2
-Kanzel,pulpit,讲坛,NOUN,B2
-Kanzler,chancellor,总理,NOUN,B2
-Kap,cape,海角,NOUN,B2
-Kapazität,capacity,容量,NOUN,B2
-Kapitalismus,capitalism,资本主义,NOUN,B2
+Juli,july,七月,NOUN,B2
+Juni,june,六月,NOUN,B2
+Gerichtsbarkeit,jurisdiction,管辖权,NOUN,B2
+Gerichtsbezirk,jurisdiction area,辖区,NOUN,B2
+wie in der Vergangenheit,just as in the past,一如既往,ADV,B2
+genau richtig,just right,恰到好处,ADV,B2
 Karate,karate,空手道,NOUN,B2
-Karotte,carrot,胡萝卜,NOUN,B2
-Karte,map,地图,NOUN,B2
-Kaschmir,cashmere,羊绒,NOUN,B2
-Kasse,cash register,收银机,NOUN,B2
-Kastanie,chestnut,板栗,NOUN,B2
-Katalog,catalog,目录,NOUN,B2
-Katalysator,catalyst,催化剂,NOUN,B2
-Katastrophe,calamity,灾难,NOUN,B2
-Kategorie,category,类别,NOUN,B2
-Kategorisierung,categorization,分类,NOUN,B2
-Katharsis,catharsis,宣泄,NOUN,B2
-Katholizismus,catholicism,天主教,NOUN,B2
-Kaufhaus,department store,百货商店,NOUN,B2
-Kausalität,causality,因果关系,NOUN,B2
-Kaution,bail,保释,NOUN,B2
-Kavallerie,cavalry,骑兵,NOUN,B2
-Kegel,cone,圆锥体,NOUN,B2
-Kehlkopf,larynx,喉,NOUN,B2
-Keller,cellar,地窖,NOUN,B2
-Keramik,ceramics,陶瓷,NOUN,B2
-Kessel,boiler,锅炉,NOUN,B2
 Kessel,kettle,水壶,NOUN,B2
-Keuschheit,chastity,贞洁,NOUN,B2
-Kfz-Versicherung,car insurance,车险,NOUN,B2
-Kiefer,jaw,下巴,NOUN,B2
-Kiefer,pine,松树,NOUN,B2
-Kilometer,kilometer,公里,NOUN,B2
+Tastatur,keyboard,键盘,NOUN,B2
+treten,kick,踢,NOUN,B2
+treten,to kick,踢,VERB,B2
 Kind,kid,小孩,NOUN,B2
-Kindergarten,nursery,托儿所,NOUN,B2
-Kindermädchen,nanny,保姆,NOUN,B2
-Kirsche,cherry,樱桃,NOUN,B2
-Kissen,cushion,垫子,NOUN,B2
-Klage,lawsuit,诉讼,NOUN,B2
-Klage,litigation,诉讼,NOUN,B2
-Klan,clan,家族,NOUN,B2
-Klarsuppe,clear soup,江瑶清羹,NOUN,B2
-Klassifikation,classification,分类,NOUN,B2
-Klassifikator,classifier for paintings cloth etc.,幅,NUM,B2
-Klassifikator,classifier for trees,棵,NUM,B2
-Klassizismus,classicism,古典主义,NOUN,B2
-Klasskamerad,classmate,同学,NOUN,B2
-Klausel,clause,从句,NOUN,B2
-Klebstoff,paste,酱,NOUN,B2
-Kleiderschrank,closet,壁橱,NOUN,B2
-Kleidung,attire,服装,NOUN,B2
-Kleidungsstück,garment,服装,NOUN,B2
-Kleine Elf,little eleven,小十一,NOUN,B2
-Kleine Neun,little nine,小九,NOUN,B2
-Kleinheit,smallness,小小,NOUN,B2
-Klerus,clergy,神职人员,NOUN,B2
-Klientelismus,clientelism,庇护主义,NOUN,B2
-Klima,climate,气候,NOUN,B2
-Klimaanlage,air conditioning,空调,NOUN,B2
-Klimawandel,climate change,气候变化,NOUN,B2
-Klippe,cliff,悬崖,NOUN,B2
-Klischee,cliche,陈词滥调,NOUN,B2
-Klon,clone,克隆体,NOUN,B2
-Kluft,rift,裂痕,NOUN,B2
-Kläger,litigant,诉讼当事人,NOUN,B2
-Kläger,plaintiff,原告,NOUN,B2
-Klärung,clarification,澄清,NOUN,B2
-Knallkörper,firecracker,鞭炮,NOUN,B2
-Knappheit,scarcity,短缺,NOUN,B2
-Kneif,pinch,捏,NOUN,B2
-Knoblauch,garlic,大蒜,NOUN,B2
-Knorpel,cartilage,软骨,NOUN,B2
-Kochtopf,cooking pot,炖锅,NOUN,B2
-Koeffizient,coefficient,系数,NOUN,B2
-Koexistenz,coexistence,共存,NOUN,B2
-Kohl,cabbage,卷心菜,NOUN,B2
-Kohlenstoff,carbon,碳,NOUN,B2
-Kohärenz,coherence,连贯性,NOUN,B2
-Kohäsion,cohesion,凝聚力,NOUN,B2
-Kolben,flask,小瓶,NOUN,B2
-Kollaborateur,collaborator,合作者,NOUN,B2
-Kolonialismus,colonialism,殖民主义,NOUN,B2
-Kolonie,colony,殖民地,NOUN,B2
-Kolonisierung,colonization,殖民化,NOUN,B2
-Komet,comet,彗星,NOUN,B2
-Komiker,comedian,喜剧演员,NOUN,B2
-Kommandoraum,command room,指挥室,NOUN,B2
-Kommen,coming,مجيء,NOUN,B2
-Kommen und Gehen,coming and going,往来,NOUN,B2
-Kommentator,commentator,评论员,NOUN,B2
-Kommission,commission,委员会,NOUN,B2
-Kommunismus,communism,共产主义,NOUN,B2
-Kommunitarismus,communitarianism,社群主义,NOUN,B2
-Kompatibilität,compatibility,兼容性,NOUN,B2
-Kompetenz,competence,能力,NOUN,B2
-Komplexität,complexity,复杂性,NOUN,B2
-Komponente,component,组成部分,NOUN,B2
-Kompost,compost,堆肥,NOUN,B2
-Kompressor,compressor,压缩机,NOUN,B2
-Komödie,comedy,喜剧,NOUN,B2
-Kondensation,condensation,凝结,NOUN,B2
-Konfiguration,configuration,配置,NOUN,B2
-Konfiszierung,confiscation,没收,NOUN,B2
-Konflikt,conflict,冲突,NOUN,B2
-Konformismus,conformism,因循守旧,NOUN,B2
-Konfrontation,confrontation,对抗,NOUN,B2
-Konföderation,confederation,邦联,NOUN,B2
-Konjugation,conjugation,变位,NOUN,B2
-Konjunktion,conjunction,连词,NOUN,B2
-Konkubine,concubine,妾,NOUN,B2
-Konnotation,connotation,内涵,NOUN,B2
-Konsens,consensus,共识,NOUN,B2
-Konserve,canned food,罐头食品,NOUN,B2
-Konsistenz,consistency,一致性,NOUN,B2
-Konstante,constant,常数,NOUN,B2
-Konsul,consul,领事,NOUN,B2
-Konsulat,consulate,领事馆,NOUN,B2
-Kontingent,quota,配额,NOUN,B2
-Kontingenz,contingency,偶然性,NOUN,B2
-Kontinuität,continuity,连续性,NOUN,B2
-Kontrollraum,control room,控制室,NOUN,B2
-Kontroverse,controversy,争议,NOUN,B2
-Konvention,convention,惯例,NOUN,B2
-Konvergenz,convergence,汇聚,NOUN,B2
-Konvulsion,convulsion,抽搐,NOUN,B2
-Koordinator,coordinator,协调员,NOUN,B2
-Kopf,on head,当头,NOUN,B2
-Kopist,copyist,抄写员,NOUN,B2
-Koralle,coral,珊瑚,NOUN,B2
-Korken,cork,软木塞,NOUN,B2
-Korn,grain,谷物,NOUN,B2
-Korrelation,correlation,相关性,NOUN,B2
-Korrespondent,correspondent,记者,NOUN,B2
-Korrespondenz,correspondence,通信,NOUN,B2
-Korrosion,corrosion,腐蚀,NOUN,B2
-Korruption,corruption,腐败,NOUN,B2
-Kostbarkeit,preciousness,珍贵,NOUN,B2
-Kosten,cost,费用,NOUN,B2
-Kosten,expense,费用,NOUN,B2
-Krabbe,crab,螃蟹,NOUN,B2
-Kraft,force,力量,NOUN,B2
-Kraftstoff,fuel,燃料,NOUN,B2
-Kralle,claw,爪子,NOUN,B2
-Krampf,spasm,痉挛,NOUN,B2
-Krankheit,malady,弊病,NOUN,B2
-Krater,crater,火山口,NOUN,B2
-Kreativität,creativity,创造力,NOUN,B2
-Krebstier,crustacean,甲壳类动物,NOUN,B2
-Kreditnehmer,borrower,借款人,NOUN,B2
-Kreide,chalk,粉笔,NOUN,B2
-Kreisverkehr,roundabout,环岛,NOUN,B2
-Kreuzfahrt,cruise,巡航,NOUN,B2
-Kreuzung,crossroads,十字路口,NOUN,B2
-Krieg führen,to wage war,作战,VERB,B2
-Kriegsgott,god of war,战神,NOUN,B2
-Kriminalität,criminality,犯罪,NOUN,B2
-Kriterium,criterion,标准,NOUN,B2
-Kritikalität,criticality,临界性,NOUN,B2
-Kritiker,critic,评论家,NOUN,B2
-Krug,jar,广口瓶,NOUN,B2
-Kruste,crust,外壳,NOUN,B2
-Krähe,crow,乌鸦,NOUN,B2
-Krönung,coronation,加冕,NOUN,B2
-Krücken benutzen,to use crutches,拄拐,VERB,B2
-Kubismus,cubism,立体主义,NOUN,B2
-Kufic,Kufic,词,ADJ,C1
-Kulturgut,cultural relic,文物,NOUN,B2
-Kunstgalerie,art gallery,美术馆,NOUN,B2
-Kunstporträt,artistic portrait,艺术照,NOUN,B2
-Kupfer,copper,铜,NOUN,B2
-Kuppel,dome,圆顶,NOUN,B2
-Kupplung,clutch,离合器,NOUN,B2
-Kältewelle,cold wave,寒潮,NOUN,B2
-Können,you can,您能,NOUN,B2
-Kühle,coolness,凉爽,NOUN,B2
-Kühlschrank,refrigerator,冰箱,NOUN,B2
-Kühlung,cooling,冷却,NOUN,B2
-Kündigung,layoff,解雇,NOUN,B2
-Lachen,your laugh,你笑,NOUN,B2
-Lachs,salmon,三文鱼,NOUN,B2
-Ladegerät,charger,充电器,NOUN,B2
-Ladung,charge,收费,NOUN,B2
-Lagerhaus,warehouse,仓库,NOUN,B2
-Lagerung,storage,收纳,NOUN,B2
-Laib,loaf,一条面包,NOUN,B2
-Laie,layman,外行,NOUN,B2
-Lamm braten,to roast lamb,烤羊,VERB,B2
-Land,countryside,乡村,NOUN,B2
-Land,land,土地,NOUN,B2
-Landesstraße,provincial highway,省道,NOUN,B2
-Landhaus,cottage,小屋,NOUN,B2
-Landschaft,scenery,风景,NOUN,B2
-Landsmann,compatriot,同胞,NOUN,B2
-Langatmigkeit,prolixity,冗长,NOUN,B2
-Langsamkeit,slowness,缓慢,NOUN,B2
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Last,load,负载,NOUN,B2
-Laster,vice,恶习,NOUN,B2
-Laterne,lantern,灯笼,NOUN,B2
-Latin (noun),Latin,词,NOUN,C1
-Laune,whim,突发奇想,NOUN,B2
-Lava,lava,熔岩,NOUN,B2
-Lawine,avalanche,雪崩,NOUN,B2
-Layout,layout,布局,NOUN,B2
-Leasing,lease,租约,NOUN,B2
-Lebensmittel,foodstuff,食品,NOUN,B2
-Lebensraum,habitat,栖息地,NOUN,B2
-Legalität,legality,合法性,NOUN,B2
-Legierung,alloy,合金,NOUN,B2
-Legitimität,legitimacy,合法性,NOUN,B2
-Lehre,apprenticeship,学徒期,NOUN,B2
-Lehrling,apprentice,学徒,NOUN,B2
-Lehrplan,curriculum,课程,NOUN,B2
-Lehrplan,syllabus,教学大纲,NOUN,B2
-Lehrsatz,precept,戒律,NOUN,B2
-Leibwächter,bodyguard,保镖,NOUN,B2
-Leiche sehen,to see corpse,见尸,VERB,B2
-Leichtes Sagen,easy to say,好说,NOUN,B2
-Leichtigkeit,ease,轻松,NOUN,B2
-Leiden,suffering,痛苦,NOUN,B2
-Leihe,borrowing,借贷,NOUN,B2
-Leistung,feat,功绩,NOUN,B2
-Leistungsfähigkeit,human capacity,人会,NOUN,B2
+mit einem Schlag zwei Fliegen mit der Klappe,kill two birds with one stone,一举两得,ADJ,B2
+Mörder,killer,杀手,NOUN,B2
+Kilometer,kilometer,公里,NOUN,B2
+Art,kind,仁慈的,ADJ,B2
+Güte,kindness,仁慈,NOUN,B2
+kinetisch,kinetic,运动的,ADJ,B2
+Verwandtschaft,kinship,亲属关系,NOUN,B2
+erkennen,to know to recognize,认识,VERB,B2
+Etikett,label,标签,NOUN,B2
+Arbeit,labor,劳动,NOUN,B2
+mühsam,laborious,费力的,ADJ,B2
+fehlen,to lack,缺乏,VERB,B2
 Leiter,ladder,梯子,NOUN,B2
-Lenkrad,steering wheel,方向盘,NOUN,B2
+Land,land,土地,NOUN,B2
+Erdrutsch,landslide,滑坡,NOUN,B2
+Spur,lane,小巷,NOUN,B2
+Laterne,lantern,灯笼,NOUN,B2
+großangelegt,large-scale,大规模的,ADJ,B2
+Kehlkopf,larynx,喉,NOUN,B2
+dauern,to last a period of time,为期,VERB,B2
+gestern Abend,last night,昨晚,ADV,B2
+letztes Jahr,last year,去年,NOUN,B2
+Spät,late,晚,ADV,B2
+seitlich,lateral,侧面的,ADJ,B2
+starten,launch,发射,NOUN,B2
+starten,to launch,发起,VERB,B2
+Lava,lava,熔岩,NOUN,B2
+Strafverfolgung,law enforcement,执法,NOUN,B2
+Klage,lawsuit,诉讼,NOUN,B2
+lax,lax,松懈的,ADJ,B2
+Schicht,layer,层,NOUN,B2
+Laie,layman,外行,NOUN,B2
+Kündigung,layoff,解雇,NOUN,B2
+Layout,layout,布局,NOUN,B2
+Faulheit,laziness,懒惰,NOUN,B2
+Tausender,lead thousand,率千,NOUN,B2
+führen,to lead to,通向,VERB,B2
+Führung,leadership,领导能力,NOUN,B2
+Flugblatt,leaflet,传单,NOUN,B2
+lecken,to leak,泄漏,VERB,B2
+Sprung,leap,跳跃,NOUN,B2
 Lernen,learning,学习,NOUN,B2
-Lesefähigkeit,literacy,读写能力,NOUN,B2
-Leser,reader,读者,NOUN,B2
-Lesung,reading,阅读,NOUN,B2
-Leuchtturm,beacon,灯塔,NOUN,B2
-Lieferant,supplier,供应商,NOUN,B2
-Limburgish,Limburgish,词,ADJ,C1
-Limousine,sedan,轿车,NOUN,B2
-Ling,Ling,叫凌,NOUN,B2
+Leasing,lease,租约,NOUN,B2
+Urlaub,leave,休假,NOUN,B2
+auslassen,to leave out,省略,VERB,B2
+Dozent,lecturer,演讲者,NOUN,B2
+Hauptbuch,ledger,总账,NOUN,B2
+Linke,left,左,NOUN,B2
+Erbe,legacy,遗产,NOUN,B2
+Rechtsberuf,legal profession,律师业,NOUN,B2
+Legalität,legality,合法性,NOUN,B2
+legal,legally,合法地,ADV,B2
+Gesetzgebung,legislation,立法,NOUN,B2
+legislativ,legislative,立法的,ADJ,B2
+Legitimität,legitimacy,合法性,NOUN,B2
+legitim,legitimate,合法的,ADJ,B2
+legitimieren,to legitimize,使合法,VERB,B2
+Freizeit,leisure,闲暇,NOUN,B2
+length,length,长度,NOUN,B2
+leniency,leniency,宽厚,NOUN,B2
+lenient,lenient,宽大的,ADJ,B2
+less,less,更少,ADV,B2
+lest,lest,唯恐,SCONJ,B2
+let alone,let alone,别说,ADV,B2
+lethal,lethal,致命的,ADJ,B2
+lettuce,lettuce,生菜,NOUN,B2
+level,to level,夷平,VERB,B2
+lexicology,lexicology,词汇学,NOUN,B2
+liaison,liaison,联络,NOUN,B2
+liberal,liberal,自由的,ADJ,B2
+liberalism,liberalism,自由主义,NOUN,B2
+liberalization,liberalization,自由化,NOUN,B2
+liberate,to liberate,解放,VERB,B2
+license plate restriction,license plate restriction,限号,NOUN,B2
+licentiousness,licentiousness,放荡,NOUN,B2
+lid,lid,盖子,NOUN,B2
+lie down,to lie down,躺,VERB,B2
+life and death,life and death,生死,NOUN,B2
+life imprisonment,life imprisonment,无期徒刑,NOUN,B2
+life retribution,life retribution,偿命,NOUN,B2
+life-and-death,life-and-death,决生,NOUN,B2
+lifetime,lifetime,一生,NOUN,B2
+lighter,lighter,打火机,NOUN,B2
+lighthouse,lighthouse,灯塔,NOUN,B2
+lightness,lightness,轻盈,NOUN,B2
+like,like,像,ADP,B2
+likeness,likeness,就象,NOUN,B2
+lime,lime,石灰,NOUN,B2
+limp,to limp,跛行,VERB,B2
+line up,to line up,排成一行,VERB,B2
+lineage,lineage,血统,NOUN,B2
+linear,linear,线性的,ADJ,B2
+linguistic,linguistic,语言的,ADJ,B2
 Linguistik,linguistics,语言学,NOUN,B2
 Link,link,链接,NOUN,B2
-Linke,left,左,NOUN,B2
 Liquidation,liquidation,清算,NOUN,B2
 Liquidität,liquidity,流动性,NOUN,B2
-List,cunning,狡猾的,ADJ,B2
-List,slyness,狡猾,NOUN,B2
+auflisten,to list,列举,VERB,B2
+zuhören,to listen attentively,倾听,VERB,B2
 Liter,liter,升,NOUN,B2
-Lob,praise,赞扬,NOUN,B2
-Lockabsicht,want to lure,想引,NOUN,B2
+Lesefähigkeit,literacy,读写能力,NOUN,B2
+Kläger,litigant,诉讼当事人,NOUN,B2
+Klage,litigation,诉讼,NOUN,B2
+Kleine Elf,little eleven,小十一,NOUN,B2
+Kleine Neun,little nine,小九,NOUN,B2
+lebhaft,lively,热闹的,ADJ,B2
+Vieh,livestock,家畜,NOUN,B2
+Last,load,负载,NOUN,B2
+Laib,loaf,一条面包,NOUN,B2
+Darlehen,loan,贷款,NOUN,B2
+Hummer,lobster,龙虾,NOUN,B2
+örtlich,local,当地的,ADJ,B2
+lokalisieren,to locate,定位,VERB,B2
+Schloss,lock,锁,NOUN,B2
+absperren,to lockdown,封城,VERB,B2
+Umkleideraum,locker room,更衣室,NOUN,B2
+Unterkunft,lodging,住宿,NOUN,B2
+erhaben,lofty,崇高的,ADJ,B2
+Stamm,log,日志,NOUN,B2
 Logik,logic,逻辑,NOUN,B2
 Logistik,logistics,后勤,NOUN,B2
-Lohn,wages,工资,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-Luftabwehr,air defense,防空,NOUN,B2
-Luxation,dislocation,脱臼,NOUN,B2
-Lähmung,paralysis,瘫痪,NOUN,B2
-Lärm,clamor,喧嚣,NOUN,B2
-Lärm machen,to make noise,闹得,VERB,B2
-Läufer,runner,跑步者,NOUN,B2
-Löschung,erasure,擦除,NOUN,B2
-Lösegeld,ransom,赎金,NOUN,B2
-Lösungsmittel,solvent,溶剂,NOUN,B2
-Lüsternheit,debauchery,放荡,NOUN,B2
-MRT,mri,核磁共振,NOUN,B2
-Machbarkeit,feasibility,可行性,NOUN,B2
-Machiavellian,Machiavellian,词,ADJ,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Mai,may,五月,NOUN,B2
-Majestät,your majesty,陛下,NOUN,B2
+Es lebe,long live,万岁,INTJ,B2
+lange Zeit,long time,长时间,ADV,B2
+Fernbus,long-distance bus,长途车,NOUN,B2
+anschauen,to look at,观看,VERB,B2
+Blick,look at you,你看你,NOUN,B2
+herabsehen,to look down upon,看不起,VERB,B2
+suchen,to look for,寻找,VERB,B2
+look for to find,to look for to find,找,VERB,B2
+loophole,loophole,漏洞,NOUN,B2
+loose,loose,松的,ADJ,B2
+loosen,to loosen,放松,VERB,B2
+loot,loot,战利品,NOUN,B2
+lord,lord,领主,NOUN,B2
+lord yu,lord yu,玉大人,NOUN,B2
+lord's words,lord's words,主说,NOUN,B2
+lose,lose,上丢,NOUN,B2
+lost,lost,迷失的,ADJ,B2
+lot,lot,许多,NOUN,B2
+lottery,lottery,彩票,NOUN,B2
+lounge,lounge,休息室,NOUN,B2
+louse,louse,虱子,NOUN,B2
+low tide,low tide,退潮,NOUN,B2
+loyal,loyal,忠诚的,ADJ,B2
+lucky,lucky,幸运的,ADJ,B2
+lucky chance,lucky chance,虽侥,NOUN,B2
+lump,lump,块,NOUN,B2
+luster,luster,光泽,NOUN,B2
+luxurious,luxurious,奢侈的,ADJ,B2
+lymph,lymph,淋巴,NOUN,B2
+lyrics,lyrics,歌词,NOUN,B2
+macroscopic,macroscopic,宏观的,ADJ,B2
+madam,madam,夫人,NOUN,B2
+magnanimity,magnanimity,宽宏大量,NOUN,B2
+magnet,magnet,磁铁,NOUN,B2
+magnificent,magnificent,壮丽的,ADJ,B2
+magnify,to magnify,放大,VERB,B2
+maid,maid,女仆,NOUN,B2
+maiden,maiden,少女,NOUN,B2
+maidservant,maidservant,女仆,NOUN,B2
+mail,mail,邮件,NOUN,B2
+mailbox,mailbox,邮箱,NOUN,B2
+main,main,主要的,ADJ,B2
+Festland,mainland,大陆,NOUN,B2
+Hauptstrom,mainstream,主流,NOUN,B2
+majestätisch,majestic,宏伟的,ADJ,B2
 Major,major,少校,NOUN,B2
+Hauptfach,major course,专业课,NOUN,B2
+Mehrheit,majority,大多数,NOUN,B2
+Fehler machen,to make a mistake,弄错,VERB,B2
+Rede halten,to make a speech,发言,VERB,B2
+Fehler,make mistake,犯错,NOUN,B2
+Lärm machen,to make noise,闹得,VERB,B2
+ausgleichen,to make up for,弥补,VERB,B2
+Hersteller,maker,制造者,NOUN,B2
 Make-up,makeup,化妆品,NOUN,B2
-Makel,flaw,缺陷,NOUN,B2
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Makler,broker,经纪人,NOUN,B2
-Maklergeschäft,brokerage,经纪业,NOUN,B2
+Krankheit,malady,弊病,NOUN,B2
+Fehlfunktion,malfunction,故障,NOUN,B2
+Bosheit,malice,恶意,NOUN,B2
+bösartig,malignant,恶性的,ADJ,B2
 Manager,manager,经理,NOUN,B2
-Mandarin,Mandarin,普通话,NOUN,A1
 Mandat,mandate,命令,NOUN,B2
-Mandel,almond,杏仁,NOUN,B2
-Mangel,shortage,短缺,NOUN,B2
-Maniok,cassava,木薯,NOUN,B2
-Manipulation,manipulation,操纵,NOUN,B2
-Manuskript,manuscript,手稿,NOUN,B2
+verpflichtend,mandatory,强制的,ADJ,B2
 Manöver,maneuver,策略,NOUN,B2
+Manipulation,manipulation,操纵,NOUN,B2
+Gut,manor,庄园,NOUN,B2
+Villa,mansion,豪宅,NOUN,B2
+herstellen,to manufacture,制造,VERB,B2
+Hersteller,manufacturer,制造商,NOUN,B2
+Manuskript,manuscript,手稿,NOUN,B2
+Viele,many,许多,ADJ,B2
+Karte,map,地图,NOUN,B2
 Marathon,marathon,马拉松,NOUN,B2
 Marginalisierung,marginalization,边缘化,NOUN,B2
+marginalisieren,to marginalize,使边缘化,VERB,B2
+marinieren,to marinate,腌制,VERB,B2
+maritim,maritime,海事的,ADJ,B2
 Marke,mark,标记,NOUN,B2
 Marketing,marketing,营销,NOUN,B2
-Marxist,Marxist,词,ADJ,C1
-Mary,Mary,词,NOUN,B2
+Eheverbindung,marriage alliance,联姻,NOUN,B2
+Ehefähigkeit,marriageable,适婚,NOUN,B2
+Märtyrertod,martyrdom,殉难,NOUN,B2
+staunen,to marvel,使惊奇,VERB,B2
 Massaker,massacre,大屠杀,NOUN,B2
-Masse,bulk,主体,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
+massiv,massive,巨大的,ADJ,B2
 Masterabschluss,master's degree,硕士学位,NOUN,B2
+Meisterwort,master's word,爷说,NOUN,B2
+Meisterwerk,masterpiece,杰作,NOUN,B2
+Meisterschaft,mastery,精通,NOUN,B2
+passen,match,火柴,NOUN,B2
+passen,to match,相配,VERB,B2
+passend,matching,配套,ADJ,B2
+Passzeit,matching time,对时,NOUN,B2
+Heiratsvermittler,matchmaker,媒,NOUN,B2
 Material,material,材料,NOUN,B2
 Materialismus,materialism,唯物主义,NOUN,B2
-Matratze,mattress,床垫,NOUN,B2
+Muttetante,maternal aunt,姨母,NOUN,B2
+Mutteronkel,maternal uncle,舅舅,NOUN,B2
+mathematisch,mathematical,数学的,ADJ,B2
 Matrix,matrix,矩阵,NOUN,B2
-Maulwurf,mole,鼹鼠,NOUN,B2
+angelegen,to matter,重要,VERB,B2
+Matratze,mattress,床垫,NOUN,B2
+reif,mature,成熟的,ADJ,B2
+Reife,maturity,成熟,NOUN,B2
 Maxime,maxim,格言,NOUN,B2
+maximal,maximum,最大,ADJ,B2
+Mai,may,五月,NOUN,B2
+ich,me,لي,NOUN,B2
+Wiese,meadow,草地,NOUN,B2
+Bände,measure word for books,本,NUM,B2
 Mechanismus,mechanism,机制,NOUN,B2
-Meerenge,strait,海峡,NOUN,B2
-Mehl,flour,面粉,NOUN,B2
-Mehr,more,更多,ADJ,B2
-Mehrdeutigkeit,ambiguity,歧义,NOUN,B2
-Mehrheit,majority,大多数,NOUN,B2
-Meister,champion,冠军,NOUN,B2
-Meisterschaft,championship,锦标赛,NOUN,B2
-Meisterschaft,mastery,精通,NOUN,B2
-Meisterwerk,masterpiece,杰作,NOUN,B2
-Meisterwort,master's word,爷说,NOUN,B2
-Meißel,chisel,凿子,NOUN,B2
-Menge,crowd,人群,NOUN,B2
-Menge,quantity,数量,NOUN,B2
-Mensch,human,人类,NOUN,B2
-Menschennatur,human nature,人性,NOUN,B2
-Merkmal,characteristic,典型的,ADJ,B2
-Merkmal,feature,特征,NOUN,B2
-Metzger,butcher,屠夫,NOUN,B2
+mechanistic,mechanistic,机制性,ADJ,B2
+medal,medal,奖牌,NOUN,B2
+media,media,媒体,NOUN,B2
+median,median,中位数,NOUN,B2
+mediation,mediation,调解,NOUN,B2
+meditation,meditation,冥想,NOUN,B2
+mediterranean,mediterranean,地中海的,ADJ,B2
+medium,medium,媒介,NOUN,B2
+melancholy,melancholy,忧郁,ADJ,B2
+melon groping,melon groping,摸瓜,NOUN,B2
+membership,membership,会员资格,NOUN,B2
+memorandum,memorandum,备忘录,NOUN,B2
+memorization,memorization,记忆,NOUN,B2
+mentality,mentality,心态,NOUN,B2
+mention,mention,提及,NOUN,B2
+mentor,mentor,导师,NOUN,B2
+mercury,mercury,汞,NOUN,B2
+merge,merge,合并,NOUN,B2
+merge,to merge,合并,VERB,B2
+meritocracy,meritocracy,精英管理,NOUN,B2
+mermaid,mermaid,美人鱼,NOUN,B2
+mess,mess,混乱,NOUN,B2
+messenger,messenger,信使,NOUN,B2
+messy,messy,混乱的,ADJ,B2
+metabolism,metabolism,新陈代谢,NOUN,B2
+metallic,metallic,金属的,ADJ,B2
+metaphor,metaphor,隐喻,NOUN,B2
+metaphysics,metaphysics,形而上学,NOUN,B2
+meter,meter,米,NOUN,B2
+methodology,methodology,方法论,NOUN,B2
+meticulous,meticulous,一丝不苟的,ADJ,B2
+metonymy,metonymy,转喻,NOUN,B2
+midst,midst,中间,NOUN,B2
+might,might,威力,NOUN,B2
+migrieren,to migrate,迁移,VERB,B2
 Migration,migration,移民,NOUN,B2
-Militärbefehl,military order,军令,NOUN,B2
+militärisch,military,军事的,ADJ,B2
 Militärgeheimdienst,military intelligence,军情,NOUN,B2
+Militärbefehl,military order,军令,NOUN,B2
 Militärmacht,military power,兵权,NOUN,B2
 Miliz,militia,民兵,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Milliarde,billion,十亿,NUM,B2
+Mühle,mill,磨坊,NOUN,B2
+Jahrtausend,millennium,千年,NOUN,B2
 Million,million,百万,NUM,B2
-Minderheit,minority,少数,NOUN,B2
-Minderjähriger,minor,未成年人,NOUN,B2
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
+beachten,to mind,介意,VERB,B2
 Mine,mine,矿井,NOUN,B2
 Mineral,mineral,矿物,NOUN,B2
 Minister,minister,臣,PART,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
+ministeriell,ministerial,部长的,ADJ,B2
+Minderjähriger,minor,未成年人,NOUN,B2
+Nebenfach,minor course,辅修课,NOUN,B2
+Minderheit,minority,少数,NOUN,B2
 Minze,mint,薄荷,NOUN,B2
+Elend,misery,痛苦,NOUN,B2
+irreführen,to mislead,误导,VERB,B2
+irreführend,misleading,诡辩的,ADJ,B2
+Fehltreffer,miss,小姐,NOUN,B2
+vermisst,missing,失踪的,ADJ,B2
 Mission,mission,任务,NOUN,B2
-Misstrauen,distrust,不信任,NOUN,B2
-Miteigentum,joint ownership,共有,NOUN,B2
-Mitgefühl,compassion,同情,NOUN,B2
-Mitgift,dowry,嫁妆,NOUN,B2
+Nebel,mist,薄雾,NOUN,B2
+misshandeln,to mistreat,أساء,VERB,B2
+missverstehen,to misunderstand,误解,VERB,B2
+mildern,to mitigate,减轻,VERB,B2
+gemischt,mixed,混合的,ADJ,B2
+mobil,mobile,移动的,ADJ,B2
+mobile Zahlung,mobile payment,移动支付,NOUN,B2
 Mobilmachung,mobilization,动员,NOUN,B2
-Modellierung,modeling,造型,NOUN,B2
-Moderation,moderation,克制,NOUN,B2
-Modernisierung,modernization,现代化,NOUN,B2
-Modifikation,modification,修改,NOUN,B2
+mobilisieren,to mobilize,动员,VERB,B2
 Modus,mode,方式,NOUN,B2
+Modellierung,modeling,造型,NOUN,B2
+moderat,moderate,适度的,ADJ,B2
+moderater Regen,moderate rain,中雨,NOUN,B2
+Moderation,moderation,克制,NOUN,B2
+modern,modern,现代的,ADJ,B2
+Modernisierung,modernization,现代化,NOUN,B2
+Bescheidenheit,modesty,谦虚,NOUN,B2
+Modifikation,modification,修改,NOUN,B2
+modifizierter Effekt,modified effect,改效,NOUN,B2
+modifiziertes Modell,modified model,改模,NOUN,B2
+modifizierter Klang,modified sound,改响,NOUN,B2
+modifiziertes System,modified system,改系,NOUN,B2
+modular,modular,模块化的,ADJ,B2
+Schimmel,mold,鞋楦,NOUN,B2
+Maulwurf,mole,鼹鼠,NOUN,B2
 Molekül,molecule,分子,NOUN,B2
-Monatsmond,month moon,月,NOUN,B2
-Mondkuchen,mooncake,月饼,NOUN,B2
+monetär,monetary,金钱的,ADJ,B2
 Monitor,monitor,显示器,NOUN,B2
+Überwachungsraum,monitoring room,监控室,NOUN,B2
+Mönch,monk,僧侣,NOUN,B2
+monopolistisch,monopolistic,垄断的,ADJ,B2
+monopolisieren,to monopolize,垄断,VERB,B2
 Monopol,monopoly,垄断,NOUN,B2
+monoton,monotonous,单调的,ADJ,B2
 Monster,monster,怪物,NOUN,B2
-Moos,moss,苔藓,NOUN,B2
+Monatsmond,month moon,月,NOUN,B2
+monatlich,monthly,每月的,ADV,B2
+monatliche Prüfung,monthly exam,月考,NOUN,B2
+Denkmal,monument,纪念碑,NOUN,B2
+Mondkuchen,mooncake,月饼,NOUN,B2
 Moral,moral,道德,NOUN,B2
 Moralität,morality,道德,NOUN,B2
-Morgendämmerung,dawn,黎明,NOUN,B2
+Mehr,more,更多,ADJ,B2
+außerdem,moreover,此外,ADV,B2
 Morgenzeitung,morning newspaper,晨报,NOUN,B2
-Moroccan,Moroccan,词,ADJ,B2
+morphologisch,morphological,形态的,ADJ,B2
 Morphologie,morphology,形态学,NOUN,B2
+verpfänden,mortgage,抵押贷款,NOUN,B2
+verpfänden,to mortgage,抵押,VERB,B2
 Mosaik,mosaic,马赛克,NOUN,B2
-Motivation,motivation,动机,NOUN,B2
-Motor,motor,发动机,NOUN,B2
-Mr. sir,Mr. sir,先生,NOUN,B2
-Mrs.,Mrs.,词,NOUN,A1
-Mundvoll,mouthful,一口,NOUN,B2
-Murong,Murong,慕容,NOUN,B2
-Murren,murmur,低语,NOUN,B2
-Museum,museum,博物馆,NOUN,B2
-Muskelschmerz,muscle pain,肌肉痛,NOUN,B2
-Muslim,muslim,مسلم,NOUN,B2
-Muslim (adj),Muslim,词,ADJ,B1
-Muster,sample,样本,NOUN,B2
-Mut,boldness,大胆,NOUN,B2
-Mut,bravery,勇敢,NOUN,B2
-Mutation,mutation,突变,NOUN,B2
+Mücke,mosquito,蚊子,NOUN,B2
+Moos,moss,苔藓,NOUN,B2
+meistens,most,最,ADV,B2
 Mutter,mother,娘,PART,B2
 Mutterberuhigung,mother's reassurance,娘放心,NOUN,B2
-Mutteronkel,maternal uncle,舅舅,NOUN,B2
-Muttetante,maternal aunt,姨母,NOUN,B2
-Märtyrertod,martyrdom,殉难,NOUN,B2
-Mönch,monk,僧侣,NOUN,B2
-Mörder,killer,杀手,NOUN,B2
-Möwe,seagull,海鸥,NOUN,B2
-Mücke,mosquito,蚊子,NOUN,B2
-Müdigkeit,fatigue,疲劳,NOUN,B2
-Müdigkeit,weariness,疲倦,NOUN,B2
-Mühle,mill,磨坊,NOUN,B2
-Mündlicher Erlass,oral decree,口谕,NOUN,B2
-Mündung,estuary,河口,NOUN,B2
-Nachbar,next door,隔壁,NOUN,B2
-Nachfolge,succession,连续,NOUN,B2
-Nachhaltigkeit,sustainability,可持续性,NOUN,B2
-Nachher,after,تلو,NOUN,B2
-Nachher,afterward,去后,NOUN,B2
-Nachhilfe,tutoring,补习,NOUN,B2
-Nachkomme,descendant,后代,NOUN,B2
-Nachlässigkeit,negligence,疏忽；过失,NOUN,B2
-Nachname,surname,姓氏,NOUN,B2
-Nachtansicht,night view,夜景,NOUN,B2
-Nachtigall,nightingale,夜莺,NOUN,B2
-Nachtwache,vigil,守夜,NOUN,B2
-Nachwirkung,aftereffect,后遗症，后果,NOUN,B2
-Nachwirkung,repercussion,反响,NOUN,B2
-Nadelwald,coniferous forest,针叶林,NOUN,B2
-Nahrung,sustenance,食物,NOUN,B2
+Bewegung,motion,运动,NOUN,B2
+motivieren,to motivate,激励,VERB,B2
+Motivation,motivation,动机,NOUN,B2
+Motor,motor,发动机,NOUN,B2
+Wohnmobil,motorhome,露营车,NOUN,B2
+Bergabfahrt,mountain descent,下山,NOUN,B2
+Gebirge,mountain range,山脉,NOUN,B2
+Mundvoll,mouthful,一口,NOUN,B2
+beiseitegehen,to move aside,移开,VERB,B2
+Film,movie,电影,NOUN,B2
+MRT,mri,核磁共振,NOUN,B2
+Schleim,mucus,黏液,NOUN,B2
+Schlamm,mud,泥,NOUN,B2
+verwirrt,muddled,混乱的,ADJ,B2
+kommunal,municipal,市政的,ADJ,B2
+Gemeinde,municipality,市镇,NOUN,B2
+Großzügigkeit,munificence,慷慨,NOUN,B2
+Murren,murmur,低语,NOUN,B2
+Muskelschmerz,muscle pain,肌肉痛,NOUN,B2
+Museum,museum,博物馆,NOUN,B2
+musikalisch,musical,موسيقي,ADJ,B2
+Partitur,musical score,乐谱,NOUN,B2
+Muslim,muslim,مسلم,NOUN,B2
+Mutation,mutation,突变,NOUN,B2
+stumm,mute,沉默的；哑的,ADJ,B2
+murmeln,to mutter,嘟囔,VERB,B2
+Hammelfleisch,mutton,羊肉,NOUN,B2
+gegenseitige Hilfe,mutual aid,互助,NOUN,B2
+gegenseitige Erzeugung,mutual generation,相生,NOUN,B2
+Gegenseitigkeitsversicherung,mutual insurance,互助保险,NOUN,B2
+gegenseitige Beschränkung,mutual restriction,相克,NOUN,B2
+gegenseitig,mutually,相互地,ADV,B2
+mein Großer,my big one,我偌大,NOUN,B2
+mein Zuhause,my place,我处,NOUN,B2
+mein Wohnsitz,my residence,我府,NOUN,B2
+Selbst,myself,我自,NOUN,B2
+Geheimnis,mystery,谜,NOUN,B2
+nörgeln,to nag,唠叨,VERB,B2
 Naivität,naivety,天真,NOUN,B2
+Kindermädchen,nanny,保姆,NOUN,B2
 Nanotechnologie,nanotechnology,纳米技术,NOUN,B2
+Nickerchen,nap,午睡,NOUN,B2
+Serviette,napkin,餐巾,NOUN,B2
 Narzissmus,narcissism,自恋,NOUN,B2
-Natan,Natan,词,NOUN,B2
+erzählen,to narrate,叙述,VERB,B2
+Erzählung,narrative,叙述；故事,NOUN,B2
+Erzähler,narrator,叙述者,NOUN,B2
+Enge,narrowness,狭窄,NOUN,B2
 Nation,nation,国家,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
+national,national,国家的,ADJ,B2
 Nationalismus,nationalism,民族主义,NOUN,B2
 Nationalität,nationality,国籍,NOUN,B2
+Verstaatlichung,nationalization,国有化,NOUN,B2
+verstaatlichen,to nationalize,国有化,VERB,B2
+einheimisch,native,本地的,ADJ,B2
+natürlich,natural,自然的,ADJ,B2
 Naturschutzgebiet,nature reserve,自然保护区,NOUN,B2
+ungezogen,naughty,淘气的,ADJ,B2
+Übelkeit,nausea,恶心,NOUN,B2
 Navigation,navigation,导航；航行,NOUN,B2
-Nebel,mist,薄雾,NOUN,B2
-Nebel,nebula,星云,NOUN,B2
-Nebenfach,minor course,辅修课,NOUN,B2
-Nebengebäude,outhouse,茅房,NOUN,B2
-Negation,negation,否定,NOUN,B2
-Neigung,inclination,倾向,NOUN,B2
-Neigung,propensity,倾向,NOUN,B2
-Nest,nest,巢,NOUN,B2
-Neuabtippen,retype,再型,NOUN,B2
-Neubestimmung,redefinition,改界,NOUN,B2
-Neujahr,new year's day,元旦,NOUN,B2
-Neuplanung,replanning,再策,NOUN,B2
-Neupositionierung,repositioning,重新定位,NOUN,B2
-Neupreisung,reprice,再价,NOUN,B2
-Neurose,neurosis,神经症,NOUN,B2
-Neutralität,neutrality,中立,NOUN,B2
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-Nichtgedanke,non-thought,非念,NOUN,B2
-Nichtigkeit,nullity,无效；无能,NOUN,B2
-Nichtkrieg,non-war,非战,NOUN,B2
-Nichtspur,non-trace,非迹,NOUN,B2
-Nichtverwendung,do not use,别用,NOUN,B2
-Nickerchen,nap,午睡,NOUN,B2
-Niedergeschlagenheit,dejection,沮丧,NOUN,B2
-Niederschlag,precipitation,降水,NOUN,B2
-Niedertracht,baseness,卑鄙,NOUN,B2
-Nießbrauch,usufruct,用益权,NOUN,B2
-Nihilismus,nihilism,虚无主义,NOUN,B2
-Nordic,Nordic,词,ADJ,C1
-Norm,norm,规范,NOUN,B2
-Notar,notary,公证人,NOUN,B2
-Notarisierung,notarization,公证,NOUN,B2
-Notausgang,seclusion exit,出关,NOUN,B2
-Notiz,notice,通知,NOUN,B2
-Notwendigkeit,necessity,必要性；必需品,NOUN,B2
-Noumenon,noumenon,本体,NOUN,B2
-November,november,十一月,NOUN,B2
-Nummer zwei,number two,二号,NOUN,B2
-Nutzen,benefit,利益,NOUN,B2
-Nutzung,utilization,利用,NOUN,B2
+nahe,near,近,ADJ,B2
 Nähe,nearby,附近的,ADJ,B2
-Nähe,beside next to,旁边,NOUN,B2
-Nähe,closeness,接近,NOUN,B2
-Nähe,proximity,邻近,NOUN,B2
-Nähen,sewing,缝纫,NOUN,B2
-Näherung,approximation,近似值,NOUN,B2
-Nüchternheit,sobriety,清醒,NOUN,B2
+beinahe,nearly,几乎,ADV,B2
+ordentlich,neat,整洁的,ADJ,B2
+Nebel,nebula,星云,NOUN,B2
+notwendigerweise,necessarily,必然地,ADV,B2
+Notwendigkeit,necessity,必要性；必需品,NOUN,B2
+Halskette,necklace,项链,NOUN,B2
+müssen,need,需要,AUX,B2
+negieren,to negate,否定,VERB,B2
+Negation,negation,否定,NOUN,B2
+Nachlässigkeit,negligence,疏忽；过失,NOUN,B2
+nachlässig,negligent,疏忽的,ADJ,B2
+vernachlässigbar,negligible,微不足道的,ADJ,B2
+nicht vernachlässigbar,negligible not,不可忽视,ADJ,B2
+Verhandlungen,negotiations,谈判,NOUN,B2
+Nest,nest,巢,NOUN,B2
+Neurose,neurosis,神经症,NOUN,B2
+neutral,neutral,中立的,ADJ,B2
+Neutralität,neutrality,中立,NOUN,B2
+Neujahr,new year's day,元旦,NOUN,B2
+nächste,next,接下来,ADV,B2
+Nachbar,next door,隔壁,NOUN,B2
+knabbern,to nibble,啃,VERB,B2
+Spitzname,nickname,绰号,NOUN,B2
+Nachtansicht,night view,夜景,NOUN,B2
+Nachtigall,nightingale,夜莺,NOUN,B2
+Nihilismus,nihilism,虚无主义,NOUN,B2
+neunzig,ninety,九十,NUM,B2
+neunte,ninth,第九,ADJ,B2
+no,no,不,ADV,B2
+no harm,no harm,没事吧,NOUN,B2
+no longer,no longer,不再,ADV,B2
+no matter,no matter,不论,CCONJ,B2
+no need,no need,不用,AUX,B2
+nobility,nobility,贵族气质,NOUN,B2
+nocturnal,nocturnal,夜间的,ADJ,B2
+noisy,noisy,吵闹的,ADJ,B2
+nomadism,nomadism,游牧生活,NOUN,B2
+nominate,to nominate,提名,VERB,B2
+nomination,nomination,提名,NOUN,B2
+non-ability,non-ability,非能,NOUN,B2
+non-abstraction,non-abstraction,非抽,NOUN,B2
+non-action,non-action,非作,NOUN,B2
+non-assistance,non-assistance,勿助,NOUN,B2
+non-belief,non-belief,非信,NOUN,B2
+non-concept,non-concept,非概,NOUN,B2
+non-construction,non-construction,非建,NOUN,B2
+non-contingent,non-contingent,非偶,NOUN,B2
+non-evidence,non-evidence,非据,NOUN,B2
+non-induction,non-induction,非归,NOUN,B2
+non-inference,non-inference,非推,NOUN,B2
+non-level,non-level,非级,NOUN,B2
+non-management,non-management,管不,NOUN,B2
+non-merit,non-merit,非功,NOUN,B2
+non-mind,non-mind,非心,NOUN,B2
+non-model,non-model,非模,NOUN,B2
+non-orbit,non-orbit,非轨,NOUN,B2
+non-order,non-order,非序,NOUN,B2
+non-shadow,non-shadow,非影,NOUN,B2
+non-sound,non-sound,非响,NOUN,B2
+non-specific,non-specific,非殊,NOUN,B2
+non-state,non-state,非态,NOUN,B2
+non-strategy,non-strategy,非略,NOUN,B2
+non-substance,non-substance,非质,NOUN,B2
+Nichtgedanke,non-thought,非念,NOUN,B2
+Nichtspur,non-trace,非迹,NOUN,B2
+Nichtkrieg,non-war,非战,NOUN,B2
+nicht konform,noncompliant,违规,ADJ,B2
+Norm,norm,规范,NOUN,B2
+normal,normal,正常的,ADJ,B2
+nördlich,northern,北方的,ADJ,B2
+nicht,not,不,ADV,B2
+nicht betreffen,to not about,不关,VERB,B2
+nicht erlauben,not allow,不许,AUX,B2
+unerlaubt,not allowed,不准,ADJ,B2
+ausbleiben,to not come,不来,VERB,B2
+nicht haben,to not have,没,VERB,B2
+nicht nur,not only,不光,CCONJ,B2
+Notarisierung,notarization,公证,NOUN,B2
+Notar,notary,公证人,NOUN,B2
+Notiz,notice,通知,NOUN,B2
+Benachrichtigung,notification,通知,NOUN,B2
+Noumenon,noumenon,本体,NOUN,B2
+romanhaft,novelistic,小说般的,ADJ,B2
+November,november,十一月,NOUN,B2
+nuklear,nuclear,核的,ADJ,B2
+Ärgernis,nuisance,麻烦事,NOUN,B2
+Nichtigkeit,nullity,无效；无能,NOUN,B2
+Nummer zwei,number two,二号,NOUN,B2
+Taubheit,numbness,麻木,NOUN,B2
+zahlreich,numerous,众多的,ADJ,B2
+Kindergarten,nursery,托儿所,NOUN,B2
+erziehen,to nurture,养育,VERB,B2
+Erziehung,nurturing,养好,NOUN,B2
+Ernährung,nutrition,营养,NOUN,B2
 Oase,oasis,绿洲,NOUN,B2
-Ob,whether,能否,NOUN,B2
-Oberschenkel,thigh,大腿,NOUN,B2
+gehorsam,obedient,顺从的,ADJ,B2
+Adipositas,obesity,肥胖,NOUN,B2
+Ziel,objective,客观的,ADJ,B2
 Objektivität,objectivity,客观性,NOUN,B2
-Observatorium,observatory,天文台,NOUN,B2
-Obsession,obsession,痴迷,NOUN,B2
+Verpflichtung,obligation,义务,NOUN,B2
+obzön,obscene,淫秽的,ADJ,B2
 Obskurantismus,obscurantism,蒙昧主义,NOUN,B2
-Obstgarten,orchard,果园,NOUN,B2
-Offenbarung,revelation,启示,NOUN,B2
-Offenheit,frankness,坦率,NOUN,B2
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
+Observatorium,observatory,天文台,NOUN,B2
+Beobachter,observer,观察者,NOUN,B2
+Obsession,obsession,痴迷,NOUN,B2
+veraltet,obsolete,过时的,ADJ,B2
+stur,obstinate,固执的,ADJ,B2
+blockieren,to obstruct,阻碍,VERB,B2
+Behinderung,obstruction,阻塞,NOUN,B2
+offensichtlich,obviously,显然,ADV,B2
+gelegentlich,occasionally,偶尔,ADV,B2
+Beschäftigung,occupation,职业,NOUN,B2
+Vorkommnis,occurrence,发生,NOUN,B2
+seltsam,odd,奇怪的,ADJ,B2
+von,of,的,ADP,B2
+Geländewagen,off-road vehicle,越野车,NOUN,B2
+beleidigen,to offend,冒犯,VERB,B2
+Angebot,offering,祭品,NOUN,B2
+offiziell,officially,正式地,ADV,B2
+Beamter,officials,官员,NOUN,B2
+oh,oh,哇,PART,B2
+oh mein Gott,oh my god,我的天,INTJ,B2
+Salbe,ointment,药膏,NOUN,B2
+Alter,old age,老年,NOUN,B2
+alter Mann,old man,老人,NOUN,B2
+alter Meister,old master,老太爷,NOUN,B2
+alter Diener,old servant,老奴,NOUN,B2
+alte Frau,old woman,老妇人,NOUN,B2
+alt,older,年长的,ADJ,B2
+älterer Bruder,older brother,大哥哥,NOUN,B2
 Omen,omen,预兆,NOUN,B2
-Ontologie,ontology,本体论,NOUN,B2
 Onze,on,,NOUN,B2
+Kopf,on head,当头,NOUN,B2
+im Gegenteil,on the contrary,相反,ADV,B2
+noch einmal,once more,再次,ADV,B2
+ein Buch,one book,一本,NUM,B2
+ein Tag,one day,一天,NUM,B2
+eine Familie,one family,一家,NUM,B2
+eine Wohnung,one flat,一张,NUM,B2
+ein Kopf,one head,一头,NUM,B2
+eine Nacht,one night,一晚,NUM,B2
+ein Satz,one set,一套,NUM,B2
+ein Schuss,one shot,一枪,NUM,B2
+nach Herzenslust,one's heart's content,尽情,ADV,B2
+einseitig,one-sided,单方面的,ADJ,B2
+nur,only,唯一的,ADJ,B2
+erst dann,only then,才,ADV,B2
+Ego,only-me,只我,NOUN,B2
+Ontologie,ontology,本体论,NOUN,B2
+offen,openly,公开地,ADV,B2
 Operation,operation,操作,NOUN,B2
-Operation,surgery,手术,NOUN,B2
 Operator,operator,经营者,NOUN,B2
+widersprechen,to oppose,反对,VERB,B2
+entgegen,opposite,相反的,ADJ,B2
 Opposition,opposition,对立,NOUN,B2
+unterdrücken,to oppress,压迫,VERB,B2
+Unterdrückung,oppression,压迫,NOUN,B2
+optisch,optical,光学的,ADJ,B2
 Optik,optics,光学,NOUN,B2
+optimistisch,optimistic,乐观的,ADJ,B2
+optimieren,to optimize,优化,VERB,B2
 Option,option,选择,NOUN,B2
+optional,optional,可选的,ADJ,B2
 Optionen,options,期权,NOUN,B2
+oral,oral,口头的,ADJ,B2
+Mündlicher Erlass,oral decree,口谕,NOUN,B2
+Umlaufbahn,orbit,轨道,NOUN,B2
+Obstgarten,orchard,果园,NOUN,B2
 Orchester,orchestra,管弦乐队,NOUN,B2
-Ordner,folder,文件夹,NOUN,B2
+Bewährungsprobe,ordeal,苦难,NOUN,B2
+ordentlich,orderly,有序的,ADJ,B2
+gewöhnlich,ordinarily,通常,ADV,B2
+gewöhnlich,ordinary,普通的,ADJ,B2
+gewöhnlicher Tag,ordinary day,平日,NOUN,B2
+gewöhnliche Leute,ordinary people,老百姓,NOUN,B2
 Organ,organ,器官,NOUN,B2
+organisch,organic,有机的,ADJ,B2
 Organisator,organizer,组织者,NOUN,B2
 Orientierung,orientation,取向,NOUN,B2
 Original,original,重原,NOUN,B2
 Originaldokument,original document,原件,NOUN,B2
 Originalität,originality,独创性,NOUN,B2
+ursprünglich,originally,最初,ADV,B2
 Ornament,ornament,装饰,NOUN,B2
+Waise,orphan,孤儿,NOUN,B2
+orthodox,orthodox,正统的,ADJ,B2
+oszillieren,to oscillate,振荡,VERB,B2
+Andere,other,其他,NOUN,B2
+andere Seite,other side,对面,NOUN,B2
+Andersartigkeit,otherness,相异性,NOUN,B2
+andere,others,他人,NOUN,B2
+Ausbruch,outburst,迸发,NOUN,B2
+Ausgestoßener,outcast,被遗弃者,NOUN,B2
+Ergebnis,outcome,结果,NOUN,B2
+veraltet,outdated,过时的,ADJ,B2
+Nebengebäude,outhouse,茅房,NOUN,B2
+Ausflug,outing,郊游,NOUN,B2
+Steckdose,outlet,出口,NOUN,B2
+umreißen,outline,大纲,NOUN,B2
+umreißen,to outline,勾勒,VERB,B2
+Ausblick,outlook,前景,NOUN,B2
+Außen,outside,外部,NOUN,B2
 Outsourcing,outsourcing,外包,NOUN,B2
+Überdomäne,over-domain,超畴,NOUN,B2
+Überstrategie,over-strategy,超策,NOUN,B2
+Überstrich,over-stroke,超程,NOUN,B2
+bedeckt,overcast,阴天的,ADJ,B2
+überziehen,to overdraw,透支,VERB,B2
+überfällig,overdue,逾期,ADJ,B2
+Überlauf,overflow,溢出,NOUN,B2
+Überlappung,overlap,重叠,NOUN,B2
+über Nacht,overnight,一夜之间,ADV,B2
+Auslandschinese,overseas chinese,华侨,NOUN,B2
+umwerfen,to overturn,打翻,VERB,B2
+überwältigend,overwhelming,压倒性的,ADJ,B2
+Eigentum,ownership,,NOUN,B2
 Oxid,oxide,氧化物,NOUN,B2
-Paar,a married couple,夫妇,NOUN,B2
-Paar,pair,一对,NOUN,B2
-Paar,a pair,一对,NUM,B2
-Paarreim,couplet,对联,NOUN,B2
+Tempo,pace,速度,NOUN,B2
+Tempomacher,pace-setter,标兵,NOUN,B2
+Verpackung,packaging,包装,NOUN,B2
 Pakt,pact,协定,NOUN,B2
+Polster,pad,垫,NOUN,B2
+Farbe,paint,油漆,NOUN,B2
+Paar,pair,一对,NOUN,B2
 Palme,palm,手掌,NOUN,B2
 Palme,palm tree,棕榈树,NOUN,B2
-Pampelmuse,pomelo,柚子,NOUN,B2
+Bauchspeicheldrüse,pancreas,胰腺,NOUN,B2
 Pandemie,pandemic,大流行病,NOUN,B2
 Panegyrik,panegyric,颂词,NOUN,B2
 Panel,panel,小组,NOUN,B2
 Pantheismus,pantheism,泛神论,NOUN,B2
 Papaya,papaya,木瓜,NOUN,B2
 Papierschnitt,paper cutting,剪纸,NOUN,B2
-Paprika,bell pepper,甜椒,NOUN,B2
 Parade,parade,游行,NOUN,B2
 Paradigma,paradigm,范例,NOUN,B2
+Vorbild,paragon,典范,NOUN,B2
 Paragraph,paragraph,段落,NOUN,B2
+parallel,parallel,平行的,ADJ,B2
+Lähmung,paralysis,瘫痪,NOUN,B2
 Parameter,parameter,参数,NOUN,B2
-Parisian,Parisian,词,ADJ,B1
+verzeihen,pardon,赦免,NOUN,B2
+verzeihen,to pardon,赦免,VERB,B2
 Parität,parity,平等,NOUN,B2
 Park,park,公园,NOUN,B2
 Parken,parking,停车,NOUN,B2
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
 Parlament,parliament,议会,NOUN,B2
 Parodie,parody,戏仿,NOUN,B2
+Bewährung,parole,假释,NOUN,B2
 Paronomasie,paronomasia,近音词双关,NOUN,B2
-Partitur,musical score,乐谱,NOUN,B2
+teilnehmen,to part,分离,VERB,B2
+sterben,to part by death,死别,VERB,B2
+Teilursache,partial cause,分因,NOUN,B2
+Teilbedeutung,partial meaning,分义,NOUN,B2
+Teilnahme,participation,参与,NOUN,B2
+partizipativ,participatory,参与式的,ADJ,B2
+Teilchen,particle,颗粒,NOUN,B2
+bestimmt,particular,特定的,ADJ,B2
+Besonderheit,particularity,特点,NOUN,B2
 Partner,partner,伙伴,NOUN,B2
 Partnerschaft,partnership,伙伴关系,NOUN,B2
+vorbeigehen,to pass by,经过,VERB,B2
 Passage,passage,段落,NOUN,B2
-Passfoto,id photo,证件照,NOUN,B2
-Passzeit,matching time,对时,NOUN,B2
-Pasta,pasta,意大利面,NOUN,B2
-Periode,period,时期,NOUN,B2
-Personal,personnel,人员,NOUN,B2
-Pestizid,pesticide,杀虫剂,NOUN,B2
-Petition,petition,请愿,NOUN,B2
-Pfahl,stake,利害关系,NOUN,B2
-Pfanne,frying pan,平底锅,NOUN,B2
-Pfeil,that arrow,那一箭,NOUN,B2
-Pflegeperson,caregiver,护理人员,NOUN,B2
-Philanthrop,philanthropist,慈善家,NOUN,B2
-Philanthropie,philanthropy,慈善,NOUN,B2
-Philippic (adj),Philippic,词,ADJ,C1
-Philosophie,philosophy,哲学,NOUN,B2
-Phobie,phobia,恐惧症,NOUN,B2
-Phonetik,phonetics,语音学,NOUN,B2
-Phonologie,phonology,音系学,NOUN,B2
-Photosynthese,photosynthesis,光合作用,NOUN,B2
-Phrase,phrase,短语,NOUN,B2
-Physiognomik,physiognomy,面相,NOUN,B2
-Physiologie,physiology,生理学,NOUN,B2
-Phänomen,phenomenon,现象,NOUN,B2
-Phänomenologie,phenomenology,现象学,NOUN,B2
-Phönix,phoenix,拿凤,NOUN,B2
-Pilger,pilgrim,朝圣者,NOUN,B2
-Pilgerfahrt,pilgrimage,朝圣,NOUN,B2
-Pingling,Pingling,等平陵,NOUN,C1
-Pistazie,pistachio,开心果,NOUN,B2
-Plagiat,plagiarism,剽窃,NOUN,B2
-Plakat,poster,海报,NOUN,B2
-Plan,scheme,计划,NOUN,B2
-Plattenspieler,record player,唱机,NOUN,B2
-Platz,square,平方的,ADJ,B2
-Platzierung,placement,放置,NOUN,B2
-Polaris,Polaris,北极星,NOUN,B2
-Politik,policy,政策,NOUN,B2
-Polizist,constable,警官,NOUN,B2
-Polster,pad,垫,NOUN,B2
-Pool,pool,水池,NOUN,B2
-Portion,portion,部分,NOUN,B2
-Porträt,portrait,肖像,NOUN,B2
-Positionierung,positioning,定位,NOUN,B2
-Postkarte,postcard,明信片,NOUN,B2
-Postulat,postulate,假定,NOUN,B2
-Pracht,grandeur,宏伟,NOUN,B2
-Pracht,splendor,辉煌,NOUN,B2
-Pragmatismus,pragmatism,实用主义,NOUN,B2
-Prahlen,boasting,夸耀,NOUN,B2
-Praktiker,practitioner,从业者,NOUN,B2
-Predigt,preaching,劝诫,NOUN,B2
-Predigt,sermon,布道,NOUN,B2
-Prekarität,precariousness,不稳定性,NOUN,B2
-Prellung,bruise,瘀伤,NOUN,B2
-Premier,premier,总理,NOUN,B2
-Premiere,premiere,首演,NOUN,B2
-Prestige,prestige,声望,NOUN,B2
-Propaganda,propaganda,宣传,NOUN,B2
-Prophet birthday,Prophet birthday,词,NOUN,B2
-Prophezeiung,prophecy,预言,NOUN,B2
-Proportion,proportion,比例,NOUN,B2
-Prosa,prose,散文,NOUN,B2
-Protagonist,protagonist,主角,NOUN,B2
-Protein,protein,蛋白质,NOUN,B2
-Protektionismus,protectionism,保护主义,NOUN,B2
-Provinz,province,省,NOUN,B2
-Provokation,provocation,挑衅,NOUN,B2
-Prozess,trial,试验,NOUN,B2
-Präambel,preamble,序言,NOUN,B2
-Präfektur,prefecture,省政府,NOUN,B2
-Präferenz,preference,偏好,NOUN,B2
-Prämisse,premise,前提,NOUN,B2
-Präsentator,presenter,主持人,NOUN,B2
-Präsidentschaft,presidency,总统任期,NOUN,B2
-Präzedenzfall,precedent,先例,NOUN,B2
-Prüfer,auditor,审计员,NOUN,B2
-Prüfungsarbeit,past exam papers,真题,NOUN,B2
-Psychologe,psychologist,心理学家,NOUN,B2
-Psychose,psychosis,精神病,NOUN,B2
-Pubertät,puberty,青春期,NOUN,B2
-Punktion,puncture,穿刺,NOUN,B2
-Punktzahl,score,比分,NOUN,B2
-Puppe,puppet,木偶,NOUN,B2
-Purpurnes Yin,purple yin,紫阴,NOUN,B2
-Putsch,coup,政变,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Qual,agony,极度痛苦,NOUN,B2
-Qual,anguish,痛苦,NOUN,B2
-Qualifikation,qualification,资格,NOUN,B2
-Qualifikation,qualifications,资格,NOUN,B2
-Quartal,quarter of a year,季度,NOUN,B2
-Quartalszeitschrift,quarterly magazine,季刊,NOUN,B2
-Quran,Quran,词,NOUN,B2
-Rabbiner,rabbi,拉比,NOUN,B2
-Rache,vengeance,报复,NOUN,B2
-Radieschen,radish,小萝卜,NOUN,B2
-Radiosender,radio station,广播电台,NOUN,B2
-Rampe,ramp,坡道,NOUN,B2
-Rang,rank,等级,NOUN,B2
-Rangliste,ranking,等级,NOUN,B2
-Raserei,frenzy,疯狂,NOUN,B2
-Rasse,race,比赛,NOUN,B2
-Rassismus,racism,种族主义,NOUN,B2
-Rat,council,委员会,NOUN,B2
-Ratenzahlung,installment,分期付款,NOUN,B2
-Ration,ration,配给,NOUN,B2
-Rationalisierung,rationalization,合理化,NOUN,B2
-Rationalismus,rationalism,理性主义,NOUN,B2
-Rationalität,rationality,理性,NOUN,B2
-Rauchen,smoking,吸烟,NOUN,B2
-Rauheit,roughness,粗糙,NOUN,B2
-Reaktionsfähigkeit,responsiveness,反应性,NOUN,B2
-Reaktor,reactor,反应堆,NOUN,B2
-Realismus,realism,现实主义,NOUN,B2
-Rebellenherz,rebellious heart,反心,NOUN,B2
-Rebellion,rebellion,叛乱,NOUN,B2
-Rechenschaftspflicht,accountability,问责制,NOUN,B2
-Rechnung,bill,账单,NOUN,B2
-Rechte,rights,权利,NOUN,B2
-Rechtsberuf,legal profession,律师业,NOUN,B2
-Rechtsstaatlichkeit,rule of law,法治,NOUN,B2
-Recycling,recycling,回收利用,NOUN,B2
-Rede,speech,演讲,NOUN,B2
-Rede halten,to make a speech,发言,VERB,B2
-Redseligkeit,talkativeness,多嘴,NOUN,B2
-Referendum,referendum,公民投票,NOUN,B2
-Reflexion,reflection,思考,NOUN,B2
-Reformismus,reformism,改唯,NOUN,B2
-Regelungen,regulations,法规,NOUN,B2
-Regenbogen,rainbow,彩虹,NOUN,B2
-Regenguss,downpour,倾盆大雨,NOUN,B2
-Regenwald,rainforest,雨林,NOUN,B2
-Regierung,governance,治理,NOUN,B2
-Regime,regime,政权,NOUN,B2
-Registrierung,registration,注册,NOUN,B2
-Regression,regression,倒退,NOUN,B2
-Reiben,rubbing,摩擦,NOUN,B2
-Reibung,friction,摩擦,NOUN,B2
-Reich,realm,领域,NOUN,B2
-Reife,maturity,成熟,NOUN,B2
-Reifen wechseln,to change tire,换胎,VERB,B2
-Reihe,row,行,NOUN,B2
-Reim,rhyme,韵脚,NOUN,B2
-Reinheit,purity,纯洁,NOUN,B2
-Reinigung,cleansing,清洗,NOUN,B2
-Reise,travel,出行,NOUN,B2
-Reisemüdigkeit,travel fatigue,车马劳顿,NOUN,B2
-Reisender,traveler,旅行家,NOUN,B2
-Reitsport,equestrianism,马术,NOUN,B2
-Reizung,irritation,刺激,NOUN,B2
-Rekonstruktion,reconstruction,重建,NOUN,B2
-Rekrutierung,recruitment,招聘,NOUN,B2
-Reorganisation,reorganization,重组,NOUN,B2
-Reporter,reporter,记者,NOUN,B2
-Repräsentativität,representativeness,代表性,NOUN,B2
-Reserve,reserve,预备,NOUN,B2
-Resonanz,resonance,共鸣,NOUN,B2
-Rest,the rest,其余,NOUN,B2
-Rettung eines Fangs,rescue a-fang,救阿方,NOUN,B2
-Revision,revision,复习,NOUN,B2
-Revolution,revolution,革命,NOUN,B2
-Rezept,prescription,处方,NOUN,B2
-Rezession,recession,衰退,NOUN,B2
-Rhetorik,rhetoric,修辞,NOUN,B2
-Richtlinie,directive,指令,NOUN,B2
-Richtung,bearing,轴承,NOUN,B2
-Richtungsschild,direction sign,指示牌,NOUN,B2
-Riemen,strap,带子,NOUN,B2
-Ring,ring,戒指,NOUN,B2
-Ringen,wrestling,摔跤,NOUN,B2
-Ringstraße,ring road,绕城,NOUN,B2
-Riss,crack,裂缝,NOUN,B2
-Ritterlichkeit,chivalry,骑士精神,NOUN,B2
-Ritual,ritual,仪式,NOUN,B2
-Rivalität,rivalry,竞争,NOUN,B2
-Rohstoff,raw material,原材料,NOUN,B2
-Rollladen,roller blind,卷帘,NOUN,B2
-Rolltreppe,escalator,自动扶梯,NOUN,B2
-Rost,rust,铁锈,NOUN,B2
-Rotterdam,Rotterdam,词,ADJ,C1
-Router,router,路由器,NOUN,B2
-Routine,routine,常规,NOUN,B2
-Ruhe,calm,冷静的,ADJ,B2
-Ruhe,rest,休息,NOUN,B2
-Ruine,ruin,废墟,NOUN,B2
-Ruinen,ruins,废墟,NOUN,B2
-Rutsche,slide,滑动,NOUN,B2
-Ruß,soot,烟灰,NOUN,B2
-Rätsel,puzzle,谜题,NOUN,B2
-Röhre,tube,أنبوب,NOUN,B2
-Rübe,turnip,芜菁,NOUN,B2
-Rückenstich,backstab,背刺,NOUN,B2
-Rückerstattung,refund,退款,NOUN,B2
-Rückfahrlicht,backup light,倒车灯,NOUN,B2
-Rückfall,relapse,再犯,NOUN,B2
-Rückfall,reversion,重归,NOUN,B2
-Rückfluss,backflow,倒流,NOUN,B2
-Rückgewinnung,retrieval,检索,NOUN,B2
-Rückgriff,resort,度假胜地,NOUN,B2
-Rücklage,reclining,躺下,NOUN,B2
-Rückmeldung,feedback,反馈,NOUN,B2
-Rückschlag,setback,挫折,NOUN,B2
-Rückseite,reverse side,反面,NOUN,B2
-Rücksichtslosigkeit,ruthlessness,无情,NOUN,B2
-Rückstand,arrears,欠款,NOUN,B2
-Rückzahlung,repayment,偿还,NOUN,B2
-Rückzug,withdrawal,撤回,NOUN,B2
-Rühren,stir,搅拌,NOUN,B2
-Rüstung,armor,盔甲,NOUN,B2
-SIM card,SIM card,词,NOUN,B1
-Saat,sowing,播种,NOUN,B2
-Sack,sack,麻袋,NOUN,B2
-Sackgasse,dead end,死胡同,NOUN,B2
-Sake,sake,缘故,NOUN,B2
-Salafism,Salafism,词,NOUN,C1
-Salbe,ointment,药膏,NOUN,B2
-Sammler,collector,收藏家,NOUN,B2
-Sand,sand,沙子,NOUN,B2
-Sandal,sandal,凉鞋,NOUN,B2
-Sandwich,sandwich,三明治,NOUN,B2
-Sanftmut,docility,温顺,NOUN,B2
-Sanktion,sanction,制裁,NOUN,B2
-Satellit,satellite,卫星,NOUN,B2
-Satire,satire,讽刺,NOUN,B2
-Saturday evening,Saturday evening,词,NOUN,C1
-Satz,rate,比率,NOUN,B2
-Sauberkeit,cleanliness,清洁,NOUN,B2
-Scan,scan,扫描件,NOUN,B2
-Schaden,harm,伤害,NOUN,B2
-Schadstoff,pollutant,污染物,NOUN,B2
-Schaltkreis,circuit,电路,NOUN,B2
-Schaltraum,switch room,配电室,NOUN,B2
-Scharlatan,charlatan,江湖骗子,NOUN,B2
-Schatzkammer,treasury,国库,NOUN,B2
-Schauder,shudder,战栗,NOUN,B2
-Schaufel,shovel,铲子,NOUN,B2
-Schaukel,swing,秋千,NOUN,B2
-Schaum,foam,泡沫,NOUN,B2
-Schauspieltext,script for play,剧本,NOUN,B2
-Schicht,layer,层,NOUN,B2
-Schichttausch,shift swap,换班,NOUN,B2
-Schichtwechsel,shift rotation,倒班,NOUN,B2
-Schiedsrichter,referee,裁判,NOUN,B2
-Schiene,splint,夹板,NOUN,B2
-Schießen,shooting,射击,NOUN,B2
-Schild,shield,盾牌,NOUN,B2
-Schildkröte,turtle,海龟,NOUN,B2
-Schimmel,mold,鞋楦,NOUN,B2
-Schizophrenie,schizophrenia,精神分裂症,NOUN,B2
-Schlachtfeld,battlefield,战场,NOUN,B2
-Schlaflosigkeit,insomnia,失眠,NOUN,B2
-Schlaflosigkeit,sleeplessness,失眠,NOUN,B2
-Schlafmittel,sleeping pill,安眠药,NOUN,B2
-Schlafsaal,dormitory,宿舍,NOUN,B2
-Schlag,beating,跳动,NOUN,B2
-Schlamm,mud,泥,NOUN,B2
-Schlange,queue,队列,NOUN,B2
-Schleim,mucus,黏液,NOUN,B2
-Schleim,phlegm,痰,NOUN,B2
-Schlichtung,arbitration,仲裁,NOUN,B2
-Schloss,lock,锁,NOUN,B2
-Schluss,conclusion,结论,NOUN,B2
-Schlussfeier,closing ceremony,闭幕仪式,NOUN,B2
-Schlussfolgerung,inference,推断,NOUN,B2
-Schläger,racket,球拍,NOUN,B2
-Schmeichelei,flattery,奉承,NOUN,B2
-Schmied,blacksmith,铁匠,NOUN,B2
-Schmuggel,smuggling,走私,NOUN,B2
-Schmuggler,smuggler,走私者,NOUN,B2
-Schnecke,snail,蜗牛,NOUN,B2
-Schneeschatten,snow shadow,雪影姐姐,NOUN,B2
-Schneesturm,blizzard,暴风雪,NOUN,B2
-Schnittpunkt,intersection,交叉点,NOUN,B2
-Schnittstelle,interface,接口,NOUN,B2
-Schnupfen,runny nose,流鼻涕,NOUN,B2
-Schnur,string,细绳,NOUN,B2
-Schrank,cabinet,内阁,NOUN,B2
-Schrank,cupboard,橱柜,NOUN,B2
-Schraubenzieher,screwdriver,螺丝刀,NOUN,B2
-Schrecken,fright,惊吓,NOUN,B2
-Schrei,shout,喊叫,NOUN,B2
-Schreiber,clerk,职员,NOUN,B2
-Schreibwaren,stationery,文具,NOUN,B2
-Schreibübung,handwriting practice,练字,NOUN,B2
-Schrein,shrine,مشعر,NOUN,B2
-Schreiner,carpenter,木匠,NOUN,B2
-Schreinerei,carpentry,木工,NOUN,B2
-Schrift,in writing,书面,NOUN,B2
-Schuhe,footwear,鞋穿,NOUN,B2
-Schuhe,shoes,鞋子,NOUN,B2
-Schuhentfernung,shoe removal,鞋脱,NOUN,B2
-Schuld,debt,债务,NOUN,B2
-Schuldner,debtor,债务人,NOUN,B2
-Schurke,scoundrel,恶棍,NOUN,B2
-Schurke,villain,反派,NOUN,B2
-Schwan,swan,天鹅,NOUN,B2
-Schwankung,fluctuation,波动,NOUN,B2
-Schweißen,welding,焊接,NOUN,B2
-Schwertkämpfer,swordsman,剑客,NOUN,B2
-Schwertloser,swordless,剑不,NOUN,B2
-Schwimmbad,swimming pool,游泳池,NOUN,B2
-Schwindel,dizziness,眩晕,NOUN,B2
-Schwindel,sham,假冒,NOUN,B2
-Schwäche,shortcoming,缺点,NOUN,B2
-Schwägerin,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-Schätzung,estimate,估计,NOUN,B2
-Schönling,handsome guy,帅哥,NOUN,B2
-Schöpfer,creator,创造者,NOUN,B2
-Schöpfung,creation,创造,NOUN,B2
-Schürze,apron,围裙,NOUN,B2
-Segeln,sailing,航行,NOUN,B2
-Sehne,tendon,肌腱,NOUN,B2
-Sehnsucht,yearning,向往,NOUN,B2
-Seide,silk,丝绸,NOUN,B2
-Seidenstoff,silk cloth,丝绸,NOUN,B2
-Seite,side,侧面,NOUN,B2
-Seitentür,side door,侧门,NOUN,B2
-Sekretariat,secretariat,秘书处,NOUN,B2
-Sekte,sect,教派,NOUN,B2
-Sektion,section,部分,NOUN,B2
-Selbst,myself,我自,NOUN,B2
-Selbst,self,自我,NOUN,B2
-Selbstaufopferung,self-sacrifice,舍己,NOUN,B2
-Selbstgespräch,soliloquy,独白,NOUN,B2
-Seligkeit,bliss,极乐,NOUN,B2
-Sellerie,celery,芹菜,NOUN,B2
-Semester,semester,学期,NOUN,B2
-Seminar,seminar,研讨会,NOUN,B2
-Semiologie,semiology,符号学，症状学,NOUN,B2
-Semiotik,semiotics,符号学,NOUN,B2
-Senat,senate,参议院,NOUN,B2
-Sendung,broadcasting,广播,NOUN,B2
-Sendung,consignment,托运,NOUN,B2
-Seniorität,seniority,资历,NOUN,B2
-Sensibilität,sensitivity,敏感性,NOUN,B2
-Sensor,sensor,传感器,NOUN,B2
-Sequenz,sequence,顺序，片段,NOUN,B2
-Serbian,Serbian,词,ADJ,C1
-Server,server,服务器,NOUN,B2
-Serviette,napkin,餐巾,NOUN,B2
-Sesam,sesame,芝麻,NOUN,B2
-Sex,sex,性别,NOUN,B2
-Shampoo,shampoo,洗发水,NOUN,B2
-Shiism,Shiism,词,NOUN,C1
-Sicherheit,safety,安全,NOUN,B2
-Sicherheitsbericht,safety report,安全报告,NOUN,B2
-Sicherung,fuse,保险丝,NOUN,B2
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Sie,you polite,您,PRON,B2
-Sieb,colander,漏勺,NOUN,B2
-Sieb,sieve,筛子,NOUN,B2
-Sieden,boiling,沸腾,NOUN,B2
-Siedlung,settlement,解决,NOUN,B2
-Simulation,simulation,模拟,NOUN,B2
-Sinnlosigkeit,futility,无用,NOUN,B2
-Sirup,syrup,糖浆,NOUN,B2
-Skala,scale,规模,NOUN,B2
-Skalpell,scalpel,手术刀,NOUN,B2
-Skelett,skeleton,骨架,NOUN,B2
-Skepsis,skepticism,怀疑主义,NOUN,B2
-Skifahren,skiing,滑雪,NOUN,B2
-Skizze,sketch,素描,NOUN,B2
-Sklaverei,slavery,奴隶制,NOUN,B2
-Skrupel,scruple,顾虑,NOUN,B2
-Skulptur,sculpture,雕塑,NOUN,B2
-Slogan,slogan,口号,NOUN,B2
-Snack,snack,小吃,NOUN,B2
-Sofa,sofa,沙发,NOUN,B2
-Softball,softball,垒球,NOUN,B2
-Software,software,软件,NOUN,B2
-Sohle,sole,鞋底,NOUN,B2
-Soldat,soldiers,官兵,NOUN,B2
-Solid-State-Laufwerk,solid-state drive,固态硬盘,NOUN,B2
-Solidarität,solidarity,团结,NOUN,B2
-Solidität,soundness,好端端,NOUN,B2
-Solvenz,solvency,偿付能力,NOUN,B2
-Song typeface,Song typeface,宋体,NOUN,C1
-Sophismus,sophism,诡辩,NOUN,B2
-Sophisterei,sophistry,诡辩,NOUN,B2
-Souverän,sovereign,主权的,ADJ,B2
-Souveränität,sovereignty,主权,NOUN,B2
-Sozialarbitration,social arbitration,社会仲裁,NOUN,B2
-Sozialstatistik,social statistics,社会统计,NOUN,B2
-Soziologe,sociologist,社会学家,NOUN,B2
-Soziologie,sociology,社会学,NOUN,B2
-Spalt,split,分裂,NOUN,B2
-Spaltung,fission,裂变,NOUN,B2
-Spanisch,spanish,西班牙语,NOUN,B2
-Spannung,suspense,悬念,NOUN,B2
-Spaziergang,stroll,闲逛,NOUN,B2
-Speer,spear,长矛,NOUN,B2
-Speichelleckerei,sycophancy,阿谀奉承,NOUN,B2
-Spektrum,spectrum,光谱,NOUN,B2
-Spekulation,speculation,推测,NOUN,B2
-Spenden einsammeln,to raise donations,募捐,VERB,B2
-Spender,donor,捐赠者,NOUN,B2
-Sperling,sparrow,麻雀,NOUN,B2
-Spezialisierung,specialization,专业化,NOUN,B2
-Spezialthema,special topic,专题,NOUN,B2
-Spezifikation,specification,规格,NOUN,B2
-Sphäre,sphere,领域,NOUN,B2
-Spinner,weirdo,怪人,NOUN,B2
-Spionage,espionage,间谍活动,NOUN,B2
-Spiritualität,spirituality,灵性,NOUN,B2
-Spitzname,nickname,绰号,NOUN,B2
-Sponsoring,sponsorship,赞助,NOUN,B2
-Sport,sport,运动,NOUN,B2
-Sportwagen,sports car,跑车,NOUN,B2
-Spray,spray,喷雾,NOUN,B2
-Sprecher,spokesperson,发言人,NOUN,B2
-Sprichwort,proverb,谚语,NOUN,B2
-Sprung,leap,跳跃,NOUN,B2
-Spur,lane,小巷,NOUN,B2
-Späher,scout,侦察员,NOUN,B2
-Spät,late,晚,ADV,B2
-Spüle,sink,水槽,NOUN,B2
-Staatsbürgerschaft,citizenship,公民身份,NOUN,B2
-Stab,stick,棍子,NOUN,B2
-Stabilität,stability,稳定,NOUN,B2
-Stagnation,stagnation,停滞,NOUN,B2
-Stahl,steel,钢,NOUN,B2
-Stamm,log,日志,NOUN,B2
-Stamm,tribe,部落,NOUN,B2
-Standard,standard,标准,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Standardisierung,standardization,标准化,NOUN,B2
-Starrheit,rigidity,僵硬,NOUN,B2
-Start,start,开始,NOUN,B2
-Start,takeoff,起飞,NOUN,B2
-Station,station,车站,NOUN,B2
-Station,ward,病房,NOUN,B2
-Statistik,statistics,统计学,NOUN,B2
-Stausee,reservoir,水库,NOUN,B2
-Stauung,congestion,拥堵,NOUN,B2
-Steckdose,outlet,出口,NOUN,B2
-Stecklinge schneiden,to take cuttings,扦插,VERB,B2
-Steifheit,stiffness,僵硬,NOUN,B2
-Steingarten,rockery,假山,NOUN,B2
-Stellvertreter,deputy,副的,ADJ,B2
-Stellvertreter,proxy,代理人,NOUN,B2
-Stenose,stenosis,狭窄,NOUN,B2
-Steppdecke,quilt,被子,NOUN,B2
-Stereotyp,stereotype,刻板印象,NOUN,B2
-Sternanis,star anise,八角,NOUN,B2
-Sternbild,constellation,星座,NOUN,B2
-Sternenhimmel,starry sky,星空,NOUN,B2
-Sternzeichen,zodiac sign,属相,NOUN,B2
-Stich,stitch,针脚,NOUN,B2
-Stickerei,embroidery,刺绣,NOUN,B2
-Stiefmutter,stepmother,后母,NOUN,B2
-Stiel,stem,茎,NOUN,B2
-Stigma,stigma,耻辱,NOUN,B2
-Stillen,breastfeeding,母乳喂养,NOUN,B2
-Stilllegung,decommissioning,退役,NOUN,B2
-Stillstand,standstill,停滞,NOUN,B2
-Stimulans,stimulant,兴奋剂,NOUN,B2
-Stoizismus,stoicism,斯多葛主义,NOUN,B2
-Stornierung,cancellation,取消,NOUN,B2
-Strafverfolgung,law enforcement,执法,NOUN,B2
-Strahl,ray,光线,NOUN,B2
-Strahlkraft,radiance,光辉,NOUN,B2
-Strahlung,radiation,辐射,NOUN,B2
-Straße,road,道路,NOUN,B2
-Streben,aspiration,抱负,NOUN,B2
-Strecke,stretch,伸展,NOUN,B2
-Streifen,strip,条带,NOUN,B2
-Streit,dispute,争论,NOUN,B2
-Streit,quarreling,再吵,NOUN,B2
-Strenge,severity,严厉,NOUN,B2
-Strom,current,当前的,ADJ,B2
-Strudel,vortex,漩涡,NOUN,B2
-Strömung,flow,流动,NOUN,B2
-Student,student,学生,NOUN,B2
-Student,undergraduate,本科生,NOUN,B2
-Stufe,steps,台阶,NOUN,B2
-Stupor,stupor,昏迷,NOUN,B2
-Stürmer,striker,罢工者,NOUN,B2
-Su Sha,Su Sha,夙砂,NOUN,B2
-Subsistenz,subsistence,生计,NOUN,B2
-Substantiierung,substantiation,论证,NOUN,B2
-Subvention,subsidy,补贴,NOUN,B2
-Suche,quest,探索,NOUN,B2
-Suche,seeking,寻求,NOUN,B2
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Super-Gesamtumfassung,super-comprehensive,超遍,NOUN,B2
-Supergedanke,super-thought,超思,NOUN,B2
-Supergrad,super-grade,超级,NOUN,B2
-Superprinzip,super-principle,超则,NOUN,B2
-Superqualität,super-quality,超质,NOUN,B2
-Supersystem,super-system,超制,NOUN,B2
-Surinamese,Surinamese,词,ADJ,C1
-Surrealismus,surrealism,超现实主义,NOUN,B2
-Susha,susha,夙砂大,NOUN,B2
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-Suspendierung,suspension,暂停,NOUN,B2
-Swedish (adj),Swedish,瑞典的,ADJ,B2
-Symbol,symbol,象征,NOUN,B2
-Symmetrie,symmetry,对称,NOUN,B2
-Symphonie,symphony,交响乐,NOUN,B2
-Symposium,symposium,研讨会,NOUN,B2
-Symptom,symptom,症状,NOUN,B2
-Synchronisation,synchronization,同步,NOUN,B2
-Synergie,synergy,协同效应,NOUN,B2
-Synonymie,synonymy,同义关系,NOUN,B2
-Syntax,syntax,句法,NOUN,B2
-Synthese,synthesis,综合,NOUN,B2
-System,system,系统,NOUN,B2
-Säge,saw,锯子,NOUN,B2
-Säkularismus,secularism,世俗主义,NOUN,B2
-Sättigung,satiety,饱足,NOUN,B2
-Säule,pillar,柱子,NOUN,B2
-Südarmee,southern army,南军,NOUN,B2
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-TV series,TV series,词,NOUN,B1
-Tablett,tray,托盘,NOUN,B2
-Tabu,taboo,禁忌,NOUN,B2
-Tadel,rebuke,责备,NOUN,B2
-Tadel,reprimand,训斥,NOUN,B2
-Tag und Nacht,day and night,昼夜,NOUN,B2
-Tagesarbeiter,day laborer,日工,NOUN,B2
-Tageszeitung,daily newspaper,日报,NOUN,B2
-Tageszuwachs,daily increase,日渐,NOUN,B2
-Tai Chi,Tai Chi,太极,NOUN,C1
-Taifun,typhoon,台风,NOUN,B2
-Taille,waist,腰,NOUN,B2
-Tajwid,Tajwid,词,NOUN,C1
-Taktik,tactic,策略,NOUN,B2
-Taktik,tactics,战术,NOUN,B2
-Talar,black robe,黑衣,NOUN,B2
-Talent,talent,天赋,NOUN,B2
-Tangente,tangent,切线,NOUN,B2
-Tapferkeit,valor,勇气,NOUN,B2
-Taschentuch,handkerchief,手帕,NOUN,B2
-Tastatur,keyboard,键盘,NOUN,B2
-Tatkraft,vigor,活力,NOUN,B2
-Tau,dew,露水,NOUN,B2
-Taube,pigeon,鸽子,NOUN,B2
-Taubheit,numbness,麻木,NOUN,B2
-Tauchen,diving,潜水,NOUN,B2
-Tauchen,scuba diving,潜水,NOUN,B2
-Tauchgang,dive,跳水,NOUN,B2
-Tausender,lead thousand,率千,NOUN,B2
-Teich,pond,池塘,NOUN,B2
-Teilbedeutung,partial meaning,分义,NOUN,B2
-Teilchen,particle,颗粒,NOUN,B2
-Teilnahme,participation,参与,NOUN,B2
-Teilung,division,分开,NOUN,B2
-Teilursache,partial cause,分因,NOUN,B2
-Telefon,phone,电话,NOUN,B2
-Telefonat,phone call,通话,NOUN,B2
-Tempo,pace,速度,NOUN,B2
-Tempomacher,pace-setter,标兵,NOUN,B2
-Tennis,tennis,网球,NOUN,B2
-Terminal,terminal,终点站,NOUN,B2
-Terminologie,terminology,术语,NOUN,B2
-Territorium,territory,领土,NOUN,B2
-Terrorismus,terrorism,恐怖主义,NOUN,B2
-Terrorist,terrorist,恐怖分子,NOUN,B2
-Test,test,测试,NOUN,B2
-Testamentsvollstrecker,executor,遗嘱执行人,NOUN,B2
-Text,text,文本,NOUN,B2
-Textilie,textile,纺织,NOUN,B2
-Thai,Thai,词,ADJ,C1
-Theater,theater,剧院,NOUN,B2
-Thema,theme,主题,NOUN,B2
-Theokratie,theocracy,神权政治,NOUN,B2
-Theologie,theology,神学,NOUN,B2
-Theorem,theorem,定理,NOUN,B2
-These,thesis,论文,NOUN,B2
-Thunfisch,tuna,金枪鱼,NOUN,B2
-Tifinagh script,Tifinagh script,词,NOUN,C1
-Tinte,ink,墨水,NOUN,B2
-Tochtergesellschaft,subsidiary,子公司,NOUN,B2
-Todesrisiko,risking death,冒死,NOUN,B2
-Todesstrafe,death penalty,死刑,NOUN,B2
-Todeswunsch,death wish,找死,NOUN,B2
-Ton,clay,黏土,NOUN,B2
-Trage,stretcher,担架,NOUN,B2
-Transaktion,transaction,交易,NOUN,B2
-Transformation,transformation,تحول,NOUN,B2
-Transmaterie,trans-matter,超物,NOUN,B2
-Transparenz,transparency,透明度,NOUN,B2
-Transplantat,graft,嫁接,NOUN,B2
-Transzendenz,transcendence,超越,NOUN,B2
-Trauerrede,eulogy,赞辞,NOUN,B2
-Traurigkeit,sadness,悲伤,NOUN,B2
-Trend,trend,趋势,NOUN,B2
-Treppe,stairs,楼梯,NOUN,B2
-Tribut,tribute,贡品,NOUN,B2
-Trivialisierung,trivialization,浅薄化,NOUN,B2
-Trivialität,triviality,琐碎,NOUN,B2
-Trophäe,trophy,奖杯,NOUN,B2
-Trost,consolation,安慰,NOUN,B2
-Trost,solace,安慰,NOUN,B2
-Trotz,defiance,挑衅,NOUN,B2
-Troupe,troupe,剧团,NOUN,B2
-Trubel,bustle,喧闹,NOUN,B2
-Trupp,squad,小队,NOUN,B2
-Truppe,troops,部队,NOUN,B2
-Träger,carrier,承运人,NOUN,B2
-Träger,porter,搬运工,NOUN,B2
-Trägheit,inertia,惯性,NOUN,B2
-Tugend,virtue,美德,NOUN,B2
-Tunika,tunic,束腰外衣,NOUN,B2
-Tunnel,tunnel,隧道,NOUN,B2
-Typ,type,类型,NOUN,B2
-Tyrann,bully,欺凌者,NOUN,B2
-Tyrann,tyrant,暴君,NOUN,B2
-Täuschung,deception,欺骗,NOUN,B2
-Täuschungswette,deception dare,你敢骗我,NOUN,B2
-Töpferei,pottery,陶器,NOUN,B2
-Tötung,homicide,杀人,NOUN,B2
-Türgriff,door handle,门把手,NOUN,B2
-Türmatte,doormat,门垫,NOUN,B2
-U-Boot,submarine,潜水艇,NOUN,B2
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-Uhr,watch,手表,NOUN,B2
-Ulzeration,ulceration,溃疡,NOUN,B2
-Umbewertung,revaluation,重新评估,NOUN,B2
-Umfang,extent,程度,NOUN,B2
-Umfang,scope,范围,NOUN,B2
-Umfrage,poll,民意调查,NOUN,B2
-Umfrage,survey,调查,NOUN,B2
-Umgebung,surroundings,周围,NOUN,B2
-Umgestaltung,reshaping,改形,NOUN,B2
-Umkehr,reversal,突变,NOUN,B2
-Umkleideraum,locker room,更衣室,NOUN,B2
-Umlaufbahn,orbit,轨道,NOUN,B2
-Umleitung,re-routing,改轨,NOUN,B2
-Umsatz,turnover,营业额,NOUN,B2
-Umsetzung,implementation,实施,NOUN,B2
-Umstrukturierung,restructuring,重组,NOUN,B2
-Umstände,situation circumstances,情形,NOUN,B2
-Umweg,detour,绕道,NOUN,B2
-Umweltbericht,environmental report,环境报告,NOUN,B2
-Unabhängigkeit,independence,独立,NOUN,B2
-Unbehagen,discomfort,不适,NOUN,B2
-Unbehagen,unease,不安,NOUN,B2
-Und,and,重而,NOUN,B2
-Und so weiter,and so on,之类,NOUN,B2
-Uneinigkeit,disagreement,不和,NOUN,B2
-Unfähigkeit,inability,无能,NOUN,B2
-Ungeheuerlichkeit,enormity,极恶,NOUN,B2
-Ungehorsam,disobedience,不服从,NOUN,B2
-Ungekühltes,uncooled,未寒,NOUN,B2
-Ungeziefer,vermin,害兽,NOUN,B2
-Unglaube,disbelief,不信,NOUN,B2
-Ungleichheit,disparity,差异,NOUN,B2
-Ungleichheit,inequality,不平等,NOUN,B2
-Unhöflichkeit,rudeness,粗鲁,NOUN,B2
-Unionismus,unionism,工会主义,NOUN,B2
-Universalität,universality,普遍性,NOUN,B2
-Unkraut,weed,杂草,NOUN,B2
-Unmöglichkeit,impossibility,不可能,NOUN,B2
-Unmöglichkeit,you cannot live,你也活不,NOUN,B2
-Unordnung,disorder,混乱,NOUN,B2
-Unreinheit,impurity,不纯,NOUN,B2
-Unruhe,unrest,动荡,NOUN,B2
-Unsicherheit,uncertainty,不确定性,NOUN,B2
-Unsinn reden,to talk nonsense,胡言乱语,VERB,B2
-Unstimmigkeit,discordance,不一致,NOUN,B2
-Unten,below,在...下面,ADP,B2
-Unterdrückung,oppression,压迫,NOUN,B2
-Unterdrückung,repression,镇压,NOUN,B2
-Unterdrückung,suppression,抑,NOUN,B2
-Untergeordneter,subordinate,下属,NOUN,B2
-Untergrund,underground,地铁,NOUN,B2
-Unterhalt,alimony,赡养费,NOUN,B2
-Unterhaltungszentrum,entertainment center,娱乐中心,NOUN,B2
-Unterkunft,lodging,住宿,NOUN,B2
-Unterkunft,shelter,庇护所,NOUN,B2
-Unterkurs,downstream,下游,NOUN,B2
-Unterlegenheit,inferiority,劣势,NOUN,B2
-Unternehmen,enterprise,企业,NOUN,B2
-Unternehmen,undertaking,事业,NOUN,B2
-Unternehmer,entrepreneur,企业家,NOUN,B2
-Unterscheidung,distinction,区别,NOUN,B2
-Unterschlagung,embezzlement,贪污,NOUN,B2
-Unterschätzung,underestimation,小看,NOUN,B2
-Unterstützung,endorsement,背书,NOUN,B2
-Untertitel,subtitle,字幕,NOUN,B2
-Unterwerfung,submission,顺从,NOUN,B2
-Unterwürfigkeit,servility,奴性,NOUN,B2
-Unvereinbarkeit,incompatibility,不兼容,NOUN,B2
-Unverschämtheit,impudence,厚颜无耻,NOUN,B2
-Unverschämtheit,insolence,无礼,NOUN,B2
-Unwilligkeit,unwillingness,不甘,NOUN,B2
-Unwürdiger,unworthy,你不配,NOUN,B2
-Unzufriedenheit,discontent,不满,NOUN,B2
-Unzufriedenheit,displeasure,不悦,NOUN,B2
-Urbanität,urbanity,都市风度,NOUN,B2
-Urlaub,leave,休假,NOUN,B2
-Urlaub,vacation,假期,NOUN,B2
-Urteil,verdict,裁决,NOUN,B2
-Utilitarismus,utilitarianism,功利主义,NOUN,B2
-Utopie,utopia,乌托邦,NOUN,B2
-VIP room,VIP room,贵宾室,NOUN,C1
-Vakanz,vacancy,空缺,NOUN,B2
-Van,van,货车,NOUN,B2
-Variable,variable,变量,NOUN,B2
-Varianz,variance,方差,NOUN,B2
-Vene,vein,静脉,NOUN,B2
-Verabschiedung,see off,送走,NOUN,B2
-Verachtung,contempt,轻视,NOUN,B2
-Verachtung,disdain,蔑视,NOUN,B2
-Veranda,porch,门廊,NOUN,B2
-Veranstaltungsort,venue,场地,NOUN,B2
-Verantwortliche,person in charge,负责人,NOUN,B2
-Verarmung,destitution,贫困,NOUN,B2
-Verband,bandage,绷带,NOUN,B2
-Verbannung,banishment,流放,NOUN,B2
-Verbindung,compound,复合性,ADJ,B2
-Verbraucher,consumer,消费者,NOUN,B2
-Verbrechen,felony,重罪,NOUN,B2
-Verbriefung,securitization,证券化,NOUN,B2
-Verbündeter,ally,盟友,NOUN,B2
-Verdauung,digestion,消化,NOUN,B2
-Verdauungsstörung,indigestion,消化不良,NOUN,B2
-Verdiensturkunde,certificate of merit,奖状,NOUN,B2
-Veredelung,refinement,修养,NOUN,B2
-Veredelung,refining,提炼,NOUN,B2
-Verehrung,veneration,崇敬,NOUN,B2
-Verfassungsmäßigkeit,constitutionality,合宪性,NOUN,B2
-Verfolgung,persecution,迫害,NOUN,B2
-Verfolgung,pursuit,追求,NOUN,B2
-Verformung,deformation,变形,NOUN,B2
-Verfügbarkeit,availability,可用性,NOUN,B2
-Verfügung,injunction,禁令,NOUN,B2
-Verhandlungen,negotiations,谈判,NOUN,B2
-Verheimlichung,concealment,隐瞒,NOUN,B2
-Verkauf,sales,打折,NOUN,B2
-Verkehr,intercourse,性交,NOUN,B2
-Verkehrsschild,road sign,路标,NOUN,B2
-Verkäufer,salesperson,销售人员,NOUN,B2
-Verlag,publishing house,出版社,NOUN,B2
-Verlassen,abandonment,抛弃,NOUN,B2
-Verleger,publisher,出版商,NOUN,B2
-Verleihung,bestowal,授予,NOUN,B2
-Verleugnung,denial,否认,NOUN,B2
-Verleumdung,defamation,诽谤,NOUN,B2
-Verliebtheit,infatuation,迷恋,NOUN,B2
-Vermeidung,avoidance,避免,NOUN,B2
-Vermesser,surveyor,测量员,NOUN,B2
-Vermittler,intermediary,中间人,NOUN,B2
-Vermittlung,switchboard,总机,NOUN,B2
-Vermutung,conjecture,推测,NOUN,B2
-Vermögenswert,asset,资产,NOUN,B2
-Vermögenswerte,assets,资产,NOUN,B2
-Vernichtung,annihilation,寂灭,NOUN,B2
-Verpackung,packaging,包装,NOUN,B2
-Verpackung,wrapping,包装,NOUN,B2
-Verpflichtung,obligation,义务,NOUN,B2
-Verrat,betrayal,背叛,NOUN,B2
-Verrat,treachery,背叛,NOUN,B2
-Versammlung,gathering,聚集,NOUN,B2
-Verschlüsselung,encryption,加密,NOUN,B2
-Verschmutzung,pollution,污染,NOUN,B2
-Verschuldung,indebtedness,负债,NOUN,B2
-Verschwendung,dissipation,挥霍,NOUN,B2
-Verschwendung,squandering,挥霍,NOUN,B2
-Verschwinden,disappearance,消失,NOUN,B2
-Version,version,版本,NOUN,B2
-Verstaatlichung,nationalization,国有化,NOUN,B2
-Verstand,sanity,理智,NOUN,B2
-Verstand,wits,心眼,NOUN,B2
-Verstauchung,sprain,扭伤,NOUN,B2
-Versteckmöglichkeit,allow hiding,许躲,NOUN,B2
-Verstopfung,constipation,便秘,NOUN,B2
-Verstorbene,deceased,死者,NOUN,B2
-Verstoß,violation,侵越,NOUN,B2
-Verständnis,comprehension,理解,NOUN,B2
-Verstärker,amplifier,放大器,NOUN,B2
-Verstärkung,amplification,放大,NOUN,B2
-Versöhnung,reconciliation,和解,NOUN,B2
-Verteilung,distribution,分布,NOUN,B2
-Vertrag,treaty,条约,NOUN,B2
-Vertrag brechen,to breach contract,违约,VERB,B2
-Vertrauen,trust,信托,NOUN,B2
-Vertraulichkeit,confidentiality,保密性,NOUN,B2
-Vertretung,representation,代表,NOUN,B2
-Verursachung,causation,因果关系,NOUN,B2
-Verurteilung,condemnation,谴责,NOUN,B2
-Verwandtschaft,kinship,亲属关系,NOUN,B2
-Verweigerung,refusal,拒绝,NOUN,B2
-Verwirrung,bewilderment,困惑,NOUN,B2
-Verwirrung,confusion,困惑,NOUN,B2
-Verwüstung,devastation,破坏,NOUN,B2
-Verzerrung,distortion,扭曲,NOUN,B2
-Verzug,default,违约,NOUN,B2
-Veröffentlichung,publication,出版物,NOUN,B2
-Veteran,veteran,老手,NOUN,B2
-Veto,veto,否决,NOUN,B2
-Vibration,vibration,振动,NOUN,B2
-Video,video,视频,NOUN,B2
-Videoaufzeichnung,video recording,录像,NOUN,B2
-Vieh,livestock,家畜,NOUN,B2
-Viele,many,许多,ADJ,B2
-Vielfalt,diversity,多样性,NOUN,B2
-Villa,mansion,豪宅,NOUN,B2
-Villa,villa,别墅,NOUN,B2
-Violine,violin,小提琴,NOUN,B2
-Virus,virus,病毒,NOUN,B2
-Vision,vision,远见,NOUN,B2
-Vitamin,vitamin,维生素,NOUN,B2
-Volk,folk,民间的,ADJ,B2
-Vollendung,completion,完成,NOUN,B2
-Vollkommenheit,perfection,完美,NOUN,B2
-Vollmacht,power of attorney,委托书,NOUN,B2
-Vollmond,full moon,满月,NOUN,B2
-Volumen,volume,体积,NOUN,B2
-Voraussetzung,prerequisite,前提,NOUN,B2
-Vorauszahlung,advance payment,预付款,NOUN,B2
 Vorbeigehen,passing,过世,NOUN,B2
-Vorbild,paragon,典范,NOUN,B2
-Voreingenommenheit,bias,偏见,NOUN,B2
-Vorgesetzter,supervisor,主管,NOUN,B2
-Vorgänger,predecessor,前任,NOUN,B2
-Vorhangstange,curtain rod,窗帘杆,NOUN,B2
-Vorhersage,prediction,预测,NOUN,B2
-Vorhut,vanguard,先锋,NOUN,B2
-Vorkommnis,occurrence,发生,NOUN,B2
-Vorladung,summons,传票,NOUN,B2
-Vorläufer,precursor,先驱,NOUN,B2
-Vorort,suburb,郊区,NOUN,B2
-Vorrat,stockpile,储备,NOUN,B2
-Vorschlag,proposition,主张,NOUN,B2
-Vorschlag,suggestion,建议,NOUN,B2
-Vorschriften,provisions,储备,NOUN,B2
-Vorsicht,prudence,谨慎,NOUN,B2
-Vorsichtsmaßnahme,precaution,预防措施,NOUN,B2
-Vorwort,preface,序言,NOUN,B2
-Vulgarität,vulgarity,粗俗,NOUN,B2
-Vulkan,volcano,火山,NOUN,B2
-Wachposten,escort guard,镖师,NOUN,B2
-Wachsamkeit,vigilance,警惕,NOUN,B2
-Wachtel,quail,鹌鹑,NOUN,B2
-Waffenstillstand,truce,休战,NOUN,B2
-Wagemut,audacity,大胆,NOUN,B2
-Wagnis,push luck,太得寸,NOUN,B2
-Wahl,election,选举,NOUN,B2
-Wahlkreis,constituency,选区,NOUN,B2
-Wahrheit aus den Tatsachen suchen,to seek truth from facts,实事求是,VERB,B2
-Wahrsagung,divination,占卜,NOUN,B2
-Waise,orphan,孤儿,NOUN,B2
-Wald,woodland,林地,NOUN,B2
-Wandern,wandering,漫游,NOUN,B2
-Wanze,bug,虫子,NOUN,B2
-Ware,commodity,商品,NOUN,B2
-Warnung,alert,警觉的,ADJ,B2
-Warten,wait,等待,NOUN,B2
-Warten auf mich,wait for me,等我,NOUN,B2
-Wartezimmer,waiting room,候诊室,NOUN,B2
-Waschmaschine,washing machine,洗衣机,NOUN,B2
-Wasserfall,water falling,水落,NOUN,B2
-Wasserfall,waterfall,瀑布,NOUN,B2
-Wasserkraft,hydro energy,水能,NOUN,B2
-Wassermelone,watermelon,西瓜,NOUN,B2
-Wassermelonenkern,watermelon seed,西瓜子,NOUN,B2
-Wasserspinat,water spinach,空心菜,NOUN,B2
-Wasserstoff,hydrogen,氢,NOUN,B2
-Webcam,webcam,网络摄像头,NOUN,B2
-Weben,weaving,编织,NOUN,B2
-Website,website,网站,NOUN,B2
-Wechsel,alternation,轮流,NOUN,B2
-Wechsel,promissory note,本票,NOUN,B2
-Weiblichkeit,femininity,女性气质,NOUN,B2
-Weide,pasture,牧场,NOUN,B2
-Weihrauch,incense,香,NOUN,B2
-Weile,while,一会儿,NOUN,B2
-Weinbecher,wine cup,这酒盏,NOUN,B2
-Weinen,crying,,NOUN,B2
-Weinrebe,vine,藤蔓,NOUN,B2
-Weitschweifigkeit,verbosity,冗长,NOUN,B2
-Weizen,wheat,小麦,NOUN,B2
-Wellenbrecher,ride break,骑破,NOUN,B2
-Welpen,puppy,小狗,NOUN,B2
-Weltanschauung,worldview,世界观,NOUN,B2
-Wendepunkt,turning point,转折点,NOUN,B2
-Wertschätzung,appreciation,欣赏,NOUN,B2
-Westgebiete,western regions,西域,NOUN,B2
-Wettbewerb,contest,比赛,NOUN,B2
-Wettbewerber,competitor,竞争者,NOUN,B2
-Wettbewerbsfähigkeit,competitiveness,竞争力,NOUN,B2
-Wichtigkeit,importance,重要性,NOUN,B2
-Widder,ram,公羊,NOUN,B2
-Widerlegung,rebuttal,反驳,NOUN,B2
-Widerspruch,contradiction,矛盾,NOUN,B2
-Widersprüchlichkeit,inconsistency,不一致,NOUN,B2
-Widmung,dedication,奉献,NOUN,B2
-Wie,how,又怎会,NOUN,B2
-Wiederabruptheit,re-abruptness,再骤,NOUN,B2
-Wiederaufforstung,reforestation,重新造林,NOUN,B2
-Wiederaufführung,re-enactment,再演,NOUN,B2
-Wiederbedeutung,re-meaning,再义,NOUN,B2
-Wiederbegrenzung,re-limit,重限,NOUN,B2
-Wiederbestellung,re-order,重序,NOUN,B2
-Wiederbeweis,re-evidence,重据,NOUN,B2
-Wiedereinreichung,re-submission,再上,NOUN,B2
-Wiedererlangung,retrieve qingming,拿回青冥,NOUN,B2
-Wiedererwägung,reconsideration,重思,NOUN,B2
-Wiederfrucht,re-fruit,再果,NOUN,B2
-Wiedergrenze,re-boundary,重界,NOUN,B2
-Wiedergrund,re-reason,重理,NOUN,B2
-Wiedergutmachung,reparation,赔偿,NOUN,B2
-Wiederherstellung,restoration,恢复,NOUN,B2
-Wiederholung,again,你又,NOUN,B2
-Wiederholung,repetition,重复,NOUN,B2
-Wiederinnen,re-inner,再内,NOUN,B2
-Wiederkampf,re-battle,重战,NOUN,B2
-Wiederkehr,recurrence,往复,NOUN,B2
-Wiederkurs,re-course,重途,NOUN,B2
-Wiederlagerung,re-layering,改层,NOUN,B2
-Wiederlogik,re-logic,再逻,NOUN,B2
-Wiederquantität,re-quantity,再量,NOUN,B2
-Wiederschaffung,re-creation,再作,NOUN,B2
-Wiedersequenzierung,re-sequencing,改骤,NOUN,B2
-Wiedertempo,re-pace,重骤,NOUN,B2
-Wiederverkauf,resale,转售,NOUN,B2
-Wiederverwendung,reuse,重用,NOUN,B2
-Wiederweg,re-path,重径,NOUN,B2
-Wiese,meadow,草地,NOUN,B2
-Wildheit,ferocity,凶猛,NOUN,B2
-Wildheit,fierceness,凶猛,NOUN,B2
-Wille des kaiserlichen Vaters,imperial father's will,父皇要,NOUN,B2
-Willkommen,welcome,欢迎,NOUN,B2
-Willkommensbankett,welcome banquet,欢迎宴,NOUN,B2
-Wimper,eyelash,睫毛,NOUN,B2
-Wind,in wind,临风,NOUN,B2
-Winter,winter,冬天,NOUN,B2
-Wirbel,fuss,大惊小怪,NOUN,B2
-Wirbelwind,whirlwind,旋风；漩涡,NOUN,B2
-Wirksamkeit,efficacy,功效,NOUN,B2
-Wischer,wiper,雨刷,NOUN,B2
-Wochentest,weekly test,周测,NOUN,B2
-Wohlfahrt,welfare,福利,NOUN,B2
-Wohlstand,prosperity,繁荣,NOUN,B2
-Wohltätigkeit,benevolence,仁慈,NOUN,B2
-Wohltätigkeit,charity,慈善,NOUN,B2
-Wohnmobil,motorhome,露营车,NOUN,B2
-Wohnraum,housing,住房,NOUN,B2
-Wohnsitz,residence,住所,NOUN,B2
-Wolf,wolf,狼,NOUN,B2
-Wortwitz,banter,戏谑,NOUN,B2
-Wortzeichen,character word,字,NOUN,B2
-Wudang,wudang,武当,NOUN,B2
-Wunder,wonder,奇迹,NOUN,B2
-Wunsch,really want,真要,NOUN,B2
-Wushk,Wushk,词,NOUN,B1
-Wut,fury,狂怒,NOUN,B2
-Wächter,sentry,卫兵,NOUN,B2
-Wähler,voter,选民,NOUN,B2
-Wählerschaft,electorate,选民,NOUN,B2
-Währung,currency,货币,NOUN,B2
-Wäsche,washing,洗涤,NOUN,B2
-Würde,dignity,尊严,NOUN,B2
-Würfel,cube,立方体,NOUN,B2
-Würfel,dice,骰子,NOUN,B2
-Wüstenbildung,desertification,荒漠化,NOUN,B2
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yoga,yoga,瑜伽,NOUN,B2
-YouTuber,YouTuber,词,NOUN,B2
-Your Highness,Your Highness,殿下,NOUN,B2
-Yu family,Yu family,玉家,NOUN,C1
-Yuanxiao,yuanxiao,元宵,NOUN,B2
-Zauberspruch,spell,咒语,NOUN,B2
-Zenit,zenith,顶点,NOUN,B2
-Zensur,censorship,审查制度,NOUN,B2
-Zentralisierung,centralization,集中化,NOUN,B2
-Zentrifugalkraft,centrifugal force,离心力,NOUN,B2
-Zentrifuge,centrifuge,离心机,NOUN,B2
-Zeremonienkappe,ceremonial cap,爵弁,NOUN,B2
-Zerschlagung,smashing,砸过,NOUN,B2
-Zerstreutheit,absent-mindedness,心不在焉,NOUN,B2
-Zeugenaussage,witness testimony,人证,NOUN,B2
-Zeugnis,testimony,证词,NOUN,B2
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang He,zhuang he,庄郃,NOUN,B2
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-Ziegel,brick,砖,NOUN,B2
-Ziel,objective,客观的,ADJ,B2
-Ziel,aim,目标,NOUN,B2
-Ziel,goal,目标,NOUN,B2
-Ziffer,digit,数字,NOUN,B2
-Zink,zinc,锌,NOUN,B2
-Zitat,citation,引用,NOUN,B2
-Zitat,quotation,报价,NOUN,B2
-Zittern,tremor,颤抖,NOUN,B2
-Zoll,inch,بوصة,NOUN,B2
-Zombie,zombie,僵尸,NOUN,B2
-Zone,zone,区域,NOUN,B2
-Zornmütigkeit,irascibility,易怒,NOUN,B2
-Zuflucht,refuge,避难所,NOUN,B2
-Zufluss,tributary,支流,NOUN,B2
-Zufriedenheit,contentment,满足,NOUN,B2
-Zugehörigkeit,affiliation,隶属关系,NOUN,B2
-Zugehörigkeit,belonging,归属感,NOUN,B2
-Zugeständnis,concession,让步,NOUN,B2
-Zulage,allowance,津贴,NOUN,B2
-Zulänglichkeit,sufficiency,充足,NOUN,B2
-Zurückhaltung,restraint,隐忍,NOUN,B2
-Zusammenarbeit,collaboration,合作,NOUN,B2
-Zusammenbruch,collapse,倒塌,NOUN,B2
-Zusammenfassung,summary,摘要,NOUN,B2
-Zusammensetzung,composition,作文,NOUN,B2
-Zusammenstellung,compilation,汇编,NOUN,B2
-Zuschuss,grant,拨款,NOUN,B2
-Zuweisung,assignment,任务,NOUN,B2
-Zwang,coercion,胁迫,NOUN,B2
-Zweirichtungsstraße,two-way street,双行道,NOUN,B2
-Zwist,discord,不和,NOUN,B2
-Zyanose,cyanosis,发绀,NOUN,B2
-Zyklone,cyclone,气旋,NOUN,B2
-Zylinder,cylinder,圆柱体,NOUN,B2
-Zymbel,cymbal,钹,NOUN,B2
-Zärtlichkeit,tenderness,柔情,NOUN,B2
-Zölibat,celibacy,独身,NOUN,B2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a mess,a mess,一团糟,ADJ,B2
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
-abate,abate,词,VERB,B2
-abbey,abbey,词,NOUN,B2
-abbot,abbot,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aber du,but you,但您,NOUN,B2
-aber ich,but i,可我,ADV,B2
-aberrant,aberrant,词,ADJ,B2
-abet,abet,词,VERB,B2
-abfangen,to intercept,拦截,VERB,B2
-abgegrenzt,clearly demarcated,分明,ADJ,B2
-abgelenkt,distracted,分心的,ADJ,B2
-abgeändertes Urteil,amended judgment,改断,NOUN,B2
-abheben,to take off,起飞,VERB,B2
-abhorrent,abhorrent,词,ADJ,B2
-abhängen,to depend,依赖,VERB,B2
-abject,abject,悲惨的,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkühlen,to cool down,冷却,VERB,B2
-abkürzen,to cut short,截断,VERB,B2
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
-able to play,able to play,能下,NOUN,B2
-ablehnen,to disavow,否认,VERB,B2
-ableiten,to deduce,推断,VERB,B2
-ableiten,to infer,推断,VERB,B2
-ablution,ablution,词,NOUN,B2
-abnehmen,decrease,减少,NOUN,B2
-abnehmen,to decrease,减少,VERB,B2
-abolition,abolition,废除,NOUN,B2
-abominable,abominable,可憎的,ADJ,B2
-abominate,abominate,词,VERB,B2
-abomination,abomination,词,NOUN,B2
-about,about,大约,ADV,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,词,NOUN,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about that,about that,关于那个,ADV,B2
-about thirty,about thirty,三十左右,NOUN,B2
-about this,about this,词,ADV,B2
-about to,about to,快要,ADV,B2
-about which,about which,词,PRON,B2
-above (noun),above,重上,NOUN,C1
-above all,above all,词,NOUN,B2
-above average,above average,词,ADJ,C1
-above over,above over,词,ADP,A2
-above-mentioned,above-mentioned,词,ADJ,B2
-abrasive,abrasive,词,ADJ,B2
-abraten,to dissuade,劝阻,VERB,B2
-abroad,abroad,在国外,ADV,B2
-abrogate,abrogate,词,VERB,B2
-abrupt,abrupt,突然的,ADJ,B2
-abscheulich,vile,卑鄙的,ADJ,B2
-abschießen,to shoot down,击落,VERB,B2
-abschirmen,to screen,筛选,VERB,B2
-abschließen,to finalize,完成,VERB,B2
-abschweifen,to digress,离题,VERB,B2
-abschwächen,to derogate,贬损,VERB,B2
-absenden,to dispatch,派遣,VERB,B2
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzen,to depose,废黜,VERB,B2
-absichtlich,deliberately,故意地,ADV,B2
-absolut,absolute,绝对的,ADJ,B2
-absolutely not,absolutely not,词,ADV,C1
-absolution,absolution,词,NOUN,C1
-absolutist,absolutist,词,ADJ,C1
-absolvieren,graduate,毕业生,NOUN,B2
-absolvieren,to graduate,毕业,VERB,B2
-absorbed,absorbed,全神贯注的,ADJ,B2
-absorbieren,to absorb,吸收,VERB,B2
-absperren,to lockdown,封城,VERB,B2
-absteigen,to dismount,下马,VERB,B2
-absteigen,to go down,下去,VERB,B2
-abstemious,abstemious,有节制的,ADJ,B2
-abstinence,abstinence,节制,NOUN,B2
-abstoßend,repulsive,令人反感的,ADJ,B2
-abstract (noun),abstract,词,NOUN,C1
-abstractionism,abstractionism,词,NOUN,C1
-abstrus,abstruse,深奥的,ADJ,B2
-absurd,absurd,荒谬的,ADJ,B2
-absurd,preposterous,荒谬的,ADJ,B2
-absurdism,absurdism,词,NOUN,C1
-abtrennen,to detach,分离,VERB,B2
-abtreten,to abdicate,退位,VERB,B2
-abundantly,abundantly,词,ADV,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuser,abuser,词,NOUN,B2
-abuses,abuses,词,NOUN,C1
-abusive,abusive,滥用的,ADJ,B2
-abweichend,divergent,分歧的,ADJ,B2
-abwesend,absent,缺席的,ADJ,B2
-abysmal,abysmal,词,ADJ,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
-accede,accede,词,VERB,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-acceptable,acceptable,可接受的,ADJ,B2
-accessibility,accessibility,可达性,NOUN,B2
-accessibility features,accessibility features,词,NOUN,B2
-accessible,accessible,易接近的,ADJ,B2
-accessory,accessory,词,NOUN,B2
-acclimatization,acclimatization,适应环境,NOUN,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
-according to,according to,要照,NOUN,B2
-accordingly consequently,accordingly consequently,词,ADV,C1
-accordion,accordion,手风琴,NOUN,B2
-accost,accost,词,VERB,B2
-accountable,accountable,负责任的,ADJ,B2
-accounting (adj),accounting,词,ADJ,C1
-accredit,to accredit,认可,VERB,B2
-accreditation,accreditation,词,NOUN,C1
-accredited,accredited,认可的,ADJ,B2
-acculturation,acculturation,文化涵化,NOUN,B2
-accumulate,to accumulate,积累,VERB,B2
-accumulation,accumulation,积累,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
-accuracy,accuracy,准确性,NOUN,B2
-accurate,accurate,准确的,ADJ,B2
-accused person,accused person,词,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
-accustom,to accustom,使习惯,VERB,B2
-accustomed,accustomed,习惯的,ADJ,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
-acerbate,acerbate,词,VERB,B2
-acerbic,acerbic,尖刻的,ADJ,B2
-ach,alas,唉,INTJ,B2
-achievable,achievable,词,ADJ,B2
-achieve,to achieve,实现,VERB,B2
-achieved,achieved,词,ADJ,B1
-acid,acid,酸,NOUN,B2
-acid (adj),acid,词,ADJ,B1
-acid sour,acid sour,词,ADJ,B2
-acidic,acidic,词,ADJ,B2
-acidity,acidity,酸度,NOUN,B2
-acolyte,acolyte,词,NOUN,B2
-acorn,acorn,词,NOUN,B1
-acoustic,acoustic,声学的,ADJ,B2
-acquire,to acquire,获得,VERB,B2
-acquired,acquired,词,ADJ,B2
-acquisition,acquisition,获得,NOUN,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
-acquit,to acquit,宣告无罪,VERB,B2
-acquittal,acquittal,无罪释放,NOUN,B2
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
-acrimony,acrimony,尖刻,NOUN,B2
-acrobat,acrobat,杂技演员,NOUN,B2
-acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,首字母缩略词,NOUN,B2
-across,across,穿过,ADP,B2
-acrostic,acrostic,词,NOUN,C1
-act jointly,act jointly,合伙,NOUN,B2
-acting,acting,行为,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
-activation,activation,词,NOUN,B2
-active population,active population,词,NOUN,C1
-activism,activism,词,NOUN,B2
-activist,activist,词,NOUN,C1
-activities,activities,词,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
-actual,actual,实际的,ADJ,B2
-actually (noun),actually,倒也,NOUN,C1
-actuate,actuate,词,VERB,B2
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
-acute,acute,剧烈的,ADJ,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
-adaptation,adaptation,适应,NOUN,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
-addict,addict,上瘾者,NOUN,B2
-addiction,addiction,上瘾,NOUN,B2
-addictive,addictive,词,ADJ,B2
-addition,addition,增加,NOUN,B2
-additional,additional,额外的,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
-adeln,to ennoble,使高贵,VERB,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
-adequate,adequate,足够的,ADJ,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherence,adherence,词,NOUN,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
-adjacency,adjacency,邻接,NOUN,B2
-adjacent,adjacent,邻近的,ADJ,B2
-adjoin,adjoin,词,VERB,B2
-adjourn,adjourn,词,VERB,B2
-adjournment,adjournment,词,NOUN,C1
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjure,adjure,词,VERB,B2
-adjust,to adjust,调整,VERB,B2
-adjustability,adjustability,词,NOUN,C1
-adjustment,adjustment,调节,NOUN,B2
-administration,administration,管理,NOUN,B2
-administrative,administrative,行政的,ADJ,B2
-administrator,administrator,管理员,NOUN,B2
-admirable,admirable,词,ADJ,B2
-admiral,admiral,海军上将,NOUN,B2
-admiration,admiration,词,NOUN,B2
-admirer,admirer,仰慕者,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible,admissible,词,ADJ,B2
-admissible eligible,admissible eligible,词,ADJ,C1
-admission,admission,词,NOUN,B1
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
-adoption,adoption,收养,NOUN,B2
-adorable,adorable,词,ADJ,B2
-adoration worship,adoration worship,词,NOUN,C1
-adornment,adornment,装饰品,NOUN,B2
-adoul notaries,adoul notaries,词,NOUN,C1
-adrenaline,adrenaline,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
-adulation,adulation,词,NOUN,C1
-adultery,adultery,词,NOUN,C1
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
-advanced,advanced,高级的,ADJ,B2
-advancement,advancement,晋升,NOUN,B2
-advent,advent,到来,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
-adversarial,adversarial,词,ADJ,B2
-adverse,adverse,不利的,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
-advertiser,advertiser,词,NOUN,B2
-advertising,advertising,广告的,ADJ,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advisory,advisory,词,ADJ,C1
-advocacy,advocacy,词,NOUN,C1
-advocate (noun),advocate,词,NOUN,B2
-aerodynamics,aerodynamics,词,NOUN,C1
-aeronautical,aeronautical,词,ADJ,B2
-aesthetic taste,aesthetic taste,词,NOUN,C1
-affability,affability,词,NOUN,C1
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
-affidavit,affidavit,词,NOUN,B2
-affinity,affinity,词,NOUN,C1
-affirmative,affirmative,词,ADJ,B2
-affix,affix,词,NOUN,B2
-affliction,affliction,灾难,NOUN,C1
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
-affront,affront,冒犯,NOUN,B2
-aforementioned,aforementioned,上述的,ADJ,B2
-afraid (noun),afraid,词,NOUN,B2
-after (adv),after,词,ADV,A1
-after all just,after all just,毕竟刚,ADV,C1
-after the example of,after the example of,词,NOUN,C1
-after this,after this,词,ADV,B2
-after-class exercises,after-class exercises,课后题,NOUN,C1
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-aged,aged,年老的,ADJ,B2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
-agglomerate,agglomerate,词,NOUN,B2
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravated,aggravated,词,ADJ,C1
-aggravating,aggravating,词,ADJ,B2
-aggravation,aggravation,词,NOUN,C1
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
-aggressor,aggressor,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
-agil,agile,敏捷的,ADJ,B2
-aging,aging,老化,NOUN,B2
-agitated,agitated,焦躁的,ADJ,B2
-agitation,agitation,词,NOUN,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (adj),agnostic,词,ADJ,B2
-agnostic (noun),agnostic,词,NOUN,B2
-agnosticism,agnosticism,词,NOUN,C1
-ago,ago,以前,ADV,B2
-agonize,agonize,词,VERB,B2
-agree,agree,一致,ADJ,B2
-agreeable,agreeable,词,ADJ,B2
-ah,ah,啊,INTJ,B2
-ah (part),ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aimless,aimless,词,ADJ,C1
-aims,aims,词,NOUN,C1
-air conditioner,air conditioner,词,NOUN,B1
-air force,air force,空军,NOUN,B2
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-airline,airline,词,NOUN,C1
-airs,airs,摆架子,NOUN,B2
-airtight,airtight,密封的,ADJ,B2
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-ajar,ajar,半开的,ADJ,B2
-akademisch,academic,学术的,ADJ,B2
-akin,akin,相似的,ADJ,B2
-aktualisieren,to update,更新,VERB,B2
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
-alarmism,alarmism,词,NOUN,C1
-alchemy,alchemy,词,NOUN,C1
-alcoholic,alcoholic,酒精的,ADJ,B2
-alder,alder,桤木,NOUN,B2
-alderman,alderman,词,NOUN,B2
-alert,alert,警报,NOUN,B2
-alertness,alertness,机敏,NOUN,C1
-algae,algae,词,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
-alibi,alibi,不在场证明,NOUN,B2
-alien,alien,外星人的,ADJ,B2
-alienable,alienable,可转让的,ADJ,B2
-alienating,alienating,使人疏远的,ADJ,B2
-alike,alike,词,ADV,B1
-alive living,alive living,活着的,ADJ,B2
-alkalinity,alkalinity,词,NOUN,C1
-all,all,جميع,NOUN,B2
-all (adj),all,全,ADJ,B2
-all (noun),all,全体,NOUN,B2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all everyone,all everyone,所有/大家,PRON,B2
-all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allay,allay,词,VERB,C1
-allegation,allegation,词,NOUN,C1
-allegiance,allegiance,词,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-alleys,alleys,词,NOUN,B2
-allies,allies,盟友,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allmählich,gradually,逐渐地,ADV,B2
-allocation,allocation,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
-allure,allure,词,NOUN,C1
-alluring,alluring,诱人的,ADJ,C1
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
-alone,alone,单独的,ADJ,B2
-aloof,aloof,词,ADJ,C1
-aloofness,aloofness,冷漠,NOUN,B2
-aloud,aloud,出声地,ADV,B2
-alpha,alpha,阿尔法,NOUN,B2
-alphabet,alphabet,字母表,NOUN,B2
-alpine,alpine,高山的,ADJ,B2
-already may particle,already may particle,词,PART,A2
-alright (noun),alright,好吧,NOUN,B1
-als ob,as if,仿佛,ADV,B2
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-alt,ancient,古老的,ADJ,B2
-alt,older,年长的,ADJ,B2
-altar,altar,词,NOUN,B2
-alte Frau,old woman,老妇人,NOUN,B2
-alter Diener,old servant,老奴,NOUN,B2
-alter Mann,old man,老人,NOUN,B2
-alter Meister,old master,老太爷,NOUN,B2
-alteration,alteration,词,NOUN,B2
-altercation,altercation,争执,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternating,alternating,交替的,ADJ,B2
-alternative,alternative,替代的,ADJ,B2
-alternatively,alternatively,交替地,ADV,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-altitude,altitude,海拔,NOUN,B2
-altogether,altogether,共,ADV,B2
-altruistic,altruistic,利他的,ADJ,B2
-alumnus,alumnus,校友,NOUN,B2
-always have,always have,总有,VERB,C1
-amalgam conflation,amalgam conflation,词,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
-amber,amber,琥珀,NOUN,B2
-ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
-ambivalence,ambivalence,词,NOUN,B2
-ambivalent,ambivalent,矛盾的,ADJ,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
-amendable,amendable,可修正的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
-amendments,amendments,词,NOUN,C1
-amends,amends,词,NOUN,C1
-amicable,amicable,友好的,ADJ,B2
-amicable out-of-court,amicable out-of-court,词,ADJ,B2
-amino acid,amino acid,氨基酸,NOUN,C1
-amnesia,amnesia,健忘症,NOUN,B2
-among them (pron),among them,其中,PRON,B2
-amoral,amoral,词,ADJ,C1
-amorphous,amorphous,无定形的,ADJ,B2
-amortisieren,to amortize,摊销,VERB,B2
-amortization,amortization,词,NOUN,C1
-amphitheater lecture hall,amphitheater lecture hall,词,NOUN,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
-amplitude range,amplitude range,词,NOUN,C1
-amputieren,to amputate,截肢,VERB,B2
-amtierende Dynastie,current dynasty,当朝,NOUN,B2
-amused,amused,词,ADJ,B2
-amusement,amusement,娱乐,NOUN,B2
-amüsant,amusing,有趣的,ADJ,B2
-an,an,词,DET,A1
-an Schlaflosigkeit leiden,to suffer from insomnia,失眠,VERB,B2
-an official standard,an official standard,标准,NOUN,B2
-anachronism,anachronism,时代错误,NOUN,B2
-anachronistic,anachronistic,时代错误的,ADJ,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,字谜游戏,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
-analog,analog,模拟的,ADJ,B2
-analog,analogous,类似的,ADJ,B2
-analogize,analogize,词,VERB,B2
-analogous similar,analogous similar,词,ADJ,C1
-analytical,analytical,分析的,ADJ,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchical,anarchical,词,ADJ,C1
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
-anathema,anathema,深恶痛绝之物,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
-ancestral,ancestral,词,ADJ,C1
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
-ancillary,ancillary,辅助的,ADJ,B2
-and (sconj),and,我也,SCONJ,B1
-and you,and you,而你…,NOUN,C1
-andere,others,他人,NOUN,B2
-andere Seite,other side,对面,NOUN,B2
-andienen,to imply,暗示,VERB,B2
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
-anemic,anemic,词,ADJ,C1
-aneurysm,aneurysm,词,NOUN,C1
-anfänglich,initial,最初的,ADJ,B2
-angeboren,innate,天生的,ADJ,B2
-angelegen,to matter,重要,VERB,B2
-angelic,angelic,天使般的,ADJ,B2
-angle of approach,angle of approach,切入点,NOUN,B2
-anguished,anguished,词,ADJ,C1
-angular,angular,有角的,ADJ,B2
-anhalten,to halt,停止,VERB,B2
-animal pen,animal pen,词,NOUN,B1
-animated,animated,词,ADJ,C1
-anise,anise,茴香,NOUN,B2
-ankern,anchor,锚,NOUN,B2
-ankern,to anchor,抛锚,VERB,B2
-annals,annals,编年史,NOUN,B2
-annehmen,to assume,假定,VERB,B2
-annehmen,to suppose,假设,VERB,B2
-annektieren,annex,附件,NOUN,B2
-annektieren,to annex,兼并,VERB,B2
-annex (noun),annex,词,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
-annexes,annexes,词,NOUN,C1
-annotation,annotation,注释,NOUN,B2
-annotieren,to annotate,注释,VERB,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annuity private income,annuity private income,词,NOUN,C1
-annulment,annulment,词,NOUN,C1
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
-anomalous,anomalous,词,ADJ,C1
-anomie,anomie,词,NOUN,C1
-anonymity,anonymity,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anonymously,anonymously,词,ADV,B2
-anorexia,anorexia,词,NOUN,C1
-another day,another day,改日,NOUN,C1
-anschauen,to look at,观看,VERB,B2
-anspielend,allusive,暗指的,ADJ,B2
-anspornen,to spur,激励,VERB,B2
-anspringen,to pounce,猛扑,VERB,B2
-ansteckend,contagious,传染性的,ADJ,B2
-answer questions,answer questions,答疑,VERB,C1
-answers,answers,词,NOUN,C1
-antagonism,antagonism,对抗,NOUN,B2
-antagonistic,antagonistic,词,ADJ,C1
-antecedent,antecedent,先行词,NOUN,B2
-antediluvian,antediluvian,词,ADJ,C1
-anteroom,anteroom,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthill,anthill,词,NOUN,C1
-anthropological,anthropological,词,ADJ,C1
-anti-Semitic,anti-Semitic,词,ADJ,C1
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-work,anti-work,反功,NOUN,C1
-antibiotic,antibiotic,抗生素,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
-anticipatory,anticipatory,词,ADJ,C1
-anticyclone,anticyclone,反气旋,NOUN,B2
-antidote,antidote,解毒剂,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
-antinomy,antinomy,词,NOUN,C1
-antiphrasis,antiphrasis,词,NOUN,C1
-antipode,antipode,对跖点,NOUN,B2
-antiquated,antiquated,过时的,ADJ,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
-antisocial,antisocial,反社会的,ADJ,B2
-antonomasia,antonomasia,词,NOUN,C1
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreiben,to impel,推动,VERB,B2
-antreten,to assume office,就任,VERB,B2
-antreten,to take office,就职,VERB,B2
-antsy,antsy,词,ADJ,C1
-antworten,to answer reply,回答,VERB,B2
-antworten,to respond,回应,VERB,B2
-antworten,to respond to,回应,VERB,B2
-anvertrauen,to confide,吐露,VERB,B2
-anvil,anvil,词,NOUN,B2
-anwerben,to enlist,征募,VERB,B2
-anxious eager,anxious eager,词,ADJ,B1
-any (adj),any,词,ADJ,B1
-any (pron),any,任何,PRON,B2
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-anziehen,to attract,吸引,VERB,B2
-apart from,apart from,除了,ADP,B2
-apartheid,apartheid,词,NOUN,C1
-apathetic,apathetic,冷漠的,ADJ,B2
-apathy,apathy,冷漠,NOUN,B2
-apex,apex,顶点,NOUN,B2
-aphasia,aphasia,失语症,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apnea,apnea,词,NOUN,C1
-apocalypse,apocalypse,词,NOUN,C1
-apocalyptic,apocalyptic,启示录的,ADJ,B2
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
-apokryph,apocryphal,杜撰的,ADJ,B2
-apolitical,apolitical,词,ADJ,B2
-apologetic,apologetic,道歉的,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apologist,apologist,辩护者,NOUN,B2
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-apoplexy,apoplexy,中风,NOUN,B2
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
-apostate,apostate,叛教者,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostle,apostle,词,NOUN,C1
-apostrophize,apostrophize,词,VERB,C1
-apotheosis,apotheosis,神化,NOUN,B2
-apotheotic,apotheotic,神化的,ADJ,B2
-app,app,词,NOUN,B1
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-appeals,appeals,词,NOUN,C1
-appeasement,appeasement,平息,NOUN,B2
-appellate,appellate,词,ADJ,C1
-appellieren,to appeal,呼吁,VERB,B2
-append,append,词,VERB,C1
-appertain,appertain,词,VERB,C1
-appetizers,appetizers,词,NOUN,B2
-applaudieren,to applaud,鼓掌,VERB,B2
-appliance,appliance,词,NOUN,B1
-applicable,applicable,词,ADJ,B2
-appointments,appointments,词,NOUN,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-appreciable,appreciable,可观的,ADJ,B2
-apprehensive,apprehensive,忧虑的,ADJ,B2
-approachable,approachable,词,ADJ,C1
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,词,NOUN,B2
-approval pleasure,approval pleasure,词,NOUN,C1
-approximate,approximate,近似的,ADJ,B2
-april,april,四月,NOUN,B2
-apt,apt,词,ADJ,C1
-aptitude,aptitude,天资,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-aqueous,aqueous,词,ADJ,B2
-arabic,arabic,阿拉伯的,ADJ,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-arbitrage,arbitrage,词,NOUN,C1
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
-arcane,arcane,神秘的,ADJ,B2
-archaeologist,archaeologist,词,NOUN,C1
-archaisch,archaic,古老的,ADJ,B2
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
-architecture photo,architecture photo,建筑照,NOUN,B2
-architektonisch,architectural,建筑的,ADJ,B2
-archival,archival,词,ADJ,C1
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-archäologisch,archaeological,考古的,ADJ,B2
-ardent,ardent,热情的,ADJ,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
-argan,argan,词,NOUN,B1
-argentinian,argentinian,阿根廷的,ADJ,B2
-arguable,arguable,词,ADJ,C1
-argumentative,argumentative,词,ADJ,C1
-argumentativeness,argumentativeness,词,NOUN,C1
-arid,arid,干旱的,ADJ,B2
-aridity,aridity,干旱,NOUN,B2
-aristocratic,aristocratic,词,ADJ,C1
-arithmetic (adj),arithmetic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
-armament,armament,词,NOUN,B2
-armband,armband,词,NOUN,C1
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armored,armored,词,ADJ,C1
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-arousal,arousal,词,NOUN,C1
-arraign,arraign,词,VERB,C1
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-array,array,排列,NOUN,B2
-arrested,arrested,被逮捕的,ADJ,B2
-arrhythmia,arrhythmia,词,NOUN,C1
-arrived present,arrived present,到了,ADV,B2
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
-arson,arson,纵火,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-arterial,arterial,词,ADJ,C1
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
-artichoke,artichoke,词,NOUN,B1
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
-articulation,articulation,清晰表达,NOUN,B2
-articulieren,to articulate,清晰表达,VERB,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,人为地,ADV,B2
-artillery,artillery,炮兵,NOUN,B2
-artistry,artistry,,NOUN,B2
-artless,artless,词,ADJ,C1
-artwork,artwork,词,NOUN,B2
-as,as,作为,SCONJ,B2
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as a precaution,as a precaution,词,ADV,C1
-as a result of which,as a result of which,由此,ADV,B2
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as far as,as far as,词,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as for (part),as for,词,PART,B1
-as if,as if,好像,SCONJ,B2
-as long as (sconj),as long as,as long as,SCONJ,B2
-as many,as many,一样多,NUM,B2
-as much,as much,词,ADV,A1
-as much as possible,as much as possible,尽可能,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
-as soon as,as soon as,一...就,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
-as well as (sconj),as well as,词,SCONJ,B2
-asbestos,asbestos,词,NOUN,C1
-ascending,ascending,词,ADJ,C1
-ascertain,ascertain,词,VERB,C1
-ascetic,ascetic,苦行的,ADJ,B2
-ascetic (noun),ascetic,词,NOUN,C1
-asexuell,asexual,无性的,ADJ,B2
-asharite school,asharite school,词,NOUN,C1
-ashen,ashen,灰白的,ADJ,B2
-ashore,ashore,词,ADV,C1
-ashtray,ashtray,烟灰缸,NOUN,B2
-asian,asian,亚洲的,ADJ,B2
-aside (noun),aside,词,NOUN,C1
-asinine,asinine,词,ADJ,C1
-asketisch,austere,严厉的,ADJ,B2
-asleep,asleep,词,ADJ,A2
-asp,asp,角蝰,NOUN,B2
-asparagus,asparagus,芦笋,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-asphalt,asphalt,沥青,NOUN,B2
-asphyxia,asphyxia,窒息,NOUN,B2
-aspirant,aspirant,词,NOUN,C1
-assail,assail,词,VERB,C1
-assailant,assailant,词,NOUN,C1
-assent (noun),assent,词,NOUN,B2
-assertion,assertion,断言,NOUN,B2
-assertiveness,assertiveness,果断,NOUN,C1
-assiduity,assiduity,词,NOUN,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduously,assiduously,词,ADV,C1
-assiduousness,assiduousness,词,NOUN,C1
-assimilieren,to assimilate,同化,VERB,B2
-associate (noun),associate,词,NOUN,B2
-associated,associated,相关的,ADJ,B2
-associative,associative,协会性质的,ADJ,C1
-assort,assort,词,VERB,C1
-assortment,assortment,词,NOUN,C1
-assoziieren,to associate,联想,VERB,B2
-assuage,assuage,词,VERB,C1
-assurance,assurance,保证,NOUN,B2
-asthenia,asthenia,词,NOUN,C1
-asthmatic,asthmatic,哮喘的,ADJ,B2
-astonished,astonished,惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astray,astray,迷路,ADJ,B2
-astride (adp),astride,词,ADP,C1
-astride (adv),astride,词,ADV,C1
-astringent (adj),astringent,词,ADJ,C1
-astringent (noun),astringent,词,NOUN,B2
-astronomer,astronomer,词,NOUN,B1
-astronomisch,astronomical,天文学的,ADJ,B2
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
-asylum shelter,asylum shelter,词,NOUN,B2
-asymmetrisch,asymmetrical,不对称的,ADJ,B2
-asymptomatic,asymptomatic,词,ADJ,C1
-asynchron,asynchronous,异步的,ADJ,B2
-asyndeton,asyndeton,词,NOUN,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
-at home (noun),at home,家里,NOUN,C1
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the bottom,at the bottom,词,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the present time,at the present time,目前,ADV,B1
-at the top,at the top,在最上面,ADV,B2
-at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
-at worst,at worst,大不了,ADV,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
-athletic,athletic,运动的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atm,atm,自动取款机,NOUN,B2
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atmospheric,atmospheric,大气的,ADJ,B2
-atomar,atomic,原子的,ADJ,B2
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atonement,atonement,赎罪,NOUN,B2
-atony,atony,词,NOUN,C1
-atrocious,atrocious,词,ADJ,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-atrocity,atrocity,暴行,NOUN,B2
-atrophy,atrophy,萎缩,NOUN,B2
-attache office,attache office,词,NOUN,C1
-attached,attached,词,ADJ,B2
-attacked,attacked,被攻击的,ADJ,B2
-attainable,attainable,可获得的,ADJ,B2
-attainment,attainment,词,NOUN,C1
-attempt at crime,attempt at crime,词,NOUN,C1
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
-attention (intj),attention,词,INTJ,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attenuation,attenuation,衰减,NOUN,C1
-attestation,attestation,词,NOUN,C1
-attitude setting,attitude setting,态度/设置,NOUN,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attribution,attribution,归因,NOUN,B2
-attributists,attributists,词,NOUN,C1
-attributive,attributive,定语的,ADJ,B2
-atypisch,atypical,非典型的,ADJ,B2
-auch,also too,也,ADV,B2
-audacious,audacious,大胆的,ADJ,B2
-audibility,audibility,词,NOUN,C1
-audible,audible,听得见的,ADJ,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
-audiovisuell,audiovisual,视听的,ADJ,B2
-audition,audition,词,NOUN,B1
-auditory,auditory,词,ADJ,C1
-aufblähen,to inflate,使膨胀,VERB,B2
-aufbrechen,to break open,撬开,VERB,B2
-aufeinanderfolgende Karten,consecutive cards,连牌,NOUN,B2
-auffrischen,to refresh,使恢复精神,VERB,B2
-auffällig,conspicuous,显著的,ADJ,B2
-aufgeben,surrender,投降,NOUN,B2
-aufgeben,to surrender,投降,VERB,B2
-aufgeklärt,enlightened,开明的,ADJ,B2
-aufholen,to catch up,赶上,VERB,B2
-aufhören,to cease,停止,VERB,B2
-aufklären,to enlighten,启发,VERB,B2
-auflisten,to list,列举,VERB,B2
-aufmuntern,to cheer up,使高兴,VERB,B2
-aufpassen,to take care,照顾,VERB,B2
-aufrecht,upright,正直的,ADJ,B2
-aufrüsten,to upgrade,升级,VERB,B2
-aufstacheln,to incite,煽动,VERB,B2
-aufstehen,to stand up,站起来,VERB,B2
-aufsteigen,to ascend,上升,VERB,B2
-aufsteigen,to go up,上升,VERB,B2
-auftauchen,to come up,出现,VERB,B2
-aufwachen,to wake,唤醒,VERB,B2
-aufzählen,to enumerate,列举,VERB,B2
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-augury,augury,词,NOUN,C1
-ausarbeiten,elaborate,详尽的,ADJ,B2
-ausarbeiten,to elaborate,制定,VERB,B2
-ausbleiben,to not come,不来,VERB,B2
-ausdehnen,to extend,延伸,VERB,B2
-ausdrücklich,expressly,明确地,ADV,B2
-ausfüllen,to fill in,填写,VERB,B2
-ausgestattet,equipped,配备的,ADJ,B2
-ausgezeichnet,distinguished,杰出,ADJ,B2
-ausgleichen,to balance,平衡,VERB,B2
-ausgleichen,to make up for,弥补,VERB,B2
-auslassen,to leave out,省略,VERB,B2
-ausliefern,to extradite,引渡,VERB,B2
-auspice,auspice,赞助,NOUN,B2
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausrenken,to dislocate,使脱臼,VERB,B2
-ausrotten,to eradicate,根除,VERB,B2
-ausrotten,to exterminate,消灭,VERB,B2
-ausschlaggebend,hold the balance of power,举足轻重,ADJ,B2
-aussetzen,to suspend,暂停,VERB,B2
-ausstatten,to endow,赋予,VERB,B2
-aussteigen,to disembark,下船,VERB,B2
-ausstellen,to exhibit,展览,VERB,B2
-australian,australian,澳大利亚的,ADJ,B2
-austrian,austrian,奥地利的,ADJ,B2
-ausweichen,to dodge,躲避,VERB,B2
-autarchy,autarchy,词,NOUN,C1
-autarky,autarky,词,NOUN,B2
-authenticated,authenticated,词,ADJ,C1
-authentifizieren,to authenticate,认证,VERB,B2
-authentisch,authentic,真实的,ADJ,B2
-authoritarianism,authoritarianism,词,NOUN,C1
-authoritative,authoritative,权威的,ADJ,B2
-authority figure,authority figure,权威人士,NOUN,B2
-authority structure,authority structure,权威结构,NOUN,B2
-autism,autism,自闭症,NOUN,B2
-autistic (adj),autistic,词,ADJ,C1
-autistic (noun),autistic,词,NOUN,C1
-autobiographical,autobiographical,词,ADJ,C1
-autocracy,autocracy,专制,NOUN,B2
-autocratic,autocratic,专制的,ADJ,B2
-automatisch,automatically,自动地,ADV,B2
-automatisieren,to automate,使自动化,VERB,B2
-automatisiert,automated,自动化的,ADJ,B2
-autonom,autonomous,自治的,ADJ,B2
-autonomy,autonomy,自治,NOUN,B2
-autoritär,authoritarian,独裁的,ADJ,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-auxiliary,auxiliary,词,ADJ,C1
-außerdem,moreover,此外,ADV,B2
-avail,avail,词,NOUN,C1
-avantgardistisch,avant-garde,前卫的,ADJ,B2
-avarice,avarice,词,NOUN,C1
-avaricious,avaricious,词,ADJ,C1
-aver,aver,词,VERB,C1
-average,average,平均数,NOUN,B2
-averageness,averageness,词,NOUN,B2
-averse,averse,厌恶的,ADJ,B2
-avert,avert,词,VERB,C1
-avid,avid,热切的,ADJ,B2
-avocado,avocado,牛油果,NOUN,C1
-avoidable,avoidable,可避免的,ADJ,B2
-avow,avow,词,VERB,C1
-award auction,award auction,词,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
-awareness raising,awareness raising,提高意识,NOUN,B2
-away,away,避开,ADP,B2
-away (adj),away,外出,ADJ,C1
-away gone,away gone,不在/离开,ADV,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awesome,awesome,词,ADJ,A2
-awful,awful,糟糕的,ADJ,B2
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-awning,awning,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiology,axiology,词,NOUN,C1
-axiomatic,axiomatic,公理的,ADJ,B2
-axioms,axioms,词,NOUN,C1
-axis axle,axis axle,词,NOUN,C1
-babble,babble,结巴,NOUN,B2
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-baby walker,baby walker,词,NOUN,B1
-babysitter,babysitter,保姆,NOUN,B2
-baccalaureate,baccalaureate,词,NOUN,B2
-bacchanal,bacchanal,狂欢,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
-back mountain,back mountain,后山,NOUN,C1
-back side,back side,背面,NOUN,B2
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-backache,backache,背痛,NOUN,B2
-backfire,backfire,词,VERB,C1
-backpacker,backpacker,词,NOUN,B1
-backside,backside,词,NOUN,B2
-backslide,backslide,词,VERB,C1
-backward,backward,向后,ADV,B2
-backyard,backyard,后院,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
-bactericide,bactericide,杀菌剂,NOUN,C1
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
-badge,badge,徽章,NOUN,B2
-badger,badger,词,NOUN,C1
-baffle,baffle,词,VERB,C1
-baggage,baggage,行李,NOUN,B2
-bagpiper,bagpiper,风笛手,NOUN,B2
-bags,bags,包,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
-balance of power,balance of power,均势,NOUN,C1
-balance sheet,balance sheet,资产负债表,NOUN,B2
-balancing,balancing,平衡的,ADJ,B2
-baldness,baldness,词,NOUN,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballad,ballad,词,NOUN,C1
-ballast,ballast,压舱物,NOUN,B2
-balloon,balloon,气球,NOUN,B2
-ballot,ballot,选票,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balsam,balsam,香脂,NOUN,B2
-balustrade,balustrade,栏杆,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
-ban (noun),ban,ban,NOUN,B2
-banal,banal,陈腐的,ADJ,B2
-bananas,bananas,词,NOUN,A1
-band tape,band tape,带子,NOUN,B2
-bandaging,bandaging,词,NOUN,C1
-bandwidth,bandwidth,词,ADJ,C1
-bang,bang,砰,INTJ,B2
-banister,banister,词,NOUN,C1
-bank card,bank card,银行卡,NOUN,B2
-bankrott,bankrupt,破产的,ADJ,B2
-bankrottgehen,to go bankrupt,破产,VERB,B2
-bankwirtschaftlich,banking,银行的,ADJ,B2
-banner headline,banner headline,词,NOUN,C1
-baptism,baptism,词,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
-bar of soap,bar of soap,词,NOUN,B2
-barbarian,barbarian,词,NOUN,B2
-barbarisch,barbaric,野蛮的,ADJ,B2
-barbarization,barbarization,野蛮化,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
-bard,bard,吟游诗人,NOUN,B2
-bare,bare,赤裸的,ADJ,B2
-bare ownership,bare ownership,虚有权,NOUN,B2
-bareheaded,bareheaded,词,ADJ,C1
-barely,barely,几乎不,ADV,B2
-barfuß,barefoot,赤脚的,ADJ,B2
-bargain,bargain,便宜货,NOUN,B2
-bargaining,bargaining,词,NOUN,C1
-barge,barge,驳船,NOUN,B2
-bark (noun),bark,词,NOUN,B2
-baron,baron,词,NOUN,B2
-barracks,barracks,词,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barrel,barrel,桶,NOUN,B2
-barren,barren,词,ADJ,C1
-barricade,barricade,路障,NOUN,B2
-barter (noun),barter,词,NOUN,C1
-barter (verb),barter,词,VERB,C1
-basal,basal,基本的,ADJ,B2
-base fertilizer,base fertilizer,基肥,NOUN,B2
-based,based,基于,ADJ,B2
-bash,bash,词,VERB,C1
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic attitude,basic attitude,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
-basic income,basic income,基本收入,NOUN,B2
-basieren,to base,基于,VERB,B2
-basing,basing,词,NOUN,C1
-bask,bask,词,VERB,C1
-baste,baste,词,VERB,C1
-basting,basting,词,NOUN,C1
-bastion,bastion,堡垒,NOUN,B2
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-bathrobe,bathrobe,词,NOUN,A2
-baton,baton,警棍,NOUN,B2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
-battlement,battlement,城垛,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be crushed,be crushed,词,VERB,C1
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
-be rumored,be rumored,词,VERB,C1
-be shot,be shot,中弹,VERB,C1
-be sorry,be sorry,抱歉,ADJ,B2
-be tender,be tender,温柔的,ADJ,B2
-beabsichtigen,to intend,打算,VERB,B2
-beachten,to mind,介意,VERB,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beans,beans,词,NOUN,A1
-bearbeiten,to edit,编辑,VERB,B2
-beaten,beaten,被打败的,ADJ,B2
-beatitude,beatitude,词,NOUN,B2
-beautification,beautification,词,NOUN,C1
-beautifully,beautifully,美丽地,ADV,B2
-beaver,beaver,词,NOUN,C1
-because of this,because of this,词,ADV,A2
-beckon,beckon,词,VERB,C1
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedachen,to roof,房顶,VERB,B2
-bedauern,to deplore,谴责,VERB,B2
-bedauern,to pity,同情,VERB,B2
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedeckt,overcast,阴天的,ADJ,B2
-bedeuten,to signify,意味着,VERB,B2
-bedingen,to condition,制约,VERB,B2
-bedingen,to entail,牵涉,VERB,B2
-bedingt,conditional,条件的,ADJ,B2
-bedsheet,bedsheet,床单,NOUN,B2
-bedside,bedside,词,NOUN,C1
-beech grove,beech grove,词,NOUN,C1
-beehive,beehive,词,NOUN,C1
-beeinflussen,to affect,影响,VERB,B2
-beenden,to terminate,终止,VERB,B2
-befall,befall,词,VERB,C1
-befit,befit,词,VERB,C1
-befolgen,to comply,遵守,VERB,B2
-before (noun),before,以前,NOUN,A1
-before one's eyes,before one's eyes,词,ADV,C1
-before previously,before previously,以前,ADV,B2
-befreien,to exempt,免除,VERB,B2
-befuddle,befuddle,词,VERB,C1
-befürworten,to advocate,提倡,VERB,B2
-beg for pity,beg for pity,乞怜,VERB,B2
-begehen,to commit a crime,犯罪,VERB,B2
-begehren,to be eager for,巴不得,VERB,B2
-begehren,to crave,渴望,VERB,B2
-begeistern,to enthuse,使热情,VERB,B2
-begeistert,elated,兴高采烈的,ADJ,B2
-begierig sein,to be eager,心切,VERB,B2
-beginnen,to begin to start,开始,VERB,B2
-beginning primer,beginning primer,词,NOUN,C1
-begleiten,escort,护卫,NOUN,B2
-begleiten,to escort,护送,VERB,B2
-begradigen,to straighten,弄直,VERB,B2
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
-behalten,to retain,保留,VERB,B2
-behaupten,to assert,断言,VERB,B2
-behavioral,behavioral,词,ADJ,B2
-behavioral pattern,behavioral pattern,词,NOUN,C1
-behaviorist,behaviorist,行为主义者,NOUN,B2
-beheading,beheading,按律当斩,NOUN,C1
-behind (noun),behind,词,NOUN,B2
-behindert,disabled,残疾的,ADJ,B2
-behoove,behoove,词,VERB,C1
-bei,by,通过,ADP,B2
-beide Hände,both hands,双手,NOUN,B2
-beinahe,nearly,几乎,ADV,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-beiseitegehen,to move aside,移开,VERB,B2
-beitreten,to join,加入,VERB,B2
-bejeweled,bejeweled,镶满宝石的,ADJ,B2
-bekannt,well-known,众所周知的,ADJ,B2
-bekämpfen,combat,战斗,NOUN,B2
-bekämpfen,to combat,对抗,VERB,B2
-belabor,belabor,词,VERB,C1
-belagern,to besiege,包围,VERB,B2
-belated,belated,词,ADJ,C1
-belatedly,belatedly,词,ADV,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-beleaguered,beleaguered,受围困的,ADJ,B2
-beleben,to revive,复兴,VERB,B2
-beleidigen,to offend,冒犯,VERB,B2
-belgian,belgian,比利时的,ADJ,B2
-belgian (noun),belgian,比利时人,NOUN,C1
-belie,belie,词,VERB,C1
-belief creed,belief creed,词,NOUN,B2
-believability,believability,词,NOUN,C1
-belittling,belittling,词,NOUN,C1
-bell tower,bell tower,词,NOUN,A2
-belligerent,belligerent,好战的,ADJ,B2
-bellows,bellows,词,NOUN,C1
-beloved,beloved,心爱的,ADJ,B2
-below,below,下面的,ADJ,B2
-below (noun),below,词,NOUN,B2
-belästigen,to trouble,有劳,VERB,B2
-belästigend,troublesome,麻烦的,ADJ,B2
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-bench seat,bench seat,词,NOUN,C1
-bending,bending,弯曲,NOUN,C1
-beneath,beneath,词,ADP,B2
-beneficence,beneficence,词,NOUN,C1
-beneficial,beneficial,词,ADJ,B2
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-benötigt werden,to be required,被要求,VERB,B2
-bequest,bequest,词,NOUN,B2
-berate,berate,词,VERB,C1
-beraten,deliberate,深思熟虑的,ADJ,B2
-beraten,to deliberate,深思熟虑,VERB,B2
-berauben,to deprive,剥夺,VERB,B2
-bereave,bereave,词,VERB,C1
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-bereichern,to enrich,使丰富,VERB,B2
-berichten,to rectify,纠正,VERB,B2
-berkeley coach,berkeley coach,,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-berth,berth,泊位,NOUN,C1
-beruhigen,to reassure,使安心,VERB,B2
-beschlagnahmen,to confiscate,没收,VERB,B2
-beschuldigen,blame,责备,NOUN,B2
-beschuldigen,to blame,责备,VERB,B2
-beschädigt sein,to be damaged,受损,VERB,B2
-beschämend,shameful,可耻的,ADJ,B2
-beschämt,ashamed,羞愧的,ADJ,B2
-beseech,beseech,词,VERB,C1
-beset,beset,词,VERB,C1
-beside,beside,在...旁边,ADP,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
-besieged,besieged,词,ADJ,B2
-besieging,besieging,词,NOUN,C1
-besiegt werden,to be defeated,会败,VERB,B2
-besitzen,to possess,拥有,VERB,B2
-besmirch,besmirch,词,VERB,C1
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-bestehen,to consist,组成,VERB,B2
-bestehen,to insist,坚持,VERB,B2
-bestial,bestial,词,ADJ,C1
-besticken,to embroider,刺绣,VERB,B2
-bestimmt,particular,特定的,ADJ,B2
-bestrafen,fine,罚款,NOUN,B2
-bestrafen,to fine,罚款,VERB,B2
-beständig,persistent,坚持不懈的,ADJ,B2
-bestätigen,to affirm,断言,VERB,B2
-besänftigen,to appease,安抚,VERB,B2
-betray one's country,betray one's country,卖国,VERB,B2
-betrothal,betrothal,订婚,NOUN,B2
-betrothal gift,betrothal gift,聘,NOUN,C1
-betrügen,to defraud,诈骗,VERB,B2
-betrügen,to swindle,诈骗,VERB,B2
-betrügerisch,deceitful,欺诈的,ADJ,B2
-better (adv),better,词,ADV,A1
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-beurlauben,to take a leave of absence,休学,VERB,B2
-beverage,beverage,词,NOUN,B2
-bevorstehend,upcoming,مقبل,ADJ,B2
-bevorzugen,to favor,偏袒,VERB,B2
-bewail,bewail,词,VERB,C1
-beware,beware,词,VERB,C1
-bewerten,to appraise,评估,VERB,B2
-bewilder,bewilder,词,VERB,C1
-bewirten,to treat guests,请客,VERB,B2
-bezaubernd,enchanting,迷人的,ADJ,B2
-bezwingen,to subdue,制服,VERB,B2
-bezüglich dieses,regarding this,对此,ADV,B2
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bids,bids,词,NOUN,C1
-biennial,biennial,词,NOUN,C1
-bifurcation,bifurcation,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big cat,big cat,词,NOUN,C1
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigger,bigger,更大的,ADJ,B2
-bigness,bigness,,NOUN,B2
-bigotry,bigotry,词,NOUN,C1
-bigwig,bigwig,大人物,NOUN,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
-bilateral,bilateral,双边的,ADJ,B2
-bilingual,bilingual,词,ADJ,C1
-bilingualism,bilingualism,词,NOUN,C1
-bilious,bilious,易怒的,ADJ,B2
-bilk,bilk,词,VERB,C1
-bill of exchange,bill of exchange,词,NOUN,C1
-billion (noun),billion,词,NOUN,B2
-billionaire,billionaire,词,NOUN,C1
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
-binder,binder,词,NOUN,A2
-binding (adj),binding,词,ADJ,C1
-binge,binge,放纵,NOUN,B2
-bingo,bingo,词,NOUN,B2
-binoculars,binoculars,双筒望远镜,NOUN,B2
-binär,binary,二进制的,ADJ,B2
-biographical,biographical,词,ADJ,C1
-biographies,biographies,词,NOUN,C1
-biologisch,biological,生物的,ADJ,B2
-biologist,biologist,生物学家,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-bis,until,直到,SCONJ,B2
-bis zu,up to,为止,ADP,B2
-biscuit,biscuit,饼干,NOUN,A2
-bisexual,bisexual,双性恋的,ADJ,B2
-bistro,bistro,小酒馆,NOUN,B2
-bit,bit,一点,NOUN,B2
-biting,biting,咬人,NOUN,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
-biweekly,biweekly,双周的,ADJ,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-blab,blab,词,VERB,C1
-black (noun),black,أسود,NOUN,C1
-black pepper,black pepper,词,NOUN,B2
-blackbird,blackbird,词,NOUN,B2
-blackout,blackout,词,NOUN,C1
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blame (noun),blame,只怪,NOUN,B2
-blanch,blanch,词,VERB,C1
-blandish,blandish,词,VERB,C1
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blazing,blazing,炽热的,ADJ,B2
-blazing ardor,blazing ardor,词,NOUN,C1
-bleak,bleak,无望的,ADJ,B2
-bleeding,bleeding,流血的,ADJ,B2
-blend,blend,词,VERB,B2
-blendend,dazzling,耀眼的,ADJ,B2
-blender,blender,搅拌机,NOUN,B2
-blending,blending,词,NOUN,C1
-blessed,blessed,受祝福的,ADJ,B2
-blight,blight,词,NOUN,C1
-blind,blind,盲的,ADJ,B2
-blind person,blind person,词,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
-blister,blister,词,NOUN,C1
-bloat,bloat,词,VERB,C1
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
-blockhead,blockhead,词,NOUN,B2
-blockieren,blockade,封锁,NOUN,B2
-blockieren,to blockade,封锁,VERB,B2
-blockieren,to obstruct,阻碍,VERB,B2
-blockieren,to stall,拖延,VERB,B2
-blocking,blocking,词,NOUN,B2
-blog post,blog post,词,NOUN,C1
-blogger,blogger,词,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
-blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-blood-related,blood-related,词,ADJ,C1
-bloodless,bloodless,不流血的,ADJ,B2
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,沾血,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-bloom of youth,bloom of youth,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
-blossoming ripening,blossoming ripening,词,NOUN,C1
-blow beating,blow beating,词,NOUN,B2
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blue (noun),blue,词,NOUN,C1
-blueprint,blueprint,词,NOUN,C1
-blueprint diagram,blueprint diagram,词,NOUN,C1
-blunder,blunder,大错,NOUN,B2
-blunt,blunt,词,ADJ,B2
-bluntness,bluntness,直说,NOUN,B2
-blurred,blurred,词,ADJ,C1
-blurriness,blurriness,词,NOUN,C1
-blurry,blurry,词,ADJ,B2
-blurt,blurt,词,VERB,C1
-bluster,bluster,词,VERB,C1
-blutig,bloody,血淋淋的,ADJ,B2
-boarder,boarder,词,NOUN,B2
-boarding,boarding,词,NOUN,C1
-boarding pass,boarding pass,登机牌,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastful,boastful,自夸的,ADJ,B2
-boastfulness,boastfulness,吹嘘,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bode,bode,词,VERB,C1
-bodies,bodies,词,NOUN,C1
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-bog,bog,沼泽,NOUN,B2
-boggle,boggle,词,VERB,C1
-bohemian,bohemian,放荡不羁的,ADJ,B2
-boil (noun),boil,词,NOUN,C1
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
-boiling (adj),boiling,词,ADJ,C1
-boisterous,boisterous,喧闹的,ADJ,B2
-boldness daring,boldness daring,词,NOUN,B2
-bolster (noun),bolster,词,NOUN,C1
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolted,bolted,词,ADJ,C1
-bombardieren,to bombard,轰炸,VERB,B2
-bombardment,bombardment,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
-bomber,bomber,词,NOUN,C1
-bondholder,bondholder,词,NOUN,C1
-bonds,bonds,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-bonfire,bonfire,篝火,NOUN,B2
-bonhomie,bonhomie,词,NOUN,C1
-bookcase,bookcase,书柜,NOUN,B2
-booking,booking,词,NOUN,A2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,词,NOUN,B2
-boorish,boorish,词,ADJ,C1
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,边境检查,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border frontier,border frontier,词,NOUN,B1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,词,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,边境地区,NOUN,B2
-bordering,bordering,词,ADJ,C1
-borders,borders,边界,NOUN,A1
-born,born,出生的,ADJ,B2
-born (noun),born,词,NOUN,B2
-born (verb),born,词,VERB,A1
-borrowed knife,borrowed knife,借刀,NOUN,B2
-boshaft,spiteful,怀恨的,ADJ,B2
-bosom,bosom,词,NOUN,C1
-boss manager,boss manager,词,NOUN,A1
-bossism,bossism,老板主义,NOUN,B2
-botanical,botanical,词,ADJ,C1
-botany,botany,词,NOUN,C1
-botched job,botched job,词,NOUN,B2
-both,both,两者的,ADJ,B2
-both (noun),both,词,NOUN,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
-both parties,both parties,双方,NOUN,B1
-bother (noun),bother,烦不,NOUN,B1
-bottle opener,bottle opener,词,NOUN,B1
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
-bounce,bounce,词,VERB,B2
-bound to,bound to,势必,ADV,B2
-boundless,boundless,无疆,NOUN,B2
-bourgeois,bourgeois,资产阶级的,ADJ,B2
-bout,bout,阵,NOUN,B2
-bovine,bovine,词,ADJ,C1
-bow (verb),bow,词,VERB,B1
-bow tie,bow tie,领结,NOUN,B2
-bower,bower,凉亭,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
-boxer,boxer,拳击手,NOUN,B2
-boycottieren,to boycott,抵制,VERB,B2
-brabant,brabant,布拉班特的,ADJ,B2
-brace,brace,词,NOUN,C1
-bracket,bracket,括号,NOUN,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-bragging,bragging,吹嘘,NOUN,B2
-braid,braid,辫子,NOUN,C1
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,词,NOUN,B2
-brainstorming,brainstorming,词,NOUN,C1
-brainwasher,brainwasher,洗脑者,NOUN,B2
-brainy,brainy,聪明的,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakeman,brakeman,词,NOUN,C1
-brakes,brakes,词,NOUN,C1
-braking,braking,词,NOUN,C1
-bran,bran,词,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
-brandneu,brand new,崭新的,ADJ,B2
-brass band,brass band,词,NOUN,B2
-brassware,brassware,词,NOUN,C1
-braten,to fry,油炸,VERB,B2
-brauchen wollen,to want to need will,要,VERB,B2
-braun,brown,棕色,ADJ,B2
-bravo,bravo,词,NOUN,B2
-brawl,brawl,斗殴,NOUN,B2
-bray,bray,词,VERB,C1
-brazen,brazen,厚颜无耻的,ADJ,B2
-brazier,brazier,词,NOUN,B1
-brazilian,brazilian,巴西的,ADJ,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of duty,breach of duty,词,NOUN,B2
-breadth,breadth,词,NOUN,C1
-breadth crossing,breadth crossing,词,NOUN,C1
-break out of prison,break out of prison,越狱,VERB,C1
-break-in,break-in,非法侵入,NOUN,B2
-breakage,breakage,词,NOUN,C1
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
-breakthrough,breakthrough,突破性,ADJ,B2
-breakup,breakup,分手,NOUN,B2
-breast,breast,乳房,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,呼吸,NOUN,B2
-breathing space,breathing space,词,NOUN,C1
-breathlessness,breathlessness,词,NOUN,B1
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
-bremsen,to brake,刹车,VERB,B2
-brennend,burning,灼热的,ADJ,B2
-breviary,breviary,词,NOUN,C1
-bribe-taker,bribe-taker,词,NOUN,C1
-bribes,bribes,词,NOUN,C1
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
-bridal trousseau,bridal trousseau,词,NOUN,C1
-bridegroom,bridegroom,词,NOUN,C1
-bridle,bridle,马勒,NOUN,B2
-brief,brief,近点说,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brigade,brigade,词,NOUN,C1
-brigand poet,brigand poet,词,NOUN,C1
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightly,brightly,词,ADV,C1
-brightness,brightness,词,NOUN,C1
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
-brim,brim,词,NOUN,C1
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-briskness,briskness,轻快,NOUN,B2
-bristle (noun),bristle,词,NOUN,C1
-brittle,brittle,易碎的,ADJ,B2
-brittleness,brittleness,词,NOUN,C1
-bro,bro,哥们,NOUN,B2
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
-broadcaster,broadcaster,广播公司,NOUN,B2
-broadcasting station,broadcasting station,词,NOUN,C1
-broaden,broaden,词,VERB,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade (part),brocade,锦,PART,A1
-broccoli,broccoli,西兰花,NOUN,C1
-brochure,brochure,小册子,NOUN,B2
-broil,broil,词,VERB,C1
-broken,broken,破碎的,ADV,B2
-brokenness,brokenness,词,NOUN,C1
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,词,ADJ,B2
-brooch,brooch,词,NOUN,C1
-brooding,brooding,忧思,NOUN,B2
-brooding (adj),brooding,词,ADJ,B2
-brook no delay,brook no delay,刻不容缓,ADJ,B2
-broom blow,broom blow,词,NOUN,C1
-brother (part),brother,兄,PART,B1
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-brow,brow,眉毛,NOUN,B2
-browbeat,browbeat,词,VERB,C1
-bruises,bruises,词,NOUN,B2
-brusqueness,brusqueness,唐突,NOUN,B2
-brutal,brutal,词,ADJ,B2
-brutalisieren,to brutalize,使变得残忍,VERB,B2
-brutality,brutality,残暴,NOUN,B2
-brutalizing,brutalizing,词,ADJ,C1
-brutally,brutally,词,ADV,C1
-brute,brute,粗野的,ADJ,B2
-bräunen,to tan,晒黑,VERB,B2
-brüllen,to bellow,吼叫,VERB,B2
-bubbling,bubbling,冒泡的,ADJ,B2
-buccaneer,buccaneer,海盗,NOUN,B2
-buckle,buckle,词,VERB,C1
-bucolic,bucolic,词,ADJ,C1
-bud,bud,芽,NOUN,B2
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budge,budge,词,VERB,C1
-budgetable,budgetable,可预算的,ADJ,B2
-budgeting,budgeting,词,NOUN,C1
-budgetär,budgetary,预算的,ADJ,B2
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-buffoon,buffoon,小丑,NOUN,B2
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulge,bulge,词,NOUN,C1
-bull,bull,词,NOUN,B1
-bulldoze,bulldoze,词,VERB,C1
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullying,bullying,词,NOUN,B2
-bulwark,bulwark,壁垒,NOUN,B2
-bumble,bumble,词,VERB,C1
-bumblebee,bumblebee,词,NOUN,C1
-bump,bump,肿块,NOUN,B2
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bunch,bunch,一群,NOUN,B2
-bundling,bundling,词,NOUN,C1
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bungler,bungler,笨手笨脚的人,NOUN,B2
-bunker,bunker,词,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-buoyant,buoyant,有浮力的,ADJ,B2
-burdensome,burdensome,繁重的,ADJ,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-bureaucratic,bureaucratic,词,ADJ,C1
-burger stand,burger stand,,NOUN,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque (adj),burlesque,词,ADJ,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burner,burner,燃烧器,NOUN,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burp (noun),burp,词,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-burst in,burst in,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
-bushy,bushy,词,ADJ,C1
-business card,business card,名片,NOUN,B1
-business sector,business sector,词,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-bust,bust,词,NOUN,B1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but this,but this,可这,NOUN,C1
-but-for,but-for,词,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-butler,butler,词,NOUN,C1
-butt,butt,臀部,NOUN,B2
-buttermilk,buttermilk,词,NOUN,A2
-buttress,buttress,扶壁,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buyer purchaser,buyer purchaser,词,NOUN,B2
-buying and selling,buying and selling,词,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-bußen,to repent,悔改,VERB,B2
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance,by chance,偶然地,ADV,B2
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
-by means of,by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
-bypass (noun),bypass,词,NOUN,C1
-bypassing,bypassing,词,NOUN,C1
-byzantine,byzantine,错综复杂的,ADJ,B2
-bösartig,malignant,恶性的,ADJ,B2
-bürsten,brush,刷子,NOUN,B2
-bürsten,to brush,刷,VERB,B2
-cabin boy,cabin boy,词,NOUN,C1
-cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
-cable car,cable car,缆车,NOUN,B1
-cache,cache,词,NOUN,C1
-cachexia,cachexia,词,NOUN,C1
-cackle,cackle,词,VERB,C1
-cacophony,cacophony,刺耳的声音,NOUN,B2
-cactus,cactus,词,NOUN,B1
-cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
-cadence,cadence,词,NOUN,B2
-cadres,cadres,词,NOUN,C1
-caesura,caesura,词,NOUN,C1
-cafeteria,cafeteria,词,NOUN,B1
-caffeine,caffeine,词,NOUN,C1
-caftan,caftan,词,NOUN,A1
-cage (verb),cage,词,VERB,C1
-caid local governor,caid local governor,词,NOUN,C1
-cajole,cajole,词,VERB,C1
-calamitous,calamitous,灾难性的,ADJ,B2
-calcareous,calcareous,词,ADJ,B2
-caliber,caliber,词,NOUN,C1
-calibrated,calibrated,词,ADJ,C1
-calibrator,calibrator,词,NOUN,C1
-caliph,caliph,词,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
-call to prayer,call to prayer,词,NOUN,B2
-caller,caller,词,NOUN,A2
-calligrapher,calligrapher,词,NOUN,C1
-callus,callus,硬茧……,NOUN,C1
-calm,calm,平静,NOUN,B2
-calming,calming,令人平静的,ADJ,B2
-calmly,calmly,平静地,ADV,B2
-calorie,calorie,词,NOUN,C1
-calve,calve,词,VERB,C1
-camouflage (noun),camouflage,词,NOUN,C1
-camp (part),camp,营,PART,A2
-campfire,campfire,词,NOUN,C1
-campsite,campsite,露营地,NOUN,B2
-campus,campus,词,NOUN,B2
-campus-like,campus-like,词,ADJ,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,词,NOUN,B2
-can may,can may,可以,AUX,A1
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
-canadian,canadian,加拿大的,ADJ,B2
-canal belt,canal belt,词,NOUN,C1
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
-cancerous,cancerous,词,ADJ,C1
-candid,candid,词,ADJ,C1
-candy shop,candy shop,词,NOUN,B2
-cane,cane,手杖,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
-canning,canning,词,NOUN,C1
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-canonical,canonical,规范的,ADJ,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
-canvas,canvas,帆布,NOUN,B2
-canvass,canvass,词,VERB,C1
-capable,capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacitate,capacitate,词,VERB,C1
-capacitor condenser,capacitor condenser,词,NOUN,C1
-caper (noun),caper,词,NOUN,B2
-capillary,capillary,词,ADJ,C1
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,词,NOUN,B2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
-capitalist,capitalist,词,NOUN,C1
-capitalization,capitalization,词,NOUN,C1
-capping,capping,词,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capsize,capsize,词,VERB,C1
-capsule,capsule,词,NOUN,B1
-captious,captious,词,ADJ,B2
-captivated,captivated,词,ADJ,C1
-captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-captive bond,captive bond,词,NOUN,C1
-car (part),car,车,PART,C1
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-caramelize,caramelize,词,VERB,C1
-carat,carat,克拉,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrate,carbohydrate,碳水化合物,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon trading,carbon trading,碳交易,NOUN,C1
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-cardboard,cardboard,硬纸板,NOUN,B2
-cardinal,cardinal,枢机主教,NOUN,B2
-care home,care home,,NOUN,B2
-care worker,care worker,词,NOUN,B2
-careen,careen,词,VERB,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-carefree,carefree,无忧无虑的,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefully,carefully,仔细地,ADV,B2
-carefulness,carefulness,细心,NOUN,B2
-carelessness,carelessness,词,NOUN,C1
-caress (noun),caress,词,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
-caricature (verb),caricature,词,VERB,B2
-caring,caring,关怀的,ADJ,B2
-carnation,carnation,词,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
-carp (verb),carp,词,VERB,C1
-carpet rug,carpet rug,地毯,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
-cartel,cartel,词,NOUN,B2
-cartography,cartography,词,NOUN,B2
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
-case law,case law,判例法,NOUN,B2
-cash conversion,cash conversion,改现,NOUN,B2
-cashier,cashier,出纳员,NOUN,B2
-casino,casino,词,NOUN,B2
-casket,casket,词,NOUN,C1
-cassation,cassation,词,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cast,cast,演员阵容,NOUN,B2
-cast (adj),cast,词,ADJ,C1
-cast iron,cast iron,词,NOUN,B2
-castanets,castanets,词,NOUN,B1
-caste,caste,词,NOUN,B2
-casting,casting,词,NOUN,C1
-castrate,castrate,词,VERB,C1
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-casuistry,casuistry,决疑法,NOUN,B2
-catachresis,catachresis,词语误用,NOUN,B2
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
-catalogue,catalogue,目录,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
-catapult,catapult,投石机,NOUN,B2
-cataract,cataract,词,NOUN,B2
-catastrophic,catastrophic,灾难性的,ADJ,B2
-catch thief,catch thief,抓贼,NOUN,C1
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorical,categorical,绝对的,ADJ,B2
-categorically,categorically,词,ADV,C1
-cater,cater,词,VERB,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教的,ADJ,B2
-catholic (noun),catholic,天主教徒,NOUN,C1
-cats,cats,猫,NOUN,B2
-cattle rancher,cattle rancher,牧场主,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-caught,caught,被捕获的,ADJ,B2
-cauldron,cauldron,词,NOUN,C1
-causal link,causal link,词,NOUN,B2
-cause of change,cause of change,改因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-caustic,caustic,词,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
-cavern,cavern,词,NOUN,B2
-cavil,cavil,词,VERB,C1
-cavity,cavity,腔,NOUN,B2
-cavort,cavort,词,VERB,C1
-caw (noun),caw,词,NOUN,C1
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-cede,cede,词,VERB,C1
-celebrant,celebrant,词,NOUN,B2
-celerity,celerity,迅速,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial (noun),celestial,词,NOUN,B2
-celestial body,celestial body,词,NOUN,B2
-celibate,celibate,词,ADJ,B2
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
-cellulose,cellulose,纤维素,NOUN,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-censure (verb),censure,词,VERB,C1
-census,census,人口普查,NOUN,B2
-centenary,centenary,词,NOUN,C1
-centennial,centennial,词,ADJ,B2
-centime,centime,词,NOUN,B2
-centipede,centipede,蜈蚣,NOUN,B2
-cento,cento,词,NOUN,C1
-central station,central station,中央车站,NOUN,B2
-centrality,centrality,词,NOUN,C1
-centre,centre,词,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-century-old,century-old,世纪的,ADJ,B2
-ceo,ceo,首席执行官,NOUN,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
-cereal,cereal,词,NOUN,B2
-cerebral,cerebral,大脑的,ADJ,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
-certain (det),certain,某些,DET,B2
-certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
-certification,certification,认证,NOUN,C1
-cessation passing,cessation passing,消亡,NOUN,C1
-chain (adj),chain,词,ADJ,C1
-chain of transmission,chain of transmission,词,NOUN,C1
-chalet,chalet,词,NOUN,B1
-chalice,chalice,词,NOUN,C1
-challenges,challenges,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
-chamberlain,chamberlain,词,NOUN,C1
-chamois,chamois,词,NOUN,C1
-chance opportunity,chance opportunity,词,NOUN,A2
-chancery,chancery,词,NOUN,C1
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chant,chant,词,VERB,C1
-chants,chants,词,NOUN,B2
-chaotisch,chaotic,混乱的,ADJ,B2
-chaperon,chaperon,词,NOUN,C1
-chaplain,chaplain,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-character assassination,character assassination,人格谋杀,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
-characteristic,characteristic,特征,NOUN,B2
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charade,charade,词,NOUN,B2
-charades,charades,打哑谜,NOUN,B2
-charakterisieren,to characterize,描绘,VERB,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
-charismatic,charismatic,有魅力的,ADJ,B2
-charitable,charitable,慈善的,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
-charmer,charmer,词,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
-chartern,charter,宪章,NOUN,B2
-chartern,to charter,租船,VERB,B2
-chase (noun),chase,追他,NOUN,B2
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
-chasten,chasten,词,VERB,C1
-chastity probity,chastity probity,词,NOUN,C1
-chatter (noun),chatter,词,NOUN,A2
-chauffeur,chauffeur,词,NOUN,C1
-chauvinism,chauvinism,沙文主义,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheaper,cheaper,更便宜的,ADJ,B2
-cheapness,cheapness,廉价,NOUN,B2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checkbook,checkbook,支票簿,NOUN,B2
-checkers,checkers,词,NOUN,A2
-checkmate,checkmate,词,NOUN,C1
-checkup,checkup,体检,NOUN,B2
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
-chemicals,chemicals,词,NOUN,C1
-chemisch,chemical,化学的,ADJ,B2
-chemist,chemist,词,NOUN,C1
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
-chest breast,chest breast,词,NOUN,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chiasmus,chiasmus,词,NOUN,C1
-chic (noun),chic,词,NOUN,C1
-chickpeas,chickpeas,词,NOUN,A2
-chide,chide,词,VERB,C1
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,词,ADV,B2
-child-rearing,child-rearing,教子,NOUN,C1
-childbirth,childbirth,分娩,NOUN,B2
-childcare,childcare,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
-chili,chili,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (noun),chill,词,NOUN,B1
-chilling,chilling,词,ADJ,C1
-chime,chime,词,NOUN,C1
-chimera,chimera,词,NOUN,C1
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
-chinese,chinese,中文,NOUN,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
-chinese language,chinese language,华文,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chitchat,chitchat,词,NOUN,B2
-chivalrous,chivalrous,词,ADJ,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,词,NOUN,C1
-choke,choke,词,VERB,B2
-cholera,cholera,词,NOUN,C1
-choleric,choleric,易怒的,ADJ,B2
-chomp,chomp,词,VERB,C1
-chop (noun),chop,砍了,NOUN,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-chore,chore,家务,NOUN,B2
-choreograph,choreograph,词,VERB,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreographic,choreographic,词,ADJ,C1
-choreography,choreography,词,NOUN,C1
-chortle,chortle,词,VERB,C1
-chosen,chosen,精选的,ADJ,B2
-christen,christen,词,VERB,C1
-christianity,christianity,基督教,NOUN,B2
-christianization,christianization,词,NOUN,C1
-christmas eve,christmas eve,平安夜,NOUN,B2
-christmas porridge,christmas porridge,词,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicle,chronicle,编年史,NOUN,B2
-chronicler,chronicler,词,NOUN,B2
-chronisch,chronic,慢性的,ADJ,B2
-chronological,chronological,词,ADJ,C1
-chronology,chronology,年表,NOUN,B2
-chubby,chubby,胖子,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-church community,church community,教会,NOUN,B2
-churn,churn,词,VERB,C1
-churn skin,churn skin,词,NOUN,B2
-cider,cider,词,NOUN,B2
-cigar,cigar,雪茄,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinematographic,cinematographic,电影的,ADJ,B2
-circular (adj),circular,词,ADJ,C1
-circular (noun),circular,词,NOUN,B2
-circulating,circulating,词,ADJ,B2
-circumference,circumference,词,NOUN,C1
-circumlocution,circumlocution,迂回说法,NOUN,B2
-circumscription,circumscription,词,NOUN,C1
-circumspect,circumspect,谨慎的,ADJ,B2
-circumspection,circumspection,词,NOUN,B2
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circumvent,circumvent,词,VERB,C1
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
-cistern,cistern,蓄水池,NOUN,B2
-citadel,citadel,词,NOUN,C1
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city centre,city centre,市中心,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
-civic,civic,词,ADJ,C1
-civic-mindedness,civic-mindedness,词,NOUN,B2
-civil war,civil war,词,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civility,civility,礼貌,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,词,ADJ,B2
-clamber,clamber,词,VERB,C1
-clamorous,clamorous,词,ADJ,B2
-clampdown,clampdown,词,NOUN,C1
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestineness,clandestineness,词,NOUN,B2
-clandestinity,clandestinity,词,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clapping,clapping,词,NOUN,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarify doubts,clarify doubts,释疑,VERB,B2
-clarity evidentness,clarity evidentness,词,NOUN,C1
-clash (noun),clash,词,NOUN,C1
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-class test,class test,词,NOUN,B1
-classical poetry,classical poetry,词,NOUN,C1
-classicist,classicist,古典主义的,ADJ,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
-classwork,classwork,课堂作业,NOUN,B2
-clatter,clatter,哗啦声,NOUN,C1
-clauses,clauses,词,NOUN,C1
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner,cleaner,更干净的,ADJ,B2
-cleaner (noun),cleaner,清洁剂,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanly,cleanly,干净地,ADV,B2
-cleanse,cleanse,词,VERB,C1
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
-clear justice,clear justice,明正,NOUN,C1
-clear limpid,clear limpid,词,ADJ,C1
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
-clearance,clearance,词,NOUN,C1
-clemency,clemency,仁慈,NOUN,B2
-clench,clench,词,VERB,C1
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
-click (noun),click,词,NOUN,C1
-clickbait,clickbait,词,NOUN,C1
-clientele,clientele,词,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-climate denial,climate denial,气候否认,NOUN,B2
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
-climbing,climbing,词,NOUN,B1
-clinch,clinch,词,VERB,C1
-clink,clink,词,NOUN,C1
-clipping,clipping,词,NOUN,C1
-clobber,clobber,词,VERB,C1
-clock watch,clock watch,钟表,NOUN,B2
-clog (noun),clog,词,NOUN,B2
-clog (verb),clog,词,VERB,C1
-cloister,cloister,回廊,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
-close a case,close a case,结案,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
-close well,close well,关好,NOUN,C1
-closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
-closedness,closedness,封闭,NOUN,C1
-closely,closely,词,ADV,B2
-closer,closer,更近的,ADJ,B2
-closer (adv),closer,词,ADV,B2
-closing,closing,词,NOUN,B2
-closing argument,closing argument,辩护词,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-clouds,clouds,云,NOUN,B1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
-cloying,cloying,词,ADJ,C1
-club blow,club blow,词,NOUN,C1
-cluck,cluck,词,NOUN,C1
-clump,clump,词,NOUN,C1
-clumsily,clumsily,词,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-clunky,clunky,词,ADJ,C1
-clutter,clutter,词,NOUN,C1
-co-,co-,词,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-occurrence,co-occurrence,词,NOUN,C1
-co-owner,co-owner,共有人,NOUN,B2
-co-ownership,co-ownership,共有产权,NOUN,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coalesce,coalesce,词,VERB,C1
-coarse rough,coarse rough,词,ADJ,C1
-coast road,coast road,词,NOUN,B2
-coastal,coastal,沿海的,ADJ,B2
-coastal (noun),coastal,词,NOUN,B2
-coastline,coastline,词,NOUN,B2
-coat of arms,coat of arms,纹章,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-cobble,cobble,词,VERB,C1
-cobbler,cobbler,词,NOUN,B2
-cock,cock,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-coddle,coddle,词,VERB,C1
-code of conduct,code of conduct,词,NOUN,C1
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-coding,coding,词,NOUN,B2
-coffee maker,coffee maker,词,NOUN,A2
-cog,cog,词,NOUN,C1
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cogito,cogito,词,NOUN,C1
-cognac,cognac,干邑,NOUN,B2
-cognate,cognate,词,NOUN,B2
-cognition,cognition,认知,NOUN,B2
-cognitive,cognitive,认知的,ADJ,B2
-cognizance,cognizance,词,NOUN,C1
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-cohort,cohort,队列,NOUN,B2
-cohort-based,cohort-based,队列的,ADJ,B2
-coil (noun),coil,词,NOUN,C1
-coin purse,coin purse,词,NOUN,B2
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coitus,coitus,词,NOUN,B2
-cola,cola,可乐,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
-coldness,coldness,词,NOUN,B2
-colic,colic,词,NOUN,C1
-coliseum,coliseum,词,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
-collation,collation,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,词,ADJ,B2
-collectie,collectie,收藏,NOUN,B2
-collections,collections,词,NOUN,C1
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-collectivization,collectivization,集体化,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiality,collegiality,词,NOUN,C1
-collegiate,collegiate,词,ADJ,B2
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial,colloquial,词,ADJ,B2
-colloquial language,colloquial language,词,NOUN,C1
-colloquium,colloquium,词,NOUN,B2
-collusion,collusion,串通,NOUN,B2
-colonial,colonial,词,ADJ,C1
-colonial settlers,colonial settlers,词,NOUN,C1
-colonist,colonist,词,NOUN,B2
-colonizing,colonizing,词,ADJ,C1
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colophon,colophon,词,NOUN,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-colored,colored,有色的,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
-coloring,coloring,词,NOUN,B2
-colorless,colorless,词,ADJ,C1
-colossal,colossal,巨大的,ADJ,B2
-colossus,colossus,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-columnar,columnar,词,ADJ,C1
-columnist,columnist,词,NOUN,C1
-combatant,combatant,词,NOUN,B2
-combative,combative,词,ADJ,B2
-combativeness,combativeness,好斗性,NOUN,B2
-combinations,combinations,词,NOUN,C1
-combinatorial,combinatorial,词,ADJ,B2
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combining,combining,词,ADJ,B2
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come on,come on,词,INTJ,C1
-comer,comer,词,NOUN,C1
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comic strip,comic strip,连环画,NOUN,B2
-comicness,comicness,词,NOUN,C1
-coming,coming,即将到来的,ADJ,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma (noun),comma,词,NOUN,B1
-commandeer,commandeer,词,VERB,C1
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
-commandment,commandment,词,NOUN,C1
-commence,commence,词,VERB,B2
-commencement,commencement,开始,NOUN,B2
-commend,commend,词,VERB,C1
-commendable,commendable,词,ADJ,C1
-commendation,commendation,词,NOUN,C1
-commensalism,commensalism,词,NOUN,B2
-commensurability,commensurability,词,NOUN,C1
-commentaries,commentaries,词,NOUN,C1
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commiserate,commiserate,词,VERB,C1
-commiseration,commiseration,同情,NOUN,B2
-commitments,commitments,词,NOUN,C1
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commodification,commodification,词,NOUN,C1
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
-commonly,commonly,词,ADV,C1
-commonplace,commonplace,词,ADJ,C1
-communal work,communal work,词,NOUN,C1
-communautarization,communautarization,社群化,NOUN,B2
-communes,communes,词,NOUN,C1
-communicativeness,communicativeness,词,NOUN,C1
-communion rail,communion rail,词,NOUN,B2
-communist,communist,共产主义者,NOUN,B2
-communitarian,communitarian,词,ADJ,C1
-community-related,community-related,社区的,ADJ,B2
-commuter,commuter,词,NOUN,A2
-comorbidity,comorbidity,词,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-comparability,comparability,词,NOUN,C1
-comparable,comparable,可比较的,ADJ,B2
-comparative,comparative,比较的,ADJ,B2
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
-compartmental,compartmental,词,ADJ,C1
-compassion sympathy,compassion sympathy,词,NOUN,B2
-compatible,compatible,词,ADJ,C1
-compelling,compelling,词,ADJ,C1
-compendious,compendious,词,ADJ,B2
-compendium,compendium,纲要,NOUN,B2
-competencies,competencies,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competition bastard,competition bastard,,NOUN,B2
-competitive,competitive,竞争的,ADJ,B2
-competitive exam,competitive exam,词,NOUN,B2
-complacency,complacency,词,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complement,complement,补充物,NOUN,B2
-complementarity,complementarity,互补性,NOUN,B2
-complete (noun),complete,具,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex,complex,建筑群,NOUN,B2
-complexion,complexion,肤色,NOUN,B2
-complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
-composable,composable,可组合的,ADJ,B2
-compositional,compositional,词,ADJ,C1
-compostable,compostable,可堆肥的,ADJ,B2
-compound,compound,化合物,NOUN,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
-comprehensibility,comprehensibility,词,NOUN,C1
-compressed,compressed,词,ADJ,C1
-compressibility,compressibility,词,NOUN,C1
-compressible,compressible,词,ADJ,C1
-comprise,comprise,词,VERB,C1
-compulsion,compulsion,词,NOUN,C1
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compunction,compunction,词,NOUN,B2
-compurgation oath,compurgation oath,词,NOUN,C1
-computability,computability,词,NOUN,C1
-computer mouse,computer mouse,词,NOUN,B1
-computer program,computer program,电脑程序,NOUN,B2
-computer science,computer science,词,NOUN,C1
-computer specialist,computer specialist,计算机专家,NOUN,B2
-con artist,con artist,词,NOUN,B1
-concatenation,concatenation,词,NOUN,B2
-concave,concave,凹的,ADJ,B2
-concavity,concavity,词,NOUN,B2
-concealed,concealed,词,ADJ,C1
-conceit,conceit,词,NOUN,C1
-conceivable,conceivable,可设想的,ADJ,B2
-concentrated,concentrated,浓,ADJ,B1
-concentric,concentric,词,ADJ,C1
-conception,conception,概念,NOUN,B2
-concepts,concepts,词,NOUN,C1
-conceptual,conceptual,概念的,ADJ,B2
-conceptualize,conceptualize,词,VERB,C1
-concerned,concerned,担忧的,ADJ,B2
-concerning (adj),concerning,词,ADJ,B2
-concerns,concerns,词,NOUN,C1
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
-concessionary,concessionary,让步的,ADJ,B2
-conch,conch,词,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
-conciliatory,conciliatory,调和的,ADJ,B2
-conciseness,conciseness,简洁,NOUN,B2
-concision,concision,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,词,ADJ,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
-concomitantly,concomitantly,词,ADV,B2
-concord,concord,和谐,NOUN,B2
-concordance,concordance,一致,NOUN,B2
-concordat,concordat,词,NOUN,B2
-concrete,concrete,混凝土,NOUN,B2
-concretization,concretization,词,NOUN,C1
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concur,concur,词,VERB,C1
-concurrence,concurrence,词,NOUN,B2
-concurrently,concurrently,词,ADV,C1
-concussion,concussion,脑震荡,NOUN,B2
-condemned,condemned,被定罪的,ADJ,B2
-condenser,condenser,词,NOUN,C1
-condescension,condescension,屈尊,NOUN,B2
-conditioning (adj),conditioning,词,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
-condom,condom,避孕套,NOUN,B2
-conducive,conducive,词,ADJ,B2
-conduciveness,conduciveness,词,NOUN,C1
-conductivity,conductivity,导电性,NOUN,B2
-conductor,conductor,词,NOUN,C1
-conduit,conduit,词,NOUN,B2
-confederal,confederal,词,ADJ,C1
-confederate,confederate,同盟者,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-confessional,confessional,宗派的,ADJ,B2
-confidant,confidant,知己,NOUN,B2
-confiding,confiding,词,NOUN,C1
-configure,configure,词,VERB,C1
-configured,configured,词,ADJ,C1
-confinement,confinement,禁闭,NOUN,B2
-confines edges,confines edges,词,NOUN,C1
-conflictual,conflictual,词,ADJ,C1
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
-conforming,conforming,词,ADJ,B2
-conformist,conformist,从众的,ADJ,B2
-conformist (noun),conformist,词,NOUN,B2
-conformity,conformity,词,NOUN,B2
-confound,confound,词,VERB,C1
-confounded,confounded,该死的,ADJ,B2
-confronted,confronted,词,ADJ,B2
-confronting,confronting,词,ADJ,B2
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusedly,confusedly,词,ADV,C1
-confusing,confusing,令人困惑的,ADJ,B2
-congeal,congeal,词,VERB,C1
-congenital,congenital,先天的,ADJ,B2
-conglomerate,conglomerate,词,NOUN,B2
-congratulations (intj),congratulations,恭喜,INTJ,B2
-congregate,congregate,词,VERB,C1
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-congruent,congruent,一致的,ADJ,B2
-conic,conic,圆锥曲线,NOUN,B2
-conifer,conifer,针叶树,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugal,conjugal,词,ADJ,B2
-conjunctural,conjunctural,词,ADJ,C1
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connector,connector,词,NOUN,B2
-connivance,connivance,词,NOUN,B2
-connive,connive,词,VERB,C1
-conniving,conniving,词,ADJ,C1
-connotative,connotative,内涵的,ADJ,B2
-conquests,conquests,征服,NOUN,C1
-consanguineous,consanguineous,词,ADJ,B2
-consanguinity,consanguinity,血缘,NOUN,B2
-conscientious objection,conscientious objection,良知抗拒,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
-consciously,consciously,词,ADV,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
-consecration,consecration,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consecutively,consecutively,连续地,ADV,B2
-consensualism,consensualism,词,NOUN,C1
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,词,ADJ,B2
-conservatism,conservatism,词,NOUN,C1
-conservatory,conservatory,音乐学院,NOUN,B2
-considerable (noun),considerable,不小,NOUN,C1
-considerably,considerably,相当地,ADV,B2
-considered,considered,词,ADJ,B1
-console (noun),console,词,NOUN,B2
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consolidation,consolidation,词,NOUN,C1
-consonance,consonance,词,NOUN,B2
-consortium,consortium,词,NOUN,B2
-conspirator,conspirator,词,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
-constancy,constancy,恒定,NOUN,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
-consternation,consternation,词,NOUN,B2
-constituencies,constituencies,词,NOUN,C1
-constituent,constituent,成分,NOUN,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
-constitutionalization,constitutionalization,词,NOUN,B2
-constitutive,constitutive,构成的,ADJ,B2
-constraints,constraints,词,NOUN,C1
-constrict,constrict,词,VERB,C1
-constructiveness,constructiveness,词,NOUN,C1
-constructivism,constructivism,建构主义,NOUN,B2
-construe,construe,词,VERB,C1
-consultations,consultations,磋商,NOUN,C1
-consultative,consultative,咨询的,ADJ,B2
-consumerist,consumerist,词,ADJ,B2
-consummate (adj),consummate,词,ADJ,B2
-consummation,consummation,词,NOUN,B2
-consumptive,consumptive,消费的,ADJ,B2
-contact person,contact person,联系人,NOUN,B2
-contacts,contacts,人脉,NOUN,B2
-contactual,contactual,接触的,ADJ,B2
-contagion,contagion,词,NOUN,B2
-containment,containment,词,NOUN,C1
-contaminated,contaminated,受污染的,ADJ,B2
-contaminating,contaminating,污染的,ADJ,B2
-contemn,contemn,蔑视,VERB,C1
-contemplation,contemplation,沉思,NOUN,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contender,contender,词,NOUN,B2
-content (adj),content,词,ADJ,B2
-contentious,contentious,有争议的,ADJ,B2
-contents,contents,内有,NOUN,B2
-contestable,contestable,可质疑的,ADJ,B2
-contested,contested,有争议的,ADJ,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,相邻的,ADJ,B2
-continence,continence,词,NOUN,B2
-continental,continental,词,ADJ,B2
-contingent,contingent,偶然的,ADJ,B2
-continual,continual,持续的,ADJ,B2
-continually,continually,词,ADV,B2
-continued,continued,持续的,ADJ,B2
-continuously,continuously,一直,ADV,A1
-contort,contort,词,VERB,C1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contraband,contraband,违禁品,NOUN,B2
-contracted,contracted,词,ADJ,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual,contractual,合同的,ADJ,B2
-contractual nature,contractual nature,词,NOUN,C1
-contractuality,contractuality,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
-contradictoriness,contradictoriness,词,NOUN,C1
-contraindicate,contraindicate,词,VERB,C1
-contraindication,contraindication,词,NOUN,C1
-contrary (adj),contrary,词,ADJ,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrast,contrast,对比,NOUN,B2
-contrastive,contrastive,词,ADJ,C1
-contributions,contributions,词,NOUN,C1
-contrite,contrite,词,ADJ,B2
-contrition,contrition,悔罪,NOUN,B2
-contrive,contrive,词,VERB,C1
-controllability,controllability,词,NOUN,C1
-controllable,controllable,可控制的,ADJ,B2
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
-contumacy,contumacy,词,NOUN,C1
-contusion,contusion,词,NOUN,B2
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convalesce,convalesce,词,VERB,B2
-convalescence,convalescence,词,NOUN,C1
-convalescent,convalescent,词,ADJ,B2
-convenant,convenant,词,NOUN,C1
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
-convening,convening,召集,NOUN,C1
-convent,convent,词,NOUN,B2
-conventionality,conventionality,词,NOUN,C1
-convergent,convergent,词,ADJ,C1
-conversation technique,conversation technique,词,NOUN,C1
-conversion,conversion,转换,NOUN,B2
-conversional,conversional,转换的,ADJ,B2
-convert (noun),convert,词,NOUN,B2
-convertibility,convertibility,可兑换性,NOUN,B2
-convertible,convertible,可兑换的,ADJ,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
-conveyance,conveyance,词,NOUN,C1
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (adj),convict,词,ADJ,B2
-convict (noun),convict,词,NOUN,C1
-convicted,convicted,被判罪的,ADJ,B2
-conviviality,conviviality,温馨,NOUN,B2
-convoke,convoke,词,VERB,C1
-convoluted,convoluted,词,ADJ,B2
-convolutional,convolutional,卷积的,ADJ,B2
-convoy,convoy,词,NOUN,B2
-convulse,convulse,词,VERB,C1
-convulsive,convulsive,词,ADJ,B2
-cooked,cooked,熟的,ADJ,B2
-cooking,cooking,烹饪,NOUN,B2
-cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,词,ADJ,B2
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
-coop,coop,词,VERB,C1
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
-cope with,cope with,应对,VERB,B2
-copious,copious,词,ADJ,B2
-coproduction,coproduction,联合制作,NOUN,B2
-coral (adj),coral,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-cord,cord,绳索,NOUN,B2
-cordiality,cordiality,词,NOUN,C1
-cordially,cordially,亲切地,ADV,B2
-cordoning,cordoning,词,NOUN,C1
-core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-cornice,cornice,檐口,NOUN,B2
-corniche,corniche,词,NOUN,C1
-corollary,corollary,推论,NOUN,B2
-corporal,corporal,下士,NOUN,B2
-corporate,corporate,公司的,ADJ,B2
-corporation,corporation,公司,NOUN,B2
-corporatism,corporatism,法团主义,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpulent,corpulent,词,ADJ,B2
-corpuscle,corpuscle,词,NOUN,C1
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correctional,correctional,词,ADJ,C1
-corrections,corrections,刑事司法,NOUN,B2
-correctness,correctness,正确性,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlative,correlative,词,ADJ,B2
-correlatively,correlatively,词,ADV,B2
-correspondence course,correspondence course,函授,NOUN,C1
-correspondents,correspondents,词,NOUN,C1
-corridors,corridors,词,NOUN,C1
-corrigible,corrigible,词,ADJ,B2
-corroboration,corroboration,证实,NOUN,B2
-corrosive,corrosive,腐蚀性的,ADJ,B2
-corrupted,corrupted,词,NOUN,B2
-corruptibility,corruptibility,词,NOUN,C1
-cortical,cortical,皮层的,ADJ,C1
-cosmetic,cosmetic,化妆品的,ADJ,B2
-cosmetics,cosmetics,化妆品,NOUN,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,词,NOUN,B2
-cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-costly,costly,昂贵的,ADJ,B2
-costs,costs,费用,NOUN,B2
-costumbrism,costumbrism,词,NOUN,B2
-costumes,costumes,词,NOUN,B2
-cosy,cosy,词,ADJ,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couch,couch,词,NOUN,B1
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-council-related,council-related,词,ADJ,C1
-councilor,councilor,市议员,NOUN,B2
-councils,councils,委员会,NOUN,C1
-counsel,counsel,词,NOUN,B2
-counselor,counselor,词,NOUN,C1
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,面容,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterargument,counterargument,反论点,NOUN,B2
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,逆流,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-counterfeiting,counterfeiting,伪造,NOUN,B2
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterproductive,counterproductive,适得其反的,ADJ,B2
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-counterweight,counterweight,词,NOUN,B2
-country land,country land,词,NOUN,A1
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
-courageous,courageous,勇敢的,ADJ,B2
-courageously,courageously,词,ADV,C1
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court clerk,court clerk,词,NOUN,C1
-court costs,court costs,词,NOUN,C1
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courteous,courteous,有礼貌的,ADJ,B2
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cove,cove,小海湾,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-cover-up,cover-up,词,NOUN,C1
-coward (adj),coward,词,ADJ,A2
-cower,cower,词,VERB,C1
-coworker,coworker,同事,NOUN,B2
-cowpeas,cowpeas,词,NOUN,B2
-crackdown,crackdown,词,NOUN,C1
-cracker,cracker,词,NOUN,B2
-cracking,cracking,词,NOUN,B2
-cradle,cradle,摇篮,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramp,cramp,抽筋,NOUN,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crass,crass,词,ADJ,B2
-cravenly,cravenly,词,ADV,C1
-craving,craving,渴求,NOUN,B2
-crayon,crayon,词,NOUN,C1
-craze,craze,狂热,NOUN,B2
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-creamy,creamy,词,ADJ,C1
-crease,crease,词,NOUN,C1
-credentials,credentials,国书,NOUN,B2
-creditor's rights,creditor's rights,债权,NOUN,B2
-credulity,credulity,轻信,NOUN,B2
-credulous,credulous,词,ADJ,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (verb),creep,词,VERB,B2
-cremate,cremate,词,VERB,C1
-cremation,cremation,词,NOUN,B2
-crenelate,crenelate,词,VERB,C1
-crescendo,crescendo,词,NOUN,C1
-crescent,crescent,crescent,NOUN,B2
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-cricket,cricket,板球,NOUN,B2
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
-criminal law,criminal law,刑法,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
-criminalization,criminalization,词,NOUN,C1
-crimson,crimson,词,ADJ,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisis-ridden,crisis-ridden,词,ADJ,C1
-crisp,crisp,词,ADJ,C1
-criticizable,criticizable,词,ADJ,B2
-critique,critique,词,NOUN,C1
-crochet,crochet,词,NOUN,C1
-crocodile,crocodile,词,NOUN,A1
-cronyism,cronyism,词,NOUN,C1
-cross-border,cross-border,边境的,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crossing the border,crossing the border,词,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-crouch (noun),crouch,词,NOUN,B2
-croup,croup,词,NOUN,C1
-crowbar,crowbar,词,NOUN,B2
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-crucible,crucible,词,NOUN,B2
-crucifixion,crucifixion,词,NOUN,C1
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruelly,cruelly,残酷地,ADV,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crumb,crumb,词,NOUN,C1
-crumbs,crumbs,词,NOUN,B2
-crunchy,crunchy,脆的,ADJ,B1
-crusade,crusade,运动,NOUN,B2
-crushing,crushing,词,NOUN,B2
-crusty,crusty,词,ADJ,B2
-cry weep,cry weep,词,VERB,A1
-crying shouting,crying shouting,词,NOUN,B1
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystal glass,crystal glass,词,NOUN,B1
-crystalline,crystalline,水晶般的,ADJ,B2
-crystallization,crystallization,词,NOUN,C1
-crystallize,crystallize,词,VERB,C1
-cubit,cubit,词,NOUN,B2
-cuckold,cuckold,词,VERB,C1
-cuddle (noun),cuddle,词,NOUN,C1
-cudgel,cudgel,棍棒,NOUN,B2
-cue,cue,词,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culminating,culminating,词,ADJ,C1
-culmination,culmination,词,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cult,cult,邪教,NOUN,B2
-cultivation,cultivation,培养,NOUN,B2
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-culturalism,culturalism,词,NOUN,C1
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cultured,cultured,词,ADJ,B2
-cumber,cumber,词,VERB,C1
-cumbersome,cumbersome,笨重的,ADJ,B2
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
-cunning,cunning,诡计,NOUN,B2
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cunningly,cunningly,词,ADV,C1
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupola,cupola,词,NOUN,C1
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curate,curate,词,VERB,C1
-curative,curative,有疗效的,ADJ,B2
-curator,curator,策展人,NOUN,B2
-curatorship,curatorship,词,NOUN,C1
-curbing,curbing,遏制,NOUN,B2
-curd,curd,词,NOUN,B2
-curdle,curdle,词,VERB,C1
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
-curiously,curiously,词,ADV,C1
-curly,curly,卷曲的,ADJ,B2
-currant,currant,醋栗,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
-current,current,电流,NOUN,B2
-current events,current events,词,NOUN,B2
-current times,current times,词,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
-curry,curry,词,NOUN,B2
-cursing,cursing,骂人,NOUN,C1
-curvature,curvature,词,NOUN,B2
-curved,curved,词,ADJ,B2
-cusp,cusp,词,NOUN,B2
-custodian,custodian,词,NOUN,B2
-customary law,customary law,词,NOUN,C1
-customer orientation,customer orientation,词,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
-customs (adj),customs,词,ADJ,C1
-customs officer,customs officer,海关官员,NOUN,B2
-cut off,cut off,割下,NOUN,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
-cutting,cutting,切割,NOUN,B2
-cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
-cyber,cyber,网络的,ADJ,B2
-cybernetics,cybernetics,词,NOUN,C1
-cyborg,cyborg,词,NOUN,C1
-cycle path,cycle path,自行车道,NOUN,B2
-cycling,cycling,词,NOUN,C1
-cyclist,cyclist,骑自行车的人,NOUN,B2
-cykel,cykel,自行车,NOUN,B2
-cylindrical,cylindrical,圆柱形的,ADJ,B2
-cynicism,cynicism,犬儒主义,NOUN,B2
-cyst,cyst,囊肿,NOUN,B2
-czech,czech,捷克的,ADJ,B2
-da,since,既然,SCONJ,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
-daft,daft,傻的,ADJ,B2
-daglig,daglig,词,ADJ,C1
-daily (adv),daily,按天,ADV,C1
-daily (noun),daily,词,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
-daily wage,daily wage,词,NOUN,C1
-dairy,dairy,词,ADJ,C1
-dal,dal,山谷,NOUN,B2
-dally,dally,词,VERB,C1
-damageable,damageable,易损的,ADJ,B2
-damages,damages,损害赔偿,NOUN,B2
-damaging,damaging,有害的,ADJ,B2
-damals,at that time,当时/那时,ADV,B2
-damask,damask,词,NOUN,B2
-damm,damm,词,NOUN,B2
-damn,damn,该死的,ADV,B2
-damn (intj),damn,该死,INTJ,B2
-damned,damned,词,ADJ,B2
-dampfen,to steam,蒸,VERB,B2
-damping,damping,词,NOUN,C1
-dance floor,dance floor,词,NOUN,B2
-dandelion,dandelion,词,NOUN,B1
-dandle,dandle,词,VERB,C1
-dandruff,dandruff,词,NOUN,B2
-dangerousness,dangerousness,危险性,NOUN,B2
-dangle,dangle,词,VERB,C1
-danish,danish,丹麦的,ADJ,B2
-dank,thanks to,多亏,ADP,B2
-dankbar sein,to be grateful,感激,VERB,B2
-dann du,then you,那你,PRON,B2
-dans,dans,舞蹈,NOUN,B2
-dapper,dapper,整洁的,ADJ,B2
-daraufhin,thereupon,随后,ADV,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-daring bold,daring bold,词,ADJ,B2
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
-darkness of night,darkness of night,词,NOUN,C1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (verb),darn,词,VERB,B2
-darstellen,to depict,描绘,VERB,B2
-darstellen,to portray,描绘,VERB,B2
-dart (noun),dart,词,NOUN,B2
-dart (verb),dart,词,VERB,C1
-darunter,among them,其中,PRON,B2
-das,that,那个,PRON,B2
-das heißt,that is,即,ADV,B2
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-data protection,data protection,词,NOUN,B2
-databas,databas,数据库,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
-datieren,to date,注明日期,VERB,B2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daub,daub,词,VERB,C1
-dauern,to last a period of time,为期,VERB,B2
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dawning,dawning,破晓,NOUN,B2
-day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,后天,NOUN,B2
-day by day,day by day,日日,ADV,B2
-day off,day off,词,NOUN,B2
-day out,day out,词,NOUN,B2
-day school,day school,词,NOUN,C1
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daycare,daycare,托儿所,NOUN,B2
-daydream (noun),daydream,词,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daylight,daylight,日光,NOUN,B2
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
-de facto,de facto,词,ADJ,C1
-de-escalation,de-escalation,词,NOUN,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-deaden,deaden,词,VERB,C1
-deadlock,deadlock,词,NOUN,C1
-deadly,deadly,致命地,ADV,B2
-deaf person,deaf person,词,NOUN,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
-deals,deals,词,NOUN,C1
-deanship,deanship,词,NOUN,C1
-dear,dear,,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
-deaths,deaths,词,NOUN,C1
-debasement,debasement,词,NOUN,C1
-debattieren,debate,辩论,NOUN,B2
-debattieren,to debate,辩论,VERB,B2
-debauch,debauch,词,VERB,C1
-debilitate,debilitate,词,VERB,C1
-debility,debility,虚弱,NOUN,C1
-debit,debit,词,VERB,C1
-debrief,debrief,词,VERB,C1
-debris,debris,词,NOUN,B2
-debris rubble,debris rubble,词,NOUN,C1
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
-decal,decal,贴花,NOUN,B2
-decalogue,decalogue,词,NOUN,B2
-decamp,decamp,词,VERB,C1
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
-deceased,deceased,已故的,ADJ,B2
-deceit,deceit,欺骗,NOUN,B2
-deceived,deceived,词,ADJ,A2
-decelerate,decelerate,词,VERB,C1
-decentralized,decentralized,词,ADJ,C1
-deceptive,deceptive,欺骗性的,ADJ,B2
-decibel,decibel,分贝,NOUN,B2
-decidedly,decidedly,坚决地,ADV,B2
-decimal,decimal,小数,NOUN,B2
-decimal (adj),decimal,词,ADJ,C1
-deciphering,deciphering,词,NOUN,C1
-decision-making,decision-making,决策,NOUN,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck,deck,词,NOUN,B1
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declamatory style,declamatory style,词,NOUN,C1
-declarant,declarant,词,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declare war,declare war,宣战,VERB,B2
-declension,declension,词,NOUN,C1
-declinable,declinable,可变格的,ADJ,B2
-decline (noun),decline,下降,NOUN,B2
-decline setting,decline setting,词,NOUN,C1
-decoding,decoding,词,NOUN,B2
-decommission,decommission,词,VERB,C1
-decompensation,decompensation,词,NOUN,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
-deconstructionist,deconstructionist,词,ADJ,C1
-decontaminate,decontaminate,词,VERB,C1
-decontamination,decontamination,去污,NOUN,B2
-decor,decor,布景,NOUN,B2
-decorated,decorated,词,ADJ,B1
-decorative,decorative,装饰性的,ADJ,B2
-decorous,decorous,词,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
-decorum,decorum,礼仪,NOUN,B2
-decoy,decoy,词,NOUN,C1
-decrease (noun),decrease,减,NOUN,B2
-decreasing,decreasing,词,ADJ,B2
-decrepit,decrepit,词,ADJ,B2
-deduct points,deduct points,扣分,VERB,C1
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
-deem,deem,词,VERB,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
-deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,词,ADV,B2
-deface,deface,词,VERB,C1
-defamatory,defamatory,词,ADJ,C1
-defamiliarization,defamiliarization,词,NOUN,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
-defection,defection,词,NOUN,B2
-defective,defective,有缺陷的,ADJ,B2
-defectiveness,defectiveness,词,NOUN,C1
-defektieren,defect,缺陷,NOUN,B2
-defektieren,to defect,叛变,VERB,B2
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,词,ADJ,C1
-defensive,defensive,防御的,ADJ,B2
-deference,deference,敬意,NOUN,B2
-deferential,deferential,词,ADJ,C1
-deficitary,deficitary,词,ADJ,C1
-defile,defile,词,VERB,C1
-definable,definable,词,ADJ,C1
-definieren,to define,定义,VERB,B2
-definite,definite,明确的,ADJ,B2
-definitiv,definitive,决定性的,ADJ,B2
-deflated,deflated,词,ADJ,B1
-deflationary,deflationary,词,ADJ,C1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deformity,deformity,词,NOUN,C1
-defunct,defunct,词,ADJ,C1
-degenerative,degenerative,退化的,ADJ,B2
-degenerieren,to degenerate,退化,VERB,B2
-degradieren,to degrade,贬低,VERB,B2
-degrading,degrading,词,ADJ,C1
-degrease,degrease,词,VERB,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
-dehydration dryness,dehydration dryness,词,NOUN,C1
-deice,deice,词,VERB,C1
-deification,deification,词,NOUN,C1
-dejt,dejt,约会,NOUN,B2
-dekadent,decadent,颓废,ADJ,B2
-dekonstruieren,to deconstruct,解构,VERB,B2
-del,del,部分,NOUN,B2
-delayed,delayed,延误的,ADJ,B2
-delegate (noun),delegate,词,NOUN,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
-delegieren,delegate,代表,NOUN,B2
-delegieren,to delegate,委派,VERB,B2
-deleterious,deleterious,词,ADJ,B2
-deletion,deletion,词,NOUN,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-deli meats,deli meats,词,NOUN,C1
-deliberateness,deliberateness,词,NOUN,C1
-deliberations,deliberations,词,NOUN,C1
-deliberatively,deliberatively,词,ADV,C1
-delicately,delicately,巧妙地,ADV,B2
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delighted,delighted,高兴的,ADJ,B2
-delimitation,delimitation,词,NOUN,C1
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-deliquesce,deliquesce,词,VERB,C1
-delirious,delirious,谵妄的,ADJ,B2
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delouse,delouse,词,VERB,C1
-delta,delta,delta,NOUN,B2
-delude,delude,词,VERB,C1
-deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
-delve,delve,词,VERB,C1
-demagogic,demagogic,词,ADJ,C1
-demagogue,demagogue,词,NOUN,C1
-demagoguery,demagoguery,煽动性,NOUN,B2
-demagogy,demagogy,蛊惑,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
-demarcation,demarcation,划界,NOUN,B2
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
-dement,dement,词,VERB,C1
-demented,demented,词,ADJ,C1
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demijohn,demijohn,词,NOUN,B2
-demobilize,demobilize,词,VERB,C1
-democrat,democrat,民主主义者,NOUN,B2
-demographic,demographic,人口统计的,ADJ,B2
-demokratisch,democratic,民主的,ADJ,B2
-demolieren,to demolish,拆除,VERB,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demonization,demonization,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demonstrator,demonstrator,词,NOUN,C1
-demonstrieren,to demonstrate,证明,VERB,B2
-demoralisieren,to demoralize,使士气低落,VERB,B2
-demoralization,demoralization,词,NOUN,C1
-demote,demote,词,VERB,C1
-demotion,demotion,降职,NOUN,B2
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-demütigen,to humiliate,羞辱,VERB,B2
-den,den,兽穴,NOUN,B2
-denationalize,denationalize,词,VERB,C1
-denial contradiction,denial contradiction,词,NOUN,C1
-denken,to think to want,想,VERB,B2
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
-dense forest,dense forest,密林,NOUN,B2
-dent,dent,凹痕,NOUN,B2
-dental,dental,词,ADJ,C1
-dentition,dentition,牙齿,NOUN,B2
-denude,denude,词,VERB,C1
-deodorize,deodorize,词,VERB,C1
-deontology,deontology,词,NOUN,C1
-department director,department director,司长,NOUN,C1
-departmental,departmental,词,ADJ,B2
-departure lounge,departure lounge,候机室,NOUN,B2
-dependence,dependence,依赖,NOUN,B2
-dependency,dependency,词,NOUN,B2
-dependent passivity,dependent passivity,词,NOUN,C1
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-deplete,deplete,词,VERB,C1
-depletion,depletion,词,NOUN,C1
-deplorable,deplorable,可悲的,ADJ,B2
-depone,depone,词,VERB,C1
-depopulation,depopulation,词,NOUN,B2
-deportation,deportation,驱逐出境,NOUN,B2
-deposed,deposed,词,ADJ,C1
-deposition,deposition,证词,NOUN,B2
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depot,depot,仓库,NOUN,B2
-depravity,depravity,堕落,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-deprecation,deprecation,词,NOUN,C1
-depredate,depredate,词,VERB,C1
-depredation,depredation,词,NOUN,C1
-depressing,depressing,词,ADJ,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
-deprimieren,to depress,使沮丧,VERB,B2
-deputation,deputation,代表团,NOUN,B2
-depute,depute,词,VERB,C1
-deputy,deputy,议员,NOUN,B2
-der,a,一个,DET,B2
-deracinate,deracinate,词,VERB,C1
-derailment,derailment,词,NOUN,C1
-derange,derange,词,VERB,C1
-derby,derby,词,NOUN,B2
-deregulate,deregulate,词,VERB,C1
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-deride,deride,词,VERB,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
-derivation,derivation,词,NOUN,C1
-dermal,dermal,词,ADJ,C1
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-desalination,desalination,词,NOUN,C1
-descant,descant,词,VERB,C1
-descend go down,descend go down,词,VERB,A1
-descendants,descendants,词,NOUN,C1
-descending,descending,词,ADJ,C1
-describable,describable,词,ADJ,C1
-descriptive,descriptive,描述性的,ADJ,B2
-descriptiveness,descriptiveness,词,NOUN,C1
-descry,descry,词,VERB,C1
-desecrate,desecrate,词,VERB,C1
-desecration,desecration,词,NOUN,C1
-desegregate,desegregate,词,VERB,C1
-deserter,deserter,词,NOUN,C1
-desertion,desertion,逃亡,NOUN,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desiccation,desiccation,词,NOUN,C1
-desinfizieren,to disinfect,消毒,VERB,B2
-desirability,desirability,可取性,NOUN,B2
-desirable,desirable,可取的,ADJ,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desirous,desirous,词,ADJ,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-desolation,desolation,荒凉,NOUN,B2
-desorientieren,to disorient,使迷失方向,VERB,B2
-despatch,despatch,词,VERB,C1
-desperately serious,desperately serious,不得了,ADJ,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despond,despond,词,VERB,C1
-despondency,despondency,词,NOUN,C1
-despotic,despotic,词,ADJ,C1
-desquamation,desquamation,词,NOUN,C1
-destabilisieren,to destabilize,使不稳定,VERB,B2
-destine,destine,词,VERB,C1
-destined,destined,,NOUN,B2
-destitute,destitute,词,ADJ,C1
-destroyed,destroyed,被毁坏的,ADJ,B2
-destroyer,destroyer,词,NOUN,C1
-destruction of property,destruction of property,毁坏财物,NOUN,C1
-detachable,detachable,词,ADJ,C1
-detached house,detached house,独栋房屋,NOUN,B2
-details,details,细细,NOUN,C1
-detainee,detainee,被拘留者,NOUN,B2
-detector,detector,词,NOUN,C1
-detention center,detention center,拘留所,NOUN,B2
-deter,deter,词,VERB,C1
-detergent,detergent,洗涤剂,NOUN,B2
-deteriorated,deteriorated,恶化的,ADJ,B2
-deterioration,deterioration,恶化,NOUN,B2
-determinant,determinant,词,NOUN,C1
-determine,determine,确定,VER! B,B2
-determined definite,determined definite,确定的,ADJ,B2
-determinist,determinist,词,ADJ,C1
-deterministisch,deterministic,决定论的,ADJ,B2
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
-detonieren,to detonate,引爆,VERB,B2
-detractor,detractor,词,NOUN,C1
-detriment,detriment,损害,NOUN,B2
-detrimental,detrimental,有害的,ADJ,B2
-detritus,detritus,词,NOUN,C1
-deutlich,distinct,明显的,ADJ,B2
-deutlich,clearly,清楚地,ADV,B2
-devaluation,devaluation,贬值,NOUN,B2
-devastated,devastated,词,ADJ,B2
-devastating,devastating,毁灭性的,ADJ,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-deviance,deviance,词,NOUN,B2
-device system,device system,词,NOUN,B1
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devilish,devilish,恶魔般的,ADJ,B2
-devious,devious,词,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid,devoid,词,ADJ,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolution,devolution,词,NOUN,C1
-devolve,devolve,词,VERB,C1
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devourer,devourer,吞噬者,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-devoutly,devoutly,词,ADV,C1
-dexterity,dexterity,灵巧,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
-diabetic,diabetic,词,ADJ,C1
-diabolical,diabolical,恶魔般的,ADJ,B2
-diachrony,diachrony,词,NOUN,C1
-diaeresis,diaeresis,词,NOUN,C1
-diagnostizieren,to diagnose,诊断,VERB,B2
-diagonal,diagonal,对角线,NOUN,B2
-diagonally,diagonally,对角地,ADV,B2
-dial (noun),dial,词,NOUN,C1
-dial (verb),dial,词,VERB,B2
-dialectic (adj),dialectic,词,ADJ,C1
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialectician,dialectician,词,NOUN,C1
-dialing code,dialing code,词,NOUN,C1
-dialogisieren,dialogue,对话,NOUN,B2
-dialogisieren,to dialogue,对话,VERB,B2
-dialogism,dialogism,词,NOUN,C1
-diameter,diameter,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
-diapers,diapers,词,NOUN,B1
-diaphanous,diaphanous,词,ADJ,C1
-diaphragm,diaphragm,横膈膜,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-diatribe,diatribe,词,NOUN,C1
-dichotomy,dichotomy,二分法,NOUN,B2
-dick,thick,厚的,ADJ,B2
-dictation,dictation,dictation,NOUN,B2
-dictator,dictator,独裁者,NOUN,B2
-diction,diction,措辞,NOUN,B2
-didactic,didactic,教学的,ADJ,B2
-didactics,didactics,词,NOUN,C1
-die Disziplin verletzen,to violate discipline,违纪,VERB,B2
-dies,this,您这,NOUN,B2
-diese,these,这些,DET,B2
-diese Drei,these three,这三,NOUN,B2
-diese Schlacht,this battle,此战,NOUN,B2
-dieser Artikel,this item,这件,NOUN,B2
-dieser Weg,this way,这样,PRON,B2
-dieses Lager,this-camp,这营,NOUN,B2
-dietary,dietary,词,ADJ,C1
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
-differenzieren,to differentiate,区分,VERB,B2
-difficult flirt,difficult flirt,,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-diffundieren,to diffuse,扩散,VERB,B2
-diffusely,diffusely,词,ADV,C1
-diffusion,diffusion,传播,NOUN,B2
-diffusion spread,diffusion spread,词,NOUN,C1
-dig up,dig up,词,VERB,B2
-digestible,digestible,词,ADJ,C1
-digital,digital,数字的,ADJ,B2
-digital currency,digital currency,数字货币,NOUN,C1
-digitized,digitized,词,ADJ,C1
-diglossia,diglossia,词,NOUN,C1
-dignified,dignified,词,ADJ,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignify,dignify,词,VERB,C1
-dignitaries,dignitaries,词,NOUN,C1
-dignitary,dignitary,高官,NOUN,B2
-digression,digression,词,NOUN,C1
-dike,dike,词,NOUN,B2
-diktieren,to dictate,口述,VERB,B2
-dilated,dilated,词,ADJ,C1
-dilatieren,to dilate,膨胀,VERB,B2
-dilatory,dilatory,拖延的,ADJ,B2
-dilution,dilution,词,NOUN,C1
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-diminutive,diminutive,指小词,NOUN,B2
-dimmed,dimmed,词,ADJ,C1
-dimple,dimple,词,NOUN,C1
-din,din,喧嚣,NOUN,B2
-dine,dine,词,VERB,C1
-dinghy,dinghy,词,NOUN,C1
-dining hall,dining hall,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
-diocesan,diocesan,词,ADJ,C1
-diocese,diocese,词,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diploma,diploma,文凭,NOUN,B2
-diplomat,diplomat,词,NOUN,C1
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-dipsomaniac,dipsomaniac,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directing,directing,导演,NOUN,B2
-directionality,directionality,词,NOUN,C1
-directive (adj),directive,词,ADJ,C1
-directness,directness,词,NOUN,C1
-director manager,director manager,主管/经理,NOUN,B2
-directorate,directorate,局,NOUN,C1
-directorship,directorship,董事职位,NOUN,B2
-directory,directory,词,NOUN,C1
-direkt,directly,直接地,ADV,B2
-dirham,dirham,词,NOUN,A1
-dirt filth,dirt filth,词,NOUN,C1
-dirt soil,dirt soil,词,NOUN,A1
-dirtier,dirtier,更脏的,ADJ,B2
-dirty trick,dirty trick,词,NOUN,B2
-disable,disable,词,VERB,C1
-disadvantaged,disadvantaged,词,ADJ,C1
-disadvantageous,disadvantageous,不利的,ADJ,B2
-disaffect,disaffect,词,VERB,C1
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disagreeing,disagreeing,不同意的,ADJ,B2
-disallow,disallow,词,VERB,C1
-disapproval,disapproval,词,NOUN,C1
-disarmament,disarmament,裁军,NOUN,B2
-disarray (noun),disarray,词,NOUN,C1
-disassembly,disassembly,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-disbursement,disbursement,词,NOUN,C1
-disc,disc,光盘,NOUN,B2
-discernment,discernment,洞察力,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
-disciplinary,disciplinary,纪律的,ADJ,B2
-disciplined,disciplined,词,ADJ,C1
-disclaim,disclaim,词,VERB,C1
-disclosure,disclosure,泄露,NOUN,C1
-disco,disco,迪厅,NOUN,B2
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
-disconnection,disconnection,词,NOUN,C1
-disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
-disconsolation,disconsolation,词,NOUN,C1
-discontinuity,discontinuity,词,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discounts,discounts,折扣,NOUN,B2
-discouragement,discouragement,词,NOUN,C1
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit,discredit,丧失信誉,NOUN,B2
-discrediting,discrediting,词,NOUN,C1
-discreetly,discreetly,词,ADV,B2
-discrepancy,discrepancy,差异,NOUN,B2
-discrete,discrete,词,ADJ,C1
-discretionary,discretionary,词,ADJ,C1
-discretionary punishment,discretionary punishment,词,NOUN,C1
-discursive,discursive,词,ADJ,C1
-disdainful,disdainful,词,ADJ,C1
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disembarkation,disembarkation,词,NOUN,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenchantment,disenchantment,幻灭,NOUN,B2
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
-disengagement,disengagement,词,NOUN,B2
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disgorge,disgorge,词,VERB,C1
-disgruntle,disgruntle,词,VERB,C1
-dish towel,dish towel,抹布,NOUN,B2
-disharmony,disharmony,不和谐,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-disheveled,disheveled,词,ADJ,B2
-dishonest,dishonest,不诚实的,ADJ,B2
-dishonor,dishonor,耻辱,NOUN,B2
-dishonorable,dishonorable,词,ADJ,C1
-disillusion,disillusion,词,VERB,C1
-disillusionment,disillusionment,词,NOUN,C1
-disincline,disincline,词,VERB,C1
-disinflation,disinflation,词,NOUN,B2
-disinhibited,disinhibited,词,ADJ,C1
-disintegration,disintegration,词,NOUN,B2
-disinter,disinter,词,VERB,C1
-disinvestment,disinvestment,词,NOUN,C1
-disjointed,disjointed,词,ADJ,C1
-disjunkt,disjoint,不相交的,ADJ,B2
-diskreditieren,to discredit,败坏名声,VERB,B2
-diskriminieren,to discriminate,歧视,VERB,B2
-diskutabel,debatable,有争议的,ADJ,B2
-diskutieren,discourse,论述,NOUN,B2
-diskutieren,to discourse,论述,VERB,B2
-dislike,dislike,厌恶,NOUN,B2
-disloyal,disloyal,不忠的,ADJ,B2
-disloyalty,disloyalty,不忠,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
-dismay (noun),dismay,词,NOUN,C1
-dismember,dismember,词,VERB,C1
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
-disobedient,disobedient,不服从的,ADJ,B2
-disorganization,disorganization,词,NOUN,B2
-disorganize,disorganize,词,VERB,C1
-disoriented,disoriented,词,ADJ,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparagement,disparagement,词,NOUN,C1
-disparate,disparate,截然不同的,ADJ,B2
-dispassionate,dispassionate,词,ADJ,C1
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displace,displace,词,VERB,C1
-displaced person,displaced person,词,NOUN,C1
-displacement,displacement,位移,NOUN,B2
-displeased,displeased,词,ADJ,C1
-disport,disport,词,VERB,C1
-disposable,disposable,一次性的,ADJ,B2
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposition,disposition,性情,NOUN,B2
-dispossessed,dispossessed,词,ADJ,C1
-disproportion,disproportion,不成比例,NOUN,B2
-disproportionate,disproportionate,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-disputation,disputation,词,NOUN,C1
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
-disqualification,disqualification,词,NOUN,C1
-disquiet,disquiet,词,NOUN,C1
-disquisition,disquisition,论述,NOUN,B2
-disrepair,disrepair,词,NOUN,C1
-disrepute,disrepute,坏名声,NOUN,B2
-disrespect,disrespect,不敬,NOUN,B2
-disrespectful,disrespectful,无礼的,ADJ,B2
-disrobe,disrobe,词,VERB,C1
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfy,dissatisfy,词,VERB,C1
-dissemble,dissemble,词,VERB,C1
-dissembling,dissembling,词,ADJ,C1
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
-dissert,dissert,词,VERB,C1
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissident,dissident,异见者,NOUN,B2
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
-dissociate,dissociate,词,VERB,C1
-dissociation,dissociation,解离,NOUN,B2
-dissolute,dissolute,词,ADJ,C1
-dissonant,dissonant,词,ADJ,C1
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distich,distich,词,NOUN,C1
-distil,distil,词,VERB,C1
-distillation,distillation,词,NOUN,C1
-distinctive,distinctive,词,ADJ,C1
-distinctly,distinctly,词,ADV,B2
-distinguishable,distinguishable,词,ADJ,C1
-distorted,distorted,歪曲的,ADJ,B2
-distrain,distrain,词,VERB,C1
-distressing,distressing,词,ADJ,B1
-distributed,distributed,词,ADJ,C1
-distributor,distributor,分销商,NOUN,B2
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
-distrustful,distrustful,词,ADJ,C1
-disturbed,disturbed,不安的,ADJ,B2
-disuse,disuse,废弃,NOUN,B2
-disziplinieren,to discipline,管教,VERB,B2
-dithyramb,dithyramb,词,NOUN,C1
-dive appear,dive appear,词,VERB,B2
-diver,diver,词,NOUN,B2
-divergence,divergence,分歧,NOUN,B2
-diverging,diverging,词,ADJ,C1
-diverse,diverse,多样的,ADJ,B2
-diversifizieren,to diversify,使多样化,VERB,B2
-divestment,divestment,词,NOUN,C1
-divide cleavage,divide cleavage,词,NOUN,B2
-divider,divider,词,NOUN,C1
-divinatory,divinatory,词,ADJ,C1
-divine,divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
-divisibility,divisibility,词,NOUN,C1
-divisible,divisible,词,ADJ,B2
-divisive,divisive,词,ADJ,C1
-divisor,divisor,词,NOUN,C1
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
-djellaba,djellaba,词,NOUN,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
-do not want,do not want,不想,VERB,B2
-do one's best (adv),do one's best,竭力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-docile,docile,温顺的,ADJ,B2
-docilely,docilely,词,ADV,C1
-doctor visit,doctor visit,,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
-doctrinaire,doctrinaire,教条主义的,ADJ,B2
-doctrine,doctrine,词,NOUN,B2
-documentary,documentary,纪录片,NOUN,B2
-documentation,documentation,文献,NOUN,B2
-documented,documented,词,ADJ,C1
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-doggedly,doggedly,词,ADV,C1
-dogmatisch,dogmatic,教条的,ADJ,B2
-dollar,dollar,词,NOUN,C1
-domain,domain,领域,NOUN,B2
-domestic,domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
-domesticate,domesticate,词,VERB,C1
-domestisch,domestic,国内的,ADJ,B2
-dominance,dominance,威权,NOUN,B2
-dominant,dominant,占主导地位的,ADJ,B2
-domineering,domineering,词,ADJ,C1
-domineeringness,domineeringness,支配欲,NOUN,B2
-dominieren,to dominate,支配,VERB,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
-donation of goods,donation of goods,捐物,NOUN,C1
-donkey foal,donkey foal,词,NOUN,B2
-doom,doom,词,VERB,C1
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door lock,door lock,门锁,NOUN,C1
-doorkeeper,doorkeeper,词,NOUN,B1
-doorway,doorway,门口,NOUN,C1
-dope (noun),dope,词,NOUN,B2
-doping,doping,词,NOUN,C1
-doping agents,doping agents,词,NOUN,B2
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
-dort,there,那儿,NOUN,B2
-dossier,dossier,档案,NOUN,B2
-dot,dot,点,NOUN,B2
-dotting,dotting,词,NOUN,C1
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubling,doubling,加倍,NOUN,B2
-doubtful,doubtful,可疑的,ADJ,B2
-doughy,doughy,面团状的,ADJ,B2
-douse,douse,词,VERB,C1
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downfall,downfall,毁灭,NOUN,B2
-downgrade,downgrade,词,VERB,C1
-downplay,downplay,词,VERB,C1
-downplaying,downplaying,词,NOUN,C1
-downright,downright,词,ADV,B1
-downsize,downsize,词,VERB,C1
-downstairs,downstairs,词,ADV,B1
-doze (noun),doze,词,NOUN,C1
-doze (verb),doze,词,VERB,C1
-doze off,doze off,词,VERB,B2
-dozens,dozens,数十个,NOUN,B2
-draconian,draconian,词,ADJ,C1
-draftsman,draftsman,绘图员,NOUN,B2
-drag,drag,拖曳,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragoon,dragoon,词,VERB,C1
-drahtlos,wireless,无线的,ADJ,B2
-drainage,drainage,词,NOUN,C1
-drainage sewage,drainage sewage,词,NOUN,C1
-dramatisieren,to dramatize,戏剧化,VERB,B2
-dramatization,dramatization,词,NOUN,C1
-drastic,drastic,词,ADJ,C1
-draught,draught,词,NOUN,C1
-draw,draw,平局,NOUN,B2
-draw blood,draw blood,抽血,VERB,B2
-draw on the experience of,to draw on the experience of,借鉴,VERB,B2
-draw out,draw out,引出,NOUN,B2
-drawback,drawback,缺点,NOUN,B2
-drawl,drawl,词,VERB,C1
-dread,dread,恐惧,NOUN,B2
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge (noun),dredge,词,NOUN,B2
-dredge (verb),dredge,词,VERB,C1
-dregs,dregs,渣滓,NOUN,B2
-dreifach,triple,三倍的,ADJ,B2
-dreizehn,thirteen,十三,NUM,B2
-drench,drench,词,VERB,C1
-dreschen,to winnow,筛选,VERB,B2
-dress up,to dress up,盛装打扮,VERB,B2
-dressed,dressed,穿着的,ADJ,B2
-dressing room,dressing room,词,NOUN,B2
-dribble,dribble,词,VERB,C1
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
-dried tofu,dried tofu,豆干,NOUN,B2
-drift,drift,漂移,NOUN,B2
-drift (verb),drift,词,VERB,B2
-drift excess,drift excess,词,NOUN,C1
-drifting,drifting,漂泊,NOUN,B2
-drill,drill,钻头,NOUN,B2
-dringend,pressing,紧迫的,ADJ,B2
-drinking,drinking,喝水,NOUN,C1
-drinking water,drinking water,饮用水,NOUN,B2
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-dritte Gabe,third bestowal,三授,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-drivel,drivel,词,NOUN,C1
-driven,driven,被驾驶的,ADJ,B2
-driving,driving,你来驾车,NOUN,C1
-drizzle,drizzle,毛毛雨,NOUN,B2
-drizzly,drizzly,词,ADJ,C1
-drool,drool,口水,NOUN,B2
-droop,droop,词,VERB,C1
-drop,to drop,掉落,VERB,B2
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
-dropper,dropper,词,NOUN,C1
-droppings,droppings,粪便,NOUN,B2
-drops,drops,词,NOUN,B1
-drowning,drowning,词,NOUN,C1
-drowsiness,drowsiness,昏睡,NOUN,B2
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drug medication,drug medication,词,NOUN,C1
-drugs,drugs,毒品,NOUN,B2
-drum,drum,鼓,NOUN,B2
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
-drunkenness,drunkenness,醉酒,NOUN,B2
-dry cleaner,dry cleaner,词,NOUN,A2
-dry land,dry land,词,NOUN,B2
-dry sausage,dry sausage,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-dual,dual,词,ADJ,C1
-dual form,dual form,词,NOUN,C1
-dualism,dualism,二元论,NOUN,B2
-duality,duality,二元性,NOUN,B2
-dub,dub,词,VERB,C1
-dubbing,dubbing,配音,NOUN,B2
-duchess,duchess,公爵夫人,NOUN,B2
-duct pipe,duct pipe,词,NOUN,B2
-ductile,ductile,词,ADJ,C1
-dude,dude,词,NOUN,A2
-due date maturity,due date maturity,词,NOUN,B2
-duel,duel,词,NOUN,C1
-duet,duet,二重奏,NOUN,B2
-dull,dull,枯燥的,ADJ,B2
-dull-witted,dull-witted,词,ADJ,B2
-dullness,dullness,迟钝,NOUN,B2
-duly,duly,词,ADV,C1
-dumbfound,dumbfound,词,VERB,C1
-dummes Mädchen,silly girl,傻丫头,NOUN,B2
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dump site,dump site,词,NOUN,B2
-dumping,dumping,倾销,NOUN,B2
-dumpling,dumpling,丸子,NOUN,B2
-dune,dune,沙丘,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-dungeon,dungeon,地牢,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicate,duplicate,! 副本,NOUN,B2
-duplicate,to duplicate,复制,VERB,B2
-duplicate (noun),duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
-duplicity,duplicity,口是心非,NOUN,B2
-durability,durability,耐用性,NOUN,B2
-durable,durable,词,ADJ,C1
-durchlässig,permeable,可渗透的,ADJ,B2
-durchmachen,to undergo,经历,VERB,B2
-durian,durian,榴莲,NOUN,C1
-durstig,thirsty,口渴的,ADJ,B2
-dusk,dusk,黄昏,NOUN,B2
-dust coat,dust coat,词,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-dutch,dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
-duvet,duvet,羽绒被,NOUN,B2
-dwell,dwell,词,VERB,C1
-dwelling,dwelling,住宅,NOUN,B2
-dwindle,dwindle,词,VERB,C1
-dwindling,dwindling,词,NOUN,C1
-dyed,dyed,词,ADJ,B1
-dying,dying,垂死的,ADJ,B2
-dying (noun),dying,dying,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamics,dynamics,词,NOUN,C1
-dynamism,dynamism,活力,NOUN,B2
-dynamite,dynamite,炸药,NOUN,B2
-dynasty,dynasty,王朝,NOUN,B2
-dysfunction,dysfunction,功能障碍,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
-dystopia,dystopia,反乌托邦,NOUN,B2
-e-reader,e-reader,电子阅读器,NOUN,B2
-each,each,每个,DET,B2
-each (noun),each,一一,NOUN,C1
-each (pron),each,各自,PRON,B2
-each every,each every,每,DET,A1
-each one,each one,词,PRON,B2
-eager,eager,渴望的,ADJ,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-eagerness,eagerness,词,NOUN,B2
-earlier,earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
-early,early,早,ADV,B2
-early (noun),early,词,NOUN,B2
-early morning,early morning,凌晨,NOUN,B2
-early morning (adv),early morning,词,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-earnest,earnest,词,ADJ,B1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears,ears,耳朵,NOUN,B2
-ears of wheat,ears of wheat,词,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easier,easier,词,ADJ,B2
-easily,easily,词,ADV,B2
-easing,easing,词,NOUN,C1
-east bank,east bank,东岸,NOUN,C1
-eastward,eastward,词,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
-eating,eating,,NOUN,B2
-eating habit,eating habit,词,NOUN,C1
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-ebb tide,ebb tide,词,NOUN,B1
-eccentricity,eccentricity,古怪,NOUN,B2
-ecclesial,ecclesial,词,ADJ,C1
-echoes,echoes,词,NOUN,C1
-echt,genuine,真正的,ADJ,B2
-eclectic,eclectic,词,ADJ,C1
-eclecticism,eclecticism,折衷主义,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-economic climate,economic climate,词,NOUN,B2
-economic cycle,economic cycle,词,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economically,economically,词,ADV,B1
-economize,economize,词,VERB,C1
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eczema,eczema,湿疹,NOUN,B2
-eddy,eddy,词,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edging,edging,镶边,NOUN,B2
-edible,edible,词,ADJ,C1
-edifying,edifying,词,ADJ,C1
-edit (noun),edit,重辑,NOUN,B2
-editing,editing,剪辑,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
-editorial office,editorial office,词,NOUN,B2
-educational,educational,教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
-efface,efface,词,VERB,C1
-effect and traces,effect and traces,词,NOUN,C1
-effect-seeking,effect-seeking,词,NOUN,C1
-effectively,effectively,有效地,ADV,B2
-effects,effects,词,NOUN,B2
-effectuate,effectuate,词,VERB,C1
-effervesce,effervesce,词,VERB,C1
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,词,ADJ,C1
-effigy,effigy,词,NOUN,C1
-effizient,efficient,高效的,ADJ,B2
-effort bet,effort bet,努力/赌注,NOUN,B2
-effortless,effortless,不费力的,ADJ,B2
-effuse,effuse,词,VERB,C1
-egalitarian,egalitarian,平等主义的,ADJ,B2
-egg card,egg card,,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-egg-laying,egg-laying,词,NOUN,B2
-ego,ego,词,NOUN,C1
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egyptian,egyptian,埃及的,ADJ,B2
-ehrenamtlich,honorary,名誉的,ADJ,B2
-ehrlich,honestly,诚实地,ADV,B2
-ehrwürdig,venerable,值得尊敬的,ADJ,B2
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eifersüchtig sein,to be jealous,嫉妒,VERB,B2
-eight (noun),eight,词,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-eighteen,eighteen,十八,NUM,B2
-eighth,eighth,第八,ADJ,B2
-eighty,eighty,八十,NUM,B2
-ein Buch,one book,一本,NUM,B2
-ein Kopf,one head,一头,NUM,B2
-ein Satz,one set,一套,NUM,B2
-ein Schuss,one shot,一枪,NUM,B2
-ein Tag,one day,一天,NUM,B2
-einatmen,to inhale,吸入,VERB,B2
-einberufen,to convene,召集,VERB,B2
-einbetten,to embed,嵌入,VERB,B2
-einbeziehen,to implicate,连累,VERB,B2
-eindeutig,clear-cut,明确的,ADJ,B2
-eindämmen,to curb,抑制,VERB,B2
-eine Familie,one family,一家,NUM,B2
-eine Nacht,one night,一晚,NUM,B2
-eine Wohnung,one flat,一张,NUM,B2
-einfach,simple,简单的,ADJ,B2
-einfach,simply,简单地,ADV,B2
-eingebildet,conceited,自负的,ADJ,B2
-eingehend,incoming,进来的,ADJ,B2
-einhalten,to comply with,遵守,VERB,B2
-einheimisch,indigenous,本土的,ADJ,B2
-einheimisch,native,本地的,ADJ,B2
-einlösen,to cash,兑现,VERB,B2
-einsalzen,to pickle,腌渍,VERB,B2
-einschalten,to turn on,打开,VERB,B2
-einschließen,to include,包括,VERB,B2
-einschreiben,to enroll,注册,VERB,B2
-einschränken,to constrain,限制,VERB,B2
-einseitig,one-sided,单方面的,ADJ,B2
-einsperren,to imprison,监禁,VERB,B2
-einstimmig,unanimous,一致的,ADJ,B2
-eintauchen,to dip,蘸,VERB,B2
-eintreten,to enter city,进城,VERB,B2
-einverleiben,to incorporate,包含,VERB,B2
-einweichen,to soak,浸透,VERB,B2
-einzeln,single,单一的,ADJ,B2
-eisern,iron,铁的,ADJ,B2
-eitern,to fester,溃烂,VERB,B2
-either (adv),either,词,ADV,B2
-ejection,ejection,喷射,NOUN,B2
-elaboration,elaboration,词,NOUN,C1
-elation,elation,兴高采烈,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
-elderly,elderly,老年人,NOUN,B2
-eldest,eldest,词,ADJ,A2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective,elective,词,ADJ,C1
-elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
-electric (noun),electric,词,NOUN,B2
-electric guitar,electric guitar,电吉他,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electric power,electric power,电力,NOUN,B2
-electrical engineering,electrical engineering,词,NOUN,C1
-electrical theory,electrical theory,词,NOUN,B2
-electrification,electrification,词,NOUN,C1
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
-electronics,electronics,电子学,NOUN,B2
-elegance,elegance,词,NOUN,C1
-elegant,elegant,优雅的,ADJ,B2
-elektronisch,electronic,电子的,ADJ,B2
-elemental,elemental,词,ADJ,B2
-elementary,elementary,基本的,ADJ,B2
-elevated,elevated,词,ADJ,C1
-eleventh,eleventh,词,NUM,B1
-elf,elf,词,NOUN,C1
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,词,NOUN,C1
-ellipsis,ellipsis,省略,NOUN,B2
-ellipsis (part),ellipsis,…,PART,C1
-elocution,elocution,演讲术,NOUN,B2
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
-else,else,词,ADV,A1
-elsewhere,elsewhere,别处,ADV,B2
-elucidation,elucidation,词,NOUN,C1
-elusive,elusive,难以捉摸的,ADJ,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciated,emaciated,词,ADJ,C1
-emaciating,emaciating,消耗的,ADJ,B2
-emaciation,emaciation,词,NOUN,C1
-email address,email address,电子邮件地址,NOUN,B2
-emanieren,to emanate,散发,VERB,B2
-emanzipieren,to emancipate,解放,VERB,B2
-embalm,embalm,词,VERB,C1
-embargo,embargo,禁运,NOUN,B2
-embattle,embattle,词,VERB,C1
-embers,embers,词,NOUN,B1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-emblem,emblem,徽章,NOUN,B2
-emblematic,emblematic,象征性的,ADJ,B2
-embodiment,embodiment,词,NOUN,B2
-embolism,embolism,栓塞,NOUN,B2
-emboss,emboss,词,VERB,C1
-embrace (noun),embrace,搂,NOUN,B2
-embrace each other,embrace each other,词,VERB,B2
-embroil,embroil,词,VERB,C1
-embryo,embryo,胚胎,NOUN,B2
-embryonic,embryonic,词,ADJ,C1
-emend,emend,词,VERB,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emerging,emerging,词,ADJ,C1
-emigration,emigration,移民,NOUN,B2
-eminence,eminence,词,NOUN,C1
-eminent,eminent,杰出的,ADJ,B2
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emitter,emitter,词,NOUN,C1
-emittieren,to emit,发出,VERB,B2
-emolument,emolument,词,NOUN,C1
-emote,emote,词,VERB,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
-emotional life,emotional life,词,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emotionally,emotionally,情感上,ADV,B2
-empathetic,empathetic,词,ADJ,B1
-empfangen,to receive mail,收件,VERB,B2
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-emphatically,emphatically,词,ADV,C1
-empirically,empirically,词,ADV,B2
-empirisch,empirical,经验的,ADJ,B2
-employability,employability,词,NOUN,B2
-employers,employers,词,NOUN,B1
-emporium,emporium,词,NOUN,C1
-empowerment,empowerment,词,NOUN,C1
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-empört,indignant,愤慨的,ADJ,B2
-emulation,emulation,模仿,NOUN,B2
-emulator,emulator,词,NOUN,C1
-emulieren,to emulate,效仿,VERB,B2
-emulsify,emulsify,词,VERB,C1
-emulsion,emulsion,词,NOUN,C1
-enamel,enamel,珐琅,NOUN,B2
-enamel (verb),enamel,词,VERB,C1
-enamor,enamor,词,VERB,C1
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encampments,encampments,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-encephalic,encephalic,词,ADJ,C1
-enchain,enchain,词,VERB,C1
-encirclement,encirclement,环绕,NOUN,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encoding,encoding,编码,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore (noun),encore,词,NOUN,C1
-encouraging,encouraging,词,ADJ,C1
-encroachment,encroachment,词,NOUN,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encrypted,encrypted,词,ADJ,B2
-encumber,encumber,词,VERB,C1
-endear,endear,词,VERB,C1
-endeavor (verb),endeavor,词,VERB,C1
-endemic,endemic,地方性的,ADJ,B2
-endemic disease,endemic disease,词,NOUN,B2
-ending,ending,了头,NOUN,C1
-endlich,finite,有限的,ADJ,B2
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,词,ADJ,C1
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowed,endowed,有天赋的,ADJ,B2
-endowment,endowment,配备,NOUN,B2
-endue,endue,词,VERB,C1
-enduring hardship,enduring hardship,词,NOUN,C1
-enemy army,enemy army,敌军,NOUN,C1
-energetisch,energetic,精力充沛的,ADJ,B2
-energize,energize,词,VERB,C1
-energy crisis,energy crisis,能源危机,NOUN,B2
-energy saving,energy saving,节能,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfold,enfold,词,VERB,C1
-enforceability,enforceability,词,NOUN,C1
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-enfranchise,enfranchise,词,VERB,C1
-engender,engender,词,VERB,C1
-engine motor,engine motor,词,NOUN,C1
-english teacher,english teacher,,NOUN,B2
-english-speaking,english-speaking,讲英语的,ADJ,B2
-engraft,engraft,词,VERB,C1
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
-engrossing,engrossing,词,ADJ,B2
-engulf,engulf,词,VERB,C1
-enigma,enigma,词,NOUN,C1
-enigmatic,enigmatic,神秘的,ADJ,B2
-enjambment,enjambment,词,NOUN,C1
-enjoin,enjoin,词,VERB,C1
-enjoyable,enjoyable,词,ADJ,B1
-enkindle,enkindle,词,VERB,C1
-enlargement,enlargement,词,NOUN,C1
-enlightening,enlightening,词,ADJ,C1
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enmesh,enmesh,词,VERB,C1
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enquire,enquire,词,VERB,C1
-enraged,enraged,词,ADJ,C1
-enriching,enriching,词,ADJ,C1
-enrolled,enrolled,词,ADJ,B2
-ensconce,ensconce,词,VERB,C1
-enshrine,enshrine,词,VERB,C1
-enshrinement,enshrinement,词,NOUN,C1
-enshroud,enshroud,词,VERB,C1
-ensign,ensign,词,NOUN,C1
-enslavement,enslavement,奴役,NOUN,B2
-enslavement by love,enslavement by love,词,NOUN,C1
-ensue,ensue,词,VERB,B2
-entanglement,entanglement,缠,NOUN,C1
-enteignen,to expropriate,征用,VERB,B2
-entelechy,entelechy,词,NOUN,C1
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
-entertainer,entertainer,词,NOUN,B2
-entertaining,entertaining,有趣的,ADJ,B2
-entfalten,to unfold,展开,VERB,B2
-entfesseln,to unleash,释放,VERB,B2
-entgegen,opposite,相反的,ADJ,B2
-entgiften,to detoxify,解毒,VERB,B2
-entgleisen,to derail,使脱轨,VERB,B2
-enticement,enticement,词,NOUN,C1
-entitle,entitle,词,VERB,C1
-entitled to exist,entitled to exist,词,ADJ,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
-entlasten,to exonerate,使无罪,VERB,B2
-entmutigen,to discourage,使气馁,VERB,B2
-entomb,entomb,词,VERB,C1
-entomology,entomology,词,NOUN,C1
-entrails,entrails,内脏,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entreat,entreat,词,VERB,C1
-entreißen,to wrest,强行夺取,VERB,B2
-entrenchment,entrenchment,词,NOUN,C1
-entrepreneurship,entrepreneurship,词,NOUN,C1
-entropy,entropy,熵,NOUN,B2
-entscheidend,crucial,至关重要的,ADJ,B2
-entschließen,to resolve,解决,VERB,B2
-entschlossen,resolute,坚决的,ADJ,B2
-entsetzen,to horrify,使惊骇,VERB,B2
-entsetzlich,horrifying,令人毛骨悚然的,ADJ,B2
-entspannt,at ease,安心,ADJ,B2
-enttäuschend,disappointing,令人失望的,ADJ,B2
-enttäuscht,disappointed,失望的,ADJ,B2
-entwaffnen,to disarm,解除武装,VERB,B2
-entwerten,to debase,贬低,VERB,B2
-entwerten,to devalue,贬值,VERB,B2
-entwickelt,developed,发达的,ADJ,B2
-entwine,entwine,词,VERB,C1
-entwöhnen,to wean,断奶,VERB,B2
-entziffern,to decipher,破译,VERB,B2
-entzückend,delightful,令人愉快的,ADJ,B2
-enumeration,enumeration,列举,NOUN,B2
-enunciative,enunciative,词,ADJ,C1
-envelop,envelop,词,VERB,C1
-envenom,envenom,词,VERB,C1
-enviable,enviable,令人羡慕的,ADJ,B2
-envious jealous,envious jealous,词,ADJ,B2
-environ,environ,词,VERB,C1
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
-envoy,envoy,词,NOUN,B2
-enwetens,enwetens,词,ADV,C1
-enzyklopädisch,encyclopedic,百科全书式的,ADJ,B2
-eon age,eon age,词,NOUN,C1
-ephemeral,ephemeral,短暂的,ADJ,B2
-epic,epic,史诗的,ADJ,B2
-epic quality,epic quality,词,NOUN,C1
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epigraph,epigraph,题词,NOUN,B2
-epikureisch,epicurean,享乐主义的,ADJ,B2
-epilepsy,epilepsy,词,NOUN,C1
-epilogue,epilogue,词,NOUN,C1
-episodic,episodic,词,ADJ,C1
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,墓志铭,NOUN,B2
-epithet,epithet,绰号,NOUN,B2
-epitomize,epitomize,词,VERB,C1
-epoch,epoch,时代,NOUN,B2
-eponymous,eponymous,词,ADJ,C1
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally,equally,词,ADV,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equatorial,equatorial,词,ADJ,C1
-equestrian,equestrian,马术的,ADJ,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,词,ADJ,C1
-equilibrate,equilibrate,词,VERB,C1
-equity,equity,公平,NOUN,B2
-equivalent,equivalent,相等的,ADJ,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
-equivocate,equivocate,词,VERB,C1
-erection,erection,词,NOUN,C1
-erfahren,experienced,老练的,ADJ,B2
-ergonomics,ergonomics,词,NOUN,C1
-ergänzend,complementary,互补的,ADJ,B2
-erhaben,lofty,崇高的,ADJ,B2
-erkennen,to detect,探测,VERB,B2
-erkennen,to know to recognize,认识,VERB,B2
-erklären,to declare,宣布,VERB,B2
-erlassen,decree,法令,NOUN,B2
-erlassen,to decree,颁布法令,VERB,B2
-erlassen,to enact,颁布,VERB,B2
-erläutern,to expound,阐述,VERB,B2
-ermahnen,to exhort,劝告,VERB,B2
-ermorden,to assassinate,暗杀,VERB,B2
-ermutigen,to encourage,鼓励,VERB,B2
-ermächtigen,to empower,授权,VERB,B2
-erneut herausgeben,to reissue,补办,VERB,B2
-erotic,erotic,色情的,ADJ,B2
-eroticism,eroticism,色情,NOUN,B2
-erpressen,to extort,敲诈,VERB,B2
-errant,errant,词,ADJ,C1
-erratic,erratic,不稳定的,ADJ,B2
-erreichen,to attain,达到,VERB,B2
-erroneous,erroneous,词,ADJ,C1
-erschrecken,to terrify,使恐惧,VERB,B2
-erschreckend,terrifying,令人恐惧的,ADJ,B2
-erschwinglich,affordable,负担得起的,ADJ,B2
-erschöpfend,exhaustive,详尽的,ADJ,B2
-erst dann,only then,才,ADV,B2
-erstatten,to reimburse,偿还,VERB,B2
-erstaunlich,amazing,令人惊叹的,ADJ,B2
-ersuchen,to solicit,恳求,VERB,B2
-erteilen,to impart,传授,VERB,B2
-erudite,erudite,博学的,ADJ,B2
-erudition,erudition,博学,NOUN,B2
-erupt,erupt,词,VERB,C1
-erwarten,to anticipate,预期,VERB,B2
-erwarten,to await,等待,VERB,B2
-erweitern,to widen,加宽,VERB,B2
-erwürgen,to strangle,扼杀,VERB,B2
-erziehen,to nurture,养育,VERB,B2
-erzählen,to narrate,叙述,VERB,B2
-erzählen,to recount,转述,VERB,B2
-erzählen,to relate to narrate,叙述,VERB,B2
-es sei denn,unless,除非,SCONJ,B2
-escaping,escaping,词,NOUN,C1
-eschatological,eschatological,词,ADJ,C1
-eschatology,eschatology,词,NOUN,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escort (noun),escort,你带人,NOUN,B2
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-esophagus,esophagus,词,NOUN,B2
-esoteric,esoteric,词,ADJ,C1
-esotericism,esotericism,词,NOUN,B2
-espresso,espresso,词,NOUN,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-essayistic quality,essayistic quality,词,NOUN,C1
-essence core,essence core,词,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-estimation,estimation,词,NOUN,C1
-estrange,estrange,词,VERB,C1
-etabliert,established,既定的,ADJ,B2
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
-ethereal,ethereal,飘渺的,ADJ,B2
-ethisch,ethical,道德的,ADJ,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
-ethnisch,ethnic,种族的,ADJ,B2
-etymology,etymology,词源学,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-eunuch,eunuch,词,NOUN,C1
-euphemistic,euphemistic,委婉的,ADJ,B2
-euphonic,euphonic,词,ADJ,C1
-euphoric,euphoric,词,ADJ,C1
-europe,europe,欧洲,PROPN,B2
-europäisch,european,欧洲的,ADJ,B2
-euthanasia,euthanasia,词,NOUN,C1
-evakuieren,to evacuate,疏散,VERB,B2
-evanesce,evanesce,词,VERB,C1
-evangelical,evangelical,词,ADJ,C1
-evangelisieren,to evangelize,传福音,VERB,B2
-evangelist,evangelist,词,NOUN,C1
-evangelization,evangelization,词,NOUN,C1
-evaporate,to evaporate,蒸发,VERB,B2
-evaporating,evaporating,词,ADJ,C1
-evaporation,evaporation,蒸发,NOUN,B2
-evasion,evasion,逃避,NOUN,B2
-evasive,evasive,回避的,ADJ,B2
-eve,eve,前夕,NOUN,C1
-even,even,偶数的,ADJ,B2
-even if,even if,即使,SCONJ,B2
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening meal,evening meal,晚餐,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-evenly,evenly,均匀地,ADV,B2
-events,events,事件,NOUN,C1
-eventual,eventual,词,ADJ,C1
-eventual outcome,eventual outcome,词,NOUN,C1
-eventually,eventually,最终,ADV,B2
-eventuate,eventuate,词,VERB,C1
-ever,ever,,NOUN,B2
-ever,to ever,里何尝,VERB,B2
-everlasting,everlasting,词,ADJ,C1
-everlastingness,everlastingness,词,NOUN,C1
-every,every,每个,PRON,B2
-every day,every day,天天,ADV,B2
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everydayness,everydayness,词,NOUN,B2
-everyone,everyone,各位,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
-evict,to evict,驱逐,VERB,B2
-eviction,eviction,驱逐,NOUN,B2
-evidence,evidence,证据,NOUN,B2
-evidence bag,evidence bag,,NOUN,B2
-evident,evident,明显的,ADJ,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
-evil,evil,邪,PART,B2
-evil (adj),evil,词,ADJ,B1
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evocation,evocation,唤起,NOUN,B2
-evocative,evocative,引起回忆的,ADJ,B2
-evoke,to evoke,唤起,VERB,B2
-evolution,evolution,进化,NOUN,B2
-evolutionary,evolutionary,词,ADJ,C1
-evolve,to evolve,进化,VERB,B2
-ewiger Bund,eternal alliance,永结,NOUN,B2
-exacerbate,to exacerbate,加剧,VERB,B2
-exacerbation,exacerbation,加剧,NOUN,B2
-exact change,exact change,词,NOUN,C1
-exactitude,exactitude,词,NOUN,C1
-exactly just,exactly just,恰好,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exactness,exactness,精确,NOUN,B2
-exaggerate,to exaggerate,夸大,VERB,B2
-exaggeration,exaggeration,夸张,NOUN,B2
-exaltation,exaltation,词,NOUN,C1
-exalted,exalted,狂热的,ADJ,B2
-exam evening,exam evening,词,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-examination,examination,考试,NOUN,B2
-exasperate,to exasperate,激怒,VERB,B2
-exasperation,exasperation,恼怒,NOUN,B2
-excavate,to excavate,挖掘,VERB,B2
-excavated,excavated,词,ADJ,B1
-excavation,excavation,词,NOUN,B2
-excavator,excavator,挖掘机,NOUN,B2
-exceed,to exceed,超过,VERB,B2
-excel,to excel,擅长,VERB,B2
-except for,except for,除了,ADP,B2
-except unless,except unless,词,ADP,A2
-exceptional,exceptional,杰出的,ADJ,B2
-exceptionality,exceptionality,特殊性,NOUN,B2
-exceptionally,exceptionally,词,ADV,B2
-excerpt,excerpt,摘录,NOUN,B2
-excess,excess,过量,NOUN,B2
-excess weight,excess weight,词,NOUN,C1
-excessively,excessively,词,ADV,C1
-excessiveness,excessiveness,词,NOUN,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excision,excision,词,NOUN,C1
-excitability,excitability,兴奋性,NOUN,B2
-excite,to excite,使兴奋,VERB,B2
-exclamation,exclamation,感叹,NOUN,B2
-exclusion,exclusion,排除,NOUN,B2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusive,exclusive,独有的,ADJ,B2
-exclusive dedication,exclusive dedication,词,NOUN,C1
-exclusively,exclusively,专门地,ADV,B2
-exclusivism,exclusivism,词,NOUN,C1
-excrement,excrement,排泄物,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,开脱,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executive board,executive board,词,NOUN,C1
-executory,executory,词,ADJ,C1
-exegete,exegete,注释家,NOUN,B2
-exemplar,exemplar,楷模,NOUN,C1
-exemplary country,exemplary country,模范国家,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercise book,exercise book,词,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exercises,exercises,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhalation,exhalation,词,NOUN,C1
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exhortation,exhortation,词,NOUN,C1
-exhumation,exhumation,词,NOUN,C1
-exhumieren,to exhume,掘出,VERB,B2
-exigent,exigent,词,ADJ,C1
-exile (noun),exile,词,NOUN,B2
-exiled,exiled,词,ADJ,C1
-existential,existential,存在主义的,ADJ,B2
-existentialism,existentialism,存在主义,NOUN,B2
-existing,existing,现有的,ADJ,B2
-exit (verb),exit,词,VERB,A1
-exkommunizieren,to excommunicate,开除教籍,VERB,B2
-exkoriarieren,to excoriate,严厉批评,VERB,B2
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,词,ADJ,C1
-exorcism,exorcism,词,NOUN,C1
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,词,ADJ,B2
-exotic,exotic,异国情调的,ADJ,B2
-exoticism,exoticism,词,NOUN,B2
-expanse,expanse,词,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expansiv,expansive,扩张的,ADJ,B2
-expatiate,expatiate,词,VERB,C1
-expatriate,expatriate,移居国外者,NOUN,B2
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expedite,expedite,词,VERB,C1
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,迅速的,ADJ,B2
-expenditures,expenditures,支出,NOUN,C1
-expensiveness,expensiveness,词,NOUN,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
-experimentation,experimentation,词,NOUN,C1
-experimentell,experimental,实验的,ADJ,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiate,expiate,词,VERB,C1
-expiration,expiration,词,NOUN,C1
-explanatory,explanatory,解释的,ADJ,B2
-expletive,expletive,词,NOUN,C1
-explicable,explicable,可解释的,ADJ,B2
-explicate,explicate,词,VERB,C1
-explicitly,explicitly,明确地,ADV,B2
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
-exploits,exploits,词,NOUN,C1
-exploration,exploration,探索,NOUN,B2
-exploratory,exploratory,词,ADJ,C1
-explosion-proof,explosion-proof,防爆,ADJ,B2
-explosiv,explosive,爆炸性的,ADJ,B2
-explosives,explosives,炸药,NOUN,B2
-exponent,exponent,指数,NOUN,B2
-exponential,exponential,指数的,ADJ,B2
-export (noun),export,词,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exportieren,export,出口,NOUN,B2
-exportieren,to export,出口,VERB,B2
-exports,exports,词,NOUN,C1
-expostulate,expostulate,词,VERB,C1
-express,express,明确的,ADJ,B2
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expression of opinion,expression of opinion,词,NOUN,B2
-expressionism,expressionism,词,NOUN,C1
-expressiveness,expressiveness,表现力,NOUN,B2
-expunge,expunge,词,VERB,C1
-exquisit,exquisite,精致的,ADJ,B2
-exquisiteness,exquisiteness,词,NOUN,C1
-extemporize,extemporize,词,VERB,C1
-extended,extended,广泛的,ADJ,B2
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,在外,NOUN,B2
-extern,external,外部的,ADJ,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinct,extinct,灭绝的,ADJ,B2
-extinguishable,extinguishable,词,ADJ,C1
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extirpation,extirpation,词,NOUN,C1
-extolling,extolling,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
-extra drink,extra drink,多喝,NOUN,C1
-extract,extract,摘录,NOUN,B2
-extrahieren,to extract,提取,VERB,B2
-extramarital,extramarital,词,ADJ,C1
-extrapolation,extrapolation,词,NOUN,C1
-extrapolieren,to extrapolate,推断,VERB,B2
-extraterrestrial,extraterrestrial,外星的,ADJ,B2
-extravagant,extravagant,奢侈的,ADJ,B2
-extraversion,extraversion,词,NOUN,C1
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremist,extremist,极端主义者,NOUN,B2
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-exuberance,exuberance,词,NOUN,C1
-exuberant,exuberant,繁茂的,ADJ,B2
-exudation,exudation,词,NOUN,C1
-exzentrisch,eccentric,古怪的,ADJ,B2
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyebrows,eyebrows,词,NOUN,A1
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
-fabricated,fabricated,词,ADJ,B2
-fabrizieren,to fabricate,捏造,VERB,B2
-fabulist,fabulist,幻想家,NOUN,B2
-fabulous,fabulous,极好的,ADJ,B2
-face,to face,面对,VERB,B2
-face reading,face reading,面相,NOUN,B2
-face recognition,face recognition,认人,NOUN,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facet,facet,方面,NOUN,B2
-facies,facies,面貌,NOUN,B2
-facilitate,to facilitate,促进,VERB,B2
-facilitation,facilitation,词,NOUN,C1
-facilities,facilities,设施,NOUN,B2
-facsimile,facsimile,副本,NOUN,B2
-facticity,facticity,词,NOUN,C1
-faction,faction,派,NOUN,B2
-factionalism,factionalism,派系主义,NOUN,B2
-factious,factious,词,ADJ,C1
-factoring,factoring,保理,NOUN,B2
-factotum,factotum,词,NOUN,C1
-factual,factual,事实的,ADJ,B2
-faculty,faculty,学院,NOUN,B2
-fad,fad,词,NOUN,C1
-fade,to fade,褪色,VERB,B2
-faded,faded,褪色的,ADJ,B2
-fading away,fading away,词,NOUN,C1
-fag,fag,词,NOUN,C1
-failed,failed,失败的,ADJ,B2
-failed bid,failed bid,流标,NOUN,B2
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-failure,failure,失败,NOUN,B2
-failure to act,failure to act,词,NOUN,C1
-faint,faint,微弱的,ADJ,B2
-faint,to faint,昏倒,VERB,B2
-faint (noun),faint,词,NOUN,C1
-fainting,fainting,晕厥,NOUN,B2
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,词,ADJ,B1
-fairly,fairly,词,ADV,C1
-fairness,fairness,词,NOUN,B2
-faith,faith,信仰,NOUN,B2
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake,fake,假的,ADJ,B2
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,假新闻,NOUN,B2
-falcon,falcon,猎鹰,NOUN,B2
-falconry,falconry,猎鹰术,NOUN,B2
-fall back,to fall back,回落,VERB,B2
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallibility,fallibility,易错性,NOUN,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-falling out,falling out,反目,NOUN,B2
-falling though,falling though,虽坠,NOUN,B2
-fallout,fallout,词,NOUN,C1
-fallow land,fallow land,词,NOUN,B2
-falsch,wrong mistake,错误,ADJ,B2
-false,false,错误的,ADJ,B2
-false oath,false oath,词,NOUN,C1
-falsehood,falsehood,谎言,NOUN,B2
-falsely,falsely,词,ADV,C1
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falsification,falsification,词,NOUN,C1
-falsity,falsity,虚假,NOUN,B2
-falten,to fold,折叠,VERB,B2
-falter,falter,词,VERB,C1
-faltering,faltering,词,ADJ,C1
-familial,familial,词,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
-familiarity,familiarity,مألوف,NOUN,B2
-family (adj),family,词,ADJ,B1
-family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family life,family life,家庭生活,NOUN,B2
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family ruin,family ruin,家破,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,词,NOUN,B2
-famine,famine,饥荒,NOUN,B2
-famish,famish,词,VERB,C1
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fan,fan,粉丝,NOUN,B2
-fanatic,fanatic,狂热的,ADJ,B2
-fanaticism,fanaticism,狂热,NOUN,B2
-fancy,fancy,词,ADJ,B1
-fancy decoration,fancy decoration,词,NOUN,C1
-fang,fang,犬齿,NOUN,B2
-fantasize,fantasize,词,VERB,C1
-fantasizing,fantasizing,词,NOUN,C1
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-farce,farce,闹剧,NOUN,B2
-fare,fare,车费,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farming,farming,农业,NOUN,B2
-farmland,farmland,农田,NOUN,C1
-farmstead,farmstead,农庄,NOUN,B2
-farrow,farrow,词,VERB,C1
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascination,fascination,魅力,NOUN,B2
-fascism,fascism,法西斯主义,NOUN,B2
-fascist (adj),fascist,词,ADJ,C1
-fascist (noun),fascist,词,NOUN,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast,to fast,禁食,VERB,B2
-fast forward,fast forward,快进,VERB,C1
-fast quick,fast quick,快的,ADJ,B2
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
-fasting,fasting,禁食,NOUN,B2
-fatalism,fatalism,宿命论,NOUN,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatalist (noun),fatalist,词,NOUN,C1
-fatality,fatality,致命性,NOUN,B2
-fatally,fatally,词,ADV,C1
-fateful,fateful,词,ADJ,C1
-father,father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatness,fatness,词,NOUN,C1
-fats,fats,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatuity,fatuity,愚昧,NOUN,B2
-fatuous,fatuous,词,ADJ,C1
-fatwa,fatwa,词,NOUN,B2
-faucet,faucet,词,NOUN,C1
-faul,rotten,腐烂的,ADJ,B2
-faulty,faulty,词,ADJ,C1
-fauna,fauna,动物群,NOUN,B2
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favorite,favorite,最爱,NOUN,B2
-favoritism,favoritism,偏袒,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawn,fawn,词,VERB,C1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
-fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
-fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
-feast,feast,盛宴,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-feces,feces,屎,NOUN,C1
-fecundate,fecundate,词,VERB,C1
-fecundity,fecundity,词,NOUN,C1
-fed up (adj),fed up,词,ADJ,B1
-fed up (noun),fed up,词,NOUN,B2
-federalization,federalization,联邦化,NOUN,B2
-federalize,federalize,词,VERB,C1
-feeble,feeble,虚弱的,ADJ,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
-feeding,feeding,词,NOUN,C1
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-fehlen,to be absent,缺席,VERB,B2
-fehlen,to lack,缺乏,VERB,B2
-feierlich,solemn,庄严的,ADJ,B2
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-felicitate,felicitate,词,VERB,C1
-felicity,felicity,词,NOUN,C1
-feline,feline,词,ADJ,C1
-fellow citizen,fellow citizen,同胞,NOUN,B2
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
-feminine,feminine,女性的,ADJ,B2
-feminist,feminist,女权主义者,NOUN,B2
-feminization,feminization,词,NOUN,C1
-fend,fend,词,VERB,C1
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-fennec fox,fennec fox,词,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fern,fern,蕨类植物,NOUN,B2
-ferociously,ferociously,词,ADV,C1
-ferret,ferret,雪貂,NOUN,B2
-ferrule,ferrule,词,NOUN,C1
-ferry,ferry,渡轮,NOUN,B2
-fertig sein,to be done,被做,VERB,B2
-fervent,fervent,词,ADJ,C1
-fervor,fervor,词,NOUN,C1
-fesselnd,captivating,迷人的,ADJ,B2
-fest,fixed,固定的,ADJ,B2
-fest greifen,to grasp firmly,抓紧,VERB,B2
-festgefahren,stuck,卡住的,ADJ,B2
-festhalten,to detain,拘留,VERB,B2
-festivals,festivals,词,NOUN,C1
-festive,festive,节日的,ADJ,B2
-festivity,festivity,词,NOUN,C1
-festlegen,to stipulate,规定,VERB,B2
-festnehmen,capture,捕获,NOUN,B2
-festnehmen,to apprehend,逮捕,VERB,B2
-festnehmen,to capture,获取,VERB,B2
-fete,fete,词,VERB,C1
-fetid,fetid,词,ADJ,C1
-fetish,fetish,恋物,NOUN,B2
-fetishism,fetishism,词,NOUN,B2
-fetter,fetter,词,VERB,C1
-feucht,damp,潮湿,ADJ,B2
-feud end,feud end,仇终,NOUN,C1
-feudal,feudal,封建,ADJ,B2
-feudal ethics,feudal ethics,礼教,NOUN,B2
-feuerfest,fireproof,防火的,ADJ,B2
-feverish,feverish,词,ADJ,C1
-few,few,几下,NOUN,B2
-fewer,fewer,较少的,ADJ,B2
-fez,fez,词,NOUN,B2
-fiancee,fiancee,未婚妻,NOUN,B2
-fib,fib,词,VERB,C1
-fibrous,fibrous,词,ADJ,C1
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictionalize,fictionalize,词,VERB,C1
-fictitious,fictitious,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fiddle (verb),fiddle,词,VERB,C1
-fidelity,fidelity,忠诚,NOUN,B2
-fidget,fidget,词,VERB,C1
-fiduciary,fiduciary,词,ADJ,C1
-fief,fief,词,NOUN,B2
-field (adj),field,词,ADJ,C1
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fiend,fiend,词,NOUN,C1
-fierce one,fierce one,词,NOUN,B2
-fiery,fiery,热烈的,ADJ,B2
-fifteen,fifteen,十五,NUM,B2
-fifth,fifth,第五,NUM,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figuration,figuration,群演,NOUN,B2
-figurative,figurative,比喻的,ADJ,B2
-figurative language,figurative language,词,NOUN,C1
-figuratively,figuratively,词,ADV,C1
-figure skating,figure skating,花样滑冰,NOUN,C1
-fiktiv,fictional,虚构的,ADJ,B2
-filament,filament,词,NOUN,C1
-filch,filch,词,VERB,C1
-file a case,file a case,立案,VERB,B2
-file expense,file expense,报账,VERB,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filings,filings,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
-fill pack,fill pack,装满,VERB,B2
-filled,filled,充满的,ADJ,B2
-fillet (noun),fillet,词,NOUN,C1
-fillet (verb),fillet,词,VERB,C1
-filling,filling,词,NOUN,B2
-film art,film art,词,NOUN,C1
-film director,film director,词,NOUN,B2
-film industry,film industry,电影业,NOUN,B2
-film movie,film movie,电影,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,词,NOUN,B2
-filming,filming,拍摄,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
-filth garbage,filth garbage,词,NOUN,C1
-filthy,filthy,肮脏的,ADJ,B2
-fin,fin,词,NOUN,B2
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
-finality,finality,词,NOUN,C1
-finals,finals,决赛,NOUN,B1
-finance,finance,金融,NOUN,B2
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financier,financier,资助者,NOUN,B2
-financing funding,financing funding,融资,NOUN,B2
-find,find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine well,fine well,词,ADJ,A1
-finely,finely,词,ADV,C1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fingernail,fingernail,指甲,NOUN,B2
-finial,finial,词,NOUN,C1
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
-finnish,finnish,芬兰的,ADJ,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-fire a gun,fire a gun,开枪,VERB,B2
-fire brigade,fire brigade,消防队,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire kick,fire kick,词,VERB,A2
-fire station,fire station,词,NOUN,C1
-firearms,firearms,枪支,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firedamp,firedamp,词,NOUN,C1
-firework,firework,词,NOUN,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firm fixed,firm fixed,词,ADJ,B1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
-first (noun),first,先将,NOUN,C1
-first aid,first aid,词,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
-first-class,first-class,一流,ADJ,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisheries,fisheries,词,NOUN,B2
-fishery,fishery,渔业,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing,fishing,钓鱼,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
-fissure,fissure,裂缝,NOUN,B2
-fistula,fistula,瘘管,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fitting out,fitting out,词,NOUN,B2
-fittings,fittings,词,NOUN,C1
-five (adj),five,词,ADJ,C1
-five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fixation,fixation,词,NOUN,C1
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flabby,flabby,词,ADJ,B2
-flaccid,flaccid,松弛的,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-flach,shallow,浅的,ADJ,B2
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrancy,flagrancy,现行,NOUN,B2
-flagrant,flagrant,词,ADJ,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable,flammable,易燃的,ADJ,B2
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
-flank (verb),flank,词,VERB,C1
-flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashlight,flashlight,词,NOUN,B2
-flat (noun),flat,词,NOUN,B1
-flat rate,flat rate,词,NOUN,B2
-flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatterer,flatterer,词,NOUN,C1
-flattering,flattering,词,ADJ,C1
-flattern,to flutter,飘动,VERB,B2
-flaunt,flaunt,词,VERB,C1
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flehen,to implore,恳求,VERB,B2
-fleißig,assiduous,勤勉的,ADJ,B2
-fleißig,hardworking,勤奋的,ADJ,B2
-flemish,flemish,佛兰芒的,ADJ,B2
-flesh,flesh,肉,NOUN,B2
-flex,flex,词,VERB,C1
-flexibel,flexible,灵活的,ADJ,B2
-flexion,flexion,词,NOUN,C1
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flickig,ragged,破烂的,ADJ,B2
-fliehen,to abscond,潜逃,VERB,B2
-flinch,flinch,词,VERB,C1
-fling (noun),fling,词,NOUN,C1
-fling (verb),fling,词,VERB,C1
-flint,flint,燧石,NOUN,B2
-flip,flip,词,VERB,B2
-flirt (noun),flirt,词,NOUN,B2
-flirt (verb),flirt,词,VERB,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-flit,flit,词,VERB,C1
-float (noun),float,词,NOUN,B2
-floating,floating,漂浮的,ADJ,B2
-floating (noun),floating,词,NOUN,C1
-floating dust,floating dust,浮尘,NOUN,B2
-flogging,flogging,词,NOUN,C1
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor story,floor story,词,NOUN,A2
-floorboard,floorboard,词,NOUN,C1
-flop,flop,词,VERB,C1
-floral,floral,词,ADJ,C1
-florid,florid,辞藻华丽的,ADJ,B2
-florieren,to flourish,繁荣,VERB,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-floundering,floundering,词,NOUN,C1
-flourishing,flourishing,繁荣的,ADJ,B2
-flourishing (noun),flourishing,词,NOUN,C1
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,词,NOUN,B2
-flowery,flowery,华丽的,ADJ,B2
-fluctuating,fluctuating,波动的,ADJ,B2
-fluency,fluency,流利,NOUN,B2
-fluently,fluently,词,ADV,C1
-fluff,fluff,词,NOUN,C1
-fluid,fluid,液体,NOUN,B2
-fluid (adj),fluid,词,ADJ,B2
-fluidity,fluidity,词,NOUN,C1
-fluidize,fluidize,词,VERB,C1
-fluids,fluids,词,NOUN,C1
-fluke,fluke,词,NOUN,B2
-flunk,flunk,词,VERB,C1
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flutist,flutist,词,NOUN,C1
-flutter (noun),flutter,词,NOUN,B2
-flying,flying,词,ADJ,B2
-flyover,flyover,词,NOUN,C1
-flyting poems,flyting poems,词,NOUN,C1
-flüchtig,fleeting,短暂的,ADJ,B2
-foal,foal,马驹,NOUN,B2
-fob,fob,词,NOUN,C1
-focalization,focalization,词,NOUN,C1
-focused,focused,专注的,ADJ,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-fokussieren,focus,焦点,NOUN,B2
-fokussieren,to focus,聚焦,VERB,B2
-fold,fold,折痕,NOUN,B2
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,枝叶,NOUN,B2
-foliar,foliar,词,ADJ,C1
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
-folkloric,folkloric,词,ADJ,C1
-folksy,folksy,乡土的,ADJ,B2
-follower enthusiast,follower enthusiast,词,NOUN,C1
-followers,followers,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-foment,foment,词,VERB,C1
-fond of food,fond of food,词,ADJ,B1
-fondle,fondle,词,VERB,C1
-fondness,fondness,词,NOUN,B2
-food,food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
-foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,镜头长度,NOUN,B2
-football camp,football camp,词,NOUN,B2
-football player,football player,词,NOUN,C1
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
-for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,为此,ADV,B2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what purpose,for what purpose,为了什么目的,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearance,forbearance,词,NOUN,C1
-forbearing,forbearing,词,ADJ,C1
-forced,forced,强迫的,ADJ,B2
-forced labor,forced labor,词,NOUN,C1
-forceful,forceful,词,ADJ,B2
-forcibly,forcibly,强制地,ADV,B2
-forcing submission,forcing submission,词,NOUN,C1
-ford,ford,词,NOUN,B2
-forearm,forearm,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
-forecast,forecast,预测,NOUN,B2
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,词,ADJ,B2
-foreknow,foreknow,词,VERB,C1
-foreman,foreman,词,NOUN,B2
-forensic,forensic,法医的,ADJ,B2
-foresee,to foresee,预见,VERB,B2
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-foresight,foresight,远见,NOUN,B2
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forest-related,forest-related,词,ADJ,B2
-forestall,forestall,词,VERB,C1
-forestry,forestry,词,ADJ,C1
-foretell,foretell,词,VERB,C1
-forever,forever,永远,ADV,B2
-forewarn,forewarn,词,VERB,C1
-foreword,foreword,词,NOUN,C1
-forfeit,forfeit,词,VERB,C1
-forfeiture,forfeiture,丧失,NOUN,B2
-forge,to forge,伪造,VERB,B2
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forger,forger,词,NOUN,C1
-forgery,forgery,伪造品,NOUN,B2
-forgetful,forgetful,健忘的,ADJ,B2
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-forgo,forgo,词,VERB,C1
-formal,formal,正式的,ADJ,B2
-formal notice,formal notice,词,NOUN,C1
-formalism,formalism,形式主义,NOUN,B2
-formalist (adj),formalist,词,ADJ,C1
-formalist (noun),formalist,词,NOUN,C1
-formality,formality,礼节,NOUN,B2
-formalize,to formalize,使正式化,VERB,B2
-formally,formally,正式地,ADV,B2
-format,format,格式,NOUN,B2
-formation,formation,组建,NOUN,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-formulate,to formulate,制定,VERB,B2
-formulation,formulation,配方,NOUN,B2
-fornicate,fornicate,词,VERB,C1
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-fort,fort,堡垒,NOUN,B2
-forthcoming,forthcoming,词,ADJ,C1
-fortification,fortification,词,NOUN,C1
-fortlet,fortlet,词,NOUN,C1
-fortschrittlich,advanced technology,先进,ADJ,B2
-fortuitous,fortuitous,偶然的,ADJ,B2
-fortunate,fortunate,幸运的,ADJ,B2
-fortunately,fortunately,幸运地,ADV,B2
-fortune teller,fortune teller,占卜者,NOUN,B2
-fortune telling,fortune telling,算命,NOUN,B2
-forty,forty,四十,NUM,B2
-forum,forum,论坛,NOUN,B2
-forums,forums,词,NOUN,C1
-forward (verb),forward,词,VERB,B2
-fossil,fossil,化石,NOUN,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-fossils,fossils,化石,NOUN,C1
-foster,foster,词,VERB,B2
-fotokopieren,photocopy,复印件,NOUN,B2
-fotokopieren,to photocopy,复印,VERB,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
-founding,founding,成立,NOUN,B2
-foundling,foundling,弃婴,NOUN,B2
-foundry,foundry,铸造厂,NOUN,B2
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fourteen,fourteen,十四,NUM,B2
-fourth (num),fourth,词,NUM,B1
-fowl,fowl,词,NOUN,C1
-foyer,foyer,词,NOUN,C1
-fractal,fractal,分形,NOUN,B2
-fraction,fraction,分数,NOUN,B2
-fraction marker,fraction marker,分之,PART,B2
-fractional,fractional,分数的,ADJ,B2
-fracture,fracture,骨折,NOUN,B2
-fractured,fractured,词,ADJ,C1
-fragile,fragile,易碎的,ADJ,B2
-fragility,fragility,脆弱,NOUN,B2
-fragment,fragment,碎片,NOUN,B2
-fragmentary,fragmentary,零碎的,ADJ,B2
-fragmentation,fragmentation,碎片化,NOUN,B2
-fragrant,fragrant,芬芳的,ADJ,B2
-frame,to frame,装框,VERB,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework,framework,框架,NOUN,B2
-framework-related,framework-related,词,ADJ,C1
-framing,framing,词,NOUN,C1
-franchise,franchise,特许经营权,NOUN,B2
-frank,frank,坦率的,ADJ,B2
-frankly,frankly,坦率地,ADV,B2
-frantic,frantic,狂乱的,ADJ,B2
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fratricide,fratricide,杀兄弟,NOUN,B2
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-fray,fray,词,VERB,C1
-frayed,frayed,词,ADJ,C1
-frazzle,frazzle,词,VERB,C1
-freckles,freckles,词,NOUN,B2
-free association,free association,词,NOUN,C1
-free of charge,free of charge,免费,NOUN,B2
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
-free off,free off,空闲的/休假,ADJ,B2
-free trade,free trade,词,NOUN,C1
-free will,free will,词,NOUN,B2
-freedmen clients,freedmen clients,词,NOUN,C1
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,词,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freely,freely,自由地,ADV,B2
-freezing,freezing,极冷的,ADJ,B2
-freight,freight,货物,NOUN,B2
-freiwillig,voluntarily,自愿地,ADV,B2
-fremde Truppen,strange troops,怪兵,NOUN,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
-frequentieren,to frequent,常去,VERB,B2
-frequently,frequently,经常,ADV,B2
-fresco,fresco,壁画,NOUN,B2
-fresh,fresh,,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshly,freshly,新鲜地,ADV,B2
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-fret,fret,词,VERB,C1
-friar,friar,词,NOUN,C1
-frictionless,frictionless,无摩擦的,ADJ,B2
-fried,fried,词,ADJ,B1
-fried food,fried food,词,NOUN,C1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-frieze,frieze,檐壁,NOUN,B2
-frigate,frigate,护卫舰,NOUN,B2
-frightening,frightening,令人恐惧的,ADJ,B2
-frightful,frightful,词,ADJ,B1
-frigid,frigid,寒冷的,ADJ,B2
-frill,frill,词,NOUN,C1
-frisian,frisian,词,ADJ,B2
-frisk,frisk,词,VERB,C1
-fritter,fritter,词,VERB,C1
-frittieren,to deep-fry,油炸,VERB,B2
-frivol,frivol,词,VERB,C1
-frivolous,frivolous,轻浮的,ADJ,B2
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-froh,joyful,快乐的,ADJ,B2
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from above,from above,从上方,ADV,B2
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
-from day,from day,日起,NOUN,B2
-from here,from here,词,ADV,B2
-from home,from home,词,ADV,B2
-from one,from one,从一,NOUN,C1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from then on,from then on,从此,ADV,B2
-from there,from there,从那里,ADV,B2
-from this,from this,词,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from which,from which,从中,ADV,B2
-from within,from within,从内部,ADV,B2
-front line,front line,前线,NOUN,B2
-front page,front page,头版,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontispiece,frontispiece,词,NOUN,C1
-frontrunner,frontrunner,词,NOUN,C1
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-froth,froth,泡沫,NOUN,B2
-frown (noun),frown,frown,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frowning,frowning,词,NOUN,C1
-frozen,frozen,冻僵的,ADJ,B2
-frozen (noun),frozen,词,NOUN,B2
-fruchtbar,fertile,肥沃的,ADJ,B2
-fructify,fructify,词,VERB,C1
-frugality,frugality,节俭,NOUN,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,果树的,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruiting,fruiting,词,ADJ,C1
-fruitless,fruitless,词,ADJ,C1
-frustrieren,to frustrate,挫败,VERB,B2
-frustrierend,frustrating,令人沮丧的,ADJ,B2
-fryer,fryer,词,NOUN,C1
-frühlingshaft,vernal,春季的,ADJ,B2
-fuchsia,fuchsia,词,NOUN,C1
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fulcrum,fulcrum,词,NOUN,C1
-fulfil,fulfil,词,VERB,C1
-fulfilled,fulfilled,满足的,ADJ,B2
-fulfillment,fulfillment,满足,NOUN,B2
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full moon banquet,full moon banquet,满月酒,NOUN,C1
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full satiated,full satiated,词,ADJ,A2
-full stop,full stop,词,NOUN,B2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,全职,ADJ,B2
-fullness,fullness,词,NOUN,C1
-fully,fully,词,ADV,C1
-fulminate,fulminate,词,VERB,C1
-fumarole,fumarole,词,NOUN,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundamental,fundamental,基本的,ADJ,B2
-fundamental rights,fundamental rights,词,NOUN,C1
-fundamentally,fundamentally,词,ADV,C1
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral home,funeral home,,NOUN,B2
-funeral rites,funeral rites,词,NOUN,C1
-funerary,funerary,词,ADJ,B2
-funereal,funereal,丧葬的,ADJ,B2
-fungal,fungal,词,ADJ,C1
-fungi,fungi,词,NOUN,B2
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funnel,funnel,漏斗,NOUN,B2
-funniness,funniness,,NOUN,B2
-furbish,furbish,词,VERB,C1
-furchtlos,intrepid,无畏的,ADJ,B2
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnished,furnished,词,ADJ,B2
-furnishing,furnishing,室内布置,NOUN,B2
-furrow,furrow,犁沟,NOUN,B2
-further (adj),further,进一步,ADJ,A2
-further additional,further additional,词,ADJ,B2
-further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
-furthest,furthest,最远,ADV,B2
-furtive,furtive,鬼鬼祟祟的,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
-fussy,fussy,挑剔的,ADJ,B2
-futile,futile,词,ADJ,C1
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurist,futurist,词,NOUN,C1
-futuristic,futuristic,词,ADJ,C1
-fuzzy,fuzzy,词,ADJ,C1
-färben,to color,着色,VERB,B2
-föderal,federal,联邦的,ADJ,B2
-führen,to lead to,通向,VERB,B2
-fünfte,fifth,خامس,ADJ,B2
-fünfzig,fifty,五十,NUM,B2
-gad,gad,词,VERB,C1
-gag,gag,词,NOUN,C1
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
-galician,galician,加利西亚的,ADJ,B2
-gallant,gallant,英勇的,ADJ,B2
-gallbladder,gallbladder,词,NOUN,C1
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
-galoppieren,to gallop,飞奔,VERB,B2
-galvanization,galvanization,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
-gamble (noun),gamble,就赌,NOUN,C1
-gambling,gambling,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game play,game play,词,NOUN,B2
-gamete,gamete,配子,NOUN,B2
-gangrene,gangrene,坏疽,NOUN,B2
-gangster,gangster,黑帮成员,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-ganze Welt,whole world,全世界,NOUN,B2
-gaol,gaol,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garb,garb,词,NOUN,C1
-garbage,garbage,词,NOUN,B2
-garble,garble,词,VERB,C1
-gardening,gardening,园艺,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
-gargle (verb),gargle,词,VERB,C1
-gargoyle,gargoyle,滴水嘴兽,NOUN,B2
-garland,garland,花环,NOUN,B2
-garment (part),garment,衣,PART,B2
-garment making,garment making,词,NOUN,C1
-garner,garner,词,VERB,C1
-garnieren,to garnish,装饰,VERB,B2
-garrison towns,garrison towns,词,NOUN,C1
-gas flame,gas flame,煤气火焰,NOUN,B2
-gas meter,gas meter,词,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
-gaseous,gaseous,气态的,ADJ,B2
-gash,gash,词,NOUN,C1
-gasket,gasket,词,NOUN,B1
-gasp (noun),gasp,词,NOUN,B2
-gasp (verb),gasp,词,VERB,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomic,gastronomic,美食的,ADJ,B2
-gastronomy,gastronomy,美食学,NOUN,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatekeeper,gatekeeper,道口看守员,NOUN,B2
-gateway,gateway,词,NOUN,C1
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauge (noun),gauge,词,NOUN,C1
-gauge meter,gauge meter,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,同性恋者,NOUN,B2
-gay man,gay man,男同性恋者,NOUN,B2
-gaze (noun),gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gazette,gazette,词,NOUN,C1
-gearbox,gearbox,变速箱,NOUN,B2
-gebildet,educated,受过教育的,ADJ,B2
-geboren werden,to be born,出生,VERB,B2
-gebunden,bound,一定的,ADJ,B2
-gedenken,to commemorate,纪念,VERB,B2
-geek,geek,极客,NOUN,C1
-gefälscht,counterfeit,假冒,ADJ,B2
-gefühllos,callous,冷酷,ADJ,B2
-gegenseitig,mutually,相互地,ADV,B2
-gegenseitige Beschränkung,mutual restriction,相克,NOUN,B2
-gegenseitige Erzeugung,mutual generation,相生,NOUN,B2
-gegenseitige Hilfe,mutual aid,互助,NOUN,B2
-gegensteuern,counter,柜台,NOUN,B2
-gegensteuern,to counter,反击,VERB,B2
-gehorsam,obedient,顺从的,ADJ,B2
-gehören,to belong to,属于,VERB,B2
-geizig,stingy,吝啬的,ADJ,B2
-gekochter Reis,cooked rice,米饭,NOUN,B2
-gel,gel,词,NOUN,C1
-gelassen,composed,稳重的,ADJ,B2
-gelassen,unruffled,从容,ADJ,B2
-gelatin,gelatin,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-geld,geld,词,VERB,C1
-gelegentlich,occasionally,偶尔,ADV,B2
-gem,gem,宝石,NOUN,B2
-gemein,common,常见的,ADJ,B2
-gemeinsam,joint,平等的,ADJ,B2
-gemischt,mixed,混合的,ADJ,B2
-genau richtig,just right,恰到好处,ADV,B2
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
-gender equality,gender equality,性别平等,NOUN,B2
-gender parity,gender parity,词,NOUN,C1
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogical,genealogical,词,ADJ,C1
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
-genehmigen,to authorize,授权,VERB,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-general practitioner,general practitioner,全科医生,NOUN,B2
-generalisieren,to generalize,概括,VERB,B2
-generality,generality,普遍性,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
-generatrix,generatrix,母线,NOUN,B2
-generell,generally,通常,ADV,B2
-generic,generic,通用的,ADJ,B2
-generieren,to generate,产生,VERB,B2
-generously,generously,慷慨地,ADV,B2
-genesen,to recuperate,恢复,VERB,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetic modification,genetic modification,词,NOUN,B2
-genetically,genetically,遗传地,ADV,B2
-genetisch,genetic,基因的,ADJ,B2
-genial,genial,词,ADJ,C1
-genial,ingenious,灵巧的,ADJ,B2
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,词,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gentle reproach,gentle reproach,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-gentrification,gentrification,词,NOUN,C1
-genuflect,genuflect,词,VERB,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genügen,to suffice,足够,VERB,B2
-geocentric,geocentric,词,ADJ,C1
-geographer,geographer,词,NOUN,C1
-geographical,geographical,地理的,ADJ,B2
-geographically,geographically,词,ADV,C1
-geolocation,geolocation,词,NOUN,C1
-geological,geological,地质的,ADJ,B2
-geology,geology,地质学,NOUN,B2
-geometer,geometer,词,NOUN,C1
-geometric,geometric,几何的,ADJ,B2
-geometry,geometry,几何学,NOUN,B2
-geophysics,geophysics,词,NOUN,C1
-geopolitical,geopolitical,地缘政治的,ADJ,B2
-geopolitics,geopolitics,地缘政治,NOUN,B2
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gerechter Zorn,righteous indignation,义愤,NOUN,B2
-geriatric,geriatric,词,ADJ,C1
-geriatrics,geriatrics,老年医学,NOUN,B2
-geringschätzen,to belittle,轻视,VERB,B2
-gerissen,shrewd,精明的,ADJ,B2
-germanic,germanic,词,ADJ,C1
-germicidal,germicidal,词,ADJ,C1
-germination,germination,发芽,NOUN,B2
-gerontocracy,gerontocracy,老人政治,NOUN,B2
-geschickt,skilled,熟练的,ADJ,B2
-geschlossen,closed,关闭的,ADJ,B2
-geschrieben,written,书面的,ADJ,B2
-geschwätzig,garrulous,喋喋不休的,ADJ,B2
-gesellig,sociable,好交际的,ADJ,B2
-gesellschaftliches Erwachen,social awakening,社会觉醒,NOUN,B2
-gesprächig,talkative,健谈的,ADJ,B2
-gestation,gestation,词,NOUN,C1
-gestern Abend,last night,昨晚,ADV,B2
-gesticulate,to gesticulate,做手势,VERB,B2
-gestohlen werden,to be stolen,失窃,VERB,B2
-gestuft,phased,阶段性,ADJ,B2
-gestural,gestural,词,ADJ,C1
-get acquainted,to get acquainted,相互认识,VERB,B2
-get angry,to get angry,生气,VERB,B2
-get off car,get off car,下车,VERB,B2
-get off work,to get off work,下班,VERB,B2
-getaway,getaway,词,NOUN,C1
-getroffen werden,to be hit,中箭,VERB,B2
-getting rich,getting rich,词,NOUN,C1
-gewalttätig,violent,暴力的,ADJ,B2
-gewidmet,devoted,忠诚的,ADJ,B2
-gewiss,certain,某些,DET,B2
-gewissenhaft,conscientious,认真的,ADJ,B2
-gewählt werden,to be elected,当选,VERB,B2
-gewöhnlich,ordinary,普通的,ADJ,B2
-gewöhnlich,ordinarily,通常,ADV,B2
-gewöhnliche Leute,ordinary people,老百姓,NOUN,B2
-gewöhnlicher Tag,ordinary day,平日,NOUN,B2
-gezwungen werden,to be forced,被迫,VERB,B2
-geänderte Politik,changed policy,改策,NOUN,B2
-geänderter Innenraum,amended interior,改内,NOUN,B2
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghost,ghost,鬼魂,NOUN,B2
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
-giant,giant,巨大的,ADJ,B2
-gibber,gibber,词,VERB,C1
-gibberish,gibberish,词,NOUN,C1
-gibe,gibe,词,VERB,C1
-giddy,giddy,头晕的,ADJ,B2
-gifted,gifted,有天赋的,ADJ,B2
-giftedness,giftedness,词,NOUN,C1
-gigantic,gigantic,巨大的,ADJ,B2
-gigolo,gigolo,面首,NOUN,B2
-gild,to gild,镀金,VERB,B2
-gilding,gilding,词,NOUN,C1
-gills,gills,词,NOUN,B2
-gin,gin,金酒,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-gipsen,to apply a cast,打石膏,VERB,B2
-giraffe,giraffe,长颈鹿,NOUN,B2
-girdle,girdle,词,NOUN,C1
-girl daughter,girl daughter,词,NOUN,A1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give to grant,to give to grant,予以,VERB,B2
-give you (noun),give you,送你,NOUN,C1
-given,given,给定,NOUN,B2
-given (adj),given,给定的,ADJ,A1
-given datum,given datum,词,NOUN,C1
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-glacial,glacial,词,ADJ,C1
-gladden,gladden,词,VERB,C1
-gladiator,gladiator,词,NOUN,C1
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glamour,glamour,词,NOUN,C1
-glance,glance,一瞥,NOUN,B2
-glance,to glance,瞥,VERB,B2
-gland,gland,腺体,NOUN,B2
-glare,glare,词,VERB,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-glebe,glebe,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-gleich,same,相同的,ADJ,B2
-gleichgültig,indifferent,冷漠的,ADJ,B2
-glide,to glide,滑行,VERB,B2
-gliding,gliding,滑翔,NOUN,B2
-glimmer,glimmer,词,NOUN,C1
-glimpse,glimpse,一瞥,NOUN,B2
-glimpse,to glimpse,瞥见,VERB,B2
-glint,glint,词,NOUN,C1
-glisten,glisten,词,VERB,C1
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-gloating,gloating,词,NOUN,C1
-global,global,全球的,ADJ,B2
-global (noun),global,全球,NOUN,B2
-global warming,global warming,气候变暖,NOUN,B2
-globalization,globalization,全球化,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-globalize,to globalize,使全球化,VERB,B2
-glomerulus,glomerulus,词,NOUN,C1
-gloominess,gloominess,忧郁,NOUN,B2
-glorification,glorification,赞美,NOUN,B2
-gloriously,gloriously,词,ADV,C1
-gloriousness,gloriousness,光荣,NOUN,B2
-glory,glory,荣耀,NOUN,B2
-gloss,gloss,光泽,NOUN,B2
-glossary,glossary,词汇表,NOUN,B2
-glossator,glossator,词,NOUN,C1
-gloves,gloves,词,NOUN,B2
-glow (verb),glow,词,VERB,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glower,glower,词,VERB,C1
-glucose,glucose,词,NOUN,C1
-glue,glue,胶水,NOUN,B2
-glut,glut,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
-gluttony,gluttony,暴食,NOUN,B2
-glyph,glyph,词,NOUN,C1
-glühend,scorching,灼热的,ADJ,B2
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
-gnosis,gnosis,灵知,NOUN,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-goalkeeper,goalkeeper,词,NOUN,B2
-gobble,gobble,词,VERB,C1
-goblin,goblin,词,NOUN,C1
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-godliness,godliness,词,NOUN,C1
-godmother,godmother,词,NOUN,C1
-godson,godson,词,NOUN,A2
-goggle,goggle,词,VERB,C1
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good day,good day,你好,INTJ,B2
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good lord,good lord,词,INTJ,B2
-good medicine,good medicine,好药,NOUN,B2
-good morning,good morning,早上好,INTJ,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good night,good night,晚安,INTJ,B2
-good offices,good offices,词,NOUN,C1
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-good-naturedness,good-naturedness,温和,NOUN,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gosh,gosh,天哪,INTJ,B2
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,词,ADJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-gouge,gouge,词,VERB,C1
-govern a country,govern a country,治国,VERB,C1
-governability,governability,可治理性,NOUN,B2
-governable,governable,可管理的,ADJ,B2
-governess,governess,词,NOUN,C1
-governorate,governorate,词,NOUN,C1
-grab,grab,揪,NOUN,B2
-gracefulness,gracefulness,词,NOUN,C1
-gracious,gracious,亲切的,ADJ,B2
-grade (verb),grade,分级,VERB,C1
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation,graduation,毕业,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-graffiti,graffiti,涂鸦,NOUN,C1
-grail,grail,词,NOUN,B2
-grammatical,grammatical,词,ADJ,C1
-grammaticality,grammaticality,合语法性,NOUN,B2
-gramophone,gramophone,词,NOUN,C1
-granary,granary,词,NOUN,C1
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand master,grand master,大师,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,夸张的,ADJ,B2
-grandiloquently,grandiloquently,词,ADV,C1
-grandiosity,grandiosity,宏伟,NOUN,B2
-grandparent,grandparent,词,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-granitic,granitic,词,ADJ,C1
-granny,granny,奶奶,NOUN,B2
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-granule,granule,词,NOUN,C1
-grapefruit,grapefruit,词,NOUN,A2
-grapes,grapes,词,NOUN,A1
-graph,graph,词,NOUN,C1
-graphic artist,graphic artist,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphic designer,graphic designer,图形设计师,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-graphology,graphology,笔迹学,NOUN,B2
-grapple,grapple,词,VERB,C1
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grasshopper,grasshopper,词,NOUN,B1
-grassroots,grassroots,词,ADJ,C1
-grate,grate,词,VERB,C1
-grater,grater,词,NOUN,B2
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-gravel,gravel,砾石,NOUN,B2
-gravely,gravely,严重地,ADV,B2
-graveyard,graveyard,墓地,NOUN,B2
-gravid,gravid,怀孕的,ADJ,B2
-gravitas,gravitas,词,NOUN,C1
-gravitation,gravitation,引力,NOUN,B2
-gravitational,gravitational,引力的,ADJ,B2
-gravity,gravity,重力,NOUN,B2
-gravity of loss,gravity of loss,词,NOUN,C1
-gray hair,gray hair,词,NOUN,B2
-grayish,grayish,词,ADJ,C1
-grazing,grazing,放牧,NOUN,B2
-graziös,graceful,优雅的,ADJ,B2
-grease (noun),grease,词,NOUN,C1
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
-great favor,great favor,大恩,NOUN,B2
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great offense,great offense,冒犯大,NOUN,B2
-great power,great power,大国,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,曾祖父,NOUN,B2
-greaten,greaten,词,VERB,C1
-greatest,greatest,词,NOUN,B2
-greatness,greatness,伟大,NOUN,B2
-greed,greed,贪婪,NOUN,B2
-greedy,greedy,贪婪的,ADJ,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊语,NOUN,B2
-greek (adj),greek,希腊的,ADJ,B2
-green blue,green blue,青,ADJ,B2
-green eye,green eye,碧眼,NOUN,B2
-green eyes,green eyes,想碧眼,NOUN,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green technology,green technology,绿色技术,NOUN,B2
-green-clad,green-clad,,NOUN,B2
-green-eyed,green-eyed,让碧眼,NOUN,B2
-greenhouse,greenhouse,温室,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-greetings,greetings,,NOUN,B2
-gregarious,gregarious,爱社交的,ADJ,B2
-greifbar,tangible,有形的,ADJ,B2
-grenade,grenade,手榴弹,NOUN,B2
-grenadier,grenadier,词,NOUN,C1
-grenznah,border,边境的,ADJ,B2
-grey,grey,灰色的,ADJ,B2
-grey area,grey area,词,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
-grieve,grieve,词,VERB,C1
-grieved,grieved,词,ADJ,B2
-grievously unjust,grievously unjust,词,ADJ,C1
-grill (noun),grill,词,NOUN,B2
-grille,grille,格栅,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grim,grim,严酷的,ADJ,B2
-grimace,grimace,词,NOUN,C1
-grime,grime,污垢,NOUN,B2
-grimness,grimness,词,NOUN,C1
-grin,to grin,咧嘴笑,VERB,B2
-grinder,grinder,词,NOUN,C1
-grip,grip,握法,NOUN,B2
-grip,to grip,紧握,VERB,B2
-grip (noun),grip,握呀,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-gripe,gripe,词,VERB,C1
-grit,grit,词,NOUN,C1
-grob,coarse,粗糙的,ADJ,B2
-grocer,grocer,词,NOUN,A2
-grocery,grocery,词,NOUN,B2
-grooming,grooming,词,NOUN,C1
-grooved,grooved,词,ADJ,C1
-grope,grope,词,VERB,C1
-gross,gross,总的,ADJ,B2
-grotesque,grotesque,怪诞的,ADJ,B2
-grotto,grotto,洞穴,NOUN,B2
-ground (adj),ground,磨碎的,ADJ,B1
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds,grounds,论据,NOUN,B2
-grounds of judgment,grounds of judgment,词,NOUN,C1
-groundwater pollution,groundwater pollution,词,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,群体工作,NOUN,B2
-grouping,grouping,词,NOUN,B2
-grouse,grouse,词,VERB,C1
-grovel,grovel,词,VERB,C1
-growing,growing,词,ADJ,B2
-growth,growth,增长,NOUN,B2
-growth rate,growth rate,词,NOUN,C1
-groß,biggest,最大,ADJ,B2
-groß,tall,高的,ADJ,B2
-großangelegt,large-scale,大规模的,ADJ,B2
-großartig,grand,宏伟的,ADJ,B2
-große Entfernung,grand distance,雄远,NOUN,B2
-grub,grub,词,NOUN,C1
-grueling,grueling,词,ADJ,C1
-gruff,gruff,阴沉的,ADJ,B2
-grumble,to grumble,抱怨,VERB,B2
-grumbler,grumbler,爱抱怨的人,NOUN,B2
-grumbling,grumbling,抱怨,NOUN,B2
-grumpy,grumpy,脾气坏的,ADJ,B2
-grundlegend,basic,基本的,ADJ,B2
-grundsätzlich,basically,基本上,ADV,B2
-grunt,grunt,词,VERB,B2
-gründen,to reason,推理,VERB,B2
-guarantee,guarantee,保证,NOUN,B2
-guarantees,guarantees,词,NOUN,C1
-guarantor,guarantor,担保人,NOUN,B2
-guardian,guardian,守卫,NOUN,B2
-guardianship,guardianship,监护,NOUN,B2
-guarding,guarding,守住,NOUN,C1
-guerrilla,guerrilla,词,NOUN,C1
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
-guess,guess,猜测,NOUN,B2
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guffaw,guffaw,哄笑,NOUN,B2
-guidance,guidance,指导,NOUN,B2
-guide,to guide,引导,VERB,B2
-guidebook,guidebook,词,NOUN,B1
-guideline,guideline,指导方针,NOUN,B2
-guiding light,guiding light,词,NOUN,C1
-guild,guild,行会,NOUN,B2
-guild (adj),guild,词,ADJ,C1
-guilder,guilder,盾,NOUN,B2
-guillotine,guillotine,断头台,NOUN,B2
-guilt,guilt,内疚,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitarist,guitarist,吉他手,NOUN,B2
-gunshot,gunshot,枪声,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-guru,guru,精神导师,NOUN,B2
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-gut sein in,to be good at,擅长,VERB,B2
-gutaussehend,good-looking,好看的,ADJ,B2
-guter Ruf,good reputation,清誉,NOUN,B2
-gutter,gutter,路沟,NOUN,B2
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
-gymnast,gymnast,体操运动员,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gynaecology,gynaecology,妇科,NOUN,B2
-gynecologist,gynecologist,词,NOUN,C1
-gyroscope,gyroscope,词,NOUN,C1
-gähnen,to yawn,打哈欠,VERB,B2
-günstige Umstände,favorable circumstances,顺境,NOUN,B2
-ha,ha,哈,INTJ,B2
-habit formation,habit formation,词,NOUN,C1
-habitability,habitability,词,NOUN,C1
-habitlessness,habitlessness,无习惯,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-habitus,habitus,词,NOUN,C1
-habous endowments,habous endowments,词,NOUN,C1
-hacken,chop,砍,NOUN,B2
-hacken,to chop,砍,VERB,B2
-hacken,to hack,入侵；盗版,VERB,B2
-hacker,hacker,黑客,NOUN,C1
-hacking,hacking,黑客行为,NOUN,B2
-hackneyed,hackneyed,词,ADJ,C1
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hag,hag,老妇,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-hair-raising,hair-raising,词,ADJ,B2
-haircut,haircut,词,NOUN,C1
-hairy,hairy,词,ADJ,C1
-hakawati,hakawati,词,NOUN,B2
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
-half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway,halfway,半途,ADV,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall (part),hall,殿,PART,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
-hallowed,hallowed,词,ADJ,C1
-halo,halo,词,NOUN,B2
-hamburger,hamburger,汉堡包,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
-handbrake,handbrake,手刹,NOUN,C1
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handlebars,handlebars,词,NOUN,C1
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-hanged,hanged,被绞死的,ADJ,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hanging,hanging,绞刑,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy cheerful,happy cheerful,词,ADJ,B1
-happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-harbour,harbour,词,NOUN,B2
-hard,hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-harder,harder,词,ADJ,A2
-hardship,hardship,艰难,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
-harmonious,harmonious,和谐的,ADJ,B2
-harmonization,harmonization,协调,NOUN,B2
-harried,harried,词,ADJ,C1
-harsh,harsh,严厉的,ADJ,B2
-harshly,harshly,词,ADV,C1
-harshness,harshness,词,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hassle,hassle,麻烦,NOUN,B2
-haste,haste,匆忙,NOUN,B2
-hastily,hastily,急忙,ADV,B2
-hasty,hasty,仓促的,ADJ,B2
-hatch,hatch,舱口,NOUN,B2
-hatching,hatching,词,NOUN,C1
-hate,hate,仇恨,NOUN,B2
-haughtily,haughtily,词,ADV,C1
-haughtiness,haughtiness,傲慢,NOUN,B2
-haughty,haughty,傲慢的,ADJ,B2
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-have a look,have a look,看一看啦,NOUN,C1
-have dinner,to have dinner,吃晚餐,VERB,B2
-have lunch,to have lunch,吃午餐,VERB,B2
-have only,to have only,唯有,VERB,B2
-have time,have time,词,VERB,B2
-have to,have to,还得,NOUN,B2
-have to (adv),have to,不得不,ADV,A1
-having a birthday,having a birthday,过生日的,ADJ,B2
-having a cold,having a cold,词,ADJ,B2
-having item,having item,有件,NOUN,C1
-hay,hay,干草,NOUN,B2
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
-hazelnut,hazelnut,榛子,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-heading,heading,标题,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headline,headline,标题,NOUN,B2
-headlines,headlines,词,NOUN,B2
-headphones,headphones,耳机,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healer,healer,词,NOUN,B2
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,医疗保健,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-heap,heap,堆,NOUN,B2
-heap cluster,heap cluster,词,NOUN,C1
-hear a case,to hear a case,审理,VERB,B2
-heard beile,heard beile,听说贝勒,NOUN,B2
-hearing aid,hearing aid,词,NOUN,B2
-hearsay,hearsay,词,NOUN,C1
-heart,heart,心,ADV,B2
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt,heartfelt,衷心的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-hearth,hearth,壁炉,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartlessness,heartlessness,词,NOUN,B2
-heartrending,heartrending,词,ADJ,C1
-heat wave,heat wave,热浪,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heating,heating,供暖,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
-heaven,heaven,天堂,NOUN,B2
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
-heavenly fragrance,heavenly fragrance,天香,NOUN,B2
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavily,heavily,沉重地,ADV,B2
-heaviness,heaviness,沉重 / 笨重,NOUN,B2
-heavy,heavy,重的,ADJ,B2
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy etiquette,heavy etiquette,礼太重,NOUN,B2
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy knot,heavy knot,重结,NOUN,B2
-heavy machine,heavy machine,重机,NOUN,B2
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-heavy type,heavy type,重型,NOUN,B2
-heavy work,heavy work,重功,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hedge,hedge,树篱,NOUN,B2
-hedonism,hedonism,享乐主义,NOUN,B2
-hedonist,hedonist,词,NOUN,C1
-hedonistic,hedonistic,享乐主义的,ADJ,B2
-heedlessness,heedlessness,词,NOUN,C1
-heel,heel,脚后跟,NOUN,B2
-hefen,hefen,河粉,NOUN,C1
-hegemony,hegemony,霸权,NOUN,B2
-hegen,to cherish,珍爱,VERB,B2
-hehe,hehe,嘿嘿,INTJ,B2
-heilig,sacred,神圣的,ADJ,B2
-heimlich,clandestine,秘密的,ADJ,B2
-heimlich,secretly,秘密地,ADV,B2
-heimtückisch,insidious,潜伏的,ADJ,B2
-heinous,heinous,词,ADJ,C1
-heir,heir,继承人,NOUN,B2
-helfen,to assist,协助,VERB,B2
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
-help assistance,to help assistance,帮助,VERB,B2
-helplessly,helplessly,无力,ADV,C1
-hem,hem,边缘,NOUN,B2
-hematoma,hematoma,血肿,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemiplegia,hemiplegia,词,NOUN,C1
-hemisphere,hemisphere,半球,NOUN,B2
-hemistich,hemistich,词,NOUN,C1
-hemmen,to inhibit,抑制,VERB,B2
-hemoglobin,hemoglobin,血红蛋白,NOUN,B2
-hemorrhage,hemorrhage,出血,NOUN,B2
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostasis,hemostasis,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
-hen,hen,母鸡,NOUN,B2
-hence,hence,因此,ADV,B2
-henceforth,henceforth,从此以后,ADV,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hepatic,hepatic,肝脏的,ADJ,B2
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,DET,B2
-her (pron),her,词,PRON,A1
-herablassend,condescending,屈尊的,ADJ,B2
-herabsehen,to look down upon,看不起,VERB,B2
-herabsteigen,to descend,下降,VERB,B2
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
-herausnehmen,to take out,拿出,VERB,B2
-herbaceous,herbaceous,草本的,ADJ,B2
-herbal tea,herbal tea,词,NOUN,B2
-herbalism,herbalism,词,NOUN,C1
-herbalist,herbalist,词,NOUN,B1
-herbarium,herbarium,词,NOUN,C1
-herbeiführen,to induce,引起,VERB,B2
-herbicide,herbicide,除草剂,NOUN,B2
-herbs,herbs,词,NOUN,B2
-herd,herd,兽群,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
-herder,herder,牧民,NOUN,B2
-here,here,此地,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here is,here is,词,ADV,A1
-here you go,here you go,请,INTJ,B2
-hereafter,hereafter,词,NOUN,C1
-hereditary,hereditary,遗传的,ADJ,B2
-heredity,heredity,遗传,NOUN,B2
-herein,herein,词,ADV,B1
-heresiarch,heresiarch,词,NOUN,C1
-heresy,heresy,异端,NOUN,B2
-heretic,heretic,异端,NOUN,B2
-heretical,heretical,词,ADJ,C1
-heretical innovation,heretical innovation,词,NOUN,C1
-heritage,heritage,遗产,NOUN,B2
-hermeneutic,hermeneutic,诠释学的,ADJ,B2
-hermeneutics,hermeneutics,词,NOUN,C1
-hermetic,hermetic,词,ADJ,C1
-hermit,hermit,隐士,NOUN,B2
-hermitage,hermitage,词,NOUN,B2
-hernia,hernia,词,NOUN,C1
-heroic,heroic,英勇的,ADJ,B2
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroin vapor,heroin vapor,,NOUN,B2
-heroine,heroine,词,NOUN,B1
-heroism,heroism,英雄主义,NOUN,B2
-heron,heron,词,NOUN,C1
-herrlich,splendid,极好的,ADJ,B2
-herstellen,to manufacture,制造,VERB,B2
-herumhetzen,to rush about,奔波,VERB,B2
-hervortreten,to emerge,出现,VERB,B2
-hesitant,hesitant,犹豫的,ADJ,B2
-hesitation,hesitation,犹豫,NOUN,B2
-heterodox,heterodox,词,ADJ,C1
-heterodoxy,heterodoxy,词,NOUN,C1
-heterogeneity,heterogeneity,异质性,NOUN,B2
-heterogeneous,heterogeneous,异质的,ADJ,B2
-heterosexual,heterosexual,词,ADJ,C1
-heulen,to howl,嚎叫,VERB,B2
-heuristic,heuristic,词,ADJ,C1
-hexadecimal,hexadecimal,词,ADJ,C1
-hexagon,hexagon,词,NOUN,C1
-hidden,hidden,隐藏的,ADJ,B2
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hide oneself,to hide oneself,躲藏,VERB,B2
-hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
-hideout,hideout,藏身处,NOUN,B2
-hider,hider,词,NOUN,B2
-hiding,hiding,ٱختباء,NOUN,B2
-hiding ambush,hiding ambush,词,NOUN,B2
-hierarchical,hierarchical,等级的,ADJ,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,词,NOUN,B2
-high school student,high school student,词,NOUN,B2
-high tall,high tall,高的,ADJ,B2
-high tide,high tide,涨潮,NOUN,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-higher,higher,更高的,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highest,highest,最高的,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
-highlight,highlight,亮点,NOUN,B2
-highlight,to highlight,强调,VERB,B2
-highlight (noun),highlight,亮点,NOUN,B2
-highlighter,highlighter,词,NOUN,C1
-hijack,hijack,词,VERB,C1
-hijacking,hijacking,词,NOUN,C1
-hike,hike,徒步旅行,NOUN,B2
-hiking,hiking,徒步,NOUN,B2
-hilarious,hilarious,滑稽的,ADJ,B2
-hills,hills,丘陵,NOUN,B2
-hilt,hilt,剑柄,NOUN,B2
-him,him,他吧,NOUN,B2
-him (pron),him,他,PRON,A1
-him her,him her,他/她,PRON,B2
-himself herself,himself herself,词,PRON,A1
-hindrance,hindrance,障碍,NOUN,B2
-hinge,hinge,合页,NOUN,B2
-hint,hint,暗示,NOUN,B2
-hinterlegen,to deposit,存放,VERB,B2
-hinunter,down,顺...而下,ADP,B2
-hiring,hiring,招聘,NOUN,B2
-hirsute,hirsute,词,ADJ,C1
-his,his,他的,PRON,B2
-his certainty,his certainty,他定,NOUN,C1
-his departure,his departure,他走,NOUN,B2
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,他/她自己的,DET,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,词,ADJ,C1
-historical,historical,历史的,ADJ,B2
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
-historicism,historicism,历史主义,NOUN,B2
-historicist,historicist,词,NOUN,C1
-historicity,historicity,历史性,NOUN,B2
-historicization,historicization,词,NOUN,C1
-historiography,historiography,史学,NOUN,B2
-history education,history education,词,NOUN,C1
-history story,history story,历史/故事,NOUN,B2
-histrionic,histrionic,词,ADJ,C1
-hit beat,hit beat,词,VERB,A2
-hitch,hitch,词,NOUN,B2
-hither,hither,到这里,ADV,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hocken,to squat,蹲,VERB,B2
-hockey,hockey,曲棍球,NOUN,C1
-hoffen,to hope to wish,希望,VERB,B2
-hold,hold,控制,NOUN,B2
-hold catch,hold catch,词,VERB,A1
-holder,holder,持有者,NOUN,B2
-holding,holding,别放,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holdup,holdup,词,NOUN,B2
-holiday feast,holiday feast,词,NOUN,A2
-holidaymaker,holidaymaker,词,NOUN,C1
-holism,holism,整体论,NOUN,B2
-hollowed,hollowed,掏空的,ADJ,B2
-holm oak,holm oak,词,NOUN,C1
-holocaust,holocaust,浩劫,NOUN,B2
-hologram,hologram,词,NOUN,C1
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home automation,home automation,词,NOUN,B1
-home hearth,home hearth,词,NOUN,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,顾家的,ADJ,B2
-homelessness,homelessness,词,NOUN,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,词,NOUN,B2
-homework duty,homework duty,词,NOUN,A2
-homiletic,homiletic,词,ADJ,C1
-homily,homily,布道,NOUN,B2
-hominization,hominization,词,NOUN,C1
-homogen,homogeneous,同质的,ADJ,B2
-homogeneity,homogeneity,同质性,NOUN,B2
-homonym,homonym,词,NOUN,C1
-homonymy,homonymy,同音异义,NOUN,B2
-homosexuell,homosexual,同性恋的,ADJ,B2
-homothety,homothety,位似,NOUN,C1
-honor culture,honor culture,词,NOUN,B2
-honorability,honorability,词,NOUN,C1
-honorable,honorable,可敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-hood,hood,兜帽,NOUN,B2
-hooligan,hooligan,流氓,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
-hoped-for,hoped-for,词,ADJ,C1
-hopeful,hopeful,词,ADJ,C1
-hopelessly,hopelessly,词,ADV,B2
-hopelessness,hopelessness,词,NOUN,C1
-horde,horde,词,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
-horoscope,horoscope,词,NOUN,B2
-horrified,horrified,惊骇的,ADJ,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitalisieren,to hospitalize,使住院,VERB,B2
-hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
-hospitalization,hospitalization,词,NOUN,C1
-hostel,hostel,词,NOUN,C1
-hostess,hostess,女服务员,NOUN,B2
-hosting,hosting,托管,NOUN,C1
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
-hotbed,hotbed,词,NOUN,C1
-hotel industry,hotel industry,词,NOUN,C1
-hotelier,hotelier,旅馆老板,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house search,house search,词,NOUN,B2
-household (adj),household,词,ADJ,B2
-household income,household income,词,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
-how many (pron),how many,多少,PRON,A1
-how to do it,how to do it,办呢,ADV,B2
-however (cconj),however,然而,CCONJ,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hubris,hubris,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
-human being,human being,词,NOUN,B1
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humane,humane,人道的,ADJ,B2
-humanist,humanist,人文主义者,NOUN,B2
-humanitarian,humanitarian,人道主义的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
-humble,humble,谦逊的,ADJ,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
-humid,humid,潮湿的,ADJ,B2
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
-humiliating,humiliating,令人羞辱的,ADJ,B2
-humming,humming,词,NOUN,B2
-hummingbird,hummingbird,词,NOUN,B2
-humorist,humorist,词,NOUN,C1
-humorous,humorous,幽默的,ADJ,B2
-hump,hump,词,NOUN,C1
-hunch,hunch,词,NOUN,B2
-hundred,hundred,一百,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (num),hundreds,词,NUM,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hyaline,hyaline,词,ADJ,C1
-hybrid,hybrid,杂交的,ADJ,B2
-hybridism,hybridism,词,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydraulic,hydraulic,液压的,ADJ,B2
-hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrology,hydrology,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
-hygienic,hygienic,卫生的,ADJ,B2
-hymnal,hymnal,词,NOUN,C1
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbole,hyperbole,夸张,NOUN,B2
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hyperthermia,hyperthermia,体温过高,NOUN,B2
-hypertrophy,hypertrophy,肥大,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
-hypotension,hypotension,词,NOUN,C1
-hypotensive,hypotensive,词,ADJ,C1
-hypothesize,hypothesize,词,VERB,B2
-hypothetically,hypothetically,词,ADV,C1
-hypothetisch,hypothetical,假设的,ADJ,B2
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
-hysterisch,hysterical,歇斯底里的,ADJ,B2
-höflich ablehnen,to decline politely,婉拒,VERB,B2
-hübsch,handsome,帅气的,ADJ,B2
-i,i,我连,NOUN,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
-ice cold,ice cold,冰冷的,ADJ,B2
-ice cube,ice cube,词,NOUN,A2
-ice pick,ice pick,,NOUN,B2
-ich,me,لي,NOUN,B2
-icicle,icicle,词,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconicity,iconicity,词,NOUN,C1
-iconoclast,iconoclast,偶像破坏者,NOUN,B2
-iconoclastic,iconoclastic,词,ADJ,C1
-iconographic,iconographic,词,ADJ,C1
-id,id,id,NOUN,B2
-ideal,ideal,理想,NOUN,B2
-idealization,idealization,词,NOUN,B2
-ideally,ideally,理想地,ADV,B2
-ideational,ideational,词,ADJ,C1
-identical,identical,完全相同的,ADJ,B2
-identification,identification,身份证明,NOUN,B2
-identifier,identifier,词,NOUN,C1
-identitarianism,identitarianism,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
-ideological,ideological,意识形态的,ADJ,B2
-ideologization,ideologization,词,NOUN,C1
-idiocy,idiocy,愚蠢,NOUN,B2
-idiom,idiom,习语,NOUN,B2
-idiomatic,idiomatic,词,ADJ,C1
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncrasy,idiosyncrasy,特质,NOUN,B2
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiot,idiot,傻瓜,ADJ,B2
-idiotic,idiotic,愚蠢的,ADJ,B2
-idle,idle,懒惰的,ADJ,B2
-idol,idol,偶像,NOUN,B2
-idolatry,idolatry,词,NOUN,B2
-idyll,idyll,田园诗,NOUN,B2
-idyllic,idyllic,词,ADJ,C1
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if only,if only,但愿,VERB,B2
-igneous,igneous,火成的,ADJ,B2
-ignition,ignition,点火,NOUN,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominious,ignominious,词,ADJ,C1
-ignominy,ignominy,词,NOUN,B2
-ignorance,ignorance,无知,NOUN,B2
-ihr,their,他们的,PRON,B2
-iliac,iliac,词,ADJ,C1
-illegal,illegal,非法的,ADJ,B2
-illegality,illegality,非法,NOUN,B2
-illegally,illegally,词,ADV,C1
-illegitimate,illegitimate,非法的,ADJ,B2
-illicit,illicit,违禁的,ADJ,B2
-illiteracy,illiteracy,词,NOUN,C1
-illiterate,illiterate,词,ADJ,B2
-illness,illness,疾病,NOUN,B2
-illogical,illogical,不合逻辑的,ADJ,B2
-illuminate,to illuminate,照亮,VERB,B2
-illumination,illumination,照明,NOUN,B2
-illuminationism,illuminationism,照明主义,NOUN,C1
-illuminator,illuminator,彩饰画家,NOUN,B2
-illusory,illusory,词,ADJ,C1
-illustrate,to illustrate,说明,VERB,B2
-illustration,illustration,插图,NOUN,B2
-illustrative,illustrative,词,ADJ,C1
-illustrious,illustrious,著名的,ADJ,B2
-im Detail,in detail,详细地,ADV,B2
-im Gegenteil,instead on the contrary,反而,ADV,B2
-im Gegenteil,on the contrary,相反,ADV,B2
-im Voraus,in advance,事先,ADV,B2
-im Wesentlichen,essentially,主要地,ADV,B2
-image,image,形象,NOUN,B2
-image formation,image formation,词,NOUN,B2
-imagery,imagery,意象,NOUN,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imagination,imagination,想象力,NOUN,B2
-imaginative,imaginative,富有想象力的,ADJ,B2
-imagined,imagined,想象的,ADJ,C1
-imaging,imaging,词,NOUN,C1
-imam,imam,伊玛目,NOUN,B2
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
-imbecility,imbecility,词,NOUN,C1
-imitative,imitative,模仿性,ADJ,B2
-immaculate,immaculate,词,ADJ,C1
-immanence,immanence,内在性,NOUN,B2
-immanent,immanent,词,ADJ,C1
-immanent,intrinsic,固有的,ADJ,B2
-immature,immature,不成熟的,ADJ,B2
-immeasurable,immeasurable,不可估量的,ADJ,B2
-immediacy,immediacy,词,NOUN,C1
-immemorial,immemorial,词,ADJ,C1
-immense,immense,巨大的,ADJ,B2
-immensely,immensely,词,ADV,B2
-immensity,immensity,词,NOUN,C1
-immerse,immerse,词,VERB,C1
-immersed,immersed,词,ADJ,C1
-immersion,immersion,沉浸,NOUN,B2
-immigrant,immigrant,移民,NOUN,B2
-immigrate,to immigrate,移入,VERB,B2
-immigration,immigration,移民,NOUN,B2
-imminence,imminence,就将,NOUN,C1
-imminent,imminent,即将来临的,ADJ,B2
-immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immodesty,immodesty,不贞,NOUN,B2
-immoral,immoral,不道德的,ADJ,B2
-immorality,immorality,词,NOUN,C1
-immortal,immortal,不朽的,ADJ,B2
-immortality,immortality,不朽,NOUN,B2
-immovable,immovable,不可移动的,ADJ,B2
-immune,immune,免疫的,ADJ,B2
-immunity,immunity,免疫力,NOUN,B2
-immunization,immunization,免疫,NOUN,B2
-immunotherapy,immunotherapy,免疫治疗,NOUN,B2
-impact,impact,影响,NOUN,B2
-impartial,impartial,词,ADJ,C1
-impartiality,impartiality,公正,NOUN,B2
-impasse,impasse,词,NOUN,C1
-impassive,impassive,词,ADJ,C1
-impassively,impassively,词,ADV,B2
-impatience,impatience,词,NOUN,C1
-impeccable,impeccable,无瑕疵的,ADJ,B2
-imperativ,imperative,必要的,ADJ,B2
-imperatively,imperatively,词,ADV,C1
-imperceptible,imperceptible,词,ADJ,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperfect,imperfect,不完美的,ADJ,B2
-imperfection,imperfection,词,NOUN,C1
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,太医,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
-imperialist,imperialist,词,ADJ,C1
-imperious,imperious,词,ADJ,C1
-impersonal,impersonal,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbably,imperturbably,词,ADV,C1
-impetuosity,impetuosity,词,NOUN,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implacably,implacably,毫不留情地,ADV,B2
-implantation,implantation,词,NOUN,C1
-implausible,implausible,词,ADJ,C1
-implicated,implicated,牵连的,ADJ,C1
-implicitly,implicitly,含蓄地,ADV,B2
-implizit,implicit,含蓄的,ADJ,B2
-impoliteness,impoliteness,词,NOUN,C1
-import,import,进口,NOUN,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-importieren,to import,进口,VERB,B2
-imports,imports,词,NOUN,C1
-imposing,imposing,宏伟的,ADJ,B2
-imposition,imposition,词,NOUN,C1
-impostor,impostor,词,NOUN,B2
-imposture,imposture,词,NOUN,C1
-impotence,impotence,无力,NOUN,B2
-impotent,impotent,词,ADJ,C1
-impound lot,impound lot,词,NOUN,B1
-impoverished,impoverished,词,ADJ,B2
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
-impressed,impressed,印象深刻的,ADJ,B2
-impressions,impressions,感想,NOUN,B2
-imprint,imprint,印记,NOUN,B2
-imprisoned,imprisoned,词,ADJ,B2
-impromptu,impromptu,即兴的,ADJ,B2
-improvidence,improvidence,词,NOUN,C1
-improvisieren,to improvise,即兴创作,VERB,B2
-improvisiert,improvised,即兴的,ADJ,B2
-imprudence,imprudence,词,NOUN,C1
-imprudent,imprudent,词,ADJ,C1
-impulsiv,impulsive,冲动的,ADJ,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-impunity,impunity,逍遥法外,NOUN,B2
-impure,impure,词,ADJ,C1
-imputation,imputation,词,NOUN,C1
-in Ordnung bringen,to put in order,收拾,VERB,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in addition to,in addition to,词,ADP,B2
-in anticipation of,in anticipation of,词,ADV,C1
-in book,in book,书里,NOUN,C1
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in deficit,in deficit,词,ADJ,C1
-in every detail,in every detail,词,ADV,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
-in here,in here,在这里面,ADV,B2
-in high spirits,in high spirits,兴致勃勃,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
-in its entirety,in its entirety,词,ADV,C1
-in me,in me,我中,NOUN,C1
-in mind,in mind,词,ADV,B2
-in need,in need,词,ADJ,A2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in private,in private,词,ADV,B2
-in return,in return,词,NOUN,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,在后面,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,词,ADV,B2
-in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
-in two,in two,成两半,ADV,B2
-in unison,in unison,齐声,ADV,B2
-in vain,in vain,徒劳,NOUN,B2
-in which,in which,在其中,PRON,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccessible,inaccessible,词,ADJ,C1
-inaccurate,inaccurate,词,ADJ,C1
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inactivity,inactivity,不活跃,NOUN,B2
-inadequate,inadequate,不足的,ADJ,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadmissible,inadmissible,不可接受的,ADJ,B2
-inadvertent,inadvertent,词,ADJ,C1
-inadvertently,inadvertently,词,ADV,B2
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inattentive,inattentive,词,ADJ,C1
-inaudible,inaudible,词,ADJ,B2
-inboard,inboard,船内的,ADV,B2
-inborn nature,inborn nature,词,NOUN,C1
-incandescence,incandescence,词,NOUN,C1
-incandescent,incandescent,白炽的,ADJ,B2
-incantation,incantation,咒语,NOUN,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incarceration,incarceration,词,NOUN,C1
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
-incentivization,incentivization,词,NOUN,C1
-inceptive,inceptive,词,ADJ,C1
-incessant,incessant,持续的,ADJ,B2
-incest,incest,词,NOUN,C1
-inchoative,inchoative,词,ADJ,C1
-incidence,incidence,发生率,NOUN,B2
-incidental,incidental,词,ADJ,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
-incipient,incipient,词,ADJ,C1
-incision,incision,切口,NOUN,B2
-incisive,incisive,深刻的,ADJ,B2
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,严酷的,ADJ,B2
-inclined prone,inclined prone,词,ADJ,C1
-including,including,包括,ADP,B2
-including (adv),including,词,ADV,A2
-inclusion,inclusion,包含,NOUN,B2
-incognito,incognito,词,ADJ,C1
-incoherence,incoherence,不连贯,NOUN,B2
-incoherent,incoherent,不连贯的,ADJ,B2
-income tax,income tax,所得税,NOUN,B2
-incommunicado,incommunicado,词,ADJ,C1
-incompatible,incompatible,词,ADJ,C1
-incompetence,incompetence,词,NOUN,C1
-incompetent,incompetent,无能的,ADJ,B2
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,不完整,NOUN,B2
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable,inconceivable,不可想象的,ADJ,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,词,NOUN,B2
-incongruous,incongruous,不协调的,ADJ,B2
-inconsiderate,inconsiderate,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontestably,incontestably,词,ADV,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorporation,incorporation,纳入,NOUN,B2
-incorrect,incorrect,不正确的,ADJ,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increased,increased,增加的,ADJ,B2
-increases,increases,增加,NOUN,C1
-increasing,increasing,增加的,ADJ,B2
-incredible,incredible,难以置信的,ADJ,B2
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
-incremental,incremental,渐进性,ADJ,B2
-inculcate,inculcate,词,VERB,C1
-incumbent,incumbent,词,ADJ,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-indebted,indebted,负债的,ADJ,B2
-indecent,indecent,词,ADJ,C1
-indecipherable,indecipherable,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
-independently,independently,独立地,ADV,B2
-indeterminate,indeterminate,词,ADJ,C1
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
-indexing,indexing,指数化,NOUN,B2
-indian (adj),indian,词,ADJ,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indigent,indigent,词,ADJ,C1
-indignity,indignity,词,NOUN,C1
-indirect,indirect,词,ADJ,C1
-indirectly,indirectly,间接地,ADV,B2
-indiscreet,indiscreet,词,ADJ,C1
-indiscretion,indiscretion,轻率,NOUN,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinct,indistinct,模糊的,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualization,individualization,词,NOUN,C1
-individually,individually,词,ADV,C1
-indoctrination,indoctrination,灌输,NOUN,B2
-indolent,indolent,词,ADJ,C1
-indomitable,indomitable,词,ADJ,C1
-indonesian,indonesian,印度尼西亚的,ADJ,B2
-indoors,indoors,在室内,ADV,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-indulge,indulge,词,VERB,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrialization,industrialization,工业化,NOUN,B2
-industriell,industrial,工业的,ADJ,B2
-industrious,industrious,词,ADJ,C1
-inedible,inedible,词,ADJ,C1
-ineffable,ineffable,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-ineffectiveness,ineffectiveness,词,NOUN,B2
-inefficiency,inefficiency,低效,NOUN,B2
-ineffizient,inefficient,低效的,ADJ,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inequity,inequity,词,NOUN,C1
-inert,inert,惰性的,ADJ,B2
-inertness,inertness,词,NOUN,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable (noun),inevitable,词,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexpressible,inexpressible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infamous,infamous,声名狼藉的,ADJ,B2
-infamy,infamy,恶名,NOUN,B2
-infant,infant,婴儿,NOUN,B2
-infantilism,infantilism,词,NOUN,C1
-infantry,infantry,步兵,NOUN,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-infected,infected,被感染的,ADJ,B2
-inferential,inferential,词,ADJ,C1
-infertility,infertility,词,NOUN,C1
-infidelity,infidelity,不忠,NOUN,B2
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infiltrieren,to infiltrate,渗透,VERB,B2
-infinitely,infinitely,词,ADV,B2
-infinity,infinity,词,NOUN,C1
-infirmary,infirmary,医务室,NOUN,B2
-inflamed,inflamed,激烈的,ADJ,B2
-inflammable,inflammable,易燃的,ADJ,B2
-inflammation,inflammation,炎症,NOUN,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflated,inflated,膨胀的,ADJ,B1
-inflationary,inflationary,词,ADJ,C1
-inflection,inflection,词尾,NOUN,B2
-inflexibility,inflexibility,僵化,NOUN,B2
-influential,influential,词,ADJ,C1
-influential person,influential person,词,NOUN,C1
-influx,influx,涌入,NOUN,B2
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
-informatics,informatics,词,NOUN,B2
-information desk,information desk,词,NOUN,B1
-information exchange,information exchange,词,NOUN,B2
-informative,informative,提供信息的,ADJ,B2
-informed,informed,见多识广的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informell,informal,非正式的,ADJ,B2
-informer,informer,词,NOUN,C1
-informers,informers,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructural,infrastructural,词,ADJ,C1
-infrastructure,infrastructure,基础设施,NOUN,B2
-infringement,infringement,侵犯,NOUN,C1
-ingratitude,ingratitude,词,NOUN,C1
-ingredients,ingredients,词,NOUN,B1
-inhabited,inhabited,词,ADJ,C1
-inharmonious,inharmonious,词,ADJ,C1
-inherence,inherence,固有,NOUN,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inherited,inherited,词,ADJ,C1
-inhibited,inhibited,词,ADJ,B2
-inhibition,inhibition,抑制,NOUN,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhuman,inhuman,不人道的,ADJ,B2
-inhumanity,inhumanity,词,NOUN,C1
-inhärent,inherent,固有的,ADJ,B2
-inimitability,inimitability,词,NOUN,C1
-initial (noun),initial,词,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
-initiation,initiation,词,NOUN,C1
-injizieren,to inject,注射,VERB,B2
-injury recovery,injury recovery,好伤,NOUN,C1
-inkling,inkling,预感,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inmate,inmate,词,NOUN,C1
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
-inner,inner,内部的,ADJ,B2
-inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
-inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
-innere Kraft,internal force,内力,NOUN,B2
-innermost,innermost,最里面的,ADV,B2
-innocent,innocent,无辜地,ADV,B2
-innocuous,innocuous,无害的,ADJ,B2
-innovativ,innovative,创新的,ADJ,B2
-innuendo,innuendo,词,NOUN,C1
-inopportune,inopportune,词,ADJ,C1
-inorganic,inorganic,词,ADJ,C1
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
-inquisition,inquisition,宗教裁判所,NOUN,B2
-inquisitive,inquisitive,好奇的,ADJ,B2
-insanely,insanely,疯狂地,ADV,B2
-insatiable,insatiable,不知足的,ADJ,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect-proof,insect-proof,防虫,ADJ,C1
-insecurity,insecurity,不安全感,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensitive,insensitive,麻木的,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
-insertion,insertion,词,NOUN,B2
-inside,inside,内部,NOUN,B2
-inside in,inside in,里,NOUN,B2
-inside of,inside of,在...里面,ADP,B2
-insidiously,insidiously,词,ADV,B2
-insightfulness,insightfulness,洞察,NOUN,B2
-insincere,insincere,词,ADJ,C1
-insinuation,insinuation,暗示,NOUN,B2
-insipid,insipid,词,ADJ,C1
-insistence persistence,insistence persistence,词,NOUN,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
-insolent conceit,insolent conceit,词,NOUN,C1
-insolvent,insolvent,无偿还能力的,ADJ,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
-inspectorate,inspectorate,词,NOUN,C1
-inspired,inspired,受启发的,ADJ,B2
-inspiring,inspiring,鼓舞人心的,ADJ,B2
-inspizieren,to inspect,检查,VERB,B2
-instabil,unstable,不稳定的,ADJ,B2
-installation assembly,installation assembly,词,NOUN,C1
-installed,installed,词,ADJ,C1
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
-instantaneous,instantaneous,瞬间的,ADJ,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instantly,instantly,词,ADV,C1
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instinctuality,instinctuality,词,NOUN,C1
-institutionalized,institutionalized,词,ADJ,C1
-institutionell,institutional,机构的,ADJ,B2
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructive,instructive,有教育意义的,ADJ,B2
-instructor,instructor,讲师,NOUN,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insufficiency,insufficiency,不足,NOUN,B2
-insulator,insulator,词,NOUN,B2
-insulin,insulin,胰岛素,NOUN,B2
-insurances,insurances,词,NOUN,C1
-insured,insured,词,NOUN,B2
-insurer,insurer,词,NOUN,C1
-insurgency,insurgency,词,NOUN,C1
-intake,intake,词,NOUN,C1
-intangible,intangible,无形的,ADJ,B2
-integer,integer,词,NOUN,C1
-integral,integral,不可或缺的,ADJ,B2
-integrieren,to integrate,整合,VERB,B2
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-intellect,intellect,智力,NOUN,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intellectual life,intellectual life,精神生活,NOUN,B2
-intellektuell,intellectual,知识的,ADJ,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
-intelligent,intelligent,聪明的,ADJ,B2
-intelligently,intelligently,词,ADV,C1
-intelligible,intelligible,词,ADJ,C1
-intemperate,intemperate,词,ADJ,C1
-intended,intended,预定的,ADJ,B2
-intended (noun),intended,intended,NOUN,B2
-intended meaning,intended meaning,词,NOUN,C1
-intensification,intensification,词,NOUN,C1
-intensive,intensive,强化的,ADJ,B2
-intensive care,intensive care,重症监护,NOUN,B2
-intensivieren,to intensify,加剧,VERB,B2
-intentionality,intentionality,词,NOUN,C1
-intentionally,intentionally,故意地,ADV,B2
-intentions,intentions,词,NOUN,C1
-interactivity,interactivity,词,NOUN,C1
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,interdiction,词,NOUN,C1
-interest rate,interest rate,利率,NOUN,B2
-interim (adj),interim,词,ADJ,C1
-interim (noun),interim,词,NOUN,B2
-interjection,interjection,词,NOUN,C1
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
-intermediate,intermediate,中级的,ADJ,B2
-intermission,intermission,词,NOUN,C1
-intermittierend,intermittent,间歇的,ADJ,B2
-intern,internal,内部的,ADJ,B2
-intern,intern,词,NOUN,C1
-internal affairs,internal affairs,内政,NOUN,C1
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
-international,international,国际的,ADJ,B2
-internationaler Student,international student,留学生,NOUN,B2
-internationalization,internationalization,词,NOUN,C1
-interpellation,interpellation,词,NOUN,C1
-interpretieren,to interpret,解释,VERB,B2
-interpretive,interpretive,词,ADJ,C1
-intertextuality,intertextuality,词,NOUN,C1
-intertwined,intertwined,词,ADJ,C1
-interval,interval,词,NOUN,C1
-interviewen,interview,面试,NOUN,B2
-interviewen,to interview,采访,VERB,B2
-interviewer,interviewer,词,NOUN,C1
-intestines,intestines,词,NOUN,B2
-intim,intimate,亲密的,ADJ,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimately,intimately,词,ADV,C1
-into (adp),into,词,ADP,A1
-intolerable,intolerable,词,ADJ,C1
-intolerant,intolerant,不容忍的,ADJ,B2
-intonational quality,intonational quality,词,NOUN,C1
-intoxication,intoxication,词,NOUN,C1
-intransigence,intransigence,词,NOUN,C1
-intransigent,intransigent,不妥协的,ADJ,B2
-intravenous drip,intravenous drip,输液,NOUN,B2
-intrepidity,intrepidity,词,NOUN,C1
-intricacy,intricacy,词,NOUN,C1
-intricate,intricate,错综复杂的,ADJ,B2
-intrigieren,to intrigue,激起兴趣,VERB,B2
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
-intrinsically,intrinsically,词,ADV,C1
-introductory,introductory,词,ADJ,C1
-introversion,introversion,词,NOUN,B2
-introvertiert,introverted,内向的,ADJ,B2
-intrusive,intrusive,词,ADJ,C1
-intuitionist,intuitionist,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-inure,inure,词,VERB,C1
-invader,invader,入侵者,NOUN,B2
-invalidated,invalidated,词,ADJ,C1
-invalidity,invalidity,词,NOUN,C1
-invariable,invariable,词,ADJ,C1
-invariably,invariably,不变地,ADV,B2
-invasieren,to invade,入侵,VERB,B2
-inventorying,inventorying,清点,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigative,investigative,词,ADJ,C1
-investment (adj),investment,词,ADJ,C1
-invincibility,invincibility,不胜,NOUN,C1
-invincible,invincible,无敌的,ADJ,B2
-inviolate,inviolate,词,ADJ,C1
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite offer,invite offer,词,VERB,A2
-invited,invited,词,ADJ,C1
-invocation,invocation,词,NOUN,C1
-invocations,invocations,词,NOUN,C1
-invoicing,invoicing,词,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
-involuntary,involuntary,无意识的,ADJ,B2
-involved party,involved party,词,NOUN,C1
-invulnerability,invulnerability,词,NOUN,C1
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-ion,ion,词,NOUN,C1
-iranian,iranian,伊朗的,ADJ,B2
-irdisch,terrestrial,地球的,ADJ,B2
-irgendein,any,任何,PRON,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰的,ADJ,B2
-irish person,irish person,爱尔兰人,NOUN,B2
-irksome,irksome,词,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
-irrational,irrational,非理性的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irreführen,to mislead,误导,VERB,B2
-irreführend,misleading,诡辩的,ADJ,B2
-irregular,irregular,不规则的,ADJ,B2
-irregularity,irregularity,不规则,NOUN,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irrelevant,irrelevant,不相关的,ADJ,B2
-irreligious,irreligious,词,ADJ,C1
-irremediably,irremediably,词,ADV,B2
-irretrievable,irretrievable,词,ADJ,C1
-irreversibel,irreversible,不可逆转的,ADJ,B2
-irreversibility,irreversibility,词,NOUN,C1
-irrigation,irrigation,词,NOUN,B2
-irritability,irritability,词,NOUN,C1
-irritable boredom,irritable boredom,词,NOUN,C1
-irritating,irritating,令人恼火的,ADJ,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamic,islamic,伊斯兰的,ADJ,B2
-islamization,islamization,词,NOUN,C1
-islander,islander,词,NOUN,C1
-isolated reports,isolated reports,词,NOUN,C1
-isolieren,to isolate,隔离,VERB,B2
-isoliert,isolated,孤立的,ADJ,B2
-isthmus,isthmus,词,NOUN,C1
-it,it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
-it neuter,it neuter,它 (中性),PRON,B2
-italian,italian,意大利的,ADJ,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-itinerant,itinerant,巡回的,ADJ,B2
-itinerary,itinerary,行程,NOUN,B2
-its,its,它的,PRON,B2
-its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-jackal,jackal,词,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
-jaded,jaded,厌倦的,ADJ,B2
-jadeite,jadeite,翡翠,NOUN,C1
-jailer,jailer,词,NOUN,B2
-janitor,janitor,词,NOUN,B2
-january,january,一月,NOUN,B2
-japanese,japanese,日本的,ADJ,B2
-jarring,jarring,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jaws,jaws,词,NOUN,C1
-jeans,jeans,牛仔裤,NOUN,B2
-jedoch,however,然而,CCONJ,B2
-jersey,jersey,词,NOUN,B1
-jest,jest,词,NOUN,C1
-jet,jet,喷气式飞机,NOUN,B2
-jet-black,jet-black,乌黑,ADJ,B2
-jeweler,jeweler,词,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewelry set,jewelry set,词,NOUN,C1
-jewelry store,jewelry store,珠宝店,NOUN,B2
-jewish,jewish,犹太的,ADJ,B2
-jews,jews,犹太人,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-jocular,jocular,词,ADJ,C1
-jocularity,jocularity,词,NOUN,B2
-joggen,to run to jog,跑步,VERB,B2
-joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-jointness,jointness,词,NOUN,C1
-joker,joker,词,NOUN,C1
-joking,joking,词,NOUN,B2
-journal,journal,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
-journalism,journalism,新闻业,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-journeying,journeying,词,NOUN,C1
-joust,joust,词,NOUN,B1
-jubeln,to exult,狂喜,VERB,B2
-jubilant,jubilant,词,ADJ,C1
-jubilation,jubilation,欢欣,NOUN,B2
-judge sentence,judge sentence,词,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
-jujube,jujube,枣子,NOUN,B2
-jumble,jumble,词,NOUN,B2
-juncture,juncture,词,NOUN,B2
-junger Mann,young man,年轻人,NOUN,B2
-junger Meister,young master,少庄主,NOUN,B2
-jungles,jungles,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junk,junk,破烂货,NOUN,B2
-junkie,junkie,词,NOUN,C1
-junta,junta,词,NOUN,C1
-jurisconsult,jurisconsult,法学专家,NOUN,B2
-jurisprudence,jurisprudence,法理学,NOUN,B2
-jurist,jurist,法学家,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
-jury,jury,陪审团,NOUN,B2
-jury service,jury service,陪审,NOUN,C1
-just,just,公正,ADJ,B2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,随便地,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
-justness,justness,公正,NOUN,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
-juxtapose,juxtapose,词,VERB,C1
-jährlich,annually,每年,ADV,B2
-kahl,bald,秃头的,ADJ,B2
-kaiserlich,imperial,帝国的,ADJ,B2
-kaiserliche Garde,imperial guard,御林,NOUN,B2
-kaiserliche Verwandte,imperial relatives,皇亲,NOUN,B2
-kaiserlicher Hof,imperial court,朝廷,NOUN,B2
-kaleidoscope,kaleidoscope,词,NOUN,B2
-kalt,coldly,冷淡地,ADV,B2
-kampagnieren,to campaign,积极参与活动,VERB,B2
-kanalisieren,to channel,疏导,VERB,B2
-kapitalisieren,to capitalize,利用,VERB,B2
-kaputtgehen,to break down,分解,VERB,B2
-kardial,cardiac,心脏的,ADJ,B2
-karikaturhaft,caricatural,漫画的,ADJ,B2
-kasbah,kasbah,词,NOUN,B1
-katastrophal,disastrous,灾难性的,ADJ,B2
-kategorisieren,to categorize,分类,VERB,B2
-kaufen,to purchase,购买,VERB,B2
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenly,keenly,词,ADV,C1
-keenness,keenness,词,NOUN,B2
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kerosene,kerosene,火油,NOUN,C1
-key point,key point,要点,NOUN,C1
-khul',khul',女方离婚,NOUN,C1
-kick (noun),kick,词,NOUN,B1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kids,kids,孩子,NOUN,B2
-killed,killed,词,NOUN,B2
-killing,killing,词,NOUN,B2
-kin,kin,词,NOUN,B2
-kind,kind,种类,NOUN,B2
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindisch,childish,幼稚的,ADJ,B2
-kindlich,filial,孝顺,ADJ,B2
-kindly,kindly,亲切地,ADV,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
-kinetisch,kinetic,运动的,ADJ,B2
-king,king,王,PART,B2
-kiosk,kiosk,亭子,NOUN,B2
-kirchlich,ecclesiastical,教会的,ADJ,B2
-kit,kit,词,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
-kiwi,kiwi,猕猴桃,NOUN,C1
-klagen,to wail,哀号,VERB,B2
-klassifizieren,to classify,分类,VERB,B2
-klassisch,classic,经典的,ADJ,B2
-klein,smallest,最小的,ADJ,B2
-klicken,to click,点击,VERB,B2
-klinisch,clinical,临床的,ADJ,B2
-klopfen,to pat,轻拍,VERB,B2
-klug,sagacious,睿智的,ADJ,B2
-knabbern,to nibble,啃,VERB,B2
-knack,knack,窍,NOUN,C1
-kneader,kneader,词,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knirschen,to crunch,嘎吱作响,VERB,B2
-knistern,to crackle,噼啪作响,VERB,B2
-knitterfrei,wrinkle-resistant,防皱,ADJ,B2
-knochig,bony,瘦骨嶙峋的,ADJ,B2
-knock,knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knockout match,knockout match,淘汰赛,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-knowledgeably,knowledgeably,词,ADV,C1
-known famous,known famous,著名的/熟悉的,ADJ,B2
-kochen,to boil,煮沸,VERB,B2
-koexistieren,to coexist,共存,VERB,B2
-kohl,kohl,词,NOUN,A1
-kohärent,coherent,连贯的,ADJ,B2
-kollektiv,collective,集体的,ADJ,B2
-kolonisieren,to colonize,殖民,VERB,B2
-komisch,comic,喜剧的,ADJ,B2
-kommerziell,commercial,商业的,ADJ,B2
-kommunal,municipal,市政的,ADJ,B2
-kommunistisch,communist,شيوعي,ADJ,B2
-kompakt,compact,紧凑的,ADJ,B2
-kompilieren,to compile,编译,VERB,B2
-komplex,complex,复杂的,ADJ,B2
-komplizieren,to complicate,使复杂化,VERB,B2
-komprimieren,to compress,压缩,VERB,B2
-kondensieren,to condense,浓缩,VERB,B2
-kondolieren,to condole,哀悼,VERB,B2
-konform,compliant,符合的,ADJ,B2
-konfrontieren,to confront,面对,VERB,B2
-konstituieren,to constitute,构成,VERB,B2
-konstruieren,to construct,建造,VERB,B2
-konstruktiv,constructive,建设性的,ADJ,B2
-konsularisch,consular,领事的,ADJ,B2
-konsultieren,to consult,咨询,VERB,B2
-kontemplativ,contemplative,沉思的,ADJ,B2
-kontemplieren,to contemplate,沉思,VERB,B2
-kontextuell,contextual,语境的,ADJ,B2
-kontinuierlich,continuous,连续的,ADJ,B2
-kontrastieren,to contrast,对比,VERB,B2
-konventionell,conventional,传统的,ADJ,B2
-konvergieren,to converge,汇聚,VERB,B2
-konversieren,to converse,交谈,VERB,B2
-konzipieren,to conceive,构想,VERB,B2
-koordinieren,to coordinate,协调,VERB,B2
-korrigieren,to correct,纠正,VERB,B2
-korruptieren,corrupt,腐败的,ADJ,B2
-korruptieren,to corrupt,腐败,VERB,B2
-kosmisch,cosmic,宇宙的,ADJ,B2
-kostbar,precious,珍贵的,ADJ,B2
-kreativ,creative,有创造力的,ADJ,B2
-kriegerisch,bellicose,好战的,ADJ,B2
-kriminalisieren,to criminalize,定罪,VERB,B2
-kriminell,criminal,犯罪的,ADJ,B2
-kritisch,critical,关键的,ADJ,B2
-kritisieren,to criticize,批评,VERB,B2
-krummrückig,hunchbacked,驼背的,ADJ,B2
-krähen,to caw,呱呱叫,VERB,B2
-krönen,to crown,加冕,VERB,B2
-kulturell,cultural,文化的,ADJ,B2
-kurz gesagt,in short,简而言之,ADV,B2
-kurzfristig gewinnorientiert,seeking instant benefit,急功近利,ADJ,B2
-kämpfen,struggle,斗争,NOUN,B2
-kämpfen,to struggle,挣扎,VERB,B2
-königlich,royal,皇家的,ADJ,B2
-können,to be able,能,VERB,B2
-können,to be able to,能够,VERB,B2
-körperlich,bodily,身体上的,ADJ,B2
-kühlen,to cool,冷却,VERB,B2
-künstlerisch,artistic,艺术的,ADJ,B2
-künstlich,artificial,人造的,ADJ,B2
-laazima,laazima,词,NOUN,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,不稳定的,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-labor-related,labor-related,词,ADJ,C1
-laboratory (adj),laboratory,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laborious striving,laborious striving,词,NOUN,C1
-laboriously,laboriously,词,ADV,C1
-labour market,labour market,词,NOUN,B1
-labyrinth,labyrinth,词,NOUN,C1
-labyrinthine,labyrinthine,词,ADJ,C1
-lace,lace,词,NOUN,C1
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-laconically,laconically,词,ADV,C1
-laconism,laconism,词,NOUN,B2
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-lacunary,lacunary,残缺的,ADJ,B2
-ladle,ladle,词,NOUN,A2
-lagern,store,商店,NOUN,B2
-lagern,to store,储存,VERB,B2
-lagoon,lagoon,词,NOUN,C1
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lamentable,lamentable,词,ADJ,C1
-lamp niche,lamp niche,词,NOUN,C1
-lampoon,lampoon,词,NOUN,C1
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
-land (adj),land,بري,ADJ,B2
-land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,土地政策,NOUN,B2
-land register,land register,地籍,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land use,land use,词,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landen,to end up,最终到达,VERB,B2
-landfill,landfill,填埋,NOUN,C1
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landmine,landmine,词,NOUN,C1
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
-landwirtschaftlich,agricultural,农业的,ADJ,B2
-langatmig,prolix,冗长的,ADJ,B2
-lange Zeit,long time,长时间,ADV,B2
-lange warten,to wait long,久等,VERB,B2
-langsam,slowly,缓慢地,ADV,B2
-language use,language use,语言使用,NOUN,B2
-languid,languid,词,ADJ,C1
-languor,languor,倦怠,NOUN,B2
-langweilig,bored,无聊的,ADJ,B2
-lapidary,lapidary,词,ADJ,B2
-lapse,lapse,疏忽,NOUN,B2
-lapse of time,lapse of time,词,NOUN,C1
-laptop,laptop,笔记本电脑,NOUN,B2
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large estate,large estate,词,NOUN,C1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larva,larva,幼虫,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
-lassitude,lassitude,词,NOUN,C1
-last evening,last evening,,NOUN,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
-lasting,lasting,词,ADJ,C1
-late,late,晚才,NOUN,B2
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-latent,latent,潜在的,ADJ,B2
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
-lateral side,lateral side,词,ADJ,C1
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin,latin,拉丁的,ADJ,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latitude leeway,latitude leeway,词,NOUN,C1
-laudable,laudable,词,ADJ,C1
-laugh (noun),laugh,词,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-launch (noun),launch,词,NOUN,B1
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,洗钱,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
-laundry detergent,laundry detergent,词,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
-lawless,lawless,无法的,ADJ,B2
-lawlessness,lawlessness,词,NOUN,C1
-lawnmower,lawnmower,割草机,NOUN,B2
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lax,lax,松懈的,ADJ,B2
-laxative,laxative,词,NOUN,C1
-laxity,laxity,松弛,NOUN,B2
-lay,lay,叙事短诗,NOUN,B2
-lay (adj),lay,词,ADJ,C1
-layer (verb),layer,压条,VERB,C1
-layer storage,layer storage,层/仓库,NOUN,B2
-layperson,layperson,外行,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
-lead actor,lead actor,主演,NOUN,B2
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf litter,leaf litter,词,NOUN,C1
-leaf page,leaf page,叶子,NOUN,B2
-leafiness,leafiness,词,NOUN,C1
-leafy,leafy,枝叶茂密的,ADJ,B2
-leak escape,leak escape,词,NOUN,B1
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
-leasing,leasing,词,NOUN,C1
-least,least,最少,ADV,B2
-least (adj),least,词,ADJ,A1
-leather goods,leather goods,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
-lebhaft,lively,热闹的,ADJ,B2
-lecken,to leak,泄漏,VERB,B2
-led astray,led astray,词,ADJ,C1
-leek,leek,词,NOUN,A2
-left hand,left hand,左手,NOUN,C1
-left-handed,left-handed,词,ADJ,C1
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leftovers,leftovers,词,NOUN,B2
-leg of lamb,leg of lamb,词,NOUN,B1
-legal,legally,合法地,ADV,B2
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal expert,legal expert,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
-legal representative,legal representative,词,NOUN,C1
-legalization,legalization,词,NOUN,C1
-legatee,legatee,受遗赠人,NOUN,B2
-legation,legation,公使馆,NOUN,B2
-legible,legible,词,ADJ,C1
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legion unit,legion unit,,NOUN,B2
-legislativ,legislative,立法的,ADJ,B2
-legislative elections,legislative elections,词,NOUN,C1
-legislator,legislator,词,NOUN,C1
-legislature,legislature,词,NOUN,B2
-legitim,legitimate,合法的,ADJ,B2
-legitimieren,to legitimize,使合法,VERB,B2
-legitimization,legitimization,词,NOUN,B2
-leicht,slightly,轻微地,ADV,B2
-leichtgläubig,gullible,易受骗的,ADJ,B2
-leisurely,leisurely,词,ADJ,C1
-leiten,conduct,行为,NOUN,B2
-leiten,to conduct,أجرى,VERB,B2
-lemon verbena,lemon verbena,词,NOUN,B2
-lemonade,lemonade,词,NOUN,A2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-length,length,长度,NOUN,B2
-lengthy,lengthy,词,ADJ,C1
-leniency,leniency,宽厚,NOUN,B2
-lenient,lenient,宽大的,ADJ,B2
-lens,lens,词,NOUN,C1
-lent,lent,大斋期,NOUN,B2
-lentil lens,lentil lens,词,NOUN,C1
-lentils,lentils,词,NOUN,A2
-lesbian,lesbian,女同性恋的,ADJ,B2
-lesion,lesion,病变,NOUN,B2
-less,less,更少,ADV,B2
-less (adj),less,较少的,ADJ,A1
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
-lest,lest,唯恐,SCONJ,B2
-let alone,let alone,别说,ADV,B2
-let alone (cconj),let alone,何况,CCONJ,B1
-lethal,lethal,致命的,ADJ,B2
-lethality,lethality,词,NOUN,C1
-lethargic,lethargic,昏睡的,ADJ,B2
-lethargy,lethargy,词,NOUN,C1
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
-lettuce,lettuce,生菜,NOUN,B2
-letztes Jahr,last year,去年,NOUN,B2
-level,to level,夷平,VERB,B2
-lever,lever,词,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-leverage,leverage,词,NOUN,B2
-levity,levity,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-lexical,lexical,词,ADJ,C1
-lexicology,lexicology,词汇学,NOUN,B2
-liabilities,liabilities,词,NOUN,C1
-liable,liable,有责任的,ADJ,B2
-liaison,liaison,联络,NOUN,B2
-libel,libel,词,NOUN,C1
-liberal,liberal,自由的,ADJ,B2
-liberalism,liberalism,自由主义,NOUN,B2
-liberalization,liberalization,自由化,NOUN,B2
-liberalize,liberalize,自由化,! VERB,B2
-liberate,to liberate,解放,VERB,B2
-liberating,liberating,解放的,ADJ,B2
-libertinism,libertinism,放荡,NOUN,B2
-liberty,liberty,词,NOUN,B2
-librarian,librarian,图书管理员,NOUN,B2
-license plate restriction,license plate restriction,限号,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
-licentiousness,licentiousness,放荡,NOUN,B2
-lichen,lichen,词,NOUN,B2
-lid,lid,盖子,NOUN,B2
-lie down,to lie down,躺,VERB,B2
-liebenswürdig,amiable,和蔼可亲的,ADJ,B2
-life (part),life,生,PART,A2
-life and death,life and death,生死,NOUN,B2
-life connection,life connection,连命,NOUN,C1
-life imprisonment,life imprisonment,无期徒刑,NOUN,B2
-life retribution,life retribution,偿命,NOUN,B2
-life sentence,life sentence,词,NOUN,B2
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-and-death,life-and-death,决生,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifeguard,lifeguard,词,NOUN,B2
-lifeless,lifeless,无生命的,ADJ,B2
-lifelong,lifelong,终身,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
-lifetime,lifetime,一生,NOUN,B2
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb,light bulb,词,NOUN,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light grey,light grey,浅灰色的,ADJ,B2
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,词,NOUN,A1
-lighter,lighter,打火机,NOUN,B2
-lightest,lightest,最轻,NOUN,C1
-lighthouse,lighthouse,灯塔,NOUN,B2
-lighting,lighting,词,NOUN,B2
-lightness,lightness,轻盈,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
-like,like,像,ADP,B2
-like (part),like,似的,PART,B1
-like as,like as,如同/好像,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,词,ADV,B1
-likely (adj),likely,词,ADJ,A1
-likely source,likely source,词,NOUN,C1
-likeness,likeness,就象,NOUN,B2
-lily,lily,百合,NOUN,B2
-limb,limb,肢体,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
-lime,lime,石灰,NOUN,B2
-liminal,liminal,阈限的,ADJ,B2
-limit border,limit border,界限,NOUN,B2
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limp,to limp,跛行,VERB,B2
-limpidity,limpidity,词,NOUN,C1
-line of conduct,line of conduct,行为方针,NOUN,B2
-line queue,line queue,词,NOUN,B1
-line up,to line up,排成一行,VERB,B2
-line-up,line-up,阵容,NOUN,B2
-lineage,lineage,血统,NOUN,B2
-lineages,lineages,词,NOUN,C1
-linear,linear,线性的,ADJ,B2
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,语言的,ADJ,B2
-linguist,linguist,词,NOUN,C1
-linguistic,linguistic,语言的,ADJ,B2
-linguistic intuition,linguistic intuition,词,NOUN,C1
-lining understudy,lining understudy,词,NOUN,B1
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linkage (noun),linkage,词,NOUN,C1
-linking,linking,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
-liquid,liquid,液态的,ADJ,B2
-lisp (noun),lisp,词,NOUN,C1
-listen (intj),listen,词,INTJ,B2
-listen up,listen up,听着,INTJ,B2
-listener,listener,听众,NOUN,B2
-listening,listening,也听,NOUN,B2
-listig,sly,狡猾的,ADJ,B2
-listing,listing,词,NOUN,C1
-listless,listless,词,ADJ,C1
-litanies,litanies,词,NOUN,C1
-literal,literal,字面的,ADJ,B2
-literalism,literalism,词,NOUN,C1
-literally,literally,字面上地,ADV,B2
-literariness,literariness,词,NOUN,C1
-literary,literary,文学的,ADJ,B2
-literary thefts,literary thefts,词,NOUN,C1
-lithe,lithe,词,ADJ,C1
-lithography,lithography,词,NOUN,C1
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litotes understatement,litotes understatement,词,NOUN,C1
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
-little (adj),little,词,ADJ,A1
-little (adv),little,词,ADV,A2
-little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,词,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
-little finger,little finger,词,NOUN,B2
-little girl,little girl,词,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,小心脏,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little sister,little sister,妹妹,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little town,little town,词,NOUN,C1
-liturgical,liturgical,词,ADJ,C1
-liturgy,liturgy,词,NOUN,C1
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-lizard,lizard,蜥蜴,NOUN,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loading,loading,词,NOUN,B2
-loanword,loanword,外来词,NOUN,C1
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,词,ADJ,C1
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
-local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-located,located,位于,ADJ,B2
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locker,locker,词,NOUN,C1
-locksmith,locksmith,词,NOUN,C1
-locomotive,locomotive,词,NOUN,C1
-lodges,lodges,道堂,NOUN,C1
-loft,loft,词,NOUN,C1
-loftiness,loftiness,高尚,NOUN,C1
-logarithm,logarithm,词,NOUN,C1
-logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logistical,logistical,词,ADJ,C1
-logistics (adj),logistics,词,ADJ,C1
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
-lokalisieren,to locate,定位,VERB,B2
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,,NOUN,B2
-long absence,long absence,久违,NOUN,C1
-long lease,long lease,词,NOUN,C1
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance runner,long-distance runner,长跑运动员,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-lasting,long-lasting,持久的,ADJ,B2
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longest,longest,أطول,NOUN,B1
-loofah,loofah,丝瓜,NOUN,C1
-look for to find,to look for to find,找,VERB,B2
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loop,loop,循环,NOUN,B2
-loophole,loophole,漏洞,NOUN,B2
-loopholes,loopholes,词,NOUN,C1
-loose,loose,松的,ADJ,B2
-loose thread,loose thread,词,NOUN,C1
-loosen,to loosen,放松,VERB,B2
-looseness,looseness,词,NOUN,C1
-loot,loot,战利品,NOUN,B2
-looting,looting,掠夺,NOUN,B2
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
-lord,lord,领主,NOUN,B2
-lord yu,lord yu,玉大人,NOUN,B2
-lord's words,lord's words,主说,NOUN,B2
-lordship,lordship,词,NOUN,C1
-lose,lose,上丢,NOUN,B2
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
-losses,losses,词,NOUN,B1
-lost,lost,迷失的,ADJ,B2
-lost tradition,lost tradition,失传,NOUN,C1
-lot,lot,许多,NOUN,B2
-lotar,lotar,词,NOUN,C1
-lots,lots,大量,NOUN,B2
-lottery,lottery,彩票,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
-loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-lounge,lounge,休息室,NOUN,B2
-louse,louse,虱子,NOUN,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-lovely,lovely,美好的,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low pressure,low pressure,低气压,NOUN,C1
-low tide,low tide,退潮,NOUN,B2
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowest,lowest,最低的,ADJ,B2
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyal,loyal,忠诚的,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucid,lucid,词,ADJ,C1
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck turn,luck turn,词,NOUN,A2
-lucky,lucky,幸运的,ADJ,B2
-lucky (noun),lucky,吉祥,NOUN,B2
-lucky chance,lucky chance,虽侥,NOUN,B2
-lucky find,lucky find,意外发现,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucrative,lucrative,有利可图的,ADJ,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-luftgestützt,aerial,航空的,ADJ,B2
-lukewarm,lukewarm,微温的,ADJ,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-lullaby,lullaby,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-luminous,luminous,发光的,ADJ,B2
-lump,lump,块,NOUN,B2
-lump in throat,lump in throat,词,NOUN,C1
-lunar,lunar,词,ADJ,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunatic,lunatic,疯子,NOUN,B2
-lupini beans,lupini beans,词,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
-lurid,lurid,词,ADJ,C1
-lust,lust,欲望,NOUN,B2
-luster,luster,光泽,NOUN,B2
-lustig,fun,有趣的,ADJ,B2
-lute,lute,词,NOUN,C1
-luxurious,luxurious,奢侈的,ADJ,B2
-lychee,lychee,荔枝,NOUN,C1
-lymph,lymph,淋巴,NOUN,B2
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyre,lyre,词,NOUN,B2
-lyrical,lyrical,抒情的,ADJ,B2
-lyricism,lyricism,词,NOUN,C1
-lyrics,lyrics,歌词,NOUN,B2
-ländlich,rural,乡村的,ADJ,B2
-löschen,to extinguish,熄灭,VERB,B2
-lösen,to untie,解开,VERB,B2
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machine (adj),machine,词,ADJ,B2
-machine learning,machine learning,机器学习,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-machinery,machinery,词,NOUN,C1
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
-macroscopic,macroscopic,宏观的,ADJ,B2
-mad,mad,词,ADJ,A1
-madam,madam,夫人,NOUN,B2
-made,made,词,ADJ,B2
-maelstrom,maelstrom,词,NOUN,C1
-mafia,mafia,黑手党,NOUN,B2
-magically,magically,魔法地,ADV,B2
-magistrate,magistrate,法官,NOUN,B2
-magnanimity,magnanimity,宽宏大量,NOUN,B2
-magnanimous,magnanimous,宽宏大量的,ADJ,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
-magnesium,magnesium,镁,NOUN,B2
-magnet,magnet,磁铁,NOUN,B2
-magnetic,magnetic,词,ADJ,B2
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
-magnificent,magnificent,壮丽的,ADJ,B2
-magnify,to magnify,放大,VERB,B2
-magnifying glass,magnifying glass,词,NOUN,C1
-magnitude,magnitude,词,NOUN,C1
-magus,magus,词,NOUN,C1
-maid,maid,女仆,NOUN,B2
-maiden,maiden,少女,NOUN,B2
-maidservant,maidservant,女仆,NOUN,B2
-maieutic,maieutic,词,ADJ,C1
-mail,mail,邮件,NOUN,B2
-mail (verb),mail,寄送,VERB,C1
-mailbox,mailbox,邮箱,NOUN,B2
-main,main,主要的,ADJ,B2
-main camp,main camp,大营,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-mainstream,mainstream,主流的,ADJ,B2
-majestätisch,majestic,宏伟的,ADJ,B2
-major,major,主要的,ADJ,B2
-major case,major case,大案,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
-make flexible,make flexible,词,VERB,C1
-makeover,makeover,改容,NOUN,C1
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-making,making,词,NOUN,B2
-maladjusted,maladjusted,词,ADJ,C1
-maladjustment,maladjustment,词,NOUN,C1
-malaria,malaria,疟疾,NOUN,B2
-male,male,男性,NOUN,B2
-male goat,male goat,词,NOUN,B2
-malefic,malefic,邪恶的,ADJ,B2
-malevolence,malevolence,恶意,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malfeasance,malfeasance,渎职,NOUN,B2
-malhun,malhun,词,NOUN,B2
-malicious,malicious,恶意的,ADJ,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
-malignity,malignity,词,NOUN,C1
-maliki school,maliki school,词,NOUN,C1
-mall,mall,词,NOUN,B2
-malleability,malleability,词,NOUN,C1
-malleable,malleable,词,ADJ,C1
-mallow greens,mallow greens,词,NOUN,B2
-malmo,malmo,马尔默,PROPN,B2
-malnutrition,malnutrition,营养不良,NOUN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mammal,mammal,哺乳动物,NOUN,B2
-mammalian,mammalian,词,ADJ,C1
-managed,managed,,NOUN,B2
-management pipe,management pipe,词,NOUN,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-mane,mane,词,NOUN,C1
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifestly,manifestly,明显地,ADV,B2
-manifesto,manifesto,宣言,NOUN,B2
-manifold,manifold,词,ADJ,B2
-manipulable,manipulable,可操纵的,ADJ,B2
-manipulator,manipulator,词,NOUN,C1
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
-mannerly,mannerly,有礼貌的,ADJ,B2
-manners,manners,词,NOUN,B2
-mannish,mannish,词,ADJ,C1
-manor (part),manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
-manslaughter,manslaughter,词,NOUN,C1
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manually,manually,手动地,ADV,B2
-manufacture,manufacture,制造,NOUN,B2
-manufacturing,manufacturing,词,NOUN,B1
-manumission,manumission,词,NOUN,C1
-manure (noun),manure,词,NOUN,C1
-many,many,许多,DET,B2
-many (noun),many,多……,NOUN,B2
-many (pron),many,词,PRON,B1
-many a,many a,词,ADJ,C1
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapping,mapping,梳理,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
-marble,marble,大理石,NOUN,B2
-marbly,marbly,词,ADJ,B2
-mare,mare,词,NOUN,B2
-marginal,marginal,边缘的,ADJ,B2
-marginalisieren,to marginalize,使边缘化,VERB,B2
-marginally,marginally,边缘地,ADV,B2
-marinade,marinade,词,NOUN,B2
-marine,marine,海洋的,ADJ,B2
-marine (noun),marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
-marinieren,to marinate,腌制,VERB,B2
-marital conjugal,marital conjugal,词,ADJ,C1
-maritim,maritime,海事的,ADJ,B2
-marker,marker,词,NOUN,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
-markets,markets,词,NOUN,C1
-maroon,maroon,词,ADJ,C1
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshal,marshal,元帅,NOUN,B2
-marshy,marshy,沼泽般的,ADJ,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martyr,martyr,词,NOUN,C1
-marvel (noun),marvel,词,NOUN,B2
-marvelous,marvelous,极好的,ADJ,B2
-mascot,mascot,吉祥物,NOUN,B2
-masculine (adj),masculine,词,ADJ,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-mash,mash,泥状食物,NOUN,B2
-mask (verb),mask,词,VERB,C1
-masochism,masochism,词,NOUN,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,词,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
-masses,masses,群众,NOUN,C1
-massiv,massive,巨大的,ADJ,B2
-massively,massively,大量地,ADV,B2
-mast (noun),mast,词,NOUN,C1
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
-masterly,masterly,词,ADJ,B2
-mastermind,mastermind,词,NOUN,C1
-mat,mat,词,NOUN,B2
-matches,matches,词,NOUN,C1
-matching use,matching use,配用,NOUN,C1
-mate,mate,词,NOUN,A2
-material (adj),material,词,ADJ,C1
-maternal,maternal,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-mathematician,mathematician,词,NOUN,C1
-mathematisch,mathematical,数学的,ADJ,B2
-matriarch,matriarch,女家长,NOUN,B2
-matriarchy,matriarchy,词,NOUN,C1
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
-mausoleum,mausoleum,词,NOUN,B1
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawkishness,mawkishness,词,NOUN,C1
-mawwal,mawwal,词,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
-maximal,maximum,最大,ADJ,B2
-maximization,maximization,词,NOUN,C1
-maximum (noun),maximum,词,NOUN,B2
-may (aux),may,词,AUX,A1
-maybe possible,maybe possible,可能,ADV,A1
-mayoral,mayoral,市长的,ADJ,B2
-maze,maze,词,NOUN,C1
-me,me,我,PRON,B2
-mead,mead,词,NOUN,C1
-meager,meager,词,ADJ,C1
-mean (noun),mean,词,NOUN,C1
-meander,meander,词,NOUN,C1
-meandering,meandering,蜿蜒的,ADJ,B2
-meaning content,meaning content,语义内容,NOUN,B2
-meaningful,meaningful,有意义的,ADJ,B2
-meaningless,meaningless,毫无意义的,ADJ,B2
-meanness,meanness,词,NOUN,C1
-measurable,measurable,词,ADJ,C1
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,词,ADJ,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mechanical,mechanical,机械的,ADJ,B2
-mechanically,mechanically,词,ADV,C1
-mechanics,mechanics,词,NOUN,C1
-mechanistic,mechanistic,机制性,ADJ,B2
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
-medal,medal,奖牌,NOUN,B2
-medal awarding,medal awarding,授勋,NOUN,B2
-medallion,medallion,词,NOUN,C1
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-media,media,媒体,NOUN,B2
-media (adj),media,词,ADJ,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media professionals,media professionals,词,NOUN,C1
-media-related,media-related,词,ADJ,B2
-median,median,中位数,NOUN,B2
-median (adj),median,词,ADJ,C1
-mediation,mediation,调解,NOUN,B2
-mediator,mediator,调解人,NOUN,C1
-medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical examiner,medical examiner,词,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,词,NOUN,C1
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
-medieval,medieval,中世纪的,ADJ,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
-meditation,meditation,冥想,NOUN,B2
-mediterranean,mediterranean,地中海的,ADJ,B2
-medium,medium,媒介,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-meek,meek,温顺的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-megabyte,megabyte,词,NOUN,C1
-megalomania,megalomania,狂妄自大,NOUN,B2
-megalomaniac,megalomaniac,词,ADJ,C1
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
-mehrdeutig,ambiguous,模棱两可的,ADJ,B2
-mehrere,several,几个,ADJ,B2
-mein Großer,my big one,我偌大,NOUN,B2
-mein Wohnsitz,my residence,我府,NOUN,B2
-mein Zuhause,my place,我处,NOUN,B2
-meistens,most,最,ADV,B2
-melancholy,melancholy,忧郁,ADJ,B2
-melancholy (noun),melancholy,忧郁,NOUN,C1
-mellifluous,mellifluous,词,ADJ,C1
-mellifluousness,mellifluousness,词,NOUN,C1
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
-melon,melon,香瓜,NOUN,C1
-melon groping,melon groping,摸瓜,NOUN,B2
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
-membership,membership,会员资格,NOUN,B2
-membrane,membrane,词,NOUN,C1
-memoir,memoir,回忆录,NOUN,B2
-memorable,memorable,难忘的,ADJ,B2
-memorandum,memorandum,备忘录,NOUN,B2
-memorial (adj),memorial,词,ADJ,C1
-memorization,memorization,记忆,NOUN,B2
-memorizer,memorizer,词,NOUN,C1
-memory loss,memory loss,词,NOUN,C1
-men,men,词,NOUN,C1
-menace,menace,词,NOUN,C1
-mendacious,mendacious,词,ADJ,C1
-meninx,meninx,词,NOUN,C1
-menses,menses,词,NOUN,B2
-mental hospital,mental hospital,精神病院,NOUN,B2
-mentality,mentality,心态,NOUN,B2
-mentally,mentally,精神上地,ADV,B2
-mention,mention,提及,NOUN,B2
-mentioned,mentioned,词,ADJ,B2
-mentor,mentor,导师,NOUN,B2
-mentoring,mentoring,词,NOUN,B2
-mercantile,mercantile,词,ADJ,C1
-mercenaries,mercenaries,词,NOUN,C1
-mercenary,mercenary,雇佣兵,NOUN,B2
-mercenary (adj),mercenary,词,ADJ,C1
-merchandise,merchandise,商品,NOUN,B2
-merchant ship,merchant ship,商船,NOUN,C1
-merciful,merciful,词,ADJ,B2
-mercilessly,mercilessly,词,ADV,C1
-mercurial,mercurial,词,ADJ,C1
-mercury,mercury,汞,NOUN,B2
-mercy blow,mercy blow,词,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
-merge,merge,合并,NOUN,B2
-merge,to merge,合并,VERB,B2
-merged,merged,词,ADJ,C1
-merger,merger,合并,NOUN,B2
-merger fusion,merger fusion,词,NOUN,B1
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
-meritocracy,meritocracy,精英管理,NOUN,B2
-merits,merits,词,NOUN,C1
-mermaid,mermaid,美人鱼,NOUN,B2
-merriment,merriment,词,NOUN,C1
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-mess,mess,混乱,NOUN,B2
-message errand,message errand,词,NOUN,B2
-messaging,messaging,词,NOUN,C1
-messenger,messenger,信使,NOUN,B2
-messy,messy,混乱的,ADJ,B2
-metabolic,metabolic,代谢的,ADJ,B2
-metabolism,metabolism,新陈代谢,NOUN,B2
-metalepsis,metalepsis,词,NOUN,C1
-metalinguistic,metalinguistic,词,ADJ,C1
-metallic,metallic,金属的,ADJ,B2
-metallurgy,metallurgy,词,NOUN,C1
-metamorphic,metamorphic,变质的,ADJ,B2
-metamorphosis,metamorphosis,词,NOUN,C1
-metaphor,metaphor,隐喻,NOUN,B2
-metaphorical,metaphorical,隐喻的,ADJ,B2
-metaphysical,metaphysical,词,ADJ,C1
-metaphysics,metaphysics,形而上学,NOUN,B2
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological,meteorological,气象的,ADJ,B2
-meteorological observations,meteorological observations,词,NOUN,C1
-meter,meter,米,NOUN,B2
-metering,metering,词,ADJ,C1
-methane,methane,词,NOUN,C1
-methodical,methodical,词,ADJ,C1
-methodological,methodological,方法论的,ADJ,B2
-methodology,methodology,方法论,NOUN,B2
-meticulous,meticulous,一丝不苟的,ADJ,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
-metonymy,metonymy,转喻,NOUN,B2
-metric,metric,公制的,ADJ,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolis,metropolis,大都市,NOUN,B2
-metropolises,metropolises,词,NOUN,C1
-metropolitan,metropolitan,词,ADJ,C1
-mettle,mettle,词,NOUN,C1
-mezzanine,mezzanine,夹层,NOUN,B2
-mich aufhalten,to stop me,拦我,VERB,B2
-microeconomic,microeconomic,词,ADJ,B2
-microscopic,microscopic,微观的,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-microwave,microwave,微波炉,NOUN,B2
-mid-morning,mid-morning,词,NOUN,C1
-midday heat,midday heat,词,NOUN,B1
-middle,middle,中间,ADV,B2
-middle (adj),middle,词,ADJ,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
-midpoint,midpoint,词,NOUN,B2
-midst,midst,中间,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
-might,might,威力,NOUN,B2
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty,mighty,词,ADJ,B1
-mighty man,mighty man,词,NOUN,B2
-mighty very,mighty very,非常,ADJ,B2
-migrant,migrant,词,NOUN,B2
-migratory,migratory,词,ADJ,C1
-migrieren,to migrate,迁移,VERB,B2
-mildern,to mitigate,减轻,VERB,B2
-mildew,mildew,词,VERB,C1
-militant,militant,词,ADJ,C1
-militaristic,militaristic,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
-military merit,military merit,军功,NOUN,C1
-military pay,military pay,军饷,NOUN,B2
-militärisch,military,军事的,ADJ,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,词,NOUN,C1
-milkman,milkman,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
-millionaire,millionaire,词,NOUN,B2
-millions of,millions of,数百万的,NUM,B2
-mime (noun),mime,词,NOUN,C1
-mimicry,mimicry,词,NOUN,B2
-minaret,minaret,词,NOUN,B1
-minatory,minatory,词,ADJ,C1
-minced meat,minced meat,词,NOUN,A2
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mine (verb),mine,开采,VERB,C1
-mineral (adj),mineral,词,ADJ,C1
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
-minibus,minibus,中巴,NOUN,B2
-minimal,minimal,微小的,ADJ,B2
-minimalism,minimalism,极简主义,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimization,minimization,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
-ministeriell,ministerial,部长的,ADJ,B2
-minivan,minivan,词,NOUN,B2
-minor,minor,较小的,ADJ,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
-minority,minority,少数派的,ADJ,B2
-minority group,minority group,少数群体,NOUN,B2
-minus,minus,减,NOUN,B2
-minuscule,minuscule,极小的,ADJ,B2
-minutes,minutes,词,NOUN,B2
-miraculous,miraculous,词,ADJ,C1
-mirage,mirage,词,NOUN,C1
-mirthful,mirthful,词,ADJ,C1
-misanthrope,misanthrope,厌世者,NOUN,B2
-misanthropic,misanthropic,词,ADJ,C1
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misconception,misconception,词,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-misdemeanor,misdemeanor,词,NOUN,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-miserly,miserly,吝啬的,ADJ,B2
-mishearing,mishearing,听错,NOUN,C1
-misjudge,misjudge,词,VERB,C1
-mismatch,mismatch,词,NOUN,C1
-misplaced,misplaced,不合时宜的,ADJ,B2
-miss teacher,miss teacher,词,NOUN,B2
-missachten,to disobey,违抗,VERB,B2
-missfallen,to displease,使不快,VERB,B2
-misshandeln,to mistreat,أساء,VERB,B2
-missile,missile,导弹,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missionizing,missionizing,词,ADJ,C1
-missions,missions,词,NOUN,C1
-missive,missive,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-missverstehen,to misunderstand,误解,VERB,B2
-mistaken,mistaken,错误的,ADJ,B2
-mistreatment,mistreatment,虐待,NOUN,B2
-misunderstood,misunderstood,词,ADJ,C1
-mit Essstäbchen essen,to use chopsticks,动筷,VERB,B2
-mit Mühe,with difficulty,困难地,ADV,B2
-mit allen Mitteln,by fair means or foul,不择手段,ADV,B2
-mit einem Schlag zwei Fliegen mit der Klappe,kill two birds with one stone,一举两得,ADJ,B2
-mitfühlen,to empathize,共情,VERB,B2
-mitfühlend,compassionate,有同情心的,ADJ,B2
-mitigating,mitigating,词,ADJ,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitigation,mitigation,词,NOUN,C1
-mitschuldig,complicit,共谋的,ADJ,B2
-mittels,by means of,通过,ADP,B2
-mitten,mitten,连指手套,NOUN,B2
-mix bar,mix bar,混吧,NOUN,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixer,mixer,词,NOUN,C1
-mixing,mixing,词,NOUN,B2
-mob,mob,词,NOUN,B2
-mobil,mobile,移动的,ADJ,B2
-mobile (noun),mobile,词,NOUN,B2
-mobile Zahlung,mobile payment,移动支付,NOUN,B2
-mobilisieren,to mobilize,动员,VERB,B2
-mobility,mobility,流动性,NOUN,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-mockery,mockery,词,NOUN,C1
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
-modem,modem,词,NOUN,C1
-moderat,moderate,适度的,ADJ,B2
-moderate snow,moderate snow,中雪,NOUN,C1
-moderater Regen,moderate rain,中雨,NOUN,B2
-moderator,moderator,词,NOUN,C1
-modern,modern,现代的,ADJ,B2
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,现代,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
-modestly,modestly,词,ADV,C1
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified structure,modified structure,改结,NOUN,C1
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
-modifizierter Effekt,modified effect,改效,NOUN,B2
-modifizierter Klang,modified sound,改响,NOUN,B2
-modifiziertes Modell,modified model,改模,NOUN,B2
-modifiziertes System,modified system,改系,NOUN,B2
-modular,modular,模块化的,ADJ,B2
-modulation,modulation,词,NOUN,C1
-module,module,词,NOUN,C1
-moisten,moisten,词,VERB,C1
-moisture,moisture,词,NOUN,B2
-moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
-mollify,mollify,词,VERB,C1
-molten,molten,词,ADJ,C1
-molting,molting,词,NOUN,C1
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,暂时地,ADV,B2
-momentous,momentous,词,ADJ,C1
-monarch,monarch,君主,NOUN,B2
-monarchy,monarchy,君主制,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monasticism,monasticism,词,NOUN,C1
-monatlich,monthly,每月的,ADV,B2
-monatliche Prüfung,monthly exam,月考,NOUN,B2
-monetization,monetization,词,NOUN,C1
-monetär,monetary,金钱的,ADJ,B2
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
-monkey ape,monkey ape,猿/猴,NOUN,B2
-monolithic,monolithic,单一的,ADJ,B2
-monologue,monologue,词,NOUN,B2
-monopolisieren,to monopolize,垄断,VERB,B2
-monopolistisch,monopolistic,垄断的,ADJ,B2
-monotheism,monotheism,词,NOUN,C1
-monoton,monotonous,单调的,ADJ,B2
-monotonic,monotonic,词,ADJ,C1
-monotony,monotony,词,NOUN,C1
-monstrous,monstrous,怪异的,ADJ,B2
-month ago,month ago,月前,NOUN,B2
-monthly (adj),monthly,每月的,ADJ,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-monumental,monumental,词,ADJ,C1
-moodiness,moodiness,词,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-mooring,mooring,词,NOUN,C1
-moose,moose,驼鹿,NOUN,B2
-mop (noun),mop,词,NOUN,B2
-moral,moral,道德的,ADJ,B2
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,人心,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralization,moralization,词,NOUN,C1
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morally,morally,词,ADV,C1
-moratorium,moratorium,暂停,NOUN,B2
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
-more,more,مزيد,NOUN,B2
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,词,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover,moreover,而且,CCONJ,B2
-morgue,morgue,词,NOUN,B1
-morning (adj),morning,词,ADJ,C1
-moroccanization,moroccanization,词,NOUN,C1
-morocco leather,morocco leather,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morpheme,morpheme,语素,NOUN,C1
-morphine,morphine,吗啡,NOUN,B2
-morphologisch,morphological,形态的,ADJ,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortality,mortality,死亡率,NOUN,B2
-mortar,mortar,词,NOUN,C1
-mortuary,mortuary,词,NOUN,B2
-moslem,moslem,词,NOUN,C1
-mosquito net,mosquito net,蚊帐,NOUN,B2
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-most,most,大多数,PRON,B2
-most (noun),most,大部分,NOUN,B2
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most like,most like,最像,NOUN,C1
-motel,motel,汽车旅馆,NOUN,B2
-moth,moth,词,NOUN,B2
-mother (part),mother,娘,PART,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherland,motherland,祖国,NOUN,B2
-motif,motif,主题,NOUN,B2
-motionless,motionless,静止的,ADJ,B2
-motivieren,to motivate,激励,VERB,B2
-motley,motley,词,ADJ,B2
-motor,motor,运动的,ADJ,B2
-motorist,motorist,词,NOUN,C1
-motorway,motorway,词,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mound,mound,土堆,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-move fast,move fast,快搬,NOUN,C1
-moving,moving,感人的,ADJ,B2
-mow,mow,词,VERB,B2
-mp,mp,国会议员,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-much (adj),much,词,ADJ,A1
-much (adv),much,词,ADV,B2
-much many,much many,许多,ADJ,B2
-mucous,mucous,词,ADJ,C1
-muddied,muddied,词,ADJ,C1
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-muezzin,muezzin,词,NOUN,B2
-muffin,muffin,词,NOUN,B2
-mufti,mufti,词,NOUN,C1
-mug (noun),mug,词,NOUN,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiple,multiple,词,ADJ,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
-murk of dawn,murk of dawn,词,NOUN,C1
-murky,murky,词,ADJ,C1
-murmeln,to mutter,嘟囔,VERB,B2
-murmuring,murmuring,词,NOUN,C1
-muscle ache,muscle ache,肌肉酸痛,NOUN,B2
-muscular,muscular,词,ADJ,C1
-muse,muse,词,VERB,B2
-museum piece,museum piece,博物馆藏品,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
-musical,musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
-musicality,musicality,词,NOUN,C1
-musikalisch,musical,موسيقي,ADJ,B2
-musk,musk,麝香,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustache,mustache,胡子,NOUN,B2
-mustard,mustard,词,NOUN,A1
-mutable,mutable,词,ADJ,C1
-mutagenic,mutagenic,词,ADJ,C1
-mutazilites,mutazilites,词,NOUN,C1
-mute person,mute person,词,NOUN,B2
-mutig,bold,大胆的,ADJ,B2
-mutig sein,to be brave,勇善,VERB,B2
-mutilate,mutilate,词,VERB,C1
-mutiny (noun),mutiny,兵变,NOUN,B2
-muttering,muttering,念叨,NOUN,C1
-mutual affection,mutual affection,词,NOUN,C1
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
-mutual pulling,mutual pulling,词,NOUN,C1
-mutual support,mutual support,互助,NOUN,C1
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzle,muzzle,口套,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myelin,myelin,词,NOUN,C1
-myriad,myriad,词,ADJ,C1
-myself,myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythical,mythical,神话般的,ADJ,B2
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
-mühsam,arduous,艰巨的,ADJ,B2
-mühsam,laborious,费力的,ADJ,B2
-müssen,need,需要,AUX,B2
-nach Herzenslust,one's heart's content,尽情,ADV,B2
-nachdenken,to ponder,沉思,VERB,B2
-nachfolgend,subsequent,随后的,ADJ,B2
-nachhaltig,sustainable,可持续的,ADJ,B2
-nachlässig,careless,粗心的,ADJ,B2
-nachlässig,negligent,疏忽的,ADJ,B2
-nachschlagen,to consult reference,参考,VERB,B2
-nadir,nadir,最低点,NOUN,B2
-nah,nah,不,INTJ,B2
-nahe,near,近,ADJ,B2
-name-calling,name-calling,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-nape,nape,后颈,NOUN,B2
-narcissistic,narcissistic,自恋的,ADJ,B2
-narcotics,narcotics,词,NOUN,C1
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
-narrative (adj),narrative,词,ADJ,C1
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
-narrators,narrators,词,NOUN,C1
-narrow-minded,narrow-minded,狭隘的,ADJ,B2
-narrowing,narrowing,变窄,NOUN,B2
-nascent,nascent,词,ADJ,C1
-national,national,国家的,ADJ,B2
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
-nationalist,nationalist,民族主义者,NOUN,B2
-nationwide,nationwide,全国,NOUN,B2
-native (noun),native,词,NOUN,C1
-native american,native american,印第安人,NOUN,B2
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-naturalization,naturalization,入籍,NOUN,B2
-naturally,naturally,自然地,ADV,B2
-naturbegabt,richly endowed by nature,得天独厚,ADJ,B2
-natürlich,natural,自然的,ADJ,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-naval,naval,词,ADJ,C1
-navel,navel,肚脐,NOUN,B2
-navigational,navigational,词,ADJ,C1
-near,near,在附近,ADP,B2
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,在附近,ADV,B2
-nearby (noun),nearby,附近,NOUN,B2
-nearest,nearest,最近的,ADJ,B2
-nearest (noun),nearest,词,NOUN,B2
-nearness,nearness,词,NOUN,B2
-neatly,neatly,整洁地,ADV,B2
-nebeneinanderstehen,to stand side by side,并列,VERB,B2
-nebulous,nebulous,词,ADJ,C1
-necessarily incumbent,necessarily incumbent,词,ADV,C1
-necklace chain,necklace chain,词,NOUN,A1
-neckline,neckline,词,NOUN,C1
-necrosis,necrosis,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
-nefarious,nefarious,词,ADJ,C1
-negativity,negativity,消极,NOUN,B2
-negieren,to negate,否定,VERB,B2
-neglect (noun),neglect,词,NOUN,C1
-negotiator,negotiator,词,NOUN,C1
-neigen,to incline,使倾斜,VERB,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
-neighbors,neighbors,词,NOUN,B1
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,词,NOUN,B2
-neither (adv),neither,词,ADV,A1
-neither (det),neither,词,DET,A2
-neither nor,neither nor,词,CCONJ,A2
-nemesis,nemesis,词,NOUN,C1
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
-neophyte,neophyte,新手；初学者,NOUN,B2
-nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
-nesting box,nesting box,词,NOUN,B1
-nettle,nettle,词,NOUN,C1
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neunte,ninth,第九,ADJ,B2
-neunzig,ninety,九十,NUM,B2
-neural,neural,词,ADJ,C1
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neurological,neurological,词,ADJ,C1
-neuron,neuron,词,NOUN,B2
-neuroscience,neuroscience,词,NOUN,C1
-neuroticism,neuroticism,词,NOUN,C1
-neutral,neutral,中立的,ADJ,B2
-neutron,neutron,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
-newcomer,newcomer,新来者,NOUN,B2
-newly,newly,词,ADV,C1
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
-news bulletin,news bulletin,词,NOUN,B2
-news report,news report,词,NOUN,B1
-news reporting,news reporting,新闻报道,NOUN,B2
-newsletter,newsletter,简报,NOUN,B2
-next (adv),next,其次,ADV,B2
-next day,next day,词,NOUN,A2
-next following,next following,词,ADJ,C1
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
-next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,词,NOUN,B2
-niche,niche,词,NOUN,C1
-nicht,do not,莫,ADV,B2
-nicht,not,不,ADV,B2
-nicht betreffen,to not about,不关,VERB,B2
-nicht erlauben,not allow,不许,AUX,B2
-nicht ertragen,to cannot bear,不堪,VERB,B2
-nicht glauben,to can't believe,不敢相信,VERB,B2
-nicht haben,to not have,没,VERB,B2
-nicht konform,noncompliant,违规,ADJ,B2
-nicht können,cannot,不能,AUX,B2
-nicht mögen,to dislike,不喜欢,VERB,B2
-nicht nur,not only,不光,CCONJ,B2
-nicht umhin können,can't help,不由得,ADV,B2
-nicht umhin können,to cannot help,忍不住,VERB,B2
-nicht vernachlässigbar,negligible not,不可忽视,ADJ,B2
-nickel,nickel,镍,NOUN,B2
-niedergeschlagen,dejected,沮丧的,ADJ,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
-nihilistic,nihilistic,词,ADJ,C1
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,氮,NOUN,B2
-no,no,不,ADV,B2
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no harm,no harm,没事吧,NOUN,B2
-no heaven,no heaven,无天,NOUN,C1
-no longer,no longer,不再,ADV,B2
-no matter,no matter,不论,CCONJ,B2
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no need,no need,不用,AUX,B2
-no not,no not,不,ADV,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-nobility,nobility,贵族气质,NOUN,B2
-nobility of character,nobility of character,词,NOUN,C1
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
-noch,yet,还,ADV,B2
-noch einmal,once more,再次,ADV,B2
-nocturnal,nocturnal,夜间的,ADJ,B2
-node,node,词,NOUN,C1
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noise row,noise row,词,NOUN,C1
-noisome,noisome,词,ADJ,C1
-noisy,noisy,吵闹的,ADJ,B2
-nomad,nomad,游牧者,NOUN,B2
-nomadism,nomadism,游牧生活,NOUN,B2
-nomads,nomads,词,NOUN,B2
-nominal,nominal,词,ADJ,C1
-nominate,to nominate,提名,VERB,B2
-nomination,nomination,提名,NOUN,B2
-nominee,nominee,词,NOUN,C1
-non-ability,non-ability,非能,NOUN,B2
-non-above,non-above,非上,NOUN,C1
-non-abstraction,non-abstraction,非抽,NOUN,B2
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-action,non-action,非作,NOUN,B2
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-assistance,non-assistance,勿助,NOUN,B2
-non-belief,non-belief,非信,NOUN,B2
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
-non-concept,non-concept,非概,NOUN,B2
-non-concrete,non-concrete,非具,NOUN,C1
-non-construction,non-construction,非建,NOUN,B2
-non-contingent,non-contingent,非偶,NOUN,B2
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-evidence,non-evidence,非据,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
-non-induction,non-induction,非归,NOUN,B2
-non-inference,non-inference,非推,NOUN,B2
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-level,non-level,非级,NOUN,B2
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-management,non-management,管不,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-merit,non-merit,非功,NOUN,B2
-non-mind,non-mind,非心,NOUN,B2
-non-model,non-model,非模,NOUN,B2
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-orbit,non-orbit,非轨,NOUN,B2
-non-order,non-order,非序,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shadow,non-shadow,非影,NOUN,B2
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-sound,non-sound,非响,NOUN,B2
-non-specific,non-specific,非殊,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-state,non-state,非态,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-strategy,non-strategy,非略,NOUN,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-substance,non-substance,非质,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
-nonconformist,nonconformist,词,NOUN,C1
-nonexistent,nonexistent,词,ADJ,C1
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonprofit,nonprofit,非营利的,ADJ,B2
-nonviolence,nonviolence,非暴力,NOUN,B2
-noodles,noodles,面条,NOUN,A1
-nor,nor,也不,CCONJ,B2
-normal,normal,正常的,ADJ,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalerweise,usually,通常,ADV,B2
-normalization,normalization,词,NOUN,C1
-normativity,normativity,词,NOUN,C1
-northeast,northeast,词,NOUN,C1
-northward,northward,词,ADV,B2
-norwegian,norwegian,挪威的,ADJ,B2
-nosology,nosology,词,NOUN,C1
-nostalgia,nostalgia,怀旧,NOUN,B2
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
-nosy,nosy,爱打听的,ADJ,B2
-not (adv),not,非,ADV,B2
-not afraid,not afraid,不怕,VERB,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
-not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
-not catch up,not catch up,非赶,NOUN,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
-notables,notables,词,NOUN,B2
-notably,notably,显著地,ADV,B2
-notarized,notarized,经公证的,ADJ,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
-note patch,note patch,词,NOUN,C1
-notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
-notifications,notifications,词,NOUN,C1
-notion,notion,词,NOUN,B2
-notoriously,notoriously,词,ADV,C1
-notwendigerweise,necessarily,必然地,ADV,B2
-notwithstanding,notwithstanding,词,ADP,C1
-nourishment,nourishment,营养,NOUN,B2
-novelty,novelty,新奇事物,NOUN,B2
-novice,novice,词,NOUN,C1
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
-nuance,nuance,细微差别,NOUN,B2
-nuclear (noun),nuclear,词,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,词,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nugget,nugget,词,NOUN,C1
-nuklear,nuclear,核的,ADJ,B2
-null and void,null and void,无效的,ADJ,C1
-nullify,nullify,词,VERB,C1
-numb,numb,麻木的,ADJ,B2
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
-numbering,numbering,词,NOUN,C1
-numeral,numeral,词,NOUN,C1
-numerical,numerical,词,ADJ,C1
-numismatic,numismatic,钱币学的,ADJ,B2
-nunation,nunation,词,NOUN,C1
-nur,only,唯一的,ADJ,B2
-nur können,can only,只能,AUX,B2
-nursing home,nursing home,养老院,NOUN,C1
-nutritional,nutritional,词,ADJ,C1
-nuts,nuts,疯狂的,ADJ,B2
-nutzen,to utilize,利用,VERB,B2
-nylon,nylon,尼龙,NOUN,C1
-nächste,next,接下来,ADV,B2
-nördlich,northern,北方的,ADJ,B2
-nörgeln,to nag,唠叨,VERB,B2
-o,o,词,PART,B1
-o'clock (adv),o'clock,词,ADV,B2
-o'clock (noun),o'clock,点,NOUN,B2
-oak,oak,词,NOUN,B1
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
-ob,whether or not,是否,SCONJ,B2
-obdurate,obdurate,词,ADJ,C1
-obelisk,obelisk,词,NOUN,C1
-ober,upper,上面的,ADJ,B2
-obese,obese,词,ADJ,B2
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
-objective,objective,目标,NOUN,B2
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-objectivism,objectivism,词,NOUN,C1
-obligatory,obligatory,词,ADJ,C1
-obliged,obliged,被迫的,ADJ,B2
-obliging,obliging,词,ADJ,B2
-oblique,oblique,斜的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-obliteration,obliteration,词,NOUN,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
-obscenity,obscenity,词,NOUN,C1
-obscurantist,obscurantist,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observable,observable,词,ADJ,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,词,ADJ,C1
-observers,observers,词,NOUN,C1
-obsess,obsess,词,VERB,B2
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstinately,obstinately,词,ADV,C1
-obstreperous,obstreperous,词,ADJ,C1
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-obzön,obscene,淫秽的,ADJ,B2
-occasional,occasional,词,ADJ,C1
-occult,occult,神秘的,ADJ,B2
-occultism,occultism,词,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-octave,octave,词,NOUN,C1
-october,october,十月,NOUN,B2
-octopus,octopus,词,NOUN,B2
-ocular,ocular,词,ADJ,C1
-oddly,oddly,词,ADV,B2
-odds,odds,赔率,NOUN,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-of,of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of by,of by,的/被,ADP,B2
-of course,of course,当然,INTJ,B2
-of first instance,of first instance,词,ADJ,C1
-of it,of it,词,ADV,B2
-of old,of old,词,ADV,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,词,ADJ,B2
-of which,of which,关于哪个,PRON,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
-off-center,off-center,词,ADJ,C1
-off-track,off-track,词,ADJ,C1
-offcuts,offcuts,词,NOUN,C1
-offen,openly,公开地,ADV,B2
-offence,offence,词,NOUN,B2
-offenlegen,to disclose,揭露,VERB,B2
-offense,offense,冒犯,NOUN,B2
-offensichtlich,obviously,显然,ADV,B2
-offensive,offensive,冒犯的,ADJ,B2
-offensive (noun),offensive,词,NOUN,C1
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
-officious,officious,词,ADJ,C1
-offiziell,officially,正式地,ADV,B2
-offshoring,offshoring,词,NOUN,B2
-offspring,offspring,幼崽,NOUN,B2
-oh,oh,哇,PART,B2
-oh (part),oh,呀,PART,B2
-oh mein Gott,oh my god,我的天,INTJ,B2
-oh my,oh my,哎呀,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oh well,oh well,算了,INTJ,B2
-ohrenfeigen,slap,拍击,NOUN,B2
-ohrenfeigen,to slap,打耳光,VERB,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oil tanker,oil tanker,词,NOUN,C1
-oilfield,oilfield,词,NOUN,C1
-ok,ok,词,INTJ,B2
-okay,okay,好的,ADJ,B2
-okay (adj),okay,词,ADJ,A1
-okay (noun),okay,好啊,NOUN,C1
-old (noun),old,夙,NOUN,B1
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
-old thief,old thief,老贼,NOUN,C1
-old-age,old-age,晚年,NOUN,C1
-old-fashioned,old-fashioned,老式的,ADJ,B2
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oleander,oleander,词,NOUN,B2
-olfactory,olfactory,词,ADJ,C1
-oligarchy,oligarchy,寡头政治,NOUN,B2
-oligopoly,oligopoly,寡头垄断,NOUN,B2
-olives,olives,词,NOUN,A2
-olympic,olympic,奥林匹克的,ADJ,B2
-omelette,omelette,煎蛋卷,NOUN,B2
-omnipotent,omnipotent,词,ADJ,C1
-omnipresent,omnipresent,无所不在的,ADJ,B2
-omniscient,omniscient,词,ADJ,C1
-on,on,进行中,ADV,B2
-on behalf of,on behalf of,代表,ADP,B2
-on board,on board,在船上,ADV,B2
-on condition,on condition,词,SCONJ,C1
-on one hand,on one hand,一方面,ADV,B2
-on purpose,on purpose,故意地,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on that day,on that day,词,ADV,C1
-on the one hand,on the one hand,一方面,ADV,B2
-on the spot,on the spot,当场,ADV,B2
-on time,on time,准时,ADV,B2
-on top,on top,在上面,ADV,B2
-on top of,on top of,在...上面,ADP,B2
-on upon,on upon,在...上,ADP,B2
-on which,on which,在其上,PRON,B2
-once (num),once,一次,NUM,B2
-oncology,oncology,词,NOUN,C1
-one (adj),one,词,ADJ,A2
-one (det),one,词,DET,C1
-one (noun),one,one,NOUN,B2
-one and a half,one and a half,一个半,NUM,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one handful,one handful,一把,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
-one-sidedness,one-sidedness,词,NOUN,B2
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
-onerous,onerous,词,ADJ,C1
-ongoing,ongoing,进行中的,ADJ,B2
-ongoing (noun),ongoing,词,NOUN,B2
-online,online,词,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,词,NOUN,C1
-onlinegehen,to go online,上网,VERB,B2
-only,only,而已,SCONJ,B2
-only (adj),only,唯一,ADJ,B2
-only (det),only,词,DET,B2
-only bringing,only bringing,只带,NOUN,C1
-only son,only son,独子,NOUN,C1
-onomatopoeia,onomatopoeia,拟声词,NOUN,B2
-oozing,oozing,词,NOUN,B2
-opacity,opacity,不透明性,NOUN,B2
-opaque,opaque,词,ADJ,C1
-open,open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
-openness,openness,开放,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
-operetta,operetta,词,NOUN,C1
-opium den,opium den,词,NOUN,B2
-opportune,opportune,词,ADJ,C1
-opportunism,opportunism,词,NOUN,C1
-opportunist,opportunist,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opportunity used,opportunity used,词,NOUN,B2
-opposing,opposing,词,ADJ,C1
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
-oppressed,oppressed,词,ADJ,B1
-oppressive,oppressive,压迫的,ADJ,B2
-oppressive weight,oppressive weight,词,NOUN,C1
-opprobrium,opprobrium,词,NOUN,C1
-opt,opt,词,VERB,C1
-optical illusion,optical illusion,词,NOUN,C1
-optics perspective,optics perspective,词,NOUN,C1
-optimal,optimal,最佳的,ADJ,B2
-optimieren,to optimize,优化,VERB,B2
-optimistisch,optimistic,乐观的,ADJ,B2
-optimization,optimization,优化,NOUN,B2
-optimum,optimum,词,NOUN,C1
-optional,optional,可选的,ADJ,B2
-optisch,optical,光学的,ADJ,B2
-opulence,opulence,词,NOUN,C1
-opulent,opulent,豪华的,ADJ,B2
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
-or something,or something,词,ADV,C1
-oracle,oracle,神谕,NOUN,B2
-oracular,oracular,词,ADJ,C1
-oral,oral,口头的,ADJ,B2
-oral cavity,oral cavity,口腔,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange,orange,橙色的,ADJ,B2
-orange color,orange color,词,ADJ,A1
-orange juice,orange juice,橙汁,NOUN,B2
-orator speaker,orator speaker,词,NOUN,C1
-oratory,oratory,词,NOUN,C1
-orbital,orbital,词,ADJ,C1
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-ordentlich,neat,整洁的,ADJ,B2
-ordentlich,orderly,有序的,ADJ,B2
-orderliness,orderliness,有序性,NOUN,B2
-ordinance,ordinance,条例,NOUN,B2
-ordnungsgemäß,properly,适当地,ADV,B2
-ore,ore,词,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organisch,organic,有机的,ADJ,B2
-organism,organism,词,NOUN,C1
-organization body,organization body,词,NOUN,B1
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
-orientation direction,orientation direction,词,NOUN,B1
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
-originally (part),originally,原,PART,B2
-originating,originating,词,ADJ,B1
-orison prayer,orison prayer,词,NOUN,C1
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,词,ADJ,B2
-orthodox,orthodox,正统的,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-oscillator,oscillator,振荡器,NOUN,C1
-osseous,osseous,词,ADJ,C1
-ostensible,ostensible,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentation,ostentation,词,NOUN,C1
-ostentatious,ostentatious,词,ADJ,C1
-ostracism,ostracism,词,NOUN,C1
-ostrich,ostrich,词,NOUN,B2
-oszillieren,to oscillate,振荡,VERB,B2
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
-other people,other people,人家,NOUN,B2
-others,others,他人,PRON,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherworldly,otherworldly,词,ADJ,C1
-ought,ought,应该,AUX,B2
-ought to,ought to,词,AUX,A2
-ounce,ounce,词,NOUN,C1
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out (adp),out,词,ADP,B2
-out here,out here,这里外面,ADV,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,格格不入的,ADJ,B2
-out there,out there,词,ADV,B2
-outbreak,outbreak,爆发,NOUN,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,外部的,ADJ,B2
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outfit,outfit,服装,NOUN,B2
-outgoing,outgoing,外向的,ADJ,C1
-outlandish,outlandish,古怪的,ADJ,B2
-outlast,outlast,词,VERB,B2
-outlaw,outlaw,歹徒,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outset,outset,词,NOUN,C1
-outside,outside,在外面,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,外界,NOUN,B2
-outsider,outsider,外人,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward,outward,向外,ADV,B2
-outward (adj),outward,词,ADJ,C1
-outward journey,outward journey,词,NOUN,C1
-ovarian,ovarian,词,ADJ,C1
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overbidding,overbidding,词,NOUN,C1
-overconsumption,overconsumption,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
-overdraft,overdraft,透支,NOUN,B2
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overhead,overhead,词,NOUN,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overlapping,overlapping,重叠的,ADJ,C1
-overload surcharge,overload surcharge,词,NOUN,C1
-overly familiar,overly familiar,词,ADJ,B2
-overreach,overreach,词,NOUN,C1
-overrule,overrule,词,VERB,C1
-overseas,overseas,词,ADV,B2
-oversight,oversight,疏忽,NOUN,B2
-overt,overt,词,ADJ,C1
-overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overview,overview,概览,NOUN,B2
-overweight,overweight,词,ADJ,C1
-overwork,overwork,词,NOUN,C1
-owed,owed,欠下的,ADJ,B2
-own,own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-owned,owned,被拥有的,ADJ,A1
-ox,ox,词,NOUN,C1
-oxidation,oxidation,词,NOUN,C1
-oxidized,oxidized,词,ADJ,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oxymoron,oxymoron,矛盾修辞法,NOUN,B2
-oyster,oyster,牡蛎,NOUN,B2
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
-pacts,pacts,词,NOUN,C1
-padding,padding,词,NOUN,C1
-paddle,paddle,词,VERB,C1
-padlock,padlock,词,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pain hurt,pain hurt,疼痛,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,词,ADJ,C1
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-painstakingly,painstakingly,细致地,ADV,B2
-paint dye,paint dye,词,VERB,A1
-paintbrush,paintbrush,词,NOUN,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-pajamas,pajamas,睡衣,NOUN,B2
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-palatable,palatable,词,ADJ,C1
-paleography,paleography,词,NOUN,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palimpsest,palimpsest,词,NOUN,C1
-palisade,palisade,词,NOUN,C1
-palliative,palliative,缓和的,ADJ,B2
-pallid,pallid,词,ADJ,C1
-pallor,pallor,苍白,NOUN,B2
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
-palpable,palpable,词,ADJ,C1
-paltriness,paltriness,词,NOUN,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
-panda,panda,熊猫,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
-pantheon,pantheon,先贤祠,NOUN,B2
-panther,panther,豹,NOUN,B2
-panties,panties,词,NOUN,C1
-pants,pants,裤子,NOUN,B2
-pants trousers,pants trousers,词,NOUN,A1
-papal bull,papal bull,词,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-parable,parable,寓言,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-paradise heaven,paradise heaven,词,NOUN,B1
-paradoxical,paradoxical,矛盾的,ADJ,B2
-paradoxically,paradoxically,词,ADV,C1
-paralipsis,paralipsis,词,NOUN,C1
-parallel,parallel,平行的,ADJ,B2
-parallelism,parallelism,词,NOUN,C1
-paralogism,paralogism,谬误推理,NOUN,B2
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
-paramount,paramount,词,ADJ,C1
-paranoia,paranoia,词,NOUN,C1
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parataxis,parataxis,意合,NOUN,B2
-parcel,parcel,包裹,NOUN,B2
-parch,parch,词,VERB,C1
-parchment,parchment,词,NOUN,C1
-pardon (noun),pardon,莫怪,NOUN,B2
-pardoning,pardoning,词,NOUN,C1
-parent-friendly,parent-friendly,,NOUN,B2
-parenthesis,parenthesis,词,NOUN,C1
-paresis,paresis,词,NOUN,C1
-pariah,pariah,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parishioner,parishioner,词,NOUN,C1
-parishioners,parishioners,词,NOUN,C1
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
-parley,parley,词,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parliamentary,parliamentary,议会的/议员,ADJ,B2
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
-parlor,parlor,词,NOUN,C1
-paronym,paronym,词,NOUN,C1
-paroxysm,paroxysm,发作,NOUN,B2
-parquet,parquet,词,NOUN,C1
-parse,parse,解析,VERB,B2
-parsimonious,parsimonious,吝啬的,ADJ,B2
-parsimony,parsimony,吝啬,NOUN,B2
-part forever,part forever,永别,VERB,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-partial,partial,部分的,ADJ,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-partially,partially,部分地,ADV,B2
-particle (part),particle,么,PART,B2
-particularize,particularize,词,VERB,B2
-particularly,particularly,特别地,ADV,B2
-partisan (adj),partisan,词,ADJ,C1
-partisan (noun),partisan,词,NOUN,C1
-partisanship,partisanship,党派性,NOUN,C1
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
-partizipativ,participatory,参与式的,ADJ,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-party to the contract,party to the contract,词,NOUN,B2
-pashalik,pashalik,词,NOUN,C1
-pass (noun),pass,过得,NOUN,C1
-passable,passable,词,ADJ,C1
-passen,match,火柴,NOUN,B2
-passen,to match,相配,VERB,B2
-passen,to suit,适合,VERB,B2
-passend,matching,配套,ADJ,B2
-passerby,passerby,词,NOUN,C1
-passionate,passionate,热情的,ADJ,B2
-passionate love,passionate love,词,NOUN,C1
 passiv,passive,被动的,ADJ,B2
-passive reliance on others,passive reliance on others,词,NOUN,C1
-past,past,过去,ADP,B2
-past events,past events,往事,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
-pastoral (adj),pastoral,词,ADJ,C1
-pastoral (noun),pastoral,词,NOUN,C1
-pastry chef,pastry chef,词,NOUN,C1
-patch tire,patch tire,补胎,VERB,C1
+Prüfungsarbeit,past exam papers,真题,NOUN,B2
+Pasta,pasta,意大利面,NOUN,B2
+Klebstoff,paste,酱,NOUN,B2
+Weide,pasture,牧场,NOUN,B2
+klopfen,to pat,轻拍,VERB,B2
 patent,patent,专利,NOUN,B2
-patently,patently,显然地,ADV,B2
-paternal,paternal,父亲的,ADJ,B2
 paternal aunt,paternal aunt,姑母,NOUN,B2
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
 pathetic,pathetic,可悲的,ADJ,B2
-pathogenic,pathogenic,致病的,ADJ,B2
 pathological,pathological,病态的,ADJ,B2
-pathology,pathology,病理学,NOUN,B2
 patient,patient,病人,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patiently,patiently,词,ADV,C1
-patriarch,patriarch,词,NOUN,C1
 patriarchy,patriarchy,父权制,NOUN,B2
-patricide,patricide,弑父,NOUN,B2
-patriot,patriot,词,NOUN,B2
 patriotism,patriotism,爱国主义,NOUN,B2
 patrol,patrol,巡逻,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
 patron,patron,赞助人,NOUN,B2
-patronage,patronage,词,NOUN,B2
-paucity,paucity,词,NOUN,C1
-pauper,pauper,词,NOUN,B2
 pause,pause,暂停,NOUN,B2
 pause,to pause,暂停,VERB,B2
-pave,pave,词,VERB,C1
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
 pavilion,pavilion,亭子,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-paving,paving,铺路,NOUN,B2
-paving stone,paving stone,词,NOUN,A2
 paw,paw,爪子,NOUN,B2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
 pay respects,to pay respects,参见,VERB,B2
 pay smilingly,to pay smilingly,笑付,VERB,B2
 pay tax,to pay tax,纳税,VERB,B2
 payment all,payment all,付都,NOUN,B2
-payments,payments,词,NOUN,C1
-pea,pea,词,NOUN,C1
-peacefully,peacefully,词,ADV,C1
-peach tree,peach tree,词,NOUN,C1
 peak,peak,顶峰,NOUN,B2
 peanut,peanut,花生,NOUN,B2
-peanut field,peanut field,词,NOUN,B2
 peasant,peasant,农民,NOUN,B2
-peat,peat,泥炭,NOUN,B2
 pebble,pebble,卵石,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
-peculiarity,peculiarity,词,NOUN,B2
-pecuniary,pecuniary,词,ADJ,C1
 pedagogical,pedagogical,教学的,ADJ,B2
 pedagogy,pedagogy,教育学,NOUN,B2
-pedal,pedal,词,NOUN,B1
-pedantic,pedantic,词,ADJ,C1
-pedantically,pedantically,词,ADV,C1
-pedantry,pedantry,迂腐,NOUN,B2
-peddler,peddler,小贩,NOUN,B2
 pedestrian,pedestrian,行人,NOUN,B2
 pedestrian bridge,pedestrian bridge,天桥,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-pediment,pediment,词,NOUN,C1
-peek,peek,词,VERB,C1
 peel,peel,皮,NOUN,B2
-peephole,peephole,门镜,NOUN,B2
 peer,peer,同龄人,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-peg,peg,词,NOUN,C1
-peinlich,awkward,尴尬的,ADJ,B2
-peitschen,to whip,鞭打,VERB,B2
-pejorative,pejorative,词,ADJ,C1
-pellucid,pellucid,词,ADJ,C1
-pelvis,pelvis,词,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalties,penalties,处罚,NOUN,C1
-penalty,penalty,惩罚,NOUN,B2
-penalty payment,penalty payment,词,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-penchant,penchant,词,NOUN,C1
-pencil case,pencil case,词,NOUN,C1
-pending,pending,词,ADJ,B1
 penetrate,to penetrate,穿透,VERB,B2
 penetration,penetration,渗透,NOUN,B2
 peninsula,peninsula,半岛,NOUN,B2
-penis,penis,词,NOUN,B2
-penitence,penitence,词,NOUN,C1
-penitent,penitent,词,ADJ,C1
-penitentiary,penitentiary,词,ADJ,C1
-pennant,pennant,词,NOUN,C1
-penniless,penniless,词,ADJ,B1
-pensive,pensive,沉思的,ADJ,B2
-penury,penury,词,NOUN,C1
-people,people,人们,PRON,B2
-peppermint,peppermint,词,NOUN,C1
 perceive,to perceive,察觉,VERB,B2
 percentage,percentage,百分比,NOUN,B2
-perceptibly,perceptibly,明显地,ADV,B2
 perception,perception,感知,NOUN,B2
-perception opinion,perception opinion,词,NOUN,B2
 perceptive,perceptive,敏锐的,ADJ,B2
-perceptual,perceptual,词,ADJ,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-peremptorily,peremptorily,词,ADV,C1
 peremptorisch,peremptory,专横的,ADJ,B2
-perennial,perennial,长期的,ADJ,B2
-perfectly,perfectly,词,ADV,A2
-perfidious,perfidious,词,ADJ,C1
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-performer,performer,词,NOUN,C1
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-peri-urban,peri-urban,词,ADJ,B2
-perilla,perilla,紫苏,NOUN,B2
-perilous,perilous,危险的,ADJ,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periodical,periodical,词,NOUN,C1
+Vollkommenheit,perfection,完美,NOUN,B2
+Gefahr,peril,危险,NOUN,B2
+Periode,period,时期,NOUN,B2
 periodisch,periodically,定期地,ADV,B2
-periodization,periodization,分期,NOUN,C1
 peripher,peripheral,外围的,ADJ,B2
-periphery,periphery,边缘,NOUN,B2
-periphrasis,periphrasis,词,NOUN,C1
-perishing,perishing,词,NOUN,B2
-peritoneum,peritoneum,腹膜,NOUN,B2
-perks,perks,词,NOUN,C1
+vergehen,to perish,死亡,VERB,B2
+Falschaussage,perjury,伪证,NOUN,B2
+Beständigkeit,permanence,持久,NOUN,B2
 permanent,permanent,永久的,ADJ,B2
-permanently,permanently,词,ADV,C1
-permeability,permeability,词,NOUN,C1
-permissible,permissible,词,ADJ,C1
-permutations,permutations,词,NOUN,C1
-pernicious,pernicious,有害的,ADJ,B2
-peroration,peroration,结语,NOUN,B2
-perpetual,perpetual,永久的,ADJ,B2
-perplex,perplex,词,VERB,C1
-perplexed,perplexed,困惑的,ADJ,B2
-persimmon,persimmon,柿子,NOUN,C1
-persistence,persistence,坚持,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
-personable,personable,词,ADJ,C1
-personal best,personal best,词,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
-personalization,personalization,词,NOUN,C1
-personalized,personalized,个性化的,ADJ,B2
-personally experience,personally experience,亲历,VERB,C1
-personification,personification,词,NOUN,C1
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicacious,perspicacious,词,ADJ,C1
-perspicacity,perspicacity,词,NOUN,B2
-persönlich,in person,亲自地,ADV,B2
+durchlässig,permeable,可渗透的,ADJ,B2
+Genehmigung,permit,许可证,NOUN,B2
+senkrecht,perpendicular,垂直的,ADJ,B2
+Verfolgung,persecution,迫害,NOUN,B2
+Ausdauer,perseverance,毅力,NOUN,B2
+beständig,persistent,坚持不懈的,ADJ,B2
+Anrede,person honorific,位,NOUN,B2
+Verantwortliche,person in charge,负责人,NOUN,B2
+Feindschaft,personal enmity,私仇,NOUN,B2
+Bestleistung,personal record,个人纪录,NOUN,B2
 persönlich,personally,就个人而言,ADV,B2
-pertinent,pertinent,词,ADJ,C1
-pertinently,pertinently,词,ADV,B2
-pervasive,pervasive,词,ADJ,C1
-perverse,perverse,任性的,ADJ,B2
-perversity,perversity,词,NOUN,C1
+Personal,personnel,人员,NOUN,B2
+Überzeugung,persuasion,说服,NOUN,B2
 pessimistisch,pessimistic,悲观的,ADJ,B2
-pest,pest,词,NOUN,C1
-pesticides,pesticides,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-petal,petal,词,NOUN,C1
-petition for review,petition for review,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
-pettiness,pettiness,词,NOUN,C1
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-phantasmagorical,phantasmagorical,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharaoh,pharaoh,法老,NOUN,B2
-pharisee,pharisee,法利赛人,NOUN,B2
+Pestizid,pesticide,杀虫剂,NOUN,B2
+Petition,petition,请愿,NOUN,B2
+Erdöl,petroleum,石油,NOUN,B2
 pharmazeutisch,pharmaceutical,制药的,ADJ,B2
-pharynx,pharynx,词,NOUN,B2
-phase,phase,阶段,NOUN,B2
-phased (adv),phased,词,ADV,B1
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-pheasant,pheasant,词,NOUN,C1
-phenomenal,phenomenal,非凡的,ADJ,B2
-phenomenological,phenomenological,词,ADJ,C1
-philanthropic,philanthropic,词,ADJ,C1
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philologist,philologist,语言学家,NOUN,B2
-philology,philology,词,NOUN,C1
-philosophical,philosophical,哲学的,ADJ,B2
-philosophizing,philosophizing,词,NOUN,C1
-philosophy of life,philosophy of life,词,NOUN,B2
-phishing,phishing,词,NOUN,B2
-phlebitis,phlebitis,词,NOUN,C1
-phlegmatic,phlegmatic,冷静的,ADJ,B2
-phloem,phloem,词,ADJ,C1
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
-phone credit,phone credit,词,NOUN,B1
-phone number,phone number,电话号码,NOUN,B2
-phoneme,phoneme,词,NOUN,C1
-phony,phony,假的,ADJ,B2
-phosphate,phosphate,词,NOUN,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-phosphorus,phosphorus,词,NOUN,C1
-photo album,photo album,影集,NOUN,C1
-photo model,photo model,词,NOUN,B2
-photogenic,photogenic,词,ADJ,C1
-photographic,photographic,词,ADJ,C1
-photogravure,photogravure,词,NOUN,C1
-photon,photon,光子,NOUN,B2
-photophobia,photophobia,词,NOUN,C1
-phototypy,phototypy,词,NOUN,C1
-phraseology,phraseology,词,NOUN,C1
-phrasing,phrasing,措辞,NOUN,B2
-physically,physically,身体上地,ADV,B2
-physicist,physicist,词,NOUN,C1
-physiological,physiological,生理的,ADJ,B2
-physiotherapist,physiotherapist,词,NOUN,B1
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-pianist,pianist,词,NOUN,C1
-picaresque,picaresque,词,ADJ,C1
-pick up a car,pick up a car,取车,VERB,B2
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickle (noun),pickle,词,NOUN,C1
-pickles,pickles,词,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-pictorial,pictorial,绘画的,ADJ,B2
-picture photo,picture photo,词,NOUN,A2
-picturesque,picturesque,如画的；别致的,ADJ,B2
-pidgin,pidgin,词,NOUN,C1
-pie,pie,派,NOUN,B2
-piece of bread,piece of bread,词,NOUN,B2
-piecework,piecework,词,NOUN,C1
-pier,pier,码头,NOUN,B2
-piety pity,piety pity,词,NOUN,B2
-pile heap,pile heap,词,NOUN,C1
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pills,pills,词,NOUN,B2
-pimp,pimp,词,NOUN,C1
-pimple,pimple,词,NOUN,B2
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
-pioneer,pioneer,先驱,NOUN,B2
-pious,pious,虔诚的,ADJ,B2
-piously,piously,词,ADV,C1
-pipa,pipa,琵琶,NOUN,B2
-piquant,piquant,词,ADJ,C1
-piracy,piracy,词,NOUN,B2
-pirated,pirated,词,ADJ,B2
-piston,piston,词,NOUN,C1
-pitch,pitch,词,NOUN,B1
-pitch darkness,pitch darkness,词,NOUN,C1
-pitchfork,pitchfork,叉子,NOUN,B2
-piteous,piteous,词,ADJ,C1
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pittance,pittance,词,NOUN,C1
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,pivotal,词,ADJ,C1
-pizza,pizza,词,NOUN,B1
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-place value,place value,位值,NOUN,C1
-placed before,placed before,词,ADJ,B2
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
-placid,placid,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
-plagen,to afflict,折磨,VERB,B2
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plaintive,plaintive,哀伤的,ADJ,C1
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
+Apotheker,pharmacist,药剂师,NOUN,B2
+gestuft,phased,阶段性,ADJ,B2
+Phänomenologie,phenomenology,现象学,NOUN,B2
+Phänomen,phenomenon,现象,NOUN,B2
+Philanthrop,philanthropist,慈善家,NOUN,B2
+Philanthropie,philanthropy,慈善,NOUN,B2
+Philosophie,philosophy,哲学,NOUN,B2
+Schleim,phlegm,痰,NOUN,B2
+Phobie,phobia,恐惧症,NOUN,B2
+Phönix,phoenix,拿凤,NOUN,B2
+Telefon,phone,电话,NOUN,B2
+Telefonat,phone call,通话,NOUN,B2
+Phonetik,phonetics,语音学,NOUN,B2
+Phonologie,phonology,音系学,NOUN,B2
+fotokopieren,photocopy,复印件,NOUN,B2
+fotokopieren,to photocopy,复印,VERB,B2
+Foto,photograph,照片,NOUN,B2
+Fotograf,photographer,摄影师,NOUN,B2
+Fotografie,photography,摄影,NOUN,B2
+Photosynthese,photosynthesis,光合作用,NOUN,B2
+Phrase,phrase,短语,NOUN,B2
+Beweismittel,physical evidence,物证,NOUN,B2
+Arzt,physician,内科医生,NOUN,B2
+Physiognomik,physiognomy,面相,NOUN,B2
+Physiologie,physiology,生理学,NOUN,B2
+einsalzen,to pickle,腌渍,VERB,B2
+Frommigkeit,piety,虔诚,NOUN,B2
+Taube,pigeon,鸽子,NOUN,B2
+Pilger,pilgrim,朝圣者,NOUN,B2
+Pilgerfahrt,pilgrimage,朝圣,NOUN,B2
+Säule,pillar,柱子,NOUN,B2
+Kneif,pinch,捏,NOUN,B2
+Kiefer,pine,松树,NOUN,B2
+Ananas,pineapple,菠萝,NOUN,B2
+Pistazie,pistachio,开心果,NOUN,B2
+Grube,pit,坑,NOUN,B2
+bedauern,to pity,同情,VERB,B2
+Platzierung,placement,放置,NOUN,B2
+Plagiat,plagiarism,剽窃,NOUN,B2
+Ebene,plain,平原,NOUN,B2
+Kläger,plaintiff,原告,NOUN,B2
+Flugzeug,plane,飞机,NOUN,B2
 planet,planet,行星,NOUN,B2
-planning,planning,规划,NOUN,B2
 plant,to plant,种植,VERB,B2
 plant out,to plant out,定植,VERB,B2
-plantain,plantain,芭蕉,NOUN,B2
 plantation,plantation,人工林,NOUN,B2
 planting,planting,种植,NOUN,B2
-plasma,plasma,血浆,NOUN,B2
 plaster,plaster,石膏,NOUN,B2
 plastic,plastic,塑料的,ADJ,B2
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
 plateau,plateau,高原,NOUN,B2
 plated,plated,镀层的,ADJ,B2
 platelet,platelet,血小板,NOUN,B2
-platforms,platforms,词,NOUN,C1
-platinum,platinum,词,NOUN,B2
-platitude,platitude,词,NOUN,C1
-plaudern,to chatter,喋喋不休,VERB,B2
-plausibility,plausibility,词,NOUN,B2
-plausible,plausible,似是而非的,ADJ,B2
 play,play,剧本,NOUN,B2
-play game,play game,游戏/玩耍,NOUN,B2
-playable,playable,可演奏的,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
 playmate,playmate,玩伴,NOUN,B2
-plays,plays,词,NOUN,C1
-playwright,playwright,剧作家,NOUN,B2
 plea,plea,辩护,NOUN,B2
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-plebiscite,plebiscite,词,NOUN,B2
 pledge,pledge,抵押,NOUN,B2
 pledge,to pledge,保证,VERB,B2
-pledge (noun),pledge,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plenary,plenary,词,ADJ,C1
-plenitude,plenitude,充足,NOUN,B2
-plentiful,plentiful,词,ADJ,B2
-plenty,plenty,充足地,ADV,B2
-plenty (noun),plenty,大量,NOUN,A2
-pleonasm,pleonasm,词,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
 pliers,pliers,钳子,NOUN,B2
 plight,plight,处境,NOUN,B2
 plot,plot,情节,NOUN,B2
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plot twist,plot twist,词,NOUN,C1
-plow,plow,词,NOUN,B2
-plow handle,plow handle,词,NOUN,C1
 plowing,plowing,犁地,NOUN,B2
-plucky,plucky,勇敢的,ADJ,B2
 plum,plum,李子,NOUN,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-plumb,plumb,词,NOUN,C1
 plumber,plumber,水管工,NOUN,B2
 plumbing,plumbing,管道工程,NOUN,B2
-plump,plump,词,ADJ,C1
 plunder,plunder,掠夺,NOUN,B2
-plundering,plundering,掠夺,NOUN,B2
-plunge,plunge,词,VERB,C1
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
 pluralism,pluralism,多元主义,NOUN,B2
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
 plush toy,plush toy,毛绒玩具,NOUN,B2
 plutocracy,plutocracy,财阀政治,NOUN,B2
-plündern,to despoil,掠夺,VERB,B2
-pneumonia,pneumonia,词,NOUN,C1
-poach,poach,词,VERB,C1
 pocket,pocket,口袋,NOUN,B2
 podcast,podcast,播客,NOUN,B2
-podcasting,podcasting,词,NOUN,B1
-poetic,poetic,词,ADJ,C1
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
 poetry collection,poetry collection,诗集,NOUN,B2
-poignant,poignant,词,ADJ,C1
-point grade,point grade,词,NOUN,A2
 point out,to point out,指出,VERB,B2
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,词,ADV,B2
-pointwise,pointwise,词,ADJ,C1
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,词,NOUN,B2
 poisoning,poisoning,中毒,NOUN,B2
-poke,poke,词,VERB,B2
-polar,polar,极地的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polarity,polarity,极性,NOUN,C1
 polarization,polarization,两极分化 / 极化,NOUN,B2
 pole,pole,极,NOUN,B2
-polemic,polemic,词,NOUN,C1
 polemical,polemical,论战的,ADJ,B2
-polemicist,polemicist,词,NOUN,C1
-police chief,police chief,警察局长,NOUN,B2
-police officer,police officer,警察,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police report,police report,,NOUN,B2
-police search,police search,词,NOUN,C1
 police station,police station,警察局,NOUN,B2
-policy-related,policy-related,词,ADJ,C1
+Politik,policy,政策,NOUN,B2
 polieren,to polish,擦亮,VERB,B2
-polish,polish,波兰的,ADJ,B2
-polish (noun),polish,精炼,NOUN,C1
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politely,politely,礼貌地,ADV,B2
-politeness,politeness,词,NOUN,C1
-politic,politic,词,ADJ,C1
-political party,political party,政党,NOUN,B2
-politically,politically,在政治上,ADV,B2
-politicization,politicization,词,NOUN,C1
-pollinic,pollinic,词,ADJ,C1
-pollster,pollster,词,NOUN,C1
-polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,连词叠用,NOUN,B2
-polytunnel,polytunnel,大棚,NOUN,B2
-pomp,pomp,词,NOUN,C1
-pompous,pompous,词,ADJ,C1
-pompously,pompously,词,ADV,C1
-ponderous,ponderous,词,ADJ,C1
-pool,pool,池,PART,B2
-pooled,pooled,词,ADJ,C1
-poor devil,poor devil,可怜虫,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,最穷的,ADJ,B2
-pop,pop,词,NOUN,B1
-popcorn,popcorn,词,ADJ,C1
-poppy,poppy,词,NOUN,B1
+Umfrage,poll,民意调查,NOUN,B2
+Bestäubung,pollination,授粉,NOUN,B2
+Schadstoff,pollutant,污染物,NOUN,B2
+verschmutzt,polluted,受污染的,ADJ,B2
+Verschmutzung,pollution,污染,NOUN,B2
+Granatapfel,pomegranate,石榴,NOUN,B2
+Pampelmuse,pomelo,柚子,NOUN,B2
+Teich,pond,池塘,NOUN,B2
+nachdenken,to ponder,沉思,VERB,B2
+Pool,pool,水池,NOUN,B2
+Beliebtheit,popularity,流行,NOUN,B2
 popularisieren,to popularize,推广,VERB,B2
-populism,populism,民粹主义,NOUN,C1
-populist,populist,民粹主义者,NOUN,B2
-populous,populous,词,ADJ,C1
-porcelain,porcelain,瓷器,NOUN,B2
-pork,pork,词,NOUN,B2
+Veranda,porch,门廊,NOUN,B2
 pornografisch,pornographic,色情的,ADJ,B2
-pornography,pornography,色情,NOUN,B2
-porosity,porosity,词,NOUN,C1
-porous,porous,词,ADJ,C1
-port harbor,port harbor,词,NOUN,A1
-portable,portable,词,ADJ,C1
-portentous,portentous,词,ADJ,C1
-portfolios,portfolios,词,NOUN,C1
-portico,portico,词,NOUN,C1
-portion serving,portion serving,词,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portrayal,portrayal,词,NOUN,B2
-portuguese,portuguese,葡萄牙语,NOUN,B2
-posh,posh,上流的,ADJ,B2
-posit,posit,词,VERB,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivism,positivism,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-possible future,possible future,词,ADJ,C1
-postage,postage,邮资,NOUN,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal code,postal code,邮政编码,NOUN,B2
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-posterity,posterity,词,NOUN,C1
-posthumous,posthumous,死后的,ADJ,B2
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
-postponement,postponement,延期,NOUN,B2
-postscript,postscript,词,NOUN,C1
-posture,posture,作势,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
-potential,potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potion,potion,词,NOUN,B2
-potter,potter,词,NOUN,B2
-poultice,poultice,词,NOUN,B2
-pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power grid,power grid,电网,NOUN,B2
-power outlet,power outlet,插座,NOUN,B1
-power station,power station,发电厂,NOUN,B2
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powers,powers,词,NOUN,C1
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatist,pragmatist,词,NOUN,C1
-prahlen,to brag,吹嘘,VERB,B2
-prairie,prairie,词,NOUN,C1
-praise singer,praise singer,词,NOUN,C1
-praiseworthy,praiseworthy,词,ADJ,C1
-praktisch,convenient,方便的,ADJ,B2
+Haferbrei,porridge,粥,NOUN,B2
+Träger,porter,搬运工,NOUN,B2
+Portion,portion,部分,NOUN,B2
+Porträt,portrait,肖像,NOUN,B2
+darstellen,to portray,描绘,VERB,B2
+Positionierung,positioning,定位,NOUN,B2
+besitzen,to possess,拥有,VERB,B2
+Besitz,possession,财产,NOUN,B2
+Postkarte,postcard,明信片,NOUN,B2
+Plakat,poster,海报,NOUN,B2
+Postulat,postulate,假定,NOUN,B2
+Töpferei,pottery,陶器,NOUN,B2
+Geflügel,poultry,家禽,NOUN,B2
+anspringen,to pounce,猛扑,VERB,B2
+Vollmacht,power of attorney,委托书,NOUN,B2
+Großmacht,powerful nation,强国,NOUN,B2
 praktisch,practically,几乎,ADV,B2
-prawn,prawn,词,NOUN,C1
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer room,prayer room,祈祷室,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-preacher,preacher,传教士,NOUN,B2
-precarious,precarious,不稳定的,ADJ,B2
-precarization,precarization,不稳定化,NOUN,B2
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
-precipice,precipice,词,NOUN,C1
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-precisely,precisely,确切地; 正好,ADV,B2
-precision,precision,精确,NOUN,B2
-preclude,preclude,词,VERB,C1
-precocious,precocious,早熟的,ADJ,B2
-precocious talent,precocious talent,词,NOUN,C1
-preconception,preconception,词,NOUN,B2
-predictable,predictable,可预测的,ADJ,B2
-predilection,predilection,词,NOUN,C1
-predisposition,predisposition,天赋,NOUN,B2
-predominance,predominance,主导地位,NOUN,B2
-predominant,predominant,词,ADJ,B2
-predominantly,predominantly,词,ADV,C1
-preeminence,preeminence,词,NOUN,B2
-preeminent,preeminent,词,ADJ,C1
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
-prefect,prefect,词,NOUN,B1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-preferable,preferable,更可取的,ADJ,B2
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-prejudiced,prejudiced,词,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-prelate,prelate,词,NOUN,C1
-preliminary,preliminary,初步的,ADJ,B2
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,词,ADJ,C1
-premature baby,premature baby,词,NOUN,B2
-prematurely,prematurely,词,ADV,C1
-prematurity,prematurity,词,NOUN,C1
-premeditate,premeditate,词,VERB,C1
-premeditation,premeditation,预谋,NOUN,B2
-premium,premium,溢价,NOUN,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
-preparedness,preparedness,词,NOUN,B1
-preponderance,preponderance,词,NOUN,C1
-preponderant,preponderant,占优势的,ADJ,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-prerogative,prerogative,特权,NOUN,B2
-prescient,prescient,词,ADJ,C1
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidential election,presidential election,总统选举,NOUN,B2
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
-press freedom,press freedom,新闻自由,NOUN,B2
-press release,press release,公报,NOUN,B2
-prestigious,prestigious,有声望的,ADJ,B2
-presumably,presumably,据推测,ADV,B2
+Praktiker,practitioner,从业者,NOUN,B2
+Pragmatismus,pragmatism,实用主义,NOUN,B2
+Lob,praise,赞扬,NOUN,B2
+Predigt,preaching,劝诫,NOUN,B2
+Präambel,preamble,序言,NOUN,B2
+Prekarität,precariousness,不稳定性,NOUN,B2
+Vorsichtsmaßnahme,precaution,预防措施,NOUN,B2
+vorhergehen,to precede,在...之前,VERB,B2
+Präzedenzfall,precedent,先例,NOUN,B2
+Lehrsatz,precept,戒律,NOUN,B2
+kostbar,precious,珍贵的,ADJ,B2
+Kostbarkeit,preciousness,珍贵,NOUN,B2
+Niederschlag,precipitation,降水,NOUN,B2
+präzise,precise,精确的,ADJ,B2
+Vorläufer,precursor,先驱,NOUN,B2
+räuberisch,predatory,掠夺的,ADJ,B2
+Vorgänger,predecessor,前任,NOUN,B2
+Dilemma,predicament,困境,NOUN,B2
+vorhersagen,to predict,预测,VERB,B2
+Vorhersage,prediction,预测,NOUN,B2
+Vorwort,preface,序言,NOUN,B2
+Präfektur,prefecture,省政府,NOUN,B2
+Präferenz,preference,偏好,NOUN,B2
+Premier,premier,总理,NOUN,B2
+Premiere,premiere,首演,NOUN,B2
+Prämisse,premise,前提,NOUN,B2
+vorbereiten,to prepare a lesson,预习,VERB,B2
+absurd,preposterous,荒谬的,ADJ,B2
+Voraussetzung,prerequisite,前提,NOUN,B2
+Rezept,prescription,处方,NOUN,B2
+Präsentator,presenter,主持人,NOUN,B2
+Erhaltung,preservation,保护,NOUN,B2
+Präsidentschaft,presidency,总统任期,NOUN,B2
+präsidial,presidential,总统的,ADJ,B2
+dringend,pressing,紧迫的,ADJ,B2
+Prestige,prestige,声望,NOUN,B2
 presume,to presume,假定,VERB,B2
-presumed,presumed,词,ADJ,B2
 presumption,presumption,自负,NOUN,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-presumptuous,presumptuous,词,ADJ,C1
 pretend,to pretend,假装,VERB,B2
 pretend to be,to pretend to be,冒充,VERB,B2
-pretender,pretender,词,NOUN,C1
-pretending to forget,pretending to forget,词,VERB,C1
 pretense,pretense,假装,NOUN,B2
-pretension,pretension,词,NOUN,C1
-pretentious,pretentious,自命不凡的,ADJ,B2
-preterition,preterition,假托,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalence,prevalence,词,NOUN,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
 prevention,prevention,预防,NOUN,B2
-preventive,preventive,词,ADJ,B2
-preview,preview,词,NOUN,C1
-previous (noun),previous,词,NOUN,B2
 previously,previously,以前,ADV,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prices,prices,词,NOUN,C1
 pricing,pricing,定价 / 收费,NOUN,B2
-prickly,prickly,词,ADJ,C1
 pride,pride,骄傲,NOUN,B2
-pride arrogance,pride arrogance,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
 primary,primary,主要的,ADJ,B2
-primary school,primary school,小学,NOUN,B2
-primary school teacher,primary school teacher,词,NOUN,C1
-primate,primate,词,NOUN,C1
-prime,prime,首要的,ADJ,B1
-prime matter,prime matter,词,NOUN,C1
-primeval forest,primeval forest,原始森林,NOUN,C1
 primitive,primitive,原始的,ADJ,B2
-primordial chaos,primordial chaos,词,NOUN,C1
 principal,principal,委托人,NOUN,B2
-principal (adj),principal,词,ADJ,B2
-principality,principality,词,NOUN,C1
-printed,printed,词,ADJ,C1
-printed form,printed form,词,NOUN,B1
 printer,printer,打印机,NOUN,B2
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-prior,prior,先前的,ADJ,B2
-priority,priority,优先的,ADJ,B2
 prism,prism,棱镜,NOUN,B2
-pristine,pristine,词,ADJ,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-privatization,privatization,词,NOUN,B2
 privilege,privilege,特权,NOUN,B2
-privileged,privileged,词,ADJ,B2
-prize,prize,奖品,NOUN,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-proactive,proactive,积极主动的,ADJ,B2
 probabilistic,probabilistic,概率的,ADJ,B2
 probability,probability,概率,NOUN,B2
-probable,probable,词,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probationary,probationary,词,ADJ,B2
-probative,probative,词,ADJ,C1
-probe,probe,探测器,NOUN,B2
-proben,to rehearse,排练,VERB,B2
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-probity,probity,正直,NOUN,B2
-problematic,problematic,词,ADJ,B2
-problematic issue,problematic issue,词,NOUN,C1
-procedural,procedural,程序的,ADJ,B2
-procedures,procedures,词,NOUN,C1
-process technique,process technique,词,NOUN,B1
-processable,processable,词,ADJ,C1
-processing,processing,处理,NOUN,B2
-processing (adj),processing,词,ADJ,C1
 procession,procession,行列,NOUN,B2
 processor,processor,处理器,NOUN,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
 procrastinate,to procrastinate,拖延,VERB,B2
 procrastination,procrastination,拖延,NOUN,B2
-prodigal,prodigal,词,ADJ,C1
-prodigality,prodigality,挥霍,NOUN,C1
-prodigious,prodigious,词,ADJ,C1
-prodigy,prodigy,神童,NOUN,B2
-productive,productive,多产的,ADJ,B2
-productivist,productivist,生产至上主义的,ADJ,B2
 productivity,productivity,生产力,NOUN,B2
-profane,profane,词,ADJ,C1
-profess,profess,词,VERB,B2
-professional ethics,professional ethics,词,NOUN,C1
-professional formation,professional formation,词,NOUN,B2
-professionalism,professionalism,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professorship,professorship,词,NOUN,C1
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
 proficient,proficient,熟练的,ADJ,B2
 profit-making,profit-making,营利性,ADJ,B2
-profitability,profitability,盈利能力,NOUN,B2
-profitable,profitable,词,ADJ,B2
-profits,profits,词,NOUN,B2
-profligate,profligate,词,ADJ,C1
 profound,profound,深刻的,ADJ,B2
-profuse,profuse,词,ADJ,C1
-profusion,profusion,词,NOUN,C1
-prognosis,prognosis,预后,NOUN,B2
-program schedule,program schedule,词,NOUN,A2
-programmed,programmed,词,ADJ,C1
 programmer,programmer,程序员,NOUN,B2
 programming,programming,编程,NOUN,B2
 progress,to progress,进步,VERB,B2
 progress report,progress report,进度报告,NOUN,B2
-progression,progression,词,NOUN,C1
 progressive,progressive,渐进的,ADJ,B2
-progressive (noun),progressive,进步人士,NOUN,B2
 progressively,progressively,逐渐地,ADV,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
 prohibition,prohibition,禁止,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
 project assignment,project assignment,项目作业,NOUN,B2
-project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projection,projection,词,NOUN,C1
-projections,projections,词,NOUN,C1
 projector,projector,投影仪,NOUN,B2
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
 proletariat,proletariat,无产阶级,NOUN,B2
-proliferate,proliferate,扩散,! VERB,B2
-proliferation,proliferation,增殖,NOUN,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolific,prolific,多产的,ADJ,B2
-prominence,prominence,词,NOUN,B2
+langatmig,prolix,冗长的,ADJ,B2
+Langatmigkeit,prolixity,冗长,NOUN,B2
+verlängern,to prolong,延长,VERB,B2
 prominent,prominent,突出的,ADJ,B2
-prominent family,prominent family,望族,NOUN,C1
-promiscuous,promiscuous,滥交的,ADJ,B2
-promoted,promoted,词,ADJ,B1
-prompt,prompt,词,ADJ,C1
-promptness,promptness,词,NOUN,C1
-prone,prone,词,ADJ,C1
-pronoun,pronoun,词,NOUN,B1
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-propaedeutic,propaedeutic,词,ADJ,C1
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-propeller,propeller,螺旋桨,NOUN,B2
-property owner,property owner,房主,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophet,prophet,先知,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
+versprechend,promising,有前途的,ADJ,B2
+Wechsel,promissory note,本票,NOUN,B2
+Befürworter,promoter,推动者,NOUN,B2
+unverzüglich,promptly,迅速地,ADV,B2
+verkünden,to promulgate,颁布,VERB,B2
+stützen,to prop,撑,VERB,B2
+Propaganda,propaganda,宣传,NOUN,B2
+Neigung,propensity,倾向,NOUN,B2
+ordnungsgemäß,properly,适当地,ADV,B2
+Prophezeiung,prophecy,预言,NOUN,B2
 prophezeien,to prophesy,预言,VERB,B2
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-propitious,propitious,词,ADJ,C1
-proponent,proponent,词,NOUN,C1
-proportional,proportional,成比例的,ADJ,B2
-proportionality,proportionality,词,NOUN,C1
-proportionally,proportionally,词,ADV,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
+Proportion,proportion,比例,NOUN,B2
+vorschlagen,to propose,提议,VERB,B2
+Vorschlag,proposition,主张,NOUN,B2
+Angemessenheit,propriety,分寸,NOUN,B2
 prosaisch,prosaic,平淡无奇的,ADJ,B2
-prose writer,prose writer,词,NOUN,C1
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutions,prosecutions,词,NOUN,C1
-proselyte,proselyte,词,NOUN,C1
-proselytism,proselytism,传教,NOUN,B2
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
-prostitution,prostitution,词,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protective cover,protective cover,词,NOUN,C1
-protector,protector,保护者,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
+Prosa,prose,散文,NOUN,B2
+Anklage,prosecution,起诉,NOUN,B2
+Aussicht,prospect,前景,NOUN,B2
+Wohlstand,prosperity,繁荣,NOUN,B2
+wohlhabend,prosperous,繁荣的,ADJ,B2
+Protagonist,protagonist,主角,NOUN,B2
+Protektionismus,protectionism,保护主义,NOUN,B2
+schützend,protective,保护的,ADJ,B2
+Protein,protein,蛋白质,NOUN,B2
 protestieren,protest,抗议,NOUN,B2
 protestieren,to protest,抗议,VERB,B2
-proton,proton,词,NOUN,C1
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-proudly,proudly,词,ADV,C1
-provable,provable,可证明的,ADJ,B2
-proverbs,proverbs,词,NOUN,C1
-providential,providential,词,ADJ,C1
-provinces,provinces,词,NOUN,C1
-provincial,provincial,地方的,ADJ,B2
-provision,provision,词,NOUN,C1
-provisional,provisional,临时的,ADJ,B2
-provisionally,provisionally,词,ADV,C1
-provocative,provocative,挑衅的,ADJ,B2
+Demonstrant,protester,示威者,NOUN,B2
+Sprichwort,proverb,谚语,NOUN,B2
+Beweise liefern,to provide evidence,举证,VERB,B2
+Feedback geben,to provide feedback,反馈,VERB,B2
+vorausgesetzt,provided that,只要,SCONJ,B2
+Anbieter,provider,提供者,NOUN,B2
+Provinz,province,省,NOUN,B2
+Landesstraße,provincial highway,省道,NOUN,B2
+Vorschriften,provisions,储备,NOUN,B2
+Provokation,provocation,挑衅,NOUN,B2
 provokieren,to provoke,激怒,VERB,B2
-prow,prow,词,NOUN,C1
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-prudent,prudent,谨慎的,ADJ,B2
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-prunkvoll,sumptuous,奢华的,ADJ,B2
-prägnant,concise,简洁的,ADJ,B2
-präsidial,presidential,总统的,ADJ,B2
-präzise,precise,精确的,ADJ,B2
-prüfen,audit,审计,NOUN,B2
-prüfen,to audit,审计,VERB,B2
-psalm,psalm,词,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
-psoriasis,psoriasis,词,NOUN,C1
-psychiatric,psychiatric,精神病的,ADJ,B2
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychological,psychological,心理的,ADJ,B2
-psychologically,psychologically,词,ADV,C1
-psychopath,psychopath,精神变态者,NOUN,B2
-psychopathy,psychopathy,词,NOUN,C1
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publicity,publicity,宣传,NOUN,B2
-puddle,puddle,水坑,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puerperal,puerperal,词,ADJ,C1
-puff,puff,一口烟,NOUN,B2
-puff pastry,puff pastry,词,NOUN,C1
-pugnacious,pugnacious,词,ADJ,C1
-pugnacity,pugnacity,词,NOUN,C1
-puissant,puissant,词,ADJ,C1
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
-pulling,pulling,拔,NOUN,B2
+Nähe,proximity,邻近,NOUN,B2
+Stellvertreter,proxy,代理人,NOUN,B2
+Vorsicht,prudence,谨慎,NOUN,B2
+Psychologe,psychologist,心理学家,NOUN,B2
+Psychose,psychosis,精神病,NOUN,B2
+Pubertät,puberty,青春期,NOUN,B2
+öffentliche Ordnung,public order,治安,NOUN,B2
+öffentliches Wohl,public welfare,公益性,NOUN,B2
+Veröffentlichung,publication,出版物,NOUN,B2
+öffentlich,publicly,公开地,ADV,B2
+Verleger,publisher,出版商,NOUN,B2
+Verlag,publishing house,出版社,NOUN,B2
 pulmonal,pulmonary,肺的,ADJ,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
-punch (verb),punch,词,VERB,B2
-punctilious,punctilious,词,ADJ,C1
-punctuality,punctuality,词,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
-puncture tap,puncture tap,词,NOUN,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
-punishable,punishable,词,ADJ,B2
-punitive,punitive,惩罚性的,ADJ,B2
-puny,puny,词,ADJ,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-purchase price,purchase price,词,NOUN,B2
-purely,purely,纯粹地,ADV,B2
-purification,purification,净化,NOUN,B2
-purifying,purifying,净化的,ADJ,B2
-puritanical,puritanical,词,ADJ,C1
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-purse,purse,词,NOUN,B1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-pus,pus,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-putrid,putrid,词,ADJ,C1
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quackery,quackery,词,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifizieren,to qualify,使合格,VERB,B2
+Kanzel,pulpit,讲坛,NOUN,B2
+Faustschlag,punch,拳击,NOUN,B2
+Interpunktion,punctuation,标点符号,NOUN,B2
+Punktion,puncture,穿刺,NOUN,B2
+Puppe,puppet,木偶,NOUN,B2
+Welpen,puppy,小狗,NOUN,B2
+kaufen,to purchase,购买,VERB,B2
+Reinheit,purity,纯洁,NOUN,B2
+Purpurnes Yin,purple yin,紫阴,NOUN,B2
+Verfolgung,pursuit,追求,NOUN,B2
+Wagnis,push luck,太得寸,NOUN,B2
+in Ordnung bringen,to put in order,收拾,VERB,B2
+Rätsel,puzzle,谜题,NOUN,B2
+Wachtel,quail,鹌鹑,NOUN,B2
+Qualifikation,qualification,资格,NOUN,B2
+Qualifikation,qualifications,资格,NOUN,B2
 qualifiziert,qualified,合格的,ADJ,B2
-qualifying,qualifying,词,ADJ,C1
+qualifizieren,to qualify,使合格,VERB,B2
 qualitativ,qualitative,定性的,ADJ,B2
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,词,ADJ,B2
 quantitativ,quantitative,定量的,ADJ,B2
-quantum,quantum,词,ADJ,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarry,quarry,词,NOUN,B1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quasi,quasi,词,ADV,B2
-quaternary,quaternary,词,ADJ,B2
-queer,queer,词,ADJ,C1
-quench,quench,词,VERB,C1
-querulous,querulous,词,ADJ,C1
-question particle,question particle,吗,PART,A1
-questioning (adj),questioning,词,ADJ,C1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-quetschen,to squeeze,挤压,VERB,B2
-quibble,quibble,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiescent,quiescent,词,ADJ,C1
-quietly,quietly,悄悄,ADV,B1
-quietude,quietude,词,NOUN,C1
-quill,quill,词,NOUN,C1
-quint,quint,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quittieren,to sign for,签收,VERB,B2
-quivering,quivering,颤抖的,ADJ,B2
-quixotic,quixotic,词,ADJ,C1
-quota sharing,quota sharing,配额分享,NOUN,C1
-quotable,quotable,可估价的,ADJ,B2
-quote (noun),quote,报价单,NOUN,B2
-quotidian,quotidian,词,ADJ,C1
-quotient,quotient,词,NOUN,B2
-rabble,rabble,词,NOUN,C1
-racist,racist,种族主义者,NOUN,B2
-racist (adj),racist,种族主义的,ADJ,C1
-racketeering,racketeering,词,NOUN,B2
-radar,radar,词,NOUN,B2
-radiant,radiant,容光焕发的,ADJ,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radicalism,radicalism,词,NOUN,C1
-radically,radically,词,ADV,B2
+Menge,quantity,数量,NOUN,B2
+streiten,quarrel,争吵,NOUN,B2
+streiten,to quarrel,争吵,VERB,B2
+Streit,quarreling,再吵,NOUN,B2
+Quartal,quarter of a year,季度,NOUN,B2
+Quartalszeitschrift,quarterly magazine,季刊,NOUN,B2
+Suche,quest,探索,NOUN,B2
+Schlange,queue,队列,NOUN,B2
+schnell,quickly,迅速地,ADV,B2
+Steppdecke,quilt,被子,NOUN,B2
+Kontingent,quota,配额,NOUN,B2
+Zitat,quotation,报价,NOUN,B2
+zitieren,quote,报价单,NOUN,B2
+zitieren,to quote,引用,VERB,B2
+Rabbiner,rabbi,拉比,NOUN,B2
+Rasse,race,比赛,NOUN,B2
+Rassismus,racism,种族主义,NOUN,B2
+Schläger,racket,球拍,NOUN,B2
+Strahlkraft,radiance,光辉,NOUN,B2
+Strahlung,radiation,辐射,NOUN,B2
 radikal,radical,激进的,ADJ,B2
-radioactivity,radioactivity,词,NOUN,C1
+Radiosender,radio station,广播电台,NOUN,B2
 radioaktiv,radioactive,放射性的,ADJ,B2
-radiography rays,radiography rays,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
-radiotherapy,radiotherapy,放疗,NOUN,B2
-radius,radius,半径,NOUN,B2
-rag,rag,破布,NOUN,B2
-rags,rags,词,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-rai,rai,词,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
-railroad,railroad,词,NOUN,B2
-rails,rails,词,NOUN,C1
-railway,railway,铁路的,ADJ,B2
-rain clouds,rain clouds,词,NOUN,C1
-rain shower,rain shower,阵雨,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy,rainy,多雨的,ADJ,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise (noun),raise,词,NOUN,B1
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-rajaz poem,rajaz poem,词,NOUN,C1
-rally (noun),rally,词,NOUN,B2
-rallying,rallying,词,NOUN,C1
-rambunctious,rambunctious,词,ADJ,C1
+Radieschen,radish,小萝卜,NOUN,B2
+flickig,ragged,破烂的,ADJ,B2
+Überfall,raid,突袭,NOUN,B2
+Regenbogen,rainbow,彩虹,NOUN,B2
+Regenwald,rainforest,雨林,NOUN,B2
+Spenden einsammeln,to raise donations,募捐,VERB,B2
+Widder,ram,公羊,NOUN,B2
+Rampe,ramp,坡道,NOUN,B2
 rampante Tyrannei,rampant tyranny,横行,NOUN,B2
-rampart,rampart,词,NOUN,C1
-ramshackle,ramshackle,词,ADJ,C1
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancorous,rancorous,词,ADJ,C1
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-range zone,range zone,词,NOUN,C1
-ranger,ranger,词,NOUN,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-ranking classification,ranking classification,词,NOUN,C1
-rapacious,rapacious,词,ADJ,C1
-rapacity,rapacity,词,NOUN,C1
-rapidly,rapidly,词,ADV,B2
-rapier,rapier,词,NOUN,C1
-rapper,rapper,说唱歌手,NOUN,B2
-rapporteur,rapporteur,词,NOUN,C1
-rapture,rapture,狂喜,NOUN,B2
-rapturous,rapturous,词,ADJ,C1
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,词,NOUN,C1
-rarity,rarity,希罕,NOUN,C1
+Groll,rancor,怨恨,NOUN,B2
+zufällig,random,随机的,ADJ,B2
+Rang,rank,等级,NOUN,B2
+Rangliste,ranking,等级,NOUN,B2
+Lösegeld,ransom,赎金,NOUN,B2
 rasch,rapid,迅速的,ADJ,B2
-rash,rash,皮疹,NOUN,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-rasieren,to shave,剃,VERB,B2
-raspy,raspy,词,ADJ,C1
-rate percentage,rate percentage,词,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
-ratio,ratio,比率,NOUN,B2
-rational,rational,词,ADJ,B2
-rationalist,rationalist,词,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
+Annäherung,rapprochement,和解,NOUN,B2
+selten,rarely,很少,ADV,B2
+Hast,rash,轻率的,ADJ,B2
+Himbeere,raspberry,覆盆子,NOUN,B2
 rattenfest,rat-proof,防鼠,ADJ,B2
-raucous,raucous,词,ADJ,C1
-ravage (noun),ravage,词,NOUN,C1
-ravenous,ravenous,词,ADJ,C1
-ravine,ravine,词,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-raw ore,raw ore,词,ADJ,C1
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-raze,raze,词,VERB,C1
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,再判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-reality,re-reality,再实,NOUN,C1
-re-route,re-route,重路,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-shape,re-shape,重形,NOUN,C1
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,再综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach,reach,范围,NOUN,B2
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reactionary,reactionary,反动,ADJ,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
-readiness to help,readiness to help,词,NOUN,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
-reaffirm,reaffirm,词,VERB,B2
+Satz,rate,比率,NOUN,B2
+Bewertung,rating,评分,NOUN,B2
+Ration,ration,配给,NOUN,B2
+Rationalismus,rationalism,理性主义,NOUN,B2
+Rationalität,rationality,理性,NOUN,B2
+Rationalisierung,rationalization,合理化,NOUN,B2
+verwüsten,to ravage,破坏,VERB,B2
+roh,raw,生的,ADJ,B2
+Rohstoff,raw material,原材料,NOUN,B2
+Strahl,ray,光线,NOUN,B2
+Wiederabruptheit,re-abruptness,再骤,NOUN,B2
+Wiederkampf,re-battle,重战,NOUN,B2
+Wiedergrenze,re-boundary,重界,NOUN,B2
+Wiederkurs,re-course,重途,NOUN,B2
+Wiederschaffung,re-creation,再作,NOUN,B2
+Wiederaufführung,re-enactment,再演,NOUN,B2
+Wiederbeweis,re-evidence,重据,NOUN,B2
+Wiederfrucht,re-fruit,再果,NOUN,B2
+Wiederinnen,re-inner,再内,NOUN,B2
+Wiederlagerung,re-layering,改层,NOUN,B2
+Wiederbegrenzung,re-limit,重限,NOUN,B2
+Wiederlogik,re-logic,再逻,NOUN,B2
+Wiederbedeutung,re-meaning,再义,NOUN,B2
+Wiederbestellung,re-order,重序,NOUN,B2
+Wiedertempo,re-pace,重骤,NOUN,B2
+Wiederweg,re-path,重径,NOUN,B2
+Wiederquantität,re-quantity,再量,NOUN,B2
+Wiedergrund,re-reason,重理,NOUN,B2
+Umleitung,re-routing,改轨,NOUN,B2
+Wiedersequenzierung,re-sequencing,改骤,NOUN,B2
+Wiedereinreichung,re-submission,再上,NOUN,B2
 reaktiv,reactive,反应的,ADJ,B2
-real estate,real estate,不动产,NOUN,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
-realist,realist,词,NOUN,C1
+Reaktor,reactor,反应堆,NOUN,B2
+Leser,reader,读者,NOUN,B2
+Lesung,reading,阅读,NOUN,B2
+Immobilie,real estate,房地产,ADJ,B2
+Realismus,realism,现实主义,NOUN,B2
 realistisch,realistic,现实的,ADJ,B2
-reality TV,reality TV,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rear,rear,后部,NOUN,B2
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reasoned,reasoned,词,ADJ,B2
-reassuring,reassuring,词,ADJ,B1
-rebab,rebab,列巴布琴,NOUN,B2
+Wunsch,really want,真要,NOUN,B2
+Reich,realm,领域,NOUN,B2
+Hinterseite,rear,后面的,ADJ,B2
+Hinterteil,rear part,后部,NOUN,B2
+gründen,to reason,推理,VERB,B2
+Beruhigung,reassurance,安抚,NOUN,B2
+beruhigen,to reassure,使安心,VERB,B2
 rebellieren,to rebel,反叛,VERB,B2
-rebellious,rebellious,叛逆的,ADJ,B2
-rebirth,rebirth,词,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (noun),rebound,词,NOUN,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recede,recede,词,VERB,C1
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-recess,recess,词,NOUN,C1
-recharge (noun),recharge,词,NOUN,B2
-rechtschaffend,righteous,正直的,ADJ,B2
-recidivism,recidivism,词,NOUN,B2
-reciprocally,reciprocally,词,ADV,B2
-reciprocate,reciprocate,词,VERB,C1
-recitation,recitation,词,NOUN,C1
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,收复,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-recognizable,recognizable,可辨认的,ADJ,B2
-recognized,recognized,词,NOUN,B2
-recombination,recombination,再结,NOUN,C1
-recommended,recommended,词,ADJ,C1
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconnoiter,reconnoiter,词,VERB,C1
-reconquest,reconquest,词,NOUN,C1
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recourse,recourse,求助,NOUN,B2
-recreation,recreation,娱乐,NOUN,B2
-recruit,recruit,新兵,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectangular,rectangular,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-rector,rector,词,NOUN,C1
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
-recurring,recurring,词,ADJ,C1
-recursive,recursive,词,ADJ,C1
+Rebellion,rebellion,叛乱,NOUN,B2
+Rebellenherz,rebellious heart,反心,NOUN,B2
+wiederaufbauen,to rebuild,重建,VERB,B2
+Tadel,rebuke,责备,NOUN,B2
+widerlegen,to rebut,反驳,VERB,B2
+Widerlegung,rebuttal,反驳,NOUN,B2
+zurückrufen,to recall,回忆,VERB,B2
+empfangen,to receive mail,收件,VERB,B2
+Befehle erhalten,to receive orders,受命,VERB,B2
+weltweite Aufmerksamkeit erhalten,to receive worldwide attention,举世瞩目,VERB,B2
+Empfänger,receiver,接收器,NOUN,B2
+Rezession,recession,衰退,NOUN,B2
+Empfänger,recipient,接受者,NOUN,B2
+reziprok,reciprocal,互惠的,ADJ,B2
+rezitieren,to recite,背诵,VERB,B2
+rücksichtslos,reckless,鲁莽的,ADJ,B2
+zurückerobern,to reclaim,收回,VERB,B2
+Rücklage,reclining,躺下,NOUN,B2
+Empfehlung durch Dritte,recommendation by others,他荐,NOUN,B2
+versöhnen,to reconcile,和解,VERB,B2
+Versöhnung,reconciliation,和解,NOUN,B2
+Aufklärung,reconnaissance,侦察,NOUN,B2
+Wiedererwägung,reconsideration,重思,NOUN,B2
+rekonstruieren,to reconstruct,重建,VERB,B2
+Rekonstruktion,reconstruction,重建,NOUN,B2
+Plattenspieler,record player,唱机,NOUN,B2
+erzählen,to recount,转述,VERB,B2
+Erholung,recovery,恢复,NOUN,B2
+rekrutieren,to recruit,招募,VERB,B2
+Rekrutierung,recruitment,招聘,NOUN,B2
+berichten,to rectify,纠正,VERB,B2
+genesen,to recuperate,恢复,VERB,B2
+Wiederkehr,recurrence,往复,NOUN,B2
+Ablehnung,recusal,回避,NOUN,B2
 recyceln,to recycle,回收利用,VERB,B2
-recycled item,recycled item,再物,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redact,redact,词,VERB,C1
-redemption,redemption,救赎,NOUN,B2
-redesign,redesign,词,NOUN,C1
-redevelopment,redevelopment,词,NOUN,C1
-redolent,redolent,词,ADJ,C1
-redoubtable,redoubtable,词,ADJ,C1
-redrawing,redrawing,重新绘制,NOUN,B2
-redress,redress,词,VERB,B2
-reduction,reduction,减少,NOUN,B2
-reductionism,reductionism,词,NOUN,C1
-redundancy,redundancy,冗余,NOUN,B2
-redundant,redundant,多余的,ADJ,B2
-reed bed,reed bed,词,NOUN,B2
-reed pen,reed pen,词,NOUN,C1
-reef,reef,词,NOUN,B2
-reefs,reefs,词,NOUN,B2
-reel,reel,词,NOUN,C1
-refereed,refereed,词,ADJ,C1
-reference framework,reference framework,词,NOUN,C1
-references,references,词,NOUN,C1
-referendum-related,referendum-related,词,ADJ,B2
-referral,referral,词,NOUN,C1
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
-reflective,reflective,词,ADJ,C1
-reflex,reflex,词,NOUN,C1
-reform (noun),reform,变革,NOUN,B2
-reformatory,reformatory,词,NOUN,C1
+Recycling,recycling,回收利用,NOUN,B2
+Neubestimmung,redefinition,改界,NOUN,B2
+verweisen,to refer,参考,VERB,B2
+Schiedsrichter,referee,裁判,NOUN,B2
+Referendum,referendum,公民投票,NOUN,B2
+veredeln,to refine,提炼,VERB,B2
+veredelt,refined,精炼的,ADJ,B2
+Veredelung,refinement,修养,NOUN,B2
+Veredelung,refining,提炼,NOUN,B2
+Reflexion,reflection,思考,NOUN,B2
+Wiederaufforstung,reforestation,重新造林,NOUN,B2
 reformieren,reform,改革,NOUN,B2
 reformieren,to reform,改革,VERB,B2
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-reformulation,reformulation,重新表述,NOUN,B2
-refractory,refractory,词,ADJ,C1
-refrain (noun),refrain,叠句,NOUN,B2
-refrigeration,refrigeration,词,NOUN,C1
-refulgent,refulgent,词,ADJ,C1
-refurbish,refurbish,词,VERB,C1
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refutable,refutable,词,ADJ,B2
-refutation,refutation,词,NOUN,C1
-regal,regal,词,ADJ,C1
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regardless,regardless,不管,ADP,B2
-regardless (adv),regardless,不管,ADV,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regelmäßig,regular,规律的,ADJ,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,再生,NOUN,B2
-regent,regent,词,NOUN,C1
-regieren,to govern,统治,VERB,B2
-regimen,regimen,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
+Reformismus,reformism,改唯,NOUN,B2
+verzichten,refrain,副歌,NOUN,B2
+verzichten,to refrain,克制,VERB,B2
+auffrischen,to refresh,使恢复精神,VERB,B2
+Kühlschrank,refrigerator,冰箱,NOUN,B2
+Zuflucht,refuge,避难所,NOUN,B2
+Flüchtling,refugee,难民,NOUN,B2
+Rückerstattung,refund,退款,NOUN,B2
+Verweigerung,refusal,拒绝,NOUN,B2
+bezüglich dieses,regarding this,对此,ADV,B2
+Regime,regime,政权,NOUN,B2
 regional,regional,地区的,ADJ,B2
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-register (noun),register,词,NOUN,B1
-registered,registered,注册的,ADJ,B2
-registered mail,registered mail,挂号信,NOUN,B2
-registration number,registration number,词,NOUN,C1
+Registrierung,registration,注册,NOUN,B2
+zurückgehen,to regress,倒退,VERB,B2
+Regression,regression,倒退,NOUN,B2
 regressiv,regressive,退步的,ADJ,B2
-regularization,regularization,词,NOUN,C1
-regulator,regulator,词,NOUN,C1
-regulatory,regulatory,监管的,ADJ,B2
+Bedauern,regret,后悔,NOUN,B2
+regelmäßig,regular,规律的,ADJ,B2
 regulieren,to regulate,调节,VERB,B2
-rehabilitation,rehabilitation,康复,NOUN,B2
-rehabilitative,rehabilitative,词,ADJ,B2
-rehearsal,rehearsal,排练,NOUN,B2
-reibungslos,smoothly,顺利,ADV,B2
-reichlich,ample,充足的,ADJ,B2
-reif,mature,成熟的,ADJ,B2
-reification,reification,词,NOUN,C1
-rein,rein,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
-reinforced,reinforced,词,ADJ,C1
-reining,reining,勒马,NOUN,B2
-reins,reins,词,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
-reissue (noun),reissue,词,NOUN,C1
-reizbar,irritable,易怒的,ADJ,B2
-reizen,to irritate,激怒,VERB,B2
-rekonstruieren,to reconstruct,重建,VERB,B2
-rekrutieren,to recruit,招募,VERB,B2
-relapse (verb),relapse,词,VERB,B2
-relating to birth,relating to birth,词,ADJ,C1
-relation,relation,词,NOUN,B1
-relational,relational,词,ADJ,B2
+Regelungen,regulations,法规,NOUN,B2
+proben,to rehearse,排练,VERB,B2
+Herrschaft,reign,统治,NOUN,B2
+erstatten,to reimburse,偿还,VERB,B2
+erneut herausgeben,to reissue,补办,VERB,B2
+wiederholen,to reiterate,重申,VERB,B2
+Ablehnung,rejection,拒绝,NOUN,B2
+sich freuen,to rejoice,欢欣,VERB,B2
+Rückfall,relapse,再犯,NOUN,B2
+erzählen,to relate to narrate,叙述,VERB,B2
 relativ,relatively,相对地,ADV,B2
 relatively speaking,relatively speaking,相对而言,ADV,B2
 relativism,relativism,相对主义,NOUN,B2
-relativist,relativist,词,ADJ,C1
-relativity,relativity,词,NOUN,C1
 relaxation,relaxation,缓和,NOUN,B2
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
 release,release,释放,NOUN,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-released,released,词,ADJ,B2
 relegate,to relegate,降级,VERB,B2
-relentless,relentless,无情的,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
 relevance,relevance,相关性,NOUN,B2
 relevant,relevant,相关的,ADJ,B2
 reliability,reliability,可靠性,NOUN,B2
 relic,relic,圣物,NOUN,B2
 relief,relief,缓解,NOUN,B2
-relieved,relieved,宽慰的,ADJ,B2
 religion,religion,宗教,NOUN,B2
-religiosity,religiosity,笃信宗教,NOUN,B2
 religious,religious,宗教的,ADJ,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiously,religiously,词,ADV,C1
-religiousness,religiousness,虔诚,NOUN,B2
-relinquish,relinquish,词,VERB,C1
-relinquishment,relinquishment,词,NOUN,C1
-relocation,relocation,搬家,NOUN,B2
-reluctance,reluctance,不情愿,NOUN,B2
-reluctant,reluctant,不情愿的,ADJ,B2
 rely,to rely,依赖,VERB,B2
 rely on,to rely on,依靠,VERB,B2
 remainder,remainder,剩余部分,NOUN,B2
-remaining,remaining,,NOUN,B2
 remains,remains,残骸,NOUN,B2
-remains spoils,remains spoils,遗体，战利品,NOUN,B2
-remand,remand,词,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
 remark,remark,评论,NOUN,B2
-remark (verb),remark,词,VERB,B2
-remarkable,remarkable,非凡的,ADJ,B2
-remarkably,remarkably,显著地,ADV,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
-remediation,remediation,词,NOUN,B2
 remedy,to remedy,补救,VERB,B2
 remembrance,remembrance,纪念,NOUN,B2
-reminder,reminder,提醒物,NOUN,B2
-reminisce,reminisce,词,VERB,C1
-reminiscence,reminiscence,词,NOUN,C1
-reminiscent,reminiscent,词,ADJ,C1
-remiss,remiss,词,ADJ,C1
-remission,remission,词,NOUN,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remnant,remnant,词,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remorseful,remorseful,悔恨的,ADJ,B2
 remote,remote,遥远的,ADJ,B2
-remote control,remote control,遥控器,NOUN,B2
-remote work,remote work,远程办公,NOUN,B2
 remote-controlled car,remote-controlled car,遥控车,NOUN,B2
 removal,removal,移除,NOUN,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-removal deletion,removal deletion,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,移除的,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
 remuneration,remuneration,报酬,NOUN,B2
 renaissance,renaissance,复兴,NOUN,B2
 renal,renal,肾脏的,ADJ,B2
-renascent,renascent,词,ADJ,C1
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
 rendezvous,rendezvous,约会,NOUN,B2
-rendition,rendition,词,NOUN,C1
-renegade,renegade,词,NOUN,C1
 renege,to renege,食言,VERB,B2
 renew,to renew,更新,VERB,B2
 renewable,renewable,可再生的,ADJ,B2
-renewable energy,renewable energy,可再生能源,NOUN,C1
 renewal,renewal,更新,NOUN,B2
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
 renminbi,renminbi,人民币,NOUN,B2
-rennen,to run quickly,奔驰,VERB,B2
-renounce,renounce,词,VERB,C1
 renovate,to renovate,翻新,VERB,B2
 renovation,renovation,翻新,NOUN,B2
 renown,renown,声誉,NOUN,B2
-renowned,renowned,著名的,ADJ,B2
-rent a car,rent a car,租车,VERB,C1
-rental,rental,词,ADJ,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
-reopening,reopening,词,NOUN,C1
 reoperation,reoperation,再术,NOUN,B2
-reordering,reordering,改序,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-reparable,reparable,词,ADJ,C1
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repatriation,repatriation,词,NOUN,C1
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
-repelling,repelling,词,VERB,C1
-repertoire,repertoire,全部曲目,NOUN,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
-reply,reply,回复,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
-reporting,reporting,报道,NOUN,B2
-representational,representational,词,ADJ,C1
-repressed,repressed,词,ADJ,C1
-repressiv,repressive,压制的,ADJ,B2
-reprieve,reprieve,暂缓执行,NOUN,B2
-reprint,reprint,词,NOUN,C1
-reprisal,reprisal,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
-reproachable,reproachable,应受责备的,ADJ,B2
-reprobate,reprobate,词,NOUN,C1
-reproducibility,reproducibility,可重复性,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
-reproduzieren,to reproduce,繁殖,VERB,B2
-reprogramming,reprogramming,改程,NOUN,B2
+Reorganisation,reorganization,重组,NOUN,B2
+Wiedergutmachung,reparation,赔偿,NOUN,B2
+zurückzahlen,to repay,偿还,VERB,B2
+Rückzahlung,repayment,偿还,NOUN,B2
+wiederholt,repeatedly,反复地,ADV,B2
+bußen,to repent,悔改,VERB,B2
+Buße,repentance,悔恨,NOUN,B2
+Nachwirkung,repercussion,反响,NOUN,B2
+Wiederholung,repetition,重复,NOUN,B2
+Neuplanung,replanning,再策,NOUN,B2
+Antwort an Eure Hoheit,reply to your-highness,回殿下,NOUN,B2
+Reporter,reporter,记者,NOUN,B2
+Neupositionierung,repositioning,重新定位,NOUN,B2
+Vertretung,representation,代表,NOUN,B2
 repräsentativ,representative,有代表性的,ADJ,B2
-reptiles,reptiles,词,NOUN,B2
-republicanism,republicanism,词,NOUN,C1
+Repräsentativität,representativeness,代表性,NOUN,B2
+Unterdrückung,repression,镇压,NOUN,B2
+repressiv,repressive,压制的,ADJ,B2
+Neupreisung,reprice,再价,NOUN,B2
+Tadel,reprimand,训斥,NOUN,B2
+reproduzieren,to reproduce,繁殖,VERB,B2
 republikanisch,republican,共和的,ADJ,B2
-repudiate,repudiate,词,VERB,C1
-repudiation,repudiation,词,NOUN,C1
-repugnant,repugnant,词,ADJ,C1
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
-request to rest,request to rest,请息,NOUN,C1
-required course,required course,必修课,NOUN,C1
-requirements,requirements,词,NOUN,C1
-requisite,requisite,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,词,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
-rescind,rescind,词,VERB,C1
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resection,resection,切除术,NOUN,B2
-resent,resent,词,VERB,C1
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
-reserves,reserves,储备,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
-residence housing,residence housing,词,NOUN,A2
-residential,residential,词,ADJ,B2
-residual,residual,残留的,ADJ,B2
-residue,residue,词,NOUN,C1
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
-resigned submission,resigned submission,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resin,resin,词,NOUN,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistant,resistant,词,ADJ,C1
-resistor,resistor,词,NOUN,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
-resolve doubts,resolve doubts,解惑,VERB,B2
-resonant,resonant,共鸣的,ADJ,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respectful,respectful,恭敬的,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respective,respective,各自的,ADJ,B2
-respectively,respectively,词,ADV,C1
+Abwehr,repulse,击退,NOUN,B2
+abstoßend,repulsive,令人反感的,ADJ,B2
+Anfrage,request,请求,NOUN,B2
+Anforderung,requirement,要求,NOUN,B2
+Wiederverkauf,resale,转售,NOUN,B2
+Rettung eines Fangs,rescue a-fang,救阿方,NOUN,B2
+Forscher,researcher,研究员,NOUN,B2
+Ähnlichkeit,resemblance,相似,NOUN,B2
+verbittert,resentful,充满愤恨的,ADJ,B2
+Groll,resentment,愤恨,NOUN,B2
+Reserve,reserve,预备,NOUN,B2
+zurückhaltend,reserved,保留的,ADJ,B2
+Stausee,reservoir,水库,NOUN,B2
+Umgestaltung,reshaping,改形,NOUN,B2
+wohnen,to reside,居住,VERB,B2
+Wohnsitz,residence,住所,NOUN,B2
+entschlossen,resolute,坚决的,ADJ,B2
+Auflösung,resolution,决心,NOUN,B2
+entschließen,to resolve,解决,VERB,B2
+Resonanz,resonance,共鸣,NOUN,B2
+Rückgriff,resort,度假胜地,NOUN,B2
 respektvoll,respectful deferential,恭敬,ADJ,B2
-respiration,respiration,呼吸作用,NOUN,B2
 respiratorisch,respiratory,呼吸的,ADJ,B2
-respite,respite,喘息,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
-respondent,respondent,被上诉人,NOUN,B2
-rest assured,rest assured,放心的,ADJ,B2
-rest stop,rest stop,词,NOUN,B1
-restate,restate,词,VERB,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-restock,restock,补货,VERB,C1
-restrain,restrain,词,VERB,C1
-restriction,restriction,限制,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
-resumption,resumption,恢复,NOUN,B2
-resurgent,resurgent,词,ADJ,C1
-resuscitate,resuscitate,词,VERB,C1
-resuscitation,resuscitation,复苏,NOUN,B2
-retailer,retailer,零售商,NOUN,B2
-retaliate,retaliate,词,VERB,C1
-retaliation,retaliation,词,NOUN,C1
-retarded,retarded,词,ADJ,C1
-retention,retention,我留,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-reticent,reticent,沉默寡言的,ADJ,B2
-retina,retina,词,NOUN,B2
-retinue,retinue,词,NOUN,B2
-retiree,retiree,退休人员,NOUN,B2
-retirement pension,retirement pension,退休金,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retranslation,retranslation,重译,NOUN,B2
-retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retroactive,retroactive,词,ADJ,C1
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-retrospective (noun),retrospective,词,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-reunification,reunification,重新统一,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
-revel,revel,词,VERB,C1
-revelry,revelry,狂欢,NOUN,B2
-revenue,revenue,收入,NOUN,C1
-revenues,revenues,词,NOUN,C1
-reverberation,reverberation,词,NOUN,C1
-reverent,reverent,虔诚的,ADJ,B2
-reverentially,reverentially,词,ADV,C1
-reverie,reverie,词,NOUN,C1
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
+antworten,to respond,回应,VERB,B2
+antworten,to respond to,回应,VERB,B2
+Antwort,response,回应,NOUN,B2
+Reaktionsfähigkeit,responsiveness,反应性,NOUN,B2
+Ruhe,rest,休息,NOUN,B2
+Wiederherstellung,restoration,恢复,NOUN,B2
+wiederherstellen,to restore,恢复,VERB,B2
+Zurückhaltung,restraint,隐忍,NOUN,B2
+Umstrukturierung,restructuring,重组,NOUN,B2
+wieder aufnehmen,to resume,重新开始,VERB,B2
+Auferstehung,resurrection,复活,NOUN,B2
+Einzelhandel,retail,零售,NOUN,B2
+behalten,to retain,保留,VERB,B2
+wiedererzählen,to retell,转述,VERB,B2
+zurücktreten,to retire,退休,VERB,B2
+zurückgetreten,retired,退休的,ADJ,B2
+Rückgewinnung,retrieval,检索,NOUN,B2
+Wiedererlangung,retrieve qingming,拿回青冥,NOUN,B2
+zurückkehren,to return first,先回,VERB,B2
+Neuabtippen,retype,再型,NOUN,B2
+Wiederverwendung,reuse,重用,NOUN,B2
+Umbewertung,revaluation,重新评估,NOUN,B2
+Offenbarung,revelation,启示,NOUN,B2
+verehren,to revere,尊敬,VERB,B2
+Ehrfurcht,reverence,尊敬,NOUN,B2
+Umkehr,reversal,突变,NOUN,B2
+umgekehrte Inklusion,reverse inclusion,反纳,NOUN,B2
+umgekehrte Reflexion,reverse reflection,反影,NOUN,B2
+Rückseite,reverse side,反面,NOUN,B2
+Rückfall,reversion,重归,NOUN,B2
+überprüfen,to review,复习,VERB,B2
 revidieren,to revise,修订,VERB,B2
-revile,revile,词,VERB,C1
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revival,revival,复兴,NOUN,B2
-revivalism,revivalism,词,NOUN,C1
-revocation,revocation,词,NOUN,C1
-revolt,revolt,叛乱,NOUN,B2
+Revision,revision,复习,NOUN,B2
+beleben,to revive,复兴,VERB,B2
+Revolution,revolution,革命,NOUN,B2
 revolutionär,revolutionary,革命的,ADJ,B2
-revolver,revolver,词,NOUN,C1
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-reziprok,reciprocal,互惠的,ADJ,B2
-rezitieren,to recite,背诵,VERB,B2
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
+Rhetorik,rhetoric,修辞,NOUN,B2
 rhetorisch,rhetorical,修辞的,ADJ,B2
 rhetorische Frage,rhetorical question,宁非,NOUN,B2
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald,ribald,词,ADJ,C1
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribbon,ribbon,丝带,NOUN,B2
-ribs,ribs,肋骨,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-richer,richer,更富的,ADJ,B2
-rickety,rickety,词,ADJ,C1
-ricochet,ricochet,词,NOUN,C1
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridicule (noun),ridicule,词,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
-riesig,vast,巨大的,ADJ,B2
-rife,rife,词,ADJ,C1
-riffraff,riffraff,词,NOUN,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rightly,rightly,正确地,ADV,B2
-rights and interests,rights and interests,权益,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
-rile,rile,词,VERB,C1
-rim,rim,词,NOUN,C1
-rings,rings,词,NOUN,B2
-ringtone,ringtone,词,NOUN,C1
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-rise (noun),rise,词,NOUN,B2
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
+Reim,rhyme,韵脚,NOUN,B2
+naturbegabt,richly endowed by nature,得天独厚,ADJ,B2
+Wellenbrecher,ride break,骑破,NOUN,B2
+Kluft,rift,裂痕,NOUN,B2
+rechtschaffend,righteous,正直的,ADJ,B2
+gerechter Zorn,righteous indignation,义愤,NOUN,B2
+Gerechtigkeit,righteousness,亦正,NOUN,B2
+Rechte,rights,权利,NOUN,B2
+starr,rigid,僵硬的,ADJ,B2
+Starrheit,rigidity,僵硬,NOUN,B2
+streng,rigorous,严格的,ADJ,B2
+Ring,ring,戒指,NOUN,B2
+Ringstraße,ring road,绕城,NOUN,B2
+Aufruhr,riot,骚乱,NOUN,B2
+steigen,rise,上涨,NOUN,B2
+steigen,to rise,上升,VERB,B2
 riskieren,to risk life,拼命,VERB,B2
-risks,risks,词,NOUN,C1
-risque,risque,有伤风化的,ADJ,B2
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
-rival,rival,对手,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-river-gauging,river-gauging,词,ADJ,C1
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-road (adj),road,词,ADJ,B2
-roadblock,roadblock,,NOUN,B2
-roadway,roadway,路面,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roar (noun),roar,词,NOUN,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
-robe,robe,词,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotics,robotics,词,NOUN,C1
-robotization,robotization,词,NOUN,C1
+Todesrisiko,risking death,冒死,NOUN,B2
+Ritual,ritual,仪式,NOUN,B2
+Rivalität,rivalry,竞争,NOUN,B2
+Flussufer,riverbank,河岸,NOUN,B2
+Straße,road,道路,NOUN,B2
+Verkehrsschild,road sign,路标,NOUN,B2
+umherstreifen,to roam,漫游,VERB,B2
+Braten,roast,烤肉,NOUN,B2
+Lamm braten,to roast lamb,烤羊,VERB,B2
 robust,robust,强健的,ADJ,B2
-robust,sturdy,坚固的,ADJ,B2
-robustness,robustness,词,NOUN,C1
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock slab,rock slab,岩板,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rod,rod,词,NOUN,B1
-rodent,rodent,啮齿动物,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
-rogue,rogue,词,NOUN,B2
-roh,raw,生的,ADJ,B2
-rolled,rolled,词,ADJ,C1
-roller skate,roller skate,词,NOUN,B1
-rolling,rolling,词,NOUN,C1
-roman,roman,罗马的,ADJ,B2
-romanhaft,novelistic,小说般的,ADJ,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-roominess,roominess,词,NOUN,C1
-roots,roots,词,NOUN,C1
-rose bush,rose bush,词,NOUN,B1
-roster,roster,词,NOUN,C1
+Steingarten,rockery,假山,NOUN,B2
+Rollladen,roller blind,卷帘,NOUN,B2
+bedachen,to roof,房顶,VERB,B2
+faul,rotten,腐烂的,ADJ,B2
+Rauheit,roughness,粗糙,NOUN,B2
+Kreisverkehr,roundabout,环岛,NOUN,B2
+wecken,to rouse,唤醒,VERB,B2
+Router,router,路由器,NOUN,B2
+Routine,routine,常规,NOUN,B2
+Reihe,row,行,NOUN,B2
+königlich,royal,皇家的,ADJ,B2
+Reiben,rubbing,摩擦,NOUN,B2
+unhöflich,rude,粗鲁的,ADJ,B2
+Unhöflichkeit,rudeness,粗鲁,NOUN,B2
+Ruine,ruin,废墟,NOUN,B2
+Ruinen,ruins,废墟,NOUN,B2
+Rechtsstaatlichkeit,rule of law,法治,NOUN,B2
+stoßen auf,to run into,碰见,VERB,B2
+rennen,to run quickly,奔驰,VERB,B2
+joggen,to run to jog,跑步,VERB,B2
+Läufer,runner,跑步者,NOUN,B2
+Schnupfen,runny nose,流鼻涕,NOUN,B2
+Bruch,rupture,破裂,NOUN,B2
+ländlich,rural,乡村的,ADJ,B2
+Eile,rush,赶往,NOUN,B2
+herumhetzen,to rush about,奔波,VERB,B2
+Rost,rust,铁锈,NOUN,B2
 rostfrei,rust-proof,防锈,ADJ,B2
-rot decomposition,rot decomposition,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
-rout,rout,溃败,NOUN,B2
-routing,routing,词,NOUN,C1
-rove,rove,词,VERB,C1
-rowboat,rowboat,词,NOUN,B2
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal court,royal court,词,NOUN,C1
-royalty,royalty,王室,NOUN,B2
-rubber,rubber,橡胶,NOUN,B2
-rubbish,rubbish,垃圾,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubble,rubble,瓦砾,NOUN,B2
-rubicund,rubicund,词,ADJ,C1
-ruby,ruby,词,NOUN,C1
-ruckus,ruckus,词,NOUN,C1
-rudely,rudely,词,ADV,C1
-rudimentary,rudimentary,词,ADJ,C1
-rueful,rueful,词,ADJ,C1
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
-ruin relic,ruin relic,词,NOUN,B2
-rulebook,rulebook,规则体系,NOUN,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-rumination,rumination,词,NOUN,C1
-ruminative,ruminative,词,ADJ,C1
-rummage,rummage,词,VERB,C1
-run away fled,run away fled,词,VERB,A1
-run over (adj),run over,词,ADJ,B2
-run-down,run-down,词,ADJ,C1
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,词,NOUN,B2
-rung,rung,词,NOUN,C1
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
-runway,runway,词,NOUN,C1
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-ruse,ruse,词,NOUN,C1
-rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rustic,rustic,乡村的,ADJ,B2
-rusty,rusty,词,ADJ,C1
-ruthless,ruthless,无情的,ADJ,B2
-rutschen,to slip,滑倒,VERB,B2
-rutschig,slippery,滑的,ADJ,B2
-rächen,to take revenge,报复,VERB,B2
-räuberisch,predatory,掠夺的,ADJ,B2
-rücksichtslos,reckless,鲁莽的,ADJ,B2
-rücksichtsvoll,considerate,体贴,ADJ,B2
-rülpsen,to burp,打嗝,VERB,B2
-sabbath,sabbath,安息日,NOUN,B2
-sabbatical,sabbatical,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-saccharine,saccharine,词,ADJ,C1
-sacrifice,sacrifice,牺牲,NOUN,B2
-sacrilege,sacrilege,亵渎,NOUN,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
-saddening,saddening,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddle pad,saddle pad,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadistic,sadistic,施虐的,ADJ,B2
-sadly,sadly,词,ADV,B2
-safe container,safe container,词,NOUN,C1
-safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
-safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-sagacity,sagacity,词,NOUN,B2
-sage,sage,词,NOUN,C1
-sail,sail,帆,NOUN,B2
-sailboat,sailboat,,NOUN,B2
-sailor,sailor,水手,NOUN,B2
-sailors,sailors,词,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-saisonal,seasonal,季节性的,ADJ,B2
-salacious,salacious,词,ADJ,C1
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salaried,salaried,词,ADJ,B2
-salesman,salesman,词,NOUN,B2
-salient,salient,词,ADJ,C1
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-saliva,saliva,词,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salt shaker,salt shaker,,NOUN,B2
-salted,salted,词,ADJ,B2
-salubrious,salubrious,词,ADJ,C1
-salutary,salutary,词,ADJ,C1
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-salzig,salty,咸的,ADJ,B2
-sama,sama,词,NOUN,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimonious,sanctimonious,伪善的,ADJ,B2
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
-sanctity,sanctity,词,NOUN,C1
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
-sands,sands,词,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sane,sane,神志正常的,ADJ,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
-santur,santur,词,NOUN,C1
-sap,sap,词,NOUN,C1
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sardonic,sardonic,词,ADJ,C1
-sat,sat,词,NOUN,B1
-satchel,satchel,词,NOUN,C1
-sated,sated,词,ADJ,B2
-satirisch,satirical,讽刺的,ADJ,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-saucepan,saucepan,词,NOUN,B2
-saucy,saucy,词,ADJ,B2
-sauer,sour,酸的,ADJ,B2
-sauna,sauna,桑拿,NOUN,B2
-saunter,saunter,词,VERB,C1
-savage,savage,savage,NOUN,B2
-savant,savant,词,NOUN,C1
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
-saving,saving,储蓄,NOUN,B2
-saving the root,saving the root,救本,NOUN,C1
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-sawdust,sawdust,词,NOUN,C1
-say he,say he,说他,NOUN,C1
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,秤,NOUN,B2
-scallion,scallion,词,NOUN,B2
-scaly,scaly,词,ADJ,C1
-scammer,scammer,词,NOUN,B2
-scandalous,scandalous,可耻的,ADJ,B2
-scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarcely,scarcely,几乎不,ADV,B2
-scarecrow,scarecrow,词,NOUN,C1
-scarf shawl,scarf shawl,词,NOUN,A1
-scathing,scathing,词,ADJ,C1
-scatterbrained,scatterbrained,词,ADJ,B2
-scattering,scattering,词,NOUN,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
-sceptical,sceptical,词,ADJ,C1
-schamlos,shameless,无耻的,ADJ,B2
-scharfsinnig,astute,精明的,ADJ,B2
-schattig,shady,阴凉的,ADJ,B2
-schaumig,foamy,多泡沫的,ADJ,B2
-scheduling,scheduling,调度；排序,NOUN,B2
-schema,schema,词,NOUN,B2
-schematic,schematic,概要的,ADJ,B2
-schism,schism,分裂,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-schlachten,slaughter,屠杀,NOUN,B2
-schlachten,to slaughter,割喉,VERB,B2
-schlecht,badly,坏地,ADV,B2
-schlechte Idee,bad idea,坏水,NOUN,B2
-schlechte Nachricht,bad news,坏消息,NOUN,B2
-schlechter,worse,更糟的,ADJ,B2
-schlechteste,worst,最坏的,ADJ,B2
-schleppen,to drag,拖,VERB,B2
-schlichten,to arbitrate,仲裁,VERB,B2
-schließen,to close account,销户,VERB,B2
-schließen,to close the door,关门,VERB,B2
-schließlich,end,端,PART,B2
-schlucken,to gulp,吞咽,VERB,B2
-schlürfen,to sip,小口喝,VERB,B2
-schlüssig,conclusive,决定性的,ADJ,B2
-schmeicheln,to flatter,奉承,VERB,B2
-schmoren,to stew,炖,VERB,B2
-schnappen,to snatch,抢夺,VERB,B2
-schnarchen,to snore,打鼾,VERB,B2
-schnell,quickly,迅速地,ADV,B2
-schnüffeln,to sniff,嗅,VERB,B2
-schockierend,shocking,令人震惊的,ADJ,B2
-scholar learned,scholar learned,词,NOUN,C1
-scholarship holder,scholarship holder,奖学金生,NOUN,B2
-scholastisch,scholastic,经院哲学的,ADJ,B2
-scholing,scholing,词,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school,school,学校的,ADJ,B2
-school bag,school bag,词,NOUN,A2
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-school year,school year,学年,NOUN,B2
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schrecklich,horrible,可怕的,ADJ,B2
-schreien,to yell,大吼,VERB,B2
-schrumpfen,to shrink,收缩,VERB,B2
-schwanken,to sway,摇摆,VERB,B2
-schweben,to float,漂浮,VERB,B2
-schweben,to hover,盘旋,VERB,B2
-schwer zu erhalten,hard to maintain,难以维持,ADJ,B2
-schwer zu sagen,hard to speak of,难以启齿,ADJ,B2
-schwer zu unterscheiden,hard to distinguish,难以区分,ADJ,B2
-schwer zu wählen,hard to choose,难以抉择,ADJ,B2
-schwieriger Angriff,difficult attack,难攻,NOUN,B2
-schwieriges Problem,difficult problem,难题,NOUN,B2
-schwindelig,dizzy,头晕的,ADJ,B2
-schwitzen,sweat,汗水,NOUN,B2
-schwitzen,to sweat,出汗,VERB,B2
-schwärmen,to daydream,幻想,VERB,B2
-schwärmen,to swarm,分群,VERB,B2
-schwärzen,to blacken,变黑,VERB,B2
-schüren,to stoke,添燃料,VERB,B2
-schützend,protective,保护的,ADJ,B2
-scientifically,scientifically,科学地,ADV,B2
-scientists,scientists,科学家,NOUN,B2
-scintillate,scintillate,词,VERB,C1
-scoff (noun),scoff,词,NOUN,C1
-scoff (verb),scoff,词,VERB,C1
-scoop,scoop,词,NOUN,B2
-scorn,scorn,轻蔑,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scorpion,scorpion,词,NOUN,A1
-scottish,scottish,词,ADJ,B2
-scour,scour,词,VERB,C1
-scouting locating,scouting locating,定位 / 侦察,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
-screenwriter,screenwriter,编剧,NOUN,B2
-screw (noun),screw,词,NOUN,C1
-scribal misreading,scribal misreading,词,NOUN,C1
-scribble (noun),scribble,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulous,scrupulous,一丝不苟的,ADJ,B2
-scrupulously,scrupulously,一丝不苟地,ADV,B2
-scrupulousness,scrupulousness,词,NOUN,C1
-scrutiny,scrutiny,明察,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scurvy,scurvy,词,NOUN,C1
-scuttle,scuttle,词,VERB,C1
-scythe,scythe,镰刀,NOUN,B2
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seal,seal,海豹,NOUN,B2
-seam,seam,词,NOUN,C1
-seaplane,seaplane,水上飞机,NOUN,B2
-seaport,seaport,海港,NOUN,C1
-search engine,search engine,搜索引擎,NOUN,B2
-search engine optimization,search engine optimization,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seated,seated,坐着的,ADJ,B2
-seats,seats,词,NOUN,C1
-seaweed,seaweed,词,NOUN,C1
-secession,secession,词,NOUN,C1
-sechste,sixth,第六,ADJ,B2
-sechzig,sixty,六十,NUM,B2
-seclusion,seclusion,闭关,NOUN,B2
-second (num),second,词,NUM,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
-secondment,secondment,词,NOUN,C1
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret recipe,secret recipe,秘制,NOUN,C1
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-sectarianism,sectarianism,词,NOUN,C1
-section chief,section chief,课长,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secular,secular,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
-secularization,secularization,世俗化,NOUN,C1
-secure (adj),secure,词,ADJ,B1
-security matter,security matter,词,NOUN,C1
-security-related,security-related,安全的，安保的,ADJ,B2
-securocratic,securocratic,词,ADJ,C1
-sedate,sedate,词,ADJ,C1
-sedative,sedative,词,NOUN,C1
-sedentary,sedentary,久坐的,ADJ,B2
-sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
-sediment,sediment,词,NOUN,C1
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-sedition,sedition,煽动叛乱,NOUN,B2
-seditious,seditious,词,ADJ,C1
-sedulous,sedulous,词,ADJ,C1
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seedy,seedy,词,ADJ,C1
-seeker,seeker,寻求者,NOUN,B2
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking intercession,seeking intercession,词,NOUN,C1
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-segregation,segregation,隔离，分离,NOUN,B2
-sein,to there's still time,来得及,VERB,B2
-sein,to was,是,VERB,B2
-seismisch,seismic,地震的,ADJ,B2
-seitlich,lateral,侧面的,ADJ,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-sektiererisch,sectarian,宗派的,ADJ,B2
-sekundär,secondary,次要的,ADJ,B2
-seldom,seldom,很少,ADV,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
-selectively,selectively,有选择地,ADV,B2
-selector,selector,词,NOUN,C1
-selektiv,selective,选择的，挑选的,ADJ,B2
-self,self,自己,PRON,B2
-self (adv),self,词,ADV,B2
-self-abasement,self-abasement,词,NOUN,C1
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
-self-defense,self-defense,自卫,NOUN,B2
-self-denial,self-denial,自我牺牲,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-employed person,self-employed person,个体经营者,NOUN,B2
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-image,self-image,自我形象,NOUN,B2
-self-interest,self-interest,私利,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-taught,self-taught,自学的,ADJ,B2
-self-worth,self-worth,词,NOUN,B2
-selfie,selfie,自拍,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfless,selfless,词,ADJ,B2
-selfless devotion,selfless devotion,词,NOUN,C1
-sellou,sellou,塞卢能量膏,NOUN,B2
-selten,rarely,很少,ADV,B2
-seltsam,odd,奇怪的,ADJ,B2
-seltsam,weird,奇怪的,ADJ,B2
-semantic,semantic,词,ADJ,C1
-semantics,semantics,语义学,NOUN,B2
-semblance,semblance,词,NOUN,C1
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
-seminary,seminary,词,NOUN,C1
-semolina,semolina,粗面粉,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-sending,sending,词,NOUN,B1
-senescence,senescence,词,NOUN,B2
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
-seniors,seniors,词,NOUN,C1
-senkrecht,perpendicular,垂直的,ADJ,B2
-sensationalism,sensationalism,词,NOUN,C1
-sense of duty,sense of duty,责任感,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
-sensibly,sensibly,明智地,ADV,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
-sensitization,sensitization,词,NOUN,B2
-sensor donor,sensor donor,传感器/捐献者,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensual,sensual,感官的,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentence verdict,sentence verdict,词,NOUN,B2
-sentenced,sentenced,被判刑的,ADJ,B2
-sentences,sentences,句子,NOUN,B2
-sentencing,sentencing,量刑,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentient,sentient,词,ADJ,C1
-sentinel,sentinel,哨兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separate,separate,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
-separatism,separatism,词,NOUN,C1
-separatist,separatist,词,NOUN,C1
-sequential,sequential,词,ADJ,C1
-seraphic,seraphic,词,ADJ,C1
-seren,serene,宁静的,ADJ,B2
-serendipity,serendipity,词,NOUN,C1
-serenely,serenely,词,ADV,C1
-serial,serial,词,NOUN,B1
-serialized drama,serialized drama,连续剧,NOUN,B2
-series of conversations,series of conversations,系列对话,NOUN,B2
-seriously,seriously,认真地,ADV,B2
-serous,serous,词,ADJ,C1
-serpentine,serpentine,词,ADJ,C1
-serum,serum,词,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve one's country,serve one's country,报国,VERB,C1
-service counter,service counter,词,NOUN,B1
-service favor,service favor,词,NOUN,A2
-service of process,service of process,词,NOUN,C1
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-service year,service year,,NOUN,B2
-services,services,词,NOUN,C1
-servile,servile,词,ADJ,C1
-servilely,servilely,奴性地,ADV,B2
-serving,serving,词,NOUN,B2
-servitude,servitude,奴役,NOUN,C1
-set a record,set a record,创造纪录,VERB,B2
-set of ideals,set of ideals,思想体系,NOUN,B2
-set square,set square,词,NOUN,B2
-set-off,set-off,词,NOUN,C1
-setting,setting,词,NOUN,B1
-setting splinting,setting splinting,词,NOUN,C1
-setting sun,setting sun,夕阳,NOUN,B2
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seven (adj),seven,词,ADJ,B2
-seventeen,seventeen,十七,NUM,B2
-sever,sever,词,VERB,C1
-several,several,若干,NOUN,B2
-several (adj),several,词,ADJ,A2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times (noun),several times,几遍,NOUN,B2
-severance,severance,词,NOUN,C1
-severely,severely,严厉地,ADV,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
-sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexily,sexily,性感地,ADV,B2
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
-sexually,sexually,在性方面,ADV,B2
-sexy,sexy,性感的,ADJ,B2
-sezieren,to dissect,解剖,VERB,B2
-sfouf,sfouf,词,NOUN,B2
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
-shading,shading,阴影,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shadows,shadows,词,NOUN,C1
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shaft,shaft,词,NOUN,B2
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,词,AUX,B2
-shambles,shambles,词,NOUN,C1
-shame culture,shame culture,词,NOUN,B2
-shame disgrace,shame disgrace,词,NOUN,B2
-shame pity,shame pity,词,NOUN,B2
-shameless person,shameless person,厚颜无耻的人,NOUN,B2
-shamelessness,shamelessness,无耻,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shards,shards,词,NOUN,B2
-shared boundary ownership,shared boundary ownership,词,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharply,sharply,词,ADV,B2
-shavings,shavings,刨花,NOUN,C1
-she (noun),she,可她,NOUN,B2
-sheaf,sheaf,捆,NOUN,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet of paper,sheet of paper,词,NOUN,B2
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift (noun),shift,轮班,NOUN,C1
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shining,shining,词,ADJ,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
-shipment,shipment,货物,NOUN,B2
-shirk,shirk,词,VERB,C1
-shit,shit,该死的,ADJ,B2
-shit crap,shit crap,废话,NOUN,B2
-shiver,shiver,寒战,NOUN,B2
-shivers,shivers,词,NOUN,B2
-shocked,shocked,震惊的,ADJ,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoe polish,shoe polish,词,NOUN,B2
-shoelace,shoelace,词,NOUN,C1
-shooter,shooter,射手,NOUN,B2
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shopkeeper,shopkeeper,词,NOUN,C1
-shopping mall,shopping mall,商场,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short film,short film,短片,NOUN,B2
-short news item,short news item,词,NOUN,C1
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-shortcomings,shortcomings,词,NOUN,C1
-shorter,shorter,更短的,ADJ,B2
-shortest,shortest,词,NOUN,B2
-shortly,shortly,不久,ADV,B2
-shotgun,shotgun,猎枪,NOUN,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-should ought to,should ought to,应该,AUX,B2
-show,show,表演,NOUN,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-showy,showy,词,ADJ,B2
-shred,shred,词,NOUN,B2
-shriek,shriek,词,VERB,C1
-shrill,shrill,尖锐的,ADJ,B2
-shrimp,shrimp,虾,NOUN,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrivel,shrivel,词,VERB,C1
-shrub,shrub,词,NOUN,C1
-shrug,shrug,词,VERB,C1
-shrunken,shrunken,词,ADJ,B2
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shutdown,shutdown,词,NOUN,C1
-shuttle,shuttle,穿梭巴士,NOUN,B2
-shyness,shyness,羞怯,NOUN,B2
-sibilant,sibilant,词,ADJ,C1
-sibling,sibling,兄弟姐妹,NOUN,B2
-sibyl,sibyl,词,NOUN,C1
-sich abspalten,to secede,脱离,VERB,B2
-sich anstrengen,to try hard to,力图,VERB,B2
-sich anstrengen,to work hard for sth to strive for success,争气,VERB,B2
-sich bestmöglich anstrengen,to do one's best,尽力,VERB,B2
-sich einigen,to compromise,危及,VERB,B2
-sich entschuldigen,to apologize,道歉,VERB,B2
-sich freuen,to rejoice,欢欣,VERB,B2
-sich lösen,to disengage,脱离,VERB,B2
-sich sehnen,to yearn for,渴望,VERB,B2
-sich unterscheiden,to differ,不同,VERB,B2
-sich verspäten,to be late,迟到,VERB,B2
+Rücksichtslosigkeit,ruthlessness,无情,NOUN,B2
+Sack,sack,麻袋,NOUN,B2
+heilig,sacred,神圣的,ADJ,B2
+traurig,sad sorrowful,悲伤,ADJ,B2
+Traurigkeit,sadness,悲伤,NOUN,B2
 sicher,safe,安全的,ADJ,B2
-sicher sein,to be safe,安好,VERB,B2
-sick leave,sick leave,病假,NOUN,B2
-sickle,sickle,词,NOUN,B2
-sickly,sickly,词,ADJ,C1
-sickness,sickness,词,NOUN,B2
-side,side,骄傲的,ADJ,B2
-side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-sideburn,sideburn,词,NOUN,B1
-sie,she,她,PRON,B2
-sie,them,他们,PRON,B2
-sie,they,他们,PRON,B2
-sie,they things,它们,PRON,B2
+Sicherheit,safety,安全,NOUN,B2
+Sicherheitsbericht,safety report,安全报告,NOUN,B2
+klug,sagacious,睿智的,ADJ,B2
+Segeln,sailing,航行,NOUN,B2
+Sake,sake,缘故,NOUN,B2
+Verkauf,sales,打折,NOUN,B2
+Verkäufer,salesperson,销售人员,NOUN,B2
+Lachs,salmon,三文鱼,NOUN,B2
+salzig,salty,咸的,ADJ,B2
+gleich,same,相同的,ADJ,B2
+Muster,sample,样本,NOUN,B2
+Sanktion,sanction,制裁,NOUN,B2
+Heiligtum,sanctuary,避难所,NOUN,B2
+Sand,sand,沙子,NOUN,B2
+Sandal,sandal,凉鞋,NOUN,B2
+Sandwich,sandwich,三明治,NOUN,B2
+Verstand,sanity,理智,NOUN,B2
+Satellit,satellite,卫星,NOUN,B2
+Sättigung,satiety,饱足,NOUN,B2
+Satire,satire,讽刺,NOUN,B2
+satirisch,satirical,讽刺的,ADJ,B2
+Säge,saw,锯子,NOUN,B2
+Gerüst,scaffold,脚手架,NOUN,B2
+verbrühen,to scald,烫伤,VERB,B2
+Skala,scale,规模,NOUN,B2
+Skalpell,scalpel,手术刀,NOUN,B2
+Betrug,scam,骗局,NOUN,B2
+Scan,scan,扫描件,NOUN,B2
+Knappheit,scarcity,短缺,NOUN,B2
+verstreuen,to scatter,分散,VERB,B2
+verstreut,scattered,分散的,ADJ,B2
+Landschaft,scenery,风景,NOUN,B2
+Plan,scheme,计划,NOUN,B2
+Schizophrenie,schizophrenia,精神分裂症,NOUN,B2
+Gelehrter,scholar,学者,NOUN,B2
+scholastisch,scholastic,经院哲学的,ADJ,B2
+wissenschaftlich,scientific,科学的,ADJ,B2
+tadeln,to scold,训斥,VERB,B2
+Umfang,scope,范围,NOUN,B2
+versengen,to scorch,烧焦,VERB,B2
+glühend,scorching,灼热的,ADJ,B2
+Punktzahl,score,比分,NOUN,B2
+Schurke,scoundrel,恶棍,NOUN,B2
+Geißel,scourge,灾祸,NOUN,B2
+Späher,scout,侦察员,NOUN,B2
+abschirmen,to screen,筛选,VERB,B2
+Schraubenzieher,screwdriver,螺丝刀,NOUN,B2
+Drehbuch,script,剧本,NOUN,B2
+Schauspieltext,script for play,剧本,NOUN,B2
+Skrupel,scruple,顾虑,NOUN,B2
+untersuchen,to scrutinize,仔细检查,VERB,B2
+Tauchen,scuba diving,潜水,NOUN,B2
+Bildhauer,sculptor,雕塑家,NOUN,B2
+Skulptur,sculpture,雕塑,NOUN,B2
+Möwe,seagull,海鸥,NOUN,B2
+suchen,to search for,寻找,VERB,B2
+würzen,to season,调味,VERB,B2
+saisonal,seasonal,季节性的,ADJ,B2
+sich abspalten,to secede,脱离,VERB,B2
+Notausgang,seclusion exit,出关,NOUN,B2
+zweites Mal,second time,再而,NOUN,B2
+sekundär,secondary,次要的,ADJ,B2
+Geheimhaltung,secrecy,保密,NOUN,B2
+Geheimtreffen,secret meeting,密会,NOUN,B2
+Sekretariat,secretariat,秘书处,NOUN,B2
+heimlich,secretly,秘密地,ADV,B2
+Sekte,sect,教派,NOUN,B2
+sektiererisch,sectarian,宗派的,ADJ,B2
+Sektion,section,部分,NOUN,B2
+Säkularismus,secularism,世俗主义,NOUN,B2
+Verbriefung,securitization,证券化,NOUN,B2
+Limousine,sedan,轿车,NOUN,B2
+verführen,to seduce,引诱,VERB,B2
+Leiche sehen,to see corpse,见尸,VERB,B2
+Verabschiedung,see off,送走,NOUN,B2
+suchen,to seek,寻找,VERB,B2
+Audienz erbitten,to seek audience,求见,VERB,B2
+Wahrheit aus den Tatsachen suchen,to seek truth from facts,实事求是,VERB,B2
+Suche,seeking,寻求,NOUN,B2
+kurzfristig gewinnorientiert,seeking instant benefit,急功近利,ADJ,B2
+seismisch,seismic,地震的,ADJ,B2
+Anfall,seizure,没收,NOUN,B2
+selektiv,selective,选择的，挑选的,ADJ,B2
+Selbst,self,自我,NOUN,B2
+Selbstaufopferung,self-sacrifice,舍己,NOUN,B2
+Egoismus,selfishness,自私,NOUN,B2
+Semester,semester,学期,NOUN,B2
+Seminar,seminar,研讨会,NOUN,B2
+Semiologie,semiology,符号学，症状学,NOUN,B2
+Semiotik,semiotics,符号学,NOUN,B2
+Senat,senate,参议院,NOUN,B2
+Seniorität,seniority,资历,NOUN,B2
+vernünftig,sensible,明智的,ADJ,B2
+Sensibilität,sensitivity,敏感性,NOUN,B2
+Sensor,sensor,传感器,NOUN,B2
+Empfindung,sentiment,情感,NOUN,B2
+Wächter,sentry,卫兵,NOUN,B2
+Sequenz,sequence,顺序，片段,NOUN,B2
+seren,serene,宁静的,ADJ,B2
+Gelassenheit,serenity,宁静,NOUN,B2
+Ernsthaftigkeit,seriousness,严肃,NOUN,B2
+Predigt,sermon,布道,NOUN,B2
+Server,server,服务器,NOUN,B2
+Dienstleister,service provider,服务商,NOUN,B2
+Anliegerstraße,service road,辅路,NOUN,B2
+Unterwürfigkeit,servility,奴性,NOUN,B2
+Sesam,sesame,芝麻,NOUN,B2
+Rückschlag,setback,挫折,NOUN,B2
+Siedlung,settlement,解决,NOUN,B2
 siebte,seventh,第七,ADJ,B2
 siebzig,seventy,七十,NUM,B2
-siege time,siege time,攻城时,NOUN,C1
-sifted,sifted,词,ADJ,C1
-sighing,sighing,叹息的,ADJ,B2
-sightseeing,sightseeing,词,NOUN,C1
-sign brand,sign brand,词,NOUN,C1
+mehrere,several,几个,ADJ,B2
+streng,severe,严厉的,ADJ,B2
+Strenge,severity,严厉,NOUN,B2
+Nähen,sewing,缝纫,NOUN,B2
+Sex,sex,性别,NOUN,B2
+Hütte,shack,棚屋,NOUN,B2
+Fessel,shackle,镣铐,NOUN,B2
+schattig,shady,阴凉的,ADJ,B2
+Hände schütteln,to shake hands,握手,VERB,B2
+flach,shallow,浅的,ADJ,B2
+Schwindel,sham,假冒,NOUN,B2
+beschämend,shameful,可耻的,ADJ,B2
+schamlos,shameless,无耻的,ADJ,B2
+Shampoo,shampoo,洗发水,NOUN,B2
+Aktionär,shareholder,股东,NOUN,B2
+rasieren,to shave,剃,VERB,B2
+sie,she,她,PRON,B2
+Unterkunft,shelter,庇护所,NOUN,B2
+Hirte,shepherd,牧羊人,NOUN,B2
+Schild,shield,盾牌,NOUN,B2
+verschieben,shift,轮班,NOUN,B2
+verschieben,to shift,改变,VERB,B2
+Schichtwechsel,shift rotation,倒班,NOUN,B2
+Schichttausch,shift swap,换班,NOUN,B2
+vorverlegen,to shift to an earlier date,提前,VERB,B2
+verschiffen,to ship out,出货,VERB,B2
+schockierend,shocking,令人震惊的,ADJ,B2
+Schuhentfernung,shoe removal,鞋脱,NOUN,B2
+Schuhe,shoes,鞋子,NOUN,B2
+abschießen,to shoot down,击落,VERB,B2
+Schießen,shooting,射击,NOUN,B2
+Einkaufen,shopping,购物,NOUN,B2
+Einkaufszentrum,shopping center,购物中心,NOUN,B2
+Mangel,shortage,短缺,NOUN,B2
+Schwäche,shortcoming,缺点,NOUN,B2
+sollen,should not,不该,AUX,B2
+Schrei,shout,喊叫,NOUN,B2
+Schaufel,shovel,铲子,NOUN,B2
+gerissen,shrewd,精明的,ADJ,B2
+Schrein,shrine,مشعر,NOUN,B2
+schrumpfen,to shrink,收缩,VERB,B2
+Schauder,shudder,战栗,NOUN,B2
+Seite,side,侧面,NOUN,B2
+Seitentür,side door,侧门,NOUN,B2
+Bürgersteig,sidewalk,人行道,NOUN,B2
+Belagerung,siege,围攻,NOUN,B2
+Sieb,sieve,筛子,NOUN,B2
+wehklagen,to sigh with sorrow,感慨,VERB,B2
+quittieren,to sign for,签收,VERB,B2
 signalisieren,signal,信号,NOUN,B2
 signalisieren,to signal,示意,VERB,B2
-signatory,signatory,词,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silencing,silencing,词,NOUN,C1
-silent quiet,silent quiet,词,ADJ,A1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-silly thing,silly thing,词,NOUN,C1
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
-silvery,silvery,词,ADJ,C1
-simian,simian,词,ADJ,C1
-similarly,similarly,同样地,ADV,B2
-simony,simony,词,NOUN,C1
-simple pure,simple pure,单纯,ADJ,B2
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplism,simplism,简单化,NOUN,C1
-simulator,simulator,词,NOUN,C1
+Bedeutung,significance,含义,NOUN,B2
+bedeuten,to signify,意味着,VERB,B2
+stummschalten,to silence,خرس,VERB,B2
+still,silent,沉默的,ADJ,B2
+Seide,silk,丝绸,NOUN,B2
+Seidenstoff,silk cloth,丝绸,NOUN,B2
+dummes Mädchen,silly girl,傻丫头,NOUN,B2
+Ähnlichkeit,similarity,相似,NOUN,B2
+Gleichnis,simile,明喻,NOUN,B2
+einfach,simple,简单的,ADJ,B2
+Einfachheit,simplicity,简单,NOUN,B2
+einfach,simply,简单地,ADV,B2
 simulieren,to simulate,模拟,VERB,B2
-simultaneously,simultaneously,同时地,ADV,B2
-simultaneously with,simultaneously with,词,ADV,C1
-since (part),since,以来,PART,B2
-since then (adv),since then,从那以后,ADV,B2
-sincerely,sincerely,真诚地,ADV,B2
-sincerity devotion,sincerity devotion,词,NOUN,B2
-sinecure,sinecure,词,NOUN,C1
-sinew,sinew,词,NOUN,C1
-single,single,单曲,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-singular (adj),singular,词,ADJ,C1
-singular (noun),singular,词,NOUN,B2
-singularity,singularity,单一性,NOUN,B2
-sinister,sinister,不祥的,ADJ,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sinuous,sinuous,词,ADJ,C1
-sir,sir,郎,PART,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-site,site,词,NOUN,B1
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-six-line stanza,six-line stanza,词,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixteen,sixteen,十六,NUM,B2
-sixth,sixth,,NOUN,B2
-size measure,size measure,尺寸 / 测量,NOUN,A2
-skate (noun),skate,词,NOUN,A2
+Simulation,simulation,模拟,NOUN,B2
+da,since,既然,SCONJ,B2
+Aufrichtigkeit,sincerity,真诚,NOUN,B2
+einzeln,single,单一的,ADJ,B2
+Einzelgedanke,single thought,一念,NOUN,B2
+Spüle,sink,水槽,NOUN,B2
+schlürfen,to sip,小口喝,VERB,B2
+Herr,sir,先生,NOUN,B2
+Schwägerin,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
+Umstände,situation circumstances,情形,NOUN,B2
+sechste,sixth,第六,ADJ,B2
+sechzig,sixty,六十,NUM,B2
 skaten,to skate,滑冰,VERB,B2
-skater,skater,,NOUN,B2
-skating,skating,滑冰,NOUN,B2
-skeletal,skeletal,词,ADJ,C1
-skeptic,skeptic,词,NOUN,C1
+Skelett,skeleton,骨架,NOUN,B2
 skeptisch,skeptical,怀疑的,ADJ,B2
-sketchiness,sketchiness,词,NOUN,C1
-ski (noun),ski,词,NOUN,C1
-ski resort,ski resort,滑雪场,NOUN,C1
-skid slip-up,skid slip-up,词,NOUN,C1
+Skepsis,skepticism,怀疑主义,NOUN,B2
+Skizze,sketch,素描,NOUN,B2
 skifahren,to ski,滑雪,VERB,B2
-skiff,skiff,词,NOUN,C1
-skilful,skilful,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skillfulness,skillfulness,词,NOUN,B2
-skin hide,skin hide,词,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-skirmish,skirmish,小规模战斗,NOUN,B2
-skylight,skylight,天窗,NOUN,B2
-slack,slack,词,ADJ,B2
-slack off,slack off,词,VERB,C1
-slackening dip,slackening dip,词,NOUN,C1
-slackness,slackness,词,NOUN,C1
-slake,slake,词,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slammer jail,slammer jail,词,NOUN,C1
-slander (noun),slander,词,NOUN,B2
-slang,slang,俚语,NOUN,B2
-slanted,slanted,斜,ADJ,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleek,sleek,词,ADJ,C1
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
-sleigh,sleigh,雪橇,NOUN,C1
-slender,slender,词,ADJ,B2
-slenderness,slenderness,纤细,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-slick,slick,词,ADJ,C1
-sliding,sliding,滑动的,ADJ,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
-slim,slim,苗条,ADJ,B2
-slimy,slimy,词,ADJ,B2
-sling,sling,词,NOUN,C1
-slip (noun),slip,词,NOUN,C1
-slip in,slip in,塞入,VERB,B2
-slit,slit,词,NOUN,C1
-slither,slither,词,VERB,C1
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slothful,slothful,懒惰的,ADJ,B2
-slovenly,slovenly,词,ADJ,C1
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
-slower,slower,更慢,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slum,slum,贫民窟,NOUN,B2
-slur,slur,词,VERB,C1
-slut,slut,荡妇,NOUN,B2
-slyly,slyly,词,ADV,C1
-small bag,small bag,词,NOUN,C1
-small basket,small basket,词,NOUN,C1
-small boat,small boat,词,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small step,small step,词,NOUN,C1
-small sword,small sword,词,NOUN,C1
-small things,small things,词,NOUN,B2
-small window,small window,词,NOUN,A2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
-smear,smear,抹,NOUN,C1
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smelting,smelting,词,NOUN,C1
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoker,smoker,词,NOUN,C1
-smoking (adj),smoking,词,ADJ,C1
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smoothness,smoothness,词,NOUN,C1
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
-smugness,smugness,词,NOUN,C1
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snap (verb),snap,词,VERB,C1
-snare,snare,词,NOUN,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneaker,sneaker,词,NOUN,A1
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sneer,sneer,词,VERB,C1
-sneeze (noun),sneeze,词,NOUN,C1
-sneezing,sneezing,词,NOUN,C1
-sniper,sniper,狙击手,NOUN,B2
-snippet,snippet,词,NOUN,C1
-snitch,snitch,告密者,NOUN,B2
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snooping,snooping,词,NOUN,C1
-snore (noun),snore,打呼,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowdrift,snowdrift,词,NOUN,B1
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-so,that way,那样,PRON,B2
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so much so many,so much so many,词,ADV,C1
-so sein,to be so,然,VERB,B2
-so thus,so thus,所以/如此,ADV,B2
+Skifahren,skiing,滑雪,NOUN,B2
+geschickt,skilled,熟练的,ADJ,B2
+verleumden,slander,诽谤,NOUN,B2
+verleumden,to slander,诽谤,VERB,B2
+ohrenfeigen,slap,拍击,NOUN,B2
+ohrenfeigen,to slap,打耳光,VERB,B2
+schlachten,slaughter,屠杀,NOUN,B2
+schlachten,to slaughter,割喉,VERB,B2
+Sklaverei,slavery,奴隶制,NOUN,B2
+Schlafmittel,sleeping pill,安眠药,NOUN,B2
+Schlaflosigkeit,sleeplessness,失眠,NOUN,B2
+Rutsche,slide,滑动,NOUN,B2
+leicht,slightly,轻微地,ADV,B2
+rutschen,to slip,滑倒,VERB,B2
+rutschig,slippery,滑的,ADJ,B2
+Slogan,slogan,口号,NOUN,B2
+Hang,slope,斜坡,NOUN,B2
+langsam,slowly,缓慢地,ADV,B2
+Langsamkeit,slowness,缓慢,NOUN,B2
+träge,sluggish,迟钝的,ADJ,B2
+listig,sly,狡猾的,ADJ,B2
+List,slyness,狡猾,NOUN,B2
+klein,smallest,最小的,ADJ,B2
+Kleinheit,smallness,小小,NOUN,B2
+zerschlagen,to smash,粉碎,VERB,B2
+Zerschlagung,smashing,砸过,NOUN,B2
+Grundkenntnisse,smattering,少量,NOUN,B2
+Rauchen,smoking,吸烟,NOUN,B2
+reibungslos,smoothly,顺利,ADV,B2
+Schmuggler,smuggler,走私者,NOUN,B2
+Schmuggel,smuggling,走私,NOUN,B2
+Snack,snack,小吃,NOUN,B2
+Schnecke,snail,蜗牛,NOUN,B2
+schnappen,to snatch,抢夺,VERB,B2
+schnüffeln,to sniff,嗅,VERB,B2
+schnarchen,to snore,打鼾,VERB,B2
+Schneeschatten,snow shadow,雪影姐姐,NOUN,B2
 so viel,so much,这么多,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-so-called,so-called,,NOUN,B2
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
-sobriquet,sobriquet,词,NOUN,C1
-soccer,soccer,足球,NOUN,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social problem,social problem,社会问题,NOUN,B2
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social standard,social standard,社会标准,NOUN,C1
-social status,social status,社会地位,NOUN,C1
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social turmoil,social turmoil,社会动荡,NOUN,C1
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义者,NOUN,B2
-socialist (adj),socialist,社会主义的,ADJ,C1
-socialization,socialization,社会化,NOUN,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,词,ADV,C1
-societal,societal,词,ADJ,B2
-sociological,sociological,词,ADJ,C1
-socket,socket,词,NOUN,C1
-soda,soda,苏打,NOUN,B2
-softness,softness,词,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software (adj),software,词,ADJ,C1
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-solange,as long as,طالما,CCONJ,B2
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-solar physics,solar physics,词,NOUN,C1
-solch,such,这样的,ADJ,B2
-solecism,solecism,语法错误,NOUN,B2
-solely,solely,词,ADV,C1
-solemn,solemn,,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solemnly,solemnly,词,ADV,C1
-solfege,solfege,词,NOUN,C1
-solicitation,solicitation,词,NOUN,C1
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solicitude,solicitude,词,NOUN,B2
-solid,solid,3D模型 / 实体,NOUN,B2
-solid substantial,solid substantial,词,ADJ,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-solipsism,solipsism,唯我论,NOUN,B2
-solitary,solitary,孤独的,ADJ,B2
-sollen,should not,不该,AUX,B2
-soloist,soloist,词,NOUN,C1
-solstice,solstice,词,NOUN,C1
-solute,solute,词,NOUN,C1
-solve a case,solve a case,破案,VERB,B2
-somber,somber,词,ADJ,B2
-some,some,一些,PRON,B2
-some (adj),some,某些,ADJ,A2
-some (noun),some,词,NOUN,B2
-some stink,some stink,些臭,NOUN,C1
-somebody,somebody,词,PRON,A1
-someone stealing,someone stealing,有人偷,NOUN,C1
-someone's,someone's,某人的,PRON,B2
-something,something,شي,NOUN,B2
-something like that,something like that,词,PRON,B2
-somewhat,somewhat,词,ADV,C1
-somewhere,somewhere,,NOUN,B2
-somnolent,somnolent,词,ADJ,C1
-son-in-law,son-in-law,词,NOUN,A2
-sonata,sonata,词,NOUN,C1
-song (part),song,歌,PART,B2
-song festival,song festival,音乐节,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-sonorous,sonorous,词,ADJ,C1
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soothing,soothing,词,ADJ,C1
-soothsayer,soothsayer,词,NOUN,B2
-sophist,sophist,词,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sophisticated,sophisticated,复杂的,ADJ,B2
-sophomoric,sophomoric,词,ADJ,C1
-soporific,soporific,词,ADJ,C1
-sorcerer,sorcerer,巫师,NOUN,B2
-sorcery,sorcery,巫术,NOUN,B2
-sordid,sordid,肮脏的,ADJ,B2
-sore,sore,疼痛的,ADJ,B2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry (noun),sorry,词,NOUN,A1
-sortie,sortie,词,NOUN,C1
-sorting,sorting,分类,NOUN,B2
-sought,sought,,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-soul spirit,soul spirit,词,NOUN,B2
-soulmate,soulmate,词,NOUN,C1
-sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,词,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-soundtrack,soundtrack,! 音轨,NOUN,B2
-sour cherry,sour cherry,词,NOUN,C1
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern,southern,南方的,ADJ,B2
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southward,southward,词,ADV,B2
-southwest,southwest,西南的,ADJ,B2
-sovereign,sovereign,君主,NOUN,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-soy,soy,词,NOUN,C1
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
+einweichen,to soak,浸透,VERB,B2
+Nüchternheit,sobriety,清醒,NOUN,B2
+gesellig,sociable,好交际的,ADJ,B2
+Sozialarbitration,social arbitration,社会仲裁,NOUN,B2
+gesellschaftliches Erwachen,social awakening,社会觉醒,NOUN,B2
+Gesellschaftsschicht,social class,社会阶层,NOUN,B2
+sozialer Kompromiss,social compromise,社会妥协,NOUN,B2
 soziale Distanzierung,social distancing,社交距离,NOUN,B2
 soziale Harmonie,social harmony,社会和谐,NOUN,B2
 soziale Identität,social identity,社会身份,NOUN,B2
@@ -15707,4785 +4191,5004 @@ soziale Interaktion,social interaction,社会互动,NOUN,B2
 soziale Mobilisierung,social mobilization,社会动员,NOUN,B2
 soziale Organisation,social organization,社会组织,NOUN,B2
 soziale Praxis,social practice,社会实践,NOUN,B2
-soziale Schichtung,social stratification,社会分层,NOUN,B2
-soziale Stabilität,social stability,社会稳定,NOUN,B2
 soziale Versöhnung,social reconciliation,社会和解,NOUN,B2
-sozialer Kompromiss,social compromise,社会妥协,NOUN,B2
+soziale Stabilität,social stability,社会稳定,NOUN,B2
+Sozialstatistik,social statistics,社会统计,NOUN,B2
+soziale Schichtung,social stratification,社会分层,NOUN,B2
 sozialer Trend,social trend,社会趋势,NOUN,B2
 soziales Vertrauen,social trust,社会信任,NOUN,B2
 sozialisieren,to socialize,交往,VERB,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
-spaciousness,spaciousness,词,NOUN,C1
-spade,spade,铲子,NOUN,B2
-spadix,spadix,词,NOUN,C1
-spalten,to cleave,劈开,VERB,B2
-spam (noun),spam,词,NOUN,B1
-span cleaner,span cleaner,词,NOUN,B2
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
-spanking,spanking,词,NOUN,B2
-spar,spar,词,VERB,C1
-spare (adj),spare,词,ADJ,B1
-spare (noun),spare,词,NOUN,C1
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
-sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
-sparsam,frugal,节俭的,ADJ,B2
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spate,spate,词,NOUN,C1
-spatial,spatial,空间的,ADJ,B2
-spatula,spatula,刮刀,NOUN,B2
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specifically,specifically,具体地,ADV,B2
-specifications,specifications,词,NOUN,C1
-specificity,specificity,词,NOUN,C1
-specious,specious,似是而非的,ADJ,B2
-spectacle,spectacle,词,NOUN,B2
-specter,specter,词,NOUN,C1
-spectrometer,spectrometer,词,NOUN,C1
-speculative,speculative,词,ADJ,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-spektakulär,spectacular,壮观的,ADJ,B2
-spektral,spectral,幽灵般的,ADJ,B2
-spekulieren,to speculate,推测,VERB,B2
-spelling,spelling,拼写,NOUN,B2
-spend the night,spend the night,词,VERB,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-sperm,sperm,精子,NOUN,B2
+Soziologe,sociologist,社会学家,NOUN,B2
+Soziologie,sociology,社会学,NOUN,B2
+Sofa,sofa,沙发,NOUN,B2
+Softball,softball,垒球,NOUN,B2
+Software,software,软件,NOUN,B2
+Boden,soil,土壤,NOUN,B2
+Aufenthalt,sojourn,逗留,NOUN,B2
+Trost,solace,安慰,NOUN,B2
+Soldat,soldiers,官兵,NOUN,B2
+Sohle,sole,鞋底,NOUN,B2
+feierlich,solemn,庄严的,ADJ,B2
+ersuchen,to solicit,恳求,VERB,B2
+um Spenden bitten,to solicit donations,募捐,VERB,B2
+Festkörper,solid,固体的,ADJ,B2
+Solid-State-Laufwerk,solid-state drive,固态硬盘,NOUN,B2
+Solidarität,solidarity,团结,NOUN,B2
+Selbstgespräch,soliloquy,独白,NOUN,B2
+Einsamkeit,solitude,孤独,NOUN,B2
+Solvenz,solvency,偿付能力,NOUN,B2
+Lösungsmittel,solvent,溶剂,NOUN,B2
+Auswurf,some out,出些,NOUN,B2
+Ruß,soot,烟灰,NOUN,B2
+Sophismus,sophism,诡辩,NOUN,B2
+Sophisterei,sophistry,诡辩,NOUN,B2
+Betriebsamkeit,sound of activity,动静,NOUN,B2
+Solidität,soundness,好端端,NOUN,B2
+sauer,sour,酸的,ADJ,B2
+Südarmee,southern army,南军,NOUN,B2
+Souverän,sovereign,主权的,ADJ,B2
+Souveränität,sovereignty,主权,NOUN,B2
+Saat,sowing,播种,NOUN,B2
+Spanisch,spanish,西班牙语,NOUN,B2
+Freizeit,spare time,业余,NOUN,B2
+Sperling,sparrow,麻雀,NOUN,B2
+Krampf,spasm,痉挛,NOUN,B2
+Speer,spear,长矛,NOUN,B2
+Spezialthema,special topic,专题,NOUN,B2
+Spezialisierung,specialization,专业化,NOUN,B2
 spezialisiert,specialized,专业的,ADJ,B2
 spezifisch,specific,具体的,ADJ,B2
+Spezifikation,specification,规格,NOUN,B2
 spezifizieren,to specify,具体说明,VERB,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-spice,spice,香料,NOUN,B2
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
-spine,spine,脊柱,NOUN,B2
-spinning,spinning,纺纱,NOUN,B2
-spinning mill,spinning mill,纺纱厂,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spiral,spiral,词,NOUN,C1
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit world,spirit world,灵界,NOUN,B2
-spirited,spirited,词,ADJ,B2
-spiritual,spiritual,精神的,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
-spite,spite,恶意,NOUN,B2
-spittle,spittle,唾沫,NOUN,B2
-splash,splash,扑通,NOUN,B2
-splay,splay,词,VERB,C1
-spleen,spleen,词,NOUN,B2
-splinter (noun),splinter,词,NOUN,B2
-split secession,split secession,分裂,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoiled,spoiled,词,ADJ,B2
-spoiled child,spoiled child,词,NOUN,B1
-spoiler,spoiler,词,NOUN,C1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-spoliation,spoliation,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
-sponsor (noun),sponsor,词,NOUN,B2
-spontaneity,spontaneity,词,NOUN,C1
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-sporadic,sporadic,词,ADJ,C1
-sporadically,sporadically,词,ADV,B2
-sports,sports,体育,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,运动公园,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot,spot,地点,NOUN,B2
-spot goods,spot goods,现货,NOUN,C1
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
-spreading,spreading,词,NOUN,C1
-spree,spree,词,NOUN,C1
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-spry,spry,词,ADJ,C1
+Exemplar,specimen,标本,NOUN,B2
+Brille,spectacles,眼镜,NOUN,B2
+spektakulär,spectacular,壮观的,ADJ,B2
+spektral,spectral,幽灵般的,ADJ,B2
+Spektrum,spectrum,光谱,NOUN,B2
+spekulieren,to speculate,推测,VERB,B2
+Spekulation,speculation,推测,NOUN,B2
+Rede,speech,演讲,NOUN,B2
+Zauberspruch,spell,咒语,NOUN,B2
+Sphäre,sphere,领域,NOUN,B2
+Geistestraining,spirit training,练神,NOUN,B2
+Spiritualität,spirituality,灵性,NOUN,B2
 spucken,to spit,吐,VERB,B2
-spurious,spurious,虚假的,ADJ,B2
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-sputum,sputum,词,NOUN,C1
-späßen,to joke,开玩笑,VERB,B2
-squabble (noun),squabble,词,NOUN,B2
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squall,squall,骤雨,NOUN,B2
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
-square,square,广场,NOUN,B2
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squid,squid,鱿鱼,NOUN,B2
-squire,squire,词,NOUN,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-staatlich,governmental,政府的,ADJ,B2
-stab (noun),stab,捅,NOUN,C1
+boshaft,spiteful,怀恨的,ADJ,B2
+herrlich,splendid,极好的,ADJ,B2
+Pracht,splendor,辉煌,NOUN,B2
+Schiene,splint,夹板,NOUN,B2
+Spalt,split,分裂,NOUN,B2
+Sprecher,spokesperson,发言人,NOUN,B2
+Sponsoring,sponsorship,赞助,NOUN,B2
+Sport,sport,运动,NOUN,B2
+Sportwagen,sports car,跑车,NOUN,B2
+Verstauchung,sprain,扭伤,NOUN,B2
+Spray,spray,喷雾,NOUN,B2
+Ausbreitung,spread,传播,NOUN,B2
+streuen,to sprinkle,撒,VERB,B2
+anspornen,to spur,激励,VERB,B2
+Trupp,squad,小队,NOUN,B2
+verschwenden,to squander,浪费,VERB,B2
+Verschwendung,squandering,挥霍,NOUN,B2
+Platz,square,平方的,ADJ,B2
+hocken,to squat,蹲,VERB,B2
+quetschen,to squeeze,挤压,VERB,B2
+Stabilität,stability,稳定,NOUN,B2
 stabilisieren,to stabilize,使稳定,VERB,B2
-stabilization,stabilization,稳定化,NOUN,B2
-stably,stably,稳定地,ADV,B2
-stack (noun),stack,词,NOUN,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
-staging,staging,上演,NOUN,B2
-stagnant,stagnant,停滞的,ADJ,B2
+Bühnenstück,stage play,舞台剧,NOUN,B2
+taumeln,to stagger,蹒跚,VERB,B2
 stagnieren,to stagnate,停滞,VERB,B2
-staid,staid,词,ADJ,C1
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalemate,stalemate,词,NOUN,C1
-stalking,stalking,词,NOUN,C1
-stall,stall,包厢座位,NOUN,B2
-stalling,stalling,词,NOUN,B2
-stalwart,stalwart,词,ADJ,C1
-stamina,stamina,词,NOUN,C1
-stammen,to come from,来自,VERB,B2
-stammering,stammering,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stampede,stampede,溃逃,NOUN,B2
-stanch,stanch,词,VERB,C1
-stand,stand,摊位,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
-standby,standby,待机,VERB,C1
-standing (adv),standing,词,ADV,A1
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-standpoint,standpoint,词,NOUN,B2
-stands,stands,词,NOUN,B2
-stanza,stanza,词,NOUN,B2
-staple,staple,词,NOUN,C1
-stapler,stapler,词,NOUN,A2
-star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-stark,stark,词,ADJ,B2
-starling,starling,词,NOUN,B2
-starr,rigid,僵硬的,ADJ,B2
-starren,gaze,目视,NOUN,B2
-starren,to gaze,凝视,VERB,B2
-start of school year,start of school year,词,NOUN,B1
-starten,launch,发射,NOUN,B2
-starten,to launch,发起,VERB,B2
-starter,starter,词,NOUN,C1
-starting point,starting point,出发点,NOUN,B2
-starting premise,starting premise,词,NOUN,C1
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-starved,starved,饥饿的,ADJ,B2
-state (adj),state,词,ADJ,B1
-state federal,state federal,州,NOUN,B2
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-statements,statements,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-statics,statics,词,NOUN,C1
-stationery shop,stationery shop,词,NOUN,B2
-statisch,static,静态的,ADJ,B2
-statism,statism,词,NOUN,C1
-statistic,statistic,统计数据,NOUN,B2
-statistisch,statistical,统计的,ADJ,B2
-statization,statization,词,NOUN,C1
-statute,statute,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-statutory rape,statutory rape,词,NOUN,C1
-staunch,staunch,坚定的,ADJ,B2
-staunen,to marvel,使惊奇,VERB,B2
-stave,stave,词,NOUN,C1
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadfastness,steadfastness,词,NOUN,B2
-steadily,steadily,稳定地,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
-steak,steak,牛排,NOUN,B2
-stealth,stealth,秘密行动,NOUN,B2
-stealthily,stealthily,词,ADV,B2
-stealthy,stealthy,词,ADJ,C1
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steep,steep,陡峭的,ADJ,B2
-steering,steering,掌舵的,ADJ,B2
-steering (noun),steering,词,NOUN,C1
+Stagnation,stagnation,停滞,NOUN,B2
+Treppe,stairs,楼梯,NOUN,B2
+Pfahl,stake,利害关系,NOUN,B2
+blockieren,to stall,拖延,VERB,B2
+Briefmarke,stamp,邮票,NOUN,B2
+Haltung,stance,立场,NOUN,B2
+nebeneinanderstehen,to stand side by side,并列,VERB,B2
+aufstehen,to stand up,站起来,VERB,B2
+Standard,standard,标准,NOUN,B2
+Standardisierung,standardization,标准化,NOUN,B2
 stehend,standing,站立的,ADJ,B2
-steigen,rise,上涨,NOUN,B2
-steigen,to rise,上升,VERB,B2
-stem (adj),stem,词,ADJ,C1
-stem cell,stem cell,干细胞,NOUN,C1
-stemming,stemming,词,ADJ,B1
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-steppe,steppe,词,NOUN,C1
-steppes,steppes,草原,NOUN,B2
-stepson,stepson,词,NOUN,A2
-sterben,to part by death,死别,VERB,B2
-stereotypical,stereotypical,词,ADJ,C1
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-steril,sterile,无菌的,ADJ,B2
-sterility,sterility,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-stern (adj),stern,词,ADJ,C1
-stern (noun),stern,词,NOUN,C1
-sternförmig,stellar,杰出的,ADJ,B2
+Stillstand,standstill,停滞,NOUN,B2
+Sternanis,star anise,八角,NOUN,B2
+Sternenhimmel,starry sky,星空,NOUN,B2
+Start,start,开始,NOUN,B2
+statisch,static,静态的,ADJ,B2
+Station,station,车站,NOUN,B2
+Schreibwaren,stationery,文具,NOUN,B2
+statistisch,statistical,统计的,ADJ,B2
+Statistik,statistics,统计学,NOUN,B2
 stetig,steady,稳定的,ADJ,B2
-stetig zunehmen,to increase steadily,与日俱增,VERB,B2
-stevedore,stevedore,词,NOUN,C1
-stew,stew,炖菜,NOUN,B2
-sticker,sticker,贴,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiff glove,stiff glove,词,NOUN,B2
-stifle,stifle,词,VERB,C1
-stifling,stifling,词,ADJ,B2
+dampfen,to steam,蒸,VERB,B2
+Dumpling,steamed stuffed bun,包子,NOUN,B2
+Stahl,steel,钢,NOUN,B2
+Lenkrad,steering wheel,方向盘,NOUN,B2
+sternförmig,stellar,杰出的,ADJ,B2
+Stiel,stem,茎,NOUN,B2
+Stenose,stenosis,狭窄,NOUN,B2
+Stiefmutter,stepmother,后母,NOUN,B2
+Stufe,steps,台阶,NOUN,B2
+Stereotyp,stereotype,刻板印象,NOUN,B2
+steril,sterile,无菌的,ADJ,B2
+schmoren,to stew,炖,VERB,B2
+Stab,stick,棍子,NOUN,B2
+Steifheit,stiffness,僵硬,NOUN,B2
+Stigma,stigma,耻辱,NOUN,B2
 stigmatisieren,to stigmatize,污名化,VERB,B2
-stigmatization,stigmatization,词,NOUN,B2
-stiletto,stiletto,词,NOUN,C1
-still,silent,沉默的,ADJ,B2
-still also,still also,还,ADV,A1
-stillen,to breastfeed,母乳喂养,VERB,B2
-stillness,stillness,静中,NOUN,B2
-stillschweigend,tacit,心照不宣的,ADJ,B2
-stilted,stilted,词,ADJ,C1
-stimulating,stimulating,词,ADJ,C1
-stimulus,stimulus,刺激,NOUN,B2
-stink (noun),stink,词,NOUN,B2
+Stimulans,stimulant,兴奋剂,NOUN,B2
+Geiz,stinginess,吝啬；小气,NOUN,B2
+geizig,stingy,吝啬的,ADJ,B2
 stinkend,stinking,发臭的,ADJ,B2
-stipend,stipend,津贴,NOUN,B2
-stipulation,stipulation,词,NOUN,C1
-stir-fry,stir-fry,炒,VERB,B1
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
-stock-market,stock-market,词,ADJ,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stocking,stocking,词,NOUN,C1
-stodgy,stodgy,词,ADJ,C1
-stoic,stoic,坚忍的,ADJ,B2
-stoically,stoically,词,ADV,C1
-stolen,stolen,被偷的,ADJ,B2
-stolen one,stolen one,词,NOUN,B2
-stolid,stolid,冷漠的,ADJ,B2
-stolpern,to stumble,绊倒,VERB,B2
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stool,stool,词,NOUN,C1
-stop bleeding,stop bleeding,止血,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-stopfen,to stuff,填塞,VERB,B2
-stopover,stopover,中途停留,NOUN,B2
-storage room,storage room,储藏室,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-stork,stork,词,NOUN,B1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-storming,storming,词,NOUN,C1
-story history,story history,词,NOUN,A1
-stout,stout,词,ADJ,C1
-stowage,stowage,词,NOUN,C1
-stoßen auf,to run into,碰见,VERB,B2
-strabismus,strabismus,词,NOUN,B2
-straight (adv),straight,直接地,ADV,B1
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
-straitened circumstances,straitened circumstances,词,NOUN,C1
-strand,strand,词,NOUN,C1
-strangely,strangely,奇怪地,ADV,B2
-strangest,strangest,词,NOUN,C1
-strangulation,strangulation,词,NOUN,C1
-strapping,strapping,词,ADJ,C1
-stratagem,stratagem,策略,NOUN,B2
+festlegen,to stipulate,规定,VERB,B2
+Rühren,stir,搅拌,NOUN,B2
+Stich,stitch,针脚,NOUN,B2
+Börse,stock exchange,证券交易所,NOUN,B2
+Aktienmarkt,stock market,股市,NOUN,B2
+Vorrat,stockpile,储备,NOUN,B2
+Stoizismus,stoicism,斯多葛主义,NOUN,B2
+schüren,to stoke,添燃料,VERB,B2
+Bauchschmerzen,stomachache,肚子痛,NOUN,B2
+mich aufhalten,to stop me,拦我,VERB,B2
+Lagerung,storage,收纳,NOUN,B2
+lagern,store,商店,NOUN,B2
+lagern,to store,储存,VERB,B2
+begradigen,to straighten,弄直,VERB,B2
+unkompliziert,straightforward,直率的,ADJ,B2
+Belastung,strain,压力,NOUN,B2
+Meerenge,strait,海峡,NOUN,B2
+fremde Truppen,strange troops,怪兵,NOUN,B2
+Fremdheit,strangeness,奇怪,NOUN,B2
+erwürgen,to strangle,扼杀,VERB,B2
+Riemen,strap,带子,NOUN,B2
 strategisch,strategic,战略的,ADJ,B2
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratification,stratification,词,NOUN,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-stratum,stratum,阶层,NOUN,B2
-straw,straw,稻草,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-streben,to aspire,渴望,VERB,B2
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street kid,street kid,词,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-streicheln,to caress,爱抚,VERB,B2
+Bach,stream,溪流,NOUN,B2
+Strecke,stretch,伸展,NOUN,B2
+Trage,stretcher,担架,NOUN,B2
 streiken,strike,罢工,NOUN,B2
 streiken,to strike,打击,VERB,B2
-streiten,quarrel,争吵,NOUN,B2
-streiten,to quarrel,争吵,VERB,B2
-streng,rigorous,严格的,ADJ,B2
-streng,severe,严厉的,ADJ,B2
-strengthening,strengthening,词,NOUN,C1
-strenuous,strenuous,费力的,ADJ,B2
-stress (noun),stress,压力,NOUN,B1
-stressful,stressful,有压力的,ADJ,B2
-stretch out,stretch out,词,VERB,B2
-stretched,stretched,词,ADJ,C1
-streuen,to sprinkle,撒,VERB,B2
-strictly,strictly,词,ADV,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-strictness,strictness,词,NOUN,B2
-stride (noun),stride,词,NOUN,C1
-strident,strident,刺耳的,ADJ,B2
-strife,strife,词,NOUN,B2
-strike-related,strike-related,词,ADJ,C1
-strikebreaker,strikebreaker,词,NOUN,C1
-striking,striking,词,ADJ,B2
-string instruments,string instruments,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-stripe,stripe,条纹,NOUN,B2
-striped,striped,有条纹的,ADJ,B2
-stripping,stripping,词,ADJ,B2
-striving,striving,词,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-stroller,stroller,婴儿车,NOUN,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structured,structured,词,ADJ,C1
-structuredness,structuredness,结构性,NOUN,B2
-structures,structures,词,NOUN,C1
+Stürmer,striker,罢工者,NOUN,B2
+Schnur,string,细绳,NOUN,B2
+Streifen,strip,条带,NOUN,B2
+Spaziergang,stroll,闲逛,NOUN,B2
 strukturell,structural,结构的,ADJ,B2
 strukturieren,structure,结构,NOUN,B2
 strukturieren,to structure,构建,VERB,B2
-stubbornness,stubbornness,固执,NOUN,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studious,studious,词,ADJ,C1
-study tour,study tour,游学,NOUN,C1
-stuffed,stuffed,词,ADJ,B1
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stumble (noun),stumble,词,NOUN,C1
-stumm,mute,沉默的；哑的,ADJ,B2
-stummschalten,to silence,خرس,VERB,B2
-stunner,stunner,词,NOUN,B2
-stunt,stunt,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupefied,stupefied,词,ADJ,C1
-stupendous,stupendous,词,ADJ,C1
-stur,obstinate,固执的,ADJ,B2
-stuttering,stuttering,词,NOUN,C1
-stylist,stylist,词,NOUN,C1
-stylistics,stylistics,词,NOUN,C1
-stymie,stymie,词,VERB,C1
-städtisch,urban,城市的,ADJ,B2
-stöbern,to browse,浏览,VERB,B2
-stören,bother,麻烦,NOUN,B2
-stören,to bother,打扰,VERB,B2
-störend,disturbing,令人不安的,ADJ,B2
-stützen,to prop,撑,VERB,B2
-suave,suave,词,ADJ,C1
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subconscious,subconscious,潜意识,NOUN,B2
-subcontracting,subcontracting,分包,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject field,subject field,科目 / 领域,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,受法律管辖的,ADJ,B2
-subject topic,subject topic,主题/话题,NOUN,B2
-subjection,subjection,词,NOUN,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
+kämpfen,struggle,斗争,NOUN,B2
+kämpfen,to struggle,挣扎,VERB,B2
+festgefahren,stuck,卡住的,ADJ,B2
+Student,student,学生,NOUN,B2
+stopfen,to stuff,填塞,VERB,B2
+stolpern,to stumble,绊倒,VERB,B2
+Stupor,stupor,昏迷,NOUN,B2
+robust,sturdy,坚固的,ADJ,B2
+bezwingen,to subdue,制服,VERB,B2
 subjektiv,subjective,主观的,ADJ,B2
-sublimation,sublimation,词,NOUN,C1
-sublime,sublime,崇高的,ADJ,B2
-subliminal,subliminal,词,ADJ,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordination,subordination,隶属,NOUN,C1
-subpoena,subpoena,词,NOUN,B2
-subsequently,subsequently,词,ADV,C1
-subservient,subservient,词,ADJ,C1
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,辅助性原则,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantially,substantially,词,ADV,B2
-substantive,substantive,实质性的,ADJ,B2
-substanziell,substantial,大量的,ADJ,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subtle,subtle,微妙的,ADJ,B2
-subtlety,subtlety,微妙,NOUN,B2
-subtly,subtly,词,ADV,C1
-suburban,suburban,词,ADJ,C1
-suburbs,suburbs,词,NOUN,B2
+unterwerfen,to subjugate,征服,VERB,B2
+U-Boot,submarine,潜水艇,NOUN,B2
+untertauchen,to submerge,淹没,VERB,B2
+Unterwerfung,submission,顺从,NOUN,B2
+Untergeordneter,subordinate,下属,NOUN,B2
+Abonnent,subscriber,订阅者,NOUN,B2
+Abonnement,subscription,订阅,NOUN,B2
+nachfolgend,subsequent,随后的,ADJ,B2
+Tochtergesellschaft,subsidiary,子公司,NOUN,B2
 subventionieren,to subsidize,资助,VERB,B2
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
-succinct,succinct,简明的,ADJ,B2
-succinctly,succinctly,词,ADV,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-such a,such a,这样的,DET,B2
-suchen,to look for,寻找,VERB,B2
-suchen,to search for,寻找,VERB,B2
-suchen,to seek,寻找,VERB,B2
-sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suffering (adj),suffering,词,ADJ,C1
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffocating,suffocating,词,ADJ,B2
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestibility,suggestibility,词,NOUN,C1
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal,suicidal,自杀的,ADJ,B2
-suicidal thought,suicidal thought,,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-suite,suite,套房,NOUN,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
+Subvention,subsidy,补贴,NOUN,B2
+Subsistenz,subsistence,生计,NOUN,B2
+substanziell,substantial,大量的,ADJ,B2
+Substantiierung,substantiation,论证,NOUN,B2
+Ersatz,substitute,替代品,NOUN,B2
+Untertitel,subtitle,字幕,NOUN,B2
+Vorort,suburb,郊区,NOUN,B2
+Nachfolge,succession,连续,NOUN,B2
 sukzessive,successively,连续地,ADV,B2
-sulfide,sulfide,词,NOUN,C1
-sulfur,sulfur,硫,NOUN,B2
-sulfuric,sulfuric,词,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sullenness,sullenness,词,NOUN,C1
-sully,sully,词,VERB,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultriness,sultriness,词,NOUN,B2
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-summarily,summarily,草率地,ADV,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
-sumptuousness,sumptuousness,词,NOUN,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower,sunflower,向日葵,NOUN,B2
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
-sunny day,sunny day,晴天,NOUN,C1
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-proof,super-proof,超证,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-theory,super-theory,超论,NOUN,C1
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-superb,superb,极好的,ADJ,B2
-supercilious,supercilious,词,ADJ,C1
-superficiality,superficiality,词,NOUN,C1
-superhero,superhero,超级英雄,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior upper,superior upper,词,ADJ,C1
-superiority,superiority,优越性/优势,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supernumerary,supernumerary,词,ADJ,C1
-supersede,supersede,词,VERB,C1
-superstitious,superstitious,迷信的,ADJ,B2
-supine,supine,词,ADJ,C1
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplication,supplication,恳求,NOUN,B2
-supplies,supplies,词,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
-support medium,support medium,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supporter advocate,supporter advocate,词,NOUN,B1
-supporters,supporters,词,NOUN,B2
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,团结的,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-supposition,supposition,词,NOUN,C1
-suppository,suppository,词,NOUN,C1
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
-suppression of us,suppression of us,压咱,NOUN,C1
-suppuration,suppuration,词,NOUN,C1
-supremacy,supremacy,霸权,NOUN,B2
-supreme,supreme,最高的,ADJ,B2
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-surcharge,surcharge,附加费,NOUN,B2
-sure,sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-surety bond,surety bond,词,NOUN,C1
-suretyship,suretyship,保证,NOUN,C1
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surgical,surgical,外科的,ADJ,B2
-surging effusive,surging effusive,词,ADJ,C1
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus,surplus,过剩的,ADJ,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
-surprised,surprised,惊讶的,ADJ,B2
-surrender (noun),surrender,就交,NOUN,B2
-surreptitious,surreptitious,秘密的,ADJ,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrogate,surrogate,词,NOUN,C1
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
-suspended,suspended,悬浮的,ADJ,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspicions,suspicions,词,NOUN,C1
-sustain,sustain,词,VERB,C1
-sustainability policy,sustainability policy,词,NOUN,C1
-svelte,svelte,词,ADJ,C1
-swab,swab,词,NOUN,B2
-swagger (noun),swagger,词,NOUN,B2
-swap,swap,词,VERB,B2
-swarm (noun),swarm,词,NOUN,C1
-swarthy,swarthy,词,ADJ,C1
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweatshirt,sweatshirt,词,NOUN,C1
-sweden,sweden,瑞典,PROPN,B2
-swedish,swedish,瑞典语,NOUN,B2
-sweepings,sweepings,词,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swiftness,swiftness,词,NOUN,C1
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,词,NOUN,C1
-swimming,swimming,游泳,NOUN,B2
-swimwear,swimwear,词,NOUN,B2
-swine,swine,猪,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swirl,swirl,词,VERB,C1
-swiss,swiss,瑞士的,ADJ,B2
-switch key,switch key,词,NOUN,C1
-switchman,switchman,词,NOUN,C1
-swollen,swollen,肿胀的,ADJ,B2
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsmanship,swordsmanship,剑术,NOUN,B2
-sycophant,sycophant,词,NOUN,C1
-sycophantic,sycophantic,词,ADJ,B2
-syllabification,syllabification,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
-syllogism,syllogism,三段论,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbolic,symbolic,象征的,ADJ,B2
+solch,such,这样的,ADJ,B2
+an Schlaflosigkeit leiden,to suffer from insomnia,失眠,VERB,B2
+Leiden,suffering,痛苦,NOUN,B2
+genügen,to suffice,足够,VERB,B2
+Zulänglichkeit,sufficiency,充足,NOUN,B2
+Erstickung,suffocation,窒息,NOUN,B2
+Vorschlag,suggestion,建议,NOUN,B2
+passen,to suit,适合,VERB,B2
+Eignung,suitability,适宜性,NOUN,B2
+zusammenfassen,to summarize,概括,VERB,B2
+Zusammenfassung,summary,摘要,NOUN,B2
+vorladen,to summon,召唤,VERB,B2
+Vorladung,summons,传票,NOUN,B2
+prunkvoll,sumptuous,奢华的,ADJ,B2
+Super-Gesamtumfassung,super-comprehensive,超遍,NOUN,B2
+Supergrad,super-grade,超级,NOUN,B2
+Superprinzip,super-principle,超则,NOUN,B2
+Superqualität,super-quality,超质,NOUN,B2
+Supersystem,super-system,超制,NOUN,B2
+Supergedanke,super-thought,超思,NOUN,B2
+überflüssig,superfluous,多余的,ADJ,B2
+überlegen,superior,更好的,ADJ,B2
+übernatürlich,supernatural,超自然的,ADJ,B2
+Aberglaube,superstition,迷信,NOUN,B2
+Aufsicht,supervision,监督,NOUN,B2
+Vorgesetzter,supervisor,主管,NOUN,B2
+Ergänzung,supplement,补充,NOUN,B2
+Lieferant,supplier,供应商,NOUN,B2
+annehmen,to suppose,假设,VERB,B2
+Unterdrückung,suppression,抑,NOUN,B2
+Anstieg,surge,激增,NOUN,B2
+Operation,surgery,手术,NOUN,B2
+Nachname,surname,姓氏,NOUN,B2
+Überschuss,surplus,过剩,NOUN,B2
+Surrealismus,surrealism,超现实主义,NOUN,B2
+aufgeben,surrender,投降,NOUN,B2
+aufgeben,to surrender,投降,VERB,B2
+Umgebung,surroundings,周围,NOUN,B2
+überwachen,to surveil,监视,VERB,B2
+Überwachung,surveillance,监视,NOUN,B2
+Umfrage,survey,调查,NOUN,B2
+Vermesser,surveyor,测量员,NOUN,B2
+Überleben,survival,生存,NOUN,B2
+Überlebender,survivor,幸存者,NOUN,B2
+Susha,susha,夙砂大,NOUN,B2
+aussetzen,to suspend,暂停,VERB,B2
+Spannung,suspense,悬念,NOUN,B2
+Suspendierung,suspension,暂停,NOUN,B2
+Nachhaltigkeit,sustainability,可持续性,NOUN,B2
+nachhaltig,sustainable,可持续的,ADJ,B2
+Nahrung,sustenance,食物,NOUN,B2
+vernähen,suture,缝合,NOUN,B2
+vernähen,to suture,缝合,VERB,B2
+Schwan,swan,天鹅,NOUN,B2
+schwärmen,to swarm,分群,VERB,B2
+schwanken,to sway,摇摆,VERB,B2
+schwitzen,sweat,汗水,NOUN,B2
+schwitzen,to sweat,出汗,VERB,B2
+Feger,sweep,扫,NOUN,B2
+süßer Traum,sweet dream,美梦,NOUN,B2
+Schwimmbad,swimming pool,游泳池,NOUN,B2
+betrügen,to swindle,诈骗,VERB,B2
+Betrüger,swindler,骗子,NOUN,B2
+Schaukel,swing,秋千,NOUN,B2
+Schaltraum,switch room,配电室,NOUN,B2
+Vermittlung,switchboard,总机,NOUN,B2
+Schwertloser,swordless,剑不,NOUN,B2
+Schwertkämpfer,swordsman,剑客,NOUN,B2
+Speichelleckerei,sycophancy,阿谀奉承,NOUN,B2
+Lehrplan,syllabus,教学大纲,NOUN,B2
+Symbol,symbol,象征,NOUN,B2
 symbolisieren,to symbolize,象征,VERB,B2
-symbolism,symbolism,象征主义,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symmetric,symmetric,词,ADJ,C1
-symmetrical,symmetrical,对称的,ADJ,B2
-sympathetic,sympathetic,同情的,ADJ,B2
+Symmetrie,symmetry,对称,NOUN,B2
 sympathisieren,to sympathize,同情,VERB,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symphonic,symphonic,交响乐的,ADJ,B2
-symptom,symptom,症,PART,B2
+Symphonie,symphony,交响乐,NOUN,B2
+Symposium,symposium,研讨会,NOUN,B2
+Symptom,symptom,症状,NOUN,B2
 symptomatisch,symptomatic,症状的,ADJ,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-symptoms,symptoms,词,NOUN,B1
-synaptic,synaptic,词,ADJ,C1
-sync,sync,同步,NOUN,B2
+Synchronisation,synchronization,同步,NOUN,B2
 synchron,synchronous,同步的,ADJ,B2
-synchronized,synchronized,词,ADJ,C1
-synchrony,synchrony,词,NOUN,C1
-syncopate,syncopate,词,VERB,C1
-syncretism,syncretism,词,NOUN,C1
-syndicate,syndicate,词,NOUN,C1
-syndrome,syndrome,综合征,NOUN,B2
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,词,NOUN,B2
-synonym,synonym,词,NOUN,C1
-synopsis,synopsis,词,NOUN,C1
-synoptic,synoptic,概要的,ADJ,B2
-syntactic,syntactic,词,ADJ,C1
-synthetic,synthetic,合成的,ADJ,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
+Synergie,synergy,协同效应,NOUN,B2
+Synonymie,synonymy,同义关系,NOUN,B2
+Syntax,syntax,句法,NOUN,B2
+Synthese,synthesis,综合,NOUN,B2
 synthetisieren,to synthesize,合成,VERB,B2
-syrian,syrian,叙利亚的,ADJ,B2
-systematically,systematically,系统地,ADV,B2
+Sirup,syrup,糖浆,NOUN,B2
+System,system,系统,NOUN,B2
 systematisch,systematic,系统的,ADJ,B2
 systemisch,systemic,全身性的,ADJ,B2
-systemless,systemless,无系统的,ADJ,B2
-süchtig sein,to be addicted,上瘾,VERB,B2
-süßer Traum,sweet dream,美梦,NOUN,B2
-t-shirt,t-shirt,词,NOUN,B1
-tab,tab,词,NOUN,C1
-tabernacle,tabernacle,词,NOUN,C1
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tablecloth,tablecloth,词,NOUN,C1
-tablet,tablet,平板电脑,NOUN,B2
-tachometer,tachometer,转速表,NOUN,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-tackling,tackling,马具,NOUN,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,词,NOUN,B2
-tact,tact,词,NOUN,C1
-tactful appeasement,tactful appeasement,词,NOUN,C1
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,不得体的,ADJ,B2
-tadellos,irreproachable,无可指责的,ADJ,B2
-tadeln,to scold,训斥,VERB,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken away,taken away,拿去,NOUN,C1
-takeover,takeover,词,NOUN,C1
-taking command,taking command,挂帅,NOUN,B2
+Tabu,taboo,禁忌,NOUN,B2
+stillschweigend,tacit,心照不宣的,ADJ,B2
+wortkarg,taciturn,沉默寡言的,ADJ,B2
 taktvoll,tactful,圆滑的,ADJ,B2
-tale,tale,词,NOUN,A1
-talented,talented,有才华的,ADJ,B2
-talisman,talisman,词,NOUN,B2
-talk show,talk show,脱口秀,NOUN,C1
-talks,talks,会谈,NOUN,C1
-tall and slender,tall and slender,词,ADJ,C1
-tally,tally,词,VERB,C1
-tamable,tamable,词,ADJ,C1
-tambourine,tambourine,词,NOUN,B2
-taming,taming,词,NOUN,C1
-tamper,tamper,词,VERB,C1
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tangle,tangle,混乱,NOUN,B2
-tank cistern,tank cistern,词,NOUN,C1
-tanned,tanned,词,ADJ,B2
+Taktik,tactic,策略,NOUN,B2
+Taktik,tactics,战术,NOUN,B2
+beurlauben,to take a leave of absence,休学,VERB,B2
+aufpassen,to take care,照顾,VERB,B2
+Stecklinge schneiden,to take cuttings,扦插,VERB,B2
+abheben,to take off,起飞,VERB,B2
+antreten,to take office,就职,VERB,B2
+herausnehmen,to take out,拿出,VERB,B2
+rächen,to take revenge,报复,VERB,B2
+Start,takeoff,起飞,NOUN,B2
+Einnahme,taking,拍摄,NOUN,B2
+Talent,talent,天赋,NOUN,B2
+Gespräch,talk,谈话,NOUN,B2
+Unsinn reden,to talk nonsense,胡言乱语,VERB,B2
+gesprächig,talkative,健谈的,ADJ,B2
+Redseligkeit,talkativeness,多嘴,NOUN,B2
+groß,tall,高的,ADJ,B2
+bräunen,to tan,晒黑,VERB,B2
+Tangente,tangent,切线,NOUN,B2
+greifbar,tangible,有形的,ADJ,B2
 tanner,tanner,制革工,NOUN,B2
-tannery,tannery,词,NOUN,B2
 tanning,tanning,晒黑,NOUN,B2
-tantamount,tantamount,词,ADJ,C1
-tantrum,tantrum,词,NOUN,C1
-tap,tap,水龙头,NOUN,B2
-tape,tape,词,NOUN,A2
-tapestry,tapestry,词,NOUN,C1
-tapfer,valiant,英勇的,ADJ,B2
-tarab,tarab,词,NOUN,B2
 target,to target,针对,VERB,B2
-target group,target group,词,NOUN,C1
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
 targeting,targeting,定位,NOUN,B2
-taro,taro,芋头,NOUN,B2
-tarragon,tarragon,龙蒿,NOUN,B2
-tarry,tarry,词,VERB,C1
-tart pie,tart pie,词,NOUN,C1
 taste preference,taste preference,口味,NOUN,B2
-tasting,tasting,词,NOUN,C1
-tasty,tasty,美味的,ADJ,B2
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tatsächlich,indeed,确实,ADV,B2
-tatter,tatter,词,NOUN,C1
 tattoo,tattoo,纹身,NOUN,B2
-tauen,to thaw,解冻,VERB,B2
-taufen,to baptize,施洗,VERB,B2
-taumeln,to stagger,蹒跚,VERB,B2
 taut,taut,绷紧的,ADJ,B2
-tautology,tautology,词,NOUN,C1
 tavern,tavern,酒馆,NOUN,B2
-tawdry,tawdry,词,ADJ,C1
-tax (adj),tax,词,ADJ,C1
-tax authorities,tax authorities,税务机关,NOUN,B2
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax rate,tax rate,词,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax return,tax return,报税,NOUN,B2
-tax revenue,tax revenue,税收,NOUN,B2
 tax-exempt,tax-exempt,免税,ADJ,B2
-taxable,taxable,应纳税的,ADJ,B2
 taxation,taxation,征税,NOUN,B2
 taxi,taxi,出租车,NOUN,B2
-taxonomy,taxonomy,分类学,NOUN,B2
-taxpayer,taxpayer,纳税人,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
 tea plantation,tea plantation,茶园,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
 teaching,teaching,教学,NOUN,B2
-teaching (adj),teaching,教学的,ADJ,C1
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
 teammate,teammate,队友,NOUN,B2
-teapot,teapot,词,NOUN,C1
 tear up,to tear up,流泪,VERB,B2
-tearing,tearing,tearing,NOUN,B2
 tears,tears,眼泪,NOUN,B2
 tease,to tease,取笑,VERB,B2
-teasing playful,teasing playful,词,ADJ,C1
 technical,technical,技术的,ADJ,B2
-technically,technically,技术上地,ADV,B2
 technician,technician,技术员,NOUN,B2
 technique,technique,技巧,NOUN,B2
 technocracy,technocracy,技术官僚主义,NOUN,B2
-technocrat,technocrat,词,NOUN,C1
-technocratic,technocratic,技术官僚的,ADJ,B2
 technological,technological,技术的,ADJ,B2
-tectonic,tectonic,词,ADJ,C1
 tedious,tedious,乏味的,ADJ,B2
-tedious painful,tedious painful,词,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-teetotal,teetotal,词,ADJ,C1
-teilnehmen,to part,分离,VERB,B2
-telecommunications,telecommunications,词,NOUN,C1
-telegraph lightning,telegraph lightning,词,NOUN,C1
-teleological,teleological,词,ADJ,B2
 teleology,teleology,目的论,NOUN,B2
-telepathy,telepathy,词,NOUN,C1
-telephones,telephones,词,NOUN,B2
-telephony,telephony,电话学,NOUN,B2
 telescope,telescope,望远镜,NOUN,B2
-televised,televised,电视播出的,ADJ,B2
 television,television,电视,NOUN,B2
-teller,teller,词,NOUN,B2
-telling-off,telling-off,词,NOUN,B1
-telltale,telltale,词,ADJ,C1
-temerity,temerity,鲁莽,NOUN,B2
 temper,temper,脾气,NOUN,B2
 temperament,temperament,气质,NOUN,B2
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperamental,temperamental,词,ADJ,C1
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-template,template,词,NOUN,C1
 temporal,temporal,时间的,ADJ,B2
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
 temporarily,temporarily,临时地,ADV,B2
 temporary refusal,temporary refusal,暂不,NOUN,B2
-temptation,temptation,词,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-tenable,tenable,词,ADJ,C1
 tenacious,tenacious,顽强的,ADJ,B2
-tenacity,tenacity,坚韧,NOUN,B2
 tenant,tenant,租户,NOUN,B2
-tend,tend,词,VERB,B2
 tendency,tendency,趋势,NOUN,B2
 tendentious,tendentious,有偏见的,ADJ,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tenement,tenement,词,NOUN,C1
-tenet,tenet,词,NOUN,C1
-tenor,tenor,男高音,NOUN,B2
-tens,tens,词,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
-tense (noun),tense,词,NOUN,B1
-tense angry,tense angry,词,ADJ,A2
-tensile,tensile,词,ADJ,C1
-tenth,tenth,第十,ADJ,B2
-tenth (noun),tenth,词,NOUN,B2
-tenuous,tenuous,词,ADJ,C1
-tenure,tenure,词,NOUN,B2
-tepid,tepid,词,ADJ,C1
-teratogenic,teratogenic,词,ADJ,B2
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-terminal,terminal,终末的,ADJ,B2
+Filet,tenderloin,里脊,NOUN,B2
+Zärtlichkeit,tenderness,柔情,NOUN,B2
+Sehne,tendon,肌腱,NOUN,B2
+Tennis,tennis,网球,NOUN,B2
+vorläufig,tentative,暂定的,ADJ,B2
+Begriff,term,学期,NOUN,B2
+Terminal,terminal,终点站,NOUN,B2
+beenden,to terminate,终止,VERB,B2
+Beendigung,termination,解除,NOUN,B2
 terminologisch,terminological,术语的,ADJ,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,词,NOUN,B2
-terrace,terrace,露台,NOUN,B2
-terribleness,terribleness,词,NOUN,B2
-terribly,terribly,可怕地/非常,ADV,B2
-terrified,terrified,极度恐惧的,ADJ,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
+Terminologie,terminology,术语,NOUN,B2
+irdisch,terrestrial,地球的,ADJ,B2
+erschrecken,to terrify,使恐惧,VERB,B2
+erschreckend,terrifying,令人恐惧的,ADJ,B2
 territorial,territorial,领土的,ADJ,B2
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terse,terse,简练的,ADJ,B2
-terseness,terseness,词,NOUN,C1
-tertiary,tertiary,第三的,ADJ,B2
-test drive,test drive,,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testator,testator,词,NOUN,C1
-testicular,testicular,词,ADJ,C1
-testimony deposition,testimony deposition,词,NOUN,C1
-tether,tether,词,NOUN,C1
-textuality,textuality,词,NOUN,C1
+Territorium,territory,领土,NOUN,B2
+Terrorismus,terrorism,恐怖主义,NOUN,B2
+Terrorist,terrorist,恐怖分子,NOUN,B2
+Test,test,测试,NOUN,B2
+Hoden,testicle,睾丸,NOUN,B2
+Zeugnis,testimony,证词,NOUN,B2
+Text,text,文本,NOUN,B2
+Textilie,textile,纺织,NOUN,B2
 textuell,textual,文本的,ADJ,B2
-texture,texture,词,NOUN,C1
-than (adv),than,词,ADV,A1
-thank god,thank god,谢天谢地,INTJ,B2
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-tharid,tharid,词,NOUN,B2
-that (noun),that,将那,NOUN,C1
-that cliff,that cliff,那山崖,NOUN,C1
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
-that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that one,that one,那个,PRON,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way,that way,往那边,ADV,B2
-that which,that which,所,PART,B2
-the Earth,the Earth,地球,NOUN,A2
-the Internet,the Internet,互联网,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,收银台,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,词,NOUN,B2
-the chain,the chain,词,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,NOUN,B2
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the emperor,the emperor,词,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masses,the masses,大众,NOUN,C1
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (pron),the one,那个人,PRON,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,词,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the rich,the rich,词,NOUN,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,相同的,ADJ,B2
-the same (pron),the same,词,PRON,C1
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the unseen,the unseen,词,NOUN,C1
-the very,the very,正是,ADV,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-theatrical,theatrical,戏剧的,ADJ,B2
-their,their,他们的,DET,B2
-thematic,thematic,主题的,ADJ,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,词,ADJ,B2
-theodicy,theodicy,词,NOUN,C1
-theologian,theologian,神学家,NOUN,B2
-theological,theological,神学的,ADJ,B2
+dank,thanks to,多亏,ADP,B2
+das,that,那个,PRON,B2
+Pfeil,that arrow,那一箭,NOUN,B2
+das heißt,that is,即,ADV,B2
+so,that way,那样,PRON,B2
+tauen,to thaw,解冻,VERB,B2
+Rest,the rest,其余,NOUN,B2
+Theater,theater,剧院,NOUN,B2
+ihr,their,他们的,PRON,B2
+sie,them,他们,PRON,B2
+Thema,theme,主题,NOUN,B2
+dann du,then you,那你,PRON,B2
+Theokratie,theocracy,神权政治,NOUN,B2
+Theologie,theology,神学,NOUN,B2
+Theorem,theorem,定理,NOUN,B2
 theoretisch,theoretical,理论的,ADJ,B2
 theoretisch,theoretically,理论上,ADV,B2
-theorize,theorize,词,VERB,B2
 therapeutisch,therapeutic,治疗的,ADJ,B2
-therapist,therapist,治疗师,NOUN,B2
-there (noun),there,那儿,NOUN,B2
-there (pron),there,那里,PRON,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-thereafter,thereafter,此后,ADV,B2
-therefore (sconj),therefore,所以,SCONJ,B2
-thermal (noun),thermal,词,NOUN,B2
+dort,there,那儿,NOUN,B2
+sein,to there's still time,来得及,VERB,B2
+daraufhin,thereupon,随后,ADV,B2
 thermisch,thermal,热的,ADJ,B2
-thermodynamics,thermodynamics,词,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-thesaurus,thesaurus,词,NOUN,C1
-these,these,这些,PRON,B2
-thespian,thespian,词,NOUN,C1
-thetic,thetic,正题的,ADJ,B2
-they female,they female,她们,PRON,B2
-they two,they two,词,PRON,A1
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thicket,thicket,灌木丛,NOUN,B2
-thickets,thickets,词,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thinker,thinker,词,NOUN,C1
-thinner,thinner,更薄的,ADJ,B2
-third (num),third,词,NUM,B1
-third place,third place,季军,NOUN,B2
-this,this,这,PRON,B2
-this (noun),this,你这,NOUN,B2
-this afternoon,this afternoon,词,ADV,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this masculine,this masculine,词,DET,A1
-this matter,this matter,这事,NOUN,B2
-this morning,this morning,今天早上,ADV,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this trick,this trick,这招,NOUN,C1
-this way,this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
-thorny,thorny,词,ADJ,C1
-thoroughly,thoroughly,词,ADV,B2
+diese,these,这些,DET,B2
+diese Drei,these three,这三,NOUN,B2
+These,thesis,论文,NOUN,B2
+sie,they,他们,PRON,B2
+sie,they things,它们,PRON,B2
+dick,thick,厚的,ADJ,B2
+Dicke,thickness,厚度,NOUN,B2
+Diebesanwesenheit,thief presence,有贼,NOUN,B2
+Oberschenkel,thigh,大腿,NOUN,B2
+denken,to think to want,想,VERB,B2
+Denken,thinking,思维,NOUN,B2
+Dünne,thinness,瘦,NOUN,B2
+dritte Gabe,third bestowal,三授,NOUN,B2
+durstig,thirsty,口渴的,ADJ,B2
+dreizehn,thirteen,十三,NUM,B2
+dies,this,您这,NOUN,B2
+diese Schlacht,this battle,此战,NOUN,B2
+dieser Artikel,this item,这件,NOUN,B2
+dieser Weg,this way,这样,PRON,B2
+dieses Lager,this-camp,这营,NOUN,B2
+Dorn,thorn,刺,NOUN,B2
+Gründlichkeit,thoroughness,彻底,NOUN,B2
 those,those,那些,PRON,B2
 thoughtful,thoughtful,体贴的,ADJ,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
-thousand (noun),thousand,词,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thrall,thrall,词,NOUN,C1
-thread (verb),thread,词,VERB,C1
-threadbare,threadbare,词,ADJ,C1
-threads,threads,词,NOUN,B2
-threatened,threatened,词,ADJ,C1
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
 three-d printing,three-d printing,3D打印,NOUN,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-threshing floor,threshing floor,词,NOUN,B2
 threshold,threshold,门槛,NOUN,B2
 thrifty,thrifty,节俭的,ADJ,B2
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thrilling,thrilling,令人兴奋的,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throng,throng,词,NOUN,C1
-throughout,throughout,词,ADP,B1
-throwing,throwing,词,NOUN,B2
 thrust,thrust,猛推,NOUN,B2
 thrust toward,thrust toward,插向,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-tick,tick,滴答声,NOUN,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,词,NOUN,B2
-ticket window,ticket window,售票窗口,NOUN,B2
-tickle,tickle,发痒,NOUN,B2
 tidal,tidal,潮汐,ADJ,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
 tide,tide,潮汐,NOUN,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tief,deeply,深深地,ADV,B2
-tier,tier,分阶,NOUN,C1
 tiger,tiger,老虎,NOUN,B2
 tight,tight,紧的,ADJ,B2
 tight grip,tight grip,手握紧,NOUN,B2
-tight-fitting,tight-fitting,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
 tighten,to tighten,紧握/收紧,VERB,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightly,tightly,词,ADV,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-tights,tights,词,NOUN,C1
 tile,tile,瓦片,NOUN,B2
 tiling,tiling,铺瓷砖,NOUN,B2
-tilt,tilt,倾斜,NOUN,B2
-timber,timber,词,NOUN,C1
-time clock,time clock,词,NOUN,B2
-time era,time era,词,NOUN,A2
-time limit,time limit,词,NOUN,B1
-time occasion,time occasion,次,NOUN,B2
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time to go to bed,time to go to bed,该睡觉了,ADV,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
 times,times,倍,NOUN,B2
-timid,timid,词,ADJ,B2
 timidity,timidity,胆怯,NOUN,B2
 timing,timing,时机,NOUN,B2
-timorous,timorous,词,ADJ,C1
 tin,tin,锡,NOUN,B2
 tingling,tingling,麻木感,NOUN,B2
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (adj),tint,词,ADJ,C1
-tint (noun),tint,词,NOUN,C1
-tiny minute,tiny minute,词,ADJ,C1
-tips,tips,词,NOUN,C1
-tirade,tirade,长篇抨击,NOUN,B2
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tireless,tireless,不知疲倦的,ADJ,B2
-tirelessly,tirelessly,词,ADV,C1
-tiresome,tiresome,累人的,ADJ,B2
-tiring,tiring,令人疲倦的,ADJ,B2
 tissue,tissue,组织,NOUN,B2
-tissue (adj),tissue,词,ADJ,C1
-titanic,titanic,词,ADJ,C1
 tithe,tithe,什一税,NOUN,B2
-titillate,titillate,词,VERB,C1
-titling,titling,词,NOUN,C1
-titular,titular,词,ADJ,C1
-to,to,去,PART,B2
-to abort,to abort,流产,VERB,B2
-to abound,to abound,词,VERB,C1
-to absolve,to absolve,赦免,VERB,B2
-to abstract,to abstract,抽象,VERB,B2
-to accentuate,to accentuate,强调,VERB,B2
-to access,to access,进入,VERB,B2
-to acclaim,to acclaim,称赞,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to acknowledge,to acknowledge,承认,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to acquiesce,to acquiesce,默许,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adduce,to adduce,引证,VERB,B2
-to adhere,to adhere,坚持,VERB,B2
-to adhere join,to adhere join,词,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to adore,to adore,爱慕,VERB,B2
-to advance (verb),to advance,前进,VERB,B2
-to afforest,to afforest,造林,VERB,B2
-to age,to age,变老,VERB,B2
-to aggravate,to aggravate,加重,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agitate,to agitate,鼓动,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to ail,to ail,使苦恼,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alert,to alert,警告,VERB,B2
-to alienate,to alienate,使疏远,VERB,B2
-to allege,to allege,宣称,VERB,B2
-to alleviate,to alleviate,缓解,VERB,B2
-to allocate,to allocate,分配,VERB,B2
-to allude,to allude,暗指,VERB,B2
-to ally,to ally,结盟,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter,to alter,改变,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to amalgamate,to amalgamate,合并,VERB,B2
-to amass,to amass,积聚,VERB,B2
-to amaze,to amaze,使吃惊,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to anathematize,to anathematize,词,VERB,C1
-to anchor (verb),to anchor,停泊,VERB,B2
-to anger,to anger,使生气,VERB,B2
-to animate,to animate,词,VERB,B2
-to annul,to annul,废除,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antagonize,to antagonize,使对立,VERB,B2
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,叛教,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to appear in court,to appear in court,词,VERB,B2
-to appear to seem,to appear to seem,出现/显得,VERB,B2
-to apply be valid,to apply be valid,适用/有效,VERB,B2
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to archive,to archive,归档,VERB,B2
-to arm,to arm,武装,VERB,B2
-to armor (verb),to armor,词,VERB,B2
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
-to ascribe,to ascribe,归因于,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to asphyxiate,to asphyxiate,使窒息,VERB,B2
-to assault,to assault,袭击,VERB,B2
-to assent,to assent,同意,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt (verb),to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attenuate,to attenuate,减弱,VERB,B2
-to attest,to attest,证明,VERB,B2
-to attribute (verb),to attribute,归因于,VERB,B2
-to audit (verb),to audit,审核,VERB,B2
-to augur,to augur,预言,VERB,B2
-to auscultate,to auscultate,听诊,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await orders,to await orders,待命,VERB,B2
-to back up,to back up,后退,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to bandage (verb),to bandage,包扎,VERB,B2
-to bare,to bare,暴露,VERB,B2
-to bargain (verb),to bargain,词,VERB,C1
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to barricade (verb),to barricade,词,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be (verb),to be,一身,VERB,A1
-to be able (aux),to be able,能够,AUX,B1
-to be able to (verb),to be able to,词,VERB,B2
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be contradicted,to be contradicted,词,VERB,B2
-to be correct,to be correct,正确,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be dissonant,to be dissonant,词,VERB,C1
-to be driven,to be driven,被驱动,VERB,B2
-to be equivalent,to be equivalent,词,VERB,C1
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be forbidden,to be forbidden,词,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be moved,to be moved,感动,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be necessary must,to be necessary must,词,VERB,A2
-to be needed,to be needed,被需要,VERB,B2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticed,to be noticed,词,VERB,B2
-to be observed,to be observed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,词,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be related,to be related,词,VERB,C1
-to be released,to be released,词,VERB,B2
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be responsible,to be responsible,词,VERB,B2
-to be said,to be said,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be struck,to be struck,词,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,不知道,VERB,B2
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be vigilant,to be vigilant,词,VERB,B2
-to be visible,to be visible,词,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to bear to endure,to bear to endure,词,VERB,C1
-to beatify,to beatify,宣福,VERB,B2
-to beautify,to beautify,美化,VERB,B2
-to become (aux),to become,词,AUX,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become alert,to become alert,词,VERB,B2
-to become bold,to become bold,词,VERB,C1
-to become certain,to become certain,词,VERB,B2
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to befriend,to befriend,与...交朋友,VERB,B2
-to beget,to beget,引起,VERB,B2
-to begin to cut into,to begin to cut into,词,VERB,C1
-to behave rudely,to behave rudely,词,VERB,C1
-to behead,to behead,斩首,VERB,B2
-to behold,to behold,注视,VERB,B2
-to benefit,to benefit,受益,VERB,B2
-to bequeath,to bequeath,遗赠,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to bet invest,to bet invest,词,VERB,B2
-to betroth,to betroth,词,VERB,C1
-to bevriezen,to bevriezen,词,VERB,C1
-to bewitch,to bewitch,迷住,VERB,B2
-to bicker,to bicker,争吵,VERB,B2
-to bid farewell,to bid farewell,词,VERB,B1
-to bide,to bide,等待,VERB,B2
-to bifurcate,to bifurcate,分叉,VERB,B2
-to bisect,to bisect,平分,VERB,B2
-to blaspheme,to blaspheme,亵渎,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to bleat,to bleat,哀叫,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to blink,to blink,眨眼,VERB,B2
-to blockade (verb),to blockade,词,VERB,B2
-to bloom,to bloom,开花,VERB,B2
-to blossom,to blossom,开花,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to bluff,to bluff,虚张声势,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to blush,to blush,脸红,VERB,B2
-to board (verb),to board,词,VERB,C1
-to boil cook,to boil cook,词,VERB,B1
-to boost,to boost,促进,VERB,B2
-to border,to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to botch,to botch,搞砸,VERB,B2
-to bottle (verb),to bottle,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to box (verb),to box,词,VERB,B2
-to brandish,to brandish,挥舞,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break into,to break into,撬开,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to bridle (verb),to bridle,词,VERB,C1
-to bring about,to bring about,促成,VERB,B2
-to bring closer,to bring closer,靠近,VERB,B2
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to bristle,to bristle,使竖起,VERB,B2
-to brush (verb),to brush,刷,VERB,B2
-to build up,to build up,构建,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to bungle,to bungle,搞砸,VERB,B2
-to burnish,to burnish,擦亮,VERB,B2
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to calibrate,to calibrate,校准,VERB,B2
-to call out,to call out,词,VERB,C1
-to call ring,to call ring,打电话,VERB,B2
-to call to contact,to call to contact,词,VERB,A2
-to calm down,to calm down,使平静,VERB,B2
-to camouflage,to camouflage,伪装,VERB,B2
-to camp,to camp,露营,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to caper,to caper,跳跃,VERB,B2
-to capitulate,to capitulate,投降,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to captivate,to captivate,迷住,VERB,B2
-to capture (verb),to capture,攻下,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carve,to carve,雕刻,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to cast (verb),to cast,词,VERB,B2
-to castigate,to castigate,严厉批评,VERB,B2
-to catalyze,to catalyze,催化,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,瞥见,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to catechize,to catechize,词,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to cauterize,to cauterize,烧灼,VERB,B2
-to cement (verb),to cement,词,VERB,B2
-to center,to center,居中,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to chair (verb),to chair,词,VERB,C1
-to change clothes,to change clothes,更衣,VERB,B1
-to charter (verb),to charter,特许,VERB,B2
-to chastise,to chastise,严惩,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chill,to chill,使冰冻,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clean out,to clean out,词,VERB,C1
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close eyes,to close eyes,闭眼,VERB,B2
-to cloy,to cloy,使厌烦,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coach (verb),to coach,辅导,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to coax,to coax,哄骗,VERB,B2
-to codify,to codify,编纂,VERB,B2
-to coerce,to coerce,强迫,VERB,B2
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to collate,to collate,核对,VERB,B2
-to combat (verb),to combat,战斗,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to come true,to come true,词,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commercialize,to commercialize,商业化,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,交融,VERB,B2
-to commute,to commute,通勤,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to complement,to complement,补充,VERB,B2
-to complete finish,to complete finish,词,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to compose (noun),to compose,合成,NOUN,B2
-to computerize,to computerize,词,VERB,C1
-to concede,to concede,承认,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concoct,to concoct,编造,VERB,B2
-to concretize,to concretize,词,VERB,C1
-to condescend,to condescend,屈尊,VERB,B2
-to condone,to condone,宽恕,VERB,B2
-to conduct (verb),to conduct,指挥,VERB,B2
-to confer,to confer,授予,VERB,B2
-to confine,to confine,限制,VERB,B2
-to conform,to conform,符合,VERB,B2
-to conjecture,to conjecture,猜测,VERB,B2
-to conjugate,to conjugate,变位,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to connote,to connote,暗示,VERB,B2
-to consent,to consent,同意,VERB,B2
-to conserve,to conserve,保存,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to consign,to consign,移交,VERB,B2
-to constipate,to constipate,词,VERB,C1
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consummate,to consummate,完成,VERB,B2
-to contend,to contend,主张,VERB,B2
-to contest (verb),to contest,词,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to cook fix,to cook fix,做/修理,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to correspond (! verb),to correspond,词,! VERB,C1
-to corroborate,to corroborate,证实,VERB,B2
-to corrode,to corrode,腐蚀,VERB,B2
-to corrupt (verb),to corrupt,词,VERB,B2
-to counter (verb),to counter,抗辩,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,词,VERB,C1
-to covet,to covet,觊觎,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to cram,to cram,填鸭式学习,VERB,B2
-to crash,to crash,碰撞,VERB,B2
-to crash into,to crash into,撞击,VERB,B2
-to creak,to creak,嘎吱作响,VERB,B2
-to croak,to croak,呱呱叫,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,挤在一起,VERB,B2
-to crumple,to crumple,弄皱,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to cuddle,to cuddle,拥抱,VERB,B2
-to culminate,to culminate,达到顶点,VERB,B2
-to curl,to curl,卷曲,VERB,B2
-to curtail,to curtail,削减,VERB,B2
-to curve (verb),to curve,词,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to cycle (verb),to cycle,循环,VERB,B2
-to dam up,to dam up,词,VERB,C1
-to dampen,to dampen,使潮湿,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to daunt,to daunt,使气馁,VERB,B2
-to dawdle,to dawdle,闲逛,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daze,to daze,使茫然,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deafen,to deafen,使聋,VERB,B2
-to deal,to deal,处理,VERB,B2
-to debate (verb),to debate,辩,VERB,B2
-to debut,to debut,首次亮相,VERB,B2
-to decant,to decant,倾析,VERB,B2
-to decentralize,to decentralize,去中心化,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,词,VERB,B2
-to declaim,to declaim,慷慨陈词,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declassify,to declassify,解密,VERB,B2
-to decode,to decode,解码,VERB,B2
-to decompress,to decompress,解压,VERB,B2
-to decontextualize,to decontextualize,词,VERB,C1
-to decouple,to decouple,分离,VERB,B2
-to decree (verb),to decree,旨,VERB,B2
-to decry,to decry,谴责,VERB,B2
-to defame,to defame,诽谤,VERB,B2
-to default (verb),to default,拖欠,VERB,B2
-to defect (verb),to defect,叛变,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defer,to defer,推迟,VERB,B2
-to deflate,to deflate,使泄气,VERB,B2
-to defray,to defray,支付,VERB,B2
-to defrost,to defrost,除霜,VERB,B2
-to defuse,to defuse,缓和,VERB,B2
-to deify,to deify,神化,VERB,B2
-to deign,to deign,屈尊,VERB,B2
-to dejta,to dejta,约会,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delegitimize,to delegitimize,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to deliberate (verb),to deliberate,审议,VERB,B2
-to delight,to delight,使高兴,VERB,B2
-to delimit,to delimit,词,VERB,C1
-to delineate,to delineate,描绘,VERB,B2
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to delude oneself,to delude oneself,词,VERB,B2
-to demarcate,to demarcate,划定界限,VERB,B2
-to demilitarize,to demilitarize,非军事化,VERB,B2
-to democratize,to democratize,民主化,VERB,B2
-to demonize,to demonize,妖魔化,VERB,B2
-to denature,to denature,使变性,VERB,B2
-to denigrate,to denigrate,诋毁,VERB,B2
-to denominate,to denominate,命名,VERB,B2
-to denote,to denote,表示,VERB,B2
-to densify,to densify,词,VERB,C1
-to depersonalize,to depersonalize,词,VERB,C1
-to depilate,to depilate,脱毛,VERB,B2
-to deploy unfold,to deploy unfold,词,VERB,C1
-to depopulate,to depopulate,使人口减少,VERB,B2
-to deport,to deport,驱逐出境,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deprave,to deprave,使堕落,VERB,B2
-to depreciate,to depreciate,贬值,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to desert,to desert,擅离职守,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to destock,to destock,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to detail,to detail,详述,VERB,B2
-to dethrone,to dethrone,废黜,VERB,B2
-to detract,to detract,贬低,VERB,B2
-to deviate,to deviate,偏离,VERB,B2
-to dialogue (verb),to dialogue,词,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to digitize,to digitize,数字化,VERB,B2
-to dilute,to dilute,稀释,VERB,B2
-to dimension (verb),to dimension,词,VERB,C1
-to dirty (verb),to dirty,词,VERB,C1
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disabuse,to disabuse,纠正错误想法,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disarrange,to disarrange,弄乱,VERB,B2
-to disarray (verb),to disarray,词,VERB,C1
-to discern,to discern,辨别,VERB,B2
-to disconcert,to disconcert,使惊慌,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to discourse (verb),to discourse,论述,VERB,B2
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disenchant,to disenchant,使清醒,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disentangle,to disentangle,解开,VERB,B2
-to disfavor,to disfavor,不利于,VERB,B2
-to disfigure,to disfigure,毁容,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to dishearten,to dishearten,使沮丧,VERB,B2
-to dishevel,to dishevel,弄乱,VERB,B2
-to dishonor,to dishonor,使蒙羞,VERB,B2
-to disinherit,to disinherit,剥夺继承权,VERB,B2
-to disintegrate,to disintegrate,瓦解,VERB,B2
-to disjoin,to disjoin,分离,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dislodge,to dislodge,逐出,VERB,B2
-to dismay,to dismay,使沮丧,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disoblige,to disoblige,词,VERB,C1
-to dispel,to dispel,消除,VERB,B2
-to dispense,to dispense,分发,VERB,B2
-to disperse,to disperse,分散,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to dispose,to dispose,处理,VERB,B2
-to dispossess,to dispossess,剥夺,VERB,B2
-to disproportion (verb),to disproportion,词,VERB,C1
-to disqualify,to disqualify,取消资格,VERB,B2
-to disrespect (verb),to disrespect,词,VERB,C1
-to disrupt,to disrupt,扰乱,VERB,B2
-to dissent (verb),to dissent,词,VERB,C1
-to dissipate,to dissipate,消散,VERB,B2
-to distance (verb),to distance,词,VERB,C1
-to distill,to distill,蒸馏,VERB,B2
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to disunite,to disunite,使分裂,VERB,B2
-to dither,to dither,犹豫不决,VERB,B2
-to diverge,to diverge,分歧,VERB,B2
-to divest,to divest,剥夺,VERB,B2
-to divulge,to divulge,泄露,VERB,B2
-to do hair,to do hair,词,VERB,C1
-to do justice to,to do justice to,词,VERB,C1
-to do make,to do make,词,VERB,A1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to dote,to dote,词,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape,to drape,悬挂,VERB,B2
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw support from,to draw support from,借助,VERB,B2
-to draw up,to draw up,起草,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drip,to drip,滴,VERB,B2
-to drive herd,to drive herd,词,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,驾驶,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry in the sun (verb),to dry in the sun,晾晒,VERB,B2
-to dry up,to dry up,词,VERB,B2
-to duck (verb),to duck,词,VERB,C1
-to dull (verb),to dull,词,VERB,C1
-to dump,to dump,抛弃,VERB,B2
-to dupe,to dupe,欺骗,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dust off,to dust off,词,VERB,C1
-to dye,to dye,染色,VERB,B2
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eavesdrop,to eavesdrop,偷听,VERB,B2
-to eclipse,to eclipse,使失色,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to edify,to edify,启发,VERB,B2
-to eject,to eject,弹出,VERB,B2
-to elaborate (verb),to elaborate,阐发,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to elevate,to elevate,提升,VERB,B2
-to elide,to elide,省略,VERB,B2
-to elucidate,to elucidate,阐明,VERB,B2
-to elude,to elude,逃避,VERB,B2
-to email (verb),to email,词,VERB,B2
-to emasculate,to emasculate,使无力,VERB,B2
-to embark,to embark,上船,VERB,B2
-to embarrass,to embarrass,使尴尬,VERB,B2
-to embolden,to embolden,使大胆,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emigrate,to emigrate,移居国外,VERB,B2
-to encircle,to encircle,环绕,VERB,B2
-to encode,to encode,编码,VERB,B2
-to encore (verb),to encore,词,VERB,C1
-to encroach,to encroach,侵蚀,VERB,B2
-to enervate,to enervate,使衰弱,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engrave,to engrave,雕刻,VERB,B2
-to engross,to engross,使全神贯注,VERB,B2
-to enhance,to enhance,增强,VERB,B2
-to enrage,to enrage,激怒,VERB,B2
-to enrapture,to enrapture,使狂喜,VERB,B2
-to enrol,to enrol,注册,VERB,B2
-to enslave,to enslave,奴役,VERB,B2
-to ensnare,to ensnare,诱捕,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthrall,to enthrall,迷住,VERB,B2
-to enthrone,to enthrone,立为王,VERB,B2
-to enunciate,to enunciate,阐明,VERB,B2
-to equal (verb),to equal,无异,VERB,B2
-to equalize,to equalize,使相等,VERB,B2
-to equate,to equate,等同,VERB,B2
-to erect behave,to erect behave,建造,VERB,B2
-to erode,to erode,侵蚀,VERB,B2
-to espy,to espy,窥探,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to eternalize,to eternalize,使永恒,VERB,B2
-to ever (verb),to ever,何尝,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to exalt,to exalt,颂扬,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to exclaim,to exclaim,呼喊,VERB,B2
-to exculpate,to exculpate,开脱,VERB,B2
-to execrate,to execrate,痛恨,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exemplify,to exemplify,举例说明,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exfoliate,to exfoliate,去角质,VERB,B2
-to exist there is,to exist there is,存在/有,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to exorcise,to exorcise,驱魔,VERB,B2
-to expatriate,to expatriate,使移居国外,VERB,B2
-to expectorate,to expectorate,吐痰,VERB,B2
-to experiment,to experiment,实验,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to expurgate,to expurgate,删节,VERB,B2
-to externalize,to externalize,使外在化,VERB,B2
-to extirpate,to extirpate,根除,VERB,B2
-to extol,to extol,赞美,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extricate,to extricate,使摆脱,VERB,B2
-to exude,to exude,散发,VERB,B2
-to fail to fulfill,to fail to fulfill,未履行,VERB,B2
-to faint (verb),to faint,昏迷,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to familiarize,to familiarize,使熟悉,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fast (verb),to fast,禁食,VERB,B2
-to fasten,to fasten,系紧,VERB,B2
-to fatten,to fatten,养肥,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign,to feign,假装,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to ferret,to ferret,搜寻,VERB,B2
-to fertilize,to fertilize,施肥,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to finally,to finally,你可算,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fine (verb),to fine,罚款,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fit suit,to fit suit,适合,VERB,B2
-to fix to prepare,to fix to prepare,词,VERB,A2
-to fix to set,to fix to set,词,VERB,B1
-to flame (verb),to flame,词,VERB,B2
-to flap,to flap,拍打,VERB,B2
-to flash,to flash,闪烁,VERB,B2
-to flatten,to flatten,使平坦,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flock,to flock,群集,VERB,B2
-to flog,to flog,鞭打,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flout,to flout,蔑视,VERB,B2
-to flow into,to flow into,词,VERB,C1
-to fluctuate,to fluctuate,波动,VERB,B2
-to flush,to flush,冲洗,VERB,B2
-to flush out,to flush out,词,VERB,B2
-to fluster,to fluster,使慌乱,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to focus (verb),to focus,聚焦,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to foist,to foist,强加,VERB,B2
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to forebode,to forebode,预兆,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to form to train,to form to train,词,VERB,B1
-to fortify,to fortify,加强,VERB,B2
-to fossilize,to fossilize,石化,VERB,B2
-to fraction,to fraction,分割,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to fraternize,to fraternize,勾结,VERB,B2
-to freshen,to freshen,使清新,VERB,B2
-to frighten away,to frighten away,词,VERB,C1
-to frolic,to frolic,嬉戏,VERB,B2
-to fumigate,to fumigate,熏蒸,VERB,B2
-to function to work,to function to work,词,VERB,B1
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse (verb),to fuse,融合,VERB,B2
-to gain,to gain,获得,VERB,B2
-to gain weight,to gain weight,变胖,VERB,B2
-to galvanize,to galvanize,激励,VERB,B2
-to gape,to gape,目瞪口呆,VERB,B2
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to gauge,to gauge,测量,VERB,B2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to germinate,to germinate,发芽,VERB,B2
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get along,to get along,词,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get fond of,to get fond of,词,VERB,C1
-to get into debt,to get into debt,词,VERB,C1
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get stuck,to get stuck,词,VERB,B2
-to get tired,to get tired,疲劳,VERB,A2
-to gift (verb),to gift,词,VERB,B1
-to gird,to gird,束紧,VERB,B2
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glance (verb),to glance,瞥,VERB,B2
-to glean,to glean,搜集,VERB,B2
-to glimpse (verb),to glimpse,瞥见,VERB,B2
-to gloss,to gloss,注释,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go deep into,to go deep into,深入,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,麻木,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up again,to go up again,词,VERB,B1
-to go up in smoke,to go up in smoke,词,VERB,B2
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to goad,to goad,刺激,VERB,B2
-to gossip,to gossip,闲聊,VERB,B2
-to graduate (verb),to graduate,毕业,VERB,B2
-to graspen,to graspen,词,VERB,B2
-to gratify,to gratify,使满足,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to gravitate,to gravitate,受吸引,VERB,B2
-to gray,to gray,变白,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to group,to group,分组,VERB,B2
-to grow fond of,to grow fond of,词,VERB,C1
-to grow old,to grow old,词,VERB,A1
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,猜中,VERB,B2
-to guillotine,to guillotine,斩首,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to gurgle (verb),to gurgle,词,VERB,C1
-to gush,to gush,涌出,VERB,B2
-to hail,to hail,下冰雹,VERB,B2
-to hail inspect,to hail inspect,盘查,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to handcuff,to handcuff,给…戴手铐,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,词,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harangue (verb),to harangue,词,VERB,B2
-to harbor,to harbor,怀有,VERB,B2
-to harden,to harden,使经受锻炼,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,词,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have (aux),to have,词,AUX,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to have to,to have to,必须,VERB,B2
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hide to disappear,to hide to disappear,词,VERB,A2
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold accountable,to hold accountable,问责,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up,to hold up,词,VERB,B2
-to hollow out,to hollow out,词,VERB,C1
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to hook (verb),to hook,词,VERB,C1
-to hope for,to hope for,盼望,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to humanize,to humanize,使人性化,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idealize,to idealize,理想化,VERB,B2
-to idolize,to idolize,崇拜,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to imbue,to imbue,词,VERB,C1
-to immobilize,to immobilize,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to implant,to implant,植入,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to imprint (verb),to imprint,词,VERB,C1
-to impute,to impute,归咎,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incarcerate,to incarcerate,词,VERB,B2
-to incentivize,to incentivize,词,VERB,C1
-to inconvenience,to inconvenience,使不便,VERB,B2
-to incriminate,to incriminate,归罪,VERB,B2
-to incur,to incur,招致,VERB,B2
-to indicate interpret,to indicate interpret,词,VERB,B2
-to indict,to indict,控告,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to indispose,to indispose,词,VERB,C1
-to indoctrinate,to indoctrinate,灌输,VERB,B2
-to induce to lead to,to induce to lead to,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to infest,to infest,滋生,VERB,B2
-to inflame,to inflame,使发炎,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict,to inflict,词,VERB,C1
-to inflict to impose,to inflict to impose,词,VERB,B2
-to inform to reach,to inform to reach,词,VERB,A2
-to infuse,to infuse,泡制,VERB,B2
-to innovate,to innovate,词,VERB,C1
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insinuate,to insinuate,暗示,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to instill,to instill,灌输,VERB,B2
-to institute (verb),to institute,词,VERB,C1
-to institutionalize,to institutionalize,制度化,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to interact,to interact,词,VERB,C1
-to intercede,to intercede,调停,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to internalize,to internalize,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to interview (verb),to interview,采访,VERB,B2
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intoxicate,to intoxicate,使中毒,VERB,B2
-to intuit,to intuit,词,VERB,C1
-to invalidate,to invalidate,证明无效,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoice,to invoice,开票,VERB,B2
-to invoke,to invoke,援引,VERB,B2
-to ironize,to ironize,讽刺,VERB,B2
-to irrigate,to irrigate,灌溉,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to jam (verb),to jam,词,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,词,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to knead,to knead,词,VERB,A1
-to knit,to knit,编织,VERB,B2
-to knock down,to knock down,词,VERB,B2
-to knock to pound,to knock to pound,词,VERB,A2
-to knot (verb),to knot,词,VERB,C1
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack basis,to lack basis,无据,VERB,B2
-to lament,to lament,哀叹,VERB,B2
-to languish,to languish,词,VERB,C1
-to laugh smile,to laugh smile,笑,VERB,A1
-to launder,to launder,洗钱,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to lay put,to lay put,放,VERB,B2
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,使入歧途,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to leaf through,to leaf through,翻阅,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to lean out,to lean out,词,VERB,B2
-to leap (verb),to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to legislate,to legislate,词,VERB,C1
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lengthen,to lengthen,延长,VERB,B2
-to lessen,to lessen,词,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to levy,to levy,征收,VERB,C1
-to license (verb),to license,词,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to light,to light,照亮,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,词,VERB,B2
-to lighten,to lighten,减轻,VERB,B2
-to linger,to linger,徘徊,VERB,B2
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live in,to live in,词,VERB,C1
-to load charge,to load charge,装载,VERB,B2
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lodge,to lodge,词,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to log in,to log in,登录,VERB,B2
-to loiter,to loiter,词,VERB,C1
-to long (verb),to long,词,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to loot (verb),to loot,词,VERB,C1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower,to lower,降低,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lunge,to lunge,词,VERB,C1
-to lurk,to lurk,词,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to maim,to maim,词,VERB,C1
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make bland,to make bland,使乏味,VERB,B2
-to make drowsy,to make drowsy,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make heavier,to make heavier,加重,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,词,VERB,C1
-to make lasting,to make lasting,词,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make one's way,to make one's way,词,VERB,B2
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make proud,to make proud,使自豪,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to make up for substitute,to make up for substitute,词,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manifest,to manifest,表明,VERB,B2
-to manure (verb),to manure,词,VERB,C1
-to map out,to map out,摸清,VERB,B2
-to mark out,to mark out,标示,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to mash (verb),to mash,词,VERB,A2
-to massacre (verb),to massacre,词,VERB,C1
-to mast,to mast,降伏,VERB,B2
-to match (verb),to match,匹配,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to maximize,to maximize,词,VERB,C1
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to head to,to mean to head to,词,VERB,A2
-to meant,to meant,意思是,VERB,B2
-to meddle,to meddle,干涉,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mention to remember,to mention to remember,词,VERB,A2
-to merge (noun),to merge,词,NOUN,B2
-to mess about,to mess about,胡搞,VERB,B2
-to mess around,to mess around,胡闹,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mime (verb),to mime,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to minimize,to minimize,最小化,VERB,B2
-to mirror,to mirror,反映,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to missed,to missed,错过,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to model (verb),to model,词,VERB,C1
-to modernize,to modernize,词,VERB,C1
-to modulate,to modulate,调节,VERB,B2
-to moon (verb),to moon,词,VERB,A2
-to moor (verb),to moor,词,VERB,B2
-to mop (verb),to mop,词,VERB,A2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to mortgage (verb),to mortgage,抵押,VERB,B2
-to mourn,to mourn,哀悼,VERB,B2
-to move away,to move away,移开,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move house,to move house,搬家,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to move touch,to move touch,使感动,VERB,B2
-to mud (verb),to mud,词,VERB,C1
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to mutiny (verb),to mutiny,词,VERB,B2
-to mystify,to mystify,神秘化,VERB,B2
-to nail,to nail,钉,VERB,B2
-to narrow,to narrow,使变窄,VERB,B2
-to navigate,to navigate,导航；航行,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need must,to need must,词,VERB,A2
-to neutralize,to neutralize,中和,VERB,B2
-to nickname,to nickname,给...起绰号,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note down,to note down,词,VERB,B2
-to nuance,to nuance,使具有细微差别,VERB,B2
-to numb,to numb,使麻木,VERB,B2
-to number (verb),to number,词,VERB,C1
-to object,to object,反对,VERB,B2
-to objectify,to objectify,客观化,VERB,B2
-to oblige,to oblige,强迫,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to ogle,to ogle,词,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to orient,to orient,词,VERB,B2
-to orient to guide,to orient to guide,词,VERB,C1
-to ostracize,to ostracize,排斥,VERB,B2
-to oust,to oust,推翻,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to outline (verb),to outline,勾勒,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overflow,to overflow,溢出,VERB,B2
-to overshadow,to overshadow,使黯然失色,VERB,B2
-to overstep,to overstep,越权,VERB,B2
-to overthrow,to overthrow,推翻,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,词,VERB,C1
-to package (verb),to package,词,VERB,C1
-to paint over,to paint over,重新粉刷,VERB,B2
-to pair (verb),to pair,词,VERB,C1
-to pamper,to pamper,纵容,VERB,B2
-to panic (verb),to panic,词,VERB,C1
-to parade,to parade,游行,VERB,B2
-to party,to party,狂欢,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pause (verb),to pause,……,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to pension off,to pension off,词,VERB,C1
-to perfect,to perfect,精修,VERB,B2
-to perforate,to perforate,词,VERB,C1
-to perform umrah,to perform umrah,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to perpetrate,to perpetrate,词,VERB,C1
-to perpetuate,to perpetuate,使永存,VERB,B2
-to persecute,to persecute,迫害,VERB,B2
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to persist,to persist,坚持,VERB,B2
-to personify,to personify,词,VERB,C1
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to photocopy (verb),to photocopy,复印,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to placate,to placate,安抚,VERB,B2
-to place put,to place put,放置,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to pledge mutually,to pledge mutually,词,VERB,C1
-to plot,to plot,密谋,VERB,B2
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plug in,to plug in,插入,VERB,B2
-to plunder,to plunder,掠夺,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to point to clock in,to point to clock in,词,VERB,B2
-to polarize,to polarize,使两极分化,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to polemicize,to polemicize,词,VERB,C1
-to pollute,to pollute,词,VERB,B2
-to portend,to portend,词,VERB,B2
-to position,to position,定位 / 安置,VERB,B2
-to post,to post,张贴,VERB,B2
-to postpone to carry over,to postpone to carry over,词,VERB,B2
-to postulate,to postulate,假定,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to powder,to powder,撒粉,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to preserve to protect,to preserve to protect,词,VERB,C1
-to preside,to preside,主持,VERB,B2
-to prick,to prick,扎,VERB,B2
-to prioritize,to prioritize,优先考虑,VERB,B2
-to privatize,to privatize,私有化,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to profile (verb),to profile,词,VERB,C1
-to program,to program,编程,VERB,B2
-to project,to project,投射,VERB,B2
-to prop up,to prop up,支撑,VERB,B2
-to propagate,to propagate,传播,VERB,B2
-to prosecute,to prosecute,起诉,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to protest (verb),to protest,抗议,VERB,B2
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pucker,to pucker,噘,VERB,B2
-to pull out hair,to pull out hair,词,VERB,C1
-to pump (verb),to pump,词,VERB,C1
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purge,to purge,清除,VERB,B2
-to purify,to purify,净化,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push through,to push through,推动,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put away,to put away,词,VERB,B2
-to put back,to put back,放回,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,使走上正轨,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to quarrel (verb),to quarrel,吵,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to quiver,to quiver,颤抖,VERB,B2
-to race (verb),to race,词,VERB,B1
-to race down,to race down,词,VERB,C1
-to radiate,to radiate,辐射,VERB,B2
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rant,to rant,咆哮,VERB,B2
-to ratify,to ratify,批准,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to rationalize,to rationalize,合理化,VERB,B2
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to rebuke,to rebuke,斥责,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to recreate,to recreate,重建,VERB,B2
-to redden,to redden,变红,VERB,B2
-to redeem,to redeem,赎回,VERB,B2
-to rediscover,to rediscover,重新发现,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to refuel,to refuel,加油,VERB,B2
-to regain,to regain,恢复,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to regret apologize,to regret apologize,词,VERB,B2
-to rehabilitate,to rehabilitate,使康复,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate,to relate,联系,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relativize,to relativize,词,VERB,C1
-to relaunch,to relaunch,重启,VERB,B2
-to relay,to relay,转达,VERB,B2
-to release from prison,to release from prison,词,VERB,B2
-to release let go,to release let go,释放/放手,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remove to pull out,to remove to pull out,词,VERB,A2
-to remunerate,to remunerate,词,VERB,C1
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,重犯,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repeal,to repeal,废除,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to repel,to repel,击退,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to replicate,to replicate,复制,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to reproach,to reproach,责备,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resonate,to resonate,共鸣,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to result,to result,产生,VERB,B2
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retort,to retort,反驳,VERB,B2
-to retrace,to retrace,追溯,VERB,B2
-to retract,to retract,撤回,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return home,to return home,词,VERB,B1
-to return something,to return something,词,VERB,A2
-to return to restore,to return to restore,词,VERB,C1
-to revalue,to revalue,重新估值,VERB,B2
-to reverse,to reverse,反转,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to riddle,to riddle,使布满孔洞,VERB,B2
-to ridicule (verb),to ridicule,词,VERB,C1
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to root out,to root out,词,VERB,C1
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to rough-hew,to rough-hew,粗加工,VERB,B2
-to round (verb),to round,词,VERB,A2
-to ruffle,to ruffle,词,VERB,C1
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to sabotage,to sabotage,破坏,VERB,B2
-to sadden,to sadden,使悲伤,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanction,to sanction,认可,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to satiate,to satiate,使饱足,VERB,B2
-to saturate,to saturate,使饱和,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to savor,to savor,品味,VERB,B2
-to saw,to saw,锯,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scamper,to scamper,词,VERB,B2
-to scan,to scan,扫描,VERB,B2
-to scare away,to scare away,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scheme (verb),to scheme,词,VERB,C1
-to score (verb),to score,词,VERB,B2
-to scourge (verb),to scourge,词,VERB,C1
-to scout,to scout,侦察,VERB,B2
-to scram,to scram,词,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to screw,to screw,拧,VERB,B2
-to scribble (verb),to scribble,词,VERB,C1
-to scrimp,to scrimp,词,VERB,C1
-to scrub,to scrub,擦洗,VERB,B2
-to sculpt,to sculpt,词,VERB,C1
-to search apply,to search apply,寻找/申请,VERB,B2
-to seat,to seat,使坐下,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to see emperor,to see emperor,面圣,VERB,C1
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to segment (verb),to segment,词,VERB,B2
-to segregate,to segregate,隔离,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sequester,to sequester,隔离,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set aside,to set aside,移开,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sexualize,to sexualize,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to sharpen,to sharpen,磨快,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shelter,to shelter,庇护,VERB,B2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shoe (verb),to shoe,词,VERB,C1
-to shoot dead,to shoot dead,击毙,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop be about,to shop be about,购物,VERB,B2
-to shop for groceries,to shop for groceries,词,VERB,A2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shroud,to shroud,覆盖,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sidestep,to sidestep,词,VERB,C1
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to signal (verb),to signal,暗讯,VERB,B2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to singe,to singe,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to situate,to situate,定位,VERB,B2
-to skein,to skein,绕成线团,VERB,B2
-to sketch,to sketch,勾勒,VERB,B2
-to skewer,to skewer,词,VERB,B2
-to skim,to skim,轻触,VERB,B2
-to skin,to skin,剥皮,VERB,B2
-to skip,to skip,词,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slap (verb),to slap,词,VERB,B2
-to slash,to slash,猛砍,VERB,B2
-to slaughter (verb),to slaughter,宰,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slice (verb),to slice,词,VERB,C1
-to slide,to slide,滑动,VERB,B2
-to slight (verb),to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to slope down,to slope down,词,VERB,B2
-to snack (verb),to snack,词,VERB,C1
-to sneak away,to sneak away,溜走,VERB,B2
-to snoop,to snoop,窥探,VERB,B2
-to snort (verb),to snort,词,VERB,B2
-to snow,to snow,下雪,VERB,B2
-to snub,to snub,冷落,VERB,B2
-to soften,to soften,使灵活,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solder,to solder,焊接,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sour (verb),to sour,词,VERB,C1
-to spam,to spam,发垃圾信息,VERB,B2
-to sparkle,to sparkle,闪耀,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to spawn,to spawn,产卵,VERB,B2
-to specialize,to specialize,专攻,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spill,to spill,溢出,VERB,B2
-to spirit away,to spirit away,变走,VERB,B2
-to splash,to splash,溅,VERB,B2
-to splint,to splint,用夹板固定,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to sponsor,to sponsor,赞助,VERB,B2
-to spot,to spot,看见,VERB,B2
-to spout,to spout,喷射,VERB,B2
-to spray (verb),to spray,词,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to sprout,to sprout,发芽,VERB,B2
-to spy,to spy,监视,VERB,B2
-to spy on,to spy on,词,VERB,C1
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stalk,to stalk,跟踪,VERB,B2
-to stammer,to stammer,结巴,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to standardize,to standardize,标准化,VERB,B2
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steal sword,to steal sword,偷剑,NOUN,B2
-to steep (verb),to steep,词,VERB,C1
-to steer control,to steer control,控制,VERB,B2
-to stem,to stem,起源于,VERB,B2
-to stem from,to stem from,源于,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stick out,to stick out,伸出,VERB,B2
-to stiffen,to stiffen,词,VERB,C1
-to stifle smother,to stifle smother,词,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop down,to stop down,词,VERB,C1
-to store (verb),to store,词,VERB,B2
-to straighten up,to straighten up,词,VERB,B2
-to stratify,to stratify,分层,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to strike (verb),to strike,打击,VERB,B2
-to strike down,to strike down,击倒,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip,to strip,裸露,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive for,to strive for,争取,VERB,B2
-to structure (verb),to structure,构建,VERB,B2
-to struggle (verb),to struggle,拼搏,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stun,to stun,词,VERB,C1
-to stylize,to stylize,词,VERB,C1
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to suborn,to suborn,教唆,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to substantiate,to substantiate,证实,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to succeed to pass,to succeed to pass,词,VERB,A2
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suit agree,to suit agree,词,VERB,B2
-to sulk,to sulk,生闷气,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplicate,to supplicate,恳求,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surname (verb),to surname,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture (verb),to suture,缝合,VERB,B2
-to swagger,to swagger,大摇大摆,VERB,B2
-to swallow up,to swallow up,词,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to sweat (verb),to sweat,出汗,VERB,B2
-to swell,to swell,使肿胀,VERB,B2
-to swing,to swing,荡秋千,VERB,B2
-to swipe,to swipe,词,VERB,C1
-to synchronize,to synchronize,词,VERB,C1
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to tag (verb),to tag,词,VERB,C1
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,记录,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take on,to take on,词,VERB,C1
-to take one's time,to take one's time,词,VERB,B2
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to talk chat,to talk chat,词,VERB,B2
-to tap to type,to tap to type,词,VERB,C1
-to tarnish,to tarnish,词,VERB,C1
-to task (verb),to task,词,VERB,C1
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to teach reading,to teach reading,词,VERB,B2
-to tear down,to tear down,拆除,VERB,B2
-to tear out,to tear out,拔出,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to tell to narrate,to tell to narrate,词,VERB,A2
-to temper (verb),to temper,词,VERB,B2
-to temporize,to temporize,拖延,VERB,B2
-to text,to text,发短信,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,词,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,认为,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrill,to thrill,使兴奋,VERB,B2
-to thrown,to thrown,词,VERB,B2
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy,to tidy,整理,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
-to tinker,to tinker,词,VERB,B1
-to tip,to tip,透露,VERB,B2
-to tip over,to tip over,翻倒,VERB,B2
-to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
-to title,to title,命名,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toast (verb),to toast,词,VERB,B2
-to topple,to topple,词,VERB,C1
-to torment,to torment,折磨,VERB,B2
-to total (verb),to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to tow,to tow,词,VERB,C1
-to trace,to trace,描绘；标出,VERB,B2
-to track (verb),to track,追踪,VERB,B2
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to transcribe,to transcribe,转录,VERB,B2
-to transfer (verb),to transfer,转移,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transgress,to transgress,违背,VERB,B2
-to transport (verb),to transport,输送,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to trivialize,to trivialize,使平庸,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tumble,to tumble,跌倒,VERB,B2
-to tune,to tune,调谐,VERB,B2
-to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to twinkle,to twinkle,词,VERB,B2
-to type,to type,打字,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbalance,to unbalance,词,VERB,C1
-to unbend,to unbend,词,VERB,B2
-to unblind,to unblind,词,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to unbutton,to unbutton,解开纽扣,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to underline,to underline,强调,VERB,B2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to undo,to undo,解开,VERB,B2
-to undress,to undress,脱衣,VERB,B2
-to unearth,to unearth,发掘,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unhook,to unhook,摘下,VERB,B2
-to unload,to unload,卸货,VERB,B2
-to unmask,to unmask,揭穿,VERB,B2
-to unplug,to unplug,词,VERB,C1
-to unravel,to unravel,解开,VERB,B2
-to unroll,to unroll,词,VERB,C1
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to untangle,to untangle,词,VERB,C1
-to unwrap,to unwrap,词,VERB,B1
-to uproot,to uproot,根除,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to use up,to use up,用完,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to vacuum (verb),to vacuum,词,VERB,A2
-to validate,to validate,验证,VERB,B2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vary,to vary,改变,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to venerate,to venerate,崇敬,VERB,B2
-to vent,to vent,倾诉,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to vilify,to vilify,诽谤,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to wane,to wane,减弱,VERB,B2
-to want (verb),to want,想要,VERB,A1
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to warp,to warp,弯曲,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch out,to watch out,小心,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to wear out,to wear out,磨损,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,使厌倦,VERB,B2
-to wed,to wed,词,VERB,C1
-to wedge,to wedge,卡住,VERB,B2
-to weed (verb),to weed,词,VERB,C1
-to weigh down,to weigh down,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to wield,to wield,行使,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wind (verb),to wind,绕,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to wither,to wither,词,VERB,B2
-to woo,to woo,词,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wring,to wring,拧干,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn,to yearn,渴望,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-to zero out,to zero out,清零,VERB,B2
-toad,toad,蟾蜍,NOUN,B2
-toast,toast,你敬酒,NOUN,B2
-tobacco,tobacco,烟草,NOUN,B2
 today,today,今天,NOUN,B2
 tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-togetherness,togetherness,词,NOUN,C1
 toil,toil,苦工,NOUN,B2
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toiling,toiling,词,ADJ,C1
-told instructed,told instructed,被告知的,ADJ,B2
 tolerance,tolerance,宽容,NOUN,B2
-tolerance dependence,tolerance dependence,词,NOUN,C1
-tolerant,tolerant,宽容的,ADJ,B2
-toll,toll,通行费,NOUN,B2
 tomb,tomb,坟墓,NOUN,B2
-tomb monument,tomb monument,词,NOUN,B2
-tombstone,tombstone,词,NOUN,C1
-tome,tome,词,NOUN,C1
 tomorrow,tomorrow,غد,NOUN,B2
-tomorrow night,tomorrow night,明晚,ADV,B2
-tonality,tonality,词,NOUN,C1
 tone,tone,语气,NOUN,B2
-tonic (adj),tonic,词,ADJ,C1
-tonic (noun),tonic,词,NOUN,C1
 tonight,tonight,今晚,NOUN,B2
-tonight (adv),tonight,今晚,ADV,A1
-tonsil,tonsil,词,NOUN,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
 too much,too much,太,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
 too soft,too soft,太软,NOUN,B2
 tool room,tool room,工具间,NOUN,B2
-tooling,tooling,词,NOUN,C1
 tools,tools,工具,NOUN,B2
 toothache,toothache,牙痛,NOUN,B2
-toothbrush,toothbrush,牙刷,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
-top,top,顶部的,ADJ,B2
 top dressing,top dressing,追肥,NOUN,B2
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-topographical,topographical,词,ADJ,C1
 topography,topography,地形,NOUN,B2
 torch,torch,手电筒,NOUN,B2
-torment (noun),torment,词,NOUN,C1
-tormentor,tormentor,词,NOUN,B2
-torments,torments,词,NOUN,B2
 tornado,tornado,龙卷风,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torque,torque,词,NOUN,C1
 torrent,torrent,激流,NOUN,B2
-torrid,torrid,词,ADJ,C1
 torsion,torsion,扭转,NOUN,B2
-torso,torso,躯干,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-tortuous,tortuous,词,ADJ,C1
 torture,to torture,折磨,VERB,B2
-torture ordeal,torture ordeal,词,NOUN,C1
-toss,toss,词,VERB,B2
 total,total,总数,NOUN,B2
-total (noun),total,都加,NOUN,A2
-totalitarian,totalitarian,极权主义的,ADJ,B2
-totalitarianism,totalitarianism,词,NOUN,C1
-totality,totality,词,NOUN,C1
-totem,totem,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
 touchability,touchability,能触摸,NOUN,B2
-touching,touching,动人的,ADJ,B2
-touchstone,touchstone,词,NOUN,C1
-touchy,touchy,易怒的,ADJ,B2
 tough,tough,艰难的,ADJ,B2
-tough guy,tough guy,硬汉,NOUN,B2
 tour,tour,旅行,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
 tourism,tourism,旅游业,NOUN,B2
 tourist,tourist,游客,NOUN,B2
-tourist (adj),tourist,旅游的,ADJ,B2
 touristic,touristic,旅游的,ADJ,B2
-tout,tout,词,VERB,C1
 toward,toward,朝向,ADP,B2
 towards,towards,朝向,ADP,B2
-towards (adv),towards,迎向,ADV,B2
-towering,towering,词,ADJ,B2
 town,town,城镇,NOUN,B2
-town hall,town hall,市政厅,NOUN,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
 township head,township head,乡长,NOUN,B2
-township road,township road,乡道,NOUN,B2
 toxic,toxic,有毒的,ADJ,B2
-toxicity,toxicity,词,NOUN,C1
-toxin,toxin,词,NOUN,C1
-toys,toys,玩具,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
 track,track,轨道,NOUN,B2
 track,to track,追踪,VERB,B2
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracking,tracking,词,NOUN,C1
-tracksuit,tracksuit,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
 tractor,tractor,拖拉机,NOUN,B2
-trade (verb),trade,词,VERB,A2
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
 trade union,trade union,工会,NOUN,B2
-trade unionist,trade unionist,词,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
 tradition,tradition,传统,NOUN,B2
 traditional,traditional,传统的,ADJ,B2
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditionally,traditionally,传统地,ADV,B2
-traditions,traditions,词,NOUN,B1
-traduce,traduce,词,VERB,C1
 traffic jam,traffic jam,交通堵塞,NOUN,B2
-traffic light,traffic light,红绿灯,NOUN,B2
 traffic restriction,traffic restriction,限行,NOUN,B2
-trafficker,trafficker,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-tragically,tragically,悲剧地,ADV,B2
-tragicness,tragicness,词,NOUN,C1
-trail,trail,词,NOUN,B1
 trailer,trailer,预告片,NOUN,B2
 train of thought,train of thought,思路,NOUN,B2
-trained,trained,词,ADJ,C1
 trainee,trainee,实习生,NOUN,B2
-trainer,trainer,教练,NOUN,B2
-trainer bastard,trainer bastard,词,NOUN,B2
-trainieren,coach,教练,NOUN,B2
-trainieren,to coach,辅导,VERB,B2
-training center,training center,培训中心,NOUN,C1
 trait,trait,特征,NOUN,B2
-traits qualities,traits qualities,词,NOUN,C1
-trajectory,trajectory,轨迹,NOUN,B2
-tram,tram,有轨电车,NOUN,B2
 trample,to trample,踩踏,VERB,B2
-trance,trance,词,NOUN,C1
 tranquil,tranquil,宁静的,ADJ,B2
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
 trans-decision,trans-decision,超断,NOUN,B2
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
 trans-guest,trans-guest,超客,NOUN,B2
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transatlantic,transatlantic,词,ADJ,C1
-transcend,transcend,词,VERB,C1
-transcript,transcript,词,NOUN,C1
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferee,transferee,词,NOUN,C1
-transferor,transferor,词,NOUN,C1
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
-transfix,transfix,词,VERB,C1
-transformer converter,transformer converter,词,NOUN,C1
-transhumance,transhumance,词,NOUN,B2
-transient,transient,词,ADJ,C1
-transistor,transistor,词,NOUN,C1
-transit,transit,运输,NOUN,C1
-transition,transition,过渡,NOUN,B2
-transitivity,transitivity,及物性,NOUN,C1
-transitorisch,transitional,过渡的,ADJ,B2
-transitory,transitory,词,ADJ,C1
-translatology,translatology,词,NOUN,C1
-translucent,translucent,词,ADJ,C1
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
-transparent,transparent,透明的,ADJ,B2
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport (adj),transport,词,ADJ,C1
-transport service,transport service,词,NOUN,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transportieren,transport,运输,NOUN,B2
-transportieren,to transport,运输,VERB,B2
-transpose,transpose,词,VERB,C1
-transregional,transregional,词,ADJ,C1
+Transmaterie,trans-matter,超物,NOUN,B2
+Transaktion,transaction,交易,NOUN,B2
+Transzendenz,transcendence,超越,NOUN,B2
 transzendent,transcendent,卓越的,ADJ,B2
 transzendental,transcendental,先验的,ADJ,B2
-trapdoor,trapdoor,活板门,NOUN,B2
-trapped,trapped,词,ADJ,A2
-trapping,trapping,词,NOUN,C1
-trash can,trash can,词,NOUN,A2
-trauma,trauma,创伤,NOUN,B2
-traumatic,traumatic,创伤的,ADJ,B2
-traurig,sad sorrowful,悲伤,ADJ,B2
-travail,travail,词,NOUN,C1
-travesty,travesty,词,NOUN,C1
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
-treacherousness,treacherousness,阴险,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treat,treat,盛宴,NOUN,B2
-treatise,treatise,词,NOUN,C1
-trek (noun),trek,词,NOUN,C1
-trembling,trembling,颤抖的,ADJ,B2
-tremendous,tremendous,词,ADJ,B2
-tremulous,tremulous,颤抖的,ADJ,B2
-trench coat,trench coat,词,NOUN,C1
-trenchant,trenchant,词,ADJ,C1
-trending,trending,词,ADJ,C1
-trennen,to disconnect,断开,VERB,B2
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-treten,kick,踢,NOUN,B2
-treten,to kick,踢,VERB,B2
-trial run,trial run,词,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tricky,tricky,词,ADJ,B2
-tricolor,tricolor,词,ADJ,C1
-trifling,trifling,微不足道的,ADJ,B2
-trigger (adj),trigger,词,ADJ,C1
-trigger imprint,trigger imprint,印记,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-triggering,triggering,触发,NOUN,B2
-trigonometry,trigonometry,词,NOUN,C1
-trilemma,trilemma,三难困境,NOUN,B2
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trilogy,trilogy,词,NOUN,B2
-trim,trim,词,VERB,C1
-trinket,trinket,小饰品,NOUN,B2
-trite,trite,陈腐的,ADJ,B2
-triumph,triumph,胜利,NOUN,B2
-trivia,trivia,词,NOUN,C1
-trivial,trivial,琐碎的,ADJ,B2
-trivializable,trivializable,可轻描淡写的,ADJ,B2
-trocar,trocar,词,NOUN,C1
-troglodyte,troglodyte,词,NOUN,C1
-troop dispatch,troop dispatch,出兵,NOUN,B2
-tropic,tropic,词,NOUN,C1
-tropical,tropical,热带的,ADJ,B2
-trotz,to in spite of,不顾,VERB,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
-troubling,troubling,词,ADJ,B2
-trout,trout,词,NOUN,C1
-trowel,trowel,词,NOUN,B2
-truculent,truculent,词,ADJ,C1
-true qi,true qi,真气,NOUN,C1
-truism,truism,自明之理,NOUN,B2
-truly,truly,词,ADV,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trust in God,trust in God,词,NOUN,C1
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
-träge,sluggish,迟钝的,ADJ,B2
-trösten,to console,安慰,VERB,B2
-tsunami,tsunami,海啸,NOUN,C1
-tuberculosis,tuberculosis,结核病,NOUN,B2
-tug,tug,词,VERB,C1
-tumble (noun),tumble,词,NOUN,C1
-tumor,tumor,肿瘤,NOUN,B2
-tumoral,tumoral,词,ADJ,C1
-tumult,tumult,词,NOUN,C1
-tumultuous,tumultuous,词,ADJ,C1
-tun,to do to make,做,VERB,B2
-tuning,tuning,词,NOUN,C1
-turban,turban,词,NOUN,B2
-turbid,turbid,词,ADJ,C1
-turbine,turbine,词,NOUN,C1
-turbulence,turbulence,词,NOUN,C1
-turbulent,turbulent,动荡的,ADJ,B2
-turgid,turgid,词,ADJ,C1
-turkey,turkey,火鸡,NOUN,B2
-turkish,turkish,土耳其的,ADJ,B2
-turmeric,turmeric,词,NOUN,B2
-turn of phrase,turn of phrase,词,NOUN,C1
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
-turntable,turntable,,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
-tutelary,tutelary,词,ADJ,C1
-tutor,tutor,导师,NOUN,C1
-tv,tv,电视,NOUN,B2
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-tweezers,tweezers,词,NOUN,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
-twist (noun),twist,词,NOUN,C1
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
-two-headed,two-headed,双头的,ADJ,B2
-twofold,twofold,双重的,ADJ,B2
-tycoon,tycoon,词,NOUN,C1
-type like,type like,词,NOUN,B2
-typically,typically,词,ADV,C1
-typographical,typographical,词,ADJ,B2
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
-täglich,daily,每天,ADV,B2
-tödlich,deadly,致命的,ADJ,B2
-töricht,foolish,愚蠢的,ADJ,B2
-ubiquitous,ubiquitous,词,ADJ,C1
-ukrainian,ukrainian,乌克兰的,ADJ,B2
-ulterior,ulterior,词,ADJ,C1
-ultimate,ultimate,最终的,ADJ,B2
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
-um,um,嗯,INTJ,B2
-um Spenden bitten,to solicit donations,募捐,VERB,B2
-um zu,in order to,以期,SCONJ,B2
-umarmen,embrace,拥抱,NOUN,B2
-umarmen,to embrace,拥抱,VERB,B2
-umbrage,umbrage,词,NOUN,C1
-umfassen,to encompass,包含,VERB,B2
-umfassend,comprehensive,全面的,ADJ,B2
-umgehen,to evade,逃避,VERB,B2
-umgekehrt,conversely,相反地,ADV,B2
-umgekehrte Inklusion,reverse inclusion,反纳,NOUN,B2
-umgekehrte Reflexion,reverse reflection,反影,NOUN,B2
-umgänglich,affable,和蔼可亲的,ADJ,B2
-umherstreifen,to roam,漫游,VERB,B2
-umleiten,to divert,转移,VERB,B2
-umreißen,outline,大纲,NOUN,B2
-umreißen,to outline,勾勒,VERB,B2
-umschreiben,to circumscribe,限制,VERB,B2
-umwandeln,to convert,转换,VERB,B2
-umweltbezogen,environmental,环境的,ADJ,B2
-umwerfen,to overturn,打翻,VERB,B2
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unangemessen,improper,不合适的,ADJ,B2
-unangemessen,inappropriate,不恰当的,ADJ,B2
-unanimity,unanimity,词,NOUN,C1
-unannehmbar,unacceptable,不可接受的,ADJ,B2
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
-unbelieving,unbelieving,词,ADJ,C1
-unbequem,uncomfortable,不舒服的,ADJ,B2
-unbestreitbar,undeniable,不可否认的,ADJ,B2
-unbeugsam,intractable,难处理的,ADJ,B2
-unbridled,unbridled,肆无忌惮的,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
-uncompromising,uncompromising,词,ADJ,B2
-unconditional,unconditional,无条件的,ADJ,B2
-unconquerable,unconquerable,词,ADJ,C1
-unconscious (noun),unconscious,词,NOUN,C1
-unconsciousness,unconsciousness,词,NOUN,C1
-uncountable,uncountable,词,ADJ,C1
-uncouth,uncouth,粗俗的,ADJ,B2
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,词,ADJ,B2
-unctuous,unctuous,谄媚的,ADJ,B2
-uncultivated,uncultivated,词,ADJ,B2
-und so weiter,and so forth,依此类推,ADV,B2
-undaunted,undaunted,词,ADJ,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under below,under below,在...下方,ADP,A2
-underclass,underclass,底层,NOUN,B2
-undercover agent,undercover agent,卧底,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
-underground,underground,地下的,ADJ,B2
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underling,underling,词,NOUN,C1
-underlying,underlying,词,ADJ,B2
-undermining authority,undermining authority,削弱权威,NOUN,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-understanding,understanding,体贴的,ADJ,B2
-understood,understood,词,ADJ,A1
-undervaluing,undervaluing,词,NOUN,C1
-underwater,underwater,词,ADJ,B2
-underworld,underworld,地下世界,NOUN,B2
-undeserved,undeserved,词,ADJ,C1
-undisturbed,undisturbed,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undoubtedly,undoubtedly,无疑地,ADV,B2
-undulate,undulate,词,VERB,C1
-undurchdringlich,impenetrable,不可穿透的,ADJ,B2
-unearned,unearned,浪得,NOUN,C1
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
-unentbehrlich,indispensable,不可或缺的,ADJ,B2
-unequivocal,unequivocal,词,ADJ,C1
-unerfahren,inexperienced,生疏的,ADJ,B2
-unerlaubt,not allowed,不准,ADJ,B2
-unerreichbar,unattainable,难以获得的,ADJ,B2
-unerring,unerring,词,ADJ,C1
-unersetzlich,irreplaceable,不可替代的,ADJ,B2
-unerträglich,unbearable,难以忍受的,ADJ,B2
-unerwartet,unexpectedly,出乎意料地,ADV,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected event,unexpected event,变故,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful,unfaithful,不忠的,ADJ,B2
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfettered,unfettered,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
-unfolding,unfolding,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable,unforgivable,不可原谅的,ADJ,B2
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfounded,unfounded,词,ADJ,C1
-unfriendly,unfriendly,不友好的,ADJ,B2
-ungainly,ungainly,笨拙的,ADJ,B2
-ungeduldig,impatient,不耐烦的,ADJ,B2
-ungerecht,unjust,不公正的,ADJ,B2
-ungeschickt,clumsy,笨拙的,ADJ,B2
-ungezogen,naughty,淘气的,ADJ,B2
-ungleich,unequal,不平等的,ADJ,B2
-unglücklich,unfortunate,不幸的,ADJ,B2
-unglücklich,unlucky,倒霉的,ADJ,B2
-ungodliness,ungodliness,词,NOUN,C1
-ungrateful,ungrateful,忘恩负义的,ADJ,B2
-unhappiness,unhappiness,词,NOUN,C1
-unharmed,unharmed,未受伤的,ADJ,B2
-unhealthy,unhealthy,词,ADJ,C1
-unhurried patience,unhurried patience,词,NOUN,C1
-unhöflich,rude,粗鲁的,ADJ,B2
-unicorn,unicorn,词,NOUN,C1
-unification,unification,词,NOUN,B2
-unified examination,unified examination,统考,NOUN,B2
-uniform,uniform,制服,NOUN,B2
-uniformity,uniformity,词,NOUN,B2
-unilateral,unilateral,单方面的,ADJ,B2
-unilateralism,unilateralism,词,NOUN,C1
-unimpeachable,unimpeachable,词,ADJ,C1
-unimpeded,unimpeded,词,ADJ,C1
-uninhabited,uninhabited,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
-union (adj),union,词,ADJ,C1
-unionist,unionist,词,ADJ,B2
-unique (noun),unique,词,NOUN,B2
-universal,universal,普遍的,ADJ,B2
-universal total,universal total,词,ADJ,C1
-universelle Anwendbarkeit,universal applicability,普适性,NOUN,B2
-universities,universities,大学,NOUN,B2
-university (adj),university,词,ADJ,C1
-university of applied sciences,university of applied sciences,词,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unknown,unknown,未知数,NOUN,B2
-unkompliziert,straightforward,直率的,ADJ,B2
-unkontrollierbar,uncontrollable,无法控制的,ADJ,B2
-unleashed,unleashed,词,ADJ,C1
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlimited,unlimited,无限的,ADJ,B2
-unlocked,unlocked,词,NOUN,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unmitigated,unmitigated,词,ADJ,C1
-unnatural,unnatural,词,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unobtrusive,unobtrusive,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
-unordentlich,disorderly,杂乱的,ADJ,B2
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unparteiisch,disinterested,公正的,ADJ,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
-unprecedented,unprecedented,史无前例的,ADJ,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpublished,unpublished,词,ADJ,B2
-unpunished,unpunished,词,ADJ,C1
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreality,unreality,虚幻,NOUN,B2
-unreasonable,unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unreflective,unreflective,词,ADJ,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
-unruhig,uneasy,不安的,ADJ,B2
-uns,us,你我,NOUN,B2
-unsafe,unsafe,词,ADJ,B1
-unscathed,unscathed,未受伤害的,ADJ,B2
-unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unsecured,unsecured,词,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unseen realities,unseen realities,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicher,uncertain,不确定的,ADJ,B2
-unsociable,unsociable,词,ADJ,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsuccessful,unsuccessful,词,ADJ,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-untenable,untenable,词,ADJ,C1
-unter,among,在……之中,ADP,B2
-unterbringen,to accommodate,容纳,VERB,B2
-unterdrücken,to oppress,压迫,VERB,B2
-untergraben,to undermine,破坏,VERB,B2
-unterlassen,to desist,停止,VERB,B2
-unterlegen,inferior,低等的,ADJ,B2
-unterstützen,to endorse,支持,VERB,B2
-untersuchen,to scrutinize,仔细检查,VERB,B2
-untertauchen,to submerge,淹没,VERB,B2
-unterwerfen,to subjugate,征服,VERB,B2
-unterzeichnen,to underwrite,承保,VERB,B2
-unthinkable,unthinkable,不可想象的,ADJ,B2
-untidiness,untidiness,凌乱,NOUN,B2
-untidy,untidy,词,ADJ,C1
-until (sconj),until,直到,SCONJ,A1
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouchable,untouchable,不可触碰的,ADJ,B2
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untrennbar,inseparable,不可分割的,ADJ,B2
-unverblümt,bluntly,直率地,ADV,B2
-unvereinbar,irreconcilable,不可调和的,ADJ,B2
-unvermeidlich,inevitable,不可避免的,ADJ,B2
-unvernünftig,unreasonable,不合理的,ADJ,B2
-unverschämt,impudent,无礼的,ADJ,B2
-unverschämt,insolent,傲慢的,ADJ,B2
-unversehrt,intact,完好无损的,ADJ,B2
-unverwischbar,indelible,不可磨灭的,ADJ,B2
-unverzüglich,promptly,迅速地,ADV,B2
-unviable,unviable,词,ADJ,C1
-unvollständig,incomplete,不完整的,ADJ,B2
-unvorstellbar,unimaginable,难以想象的,ADJ,B2
-unwanted,unwanted,不受欢迎的,ADJ,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unwiderlegbar,irrefutable,无可辩驳的,ADJ,B2
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwise,unwise,词,ADJ,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
-unzufrieden,dissatisfied,不满的,ADJ,B2
-unzureichend,insufficient,不足的,ADJ,B2
-unüberwindlich,insurmountable,不可逾越的,ADJ,B2
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbraid,upbraid,词,VERB,C1
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-upheaval,upheaval,剧变,NOUN,B2
-uphold,uphold,词,VERB,C1
-upholding of rights,upholding of rights,词,NOUN,C1
-upload (noun),upload,词,NOUN,C1
-upper class,upper class,上层,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upright,upright,直立地,ADV,B2
-uprightness,uprightness,词,NOUN,B2
-uprooted,uprooted,词,ADJ,C1
-ups and downs,ups and downs,词,NOUN,B2
-upset,upset,心烦的,ADJ,B2
-upshot,upshot,词,NOUN,C1
-upstart,upstart,暴发户,NOUN,B2
-upstart (adj),upstart,词,ADJ,C1
-upward,upward,向上,ADV,B2
-upwards,upwards,向上,ADV,B2
-urban area,urban area,词,NOUN,C1
-urbane,urbane,词,ADJ,C1
-urbanism,urbanism,词,NOUN,B2
-urbanization,urbanization,城市化,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urine,urine,尿,NOUN,C1
-ursprünglich,originally,最初,ADV,B2
-us (noun),us,你我,NOUN,B2
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
-usb flash drive,usb flash drive,U盘,NOUN,B2
-usefulness avail,usefulness avail,效用,NOUN,C1
-useless zero,useless zero,词,ADJ,A2
-uselessly,uselessly,词,ADV,C1
-using this,using this,用这,NOUN,C1
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-usurpation,usurpation,词,NOUN,C1
-usurpieren,to usurp,篡夺,VERB,B2
-usury,usury,词,NOUN,C1
-utensil,utensil,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
-utilitaristisch,utilitarian,功利的,ADJ,B2
-utility,utility,效用,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
-utmost extreme end,utmost extreme end,词,NOUN,C1
-utopisch,utopian,乌托邦式的,ADJ,B2
-utter,utter,词,ADJ,C1
-utterance-related,utterance-related,词,ADJ,C1
-vacant lot,vacant lot,空地,NOUN,C1
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccinal,vaccinal,词,ADJ,C1
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vacillate,vacillate,词,VERB,C1
-vacuous,vacuous,词,ADJ,C1
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum cleaner,vacuum cleaner,词,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vagabond,vagabond,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
-vagary,vagary,词,NOUN,C1
-vage,vague,含糊的,ADJ,B2
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vaguely,vaguely,词,ADV,C1
-vagueness,vagueness,模糊,NOUN,C1
-vain,vain,徒劳的,ADJ,B2
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vainglory,vainglory,词,NOUN,C1
-vakant,vacant,空缺的,ADJ,B2
-valedictory,valedictory,词,ADJ,C1
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
-valid,valid,有效的,ADJ,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-valve,valve,词,NOUN,C1
-vanilla,vanilla,词,NOUN,C1
-vanishing,vanishing,词,NOUN,C1
-vanquish,vanquish,词,VERB,C1
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
-variable,variable,多变的,ADJ,B2
-variables,variables,词,NOUN,C1
-variant,variant,变体,NOUN,B2
-variation,variation,变化,NOUN,B2
-variegate,variegate,词,VERB,C1
-various,various,各种各样的,ADJ,B2
-varnish,varnish,清漆,NOUN,B2
-varying,varying,词,ADJ,B2
-vase,vase,花瓶,NOUN,B2
-vassal,vassal,之臣,NOUN,C1
-vastness,vastness,词,NOUN,B2
-vat,vat,增值税,NOUN,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunt,vaunt,词,VERB,C1
-vaunted,vaunted,词,ADJ,B2
-vector,vector,词,NOUN,C1
-veer,veer,词,VERB,C1
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vehemence,vehemence,词,NOUN,C1
-vehement,vehement,激烈的,ADJ,B2
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiled,veiled,隐晦的,ADJ,B2
-velarization,velarization,词,NOUN,C1
-vending machine,vending machine,自动售货机,NOUN,B2
-veneer,veneer,词,NOUN,C1
-venereal disease,venereal disease,性病,NOUN,B2
-venial,venial,词,ADJ,C1
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-venture (noun),venture,词,NOUN,B2
-verabreichen,to dispense medicine,配药,VERB,B2
-verabscheuen,to abhor,憎恶,VERB,B2
-verabscheuen,to detest,厌恶,VERB,B2
-verabscheuungswürdig,detestable,可恶的,ADJ,B2
-verachtenswert,despicable,可鄙的,ADJ,B2
-veracity,veracity,词,NOUN,C1
-veraltet,obsolete,过时的,ADJ,B2
-veraltet,outdated,过时的,ADJ,B2
-verantwortlich sein für,to be responsible for,负责,VERB,B2
-verantwortungslos,irresponsible,不负责任的,ADJ,B2
-verbal,verbal,词,ADJ,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbalize,verbalize,词,VERB,B2
-verbannen,exile,流亡,NOUN,B2
-verbannen,to banish,流放,VERB,B2
-verbannen,to exile,流放,VERB,B2
-verbatim,verbatim,词,ADV,C1
-verbieten,ban,禁令,NOUN,B2
-verbieten,to ban,禁止,VERB,B2
-verbittert,resentful,充满愤恨的,ADJ,B2
-verbosely,verbosely,词,ADV,C1
-verboten,forbidden,被禁止的,ADJ,B2
-verbotenes Land,forbidden land,禁地,NOUN,B2
-verbrannt,burnt,烧焦的,ADJ,B2
-verbrauchen,to consume,消费,VERB,B2
-verbreiten,to disseminate,传播,VERB,B2
-verbrennen,to incinerate,焚烧,VERB,B2
-verbrühen,to scald,烫伤,VERB,B2
-verdammt,damn,该死,INTJ,B2
-verdant,verdant,词,ADJ,C1
-verdauend,digestive,消化的,ADJ,B2
-verdienen,to deserve,值得,VERB,B2
-verdrehen,to twist,扭曲,VERB,B2
-verdreht,twisted,扭曲的,ADJ,B2
-veredeln,to refine,提炼,VERB,B2
-veredelt,refined,精炼的,ADJ,B2
-verehren,to revere,尊敬,VERB,B2
-vereinigen,to unify,统一,VERB,B2
-verfassungsmäßig,constitutional,宪法的,ADJ,B2
-verfestigen,to entrench,巩固,VERB,B2
-verfolgen,chase,追逐,NOUN,B2
-verfolgen,to chase,追逐,VERB,B2
-verformen,to deform,使变形,VERB,B2
-verformt,deformed,畸形的,ADJ,B2
-verfälschen,to adulterate,掺杂,VERB,B2
-verführen,to seduce,引诱,VERB,B2
-vergangen,bygone,过去的,ADJ,B2
-verge,verge,词,NOUN,C1
-vergehen,to perish,死亡,VERB,B2
-verifiable,verifiable,词,ADJ,C1
-verification,verification,词,NOUN,C1
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkörpern,to embody,体现,VERB,B2
-verkünden,to promulgate,颁布,VERB,B2
-verlassen,to abandon,放弃,VERB,B2
-verleihen,to bestow,授予,VERB,B2
-verletzen,to infringe,侵犯,VERB,B2
-verletzt,injured,受伤的,ADJ,B2
-verleumden,slander,诽谤,NOUN,B2
-verleumden,to slander,诽谤,VERB,B2
-verliebt,in love,恋爱中的,ADJ,B2
-verlocken,to entice,引诱,VERB,B2
-verlängern,to prolong,延长,VERB,B2
-vermeintlich,alleged,所谓的,ADJ,B2
-vermilion,vermilion,词,NOUN,B2
-vermisst,missing,失踪的,ADJ,B2
-vernachlässigbar,negligible,微不足道的,ADJ,B2
-vernacular,vernacular,词,NOUN,C1
-vernichten,to annihilate,消灭,VERB,B2
-vernichtende Niederlage,crushing defeat,惨败,NOUN,B2
-vernier,vernier,词,NOUN,C1
-vernähen,suture,缝合,NOUN,B2
-vernähen,to suture,缝合,VERB,B2
-vernünftig,sensible,明智的,ADJ,B2
-verpflichtend,mandatory,强制的,ADJ,B2
-verpfänden,mortgage,抵押贷款,NOUN,B2
-verpfänden,to mortgage,抵押,VERB,B2
-verringern,to diminish,减少,VERB,B2
-verräterisch,treacherous,背叛的,ADJ,B2
-verrückt,insane,疯狂的,ADJ,B2
-versatile,versatile,多才多艺的,ADJ,B2
-versatility,versatility,词,NOUN,B2
-verschieben,shift,轮班,NOUN,B2
-verschieben,to shift,改变,VERB,B2
-verschiedene Abteilungen,various departments,各部,NOUN,B2
-verschiffen,to ship out,出货,VERB,B2
-verschlechtern,to deteriorate,恶化,VERB,B2
-verschlingen,to devour,吞食,VERB,B2
-verschmutzt,polluted,受污染的,ADJ,B2
-verschwenden,to squander,浪费,VERB,B2
-verschwenderisch,wasteful,浪费的,ADJ,B2
-verschwinden,to vanish,消失,VERB,B2
-verschwören,to collude,勾结,VERB,B2
-verschönern,to embellish,装饰,VERB,B2
-verse,verse,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versengen,to scorch,烧焦,VERB,B2
-versiert,versed,精通的,ADJ,B2
-versification,versification,词,NOUN,C1
-versprechend,promising,有前途的,ADJ,B2
-verstaatlichen,to nationalize,国有化,VERB,B2
-verstehen,to comprehend,理解,VERB,B2
-verstoßen,to contravene,违反,VERB,B2
-verstreuen,to scatter,分散,VERB,B2
-verstreut,scattered,分散的,ADJ,B2
-verstricken,to entangle,使纠缠,VERB,B2
-verstärken,to amplify,放大,VERB,B2
-versus,versus,对,ADP,B2
-versöhnen,to reconcile,和解,VERB,B2
-vertebra,vertebra,词,NOUN,B2
-verteidigen,to defend one's country,卫国,VERB,B2
-vertex,vertex,词,NOUN,C1
-vertiefen,to deepen,加深,VERB,B2
-vertigo,vertigo,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertikal,vertical,垂直的,ADJ,B2
-vertrauenswürdig,trustworthy,值得信赖的,ADJ,B2
-vertreiben,to expel,开除,VERB,B2
-verurteilen,to convict,定罪,VERB,B2
-verurteilen,to denounce,谴责,VERB,B2
-verweigern,won't do,不行,ADJ,B2
-verweigern,to won't do,不成,VERB,B2
-verweisen,to refer,参考,VERB,B2
-verwerfen,to discard,丢弃,VERB,B2
-verwirrt,confused,困惑的,ADJ,B2
-verwirrt,muddled,混乱的,ADJ,B2
-verwundet,wounded,受伤的,ADJ,B2
-verwüsten,to devastate,摧毁,VERB,B2
-verwüsten,to ravage,破坏,VERB,B2
-very best,very best,词,ADJ,B2
-very deep,very deep,很深,ADJ,B2
-very fine,very fine,词,ADJ,C1
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-verzaubert sein,to be entranced,出神,VERB,B2
-verzeihen,pardon,赦免,NOUN,B2
-verzeihen,to pardon,赦免,VERB,B2
-verzichten,refrain,副歌,NOUN,B2
-verzichten,to refrain,克制,VERB,B2
-veränderter Mechanismus,altered mechanism,改机,NOUN,B2
-vestige,vestige,词,NOUN,C1
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-viable,viable,可行的,ADJ,B2
-vial,vial,词,NOUN,C1
-vibrant,vibrant,词,ADJ,C1
-vicarious,vicarious,词,ADJ,C1
-vice versa,vice versa,反之亦然,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
-vicious,vicious,词,ADJ,B2
-vicissitude,vicissitude,变迁,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-video clip,video clip,词,NOUN,C1
-video on demand,video on demand,点播,NOUN,C1
-videotape,videotape,词,NOUN,C1
-viewer,viewer,观众,NOUN,B2
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigilant,vigilant,警惕的,ADJ,B2
-vignette,vignette,词,NOUN,C1
-vigor of prime,vigor of prime,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
-vile,vile,可憎地,ADV,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-villainy,villainy,邪恶,NOUN,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vineyard,vineyard,葡萄园,NOUN,C1
-vintage,vintage,佳酿,NOUN,B2
-violate regulations,violate regulations,违规,VERB,C1
-violations,violations,词,NOUN,C1
-violent act,violent act,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violet (noun),violet,词,NOUN,B2
-viper,viper,词,NOUN,B2
-viral,viral,病毒性的,ADJ,C1
-virginal,virginal,处女的,ADJ,B2
-virtual reality,virtual reality,虚拟现实,NOUN,B2
-virtuell,virtual,虚拟的,ADJ,B2
-virtuoso,virtuoso,词,NOUN,C1
-virulent,virulent,恶性的,ADJ,B2
-viscosity,viscosity,词,NOUN,C1
-viscount,viscount,词,NOUN,C1
-visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
-visionary,visionary,词,NOUN,C1
-visiting ban,visiting ban,,NOUN,B2
-viskos,viscous,黏稠的,ADJ,B2
-visualize,visualize,词,VERB,C1
-visuell,visual,视觉的,ADJ,B2
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vitiate,vitiate,词,VERB,C1
-vitriolic,vitriolic,词,ADJ,C1
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
-vocabulary,vocabulary,词,NOUN,C1
-vocal range,vocal range,词,NOUN,C1
-vocalization,vocalization,词,NOUN,C1
-vocation,vocation,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vociferous,vociferous,词,ADJ,C1
-vogue,vogue,流行,NOUN,B2
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-voicing,voicing,词,NOUN,C1
-void,void,最无,NOUN,B2
-vokal,vocal,直言的,ADJ,B2
-volatil,volatile,易变的,ADJ,B2
-volatility,volatility,词,NOUN,C1
-volcanic,volcanic,词,ADJ,C1
-volition,volition,词,NOUN,C1
-volle Leistung,full power,全力,NOUN,B2
-voller Name,full name,大名,NOUN,B2
-volleyball,volleyball,排球,NOUN,B2
-vollständig,entirely,完全地,ADV,B2
-voltage,voltage,词,NOUN,C1
-voluble,voluble,词,ADJ,C1
-volume measure,volume measure,词,NOUN,B2
-volumetric,volumetric,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-voluntariness,voluntariness,词,NOUN,C1
-voluntarist,voluntarist,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
-volunteering,volunteering,志愿服务,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-vomit (noun),vomit,词,NOUN,B2
-vomiting,vomiting,词,NOUN,C1
-von,of,的,ADP,B2
-von Kindheit an,from childhood,从小,ADV,B2
-von nun an,from now on,今后,ADV,B2
-vor,in front of,在……前面,ADP,B2
-voracious,voracious,词,ADJ,C1
-voracity,voracity,词,NOUN,C1
-vorangehen,to go first,先去,VERB,B2
-vorausgesetzt,provided that,只要,SCONJ,B2
-vorbeigehen,to pass by,经过,VERB,B2
-vorbereiten,to prepare a lesson,预习,VERB,B2
-voreingenommen,biased,有偏见的,ADJ,B2
-vorhergehen,to precede,在...之前,VERB,B2
-vorhersagen,to predict,预测,VERB,B2
-vorladen,to summon,召唤,VERB,B2
-vorläufig,tentative,暂定的,ADJ,B2
-vorrücken,advance,进展,NOUN,B2
-vorrücken,to advance,前进,VERB,B2
-vorschlagen,to propose,提议,VERB,B2
-vorsichtig,cautious,小心的,ADJ,B2
-vorsichtig und gewissenhaft,cautious and conscientious,兢兢业业,ADJ,B2
-vorstellen,to envision,展望,VERB,B2
-vorteilhaft,advantageous,有利的,ADJ,B2
-vortragen,to carry forward,发扬,VERB,B2
-vorverlegen,to shift to an earlier date,提前,VERB,B2
-votary,votary,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
-votive offering,votive offering,词,NOUN,C1
-vouch,vouch,词,VERB,C1
-vouchsafe,vouchsafe,词,VERB,C1
-vowel,vowel,词,NOUN,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vs,vs,与...相对,ADP,B2
-vulgär,vulgar,粗俗的,ADJ,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulnerable,vulnerable,易受伤害的,ADJ,B2
-vulture,vulture,词,NOUN,B2
-wackelig,flimsy,脆弱的,ADJ,B2
-wackeln,to wobble,摇晃,VERB,B2
-wading,wading,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-waft,waft,词,VERB,C1
-wage earner,wage earner,词,NOUN,C1
-wage murder unit,wage murder unit,词,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-wager,wager,词,NOUN,C1
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wahre Form,true form,原形,NOUN,B2
-wahre Konzession,true concession,真让,NOUN,B2
-wahres Herz,true heart,本心,NOUN,B2
-wailing,wailing,词,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waive,waive,词,VERB,C1
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-walker,walker,词,NOUN,C1
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wall-mounted,wall-mounted,词,ADJ,C1
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
-wan,wan,词,ADJ,B2
-wanderer,wanderer,词,NOUN,C1
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
-wandern,to wander,漫步,VERB,B2
-want (adp),want,我要,ADP,A2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warble (verb),warble,词,VERB,C1
-warehouse store,warehouse store,词,NOUN,B1
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,词,ADJ,B2
-warmly,warmly,热情地,ADV,B2
-warmonger,warmonger,词,NOUN,C1
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrant,warrant,令状,NOUN,B2
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wary,wary,谨慎的,ADJ,B2
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-washer,washer,词,NOUN,B2
-wasserdicht,waterproof,防水的,ADJ,B2
-waste disposal site,waste disposal site,词,NOUN,B1
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wastewater,wastewater,废水,NOUN,C1
-watch of the night,watch of the night,词,NOUN,C1
-watched,watched,词,NOUN,B2
-watchmaking,watchmaking,词,NOUN,C1
-watchtower,watchtower,词,NOUN,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water garment,water garment,水衣,NOUN,C1
-water heater,water heater,热水器,NOUN,B2
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-watercourse,watercourse,河道,NOUN,B1
-watering,watering,词,NOUN,B2
-waterproof (verb),waterproof,词,VERB,C1
-watershed,watershed,词,NOUN,C1
-waterskin,waterskin,词,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-wax,wax,蜡,NOUN,B2
-waxen,waxen,词,ADJ,C1
-waylay,waylay,词,VERB,C1
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weakened,weakened,词,ADJ,C1
-weakening,weakening,减弱,NOUN,B2
-weakly,weakly,词,ADV,C1
-weal,weal,词,NOUN,C1
-wealthy,wealthy,富有的,ADJ,B2
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
-weapon arms,weapon arms,词,NOUN,A1
-wear,wear,磨损,NOUN,B2
-wear tear,wear tear,词,NOUN,C1
-wearily,wearily,词,ADV,C1
-wearisome,wearisome,词,ADJ,C1
-weary,weary,疲倦的,ADJ,B2
-weather forecast,weather forecast,词,NOUN,B1
-weather institute,weather institute,词,NOUN,B2
-weathering,weathering,词,NOUN,C1
-weaver,weaver,词,NOUN,B1
-wechseln,to alternate,交替,VERB,B2
-wecken,to rouse,唤醒,VERB,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weeping,weeping,痛哭,NOUN,C1
-wehklagen,to sigh with sorrow,感慨,VERB,B2
-weibliche Verwandte,female relatives,女眷,NOUN,B2
-weighing,weighing,词,NOUN,B2
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
-weinen,to weep,哭泣,VERB,B2
-weitschweifig,verbose,冗长的,ADJ,B2
-welcher,which one,哪一个,PRON,B2
-welcome (intj),welcome,词,INTJ,A1
-welcome committee,welcome committee,,NOUN,B2
-welcoming,welcoming,舒适的,ADJ,B2
-weld,weld,词,VERB,C1
-welder,welder,词,NOUN,C1
-welfare home,welfare home,福利院,NOUN,C1
-well known,well known,家喻户晓,ADJ,C1
-well-crafted,well-crafted,词,ADJ,B2
-well-disposed,well-disposed,词,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-liked,well-liked,词,ADJ,B2
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welter,welter,词,NOUN,C1
-weltweite Aufmerksamkeit erhalten,to receive worldwide attention,举世瞩目,VERB,B2
-wen,whom,谁,PRON,B2
-wend,wend,词,VERB,C1
-wenig,a little,一点,ADJ,B2
-wenige,few,很少的,ADJ,B2
-wenn,when,当...时,SCONJ,B2
-werewolf,werewolf,狼人,NOUN,B2
-western,western,西方的,ADJ,B2
-westerner,westerner,词,NOUN,B2
-westward,westward,向西,ADV,B2
-westward (noun),westward,往西,NOUN,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wetteifern,to vie,竞争,VERB,B2
-wetten,gamble,赌博,NOUN,B2
-wetten,to gamble,赌博,VERB,B2
-wharf,wharf,码头,NOUN,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
-when (adp),when,之时,ADP,B2
-when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-whereas (cconj),whereas,词,CCONJ,B2
-whereas (sconj),whereas,词,SCONJ,C1
-whereas since,whereas since,词,SCONJ,A2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whet,whet,词,VERB,C1
-whether (part),whether,词,PART,A1
-whey,whey,乳清,NOUN,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
-whiny,whiny,词,ADJ,C1
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
-whisk,whisk,打蛋器,NOUN,B2
-whisk whip,whisk whip,词,NOUN,B1
-whistleblower,whistleblower,词,NOUN,C1
-whistling,whistling,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whiting,whiting,词,NOUN,B2
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-wholehearted,wholehearted,词,ADJ,C1
-wholesale (adv),wholesale,词,ADV,B1
-wholesome,wholesome,词,ADJ,C1
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
-wicked,wicked,邪恶的,ADJ,B2
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,加宽,NOUN,B2
-widerlegen,to rebut,反驳,VERB,B2
-widersprechen,to disagree,不同意,VERB,B2
-widersprechen,to oppose,反对,VERB,B2
-widersprüchlich,contradictory,矛盾的,ADJ,B2
-widersprüchlich,inconsistent,不一致的,ADJ,B2
-widmen,to dedicate,致力于,VERB,B2
-widmen,to devote,奉献,VERB,B2
-widower,widower,词,NOUN,C1
-widowhood,widowhood,词,NOUN,C1
-wie,as,像,ADP,B2
-wie in der Vergangenheit,just as in the past,一如既往,ADV,B2
-wie viel,how much,多少,PRON,B2
-wie viele,how many,多少,NUM,B2
-wieder aufnehmen,to resume,重新开始,VERB,B2
-wiederaufbauen,to rebuild,重建,VERB,B2
-wiedererzählen,to retell,转述,VERB,B2
-wiederherstellen,to restore,恢复,VERB,B2
-wiederholen,to reiterate,重申,VERB,B2
-wiederholt,repeatedly,反复地,ADV,B2
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wig,wig,假发,NOUN,B2
-wild,fierce,凶猛的,ADJ,B2
-wild,wild,野生的,ADJ,B2
-wild beast,wild beast,词,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will shall,will shall,将要/会,AUX,B2
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
-willentlich,willful,任性的,ADJ,B2
-willing,willing,肯,AUX,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willkürlich,arbitrary,任意的,ADJ,B2
-willow,willow,词,NOUN,B2
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-win,win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-winddicht,windproof,挡风的,ADJ,B2
-winden,wind,风,NOUN,B2
-winden,to wind,缠绕,VERB,B2
-windfall,windfall,意外之财,NOUN,B2
-winding,winding,蜿蜒的,ADJ,B2
-windless,windless,无风的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
-windowsill,windowsill,窗台,NOUN,C1
-windy day,windy day,风天,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
-winsome,winsome,词,ADJ,C1
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wintry,wintry,冬天的,ADJ,B2
-wir,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
-wir beide,we two,我俩,PRON,B2
-wired,wired,词,ADJ,C1
-wirtschaftlich,economic,经济的,ADJ,B2
-wischen,to wipe,擦,VERB,B2
-wisely,wisely,明智地,ADV,B2
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wissenschaftlich,scientific,科学的,ADJ,B2
-wistful,wistful,词,ADJ,C1
-wit,wit,词,NOUN,C1
-witchcraft,witchcraft,巫术,NOUN,B2
-with me,with me,词,PRON,A1
-with that,with that,以此,ADV,B2
-with the aim of,with the aim of,词,ADP,C1
-with this,with this,以此,ADV,B2
-with which,with which,词,PRON,A2
-with you,with you,词,PRON,A1
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawal fold,withdrawal fold,词,NOUN,C1
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without further ado,without further ado,毫不犹豫地,ADV,B2
-withstand,withstand,词,VERB,C1
-witness examination,witness examination,证人询问,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,词,NOUN,C1
-wittiness,wittiness,风趣,NOUN,B2
-witty saying,witty saying,词,NOUN,C1
-wizened,wizened,词,ADJ,C1
-woe (noun),woe,词,NOUN,C1
-wohlhabend,prosperous,繁荣的,ADJ,B2
-wohlwollend,benevolent,仁慈的,ADJ,B2
-wohlüberlegt,well-considered,深思熟虑的,ADJ,B2
-wohnen,to reside,居住,VERB,B2
-wollen,willing,乐意的,ADJ,B2
-wollen,to want,想要,VERB,B2
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wonderful (adv),wonderful,词,ADV,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-wooded,wooded,树木茂盛的,ADJ,B2
-wooden,wooden,木制的,ADJ,B2
-woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
-word choice,word choice,措辞,NOUN,B2
-wording,wording,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-workday,workday,词,NOUN,C1
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working,working,词,ADJ,C1
-working class,working class,工人阶级,NOUN,B2
-working day,working day,词,NOUN,B2
-working method,working method,词,NOUN,B2
-workout,workout,词,NOUN,C1
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world champion,world champion,世界冠军,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-worldliness,worldliness,词,NOUN,C1
-worldly,worldly,世俗的,ADJ,B2
-wormwood,wormwood,词,NOUN,A2
-worn,worn,磨损的,ADJ,B2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worsening,worsening,词,NOUN,C1
-worst,worst,最差的,ADV,B2
-worst (noun),worst,词,NOUN,C1
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthless,worthless,无价值的,ADJ,B2
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-wortkarg,taciturn,沉默寡言的,ADJ,B2
-would,would,将要,AUX,B2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wrapper,wrapper,词,NOUN,C1
-wrathful,wrathful,词,ADJ,C1
-wreckage,wreckage,词,NOUN,C1
-wrench,wrench,词,NOUN,C1
-wretched,wretched,词,ADJ,C1
-wretchedness,wretchedness,悲惨,NOUN,C1
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
-writ,writ,词,NOUN,C1
-writhe,writhe,词,VERB,C1
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
-wrongdoer,wrongdoer,罪犯,NOUN,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
-wunderschön,gorgeous,华丽的,ADJ,B2
-wählen,to elect,选举,VERB,B2
-wässern,to water,浇水,VERB,B2
-wöchentlich,weekly,每周的,ADJ,B2
-würzen,to season,调味,VERB,B2
-wüst,desolate,荒凉的,ADJ,B2
-wütend,furious,愤怒的,ADJ,B2
-x-ray,x-ray,X光片,NOUN,B2
-xenophobia,xenophobia,排外心理,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
-yarn,yarn,纱线,NOUN,B2
-yeah,yeah,词,INTJ,A1
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
-yeoman,yeoman,词,NOUN,C1
-yep,yep,是的,INTJ,B2
-yes (adv),yes,词,ADV,A2
-yes (part),yes,是的,PART,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yes indeed (adv),yes indeed,词,ADV,B2
-yesteryear,yesteryear,词,NOUN,C1
-yin needle,yin needle,阴针,NOUN,C1
-yo,yo,哟,PART,B2
-yoke,yoke,枷锁,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you masculine,you masculine,词,PRON,A1
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
-young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,词,ADJ,B2
-your,your,你的,PRON,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your plural,your plural,你们的,DET,B2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yourself,yourself,你自己,PRON,B2
-youth culture,youth culture,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful,youthful,词,ADJ,C1
-youthful vigor,youthful vigor,词,NOUN,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
-zahlreich,numerous,众多的,ADJ,B2
-zajal,zajal,词,NOUN,B2
-zany,zany,词,ADJ,C1
-zart,delicate,精致的,ADJ,B2
-zeal,zeal,热情,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zeitgenössisch,contemporary,当代的,ADJ,B2
-zellige tiles,zellige tiles,词,NOUN,A2
-zellulär,cellular,细胞的,ADJ,B2
-zementieren,cement,水泥,NOUN,B2
-zementieren,to cement,巩固,VERB,B2
-zen master,zen master,禅师,NOUN,B2
-zensieren,to censor,审查,VERB,B2
-zentral,central,中心的,ADJ,B2
-zentralisieren,to centralize,集中,VERB,B2
-zephyr,zephyr,词,NOUN,C1
-zerdrücken,to crush,压碎,VERB,B2
-zerfallen,to decompose,分解,VERB,B2
-zerlegen,to disassemble,拆卸,VERB,B2
-zerlegen,to dismantle,拆除,VERB,B2
-zero,zero,零,NOUN,B2
-zeroing,zeroing,词,NOUN,C1
-zerschlagen,to smash,粉碎,VERB,B2
-zerstörerisch,destructive,مدمر,ADJ,B2
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
-zeugen,to witness,目击,VERB,B2
-zirkulieren,to circulate,循环,VERB,B2
-zitieren,quote,报价单,NOUN,B2
-zitieren,to cite,引用,VERB,B2
-zitieren,to quote,引用,VERB,B2
-zivil,civil,民事的,ADJ,B2
-zivilisiert,civilized,文明的,ADJ,B2
-zongzi,zongzi,粽子,NOUN,B2
-zoo,zoo,动物园,NOUN,B2
-zufällig,accidental,偶然的,ADJ,B2
-zufällig,casual,随意的,ADJ,B2
-zufällig,random,随机的,ADJ,B2
-zuhören,to listen attentively,倾听,VERB,B2
-zum Beispiel,for example,例如,ADV,B2
-zunehmend,increasingly,越来越,ADV,B2
-zurückerobern,to reclaim,收回,VERB,B2
-zurückgehen,decline,衰退,NOUN,B2
-zurückgehen,to decline,下降,VERB,B2
-zurückgehen,to regress,倒退,VERB,B2
-zurückgetreten,retired,退休的,ADJ,B2
-zurückhaltend,reserved,保留的,ADJ,B2
-zurückkehren,to return first,先回,VERB,B2
-zurückrufen,to recall,回忆,VERB,B2
-zurücktreten,to retire,退休,VERB,B2
-zurückzahlen,to repay,偿还,VERB,B2
-zurückziehen,to withdraw,撤回,VERB,B2
-zusammen mit,along with,随着,ADP,B2
-zusammenarbeiten,to collaborate,合作,VERB,B2
-zusammenfallen,to coincide,同时发生,VERB,B2
-zusammenfassen,to summarize,概括,VERB,B2
-zuschreiben,attribute,属性,NOUN,B2
-zuschreiben,to attribute,归因于,VERB,B2
-zusätzlich,collateral,附属的,ADJ,B2
-zuversichtlich,confident,自信的,ADJ,B2
-zuweisen,to assign,分配,VERB,B2
-zwanghaft,compulsive,强迫性的,ADJ,B2
-zwei Tiere,two animals,两只,NUM,B2
-zweites Mal,second time,再而,NOUN,B2
-zyklen,cycle,循环,NOUN,B2
-zyklen,to cycle,骑自行车,VERB,B2
-zyklisch,cyclical,周期的,ADJ,B2
-zynisch,cynical,愤世嫉俗的,ADJ,B2
-zählen,to count as,算,VERB,B2
-zähllos,countless,无数的,ADJ,B2
-Ähnlichkeit,resemblance,相似,NOUN,B2
-Ähnlichkeit,similarity,相似,NOUN,B2
-Ältere,elderly,年长的,ADJ,B2
-Änderung,amendment,修正案,NOUN,B2
-Äquivalent,equivalent,等价物,NOUN,B2
-Ära,era,时代,NOUN,B2
-Ärger,annoyance,烦恼,NOUN,B2
-Ärgernis,nuisance,麻烦事,NOUN,B2
-Ästhetik,aesthetics,美学,NOUN,B2
-Äußerste,utmost,你尽,NOUN,B2
-Äußerung,utterance,话语,NOUN,B2
-Ödland,wasteland,荒地,NOUN,B2
-Ökologie,ecology,生态学,NOUN,B2
-Ökosystem,ecosystem,生态系统,NOUN,B2
-Übelkeit,nausea,恶心,NOUN,B2
-Überdomäne,over-domain,超畴,NOUN,B2
-Übereinstimmung,accord with,合乎,NOUN,B2
-Überfall,assault,袭击,NOUN,B2
-Überfall,raid,突袭,NOUN,B2
-Übergabe,handover,拿给,NOUN,B2
-Übergang,crossing,交叉口,NOUN,B2
-Überlappung,overlap,重叠,NOUN,B2
-Überlauf,overflow,溢出,NOUN,B2
-Überleben,survival,生存,NOUN,B2
-Überlebender,survivor,幸存者,NOUN,B2
-Übernutzung,hyper-use,超用,NOUN,B2
-Überredung,coaxing,哄得,NOUN,B2
-Überschuss,surplus,过剩,NOUN,B2
-Übersetzer,translator,译者,NOUN,B2
-Überstrategie,over-strategy,超策,NOUN,B2
-Überstrich,over-stroke,超程,NOUN,B2
-Übertragung,transmission,传输,NOUN,B2
-Übertragung,transmission to you,传你,NOUN,B2
-Übertretung,transgression,违犯,NOUN,B2
-Überwachung,surveillance,监视,NOUN,B2
-Überwachungsraum,monitoring room,监控室,NOUN,B2
-Überzeugung,conviction,定罪,NOUN,B2
-Überzeugung,persuasion,说服,NOUN,B2
-älterer Bruder,older brother,大哥哥,NOUN,B2
-ändern,to amend,修订,VERB,B2
-ängstlich,afraid,害怕的,ADJ,B2
-ästhetisch,aesthetic,审美的,ADJ,B2
-öffentlich,publicly,公开地,ADV,B2
-öffentliche Ordnung,public order,治安,NOUN,B2
-öffentliches Wohl,public welfare,公益性,NOUN,B2
-ökologisch,ecological,生态的,ADJ,B2
-örtlich,local,当地的,ADJ,B2
-östlich,eastern,东方的,ADJ,B2
-üben,to exercise,锻炼,VERB,B2
-über,about,关于,ADP,B2
-über,above,在...之上,ADP,B2
-über Nacht,overnight,一夜之间,ADV,B2
-überflüssig,superfluous,多余的,ADJ,B2
-überfällig,overdue,逾期,ADJ,B2
-überlegen,superior,更好的,ADJ,B2
-übermitteln,to convey,传达,VERB,B2
-übermütig,cocky,傲慢的,ADJ,B2
-übernatürlich,supernatural,超自然的,ADJ,B2
-überprüfen,to review,复习,VERB,B2
-überrascht sein,to be surprised,感到惊讶,VERB,B2
 übertragen,transfer,转移,NOUN,B2
 übertragen,to transfer,转移,VERB,B2
-überwachen,to surveil,监视,VERB,B2
-überwältigend,overwhelming,压倒性的,ADJ,B2
-überzeugt,convinced,确信的,ADJ,B2
-überziehen,to overdraw,透支,VERB,B2
-üblich,customary,习惯的,ADJ,B2
-übrig bleiben,to be left over,剩余,VERB,B2
+Transformation,transformation,تحول,NOUN,B2
+Übertretung,transgression,违犯,NOUN,B2
+transitorisch,transitional,过渡的,ADJ,B2
+Übersetzer,translator,译者,NOUN,B2
+Übertragung,transmission,传输,NOUN,B2
+Übertragung,transmission to you,传你,NOUN,B2
+Transparenz,transparency,透明度,NOUN,B2
+transparent,transparent,透明的,ADJ,B2
+transportieren,transport,运输,NOUN,B2
+transportieren,to transport,运输,VERB,B2
+Reise,travel,出行,NOUN,B2
+Reisemüdigkeit,travel fatigue,车马劳顿,NOUN,B2
+Reisender,traveler,旅行家,NOUN,B2
+Tablett,tray,托盘,NOUN,B2
+verräterisch,treacherous,背叛的,ADJ,B2
+Verrat,treachery,背叛,NOUN,B2
+Schatzkammer,treasury,国库,NOUN,B2
+bewirten,to treat guests,请客,VERB,B2
+Vertrag,treaty,条约,NOUN,B2
+Zittern,tremor,颤抖,NOUN,B2
+Graben,trench,沟渠,NOUN,B2
+Trend,trend,趋势,NOUN,B2
+Prozess,trial,试验,NOUN,B2
+Stamm,tribe,部落,NOUN,B2
+Zufluss,tributary,支流,NOUN,B2
+Tribut,tribute,贡品,NOUN,B2
+Auslöser,trigger,触发器,NOUN,B2
+dreifach,triple,三倍的,ADJ,B2
+trivial,trivial,琐碎的,ADJ,B2
+Trivialität,triviality,琐碎,NOUN,B2
+Trivialisierung,trivialization,浅薄化,NOUN,B2
+Truppe,troops,部队,NOUN,B2
+Trophäe,trophy,奖杯,NOUN,B2
+belästigen,to trouble,有劳,VERB,B2
+belästigend,troublesome,麻烦的,ADJ,B2
+Troupe,troupe,剧团,NOUN,B2
+Waffenstillstand,truce,休战,NOUN,B2
+wahre Konzession,true concession,真让,NOUN,B2
+wahre Form,true form,原形,NOUN,B2
+wahres Herz,true heart,本心,NOUN,B2
+Vertrauen,trust,信托,NOUN,B2
+vertrauenswürdig,trustworthy,值得信赖的,ADJ,B2
+sich anstrengen,to try hard to,力图,VERB,B2
+Röhre,tube,أنبوب,NOUN,B2
+Thunfisch,tuna,金枪鱼,NOUN,B2
+Tunika,tunic,束腰外衣,NOUN,B2
+Tunnel,tunnel,隧道,NOUN,B2
+Aufruhr,turmoil,混乱,NOUN,B2
+einschalten,to turn on,打开,VERB,B2
+Blinker,turn signal,转向灯,NOUN,B2
+Wendepunkt,turning point,转折点,NOUN,B2
+Rübe,turnip,芜菁,NOUN,B2
+Beteiligung,turnout,出席率,NOUN,B2
+Umsatz,turnover,营业额,NOUN,B2
+Schildkröte,turtle,海龟,NOUN,B2
+Betreuung,tutelage,监护,NOUN,B2
+Nachhilfe,tutoring,补习,NOUN,B2
+verdrehen,to twist,扭曲,VERB,B2
+verdreht,twisted,扭曲的,ADJ,B2
+zwei Tiere,two animals,两只,NUM,B2
+Zweirichtungsstraße,two-way street,双行道,NOUN,B2
+Typ,type,类型,NOUN,B2
+Taifun,typhoon,台风,NOUN,B2
+Tyrann,tyrant,暴君,NOUN,B2
+Hässlichkeit,ugliness,丑陋,NOUN,B2
+Geschwür,ulcer,溃疡,NOUN,B2
+Ulzeration,ulceration,溃疡,NOUN,B2
+unannehmbar,unacceptable,不可接受的,ADJ,B2
+einstimmig,unanimous,一致的,ADJ,B2
+unerreichbar,unattainable,难以获得的,ADJ,B2
+unerträglich,unbearable,难以忍受的,ADJ,B2
+unsicher,uncertain,不确定的,ADJ,B2
+Unsicherheit,uncertainty,不确定性,NOUN,B2
+unbequem,uncomfortable,不舒服的,ADJ,B2
+unkontrollierbar,uncontrollable,无法控制的,ADJ,B2
+Ungekühltes,uncooled,未寒,NOUN,B2
+unbestreitbar,undeniable,不可否认的,ADJ,B2
+Unterschätzung,underestimation,小看,NOUN,B2
+durchmachen,to undergo,经历,VERB,B2
+Student,undergraduate,本科生,NOUN,B2
+Untergrund,underground,地铁,NOUN,B2
+untergraben,to undermine,破坏,VERB,B2
+Unternehmen,undertaking,事业,NOUN,B2
+unterzeichnen,to underwrite,承保,VERB,B2
+Unbehagen,unease,不安,NOUN,B2
+unruhig,uneasy,不安的,ADJ,B2
+Arbeitslosigkeit,unemployment,失业,NOUN,B2
+ungleich,unequal,不平等的,ADJ,B2
+unerwartet,unexpectedly,出乎意料地,ADV,B2
+entfalten,to unfold,展开,VERB,B2
+unglücklich,unfortunate,不幸的,ADJ,B2
+vereinigen,to unify,统一,VERB,B2
+unvorstellbar,unimaginable,难以想象的,ADJ,B2
+Gewerkschaft,union,工会,NOUN,B2
+Unionismus,unionism,工会主义,NOUN,B2
+Einzigartigkeit,uniqueness,独特,NOUN,B2
+universelle Anwendbarkeit,universal applicability,普适性,NOUN,B2
+Universalität,universality,普遍性,NOUN,B2
+ungerecht,unjust,不公正的,ADJ,B2
+entfesseln,to unleash,释放,VERB,B2
+es sei denn,unless,除非,SCONJ,B2
+unglücklich,unlucky,倒霉的,ADJ,B2
+unvernünftig,unreasonable,不合理的,ADJ,B2
+Unruhe,unrest,动荡,NOUN,B2
+gelassen,unruffled,从容,ADJ,B2
+instabil,unstable,不稳定的,ADJ,B2
+lösen,to untie,解开,VERB,B2
+bis,until,直到,SCONJ,B2
+Enthüllungsfeier,unveiling ceremony,揭幕仪式,NOUN,B2
+Unwilligkeit,unwillingness,不甘,NOUN,B2
+Unwürdiger,unworthy,你不配,NOUN,B2
+bis zu,up to,为止,ADP,B2
+Erziehung,upbringing,教养,NOUN,B2
+bevorstehend,upcoming,مقبل,ADJ,B2
+aktualisieren,to update,更新,VERB,B2
+aufrüsten,to upgrade,升级,VERB,B2
+ober,upper,上面的,ADJ,B2
+aufrecht,upright,正直的,ADJ,B2
+Entwurzelung,uprooting,背井离乡,NOUN,B2
+städtisch,urban,城市的,ADJ,B2
+Urbanität,urbanity,都市风度,NOUN,B2
+uns,us,你我,NOUN,B2
+mit Essstäbchen essen,to use chopsticks,动筷,VERB,B2
+Krücken benutzen,to use crutches,拄拐,VERB,B2
+Benutzer,user,用户,NOUN,B2
+normalerweise,usually,通常,ADV,B2
+Nießbrauch,usufruct,用益权,NOUN,B2
+usurpieren,to usurp,篡夺,VERB,B2
+utilitaristisch,utilitarian,功利的,ADJ,B2
+Utilitarismus,utilitarianism,功利主义,NOUN,B2
+Nutzung,utilization,利用,NOUN,B2
+nutzen,to utilize,利用,VERB,B2
+Äußerste,utmost,你尽,NOUN,B2
+Utopie,utopia,乌托邦,NOUN,B2
+utopisch,utopian,乌托邦式的,ADJ,B2
+Äußerung,utterance,话语,NOUN,B2
+Vakanz,vacancy,空缺,NOUN,B2
+vakant,vacant,空缺的,ADJ,B2
+Urlaub,vacation,假期,NOUN,B2
+Impfstoff,vaccine,疫苗,NOUN,B2
+vage,vague,含糊的,ADJ,B2
+tapfer,valiant,英勇的,ADJ,B2
+Gültigkeit,validity,有效期,NOUN,B2
+Tapferkeit,valor,勇气,NOUN,B2
+Bewertung,valuation,估值,NOUN,B2
+Van,van,货车,NOUN,B2
+Vorhut,vanguard,先锋,NOUN,B2
+verschwinden,to vanish,消失,VERB,B2
+Eitelkeit,vanity,虚荣,NOUN,B2
+Variable,variable,变量,NOUN,B2
+Varianz,variance,方差,NOUN,B2
+verschiedene Abteilungen,various departments,各部,NOUN,B2
+riesig,vast,巨大的,ADJ,B2
+Gewölbe,vault,金库,NOUN,B2
+Gemüsegarten,vegetable garden,果园,NOUN,B2
+Fahrzeugzulassung,vehicle registration,行驶证,NOUN,B2
+Vene,vein,静脉,NOUN,B2
+ehrwürdig,venerable,值得尊敬的,ADJ,B2
+Verehrung,veneration,崇敬,NOUN,B2
+Rache,vengeance,报复,NOUN,B2
+Belüftung,ventilation,通风,NOUN,B2
+Veranstaltungsort,venue,场地,NOUN,B2
+weitschweifig,verbose,冗长的,ADJ,B2
+Weitschweifigkeit,verbosity,冗长,NOUN,B2
+Urteil,verdict,裁决,NOUN,B2
+Ungeziefer,vermin,害兽,NOUN,B2
+frühlingshaft,vernal,春季的,ADJ,B2
+versiert,versed,精通的,ADJ,B2
+Version,version,版本,NOUN,B2
+vertikal,vertical,垂直的,ADJ,B2
+Gefäß,vessel,船,NOUN,B2
+Veteran,veteran,老手,NOUN,B2
+Veto,veto,否决,NOUN,B2
+Vibration,vibration,振动,NOUN,B2
+Laster,vice,恶习,NOUN,B2
+Video,video,视频,NOUN,B2
+Bildplatte,video disc,影碟,NOUN,B2
+Videoaufzeichnung,video recording,录像,NOUN,B2
+wetteifern,to vie,竞争,VERB,B2
+Nachtwache,vigil,守夜,NOUN,B2
+Wachsamkeit,vigilance,警惕,NOUN,B2
+Tatkraft,vigor,活力,NOUN,B2
+abscheulich,vile,卑鄙的,ADJ,B2
+Villa,villa,别墅,NOUN,B2
+Dorfvorsteher,village head,村长,NOUN,B2
+Schurke,villain,反派,NOUN,B2
+Weinrebe,vine,藤蔓,NOUN,B2
+die Disziplin verletzen,to violate discipline,违纪,VERB,B2
+Verstoß,violation,侵越,NOUN,B2
+gewalttätig,violent,暴力的,ADJ,B2
+Violine,violin,小提琴,NOUN,B2
+virtuell,virtual,虚拟的,ADJ,B2
+Tugend,virtue,美德,NOUN,B2
+Virus,virus,病毒,NOUN,B2
+viskos,viscous,黏稠的,ADJ,B2
+Vision,vision,远见,NOUN,B2
+visuell,visual,视觉的,ADJ,B2
+Vitamin,vitamin,维生素,NOUN,B2
+vokal,vocal,直言的,ADJ,B2
+volatil,volatile,易变的,ADJ,B2
+Vulkan,volcano,火山,NOUN,B2
+Volumen,volume,体积,NOUN,B2
+freiwillig,voluntarily,自愿地,ADV,B2
+Freiwilliger,volunteer,志愿者,NOUN,B2
+Strudel,vortex,漩涡,NOUN,B2
+Wähler,voter,选民,NOUN,B2
+Abstimmung,voting,投票,NOUN,B2
+Gelübde,vow,誓言,NOUN,B2
+vulgär,vulgar,粗俗的,ADJ,B2
+Vulgarität,vulgarity,粗俗,NOUN,B2
+Krieg führen,to wage war,作战,VERB,B2
+Lohn,wages,工资,NOUN,B2
+klagen,to wail,哀号,VERB,B2
+Taille,waist,腰,NOUN,B2
+Warten,wait,等待,NOUN,B2
+Warten auf mich,wait for me,等我,NOUN,B2
+lange warten,to wait long,久等,VERB,B2
+Wartezimmer,waiting room,候诊室,NOUN,B2
+aufwachen,to wake,唤醒,VERB,B2
+wandern,to wander,漫步,VERB,B2
+Wandern,wandering,漫游,NOUN,B2
+wollen,to want,想要,VERB,B2
+Lockabsicht,want to lure,想引,NOUN,B2
+brauchen wollen,to want to need will,要,VERB,B2
+Station,ward,病房,NOUN,B2
+Lagerhaus,warehouse,仓库,NOUN,B2
+Erwärmung,warming,变暖,NOUN,B2
+Garantie,warranty,保修单,NOUN,B2
+sein,to was,是,VERB,B2
+Wäsche,washing,洗涤,NOUN,B2
+Waschmaschine,washing machine,洗衣机,NOUN,B2
+Abfall,waste,浪费,NOUN,B2
+verschwenderisch,wasteful,浪费的,ADJ,B2
+Ödland,wasteland,荒地,NOUN,B2
+Uhr,watch,手表,NOUN,B2
+wässern,to water,浇水,VERB,B2
+Wasserfall,water falling,水落,NOUN,B2
+Wasserspinat,water spinach,空心菜,NOUN,B2
+Aquarell,watercolor,水彩画,NOUN,B2
+Wasserfall,waterfall,瀑布,NOUN,B2
+Wassermelone,watermelon,西瓜,NOUN,B2
+Wassermelonenkern,watermelon seed,西瓜子,NOUN,B2
+wasserdicht,waterproof,防水的,ADJ,B2
+wir,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
+wir beide,we two,我俩,PRON,B2
+entwöhnen,to wean,断奶,VERB,B2
+Entwöhnung,weaning,断奶,NOUN,B2
+Müdigkeit,weariness,疲倦,NOUN,B2
+Weben,weaving,编织,NOUN,B2
+Webcam,webcam,网络摄像头,NOUN,B2
+Website,website,网站,NOUN,B2
+Hochzeitsfoto,wedding photo,婚纱照,NOUN,B2
+Unkraut,weed,杂草,NOUN,B2
+Kalenderwoche,week number,周次,NOUN,B2
+wöchentlich,weekly,每周的,ADJ,B2
+Wochentest,weekly test,周测,NOUN,B2
+weinen,to weep,哭泣,VERB,B2
+seltsam,weird,奇怪的,ADJ,B2
+Spinner,weirdo,怪人,NOUN,B2
+Willkommen,welcome,欢迎,NOUN,B2
+Willkommensbankett,welcome banquet,欢迎宴,NOUN,B2
+Schweißen,welding,焊接,NOUN,B2
+Wohlfahrt,welfare,福利,NOUN,B2
+Brunnen,well,井,NOUN,B2
+wohlüberlegt,well-considered,深思熟虑的,ADJ,B2
+bekannt,well-known,众所周知的,ADJ,B2
+Westgebiete,western regions,西域,NOUN,B2
+Feuchtgebiet,wetland,湿地,NOUN,B2
+Weizen,wheat,小麦,NOUN,B2
+wenn,when,当...时,SCONJ,B2
+Aufenthaltsort,whereabouts,行踪,NOUN,B2
+Ob,whether,能否,NOUN,B2
+ob,whether or not,是否,SCONJ,B2
+welcher,which one,哪一个,PRON,B2
+Weile,while,一会儿,NOUN,B2
+Laune,whim,突发奇想,NOUN,B2
+peitschen,to whip,鞭打,VERB,B2
+Wirbelwind,whirlwind,旋风；漩涡,NOUN,B2
+Flüstern,whisper,低语,NOUN,B2
+Ganzes,whole,整体,NOUN,B2
+ganze Welt,whole world,全世界,NOUN,B2
+Großhandel,wholesale,批发,NOUN,B2
+wen,whom,谁,PRON,B2
+erweitern,to widen,加宽,VERB,B2
+Breite,width,宽度,NOUN,B2
+wild,wild,野生的,ADJ,B2
+willentlich,willful,任性的,ADJ,B2
+wollen,willing,乐意的,ADJ,B2
+Bereitschaft,willingness,乐意,NOUN,B2
+winden,wind,风,NOUN,B2
+winden,to wind,缠绕,VERB,B2
+Fensterglas,window glass,窗玻璃,NOUN,B2
+winddicht,windproof,挡风的,ADJ,B2
+Weinbecher,wine cup,这酒盏,NOUN,B2
+dreschen,to winnow,筛选,VERB,B2
+Winter,winter,冬天,NOUN,B2
+wischen,to wipe,擦,VERB,B2
+Wischer,wiper,雨刷,NOUN,B2
+drahtlos,wireless,无线的,ADJ,B2
+mit Mühe,with difficulty,困难地,ADV,B2
+zurückziehen,to withdraw,撤回,VERB,B2
+Rückzug,withdrawal,撤回,NOUN,B2
+zeugen,to witness,目击,VERB,B2
+Zeugenaussage,witness testimony,人证,NOUN,B2
+Verstand,wits,心眼,NOUN,B2
+wackeln,to wobble,摇晃,VERB,B2
+Wolf,wolf,狼,NOUN,B2
+verweigern,won't do,不行,ADJ,B2
+verweigern,to won't do,不成,VERB,B2
+Wunder,wonder,奇迹,NOUN,B2
+Aurikel,wood ear mushroom,木耳,NOUN,B2
+Wald,woodland,林地,NOUN,B2
+sich anstrengen,to work hard for sth to strive for success,争气,VERB,B2
+Weltanschauung,worldview,世界观,NOUN,B2
+schlechter,worse,更糟的,ADJ,B2
+Anbetung,worship,崇拜,NOUN,B2
+schlechteste,worst,最坏的,ADJ,B2
+verwundet,wounded,受伤的,ADJ,B2
+Verpackung,wrapping,包装,NOUN,B2
+entreißen,to wrest,强行夺取,VERB,B2
+Ringen,wrestling,摔跤,NOUN,B2
+Elend,wretch,令人厌恶的人,NOUN,B2
+knitterfrei,wrinkle-resistant,防皱,ADJ,B2
+geschrieben,written,书面的,ADJ,B2
+falsch,wrong mistake,错误,ADJ,B2
+Wudang,wudang,武当,NOUN,B2
+gähnen,to yawn,打哈欠,VERB,B2
+sich sehnen,to yearn for,渴望,VERB,B2
+Sehnsucht,yearning,向往,NOUN,B2
+Jahr,years,数年,NOUN,B2
+Hefe,yeast,酵母,NOUN,B2
+schreien,to yell,大吼,VERB,B2
+Ja,yes,是啊,NOUN,B2
+Gestern,yesterday,بارحة,NOUN,B2
+noch,yet,还,ADV,B2
+Ertrag,yield,产量,NOUN,B2
+Yoga,yoga,瑜伽,NOUN,B2
+Können,you can,您能,NOUN,B2
+Unmöglichkeit,you cannot live,你也活不,NOUN,B2
+Sie,you polite,您,PRON,B2
+junger Mann,young man,年轻人,NOUN,B2
+junger Meister,young master,少庄主,NOUN,B2
+Jugendlicher,young person,年轻人,NOUN,B2
+Lachen,your laugh,你笑,NOUN,B2
+Majestät,your majesty,陛下,NOUN,B2
+Yuanxiao,yuanxiao,元宵,NOUN,B2
+Zenit,zenith,顶点,NOUN,B2
+Zhuang He,zhuang he,庄郃,NOUN,B2
+Zink,zinc,锌,NOUN,B2
+Sternzeichen,zodiac sign,属相,NOUN,B2
+Zombie,zombie,僵尸,NOUN,B2
+Zone,zone,区域,NOUN,B2
+solid,solid,3D模型 / 实体,NOUN,B2
+ideal,ideal,理想,NOUN,B2
+characteristic,characteristic,特征,NOUN,B2
+calm,calm,平静,NOUN,B2
+kind,kind,种类,NOUN,B2
+current,current,电流,NOUN,B2
+of,of,之,PART,B2
+nearby,nearby,在附近,ADV,B2
+willing,willing,肯,AUX,B2
+square,square,广场,NOUN,B2
+asian,asian,亚洲的,ADJ,B2
+to light,to light,照亮,VERB,B2
+real estate,real estate,不动产,NOUN,B2
+existing,existing,现有的,ADJ,B2
+sir,sir,郎,PART,B2
+cunning,cunning,诡计,NOUN,B2
+barrel,barrel,桶,NOUN,B2
+frightening,frightening,令人恐惧的,ADJ,B2
+delighted,delighted,高兴的,ADJ,B2
+intensive,intensive,强化的,ADJ,B2
+to unload,to unload,卸货,VERB,B2
+alert,alert,警报,NOUN,B2
+concrete,concrete,混凝土,NOUN,B2
+southern,southern,南方的,ADJ,B2
+incantation,incantation,咒语,NOUN,B2
+democrat,democrat,民主主义者,NOUN,B2
+emigration,emigration,移民,NOUN,B2
+simultaneously,simultaneously,同时地,ADV,B2
+divine,divine,如神,NOUN,B2
+police officer,police officer,警察,NOUN,B2
+elsewhere,elsewhere,别处,ADV,B2
+me,me,我,PRON,B2
+tenth,tenth,第十,ADJ,B2
+alternative,alternative,替代的,ADJ,B2
+october,october,十月,NOUN,B2
+to sharpen,to sharpen,磨快,VERB,B2
+western,western,西方的,ADJ,B2
+conceivable,conceivable,可设想的,ADJ,B2
+rear,rear,后部,NOUN,B2
+as,as,作为,SCONJ,B2
+advanced,advanced,高级的,ADJ,B2
+metropolis,metropolis,大都市,NOUN,B2
+deputy,deputy,议员,NOUN,B2
+shooter,shooter,射手,NOUN,B2
+january,january,一月,NOUN,B2
+eighth,eighth,第八,ADJ,B2
+sovereign,sovereign,君主,NOUN,B2
+chinese language,chinese language,华文,NOUN,B2
+polish,polish,波兰的,ADJ,B2
+henceforth,henceforth,从此以后,ADV,B2
+puddle,puddle,水坑,NOUN,B2
+wig,wig,假发,NOUN,B2
+incidence,incidence,发生率,NOUN,B2
+emblematic,emblematic,象征性的,ADJ,B2
+of which,of which,关于哪个,PRON,B2
+gaseous,gaseous,气态的,ADJ,B2
+show,show,表演,NOUN,B2
+disarmament,disarmament,裁军,NOUN,B2
+worthless,worthless,无价值的,ADJ,B2
+spatial,spatial,空间的,ADJ,B2
+monstrous,monstrous,怪异的,ADJ,B2
+impartiality,impartiality,公正,NOUN,B2
+carefully,carefully,仔细地,ADV,B2
+to build up,to build up,构建,VERB,B2
+ungrateful,ungrateful,忘恩负义的,ADJ,B2
+literal,literal,字面的,ADJ,B2
+power grid,power grid,电网,NOUN,B2
+shamelessness,shamelessness,无耻,NOUN,B2
+duplicity,duplicity,口是心非,NOUN,B2
+divergence,divergence,分歧,NOUN,B2
+unharmed,unharmed,未受伤的,ADJ,B2
+focused,focused,专注的,ADJ,B2
+corporal,corporal,下士,NOUN,B2
+to incur,to incur,招致,VERB,B2
+to bleat,to bleat,哀叫,VERB,B2
+congenital,congenital,先天的,ADJ,B2
+to border,to border,接壤,VERB,B2
+to conjecture,to conjecture,猜测,VERB,B2
+to slide,to slide,滑动,VERB,B2
+irregularity,irregularity,不规则,NOUN,B2
+wisely,wisely,明智地,ADV,B2
+to sadden,to sadden,使悲伤,VERB,B2
+intentionally,intentionally,故意地,ADV,B2
+wear,wear,磨损,NOUN,B2
+eighteen,eighteen,十八,NUM,B2
+erudition,erudition,博学,NOUN,B2
+entropy,entropy,熵,NOUN,B2
+dilatory,dilatory,拖延的,ADJ,B2
+partially,partially,部分地,ADV,B2
+figurative,figurative,比喻的,ADJ,B2
+turkey,turkey,火鸡,NOUN,B2
+looting,looting,掠夺,NOUN,B2
+meteorological,meteorological,气象的,ADJ,B2
+terribly,terribly,可怕地/非常,ADV,B2
+sexually,sexually,在性方面,ADV,B2
+nor,nor,也不,CCONJ,B2
+paternal,paternal,父亲的,ADJ,B2
+fallibility,fallibility,易错性,NOUN,B2
+to hail,to hail,下冰雹,VERB,B2
+to diverge,to diverge,分歧,VERB,B2
+to privatize,to privatize,私有化,VERB,B2
+to alert,to alert,警告,VERB,B2
+air force,air force,空军,NOUN,B2
+canadian,canadian,加拿大的,ADJ,B2
+monarch,monarch,君主,NOUN,B2
+welcoming,welcoming,舒适的,ADJ,B2
+cashier,cashier,出纳员,NOUN,B2
+to sponsor,to sponsor,赞助,VERB,B2
+to abort,to abort,流产,VERB,B2
+least,least,最少,ADV,B2
+to radiate,to radiate,辐射,VERB,B2
+reunification,reunification,重新统一,NOUN,B2
+illustrious,illustrious,著名的,ADJ,B2
+fortuitous,fortuitous,偶然的,ADJ,B2
+homonymy,homonymy,同音异义,NOUN,B2
+rebellious,rebellious,叛逆的,ADJ,B2
+unthinkable,unthinkable,不可想象的,ADJ,B2
+toll,toll,通行费,NOUN,B2
+embolism,embolism,栓塞,NOUN,B2
+to numb,to numb,使麻木,VERB,B2
+restriction,restriction,限制,NOUN,B2
+daycare,daycare,托儿所,NOUN,B2
+general practitioner,general practitioner,全科医生,NOUN,B2
+to desert,to desert,擅离职守,VERB,B2
+flourishing,flourishing,繁荣的,ADJ,B2
+inefficiency,inefficiency,低效,NOUN,B2
+to put back,to put back,放回,VERB,B2
+imposing,imposing,宏伟的,ADJ,B2
+to refuel,to refuel,加油,VERB,B2
+decal,decal,贴花,NOUN,B2
+scientifically,scientifically,科学地,ADV,B2
+snitch,snitch,告密者,NOUN,B2
+draftsman,draftsman,绘图员,NOUN,B2
+manifesto,manifesto,宣言,NOUN,B2
+epigraph,epigraph,题词,NOUN,B2
+family life,family life,家庭生活,NOUN,B2
+explicitly,explicitly,明确地,ADV,B2
+competitive,competitive,竞争的,ADJ,B2
+to dispense,to dispense,分发,VERB,B2
+embryo,embryo,胚胎,NOUN,B2
+psychological,psychological,心理的,ADJ,B2
+to project,to project,投射,VERB,B2
+consanguinity,consanguinity,血缘,NOUN,B2
+break-in,break-in,非法侵入,NOUN,B2
+wording,wording,措辞,NOUN,B2
+to arm,to arm,武装,VERB,B2
+complex,complex,建筑群,NOUN,B2
+nomad,nomad,游牧者,NOUN,B2
+purification,purification,净化,NOUN,B2
+literary,literary,文学的,ADJ,B2
+hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
+paroxysm,paroxysm,发作,NOUN,B2
+guild,guild,行会,NOUN,B2
+frozen,frozen,冻僵的,ADJ,B2
+brutality,brutality,残暴,NOUN,B2
+schematic,schematic,概要的,ADJ,B2
+languor,languor,倦怠,NOUN,B2
+cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
+administrator,administrator,管理员,NOUN,B2
+catholic,catholic,天主教的,ADJ,B2
+prestigious,prestigious,有声望的,ADJ,B2
+indoctrination,indoctrination,灌输,NOUN,B2
+invader,invader,入侵者,NOUN,B2
+commiseration,commiseration,同情,NOUN,B2
+to gape,to gape,目瞪口呆,VERB,B2
+superiority,superiority,优越性/优势,NOUN,B2
+partial,partial,部分的,ADJ,B2
+stand,stand,摊位,NOUN,B2
+hundred,hundred,一百,NOUN,B2
+rehabilitation,rehabilitation,康复,NOUN,B2
+conservatory,conservatory,音乐学院,NOUN,B2
+fire brigade,fire brigade,消防队,NOUN,B2
+distributor,distributor,分销商,NOUN,B2
+balloon,balloon,气球,NOUN,B2
+cardinal,cardinal,枢机主教,NOUN,B2
+dignitary,dignitary,高官,NOUN,B2
+to spy,to spy,监视,VERB,B2
+to uproot,to uproot,根除,VERB,B2
+thematic,thematic,主题的,ADJ,B2
+eccentricity,eccentricity,古怪,NOUN,B2
+humanist,humanist,人文主义者,NOUN,B2
+gruff,gruff,阴沉的,ADJ,B2
+indiscretion,indiscretion,轻率,NOUN,B2
+front page,front page,头版,NOUN,B2
+to relaunch,to relaunch,重启,VERB,B2
+self,self,自己,PRON,B2
+fauna,fauna,动物群,NOUN,B2
+philosophical,philosophical,哲学的,ADJ,B2
+infidelity,infidelity,不忠,NOUN,B2
+comparable,comparable,可比较的,ADJ,B2
+hotelier,hotelier,旅馆老板,NOUN,B2
+instructive,instructive,有教育意义的,ADJ,B2
+to tear out,to tear out,拔出,VERB,B2
+to rough-hew,to rough-hew,粗加工,VERB,B2
+sacrifice,sacrifice,牺牲,NOUN,B2
+philologist,philologist,语言学家,NOUN,B2
+to snoop,to snoop,窥探,VERB,B2
+advent,advent,到来,NOUN,B2
+elocution,elocution,演讲术,NOUN,B2
+infamy,infamy,恶名,NOUN,B2
+devilish,devilish,恶魔般的,ADJ,B2
+graphology,graphology,笔迹学,NOUN,B2
+colored,colored,有色的,ADJ,B2
+on top,on top,在上面,ADV,B2
+gifted,gifted,有天赋的,ADJ,B2
+to experiment,to experiment,实验,VERB,B2
+to seat,to seat,使坐下,VERB,B2
+cosmetic,cosmetic,化妆品的,ADJ,B2
+remarkably,remarkably,显著地,ADV,B2
+tax authorities,tax authorities,税务机关,NOUN,B2
+to title,to title,命名,VERB,B2
+vulnerable,vulnerable,易受伤害的,ADJ,B2
+infected,infected,被感染的,ADJ,B2
+complement,complement,补充物,NOUN,B2
+mobility,mobility,流动性,NOUN,B2
+to benefit,to benefit,受益,VERB,B2
+medieval,medieval,中世纪的,ADJ,B2
+admirer,admirer,仰慕者,NOUN,B2
+dependence,dependence,依赖,NOUN,B2
+grumpy,grumpy,脾气坏的,ADJ,B2
+generality,generality,普遍性,NOUN,B2
+carefree,carefree,无忧无虑的,ADJ,B2
+technically,technically,技术上地,ADV,B2
+desirable,desirable,可取的,ADJ,B2
+fifteen,fifteen,十五,NUM,B2
+laxity,laxity,松弛,NOUN,B2
+cigar,cigar,雪茄,NOUN,B2
+latin,latin,拉丁的,ADJ,B2
+considerably,considerably,相当地,ADV,B2
+sunflower,sunflower,向日葵,NOUN,B2
+to anger,to anger,使生气,VERB,B2
+to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
+conciliatory,conciliatory,调和的,ADJ,B2
+rodent,rodent,啮齿动物,NOUN,B2
+physiological,physiological,生理的,ADJ,B2
+insensitive,insensitive,麻木的,ADJ,B2
+self-denial,self-denial,自我牺牲,NOUN,B2
+favorite,favorite,最爱,NOUN,B2
+witchcraft,witchcraft,巫术,NOUN,B2
+tumor,tumor,肿瘤,NOUN,B2
+to gain weight,to gain weight,变胖,VERB,B2
+muzzle,muzzle,口套,NOUN,B2
+relocation,relocation,搬家,NOUN,B2
+to wear out,to wear out,磨损,VERB,B2
+pornography,pornography,色情,NOUN,B2
+diffusion,diffusion,传播,NOUN,B2
+trajectory,trajectory,轨迹,NOUN,B2
+credulity,credulity,轻信,NOUN,B2
+asthmatic,asthmatic,哮喘的,ADJ,B2
+to camouflage,to camouflage,伪装,VERB,B2
+to harden,to harden,使经受锻炼,VERB,B2
+imprint,imprint,印记,NOUN,B2
+to strike down,to strike down,击倒,VERB,B2
+exuberant,exuberant,繁茂的,ADJ,B2
+to strip,to strip,裸露,VERB,B2
+spinning mill,spinning mill,纺纱厂,NOUN,B2
+to perfect,to perfect,精修,VERB,B2
+to abstract,to abstract,抽象,VERB,B2
+ribbon,ribbon,丝带,NOUN,B2
+therapist,therapist,治疗师,NOUN,B2
+fellow citizen,fellow citizen,同胞,NOUN,B2
+time occasion,time occasion,次,NOUN,B2
+heavily,heavily,沉重地,ADV,B2
+theological,theological,神学的,ADJ,B2
+proselytism,proselytism,传教,NOUN,B2
+to access,to access,进入,VERB,B2
+babysitter,babysitter,保姆,NOUN,B2
+coproduction,coproduction,联合制作,NOUN,B2
+located,located,位于,ADJ,B2
+rapture,rapture,狂喜,NOUN,B2
+reticent,reticent,沉默寡言的,ADJ,B2
+damages,damages,损害赔偿,NOUN,B2
+novelty,novelty,新奇事物,NOUN,B2
+farmstead,farmstead,农庄,NOUN,B2
+to gossip,to gossip,闲聊,VERB,B2
+to debut,to debut,首次亮相,VERB,B2
+jewish,jewish,犹太的,ADJ,B2
+sailor,sailor,水手,NOUN,B2
+concerned,concerned,担忧的,ADJ,B2
+scholarship holder,scholarship holder,奖学金生,NOUN,B2
+generic,generic,通用的,ADJ,B2
+to overflow,to overflow,溢出,VERB,B2
+incredible,incredible,难以置信的,ADJ,B2
+stratum,stratum,阶层,NOUN,B2
+to bristle,to bristle,使竖起,VERB,B2
+cardboard,cardboard,硬纸板,NOUN,B2
+old-fashioned,old-fashioned,老式的,ADJ,B2
+reporting,reporting,报道,NOUN,B2
+to wedge,to wedge,卡住,VERB,B2
+unconditional,unconditional,无条件的,ADJ,B2
+stroller,stroller,婴儿车,NOUN,B2
+reminder,reminder,提醒物,NOUN,B2
+childbirth,childbirth,分娩,NOUN,B2
+taxpayer,taxpayer,纳税人,NOUN,B2
+pharaoh,pharaoh,法老,NOUN,B2
+to prop up,to prop up,支撑,VERB,B2
+unfaithful,unfaithful,不忠的,ADJ,B2
+propeller,propeller,螺旋桨,NOUN,B2
+apostate,apostate,叛教者,NOUN,B2
+erotic,erotic,色情的,ADJ,B2
+cognition,cognition,认知,NOUN,B2
+cavity,cavity,腔,NOUN,B2
+presumably,presumably,据推测,ADV,B2
+eroticism,eroticism,色情,NOUN,B2
+understanding,understanding,体贴的,ADJ,B2
+highlight,highlight,亮点,NOUN,B2
+immodesty,immodesty,不贞,NOUN,B2
+narrow-minded,narrow-minded,狭隘的,ADJ,B2
+census,census,人口普查,NOUN,B2
+flagrancy,flagrancy,现行,NOUN,B2
+olympic,olympic,奥林匹克的,ADJ,B2
+turkish,turkish,土耳其的,ADJ,B2
+to nail,to nail,钉,VERB,B2
+bare,bare,赤裸的,ADJ,B2
+tap,tap,水龙头,NOUN,B2
+gastronomy,gastronomy,美食学,NOUN,B2
+puff,puff,一口烟,NOUN,B2
+itinerary,itinerary,行程,NOUN,B2
+triggering,triggering,触发,NOUN,B2
+insulin,insulin,胰岛素,NOUN,B2
+the same,the same,相同的,ADJ,B2
+cynicism,cynicism,犬儒主义,NOUN,B2
+to standardize,to standardize,标准化,VERB,B2
+demarcation,demarcation,划界,NOUN,B2
+mentally,mentally,精神上地,ADV,B2
+undoubtedly,undoubtedly,无疑地,ADV,B2
+instantaneous,instantaneous,瞬间的,ADJ,B2
+to distill,to distill,蒸馏,VERB,B2
+town hall,town hall,市政厅,NOUN,B2
+on top of,on top of,在...上面,ADP,B2
+on purpose,on purpose,故意地,ADV,B2
+to implant,to implant,植入,VERB,B2
+scandalous,scandalous,可耻的,ADJ,B2
+extract,extract,摘录,NOUN,B2
+gravitation,gravitation,引力,NOUN,B2
+disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
+squall,squall,骤雨,NOUN,B2
+feminine,feminine,女性的,ADJ,B2
+good morning,good morning,早上好,INTJ,B2
+insecurity,insecurity,不安全感,NOUN,B2
+consecutively,consecutively,连续地,ADV,B2
+conversion,conversion,转换,NOUN,B2
+moral,moral,道德的,ADJ,B2
+metric,metric,公制的,ADJ,B2
+gutter,gutter,路沟,NOUN,B2
+complexion,complexion,肤色,NOUN,B2
+blessed,blessed,受祝福的,ADJ,B2
+vending machine,vending machine,自动售货机,NOUN,B2
+corrosive,corrosive,腐蚀性的,ADJ,B2
+to move touch,to move touch,使感动,VERB,B2
+fetish,fetish,恋物,NOUN,B2
+someone's,someone's,某人的,PRON,B2
+coat of arms,coat of arms,纹章,NOUN,B2
+ellipsis,ellipsis,省略,NOUN,B2
+co-owner,co-owner,共有人,NOUN,B2
+documentary,documentary,纪录片,NOUN,B2
+incorrect,incorrect,不正确的,ADJ,B2
+frugality,frugality,节俭,NOUN,B2
+conception,conception,概念,NOUN,B2
+hedonism,hedonism,享乐主义,NOUN,B2
+mitten,mitten,连指手套,NOUN,B2
+mechanical,mechanical,机械的,ADJ,B2
+desertion,desertion,逃亡,NOUN,B2
+combativeness,combativeness,好斗性,NOUN,B2
+to minimize,to minimize,最小化,VERB,B2
+funereal,funereal,丧葬的,ADJ,B2
+to ally,to ally,结盟,VERB,B2
+tasty,tasty,美味的,ADJ,B2
+to load charge,to load charge,装载,VERB,B2
+festive,festive,节日的,ADJ,B2
+stealth,stealth,秘密行动,NOUN,B2
+x-ray,x-ray,X光片,NOUN,B2
+impotence,impotence,无力,NOUN,B2
+to dump,to dump,抛弃,VERB,B2
+to plug in,to plug in,插入,VERB,B2
+steep,steep,陡峭的,ADJ,B2
+clemency,clemency,仁慈,NOUN,B2
+symptom,symptom,症,PART,B2
+depravity,depravity,堕落,NOUN,B2
+little sister,little sister,妹妹,NOUN,B2
+marine,marine,海洋的,ADJ,B2
+to intercede,to intercede,调停,VERB,B2
+fatalism,fatalism,宿命论,NOUN,B2
+seated,seated,坐着的,ADJ,B2
+deplorable,deplorable,可悲的,ADJ,B2
+kiosk,kiosk,亭子,NOUN,B2
+this morning,this morning,今天早上,ADV,B2
+autonomy,autonomy,自治,NOUN,B2
+exploration,exploration,探索,NOUN,B2
+defensive,defensive,防御的,ADJ,B2
+alphabet,alphabet,字母表,NOUN,B2
+flowery,flowery,华丽的,ADJ,B2
+carbohydrate,carbohydrate,碳水化合物,NOUN,B2
+insufficiency,insufficiency,不足,NOUN,B2
+formulation,formulation,配方,NOUN,B2
+condescension,condescension,屈尊,NOUN,B2
+to engrave,to engrave,雕刻,VERB,B2
+to move away,to move away,移开,VERB,B2
+belgian,belgian,比利时的,ADJ,B2
+to parade,to parade,游行,VERB,B2
+wintry,wintry,冬天的,ADJ,B2
+infirmary,infirmary,医务室,NOUN,B2
+to dishonor,to dishonor,使蒙羞,VERB,B2
+irritating,irritating,令人恼火的,ADJ,B2
+historicity,historicity,历史性,NOUN,B2
+seal,seal,海豹,NOUN,B2
+symbolic,symbolic,象征的,ADJ,B2
+parliamentary,parliamentary,议会的/议员,ADJ,B2
+villainy,villainy,邪恶,NOUN,B2
+italian,italian,意大利的,ADJ,B2
+swedish,swedish,瑞典语,NOUN,B2
+fragmentary,fragmentary,零碎的,ADJ,B2
+illumination,illumination,照明,NOUN,B2
+metaphorical,metaphorical,隐喻的,ADJ,B2
+psychopath,psychopath,精神变态者,NOUN,B2
+fictitious,fictitious,虚构的,ADJ,B2
+mythical,mythical,神话般的,ADJ,B2
+baton,baton,警棍,NOUN,B2
+congruent,congruent,一致的,ADJ,B2
+to age,to age,变老,VERB,B2
+school,school,学校的,ADJ,B2
+eighty,eighty,八十,NUM,B2
+failed,failed,失败的,ADJ,B2
+inspiring,inspiring,鼓舞人心的,ADJ,B2
+discernment,discernment,洞察力,NOUN,B2
+insolvent,insolvent,无偿还能力的,ADJ,B2
+to indoctrinate,to indoctrinate,灌输,VERB,B2
+inkling,inkling,预感,NOUN,B2
+hypertrophy,hypertrophy,肥大,NOUN,B2
+torso,torso,躯干,NOUN,B2
+uniform,uniform,制服,NOUN,B2
+finnish,finnish,芬兰的,ADJ,B2
+rag,rag,破布,NOUN,B2
+cyclist,cyclist,骑自行车的人,NOUN,B2
+superstitious,superstitious,迷信的,ADJ,B2
+diabolical,diabolical,恶魔般的,ADJ,B2
+rubbish,rubbish,垃圾,NOUN,B2
+to insinuate,to insinuate,暗示,VERB,B2
+to consent,to consent,同意,VERB,B2
+brief,brief,近点说,NOUN,B2
+lowest,lowest,最低的,ADJ,B2
+inconceivable,inconceivable,不可想象的,ADJ,B2
+grotto,grotto,洞穴,NOUN,B2
+didactic,didactic,教学的,ADJ,B2
+ejection,ejection,喷射,NOUN,B2
+offspring,offspring,幼崽,NOUN,B2
+frigate,frigate,护卫舰,NOUN,B2
+sorcerer,sorcerer,巫师,NOUN,B2
+epic,epic,史诗的,ADJ,B2
+to trace,to trace,描绘；标出,VERB,B2
+magistrate,magistrate,法官,NOUN,B2
+canonical,canonical,规范的,ADJ,B2
+to knit,to knit,编织,VERB,B2
+to spot,to spot,看见,VERB,B2
+meaningless,meaningless,毫无意义的,ADJ,B2
+relieved,relieved,宽慰的,ADJ,B2
+wooded,wooded,树木茂盛的,ADJ,B2
+alcoholic,alcoholic,酒精的,ADJ,B2
+desolation,desolation,荒凉,NOUN,B2
+deposition,deposition,证词,NOUN,B2
+soda,soda,苏打,NOUN,B2
+lapse,lapse,疏忽,NOUN,B2
+sperm,sperm,精子,NOUN,B2
+hood,hood,兜帽,NOUN,B2
+inside,inside,内部,NOUN,B2
+to idealize,to idealize,理想化,VERB,B2
+impunity,impunity,逍遥法外,NOUN,B2
+about,about,大约,ADV,B2
+ultimate,ultimate,最终的,ADJ,B2
+politically,politically,在政治上,ADV,B2
+separate,separate,分开的,ADJ,B2
+reach,reach,范围,NOUN,B2
+greek,greek,希腊语,NOUN,B2
+choleric,choleric,易怒的,ADJ,B2
+to bring closer,to bring closer,靠近,VERB,B2
+him her,him her,他/她,PRON,B2
+trembling,trembling,颤抖的,ADJ,B2
+to plot,to plot,密谋,VERB,B2
+to sketch,to sketch,勾勒,VERB,B2
+to corroborate,to corroborate,证实,VERB,B2
+artillery,artillery,炮兵,NOUN,B2
+ordinance,ordinance,条例,NOUN,B2
+evocation,evocation,唤起,NOUN,B2
+to result,to result,产生,VERB,B2
+controllable,controllable,可控制的,ADJ,B2
+mistreatment,mistreatment,虐待,NOUN,B2
+chronology,chronology,年表,NOUN,B2
+to wring,to wring,拧干,VERB,B2
+extremist,extremist,极端主义者,NOUN,B2
+to irrigate,to irrigate,灌溉,VERB,B2
+carpet rug,carpet rug,地毯,NOUN,B2
+jewelry store,jewelry store,珠宝店,NOUN,B2
+disc,disc,光盘,NOUN,B2
+deceased,deceased,已故的,ADJ,B2
+imperfect,imperfect,不完美的,ADJ,B2
+moratorium,moratorium,暂停,NOUN,B2
+jubilation,jubilation,欢欣,NOUN,B2
+to indict,to indict,控告,VERB,B2
+inhuman,inhuman,不人道的,ADJ,B2
+to inconvenience,to inconvenience,使不便,VERB,B2
+homogeneity,homogeneity,同质性,NOUN,B2
+tv,tv,电视,NOUN,B2
+near,near,在附近,ADP,B2
+tablet,tablet,平板电脑,NOUN,B2
+navel,navel,肚脐,NOUN,B2
+circumspect,circumspect,谨慎的,ADJ,B2
+broadcaster,broadcaster,广播公司,NOUN,B2
+daylight,daylight,日光,NOUN,B2
+to flash,to flash,闪烁,VERB,B2
+prior,prior,先前的,ADJ,B2
+exponential,exponential,指数的,ADJ,B2
+diploma,diploma,文凭,NOUN,B2
+gardening,gardening,园艺,NOUN,B2
+to undress,to undress,脱衣,VERB,B2
+counterfeiting,counterfeiting,伪造,NOUN,B2
+sixteen,sixteen,十六,NUM,B2
+hermit,hermit,隐士,NOUN,B2
+revolt,revolt,叛乱,NOUN,B2
+corollary,corollary,推论,NOUN,B2
+disloyal,disloyal,不忠的,ADJ,B2
+homily,homily,布道,NOUN,B2
+deference,deference,敬意,NOUN,B2
+flammable,flammable,易燃的,ADJ,B2
+to draw up,to draw up,起草,VERB,B2
+incompetent,incompetent,无能的,ADJ,B2
+idiosyncrasy,idiosyncrasy,特质,NOUN,B2
+cognitive,cognitive,认知的,ADJ,B2
+councilor,councilor,市议员,NOUN,B2
+holocaust,holocaust,浩劫,NOUN,B2
+fascism,fascism,法西斯主义,NOUN,B2
+inquisition,inquisition,宗教裁判所,NOUN,B2
+long-lasting,long-lasting,持久的,ADJ,B2
+unlimited,unlimited,无限的,ADJ,B2
+to lighten,to lighten,减轻,VERB,B2
+that one,that one,那个,PRON,B2
+exactness,exactness,精确,NOUN,B2
+seriously,seriously,认真地,ADV,B2
+contestable,contestable,可质疑的,ADJ,B2
+calamitous,calamitous,灾难性的,ADJ,B2
+to impute,to impute,归咎,VERB,B2
+categorical,categorical,绝对的,ADJ,B2
+precisely,precisely,确切地; 正好,ADV,B2
+to crash,to crash,碰撞,VERB,B2
+rubble,rubble,瓦砾,NOUN,B2
+redemption,redemption,救赎,NOUN,B2
+unreality,unreality,虚幻,NOUN,B2
+influx,influx,涌入,NOUN,B2
+to nickname,to nickname,给...起绰号,VERB,B2
+confessional,confessional,宗派的,ADJ,B2
+continued,continued,持续的,ADJ,B2
+to overstep,to overstep,越权,VERB,B2
+cylindrical,cylindrical,圆柱形的,ADJ,B2
+to skim,to skim,轻触,VERB,B2
+motionless,motionless,静止的,ADJ,B2
+dying,dying,垂死的,ADJ,B2
+to position,to position,定位 / 安置,VERB,B2
+to undo,to undo,解开,VERB,B2
+listener,listener,听众,NOUN,B2
+devastating,devastating,毁灭性的,ADJ,B2
+devaluation,devaluation,贬值,NOUN,B2
+dangerousness,dangerousness,危险性,NOUN,B2
+endowment,endowment,配备,NOUN,B2
+gerontocracy,gerontocracy,老人政治,NOUN,B2
+incoherent,incoherent,不连贯的,ADJ,B2
+circumlocution,circumlocution,迂回说法,NOUN,B2
+illustration,illustration,插图,NOUN,B2
+descriptive,descriptive,描述性的,ADJ,B2
+to neutralize,to neutralize,中和,VERB,B2
+to invoke,to invoke,援引,VERB,B2
+drool,drool,口水,NOUN,B2
+immovable,immovable,不可移动的,ADJ,B2
+remote control,remote control,遥控器,NOUN,B2
+alone,alone,单独的,ADJ,B2
+duchess,duchess,公爵夫人,NOUN,B2
+inadmissible,inadmissible,不可接受的,ADJ,B2
+barely,barely,几乎不,ADV,B2
+shiver,shiver,寒战,NOUN,B2
+fiery,fiery,热烈的,ADJ,B2
+eminent,eminent,杰出的,ADJ,B2
+jurist,jurist,法学家,NOUN,B2
+to snow,to snow,下雪,VERB,B2
+to intoxicate,to intoxicate,使中毒,VERB,B2
+fragility,fragility,脆弱,NOUN,B2
+to narrow,to narrow,使变窄,VERB,B2
+picturesque,picturesque,如画的；别致的,ADJ,B2
+halfway,halfway,半途,ADV,B2
+express,express,明确的,ADJ,B2
+oh well,oh well,算了,INTJ,B2
+to trivialize,to trivialize,使平庸,VERB,B2
+islamic,islamic,伊斯兰的,ADJ,B2
+free of charge,free of charge,免费,NOUN,B2
+subconscious,subconscious,潜意识,NOUN,B2
+including,including,包括,ADP,B2
+theatrical,theatrical,戏剧的,ADJ,B2
+yarn,yarn,纱线,NOUN,B2
+chinese,chinese,中文,NOUN,B2
+marble,marble,大理石,NOUN,B2
+to torment,to torment,折磨,VERB,B2
+to group,to group,分组,VERB,B2
+to sabotage,to sabotage,破坏,VERB,B2
+gravely,gravely,严重地,ADV,B2
+to swing,to swing,荡秋千,VERB,B2
+to delight,to delight,使高兴,VERB,B2
+to back up,to back up,后退,VERB,B2
+to inflame,to inflame,使发炎,VERB,B2
+emblem,emblem,徽章,NOUN,B2
+ashtray,ashtray,烟灰缸,NOUN,B2
+nearest,nearest,最近的,ADJ,B2
+to make proud,to make proud,使自豪,VERB,B2
+renowned,renowned,著名的,ADJ,B2
+to instill,to instill,灌输,VERB,B2
+prophet,prophet,先知,NOUN,B2
+to be moved,to be moved,感动,VERB,B2
+driven,driven,被驾驶的,ADJ,B2
+to unmask,to unmask,揭穿,VERB,B2
+casuistry,casuistry,决疑法,NOUN,B2
+moving,moving,感人的,ADJ,B2
+to expatriate,to expatriate,使移居国外,VERB,B2
+to swell,to swell,使肿胀,VERB,B2
+to infuse,to infuse,泡制,VERB,B2
+to redden,to redden,变红,VERB,B2
+duvet,duvet,羽绒被,NOUN,B2
+to have to,to have to,必须,VERB,B2
+two-headed,two-headed,双头的,ADJ,B2
+tiresome,tiresome,累人的,ADJ,B2
+to stammer,to stammer,结巴,VERB,B2
+dictator,dictator,独裁者,NOUN,B2
+fatuity,fatuity,愚昧,NOUN,B2
+to spawn,to spawn,产卵,VERB,B2
+comic strip,comic strip,连环画,NOUN,B2
+to repeal,to repeal,废除,VERB,B2
+to skin,to skin,剥皮,VERB,B2
+dissident,dissident,异见者,NOUN,B2
+lay,lay,叙事短诗,NOUN,B2
+to lengthen,to lengthen,延长,VERB,B2
+industrialization,industrialization,工业化,NOUN,B2
+to recreate,to recreate,重建,VERB,B2
+weakening,weakening,减弱,NOUN,B2
+self-employed person,self-employed person,个体经营者,NOUN,B2
+contingent,contingent,偶然的,ADJ,B2
+manufacture,manufacture,制造,NOUN,B2
+symmetrical,symmetrical,对称的,ADJ,B2
+physically,physically,身体上地,ADV,B2
+counterargument,counterargument,反论点,NOUN,B2
+to riddle,to riddle,使布满孔洞,VERB,B2
+surprised,surprised,惊讶的,ADJ,B2
+effectively,effectively,有效地,ADV,B2
+skylight,skylight,天窗,NOUN,B2
+pathology,pathology,病理学,NOUN,B2
+defective,defective,有缺陷的,ADJ,B2
+stopover,stopover,中途停留,NOUN,B2
+from there,from there,从那里,ADV,B2
+to dissipate,to dissipate,消散,VERB,B2
+minimal,minimal,微小的,ADJ,B2
+atmospheric,atmospheric,大气的,ADJ,B2
+phase,phase,阶段,NOUN,B2
+infantry,infantry,步兵,NOUN,B2
+doubtful,doubtful,可疑的,ADJ,B2
+chosen,chosen,精选的,ADJ,B2
+hinge,hinge,合页,NOUN,B2
+to detail,to detail,详述,VERB,B2
+hold,hold,控制,NOUN,B2
+to assault,to assault,袭击,VERB,B2
+pool,pool,池,PART,B2
+gymnast,gymnast,体操运动员,NOUN,B2
+imaginative,imaginative,富有想象力的,ADJ,B2
+to move house,to move house,搬家,VERB,B2
+to sulk,to sulk,生闷气,VERB,B2
+glance,glance,一瞥,NOUN,B2
+to post,to post,张贴,VERB,B2
+fidelity,fidelity,忠诚,NOUN,B2
+hydraulic,hydraulic,液压的,ADJ,B2
+recognizable,recognizable,可辨认的,ADJ,B2
+nape,nape,后颈,NOUN,B2
+fussy,fussy,挑剔的,ADJ,B2
+counterproductive,counterproductive,适得其反的,ADJ,B2
+endemic,endemic,地方性的,ADJ,B2
+to ironize,to ironize,讽刺,VERB,B2
+synthetic,synthetic,合成的,ADJ,B2
+to set aside,to set aside,移开,VERB,B2
+detriment,detriment,损害,NOUN,B2
+tangle,tangle,混乱,NOUN,B2
+diminutive,diminutive,指小词,NOUN,B2
+to infest,to infest,滋生,VERB,B2
+contrast,contrast,对比,NOUN,B2
+to oblige,to oblige,强迫,VERB,B2
+humanitarian,humanitarian,人道主义的,ADJ,B2
+minority,minority,少数派的,ADJ,B2
+jurisprudence,jurisprudence,法理学,NOUN,B2
+scrupulously,scrupulously,一丝不苟地,ADV,B2
+objective,objective,目标,NOUN,B2
+generously,generously,慷慨地,ADV,B2
+decorative,decorative,装饰性的,ADJ,B2
+stripe,stripe,条纹,NOUN,B2
+adjustment,adjustment,调节,NOUN,B2
+overview,overview,概览,NOUN,B2
+warmly,warmly,热情地,ADV,B2
+frieze,frieze,檐壁,NOUN,B2
+to program,to program,编程,VERB,B2
+educational,educational,教育的,ADJ,B2
+lyrical,lyrical,抒情的,ADJ,B2
+to leaf through,to leaf through,翻阅,VERB,B2
+perplexed,perplexed,困惑的,ADJ,B2
+grandiosity,grandiosity,宏伟,NOUN,B2
+postage,postage,邮资,NOUN,B2
+to oust,to oust,推翻,VERB,B2
+to prioritize,to prioritize,优先考虑,VERB,B2
+specifically,specifically,具体地,ADV,B2
+to camp,to camp,露营,VERB,B2
+disproportion,disproportion,不成比例,NOUN,B2
+bragging,bragging,吹嘘,NOUN,B2
+fang,fang,犬齿,NOUN,B2
+deterioration,deterioration,恶化,NOUN,B2
+fatality,fatality,致命性,NOUN,B2
+campsite,campsite,露营地,NOUN,B2
+boxer,boxer,拳击手,NOUN,B2
+enviable,enviable,令人羡慕的,ADJ,B2
+vat,vat,增值税,NOUN,B2
+heterogeneity,heterogeneity,异质性,NOUN,B2
+to gloss,to gloss,注释,VERB,B2
+parsimony,parsimony,吝啬,NOUN,B2
+extended,extended,广泛的,ADJ,B2
+curly,curly,卷曲的,ADJ,B2
+decidedly,decidedly,坚决地,ADV,B2
+junk,junk,破烂货,NOUN,B2
+swollen,swollen,肿胀的,ADJ,B2
+to shelter,to shelter,庇护,VERB,B2
+english-speaking,english-speaking,讲英语的,ADJ,B2
+exegete,exegete,注释家,NOUN,B2
+inclusion,inclusion,包含,NOUN,B2
+by chance,by chance,偶然地,ADV,B2
+to eclipse,to eclipse,使失色,VERB,B2
+consultative,consultative,咨询的,ADJ,B2
+good night,good night,晚安,INTJ,B2
+entrails,entrails,内脏,NOUN,B2
+asphalt,asphalt,沥青,NOUN,B2
+disagreeing,disagreeing,不同意的,ADJ,B2
+muscle ache,muscle ache,肌肉酸痛,NOUN,B2
+feminist,feminist,女权主义者,NOUN,B2
+pajamas,pajamas,睡衣,NOUN,B2
+enumeration,enumeration,列举,NOUN,B2
+floating,floating,漂浮的,ADJ,B2
+condom,condom,避孕套,NOUN,B2
+gangrene,gangrene,坏疽,NOUN,B2
+downfall,downfall,毁灭,NOUN,B2
+lizard,lizard,蜥蜴,NOUN,B2
+stabilization,stabilization,稳定化,NOUN,B2
+railway,railway,铁路的,ADJ,B2
+massively,massively,大量地,ADV,B2
+curative,curative,有疗效的,ADJ,B2
+press release,press release,公报,NOUN,B2
+stimulus,stimulus,刺激,NOUN,B2
+to relate,to relate,联系,VERB,B2
+highest,highest,最高的,ADJ,B2
+to sanction,to sanction,认可,VERB,B2
+terrified,terrified,极度恐惧的,ADJ,B2
+to stem,to stem,起源于,VERB,B2
+etymology,etymology,词源学,NOUN,B2
+to lower,to lower,降低,VERB,B2
+self-taught,self-taught,自学的,ADJ,B2
+hanging,hanging,绞刑,NOUN,B2
+universal,universal,普遍的,ADJ,B2
+terrace,terrace,露台,NOUN,B2
+electronics,electronics,电子学,NOUN,B2
+to divulge,to divulge,泄露,VERB,B2
+offensive,offensive,冒犯的,ADJ,B2
+fort,fort,堡垒,NOUN,B2
+to center,to center,居中,VERB,B2
+find,find,发现物,NOUN,B2
+to mirror,to mirror,反映,VERB,B2
+hemp,hemp,大麻,NOUN,B2
+apathetic,apathetic,冷漠的,ADJ,B2
+to collate,to collate,核对,VERB,B2
+lucrative,lucrative,有利可图的,ADJ,B2
+profitability,profitability,盈利能力,NOUN,B2
+bump shock,bump shock,碰撞/震惊,NOUN,B2
+peat,peat,泥炭,NOUN,B2
+supremacy,supremacy,霸权,NOUN,B2
+student loan,student loan,助学贷款,NOUN,B2
+terminus,terminus,,NOUN,B2
+strident,strident,刺耳的,ADJ,B2
+further on,further on,更远处,ADV,B2
+windfall,windfall,意外之财,NOUN,B2
+annals,annals,编年史,NOUN,B2
+staunch,staunch,坚定的,ADJ,B2
+contractualization,contractualization,契约化,NOUN,B2
+watertight,watertight,,NOUN,B2
+inert,inert,惰性的,ADJ,B2
+limit border,limit border,界限,NOUN,B2
+brittle,brittle,易碎的,ADJ,B2
+nameable,nameable,可命名的,ADJ,B2
+neonatal,neonatal,新生儿的,ADJ,B2
+where i,where i,,NOUN,B2
+on which,on which,在其上,PRON,B2
+tidal movement,tidal movement,潮汐运动,NOUN,B2
+ground basis,ground basis,基础/理由,NOUN,B2
+existential,existential,存在主义的,ADJ,B2
+bare ownership,bare ownership,虚有权,NOUN,B2
+humble,humble,谦逊的,ADJ,B2
+burger stand,burger stand,,NOUN,B2
+national coach,national coach,国家队教练,NOUN,B2
+neophyte,neophyte,新手；初学者,NOUN,B2
+swine,swine,猪,NOUN,B2
+domestic,domestic,国内,NOUN,B2
+athletic,athletic,运动的,ADJ,B2
+to place put,to place put,放置,VERB,B2
+urbanization,urbanization,城市化,NOUN,B2
+antibiotic,antibiotic,抗生素,NOUN,B2
+here hither,here hither,这里/到这里,ADV,B2
+at the top,at the top,在最上面,ADV,B2
+forensic,forensic,法医的,ADJ,B2
+matter of time,matter of time,时间问题,NOUN,B2
+cover blanket,cover blanket,覆盖物,NOUN,B2
+to complement,to complement,补充,VERB,B2
+totalitarian,totalitarian,极权主义的,ADJ,B2
+e-reader,e-reader,电子阅读器,NOUN,B2
+sync,sync,同步,NOUN,B2
+religiosity,religiosity,笃信宗教,NOUN,B2
+ready finished,ready finished,准备好的/完成的,ADJ,B2
+self-care,self-care,自我护理,NOUN,B2
+reformulation,reformulation,重新表述,NOUN,B2
+to encroach,to encroach,侵蚀,VERB,B2
+counterproductivity,counterproductivity,适得其反,NOUN,B2
+liable,liable,有责任的,ADJ,B2
+disrespect,disrespect,不敬,NOUN,B2
+indexing,indexing,指数化,NOUN,B2
+mighty very,mighty very,非常,ADJ,B2
+to incriminate,to incriminate,归罪,VERB,B2
+spice,spice,香料,NOUN,B2
+public holiday,public holiday,公共假日,ADJ,B2
+to vary,to vary,改变,VERB,B2
+more pl,more pl,更多,ADJ,B2
+symbolism,symbolism,象征主义,NOUN,B2
+to spill,to spill,溢出,VERB,B2
+to transgress,to transgress,违背,VERB,B2
+upset,upset,心烦的,ADJ,B2
+listen up,listen up,听着,INTJ,B2
+airs,airs,摆架子,NOUN,B2
+trade barrier,trade barrier,贸易壁垒,NOUN,B2
+feeble-minded,feeble-minded,弱智的,ADJ,B2
+to deprave,to deprave,使堕落,VERB,B2
+surely safe,surely safe,肯定地,ADV,B2
+caring,caring,关怀的,ADJ,B2
+viable,viable,可行的,ADJ,B2
+one-way,one-way,单向的,ADJ,B2
+anathema,anathema,深恶痛绝之物,NOUN,B2
+implicitly,implicitly,含蓄地,ADV,B2
+ascetic,ascetic,苦行的,ADJ,B2
+paralympic,paralympic,残奥会的,ADJ,B2
+colder,colder,更冷的,ADJ,B2
+sulfur,sulfur,硫,NOUN,B2
+demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
+fjeld cleft,fjeld cleft,,NOUN,B2
+lethargic,lethargic,昏睡的,ADJ,B2
+six-year-old,six-year-old,,NOUN,B2
+approximate,approximate,近似的,ADJ,B2
+deceit,deceit,欺骗,NOUN,B2
+unknown,unknown,未知数,NOUN,B2
+to auscultate,to auscultate,听诊,VERB,B2
+hard,hard,努力地,ADV,B2
+bumpy,bumpy,凹凸不平的,ADJ,B2
+intended,intended,预定的,ADJ,B2
+minority group,minority group,少数群体,NOUN,B2
+proposal suggestion,proposal suggestion,建议,NOUN,B2
+more,more,مزيد,NOUN,B2
+scrupulous,scrupulous,一丝不苟的,ADJ,B2
+all everyone,all everyone,所有/大家,PRON,B2
+habitual behavior,habitual behavior,习惯行为,NOUN,B2
+play game,play game,游戏/玩耍,NOUN,B2
+painless,painless,,NOUN,B2
+bulwark,bulwark,壁垒,NOUN,B2
+distorted,distorted,歪曲的,ADJ,B2
+humane,humane,人道的,ADJ,B2
+cerebral,cerebral,大脑的,ADJ,B2
+shrimp,shrimp,虾,NOUN,B2
+to substantiate,to substantiate,证实,VERB,B2
+methodological,methodological,方法论的,ADJ,B2
+connective,connective,连接的,ADJ,B2
+eczema,eczema,湿疹,NOUN,B2
+buffoon,buffoon,小丑,NOUN,B2
+triumph,triumph,胜利,NOUN,B2
+nineteen,nineteen,十九,NUM,B2
+disposable,disposable,一次性的,ADJ,B2
+cats,cats,猫,NOUN,B2
+tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
+socialization,socialization,社会化,NOUN,B2
+bike basket,bike basket,车筐,NOUN,B2
+prognosis,prognosis,预后,NOUN,B2
+lifeless,lifeless,无生命的,ADJ,B2
+buoyant,buoyant,有浮力的,ADJ,B2
+all,all,جميع,NOUN,B2
+to disfavor,to disfavor,不利于,VERB,B2
+fissure,fissure,裂缝,NOUN,B2
+to deafen,to deafen,使聋,VERB,B2
+the career,the career,职业生涯,NOUN,B2
+supplication,supplication,恳求,NOUN,B2
+temerity,temerity,鲁莽,NOUN,B2
+drag,drag,拖曳,NOUN,B2
+hair bun,hair bun,发髻,NOUN,B2
+complementarity,complementarity,互补性,NOUN,B2
+line of conduct,line of conduct,行为方针,NOUN,B2
+locked,locked,锁定的,ADJ,B2
+layer storage,layer storage,层/仓库,NOUN,B2
+to vegetate,to vegetate,苟活,VERB,B2
+beautifully,beautifully,美丽地,ADV,B2
+fare,fare,车费,NOUN,B2
+to consummate,to consummate,完成,VERB,B2
+to allege,to allege,宣称,VERB,B2
+numb,numb,麻木的,ADJ,B2
+to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
+outlaw,outlaw,歹徒,NOUN,B2
+every,every,每个,PRON,B2
+conductivity,conductivity,导电性,NOUN,B2
+to retrace,to retrace,追溯,VERB,B2
+compound,compound,化合物,NOUN,B2
+to perpetuate,to perpetuate,使永存,VERB,B2
+to dishevel,to dishevel,弄乱,VERB,B2
+to depilate,to depilate,脱毛,VERB,B2
+to disenchant,to disenchant,使清醒,VERB,B2
+brawl,brawl,斗殴,NOUN,B2
+tyrannical,tyrannical,专横的,ADJ,B2
+punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
+seldom,seldom,很少,ADV,B2
+to situate,to situate,定位,VERB,B2
+equal treatment,equal treatment,平等待遇,NOUN,B2
+guilt-ridden,guilt-ridden,内疚的,ADJ,B2
+to deal,to deal,处理,VERB,B2
+to specialize,to specialize,专攻,VERB,B2
+to vampirize,to vampirize,吸血,VERB,B2
+chief physician,chief physician,主任医师,NOUN,B2
+professionally active,professionally active,在职,NOUN,B2
+premeditation,premeditation,预谋,NOUN,B2
+idiotic,idiotic,愚蠢的,ADJ,B2
+swimming,swimming,游泳,NOUN,B2
+short film,short film,短片,NOUN,B2
+to disrupt,to disrupt,扰乱,VERB,B2
+soundtrack,soundtrack,! 音轨,NOUN,B2
+the casinos,the casinos,赌场,NOUN,B2
+buccaneer,buccaneer,海盗,NOUN,B2
+hatch,hatch,舱口,NOUN,B2
+fictional character,fictional character,虚构角色,NOUN,B2
+like that,like that,像那样,ADV,B2
+vain,vain,徒劳的,ADJ,B2
+motif,motif,主题,NOUN,B2
+to absolve,to absolve,赦免,VERB,B2
+to bump push,to bump push,推/碰撞,VERB,B2
+trinket,trinket,小饰品,NOUN,B2
+costs,costs,费用,NOUN,B2
+shuttle,shuttle,穿梭巴士,NOUN,B2
+junior jersey,junior jersey,,NOUN,B2
+to be felled,to be felled,被砍倒,VERB,B2
+variant,variant,变体,NOUN,B2
+nonprofit,nonprofit,非营利的,ADJ,B2
+news reporting,news reporting,新闻报道,NOUN,B2
+would,would,将要,AUX,B2
+to recharge,to recharge,充电,VERB,B2
+roadway,roadway,路面,NOUN,B2
+precarization,precarization,不稳定化,NOUN,B2
+culture of greed,culture of greed,贪得无厌文化,NOUN,B2
+outdoors,outdoors,户外,ADV,B2
+to buy back,to buy back,赎回,VERB,B2
+meaning content,meaning content,语义内容,NOUN,B2
+chauvinistic,chauvinistic,沙文主义的,ADJ,B2
+to adore,to adore,爱慕,VERB,B2
+to reopen,to reopen,重新开放,VERB,B2
+one you,one you,人们,PRON,B2
+latent,latent,潜在的,ADJ,B2
+omnipresent,omnipresent,无所不在的,ADJ,B2
+slum,slum,贫民窟,NOUN,B2
+co-determination,co-determination,共同决定权,NOUN,B2
+resuscitation,resuscitation,复苏,NOUN,B2
+elementary,elementary,基本的,ADJ,B2
+ace carcass,ace carcass,王牌/尸体,NOUN,B2
+curfew,curfew,宵禁,NOUN,B2
+shyness,shyness,羞怯,NOUN,B2
+surreptitious,surreptitious,秘密的,ADJ,B2
+to allude,to allude,暗指,VERB,B2
+from behind,from behind,从后面,ADV,B2
+resource shortage,resource shortage,资源短缺,NOUN,B2
+damageable,damageable,易损的,ADJ,B2
+lunatic,lunatic,疯子,NOUN,B2
+to extirpate,to extirpate,根除,VERB,B2
+plenitude,plenitude,充足,NOUN,B2
+to eternalize,to eternalize,使永恒,VERB,B2
+ferry,ferry,渡轮,NOUN,B2
+fulfillment,fulfillment,满足,NOUN,B2
+nuclear war,nuclear war,核战争,NOUN,B2
+insanely,insanely,疯狂地,ADV,B2
+to dismay,to dismay,使沮丧,VERB,B2
+occupational pension,occupational pension,职业养老金,NOUN,B2
+mp,mp,国会议员,NOUN,B2
+cudgel,cudgel,棍棒,NOUN,B2
+sadistic,sadistic,施虐的,ADJ,B2
+his her its their,his her its their,他的/她的/它的/他们的,DET,B2
+to decant,to decant,倾析,VERB,B2
+incorporation,incorporation,纳入,NOUN,B2
+to decouple,to decouple,分离,VERB,B2
+airtight,airtight,密封的,ADJ,B2
+group member,group member,群体成员,NOUN,B2
+acerbic,acerbic,尖刻的,ADJ,B2
+to bluff,to bluff,虚张声势,VERB,B2
+cloister,cloister,回廊,NOUN,B2
+domain,domain,领域,NOUN,B2
+to put set,to put set,放置,VERB,B2
+selected,selected,选中的,ADJ,B2
+disturbed,disturbed,不安的,ADJ,B2
+palliative,palliative,缓和的,ADJ,B2
+veiled,veiled,隐晦的,ADJ,B2
+obliged,obliged,被迫的,ADJ,B2
+vigilant,vigilant,警惕的,ADJ,B2
+appeasement,appeasement,平息,NOUN,B2
+thetic,thetic,正题的,ADJ,B2
+to disfigure,to disfigure,毁容,VERB,B2
+attributive,attributive,定语的,ADJ,B2
+ideally,ideally,理想地,ADV,B2
+to meant,to meant,意思是,VERB,B2
+should ought to,should ought to,应该,AUX,B2
+crusade,crusade,运动,NOUN,B2
+from within,from within,从内部,ADV,B2
+outcome ending,outcome ending,结局，解决,NOUN,B2
+thicker,thicker,更厚的,ADJ,B2
+shady suspicious,shady suspicious,可疑的,ADJ,B2
+villainous,villainous,恶棍的,ADJ,B2
+playwright,playwright,剧作家,NOUN,B2
+sexy,sexy,性感的,ADJ,B2
+upright,upright,直立地,ADV,B2
+values base,values base,价值基础,NOUN,B2
+acculturation,acculturation,文化涵化,NOUN,B2
+jews,jews,犹太人,NOUN,B2
+to dawdle,to dawdle,闲逛,VERB,B2
+to saturate,to saturate,使饱和,VERB,B2
+cradle,cradle,摇篮,NOUN,B2
+mammal,mammal,哺乳动物,NOUN,B2
+sail,sail,帆,NOUN,B2
+irish person,irish person,爱尔兰人,NOUN,B2
+photon,photon,光子,NOUN,B2
+cheapness,cheapness,廉价,NOUN,B2
+autism,autism,自闭症,NOUN,B2
+dator,dator,电脑,NOUN,B2
+superb,superb,极好的,ADJ,B2
+to bungle,to bungle,搞砸,VERB,B2
+slut,slut,荡妇,NOUN,B2
+numismatic,numismatic,钱币学的,ADJ,B2
+faint,faint,微弱的,ADJ,B2
+demagogy,demagogy,蛊惑,NOUN,B2
+enamel,enamel,珐琅,NOUN,B2
+meticulously,meticulously,一丝不苟地,ADV,B2
+to map out,to map out,摸清,VERB,B2
+phlegmatic,phlegmatic,冷静的,ADJ,B2
+to do sports,to do sports,运动,VERB,B2
+side,side,骄傲的,ADJ,B2
+to freshen,to freshen,使清新,VERB,B2
+solecism,solecism,语法错误,NOUN,B2
+to log in,to log in,登录,VERB,B2
+iranian,iranian,伊朗的,ADJ,B2
+doctor visit,doctor visit,,NOUN,B2
+dans,dans,舞蹈,NOUN,B2
+to navigate,to navigate,导航；航行,VERB,B2
+family circle,family circle,家庭圈子,NOUN,B2
+ago,ago,以前,ADV,B2
+cooked,cooked,熟的,ADJ,B2
+super dead,super dead,,NOUN,B2
+thicket,thicket,灌木丛,NOUN,B2
+emotional experience,emotional experience,情感体验,NOUN,B2
+film movie,film movie,电影,NOUN,B2
+to fasten,to fasten,系紧,VERB,B2
+depot,depot,仓库,NOUN,B2
+tropical,tropical,热带的,ADJ,B2
+to stitch,to stitch,缝,VERB,B2
+asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
+historicism,historicism,历史主义,NOUN,B2
+racist,racist,种族主义者,NOUN,B2
+to slash,to slash,猛砍,VERB,B2
+detention center,detention center,拘留所,NOUN,B2
+full of life,full of life,充满活力的,ADJ,B2
+sinister,sinister,不祥的,ADJ,B2
+deleveraging,deleveraging,去杠杆化,NOUN,B2
+tax exemption,tax exemption,免税,NOUN,B2
+to digitize,to digitize,数字化,VERB,B2
+dissatisfaction,dissatisfaction,不满,NOUN,B2
+city centre,city centre,市中心,NOUN,B2
+implacably,implacably,毫不留情地,ADV,B2
+skilful,skilful,熟练的,ADJ,B2
+phone number,phone number,电话号码,NOUN,B2
+splash,splash,扑通,NOUN,B2
+on behalf of,on behalf of,代表,ADP,B2
+lent,lent,大斋期,NOUN,B2
+repertoire,repertoire,全部曲目,NOUN,B2
+win,win,胜利,NOUN,B2
+shocked,shocked,震惊的,ADJ,B2
+bog,bog,沼泽,NOUN,B2
+instructor,instructor,讲师,NOUN,B2
+filthy,filthy,肮脏的,ADJ,B2
+to overshadow,to overshadow,使黯然失色,VERB,B2
+clock watch,clock watch,钟表,NOUN,B2
+to familiarize,to familiarize,使熟悉,VERB,B2
+corporate,corporate,公司的,ADJ,B2
+wait-and-see,wait-and-see,观望的,ADJ,B2
+authoritative,authoritative,权威的,ADJ,B2
+landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
+band tape,band tape,带子,NOUN,B2
+dent,dent,凹痕,NOUN,B2
+impromptu,impromptu,即兴的,ADJ,B2
+orange juice,orange juice,橙汁,NOUN,B2
+periphery,periphery,边缘,NOUN,B2
+gastronomic,gastronomic,美食的,ADJ,B2
+genital,genital,生殖器,NOUN,B2
+to beget,to beget,引起,VERB,B2
+to manifest,to manifest,表明,VERB,B2
+breach of contract,breach of contract,违约,NOUN,B2
+to purify,to purify,净化,VERB,B2
+spinning,spinning,纺纱,NOUN,B2
+to postulate,to postulate,假定,VERB,B2
+guffaw,guffaw,哄笑,NOUN,B2
+to venerate,to venerate,崇敬,VERB,B2
+cellulose,cellulose,纤维素,NOUN,B2
+by now,by now,此时,ADV,B2
+basal,basal,基本的,ADJ,B2
+averse,averse,厌恶的,ADJ,B2
+to preside,to preside,主持,VERB,B2
+tremulous,tremulous,颤抖的,ADJ,B2
+syllable,syllable,音节,NOUN,B2
+sanitation,sanitation,卫生,NOUN,B2
+checkup,checkup,体检,NOUN,B2
+psychoanalysis,psychoanalysis,精神分析,NOUN,B2
+unfriendly,unfriendly,不友好的,ADJ,B2
+graveyard,graveyard,墓地,NOUN,B2
+capital gain,capital gain,增值,NOUN,B2
+fresh,fresh,,NOUN,B2
+increased,increased,增加的,ADJ,B2
+arson,arson,纵火,NOUN,B2
+royalty,royalty,王室,NOUN,B2
+cleanly,cleanly,干净地,ADV,B2
+comparative,comparative,比较的,ADJ,B2
+to know feel,to know feel,认识/感觉,VERB,B2
+evidence bag,evidence bag,,NOUN,B2
+to placate,to placate,安抚,VERB,B2
+how long,how long,多久,ADV,B2
+optimization,optimization,优化,NOUN,B2
+steak,steak,牛排,NOUN,B2
+little one,little one,小家伙,NOUN,B2
+to type,to type,打字,VERB,B2
+advancement,advancement,晋升,NOUN,B2
+suicide candidate,suicide candidate,,NOUN,B2
+slam,slam,,NOUN,B2
+libertinism,libertinism,放荡,NOUN,B2
+dossier,dossier,档案,NOUN,B2
+journalism,journalism,新闻业,NOUN,B2
+reluctance,reluctance,不情愿,NOUN,B2
+monolithic,monolithic,单一的,ADJ,B2
+duplicate,duplicate,! 副本,NOUN,B2
+surcharge,surcharge,附加费,NOUN,B2
+binoculars,binoculars,双筒望远镜,NOUN,B2
+extraterrestrial,extraterrestrial,外星的,ADJ,B2
+all kinds,all kinds,各种各样的,DET,B2
+hallelujah,hallelujah,哈利路亚,INTJ,B2
+extravagant,extravagant,奢侈的,ADJ,B2
+to attest,to attest,证明,VERB,B2
+declinable,declinable,可变格的,ADJ,B2
+to rant,to rant,咆哮,VERB,B2
+to fatten,to fatten,养肥,VERB,B2
+antagonism,antagonism,对抗,NOUN,B2
+snot,snot,鼻涕,NOUN,B2
+volunteer work,volunteer work,志愿工作,NOUN,B2
+gender equality,gender equality,性别平等,NOUN,B2
+optimal,optimal,最佳的,ADJ,B2
+will shall,will shall,将要/会,AUX,B2
+told instructed,told instructed,被告知的,ADJ,B2
+state secretary,state secretary,国务秘书,NOUN,B2
+articulation,articulation,清晰表达,NOUN,B2
+reduction,reduction,减少,NOUN,B2
+about that,about that,关于那个,ADV,B2
+orange,orange,橙色的,ADJ,B2
+grand duke,grand duke,大公,NOUN,B2
+aloofness,aloofness,冷漠,NOUN,B2
+wooden,wooden,木制的,ADJ,B2
+tired of,tired of,,NOUN,B2
+up there,up there,在那上面,ADV,B2
+retailer,retailer,零售商,NOUN,B2
+longer,longer,更长的,ADJ,B2
+fewer,fewer,较少的,ADJ,B2
+just precis,just precis,恰好,ADV,B2
+determine,determine,确定,VER! B,B2
+to disqualify,to disqualify,取消资格,VERB,B2
+to elide,to elide,省略,VERB,B2
+to meditate,to meditate,沉思,VERB,B2
+overdraft,overdraft,透支,NOUN,B2
+existentialism,existentialism,存在主义,NOUN,B2
+substandard,substandard,,NOUN,B2
+ratio,ratio,比率,NOUN,B2
+infrastructure,infrastructure,基础设施,NOUN,B2
+to missed,to missed,错过,VERB,B2
+to extol,to extol,赞美,VERB,B2
+vaccine-related,vaccine-related,疫苗的,ADJ,B2
+antidote,antidote,解毒剂,NOUN,B2
+to exorcise,to exorcise,驱魔,VERB,B2
+beleaguered,beleaguered,受围困的,ADJ,B2
+humid,humid,潮湿的,ADJ,B2
+to blaspheme,to blaspheme,亵渎,VERB,B2
+honorable,honorable,可敬的,ADJ,B2
+bejeweled,bejeweled,镶满宝石的,ADJ,B2
+intricate,intricate,错综复杂的,ADJ,B2
+disrepute,disrepute,坏名声,NOUN,B2
+to culminate,to culminate,达到顶点,VERB,B2
+rubber,rubber,橡胶,NOUN,B2
+to wane,to wane,减弱,VERB,B2
+asp,asp,角蝰,NOUN,B2
+fluid,fluid,液体,NOUN,B2
+corporation,corporation,公司,NOUN,B2
+cricket,cricket,板球,NOUN,B2
+din,din,喧嚣,NOUN,B2
+to captivate,to captivate,迷住,VERB,B2
+slothful,slothful,懒惰的,ADJ,B2
+baggage,baggage,行李,NOUN,B2
+to embolden,to embolden,使大胆,VERB,B2
+to creak,to creak,嘎吱作响,VERB,B2
+fluency,fluency,流利,NOUN,B2
+to coerce,to coerce,强迫,VERB,B2
+to enunciate,to enunciate,阐明,VERB,B2
+to bisect,to bisect,平分,VERB,B2
+to calibrate,to calibrate,校准,VERB,B2
+to discern,to discern,辨别,VERB,B2
+assurance,assurance,保证,NOUN,B2
+itinerant,itinerant,巡回的,ADJ,B2
+to flog,to flog,鞭打,VERB,B2
+to sparkle,to sparkle,闪耀,VERB,B2
+miserly,miserly,吝啬的,ADJ,B2
+outlandish,outlandish,古怪的,ADJ,B2
+arid,arid,干旱的,ADJ,B2
+to demarcate,to demarcate,划定界限,VERB,B2
+to connote,to connote,暗示,VERB,B2
+tobacco,tobacco,烟草,NOUN,B2
+disrespectful,disrespectful,无礼的,ADJ,B2
+to enthrone,to enthrone,立为王,VERB,B2
+insatiable,insatiable,不知足的,ADJ,B2
+ajar,ajar,半开的,ADJ,B2
+spelling,spelling,拼写,NOUN,B2
+dungeon,dungeon,地牢,NOUN,B2
+to dethrone,to dethrone,废黜,VERB,B2
+to drip,to drip,滴,VERB,B2
+to calm down,to calm down,使平静,VERB,B2
+to supplicate,to supplicate,恳求,VERB,B2
+limb,limb,肢体,NOUN,B2
+audacious,audacious,大胆的,ADJ,B2
+aged,aged,年老的,ADJ,B2
+to fossilize,to fossilize,石化,VERB,B2
+to denigrate,to denigrate,诋毁,VERB,B2
+integral,integral,不可或缺的,ADJ,B2
+intangible,intangible,无形的,ADJ,B2
+famine,famine,饥荒,NOUN,B2
+bubbling,bubbling,冒泡的,ADJ,B2
+to contend,to contend,主张,VERB,B2
+drunkenness,drunkenness,醉酒,NOUN,B2
+to democratize,to democratize,民主化,VERB,B2
+anachronistic,anachronistic,时代错误的,ADJ,B2
+igneous,igneous,火成的,ADJ,B2
+to disabuse,to disabuse,纠正错误想法,VERB,B2
+jet,jet,喷气式飞机,NOUN,B2
+to goad,to goad,刺激,VERB,B2
+to equate,to equate,等同,VERB,B2
+wicked,wicked,邪恶的,ADJ,B2
+bookcase,bookcase,书柜,NOUN,B2
+to yearn,to yearn,渴望,VERB,B2
+cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
+amendable,amendable,可修正的,ADJ,B2
+to segregate,to segregate,隔离,VERB,B2
+incision,incision,切口,NOUN,B2
+to annul,to annul,废除,VERB,B2
+incandescent,incandescent,白炽的,ADJ,B2
+to embark,to embark,上船,VERB,B2
+altercation,altercation,争执,NOUN,B2
+glimpse,glimpse,一瞥,NOUN,B2
+phenomenal,phenomenal,非凡的,ADJ,B2
+to decode,to decode,解码,VERB,B2
+boastful,boastful,自夸的,ADJ,B2
+invincible,invincible,无敌的,ADJ,B2
+bard,bard,吟游诗人,NOUN,B2
+disobedient,disobedient,不服从的,ADJ,B2
+scorn,scorn,轻蔑,NOUN,B2
+to encircle,to encircle,环绕,VERB,B2
+to splash,to splash,溅,VERB,B2
+to daunt,to daunt,使气馁,VERB,B2
+bastion,bastion,堡垒,NOUN,B2
+schism,schism,分裂,NOUN,B2
+to alleviate,to alleviate,缓解,VERB,B2
+jury,jury,陪审团,NOUN,B2
+rival,rival,对手,NOUN,B2
+to expurgate,to expurgate,删节,VERB,B2
+ethereal,ethereal,飘渺的,ADJ,B2
+to bifurcate,to bifurcate,分叉,VERB,B2
+plundering,plundering,掠夺,NOUN,B2
+to capitulate,to capitulate,投降,VERB,B2
+virulent,virulent,恶性的,ADJ,B2
+stew,stew,炖菜,NOUN,B2
+inadequate,inadequate,不足的,ADJ,B2
+malnutrition,malnutrition,营养不良,NOUN,B2
+alibi,alibi,不在场证明,NOUN,B2
+feeble,feeble,虚弱的,ADJ,B2
+displacement,displacement,位移,NOUN,B2
+byzantine,byzantine,错综复杂的,ADJ,B2
+to depreciate,to depreciate,贬值,VERB,B2
+intransigent,intransigent,不妥协的,ADJ,B2
+apologist,apologist,辩护者,NOUN,B2
+inflammation,inflammation,炎症,NOUN,B2
+ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
+to enervate,to enervate,使衰弱,VERB,B2
+to vilify,to vilify,诽谤,VERB,B2
+to fluster,to fluster,使慌乱,VERB,B2
+to disarrange,to disarrange,弄乱,VERB,B2
+incongruous,incongruous,不协调的,ADJ,B2
+to fraternize,to fraternize,勾结,VERB,B2
+to edify,to edify,启发,VERB,B2
+abstemious,abstemious,有节制的,ADJ,B2
+prize,prize,奖品,NOUN,B2
+to augur,to augur,预言,VERB,B2
+hepatic,hepatic,肝脏的,ADJ,B2
+postponement,postponement,延期,NOUN,B2
+humiliating,humiliating,令人羞辱的,ADJ,B2
+pious,pious,虔诚的,ADJ,B2
+freight,freight,货物,NOUN,B2
+to daze,to daze,使茫然,VERB,B2
+incessant,incessant,持续的,ADJ,B2
+spurious,spurious,虚假的,ADJ,B2
+abject,abject,悲惨的,ADJ,B2
+nosy,nosy,爱打听的,ADJ,B2
+promiscuous,promiscuous,滥交的,ADJ,B2
+to denote,to denote,表示,VERB,B2
+to exculpate,to exculpate,开脱,VERB,B2
+import,import,进口,NOUN,B2
+to scrub,to scrub,擦洗,VERB,B2
+to disconcert,to disconcert,使惊慌,VERB,B2
+dexterity,dexterity,灵巧,NOUN,B2
+corroboration,corroboration,证实,NOUN,B2
+to ascribe,to ascribe,归因于,VERB,B2
+stagnant,stagnant,停滞的,ADJ,B2
+format,format,格式,NOUN,B2
+craving,craving,渴求,NOUN,B2
+bonfire,bonfire,篝火,NOUN,B2
+gargoyle,gargoyle,滴水嘴兽,NOUN,B2
+gunshot,gunshot,枪声,NOUN,B2
+to acclaim,to acclaim,称赞,VERB,B2
+stoic,stoic,坚忍的,ADJ,B2
+equivalent,equivalent,相等的,ADJ,B2
+tick,tick,滴答声,NOUN,B2
+sane,sane,神志正常的,ADJ,B2
+to rebuke,to rebuke,斥责,VERB,B2
+to ail,to ail,使苦恼,VERB,B2
+atrocity,atrocity,暴行,NOUN,B2
+oracle,oracle,神谕,NOUN,B2
+wealthy,wealthy,富有的,ADJ,B2
+irrational,irrational,非理性的,ADJ,B2
+deportation,deportation,驱逐出境,NOUN,B2
+bracket,bracket,括号,NOUN,B2
+terse,terse,简练的,ADJ,B2
+to enslave,to enslave,奴役,VERB,B2
+to flap,to flap,拍打,VERB,B2
+inhibition,inhibition,抑制,NOUN,B2
+to snub,to snub,冷落,VERB,B2
+to extricate,to extricate,使摆脱,VERB,B2
+frigid,frigid,寒冷的,ADJ,B2
+evocative,evocative,引起回忆的,ADJ,B2
+impeccable,impeccable,无瑕疵的,ADJ,B2
+to commercialize,to commercialize,商业化,VERB,B2
+to enrapture,to enrapture,使狂喜,VERB,B2
+apologetic,apologetic,道歉的,ADJ,B2
+opulent,opulent,豪华的,ADJ,B2
+barge,barge,驳船,NOUN,B2
+cultivation,cultivation,培养,NOUN,B2
+infamous,infamous,声名狼藉的,ADJ,B2
+to fortify,to fortify,加强,VERB,B2
+reverent,reverent,虔诚的,ADJ,B2
+to divest,to divest,剥夺,VERB,B2
+to disinherit,to disinherit,剥夺继承权,VERB,B2
+hyperbole,hyperbole,夸张,NOUN,B2
+to boost,to boost,促进,VERB,B2
+to fertilize,to fertilize,施肥,VERB,B2
+to satiate,to satiate,使饱足,VERB,B2
+arcane,arcane,神秘的,ADJ,B2
+discrepancy,discrepancy,差异,NOUN,B2
+to deport,to deport,驱逐出境,VERB,B2
+to cram,to cram,填鸭式学习,VERB,B2
+to fumigate,to fumigate,熏蒸,VERB,B2
+cramp,cramp,抽筋,NOUN,B2
+touching,touching,动人的,ADJ,B2
+immature,immature,不成熟的,ADJ,B2
+bacchanal,bacchanal,狂欢,NOUN,B2
+feast,feast,盛宴,NOUN,B2
+to botch,to botch,搞砸,VERB,B2
+scarcely,scarcely,几乎不,ADV,B2
+evasion,evasion,逃避,NOUN,B2
+to disperse,to disperse,分散,VERB,B2
+behaviorist,behaviorist,行为主义者,NOUN,B2
+beloved,beloved,心爱的,ADJ,B2
+to elude,to elude,逃避,VERB,B2
+bohemian,bohemian,放荡不羁的,ADJ,B2
+akin,akin,相似的,ADJ,B2
+brainwasher,brainwasher,洗脑者,NOUN,B2
+bossism,bossism,老板主义,NOUN,B2
+weary,weary,疲倦的,ADJ,B2
+apathy,apathy,冷漠,NOUN,B2
+skirmish,skirmish,小规模战斗,NOUN,B2
+shrill,shrill,尖锐的,ADJ,B2
+affront,affront,冒犯,NOUN,B2
+to deify,to deify,神化,VERB,B2
+garland,garland,花环,NOUN,B2
+brow,brow,眉毛,NOUN,B2
+to covet,to covet,觊觎,VERB,B2
+to sprout,to sprout,发芽,VERB,B2
+funnel,funnel,漏斗,NOUN,B2
+to gravitate,to gravitate,受吸引,VERB,B2
+to disintegrate,to disintegrate,瓦解,VERB,B2
+incoherence,incoherence,不连贯,NOUN,B2
+to ensnare,to ensnare,诱捕,VERB,B2
+constituent,constituent,成分,NOUN,B2
+fratricide,fratricide,杀兄弟,NOUN,B2
+ardent,ardent,热情的,ADJ,B2
+to forebode,to forebode,预兆,VERB,B2
+acceptable,acceptable,可接受的,ADJ,B2
+exotic,exotic,异国情调的,ADJ,B2
+to dilute,to dilute,稀释,VERB,B2
+cistern,cistern,蓄水池,NOUN,B2
+badge,badge,徽章,NOUN,B2
+to enrage,to enrage,激怒,VERB,B2
+ashen,ashen,灰白的,ADJ,B2
+aging,aging,老化,NOUN,B2
+diaphragm,diaphragm,横膈膜,NOUN,B2
+magnanimous,magnanimous,宽宏大量的,ADJ,B2
+sorcery,sorcery,巫术,NOUN,B2
+excrement,excrement,排泄物,NOUN,B2
+belligerent,belligerent,好战的,ADJ,B2
+detergent,detergent,洗涤剂,NOUN,B2
+sniper,sniper,狙击手,NOUN,B2
+bourgeois,bourgeois,资产阶级的,ADJ,B2
+to shroud,to shroud,覆盖,VERB,B2
+demagoguery,demagoguery,煽动性,NOUN,B2
+to erode,to erode,侵蚀,VERB,B2
+to denature,to denature,使变性,VERB,B2
+to alter,to alter,改变,VERB,B2
+to exude,to exude,散发,VERB,B2
+betrothal,betrothal,订婚,NOUN,B2
+to adhere,to adhere,坚持,VERB,B2
+to deign,to deign,屈尊,VERB,B2
+to allocate,to allocate,分配,VERB,B2
+antipode,antipode,对跖点,NOUN,B2
+anachronism,anachronism,时代错误,NOUN,B2
+docile,docile,温顺的,ADJ,B2
+to cloy,to cloy,使厌烦,VERB,B2
+to delineate,to delineate,描绘,VERB,B2
+to flatten,to flatten,使平坦,VERB,B2
+stipend,stipend,津贴,NOUN,B2
+to dispose,to dispose,处理,VERB,B2
+worn,worn,磨损的,ADJ,B2
+to gratify,to gratify,使满足,VERB,B2
+uncouth,uncouth,粗俗的,ADJ,B2
+disuse,disuse,废弃,NOUN,B2
+to galvanize,to galvanize,激励,VERB,B2
+freezing,freezing,极冷的,ADJ,B2
+to retract,to retract,撤回,VERB,B2
+aforementioned,aforementioned,上述的,ADJ,B2
+convertibility,convertibility,可兑换性,NOUN,B2
+absorbed,absorbed,全神贯注的,ADJ,B2
+to beautify,to beautify,美化,VERB,B2
+sore,sore,疼痛的,ADJ,B2
+vogue,vogue,流行,NOUN,B2
+elusive,elusive,难以捉摸的,ADJ,B2
+to confine,to confine,限制,VERB,B2
+to cauterize,to cauterize,烧灼,VERB,B2
+to unearth,to unearth,发掘,VERB,B2
+to dishearten,to dishearten,使沮丧,VERB,B2
+unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
+amorphous,amorphous,无定形的,ADJ,B2
+attribution,attribution,归因,NOUN,B2
+to stratify,to stratify,分层,VERB,B2
+frivolous,frivolous,轻浮的,ADJ,B2
+wax,wax,蜡,NOUN,B2
+soccer,soccer,足球,NOUN,B2
+mezzanine,mezzanine,夹层,NOUN,B2
+saving,saving,储蓄,NOUN,B2
+apprehensive,apprehensive,忧虑的,ADJ,B2
+to unravel,to unravel,解开,VERB,B2
+to overthrow,to overthrow,推翻,VERB,B2
+buttress,buttress,扶壁,NOUN,B2
+assertion,assertion,断言,NOUN,B2
+to germinate,to germinate,发芽,VERB,B2
+unprecedented,unprecedented,史无前例的,ADJ,B2
+bloodless,bloodless,不流血的,ADJ,B2
+remorseful,remorseful,悔恨的,ADJ,B2
+shipment,shipment,货物,NOUN,B2
+to engross,to engross,使全神贯注,VERB,B2
+chronicle,chronicle,编年史,NOUN,B2
+phony,phony,假的,ADJ,B2
+oblique,oblique,斜的,ADJ,B2
+to glean,to glean,搜集,VERB,B2
+to eject,to eject,弹出,VERB,B2
+vase,vase,花瓶,NOUN,B2
+vicissitude,vicissitude,变迁,NOUN,B2
+burner,burner,燃烧器,NOUN,B2
+stratagem,stratagem,策略,NOUN,B2
+to bewitch,to bewitch,迷住,VERB,B2
+shotgun,shotgun,猎枪,NOUN,B2
+adverse,adverse,不利的,ADJ,B2
+mistaken,mistaken,错误的,ADJ,B2
+bower,bower,凉亭,NOUN,B2
+unforgivable,unforgivable,不可原谅的,ADJ,B2
+ancillary,ancillary,辅助的,ADJ,B2
+bagpiper,bagpiper,风笛手,NOUN,B2
+to amalgamate,to amalgamate,合并,VERB,B2
+den,den,兽穴,NOUN,B2
+reluctant,reluctant,不情愿的,ADJ,B2
+spine,spine,脊柱,NOUN,B2
+to exclaim,to exclaim,呼喊,VERB,B2
+to condescend,to condescend,屈尊,VERB,B2
+ephemeral,ephemeral,短暂的,ADJ,B2
+immoral,immoral,不道德的,ADJ,B2
+inspired,inspired,受启发的,ADJ,B2
+to deflate,to deflate,使泄气,VERB,B2
+wary,wary,谨慎的,ADJ,B2
+abstinence,abstinence,节制,NOUN,B2
+sacrilege,sacrilege,亵渎,NOUN,B2
+to gauge,to gauge,测量,VERB,B2
+erudite,erudite,博学的,ADJ,B2
+spite,spite,恶意,NOUN,B2
+to depopulate,to depopulate,使人口减少,VERB,B2
+favoritism,favoritism,偏袒,NOUN,B2
+auspice,auspice,赞助,NOUN,B2
+confederate,confederate,同盟者,NOUN,B2
+sublime,sublime,崇高的,ADJ,B2
+misanthrope,misanthrope,厌世者,NOUN,B2
+equity,equity,公平,NOUN,B2
+hemisphere,hemisphere,半球,NOUN,B2
+deceptive,deceptive,欺骗性的,ADJ,B2
+exponent,exponent,指数,NOUN,B2
+cacophony,cacophony,刺耳的声音,NOUN,B2
+battlement,battlement,城垛,NOUN,B2
+enigmatic,enigmatic,神秘的,ADJ,B2
+froth,froth,泡沫,NOUN,B2
+aptitude,aptitude,天资,NOUN,B2
+to enthrall,to enthrall,迷住,VERB,B2
+balustrade,balustrade,栏杆,NOUN,B2
+barricade,barricade,路障,NOUN,B2
+to gain,to gain,获得,VERB,B2
+to assent,to assent,同意,VERB,B2
+concord,concord,和谐,NOUN,B2
+avid,avid,热切的,ADJ,B2
+zeal,zeal,热情,NOUN,B2
+to elucidate,to elucidate,阐明,VERB,B2
+decorum,decorum,礼仪,NOUN,B2
+to embarrass,to embarrass,使尴尬,VERB,B2
+asparagus,asparagus,芦笋,NOUN,B2
+dapper,dapper,整洁的,ADJ,B2
+alienable,alienable,可转让的,ADJ,B2
+fabulous,fabulous,极好的,ADJ,B2
+to equalize,to equalize,使相等,VERB,B2
+cast,cast,演员阵容,NOUN,B2
+to attenuate,to attenuate,减弱,VERB,B2
+gregarious,gregarious,爱社交的,ADJ,B2
+apotheotic,apotheotic,神化的,ADJ,B2
+apex,apex,顶点,NOUN,B2
+contrition,contrition,悔罪,NOUN,B2
+ruthless,ruthless,无情的,ADJ,B2
+crystalline,crystalline,水晶般的,ADJ,B2
+burdensome,burdensome,繁重的,ADJ,B2
+to disunite,to disunite,使分裂,VERB,B2
+to exfoliate,to exfoliate,去角质,VERB,B2
+risque,risque,有伤风化的,ADJ,B2
+cumbersome,cumbersome,笨重的,ADJ,B2
+bilious,bilious,易怒的,ADJ,B2
+gin,gin,金酒,NOUN,B2
+biweekly,biweekly,双周的,ADJ,B2
+brooding,brooding,忧思,NOUN,B2
+to decompress,to decompress,解压,VERB,B2
+intellect,intellect,智力,NOUN,B2
+contraband,contraband,违禁品,NOUN,B2
+autocratic,autocratic,专制的,ADJ,B2
+to condone,to condone,宽恕,VERB,B2
+stolid,stolid,冷漠的,ADJ,B2
+to swagger,to swagger,大摇大摆,VERB,B2
+to declassify,to declassify,解密,VERB,B2
+binge,binge,放纵,NOUN,B2
+trifling,trifling,微不足道的,ADJ,B2
+frantic,frantic,狂乱的,ADJ,B2
+to asphyxiate,to asphyxiate,使窒息,VERB,B2
+to foist,to foist,强加,VERB,B2
+sedentary,sedentary,久坐的,ADJ,B2
+dishonor,dishonor,耻辱,NOUN,B2
+humorous,humorous,幽默的,ADJ,B2
+to consign,to consign,移交,VERB,B2
+immense,immense,巨大的,ADJ,B2
+erratic,erratic,不稳定的,ADJ,B2
+haughty,haughty,傲慢的,ADJ,B2
+cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
+to beatify,to beatify,宣福,VERB,B2
+to redeem,to redeem,赎回,VERB,B2
+inquisitive,inquisitive,好奇的,ADJ,B2
+incisive,incisive,深刻的,ADJ,B2
+conciseness,conciseness,简洁,NOUN,B2
+brazen,brazen,厚颜无耻的,ADJ,B2
+to adduce,to adduce,引证,VERB,B2
+to temporize,to temporize,拖延,VERB,B2
+brochure,brochure,小册子,NOUN,B2
+tireless,tireless,不知疲倦的,ADJ,B2
+matriarch,matriarch,女家长,NOUN,B2
+vehement,vehement,激烈的,ADJ,B2
+to curtail,to curtail,削减,VERB,B2
+to expectorate,to expectorate,吐痰,VERB,B2
+to stalk,to stalk,跟踪,VERB,B2
+astonished,astonished,惊讶的,ADJ,B2
+catapult,catapult,投石机,NOUN,B2
+disparate,disparate,截然不同的,ADJ,B2
+brusqueness,brusqueness,唐突,NOUN,B2
+entertaining,entertaining,有趣的,ADJ,B2
+to alienate,to alienate,使疏远,VERB,B2
+pensive,pensive,沉思的,ADJ,B2
+atonement,atonement,赎罪,NOUN,B2
+to corrode,to corrode,腐蚀,VERB,B2
+to afforest,to afforest,造林,VERB,B2
+altitude,altitude,海拔,NOUN,B2
+plausible,plausible,似是而非的,ADJ,B2
+to brandish,to brandish,挥舞,VERB,B2
+sanctimonious,sanctimonious,伪善的,ADJ,B2
+boisterous,boisterous,喧闹的,ADJ,B2
+iconoclast,iconoclast,偶像破坏者,NOUN,B2
+blunder,blunder,大错,NOUN,B2
+ungainly,ungainly,笨拙的,ADJ,B2
+upstart,upstart,暴发户,NOUN,B2
+to defame,to defame,诽谤,VERB,B2
+biting,biting,咬人,NOUN,B2
+to exalt,to exalt,颂扬,VERB,B2
+dichotomy,dichotomy,二分法,NOUN,B2
+bargain,bargain,便宜货,NOUN,B2
+attainable,attainable,可获得的,ADJ,B2
+oversight,oversight,疏忽,NOUN,B2
+gem,gem,宝石,NOUN,B2
+to detract,to detract,贬低,VERB,B2
+contemplation,contemplation,沉思,NOUN,B2
+graduation,graduation,毕业,NOUN,B2
+to skein,to skein,绕成线团,VERB,B2
+slenderness,slenderness,纤细,NOUN,B2
+hygienic,hygienic,卫生的,ADJ,B2
+curator,curator,策展人,NOUN,B2
+horrified,horrified,惊骇的,ADJ,B2
+scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
+reclamation,reclamation,收复,NOUN,B2
+bungler,bungler,笨手笨脚的人,NOUN,B2
+to lead astray,to lead astray,使入歧途,VERB,B2
+to spirit away,to spirit away,变走,VERB,B2
+appreciable,appreciable,可观的,ADJ,B2
+deteriorated,deteriorated,恶化的,ADJ,B2
+cove,cove,小海湾,NOUN,B2
+intermediate,intermediate,中级的,ADJ,B2
+gamete,gamete,配子,NOUN,B2
+scythe,scythe,镰刀,NOUN,B2
+idiot,idiot,傻瓜,ADJ,B2
+to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
+to humanize,to humanize,使人性化,VERB,B2
+fractional,fractional,分数的,ADJ,B2
+centipede,centipede,蜈蚣,NOUN,B2
+to idolize,to idolize,崇拜,VERB,B2
+set of ideals,set of ideals,思想体系,NOUN,B2
+epithet,epithet,绰号,NOUN,B2
+autocracy,autocracy,专制,NOUN,B2
+to plunder,to plunder,掠夺,VERB,B2
+equestrian,equestrian,马术的,ADJ,B2
+celerity,celerity,迅速,NOUN,B2
+musk,musk,麝香,NOUN,B2
+to splint,to splint,用夹板固定,VERB,B2
+seaplane,seaplane,水上飞机,NOUN,B2
+to go numb,to go numb,麻木,VERB,B2
+to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
+insinuation,insinuation,暗示,NOUN,B2
+cane,cane,手杖,NOUN,B2
+shameless person,shameless person,厚颜无耻的人,NOUN,B2
+excitability,excitability,兴奋性,NOUN,B2
+inflection,inflection,词尾,NOUN,B2
+hooligan,hooligan,流氓,NOUN,B2
+disquisition,disquisition,论述,NOUN,B2
+to fail to fulfill,to fail to fulfill,未履行,VERB,B2
+to gush,to gush,涌出,VERB,B2
+annotation,annotation,注释,NOUN,B2
+fanatic,fanatic,狂热的,ADJ,B2
+gatekeeper,gatekeeper,道口看守员,NOUN,B2
+emulation,emulation,模仿,NOUN,B2
+charitable,charitable,慈善的,ADJ,B2
+cattle rancher,cattle rancher,牧场主,NOUN,B2
+to codify,to codify,编纂,VERB,B2
+narrowing,narrowing,变窄,NOUN,B2
+countercurrent,countercurrent,逆流,NOUN,B2
+inclement,inclement,严酷的,ADJ,B2
+every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
+confinement,confinement,禁闭,NOUN,B2
+sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
+to put on track,to put on track,使走上正轨,VERB,B2
+stampede,stampede,溃逃,NOUN,B2
+to gray,to gray,变白,VERB,B2
+confidant,confidant,知己,NOUN,B2
+wharf,wharf,码头,NOUN,B2
+brute,brute,粗野的,ADJ,B2
+to elevate,to elevate,提升,VERB,B2
+babble,babble,结巴,NOUN,B2
+to dispossess,to dispossess,剥夺,VERB,B2
+to crowd together,to crowd together,挤在一起,VERB,B2
+to guess right,to guess right,猜中,VERB,B2
+to espy,to espy,窥探,VERB,B2
+collusion,collusion,串通,NOUN,B2
+concordance,concordance,一致,NOUN,B2
+colossal,colossal,巨大的,ADJ,B2
+fortune teller,fortune teller,占卜者,NOUN,B2
+devourer,devourer,吞噬者,NOUN,B2
+flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
+contiguous,contiguous,相邻的,ADJ,B2
+widening,widening,加宽,NOUN,B2
+to unbutton,to unbutton,解开纽扣,VERB,B2
+to defer,to defer,推迟,VERB,B2
+spatula,spatula,刮刀,NOUN,B2
+to disentangle,to disentangle,解开,VERB,B2
+to apostatize,to apostatize,叛教,VERB,B2
+untidiness,untidiness,凌乱,NOUN,B2
+governability,governability,可治理性,NOUN,B2
+discredit,discredit,丧失信誉,NOUN,B2
+to handcuff,to handcuff,给…戴手铐,VERB,B2
+to fluctuate,to fluctuate,波动,VERB,B2
+generatrix,generatrix,母线,NOUN,B2
+long-distance runner,long-distance runner,长跑运动员,NOUN,B2
+prolific,prolific,多产的,ADJ,B2
+galician,galician,加利西亚的,ADJ,B2
+to meddle,to meddle,干涉,VERB,B2
+exalted,exalted,狂热的,ADJ,B2
+involuntary,involuntary,无意识的,ADJ,B2
+ferret,ferret,雪貂,NOUN,B2
+ballast,ballast,压舱物,NOUN,B2
+illogical,illogical,不合逻辑的,ADJ,B2
+to guillotine,to guillotine,斩首,VERB,B2
+bunch,bunch,一群,NOUN,B2
+justness,justness,公正,NOUN,B2
+disenchantment,disenchantment,幻灭,NOUN,B2
+grandiloquent,grandiloquent,夸张的,ADJ,B2
+fruit tree,fruit tree,果树的,ADJ,B2
+hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+suicidal,suicidal,自杀的,ADJ,B2
+doctrinaire,doctrinaire,教条主义的,ADJ,B2
+quotable,quotable,可估价的,ADJ,B2
+tickle,tickle,发痒,NOUN,B2
+compendium,compendium,纲要,NOUN,B2
+tackling,tackling,马具,NOUN,B2
+leafy,leafy,枝叶茂密的,ADJ,B2
+to vent,to vent,倾诉,VERB,B2
+to gird,to gird,束紧,VERB,B2
+furtive,furtive,鬼鬼祟祟的,ADJ,B2
+exculpation,exculpation,开脱,NOUN,B2
+countenance,countenance,面容,NOUN,B2
+falconry,falconry,猎鹰术,NOUN,B2
+conic,conic,圆锥曲线,NOUN,B2
+disloyalty,disloyalty,不忠,NOUN,B2
+to thrill,to thrill,使兴奋,VERB,B2
+herbaceous,herbaceous,草本的,ADJ,B2
+alien,alien,外星人的,ADJ,B2
+inflamed,inflamed,激烈的,ADJ,B2
+informative,informative,提供信息的,ADJ,B2
+aridity,aridity,干旱,NOUN,B2
+to encode,to encode,编码,VERB,B2
+epitaph,epitaph,墓志铭,NOUN,B2
+indistinct,indistinct,模糊的,ADJ,B2
+expeditious,expeditious,迅速的,ADJ,B2
+varnish,varnish,清漆,NOUN,B2
+to go deep into,to go deep into,深入,VERB,B2
+duet,duet,二重奏,NOUN,B2
+home-loving,home-loving,顾家的,ADJ,B2
+to coax,to coax,哄骗,VERB,B2
+pharisee,pharisee,法利赛人,NOUN,B2
+gravid,gravid,怀孕的,ADJ,B2
+condemned,condemned,被定罪的,ADJ,B2
+delirious,delirious,谵妄的,ADJ,B2
+apotheosis,apotheosis,神化,NOUN,B2
+squid,squid,鱿鱼,NOUN,B2
+unbridled,unbridled,肆无忌惮的,ADJ,B2
+grotesque,grotesque,怪诞的,ADJ,B2
+blazing,blazing,炽热的,ADJ,B2
+to be unaware,to be unaware,不知道,VERB,B2
+out of place,out of place,格格不入的,ADJ,B2
+revelry,revelry,狂欢,NOUN,B2
+to wield,to wield,行使,VERB,B2
+excavator,excavator,挖掘机,NOUN,B2
+to powder,to powder,撒粉,VERB,B2
+flaccid,flaccid,松弛的,ADJ,B2
+egalitarian,egalitarian,平等主义的,ADJ,B2
+cord,cord,绳索,NOUN,B2
+disadvantageous,disadvantageous,不利的,ADJ,B2
+foliage,foliage,枝叶,NOUN,B2
+winding,winding,蜿蜒的,ADJ,B2
+to antagonize,to antagonize,使对立,VERB,B2
+apoplexy,apoplexy,中风,NOUN,B2
+land register,land register,地籍,NOUN,B2
+intolerant,intolerant,不容忍的,ADJ,B2
+japanese,japanese,日本的,ADJ,B2
+pernicious,pernicious,有害的,ADJ,B2
+speculator,speculator,投机者,NOUN,B2
+lucidity,lucidity,清醒 / 明晰,NOUN,B2
+infant,infant,婴儿,NOUN,B2
+holder,holder,持有者,NOUN,B2
+ataxia,ataxia,共济失调,NOUN,B2
+slowdown,slowdown,减速,NOUN,B2
+mosquito net,mosquito net,蚊帐,NOUN,B2
+furrow,furrow,犁沟,NOUN,B2
+unscathed,unscathed,未受伤害的,ADJ,B2
+except for,except for,除了,ADP,B2
+thrilling,thrilling,令人兴奋的,ADJ,B2
+foal,foal,马驹,NOUN,B2
+unilateral,unilateral,单方面的,ADJ,B2
+perennial,perennial,长期的,ADJ,B2
+bud,bud,芽,NOUN,B2
+bridle,bridle,马勒,NOUN,B2
+philippic,philippic,猛烈的抨击,NOUN,B2
+to appear to seem,to appear to seem,出现/显得,VERB,B2
+painstakingly,painstakingly,细致地,ADV,B2
+decor,decor,布景,NOUN,B2
+scheduling,scheduling,调度；排序,NOUN,B2
+editing,editing,剪辑,NOUN,B2
+to blossom,to blossom,开花,VERB,B2
+to plane,to plane,刨,VERB,B2
+sordid,sordid,肮脏的,ADJ,B2
+to emasculate,to emasculate,使无力,VERB,B2
+trusting,trusting,信任的,ADJ,B2
+costly,costly,昂贵的,ADJ,B2
+to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
+obtaining,obtaining,获得,NOUN,B2
+luminous,luminous,发光的,ADJ,B2
+prodigy,prodigy,神童,NOUN,B2
+multinational,multinational,跨国公司,NOUN,B2
+split secession,split secession,分裂,NOUN,B2
+notarized,notarized,经公证的,ADJ,B2
+psychiatric,psychiatric,精神病的,ADJ,B2
+contaminated,contaminated,受污染的,ADJ,B2
+fluctuating,fluctuating,波动的,ADJ,B2
+to soften,to soften,使灵活,VERB,B2
+to conjugate,to conjugate,变位,VERB,B2
+polar,polar,极地的,ADJ,B2
+to declaim,to declaim,慷慨陈词,VERB,B2
+respondent,respondent,被上诉人,NOUN,B2
+lust,lust,欲望,NOUN,B2
+catachresis,catachresis,词语误用,NOUN,B2
+tv movie,tv movie,电视电影,NOUN,B2
+sophisticated,sophisticated,复杂的,ADJ,B2
+respectful,respectful,恭敬的,ADJ,B2
+charismatic,charismatic,有魅力的,ADJ,B2
+constancy,constancy,恒定,NOUN,B2
+to relay,to relay,转达,VERB,B2
+to reproach,to reproach,责备,VERB,B2
+reprieve,reprieve,暂缓执行,NOUN,B2
+marvelous,marvelous,极好的,ADJ,B2
+doe,doe,雌鹿,NOUN,B2
+larva,larva,幼虫,NOUN,B2
+bicameral,bicameral,两院制的,ADJ,B2
+demographic,demographic,人口统计的,ADJ,B2
+anaphora,anaphora,首语重复修辞,NOUN,B2
+opacity,opacity,不透明性,NOUN,B2
+taxonomy,taxonomy,分类学,NOUN,B2
+advertising,advertising,广告的,ADJ,B2
+pathogenic,pathogenic,致病的,ADJ,B2
+relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+attractiveness,attractiveness,吸引力,NOUN,B2
+tilt,tilt,倾斜,NOUN,B2
+to make stupid,to make stupid,使愚蠢,VERB,B2
+cornice,cornice,檐口,NOUN,B2
+to accentuate,to accentuate,强调,VERB,B2
+trapdoor,trapdoor,活板门,NOUN,B2
+prosody,prosody,韵律学,NOUN,B2
+others,others,他人,PRON,B2
+courteous,courteous,有礼貌的,ADJ,B2
+ballot,ballot,选票,NOUN,B2
+jointly,jointly,共同地,ADV,B2
+predominance,predominance,主导地位,NOUN,B2
+balm,balm,香脂,NOUN,B2
+masonry,masonry,砌体,NOUN,B2
+political party,political party,政党,NOUN,B2
+chore,chore,家务,NOUN,B2
+iatrogenic,iatrogenic,医源性的,ADJ,B2
+prerogative,prerogative,特权,NOUN,B2
+to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
+choreographer,choreographer,编舞者,NOUN,B2
+to burnish,to burnish,擦亮,VERB,B2
+amnesia,amnesia,健忘症,NOUN,B2
+to bequeath,to bequeath,遗赠,VERB,B2
+subtle,subtle,微妙的,ADJ,B2
+to carve,to carve,雕刻,VERB,B2
+to savor,to savor,品味,VERB,B2
+corporatism,corporatism,法团主义,NOUN,B2
+to lament,to lament,哀叹,VERB,B2
+minimalism,minimalism,极简主义,NOUN,B2
+security-related,security-related,安全的，安保的,ADJ,B2
+atrophy,atrophy,萎缩,NOUN,B2
+to frolic,to frolic,嬉戏,VERB,B2
+to defuse,to defuse,缓和,VERB,B2
+delicately,delicately,巧妙地,ADV,B2
+to fraction,to fraction,分割,VERB,B2
+to deviate,to deviate,偏离,VERB,B2
+personalized,personalized,个性化的,ADJ,B2
+to drape,to drape,悬挂,VERB,B2
+fold,fold,折痕,NOUN,B2
+rustic,rustic,乡村的,ADJ,B2
+doubling,doubling,加倍,NOUN,B2
+breast,breast,乳房,NOUN,B2
+to flout,to flout,蔑视,VERB,B2
+particularly,particularly,特别地,ADV,B2
+upheaval,upheaval,剧变,NOUN,B2
+to serve a route,to serve a route,为...提供交通服务,VERB,B2
+mound,mound,土堆,NOUN,B2
+pallor,pallor,苍白,NOUN,B2
+rout,rout,溃败,NOUN,B2
+resourceful,resourceful,机灵的,ADJ,B2
+awareness raising,awareness raising,提高意识,NOUN,B2
+granny,granny,奶奶,NOUN,B2
+sheaf,sheaf,捆,NOUN,B2
+locality,locality,地点,NOUN,B2
+facies,facies,面貌,NOUN,B2
+aphasia,aphasia,失语症,NOUN,B2
+feature film,feature film,故事片,NOUN,B2
+perpetual,perpetual,永久的,ADJ,B2
+probe,probe,探测器,NOUN,B2
+to commute,to commute,通勤,VERB,B2
+to reverse,to reverse,反转,VERB,B2
+water heater,water heater,热水器,NOUN,B2
+proliferation,proliferation,增殖,NOUN,B2
+pantheon,pantheon,先贤祠,NOUN,B2
+detainee,detainee,被拘留者,NOUN,B2
+summarily,summarily,草率地,ADV,B2
+to defrost,to defrost,除霜,VERB,B2
+perilous,perilous,危险的,ADJ,B2
+to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
+to execrate,to execrate,痛恨,VERB,B2
+to resonate,to resonate,共鸣,VERB,B2
+factoring,factoring,保理,NOUN,B2
+detached house,detached house,独栋房屋,NOUN,B2
+to amass,to amass,积聚,VERB,B2
+independently,independently,独立地,ADV,B2
+severely,severely,严厉地,ADV,B2
+traditionally,traditionally,传统地,ADV,B2
+tenacity,tenacity,坚韧,NOUN,B2
+politely,politely,礼貌地,ADV,B2
+paper clip,paper clip,回形针,NOUN,B2
+to unbridle,to unbridle,解开,VERB,B2
+yoke,yoke,枷锁,NOUN,B2
+cohort,cohort,队列,NOUN,B2
+respective,respective,各自的,ADJ,B2
+newcomer,newcomer,新来者,NOUN,B2
+bookplate,bookplate,藏书票,NOUN,B2
+frankly,frankly,坦率地,ADV,B2
+passionate,passionate,热情的,ADJ,B2
+panther,panther,豹,NOUN,B2
+antisemitism,antisemitism,反犹太主义,NOUN,B2
+to generate engender,to generate engender,产生,VERB,B2
+to sequester,to sequester,隔离,VERB,B2
+invariably,invariably,不变地,ADV,B2
+stall,stall,包厢座位,NOUN,B2
+major,major,主要的,ADJ,B2
+expatriate,expatriate,移居国外者,NOUN,B2
+gallop,gallop,疾驰,NOUN,B2
+array,array,排列,NOUN,B2
+malfeasance,malfeasance,渎职,NOUN,B2
+to ratify,to ratify,批准,VERB,B2
+to defray,to defray,支付,VERB,B2
+to gratinate,to gratinate,烤成焦皮,VERB,B2
+various,various,各种各样的,ADJ,B2
+to flock,to flock,群集,VERB,B2
+to appal,to appal,使惊恐,VERB,B2
+to crash into,to crash into,撞击,VERB,B2
+communist,communist,共产主义者,NOUN,B2
+lymphatic,lymphatic,淋巴的,ADJ,B2
+paradoxical,paradoxical,矛盾的,ADJ,B2
+supreme,supreme,最高的,ADJ,B2
+bump,bump,肿块,NOUN,B2
+librarian,librarian,图书管理员,NOUN,B2
+craze,craze,狂热,NOUN,B2
+pedantry,pedantry,迂腐,NOUN,B2
+bulgarian,bulgarian,保加利亚的,ADJ,B2
+syllogism,syllogism,三段论,NOUN,B2
+to conserve,to conserve,保存,VERB,B2
+grumbler,grumbler,爱抱怨的人,NOUN,B2
+prophylaxis,prophylaxis,预防,NOUN,B2
+to invalidate,to invalidate,证明无效,VERB,B2
+to suborn,to suborn,教唆,VERB,B2
+solipsism,solipsism,唯我论,NOUN,B2
+to curl,to curl,卷曲,VERB,B2
+to start again,to start again,重新开始,VERB,B2
+detrimental,detrimental,有害的,ADJ,B2
+mortality,mortality,死亡率,NOUN,B2
+to prosper,to prosper,繁荣,VERB,B2
+televised,televised,电视播出的,ADJ,B2
+tirade,tirade,长篇抨击,NOUN,B2
+rainy,rainy,多雨的,ADJ,B2
+hesitant,hesitant,犹豫的,ADJ,B2
+fit,fit,适合的,ADJ,B2
+preliminary,preliminary,初步的,ADJ,B2
+semantics,semantics,语义学,NOUN,B2
+kindly,kindly,亲切地,ADV,B2
+to tumble,to tumble,跌倒,VERB,B2
+truism,truism,自明之理,NOUN,B2
+civility,civility,礼貌,NOUN,B2
+to dye,to dye,染色,VERB,B2
+respite,respite,喘息,NOUN,B2
+annexation,annexation,吞并,NOUN,B2
+oligarchy,oligarchy,寡头政治,NOUN,B2
+disciplinary,disciplinary,纪律的,ADJ,B2
+to dither,to dither,犹豫不决,VERB,B2
+bailiff,bailiff,法警,NOUN,B2
+to croak,to croak,呱呱叫,VERB,B2
+accuracy,accuracy,准确性,NOUN,B2
+calmly,calmly,平静地,ADV,B2
+predictable,predictable,可预测的,ADJ,B2
+to hail inspect,to hail inspect,盘查,VERB,B2
+narcissistic,narcissistic,自恋的,ADJ,B2
+mash,mash,泥状食物,NOUN,B2
+nostalgia,nostalgia,怀旧,NOUN,B2
+inexorably,inexorably,不可阻挡地,ADV,B2
+vintage,vintage,佳酿,NOUN,B2
+solitary,solitary,孤独的,ADJ,B2
+to make heavier,to make heavier,加重,VERB,B2
+to rally,to rally,团结,VERB,B2
+relentless,relentless,无情的,ADJ,B2
+pioneer,pioneer,先驱,NOUN,B2
+frequently,frequently,经常,ADV,B2
+pleura,pleura,胸膜,NOUN,B2
+mascot,mascot,吉祥物,NOUN,B2
+accessibility,accessibility,可达性,NOUN,B2
+penalty,penalty,惩罚,NOUN,B2
+damaging,damaging,有害的,ADJ,B2
+trauma,trauma,创伤,NOUN,B2
+merchandise,merchandise,商品,NOUN,B2
+to demonize,to demonize,妖魔化,VERB,B2
+not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
+prosecution service,prosecution service,检察院,NOUN,B2
+to ferret,to ferret,搜寻,VERB,B2
+to crumple,to crumple,弄皱,VERB,B2
+to acquiesce,to acquiesce,默许,VERB,B2
+to caper,to caper,跳跃,VERB,B2
+balance sheet,balance sheet,资产负债表,NOUN,B2
+filming,filming,拍摄,NOUN,B2
+separately,separately,分开地，单独地,ADV,B2
+preponderant,preponderant,占优势的,ADJ,B2
+pretentious,pretentious,自命不凡的,ADJ,B2
+hike,hike,徒步旅行,NOUN,B2
+potentially,potentially,潜在地,ADV,B2
+straw,straw,稻草,NOUN,B2
+acoustic,acoustic,声学的,ADJ,B2
+naturally,naturally,自然地,ADV,B2
+know-how,know-how,诀窍,NOUN,B2
+to behead,to behead,斩首,VERB,B2
+to cuddle,to cuddle,拥抱,VERB,B2
+to chastise,to chastise,严惩,VERB,B2
+to decry,to decry,谴责,VERB,B2
+precarious,precarious,不稳定的,ADJ,B2
+flesh,flesh,肉,NOUN,B2
+lubricity,lubricity,好色 / 淫荡,NOUN,B2
+talented,talented,有才华的,ADJ,B2
+apocalyptic,apocalyptic,启示录的,ADJ,B2
+to disjoin,to disjoin,分离,VERB,B2
+offense,offense,冒犯,NOUN,B2
+rain shower,rain shower,阵雨,NOUN,B2
+peritoneum,peritoneum,腹膜,NOUN,B2
+this,this,这,PRON,B2
+hacking,hacking,黑客行为,NOUN,B2
+layperson,layperson,外行,NOUN,B2
+fulfilled,fulfilled,满足的,ADJ,B2
+awful,awful,糟糕的,ADJ,B2
+to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
+braggadocio,braggadocio,吹牛,NOUN,B2
+tertiary,tertiary,第三的,ADJ,B2
+planning,planning,规划,NOUN,B2
+screenwriter,screenwriter,编剧,NOUN,B2
+to concoct,to concoct,编造,VERB,B2
+to dislodge,to dislodge,逐出,VERB,B2
+to dupe,to dupe,欺骗,VERB,B2
+tenor,tenor,男高音,NOUN,B2
+resonant,resonant,共鸣的,ADJ,B2
+supporting document,supporting document,证明文件,NOUN,B2
+touchy,touchy,易怒的,ADJ,B2
+to dispel,to dispel,消除,VERB,B2
+antiquated,antiquated,过时的,ADJ,B2
+unforeseen,unforeseen,意外的,ADJ,B2
+to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
+occult,occult,神秘的,ADJ,B2
+probable likely,probable likely,可能的,ADJ,B2
+to blush,to blush,脸红,VERB,B2
+to bloom,to bloom,开花,VERB,B2
+to feign,to feign,假装,VERB,B2
+notch,notch,刻痕,NOUN,B2
+summer visitor,summer visitor,暑期游客,NOUN,B2
+subcontracting,subcontracting,分包,NOUN,B2
+volunteering,volunteering,志愿服务,NOUN,B2
+to break into,to break into,撬开,VERB,B2
+spade,spade,铲子,NOUN,B2
+subtlety,subtlety,微妙,NOUN,B2
+abusive,abusive,滥用的,ADJ,B2
+persistence,persistence,坚持,NOUN,B2
+cutting,cutting,切割,NOUN,B2
+revival,revival,复兴,NOUN,B2
+to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
+precocious,precocious,早熟的,ADJ,B2
+regulatory,regulatory,监管的,ADJ,B2
+versatile,versatile,多才多艺的,ADJ,B2
+gently,gently,轻轻地,ADV,B2
+microwave,microwave,微波炉,NOUN,B2
+harsh,harsh,严厉的,ADJ,B2
+to purge,to purge,清除,VERB,B2
+taxable,taxable,应纳税的,ADJ,B2
+flow rate,flow rate,流量,NOUN,B2
+financing funding,financing funding,融资,NOUN,B2
+breakup,breakup,分手,NOUN,B2
+historically,historically,历史上,ADV,B2
+preferable,preferable,更可取的,ADJ,B2
+elation,elation,兴高采烈,NOUN,B2
+to pamper,to pamper,纵容,VERB,B2
+to persecute,to persecute,迫害,VERB,B2
+deeply moving,deeply moving,令人感动的,ADJ,B2
+onomatopoeia,onomatopoeia,拟声词,NOUN,B2
+resumption,resumption,恢复,NOUN,B2
+pusillanimous,pusillanimous,怯懦的,ADJ,B2
+their,their,他们的,DET,B2
+decontamination,decontamination,去污,NOUN,B2
+to launder,to launder,洗钱,VERB,B2
+to concede,to concede,承认,VERB,B2
+perceptibly,perceptibly,明显地,ADV,B2
+closing argument,closing argument,辩护词,NOUN,B2
+sentinel,sentinel,哨兵,NOUN,B2
+precision,precision,精确,NOUN,B2
+parsimonious,parsimonious,吝啬的,ADJ,B2
+quiddity,quiddity,本质,NOUN,B2
+bodywork,bodywork,车身,NOUN,B2
+renunciation,renunciation,放弃,NOUN,B2
+canvas,canvas,帆布,NOUN,B2
+formally,formally,正式地,ADV,B2
+loop,loop,循环,NOUN,B2
+mercenary,mercenary,雇佣兵,NOUN,B2
+angelic,angelic,天使般的,ADJ,B2
+disdainfully,disdainfully,轻蔑地,ADV,B2
+lesion,lesion,病变,NOUN,B2
+residual,residual,残留的,ADJ,B2
+cooking,cooking,烹饪,NOUN,B2
+sorting,sorting,分类,NOUN,B2
+to castigate,to castigate,严厉批评,VERB,B2
+innocuous,innocuous,无害的,ADJ,B2
+perverse,perverse,任性的,ADJ,B2
+dishonest,dishonest,不诚实的,ADJ,B2
+to transcribe,to transcribe,转录,VERB,B2
+posthumous,posthumous,死后的,ADJ,B2
+freely,freely,自由地,ADV,B2
+recreation,recreation,娱乐,NOUN,B2
+oxymoron,oxymoron,矛盾修辞法,NOUN,B2
+redundancy,redundancy,冗余,NOUN,B2
+angular,angular,有角的,ADJ,B2
+sedition,sedition,煽动叛乱,NOUN,B2
+to warp,to warp,弯曲,VERB,B2
+pickaxe,pickaxe,镐；锄,NOUN,B2
+notably,notably,显著地,ADV,B2
+semolina,semolina,粗面粉,NOUN,B2
+antecedent,antecedent,先行词,NOUN,B2
+acclimatization,acclimatization,适应环境,NOUN,B2
+probity,probity,正直,NOUN,B2
+sensual,sensual,感官的,ADJ,B2
+malevolence,malevolence,恶意,NOUN,B2
+theologian,theologian,神学家,NOUN,B2
+remote work,remote work,远程办公,NOUN,B2
+specious,specious,似是而非的,ADJ,B2
+drawback,drawback,缺点,NOUN,B2
+to conform,to conform,符合,VERB,B2
+to confer,to confer,授予,VERB,B2
+to strip bare,to strip bare,洗劫,VERB,B2
+practicing believer,practicing believer,信徒,NOUN,B2
+to make bland,to make bland,使乏味,VERB,B2
+pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
+peroration,peroration,结语,NOUN,B2
+indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+food-processing,food-processing,食品加工的,ADJ,B2
+parataxis,parataxis,意合,NOUN,B2
+to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
+hostess,hostess,女服务员,NOUN,B2
+obstetrics,obstetrics,产科学,NOUN,B2
+wrongdoer,wrongdoer,罪犯,NOUN,B2
+to pour out,to pour out,倾诉,VERB,B2
+guru,guru,精神导师,NOUN,B2
+freshly,freshly,新鲜地,ADV,B2
+perfidy,perfidy,背信弃义,NOUN,B2
+cordially,cordially,亲切地,ADV,B2
+street interview,street interview,街头采访,NOUN,B2
+manually,manually,手动地,ADV,B2
+slang,slang,俚语,NOUN,B2
+eight-line stanza,eight-line stanza,八行诗,NOUN,B2
+diagonal,diagonal,对角线,NOUN,B2
+customs officer,customs officer,海关官员,NOUN,B2
+depressive,depressive,抑郁的，压抑的,ADJ,B2
+lawnmower,lawnmower,割草机,NOUN,B2
+proportional,proportional,成比例的,ADJ,B2
+picking,picking,采摘,NOUN,B2
+airfield,airfield,飞机场,NOUN,B2
+apodictic,apodictic,确证的,ADJ,B2
+indirectly,indirectly,间接地,ADV,B2
+to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
+to fall to,to fall to,落到...身上,VERB,B2
+magnesium,magnesium,镁,NOUN,B2
+quashing,quashing,撤销,NOUN,B2
+recruiter,recruiter,招聘人员,NOUN,B2
+toad,toad,蟾蜍,NOUN,B2
+sovereigntist,sovereigntist,主权主义者,NOUN,B2
+clumsiness,clumsiness,笨拙,NOUN,B2
+media library,media library,多媒体图书馆,NOUN,B2
+caterpillar,caterpillar,毛毛虫,NOUN,B2
+sincerely,sincerely,真诚地,ADV,B2
+to move to pity,to move to pity,使怜悯,VERB,B2
+typology,typology,类型学,NOUN,B2
+heatwave,heatwave,热浪,NOUN,B2
+stressful,stressful,有压力的,ADJ,B2
+unofficially,unofficially,非正式地,ADV,B2
+to chill,to chill,使冰冻,VERB,B2
+triangular,triangular,三角形的,ADJ,B2
+pitchfork,pitchfork,叉子,NOUN,B2
+french-speaking,french-speaking,讲法语的,ADJ,B2
+symptomatology,symptomatology,症状学,NOUN,B2
+dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
+to raise awareness,to raise awareness,提高意识,VERB,B2
+about sixty,about sixty,六十来个,NOUN,B2
+indiscriminately,indiscriminately,不加区别地,ADV,B2
+the blues,the blues,忧郁,NOUN,B2
+legatee,legatee,受遗赠人,NOUN,B2
+to resell,to resell,转售,VERB,B2
+juvenile,juvenile,青少年的,ADJ,B2
+consecutive,consecutive,连续的,ADJ,B2
+penal,penal,刑事的,ADJ,B2
+pamphleteer,pamphleteer,小册子作者,NOUN,B2
+segregation,segregation,隔离，分离,NOUN,B2
+moralism,moralism,道德主义,NOUN,B2
+sexism,sexism,性别歧视,NOUN,B2
+case law,case law,判例法,NOUN,B2
+to nuance,to nuance,使具有细微差别,VERB,B2
+setting sun,setting sun,夕阳,NOUN,B2
+to subsist,to subsist,存在,VERB,B2
+coastal,coastal,沿海的,ADJ,B2
+lukewarm,lukewarm,微温的,ADJ,B2
+marrow,marrow,骨髓,NOUN,B2
+bistro,bistro,小酒馆,NOUN,B2
+untouchable,untouchable,不可触碰的,ADJ,B2
+alternatively,alternatively,交替地,ADV,B2
+stage fright,stage fright,怯场,NOUN,B2
+socialist,socialist,社会主义者,NOUN,B2
+obsequiousness,obsequiousness,谄媚,NOUN,B2
+heartening,heartening,令人高兴的,ADJ,B2
+as soon as,as soon as,一...就,ADV,B2
+roman,roman,罗马的,ADJ,B2
+heroically,heroically,英勇地,ADV,B2
+flint,flint,燧石,NOUN,B2
+delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
+to maltreat,to maltreat,虐待,VERB,B2
+obsequiously,obsequiously,谄媚地,ADV,B2
+telephony,telephony,电话学,NOUN,B2
+food,food,食品的,ADJ,B2
+carcass,carcass,骨架,NOUN,B2
+faithful loyal,faithful loyal,忠诚的,ADJ,B2
+symphonic,symphonic,交响乐的,ADJ,B2
+undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+treat,treat,盛宴,NOUN,B2
+generational,generational,代际的,ADJ,B2
+alpine,alpine,高山的,ADJ,B2
+servilely,servilely,奴性地,ADV,B2
+checkbook,checkbook,支票簿,NOUN,B2
+productive,productive,多产的,ADJ,B2
+tv viewer,tv viewer,电视观众,NOUN,B2
+release of lien,release of lien,解除扣押,NOUN,B2
+asphyxia,asphyxia,窒息,NOUN,B2
+registered mail,registered mail,挂号信,NOUN,B2
+to push to grow,to push to grow,推/生长,VERB,B2
+a lot,a lot,很多,ADV,B2
+populist,populist,民粹主义者,NOUN,B2
+rapper,rapper,说唱歌手,NOUN,B2
+marshal,marshal,元帅,NOUN,B2
+purely,purely,纯粹地,ADV,B2
+currant,currant,醋栗,NOUN,B2
+anarchist,anarchist,无政府主义者,NOUN,B2
+manifestly,manifestly,明显地,ADV,B2
+irregular,irregular,不规则的,ADJ,B2
+jurisconsult,jurisconsult,法学专家,NOUN,B2
+lymph node,lymph node,淋巴结,NOUN,B2
+litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
+worrying,worrying,令人担忧的,ADJ,B2
+to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
+oyster,oyster,牡蛎,NOUN,B2
+underground,underground,地下的,ADJ,B2
+retiree,retiree,退休人员,NOUN,B2
+reproducibility,reproducibility,可重复性,NOUN,B2
+agitated,agitated,焦躁的,ADJ,B2
+nationalist,nationalist,民族主义者,NOUN,B2
+fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+productivist,productivist,生产至上主义的,ADJ,B2
+pictorial,pictorial,绘画的,ADJ,B2
+to taint,to taint,玷污,VERB,B2
+fingernail,fingernail,指甲,NOUN,B2
+marginally,marginally,边缘地,ADV,B2
+biologist,biologist,生物学家,NOUN,B2
+polysyndeton,polysyndeton,连词叠用,NOUN,B2
+recourse,recourse,求助,NOUN,B2
+subject to the law,subject to the law,受法律管辖的,ADJ,B2
+deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
+remains spoils,remains spoils,遗体，战利品,NOUN,B2
+to mark out,to mark out,标示,VERB,B2
+sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
+geriatrics,geriatrics,老年医学,NOUN,B2
+playable,playable,可演奏的,ADJ,B2
+to commune,to commune,交融,VERB,B2
+hyperthermia,hyperthermia,体温过高,NOUN,B2
+to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
+preterition,preterition,假托,NOUN,B2
+nitrogen,nitrogen,氮,NOUN,B2
+preacher,preacher,传教士,NOUN,B2
+about thirty,about thirty,三十左右,NOUN,B2
+to spout,to spout,喷射,VERB,B2
+traumatic,traumatic,创伤的,ADJ,B2
+several,several,若干,NOUN,B2
+parable,parable,寓言,NOUN,B2
+to stem from,to stem from,源于,VERB,B2
+priority,priority,优先的,ADJ,B2
+most,most,大多数,PRON,B2
+to tip over,to tip over,翻倒,VERB,B2
+foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
+be tender,be tender,温柔的,ADJ,B2
+fistula,fistula,瘘管,NOUN,B2
+to catch sight of,to catch sight of,瞥见,VERB,B2
+artificially,artificially,人为地,ADV,B2
+forfeiture,forfeiture,丧失,NOUN,B2
+recruit,recruit,新兵,NOUN,B2
+genetically,genetically,遗传地,ADV,B2
+scouting locating,scouting locating,定位 / 侦察,NOUN,B2
+subsidiarity,subsidiarity,辅助性原则,NOUN,B2
+dish towel,dish towel,抹布,NOUN,B2
+co-ownership,co-ownership,共有产权,NOUN,B2
+momentarily,momentarily,暂时地,ADV,B2
+to rediscover,to rediscover,重新发现,VERB,B2
+paralogism,paralogism,谬误推理,NOUN,B2
+cyst,cyst,囊肿,NOUN,B2
+resection,resection,切除术,NOUN,B2
+patently,patently,显然地,ADV,B2
+ticket window,ticket window,售票窗口,NOUN,B2
+to weary to tire,to weary to tire,使厌倦,VERB,B2
+tuberculosis,tuberculosis,结核病,NOUN,B2
+overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
+blender,blender,搅拌机,NOUN,B2
+degenerative,degenerative,退化的,ADJ,B2
+fresco,fresco,壁画,NOUN,B2
+receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
+on upon,on upon,在...上,ADP,B2
+to unhook,to unhook,摘下,VERB,B2
+footage,footage,镜头长度,NOUN,B2
+droppings,droppings,粪便,NOUN,B2
+computer specialist,computer specialist,计算机专家,NOUN,B2
+cruelly,cruelly,残酷地,ADV,B2
+selectively,selectively,有选择地,ADV,B2
+lily,lily,百合,NOUN,B2
+illuminator,illuminator,彩饰画家,NOUN,B2
+acronym,acronym,首字母缩略词,NOUN,B2
+similarly,similarly,同样地,ADV,B2
+bedsheet,bedsheet,床单,NOUN,B2
+surplus,surplus,过剩的,ADJ,B2
+to mast,to mast,降伏,VERB,B2
+to drive lead,to drive lead,驾驶,VERB,B2
+fishing,fishing,钓鱼,NOUN,B2
+lucky find,lucky find,意外发现,NOUN,B2
+cross-border,cross-border,边境的,ADJ,B2
+community-related,community-related,社区的,ADJ,B2
+dynamism,dynamism,活力,NOUN,B2
+great-grandfather,great-grandfather,曾祖父,NOUN,B2
+supportive,supportive,团结的,ADJ,B2
+tarragon,tarragon,龙蒿,NOUN,B2
+regeneration,regeneration,再生,NOUN,B2
+scales,scales,秤,NOUN,B2
+trilemma,trilemma,三难困境,NOUN,B2
+indebted,indebted,负债的,ADJ,B2
+skating,skating,滑冰,NOUN,B2
+malaria,malaria,疟疾,NOUN,B2
+boastfulness,boastfulness,吹嘘,NOUN,B2
+anagram,anagram,字谜游戏,NOUN,B2
+cinematographic,cinematographic,电影的,ADJ,B2
+fake news,fake news,假新闻,NOUN,B2
+derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
+hematoma,hematoma,血肿,NOUN,B2
+malefic,malefic,邪恶的,ADJ,B2
+enslavement,enslavement,奴役,NOUN,B2
+chauvinism,chauvinism,沙文主义,NOUN,B2
+striped,striped,有条纹的,ADJ,B2
+oligopoly,oligopoly,寡头垄断,NOUN,B2
+breathing,breathing,呼吸,NOUN,B2
+laundering,laundering,洗钱,NOUN,B2
+systematically,systematically,系统地,ADV,B2
+accordion,accordion,手风琴,NOUN,B2
+naturalization,naturalization,入籍,NOUN,B2
+little son,little son,小儿子,NOUN,B2
+exceptionality,exceptionality,特殊性,NOUN,B2
+as if,as if,好像,SCONJ,B2
+christianity,christianity,基督教,NOUN,B2
+having a birthday,having a birthday,过生日的,ADJ,B2
+synoptic,synoptic,概要的,ADJ,B2
+to asphalt,to asphalt,铺沥青,VERB,B2
+satisfying,satisfying,令人满意的,ADJ,B2
+conceptual,conceptual,概念的,ADJ,B2
+remaining,remaining,,NOUN,B2
+danish,danish,丹麦的,ADJ,B2
+grand duchy,grand duchy,大公国,NOUN,B2
+norwegian,norwegian,挪威的,ADJ,B2
+basic income,basic income,基本收入,NOUN,B2
+exclusionary,exclusionary,排他性的,ADJ,B2
+concessionary,concessionary,让步的,ADJ,B2
+continual,continual,持续的,ADJ,B2
+only,only,而已,SCONJ,B2
+prayer room,prayer room,祈祷室,NOUN,B2
+egyptian,egyptian,埃及的,ADJ,B2
+diverse,diverse,多样的,ADJ,B2
+gay man,gay man,男同性恋者,NOUN,B2
+depicting,depicting,描绘的,ADJ,B2
+religiousness,religiousness,虔诚,NOUN,B2
+dissociation,dissociation,解离,NOUN,B2
+timeline,timeline,时间线,NOUN,B2
+directorship,directorship,董事职位,NOUN,B2
+bleak,bleak,无望的,ADJ,B2
+orderliness,orderliness,有序性,NOUN,B2
+retranslation,retranslation,重译,NOUN,B2
+truthful,truthful,忠于事实的,ADJ,B2
+to tweet,to tweet,发推文,VERB,B2
+member state,member state,成员国,NOUN,B2
+youth trauma,youth trauma,童年创伤,NOUN,B2
+concave,concave,凹的,ADJ,B2
+provincial,provincial,地方的,ADJ,B2
+compulsiveness,compulsiveness,强迫性,NOUN,B2
+windless,windless,无风的,ADJ,B2
+furnishing,furnishing,室内布置,NOUN,B2
+oppressive,oppressive,压迫的,ADJ,B2
+extinct,extinct,灭绝的,ADJ,B2
+liquid,liquid,液态的,ADJ,B2
+position of authority,position of authority,! 权威地位,NOUN,B2
+to keep silent,to keep silent,保持沉默,VERB,B2
+in which,in which,在其中,PRON,B2
+dismal,dismal,令人失望的,ADJ,B2
+gloriousness,gloriousness,光荣,NOUN,B2
+valid,valid,有效的,ADJ,B2
+male,male,男性,NOUN,B2
+grandparenthood,grandparenthood,祖父母身份,NOUN,B2
+explicable,explicable,可解释的,ADJ,B2
+one hundred,one hundred,一百,NUM,B2
+to externalize,to externalize,使外在化,VERB,B2
+group culture,group culture,群体文化,NOUN,B2
+constructivism,constructivism,建构主义,NOUN,B2
+minuscule,minuscule,极小的,ADJ,B2
+catalogue,catalogue,目录,NOUN,B2
+gosh,gosh,天哪,INTJ,B2
+unctuous,unctuous,谄媚的,ADJ,B2
+to set rates,to set rates,定价,VERB,B2
+to bully,to bully,欺凌,VERB,B2
+abominable,abominable,可憎的,ADJ,B2
+informedness,informedness,知情度,NOUN,B2
+little hand,little hand,小手,NOUN,B2
+metabolic,metabolic,代谢的,ADJ,B2
+to amaze,to amaze,使吃惊,VERB,B2
+southeast,southeast,东南,NOUN,B2
+to commentate,to commentate,评论,VERB,B2
+gracious,gracious,亲切的,ADJ,B2
+gratuity,gratuity,酬金,NOUN,B2
+mainstream,mainstream,主流的,ADJ,B2
+steering,steering,掌舵的,ADJ,B2
+to mess about,to mess about,胡搞,VERB,B2
+bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
+maximal,maximal,最大的,ADJ,B2
+tolerant,tolerant,宽容的,ADJ,B2
+sporty,sporty,运动的,ADJ,B2
+enforcement policy,enforcement policy,执法政策,NOUN,B2
+australian,australian,澳大利亚的,ADJ,B2
+terminal,terminal,终末的,ADJ,B2
+for this purpose,for this purpose,为此,ADV,B2
+finance,finance,金融,NOUN,B2
+shading,shading,阴影,NOUN,B2
+to objectify,to objectify,客观化,VERB,B2
+systemless,systemless,无系统的,ADJ,B2
+to theatricalize,to theatricalize,戏剧化,VERB,B2
+spot,spot,地点,NOUN,B2
+showing,showing,表现,NOUN,B2
+virginal,virginal,处女的,ADJ,B2
+line-up,line-up,阵容,NOUN,B2
+kindred spirit,kindred spirit,志同道合者,NOUN,B2
+to use up,to use up,用完,VERB,B2
+selfish,selfish,,NOUN,B2
+redundant,redundant,多余的,ADJ,B2
+budgetable,budgetable,可预算的,ADJ,B2
+colour,colour,颜色,NOUN,B2
+higher professional education,higher professional education,高等专业教育,NOUN,B2
+reproachable,reproachable,应受责备的,ADJ,B2
+light brown,light brown,浅棕色的,ADJ,B2
+minus,minus,减,NOUN,B2
+accessible,accessible,易接近的,ADJ,B2
+leading role,leading role,主角,NOUN,B2
+viewer,viewer,观众,NOUN,B2
+to revitalize,to revitalize,使复苏,VERB,B2
+average,average,平均数,NOUN,B2
+to play football,to play football,踢足球,VERB,B2
+correctness,correctness,正确性,NOUN,B2
+audible,audible,听得见的,ADJ,B2
+collegial,collegial,同事的,ADJ,B2
+to demilitarize,to demilitarize,非军事化,VERB,B2
+mannerly,mannerly,有礼貌的,ADJ,B2
+hollowed,hollowed,掏空的,ADJ,B2
+crystal clear,crystal clear,清澈的,ADJ,B2
+zoo,zoo,动物园,NOUN,B2
+syndrome,syndrome,综合征,NOUN,B2
+gynaecology,gynaecology,妇科,NOUN,B2
+border post,border post,边防哨所,NOUN,B2
+paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
+curbing,curbing,遏制,NOUN,B2
+remarkable,remarkable,非凡的,ADJ,B2
+embargo,embargo,禁运,NOUN,B2
+technocratic,technocratic,技术官僚的,ADJ,B2
+moralizing,moralizing,说教的,ADJ,B2
+expressiveness,expressiveness,表现力,NOUN,B2
+versus,versus,对,ADP,B2
+to play sports,to play sports,做运动,VERB,B2
+border community,border community,边境社区,NOUN,B2
+life's work,life's work,毕生事业,NOUN,B2
+yourself,yourself,你自己,PRON,B2
+malicious,malicious,恶意的,ADJ,B2
+to revalue,to revalue,重新估值,VERB,B2
+closer,closer,更近的,ADJ,B2
+conspiratorial,conspiratorial,阴谋的,ADJ,B2
+guidance,guidance,指导,NOUN,B2
+benignity,benignity,良性,NOUN,B2
+class struggle,class struggle,阶级斗争,NOUN,B2
+desirability,desirability,可取性,NOUN,B2
+liberalize,liberalize,自由化,! VERB,B2
+group mentality,group mentality,群体心态,NOUN,B2
+member of parliament,member of parliament,议员,NOUN,B2
+grammaticality,grammaticality,合语法性,NOUN,B2
+alienating,alienating,使人疏远的,ADJ,B2
+avoidable,avoidable,可避免的,ADJ,B2
+criminal law,criminal law,刑法,NOUN,B2
+group solidarity,group solidarity,群体团结,NOUN,B2
+surgical,surgical,外科的,ADJ,B2
+to solder,to solder,焊接,VERB,B2
+irish,irish,爱尔兰的,ADJ,B2
+universities,universities,大学,NOUN,B2
+entranced,entranced,痴迷的,ADJ,B2
+aghast,aghast,惊骇的,ADJ,B2
+diction,diction,措辞,NOUN,B2
+to technologize,to technologize,技术化,VERB,B2
+gallows humor,gallows humor,绞刑架幽默,NOUN,B2
+cycle path,cycle path,自行车道,NOUN,B2
+misplaced,misplaced,不合时宜的,ADJ,B2
+presidential election,presidential election,总统选举,NOUN,B2
+marginal,marginal,边缘的,ADJ,B2
+place of residence,place of residence,居住地,NOUN,B2
+to pauperize,to pauperize,使贫困,VERB,B2
+healing power,healing power,疗效,NOUN,B2
+to draw water,to draw water,打水,VERB,B2
+cohort-based,cohort-based,队列的,ADJ,B2
+publicity,publicity,宣传,NOUN,B2
+to walk around,to walk around,四处走动,VERB,B2
+spiritual,spiritual,精神的,ADJ,B2
+physiotherapy,physiotherapy,物理治疗,NOUN,B2
+founding,founding,成立,NOUN,B2
+family reunification,family reunification,家庭团聚,NOUN,B2
+to validate,to validate,验证,VERB,B2
+unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
+exemplary country,exemplary country,模范国家,NOUN,B2
+consolidating,consolidating,巩固的,ADJ,B2
+eclecticism,eclecticism,折衷主义,NOUN,B2
+statistic,statistic,统计数据,NOUN,B2
+hazard report,hazard report,危险报告,NOUN,B2
+dentition,dentition,牙齿,NOUN,B2
+front line,front line,前线,NOUN,B2
+conference-based,conference-based,会议的,ADJ,B2
+court case,court case,诉讼,NOUN,B2
+plucky,plucky,勇敢的,ADJ,B2
+two-dimensional,two-dimensional,二维的,ADJ,B2
+purifying,purifying,净化的,ADJ,B2
+to be correct,to be correct,正确,VERB,B2
+to rehabilitate,to rehabilitate,使康复,VERB,B2
+factual,factual,事实的,ADJ,B2
+sighing,sighing,叹息的,ADJ,B2
+to tune,to tune,调谐,VERB,B2
+collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
+little brother,little brother,小弟弟,NOUN,B2
+one-way traffic,one-way traffic,单向通行,NOUN,B2
+national anthem,national anthem,国歌,NOUN,B2
+to replicate,to replicate,复制,VERB,B2
+to catalyze,to catalyze,催化,VERB,B2
+nauseous,nauseous,恶心的,ADJ,B2
+to modulate,to modulate,调节,VERB,B2
+cult,cult,邪教,NOUN,B2
+grave desecration,grave desecration,亵渎坟墓,NOUN,B2
+effortless,effortless,不费力的,ADJ,B2
+worth mentioning,worth mentioning,值得一提的,ADJ,B2
+to settle up,to settle up,结账,VERB,B2
+portuguese,portuguese,葡萄牙语,NOUN,B2
+meaningful,meaningful,有意义的,ADJ,B2
+moreover,moreover,而且,CCONJ,B2
+contested,contested,有争议的,ADJ,B2
+to instrumentalize,to instrumentalize,工具化,VERB,B2
+labor market,labor market,劳动力市场,NOUN,B2
+to lug,to lug,搬运,VERB,B2
+convertible,convertible,可兑换的,ADJ,B2
+upwards,upwards,向上,ADV,B2
+on,on,进行中,ADV,B2
+altruistic,altruistic,利他的,ADJ,B2
+hence,hence,因此,ADV,B2
+new construction,new construction,新建建筑,NOUN,B2
+jaded,jaded,厌倦的,ADJ,B2
+dominance,dominance,威权,NOUN,B2
+immanence,immanence,内在性,NOUN,B2
+coming,coming,即将到来的,ADJ,B2
+well-groomed,well-groomed,整洁的,ADJ,B2
+hassle,hassle,麻烦,NOUN,B2
+to text,to text,发短信,VERB,B2
+headscarf,headscarf,头巾,NOUN,B2
+courageous,courageous,勇敢的,ADJ,B2
+posh,posh,上流的,ADJ,B2
+daft,daft,傻的,ADJ,B2
+abolition,abolition,废除,NOUN,B2
+knowledge transfer,knowledge transfer,知识传授,NOUN,B2
+merger,merger,合并,NOUN,B2
+to stick out,to stick out,伸出,VERB,B2
+emaciating,emaciating,消耗的,ADJ,B2
+bisexual,bisexual,双性恋的,ADJ,B2
+with this,with this,以此,ADV,B2
+to decentralize,to decentralize,去中心化,VERB,B2
+contact person,contact person,联系人,NOUN,B2
+connecting,connecting,连接的,ADJ,B2
+proliferate,proliferate,扩散,! VERB,B2
+milky,milky,乳白色的,ADJ,B2
+to rent out,to rent out,出租,VERB,B2
+to retort,to retort,反驳,VERB,B2
+variation,variation,变化,NOUN,B2
+april,april,四月,NOUN,B2
+mysticism,mysticism,神秘主义,NOUN,B2
+humanities,humanities,人文学科,NOUN,B2
+power station,power station,发电厂,NOUN,B2
+bit,bit,一点,NOUN,B2
+peddler,peddler,小贩,NOUN,B2
+broadening,broadening,拓宽,NOUN,B2
+this evening,this evening,今晚,ADV,B2
+pregnant woman,pregnant woman,孕妇,NOUN,B2
+rest assured,rest assured,放心的,ADJ,B2
+to tax to burden,to tax to burden,征税,VERB,B2
+radius,radius,半径,NOUN,B2
+decibel,decibel,分贝,NOUN,B2
+minor,minor,较小的,ADJ,B2
+small gift,small gift,小礼物,NOUN,B2
+museum piece,museum piece,博物馆藏品,NOUN,B2
+florid,florid,辞藻华丽的,ADJ,B2
+crisis situation,crisis situation,危机局势,NOUN,B2
+to ostracize,to ostracize,排斥,VERB,B2
+dislike,dislike,厌恶,NOUN,B2
+syrian,syrian,叙利亚的,ADJ,B2
+to scan,to scan,扫描,VERB,B2
+worldly,worldly,世俗的,ADJ,B2
+contentious,contentious,有争议的,ADJ,B2
+communautarization,communautarization,社群化,NOUN,B2
+connotative,connotative,内涵的,ADJ,B2
+to spam,to spam,发垃圾信息,VERB,B2
+macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+at the back,at the back,在后面,ADV,B2
+neighbour,neighbour,邻居,NOUN,B2
+schoolboy,schoolboy,学生,NOUN,B2
+to sublimate,to sublimate,升华,VERB,B2
+for this,for this,为此,ADV,B2
+witness examination,witness examination,证人询问,NOUN,B2
+climate denial,climate denial,气候否认,NOUN,B2
+turbulent,turbulent,动荡的,ADJ,B2
+to sensitize,to sensitize,提高意识,VERB,B2
+microscopic,microscopic,微观的,ADJ,B2
+toothless,toothless,无齿的,ADJ,B2
+to telework,to telework,远程办公,VERB,B2
+venereal disease,venereal disease,性病,NOUN,B2
+to persevere,to persevere,坚持,VERB,B2
+to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
+heath,heath,石楠荒原,NOUN,B2
+guilder,guilder,盾,NOUN,B2
+financier,financier,资助者,NOUN,B2
+filipino,filipino,菲律宾的,ADJ,B2
+to agitate,to agitate,鼓动,VERB,B2
+multipart,multipart,多部分的,ADJ,B2
+all-round,all-round,全面的,ADJ,B2
+her,her,她的,DET,B2
+vacuum,vacuum,真空的,ADJ,B2
+newsletter,newsletter,简报,NOUN,B2
+whisk,whisk,打蛋器,NOUN,B2
+very hard,very hard,极硬的,ADJ,B2
+to regionalize,to regionalize,区域化,VERB,B2
+suspended,suspended,悬浮的,ADJ,B2
+to plagiarize,to plagiarize,剽窃,VERB,B2
+axiomatic,axiomatic,公理的,ADJ,B2
+antisocial,antisocial,反社会的,ADJ,B2
+transition,transition,过渡,NOUN,B2
+to drop off,to drop off,放下,VERB,B2
+such a,such a,这样的,DET,B2
+noise nuisance,noise nuisance,噪音扰民,NOUN,B2
+amicable,amicable,友好的,ADJ,B2
+fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
+vs,vs,与...相对,ADP,B2
+mayoral,mayoral,市长的,ADJ,B2
+health policy,health policy,健康政策,NOUN,B2
+inheritance law,inheritance law,继承法,NOUN,B2
+bent,bent,弯的,ADJ,B2
+inventorying,inventorying,清点,NOUN,B2
+religious war,religious war,宗教战争,NOUN,B2
+to immunize,to immunize,免疫,VERB,B2
+analytical,analytical,分析的,ADJ,B2
+to invoice,to invoice,开票,VERB,B2
+life-size,life-size,真人大小的,ADJ,B2
+bilateral,bilateral,双边的,ADJ,B2
+little sun,little sun,小太阳,NOUN,B2
+collectomania,collectomania,收藏癖,NOUN,B2
+workable,workable,可加工的,ADJ,B2
+composable,composable,可组合的,ADJ,B2
+disco,disco,迪厅,NOUN,B2
+laptop,laptop,笔记本电脑,NOUN,B2
+legation,legation,公使馆,NOUN,B2
+group norm,group norm,群体规范,NOUN,B2
+inflexibility,inflexibility,僵化,NOUN,B2
+to enrol,to enrol,注册,VERB,B2
+insightfulness,insightfulness,洞察,NOUN,B2
+catastrophic,catastrophic,灾难性的,ADJ,B2
+to industrialize,to industrialize,工业化,VERB,B2
+fossil fuel,fossil fuel,化石燃料,NOUN,B2
+megalomanic,megalomanic,狂妄自大的,ADJ,B2
+contractual,contractual,合同的,ADJ,B2
+school year,school year,学年,NOUN,B2
+to persist,to persist,坚持,VERB,B2
+postal code,postal code,邮政编码,NOUN,B2
+property right,property right,所有权,NOUN,B2
+customer service,customer service,客户服务,NOUN,B2
+aloud,aloud,出声地,ADV,B2
+court fee,court fee,诉讼费,NOUN,B2
+globalization process,globalization process,全球化进程,NOUN,B2
+film star,film star,,NOUN,B2
+memorable,memorable,难忘的,ADJ,B2
+factionalism,factionalism,派系主义,NOUN,B2
+austrian,austrian,奥地利的,ADJ,B2
+family composition,family composition,家庭构成,NOUN,B2
+frictionless,frictionless,无摩擦的,ADJ,B2
+off,off,关,ADP,B2
+fatty,fatty,脂肪的,ADJ,B2
+ceremonial,ceremonial,仪式的,ADJ,B2
+ice cold,ice cold,冰冷的,ADJ,B2
+heated,heated,激昂的,ADJ,B2
+constitutive,constitutive,构成的,ADJ,B2
+character assassination,character assassination,人格谋杀,NOUN,B2
+meek,meek,温顺的,ADJ,B2
+contaminating,contaminating,污染的,ADJ,B2
+conversional,conversional,转换的,ADJ,B2
+federalization,federalization,联邦化,NOUN,B2
+gravitational,gravitational,引力的,ADJ,B2
+amusement,amusement,娱乐,NOUN,B2
+paralysed,paralysed,瘫痪的,ADJ,B2
+energy crisis,energy crisis,能源危机,NOUN,B2
+search engine,search engine,搜索引擎,NOUN,B2
+parliamentary elections,parliamentary elections,议会选举,NOUN,B2
+petrol,petrol,汽油,NOUN,B2
+final score,final score,最终比分,NOUN,B2
+holism,holism,整体论,NOUN,B2
+from which,from which,从中,ADV,B2
+family tension,family tension,家庭紧张,NOUN,B2
+drinking water,drinking water,饮用水,NOUN,B2
+state of mind,state of mind,精神状态,NOUN,B2
+destined,destined,,NOUN,B2
+tens of thousands,tens of thousands,数万,NUM,B2
+licentious,licentious,放荡的,ADJ,B2
+visible,visible,可见的,ADJ,B2
+few,few,几下,NOUN,B2
+schooled person,schooled person,受过培训者,NOUN,B2
+swiss,swiss,瑞士的,ADJ,B2
+to polarize,to polarize,使两极分化,VERB,B2
+atheistic,atheistic,无神论的,ADJ,B2
+accountable,accountable,负责任的,ADJ,B2
+guideline,guideline,指导方针,NOUN,B2
+native american,native american,印第安人,NOUN,B2
+provisional,provisional,临时的,ADJ,B2
+lacunary,lacunary,残缺的,ADJ,B2
+to hold accountable,to hold accountable,问责,VERB,B2
+utility,utility,效用,NOUN,B2
+data processing,data processing,数据处理,NOUN,B2
+irrelevance,irrelevance,无关,NOUN,B2
+to repel,to repel,击退,VERB,B2
+one and a half,one and a half,一个半,NUM,B2
+loyalty to authority,loyalty to authority,服从权威,NOUN,B2
+associated,associated,相关的,ADJ,B2
+southwest,southwest,西南的,ADJ,B2
+emotional expression,emotional expression,! 情感表达,NOUN,B2
+commencement,commencement,开始,NOUN,B2
+to propagate,to propagate,传播,VERB,B2
+religious strife,religious strife,宗教纷争,NOUN,B2
+heartfelt,heartfelt,衷心的,ADJ,B2
+trivializable,trivializable,可轻描淡写的,ADJ,B2
+bombardment,bombardment,轰炸,NOUN,B2
+to mystify,to mystify,神秘化,VERB,B2
+dutchman,dutchman,荷兰人,NOUN,B2
+bicycle repairer,bicycle repairer,修车匠,NOUN,B2
+to,to,去,PART,B2
+egocentrism,egocentrism,自我中心,NOUN,B2
+palestinian,palestinian,巴勒斯坦的,ADJ,B2
+toys,toys,玩具,NOUN,B2
+endowed,endowed,有天赋的,ADJ,B2
+hungarian,hungarian,匈牙利的,ADJ,B2
+expertise center,expertise center,专业中心,NOUN,B2
+sympathetic,sympathetic,同情的,ADJ,B2
+run-up,run-up,助跑,NOUN,B2
+to aggravate,to aggravate,加重,VERB,B2
+manual,manual,手工的,ADJ,B2
+flemish,flemish,佛兰芒的,ADJ,B2
+toothbrush,toothbrush,牙刷,NOUN,B2
+to emigrate,to emigrate,移居国外,VERB,B2
+email address,email address,电子邮件地址,NOUN,B2
+the one,the one,,NOUN,B2
+grand officer,grand officer,大官,NOUN,B2
+motor,motor,运动的,ADJ,B2
+ukrainian,ukrainian,乌克兰的,ADJ,B2
+border arrangement,border arrangement,边境安排,NOUN,B2
+metamorphic,metamorphic,变质的,ADJ,B2
+to localize,to localize,本地化,VERB,B2
+undermining authority,undermining authority,削弱权威,NOUN,B2
+group individual,group individual,群体个体,NOUN,B2
+elderly,elderly,老年人,NOUN,B2
+brazilian,brazilian,巴西的,ADJ,B2
+nuts,nuts,疯狂的,ADJ,B2
+coloredness,coloredness,有色性,NOUN,B2
+berlijns,berlijns,柏林的,ADJ,B2
+judgement,judgement,评估,NOUN,B2
+manipulable,manipulable,可操纵的,ADJ,B2
+depicted,depicted,描绘的,ADJ,B2
+many,many,许多,DET,B2
+cosmetics,cosmetics,化妆品,NOUN,B2
+diplomatic relations,diplomatic relations,外交关系,NOUN,B2
+to pucker,to pucker,噘,VERB,B2
+how come,how come,怎么会,INTJ,B2
+structuredness,structuredness,结构性,NOUN,B2
+to break off,to break off,中断,VERB,B2
+to tidy,to tidy,整理,VERB,B2
+solemn,solemn,,NOUN,B2
+habitlessness,habitlessness,无习惯,NOUN,B2
+increasing,increasing,增加的,ADJ,B2
+south african,south african,南非的,ADJ,B2
+your,your,你的,PRON,B2
+folksy,folksy,乡土的,ADJ,B2
+redrawing,redrawing,重新绘制,NOUN,B2
+largely,largely,主要地,ADV,B2
+to contextualize,to contextualize,置于语境,VERB,B2
+editor-in-chief,editor-in-chief,主编,NOUN,B2
+documentation,documentation,文献,NOUN,B2
+outside,outside,在外面,ADP,B2
+traditional costume,traditional costume,传统服饰,NOUN,B2
+special offer,special offer,特价,NOUN,B2
+balancing,balancing,平衡的,ADJ,B2
+shit,shit,该死的,ADJ,B2
+dispirited,dispirited,沮丧的,ADJ,B2
+potential,potential,潜在的,ADJ,B2
+ourselves,ourselves,我们自己,PRON,B2
+explanatory,explanatory,解释的,ADJ,B2
+source citation,source citation,出处注明,NOUN,B2
+vice versa,vice versa,反之亦然,ADJ,B2
+bleeding,bleeding,流血的,ADJ,B2
+children's rights,children's rights,儿童权利,NOUN,B2
+arabic,arabic,阿拉伯的,ADJ,B2
+demotion,demotion,降职,NOUN,B2
+to revolutionize,to revolutionize,革命化,VERB,B2
+with that,with that,以此,ADV,B2
+parish priest,parish priest,本堂神父,NOUN,B2
+tram,tram,有轨电车,NOUN,B2
+for a moment,for a moment,片刻,ADV,B2
+provable,provable,可证明的,ADJ,B2
+some,some,一些,PRON,B2
+owed,owed,欠下的,ADJ,B2
+midfielder,midfielder,中场球员,NOUN,B2
+solar panel,solar panel,太阳能电池板,NOUN,B2
+church community,church community,教会,NOUN,B2
+liberating,liberating,解放的,ADJ,B2
+healthcare,healthcare,医疗保健,NOUN,B2
+figuration,figuration,群演,NOUN,B2
+inactivity,inactivity,不活跃,NOUN,B2
+by means of,by means of,凭借,NOUN,B2
+in the back,in the back,在后面,ADV,B2
+series of conversations,series of conversations,系列对话,NOUN,B2
+day after tomorrow,day after tomorrow,后天,NOUN,B2
+plenty,plenty,充足地,ADV,B2
+myself,myself,我自己,PRON,B2
+disharmony,disharmony,不和谐,NOUN,B2
+barbarization,barbarization,野蛮化,NOUN,B2
+land policy,land policy,土地政策,NOUN,B2
+it,it,信息技术,NOUN,B2
+governable,governable,可管理的,ADJ,B2
+just like that,just like that,随便地,ADV,B2
+paving,paving,铺路,NOUN,B2
+fabulist,fabulist,幻想家,NOUN,B2
+regardless,regardless,不管,ADP,B2
+hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
+twofold,twofold,双重的,ADJ,B2
+sentences,sentences,句子,NOUN,B2
+alternating,alternating,交替的,ADJ,B2
+sports park,sports park,运动公园,NOUN,B2
+removed,removed,移除的,ADJ,B2
+world champion,world champion,世界冠军,NOUN,B2
+hem,hem,边缘,NOUN,B2
+border check,border check,边境检查,NOUN,B2
+rightly,rightly,正确地,ADV,B2
+brabant,brabant,布拉班特的,ADJ,B2
+group work,group work,群体工作,NOUN,B2
+domineeringness,domineeringness,支配欲,NOUN,B2
+lifelong,lifelong,终身,ADJ,B2
+authority structure,authority structure,权威结构,NOUN,B2
+deputation,deputation,代表团,NOUN,B2
+people,people,人们,PRON,B2
+meandering,meandering,蜿蜒的,ADJ,B2
+both,both,两者的,ADJ,B2
+past,past,过去,ADP,B2
+dutch,dutch,荷兰语,NOUN,B2
+below,below,下面的,ADJ,B2
+tomorrow night,tomorrow night,明晚,ADV,B2
+grand master,grand master,大师,NOUN,B2
+to saw,to saw,锯,VERB,B2
+full-time,full-time,全职,ADJ,B2
+subject field,subject field,科目 / 领域,NOUN,B2
+conviviality,conviviality,温馨,NOUN,B2
+film industry,film industry,电影业,NOUN,B2
+primary school,primary school,小学,NOUN,B2
+song festival,song festival,音乐节,NOUN,B2
+little heart,little heart,小心脏,NOUN,B2
+lawless,lawless,无法的,ADJ,B2
+in unison,in unison,齐声,ADV,B2
+neatly,neatly,整洁地,ADV,B2
+contactual,contactual,接触的,ADJ,B2
+compostable,compostable,可堆肥的,ADJ,B2
+as many,as many,一样多,NUM,B2
+century-old,century-old,世纪的,ADJ,B2
+self-interest,self-interest,私利,NOUN,B2
+collectivization,collectivization,集体化,NOUN,B2
+fishery,fishery,渔业,NOUN,B2
+liminal,liminal,阈限的,ADJ,B2
+tactless,tactless,不得体的,ADJ,B2
+without further ado,without further ado,毫不犹豫地,ADV,B2
+as a result of which,as a result of which,由此,ADV,B2
+euphemistic,euphemistic,委婉的,ADJ,B2
+to reoffend,to reoffend,重犯,VERB,B2
+border region,border region,边境地区,NOUN,B2
+patricide,patricide,弑父,NOUN,B2
+on the one hand,on the one hand,一方面,ADV,B2
+duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
+graphic designer,graphic designer,图形设计师,NOUN,B2
+megalomania,megalomania,狂妄自大,NOUN,B2
+to shoot dead,to shoot dead,击毙,VERB,B2
+lingual,lingual,语言的,ADJ,B2
+light grey,light grey,浅灰色的,ADJ,B2
+classicist,classicist,古典主义的,ADJ,B2
+tiring,tiring,令人疲倦的,ADJ,B2
+conformist,conformist,从众的,ADJ,B2
+intellectual life,intellectual life,精神生活,NOUN,B2
+middle,middle,中间,ADV,B2
+nonviolence,nonviolence,非暴力,NOUN,B2
+inherence,inherence,固有,NOUN,B2
+conscientious objection,conscientious objection,良知抗拒,NOUN,B2
+spirit world,spirit world,灵界,NOUN,B2
+convolutional,convolutional,卷积的,ADJ,B2
+argentinian,argentinian,阿根廷的,ADJ,B2
+predisposition,predisposition,天赋,NOUN,B2
+authority figure,authority figure,权威人士,NOUN,B2
+marshy,marshy,沼泽般的,ADJ,B2
+whey,whey,乳清,NOUN,B2
+for that purpose,for that purpose,为此,ADV,B2
+brainy,brainy,聪明的,ADJ,B2
+to archive,to archive,归档,VERB,B2
+collectie,collectie,收藏,NOUN,B2
+unwanted,unwanted,不受欢迎的,ADJ,B2
+good-naturedness,good-naturedness,温和,NOUN,B2
+for what purpose,for what purpose,为了什么目的,ADV,B2
+labile,labile,不稳定的,ADJ,B2
+consumptive,consumptive,消费的,ADJ,B2
+incompleteness,incompleteness,不完整,NOUN,B2
+to take minutes,to take minutes,记录,VERB,B2
+czech,czech,捷克的,ADJ,B2
+backyard,backyard,后院,NOUN,B2
+variable,variable,多变的,ADJ,B2
+indonesian,indonesian,印度尼西亚的,ADJ,B2
+processing,processing,处理,NOUN,B2
+outside world,outside world,外界,NOUN,B2
+in here,in here,在这里面,ADV,B2
+present time,present time,现在,NOUN,B2
+nuclear weapon,nuclear weapon,核武器,NOUN,B2
+freedom of assembly,freedom of assembly,集会自由,NOUN,B2
+field medic,field medic,战地医生,NOUN,B2
+salon,salon,沙龙,NOUN,B2
+to consider think,to consider think,考虑/思考,VERB,B2
+to be taken,to be taken,被拿走,VERB,B2
+snazzy,snazzy,时髦的,ADJ,B2
+fired,fired,被解雇的,ADJ,B2
+online dating profile,online dating profile,,NOUN,B2
+sibling,sibling,兄弟姐妹,NOUN,B2
+to flee escape,to flee escape,逃跑,VERB,B2
+kidnapped,kidnapped,被绑架的,ADJ,B2
+to flush,to flush,冲洗,VERB,B2
+press freedom,press freedom,新闻自由,NOUN,B2
+demonstrative,demonstrative,演示的,ADJ,B2
+underclass,underclass,底层,NOUN,B2
+effort bet,effort bet,努力/赌注,NOUN,B2
+observation skill,observation skill,,NOUN,B2
+gaping,gaping,,NOUN,B2
+meeting hit,meeting hit,会面/击中,NOUN,B2
+freedom of speech,freedom of speech,言论自由,NOUN,B2
+ribs,ribs,肋骨,NOUN,B2
+to object,to object,反对,VERB,B2
+much many,much many,许多,ADJ,B2
+of by,of by,的/被,ADP,B2
+nourishment,nourishment,营养,NOUN,B2
+the safe,the safe,保险箱,NOUN,B2
+millions of,millions of,数百万的,NUM,B2
+self-esteem,self-esteem,自尊,NOUN,B2
+mapping,mapping,梳理,NOUN,B2
+strangely,strangely,奇怪地,ADV,B2
+freedom of opinion,freedom of opinion,意见自由,NOUN,B2
+terrorists,terrorists,恐怖分子们,NOUN,B2
+nah,nah,不,INTJ,B2
+bro,bro,哥们,NOUN,B2
+fascinated,fascinated,着迷的,ADJ,B2
+moose,moose,驼鹿,NOUN,B2
+citrus,citrus,柑橘,NOUN,B2
+attempted murder,attempted murder,谋杀未遂,NOUN,B2
+good day,good day,你好,INTJ,B2
+kind sort,kind sort,种类,NOUN,B2
+rock slab,rock slab,岩板,NOUN,B2
+care home,care home,,NOUN,B2
+keen eager,keen eager,渴望的,ADJ,B2
+witness protection,witness protection,,NOUN,B2
+to warm,to warm,加热,VERB,B2
+to diet,to diet,减肥,VERB,B2
+to stay awake,to stay awake,守夜,VERB,B2
+to function work,to function work,运作/起作用,VERB,B2
+couple pair,couple pair,一对,NOUN,B2
+civilisation,civilisation,文明,NOUN,B2
+deck tire,deck tire,甲板/轮胎,NOUN,B2
+abroad,abroad,在国外,ADV,B2
+underworld,underworld,地下世界,NOUN,B2
+for sale,for sale,待售,ADJ,B2
+to bring lead,to bring lead,带来/引导,VERB,B2
+suite,suite,套房,NOUN,B2
+recall,recall,回忆,NOUN,B2
+thoughtfully,thoughtfully,体贴地,ADV,B2
+brain activity,brain activity,,NOUN,B2
+motel,motel,汽车旅馆,NOUN,B2
+parcel,parcel,包裹,NOUN,B2
+cultural heritage,cultural heritage,文化遗产,NOUN,B2
+kind species,kind species,种类/物种,NOUN,B2
+to be created,to be created,被创造,VERB,B2
+arrived present,arrived present,到了,ADV,B2
+enormously,enormously,巨大地,ADV,B2
+light-year,light-year,,NOUN,B2
+inboard,inboard,船内的,ADV,B2
+filled,filled,充满的,ADJ,B2
+younger,younger,较年轻的,ADJ,B2
+to come loose,to come loose,松脱,VERB,B2
+balsam,balsam,香脂,NOUN,B2
+student residence,student residence,学生宿舍,NOUN,B2
+roadblock,roadblock,,NOUN,B2
+dozens,dozens,数十个,NOUN,B2
+decimal,decimal,小数,NOUN,B2
+guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
+so-called,so-called,,NOUN,B2
+that to,that to,那/去,PART,B2
+all-clear,all-clear,许可信号,NOUN,B2
+service year,service year,,NOUN,B2
+preliminary investigation,preliminary investigation,,NOUN,B2
+chili,chili,辣椒,NOUN,B2
+databas,databas,数据库,NOUN,B2
+malmo,malmo,马尔默,PROPN,B2
+loathing,loathing,,NOUN,B2
+darn,darn,哎呀,INTJ,B2
+best friend,best friend,最好的朋友,NOUN,B2
+drugs,drugs,毒品,NOUN,B2
+lower,lower,较低的,ADJ,B2
+to raise bring up,to raise bring up,抚养,VERB,B2
+to leave stick,to leave stick,离开/刺,VERB,B2
+drug dealer,drug dealer,毒贩,NOUN,B2
+hint,hint,暗示,NOUN,B2
+the guy,the guy,那个男人,NOUN,B2
+last evening,last evening,,NOUN,B2
+strenuous,strenuous,费力的,ADJ,B2
+to use to usually,to use to usually,通常/习惯于,VERB,B2
+too late,too late,太迟,ADV,B2
+resistance movement,resistance movement,抵抗运动,NOUN,B2
+knowledge exchange,knowledge exchange,知识交流,NOUN,B2
+prayer trap,prayer trap,,NOUN,B2
+nerd,nerd,书呆子,NOUN,B2
+berkeley coach,berkeley coach,,NOUN,B2
+in two,in two,成两半,ADV,B2
+explosives,explosives,炸药,NOUN,B2
+from above,from above,从上方,ADV,B2
+to train exercise,to train exercise,训练/锻炼,VERB,B2
+middle class,middle class,中产阶层,NOUN,B2
+matter of conscience,matter of conscience,良心问题,NOUN,B2
+sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
+ride lift,ride lift,搭车,NOUN,B2
+mafia,mafia,黑手党,NOUN,B2
+sure safe,sure safe,确定的,ADJ,B2
+greetings,greetings,,NOUN,B2
+entrance ticket,entrance ticket,门票,NOUN,B2
+ears,ears,耳朵,NOUN,B2
+parent-friendly,parent-friendly,,NOUN,B2
+certainly,certainly,当然,INTJ,B2
+sliding,sliding,滑动的,ADJ,B2
+lab,lab,实验室,NOUN,B2
+morphine,morphine,吗啡,NOUN,B2
+fine pretty,fine pretty,美丽的,ADJ,B2
+gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
+clear,clear,当然,ADV,B2
+top great,top great,顶部/极好,NOUN,B2
+twenty-two-year-old,twenty-two-year-old,,NOUN,B2
+pier,pier,码头,NOUN,B2
+in peace,in peace,不受打扰地,ADV,B2
+penance,penance,忏悔,NOUN,B2
+to be needed,to be needed,被需要,VERB,B2
+bike helmet,bike helmet,自行车头盔,NOUN,B2
+sailboat,sailboat,,NOUN,B2
+suicidal thought,suicidal thought,,NOUN,B2
+electric motor,electric motor,电动机,NOUN,B2
+family relatives,family relatives,亲属,NOUN,B2
+fast,fast,快地,ADV,B2
+monarchy,monarchy,君主制,NOUN,B2
+pain relief,pain relief,,NOUN,B2
+fair decent,fair decent,公平的/正派的,ADJ,B2
+to zero out,to zero out,清零,VERB,B2
+swim training,swim training,,NOUN,B2
+mental hospital,mental hospital,精神病院,NOUN,B2
+sense of shame,sense of shame,,NOUN,B2
+locked in,locked in,被关在里面的,ADJ,B2
+pants,pants,裤子,NOUN,B2
+stolen,stolen,被偷的,ADJ,B2
+to be included,to be included,包含,VERB,B2
+funniness,funniness,,NOUN,B2
+outbreak,outbreak,爆发,NOUN,B2
+premium,premium,溢价,NOUN,B2
+grille,grille,格栅,NOUN,B2
+single,single,单曲,NOUN,B2
+medical help,medical help,,NOUN,B2
+gothenburg,gothenburg,哥德堡,PROPN,B2
+managed,managed,,NOUN,B2
+english teacher,english teacher,,NOUN,B2
+literally,literally,字面上地,ADV,B2
+leaf page,leaf page,叶子,NOUN,B2
+to light a fire,to light a fire,生火,VERB,B2
+mr master,mr master,先生/主人,NOUN,B2
+pine needle,pine needle,针叶,NOUN,B2
+funeral home,funeral home,,NOUN,B2
+sweetness,sweetness,,NOUN,B2
+hooray,hooray,万岁,INTJ,B2
+angle of approach,angle of approach,切入点,NOUN,B2
+thereafter,thereafter,此后,ADV,B2
+although,although,尽管,CCONJ,B2
+latest,latest,最新的,ADJ,B2
+change exchange,change exchange,改变/交换,NOUN,B2
+work environment,work environment,工作环境,NOUN,B2
+to fit suit,to fit suit,适合,VERB,B2
+to be driven,to be driven,被驱动,VERB,B2
+to be counted,to be counted,被算作,VERB,B2
+its,its,它的,PRON,B2
+social problem,social problem,社会问题,NOUN,B2
+indigenous people,indigenous people,原住民,NOUN,B2
+bigwig,bigwig,大人物,NOUN,B2
+something,something,شي,NOUN,B2
+magically,magically,魔法地,ADV,B2
+number one,number one,第一名,NOUN,B2
+he this one,he this one,他/这位,PRON,B2
+concussion,concussion,脑震荡,NOUN,B2
+bank card,bank card,银行卡,NOUN,B2
+known famous,known famous,著名的/熟悉的,ADJ,B2
+bigger,bigger,更大的,ADJ,B2
+alive living,alive living,活着的,ADJ,B2
+following page,following page,,NOUN,B2
+more important,more important,更重要的,ADJ,B2
+to screw,to screw,拧,VERB,B2
+fun joke,fun joke,乐趣/玩笑,NOUN,B2
+agree,agree,一致,ADJ,B2
+to step down,to step down,辞职,VERB,B2
+monkey ape,monkey ape,猿/猴,NOUN,B2
+conifer,conifer,针叶树,NOUN,B2
+sure,sure,当然,ADV,B2
+to steer control,to steer control,控制,VERB,B2
+starved,starved,饥饿的,ADJ,B2
+artistry,artistry,,NOUN,B2
+to trap fell,to trap fell,困住/砍倒,VERB,B2
+half-year,half-year,半年,NOUN,B2
+hither,hither,到这里,ADV,B2
+guest tester,guest tester,,NOUN,B2
+contacts,contacts,人脉,NOUN,B2
+computer program,computer program,电脑程序,NOUN,B2
+hanged,hanged,被绞死的,ADJ,B2
+butt,butt,臀部,NOUN,B2
+to bicker,to bicker,争吵,VERB,B2
+violently,violently,暴力地,ADV,B2
+to decide determine,to decide determine,决定/确定,VERB,B2
+so thus,so thus,所以/如此,ADV,B2
+to wipe out,to wipe out,消灭,VERB,B2
+citizenship right,citizenship right,公民权,NOUN,B2
+at once,at once,立刻,ADV,B2
+to drink binge,to drink binge,狂饮,VERB,B2
+to dampen,to dampen,使潮湿,VERB,B2
+to denominate,to denominate,命名,VERB,B2
+these,these,这些,PRON,B2
+test drive,test drive,,NOUN,B2
+disposition,disposition,性情,NOUN,B2
+itself,itself,它自己,PRON,B2
+the sick,the sick,病人,NOUN,B2
+more beautiful,more beautiful,更美的,ADJ,B2
+atomic nucleus,atomic nucleus,原子核,NOUN,B2
+to paint over,to paint over,重新粉刷,VERB,B2
+working class,working class,工人阶级,NOUN,B2
+to harbor,to harbor,怀有,VERB,B2
+sentenced,sentenced,被判刑的,ADJ,B2
+upper floor,upper floor,楼上,NOUN,B2
+salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
+scientists,scientists,科学家,NOUN,B2
+lots,lots,大量,NOUN,B2
+poor wretched,poor wretched,可怜的,ADJ,B2
+welcome committee,welcome committee,,NOUN,B2
+self-image,self-image,自我形象,NOUN,B2
+to find oneself,to find oneself,处于,VERB,B2
+ace,ace,王牌,NOUN,B2
+your plural,your plural,你们的,DET,B2
+values,values,价值观,NOUN,B2
+goodbye kiss,goodbye kiss,,NOUN,B2
+atm,atm,自动取款机,NOUN,B2
+sun sensitivity,sun sensitivity,,NOUN,B2
+load cargo,load cargo,货物/负荷,NOUN,B2
+egg card,egg card,,NOUN,B2
+wife mrs,wife mrs,妻子/夫人,NOUN,B2
+definite,definite,明确的,ADJ,B2
+evenly,evenly,均匀地,ADV,B2
+determined definite,determined definite,确定的,ADJ,B2
+healthcare worker,healthcare worker,医护人员,NOUN,B2
+to behold,to behold,注视,VERB,B2
+freedom of the press,freedom of the press,出版自由,NOUN,B2
+heroin vapor,heroin vapor,,NOUN,B2
+nuance,nuance,细微差别,NOUN,B2
+bags,bags,包,NOUN,B2
+other others,other others,其他,DET,B2
+degree exam,degree exam,学位/考试,NOUN,B2
+oh really,oh really,真的吗,INTJ,B2
+back side,back side,背面,NOUN,B2
+to quiver,to quiver,颤抖,VERB,B2
+scene stage,scene stage,场景/舞台,NOUN,B2
+long,long,,NOUN,B2
+director manager,director manager,主管/经理,NOUN,B2
+hag,hag,老妇,NOUN,B2
+stably,stably,稳定地,ADV,B2
+electric power,electric power,电力,NOUN,B2
+to rot,to rot,腐烂,VERB,B2
+income tax,income tax,所得税,NOUN,B2
+eating,eating,,NOUN,B2
+mustache,mustache,胡子,NOUN,B2
+safe secure,safe secure,安全的/可靠的,ADJ,B2
+squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
+sinner,sinner,罪人,NOUN,B2
+shortly,shortly,不久,ADV,B2
+to enhance,to enhance,增强,VERB,B2
+attacked,attacked,被攻击的,ADJ,B2
+chubby,chubby,胖子,NOUN,B2
+every other,every other,每隔一个,DET,B2
+caught,caught,被捕获的,ADJ,B2
+arrested,arrested,被逮捕的,ADJ,B2
+firearms,firearms,枪支,NOUN,B2
+to food give birth,to food give birth,食物/生育,VERB,B2
+diagonally,diagonally,对角地,ADV,B2
+to occupy oneself,to occupy oneself,从事,VERB,B2
+the guy's,the guy's,那个男人的,NOUN,B2
+good well,good well,好/很好,ADJ,B2
+impressed,impressed,印象深刻的,ADJ,B2
+emotionally,emotionally,情感上,ADV,B2
+innocent,innocent,无辜地,ADV,B2
+experience exchange,experience exchange,经验交流,NOUN,B2
+good behavior,good behavior,,NOUN,B2
+green-clad,green-clad,,NOUN,B2
+broken,broken,破碎的,ADV,B2
+chips,chips,薯片,NOUN,B2
+difficult flirt,difficult flirt,,NOUN,B2
+cognac,cognac,干邑,NOUN,B2
+hot dog stand,hot dog stand,小吃摊,NOUN,B2
+corpse alike,corpse alike,尸体/相似的,NOUN,B2
+big brother,big brother,哥哥,NOUN,B2
+what kind of,what kind of,什么样的,PRON,B2
+ceo,ceo,首席执行官,NOUN,B2
+to call ring,to call ring,打电话,VERB,B2
+confusing,confusing,令人困惑的,ADJ,B2
+loudly,loudly,大声地,ADV,B2
+to be punished,to be punished,受罚,VERB,B2
+like this,like this,,NOUN,B2
+armorer,armorer,,NOUN,B2
+to account for,to account for,说明,VERB,B2
+dejt,dejt,约会,NOUN,B2
+to prosecute,to prosecute,起诉,VERB,B2
+it common,it common,它 (通性),PRON,B2
+self-evident,self-evident,,NOUN,B2
+informed,informed,见多识广的,ADJ,B2
+faster,faster,更快的,ADJ,B2
+action plan,action plan,行动方案,NOUN,B2
+seen,seen,被看见,ADJ,B2
+chill,chill,放松,ADJ,B2
+to mourn,to mourn,哀悼,VERB,B2
+to tear down,to tear down,拆除,VERB,B2
+to furlough,to furlough,临时解雇,VERB,B2
+subject topic,subject topic,主题/话题,NOUN,B2
+out here,out here,这里外面,ADV,B2
+pavement,pavement,人行道,NOUN,B2
+astray,astray,迷路,ADJ,B2
+epoch,epoch,时代,NOUN,B2
+phrasing,phrasing,措辞,NOUN,B2
+older woman,older woman,老妇人,NOUN,B2
+registered,registered,注册的,ADJ,B2
+elite unit,elite unit,,NOUN,B2
+zero,zero,零,NOUN,B2
+to be tricked,to be tricked,被欺骗,VERB,B2
+pre,pre,,NOUN,B2
+upward,upward,向上,ADV,B2
+lifestyle,lifestyle,生活方式,NOUN,B2
+christmas present,christmas present,圣诞礼物,NOUN,B2
+apart from,apart from,除了,ADP,B2
+part-time worker,part-time worker,兼职工,NOUN,B2
+central station,central station,中央车站,NOUN,B2
+based,based,基于,ADJ,B2
+cola,cola,可乐,NOUN,B2
+to be saved,to be saved,获救,VERB,B2
+smart clever,smart clever,聪明的,ADJ,B2
+to underline,to underline,强调,VERB,B2
+date fruit,date fruit,椰枣,NOUN,B2
+civilian,civilian,平民的,ADJ,B2
+trigger mechanism,trigger mechanism,,NOUN,B2
+sought,sought,,NOUN,B2
+to exist there is,to exist there is,存在/有,VERB,B2
+personal integrity,personal integrity,个人隐私,NOUN,B2
+to separate divorce,to separate divorce,分离/离婚,VERB,B2
+history story,history story,历史/故事,NOUN,B2
+away gone,away gone,不在/离开,ADV,B2
+legion unit,legion unit,,NOUN,B2
+the other day,the other day,前几天,ADV,B2
+dear,dear,,NOUN,B2
+xenophobia,xenophobia,排外心理,NOUN,B2
+stockholm,stockholm,斯德哥尔摩,PROPN,B2
+word choice,word choice,措辞,NOUN,B2
+ever,ever,,NOUN,B2
+indoors,indoors,在室内,ADV,B2
+omelette,omelette,煎蛋卷,NOUN,B2
+the it,the it,那,DET,B2
+to blink,to blink,眨眼,VERB,B2
+to acknowledge,to acknowledge,承认,VERB,B2
+cultural encounter,cultural encounter,文化交汇,NOUN,B2
+own,own,自己的,DET,B2
+the very,the very,正是,ADV,B2
+heart,heart,心,ADV,B2
+to mess around,to mess around,胡闹,VERB,B2
+cancelled set,cancelled set,取消的/设定的,ADJ,B2
+innermost,innermost,最里面的,ADV,B2
+sunglasses,sunglasses,太阳镜,NOUN,B2
+furthest,furthest,最远,ADV,B2
+to cook fix,to cook fix,做/修理,VERB,B2
+for because,for because,因为,CCONJ,B2
+pie,pie,派,NOUN,B2
+before previously,before previously,以前,ADV,B2
+beside,beside,在...旁边,ADP,B2
+coworker,coworker,同事,NOUN,B2
+yes indeed,yes indeed,正是,INTJ,B2
+to sneak away,to sneak away,溜走,VERB,B2
+headline,headline,标题,NOUN,B2
+farm yard,farm yard,农场,NOUN,B2
+to shop be about,to shop be about,购物,VERB,B2
+to kidnapped,to kidnapped,绑架,VERB,B2
+language use,language use,语言使用,NOUN,B2
+to watch out,to watch out,小心,VERB,B2
+eidsvold,eidsvold,,NOUN,B2
+to exemplify,to exemplify,举例说明,VERB,B2
+alarm center,alarm center,报警中心,NOUN,B2
+alder,alder,桤木,NOUN,B2
+blood test,blood test,验血,NOUN,B2
+dal,dal,山谷,NOUN,B2
+odds,odds,赔率,NOUN,B2
+to close eyes,to close eyes,闭眼,VERB,B2
+happily,happily,快乐地,ADV,B2
+devil bastard,devil bastard,混蛋,NOUN,B2
+cheaper,cheaper,更便宜的,ADJ,B2
+to bide,to bide,等待,VERB,B2
+capable good,capable good,能干的/优秀的,ADJ,B2
+property owner,property owner,房主,NOUN,B2
+dot,dot,点,NOUN,B2
+to acquaint,to acquaint,使熟悉,VERB,B2
+edging,edging,镶边,NOUN,B2
+the devil bastard,the devil bastard,混蛋,NOUN,B2
+alpha,alpha,阿尔法,NOUN,B2
+super high,super high,,NOUN,B2
+poor devil,poor devil,可怜虫,NOUN,B2
+to puncture deflate,to puncture deflate,刺破,VERB,B2
+sexily,sexily,性感地,ADV,B2
+more fun,more fun,更有趣的,ADJ,B2
+side page,side page,侧面/页,NOUN,B2
+to push through,to push through,推动,VERB,B2
+organically,organically,有机地,ADV,B2
+paralyzed,paralyzed,瘫痪的,ADJ,B2
+to regain,to regain,恢复,VERB,B2
+paternal grandmother,paternal grandmother,祖母,NOUN,B2
+to bark scold,to bark scold,吠/责骂,VERB,B2
+on board,on board,在船上,ADV,B2
+reply,reply,回复,NOUN,B2
+to get acquire,to get acquire,获得/弄到,VERB,B2
+ongoing,ongoing,进行中的,ADJ,B2
+ought,ought,应该,AUX,B2
+baptized,baptized,受洗的,ADJ,B2
+the chinese,the chinese,中国人,NOUN,B2
+free off,free off,空闲的/休假,ADJ,B2
+intelligence service,intelligence service,情报机构,NOUN,B2
+half hour,half hour,半小时,NOUN,B2
+to dismiss fire,to dismiss fire,解雇,VERB,B2
+seventeen,seventeen,十七,NUM,B2
+freedom of religion,freedom of religion,宗教自由,NOUN,B2
+police chief,police chief,警察局长,NOUN,B2
+lesbian,lesbian,女同性恋的,ADJ,B2
+knock,knock,敲击,NOUN,B2
+down there,down there,在那下面,ADV,B2
+high tall,high tall,高的,ADJ,B2
+death,death,致死,ADV,B2
+radiant,radiant,容光焕发的,ADJ,B2
+to have strength,to have strength,有力气,VERB,B2
+sabbath,sabbath,安息日,NOUN,B2
+marine corps,marine corps,海军陆战队,NOUN,B2
+bang,bang,砰,INTJ,B2
+seeker,seeker,寻求者,NOUN,B2
+to fall crash,to fall crash,坠落/猛冲,VERB,B2
+it neuter,it neuter,它 (中性),PRON,B2
+milk tooth,milk tooth,,NOUN,B2
+poison gas,poison gas,毒气,NOUN,B2
+full drunk,full drunk,满的/醉的,ADJ,B2
+tough guy,tough guy,硬汉,NOUN,B2
+to party,to party,狂欢,VERB,B2
+nicely nice,nicely nice,美好地,ADV,B2
+to lay put,to lay put,放,VERB,B2
+werewolf,werewolf,狼人,NOUN,B2
+to scout,to scout,侦察,VERB,B2
+good-looking person,good-looking person,帅哥/美女,NOUN,B2
+gangster,gangster,黑帮成员,NOUN,B2
+girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
+creep,creep,令人厌恶的人,NOUN,B2
+eider hunter,eider hunter,,NOUN,B2
+just over,just over,稍微超过,ADV,B2
+to give a ride,to give a ride,载送一程,VERB,B2
+fiancee,fiancee,未婚妻,NOUN,B2
+law team,law team,法律/团队,NOUN,B2
+quivering,quivering,颤抖的,ADJ,B2
+unarmed,unarmed,手无寸铁的,ADJ,B2
+meatballs,meatballs,肉丸,NOUN,B2
+datum,datum,日期,NOUN,B2
+inflammable,inflammable,易燃的,ADJ,B2
+confounded,confounded,该死的,ADJ,B2
+shedding,shedding,,NOUN,B2
+to blunder,to blunder,犯大错,VERB,B2
+to linger,to linger,徘徊,VERB,B2
+special agent,special agent,特工,NOUN,B2
+to bare,to bare,暴露,VERB,B2
+poorer,poorer,更穷的,ADJ,B2
+thank god,thank god,谢天谢地,INTJ,B2
+sixth,sixth,,NOUN,B2
+late,late,晚才,NOUN,B2
+delayed,delayed,延误的,ADJ,B2
+hamburger,hamburger,汉堡包,NOUN,B2
+rug,rug,地毯,NOUN,B2
+dressed,dressed,穿着的,ADJ,B2
+rash,rash,皮疹,NOUN,B2
+top,top,顶部的,ADJ,B2
+knocked out,knocked out,被淘汰的,ADJ,B2
+earlier,earlier,更早的,ADJ,B2
+gay,gay,同性恋者,NOUN,B2
+all of it,all of it,全部,PRON,B2
+overfall,overfall,,NOUN,B2
+away,away,避开,ADP,B2
+work task,work task,工作任务,NOUN,B2
+to mean entail,to mean entail,意味着,VERB,B2
+slower,slower,更慢,ADJ,B2
+all of them,all of them,大家,PRON,B2
+somewhere,somewhere,,NOUN,B2
+track trace,track trace,痕迹/轨道,NOUN,B2
+deadly,deadly,致命地,ADV,B2
+fair hair,fair hair,,NOUN,B2
+to make out,to make out,接吻,VERB,B2
+skater,skater,,NOUN,B2
+trainer,trainer,教练,NOUN,B2
+backward,backward,向后,ADV,B2
+this way,this way,这边,ADV,B2
+the day after tomorrow,the day after tomorrow,后天,NOUN,B2
+to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
+retirement pension,retirement pension,退休金,NOUN,B2
+gas flame,gas flame,煤气火焰,NOUN,B2
+europe,europe,欧洲,PROPN,B2
+self-defense,self-defense,自卫,NOUN,B2
+closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
+visiting ban,visiting ban,,NOUN,B2
+to think opine,to think opine,认为,VERB,B2
+evening meal,evening meal,晚餐,NOUN,B2
+thinner,thinner,更薄的,ADJ,B2
+westward,westward,向西,ADV,B2
+calming,calming,令人平静的,ADJ,B2
+competition bastard,competition bastard,,NOUN,B2
+damn,damn,该死的,ADV,B2
+attitude setting,attitude setting,态度/设置,NOUN,B2
+turntable,turntable,,NOUN,B2
+okay,okay,好的,ADJ,B2
+convicted,convicted,被判罪的,ADJ,B2
+fifth,fifth,第五,NUM,B2
+shorter,shorter,更短的,ADJ,B2
+bigness,bigness,,NOUN,B2
+starting point,starting point,出发点,NOUN,B2
+beaten,beaten,被打败的,ADJ,B2
+open,open,开放地,ADV,B2
+outer,outer,外部的,ADJ,B2
+police report,police report,,NOUN,B2
+steadily,steadily,稳定地,ADV,B2
+superhero,superhero,超级英雄,NOUN,B2
+to dejta,to dejta,约会,VERB,B2
+the cash register,the cash register,收银台,NOUN,B2
+protector,protector,保护者,NOUN,B2
+outward,outward,向外,ADV,B2
+born,born,出生的,ADJ,B2
+cleaner,cleaner,更干净的,ADJ,B2
+cykel,cykel,自行车,NOUN,B2
+destroyed,destroyed,被毁坏的,ADJ,B2
+ice pick,ice pick,,NOUN,B2
+tax return,tax return,报税,NOUN,B2
+dirtier,dirtier,更脏的,ADJ,B2
+sensibly,sensibly,明智地,ADV,B2
+to release let go,to release let go,释放/放手,VERB,B2
+tragically,tragically,悲剧地,ADV,B2
+lovely,lovely,美好的,ADJ,B2
+kids,kids,孩子,NOUN,B2
+sensor donor,sensor donor,传感器/捐献者,NOUN,B2
+sauna,sauna,桑拿,NOUN,B2
+to search apply,to search apply,寻找/申请,VERB,B2
+bow tie,bow tie,领结,NOUN,B2
+here you go,here you go,请,INTJ,B2
+to apply be valid,to apply be valid,适用/有效,VERB,B2
+in vain,in vain,徒劳,NOUN,B2
+shit crap,shit crap,废话,NOUN,B2
+like as,like as,如同/好像,ADV,B2
+upper class,upper class,上层,NOUN,B2
+poorest,poorest,最穷的,ADJ,B2
+sweden,sweden,瑞典,PROPN,B2
+salt shaker,salt shaker,,NOUN,B2
+state federal,state federal,州,NOUN,B2
+del,del,部分,NOUN,B2
+vile,vile,可憎地,ADV,B2
+inside of,inside of,在...里面,ADP,B2
+doughy,doughy,面团状的,ADJ,B2
+exactly just,exactly just,恰好,ADV,B2
+his her own,his her own,他/她自己的,DET,B2
+worst,worst,最差的,ADV,B2
+sentencing,sentencing,量刑,NOUN,B2
+of course,of course,当然,INTJ,B2
+christmas eve,christmas eve,平安夜,NOUN,B2
+time to go to bed,time to go to bed,该睡觉了,ADV,B2
+sense of duty,sense of duty,责任感,NOUN,B2
+that way,that way,往那边,ADV,B2
+giddy,giddy,头晕的,ADJ,B2
+rulebook,rulebook,规则体系,NOUN,B2
+electric guitar,electric guitar,电吉他,NOUN,B2
+richer,richer,更富的,ADJ,B2
+pain hurt,pain hurt,疼痛,ADJ,B2
+corrections,corrections,刑事司法,NOUN,B2
+to erect behave,to erect behave,建造,VERB,B2
+to tip,to tip,透露,VERB,B2
+trigger imprint,trigger imprint,印记,NOUN,B2
+yep,yep,是的,INTJ,B2
+partial norm,partial norm,分范,NOUN,B2
+one machine,one machine,一架,NUM,B2
+proactive,proactive,积极主动的,ADJ,B2
+domestic debt,domestic debt,内债,NOUN,B2
+sufficient flight,sufficient flight,飞够,NOUN,B2
+he she,he she,伊,PRON,B2
+mangosteen,mangosteen,山竹,NOUN,B2
+meridian,meridian,经脉,NOUN,B2
+toast,toast,你敬酒,NOUN,B2
+just,just,公正,ADJ,B2
+social custom,social custom,社会习俗,NOUN,B2
+amended generality,amended generality,改般,NOUN,B2
+jeans,jeans,牛仔裤,NOUN,B2
+crafty,crafty,狡猾,ADJ,B2
+trite,trite,陈腐的,ADJ,B2
+to wash with water,to wash with water,水洗,VERB,B2
+half-day,half-day,半天,NOUN,B2
+to extort a bribe,to extort a bribe,索贿,VERB,B2
+sub-reality,sub-reality,分实,NOUN,B2
+hard to measure,hard to measure,难以衡量,ADJ,B2
+to for example,to for example,比如,VERB,B2
+rethinking,rethinking,重想,NOUN,B2
+warrant,warrant,令状,NOUN,B2
+recounting,recounting,再叙,NOUN,B2
+to concern all,to concern all,凡事,VERB,B2
+timely,timely,适时,ADJ,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+foul smell,foul smell,骚味,NOUN,B2
+human life,human life,人命,NOUN,B2
+social value,social value,社会价值,NOUN,B2
+to donate blood,to donate blood,献血,VERB,B2
+hardship,hardship,艰难,NOUN,B2
+rehearsal,rehearsal,排练,NOUN,B2
+otherwise,otherwise,要不,PART,B2
+shooting star,shooting star,流星,NOUN,B2
+changed work,changed work,改工,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+your arrow,your arrow,若非你一箭,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
+amended synthesis,amended synthesis,改综,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+feudal ethics,feudal ethics,礼教,NOUN,B2
+very deep,very deep,很深,ADJ,B2
+bungee jumping,bungee jumping,蹦极,NOUN,B2
+non-knot,non-knot,非结,NOUN,B2
+bizarre case,bizarre case,奇案,NOUN,B2
+provocative,provocative,挑衅的,ADJ,B2
+non-possible,non-possible,非可,NOUN,B2
+main camp,main camp,大营,NOUN,B2
+imperial father,imperial father,父皇,NOUN,B2
+tendering,tendering,招标,NOUN,B2
+characteristic feature,characteristic feature,特点,NOUN,B2
+adversity,adversity,逆境,NOUN,B2
+partial basis,partial basis,分据,NOUN,B2
+waist token,waist token,腰牌,NOUN,B2
+sister yu,sister yu,俞姐,NOUN,B2
+no matter what,no matter what,无论,ADV,B2
+one building,one building,一座,NUM,B2
+to finally,to finally,你可算,VERB,B2
+how enough,how enough,哪够,NOUN,B2
+which seat,which seat,哪座,NOUN,B2
+succinct,succinct,简明的,ADJ,B2
+to seek peace,to seek peace,主和,VERB,B2
+case details,case details,案情,NOUN,B2
+motto,motto,座右铭,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+social activity,social activity,社会活动,NOUN,B2
+survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
+malicious words,malicious words,恶言,NOUN,B2
+social mediation,social mediation,社会调解,NOUN,B2
+gearbox,gearbox,变速箱,NOUN,B2
+hyper-target,hyper-target,超的,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+departure lounge,departure lounge,候机室,NOUN,B2
+social fairness,social fairness,社会公平,NOUN,B2
+to hope for,to hope for,盼望,VERB,B2
+great victory,great victory,大胜,NOUN,B2
+not bad,not bad,不错,ADJ,B2
+amended particular,amended particular,改特,NOUN,B2
+shopping mall,shopping mall,商场,NOUN,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
+wanting you,wanting you,要你,NOUN,B2
+to be afraid,to be afraid,害怕,VERB,B2
+re-criterion,re-criterion,重准,NOUN,B2
+non-technique,non-technique,非术,NOUN,B2
+cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
+earnest sincere,earnest sincere,恳切,ADJ,B2
+town mayor,town mayor,镇长,NOUN,B2
+traditional chinese painting,traditional chinese painting,国画,NOUN,B2
+acrobatics,acrobatics,杂技,NOUN,B2
+disposable diaper,disposable diaper,纸尿裤,NOUN,B2
+prudent,prudent,谨慎的,ADJ,B2
+inner heart,inner heart,内心,NOUN,B2
+walnut,walnut,核桃,NOUN,B2
+affordability,affordability,得起,NOUN,B2
+how dare,how dare,岂敢,NOUN,B2
+non-iron,non-iron,免烫,ADJ,B2
+to do what,to do what,干嘛,VERB,B2
+virtual reality,virtual reality,虚拟现实,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+kneeling,kneeling,跪,NOUN,B2
+reverse result,reverse result,反果,NOUN,B2
+dense forest,dense forest,密林,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+changed route,changed route,改路,NOUN,B2
+to thresh,to thresh,脱粒,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+overthinking,overthinking,你想多,NOUN,B2
+non-necessary,non-necessary,非必,NOUN,B2
+incremental,incremental,渐进性,ADJ,B2
+outer-gate,outer-gate,外门,NOUN,B2
+star search,star search,找星,NOUN,B2
+reverse origin,reverse origin,反原,NOUN,B2
+adequacy,adequacy,也不错,NOUN,B2
+inversion,inversion,反演,NOUN,B2
+from away from,from away from,离,ADP,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+that evening,that evening,当晚,NOUN,B2
+film roll,film roll,胶卷,NOUN,B2
+upper part,upper part,上部,NOUN,B2
+to shut up,to shut up,闭嘴,VERB,B2
+not good,not good,不好,ADJ,B2
+social progress,social progress,社会进步,NOUN,B2
+altogether,altogether,共,ADV,B2
+modified ability,modified ability,改能,NOUN,B2
+sucking,sucking,嗦,NOUN,B2
+not very good,not very good,不太好,ADJ,B2
+spiral pattern,spiral pattern,旋纹,NOUN,B2
+sticky note,sticky note,便签,NOUN,B2
+could it be,could it be,难不成,ADJ,B2
+outfit,outfit,服装,NOUN,B2
+meridians,meridians,筋脉,NOUN,B2
+re-grading,re-grading,改级,NOUN,B2
+my scrutiny,my scrutiny,我看你,NOUN,B2
+it is a pity,it is a pity,可惜,ADJ,B2
+polytunnel,polytunnel,大棚,NOUN,B2
+summer grass,summer grass,夏草,NOUN,B2
+now,now,此刻,NOUN,B2
+brook no delay,brook no delay,刻不容缓,ADJ,B2
+cilantro,cilantro,香菜,NOUN,B2
+further debate,further debate,再辩,NOUN,B2
+to act rashly,to act rashly,妄动,VERB,B2
+will surely,will surely,定会,AUX,B2
+heavy snow,heavy snow,大雪,NOUN,B2
+foot-warming,foot-warming,捂脚,NOUN,B2
+floating dust,floating dust,浮尘,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+cut off,cut off,割下,NOUN,B2
+surfing,surfing,冲浪,NOUN,B2
+well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
+not intentional,not intentional,不是故意,ADJ,B2
+all day,all day,整天,ADV,B2
+modern dance,modern dance,现代舞,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+to ambush,to ambush,埋伏,VERB,B2
+alumnus,alumnus,校友,NOUN,B2
+to transfer schools,to transfer schools,转学,VERB,B2
+um,um,嗯,INTJ,B2
+altered art,altered art,改艺,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+heart disease,heart disease,心脏病,NOUN,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+singularity,singularity,单一性,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+big data,big data,大数据,NOUN,B2
+charades,charades,打哑谜,NOUN,B2
+this matter,this matter,这事,NOUN,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+bloodshed,bloodshed,血腥,NOUN,B2
+re-argument,re-argument,重论,NOUN,B2
+foreign debt,foreign debt,外债,NOUN,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+side effect,side effect,副作用,NOUN,B2
+measure word flat objects,measure word flat objects,张,NOUN,B2
+hyper-origin,hyper-origin,超原,NOUN,B2
+but also,but also,但也,NOUN,B2
+captive,captive,俘虏,NOUN,B2
+cannot stay,cannot stay,不住,PART,B2
+moisture-proof,moisture-proof,防潮,ADJ,B2
+taking command,taking command,挂帅,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+re-concretization,re-concretization,再具,NOUN,B2
+jianghu world,jianghu world,江湖上,NOUN,B2
+as expected,as expected,果然,ADV,B2
+to return a car,to return a car,送车,VERB,B2
+for to,for to,为,ADP,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+entrapment,entrapment,身陷,NOUN,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+running around,running around,跑遍,NOUN,B2
+this indeed,this indeed,这倒,NOUN,B2
+quick lie-down,quick lie-down,快躺,NOUN,B2
+notepad,notepad,记事本,NOUN,B2
+courtyard guard,courtyard guard,护院,NOUN,B2
+major case,major case,大案,NOUN,B2
+elective course,elective course,选修课,NOUN,B2
+tactile paving,tactile paving,盲道,NOUN,B2
+to befriend,to befriend,与...交朋友,VERB,B2
+to not run,to not run,别跑,VERB,B2
+to raise funds,to raise funds,筹资,VERB,B2
+anti-universality,anti-universality,反普,NOUN,B2
+credentials,credentials,国书,NOUN,B2
+enoki mushroom,enoki mushroom,金针菇,NOUN,B2
+gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
+shh,shh,嘘,INTJ,B2
+to file for record,to file for record,备案,VERB,B2
+bound to,bound to,势必,ADV,B2
+grab,grab,揪,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
+sports exercise,sports exercise,运动,NOUN,B2
+red robe,red robe,红衣,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+borrowed knife,borrowed knife,借刀,NOUN,B2
+sound sleep,sound sleep,你踏实睡,NOUN,B2
+reincarnation,reincarnation,再体,NOUN,B2
+express car,express car,快车,NOUN,B2
+non-view,non-view,非观,NOUN,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to lose bid,to lose bid,落标,VERB,B2
+super-form,super-form,超形,NOUN,B2
+car wash,car wash,洗车,NOUN,B2
+can be at,can be at,可在,NOUN,B2
+to fall behind,to fall behind,落后,VERB,B2
+void,void,最无,NOUN,B2
+older sister,older sister,姐姐,NOUN,B2
+fax,fax,传真,NOUN,B2
+sha dynasty,sha dynasty,砂朝,NOUN,B2
+multi-level garage,multi-level garage,立体车库,NOUN,B2
+heaven and earth,heaven and earth,天地,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+to statistics,to statistics,统计,VERB,B2
+dignified manner,dignified manner,威仪,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+emphasize,emphasize,着重,ADV,B2
+to reflect on,to reflect on,思考,VERB,B2
+that pair,that pair,那付,NOUN,B2
+your photo,your photo,照你,NOUN,B2
+loud and clear,loud and clear,响亮,ADJ,B2
+unreasonable,unreasonable,不情,NOUN,B2
+cause of defeat,cause of defeat,败因,NOUN,B2
+good medicine,good medicine,好药,NOUN,B2
+that which,that which,所,PART,B2
+counter-boundary,counter-boundary,反界,NOUN,B2
+classifier for documents portions,classifier for documents portions,份,NOUN,B2
+plain and simple,plain and simple,朴素,ADJ,B2
+too small,too small,太小,ADJ,B2
+all night,all night,通宵,NOUN,B2
+plasma,plasma,血浆,NOUN,B2
+subcategory,subcategory,分目,NOUN,B2
+year by year,year by year,逐年,ADV,B2
+i,i,我连,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+to lack basis,to lack basis,无据,VERB,B2
+cantaloupe,cantaloupe,哈密瓜,NOUN,B2
+to not lose,to not lose,别丢,VERB,B2
+worry-free,worry-free,无忧,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+breakthrough,breakthrough,突破性,ADJ,B2
+lover sweetheart,lover sweetheart,情人,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
+traffic light,traffic light,红绿灯,NOUN,B2
+audio equipment,audio equipment,音响,NOUN,B2
+neighborhood head,neighborhood head,里长,NOUN,B2
+paternity leave,paternity leave,陪产假,NOUN,B2
+exchange goods,exchange goods,换货,NOUN,B2
+next week,next week,下周,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+to linkage,to linkage,联动,VERB,B2
+eyes,eyes,眼中,NOUN,B2
+nadir,nadir,最低点,NOUN,B2
+social morality,social morality,社会公德,NOUN,B2
+to die for,to die for,死要,VERB,B2
+quick removal,quick removal,赶快脱,NOUN,B2
+i'm afraid,i'm afraid,恐怕,ADV,B2
+extreme height,extreme height,极高,NOUN,B2
+marriage leave,marriage leave,婚假,NOUN,B2
+special-purpose trip,special-purpose trip,专程,ADV,B2
+housework,housework,家务,NOUN,B2
+i-than,i-than,我比,NOUN,B2
+mulberry,mulberry,桑葚,NOUN,B2
+inner side,inner side,内侧,NOUN,B2
+sex appeal,sex appeal,性感,NOUN,B2
+trans-idealism,trans-idealism,超唯,NOUN,B2
+to recommend for admission,to recommend for admission,保送,VERB,B2
+usb flash drive,usb flash drive,U盘,NOUN,B2
+holy decree,holy decree,圣令,NOUN,B2
+to study deeply,to study deeply,钻研,VERB,B2
+why not,why not,何不,ADV,B2
+super-distinction,super-distinction,超殊,NOUN,B2
+my taking,my taking,我拿,NOUN,B2
+foe,foe,敌友,NOUN,B2
+explosion-proof,explosion-proof,防爆,ADJ,B2
+this route,this route,这路,NOUN,B2
+birthmark,birthmark,胎记,NOUN,B2
+financial center,financial center,金融中心,NOUN,B2
+pounding,pounding,捶,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+be sorry,be sorry,抱歉,ADJ,B2
+trans-induction,trans-induction,超归,NOUN,B2
+to seek you,to seek you,寻你,VERB,B2
+eldest brother,eldest brother,做大哥,NOUN,B2
+second letter,second letter,再信,NOUN,B2
+counter-belief,counter-belief,反信,NOUN,B2
+past events,past events,往事,NOUN,B2
+swordsmanship,swordsmanship,剑术,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+logic modification,logic modification,改逻,NOUN,B2
+crowded,crowded,拥挤,ADJ,B2
+super-internal,super-internal,超内,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+nuclear energy,nuclear energy,核能,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+law,law,法,PART,B2
+zen master,zen master,禅师,NOUN,B2
+bluntness,bluntness,直说,NOUN,B2
+intravenous drip,intravenous drip,输液,NOUN,B2
+for a time,for a time,一度,ADV,B2
+cause of change,cause of change,改因,NOUN,B2
+equally matched,equally matched,不相上下,ADJ,B2
+external hard drive,external hard drive,移动硬盘,NOUN,B2
+immobility,immobility,都无动,NOUN,B2
+land expansion,land expansion,拓土,NOUN,B2
+pushover,pushover,善茬,NOUN,B2
+family background,family background,出身,NOUN,B2
+on the spot,on the spot,当场,ADV,B2
+sea level rise,sea level rise,海平面上升,NOUN,B2
+no not,no not,不,ADV,B2
+nephews,nephews,子侄,NOUN,B2
+common sense,common sense,常识,NOUN,B2
+capable,capable,有本事,NOUN,B2
+revised image,revised image,改影,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+according to,according to,要照,NOUN,B2
+spending,spending,行用,NOUN,B2
+re-analysis,re-analysis,重析,NOUN,B2
+homestay,homestay,民宿,NOUN,B2
+at worst,at worst,大不了,ADV,B2
+stuffed crab,stuffed crab,蟹酿,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+creditor's rights,creditor's rights,债权,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+sick leave,sick leave,病假,NOUN,B2
+month ago,month ago,月前,NOUN,B2
+altered path,altered path,改径,NOUN,B2
+to pay off,to pay off,清偿,VERB,B2
+medal awarding,medal awarding,授勋,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+in those days,in those days,当年,NOUN,B2
+cutting grass,cutting grass,斩草,NOUN,B2
+main street,main street,大街,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+exchange meeting,exchange meeting,交流会,NOUN,B2
+high-speed,high-speed,高速,ADJ,B2
+senior male student,senior male student,学长,NOUN,B2
+trans-er,trans-er,超而,NOUN,B2
+over-skill,over-skill,超技,NOUN,B2
+can-exit,can-exit,还出得来,NOUN,B2
+polyester,polyester,涤纶,NOUN,B2
+retrial,retrial,再审,NOUN,B2
+then he,then he,那他,NOUN,B2
+to eavesdrop,to eavesdrop,偷听,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+not catch up,not catch up,非赶,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+good faith,good faith,信义,NOUN,B2
+recycled item,recycled item,再物,NOUN,B2
+non-number,non-number,非数,NOUN,B2
+amended possibility,amended possibility,改可,NOUN,B2
+initial stage,initial stage,初期,NOUN,B2
+social awareness,social awareness,社会觉悟,NOUN,B2
+coral reef,coral reef,珊瑚礁,NOUN,B2
+to send mail,to send mail,寄件,VERB,B2
+death news,death news,死讯,NOUN,B2
+able to play,able to play,能下,NOUN,B2
+supreme fate,supreme fate,上缘,NOUN,B2
+re-tolerance,re-tolerance,再容,NOUN,B2
+white blood cell,white blood cell,白细胞,NOUN,B2
+mock exam,mock exam,模拟考,NOUN,B2
+heavy effect,heavy effect,重效,NOUN,B2
+hearth,hearth,壁炉,NOUN,B2
+to wanted,to wanted,通缉,VERB,B2
+to dry clean,to dry clean,干洗,VERB,B2
+return destination,return destination,回哪,NOUN,B2
+historical site,historical site,古迹,NOUN,B2
+patient sufferer,patient sufferer,患者,NOUN,B2
+simple pure,simple pure,单纯,ADJ,B2
+re-basis,re-basis,再据,NOUN,B2
+taro,taro,芋头,NOUN,B2
+re-route,re-route,重路,NOUN,B2
+listening,listening,也听,NOUN,B2
+stone,stone,石,PART,B2
+main road,main road,主路,NOUN,B2
+sub-method,sub-method,分法,NOUN,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+moonlight,moonlight,月色,NOUN,B2
+your word,your word,听你,NOUN,B2
+happy event,happy event,喜事,NOUN,B2
+this sword,this sword,这剑,NOUN,B2
+jujube,jujube,枣子,NOUN,B2
+proclamation,proclamation,宣大,NOUN,B2
+eavesdropping,eavesdropping,偷听,NOUN,B2
+procedural,procedural,程序的,ADJ,B2
+medical care,medical care,医疗,NOUN,B2
+missile,missile,导弹,NOUN,B2
+inside in,inside in,里,NOUN,B2
+great joy,great joy,大喜,NOUN,B2
+direct sales,direct sales,直销,NOUN,B2
+radiotherapy,radiotherapy,放疗,NOUN,B2
+you except,you except,你除,NOUN,B2
+herbicide,herbicide,除草剂,NOUN,B2
+over-degree,over-degree,超阶,NOUN,B2
+core course,core course,核心课,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+non-theory,non-theory,非论,NOUN,B2
+to not seen,to not seen,不见,VERB,B2
+all at once,all at once,一下子,ADV,B2
+re-verification,re-verification,改证,NOUN,B2
+mutual treatment,mutual treatment,相待,NOUN,B2
+too big,too big,太大,ADJ,B2
+to break a record,to break a record,打破纪录,VERB,B2
+final exam,final exam,期末考,NOUN,B2
+anti-static,anti-static,防静电,ADJ,B2
+boundless,boundless,无疆,NOUN,B2
+to serve as,to serve as,充当,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+re-substance,re-substance,再质,NOUN,B2
+light rain,light rain,小雨,NOUN,B2
+undercover agent,undercover agent,卧底,NOUN,B2
+little bitch,little bitch,小婊子,NOUN,B2
+who polite,who polite,哪位,PRON,B2
+to pioneer,to pioneer,首创,VERB,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+over-model,over-model,超模,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+certain fall,certain fall,必倒,NOUN,B2
+anticyclone,anticyclone,反气旋,NOUN,B2
+safe haven,safe haven,避风港,NOUN,B2
+supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
+reordering,reordering,改序,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+air raid,air raid,空袭,NOUN,B2
+to fall down,to fall down,倒下,VERB,B2
+historical record,historical record,历史纪录,NOUN,B2
+re-possibility,re-possibility,重可,NOUN,B2
+larger,larger,再大,NOUN,B2
+wind speed,wind speed,风速,NOUN,B2
+award ceremony,award ceremony,颁奖典礼,NOUN,B2
+super-special,super-special,超特,NOUN,B2
+graduate student,graduate student,研究生,NOUN,B2
+machine learning,machine learning,机器学习,NOUN,B2
+random posting,random posting,乱贴,NOUN,B2
+unwinnable,unwinnable,打不赢,NOUN,B2
+postwar,postwar,战后,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+third place,third place,季军,NOUN,B2
+family happiness,family happiness,天伦之乐,NOUN,B2
+hot water,hot water,热水,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+two days,two days,两天,NUM,B2
+guqin,guqin,古琴,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
+table grape,table grape,提子,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+over-order,over-order,超序,NOUN,B2
+everyone,everyone,各位,NOUN,B2
+heavy capacity,heavy capacity,重容,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+pipa,pipa,琵琶,NOUN,B2
+so as not to,so as not to,免得,SCONJ,B2
+war cessation,war cessation,战息,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
+perilla,perilla,紫苏,NOUN,B2
+re-specialization,re-specialization,重特,NOUN,B2
+panda,panda,熊猫,NOUN,B2
+sum total,sum total,总而,NOUN,B2
+adolescent,adolescent,青少年,NOUN,B2
+rights and interests,rights and interests,权益,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+unstoppable,unstoppable,不可阻挡,ADJ,B2
+why bother,why bother,何必,ADV,B2
+overthrow,overthrow,扳倒,NOUN,B2
+chest stab,chest stab,胸刺,NOUN,B2
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
+rashly,rashly,轻举,ADV,B2
+social structure,social structure,社会结构,NOUN,B2
+revealing,revealing,现出,NOUN,B2
+amended unity,amended unity,改一,NOUN,B2
+hedonistic,hedonistic,享乐主义的,ADJ,B2
+to strive for,to strive for,争取,VERB,B2
+two people,two people,两名,NUM,B2
+social movement,social movement,社会运动,NOUN,B2
+dare gamble,dare gamble,敢赌,NOUN,B2
+change of mind,change of mind,改念,NOUN,B2
+push further,push further,进尺,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+hyper-intent,hyper-intent,超意,NOUN,B2
+to send back,to send back,传回,VERB,B2
+social ethos,social ethos,社会风气,NOUN,B2
+non-observation,non-observation,非察,NOUN,B2
+ceramic art,ceramic art,陶艺,NOUN,B2
+re-observation,re-observation,再观,NOUN,B2
+young wife,young wife,小媳,NOUN,B2
+visibility,visibility,能见度,NOUN,B2
+excretion,excretion,排泄,NOUN,B2
+eavesdrop,eavesdrop,营听,NOUN,B2
+senior,senior,前辈,NOUN,B2
+to wiretap,to wiretap,监听,VERB,B2
+entering home,entering home,进家,NOUN,B2
+hundred million,hundred million,亿,NUM,B2
+ginseng,ginseng,人参,NOUN,B2
+non-sudden,non-sudden,非骤,NOUN,B2
+later stage,later stage,后期,NOUN,B2
+windy day,windy day,风天,NOUN,B2
+nickel,nickel,镍,NOUN,B2
+scenic spot,scenic spot,名胜,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+super-observation,super-observation,超察,NOUN,B2
+big dipper,big dipper,北斗七星,NOUN,B2
+quite good,quite good,挺好,NOUN,B2
+limbs,limbs,手脚,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+unsolved case,unsolved case,疑案,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to love dearly,to love dearly,心疼,VERB,B2
+military pay,military pay,军饷,NOUN,B2
+over-side,over-side,超方,NOUN,B2
+annual leave,annual leave,年假,NOUN,B2
+to be far from,to be far from,绝非,VERB,B2
+substantive,substantive,实质性的,ADJ,B2
+empress mother,empress mother,你母后,NOUN,B2
+both eyes,both eyes,双眼,NOUN,B2
+rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
+waiter attendant,waiter attendant,服务员,NOUN,B2
+your head,your head,你头上,NOUN,B2
+but majesty,but majesty,可陛,NOUN,B2
+energy saving,energy saving,节能,NOUN,B2
+to use force,to use force,动武,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+national record,national record,全国纪录,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
+to work part-time,to work part-time,打工,VERB,B2
+social phenomenon,social phenomenon,社会现象,NOUN,B2
+super-number,super-number,超数,NOUN,B2
+king,king,王,PART,B2
+flanking,flanking,包抄,NOUN,B2
+coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
+snow lotus,snow lotus,雪莲,NOUN,B2
+musical,musical,音乐剧,NOUN,B2
+personal effort,personal effort,亲力,NOUN,B2
+at the instant sth happens,at the instant sth happens,临时,ADV,B2
+next meeting,next meeting,下回遇,NOUN,B2
+to await orders,to await orders,待命,VERB,B2
+equal size,equal size,等大,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+re-generalization,re-generalization,重般,NOUN,B2
+project report,project report,项目报告,NOUN,B2
+local tyrant,local tyrant,豪强,NOUN,B2
+chinese cabbage,chinese cabbage,白菜,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+peephole,peephole,门镜,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+army morale,army morale,军心,NOUN,B2
+social hierarchy,social hierarchy,社会等级,NOUN,B2
+that is to say,that is to say,也就是说,SCONJ,B2
+value change,value change,改值,NOUN,B2
+what kind,what kind,什么样,PRON,B2
+punitive,punitive,惩罚性的,ADJ,B2
+mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+to follow up,to follow up,追问,VERB,B2
+non-righteousness,non-righteousness,非义,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+your parents,your parents,你爹娘,NOUN,B2
+two sons,two sons,儿俩,NOUN,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+over-form,over-form,超式,NOUN,B2
+hard to determine,hard to determine,难以确定,ADJ,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+don't,don't,可别,AUX,B2
+to be located at,to be located at,位于,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
+amber,amber,琥珀,NOUN,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
+architecture photo,architecture photo,建筑照,NOUN,B2

--- a/spanish/expansion.csv
+++ b/spanish/expansion.csv
@@ -1,1644 +1,364 @@
 Spanish_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
-African,African,词,ADJ,B1
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Alawi,Alawi,词,NOUN,C1
-Alice,Alice,词,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
-Amazigh,Amazigh,词,NOUN,C1
-American (noun),American,词,NOUN,B2
-Andalusian,Andalusian,词,ADJ,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
-Balkanization,Balkanization,词,NOUN,C1
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Brother He,Brother He,郃弟,NOUN,B2
-Brussels,Brussels,词,ADJ,C1
-Calvinism,Calvinism,词,NOUN,C1
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese (noun),Chinese,中文,NOUN,C1
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Christian (adj),Christian,词,ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-DIY,DIY,词,NOUN,C1
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-Ed,Ed,词,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-England,England,词,PROPN,B1
-English language,English language,词,NOUN,A2
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Fauvism,Fauvism,词,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-French (adj),French,法语,ADJ,C1
-French language,French language,词,NOUN,A2
-French-speaking world,French-speaking world,词,NOUN,B2
-Frenchification,Frenchification,词,NOUN,C1
-Friday evening,Friday evening,词,NOUN,C1
-Gnawa,Gnawa,词,NOUN,B2
-Gothic,Gothic,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-Hurufiyya,Hurufiyya,词,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IT-related,IT-related,词,ADJ,C1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Irish (noun),Irish,词,NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
-Israeli,Israeli,词,ADJ,B2
-Italian (adj),Italian,意大利的,ADJ,C1
-January evening,January evening,词,NOUN,B2
-Japanese (adj),Japanese,日本的,ADJ,C1
-Japanese person,Japanese person,词,NOUN,C1
-Jesuit,Jesuit,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
-Kufic,Kufic,词,ADJ,C1
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Limburgish,Limburgish,词,ADJ,C1
-Ling,Ling,叫凌,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Marxist,Marxist,词,ADJ,C1
-Mary,Mary,词,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Mon,Mon,词,NOUN,C1
-Moroccan,Moroccan,词,ADJ,B2
-Mr. sir,Mr. sir,先生,NOUN,B2
-Ms.,Ms.,词,NOUN,C1
-Murong,Murong,慕容,NOUN,B2
-Muslim (adj),Muslim,词,ADJ,B1
-Natan,Natan,词,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
-Navidad,christmas,圣诞节,NOUN,B2
-New Year dress,New Year dress,词,NOUN,B2
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-No.,No.,词,NOUN,C1
-Nordic,Nordic,词,ADJ,C1
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
-Parisian,Parisian,词,ADJ,B1
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Polaris,Polaris,北极星,NOUN,B2
-Prophet birthday,Prophet birthday,词,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Quran,Quran,词,NOUN,B2
-Rotterdam,Rotterdam,词,ADJ,C1
-SIM card,SIM card,词,NOUN,B1
-Salafism,Salafism,词,NOUN,C1
-San Nicolás,santa claus,圣诞老人,NOUN,B2
-Saturday evening,Saturday evening,词,NOUN,C1
-Serbian,Serbian,词,ADJ,C1
-Shiism,Shiism,词,NOUN,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Su Sha,Su Sha,夙砂,NOUN,B2
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Surinamese,Surinamese,词,ADJ,C1
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-Swedish (adj),Swedish,瑞典的,ADJ,B2
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-TV series,TV series,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Tajwid,Tajwid,词,NOUN,C1
-Thai,Thai,词,ADJ,C1
-Tifinagh script,Tifinagh script,词,NOUN,C1
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-VIP room,VIP room,贵宾室,NOUN,C1
-Whistles,Whistles,词,NOUN,C1
-Wudang,wudang,武当,NOUN,B2
-Wushk,Wushk,词,NOUN,B1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-YouTuber,YouTuber,词,NOUN,B2
-Your Highness,Your Highness,殿下,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a corto plazo,short-term,短期的,ADJ,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
-a little,a little,一点儿,ADV,B2
-a lo largo de,along,沿着,ADP,B2
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a menos que,unless,除非,SCONJ,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a partir de ahora,from now on,今后,ADV,B2
-a pesar de,despite,尽管,ADP,B2
-a pesar de,to in spite of,不顾,VERB,B2
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a regañadientes,reluctantly,不情愿地,ADV,B2
-a sound,a sound,一声,NUM,B2
-a tiempo,in time,及时地,ADV,B2
-a toast,a toast,我来敬,NOUN,C1
-a través de,through,通过,ADP,B2
-a veces,sometimes,有时,ADV,B2
-abajo,below,在...下面,ADP,B2
-abajo,down,顺...而下,ADP,B2
-abate,abate,词,VERB,B2
-abbey,abbey,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-abeja,bee,蜜蜂,NOUN,B2
-aberrant,aberrant,词,ADJ,B2
-aberziehung,aberziehung,词,NOUN,B2
-abet,abet,词,VERB,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abhorrent,abhorrent,词,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkunft,abkunft,词,NOUN,C1
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
-able to play,able to play,能下,NOUN,B2
-ablution,ablution,词,NOUN,B2
-abogacía,legal profession,律师业,NOUN,B2
-abogado,attorney,律师,NOUN,B2
-abogar,to advocate,提倡,VERB,B2
-abolition,abolition,废除,NOUN,B2
-abominable,abominable,可憎的,ADJ,B2
-abominate,abominate,词,VERB,B2
-abomination,abomination,词,NOUN,B2
-abordar,to tackle,处理,VERB,B2
-about,about,大约,ADV,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,五十左右,NOUN,B2
-about it,about it,关于它,ADV,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about that,about that,关于那个,ADV,B2
-about thirty,about thirty,三十左右,NOUN,B2
-about this,about this,关于这个,ADV,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-about which,about which,关于什么,PRON,B2
-above,above,上面,ADV,B2
-above (noun),above,重上,NOUN,C1
-above all,above all,,NOUN,B2
-above average,above average,词,ADJ,C1
-above over,above over,词,ADP,A2
-above-mentioned,above-mentioned,上述的,ADJ,B2
-abpflegung,abpflegung,词,NOUN,C1
-abrasive,abrasive,词,ADJ,B2
+mente,-ly,地,PART,B2
+un poco,a bit,一点,ADV,B2
+un poco,a little,一点,ADJ,B2
+pareja casada,a married couple,夫妇,NOUN,B2
+par,a pair,一对,NUM,B2
+pila,a pile,一堆,NUM,B2
+pozo,a well,井,NOUN,B2
+rato,a while,一会儿,NOUN,B2
+capacidad,ability,能力,NOUN,B2
+capaz,able,能够的,ADJ,B2
+anormal,abnormal,异常的,ADJ,B2
+sobre,about,关于,ADP,B2
+arriba,above,在...之上,ADP,B2
 abrasión,abrasion,擦伤,NOUN,B2
-abrazadera,clamp,夹钳,NOUN,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
-abroad,abroad,在国外,ADV,B2
-abrogate,abrogate,词,VERB,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
-absolutely not,absolutely not,词,ADV,C1
-absolution,absolution,词,NOUN,C1
-absolutist,absolutist,词,ADJ,C1
+extranjero,abroad,国外,NOUN,B2
+huir,to abscond,潜逃,VERB,B2
 absoluto,absolute,绝对的,ADJ,B2
-absprache,absprache,词,NOUN,C1
-abstenerse,to refrain,克制,VERB,B2
-abstract (noun),abstract,词,NOUN,C1
-abstractionism,abstractionism,词,NOUN,C1
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-absurdism,absurdism,词,NOUN,C1
-absurdo,preposterous,荒谬的,ADJ,B2
-abtheilung,abtheilung,词,NOUN,C1
-abuela,grandma,奶奶,NOUN,B2
-abundantly,abundantly,词,ADV,C1
-aburrido,bored,无聊的,ADJ,B2
-aburrido,boring,无聊的,ADJ,B2
 abusar,to abuse,滥用,VERB,B2
-abuse case,abuse case,词,NOUN,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuser,abuser,滥用者,NOUN,B2
-abuses,abuses,词,NOUN,C1
-abusive,abusive,滥用的,ADJ,B2
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-abysmal,abysmal,词,ADJ,B2
-acabado,finishing,装修,NOUN,B2
-academic,academic,学者,NOUN,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
 académico,academic,学术的,ADJ,B2
-acantilado,cliff,悬崖,NOUN,B2
-acariciar,to pat,轻拍,VERB,B2
-accede,accede,词,VERB,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-accesión,accession,即位,NOUN,B2
-accessibility,accessibility,可达性,NOUN,B2
-accessibility features,accessibility features,词,NOUN,B2
-accessible,accessible,易接近的,ADJ,B2
-accessory,accessory,配件,NOUN,B2
-accidental,accidental,偶然的,ADJ,B2
-accidentalmente,accidentally,意外地,ADV,B2
-accidentarse,to have an accident,遭遇意外,VERB,B2
-accidente de coche,car accident,车祸,NOUN,B2
-accionista,shareholder,股东,NOUN,B2
-acclimatization,acclimatization,适应环境,NOUN,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
-according to,according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordingly consequently,accordingly consequently,词,ADV,C1
-accordion,accordion,手风琴,NOUN,B2
-accost,accost,词,VERB,B2
-accountable,accountable,负责任的,ADJ,B2
-accounting (adj),accounting,词,ADJ,C1
-accreditation,accreditation,词,NOUN,C1
-accredited,accredited,认可的,ADJ,B2
-acculturation,acculturation,文化涵化,NOUN,B2
-accumulation,accumulation,积累,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
-accuracy,accuracy,准确性,NOUN,B2
-accused,accused,词,NOUN,B2
-accused person,accused person,被告,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
-accustomed,accustomed,习惯的,ADJ,B2
-ace,ace,王牌,NOUN,B2
-ace carcass,ace carcass,王牌/尸体,NOUN,B2
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
 aceleración,acceleration,加速,NOUN,B2
 acelerador,accelerator,油门,NOUN,B2
 aceptación,acceptance,接受,NOUN,B2
-acera,sidewalk,人行道,NOUN,B2
-acerbate,acerbate,词,VERB,B2
-acercamiento,rapprochement,和解,NOUN,B2
-acero,steel,钢,NOUN,B2
-achievable,achievable,可实现的,ADJ,B2
+accesión,accession,即位,NOUN,B2
+accidental,accidental,偶然的,ADJ,B2
+accidentalmente,accidentally,意外地,ADV,B2
+lograr,to accomplish,完成,VERB,B2
+conformidad,accord with,合乎,NOUN,B2
+según,according to,根据,ADP,B2
+cuenta,account,账户,NOUN,B2
+responsabilidad,accountability,问责制,NOUN,B2
+contable,accountant,会计师,NOUN,B2
+contabilidad,accounting,会计,NOUN,B2
+accredited,accredited,认可的,ADJ,B2
+accumulation,accumulation,积累,NOUN,B2
+accustomed,accustomed,习惯的,ADJ,B2
 acid,acid,酸,NOUN,B2
-acid sour,acid sour,词,ADJ,B2
-acidic,acidic,词,ADJ,B2
-acogedor,cozy,舒适的,ADJ,B2
-acolyte,acolyte,词,NOUN,B2
-acompañar,to come along,一起来,VERB,B2
-acorn,acorn,词,NOUN,B1
-acortar,to shorten,缩短,VERB,B2
-acostarse,to lie down,躺,VERB,B2
-acoustic,acoustic,声学的,ADJ,B2
 acoustics,acoustics,声学,NOUN,B2
-acquired,acquired,词,ADJ,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
 acquittal,acquittal,无罪释放,NOUN,B2
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
 acrobat,acrobat,杂技演员,NOUN,B2
-acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,首字母缩略词,NOUN,B2
 across,across,穿过,ADP,B2
-across (adv),across,越过,ADV,C1
-acrostic,acrostic,词,NOUN,C1
 act,act,行动,NOUN,B2
 act jointly,act jointly,合伙,NOUN,B2
-act of kneeling,act of kneeling,词,NOUN,C1
 acting,acting,行为,NOUN,B2
-action document,action document,词,NOUN,B2
-action plan,action plan,行动方案,NOUN,B2
 activate,to activate,激活,VERB,B2
-activation,activation,词,NOUN,B2
 active,active,活跃的,ADJ,B2
-active population,active population,词,NOUN,C1
-activism,activism,激进主义,NOUN,B2
-activist,activist,词,NOUN,C1
-activities,activities,词,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
-actuación,performance,表现,NOUN,B2
 actual,actual,实际的,ADJ,B2
 actually,actually,实际上,ADV,B2
-actually (noun),actually,倒也,NOUN,C1
-actualmente,currently,目前,ADV,B2
-actuate,actuate,词,VERB,B2
-acuarela,watercolor,水彩画,NOUN,B2
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
 acute,acute,剧烈的,ADJ,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
 adaptation,adaptation,适应,NOUN,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
 addict,addict,上瘾者,NOUN,B2
-addictive,addictive,词,ADJ,B2
 addition,addition,增加,NOUN,B2
 additional,additional,额外的,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
-adecuadamente,properly,适当地,ADV,B2
-adecuado,proper,适当的,ADJ,B2
-adelantar,to overtake,超过,VERB,B2
-adelantar,to shift to an earlier date,提前,VERB,B2
-adelante,ahead,在前面,ADV,B2
-adelante,forth,向前,ADV,B2
-además,furthermore,此外,ADV,B2
-además,in addition,此外,ADV,B2
-además,moreover,此外,ADV,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherirse,to cling,紧贴,VERB,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
-adivinación,fortune telling,算命,NOUN,B2
-adivinar,guess,猜测,NOUN,B2
-adivinar,to guess,猜,VERB,B2
-adiós,bye,再见,INTJ,B2
 adjacency,adjacency,邻接,NOUN,B2
-adjoin,adjoin,词,VERB,B2
-adjourn,adjourn,词,VERB,B2
-adjournment,adjournment,词,NOUN,C1
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjuntar,to attach,附加,VERB,B2
-adjunto,deputy,副的,ADJ,B2
-adjure,adjure,词,VERB,B2
-adjustability,adjustability,词,NOUN,C1
-adjustment,adjustment,调节,NOUN,B2
 administer,to administer,管理,VERB,B2
 administrative,administrative,行政的,ADJ,B2
-administrative offense,administrative offense,词,NOUN,C1
-administrator,administrator,管理员,NOUN,B2
-admirable,admirable,词,ADJ,B2
 admiral,admiral,海军上将,NOUN,B2
-admiration,admiration,词,NOUN,B2
 admire,to admire,钦佩,VERB,B2
-admirer,admirer,仰慕者,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible,admissible,词,ADJ,B2
-admissible eligible,admissible eligible,词,ADJ,C1
-admission,admission,词,NOUN,B1
 admit,to admit,承认,VERB,B2
-admitted,admitted,词,ADJ,B2
 admittedly,admittedly,诚然,ADV,B2
 admonish,to admonish,告诫,VERB,B2
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
 adoption,adoption,收养,NOUN,B2
-adorable,adorable,词,ADJ,B2
-adorar,worship,崇拜,NOUN,B2
-adorar,to worship,崇拜,VERB,B2
-adoration worship,adoration worship,词,NOUN,C1
-adoul notaries,adoul notaries,词,NOUN,C1
-adrenaline,adrenaline,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
-adulación,sycophancy,阿谀奉承,NOUN,B2
-adulation,adulation,词,NOUN,C1
 adult,adult,成年的,ADJ,B2
 adulterate,to adulterate,掺杂,VERB,B2
-adultery,adultery,词,NOUN,C1
 adulthood,adulthood,成年,NOUN,B2
-advance guard,advance guard,先遣,NOUN,B2
 advance payment,advance payment,预付款,NOUN,B2
 advanced study,advanced study,深造,NOUN,B2
 advanced technology,advanced technology,先进,ADJ,B2
-advancement,advancement,晋升,NOUN,B2
-advent,advent,到来,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
-adversarial,adversarial,词,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
-advertiser,advertiser,词,NOUN,B2
-advertising,advertising,广告的,ADJ,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
-advisory,advisory,词,ADJ,C1
-advocacy,advocacy,词,NOUN,C1
-advocate (noun),advocate,词,NOUN,B2
-aerodynamics,aerodynamics,词,NOUN,C1
-aeronautical,aeronautical,词,ADJ,B2
-aerosol,spray,喷雾,NOUN,B2
-aesthetic taste,aesthetic taste,词,NOUN,C1
-afeitar,to shave,剃,VERB,B2
-affability,affability,词,NOUN,C1
-affected,affected,受影响的,ADJ,B2
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
-affidavit,affidavit,词,NOUN,B2
-affinity,affinity,词,NOUN,C1
-affirmative,affirmative,词,ADJ,B2
-affix,affix,词,NOUN,B2
-affliction,affliction,灾难,NOUN,C1
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
-aficionado,amateur,业余爱好者,NOUN,B2
+ventajoso,advantageous,有利的,ADJ,B2
+anunciar,to advertise,做广告,VERB,B2
+publicidad,advertising,广告业,NOUN,B2
+abogar,to advocate,提倡,VERB,B2
+aéreo,aerial,航空的,ADJ,B2
+asunto,affair,事务,NOUN,B2
+salón de eventos,affair hall,事殿,NOUN,B2
 afiliado,affiliate,附属机构,NOUN,B2
-afortunado,fortunate,幸运的,ADJ,B2
-afraid,afraid,害怕的,ADJ,B2
-afraid (noun),afraid,词,NOUN,B2
-after,after,تلو,NOUN,B2
-after (sconj),after,after,SCONJ,A1
-after all just,after all just,毕竟刚,ADV,C1
-after the example of,after the example of,词,NOUN,C1
-after this,after this,词,ADV,B2
-after to,after to,词,ADP,A2
-after-class exercises,after-class exercises,课后题,NOUN,C1
-aftermath,aftermath,随后,NOUN,C1
-agacharse,to squat,蹲,VERB,B2
-again,again,你又,NOUN,B2
-against it,against it,词,ADV,A2
-agarrar,grip,握法,NOUN,B2
-agarrar,to grip,紧握,VERB,B2
-agarre firme,tight grip,手握紧,NOUN,B2
-agasajar,to treat guests,请客,VERB,B2
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
+forestación,afforestation,植树造林,NOUN,B2
+después de,after,在...之后,ADP,B2
+después de todo,after all,毕竟,ADV,B2
+después de eso,after that,此后,ADV,B2
+después de lo cual,after which,之后,ADV,B2
+secuela,aftereffect,后遗症，后果,NOUN,B2
+tarde,afternoon,下午,NOUN,B2
+posterioridad,afterward,去后,NOUN,B2
+después,afterwards,后来,ADV,B2
+repetición,again,再次,ADV,B2
 agente,agent,代理人,NOUN,B2
-agglomerate,agglomerate,词,NOUN,B2
-aggravated,aggravated,词,ADJ,C1
-aggravating,aggravating,词,ADJ,B2
-aggravation,aggravation,词,NOUN,C1
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
-aggressor,aggressor,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
-agitated,agitated,焦躁的,ADJ,B2
-agitation,agitation,词,NOUN,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (noun),agnostic,词,NOUN,B2
-agnosticism,agnosticism,词,NOUN,C1
-ago,ago,以前,ADV,B2
-agonize,agonize,词,VERB,B2
-agree,agree,一致,ADJ,B2
-agreeable,agreeable,词,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
 agresividad,aggressiveness,攻击性,NOUN,B2
-agricultura,agriculture,农业,NOUN,B2
-agricultura,farming,农业,NOUN,B2
-agrio,sour,酸的,ADJ,B2
+ágil,agile,敏捷的,ADJ,B2
 agrícola,agricultural,农业的,ADJ,B2
-aguantar,to hold on,抓住,VERB,B2
-aguas abajo,downstream,下游,NOUN,B2
+agricultura,agriculture,农业,NOUN,B2
 ah,ah,啊,INTJ,B2
-ah (part),ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-ahora mismo,just now,刚刚,ADV,B2
-ahorrador,thrifty,节俭的,ADJ,B2
-ahorrar,to spare,节省,VERB,B2
-ahorro,savings,存款,NOUN,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aimless,aimless,词,ADJ,C1
-aims,aims,词,NOUN,C1
-air conditioner,air conditioner,词,NOUN,B1
-air force,air force,空军,NOUN,B2
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-airline,airline,词,NOUN,C1
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-ajedrez,chess,国际象棋,NOUN,B2
-ajetreo,busyness,事忙,NOUN,B2
-ajo,garlic,大蒜,NOUN,B2
-ajustado,fitting,合适的,ADJ,B2
-al lado,beside next to,旁边,NOUN,B2
-al menos,at least,至少,ADV,B2
-al mismo tiempo,at the same time,同时,ADV,B2
-al respecto,regarding this,对此,ADV,B2
-alarm (verb),alarm,词,VERB,B2
-alarm center,alarm center,报警中心,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
+adelante,ahead,在前面,ADV,B2
+apuntar,aim,目标,NOUN,B2
+apuntar,to aim,瞄准,VERB,B2
+defensa aérea,air defense,防空,NOUN,B2
+avión,airplane,飞机,NOUN,B2
 alarmante,alarming,令人担忧的,ADJ,B2
-alarmism,alarmism,词,NOUN,C1
-albaricoque,apricot,杏,NOUN,B2
-alboroto,fuss,大惊小怪,NOUN,B2
-albóndiga cocida,cooked meatball,丸子熟,NOUN,B2
-alcaide,warden,看守人,NOUN,B2
-alcanzable,reachable,可到达的,ADJ,B2
-alcanzar,to attain,达到,VERB,B2
-alcanzar,to reach,到达,VERB,B2
-alchemy,alchemy,词,NOUN,C1
+ay,alas,唉,INTJ,B2
+álbum,album,相册,NOUN,B2
 alcohol,alcohol,酒精,NOUN,B2
-alcoholic,alcoholic,酒精的,ADJ,B2
 alcohólico,alcoholic,酗酒者,NOUN,B2
-alder,alder,桤木,NOUN,B2
-alderman,alderman,市议员,NOUN,B2
-aleación,alloy,合金,NOUN,B2
-aleatorio,random,随机的,ADJ,B2
-alegre,cheerful,愉快的,ADJ,B2
-alemán,german,德国人,NOUN,B2
-alert (noun),alert,警报,NOUN,B1
 alerta,alert,警报,NOUN,B2
-alerta temprana,early warning,预警,NOUN,B2
-alertness,alertness,机敏,NOUN,C1
-alfabético,alphabetical,按字母顺序的,ADJ,B2
-alfilerar,to pin,别住,VERB,B2
-alfombra,carpet,地毯,NOUN,B2
-algae,algae,词,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
+álgebra,algebra,代数,NOUN,B2
 algoritmo,algorithm,算法,NOUN,B2
-alguien,anyone,任何人,PRON,B2
-alianza eterna,eternal alliance,永结,NOUN,B2
-alianza matrimonial,marriage alliance,联姻,NOUN,B2
-alicates,pliers,钳子,NOUN,B2
+extraterrestre,alien,外星人,NOUN,B2
 alienación,alienation,异化,NOUN,B2
-alienating,alienating,使人疏远的,ADJ,B2
-alike,alike,词,ADV,B1
-alimento,feed,饲料,NOUN,B2
-alimento,foodstuff,食品,NOUN,B2
 alineación,alignment,结盟,NOUN,B2
-alisar,smooth,光滑的,ADJ,B2
-alisar,to smooth,使光滑,VERB,B2
-alive living,alive living,活着的,ADJ,B2
-alkalinity,alkalinity,词,NOUN,C1
-all,all,جميع,NOUN,B2
-all (adj),all,全,ADJ,B2
-all (adv),all,全都,ADV,B2
-all (pron),all,全部,PRON,A2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all everyone,all everyone,所有/大家,PRON,B2
-all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all of it,all of it,全部,PRON,B2
-all of them,all of them,大家,PRON,B2
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,诸圣节,NOUN,B2
-all the more,all the more,更加,ADV,B2
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-clear,all-clear,许可信号,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allanamiento,burglary,入室盗窃罪,NOUN,B2
-allay,allay,词,VERB,C1
-allegation,allegation,词,NOUN,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allegiance,allegiance,忠诚,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-alleys,alleys,词,NOUN,B2
-allies,allies,盟友,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allocation,allocation,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
-allure,allure,词,NOUN,C1
-alluring,alluring,诱人的,ADJ,C1
-allí,there,那儿,NOUN,B2
-almacén,warehouse,仓库,NOUN,B2
-almohada,pillow,枕头,NOUN,B2
-almohadilla,pad,垫,NOUN,B2
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
-alone,alone,单独的,ADJ,B2
-aloof,aloof,词,ADJ,C1
-aloud,aloud,出声地,ADV,B2
-alpha,alpha,阿尔法,NOUN,B2
-alphabet,alphabet,字母表,NOUN,B2
-alpine,alpine,高山的,ADJ,B2
-already may particle,already may particle,词,PART,A2
-alrededor,around,在周围,ADP,B2
-alrededores,surroundings,周围,NOUN,B2
-alright (noun),alright,好吧,NOUN,B1
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-altar,altar,词,NOUN,B2
-alteration,alteration,改变,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
-alternancia,alternation,轮流,NOUN,B2
-alternating,alternating,交替的,ADJ,B2
-alternative,alternative,替代的,ADJ,B2
-alternatively,alternatively,交替地,ADV,B2
-alteza,highness,殿下,NOUN,B2
-although,although,尽管,CCONJ,B2
-although (adp),although,虽,ADP,B1
-alto,high,高的,ADJ,B2
-altogether,altogether,共,ADV,B2
-altruistic,altruistic,利他的,ADJ,B2
-alucinación,hallucination,幻觉,NOUN,B2
-aluminio,aluminum,铝,NOUN,B2
-alumnus,alumnus,校友,NOUN,B2
-alusión,allusion,暗示,NOUN,B2
-always have,always have,总有,VERB,C1
+pensión alimenticia,alimony,赡养费,NOUN,B2
+todo,all,全部,ADV,B2
+todo el día,all day long,一整天,NOUN,B2
+presuntamente,allegedly,据称,ADV,B2
 alérgico,allergic,过敏的,ADJ,B2
-amado,beloved,爱人,NOUN,B2
-amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
-amamantar,to breastfeed,母乳喂养,VERB,B2
-amanecer,sunrise,日出,NOUN,B2
-amante,mistress,情妇,NOUN,B2
-amargura,bitterness,苦涩,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
-ambas manos,both hands,双手,NOUN,B2
-amber,amber,琥珀,NOUN,B2
-ambicioso,ambitious,有雄心的,ADJ,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
+permiso de ocultación,allow hiding,许躲,NOUN,B2
+asignación,allowance,津贴,NOUN,B2
+permitido,allowed,被允许的,ADJ,B2
+aleación,alloy,合金,NOUN,B2
+alusión,allusion,暗示,NOUN,B2
+a lo largo de,along,沿着,ADP,B2
+junto con,along with,随着,ADP,B2
+alfabético,alphabetical,按字母顺序的,ADJ,B2
+bien,alright,好的,ADV,B2
+también,also too,也,ADV,B2
+significado alterado,altered meaning,改义,NOUN,B2
+mecanismo alterado,altered mechanism,改机,NOUN,B2
+alternancia,alternation,轮流,NOUN,B2
+aluminio,aluminum,铝,NOUN,B2
+aficionado,amateur,业余爱好者,NOUN,B2
+asombro,amazement,惊愕,NOUN,B2
 ambiguo,ambiguous,模棱两可的,ADJ,B2
-ambivalence,ambivalence,词,NOUN,B2
-ambos,both,两者都,CCONJ,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
-amenazador,threatening,具有威胁性的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
+ambicioso,ambitious,有雄心的,ADJ,B2
+interior modificado,amended interior,改内,NOUN,B2
 amended judgment,amended judgment,改断,NOUN,B2
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
-amendments,amendments,词,NOUN,C1
 american,american,美国的,ADJ,B2
 amiable,amiable,和蔼可亲的,ADJ,B2
-amicable,amicable,友好的,ADJ,B2
-amicable out-of-court,amicable out-of-court,友好的 / 庭外和解的,ADJ,B2
-amigable,friendly,友好的,ADJ,B2
-amigo,buddy,伙伴,NOUN,B2
-amino acid,amino acid,氨基酸,NOUN,C1
 ammunition,ammunition,弹药,NOUN,B2
-amnesia,amnesia,健忘症,NOUN,B2
 among,among,在……之中,ADP,B2
 among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amontonar,to pile up,堆积,VERB,B2
-amoral,amoral,词,ADJ,C1
-amortization,amortization,词,NOUN,C1
 amount,amount,数量,NOUN,B2
 amount to,to amount to,总计,VERB,B2
-amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
 ample,ample,充足的,ADJ,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
 amplification,amplification,放大,NOUN,B2
 amplifier,amplifier,放大器,NOUN,B2
-amplitude range,amplitude range,词,NOUN,C1
 amputation,amputation,截肢,NOUN,B2
-amueblar,to furnish,提供,VERB,B2
-amused,amused,词,ADJ,B2
-amusement,amusement,娱乐,NOUN,B2
 amusing,amusing,有趣的,ADJ,B2
-an,an,词,DET,A1
-an official standard,an official standard,标准,NOUN,B2
-anacardo,cashew,腰果,NOUN,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,字谜游戏,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
-analgésico,painkiller,止痛药,NOUN,B2
 analog,analog,模拟的,ADJ,B2
-analogize,analogize,词,VERB,B2
-analogous similar,analogous similar,词,ADJ,C1
 analogy,analogy,类比,NOUN,B2
 analyst,analyst,分析师,NOUN,B2
-analytical,analytical,分析的,ADJ,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchical,anarchical,词,ADJ,C1
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
 ancestors,ancestors,祖先,NOUN,B2
-ancestral,ancestral,词,ADJ,C1
 anchor,anchor,锚,NOUN,B2
 anchorage,anchorage,锚地,NOUN,B2
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
 ancient,ancient,古老的,ADJ,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
 ancient times,ancient times,古代,NOUN,B2
 and,and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
 and so forth,and so forth,依此类推,ADV,B2
 and so on,and so on,之类,NOUN,B2
-and you,and you,而你…,NOUN,C1
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
-anemic,anemic,词,ADJ,C1
-anerziehung,anerziehung,词,NOUN,C1
 anesthetic,anesthetic,麻醉剂,NOUN,B2
-aneurysm,aneurysm,词,NOUN,C1
-anfahrt,anfahrt,词,NOUN,C1
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angelic,angelic,天使般的,ADJ,B2
-angestaltung,angestaltung,词,NOUN,C1
 angle,angle,角度,NOUN,B2
-angle of approach,angle of approach,切入点,NOUN,B2
-anguished,anguished,词,ADJ,C1
-angular,angular,有角的,ADJ,B2
-anhelar,to crave,渴望,VERB,B2
 animal,animal,动物,NOUN,B2
-animal pen,animal pen,词,NOUN,B1
-animar,to cheer,欢呼,VERB,B2
-animarse,to cheer up,使高兴,VERB,B2
-animated,animated,词,ADJ,C1
 animated film,animated film,动画片,NOUN,B2
 animation,animation,动画,NOUN,B2
-anise,anise,茴香,NOUN,B2
 ankle,ankle,脚踝,NOUN,B2
-annals,annals,编年史,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
-annexes,annexes,词,NOUN,C1
 annihilation,annihilation,寂灭,NOUN,B2
 announcement,announcement,公告,NOUN,B2
 annoyed,annoyed,恼火的,ADJ,B2
 annual,annual,年度的,ADJ,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annual wage,annual wage,年薪,NOUN,B2
-annuity private income,annuity private income,词,NOUN,C1
-annulment,annulment,词,NOUN,C1
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
-anomalous,anomalous,词,ADJ,C1
-anomie,anomie,词,NOUN,C1
-anonymity,anonymity,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anonymously,anonymously,词,ADV,B2
-anorexia,anorexia,词,NOUN,C1
-anormal,abnormal,异常的,ADJ,B2
-anotar,to note,记录,VERB,B2
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansiar,to be eager for,巴不得,VERB,B2
-ansicht,ansicht,词,NOUN,C1
-ansinnung,ansinnung,词,NOUN,C1
-ansioso,anxious,焦虑的,ADJ,B2
-ansioso,eager,渴望的,ADJ,B2
-ansprache,ansprache,词,NOUN,C1
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-answer questions,answer questions,答疑,VERB,C1
-answers,answers,词,NOUN,C1
-antagonistic,antagonistic,词,ADJ,C1
-antecedent,antecedent,先行词,NOUN,B2
-antediluvian,antediluvian,词,ADJ,C1
-anteilung,anteilung,词,NOUN,B2
+informe anual,annual report,年报,NOUN,B2
+anualmente,annually,每年,ADV,B2
+anónimo,anonymous,匿名的,ADJ,B2
+responder,to answer reply,回答,VERB,B2
 antena,antenna,天线,NOUN,B2
-anterior,former,以前的,ADJ,B2
-anteriormente,formerly,以前,ADV,B2
-anteroom,anteroom,词,NOUN,B2
-antes,earlier,刚才,ADV,B2
-antes de que,before,在...之前,SCONJ,B2
-antheilung,antheilung,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthropological,anthropological,词,ADJ,C1
-anti-Semitic,anti-Semitic,词,ADJ,C1
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-work,anti-work,反功,NOUN,C1
+antropomorfismo,anthropomorphism,拟人化,NOUN,B2
 antiabstracción,anti-abstraction,反抽,NOUN,B2
 antiacción,anti-action,反作,NOUN,B2
-antiarrugas,wrinkle-resistant,防皱,ADJ,B2
-antibiotic,antibiotic,抗生素,NOUN,B2
-antibiótico,antibiotics,抗生素,NOUN,B2
-anticipación,anticipation,预期,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
-anticipatory,anticipatory,词,ADJ,C1
-anticuerpo,antibody,抗体,NOUN,B2
-anticyclone,anticyclone,反气旋,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
 antigeneralidad,anti-generality,反般,NOUN,B2
-antiguerra,anti-war,反战,NOUN,B2
-antigüedad,antique,古老的,ADJ,B2
-antigüedad,seniority,资历,NOUN,B2
 antiintegración,anti-integration,反合,NOUN,B2
-antimateria,counter-matter,反物,NOUN,B2
 antimedida,anti-measure,反度,NOUN,B2
-antinomy,antinomy,词,NOUN,C1
 antiomnipresencia,anti-omnipresence,反遍,NOUN,B2
-antioxidante,antioxidant,抗氧化剂,NOUN,B2
-antiphrasis,antiphrasis,词,NOUN,C1
-antiquated,antiquated,过时的,ADJ,B2
-antique,antique,古董,NOUN,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antirratas,rat-proof,防鼠,ADJ,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
-antisocial,antisocial,反社会的,ADJ,B2
-antiséptico,antiseptic,防腐剂,NOUN,B2
-antología poética,poetry collection,诗集,NOUN,B2
-antonomasia,antonomasia,词,NOUN,C1
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreibung,antreibung,词,NOUN,C1
-antropomorfismo,anthropomorphism,拟人化,NOUN,B2
-antsy,antsy,词,ADJ,C1
+antiguerra,anti-war,反战,NOUN,B2
+antibiótico,antibiotics,抗生素,NOUN,B2
+anticuerpo,antibody,抗体,NOUN,B2
+anticipación,anticipation,预期,NOUN,B2
 antígeno,antigen,抗原,NOUN,B2
+antioxidante,antioxidant,抗氧化剂,NOUN,B2
+antigüedad,antique,古老的,ADJ,B2
+antiséptico,antiseptic,防腐剂,NOUN,B2
 antítesis,antithesis,对立面,NOUN,B2
 antónimo,antonym,反义词,NOUN,B2
-anualmente,annually,每年,ADV,B2
-anunciar,to advertise,做广告,VERB,B2
-anvil,anvil,词,NOUN,B2
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-any (adj),any,词,ADJ,B1
-any (adv),any,词,ADV,B2
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anything,anything,任何事,PRON,B2
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-anís estrellado,star anise,八角,NOUN,B2
-anónimo,anonymous,匿名的,ADJ,B2
-aparato,apparatus,仪器,NOUN,B2
-aparcamiento,parking lot,停车场,NOUN,B2
-aparentemente,apparently,显然,ADV,B2
-aparentemente,seemingly,表面上,ADV,B2
-apart from,apart from,除了,ADP,B2
-apart from (verb),apart from,词,VERB,C1
-apartarse,to move aside,移开,VERB,B2
+ansioso,anxious,焦虑的,ADJ,B2
+cualquiera,any,任何,PRON,B2
+alguien,anyone,任何人,PRON,B2
+de todos modos,anyway,无论如何,ADV,B2
 aparte,apart,分开,ADV,B2
-apartheid,apartheid,词,NOUN,C1
+disculparse,to apologize,道歉,VERB,B2
+apostasía,apostasy,叛教,NOUN,B2
+aparato,apparatus,仪器,NOUN,B2
+aparentemente,apparently,显然,ADV,B2
 apelación,appeal,呼吁,NOUN,B2
 apelante,appellant,上诉人,NOUN,B2
-apellido,surname,姓氏,NOUN,B2
-apenado,sad sorrowful,悲伤,ADJ,B2
-apertura de ofertas,bid opening,开标,NOUN,B2
-aphasia,aphasia,失语症,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apio,celery,芹菜,NOUN,B2
-aplastamiento,smashing,砸过,NOUN,B2
-aplastar,to smash,粉碎,VERB,B2
-aplaudir,to clap,拍手,VERB,B2
 aplicabilidad,applicability,适用性,NOUN,B2
-aplicabilidad universal,universal applicability,普适性,NOUN,B2
 aplicar un yeso,to apply a cast,打石膏,VERB,B2
-apnea,apnea,词,NOUN,C1
-apocalypse,apocalypse,词,NOUN,C1
-apocalyptic,apocalyptic,启示录的,ADJ,B2
-apocryphal,apocryphal,杜撰的,ADJ,B2
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
-apolitical,apolitical,非政治的,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
-apostar,gamble,赌博,NOUN,B2
-apostar,to gamble,赌博,VERB,B2
-apostasía,apostasy,叛教,NOUN,B2
-apostle,apostle,词,NOUN,C1
-apostrophize,apostrophize,词,VERB,C1
-apoyante,supporter,支持者,NOUN,B2
-apoyar,to prop,撑,VERB,B2
-apoyar,to support,支持,VERB,B2
-app,app,词,NOUN,B1
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-appeals,appeals,词,NOUN,C1
-appeasement,appeasement,平息,NOUN,B2
-appellate,appellate,词,ADJ,C1
-append,append,词,VERB,C1
-appertain,appertain,词,VERB,C1
-appetizers,appetizers,词,NOUN,B2
-appliance,appliance,词,NOUN,B1
-applicable,applicable,适用的,ADJ,B2
-appointments,appointments,词,NOUN,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-approachable,approachable,词,ADJ,C1
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,挪用,NOUN,B2
-approval pleasure,approval pleasure,词,NOUN,C1
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
-approximate,approximate,近似的,ADJ,B2
+valorar,to appraise,评估,VERB,B2
 apreciación,appreciation,欣赏,NOUN,B2
+banquete de agradecimiento,appreciation banquet,答谢宴,NOUN,B2
 aprendiz,apprentice,学徒,NOUN,B2
 aprendizaje,apprenticeship,学徒期,NOUN,B2
-apresurado,hasty,仓促的,ADJ,B2
-apresurarse,rush,赶往,NOUN,B2
-apresurarse,to rush,冲,VERB,B2
-apretado,tight,紧的,ADJ,B2
-apretar,to tighten,紧握/收紧,VERB,B2
-april,april,四月,NOUN,B2
-aprovechar la experiencia de,to draw on the experience of,借鉴,VERB,B2
 aproximadamente,approximately,大约,ADV,B2
-aproximadamente,roughly,大约,ADV,B2
-apt,apt,词,ADJ,C1
-aptitud,fitness,健康,NOUN,B2
-apuesta,bet,打赌,NOUN,B2
-apuntar,aim,目标,NOUN,B2
-apuntar,target,目标,NOUN,B2
-apuntar,to aim,瞄准,VERB,B2
-apuntar,to target,针对,VERB,B2
-apuro,plight,处境,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-aqueous,aqueous,词,ADJ,B2
-aquí,here,此地,NOUN,B2
-arabic,arabic,阿拉伯的,ADJ,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-arado,plowing,犁地,NOUN,B2
-arbitrage,arbitrage,词,NOUN,C1
-arbitraje social,social arbitration,社会仲裁,NOUN,B2
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
-arbusto,bush,灌木,NOUN,B2
-archaeologist,archaeologist,词,NOUN,C1
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
-archipelago,archipelago,群岛,NOUN,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-archival,archival,词,ADJ,C1
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-archivo,archive,档案,NOUN,B2
-arcilla,clay,黏土,NOUN,B2
+albaricoque,apricot,杏,NOUN,B2
+delantal,apron,围裙,NOUN,B2
 arco,arc,弧,NOUN,B2
 arco,arch,拱门,NOUN,B2
-arcoíris,rainbow,彩虹,NOUN,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
-ardiente,burning,灼热的,ADJ,B2
-arena,arena,竞技场,NOUN,B2
-argan,argan,词,NOUN,B1
-argentinian,argentinian,阿根廷的,ADJ,B2
-arguable,arguable,词,ADJ,C1
-argumentación,argumentation,论证体系,NOUN,B2
-argumentative,argumentative,词,ADJ,C1
-argumentativeness,argumentativeness,词,NOUN,C1
-argumento,argument,争论,NOUN,B2
-ariete,ram,公羊,NOUN,B2
-aristocratic,aristocratic,词,ADJ,C1
-arithmetic (adj),arithmetic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
-arma homicida,murder weapon,凶器,NOUN,B2
-armado,armed,武装的,ADJ,B2
-armament,armament,词,NOUN,B2
-armario,closet,壁橱,NOUN,B2
-armband,armband,词,NOUN,C1
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armonioso,harmonious,和谐的,ADJ,B2
-armonización,harmonization,协调,NOUN,B2
-armored,armored,词,ADJ,C1
-armorer,armorer,,NOUN,B2
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-aroma celestial,heavenly fragrance,天香,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-around,around,到处,ADV,B2
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arousal,arousal,词,NOUN,C1
-arpa,harp,竖琴,NOUN,B2
-arqueología,archaeology,考古学,NOUN,B2
 arqueológico,archaeological,考古的,ADJ,B2
-arquitectura,architecture,建筑,NOUN,B2
+arqueología,archaeology,考古学,NOUN,B2
 arquitectónico,architectural,建筑的,ADJ,B2
-arraign,arraign,词,VERB,C1
-arrancar,to wrest,强行夺取,VERB,B2
-arranged,arranged,词,ADJ,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-arrastrar,to carry forward,发扬,VERB,B2
-array,array,排列,NOUN,B2
-arreglárselas,to make do,做,VERB,B2
-arrepentimiento,repentance,悔恨,NOUN,B2
-arrepentirse,to repent,悔改,VERB,B2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrested,arrested,被逮捕的,ADJ,B2
-arrhythmia,arrhythmia,词,NOUN,C1
-arriba,above,在...之上,ADP,B2
-arriesgar,to risk life,拼命,VERB,B2
-arrived present,arrived present,到了,ADV,B2
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
-arroyo,brook,小溪,NOUN,B2
-arroz,rice,米饭,NOUN,B2
-arroz cocido,cooked rice,米饭,NOUN,B2
+arquitectura,architecture,建筑,NOUN,B2
+archivo,archive,档案,NOUN,B2
+área,area,区域,NOUN,B2
+argumento,argument,争论,NOUN,B2
+argumentación,argumentation,论证体系,NOUN,B2
+surgir,to arise,出现,VERB,B2
+sillón,armchair,扶手椅,NOUN,B2
+armado,armed,武装的,ADJ,B2
+alrededor,around,在周围,ADP,B2
+despertar,to arouse,引起,VERB,B2
+atraso,arrears,欠款,NOUN,B2
+llegada,arrival,到达,NOUN,B2
 arsenal,arsenal,军火库,NOUN,B2
-arson,arson,纵火,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-arterial,arterial,词,ADJ,C1
-artesano,craftsman,工匠,NOUN,B2
-artesanía,craftsmanship,手工艺,NOUN,B2
-artesanía,handicraft,工艺品,NOUN,B2
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
-artichoke,artichoke,词,NOUN,B1
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
-articulation,articulation,清晰表达,NOUN,B2
+galería de arte,art gallery,美术馆,NOUN,B2
 artificial,artificial,人造的,ADJ,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,人为地,ADV,B2
-artillery,artillery,炮兵,NOUN,B2
-artistic,artistic,艺术的,ADJ,B2
-artistry,artistry,,NOUN,B2
-artless,artless,词,ADJ,C1
-artwork,artwork,艺术品,NOUN,B2
-arándano,blueberry,蓝莓,NOUN,B2
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as (sconj),as,如同,SCONJ,A1
-as a precaution,as a precaution,词,ADV,C1
-as a result of which,as a result of which,由此,ADV,B2
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as far as,as far as,就……而言,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as for (part),as for,词,PART,B1
-as if,as if,好像,SCONJ,B2
-as long as,as long as,只要,SCONJ,B2
-as many,as many,一样多,NUM,B2
-as much,as much,词,ADV,A1
-as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,尽可能地,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
+retrato artístico,artistic portrait,艺术照,NOUN,B2
+como,as,作为,SCONJ,B2
+como si,as if,仿佛,ADV,B2
+siempre que,as long as,طالما,CCONJ,B2
 as soon as,as soon as,一...就,SCONJ,B2
-as soon as (adv),as soon as,一...就,ADV,B2
-as soon as possible,as soon as possible,词,ADV,C1
-as that who,as that who,词,PRON,A2
-as usual,as usual,照常,ADV,B1
 as well as,as well as,以及,CCONJ,B2
-as well as (sconj),as well as,词,SCONJ,B2
-as when,as when,词,SCONJ,A1
-asado,roast,烤肉,NOUN,B2
-asar,to roast lamb,烤羊,VERB,B2
-asbestos,asbestos,词,NOUN,C1
 ascend,to ascend,上升,VERB,B2
-ascending,ascending,词,ADJ,C1
 ascension,ascension,升天,NOUN,B2
-ascertain,ascertain,词,VERB,C1
-ascetic (noun),ascetic,词,NOUN,C1
-asesino,killer,杀手,NOUN,B2
-asesino en serie,serial killer,连环杀手,NOUN,B2
-asesoramiento,counseling,咨询,NOUN,B2
 asexual,asexual,无性的,ADJ,B2
-asfixia,suffocation,窒息,NOUN,B2
-asfixiar,to suffocate,窒息,VERB,B2
-asharite school,asharite school,词,NOUN,C1
-ashes,ashes,词,NOUN,B2
-ashore,ashore,词,ADV,C1
-ashtray,ashtray,烟灰缸,NOUN,B2
-asian,asian,亚洲的,ADJ,B2
-aside (noun),aside,词,NOUN,C1
-asiento trasero,back seat,后座,NOUN,B2
-asignación,allowance,津贴,NOUN,B2
-asignación individual,individual assignment,个人作业,NOUN,B2
-asinine,asinine,词,ADJ,C1
-asir,to grasp firmly,抓紧,VERB,B2
-asleep,asleep,词,ADJ,A2
-asociación,partnership,伙伴关系,NOUN,B2
-asombro,amazement,惊愕,NOUN,B2
-asombro,awe,敬畏,NOUN,B2
 aspect,aspect,方面,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-asphalt,asphalt,沥青,NOUN,B2
-asphyxia,asphyxia,窒息,NOUN,B2
-aspirant,aspirant,词,NOUN,C1
 aspiration,aspiration,抱负,NOUN,B2
 ass,ass,驴,NOUN,B2
-assail,assail,词,VERB,C1
-assailant,assailant,词,NOUN,C1
 assassin,assassin,刺客,NOUN,B2
 assassinate,to assassinate,暗杀,VERB,B2
 assassination,assassination,暗杀,NOUN,B2
-assertiveness,assertiveness,果断,NOUN,C1
 assess,to assess,评估,VERB,B2
 assessment,assessment,评估,NOUN,B2
 asset,asset,资产,NOUN,B2
 assets,assets,资产,NOUN,B2
-asshole,asshole,词,NOUN,A2
-assiduity,assiduity,词,NOUN,B2
 assiduous,assiduous,勤勉的,ADJ,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduously,assiduously,词,ADV,C1
-assiduousness,assiduousness,词,NOUN,C1
 assignment,assignment,任务,NOUN,B2
 assistance,assistance,援助,NOUN,B2
-associated,associated,相关的,ADJ,B2
-associative,associative,协会性质的,ADJ,C1
-assort,assort,词,VERB,C1
-assortment,assortment,词,NOUN,C1
-assuage,assuage,词,VERB,C1
 assume office,to assume office,就任,VERB,B2
 assumption,assumption,假设,NOUN,B2
 assure,to assure,保证,VERB,B2
 asteroid,asteroid,小行星,NOUN,B2
-asthenia,asthenia,词,NOUN,C1
 asthma,asthma,哮喘,NOUN,B2
-asthmatic,asthmatic,哮喘的,ADJ,B2
 astonish,to astonish,使惊讶,VERB,B2
 astonishing,astonishing,令人惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
 astonishment,astonishment,惊讶,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astray,astray,迷路,ADJ,B2
-astride (adp),astride,词,ADP,C1
-astringent (adj),astringent,词,ADJ,C1
-astronomer,astronomer,词,NOUN,B1
 astronomical,astronomical,天文学的,ADJ,B2
-astucia,cunning,诡计,NOUN,B2
-astucia,slyness,狡猾,NOUN,B2
 astute,astute,精明的,ADJ,B2
-asumir,to take over,接管,VERB,B2
-asunto,affair,事务,NOUN,B2
-asustado,scared,害怕的,ADJ,B2
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
 asymmetrical,asymmetrical,不对称的,ADJ,B2
-asymptomatic,asymptomatic,词,ADJ,C1
 asynchronous,asynchronous,异步的,ADJ,B2
-asyndeton,asyndeton,连词省略,NOUN,B2
-así,thus,因此,ADV,B2
-así,that way,那样,PRON,B2
-así,this way,这样,PRON,B2
 at,at,在,ADP,B2
 at all,at all,根本,ADV,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
 at any time,at any time,随时,ADV,B2
 at ease,at ease,安心,ADJ,B2
-at home (noun),at home,家里,NOUN,C1
-at it,at it,靠近,ADV,B2
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,夜间,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at once,at once,立刻,ADV,B2
-at someone's invitation,at someone's invitation,应邀,ADV,C1
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the bottom,at the bottom,在底部,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
-at the top,at the top,在最上面,ADV,B2
-at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
-at worst,at worst,大不了,ADV,B2
-atacante,attacker,攻击者,NOUN,B2
-atado,bound,一定的,ADJ,B2
-atajo,shortcut,捷径,NOUN,B2
-ataque difícil,difficult attack,难攻,NOUN,B2
-atar,to tie up,绑,VERB,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
-atender,to pay attention,注意,VERB,B2
-atesorar,to cherish,珍爱,VERB,B2
-atestiguar,to witness,目击,VERB,B2
-atheism,atheism,无神论,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
-athletic,athletic,运动的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atm,atm,自动取款机,NOUN,B2
-atmospheric,atmospheric,大气的,ADJ,B2
-atomic bomb,atomic bomb,词,NOUN,B1
-atomic nucleus,atomic nucleus,原子核,NOUN,B2
-atony,atony,词,NOUN,C1
-atracción,attraction,吸引力,NOUN,B2
-atraso,arrears,欠款,NOUN,B2
-atravesar,to go through,经历,VERB,B2
-atravesar,to see through,看穿,VERB,B2
-atributo,attribute,属性,NOUN,B2
-atrocious,atrocious,词,ADJ,C1
-atrophy,atrophy,萎缩,NOUN,B2
-atrás,backwards,向后,ADV,B2
-attache office,attache office,词,NOUN,C1
-attacked,attacked,被攻击的,ADJ,B2
-attainment,attainment,词,NOUN,C1
-attempt at crime,attempt at crime,词,NOUN,C1
-attempted murder,attempted murder,谋杀未遂,NOUN,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
-attention,attention,立正,INTJ,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attenuation,attenuation,衰减,NOUN,C1
-attestation,attestation,词,NOUN,C1
-attitude setting,attitude setting,态度/设置,NOUN,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attributists,attributists,词,NOUN,C1
-attributive,attributive,定语的,ADJ,B2
-atípico,atypical,非典型的,ADJ,B2
+en casa,at home,在家,ADV,B2
+al menos,at least,至少,ADV,B2
+entonces,at that time,当时/那时,ADV,B2
+al mismo tiempo,at the same time,同时,ADV,B2
+átomo,atom,原子,NOUN,B2
 atómico,atomic,原子的,ADJ,B2
-audibility,audibility,词,NOUN,C1
-audible,audible,听得见的,ADJ,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
-audiovisual,audiovisual,视听的,ADJ,B2
-auditor,auditor,审计员,NOUN,B2
-auditory,auditory,词,ADJ,C1
+adjuntar,to attach,附加,VERB,B2
+atacante,attacker,攻击者,NOUN,B2
+alcanzar,to attain,达到,VERB,B2
+abogado,attorney,律师,NOUN,B2
+atracción,attraction,吸引力,NOUN,B2
+atributo,attribute,属性,NOUN,B2
+atípico,atypical,非典型的,ADJ,B2
 auditoría,audit,审计,NOUN,B2
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-augury,augury,词,NOUN,C1
-aullar,to wail,哀号,VERB,B2
-aumentar constantemente,to increase steadily,与日俱增,VERB,B2
-aumento diario,daily increase,日渐,NOUN,B2
-auriculares,headphones,耳机,NOUN,B2
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
+auditor,auditor,审计员,NOUN,B2
 austeridad,austerity,紧缩,NOUN,B2
-austheilung,austheilung,词,NOUN,C1
-australian,australian,澳大利亚的,ADJ,B2
-austreibung,austreibung,词,NOUN,C1
-austrian,austrian,奥地利的,ADJ,B2
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarchy,autarchy,词,NOUN,C1
 autenticación,authentication,认证,NOUN,B2
-authenticated,authenticated,词,ADJ,C1
-authoritarianism,authoritarianism,词,NOUN,C1
-authoritative,authoritative,权威的,ADJ,B2
-authority figure,authority figure,权威人士,NOUN,B2
-authority structure,authority structure,权威结构,NOUN,B2
-autism,autism,自闭症,NOUN,B2
-autistic (adj),autistic,词,ADJ,C1
-autistic (noun),autistic,词,NOUN,C1
-autobiografía,autobiography,自传,NOUN,B2
-autobiographical,autobiographical,词,ADJ,C1
-autocaravana,motorhome,露营车,NOUN,B2
-autoconfianza,self-confidence,自信,NOUN,B2
-automatización,automation,自动化,NOUN,B2
-automatizado,automated,自动化的,ADJ,B2
-automatizar,to automate,使自动化,VERB,B2
-automáticamente,automatically,自动地,ADV,B2
-automático,automatic,自动的,ADJ,B2
-autonomous,autonomous,自治的,ADJ,B2
-autonomy,autonomy,自治,NOUN,B2
 autorizado,authorized,有资格的,ADJ,B2
-autosacrificio,self-sacrifice,舍己,NOUN,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-auxiliary,auxiliary,词,ADJ,C1
-avail,avail,词,NOUN,C1
-avance,breakthrough,突破,NOUN,B2
-avarice,avarice,词,NOUN,C1
-avaricious,avaricious,词,ADJ,C1
-avellana,hazelnut,榛子,NOUN,B2
+autobiografía,autobiography,自传,NOUN,B2
+automatizar,to automate,使自动化,VERB,B2
+automatizado,automated,自动化的,ADJ,B2
+automático,automatic,自动的,ADJ,B2
+automáticamente,automatically,自动地,ADV,B2
+automatización,automation,自动化,NOUN,B2
+vanguardista,avant-garde,前卫的,ADJ,B2
+vengar,to avenge,复仇,VERB,B2
 avenida,avenue,大道,NOUN,B2
-aver,aver,词,VERB,C1
-average,average,平均数,NOUN,B2
-averageness,averageness,平庸,NOUN,B2
-avergonzar,to shame,使羞愧,VERB,B2
-averse,averse,厌恶的,ADJ,B2
-avert,avert,词,VERB,C1
-avería,malfunction,故障,NOUN,B2
-aves de corral,poultry,家禽,NOUN,B2
-avión,airplane,飞机,NOUN,B2
-avocado,avocado,牛油果,NOUN,C1
-avoidable,avoidable,可避免的,ADJ,B2
-avow,avow,词,VERB,C1
-award auction,award auction,裁定 / 拍卖,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
-awareness raising,awareness raising,提高意识,NOUN,B2
-away,away,避开,ADP,B2
-away (adj),away,外出,ADJ,C1
-away gone,away gone,不在/离开,ADV,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awesome,awesome,词,ADJ,A2
-awful,awful,糟糕的,ADJ,B2
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-awning,awning,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiology,axiology,词,NOUN,C1
+promedio,average,平均,ADJ,B2
+evitación,avoidance,避免,NOUN,B2
+esperar,to await,等待,VERB,B2
+despertar,to awaken,唤醒,VERB,B2
+despertar,awakening,觉醒,NOUN,B2
+premio,award,奖项,NOUN,B2
+conciencia,awareness,意识,NOUN,B2
+lejos,away,离开,ADV,B2
+asombro,awe,敬畏,NOUN,B2
+incómodo,awkward,尴尬的,ADJ,B2
 axioma,axiom,公理,NOUN,B2
-axiomatic,axiomatic,公理的,ADJ,B2
-axioms,axioms,词,NOUN,C1
-axis axle,axis axle,词,NOUN,C1
-ay,alas,唉,INTJ,B2
-ay,ouch,哎哟,INTJ,B2
-ayuda,go help,去帮,NOUN,B2
-ayuda mutua,mutual aid,互助,NOUN,B2
-ayudar,to help assistance,帮助,VERB,B2
-ayunar,to fast,禁食,VERB,B2
-ayuno,fasting,禁食,NOUN,B2
-aéreo,aerial,航空的,ADJ,B2
 ba zi,ba zi,八字,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby walker,baby walker,词,NOUN,B1
-baccalaureate,baccalaureate,词,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
-back mountain,back mountain,后山,NOUN,C1
-back side,back side,背面,NOUN,B2
-back then,back then,词,ADV,A1
-back way,back way,词,NOUN,B1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-backache,backache,背痛,NOUN,B2
-backdrop,backdrop,背景,NOUN,B2
-backfire,backfire,词,VERB,C1
-backpacker,backpacker,词,NOUN,B1
-backside,backside,臀部,NOUN,B2
-backslide,backslide,词,VERB,C1
-backward,backward,向后,ADV,B2
-backyard,backyard,后院,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
+soltero,bachelor,单身汉,NOUN,B2
+licenciatura,bachelor's degree,学士学位,NOUN,B2
+espalda,back,背面,NOUN,B2
+puerta trasera,back door,后门,NOUN,B2
+asiento trasero,back seat,后座,NOUN,B2
+columna vertebral,backbone,脊梁,NOUN,B2
+reflujo,backflow,倒流,NOUN,B2
+fondo,background,背景,NOUN,B2
+mochila,backpack,背包,NOUN,B2
+puñalada por la espalda,backstab,背刺,NOUN,B2
+telón,backstage,幕后,NOUN,B2
+respaldo,backup,备份,NOUN,B2
+luz de marcha atrás,backup light,倒车灯,NOUN,B2
+atrás,backwards,向后,ADV,B2
+tocino,bacon,培根,NOUN,B2
 bacteria,bacteria,细菌,NOUN,B2
-bactericide,bactericide,杀菌剂,NOUN,C1
-bad (noun),bad,词,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
-badger,badger,词,NOUN,C1
-baffle,baffle,词,VERB,C1
-bags,bags,包,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
-bajo,under,在...下面,ADP,B2
-bakery,bakery,词,NOUN,A2
-balance of power,balance of power,均势,NOUN,C1
-balance sheet,balance sheet,资产负债表,NOUN,B2
-balancear,to sway,摇摆,VERB,B2
-balancing,balancing,平衡的,ADJ,B2
-baldness,baldness,词,NOUN,B2
-baldosa,tile,瓦片,NOUN,B2
-baldosado,tiling,铺瓷砖,NOUN,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballad,ballad,词,NOUN,C1
+mala idea,bad idea,坏水,NOUN,B2
+mala suerte,bad luck,倒霉,NOUN,B2
+malas noticias,bad news,坏消息,NOUN,B2
+mala cosa,bad thing,坏事,NOUN,B2
+bádminton,badminton,羽毛球,NOUN,B2
+hornear,to bake,烘焙,VERB,B2
+panadero,baker,面包师,NOUN,B2
+equilibrado,balanced,平衡的,ADJ,B2
 ballet,ballet,芭蕾舞,NOUN,B2
-ballot,ballot,选票,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balsam,balsam,香脂,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
-ban (noun),ban,ban,NOUN,B2
+prohibir,ban,禁令,NOUN,B2
+prohibir,to ban,禁止,VERB,B2
 banal,banal,陈腐的,ADJ,B2
-bananas,bananas,词,NOUN,A1
-band tape,band tape,带子,NOUN,B2
-band volume,band volume,词,NOUN,C1
-bandada,flock,兽群,NOUN,B2
-bandaging,bandaging,词,NOUN,C1
-bandeja,tray,托盘,NOUN,B2
-bandwidth,bandwidth,词,ADJ,C1
-bang,bang,砰,INTJ,B2
+plátano,banana,香蕉,NOUN,B2
+venda,bandage,绷带,NOUN,B2
+golpe,bang,巨响,NOUN,B2
 banishment,banishment,流放,NOUN,B2
-banister,banister,词,NOUN,C1
-bank card,bank card,银行卡,NOUN,B2
 banking,banking,银行的,ADJ,B2
 banknote,banknote,钞票,NOUN,B2
-bankrupt,bankrupt,破产的,ADJ,B2
-banner headline,banner headline,词,NOUN,C1
 banquet,banquet,宴会,NOUN,B2
-banquete de agradecimiento,appreciation banquet,答谢宴,NOUN,B2
 banter,banter,戏谑,NOUN,B2
-bao,steamed stuffed bun,包子,NOUN,B2
-baptism,baptism,词,NOUN,B2
-baptized,baptized,受洗的,ADJ,B2
 bar,bar,酒吧,NOUN,B2
-bar,pub,酒吧,NOUN,B2
-bar of soap,bar of soap,词,NOUN,B2
 barbaric,barbaric,野蛮的,ADJ,B2
-barbarization,barbarization,野蛮化,NOUN,B2
 barbecue,barbecue,烧烤,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
-bare,bare,赤裸的,ADJ,B2
-bare ownership,bare ownership,虚有权,NOUN,B2
-bareheaded,bareheaded,词,ADJ,C1
-bargaining,bargaining,词,NOUN,C1
-barking,barking,词,NOUN,B2
 barley,barley,大麦,NOUN,B2
-baron,baron,词,NOUN,B2
 baroness,baroness,女男爵,NOUN,B2
-barracks,barracks,兵营,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barrel,barrel,桶,NOUN,B2
-barren,barren,词,ADJ,C1
-barrenness,barrenness,词,NOUN,C1
-barrido,sweep,扫,NOUN,B2
-barter (noun),barter,词,NOUN,C1
-barter (verb),barter,词,VERB,C1
-basal,basal,基本的,ADJ,B2
 base,base,基础,NOUN,B2
-base de datos,database,数据库,NOUN,B2
-base fertilizer,base fertilizer,基肥,NOUN,B2
 baseball,baseball,棒球,NOUN,B2
-based,based,基于,ADJ,B2
 basement,basement,地下室,NOUN,B2
 baseness,baseness,卑鄙,NOUN,B2
-bash,bash,词,VERB,C1
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic attitude,basic attitude,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
-basic income,basic income,基本收入,NOUN,B2
 basically,basically,基本上,ADV,B2
 basil,basil,罗勒,NOUN,B2
 basin,basin,盆,NOUN,B2
-basing,basing,词,NOUN,C1
-bask,bask,词,VERB,C1
 basketball,basketball,篮球,NOUN,B2
 bass,bass,贝斯,NOUN,B2
-bastante,rather,相当,ADV,B2
-baste,baste,词,VERB,C1
 bat,bat,蝙蝠,NOUN,B2
 bath,bath,洗澡,NOUN,B2
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
 bathe,to bathe,洗澡,VERB,B2
-bathrobe,bathrobe,词,NOUN,A2
 bathtub,bathtub,浴缸,NOUN,B2
-baton,baton,警棍,NOUN,B2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
 battlefield,battlefield,战场,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
 be,be,是,AUX,B2
 be able,to be able,能,VERB,B2
 be able to,be able to,能,AUX,B2
@@ -1646,18042 +366,8100 @@ be absent,to be absent,缺席,VERB,B2
 be addicted,to be addicted,上瘾,VERB,B2
 be allowed,be allowed,允许,AUX,B2
 be ashamed,to be ashamed,感到羞愧,VERB,B2
-be assassinated,be assassinated,遇刺,VERB,C1
 be brave,to be brave,勇善,VERB,B2
 be called,to be called,叫做,VERB,B2
-be crushed,be crushed,词,VERB,C1
 be damaged,to be damaged,受损,VERB,B2
 be defeated,to be defeated,会败,VERB,B2
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
-be rumored,be rumored,词,VERB,C1
-be shot,be shot,中弹,VERB,C1
-be sorry,be sorry,抱歉,ADJ,B2
-be tender,be tender,温柔的,ADJ,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beans,beans,词,NOUN,A1
-beaten,beaten,被打败的,ADJ,B2
-beatitude,beatitude,至福,NOUN,B2
-beaver,beaver,词,NOUN,C1
-beca,scholarship,奖学金,NOUN,B2
-because (cconj),because,词,CCONJ,A2
-because of this,because of this,词,ADV,A2
-becerro,calf,小腿,NOUN,B2
-beckon,beckon,词,VERB,C1
-become,become,成为,AUX,B2
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedsheet,bedsheet,床单,NOUN,B2
-bedside,bedside,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beehive,beehive,词,NOUN,C1
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
-befahrt,befahrt,词,NOUN,C1
-befall,befall,词,VERB,C1
-befassung,befassung,词,NOUN,C1
-befit,befit,词,VERB,C1
-beforderung,beforderung,词,NOUN,C1
-before (noun),before,以前,NOUN,A1
-before one's eyes,before one's eyes,词,ADV,C1
-before previously,before previously,以前,ADV,B2
-before that,before that,词,ADV,B1
-befuddle,befuddle,词,VERB,C1
-beg for pity,beg for pity,乞怜,VERB,B2
-begabe,begabe,词,NOUN,C1
-begestaltung,begestaltung,词,NOUN,C1
-beginning primer,beginning primer,词,NOUN,C1
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
-behavioral,behavioral,词,ADJ,B2
-behavioral pattern,behavioral pattern,词,NOUN,C1
-beheading,beheading,按律当斩,NOUN,C1
-behind (adp),behind,在后面,ADP,A1
-behind (noun),behind,词,NOUN,B2
-behind it,behind it,在后面,ADV,B2
-behoove,behoove,词,VERB,C1
-beile,heard beile,听说贝勒,NOUN,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-bekunft,bekunft,词,NOUN,C1
-belabor,belabor,词,VERB,C1
-belated,belated,词,ADJ,C1
-belatedly,belatedly,词,ADV,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-belgian,belgian,比利时的,ADJ,B2
-belgian (noun),belgian,比利时人,NOUN,C1
-belie,belie,词,VERB,C1
-belief creed,belief creed,词,NOUN,B2
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-believability,believability,词,NOUN,C1
-belittling,belittling,词,NOUN,C1
-bell tower,bell tower,词,NOUN,A2
-below,below,下面,ADV,B2
-below (adj),below,下面的,ADJ,B1
-below (noun),below,词,NOUN,B2
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-benahme,benahme,词,NOUN,B2
-bench seat,bench seat,词,NOUN,C1
-bending,bending,弯曲,NOUN,C1
-beneath,beneath,词,ADP,B2
-beneficence,beneficence,词,NOUN,C1
-beneficial,beneficial,有益的,ADJ,B2
+estar hecho,to be done,被做,VERB,B2
+estar ansioso,to be eager,心切,VERB,B2
+ansiar,to be eager for,巴不得,VERB,B2
+ser elegido,to be elected,当选,VERB,B2
+estar embelesado,to be entranced,出神,VERB,B2
+ser forzado,to be forced,被迫,VERB,B2
+ser bueno en,to be good at,擅长,VERB,B2
+estar agradecido,to be grateful,感激,VERB,B2
+ser golpeado,to be hit,中箭,VERB,B2
+estar celoso,to be jealous,嫉妒,VERB,B2
+llegar tarde,to be late,迟到,VERB,B2
+estar ubicado,to be located,位于,VERB,B2
+faltar,to be missing,缺少,VERB,B2
+estar de servicio,to be on duty,值班,VERB,B2
+ser requerido,to be required,被要求,VERB,B2
+ser responsable de,to be responsible for,负责,VERB,B2
+tener razón,to be right,正确,VERB,B2
+estar a salvo,to be safe,安好,VERB,B2
+estar callado,to be silent,沉默,VERB,B2
+ser así,to be so,然,VERB,B2
+ser robado,to be stolen,失窃,VERB,B2
+sorprenderse,to be surprised,感到惊讶,VERB,B2
+ser útil,to be useful,有用,VERB,B2
+soportar,to bear,忍受,VERB,B2
+soportable,bearable,可忍受的,ADJ,B2
+porte,bearing,轴承,NOUN,B2
+paliza,beating,跳动,NOUN,B2
+porque,because,因为,CCONJ,B2
+por,because of,因为,ADP,B2
+abeja,bee,蜜蜂,NOUN,B2
+pitido,beep,吱吱声,NOUN,B2
+escarabajo,beetle,甲虫,NOUN,B2
+antes de que,before,在...之前,SCONJ,B2
+mendigo,beggar,乞丐,NOUN,B2
+mendicidad,begging,乞讨,NOUN,B2
+empezar,to begin to start,开始,VERB,B2
+principiante,beginner,初学者,NOUN,B2
+detrás,behind,在...后面,ADP,B2
+ente,being,存在,NOUN,B2
+creer,to believe,相信,VERB,B2
+pimiento,bell pepper,甜椒,NOUN,B2
+vientre,belly,肚子,NOUN,B2
+pertenecer,to belong to,属于,VERB,B2
+pertenencia,belonging,归属感,NOUN,B2
+pertenencias,belongings,所属物,NOUN,B2
+amado,beloved,爱人,NOUN,B2
+abajo,below,在...下面,ADP,B2
+curva,bend,弯道,NOUN,B2
 benevolencia,benevolence,仁慈,NOUN,B2
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-bepflegung,bepflegung,词,NOUN,B2
-bequest,bequest,词,NOUN,B2
-berate,berate,词,VERB,C1
-bereave,bereave,词,VERB,C1
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-berichtung,berichtung,词,NOUN,C1
-berkeley coach,berkeley coach,,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beschaft,beschaft,词,NOUN,C1
-beschrift,beschrift,词,NOUN,C1
-beseech,beseech,词,VERB,C1
-beset,beset,词,VERB,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
-beside,beside,在...旁边,ADP,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
-besieging,besieging,词,NOUN,C1
-besinnung,besinnung,词,NOUN,C1
-besmirch,besmirch,词,VERB,C1
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best friend,best friend,最好的朋友,NOUN,B2
-best possible,best possible,词,ADJ,C1
-bestial,bestial,词,ADJ,C1
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betray one's country,betray one's country,卖国,VERB,B2
-betreibung,betreibung,词,NOUN,C1
-betrothal gift,betrothal gift,聘,NOUN,C1
-better (adv),better,词,ADV,A1
-better (noun),better,越好,NOUN,B2
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-beverage,beverage,词,NOUN,B2
-bewail,bewail,词,VERB,C1
-bewandel,bewandel,词,NOUN,C1
-beware,beware,词,VERB,C1
-beweisung,beweisung,词,NOUN,C1
-bewilder,bewilder,词,VERB,C1
-bewirkung,bewirkung,词,NOUN,C1
+al lado,beside next to,旁边,NOUN,B2
+mejor,best,最好的,ADJ,B2
+otorgar,to bestow,授予,VERB,B2
+otorgamiento,bestowal,授予,NOUN,B2
+apuesta,bet,打赌,NOUN,B2
+mejor,better,越好,NOUN,B2
+desconcierto,bewilderment,困惑,NOUN,B2
+más allá,beyond,在...之外,ADP,B2
 bianzhong,bianzhong,编钟,NOUN,B2
+sesgo,bias,偏见,NOUN,B2
+sesgado,biased,有偏见的,ADJ,B2
 bibliografía,bibliography,参考书目,NOUN,B2
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid,bid,出价,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bids,bids,词,NOUN,C1
-bien,alright,好的,ADV,B2
-bien,good,خير,NOUN,B2
-bienestar público,public welfare,公益性,NOUN,B2
-biennial,biennial,词,NOUN,C1
-bifurcation,bifurcation,词,NOUN,C1
-big brother,big brother,哥哥,NOUN,B2
-big cat,big cat,词,NOUN,C1
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-bigger,bigger,更大的,ADJ,B2
-bigness,bigness,,NOUN,B2
-bigotry,bigotry,词,NOUN,C1
-bigwig,bigwig,大人物,NOUN,B2
-bike basket,bike basket,车筐,NOUN,B2
-bike helmet,bike helmet,自行车头盔,NOUN,B2
-bike lane,bike lane,自行车道,NOUN,B2
-bilateral,bilateral,双边的,ADJ,B2
-bilingual,bilingual,词,ADJ,C1
-bilingualism,bilingualism,词,NOUN,C1
-bilk,bilk,词,VERB,C1
-bill of exchange,bill of exchange,词,NOUN,C1
+colusión de licitación,bid collusion,串标,NOUN,B2
+evaluación de ofertas,bid evaluation,评标,NOUN,B2
+apertura de ofertas,bid opening,开标,NOUN,B2
+mayor,biggest,最大,ADJ,B2
 billar,billiards,台球,NOUN,B2
-billion,billion,十亿,NUM,B2
-billion (noun),billion,词,NOUN,B2
-billionaire,billionaire,词,NOUN,C1
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
-binder,binder,词,NOUN,A2
-binding (adj),binding,词,ADJ,C1
-bingo,bingo,词,NOUN,B2
-binoculars,binoculars,双筒望远镜,NOUN,B2
 biodiversidad,biodiversity,生物多样性,NOUN,B2
 biografía,biography,传记,NOUN,B2
-biographical,biographical,词,ADJ,C1
-biographies,biographies,词,NOUN,C1
-biologist,biologist,生物学家,NOUN,B2
 biomasa,biomass,生物质,NOUN,B2
 biotecnología,biotechnology,生物技术,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-biscuit,biscuit,饼干,NOUN,A2
-bisexual,bisexual,双性恋的,ADJ,B2
-bistro,bistro,小酒馆,NOUN,B2
-bit,bit,一点,NOUN,B2
-bitch,bitch,母狗,NOUN,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-blab,blab,词,VERB,C1
-black (noun),black,أسود,NOUN,C1
-black pepper,black pepper,词,NOUN,B2
-blackbird,blackbird,乌鸫,NOUN,B2
-blackout,blackout,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blah,blah,词,INTJ,C1
-blanch,blanch,词,VERB,C1
-blandish,blandish,词,VERB,C1
-blandura excesiva,too soft,太软,NOUN,B2
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blazing ardor,blazing ardor,词,NOUN,C1
-bleak,bleak,无望的,ADJ,B2
-bleeding,bleeding,流血的,ADJ,B2
-blend,blend,词,VERB,B2
-blender,blender,搅拌机,NOUN,B2
-blending,blending,词,NOUN,C1
-blight,blight,词,NOUN,C1
-blind person,blind person,词,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
-blister,blister,词,NOUN,C1
-bloat,bloat,词,VERB,C1
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
-blockhead,blockhead,笨蛋,NOUN,B2
-blocking,blocking,词,NOUN,B2
-blog,blog,博客,NOUN,B2
-blog post,blog post,词,NOUN,C1
-blogger,blogger,词,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
-blood sugar,blood sugar,血糖,NOUN,B2
-blood test,blood test,验血,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-blood-related,blood-related,词,ADJ,C1
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,沾血,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-bloom of youth,bloom of youth,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
+nacimiento,birth,出生,NOUN,B2
+obispo,bishop,主教,NOUN,B2
+mordisco,bite,一口,NOUN,B2
+mordedura,biting,咬人,NOUN,B2
+amargura,bitterness,苦涩,NOUN,B2
+extraño,bizarre,奇异的,ADJ,B2
+toga negra,black robe,黑衣,NOUN,B2
+mora,blackberry,黑莓,NOUN,B2
+pizarra,blackboard,黑板,NOUN,B2
+herrero,blacksmith,铁匠,NOUN,B2
+hoja,blade,刀片,NOUN,B2
+culpa,blame,责备,NOUN,B2
+manta,blanket,毯子,NOUN,B2
+incendio,blaze,火焰,NOUN,B2
+lejía,bleach,漂白剂,NOUN,B2
+hemorragia,bleeding,出血,NOUN,B2
+mancha,blemish,瑕疵,NOUN,B2
+persiana,blind,百叶窗,NOUN,B2
+dicha,bliss,极乐,NOUN,B2
+ventisca,blizzard,暴风雪,NOUN,B2
 bloque,bloc,阵营,NOUN,B2
 bloque,block,街区,NOUN,B2
 bloquear,to blockade,封锁,VERB,B2
-blossoming ripening,blossoming ripening,词,NOUN,C1
-blow beating,blow beating,殴打,NOUN,B2
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blue (noun),blue,词,NOUN,C1
-blueprint,blueprint,词,NOUN,C1
-blueprint diagram,blueprint diagram,词,NOUN,C1
-blunt,blunt,词,ADJ,B2
-bluntness,bluntness,直说,NOUN,B2
-blurriness,blurriness,词,NOUN,C1
-blurry,blurry,词,ADJ,B2
-blurt,blurt,词,VERB,C1
+blog,blog,博客,NOUN,B2
+deuda de sangre,blood debt,血债,NOUN,B2
+presión arterial,blood pressure,血压,NOUN,B2
+mar de sangre,blood sea,血海,NOUN,B2
 blusa,blouse,女衬衫,NOUN,B2
-bluster,bluster,词,VERB,C1
-boarder,boarder,寄宿生,NOUN,B2
-boarding,boarding,词,NOUN,C1
-boarding pass,boarding pass,登机牌,NOUN,B2
-boastfulness,boastfulness,吹嘘,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bocado,mouthful,一口,NOUN,B2
-bode,bode,词,VERB,C1
-bodies,bodies,词,NOUN,C1
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-boggle,boggle,词,VERB,C1
-boicotear,to boycott,抵制,VERB,B2
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
-boiling (adj),boiling,词,ADJ,C1
-boldness daring,boldness daring,词,NOUN,B2
-bolster (noun),bolster,词,NOUN,C1
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolígrafo,pen,钢笔,NOUN,B2
-bomba,pump,泵,NOUN,B2
-bombardment,bombardment,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
-bomber,bomber,词,NOUN,C1
-bombástico,bombastic,夸大的,ADJ,B2
-bondholder,bondholder,词,NOUN,C1
-bonds,bonds,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-bonhomie,bonhomie,词,NOUN,C1
-booking,booking,词,NOUN,A2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,书店,NOUN,B2
-boorish,boorish,词,ADJ,C1
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,边境检查,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border frontier,border frontier,词,NOUN,B1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,边境立法,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,边境地区,NOUN,B2
-bordering,bordering,词,ADJ,C1
-borders,borders,边界,NOUN,A1
-born,born,出生的,ADJ,B2
-born (noun),born,词,NOUN,B2
-born (verb),born,词,VERB,A1
-borrado,erasure,擦除,NOUN,B2
-borrador,draft,草稿,NOUN,B2
-borrador,eraser,橡皮擦,NOUN,B2
-borrowed,borrowed,词,ADJ,C1
-borrowed knife,borrowed knife,借刀,NOUN,B2
-bosque,woodland,林地,NOUN,B2
-boss female,boss female,词,NOUN,B2
-boss manager,boss manager,词,NOUN,A1
-botanical,botanical,词,ADJ,C1
-botany,botany,词,NOUN,C1
-both,both,两者,PRON,B2
-both (adj),both,两者的,ADJ,B2
-both (cconj),both,both,CCONJ,A2
-both (noun),both,词,NOUN,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
-both parties,both parties,双方,NOUN,B1
-bottle opener,bottle opener,词,NOUN,B1
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
-bounce,bounce,词,VERB,B2
-bound to,bound to,势必,ADV,B2
-boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bout,bout,阵,NOUN,B2
-bovine,bovine,词,ADJ,C1
-bow (verb),bow,词,VERB,B1
-bow tie,bow tie,领结,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
-boxeo,boxing,拳击,NOUN,B2
-boxer,boxer,拳击手,NOUN,B2
-brabant,brabant,布拉班特的,ADJ,B2
-brace,brace,词,NOUN,C1
-bragas,underpants,内裤,NOUN,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-braid,braid,辫子,NOUN,C1
-brain activity,brain activity,,NOUN,B2
-brain damage,brain damage,,NOUN,B2
-brainstorming,brainstorming,词,NOUN,C1
-brainy,brainy,聪明的,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakes,brakes,词,NOUN,C1
-braking,braking,词,NOUN,C1
-bran,bran,词,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
-brassware,brassware,词,NOUN,C1
-bravo,bravo,词,NOUN,B2
-brawl,brawl,斗殴,NOUN,B2
-bray,bray,词,VERB,C1
-brazier,brazier,词,NOUN,B1
-brazilian,brazilian,巴西的,ADJ,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of duty,breach of duty,渎职,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-bread roll,bread roll,小圆面包,NOUN,B2
-breadth,breadth,词,NOUN,C1
-breadth crossing,breadth crossing,词,NOUN,C1
-break fraction,break fraction,词,NOUN,C1
-break out of prison,break out of prison,越狱,VERB,C1
-break-in,break-in,非法侵入,NOUN,B2
-breakage,breakage,词,NOUN,C1
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
-breakthrough,breakthrough,突破性,ADJ,B2
-breakup,breakup,分手,NOUN,B2
-breast,breast,乳房,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,呼吸,NOUN,B2
-breathing space,breathing space,词,NOUN,C1
-breathlessness,breathlessness,词,NOUN,B1
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
-brevedad,brevity,简洁,NOUN,B2
-breviary,breviary,词,NOUN,C1
-bribe-taker,bribe-taker,词,NOUN,C1
-bribes,bribes,词,NOUN,C1
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
-bridal trousseau,bridal trousseau,词,NOUN,C1
-bridegroom,bridegroom,词,NOUN,C1
-bridle,bridle,马勒,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefcase,briefcase,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brigand poet,brigand poet,词,NOUN,C1
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightly,brightly,词,ADV,C1
-brightness,brightness,词,NOUN,C1
-brillante,bright,明亮的,ADJ,B2
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
-brillo,brilliance,辉煌,NOUN,B2
-brim,brim,词,NOUN,C1
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-brisa,breeze,微风,NOUN,B2
-briskness,briskness,轻快,NOUN,B2
-bristle (noun),bristle,词,NOUN,C1
-britano,briton,英国人,NOUN,B2
-brittleness,brittleness,词,NOUN,C1
-británico,british,英国的,ADJ,B2
-bro,bro,哥们,NOUN,B2
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
-broadcaster,broadcaster,广播公司,NOUN,B2
-broaden,broaden,词,VERB,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade (part),brocade,锦,PART,A1
-brocado,brocade,锦绣,NOUN,B2
-broccoli,broccoli,西兰花,NOUN,C1
-broil,broil,词,VERB,C1
-broke,broke,破产的,ADJ,B2
-broken,broken,破碎的,ADV,B2
-brokenness,brokenness,词,NOUN,C1
-bronceado,tanning,晒黑,NOUN,B2
-bronze ware,bronze ware,青铜器,NOUN,C1
-brooch,brooch,词,NOUN,C1
-brook no delay,brook no delay,刻不容缓,ADJ,B2
-brother (part),brother,兄,PART,B1
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-browbeat,browbeat,词,VERB,C1
-bruises,bruises,词,NOUN,B2
-bruma,mist,薄雾,NOUN,B2
-brutal,brutal,词,ADJ,B2
-brutality,brutality,残暴,NOUN,B2
-brutalizing,brutalizing,词,ADJ,C1
-brutally,brutally,词,ADV,C1
-bruto,gross,总的,ADJ,B2
-buceo,scuba diving,潜水,NOUN,B2
-buckle,buckle,词,VERB,C1
-bucolic,bucolic,词,ADJ,C1
-bud,bud,芽,NOUN,B2
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budge,budge,词,VERB,C1
-budgetable,budgetable,可预算的,ADJ,B2
-budgeting,budgeting,词,NOUN,C1
-buena reputación,good reputation,清誉,NOUN,B2
-buena suerte,good luck,好运,NOUN,B2
-bufanda,scarf,围巾,NOUN,B2
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulge,bulge,词,NOUN,C1
-bull,bull,词,NOUN,B1
-bulldog,bulldog,斗牛犬,NOUN,B2
-bulldoze,bulldoze,词,VERB,C1
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bulletproof,bulletproof,词,NOUN,B2
-bullicio,sound of activity,动静,NOUN,B2
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bullying,bullying,词,NOUN,B2
-bum,bum,流浪汉,NOUN,B2
-bumble,bumble,词,VERB,C1
-bumblebee,bumblebee,词,NOUN,C1
-bump,bump,肿块,NOUN,B2
-bump shock,bump shock,碰撞/震惊,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bundling,bundling,词,NOUN,C1
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bunker,bunker,词,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-burdened,burdened,负担重的,ADJ,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-burger stand,burger stand,,NOUN,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burned,burned,词,ADJ,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
-buscado,wanted,故意的,ADJ,B2
-buscar,to search,搜索,VERB,B2
-buscar,to search for,寻找,VERB,B2
-buscar,to seek,寻找,VERB,B2
-buscar la verdad en los hechos,to seek truth from facts,实事求是,VERB,B2
-bushy,bushy,词,ADJ,C1
-business card,business card,名片,NOUN,B1
-business sector,business sector,商业界,NOUN,B2
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-bust,bust,词,NOUN,B1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-but (adv),but,却,ADV,A1
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but-for,but-for,词,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-butler,butler,词,NOUN,C1
-butt,butt,臀部,NOUN,B2
-buttermilk,buttermilk,词,NOUN,A2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buyer purchaser,buyer purchaser,买方,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance,by chance,偶然地,ADV,B2
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by heart,by heart,词,ADV,B2
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
-by means of,by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
-bypass,bypass surgery,搭桥手术,NOUN,B2
-bypass (noun),bypass,词,NOUN,C1
-bypassing,bypassing,词,NOUN,C1
-bádminton,badminton,羽毛球,NOUN,B2
-búsqueda,quest,探索,NOUN,B2
-búsqueda,seeking,寻求,NOUN,B2
-caballero,knight,骑士,NOUN,B2
-caballería,cavalry,骑兵,NOUN,B2
-cabina,booth,摊位,NOUN,B2
-cable,cable,电缆,NOUN,B2
-cable car,cable car,缆车,NOUN,B1
-cache,cache,词,NOUN,C1
-cachemir,cashmere,羊绒,NOUN,B2
-cachexia,cachexia,词,NOUN,C1
-cachorro,cub,幼兽,NOUN,B2
-cackle,cackle,词,VERB,C1
-cactus,cactus,词,NOUN,B1
-cada,every,每个,DET,B2
-cada,each,每个,PRON,B2
-cadena industrial,industry chain,产业链,NOUN,B2
-cadena perpetua,life imprisonment,无期徒刑,NOUN,B2
-cadres,cadres,词,NOUN,C1
-caesura,caesura,词,NOUN,C1
-caffeine,caffeine,词,NOUN,C1
-caftan,caftan,词,NOUN,A1
-café,cafe,咖啡馆,NOUN,B2
-caid local governor,caid local governor,词,NOUN,C1
-caja,checkout,收银台,NOUN,B2
-caja,crate,板条箱,NOUN,B2
-caja fuerte,safe,保险箱,NOUN,B2
-caja registradora,cash register,收银机,NOUN,B2
-cajole,cajole,词,VERB,C1
-calculadora,calculator,计算器,NOUN,B2
+soplar,to blow,吹,VERB,B2
+arándano,blueberry,蓝莓,NOUN,B2
+tabla,board,木板,NOUN,B2
+internado,boarding school,寄宿学校,NOUN,B2
+jactancia,boasting,夸耀,NOUN,B2
 caldera,boiler,锅炉,NOUN,B2
-calentamiento,warming,变暖,NOUN,B2
-calentamiento global,global warming,气候变暖,NOUN,B2
-caliber,caliber,词,NOUN,C1
+bombástico,bombastic,夸大的,ADJ,B2
+reservar,to book,预订,VERB,B2
+folleto,booklet,小册子,NOUN,B2
+cabina,booth,摊位,NOUN,B2
+aburrido,bored,无聊的,ADJ,B2
+aburrido,boring,无聊的,ADJ,B2
+tomar prestado,to borrow,借,VERB,B2
+prestatario,borrower,借款人,NOUN,B2
+préstamo,borrowing,借贷,NOUN,B2
+ambos,both,两者都,CCONJ,B2
+ambas manos,both hands,双手,NOUN,B2
+piedra,boulder,巨石,NOUN,B2
+atado,bound,一定的,ADJ,B2
+cuenco,bowl,碗,NOUN,B2
+boxeo,boxing,拳击,NOUN,B2
+boicotear,to boycott,抵制,VERB,B2
+pulsera,bracelet,手镯,NOUN,B2
+valentía,bravery,勇敢,NOUN,B2
+incumplir contrato,to breach contract,违约,VERB,B2
+romper,to break up,破裂,VERB,B2
+avance,breakthrough,突破,NOUN,B2
+amamantar,to breastfeed,母乳喂养,VERB,B2
+lactancia,breastfeeding,母乳喂养,NOUN,B2
+raza,breed,品种,NOUN,B2
+brisa,breeze,微风,NOUN,B2
+brevedad,brevity,简洁,NOUN,B2
+cervecería,brewery,啤酒厂,NOUN,B2
+cámara nupcial,bridal chamber,洞房,NOUN,B2
+novia,bride,新娘,NOUN,B2
+informe,brief,近点说,NOUN,B2
+brillante,bright,明亮的,ADJ,B2
+brillo,brilliance,辉煌,NOUN,B2
+devolver,to bring back,带回,VERB,B2
+traída,bringing,جلب,NOUN,B2
+británico,british,英国的,ADJ,B2
+britano,briton,英国人,NOUN,B2
+transmitir,broadcast,广播,NOUN,B2
+transmitir,to broadcast,播出,VERB,B2
+radiodifusión,broadcasting,广播,NOUN,B2
+brocado,brocade,锦绣,NOUN,B2
+corredor,broker,经纪人,NOUN,B2
+arroyo,brook,小溪,NOUN,B2
+hojear,to browse,浏览,VERB,B2
+navegador,browser,浏览器,NOUN,B2
+moretón,bruise,瘀伤,NOUN,B2
+ciervo,buck,美元,NOUN,B2
+trigo sarraceno,buckwheat,荞麦,NOUN,B2
+amigo,buddy,伙伴,NOUN,B2
+presupuesto,budget,预算,NOUN,B2
+presupuestario,budgetary,预算的,ADJ,B2
+volumen,bulk,主体,NOUN,B2
+matón,bully,欺凌者,NOUN,B2
+oficina,bureau,局,NOUN,B2
+ladrón,burglar,窃贼,NOUN,B2
+allanamiento,burglary,入室盗窃罪,NOUN,B2
+quemadura,burn,烧伤,NOUN,B2
+ardiente,burning,灼热的,ADJ,B2
+quemado,burnt,烧焦的,ADJ,B2
+eructar,to burp,打嗝,VERB,B2
+reventar,to burst,爆发,VERB,B2
+arbusto,bush,灌木,NOUN,B2
+reunión de negocios,business meeting,洽谈会,NOUN,B2
+ajetreo,busyness,事忙,NOUN,B2
+pero,but,然而,ADV,B2
+pero yo,but i,可我,ADV,B2
+pero tú,but you,但您,NOUN,B2
+mariposa,butterfly,蝴蝶,NOUN,B2
+nalgas,buttocks,屁股,NOUN,B2
+comprador,buyer,买家,NOUN,B2
+por medios lícitos o ilícitos,by fair means or foul,不择手段,ADV,B2
+medio,by means of,通过,ADP,B2
+por cierto,by the way,顺便说一下,ADV,B2
+adiós,bye,再见,INTJ,B2
+pasado,bygone,过去的,ADJ,B2
+bypass,bypass surgery,搭桥手术,NOUN,B2
+col,cabbage,卷心菜,NOUN,B2
+cable,cable,电缆,NOUN,B2
+café,cafe,咖啡馆,NOUN,B2
+pastel,cake,蛋糕,NOUN,B2
+calculadora,calculator,计算器,NOUN,B2
+becerro,calf,小腿,NOUN,B2
 calibración,calibration,校准,NOUN,B2
-calibrated,calibrated,词,ADJ,C1
-calibrator,calibrator,词,NOUN,C1
-calificaciones,qualifications,资格,NOUN,B2
-calificación,grading,评分；记号,NOUN,B2
-calificación,qualification,资格,NOUN,B2
-calificación,rating,评分,NOUN,B2
-caligrafía,handwriting,笔迹,NOUN,B2
-caligrafía,handwriting practice,练字,NOUN,B2
-caliph,caliph,词,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
-call to prayer,call to prayer,词,NOUN,B2
-callejón sin salida,dead end,死胡同,NOUN,B2
-caller,caller,词,NOUN,A2
-calligrapher,calligrapher,词,NOUN,C1
-callus,callus,硬茧……,NOUN,C1
-calming,calming,令人平静的,ADJ,B2
-calmly,calmly,平静地,ADV,B2
-calor,warmth,温暖,NOUN,B2
-calorie,calorie,词,NOUN,C1
-calve,calve,词,VERB,C1
-calzado,footwear,鞋穿,NOUN,B2
-camarera,waitress,女服务员,NOUN,B2
-cambiar,shift,轮班,NOUN,B2
-cambiar,to change tire,换胎,VERB,B2
-cambiar,to shift,改变,VERB,B2
-cambio climático,climate change,气候变化,NOUN,B2
+insensible,callous,冷酷,ADJ,B2
 camello,camel,骆驼,NOUN,B2
-caminar,to hike,徒步旅行,VERB,B2
-camouflage (noun),camouflage,词,NOUN,C1
-camp (part),camp,营,PART,A2
 campañar,to campaign,积极参与活动,VERB,B2
-campfire,campfire,词,NOUN,C1
 camping,camping,露营,NOUN,B2
-campsite,campsite,露营地,NOUN,B2
-campus,campus,词,NOUN,B2
-campus-like,campus-like,校园式的,ADJ,B2
-can (noun),can,词,NOUN,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can jar,can jar,罐子,NOUN,B2
-can may,can may,可以,AUX,A1
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
-canadian,canadian,加拿大的,ADJ,B2
+poder,can,能够,AUX,B2
+poder solo,can only,只能,AUX,B2
+no creer,to can't believe,不敢相信,VERB,B2
+no poder evitar,can't help,不由得,ADV,B2
 canal,canal,运河,NOUN,B2
-canal belt,canal belt,词,NOUN,C1
 cancelación,cancellation,取消,NOUN,B2
-cancelled set,cancelled set,取消的/设定的,ADJ,B2
-cancerous,cancerous,词,ADJ,C1
-canciller,chancellor,总理,NOUN,B2
-candelabro,chandelier,吊灯,NOUN,B2
-candid,candid,词,ADJ,C1
-cannabis,cannabis,大麻,NOUN,B2
-canning,canning,词,NOUN,C1
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-cansar,tire,轮胎,NOUN,B2
-cansar,to tire,使疲倦,VERB,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-canteen,canteen,食堂,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
-canvas,canvas,帆布,NOUN,B2
-canvass,canvass,词,VERB,C1
-capa,cape,海角,NOUN,B2
-capable,capable,有本事,NOUN,B2
-capable good,capable good,能干的/优秀的,ADJ,B2
-capacidad,ability,能力,NOUN,B2
-capacidad,capability,能力,NOUN,B2
-capacitate,capacitate,词,VERB,C1
-capacitor condenser,capacitor condenser,词,NOUN,C1
-caparazón,shell,壳,NOUN,B2
-capaz,able,能够的,ADJ,B2
-capillary,capillary,词,ADJ,C1
-capital,capital,首都,NOUN,B2
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,资本外逃,NOUN,B2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
-capitalist,capitalist,词,NOUN,C1
-capitalization,capitalization,词,NOUN,C1
-capitulation,capitulation,词,NOUN,C1
-capping,capping,封顶,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capsize,capsize,词,VERB,C1
-capsule,capsule,词,NOUN,B1
-captivated,captivated,词,ADJ,C1
-captive,captive,俘虏,NOUN,B2
-captive bond,captive bond,词,NOUN,C1
-captura,catch,捕捉,NOUN,B2
-car (part),car,车,PART,C1
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-característica,feature,特征,NOUN,B2
-característico,characteristic,典型的,ADJ,B2
-caramelize,caramelize,词,VERB,C1
+vela,candle,蜡烛,NOUN,B2
 caramelo,candy,糖果,NOUN,B2
-carat,carat,克拉,NOUN,B2
-caravana,caravan,房车,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
-carbon trading,carbon trading,碳交易,NOUN,C1
-carbono,carbon,碳,NOUN,B2
-carbón,charcoal,木炭,NOUN,B2
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-care home,care home,,NOUN,B2
-care worker,care worker,护理人员,NOUN,B2
-careen,careen,词,VERB,C1
-career leap,career leap,词,NOUN,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefully,carefully,仔细地,ADV,B2
-carefulness,carefulness,细心,NOUN,B2
-carer,carer,词,NOUN,C1
-carga,cargo,货物,NOUN,B2
-carga,charge,收费,NOUN,B2
-cargador,charger,充电器,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
-caricatura,caricature,讽刺画,NOUN,B2
-caricaturesco,caricatural,漫画的,ADJ,B2
-caring,caring,关怀的,ADJ,B2
-carisma,charisma,个人魅力,NOUN,B2
-cariño,darling,亲爱的,NOUN,B2
-cariño,sweetheart,爱人,NOUN,B2
-carnaval,carnival,狂欢节,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
-carp (verb),carp,词,VERB,C1
-carpintero,carpenter,木匠,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
-carrera,race,比赛,NOUN,B2
-carrera,run,跑步,NOUN,B2
-carrera,running,进行中的,NOUN,B2
-carrera principal,major course,专业课,NOUN,B2
-carretera de servicio,service road,辅路,NOUN,B2
-carretera provincial,provincial highway,省道,NOUN,B2
-carrot,carrot,胡萝卜,NOUN,B2
-carruaje,carriage,马车,NOUN,B2
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
-carta,charter,宪章,NOUN,B2
-cartel,cartel,卡特尔,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
-casadera,marriageable,适婚,NOUN,B2
-casamentero,matchmaker,媒,NOUN,B2
-cascada,waterfall,瀑布,NOUN,B2
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
-case law,case law,判例法,NOUN,B2
-cash conversion,cash conversion,改现,NOUN,B2
-casi,nearly,几乎,ADV,B2
-casino,casino,词,NOUN,B2
-cassation,cassation,词,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cast (adj),cast,词,ADJ,C1
-cast iron,cast iron,词,NOUN,B2
-castanets,castanets,词,NOUN,B1
-castaña,chestnut,板栗,NOUN,B2
-casting,casting,词,NOUN,C1
-castrate,castrate,词,VERB,C1
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-catachresis,catachresis,词语误用,NOUN,B2
-catalizador,catalyst,催化剂,NOUN,B2
-catalogue,catalogue,目录,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
-catastrophic,catastrophic,灾难性的,ADJ,B2
-catch thief,catch thief,抓贼,NOUN,C1
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorical,categorical,绝对的,ADJ,B2
-categorically,categorically,词,ADV,C1
-cater,cater,词,VERB,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教的,ADJ,B2
-catholic (noun),catholic,天主教徒,NOUN,C1
-cats,cats,猫,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-caught,caught,被捕获的,ADJ,B2
-cauldron,cauldron,词,NOUN,C1
-causa de muerte,cause of death,死因,NOUN,B2
-causa parcial,partial cause,分因,NOUN,B2
-causal,causal,因果的,ADJ,B2
-causal link,causal link,因果关系,NOUN,B2
-causalidad,causation,因果关系,NOUN,B2
-cause of change,cause of change,改因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-cauteloso y concienzudo,cautious and conscientious,兢兢业业,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
-cavern,cavern,词,NOUN,B2
-cavil,cavil,词,VERB,C1
-cavort,cavort,词,VERB,C1
-caída de agua,water falling,水落,NOUN,B2
+comida enlatada,canned food,罐头食品,NOUN,B2
+no poder,cannot,不能,AUX,B2
+no soportar,to cannot bear,不堪,VERB,B2
+no poder evitar,to cannot help,忍不住,VERB,B2
 cañón,canyon,峡谷,NOUN,B2
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-cede,cede,词,VERB,C1
+capacidad,capability,能力,NOUN,B2
+capa,cape,海角,NOUN,B2
+capital,capital,首都,NOUN,B2
+accidente de coche,car accident,车祸,NOUN,B2
+seguro de automóvil,car insurance,车险,NOUN,B2
+caravana,caravan,房车,NOUN,B2
+carbono,carbon,碳,NOUN,B2
+impuesto sobre el carbono,carbon tax,碳税,NOUN,B2
+importar,to care,照顾,VERB,B2
+cuidar,to care for,照顾,VERB,B2
+cuidador,caregiver,护理人员,NOUN,B2
+conserje,caretaker,房屋管理员,NOUN,B2
+carga,cargo,货物,NOUN,B2
+caricaturesco,caricatural,漫画的,ADJ,B2
+caricatura,caricature,讽刺画,NOUN,B2
+carnaval,carnival,狂欢节,NOUN,B2
+carpintero,carpenter,木匠,NOUN,B2
+alfombra,carpet,地毯,NOUN,B2
+carruaje,carriage,马车,NOUN,B2
+transportista,carrier,承运人,NOUN,B2
+arrastrar,to carry forward,发扬,VERB,B2
+cobrar,to cash,兑现,VERB,B2
+caja registradora,cash register,收银机,NOUN,B2
+anacardo,cashew,腰果,NOUN,B2
+cachemir,cashmere,羊绒,NOUN,B2
+yuca,cassava,木薯,NOUN,B2
+informal,casual,随意的,ADJ,B2
+catalizador,catalyst,催化剂,NOUN,B2
+captura,catch,捕捉,NOUN,B2
+ponerse al día,to catch up,赶上,VERB,B2
+coliflor,cauliflower,花椰菜,NOUN,B2
+causalidad,causation,因果关系,NOUN,B2
+causa de muerte,cause of death,死因,NOUN,B2
+precaución,caution,谨慎,NOUN,B2
+cauteloso y concienzudo,cautious and conscientious,兢兢业业,ADJ,B2
+caballería,cavalry,骑兵,NOUN,B2
+techo,ceiling,天花板,NOUN,B2
 celebridad,celebrity,名人,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial (noun),celestial,词,NOUN,B2
-celestial body,celestial body,词,NOUN,B2
+apio,celery,芹菜,NOUN,B2
 celibato,celibacy,独身,NOUN,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
-cellulose,cellulose,纤维素,NOUN,B2
+teléfono celular,cell phone,手机,NOUN,B2
 celular,cellular,细胞的,ADJ,B2
 cemento,cement,水泥,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-censure (verb),censure,词,VERB,C1
-centenary,centenary,词,NOUN,C1
-centime,centime,词,NOUN,B2
-centinela,sentry,卫兵,NOUN,B2
-cento,cento,词,NOUN,C1
 central,central,中心的,ADJ,B2
-central station,central station,中央车站,NOUN,B2
-centrality,centrality,词,NOUN,C1
 centralización,centralization,集中化,NOUN,B2
-centre,centre,词,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-centro comercial,shopping center,购物中心,NOUN,B2
+fuerza centrífuga,centrifugal force,离心力,NOUN,B2
 centrífuga,centrifuge,离心机,NOUN,B2
-century-old,century-old,世纪的,ADJ,B2
-ceo,ceo,首席执行官,NOUN,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
-cercano,close,近的,ADJ,B2
-cercano,near,近,ADJ,B2
-cercanía,nearby,在附近,ADV,B2
-cercanía,closeness,接近,NOUN,B2
-cereal,cereal,词,NOUN,B2
-cerebral,cerebral,大脑的,ADJ,B2
-ceremonia de clausura,closing ceremony,闭幕仪式,NOUN,B2
-ceremonia de inauguración,unveiling ceremony,揭幕仪式,NOUN,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
-cerrar,to close account,销户,VERB,B2
-cerrar,to close the door,关门,VERB,B2
-certain,certain,某些,DET,B2
-certain fall,certain fall,必倒,NOUN,B2
-certainly,certainly,当然,INTJ,B2
+gorro ceremonial,ceremonial cap,爵弁,NOUN,B2
+cierto,certain,确定的,ADJ,B2
+ciertamente,certainly,当然,ADV,B2
 certificado de mérito,certificate of merit,奖状,NOUN,B2
 certificar,to certify,证明,VERB,B2
-certification,certification,认证,NOUN,C1
-cervecería,brewery,啤酒厂,NOUN,B2
-cerámica,pottery,陶器,NOUN,B2
-cessation passing,cessation passing,消亡,NOUN,C1
-chain (adj),chain,词,ADJ,C1
-chain mail,chain mail,锁子甲,NOUN,B2
-chain of transmission,chain of transmission,词,NOUN,C1
-chalet,chalet,词,NOUN,B1
-chalice,chalice,词,NOUN,C1
-challenges,challenges,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
-chamberlain,chamberlain,词,NOUN,C1
+presidente,chairman,主席,NOUN,B2
+presidente,chairperson,主席,NOUN,B2
+tiza,chalk,粉笔,NOUN,B2
+cámara,chamber,房间,NOUN,B2
 champaña,champagne,香槟,NOUN,B2
-champú,shampoo,洗发水,NOUN,B2
-chance opportunity,chance opportunity,词,NOUN,A2
-chancery,chancery,词,NOUN,C1
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change exchange,change exchange,改变/交换,NOUN,B2
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chant,chant,词,VERB,C1
-chants,chants,词,NOUN,B2
-chaperon,chaperon,词,NOUN,C1
-chaplain,chaplain,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-character assassination,character assassination,人格谋杀,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charades,charades,打哑谜,NOUN,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
-charismatic,charismatic,有魅力的,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
-charmer,charmer,词,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
-chasten,chasten,词,VERB,C1
-chastity probity,chastity probity,词,NOUN,C1
-chatter (noun),chatter,词,NOUN,A2
-chauffeur,chauffeur,词,NOUN,C1
-chauvinism,chauvinism,沙文主义,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheaper,cheaper,更便宜的,ADJ,B2
-cheapness,cheapness,廉价,NOUN,B2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checkbook,checkbook,支票簿,NOUN,B2
-checked,checked,词,ADJ,C1
-checkers,checkers,词,NOUN,A2
-checkmark,checkmark,词,NOUN,C1
-checkmate,checkmate,词,NOUN,C1
-cheekbone,cheekbone,词,NOUN,C1
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
-cheers,cheers,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
-chemical,chemical,化学品,NOUN,B2
-chemicals,chemicals,词,NOUN,C1
-chemist,chemist,词,NOUN,C1
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
-chest breast,chest breast,胸部/乳房,NOUN,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chiasmus,chiasmus,词,NOUN,C1
-chic (adj),chic,词,ADJ,C1
-chic (noun),chic,词,NOUN,C1
-chica tonta,silly girl,傻丫头,NOUN,B2
-chickpeas,chickpeas,词,NOUN,A2
-chicle,gum,牙龈,NOUN,B2
-chide,chide,词,VERB,C1
-chief physician,chief physician,主任医师,NOUN,B2
-chiefly,chiefly,主要地,ADV,B2
-chieftain,chieftain,酋长,NOUN,B2
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childbirth,childbirth,分娩,NOUN,B2
-childcare,childcare,词,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
-chili,chili,辣椒,NOUN,B2
-chill,chill,放松,ADJ,B2
-chill (noun),chill,词,NOUN,B1
-chime,chime,词,NOUN,C1
+canciller,chancellor,总理,NOUN,B2
+candelabro,chandelier,吊灯,NOUN,B2
+cambiar,to change tire,换胎,VERB,B2
+política modificada,changed policy,改策,NOUN,B2
+palabra de carácter,character word,字,NOUN,B2
+característico,characteristic,典型的,ADJ,B2
+carbón,charcoal,木炭,NOUN,B2
+carga,charge,收费,NOUN,B2
+cargador,charger,充电器,NOUN,B2
+carisma,charisma,个人魅力,NOUN,B2
+gráfico,chart,图表,NOUN,B2
+carta,charter,宪章,NOUN,B2
+persecución,chase,追逐,NOUN,B2
+engañar,to cheat,欺骗,VERB,B2
+caja,checkout,收银台,NOUN,B2
+mejilla,cheek,脸颊,NOUN,B2
+desvergonzado,cheeky,厚颜无耻的,ADJ,B2
+animar,to cheer,欢呼,VERB,B2
+animarse,to cheer up,使高兴,VERB,B2
+alegre,cheerful,愉快的,ADJ,B2
+salud,cheers,干杯,INTJ,B2
+químico,chemical,化学的,ADJ,B2
+química,chemistry,化学,NOUN,B2
+atesorar,to cherish,珍爱,VERB,B2
+ajedrez,chess,国际象棋,NOUN,B2
+dolor de pecho,chest pain,胸痛,NOUN,B2
+castaña,chestnut,板栗,NOUN,B2
+masticar,to chew,咀嚼,VERB,B2
+pollito,chick,小鸡,NOUN,B2
+niño,child,儿童,NOUN,B2
 chimenea,chimney,烟囱,NOUN,B2
-chinese,chinese,中国的,ADJ,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
-chinese language,chinese language,华文,NOUN,B2
-chino de ultramar,overseas chinese,华侨,NOUN,B2
-chips,chips,薯片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chitchat,chitchat,词,NOUN,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
+mentón,chin,下巴,NOUN,B2
+papa frita,chip,碎片,NOUN,B2
 chocolate,chocolate,巧克力,NOUN,B2
-choke,choke,词,VERB,B2
-cholera,cholera,词,NOUN,C1
-chomp,chomp,词,VERB,C1
-chop (noun),chop,砍了,NOUN,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-chore,chore,家务,NOUN,B2
-choreograph,choreograph,词,VERB,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreographic,choreographic,词,ADJ,C1
-choreography,choreography,词,NOUN,C1
-chortle,chortle,词,VERB,C1
-christen,christen,词,VERB,C1
-christianity,christianity,基督教,NOUN,B2
-christianization,christianization,词,NOUN,C1
-christmas eve,christmas eve,平安夜,NOUN,B2
-christmas porridge,christmas porridge,,NOUN,B2
-christmas present,christmas present,圣诞礼物,NOUN,B2
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronological,chronological,词,ADJ,C1
-chronology,chronology,年表,NOUN,B2
-chubasquero,raincoat,雨衣,NOUN,B2
-chubby,chubby,胖子,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-chupar,to suck,吸,VERB,B2
-church community,church community,教会,NOUN,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn,churn,词,VERB,C1
-churn skin,churn skin,词,NOUN,B2
+colesterol,cholesterol,胆固醇,NOUN,B2
+cortar,chop,砍,NOUN,B2
+cortar,to chop,砍,VERB,B2
+Navidad,christmas,圣诞节,NOUN,B2
+cromosoma,chromosome,染色体,NOUN,B2
+cigarrillo,cigarette,香烟,NOUN,B2
+circuncisión,circumcision,割礼,NOUN,B2
+citación,citation,引用,NOUN,B2
+civil,civil,民事的,ADJ,B2
+civil,civilian,平民,NOUN,B2
+reclamo,claim,要求,NOUN,B2
+abrazadera,clamp,夹钳,NOUN,B2
+clan,clan,家族,NOUN,B2
+aplaudir,to clap,拍手,VERB,B2
+clásico,classic,经典作品,NOUN,B2
+clásico,classical,古典的,ADJ,B2
+clasicismo,classicism,古典主义,NOUN,B2
+pieza,classifier for paintings cloth etc.,幅,NUM,B2
+unidad,classifier for trees,棵,NUM,B2
+cláusula,clause,从句,NOUN,B2
+arcilla,clay,黏土,NOUN,B2
+limpiar,to clean up,清理,VERB,B2
+limpieza,cleansing,清洗,NOUN,B2
+conocimiento,clear knowledge,明知,NOUN,B2
+sopa,clear soup,江瑶清羹,NOUN,B2
+inequívoco,clear-cut,明确的,ADJ,B2
+despeje,clearing,林中空地,NOUN,B2
+claramente delimitado,clearly demarcated,分明,ADJ,B2
+clero,clergy,神职人员,NOUN,B2
+ingenioso,clever,聪明的,ADJ,B2
+cliché,cliche,陈词滥调,NOUN,B2
+cliente,client,客户,NOUN,B2
+clientelismo,clientelism,庇护主义,NOUN,B2
+acantilado,cliff,悬崖,NOUN,B2
+clima,climate,气候,NOUN,B2
+cambio climático,climate change,气候变化,NOUN,B2
+clímax,climax,高潮,NOUN,B2
+adherirse,to cling,紧贴,VERB,B2
+clip,clip,夹子,NOUN,B2
+guardarropa,cloakroom,衣帽间,NOUN,B2
+clon,clone,克隆体,NOUN,B2
+cercano,close,近的,ADJ,B2
+cerrar,to close account,销户,VERB,B2
+cerrar,to close the door,关门,VERB,B2
+cercanía,closeness,接近,NOUN,B2
+armario,closet,壁橱,NOUN,B2
+ceremonia de clausura,closing ceremony,闭幕仪式,NOUN,B2
+coágulo,clot,凝块,NOUN,B2
+tela,cloth,布,NOUN,B2
+nublado,cloudy,阴沉的,ADJ,B2
+payaso,clown,小丑,NOUN,B2
+club,club,俱乐部,NOUN,B2
+cúmulo,cluster,簇,NOUN,B2
+entrenar,to coach,辅导,VERB,B2
+persuasión,coaxing,哄得,NOUN,B2
+cocaína,cocaine,可卡因,NOUN,B2
+coeficiente,coefficient,系数,NOUN,B2
+sangre fría,cold blood,冷血,NOUN,B2
+ola de frío,cold wave,寒潮,NOUN,B2
+fríamente,coldly,冷淡地,ADV,B2
+colaborador,collaborator,合作者,NOUN,B2
+collar,collar,衣领,NOUN,B2
+colectivo,collective,集体的,ADJ,B2
+colisionar,to collide,碰撞,VERB,B2
+coludir,to collude,勾结,VERB,B2
+colon,colon,冒号,NOUN,B2
+colonialismo,colonialism,殖民主义,NOUN,B2
+colorear,color,颜色,NOUN,B2
+colorear,to color,着色,VERB,B2
+coma,coma,昏迷,NOUN,B2
+peinar,comb,梳子,NOUN,B2
+peinar,to comb,梳头,VERB,B2
+combatir,to combat,对抗,VERB,B2
+combate,combating,打击,NOUN,B2
+acompañar,to come along,一起来,VERB,B2
+volver,to come back,回来,VERB,B2
+provenir,to come from,来自,VERB,B2
+venir,to come here,来到这里,VERB,B2
+entrar,to come in,进来,VERB,B2
+salir,to come out,出来,VERB,B2
+pasar,to come over,顺道来访,VERB,B2
+subir,to come up,出现,VERB,B2
+comediante,comedian,喜剧演员,NOUN,B2
+comet,comet,彗星,NOUN,B2
+coming,coming,مجيء,NOUN,B2
+coming and going,coming and going,往来,NOUN,B2
+command,to command,命令,VERB,B2
+command room,command room,指挥室,NOUN,B2
+commentator,commentator,评论员,NOUN,B2
+commerce,commerce,商业,NOUN,B2
+commissioner,commissioner,专员,NOUN,B2
+committed,committed,投入的,ADJ,B2
+commodity,commodity,商品,NOUN,B2
+commonality,commonality,共同点,NOUN,B2
+commotion,commotion,骚动,NOUN,B2
+communism,communism,共产主义,NOUN,B2
+communist,communist,شيوعي,ADJ,B2
+communitarianism,communitarianism,社群主义,NOUN,B2
+companion,companion,同伴,NOUN,B2
+companionship,companionship,陪伴,NOUN,B2
+compensatory leave,compensatory leave,调休,NOUN,B2
+competence,competence,能力,NOUN,B2
+competitor,competitor,竞争者,NOUN,B2
+complaint,complaint,投诉,NOUN,B2
+completion,completion,完成,NOUN,B2
+complexity,complexity,复杂性,NOUN,B2
+compliant,compliant,符合的,ADJ,B2
+complicit,complicit,共谋的,ADJ,B2
+comply,to comply,遵守,VERB,B2
+composed,composed,稳重的,ADJ,B2
+composer,composer,作曲家,NOUN,B2
+compost,compost,堆肥,NOUN,B2
+compound,compound,复合性,ADJ,B2
+comprehend,to comprehend,理解,VERB,B2
+comprehension,comprehension,理解,NOUN,B2
+comprehensive,comprehensive,全面的,ADJ,B2
+compressor,compressor,压缩机,NOUN,B2
+compromise,compromise,妥协,NOUN,B2
+compromise,to compromise,危及,VERB,B2
+computing,computing,计算机科学,NOUN,B2
+conceal,to conceal,隐藏,VERB,B2
+concern,concern,担忧,NOUN,B2
+condemnation,condemnation,谴责,NOUN,B2
+condense,to condense,浓缩,VERB,B2
+conditional,conditional,条件的,ADJ,B2
+condolences,condolences,哀悼,NOUN,B2
+conduct,conduct,行为,NOUN,B2
+conduct,to conduct,أجرى,VERB,B2
+cone,cone,圆锥体,NOUN,B2
+confidentiality,confidentiality,保密性,NOUN,B2
+configuration,configuration,配置,NOUN,B2
+conformism,conformism,因循守旧,NOUN,B2
+coniferous forest,coniferous forest,针叶林,NOUN,B2
+conjugation,conjugation,变位,NOUN,B2
+connected,connected,连接的,ADJ,B2
+consciousness,consciousness,意识,NOUN,B2
+consecutive cards,consecutive cards,连牌,NOUN,B2
+consequently,consequently,因此,ADV,B2
+conservation,conservation,保护,NOUN,B2
+conservative,conservative,保守的,ADJ,B2
+considerable,considerable,相当大的,ADJ,B2
+considerate,considerate,体贴,ADJ,B2
+consort,consort,福晋,NOUN,B2
+constant,constant,常数,NOUN,B2
+constantly,constantly,不断地,ADV,B2
+constitution,constitution,宪法,NOUN,B2
+constitutional,constitutional,宪法的,ADJ,B2
+constitutionality,constitutionality,合宪性,NOUN,B2
+construct,to construct,建造,VERB,B2
+construction site,construction site,工地,NOUN,B2
+constructive,constructive,建设性的,ADJ,B2
+consular,consular,领事的,ADJ,B2
+consult reference,to consult reference,参考,VERB,B2
+consultor,consultant,顾问,NOUN,B2
+consulta,consultation,咨询,NOUN,B2
+consumidor,consumer,消费者,NOUN,B2
+contactar,to contact,联系,VERB,B2
+contaminar,to contaminate,污染,VERB,B2
+satisfacción,contentment,满足,NOUN,B2
+concurso,contest,比赛,NOUN,B2
+contextual,contextual,语境的,ADJ,B2
+continuación,continuation,延续,NOUN,B2
+continuidad,continuity,连续性,NOUN,B2
+contrario,contrary,反而,NOUN,B2
+intención contraria,contrary intention,反意,NOUN,B2
+control,control,控制,NOUN,B2
+sala de control,control room,控制室,NOUN,B2
+contrariamente,conversely,相反地,ADV,B2
+transmitir,to convey,传达,VERB,B2
+condenar,to convict,定罪,VERB,B2
+convencido,convinced,确信的,ADJ,B2
+albóndiga cocida,cooked meatball,丸子熟,NOUN,B2
+arroz cocido,cooked rice,米饭,NOUN,B2
+olla,cooking pot,炖锅,NOUN,B2
+enfriar,to cool down,冷却,VERB,B2
+cooperar,to cooperate,合作,VERB,B2
+cooperación,cooperation,合作,NOUN,B2
+coordenada,coordinate,坐标,NOUN,B2
+coordinador,coordinator,协调员,NOUN,B2
+policía,cop,警察,NOUN,B2
+derechos de autor,copyright,版权,NOUN,B2
+coral,coral,珊瑚,NOUN,B2
+núcleo,core,核心,NOUN,B2
+corcho,cork,软木塞,NOUN,B2
+maíz,corn,玉米,NOUN,B2
+coronación,coronation,加冕,NOUN,B2
+corredor,corridor,走廊,NOUN,B2
+corrupto,corrupt,腐败的,ADJ,B2
+disfraz,costume,戏服,NOUN,B2
+toser,cough,咳嗽,NOUN,B2
+toser,to cough,咳嗽,VERB,B2
+asesoramiento,counseling,咨询,NOUN,B2
+contar,to count as,算,VERB,B2
+contrarrestar,counter,柜台,NOUN,B2
+contrarrestar,to counter,反击,VERB,B2
+contraforma,counter-form,反式,NOUN,B2
+contralógica,counter-logic,反逻,NOUN,B2
+antimateria,counter-matter,反物,NOUN,B2
+contramecanismo,counter-mechanism,反机,NOUN,B2
+contramodelo,counter-model,反模,NOUN,B2
+contraobservación,counter-observation,反察,NOUN,B2
+contracalidad,counter-quality,反质,NOUN,B2
+contraruta,counter-route,反途,NOUN,B2
+contrahabilidad,counter-skill,反技,NOUN,B2
+contrasuela,counter-sole,反唯,NOUN,B2
+contraestructura,counter-structure,反结,NOUN,B2
+contrasistema,counter-system,反系,NOUN,B2
+contratécnica,counter-technique,反术,NOUN,B2
+contratendencia,counter-trend,反势,NOUN,B2
+contratipo,counter-type,反型,NOUN,B2
+falso,counterfeit,假冒,ADJ,B2
+contraparte,counterpart,对应的人或物,NOUN,B2
+condesa,countess,女伯爵,NOUN,B2
+incontable,countless,无数的,ADJ,B2
+condado,county,县,NOUN,B2
+distico,couplet,对联,NOUN,B2
+desestimación,court dismissal,退朝,NOUN,B2
+pacto,covenant,契约,NOUN,B2
+codicia,covetousness,贪欲,NOUN,B2
+cobarde,coward,懦夫,NOUN,B2
+cobarde,cowardly,懦弱的,ADJ,B2
+acogedor,cozy,舒适的,ADJ,B2
+oficio,craft,工艺,NOUN,B2
+artesano,craftsman,工匠,NOUN,B2
+artesanía,craftsmanship,手工艺,NOUN,B2
+caja,crate,板条箱,NOUN,B2
+anhelar,to crave,渴望,VERB,B2
+gatear,to crawl,爬行,VERB,B2
+creativo,creative,有创造力的,ADJ,B2
+creatividad,creativity,创造力,NOUN,B2
+creador,creator,创造者,NOUN,B2
+credibilidad,credibility,可信度,NOUN,B2
+tarjeta de crédito,credit card,信用卡,NOUN,B2
+derecho del acreedor,creditor's right,债权,NOUN,B2
+escena del crimen,crime scene,犯罪现场,NOUN,B2
+criminalizar,to criminalize,定罪,VERB,B2
+crisis,crisis,危机,NOUN,B2
+crítico,critic,评论家,NOUN,B2
+criticidad,criticality,临界性,NOUN,B2
+torcido,crooked,弯曲的,ADJ,B2
+cultivo,crop,庄稼,NOUN,B2
+cruce,crossing,交叉口,NOUN,B2
+cuervo,crow,乌鸦,NOUN,B2
+multitud,crowd,人群,NOUN,B2
+crucial,crucial,至关重要的,ADJ,B2
+cruel,cruel,残忍的,ADJ,B2
+crujir,to crunch,嘎吱作响,VERB,B2
+derrota aplastante,crushing defeat,惨败,NOUN,B2
+muleta,crutch,拐杖,NOUN,B2
+llanto,crying,,NOUN,B2
+cristal,crystal,水晶,NOUN,B2
+cachorro,cub,幼兽,NOUN,B2
+cubo,cube,立方体,NOUN,B2
+cubismo,cubism,立体主义,NOUN,B2
+pepino,cucumber,黄瓜,NOUN,B2
+cultural,cultural,文化的,ADJ,B2
+reliquia cultural,cultural relic,文物,NOUN,B2
+astucia,cunning,诡计,NOUN,B2
+contener,to curb,抑制,VERB,B2
+moneda,currency,货币,NOUN,B2
+dinastía actual,current dynasty,当朝,NOUN,B2
+actualmente,currently,目前,ADV,B2
+currículo,curriculum,课程,NOUN,B2
+maldecir,curse,诅咒,NOUN,B2
+maldecir,to curse,诅咒,VERB,B2
+varilla de cortina,curtain rod,窗帘杆,NOUN,B2
+cortar,to cut off,切断,VERB,B2
+tierno,cute,可爱的,ADJ,B2
 cianosis,cyanosis,发绀,NOUN,B2
 ciber,cyber,网络的,ADJ,B2
 ciberseguridad,cybersecurity,网络安全,NOUN,B2
 ciclar,to cycle,骑自行车,VERB,B2
-cider,cider,苹果酒,NOUN,B2
-cielo,heaven,天堂,NOUN,B2
-cielo estrellado,starry sky,星空,NOUN,B2
-científico,scientific,科学的,ADJ,B2
-ciertamente,certainly,当然,ADV,B2
-cierto,certain,确定的,ADJ,B2
-ciervo,buck,美元,NOUN,B2
-cigarette butt,cigarette butt,烟头,NOUN,B2
-cigarrillo,cigarette,香烟,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cilindro,cylinder,圆柱体,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinematographic,cinematographic,电影的,ADJ,B2
-cinético,kinetic,运动的,ADJ,B2
-circular (adj),circular,词,ADJ,C1
-circular (noun),circular,词,NOUN,B2
-circulating,circulating,词,ADJ,B2
-circumference,circumference,词,NOUN,C1
-circumscription,circumscription,词,NOUN,C1
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circumvent,circumvent,词,VERB,C1
-circuncisión,circumcision,割礼,NOUN,B2
-circunstancias favorables,favorable circumstances,顺境,NOUN,B2
-ciruela,plum,李子,NOUN,B2
-cita,quotation,报价,NOUN,B2
-cita,rendezvous,约会,NOUN,B2
-citación,citation,引用,NOUN,B2
-citadel,citadel,词,NOUN,C1
-citas,dating,年代测定,NOUN,B2
-citizenship right,citizenship right,公民权,NOUN,B2
-citrus,citrus,柑橘,NOUN,B2
-city centre,city centre,市中心,NOUN,B2
-city council,city council,市议会,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic,civic,词,ADJ,C1
-civil,civil,民事的,ADJ,B2
-civil,civilian,平民,NOUN,B2
-civil war,civil war,内战,NOUN,B2
-civilian,civilian,平民的,ADJ,B2
-civilisation,civilisation,文明,NOUN,B2
-civility,civility,礼貌,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clamber,clamber,词,VERB,C1
-clampdown,clampdown,词,NOUN,C1
-clan,clan,家族,NOUN,B2
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestinity,clandestinity,秘密状态,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clapping,clapping,词,NOUN,B2
-claramente delimitado,clearly demarcated,分明,ADJ,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarify doubts,clarify doubts,释疑,VERB,B2
-clarity evidentness,clarity evidentness,词,NOUN,C1
-clase social,social class,社会阶层,NOUN,B2
-clash (noun),clash,词,NOUN,C1
-clasicismo,classicism,古典主义,NOUN,B2
-clasificar,to sort,分类,VERB,B2
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-class test,class test,词,NOUN,B1
-classic (noun),classic,经典,NOUN,C1
-classical poetry,classical poetry,词,NOUN,C1
-classicist,classicist,古典主义的,ADJ,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
-classwork,classwork,课堂作业,NOUN,B2
-clatter,clatter,哗啦声,NOUN,C1
-clauses,clauses,词,NOUN,C1
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner,cleaner,更干净的,ADJ,B2
-cleaner (noun),cleaner,清洁剂,NOUN,B2
-cleaning,cleaning,清洁,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanly,cleanly,干净地,ADV,B2
-cleanse,cleanse,词,VERB,C1
-cleanup,cleanup,清理,NOUN,C1
-clear,clear,当然,ADV,B2
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
-clear limpid,clear limpid,词,ADJ,C1
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
-clearance,clearance,词,NOUN,C1
-clearing of the throat,clearing of the throat,词,NOUN,C1
-clench,clench,词,VERB,C1
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
-clero,clergy,神职人员,NOUN,B2
-cliché,cliche,陈词滥调,NOUN,B2
-click (noun),click,词,NOUN,C1
-clickbait,clickbait,词,NOUN,C1
-cliente,client,客户,NOUN,B2
-clientelismo,clientelism,庇护主义,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-clima,climate,气候,NOUN,B2
-climate denial,climate denial,气候否认,NOUN,B2
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
-climbing,climbing,词,NOUN,B1
-clinch,clinch,词,VERB,C1
-clink,clink,词,NOUN,C1
-clinking,clinking,词,NOUN,C1
-clip,clip,夹子,NOUN,B2
-clipping,clipping,词,NOUN,C1
-clobber,clobber,词,VERB,C1
-clock watch,clock watch,钟表,NOUN,B2
-clog (noun),clog,词,NOUN,B2
-clog (verb),clog,词,VERB,C1
-cloister,cloister,回廊,NOUN,B2
-clon,clone,克隆体,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
-close a case,close a case,结案,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
-close well,close well,关好,NOUN,C1
-closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
-closedness,closedness,封闭,NOUN,C1
-closely,closely,紧密地,ADV,B2
-closer,closer,更近的,ADJ,B2
-closer (adv),closer,词,ADV,B2
-closing,closing,词,NOUN,B2
-closing argument,closing argument,辩护词,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-clouds,clouds,云,NOUN,B1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
-club,club,俱乐部,NOUN,B2
-cluck,cluck,词,NOUN,C1
-clueless,clueless,词,ADJ,C1
-clump,clump,词,NOUN,C1
-clumsily,clumsily,笨拙地,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-clunky,clunky,词,ADJ,C1
-clutter,clutter,词,NOUN,C1
-clásico,classical,古典的,ADJ,B2
-clásico,classic,经典作品,NOUN,B2
-cláusula,clause,从句,NOUN,B2
-clímax,climax,高潮,NOUN,B2
-co-,co-,共同,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-determination,co-determination,共同决定权,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-occurrence,co-occurrence,词,NOUN,C1
-co-ownership,co-ownership,共有产权,NOUN,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coalesce,coalesce,词,VERB,C1
-coarse rough,coarse rough,词,ADJ,C1
-coastal,coastal,沿海的,ADJ,B2
-coastal (noun),coastal,词,NOUN,B2
-coastline,coastline,词,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-cobarde,cowardly,懦弱的,ADJ,B2
-cobarde,coward,懦夫,NOUN,B2
-cobble,cobble,词,VERB,C1
-cobbler,cobbler,词,NOUN,B2
-cobrar,to cash,兑现,VERB,B2
-cocaína,cocaine,可卡因,NOUN,B2
-coche a control remoto,remote-controlled car,遥控车,NOUN,B2
-coche deportivo,sports car,跑车,NOUN,B2
-cock,cock,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-coddle,coddle,词,VERB,C1
-code of conduct,code of conduct,词,NOUN,C1
-codicia,covetousness,贪欲,NOUN,B2
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-codorniz,quail,鹌鹑,NOUN,B2
-coeficiente,coefficient,系数,NOUN,B2
-coffee maker,coffee maker,词,NOUN,A2
-cog,cog,词,NOUN,C1
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cogito,cogito,词,NOUN,C1
-cognac,cognac,干邑,NOUN,B2
-cognizance,cognizance,词,NOUN,C1
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-cohete,rocket,火箭,NOUN,B2
-cohort,cohort,队列,NOUN,B2
-cohort-based,cohort-based,队列的,ADJ,B2
-coil (noun),coil,词,NOUN,C1
-coin purse,coin purse,零钱包,NOUN,B2
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coke,coke,可卡因,NOUN,B2
-col,cabbage,卷心菜,NOUN,B2
-cola,cola,可乐,NOUN,B2
-cola,tail,尾巴,NOUN,B2
-colaborador,collaborator,合作者,NOUN,B2
-colarse,to sneak,潜行,VERB,B2
-colcha,quilt,被子,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold weather,cold weather,天冷,NOUN,C1
-colder,colder,更冷的,ADJ,B2
-coldness,coldness,词,NOUN,B2
-colectivo,collective,集体的,ADJ,B2
-colesterol,cholesterol,胆固醇,NOUN,B2
-colgar,to hang up,挂断,VERB,B2
-colic,colic,词,NOUN,C1
-coliflor,cauliflower,花椰菜,NOUN,B2
-colinas,hills,丘陵,NOUN,B2
-colisionar,to collide,碰撞,VERB,B2
-collar,collar,衣领,NOUN,B2
-collar,necklace,项链,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,收集的,ADJ,B2
-collectie,collectie,收藏,NOUN,B2
-collections,collections,词,NOUN,C1
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-collectivization,collectivization,集体化,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
-college,college,学院,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiality,collegiality,词,NOUN,C1
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial language,colloquial language,词,NOUN,C1
-colocación,placement,放置,NOUN,B2
-colon,colon,冒号,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
-colonial,colonial,词,ADJ,C1
-colonial settlers,colonial settlers,词,NOUN,C1
-colonialismo,colonialism,殖民主义,NOUN,B2
-colonist,colonist,词,NOUN,B2
-colonizing,colonizing,词,ADJ,C1
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
-colony,colony,殖民地,NOUN,B2
-colorear,color,颜色,NOUN,B2
-colorear,to color,着色,VERB,B2
-colored,colored,有色的,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
-coloring,coloring,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-coludir,to collude,勾结,VERB,B2
-columna vertebral,backbone,脊梁,NOUN,B2
-columnar,columnar,词,ADJ,C1
-columnist,columnist,词,NOUN,C1
-columpio,swing,秋千,NOUN,B2
-colusión de licitación,bid collusion,串标,NOUN,B2
-coma,coma,昏迷,NOUN,B2
-combate,combating,打击,NOUN,B2
-combatir,to combat,对抗,VERB,B2
-combinations,combinations,词,NOUN,C1
-combinatorial,combinatorial,组合的,ADJ,B2
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combining,combining,结合的,ADJ,B2
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
-come on,come on,词,INTJ,C1
-comediante,comedian,喜剧演员,NOUN,B2
-comentario,remark,评论,NOUN,B2
-comer,comer,词,NOUN,C1
-comet,comet,彗星,NOUN,B2
-cometa,kite,风筝,NOUN,B2
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comforted,comforted,宽慰,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comicness,comicness,词,NOUN,C1
-comida,meal,一餐,NOUN,B2
-comida enlatada,canned food,罐头食品,NOUN,B2
-coming,coming,مجيء,NOUN,B2
-coming (adj),coming,即将到来的,ADJ,C1
-coming and going,coming and going,往来,NOUN,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma,comma,逗号,PUNCT,B2
-command,to command,命令,VERB,B2
-command room,command room,指挥室,NOUN,B2
-commandeer,commandeer,词,VERB,C1
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
-commandment,commandment,词,NOUN,C1
-commence,commence,词,VERB,B2
-commencement,commencement,开始,NOUN,B2
-commend,commend,词,VERB,C1
-commendation,commendation,词,NOUN,C1
-commensurability,commensurability,词,NOUN,C1
-commentaries,commentaries,词,NOUN,C1
-commentator,commentator,评论员,NOUN,B2
-commerce,commerce,商业,NOUN,B2
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commiserate,commiserate,词,VERB,C1
-commissioner,commissioner,专员,NOUN,B2
-commitments,commitments,词,NOUN,C1
-committed,committed,投入的,ADJ,B2
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commodification,commodification,词,NOUN,C1
-commodity,commodity,商品,NOUN,B2
-common good,common good,词,NOUN,B2
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
-commonality,commonality,共同点,NOUN,B2
-commonly,commonly,词,ADV,C1
-commonplace,commonplace,词,ADJ,C1
-commotion,commotion,骚动,NOUN,B2
-communal work,communal work,词,NOUN,C1
-communautarization,communautarization,社群化,NOUN,B2
-communes,communes,词,NOUN,C1
-communicativeness,communicativeness,词,NOUN,C1
-communism,communism,共产主义,NOUN,B2
-communist,communist,شيوعي,ADJ,B2
-communist (noun),communist,共产主义者,NOUN,C1
-communitarian,communitarian,词,ADJ,C1
-communitarianism,communitarianism,社群主义,NOUN,B2
-community-related,community-related,社区的,ADJ,B2
-commuter,commuter,词,NOUN,A2
-como,as,作为,SCONJ,B2
-como si,as if,仿佛,ADV,B2
-comorbidity,comorbidity,共病,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-companion,companion,同伴,NOUN,B2
-companionship,companionship,陪伴,NOUN,B2
-comparability,comparability,词,NOUN,C1
-comparative,comparative,比较的,ADJ,B2
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
-compartmental,compartmental,词,ADJ,C1
-compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
-compatible,compatible,词,ADJ,C1
-compañero,fellow,家伙,NOUN,B2
-compañero de equipo,teammate,队友,NOUN,B2
-compañero de juegos,playmate,玩伴,NOUN,B2
-compañero de piso,roommate,室友,NOUN,B2
-compelling,compelling,词,ADJ,C1
-compensar,to make up for,弥补,VERB,B2
-compensatory leave,compensatory leave,调休,NOUN,B2
-competence,competence,能力,NOUN,B2
-competencies,competencies,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competition bastard,competition bastard,,NOUN,B2
-competitive,competitive,竞争的,ADJ,B2
-competitive exam,competitive exam,词,NOUN,B2
-competitor,competitor,竞争者,NOUN,B2
-complaint,complaint,投诉,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complementarity,complementarity,互补性,NOUN,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
-completion,completion,完成,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex,complex,建筑群,NOUN,B2
-complexity,complexity,复杂性,NOUN,B2
-compliant,compliant,符合的,ADJ,B2
-complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
-complicit,complicit,共谋的,ADJ,B2
-comply,to comply,遵守,VERB,B2
-composable,composable,可组合的,ADJ,B2
-composed,composed,稳重的,ADJ,B2
-composer,composer,作曲家,NOUN,B2
-compositional,compositional,词,ADJ,C1
-compost,compost,堆肥,NOUN,B2
-compostable,compostable,可堆肥的,ADJ,B2
-compound,compound,复合性,ADJ,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
-comprador,buyer,买家,NOUN,B2
-comprar,to purchase,购买,VERB,B2
-comprar,to shop,购物,VERB,B2
-compras,shopping,购物,NOUN,B2
-comprehend,to comprehend,理解,VERB,B2
-comprehensibility,comprehensibility,词,NOUN,C1
-comprehension,comprehension,理解,NOUN,B2
-comprehensive,comprehensive,全面的,ADJ,B2
-comprensible,understandable,可理解的,ADJ,B2
-compressed,compressed,词,ADJ,C1
-compressibility,compressibility,词,NOUN,C1
-compressible,compressible,词,ADJ,C1
-compressor,compressor,压缩机,NOUN,B2
-comprise,comprise,词,VERB,C1
-compromise,compromise,妥协,NOUN,B2
-compromise,to compromise,危及,VERB,B2
-compromiso social,social compromise,社会妥协,NOUN,B2
-compulsion,compulsion,词,NOUN,C1
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compurgation oath,compurgation oath,词,NOUN,C1
-computability,computability,词,NOUN,C1
-computer mouse,computer mouse,词,NOUN,B1
-computer program,computer program,电脑程序,NOUN,B2
-computer specialist,computer specialist,计算机专家,NOUN,B2
-computing,computing,计算机科学,NOUN,B2
-común,joint,平等的,ADJ,B2
-con artist,con artist,词,NOUN,B1
-con más frecuencia,more often,更频繁,ADV,B2
-concave,concave,凹的,ADJ,B2
-conceal,to conceal,隐藏,VERB,B2
-concealed,concealed,词,ADJ,C1
-conceder,to give to grant,予以,VERB,B2
-conceivable,conceivable,可设想的,ADJ,B2
-concentrated,concentrated,浓,ADJ,B1
-concentric,concentric,词,ADJ,C1
-concepts,concepts,词,NOUN,C1
-conceptual,conceptual,概念的,ADJ,B2
-conceptualize,conceptualize,词,VERB,C1
-concern,concern,担忧,NOUN,B2
-concerned,concerned,担忧的,ADJ,B2
-concerning,concerning,关于,ADP,B2
-concerns,concerns,词,NOUN,C1
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
-concessionary,concessionary,让步的,ADJ,B2
-conciencia,awareness,意识,NOUN,B2
-concision,concision,简洁,NOUN,C1
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,推断的,ADJ,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
-concomitantly,concomitantly,词,ADV,B2
-concretization,concretization,词,NOUN,C1
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concur,concur,词,VERB,C1
-concurrently,concurrently,词,ADV,C1
-concurso,contest,比赛,NOUN,B2
-concussion,concussion,脑震荡,NOUN,B2
-condado,county,县,NOUN,B2
-condemnation,condemnation,谴责,NOUN,B2
-condenar,to convict,定罪,VERB,B2
-condenar,to sentence,判决,VERB,B2
-condense,to condense,浓缩,VERB,B2
-condenser,condenser,词,NOUN,C1
-condesa,countess,女伯爵,NOUN,B2
-conditional,conditional,条件的,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
-condolences,condolences,哀悼,NOUN,B2
-condom,condom,避孕套,NOUN,B2
-conduciveness,conduciveness,词,NOUN,C1
-conduct,conduct,行为,NOUN,B2
-conduct,to conduct,أجرى,VERB,B2
-conductivity,conductivity,导电性,NOUN,B2
-conductor,conductor,词,NOUN,C1
-conductor designado,designated driver,代驾,NOUN,B2
-cone,cone,圆锥体,NOUN,B2
-conectarse,to go online,上网,VERB,B2
-confederal,confederal,词,ADJ,C1
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-conferencia de prensa,press conference,新闻发布会,NOUN,B2
-confetti,confetti,词,NOUN,C1
-confianza,reliance,信赖,NOUN,B2
-confiar,to rely,依赖,VERB,B2
-confiar en,to rely on,依靠,VERB,B2
-confidentiality,confidentiality,保密性,NOUN,B2
-confiding,confiding,词,NOUN,C1
-configuration,configuration,配置,NOUN,B2
-configure,configure,词,VERB,C1
-configured,configured,词,ADJ,C1
-confines edges,confines edges,词,NOUN,C1
-conflictual,conflictual,词,ADJ,C1
-conform to,conform to,符合,VERB,A2
-conformidad,accord with,合乎,NOUN,B2
-conforming,conforming,遵从的,ADJ,B2
-conformism,conformism,因循守旧,NOUN,B2
-conformist,conformist,从众的,ADJ,B2
-conformity,conformity,词,NOUN,B2
-confound,confound,词,VERB,C1
-confounded,confounded,该死的,ADJ,B2
-confronting,confronting,对峙的,ADJ,B2
-confundir,puzzle,谜题,NOUN,B2
-confundir,to puzzle,使困惑,VERB,B2
-confused (adv),confused,词,ADV,B1
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusedly,confusedly,词,ADV,C1
-confusing,confusing,令人困惑的,ADJ,B2
-congeal,congeal,词,VERB,C1
-congratulations,congratulations,祝贺,NOUN,B2
-congregate,congregate,词,VERB,C1
-conifer,conifer,针叶树,NOUN,B2
-coniferous forest,coniferous forest,针叶林,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugation,conjugation,变位,NOUN,B2
-conjunctural,conjunctural,词,ADJ,C1
-conmutador,switchboard,总机,NOUN,B2
-connected,connected,连接的,ADJ,B2
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connector,connector,词,NOUN,B2
-connive,connive,词,VERB,C1
-conniving,conniving,词,ADJ,C1
-connotative,connotative,内涵的,ADJ,B2
-conocer,to get acquainted,相互认识,VERB,B2
-conocido,known,已知的,ADJ,B2
-conocimiento,clear knowledge,明知,NOUN,B2
-conquests,conquests,征服,NOUN,C1
-conscientious objection,conscientious objection,良知抗拒,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
-consciously,consciously,有意识地,ADV,B2
-consciousness,consciousness,意识,NOUN,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
-consecration,consecration,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
-consecutive cards,consecutive cards,连牌,NOUN,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consensualism,consensualism,词,NOUN,C1
-consequences,consequences,后果,NOUN,B1
-consequently,consequently,因此,ADV,B2
-conserje,caretaker,房屋管理员,NOUN,B2
-conservation,conservation,保护,NOUN,B2
-conservatism,conservatism,词,NOUN,C1
-conservative,conservative,保守的,ADJ,B2
-considerable,considerable,相当大的,ADJ,B2
-considerable (noun),considerable,不小,NOUN,C1
-considerably,considerably,相当地,ADV,B2
-considerate,considerate,体贴,ADJ,B2
-considered,considered,词,ADJ,B1
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consolidation,consolidation,词,NOUN,C1
-consort,consort,福晋,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
-constancy,constancy,恒定,NOUN,B2
-constant,constant,常数,NOUN,B2
-constantly,constantly,不断地,ADV,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
-constituencies,constituencies,词,NOUN,C1
-constitution,constitution,宪法,NOUN,B2
-constitutional,constitutional,宪法的,ADJ,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
-constitutionality,constitutionality,合宪性,NOUN,B2
-constitutionalization,constitutionalization,词,NOUN,B2
-constitutive,constitutive,构成的,ADJ,B2
-constraints,constraints,词,NOUN,C1
-constrict,constrict,词,VERB,C1
-construct,to construct,建造,VERB,B2
-construction site,construction site,工地,NOUN,B2
-constructive,constructive,建设性的,ADJ,B2
-constructiveness,constructiveness,词,NOUN,C1
-constructivism,constructivism,建构主义,NOUN,B2
-construe,construe,词,VERB,C1
-consular,consular,领事的,ADJ,B2
-consult reference,to consult reference,参考,VERB,B2
-consulta,consultation,咨询,NOUN,B2
-consultations,consultations,磋商,NOUN,C1
-consultor,consultant,顾问,NOUN,B2
-consumerist,consumerist,词,ADJ,B2
-consumidor,consumer,消费者,NOUN,B2
-consumptive,consumptive,消费的,ADJ,B2
-contabilidad,accounting,会计,NOUN,B2
-contable,accountant,会计师,NOUN,B2
-contact person,contact person,联系人,NOUN,B2
-contactar,to contact,联系,VERB,B2
-contacts,contacts,人脉,NOUN,B2
-contactual,contactual,接触的,ADJ,B2
-containment,containment,词,NOUN,C1
-contaminado,polluted,受污染的,ADJ,B2
-contaminante,pollutant,污染物,NOUN,B2
-contaminar,to contaminate,污染,VERB,B2
-contaminated,contaminated,受污染的,ADJ,B2
-contaminating,contaminating,污染的,ADJ,B2
-contar,to count as,算,VERB,B2
-contemn,contemn,蔑视,VERB,C1
-contemplar,gaze,目视,NOUN,B2
-contemplar,to gaze,凝视,VERB,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contener,to curb,抑制,VERB,B2
-content (adj),content,词,ADJ,B2
-contentious,contentious,有争议的,ADJ,B2
-contento,glad,高兴的,ADJ,B2
-contents,contents,内有,NOUN,B2
-contested,contested,有争议的,ADJ,B2
-contextual,contextual,语境的,ADJ,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
-continental,continental,词,ADJ,B2
-continuación,continuation,延续,NOUN,B2
-continual,continual,持续的,ADJ,B2
-continually,continually,不断地,ADV,B2
-continued,continued,持续的,ADJ,B2
-continuidad,continuity,连续性,NOUN,B2
-continuously,continuously,一直,ADV,A1
-contort,contort,词,VERB,C1
-contrabando,smuggling,走私,NOUN,B2
-contracalidad,counter-quality,反质,NOUN,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual,contractual,合同的,ADJ,B2
-contractual nature,contractual nature,词,NOUN,C1
-contractuality,contractuality,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
-contradictoriness,contradictoriness,词,NOUN,C1
-contraestructura,counter-structure,反结,NOUN,B2
-contraforma,counter-form,反式,NOUN,B2
-contrahabilidad,counter-skill,反技,NOUN,B2
-contraindicate,contraindicate,词,VERB,C1
-contraindication,contraindication,词,NOUN,C1
-contralógica,counter-logic,反逻,NOUN,B2
-contramecanismo,counter-mechanism,反机,NOUN,B2
-contramodelo,counter-model,反模,NOUN,B2
-contraobservación,counter-observation,反察,NOUN,B2
-contraparte,counterpart,对应的人或物,NOUN,B2
-contrariamente,conversely,相反地,ADV,B2
-contrario,contrary,反而,NOUN,B2
-contrarrestar,counter,柜台,NOUN,B2
-contrarrestar,to counter,反击,VERB,B2
-contraruta,counter-route,反途,NOUN,B2
-contrary (adj),contrary,词,ADJ,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrasistema,counter-system,反系,NOUN,B2
-contrastive,contrastive,词,ADJ,C1
-contrasuela,counter-sole,反唯,NOUN,B2
-contratación,hiring,招聘,NOUN,B2
-contratendencia,counter-trend,反势,NOUN,B2
-contratipo,counter-type,反型,NOUN,B2
-contratécnica,counter-technique,反术,NOUN,B2
-contributions,contributions,词,NOUN,C1
-contrive,contrive,词,VERB,C1
-control,control,控制,NOUN,B2
-controllability,controllability,词,NOUN,C1
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
-contumacy,contumacy,词,NOUN,C1
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convalesce,convalesce,词,VERB,B2
-convalescence,convalescence,词,NOUN,C1
-convenant,convenant,词,NOUN,C1
-convencido,convinced,确信的,ADJ,B2
-convenience store,convenience store,便利店,NOUN,C1
-convening,convening,召集,NOUN,C1
-conventionality,conventionality,词,NOUN,C1
-convergent,convergent,词,ADJ,C1
-conversation technique,conversation technique,词,NOUN,C1
-conversional,conversional,转换的,ADJ,B2
-convertible,convertible,可兑换的,ADJ,B2
-conveyance,conveyance,词,NOUN,C1
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (noun),convict,词,NOUN,C1
-convicted,convicted,被判罪的,ADJ,B2
-conviviality,conviviality,温馨,NOUN,B2
-convoke,convoke,词,VERB,C1
-convolutional,convolutional,卷积的,ADJ,B2
-convoy,convoy,词,NOUN,B2
-convulse,convulse,词,VERB,C1
-cookbook,cookbook,词,NOUN,C1
-cooked,cooked,熟的,ADJ,B2
-cooking,cooking,烹饪,NOUN,B2
-cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,冷静的,ADJ,B2
-cooler,cooler,词,ADJ,C1
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
-coop,coop,词,VERB,C1
-cooperación,cooperation,合作,NOUN,B2
-cooperar,to cooperate,合作,VERB,B2
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
-coordenada,coordinate,坐标,NOUN,B2
-coordinador,coordinator,协调员,NOUN,B2
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
-cope with,cope with,应对,VERB,B2
-copo de nieve,snowflake,雪花,NOUN,B2
-copropiedad,joint ownership,共有,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
-coral,coral,珊瑚,NOUN,B2
-coral (adj),coral,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-corazón rebelde,rebellious heart,反心,NOUN,B2
-corcho,cork,软木塞,NOUN,B2
-cordero,mutton,羊肉,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordiality,cordiality,词,NOUN,C1
-cordially,cordially,亲切地,ADV,B2
-cordoning,cordoning,词,NOUN,C1
-core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-cornice,cornice,檐口,NOUN,B2
-corniche,corniche,词,NOUN,C1
-coronación,coronation,加冕,NOUN,B2
-corporal,corporal,下士,NOUN,B2
-corporatism,corporatism,法团主义,NOUN,B2
-corpse alike,corpse alike,尸体/相似的,NOUN,B2
-corpuscle,corpuscle,词,NOUN,C1
-corrección de pruebas,proofreading,校对,NOUN,B2
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correctional,correctional,词,ADJ,C1
-corrections,corrections,刑事司法,NOUN,B2
-correctness,correctness,正确性,NOUN,B2
-corredor,broker,经纪人,NOUN,B2
-corredor,corridor,走廊,NOUN,B2
-corredor,runner,跑步者,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlatively,correlatively,词,ADV,B2
-correo,post,邮件,NOUN,B2
-correr,to run quickly,奔驰,VERB,B2
-correspondence course,correspondence course,函授,NOUN,C1
-correspondents,correspondents,词,NOUN,C1
-correspondiente,matching,配套,ADJ,B2
-corridors,corridors,词,NOUN,C1
-corriente principal,mainstream,主流,NOUN,B2
-corrupted,corrupted,,NOUN,B2
-corruptibility,corruptibility,词,NOUN,C1
-corrupto,corrupt,腐败的,ADJ,B2
-cortar,chop,砍,NOUN,B2
-cortar,to chop,砍,VERB,B2
-cortar,to cut off,切断,VERB,B2
-corte imperial,imperial court,朝廷,NOUN,B2
-cortical,cortical,皮层的,ADJ,C1
-cosmetics,cosmetics,化妆品,NOUN,B2
-cosmic,cosmic,宇宙的,ADJ,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,宇宙学,NOUN,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
-costly,costly,昂贵的,ADJ,B2
-costs,costs,费用,NOUN,B2
-costumbre,habitually in the past,往常,NOUN,B2
-costumes,costumes,词,NOUN,B2
-cosy,cosy,舒适的,ADJ,B2
-cottage,cottage,小屋,NOUN,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couch,couch,词,NOUN,B1
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-council-related,council-related,词,ADJ,C1
-councils,councils,委员会,NOUN,C1
-counsel,counsel,词,NOUN,B2
-counselor,counselor,词,NOUN,C1
-countability,countability,屈指可数,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterargument,counterargument,反论点,NOUN,B2
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-counterfactual,counterfactual,反实,NOUN,C1
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-country land,country land,词,NOUN,A1
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-couple pair,couple pair,一对,NOUN,B2
-courageous,courageous,勇敢的,ADJ,B2
-courageously,courageously,词,ADV,C1
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court clerk,court clerk,词,NOUN,C1
-court costs,court costs,词,NOUN,C1
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courteous,courteous,有礼貌的,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cousin female,cousin female,词,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover blanket,cover blanket,覆盖物,NOUN,B2
-cover-up,cover-up,词,NOUN,C1
-coward (noun),coward,懦夫,NOUN,B1
-cower,cower,词,VERB,C1
-coworker,coworker,同事,NOUN,B2
-cowpeas,cowpeas,词,NOUN,B2
-coágulo,clot,凝块,NOUN,B2
-crackdown,crackdown,词,NOUN,C1
-cracker,cracker,饼干,NOUN,B2
-cracking,cracking,词,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramped,cramped,词,ADJ,C1
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crap,crap,屎,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-cravenly,cravenly,词,ADV,C1
-crayon,crayon,词,NOUN,C1
-craze,craze,狂热,NOUN,B2
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creador,creator,创造者,NOUN,B2
-creamy,creamy,词,ADJ,C1
-crease,crease,词,NOUN,C1
-creatividad,creativity,创造力,NOUN,B2
-creativo,creative,有创造力的,ADJ,B2
-crecer,to grow up,成长,VERB,B2
-crecientemente,increasingly,越来越,ADV,B2
-credentials,credentials,国书,NOUN,B2
-credibilidad,credibility,可信度,NOUN,B2
-credible,credible,词,ADJ,C1
-creditor's rights,creditor's rights,债权,NOUN,B2
-creep,creep,令人厌恶的人,NOUN,B2
-creep (verb),creep,词,VERB,B2
-creepy,creepy,令人毛骨悚然的,ADJ,B2
-creer,to believe,相信,VERB,B2
-cremate,cremate,词,VERB,C1
-cremation,cremation,火化,NOUN,B2
-crenelate,crenelate,词,VERB,C1
-crepúsculo,dusk,黄昏,NOUN,B2
-crescendo,crescendo,词,NOUN,C1
-crescent,crescent,crescent,NOUN,B2
-criada,maidservant,女仆,NOUN,B2
-crianza,nurturing,养好,NOUN,B2
-criar,to nurture,养育,VERB,B2
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-criminal law,criminal law,刑法,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
-criminalizar,to criminalize,定罪,VERB,B2
-criminalization,criminalization,词,NOUN,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis,crisis,危机,NOUN,B2
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisis-ridden,crisis-ridden,词,ADJ,C1
-crisp,crisp,词,ADJ,C1
-cristal,crystal,水晶,NOUN,B2
-criticidad,criticality,临界性,NOUN,B2
-critique,critique,词,NOUN,C1
-crocodile,crocodile,词,NOUN,A1
-cromosoma,chromosome,染色体,NOUN,B2
-cronyism,cronyism,词,NOUN,C1
-crook,crook,骗子,NOUN,B2
-cross-border,cross-border,边境的,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crossing the border,crossing the border,越境,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-crouch (noun),crouch,词,NOUN,B2
-crowbar,crowbar,词,NOUN,B2
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-cruce,crossing,交叉口,NOUN,B2
-crucial,crucial,至关重要的,ADJ,B2
-crucifixion,crucifixion,词,NOUN,C1
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruel,cruel,残忍的,ADJ,B2
-cruelly,cruelly,残酷地,ADV,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crujir,to crunch,嘎吱作响,VERB,B2
-crumb,crumb,词,NOUN,C1
-crumbs,crumbs,词,NOUN,B2
-crunching,crunching,词,NOUN,C1
-crunchy,crunchy,脆的,ADJ,B1
-crusade,crusade,运动,NOUN,B2
-crushing,crushing,词,NOUN,B2
-cry weep,cry weep,词,VERB,A1
-crying shouting,crying shouting,词,NOUN,B1
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystal glass,crystal glass,词,NOUN,B1
-crystallization,crystallization,词,NOUN,C1
-crystallize,crystallize,词,VERB,C1
-crítico,critic,评论家,NOUN,B2
-cuaderno,notebook,笔记本,NOUN,B2
-cuadrado,square,平方的,ADJ,B2
-cualificado,qualified,合格的,ADJ,B2
-cualitativo,qualitative,定性的,ADJ,B2
-cualquiera,any,任何,PRON,B2
-cuando,if when,如果,SCONJ,B2
-cuantitativo,quantitative,定量的,ADJ,B2
-cuarenta,forty,四十,NUM,B2
-cuarto,fourth,第四,ADJ,B2
-cuarto,quarter,四分之一,NOUN,B2
-cubismo,cubism,立体主义,NOUN,B2
-cubit,cubit,词,NOUN,B2
-cubo,cube,立方体,NOUN,B2
-cuckold,cuckold,词,VERB,C1
-cuddle (noun),cuddle,词,NOUN,C1
-cue,cue,词,NOUN,B2
-cuenco,bowl,碗,NOUN,B2
-cuenta,account,账户,NOUN,B2
-cuento de hadas,fairy tale,童话,NOUN,B2
-cuerda,rope,绳子,NOUN,B2
-cuervo,crow,乌鸦,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuidador,caregiver,护理人员,NOUN,B2
-cuidar,to care for,照顾,VERB,B2
-cuidar,to take care,照顾,VERB,B2
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culminating,culminating,词,ADJ,C1
-culpa,blame,责备,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cult,cult,邪教,NOUN,B2
-cultivo,crop,庄稼,NOUN,B2
-cultural,cultural,文化的,ADJ,B2
-cultural center,cultural center,文化馆,NOUN,C1
-cultural encounter,cultural encounter,文化交汇,NOUN,B2
-cultural heritage,cultural heritage,文化遗产,NOUN,B2
-culturalism,culturalism,词,NOUN,C1
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cumber,cumber,词,VERB,C1
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cunningly,cunningly,词,ADV,C1
-cupboard,cupboard,橱柜,NOUN,B2
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupola,cupola,词,NOUN,C1
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curación,healing,治愈,NOUN,B2
-curar,to heal,治愈,VERB,B2
-curate,curate,词,VERB,C1
-curatorship,curatorship,词,NOUN,C1
-curbing,curbing,遏制,NOUN,B2
-curdle,curdle,词,VERB,C1
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curfew,curfew,宵禁,NOUN,B2
-curiously,curiously,词,ADV,C1
-currant,currant,醋栗,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
-current events,current events,时事,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
-curry,curry,词,NOUN,B2
-currículo,curriculum,课程,NOUN,B2
-cursing,cursing,骂人,NOUN,C1
-curva,bend,弯道,NOUN,B2
-custodian,custodian,词,NOUN,B2
-customary law,customary law,词,NOUN,C1
-customer orientation,customer orientation,客户导向,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
-customs (adj),customs,词,ADJ,C1
-customs officer,customs officer,海关官员,NOUN,B2
-cut off,cut off,割下,NOUN,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
-cutting,cutting,切割,NOUN,B2
-cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
-cybernetics,cybernetics,词,NOUN,C1
-cyborg,cyborg,词,NOUN,C1
-cycle path,cycle path,自行车道,NOUN,B2
-cycling,cycling,词,NOUN,C1
-cyclist,cyclist,骑自行车的人,NOUN,B2
-cykel,cykel,自行车,NOUN,B2
-cylindrical,cylindrical,圆柱形的,ADJ,B2
-cyst,cyst,囊肿,NOUN,B2
-czech,czech,捷克的,ADJ,B2
-cámara,chamber,房间,NOUN,B2
-cámara nupcial,bridal chamber,洞房,NOUN,B2
 cíclico,cyclical,周期的,ADJ,B2
-cúmulo,cluster,簇,NOUN,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dachshund,dachshund,词,NOUN,A1
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
-daddy,daddy,爸爸,NOUN,B2
-dado,dice,骰子,NOUN,B2
-dado,given,给定,NOUN,B2
-daft,daft,傻的,ADJ,B2
+cilindro,cylinder,圆柱体,NOUN,B2
+platillo,cymbal,钹,NOUN,B2
 daga,dagger,匕首,NOUN,B2
-daglig,daglig,词,ADJ,C1
-daily (noun),daily,词,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
-dairy,dairy,词,ADJ,C1
-dal,dal,山谷,NOUN,B2
-dally,dally,词,VERB,C1
-dama,lady,女士,NOUN,B2
-damageable,damageable,易损的,ADJ,B2
-damages,damages,损害赔偿,NOUN,B2
-damaging,damaging,有害的,ADJ,B2
-damm,damm,池塘,NOUN,B2
-damn,damn,该死的,ADV,B2
-damned,damned,词,ADJ,B2
-damping,damping,词,NOUN,C1
-dance floor,dance floor,舞池,NOUN,B2
-dandelion,dandelion,词,NOUN,B1
-dandle,dandle,词,VERB,C1
-dangerousness,dangerousness,危险性,NOUN,B2
-dangle,dangle,词,VERB,C1
-danish,danish,丹麦的,ADJ,B2
+aumento diario,daily increase,日渐,NOUN,B2
+periódico diario,daily newspaper,日报,NOUN,B2
+maldecir,damn,该死的,ADJ,B2
+maldecir,to damn,诅咒,VERB,B2
+húmedo,damp,潮湿,ADJ,B2
 danmei,danmei,但没,NOUN,B2
-dans,dans,舞蹈,NOUN,B2
-dar un discurso,to make a speech,发言,VERB,B2
-dar un paso,to step,踩,VERB,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
-darkness of night,darkness of night,词,NOUN,C1
-darn,darn,哎呀,INTJ,B2
-darn (adj),darn,词,ADJ,B1
-darn (verb),darn,词,VERB,B2
-dart (verb),dart,词,VERB,C1
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data leak,data leak,词,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-data protection,data protection,数据保护,NOUN,B2
-databas,databas,数据库,NOUN,B2
-date fruit,date fruit,椰枣,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
-dato,piece of information,信息,NOUN,B2
-dator,dator,电脑,NOUN,B2
-datum,datum,日期,NOUN,B2
-daub,daub,词,VERB,C1
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dawning,dawning,破晓,NOUN,B2
-day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,后天,NOUN,B2
-day by day,day by day,日日,ADV,B2
-day out,day out,一日游,NOUN,B2
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daylight,daylight,日光,NOUN,B2
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
-de este modo,thereby,从而,ADV,B2
-de facto,de facto,词,ADJ,C1
-de lo contrario,otherwise,否则,ADV,B2
-de todos modos,anyway,无论如何,ADV,B2
-de-escalation,de-escalation,词,NOUN,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-dead person,dead person,词,NOUN,B1
-deaden,deaden,词,VERB,C1
-deadlock,deadlock,词,NOUN,C1
-deadly,deadly,致命地,ADV,B2
-deaf person,deaf person,词,NOUN,B2
-deafness,deafness,听不,NOUN,C1
-deals,deals,词,NOUN,C1
-deambulación,wandering,漫游,NOUN,B2
-deanship,deanship,词,NOUN,C1
-dear,dear,,NOUN,B2
-dearest,dearest,最爱的人,NOUN,B2
-death,death,致死,ADV,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
-death wish,death wish,找死,NOUN,B2
-deaths,deaths,词,NOUN,C1
-debajo,underneath,在下面,ADV,B2
-debate,debate,辩论,NOUN,B2
-debauch,debauch,词,VERB,C1
-debauchery,debauchery,放荡,NOUN,B2
-deber,must,必须,AUX,B2
-deber,should,应该,AUX,B2
-deber,duty,责任,NOUN,B2
-deber,to owe,欠,VERB,B2
-debido a,due to,由于,ADP,B2
-debilitate,debilitate,词,VERB,C1
-debility,debility,虚弱,NOUN,C1
-debit,debit,词,VERB,C1
-debrief,debrief,词,VERB,C1
-debris,debris,词,NOUN,B2
-debris rubble,debris rubble,词,NOUN,C1
-debts,debts,债务,NOUN,B2
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
-debut,debut,初次登台,NOUN,B2
-decadent,decadent,颓废,ADJ,B2
-decamp,decamp,词,VERB,C1
+cariño,darling,亲爱的,NOUN,B2
+tablero,dashboard,仪表盘,NOUN,B2
+base de datos,database,数据库,NOUN,B2
+citas,dating,年代测定,NOUN,B2
+día y noche,day and night,昼夜,NOUN,B2
+callejón sin salida,dead end,死胡同,NOUN,B2
+fecha límite,deadline,截止日期,NOUN,B2
+tratar,to deal with,处理,VERB,B2
+distribuidor,dealer,经销商,NOUN,B2
 decano,dean,院长,NOUN,B2
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
+pena de muerte,death penalty,死刑,NOUN,B2
+death wish,death wish,找死,NOUN,B2
+debate,debate,辩论,NOUN,B2
+debauchery,debauchery,放荡,NOUN,B2
+debts,debts,债务,NOUN,B2
+decadent,decadent,颓废,ADJ,B2
 deceased,deceased,死者,NOUN,B2
-deceit,deceit,欺骗,NOUN,B2
 deceitful,deceitful,欺诈的,ADJ,B2
-deceived,deceived,词,ADJ,A2
-decelerate,decelerate,词,VERB,C1
-decencia,propriety,分寸,NOUN,B2
 decentralization,decentralization,权力下放,NOUN,B2
-decentralized,decentralized,词,ADJ,C1
-decepcionado,disappointed,失望的,ADJ,B2
 deception dare,deception dare,你敢骗我,NOUN,B2
-decibel,decibel,分贝,NOUN,B2
-decimal,decimal,小数,NOUN,B2
-decimal (adj),decimal,词,ADJ,C1
-deciphering,deciphering,词,NOUN,C1
-decir,to tell,告诉,VERB,B2
 decision-maker,decision-maker,决策者,NOUN,B2
-decision-making,decision-making,决策,NOUN,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck,deck,词,NOUN,B1
-deck tire,deck tire,甲板/轮胎,NOUN,B2
-declamatory style,declamatory style,词,NOUN,C1
-declarar,to state,说明,VERB,B2
 declaration,declaration,宣言,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declare war,declare war,宣战,VERB,B2
-declension,declension,词,NOUN,C1
-declinable,declinable,可变格的,ADJ,B2
 decline,decline,衰退,NOUN,B2
 decline politely,to decline politely,婉拒,VERB,B2
-decline setting,decline setting,词,NOUN,C1
-decommission,decommission,词,VERB,C1
 decommissioning,decommissioning,退役,NOUN,B2
-decompensation,decompensation,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
 deconstruct,to deconstruct,解构,VERB,B2
 deconstruction,deconstruction,解构主义,NOUN,B2
-deconstructionist,deconstructionist,词,ADJ,C1
-decontaminate,decontaminate,词,VERB,C1
-decontamination,decontamination,去污,NOUN,B2
-decor,decor,布景,NOUN,B2
-decorated,decorated,词,ADJ,B1
-decorative,decorative,装饰性的,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
-decoy,decoy,词,NOUN,C1
 decree,decree,法令,NOUN,B2
 decryption,decryption,解密,NOUN,B2
-dedicar,to devote,奉献,VERB,B2
 dedication,dedication,奉献,NOUN,B2
-dedo del pie,toe,脚趾,NOUN,B2
 deduct,to deduct,扣除,VERB,B2
-deduct points,deduct points,扣分,VERB,C1
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
 deed,deed,行为,NOUN,B2
-deem,deem,词,VERB,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
 deep-fry,to deep-fry,油炸,VERB,B2
-deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,深刻地,ADV,B2
-deface,deface,词,VERB,C1
-defamatory,defamatory,词,ADJ,C1
-defamiliarization,defamiliarization,词,NOUN,C1
 default,default,违约,NOUN,B2
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
 defect,to defect,叛变,VERB,B2
-defectiveness,defectiveness,词,NOUN,C1
-defecto,shortcoming,缺点,NOUN,B2
 defend one's country,to defend one's country,卫国,VERB,B2
-defensa aérea,air defense,防空,NOUN,B2
-defense deployment,defense deployment,布防,NOUN,C1
-defense lawyer,defense lawyer,词,NOUN,B2
-defense to death,defense to death,死守,NOUN,B2
 defiance,defiance,挑衅,NOUN,B2
-defile,defile,词,VERB,C1
-definite,definite,明确的,ADJ,B2
 definition,definition,定义,NOUN,B2
-deflated,deflated,词,ADJ,B1
 deflation,deflation,通货紧缩,NOUN,B2
-deflationary,deflationary,词,ADJ,C1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deformity,deformity,词,NOUN,C1
-defunct,defunct,词,ADJ,C1
 defy,to defy,违抗,VERB,B2
-degenerative,degenerative,退化的,ADJ,B2
-degrease,degrease,词,VERB,C1
-degree exam,degree exam,学位/考试,NOUN,B2
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
 dehydration,dehydration,脱水,NOUN,B2
-dehydration dryness,dehydration dryness,词,NOUN,C1
-deice,deice,词,VERB,C1
 deism,deism,自然神论,NOUN,B2
-dejar,let,让,AUX,B2
-dejar,to let,让,VERB,B2
-dejar caer,to drop,掉落,VERB,B2
-dejt,dejt,约会,NOUN,B2
-del,del,部分,NOUN,B2
-delantal,apron,围裙,NOUN,B2
-delante de,in front of,在……前面,ADP,B2
-delayed,delayed,延误的,ADJ,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
 delete,to delete,删除,VERB,B2
-deleterious,deleterious,词,ADJ,B2
-deletion,deletion,词,NOUN,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-delgado,thin,瘦的,ADJ,B2
-deli meats,deli meats,词,NOUN,C1
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
 deliberately,deliberately,故意地,ADV,B2
-deliberateness,deliberateness,词,NOUN,C1
-deliberations,deliberations,词,NOUN,C1
-deliberatively,deliberatively,词,ADV,C1
-delicately,delicately,巧妙地,ADV,B2
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delighted,delighted,高兴的,ADJ,B2
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-deliquesce,deliquesce,词,VERB,C1
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delivery van,delivery van,厢式送货车,NOUN,B2
-delouse,delouse,词,VERB,C1
-delta,delta,delta,NOUN,B2
-delude,delude,词,VERB,C1
-deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
 delusion,delusion,幻想,NOUN,B2
-delve,delve,词,VERB,C1
-demagogic,demagogic,词,ADJ,C1
-demagogy,demagogy,蛊惑,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
-demandante,plaintiff,原告,NOUN,B2
 demanding,demanding,要求高的,ADJ,B2
-demasiado,too,太,ADV,B2
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
-dement,dement,词,VERB,C1
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demobilize,demobilize,词,VERB,C1
+desmilitarización,demilitarization,去武,NOUN,B2
 democracia,democracy,民主,NOUN,B2
-democrat,democrat,民主主义者,NOUN,B2
 democrático,democratic,民主的,ADJ,B2
 demografía,demography,人口学,NOUN,B2
-demographic,demographic,人口统计的,ADJ,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonization,demonization,词,NOUN,C1
-demons,demons,词,NOUN,C1
-demonstrative,demonstrative,演示的,ADJ,B2
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demonstrator,demonstrator,词,NOUN,C1
-demote,demote,词,VERB,C1
-demotion,demotion,降职,NOUN,B2
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-denationalize,denationalize,词,VERB,C1
-denial contradiction,denial contradiction,词,NOUN,C1
-denim jacket,denim jacket,词,NOUN,C1
 denotación,denotation,外延,NOUN,B2
-dense forest,dense forest,密林,NOUN,B2
 denso,dense,密集的,ADJ,B2
-dental,dental,词,ADJ,C1
 dentista,dentist,牙医,NOUN,B2
-dentition,dentition,牙齿,NOUN,B2
-dentro,within,在……之内,ADP,B2
-denude,denude,词,VERB,C1
-deodorize,deodorize,词,VERB,C1
-deontology,deontology,词,NOUN,C1
-department director,department director,司长,NOUN,C1
-departmental,departmental,词,ADJ,B2
-departure lounge,departure lounge,候机室,NOUN,B2
-dependency,dependency,词,NOUN,B2
-dependent passivity,dependent passivity,词,NOUN,C1
+partir,to depart,离开,VERB,B2
+jefe de departamento,department head,厅长,NOUN,B2
+grandes almacenes,department store,百货商店,NOUN,B2
+salida,departure,离开,NOUN,B2
 depender de,to depend on,依赖,VERB,B2
 dependiente,dependent,依赖的,ADJ,B2
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-deplete,deplete,词,VERB,C1
-depletion,depletion,词,NOUN,C1
-depone,depone,词,VERB,C1
+representar,to depict,描绘,VERB,B2
 deponer,to depose,废黜,VERB,B2
-depopulation,depopulation,词,NOUN,B2
-deposed,deposed,词,ADJ,C1
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depot,depot,仓库,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-deprecation,deprecation,词,NOUN,C1
-depredador,predatory,掠夺的,ADJ,B2
-depredate,depredate,词,VERB,C1
-depressing,depressing,令人沮丧的,ADJ,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
 deprimido,depressed,沮丧的,ADJ,B2
-deputation,deputation,代表团,NOUN,B2
-depute,depute,词,VERB,C1
-deracinate,deracinate,词,VERB,C1
-derange,derange,词,VERB,C1
-derby,derby,词,NOUN,B2
-derecho,right,正确的,ADJ,B2
-derecho del acreedor,creditor's right,债权,NOUN,B2
-derechos,rights,权利,NOUN,B2
-derechos de autor,copyright,版权,NOUN,B2
-deregulate,deregulate,词,VERB,C1
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-deride,deride,词,VERB,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
-deriva,drifting,漂泊,NOUN,B2
-dermal,dermal,词,ADJ,C1
-derribar,to shoot down,击落,VERB,B2
-derrota aplastante,crushing defeat,惨败,NOUN,B2
-desagradable,nasty,令人不快的,ADJ,B2
-desalination,desalination,词,NOUN,C1
-desarrollador,developer,开发商,NOUN,B2
-desastre,wreck,残骸,NOUN,B2
-descanso de montada,ride break,骑破,NOUN,B2
-descant,descant,词,VERB,C1
-descarga,discharge,放电,NOUN,B2
-descargar,to download,下载,VERB,B2
-descend go down,descend go down,词,VERB,A1
-descendants,descendants,词,NOUN,C1
-descending,descending,词,ADJ,C1
-descenso de montaña,mountain descent,下山,NOUN,B2
-desconcertante,unclear,不清楚的,ADJ,B2
-desconcierto,bewilderment,困惑,NOUN,B2
-describable,describable,词,ADJ,C1
-descriptiveness,descriptiveness,词,NOUN,C1
-descry,descry,词,VERB,C1
-desde la infancia,from childhood,从小,ADV,B2
-desdichado,unlucky,倒霉的,ADJ,B2
-desear,to wish,希望,VERB,B2
-desecrate,desecrate,词,VERB,C1
-desecration,desecration,词,NOUN,C1
-desegregate,desegregate,词,VERB,C1
-desempleado,unemployed,失业的,ADJ,B2
-deseo de atraer,want to lure,想引,NOUN,B2
-deseo genuino,really want,真要,NOUN,B2
+privación,deprivation,剥夺,NOUN,B2
+adjunto,deputy,副的,ADJ,B2
 desertificación,desertification,荒漠化,NOUN,B2
-deserving,deserving,才配得,NOUN,C1
-desestabilización,destabilization,动摇,NOUN,B2
-desestimación,court dismissal,退朝,NOUN,B2
-desgraciado,wretch,令人厌恶的人,NOUN,B2
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desintoxicar,to detoxify,解毒,VERB,B2
-desirability,desirability,可取性,NOUN,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desirous,desirous,词,ADJ,C1
-desk chest of drawers,desk chest of drawers,词,NOUN,B2
-desmayo,fainting,晕厥,NOUN,B2
-desmilitarización,demilitarization,去武,NOUN,B2
-desmontar,to disassemble,拆卸,VERB,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-desordenado,messy,混乱的,ADJ,B2
-despatch,despatch,词,VERB,C1
-despedida,see off,送走,NOUN,B2
-despedirse,to say goodbye,告别,VERB,B2
-despeje,clearing,林中空地,NOUN,B2
-desperately serious,desperately serious,不得了,ADJ,B2
-despertar,awakening,觉醒,NOUN,B2
-despertar,to arouse,引起,VERB,B2
-despertar,to awaken,唤醒,VERB,B2
-despertar,to wake,唤醒,VERB,B2
-despertar social,social awakening,社会觉醒,NOUN,B2
-despiadado,ruthlessness,无情,NOUN,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despond,despond,词,VERB,C1
-despondency,despondency,词,NOUN,C1
-desprenderse,to get rid of,摆脱,VERB,B2
-después,afterwards,后来,ADV,B2
-después de,after,在...之后,ADP,B2
-después de eso,after that,此后,ADV,B2
-después de lo cual,after which,之后,ADV,B2
-después de todo,after all,毕竟,ADV,B2
-destacar,to highlight,强调,VERB,B2
-destine,destine,词,VERB,C1
-destined,destined,,NOUN,B2
-destino,destiny,命运,NOUN,B2
-destitute,destitute,词,ADJ,C1
-destornillador,screwdriver,螺丝刀,NOUN,B2
-destroyed,destroyed,被毁坏的,ADJ,B2
-destruction of property,destruction of property,毁坏财物,NOUN,C1
-destructivo,destructive,مدمر,ADJ,B2
-desvergonzado,cheeky,厚颜无耻的,ADJ,B2
-desvoluntad,unwillingness,不甘,NOUN,B2
-detached house,detached house,独栋房屋,NOUN,B2
-details,details,细细,NOUN,C1
-detainee,detainee,被拘留者,NOUN,B2
-detallado,detailed,详细的,ADJ,B2
-detective,detective,侦探,NOUN,B2
-detective force,detective force,刑警,NOUN,B2
-detector,detector,词,NOUN,C1
-detención,detention,拘留,NOUN,B2
-detener,to detain,拘留,VERB,B2
-detener,to halt,停止,VERB,B2
-detenerse,to stall,拖延,VERB,B2
-detention center,detention center,拘留所,NOUN,B2
-deter,deter,词,VERB,C1
-deterioro,impairment,左手废,NOUN,B2
-determinación,determination,决心,NOUN,B2
-determinant,determinant,词,NOUN,C1
-determine,determine,确定,VER! B,B2
-determined definite,determined definite,确定的,ADJ,B2
-determinismo,determinism,决定论,NOUN,B2
-determinist,determinist,词,ADJ,C1
-determinista,deterministic,决定论的,ADJ,B2
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
-detestable,detestable,可恶的,ADJ,B2
-detractor,detractor,词,NOUN,C1
-detrimental,detrimental,有害的,ADJ,B2
-detritus,detritus,词,NOUN,C1
-detrás,behind,在...后面,ADP,B2
-deuda de sangre,blood debt,血债,NOUN,B2
-devastated,devastated,崩溃的,ADJ,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-deviance,deviance,词,NOUN,B2
-device system,device system,词,NOUN,B1
-devices,devices,设备,NOUN,B2
-devil bastard,devil bastard,混蛋,NOUN,B2
-devil damn,devil damn,词,NOUN,A1
-devious,devious,词,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolution,devolution,词,NOUN,C1
-devolve,devolve,词,VERB,C1
-devolver,to bring back,带回,VERB,B2
-devolver,to give back,归还,VERB,B2
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devouring,devouring,必噬,NOUN,C1
-devoutly,devoutly,词,ADV,C1
-diabetes,diabetes,糖尿病,NOUN,B2
-diabetic,diabetic,词,ADJ,C1
-diachrony,diachrony,词,NOUN,C1
-diaeresis,diaeresis,词,NOUN,C1
-diagonal,diagonal,对角线,NOUN,B2
-diagonally,diagonally,对角地,ADV,B2
-diagrama,diagram,图表,NOUN,B2
-dial (noun),dial,词,NOUN,C1
-dial (verb),dial,词,VERB,B2
-dialectic (adj),dialectic,词,ADJ,C1
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialectician,dialectician,词,NOUN,C1
-dialecto,dialect,方言,NOUN,B2
-dialing code,dialing code,词,NOUN,C1
-dialogar,to dialogue,对话,VERB,B2
-dialogism,dialogism,词,NOUN,C1
-diameter,diameter,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
-diapers,diapers,词,NOUN,B1
-diario,diary,日记,NOUN,B2
-diarrea,diarrhea,腹泻,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-dibujo,drawing,图画,NOUN,B2
-diccionario,dictionary,词典,NOUN,B2
-dicha,bliss,极乐,NOUN,B2
-dicho,saying,格言,NOUN,B2
-dictation,dictation,dictation,NOUN,B2
-diction,diction,措辞,NOUN,B2
-didactics,didactics,词,NOUN,C1
-diestro,proficient,熟练的,ADJ,B2
-diezmo,tithe,什一税,NOUN,B2
-different,different,不同地,ADV,B2
-difficult flirt,difficult flirt,,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
-diffusely,diffusely,词,ADV,C1
-diffusion spread,diffusion spread,词,NOUN,C1
-difundir,to diffuse,扩散,VERB,B2
-difícil,hard to choose,难以抉择,ADJ,B2
-difícilmente,with difficulty,困难地,ADV,B2
-dig up,dig up,词,VERB,B2
-digirir,to digest,消化,VERB,B2
-digital,digital,数字的,ADJ,B2
-digital currency,digital currency,数字货币,NOUN,C1
-digitalización,digitization,数字化,NOUN,B2
-digitized,digitized,词,ADJ,C1
-diglossia,diglossia,词,NOUN,C1
-dignified,dignified,词,ADJ,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignify,dignify,词,VERB,C1
-dignitaries,dignitaries,词,NOUN,C1
-digno,worth,值得的,ADJ,B2
-dike,dike,词,NOUN,B2
-dilution,dilution,词,NOUN,C1
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-dimple,dimple,词,NOUN,C1
-dinastía actual,current dynasty,当朝,NOUN,B2
-dine,dine,词,VERB,C1
-dinghy,dinghy,词,NOUN,C1
-dining hall,dining hall,词,NOUN,C1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
-diocese,diocese,词,NOUN,B2
-dios de la guerra,god of war,战神,NOUN,B2
-diosa,goddess,女神,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diploma,diploma,文凭,NOUN,B2
-diplomat,diplomat,词,NOUN,C1
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-diplomático,tactful,圆滑的,ADJ,B2
-dirección,direction,方向,NOUN,B2
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directamente,directly,直接地,ADV,B2
-directing,directing,导演,NOUN,B2
-directionality,directionality,词,NOUN,C1
-directiva,directive,指令,NOUN,B2
-directive (adj),directive,词,ADJ,C1
-directness,directness,词,NOUN,C1
-director,director,导演,NOUN,B2
-director,principal,委托人,NOUN,B2
-director manager,director manager,主管/经理,NOUN,B2
-directorate,directorate,局,NOUN,C1
-directorship,directorship,董事职位,NOUN,B2
-directory,directory,词,NOUN,C1
-dirham,dirham,词,NOUN,A1
-dirigir,to steer,引导,VERB,B2
-dirt filth,dirt filth,词,NOUN,C1
-dirt soil,dirt soil,词,NOUN,A1
-dirtier,dirtier,更脏的,ADJ,B2
-dirty bastard,dirty bastard,词,NOUN,C1
-disable,disable,词,VERB,C1
-disadvantaged,disadvantaged,词,ADJ,C1
-disaffect,disaffect,词,VERB,C1
-disallow,disallow,词,VERB,C1
-disarray (noun),disarray,词,NOUN,C1
-disassembly,disassembly,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-discapacidad,disability,残疾,NOUN,B2
-disciple,disciple,门徒,NOUN,B2
-disciplinary,disciplinary,纪律的,ADJ,B2
-discipline,discipline,纪律,NOUN,B2
-disciplined,disciplined,词,ADJ,C1
-disclaim,disclaim,词,VERB,C1
-disclose,to disclose,揭露,VERB,B2
-disclosure,disclosure,泄露,NOUN,C1
-disco,disco,迪厅,NOUN,B2
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
-discontinue,to discontinue,停止,VERB,B2
-discontinuity,discontinuity,词,NOUN,B2
-discounts,discounts,折扣,NOUN,B2
-discourse,discourse,论述,NOUN,B2
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discrediting,discrediting,词,NOUN,C1
-discreetly,discreetly,词,ADV,B2
-discrete,discrete,词,ADJ,C1
-discretionary punishment,discretionary punishment,词,NOUN,C1
-disculparse,to apologize,道歉,VERB,B2
-discusión,quarreling,再吵,NOUN,B2
-discuss,to discuss,讨论,VERB,B2
-discutir,quarrel,争吵,NOUN,B2
-discutir,to quarrel,争吵,VERB,B2
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disease,disease,疾病,NOUN,B2
-disembarkation,disembarkation,词,NOUN,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
-disengagement,disengagement,词,NOUN,B2
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-diseñador,designer,设计者,NOUN,B2
 diseñar,to design,设计,VERB,B2
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disfraz,costume,戏服,NOUN,B2
-disfunción,dysfunction,功能障碍,NOUN,B2
-disgorge,disgorge,词,VERB,C1
-disgruntle,disgruntle,词,VERB,C1
+conductor designado,designated driver,代驾,NOUN,B2
+diseñador,designer,设计者,NOUN,B2
+escritorio,desk,书桌,NOUN,B2
+a pesar de,despite,尽管,ADP,B2
+desestabilización,destabilization,动摇,NOUN,B2
+destino,destiny,命运,NOUN,B2
+indigencia,destitution,贫困,NOUN,B2
+destructivo,destructive,مدمر,ADJ,B2
+detallado,detailed,详细的,ADJ,B2
+detener,to detain,拘留,VERB,B2
+detective,detective,侦探,NOUN,B2
+detención,detention,拘留,NOUN,B2
+determinación,determination,决心,NOUN,B2
+determinismo,determinism,决定论,NOUN,B2
+determinista,deterministic,决定论的,ADJ,B2
+detestable,detestable,可恶的,ADJ,B2
+desintoxicar,to detoxify,解毒,VERB,B2
+desarrollador,developer,开发商,NOUN,B2
+idear,to devise,设计,VERB,B2
+dedicar,to devote,奉献,VERB,B2
+rocío,dew,露水,NOUN,B2
+diagrama,diagram,图表,NOUN,B2
+dialecto,dialect,方言,NOUN,B2
+dialogar,to dialogue,对话,VERB,B2
+pañal,diaper,尿布,NOUN,B2
+diarrea,diarrhea,腹泻,NOUN,B2
+diario,diary,日记,NOUN,B2
+dado,dice,骰子,NOUN,B2
+diccionario,dictionary,词典,NOUN,B2
+ataque difícil,difficult attack,难攻,NOUN,B2
+problema difícil,difficult problem,难题,NOUN,B2
+difundir,to diffuse,扩散,VERB,B2
+digirir,to digest,消化,VERB,B2
+excavación,digging,挖掘,NOUN,B2
+dígito,digit,数字,NOUN,B2
+digital,digital,数字的,ADJ,B2
+digitalización,digitization,数字化,NOUN,B2
+sumergir,to dip,蘸,VERB,B2
+dirección,direction,方向,NOUN,B2
+señal de dirección,direction sign,指示牌,NOUN,B2
+directiva,directive,指令,NOUN,B2
+directamente,directly,直接地,ADV,B2
+director,director,导演,NOUN,B2
+suciedad,dirt,污垢,NOUN,B2
+discapacidad,disability,残疾,NOUN,B2
+decepcionado,disappointed,失望的,ADJ,B2
+desmontar,to disassemble,拆卸,VERB,B2
+renegar,to disavow,否认,VERB,B2
+incredulidad,disbelief,不信,NOUN,B2
+descarga,discharge,放电,NOUN,B2
+disciple,disciple,门徒,NOUN,B2
+discipline,discipline,纪律,NOUN,B2
+disclose,to disclose,揭露,VERB,B2
+discontinue,to discontinue,停止,VERB,B2
+discourse,discourse,论述,NOUN,B2
+discuss,to discuss,讨论,VERB,B2
+disease,disease,疾病,NOUN,B2
 dish,dish,盘子,NOUN,B2
-dish towel,dish towel,抹布,NOUN,B2
-disharmony,disharmony,不和谐,NOUN,B2
-dishes,dishes,词,NOUN,C1
-dishonest,dishonest,不诚实的,ADJ,B2
-disillusion,disillusion,词,VERB,C1
-disincline,disincline,词,VERB,C1
 disinfectant,disinfectant,消毒剂,NOUN,B2
-disinflation,disinflation,词,NOUN,B2
-disintegration,disintegration,词,NOUN,B2
-disinter,disinter,词,VERB,C1
-disinvestment,disinvestment,词,NOUN,C1
-disjoint,disjoint,不相交的,ADJ,B2
 disk,disk,唱片,NOUN,B2
-dislike,dislike,厌恶,NOUN,B2
 dislike,to dislike,不喜欢,VERB,B2
-dislike (noun),dislike,厌恶,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
 dismantling,dismantling,拆除，瓦解,NOUN,B2
-dismay (noun),dismay,词,NOUN,C1
-dismember,dismember,词,VERB,C1
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
-disorganize,disorganize,词,VERB,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparagement,disparagement,词,NOUN,C1
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
 dispense medicine,to dispense medicine,配药,VERB,B2
-dispersal,dispersal,全散,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displace,displace,词,VERB,C1
-displaced person,displaced person,词,NOUN,C1
 display,display,展示,NOUN,B2
-disport,disport,词,VERB,C1
-disposable,disposable,一次性的,ADJ,B2
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposed,disposed,词,ADJ,C1
-disposition,disposition,性情,NOUN,B2
-dispossessed,dispossessed,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-disputa,falling out,反目,NOUN,B2
-disputation,disputation,词,NOUN,C1
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
 disputed,disputed,有争议的,ADJ,B2
-disputed case,disputed case,词,NOUN,C1
-disquiet,disquiet,词,NOUN,C1
 disregard,to disregard,忽视,VERB,B2
-disrepair,disrepair,词,NOUN,C1
-disrobe,disrobe,词,VERB,C1
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfaction,dissatisfaction,不满,NOUN,B2
-dissatisfy,dissatisfy,词,VERB,C1
 dissect,to dissect,解剖,VERB,B2
-dissemble,dissemble,词,VERB,C1
-disseminator,disseminator,传播者,NOUN,C1
-dissert,dissert,词,VERB,C1
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissociate,dissociate,词,VERB,C1
-dissociation,dissociation,解离,NOUN,B2
-distanciamiento,estrangement,疏离,NOUN,B2
-distanciamiento social,social distancing,社交距离,NOUN,B2
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distich,distich,词,NOUN,C1
-distico,couplet,对联,NOUN,B2
-distil,distil,词,VERB,C1
-distillation,distillation,词,NOUN,C1
 distinct,distinct,明显的,ADJ,B2
-distinctly,distinctly,清楚地,ADV,B2
 distinguished,distinguished,杰出,ADJ,B2
-distopía,dystopia,反乌托邦,NOUN,B2
-distorted,distorted,歪曲的,ADJ,B2
-distorted image,distorted image,扭曲的形象,NOUN,B2
 distraction,distraction,分心,NOUN,B2
-distrain,distrain,词,VERB,C1
-distressing,distressing,词,ADJ,B1
-distribuidor,dealer,经销商,NOUN,B2
-distributed,distributed,词,ADJ,C1
-distributor,distributor,分销商,NOUN,B2
 district head,district head,区长,NOUN,B2
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
-disturbed,disturbed,不安的,ADJ,B2
-ditch,ditch,沟渠,NOUN,B2
-dithyramb,dithyramb,词,NOUN,C1
 dive,dive,跳水,NOUN,B2
-dive appear,dive appear,词,VERB,B2
-diver,diver,词,NOUN,B2
-diverging,diverging,词,ADJ,C1
-diverse,diverse,多样的,ADJ,B2
-diversos departamentos,various departments,各部,NOUN,B2
-divestment,divestment,词,NOUN,C1
-divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
-divider,divider,词,NOUN,C1
 divine,divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
 diving,diving,潜水,NOUN,B2
-divisible,divisible,可分的,ADJ,B2
-divisor,divisor,词,NOUN,C1
 divorce,to divorce,离婚,VERB,B2
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
 dizziness,dizziness,眩晕,NOUN,B2
 dizzy,dizzy,头晕的,ADJ,B2
-djellaba,djellaba,词,NOUN,B2
 do,to do,做,VERB,B2
 do not,do not,莫,ADV,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
 do not use,do not use,别用,NOUN,B2
-do not want,do not want,不想,VERB,B2
 do one's best,to do one's best,尽力,VERB,B2
-do one's best (adv),do one's best,竭力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
 do to make,to do to make,做,VERB,B2
-doblaje,dubbing,配音,NOUN,B2
-doblar,to double,加倍,VERB,B2
-docilely,docilely,词,ADV,C1
-doctor visit,doctor visit,,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
 doctorate,doctorate,博士学位,NOUN,B2
-doctrine,doctrine,词,NOUN,B2
-documentary,documentary,纪录片,NOUN,B2
-documentation,documentation,文献,NOUN,B2
-documented,documented,词,ADJ,C1
-documento original,original document,原件,NOUN,B2
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-doggedly,doggedly,词,ADV,C1
 dogma,dogma,教条,NOUN,B2
-dollar,dollar,词,NOUN,C1
-dolor de cabeza,headache,头痛,NOUN,B2
-dolor de pecho,chest pain,胸痛,NOUN,B2
-dolor muscular,muscle pain,肌肉痛,NOUN,B2
 dolphin,dolphin,海豚,NOUN,B2
-domain,domain,领域,NOUN,B2
-domestic,domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
 domesticación,domestication,驯化,NOUN,B2
-domesticate,domesticate,词,VERB,C1
-dominance,dominance,威权,NOUN,B2
-dominar,master,大师,NOUN,B2
-dominar,to master,掌握,VERB,B2
-domineering,domineering,词,ADJ,C1
-domineeringness,domineeringness,支配欲,NOUN,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
 donación,donation,捐款,NOUN,B2
-donation of goods,donation of goods,捐物,NOUN,C1
-donkey foal,donkey foal,词,NOUN,B2
-doom,doom,词,VERB,C1
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
-door lock,door lock,门锁,NOUN,C1
-doorbell button,doorbell button,门铃按钮,NOUN,B2
-doorkeeper,doorkeeper,词,NOUN,B1
-doorway,doorway,门口,NOUN,C1
-dope (noun),dope,词,NOUN,B2
-doping,doping,词,NOUN,C1
-doping agents,doping agents,词,NOUN,B2
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
-dormirse,to fall asleep,入睡,VERB,B2
+hecho,done,事已,NOUN,B2
+manija,door handle,门把手,NOUN,B2
+timbre,doorbell,门铃,NOUN,B2
+portero,doorman,门卫,NOUN,B2
+felpudo,doormat,门垫,NOUN,B2
 dormitorio,dormitory,宿舍,NOUN,B2
 dosificación,dosage,剂量,NOUN,B2
 dosis,dose,剂量,NOUN,B2
-dossier,dossier,档案,NOUN,B2
-dot,dot,点,NOUN,B2
-dotting,dotting,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubling,doubling,加倍,NOUN,B2
-doughy,doughy,面团状的,ADJ,B2
-douse,douse,词,VERB,C1
-down (adp),down,下,ADP,B2
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down there,down there,在那下面,ADV,B2
-down to,down to,以至,SCONJ,B2
-downfall,downfall,毁灭,NOUN,B2
-downgrade,downgrade,词,VERB,C1
-downplay,downplay,词,VERB,C1
-downplaying,downplaying,词,NOUN,C1
-downright,downright,词,ADV,B1
-downsize,downsize,词,VERB,C1
-downstairs,downstairs,词,ADV,B1
-doze (verb),doze,词,VERB,C1
-doze off,doze off,词,VERB,B2
-dozens,dozens,数十个,NOUN,B2
-draftsman,draftsman,绘图员,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-dragoon,dragoon,词,VERB,C1
+doblar,to double,加倍,VERB,B2
+abajo,down,顺...而下,ADP,B2
+descargar,to download,下载,VERB,B2
+aguas abajo,downstream,下游,NOUN,B2
+hacia abajo,downwards,向下,ADV,B2
+borrador,draft,草稿,NOUN,B2
 dragón,dragon,龙,NOUN,B2
-drainage sewage,drainage sewage,词,NOUN,C1
 drama,drama,戏剧,NOUN,B2
-dramatizar,to dramatize,戏剧化,VERB,B2
-dramatization,dramatization,词,NOUN,C1
 dramático,dramatic,戏剧性的,ADJ,B2
-draught,draught,词,NOUN,C1
-draw,draw,平局,NOUN,B2
-draw blood,draw blood,抽血,VERB,B2
-drawback,drawback,缺点,NOUN,B2
-drawl,drawl,词,VERB,C1
-dread (noun),dread,胆战,NOUN,B2
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge,dredge,,NOUN,B2
-dredge (verb),dredge,词,VERB,C1
-drench,drench,词,VERB,C1
-dressed,dressed,穿着的,ADJ,B2
-dressing room,dressing room,词,NOUN,B2
-dribble,dribble,词,VERB,C1
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
-drift (verb),drift,词,VERB,B2
-drift excess,drift excess,词,NOUN,C1
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinking water,drinking water,饮用水,NOUN,B2
-drinks,drinks,词,NOUN,C1
-drive,drive,动力,NOUN,B2
-drivel,drivel,词,NOUN,C1
-driven,driven,被驾驶的,ADJ,B2
-driving,driving,你来驾车,NOUN,C1
-drizzly,drizzly,词,ADJ,C1
+dramatizar,to dramatize,戏剧化,VERB,B2
+aprovechar la experiencia de,to draw on the experience of,借鉴,VERB,B2
+extracción,draw out,引出,NOUN,B2
+dibujo,drawing,图画,NOUN,B2
+temer,dread,恐惧,NOUN,B2
+temer,to dread,畏惧,VERB,B2
+posos,dregs,渣滓,NOUN,B2
+tofu seco,dried tofu,豆干,NOUN,B2
+deriva,drifting,漂泊,NOUN,B2
+taladro,drill,钻头,NOUN,B2
+licencia de conducir,driver's license,驾驶证,NOUN,B2
+entrada,driveway,车道,NOUN,B2
+llovizna,drizzle,毛毛雨,NOUN,B2
 dron,drone,无人机,NOUN,B2
-droop,droop,词,VERB,C1
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
-droppings,droppings,粪便,NOUN,B2
-drops,drops,词,NOUN,B1
-drowning,drowning,词,NOUN,C1
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
-drug dealer,drug dealer,毒贩,NOUN,B2
-drug medication,drug medication,词,NOUN,C1
-drugs,drugs,毒品,NOUN,B2
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
-dry cleaner,dry cleaner,词,NOUN,A2
-dry land,dry land,词,NOUN,B2
-dry sausage,dry sausage,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-dual,dual,词,ADJ,C1
-dual form,dual form,词,NOUN,C1
-dualidad,duality,二元性,NOUN,B2
+dejar caer,to drop,掉落,VERB,B2
+sequía,drought,干旱,NOUN,B2
+tambor,drum,鼓,NOUN,B2
 dualismo,dualism,二元论,NOUN,B2
-dub,dub,词,VERB,C1
-duct pipe,duct pipe,管道,NOUN,B2
-dude,dude,词,NOUN,A2
-due date maturity,due date maturity,词,NOUN,B2
-duel,duel,词,NOUN,C1
-dulce,sweetie,亲爱的,NOUN,B2
-dulces,sweets,甜食,NOUN,B2
-dull,dull,枯燥的,ADJ,B2
-dull-witted,dull-witted,词,ADJ,B2
-duly,duly,词,ADV,C1
-dumbfound,dumbfound,词,VERB,C1
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dump site,dump site,词,NOUN,B2
-dumping,dumping,倾销,NOUN,B2
-duna,dune,沙丘,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-duplicate,duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
+dualidad,duality,二元性,NOUN,B2
+doblaje,dubbing,配音,NOUN,B2
+pato,duck,鸭子,NOUN,B2
+debido a,due to,由于,ADP,B2
 duque,duke,公爵,NOUN,B2
-durable,durable,词,ADJ,C1
-durante años,for years,多年,ADV,B2
+monotonía,dullness,迟钝,NOUN,B2
+mudo,dumb,愚蠢的,ADJ,B2
+empanada,dumpling,丸子,NOUN,B2
+duna,dune,沙丘,NOUN,B2
 durante el día,during the day,在白天,ADV,B2
-durante la noche,overnight,一夜之间,ADV,B2
-durian,durian,榴莲,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-dutch,dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty of care,duty of care,词,NOUN,C1
-duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
-dwell,dwell,词,VERB,C1
-dwindle,dwindle,词,VERB,C1
-dwindling,dwindling,词,NOUN,C1
-dyed,dyed,词,ADJ,B1
-dying,dying,垂死的,ADJ,B2
-dying (noun),dying,dying,NOUN,B2
-dying without,dying without,将死无,NOUN,C1
-dynamics,dynamics,词,NOUN,C1
-dynamism,dynamism,活力,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
-día ordinario,ordinary day,平日,NOUN,B2
-día y noche,day and night,昼夜,NOUN,B2
-dígito,digit,数字,NOUN,B2
-e-reader,e-reader,电子阅读器,NOUN,B2
-each (noun),each,一一,NOUN,C1
-each (pron),each,各自,PRON,B2
-each every,each every,每,DET,A1
-each one,each one,每人,PRON,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-earlier,earlier,更早的,ADJ,B2
-earliness,earliness,你早,NOUN,C1
-early (adj),early,早的,ADJ,A1
-early (noun),early,词,NOUN,B2
-early morning,early morning,清晨,ADV,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-earnest,earnest,词,ADJ,B1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears,ears,耳朵,NOUN,B2
-ears of wheat,ears of wheat,词,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easier,easier,更容易的,ADJ,B2
-easily,easily,词,ADV,B2
-easing,easing,词,NOUN,C1
-east bank,east bank,东岸,NOUN,C1
-eastward,eastward,向东,ADV,B2
-easy defense,easy defense,易守,NOUN,C1
-eating,eating,,NOUN,B2
-eating habit,eating habit,词,NOUN,C1
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-ebb tide,ebb tide,词,NOUN,B1
-eccentric person,eccentric person,词,NOUN,C1
-echoes,echoes,词,NOUN,C1
-eclecticism,eclecticism,折衷主义,NOUN,B2
-eclipse,eclipse,日食,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-eco,echo,回声,NOUN,B2
-ecológico,ecological,生态的,ADJ,B2
-economic climate,economic climate,词,NOUN,B2
-economic cycle,economic cycle,经济周期,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economical,economical,词,ADJ,A1
-economically,economically,词,ADV,B1
-economize,economize,词,VERB,C1
-ecosistema,ecosystem,生态系统,NOUN,B2
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-eczema,eczema,湿疹,NOUN,B2
-eddy,eddy,漩涡,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edging,edging,镶边,NOUN,B2
-edible,edible,词,ADJ,C1
-edicto,edict,法令,NOUN,B2
-edit (noun),edit,重辑,NOUN,B2
-editing,editing,剪辑,NOUN,B2
-editor,editor,编辑,NOUN,B2
-editor,publisher,出版商,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
-editorial,editorial,社论,NOUN,B2
-editorial,publishing house,出版社,NOUN,B2
-editorial office,editorial office,编辑部,NOUN,B2
-educado,educated,受过教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
-eeg,eeg,脑电图,NOUN,B2
-efecto modificado,modified effect,改效,NOUN,B2
-efface,efface,词,VERB,C1
-effect and traces,effect and traces,词,NOUN,C1
-effect-seeking,effect-seeking,词,NOUN,C1
-effectively,effectively,有效地,ADV,B2
-effects,effects,词,NOUN,B2
-effectuate,effectuate,词,VERB,C1
-effervesce,effervesce,词,VERB,C1
-efficacy,efficacy,功效,NOUN,B2
-effort bet,effort bet,努力/赌注,NOUN,B2
-effortless,effortless,不费力的,ADJ,B2
-effuse,effuse,词,VERB,C1
-egg card,egg card,,NOUN,B2
-egg-laying,egg-laying,产卵,NOUN,B2
-eggplant,eggplant,茄子,NOUN,B2
-ego,ego,词,NOUN,C1
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoísmo,selfishness,自私,NOUN,B2
-egyptian,egyptian,埃及的,ADJ,B2
-eh,eh,词,INTJ,C1
-eider hunter,eider hunter,,NOUN,B2
-eider track,eider track,词,NOUN,B2
-eidsvold,eidsvold,,NOUN,B2
-eight (noun),eight,词,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-eighteen,eighteen,十八,NUM,B2
-eighth,eighth,第八,ADJ,B2
-eighty,eighty,八十,NUM,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
-either,either,或者,CCONJ,B2
-either (adv),either,词,ADV,B2
-ejército del sur,southern army,南军,NOUN,B2
-el resto,the rest,其余,NOUN,B2
+crepúsculo,dusk,黄昏,NOUN,B2
+deber,duty,责任,NOUN,B2
+disfunción,dysfunction,功能障碍,NOUN,B2
+distopía,dystopia,反乌托邦,NOUN,B2
+cada,each,每个,PRON,B2
 el uno al otro,each other,互相,PRON,B2
+ansioso,eager,渴望的,ADJ,B2
+águila,eagle,鹰,NOUN,B2
+antes,earlier,刚才,ADV,B2
+temprano,early,早的,ADJ,B2
+alerta temprana,early warning,预警,NOUN,B2
+ganar,to earn,赚取,VERB,B2
+terremoto,earthquake,地震,NOUN,B2
+este,east,东方,NOUN,B2
+fácil de decir,easy to say,好说,NOUN,B2
+eco,echo,回声,NOUN,B2
+eclipse,eclipse,日食,NOUN,B2
+ecológico,ecological,生态的,ADJ,B2
+ecosistema,ecosystem,生态系统,NOUN,B2
+edicto,edict,法令,NOUN,B2
+editor,editor,编辑,NOUN,B2
+editorial,editorial,社论,NOUN,B2
+educado,educated,受过教育的,ADJ,B2
+eeg,eeg,脑电图,NOUN,B2
+efficacy,efficacy,功效,NOUN,B2
+eggplant,eggplant,茄子,NOUN,B2
+either,either,或者,CCONJ,B2
 elasticity,elasticity,弹性,NOUN,B2
 elated,elated,兴高采烈的,ADJ,B2
-elation,elation,兴高采烈,NOUN,B2
-elder brother,elder brother,兄长,NOUN,B1
 elderly,elderly,年长的,ADJ,B2
-elderly (noun),elderly,老弱,NOUN,B2
-eldest,eldest,词,ADJ,A2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
 eldest son,eldest son,长子,NOUN,B2
 elect,to elect,选举,VERB,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective course,elective course,选修课,NOUN,B2
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
 electric,electric,电动的,ADJ,B2
-electric (noun),electric,词,NOUN,B2
-electric guitar,electric guitar,电吉他,NOUN,B2
-electric motor,electric motor,电动机,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electric power,electric power,电力,NOUN,B2
-electrical engineering,electrical engineering,词,NOUN,C1
-electrical theory,electrical theory,电学,NOUN,B2
 electrician,electrician,电工,NOUN,B2
-electrification,electrification,词,NOUN,C1
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
 electronic payment,electronic payment,电子支付,NOUN,B2
-electronics,electronics,电子学,NOUN,B2
-elemental,elemental,词,ADJ,B2
-elementary,elementary,基本的,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
-eleven,eleven,十一,NOUN,B2
-eleventh,eleventh,词,NUM,B1
-elf,elf,词,NOUN,C1
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
-eliminación,removal,移除,NOUN,B2
 elite,elite,精英,NOUN,B2
-elite unit,elite unit,,NOUN,B2
-elitism,elitism,词,NOUN,C1
-ellipsis (part),ellipsis,…,PART,C1
-ello,id,证件,NOUN,B2
-ellos,they things,它们,PRON,B2
-elogio,eulogy,赞辞,NOUN,B2
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
-else,else,词,ADV,A1
-elsewhere,elsewhere,别处,ADV,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciating,emaciating,消耗的,ADJ,B2
-emaciation,emaciation,词,NOUN,C1
 email,email,电子邮件,NOUN,B2
-email address,email address,电子邮件地址,NOUN,B2
-embargo,embargo,禁运,NOUN,B2
 embarrassed,embarrassed,尴尬的,ADJ,B2
-embattle,embattle,词,VERB,C1
-embers,embers,词,NOUN,B1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-embodiment,embodiment,词,NOUN,B2
-emboss,emboss,词,VERB,C1
 embrace,embrace,拥抱,NOUN,B2
-embrace each other,embrace each other,词,VERB,B2
 embroidery,embroidery,刺绣,NOUN,B2
-embroil,embroil,词,VERB,C1
-embryonic,embryonic,词,ADJ,C1
-emend,emend,词,VERB,B2
-emerald,emerald,祖母绿,NOUN,B2
 emergence,emergence,涌现,NOUN,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
 emergency room,emergency room,急诊室,NOUN,B2
-emerging,emerging,词,ADJ,C1
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
-emisora,radio station,广播电台,NOUN,B2
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emote,emote,词,VERB,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
-emotional life,emotional life,情感生活,NOUN,B2
 emotionality,emotionality,感性/情绪化,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emotionally,emotionally,情感上,ADV,B2
-empanada,dumpling,丸子,NOUN,B2
-emparejar,to match,相配,VERB,B2
-empathetic,empathetic,词,ADJ,B1
 empathy,empathy,共情,NOUN,B2
-empezar,to begin to start,开始,VERB,B2
-emphasize,emphasize,着重,ADV,B2
-emphatically,emphatically,词,ADV,C1
-empirical,empirical,经验的,ADJ,B2
 employ,to employ,雇用,VERB,B2
-employability,employability,词,NOUN,B2
 employer,employer,雇主,NOUN,B2
-employers,employers,词,NOUN,B1
 employment,employment,就业,NOUN,B2
 empower,to empower,授权,VERB,B2
-empowerment,empowerment,词,NOUN,C1
-emprendimiento,undertaking,事业,NOUN,B2
 empress,empress,女皇,NOUN,B2
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
 emptiness,emptiness,空虚,NOUN,B2
 empty fame,empty fame,虚名,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empuje,thrust,猛推,NOUN,B2
-empuje hacia,thrust toward,插向,NOUN,B2
-empuñadura,hilt,剑柄,NOUN,B2
-emulator,emulator,词,NOUN,C1
-emulsify,emulsify,词,VERB,C1
-emulsion,emulsion,词,NOUN,C1
-en alguna parte,somewhere,某处,ADV,B2
-en casa,at home,在家,ADV,B2
-en caso de que,in case,如果,SCONJ,B2
-en el cielo,in the sky,天上,NOUN,B2
-en el viento,in wind,临风,NOUN,B2
-en ello,in it,在里面,ADV,B2
-en general,overall,总体上,ADV,B2
-en ninguna parte,nowhere,无处,ADV,B2
-en persona,in person,亲自地,ADV,B2
-en primer lugar,first of all,首先,ADV,B2
-en resumen,in short,简而言之,ADV,B2
-en vano,in vain,徒劳,ADV,B2
-enamor,enamor,词,VERB,C1
-enamorarse,to fall in love,坠入爱河,VERB,B2
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encampments,encampments,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-enchain,enchain,词,VERB,C1
 enchant,to enchant,使着迷,VERB,B2
-encima,over,在...上方,ADP,B2
-encirclement,encirclement,环绕,NOUN,B2
 enclose,to enclose,围住,VERB,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encoding,encoding,编码,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore (noun),encore,词,NOUN,C1
 encounter,encounter,相遇,NOUN,B2
 encounter,to encounter,遭遇,VERB,B2
-encounter (noun),encounter,遇上,NOUN,B2
-encouraging,encouraging,词,ADJ,C1
-encroachment,encroachment,词,NOUN,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encrypted,encrypted,词,ADJ,B2
 encryption,encryption,加密,NOUN,B2
-encuesta,poll,民意调查,NOUN,B2
-encumber,encumber,词,VERB,C1
 encyclopedia,encyclopedia,百科全书,NOUN,B2
 end,end,端,PART,B2
 end,to end,结束,VERB,B2
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
 end up,to end up,最终到达,VERB,B2
 endanger,to endanger,危及,VERB,B2
 endangered,endangered,濒危的,ADJ,B2
-endear,endear,词,VERB,C1
-endeavor,endeavor,努力,NOUN,B2
-endeavor (verb),endeavor,词,VERB,C1
-endemic disease,endemic disease,地方病,NOUN,B2
-ending,ending,了头,NOUN,C1
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowed,endowed,有天赋的,ADJ,B2
-endue,endue,词,VERB,C1
 endurance,endurance,坚忍,NOUN,B2
-enduring hardship,enduring hardship,词,NOUN,C1
-enemistad personal,personal enmity,私仇,NOUN,B2
-enemy army,enemy army,敌军,NOUN,C1
 enemy must,enemy must,仇必,NOUN,B2
-enemy of the state,enemy of the state,词,NOUN,C1
 enemy state,enemy state,敌国,NOUN,B2
-energize,energize,词,VERB,C1
 energy,energy,能量,NOUN,B2
-energy crisis,energy crisis,能源危机,NOUN,B2
-energy saving,energy saving,节能,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfermar,to fall ill,患病,VERB,B2
-enfermedad,malady,弊病,NOUN,B2
-enfermo,ill,生病的,ADJ,B2
-enfold,enfold,词,VERB,C1
 enforce,to enforce,执行,VERB,B2
-enforceability,enforceability,词,NOUN,C1
 enforcement,enforcement,执行,NOUN,B2
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-enfranchise,enfranchise,词,VERB,C1
-enfriar,to cool down,冷却,VERB,B2
 engage,to engage,从事,VERB,B2
 engaged,engaged,订婚的,ADJ,B2
 engagement,engagement,订婚,NOUN,B2
-engañar,to cheat,欺骗,VERB,B2
-engañar,to trick,欺骗,VERB,B2
-engañoso,misleading,诡辩的,ADJ,B2
-engender,engender,词,VERB,C1
-engine motor,engine motor,词,NOUN,C1
 english,english,英国的,ADJ,B2
-english teacher,english teacher,,NOUN,B2
-english-speaking,english-speaking,讲英语的,ADJ,B2
 englishman,englishman,英国人,NOUN,B2
-engraft,engraft,词,VERB,C1
-engrasar,to grease,涂油,VERB,B2
-engrave in mind,engrave in mind,铭记,VERB,C1
 engraving,engraving,版画,NOUN,B2
-engrossing,engrossing,引人入胜的,ADJ,B2
-engulf,engulf,词,VERB,C1
-enigma,enigma,词,NOUN,C1
-enjambment,enjambment,词,NOUN,C1
-enjoin,enjoin,词,VERB,C1
-enjoyable,enjoyable,词,ADJ,B1
-enjoyed,enjoyed,词,ADJ,C1
-enkindle,enkindle,词,VERB,C1
-enlace,liaison,联络,NOUN,B2
-enlargement,enlargement,词,NOUN,C1
 enlighten,to enlighten,启发,VERB,B2
 enlightenment,enlightenment,澄清,NOUN,B2
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enloquecer,to go crazy,发疯,VERB,B2
-enmesh,enmesh,词,VERB,C1
-enojarse,to get angry,生气,VERB,B2
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enormously,enormously,巨大地,ADV,B2
 enough,enough,足够,ADV,B2
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enquire,enquire,词,VERB,C1
-enrolled,enrolled,词,ADJ,B2
-enrutador,router,路由器,NOUN,B2
-ensconce,ensconce,词,VERB,C1
-enshrine,enshrine,词,VERB,C1
-enshrinement,enshrinement,词,NOUN,C1
-enshroud,enshroud,词,VERB,C1
-ensign,ensign,词,NOUN,C1
-enslavement,enslavement,奴役,NOUN,B2
-enslavement by love,enslavement by love,词,NOUN,C1
-ensue,ensue,词,VERB,B2
-entanglement,entanglement,缠,NOUN,C1
-ente,being,存在,NOUN,B2
 enter city,to enter city,进城,VERB,B2
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
 enterprise,enterprise,企业,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertainer,entertainer,词,NOUN,B2
 entertainment center,entertainment center,娱乐中心,NOUN,B2
 enthusiast,enthusiast,爱好者,NOUN,B2
-enticement,enticement,词,NOUN,C1
 entire,entire,整个的,ADJ,B2
 entirety,entirety,全部,NOUN,B2
-entitle,entitle,词,VERB,C1
-entitled to exist,entitled to exist,词,ADJ,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
-entomb,entomb,词,VERB,C1
-entonces,at that time,当时/那时,ADV,B2
-entonces,thereupon,随后,ADV,B2
 entourage,entourage,随从,NOUN,B2
-entrada,driveway,车道,NOUN,B2
-entrance ticket,entrance ticket,门票,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrante,incoming,进来的,ADJ,B2
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entrar,to come in,进来,VERB,B2
-entrar,to go in,进去,VERB,B2
-entreat,entreat,词,VERB,C1
-entrega,handover,拿给,NOUN,B2
-entregar,to hand over,交付,VERB,B2
-entrenamiento espiritual,spirit training,练神,NOUN,B2
-entrenar,to coach,辅导,VERB,B2
-entrenchment,entrenchment,词,NOUN,C1
-entrepreneurship,entrepreneurship,词,NOUN,C1
-entretanto,meantime,同时,NOUN,B2
-entropy,entropy,熵,NOUN,B2
 entry,entry,入口,NOUN,B2
-entwine,entwine,词,VERB,C1
-enunciado,utterance,话语,NOUN,B2
-enunciative,enunciative,词,ADJ,C1
-envejecer,to vie,竞争,VERB,B2
-envelop,envelop,词,VERB,C1
 envelope,envelope,信封,NOUN,B2
-envenom,envenom,词,VERB,C1
-enviar,to ship out,出货,VERB,B2
-envious jealous,envious jealous,嫉妒的,ADJ,B2
-environ,environ,词,VERB,C1
 environmental,environmental,环境的,ADJ,B2
 environmental protection,environmental protection,环境保护,NOUN,B2
 environmental report,environmental report,环境报告,NOUN,B2
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
 envision,to envision,展望,VERB,B2
-envoy,envoy,词,NOUN,B2
-enwetens,enwetens,词,ADV,C1
 enzyme,enzyme,酶,NOUN,B2
-eon age,eon age,词,NOUN,C1
-epic quality,epic quality,词,NOUN,C1
-epilepsy,epilepsy,词,NOUN,C1
-epitomize,epitomize,词,VERB,C1
-epoch,epoch,时代,NOUN,B2
 equal,equal,相等的,ADJ,B2
-equal size,equal size,等大,NOUN,B2
-equal treatment,equal treatment,平等待遇,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally,equally,同样地,ADV,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equatorial,equatorial,词,ADJ,C1
-equilibrado,balanced,平衡的,ADJ,B2
-equilibrado,hold the balance of power,举足轻重,ADJ,B2
-equilibrate,equilibrate,词,VERB,C1
+igualdad,equality,平等,NOUN,B2
 equilibrio,equilibrium,平衡,NOUN,B2
 equipado,equipped,配备的,ADJ,B2
-equipo,gear,齿轮,NOUN,B2
-equipo,team,团队,NOUN,B2
-equipo esencial,essential equipment,要置,NOUN,B2
-equivalent (adj),equivalent,相等的,ADJ,B2
-equivalent to,equivalent to,相当,ADJ,B1
 equivalente,equivalent,等价物,NOUN,B2
-equivocado,wrong mistake,错误,ADJ,B2
-equivocarse,to mistake,弄错,VERB,B2
-equivocate,equivocate,词,VERB,C1
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergestaltung,ergestaltung,词,NOUN,C1
-ergonomics,ergonomics,词,NOUN,C1
-erhu,erhu,二胡,NOUN,B2
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
-erpflegung,erpflegung,词,NOUN,C1
 erradicación,eradication,根除,NOUN,B2
-errant,errant,词,ADJ,C1
+borrador,eraser,橡皮擦,NOUN,B2
+borrado,erasure,擦除,NOUN,B2
+erhu,erhu,二胡,NOUN,B2
+recado,errand,差事,NOUN,B2
 errata,errata,勘误,NOUN,B2
-erregelung,erregelung,词,NOUN,C1
 error,error,错误,NOUN,B2
-error,make mistake,犯错,NOUN,B2
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
-eructar,to burp,打嗝,VERB,B2
-erudito,scholar,学者,NOUN,B2
-erupt,erupt,词,VERB,C1
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
-es decir,namely,即,ADV,B2
-es decir,that is,即,ADV,B2
-esa flecha,that arrow,那一箭,NOUN,B2
 escalar,to escalate,升级,VERB,B2
-escalera,ladder,梯子,NOUN,B2
 escalera mecánica,escalator,自动扶梯,NOUN,B2
-escalonado,phased,阶段性,ADJ,B2
-escaneo,scan,扫描件,NOUN,B2
-escaping,escaping,词,NOUN,C1
-escarabajo,beetle,甲虫,NOUN,B2
-escasez,shortage,短缺,NOUN,B2
-escena del crimen,crime scene,犯罪现场,NOUN,B2
-eschatological,eschatological,词,ADJ,C1
-eschatology,eschatology,词,NOUN,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escolástico,scholastic,经院哲学的,ADJ,B2
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-escritorio,desk,书桌,NOUN,B2
-escuadrón,squad,小队,NOUN,B2
+guardia de escolta,escort guard,镖师,NOUN,B2
+equipo esencial,essential equipment,要置,NOUN,B2
 esencialmente,essentially,主要地,ADV,B2
-esforzarse,to work hard for sth to strive for success,争气,VERB,B2
-esguince,sprain,扭伤,NOUN,B2
-esophagus,esophagus,词,NOUN,B2
-esos,those,那些,DET,B2
-esotericism,esotericism,秘教,NOUN,B2
-espacio,space,空间,NOUN,B2
-espalda,back,背面,NOUN,B2
-espantoso,scary,可怕的,ADJ,B2
-español,spanish,西班牙语,NOUN,B2
-especialidad,specialty,专业,NOUN,B2
-especializado,specialized,专业的,ADJ,B2
-especie,species,物种,NOUN,B2
-espera,wait,等待,NOUN,B2
-espera,wait for me,等我,NOUN,B2
-esperar,to await,等待,VERB,B2
-esperar mucho,to wait long,久等,VERB,B2
-espinaca de agua,water spinach,空心菜,NOUN,B2
-espontáneo,spontaneous,自发的,ADJ,B2
-espresso,espresso,浓缩咖啡,NOUN,B2
-esquejar,to take cuttings,扦插,VERB,B2
-esquema,outline,大纲,NOUN,B2
-essayistic quality,essayistic quality,词,NOUN,C1
-essence core,essence core,词,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
-esta batalla,this battle,此战,NOUN,B2
-esta noche,tonight,今晚,NOUN,B2
-estable,steady,稳定的,ADJ,B2
 establecido,established,既定的,ADJ,B2
-estacional,seasonal,季节性的,ADJ,B2
-estado de derecho,rule of law,法治,NOUN,B2
-estancarse,to stagnate,停滞,VERB,B2
-estandarización,standardization,标准化,NOUN,B2
-estar a salvo,to be safe,安好,VERB,B2
-estar agradecido,to be grateful,感激,VERB,B2
-estar ansioso,to be eager,心切,VERB,B2
-estar callado,to be silent,沉默,VERB,B2
-estar celoso,to be jealous,嫉妒,VERB,B2
-estar de servicio,to be on duty,值班,VERB,B2
-estar embelesado,to be entranced,出神,VERB,B2
-estar hecho,to be done,被做,VERB,B2
-estar ubicado,to be located,位于,VERB,B2
-estatus,status,地位,NOUN,B2
-este,east,东方,NOUN,B2
-este,this,您这,NOUN,B2
-este artículo,this item,这件,NOUN,B2
-este campamento,this-camp,这营,NOUN,B2
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-estenosis,stenosis,狭窄,NOUN,B2
 estima,esteem,尊重,NOUN,B2
-estimation,estimation,词,NOUN,C1
-estos,these,这些,DET,B2
-estos tres,these three,这三,NOUN,B2
-estrange,estrange,词,VERB,C1
-estrechar la mano,to shake hands,握手,VERB,B2
-estudiante de pregrado,undergraduate,本科生,NOUN,B2
-estándar,standard,标准,NOUN,B2
-etapa final,final stage,末期,NOUN,B2
-etc,etc,等等,NOUN,B2
-etc.,etc.,词,ADV,C1
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
+distanciamiento,estrangement,疏离,NOUN,B2
+alianza eterna,eternal alliance,永结,NOUN,B2
 ethereum,ethereum,以太坊,NOUN,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
-etiqueta pesada,heavy etiquette,礼太重,NOUN,B2
+ética,ethics,伦理学,NOUN,B2
 etnia,ethnicity,种族,NOUN,B2
 etnografía,ethnography,人种学,NOUN,B2
 etnología,ethnology,民族学,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-euphemistic,euphemistic,委婉的,ADJ,B2
-europe,europe,欧洲,PROPN,B2
+elogio,eulogy,赞辞,NOUN,B2
 europeo,european,欧洲的,ADJ,B2
 evacuación,evacuation,疏散,NOUN,B2
-evaluación de ofertas,bid evaluation,评标,NOUN,B2
-evanesce,evanesce,词,VERB,C1
-evangelization,evangelization,词,NOUN,C1
-evaporating,evaporating,词,ADJ,C1
-eve,eve,前夕,NOUN,C1
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening meal,evening meal,晚餐,NOUN,B2
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-evenly,evenly,均匀地,ADV,B2
-events,events,事件,NOUN,C1
-eventual,eventual,词,ADJ,C1
-eventual outcome,eventual outcome,词,NOUN,C1
+par,even,偶数的,ADJ,B2
+incluso si,even if,即使,SCONJ,B2
+tarde,evening,晚上,NOUN,B2
 eventualmente,eventually,最终,ADV,B2
-eventuate,eventuate,词,VERB,C1
-ever,ever,,NOUN,B2
-everlastingness,everlastingness,词,NOUN,C1
-every,every,每个,PRON,B2
+siempre,ever,曾经,ADV,B2
+siempre,to ever,里何尝,VERB,B2
+cada,every,每个,DET,B2
 every day,every day,天天,ADV,B2
-every day (noun),every day,每天,NOUN,C1
-every other,every other,每隔一个,DET,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
 everyone,everyone,每个人,PRON,B2
-everyone (noun),everyone,人人,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
 everything,everything,一切,PRON,B2
 everywhere,everywhere,到处,ADV,B2
-evidence bag,evidence bag,,NOUN,B2
-evidente,obvious,明显的,ADJ,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
 evil,evil,恶行,NOUN,B2
-evil (adj),evil,词,ADJ,B1
-evil (part),evil,邪,PART,B2
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evitación,avoidance,避免,NOUN,B2
-evolutionary,evolutionary,词,ADJ,C1
 exacerbation,exacerbation,加剧,NOUN,B2
-exact change,exact change,词,NOUN,C1
-exactly just,exactly just,恰好,ADV,B2
-exactly the same,exactly the same,一模一样,ADJ,B2
-exactness,exactness,精确,NOUN,B2
-exam evening,exam evening,,NOUN,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-examen,past exam papers,真题,NOUN,B2
-examen mensual,monthly exam,月考,NOUN,B2
 examination,examination,考试,NOUN,B2
-excavación,digging,挖掘,NOUN,B2
-excavated,excavated,词,ADJ,B1
-excavation,excavation,词,NOUN,B2
-excederse,to take a leave of absence,休学,VERB,B2
 excel,to excel,擅长,VERB,B2
 except,except,除了,ADP,B2
-except for,except for,除了,ADP,B2
-except unless,except unless,词,ADP,A2
-exceptionality,exceptionality,特殊性,NOUN,B2
-exceptionally,exceptionally,例外地,ADV,B2
 excerpt,excerpt,摘录,NOUN,B2
-excess weight,excess weight,词,NOUN,C1
-excessively,excessively,词,ADV,C1
-excessiveness,excessiveness,词,NOUN,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excision,excision,词,NOUN,C1
 excited,excited,兴奋的,ADJ,B2
-exclamation (punct),exclamation,词,PUNCT,A2
 excluded,excluded,排除在外的,ADJ,B2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusive dedication,exclusive dedication,词,NOUN,C1
 exclusively,exclusively,专门地,ADV,B2
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
 execution,execution,执行,NOUN,B2
 executioner,executioner,刽子手,NOUN,B2
 executive,executive,行政主管,NOUN,B2
-executive board,executive board,词,NOUN,C1
-executory,executory,词,ADJ,C1
-exemplar,exemplar,楷模,NOUN,C1
-exemplary country,exemplary country,模范国家,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exento de impuestos,tax-exempt,免税,ADJ,B2
 exercise,to exercise,锻炼,VERB,B2
-exercise book,exercise book,词,NOUN,C1
-exercise equipment,exercise equipment,词,NOUN,B2
-exercise of authority,exercise of authority,词,NOUN,B2
-exercises,exercises,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhausting,exhausting,词,ADJ,B2
 exhaustive,exhaustive,详尽的,ADJ,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exigent,exigent,词,ADJ,C1
-existentialism,existentialism,存在主义,NOUN,B2
-existing,existing,现有的,ADJ,B2
-exit (verb),exit,词,VERB,A1
-exitoso,successful,成功的,ADJ,B2
-exorcism,exorcism,词,NOUN,C1
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,外传的,ADJ,B2
-exoticism,exoticism,异国情调,NOUN,B2
-expanse,expanse,词,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expatiate,expatiate,词,VERB,C1
-expatriate,expatriate,移居国外者,NOUN,B2
 expect,to expect,期待,VERB,B2
-expedite,expedite,词,VERB,C1
 expend,to expend,花费,VERB,B2
 expenditure,expenditure,支出,NOUN,B2
-expenditures,expenditures,支出,NOUN,C1
-expensiveness,expensiveness,词,NOUN,B2
-experience exchange,experience exchange,经验交流,NOUN,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
 experimental,experimental,实验的,ADJ,B2
-expert opinion,expert opinion,专家意见,NOUN,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiate,expiate,词,VERB,C1
 expiry,expiry,失效,NOUN,B2
-explanatory,explanatory,解释的,ADJ,B2
-explicable,explicable,可解释的,ADJ,B2
-explicate,explicate,词,VERB,C1
-exploits,exploits,词,NOUN,C1
-exploración,reconnaissance,侦察,NOUN,B2
-explorador,scout,侦察员,NOUN,B2
-explosion-proof,explosion-proof,防爆,ADJ,B2
 explosive,explosive,炸药,NOUN,B2
-explosives,explosives,炸药,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exports,exports,词,NOUN,C1
 expose,to expose,暴露,VERB,B2
 exposition,exposition,阐述,NOUN,B2
-expostulate,expostulate,词,VERB,C1
 exposure,exposure,暴露,NOUN,B2
 expound,to expound,阐述,VERB,B2
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
 expression,expression,表达,NOUN,B2
-expression of opinion,expression of opinion,意见表达,NOUN,B2
-expressionism,expressionism,词,NOUN,C1
-expressiveness,expressiveness,表现力,NOUN,B2
 expressly,expressly,明确地,ADV,B2
-expunge,expunge,词,VERB,C1
-extemporize,extemporize,词,VERB,C1
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
 extent,extent,程度,NOUN,B2
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,在外,NOUN,B2
-exterior,outside,外部,NOUN,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinct,extinct,灭绝的,ADJ,B2
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extolling,extolling,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
 extra,extra,额外的,ADJ,B2
-extra (adv),extra,词,ADV,A1
-extra (noun),extra,群众演员,NOUN,B2
-extra drink,extra drink,多喝,NOUN,C1
-extracción,draw out,引出,NOUN,B2
-extramarital,extramarital,词,ADJ,C1
-extranjero,abroad,国外,NOUN,B2
-extraterrestre,alien,外星人,NOUN,B2
-extraversion,extraversion,词,NOUN,C1
-extraño,bizarre,奇异的,ADJ,B2
-extremadamente,extremely,极其,ADV,B2
 extreme,extreme,أقصى,NOUN,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremity,extremity,极为,NOUN,B2
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-exudation,exudation,词,NOUN,C1
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyebrows,eyebrows,词,NOUN,A1
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
+extremadamente,extremely,极其,ADV,B2
+pestaña,eyelash,睫毛,NOUN,B2
+párpado,eyelid,眼皮,NOUN,B2
+testigo ocular,eyewitness,目击,NOUN,B2
+tela,fabric,织物,NOUN,B2
 fabricación,fabrication,捏造,NOUN,B2
-fabricar,to manufacture,制造,VERB,B2
-fabricated,fabricated,词,ADJ,B2
-fabulist,fabulist,幻想家,NOUN,B2
+fisionomía,face reading,面相,NOUN,B2
+reconocimiento facial,face recognition,认人,NOUN,B2
+instalaciones,facilities,设施,NOUN,B2
+instalación,facility,设施,NOUN,B2
 facción,faction,派,NOUN,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facies,facies,面貌,NOUN,B2
-facilitation,facilitation,词,NOUN,C1
-facticity,facticity,词,NOUN,C1
-factionalism,factionalism,派系主义,NOUN,B2
 factor,factor,因素,NOUN,B2
-factoring,factoring,保理,NOUN,B2
-factual,factual,事实的,ADJ,B2
-fad,fad,词,NOUN,C1
-fade away,fade away,词,VERB,C1
-fading away,fading away,词,NOUN,C1
-fag,fag,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-failure to act,failure to act,词,NOUN,C1
-faint,faint,微弱的,ADJ,B2
-fair decent,fair decent,公平的/正派的,ADJ,B2
-fair hair,fair hair,,NOUN,B2
-fair-haired,fair-haired,词,ADJ,B1
-fairly,fairly,词,ADV,C1
-fairness,fairness,词,NOUN,B2
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,假新闻,NOUN,B2
-falacia,fallacy,谬误,NOUN,B2
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallecer,to pass away,流逝,VERB,B2
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-fallout,fallout,词,NOUN,C1
-fallow land,fallow land,词,NOUN,B2
-false oath,false oath,词,NOUN,C1
-falsedad,falsehood,谎言,NOUN,B2
-falsely,falsely,词,ADV,C1
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falsificación,forgery,伪造品,NOUN,B2
-falsificar,to falsify,伪造,VERB,B2
-falsification,falsification,词,NOUN,C1
-falso,counterfeit,假冒,ADJ,B2
+intento fallido,failed bid,流标,NOUN,B2
+desmayo,fainting,晕厥,NOUN,B2
+cuento de hadas,fairy tale,童话,NOUN,B2
 falso,fake,假的,ADJ,B2
-falta,miss,小姐,NOUN,B2
-faltar,to be missing,缺少,VERB,B2
-falter,falter,词,VERB,C1
-familial,familial,词,ADJ,B2
+dormirse,to fall asleep,入睡,VERB,B2
+retroceder,to fall back,回落,VERB,B2
+enfermar,to fall ill,患病,VERB,B2
+enamorarse,to fall in love,坠入爱河,VERB,B2
+falacia,fallacy,谬误,NOUN,B2
+disputa,falling out,反目,NOUN,B2
+fracaso,falling though,虽坠,NOUN,B2
+falsedad,falsehood,谎言,NOUN,B2
+falsificar,to falsify,伪造,VERB,B2
 familiar,familiar,熟悉的,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
 familiaridad,familiarity,مألوف,NOUN,B2
-family (adj),family,词,ADJ,B1
-family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family life,family life,家庭生活,NOUN,B2
-family portrait,family portrait,全家福,NOUN,B2
-family relatives,family relatives,亲属,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,家庭纽带,NOUN,B2
-famish,famish,词,VERB,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fanatical,fanatical,词,ADJ,C1
-fancy,fancy,词,ADJ,B1
-fantasize,fantasize,词,VERB,C1
-fantasizing,fantasizing,词,NOUN,C1
+miembro de la familia,family member,家庭成员,NOUN,B2
+ruina familiar,family ruin,家破,NOUN,B2
 fantasía,fantasy,幻想,NOUN,B2
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farm yard,farm yard,农场,NOUN,B2
-farmacéutico,pharmaceutical,制药的,ADJ,B2
-farmland,farmland,农田,NOUN,C1
-farrow,farrow,词,VERB,C1
-farsa,sham,假冒,NOUN,B2
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascinated,fascinated,着迷的,ADJ,B2
-fascist (adj),fascist,词,ADJ,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,fast,快地,ADV,B2
-fast forward,fast forward,快进,VERB,C1
-fastening,fastening,要扎紧,NOUN,B2
-faster,faster,更快的,ADJ,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatally,fatally,词,ADV,C1
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatiga de viaje,travel fatigue,车马劳顿,NOUN,B2
-fats,fats,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatwa,fatwa,词,NOUN,B2
-fauna,fauna,动物群,NOUN,B2
+lejano,far,远的,ADJ,B2
+granja,farm,农场,NOUN,B2
+agricultura,farming,农业,NOUN,B2
+moda,fashion,时尚,NOUN,B2
+ayunar,to fast,禁食,VERB,B2
+rápido,fast quick,快的,ADJ,B2
+ayuno,fasting,禁食,NOUN,B2
+grasa,fat,脂肪,NOUN,B2
+padre,father,父,PART,B2
+suegro,father-in-law,岳父/公公,NOUN,B2
 favor,favor,恩惠,NOUN,B2
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favorite,favorite,最爱,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawn,fawn,词,VERB,C1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
-fax,fax,传真,NOUN,B2
-faze,faze,词,VERB,B1
-fear book,fear book,怕本,NOUN,B2
-fear of heights,fear of heights,词,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-feces,feces,屎,NOUN,C1
-fecha límite,deadline,截止日期,NOUN,B2
-fecundate,fecundate,词,VERB,C1
-fed up,fed up,受够了,NOUN,B2
+circunstancias favorables,favorable circumstances,顺境,NOUN,B2
+viabilidad,feasibility,可行性,NOUN,B2
+pluma,feather,羽毛,NOUN,B2
+característica,feature,特征,NOUN,B2
 federal,federal,联邦的,ADJ,B2
 federalismo,federalism,联邦主义,NOUN,B2
-federalization,federalization,联邦化,NOUN,B2
-federalize,federalize,词,VERB,C1
-fee,fee,费用,NOUN,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
-feeding,feeding,词,NOUN,C1
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-felicitate,felicitate,词,VERB,C1
-felicity,felicity,词,NOUN,C1
-felpudo,doormat,门垫,NOUN,B2
-felt,felt,词,NOUN,C1
-female,female,雌性,NOUN,B2
-female general,female general,女将,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
+alimento,feed,饲料,NOUN,B2
+retroalimentación,feedback,反馈,NOUN,B2
+compañero,fellow,家伙,NOUN,B2
+mujer,female,女性的,ADJ,B2
+parientes femeninas,female relatives,女眷,NOUN,B2
 feminidad,femininity,女性气质,NOUN,B2
-feminization,feminization,词,NOUN,C1
-fend,fend,词,VERB,C1
-feng shui,feng shui,风水,NOUN,C1
-fennec fox,fennec fox,词,NOUN,B2
-fenomenología,phenomenology,现象学,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fern,fern,蕨类植物,NOUN,B2
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferociously,ferociously,词,ADV,C1
-ferry,ferry,渡轮,NOUN,B2
-fervor,fervor,词,NOUN,C1
+supurar,to fester,溃烂,VERB,B2
 festival,festival,节日,NOUN,B2
-festivals,festivals,词,NOUN,C1
-festivity,festivity,词,NOUN,C1
-fete,fete,词,VERB,C1
-fetter,fetter,词,VERB,C1
-feud end,feud end,仇终,NOUN,C1
-feudal,feudal,封建,ADJ,B2
-feudal ethics,feudal ethics,礼教,NOUN,B2
+traer,to fetch,取来,VERB,B2
 feudo,feud,世仇,NOUN,B2
-few,few,几下,NOUN,B2
-fewer,fewer,较少的,ADJ,B2
-fez,fez,词,NOUN,B2
-fiancee,fiancee,未婚妻,NOUN,B2
-fib,fib,词,VERB,C1
+feudal,feudal,封建,ADJ,B2
+pocos,few,很少的,ADJ,B2
+novio,fiance,未婚夫,NOUN,B2
 fibrosis,fibrosis,纤维化,NOUN,B2
-fickleness,fickleness,反复无常,NOUN,B2
 ficticio,fictional,虚构的,ADJ,B2
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictionalize,fictionalize,词,VERB,C1
-fiddle (verb),fiddle,词,VERB,C1
-fidget,fidget,词,VERB,C1
-fief,fief,封地,NOUN,B2
-field (adj),field,词,ADJ,C1
-field medic,field medic,战地医生,NOUN,B2
-fieldwork,fieldwork,词,NOUN,B1
-fierce one,fierce one,词,NOUN,B2
-fifth,fifth,第五,NUM,B2
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figuration,figuration,群演,NOUN,B2
-figurative language,figurative language,词,NOUN,C1
-figure skating,figure skating,花样滑冰,NOUN,C1
-fijo,fixed,固定的,ADJ,B2
-filch,filch,词,VERB,C1
-file a case,file a case,立案,VERB,B2
-file expense,file expense,报账,VERB,B2
+quinto,fifth,خامس,ADJ,B2
 filial,filial,孝顺,ADJ,B2
-filings,filings,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
-fill pack,fill pack,装满,VERB,B2
-filled,filled,充满的,ADJ,B2
-fillet (verb),fillet,词,VERB,C1
-filling,filling,词,NOUN,B2
-film art,film art,词,NOUN,C1
-film director,film director,词,NOUN,B2
-film industry,film industry,电影业,NOUN,B2
-film movie,film movie,电影,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,电影制片厂,NOUN,B2
+llenar,to fill in,填写,VERB,B2
 filmar,film,电影,NOUN,B2
 filmar,to film,拍摄,VERB,B2
-filming,filming,拍摄,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
-filth garbage,filth garbage,词,NOUN,C1
-fin,fin,词,NOUN,B2
 final,final,最终的,ADJ,B2
-final (noun),final,决赛,NOUN,B1
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
-finality,finality,词,NOUN,C1
-finalmente,ultimately,最终,ADV,B2
-finals,finals,决赛,NOUN,B1
-finance,finance,金融,NOUN,B2
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financier,financier,资助者,NOUN,B2
-financing funding,financing funding,融资,NOUN,B2
-find,find,发现物,NOUN,B2
-find back,find back,找回来,NOUN,C1
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
-fine arts,fine arts,美术,NOUN,B1
-fine pretty,fine pretty,美丽的,ADJ,B2
-fine print,fine print,词,NOUN,C1
-fine well,fine well,词,ADJ,A1
-finely,finely,词,ADV,C1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fingernail,fingernail,指甲,NOUN,B2
-fingir,to pretend to be,冒充,VERB,B2
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-fire a gun,fire a gun,开枪,VERB,B2
-fire brigade,fire brigade,消防队,NOUN,B2
-fire department,fire department,词,NOUN,B2
-fire kick,fire kick,词,VERB,A2
-fire station,fire station,词,NOUN,C1
-firearms,firearms,枪支,NOUN,B2
-fired,fired,被解雇的,ADJ,B2
-firework,firework,词,NOUN,B2
-firm,firm,公司,NOUN,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firm fixed,firm fixed,词,ADJ,B1
-firmar por,to sign for,签收,VERB,B2
+etapa final,final stage,末期,NOUN,B2
+hallazgo,finding,发现,NOUN,B2
+multar,fine,好的,ADJ,B2
+multar,to fine,罚款,VERB,B2
+piel fina,fine skin,细皮,NOUN,B2
+huella dactilar,fingerprint,指纹,NOUN,B2
+acabado,finishing,装修,NOUN,B2
+incendiar,to fire,开火,VERB,B2
+petardo,firecracker,鞭炮,NOUN,B2
+ignífugo,fireproof,防火的,ADJ,B2
+fuegos artificiales,fireworks,烟花,NOUN,B2
 firme,firm,坚固的,ADJ,B2
-first (adv),first,先,ADV,A2
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first aid,first aid,词,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
-first-class,first-class,一流,ADJ,B2
-firstly,firstly,首先,ADV,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fiscalidad,taxation,征税,NOUN,B2
-fiscalía,prosecution,起诉,NOUN,B2
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisheries,fisheries,词,NOUN,B2
-fishery,fishery,渔业,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing,fishing,钓鱼,NOUN,B2
-fishing rod,fishing rod,钓竿,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
-fisionomía,face reading,面相,NOUN,B2
-fistula,fistula,瘘管,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fit (noun),fit,词,NOUN,B2
-fitting out,fitting out,词,NOUN,B2
-five (adj),five,词,ADJ,C1
-five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fixation,fixation,词,NOUN,C1
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjeld cleft,fjeld cleft,,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flabby,flabby,词,ADJ,B2
-flag (part),flag,旗,PART,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
-flanking,flanking,包抄,NOUN,B2
-flap (noun),flap,词,NOUN,C1
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashback,flashback,词,NOUN,C1
-flat (noun),flat,词,NOUN,B1
-flat rate,flat rate,包干费,NOUN,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatterer,flatterer,词,NOUN,C1
-flaunt,flaunt,词,VERB,C1
-flauta,flute,长笛,NOUN,B2
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flemish,flemish,佛兰芒的,ADJ,B2
-flesh,flesh,肉,NOUN,B2
-flex,flex,词,VERB,C1
+primero,first,首先,ADV,B2
+primera convocatoria,first capping,首加缁布冠,NOUN,B2
+primer borrador,first draft,初稿,NOUN,B2
+primer mérito,first merit,首功,NOUN,B2
+nombre,first name,名字,NOUN,B2
+en primer lugar,first of all,首先,ADV,B2
+pescar,to fish,钓鱼,VERB,B2
+pescador,fisherman,渔夫,NOUN,B2
+puño,fist,拳头,NOUN,B2
+aptitud,fitness,健康,NOUN,B2
+ajustado,fitting,合适的,ADJ,B2
+fijo,fixed,固定的,ADJ,B2
+llama,flame,火焰,NOUN,B2
+plano,flat,扁平的,ADJ,B2
 flexibilidad,flexibility,灵活性,NOUN,B2
 flexible,flexible,灵活的,ADJ,B2
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flinch,flinch,词,VERB,C1
-fling (verb),fling,词,VERB,C1
-flint,flint,燧石,NOUN,B2
-flip,flip,词,VERB,B2
-flirt (verb),flirt,词,VERB,B2
-flit,flit,词,VERB,C1
-float (noun),float,词,NOUN,B2
-floating (noun),floating,词,NOUN,C1
-floating dust,floating dust,浮尘,NOUN,B2
-flogging,flogging,词,NOUN,C1
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floor story,floor story,词,NOUN,A2
-flop,flop,词,VERB,C1
-flora,flora,植物群,NOUN,B2
-floral,floral,词,ADJ,C1
-florid,florid,辞藻华丽的,ADJ,B2
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-floundering,floundering,词,NOUN,C1
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,开花,NOUN,B2
-fluctuating,fluctuating,波动的,ADJ,B2
-fluently,fluently,词,ADV,C1
-fluff,fluff,词,NOUN,C1
-fluid (adj),fluid,词,ADJ,B2
-fluidize,fluidize,词,VERB,C1
-fluido,fluent,流利的,ADJ,B2
-fluids,fluids,词,NOUN,C1
-flunk,flunk,词,VERB,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flutter (noun),flutter,词,NOUN,B2
-flying,flying,飞行的,ADJ,B2
-flyover,flyover,词,NOUN,C1
-flyting poems,flyting poems,词,NOUN,C1
-foal,foal,马驹,NOUN,B2
-fob,fob,词,NOUN,C1
-focalización,targeting,定位,NOUN,B2
-focalization,focalization,词,NOUN,C1
-focused,focused,专注的,ADJ,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-fold,fold,折痕,NOUN,B2
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliar,foliar,词,ADJ,C1
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
-folksy,folksy,乡土的,ADJ,B2
-folleto,booklet,小册子,NOUN,B2
-follower enthusiast,follower enthusiast,词,NOUN,C1
-followers,followers,词,NOUN,C1
-following (adj),following,词,ADJ,B2
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following page,following page,,NOUN,B2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-foment,foment,词,VERB,C1
-fond of food,fond of food,词,ADJ,B1
-fondle,fondle,词,VERB,C1
-fondness,fondness,词,NOUN,B2
-fondo,background,背景,NOUN,B2
-fondo,fund,基金,NOUN,B2
-fonología,phonology,音系学,NOUN,B2
-fontanero,plumber,水管工,NOUN,B2
-fonética,phonetics,语音学,NOUN,B2
-food,food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
-foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,镜头长度,NOUN,B2
-football camp,football camp,词,NOUN,B2
-football player,football player,词,NOUN,C1
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footsteps,footsteps,后尘,NOUN,C1
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
-for a time,for a time,一度,ADV,B2
-for because,for because,因为,CCONJ,B2
-for each other,for each other,相互,ADV,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for hours,for hours,词,ADJ,B2
-for my sake,for my sake,词,ADV,C1
-for now (part),for now,权,PART,C1
-for sale,for sale,待售,ADJ,B2
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,为此,ADV,B2
-for the,for the,词,ADP,A2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what purpose,for what purpose,为了什么目的,ADV,B2
-for your sake,for your sake,词,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearance,forbearance,词,NOUN,C1
-forbearing,forbearing,词,ADJ,C1
-forced labor,forced labor,词,NOUN,C1
-forcing submission,forcing submission,词,NOUN,C1
-ford,ford,词,NOUN,B2
-forearm,forearm,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreign strange,foreign strange,外国的/陌生的,ADJ,B2
-foreknow,foreknow,词,VERB,C1
-forenoon,forenoon,词,NOUN,A1
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-forest-related,forest-related,词,ADJ,B2
-forestación,afforestation,植树造林,NOUN,B2
-forestall,forestall,词,VERB,C1
-forestry,forestry,词,ADJ,C1
-foretell,foretell,词,VERB,C1
-forewarn,forewarn,词,VERB,C1
-foreword,foreword,词,NOUN,C1
-forfeit,forfeit,词,VERB,C1
-forfeiture,forfeiture,丧失,NOUN,B2
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-forgo,forgo,词,VERB,C1
-forma,form,形式,NOUN,B2
-formación,formation,组建,NOUN,B2
-formal,formal,正式的,ADJ,B2
-formal notice,formal notice,词,NOUN,C1
-formalist (adj),formalist,词,ADJ,C1
-formally,formally,正式地,ADV,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-fornicate,fornicate,词,VERB,C1
-foro,forum,论坛,NOUN,B2
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-fort,fort,堡垒,NOUN,B2
-fortaleza,fortress,堡垒,NOUN,B2
-forums,forums,词,NOUN,C1
-forward (verb),forward,词,VERB,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossils,fossils,化石,NOUN,C1
-foster,foster,词,VERB,B2
-foto de identidad,id photo,证件照,NOUN,B2
-fotocopiar,to photocopy,复印,VERB,B2
-fotografiar,to photograph,拍照,VERB,B2
-fotografía,photography,摄影,NOUN,B2
-fotosíntesis,photosynthesis,光合作用,NOUN,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
-founding,founding,成立,NOUN,B2
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fourth (num),fourth,词,NUM,B1
-fowl,fowl,词,NOUN,C1
-foyer,foyer,词,NOUN,C1
-fracaso,falling though,虽坠,NOUN,B2
-fracción,fraction marker,分之,PART,B2
-fractal,fractal,分形,NOUN,B2
-fractured,fractured,词,ADJ,C1
-frambuesa,raspberry,覆盆子,NOUN,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework-related,framework-related,词,ADJ,C1
-francés,french,法国的,ADJ,B2
-frankly,frankly,坦率地,ADV,B2
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudster,fraudster,词,NOUN,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-fray,fray,词,VERB,C1
-frazzle,frazzle,词,VERB,C1
-freckles,freckles,词,NOUN,B2
-free association,free association,词,NOUN,C1
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
-free off,free off,空闲的/休假,ADJ,B2
-free trade,free trade,词,NOUN,C1
-freedmen clients,freedmen clients,词,NOUN,C1
-freedom of assembly,freedom of assembly,集会自由,NOUN,B2
-freedom of choice,freedom of choice,选择自由,NOUN,B2
-freedom of opinion,freedom of opinion,意见自由,NOUN,B2
-freedom of religion,freedom of religion,宗教自由,NOUN,B2
-freedom of speech,freedom of speech,言论自由,NOUN,B2
-freedom of the press,freedom of the press,出版自由,NOUN,B2
-freely,freely,自由地,ADV,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
-frente,forehead,前额,NOUN,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
-frequently,frequently,经常,ADV,B2
-fresco,fresh,新鲜的,ADJ,B2
-fresco,fresco,壁画,NOUN,B2
-fresh,fresh,,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshly,freshly,新鲜地,ADV,B2
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-fret,fret,词,VERB,C1
-frictionless,frictionless,无摩擦的,ADJ,B2
-fried,fried,词,ADJ,B1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-friends with,friends with,词,ADJ,B2
-frightening,frightening,令人恐惧的,ADJ,B2
-frill,frill,词,NOUN,C1
-frisian,frisian,弗里斯兰的,ADJ,B2
-frisk,frisk,词,VERB,C1
-fritter,fritter,词,VERB,C1
-frivol,frivol,词,VERB,C1
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-from above,from above,从上方,ADV,B2
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from behind,from behind,从后面,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
-from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from here,from here,从这里,ADV,B2
-from home,from home,从家里,ADV,B2
-from it,from it,从中,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from there,from there,从那里,ADV,B2
-from this,from this,由此,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from where,from where,从哪里,ADV,B2
-from which,from which,从中,ADV,B2
-from within,from within,从内部,ADV,B2
-front line,front line,前线,NOUN,B2
-front page,front page,头版,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontispiece,frontispiece,词,NOUN,C1
-frontrunner,frontrunner,词,NOUN,C1
-frostbite,frostbite,冻伤,NOUN,B2
-frosty,frosty,词,ADJ,A1
-frown (noun),frown,frown,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frowning,frowning,词,NOUN,C1
-frozen (noun),frozen,词,NOUN,B2
-fructify,fructify,词,VERB,C1
-frugal,frugal,节俭的,ADJ,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruiting,fruiting,词,ADJ,C1
-frustrar,to thwart,阻挠,VERB,B2
 frágil,flimsy,脆弱的,ADJ,B2
-fríamente,coldly,冷淡地,ADV,B2
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuegos artificiales,fireworks,烟花,NOUN,B2
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fuente,fountain,喷泉,NOUN,B2
-fuera,out,在外面,ADV,B2
-fuera de,out of,从...出来,ADP,B2
-fuerza,force,力量,NOUN,B2
-fuerza centrífuga,centrifugal force,离心力,NOUN,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fulfil,fulfil,词,VERB,C1
-fulfilled,fulfilled,满足的,ADJ,B2
-full amount,full amount,足足,NOUN,C1
-full drunk,full drunk,满的/醉的,ADJ,B2
-full fed,full fed,词,ADJ,A1
-full fed up,full fed up,词,ADJ,B1
-full moon banquet,full moon banquet,满月酒,NOUN,C1
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full satiated,full satiated,词,ADJ,A2
-full stop,full stop,词,NOUN,B2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,全职,ADJ,B2
-fully,fully,词,ADV,C1
-fulminate,fulminate,词,VERB,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fun joke,fun joke,乐趣/玩笑,NOUN,B2
-funcional,functional,功能的,ADJ,B2
-funcionar,to function,运作,VERB,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundador,founder,创始人,NOUN,B2
-fundamental rights,fundamental rights,词,NOUN,C1
-fundamentally,fundamentally,词,ADV,C1
-funding,funding,词,NOUN,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral,funeral,葬礼,NOUN,B2
-funeral home,funeral home,,NOUN,B2
-funerary,funerary,丧葬的,ADJ,B2
-fungi,fungi,词,NOUN,B2
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funniness,funniness,,NOUN,B2
-furbish,furbish,词,VERB,C1
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnished,furnished,词,ADJ,B2
-furnishing,furnishing,室内布置,NOUN,B2
-furrow,furrow,犁沟,NOUN,B2
-further,further,进一步,ADV,B2
-further additional,further additional,词,ADJ,B2
-further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
-furthest,furthest,最远,ADV,B2
-fusión,merge,合并,NOUN,B2
-fussy,fussy,挑剔的,ADJ,B2
-future (adj),future,未来的,ADJ,C1
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
-futurismo,futurism,未来主义,NOUN,B2
-futuristic,futuristic,词,ADJ,C1
-futuro,future,未来的,ADJ,B2
-fuzzy,fuzzy,词,ADJ,C1
-fácil de decir,easy to say,好说,NOUN,B2
-fénix,phoenix,拿凤,NOUN,B2
-férula,splint,夹板,NOUN,B2
-física,physics,物理,NOUN,B2
-fósil,fossil,化石,NOUN,B2
+bandada,flock,兽群,NOUN,B2
+fluido,fluent,流利的,ADJ,B2
+flauta,flute,长笛,NOUN,B2
+mosca,fly,苍蝇,NOUN,B2
+niebla,fog,雾,NOUN,B2
+pueblo,folk,民间的,ADJ,B2
+alimento,foodstuff,食品,NOUN,B2
 fútbol,football,足球,NOUN,B2
-gad,gad,词,VERB,C1
-gag,gag,词,NOUN,C1
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
-galería de arte,art gallery,美术馆,NOUN,B2
-gallbladder,gallbladder,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
-galvanization,galvanization,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
-gamble (noun),gamble,就赌,NOUN,C1
-gambling,gambling,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game play,game play,游戏/比赛,NOUN,B2
-game rule,game rule,游戏规则,NOUN,B2
+puente peatonal,footbridge,人行天桥,NOUN,B2
+calzado,footwear,鞋穿,NOUN,B2
+por ejemplo,for example,例如,ADV,B2
+gratis,for free,免费,ADV,B2
+por ello,for it,为此,ADV,B2
+por ahora,for now,暂时,ADV,B2
+por,for the sake of,为了,ADP,B2
+por qué,for what,为了什么,ADV,B2
+durante años,for years,多年,ADV,B2
+prohibido,forbidden,被禁止的,ADJ,B2
+tierra prohibida,forbidden land,禁地,NOUN,B2
+fuerza,force,力量,NOUN,B2
+pronóstico,forecast,预测,NOUN,B2
+frente,forehead,前额,NOUN,B2
+prever,to foresee,预见,VERB,B2
+previsión,foresight,远见,NOUN,B2
+para siempre,forever,永远,ADV,B2
+falsificación,forgery,伪造品,NOUN,B2
+perdón,forgiveness,宽恕,NOUN,B2
+tenedor,fork,叉子,NOUN,B2
+forma,form,形式,NOUN,B2
+formal,formal,正式的,ADJ,B2
+formación,formation,组建,NOUN,B2
+anterior,former,以前的,ADJ,B2
+anteriormente,formerly,以前,ADV,B2
+adelante,forth,向前,ADV,B2
+fortaleza,fortress,堡垒,NOUN,B2
+afortunado,fortunate,幸运的,ADJ,B2
+adivinación,fortune telling,算命,NOUN,B2
+cuarenta,forty,四十,NUM,B2
+foro,forum,论坛,NOUN,B2
+fósil,fossil,化石,NOUN,B2
+fundador,founder,创始人,NOUN,B2
+fuente,fountain,喷泉,NOUN,B2
+cuarto,fourth,第四,ADJ,B2
+zorro,fox,狐狸,NOUN,B2
+fracción,fraction marker,分之,PART,B2
+marco,framework,框架,NOUN,B2
+raro,freak,怪人,NOUN,B2
+tiempo libre,free time,业余时间,NOUN,B2
+lluvia congelada,freezing rain,冻雨,NOUN,B2
+francés,french,法国的,ADJ,B2
+fresco,fresh,新鲜的,ADJ,B2
+refrigerador,fridge,冰箱,NOUN,B2
+amigable,friendly,友好的,ADJ,B2
+papas fritas,fries,炸薯条,NOUN,B2
+rana,frog,青蛙,NOUN,B2
+desde la infancia,from childhood,从小,ADV,B2
+a partir de ahora,from now on,今后,ADV,B2
+puerta principal,front door,正门,NOUN,B2
+frugal,frugal,节俭的,ADJ,B2
+sartén,frying pan,平底锅,NOUN,B2
+luna llena,full moon,满月,NOUN,B2
+nombre completo,full name,大名,NOUN,B2
+potencia máxima,full power,全力,NOUN,B2
+funcionar,to function,运作,VERB,B2
+funcional,functional,功能的,ADJ,B2
+fondo,fund,基金,NOUN,B2
+funeral,funeral,葬礼,NOUN,B2
+piel,fur,毛皮,NOUN,B2
+amueblar,to furnish,提供,VERB,B2
+mueble,furniture,家具,NOUN,B2
+ulteriormente,further,进一步的,ADJ,B2
+además,furthermore,此外,ADV,B2
+alboroto,fuss,大惊小怪,NOUN,B2
+futuro,future,未来的,ADJ,B2
+futurismo,futurism,未来主义,NOUN,B2
 ganancia,gain,收益,NOUN,B2
-ganar,to earn,赚取,VERB,B2
-gangster,gangster,黑帮成员,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-gaol,gaol,词,NOUN,C1
-gaping,gaping,,NOUN,B2
-garantía,warranty,保修单,NOUN,B2
-garb,garb,词,NOUN,C1
-garbage,garbage,词,NOUN,B2
-garble,garble,词,VERB,C1
-gargle (verb),gargle,词,VERB,C1
-garment (part),garment,衣,PART,B2
-garment making,garment making,词,NOUN,C1
-garner,garner,词,VERB,C1
-garrison towns,garrison towns,词,NOUN,C1
-gas flame,gas flame,煤气火焰,NOUN,B2
-gas meter,gas meter,,NOUN,B2
-gash,gash,词,NOUN,C1
-gasket,gasket,词,NOUN,B1
-gasp (verb),gasp,词,VERB,B2
-gastronomic,gastronomic,美食的,ADJ,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatear,to crawl,爬行,VERB,B2
-gateway,gateway,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauge meter,gauge meter,词,NOUN,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,快乐的,ADJ,B2
-gay (noun),gay,同性恋者,NOUN,B2
-gay man,gay man,男同性恋者,NOUN,B2
-gaze (noun),gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gearbox,gearbox,变速箱,NOUN,B2
-geek,geek,极客,NOUN,C1
-geerziehung,geerziehung,词,NOUN,C1
-gefahrt,gefahrt,词,NOUN,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gekunft,gekunft,词,NOUN,C1
-gel,gel,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-geld,geld,词,VERB,C1
-gemir,to groan,呻吟,VERB,B2
-gemstone,gemstone,词,NOUN,C1
-genahme,genahme,词,NOUN,C1
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
-gender equality,gender equality,性别平等,NOUN,B2
-gender parity,gender parity,词,NOUN,C1
-gene therapy,gene therapy,基因治疗,NOUN,C1
-genealogical,genealogical,词,ADJ,C1
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
-generación mutua,mutual generation,相生,NOUN,B2
+apostar,gamble,赌博,NOUN,B2
+apostar,to gamble,赌博,VERB,B2
+pandilla,gang,帮派,NOUN,B2
+ajo,garlic,大蒜,NOUN,B2
+puerta,gate,大门,NOUN,B2
+reunión,gathering,聚集,NOUN,B2
+contemplar,gaze,目视,NOUN,B2
+contemplar,to gaze,凝视,VERB,B2
+equipo,gear,齿轮,NOUN,B2
+género,gender,性别,NOUN,B2
 general,general,一般的,ADJ,B2
-general (noun),general,将军,NOUN,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-general practitioner,general practitioner,全科医生,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generations,generations,词,NOUN,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
 generosidad,generosity,慷慨,NOUN,B2
-generously,generously,慷慨地,ADV,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetic modification,genetic modification,基因改造,NOUN,B2
-genetically,genetically,遗传地,ADV,B2
-genial,genial,词,ADJ,C1
-genio,temper,脾气,NOUN,B2
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,种族灭绝,NOUN,B2
 genoma,genome,基因组,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gente ordinaria,ordinary people,老百姓,NOUN,B2
 gentil,gentle,温柔的,ADJ,B2
-gentle reproach,gentle reproach,词,NOUN,C1
-gentlemen,gentlemen,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-gentrification,gentrification,词,NOUN,C1
-genuflect,genuflect,词,VERB,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geographically,geographically,词,ADV,C1
-geolocation,geolocation,词,NOUN,C1
-geopolítica,geopolitics,地缘政治,NOUN,B2
 geopolítico,geopolitical,地缘政治的,ADJ,B2
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gepflegung,gepflegung,词,NOUN,C1
-geregelung,geregelung,词,NOUN,C1
-geriatrics,geriatrics,老年医学,NOUN,B2
-gerichtung,gerichtung,词,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,德国人,NOUN,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-gesprache,gesprache,词,NOUN,C1
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-getaway,getaway,词,NOUN,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-getting rich,getting rich,词,NOUN,C1
-gewandel,gewandel,词,NOUN,C1
-geweisung,geweisung,词,NOUN,C1
-gewirkung,gewirkung,词,NOUN,C1
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghostly look,ghostly look,鬼样子,NOUN,B2
-giant (noun),giant,巨人,NOUN,B1
-gibber,gibber,词,VERB,C1
-gibe,gibe,词,VERB,C1
-giddy,giddy,头晕的,ADJ,B2
-gifted,gifted,有天赋的,ADJ,B2
-giftedness,giftedness,词,NOUN,C1
+geopolítica,geopolitics,地缘政治,NOUN,B2
+alemán,german,德国人,NOUN,B2
+conocer,to get acquainted,相互认识,VERB,B2
+enojarse,to get angry,生气,VERB,B2
+perderse,to get lost,迷路,VERB,B2
+salir,to get off work,下班,VERB,B2
+desprenderse,to get rid of,摆脱,VERB,B2
+levantarse,to get up,起床,VERB,B2
 gigante,giant,巨人,NOUN,B2
 gigoló,gigolo,面首,NOUN,B2
-gilding,gilding,词,NOUN,C1
-gills,gills,词,NOUN,B2
-gimnasio,gymnasium,体育馆,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-girdle,girdle,词,NOUN,C1
-girl daughter,girl daughter,词,NOUN,A1
-girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
-give you (noun),give you,送你,NOUN,C1
-given (noun),given,给定,NOUN,B2
-given datum,given datum,词,NOUN,C1
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-glacial,glacial,词,ADJ,C1
-gladden,gladden,词,VERB,C1
-gladly,gladly,乐意地,ADV,B2
-gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glamour,glamour,词,NOUN,C1
-glance,glance,一瞥,NOUN,B2
-glare,glare,词,VERB,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-glib,glib,伶牙俐齿的,ADJ,B2
-gliding,gliding,滑翔,NOUN,B2
-glimmer,glimmer,词,NOUN,C1
-glint,glint,词,NOUN,C1
-glisten,glisten,词,VERB,C1
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-gloating,gloating,词,NOUN,C1
+jengibre,ginger,姜,NOUN,B2
+devolver,to give back,归还,VERB,B2
+conceder,to give to grant,予以,VERB,B2
+rendirse,to give up,放弃,VERB,B2
+dado,given,给定,NOUN,B2
+contento,glad,高兴的,ADJ,B2
+mirar,to glance,瞥,VERB,B2
 global,global,全球的,ADJ,B2
-global (noun),global,全球,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-gloriousness,gloriousness,光荣,NOUN,B2
-glossary,glossary,词汇表,NOUN,B2
-gloves,gloves,词,NOUN,B2
-glow (verb),glow,词,VERB,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glower,glower,词,VERB,C1
-glucose,glucose,词,NOUN,C1
-glut,glut,词,NOUN,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
+calentamiento global,global warming,气候变暖,NOUN,B2
+tristeza,gloominess,忧郁,NOUN,B2
+sombrío,gloomy,阴郁的,ADJ,B2
+resplandor,glow,光芒,NOUN,B2
+pegamento,glue,胶水,NOUN,B2
 gnosis,gnosis,灵知,NOUN,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-go away,go away,词,VERB,C1
-go wrong,go wrong,词,VERB,C1
-goalkeeper,goalkeeper,守门员,NOUN,B2
-gobble,gobble,词,VERB,C1
-gobernanza,governance,治理,NOUN,B2
-gobernar,to govern,统治,VERB,B2
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-godliness,godliness,词,NOUN,C1
-godmother,godmother,词,NOUN,C1
-godson,godson,词,NOUN,A2
-goggle,goggle,词,VERB,C1
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-golpe,bang,巨响,NOUN,B2
-golpe,hit,击中,NOUN,B2
-golpear,to knock,敲,VERB,B2
-gong,gong,锣,NOUN,B2
-good behavior,good behavior,,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good day,good day,你好,INTJ,B2
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good heavens,good heavens,天哪,INTJ,B2
-good lord,good lord,词,INTJ,B2
-good medicine,good medicine,好药,NOUN,B2
-good morning,good morning,早上好,INTJ,B2
-good news,good news,有好事,NOUN,C1
-good night,good night,晚安,INTJ,B2
-good offices,good offices,词,NOUN,C1
-good thing,good thing,好事,NOUN,B2
-good well,good well,好/很好,ADJ,B2
-good-looking person,good-looking person,帅哥/美女,NOUN,B2
-good-naturedness,good-naturedness,温和,NOUN,B2
-goodbye kiss,goodbye kiss,,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gorrión,sparrow,麻雀,NOUN,B2
-gorro ceremonial,ceremonial cap,爵弁,NOUN,B2
-gosh,gosh,天哪,INTJ,B2
-gothenburg,gothenburg,哥德堡,PROPN,B2
-gouge,gouge,词,VERB,C1
+regresar,to go back,回去,VERB,B2
+quebrar,to go bankrupt,破产,VERB,B2
+enloquecer,to go crazy,发疯,VERB,B2
+ir primero,to go first,先去,VERB,B2
+ayuda,go help,去帮,NOUN,B2
+entrar,to go in,进去,VERB,B2
+conectarse,to go online,上网,VERB,B2
+salir,to go out,出去,VERB,B2
+atravesar,to go through,经历,VERB,B2
+dios de la guerra,god of war,战神,NOUN,B2
+diosa,goddess,女神,NOUN,B2
+bien,good,خير,NOUN,B2
+buena suerte,good luck,好运,NOUN,B2
+buena reputación,good reputation,清誉,NOUN,B2
+guapo,good-looking,好看的,ADJ,B2
+precioso,gorgeous,华丽的,ADJ,B2
 gourmet,gourmet,美食家,NOUN,B2
-govern a country,govern a country,治国,VERB,C1
-governable,governable,可管理的,ADJ,B2
-governess,governess,词,NOUN,C1
-grab,grab,揪,NOUN,B2
-grabación de vídeo,video recording,录像,NOUN,B2
-gracefulness,gracefulness,词,NOUN,C1
-gracias,thank you,谢谢,INTJ,B2
-gracias,thanks,谢谢,NOUN,B2
-gracias a,thanks to,多亏,ADP,B2
-gracious,gracious,亲切的,ADJ,B2
-grade (verb),grade,分级,VERB,C1
+gobernar,to govern,统治,VERB,B2
+gobernanza,governance,治理,NOUN,B2
 grado,grade,等级,NOUN,B2
-graduado,graduate,毕业生,NOUN,B2
+calificación,grading,评分；记号,NOUN,B2
 gradual,gradual,逐渐的,ADJ,B2
 gradualmente,gradually,逐渐地,ADV,B2
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-graffiti,graffiti,涂鸦,NOUN,C1
-grail,grail,圣杯,NOUN,B2
-grammaticality,grammaticality,合语法性,NOUN,B2
+graduado,graduate,毕业生,NOUN,B2
+injerto,graft,嫁接,NOUN,B2
 gramo,gram,克,NOUN,B2
 gran distancia,grand distance,雄远,NOUN,B2
+nieto,grandchild,孙辈,NOUN,B2
+nieta,granddaughter,孙女,NOUN,B2
+grandeza,grandeur,宏伟,NOUN,B2
+grandioso,grandiose,浮夸的,ADJ,B2
+abuela,grandma,奶奶,NOUN,B2
+subvención,grant,拨款,NOUN,B2
+uva,grape,葡萄,NOUN,B2
+gráfico,graphic,图形的,ADJ,B2
+asir,to grasp firmly,抓紧,VERB,B2
+tumba,grave,坟墓,NOUN,B2
+gris,gray,灰色的,ADJ,B2
+pastar,to graze,吃草,VERB,B2
+pastoreo,grazing,放牧,NOUN,B2
+engrasar,to grease,涂油,VERB,B2
 gran favor,great favor,大恩,NOUN,B2
 gran ofensa,great offense,冒犯大,NOUN,B2
 gran poder,great power,大国,NOUN,B2
-granada,pomegranate,石榴,NOUN,B2
-granary,granary,词,NOUN,C1
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand master,grand master,大师,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
-grandes almacenes,department store,百货商店,NOUN,B2
-grandeza,grandeur,宏伟,NOUN,B2
 grandeza,greatness,伟大,NOUN,B2
-grandiloquently,grandiloquently,词,ADV,C1
-grandioso,grandiose,浮夸的,ADJ,B2
-grandpa,grandpa,爷爷,NOUN,B2
-grandparent,grandparent,词,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granja,farm,农场,NOUN,B2
-granny,granny,奶奶,NOUN,B2
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-grapefruit,grapefruit,词,NOUN,A2
-grapes,grapes,词,NOUN,A1
-graph,graph,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphic designer,graphic designer,图形设计师,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-grapple,grapple,词,VERB,C1
-grasa,fat,脂肪,NOUN,B2
-grasp (noun),grasp,把及,NOUN,C1
-grasp understand,grasp understand,词,VERB,B1
-grasshopper,grasshopper,词,NOUN,B1
-grassroots,grassroots,词,ADJ,C1
-grate,grate,词,VERB,C1
-grater,grater,词,NOUN,B2
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratis,for free,免费,ADV,B2
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-graveyard,graveyard,墓地,NOUN,B2
-gravitas,gravitas,词,NOUN,C1
-gravitational,gravitational,引力的,ADJ,B2
-gravity of loss,gravity of loss,词,NOUN,C1
-gray hair,gray hair,词,NOUN,B2
-grease (noun),grease,词,NOUN,C1
-great (adv),great,词,ADV,B1
-great chaos,great chaos,大乱,NOUN,C1
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,曾祖父,NOUN,B2
-greaten,greaten,词,VERB,C1
-greatest,greatest,词,NOUN,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊的,ADJ,B2
-green blue,green blue,青,ADJ,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-green-clad,green-clad,,NOUN,B2
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-greetings,greetings,,NOUN,B2
-grey area,grey area,灰色地带,NOUN,B2
-grid,grid,网格,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
-grieta,rift,裂痕,NOUN,B2
-grieve,grieve,词,VERB,C1
-grievously unjust,grievously unjust,词,ADJ,C1
-grill (noun),grill,词,NOUN,B2
-grille,grille,格栅,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grimace,grimace,词,NOUN,C1
-grimness,grimness,词,NOUN,C1
-grinder,grinder,词,NOUN,C1
-grip (noun),grip,握呀,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-gripe,gripe,词,VERB,C1
-gris,gray,灰色的,ADJ,B2
-grit,grit,词,NOUN,C1
-gritar,scream,尖叫,NOUN,B2
-gritar,to scream,尖叫,VERB,B2
-groan,groan,呻吟,NOUN,B2
-grocer,grocer,词,NOUN,A2
-grocery,grocery,词,NOUN,B2
-grooming,grooming,词,NOUN,C1
-grope,grope,词,VERB,C1
-ground (adj),ground,磨碎的,ADJ,B1
-ground basis,ground basis,基础/理由,NOUN,B2
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds of judgment,grounds of judgment,词,NOUN,C1
-groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,群体工作,NOUN,B2
-grouping,grouping,词,NOUN,B2
-grouse,grouse,词,VERB,C1
-grovel,grovel,词,VERB,C1
-growing,growing,词,ADJ,B2
-grown,grown,长大的,ADJ,B2
-growth rate,growth rate,词,NOUN,C1
-grub,grub,词,NOUN,C1
-grueling,grueling,词,ADJ,C1
-grumbler,grumbler,爱抱怨的人,NOUN,B2
-grunt,grunt,词,VERB,B2
-gráfico,graphic,图形的,ADJ,B2
-gráfico,chart,图表,NOUN,B2
-guapo,good-looking,好看的,ADJ,B2
-guapo,handsome guy,帅哥,NOUN,B2
-guarantees,guarantees,词,NOUN,C1
-guardarropa,cloakroom,衣帽间,NOUN,B2
-guardería,nursery,托儿所,NOUN,B2
-guardia de escolta,escort guard,镖师,NOUN,B2
-guardia de seguridad,security guard,保安,NOUN,B2
-guardia imperial,imperial guard,御林,NOUN,B2
-guardianship,guardianship,监护,NOUN,B2
-guarding,guarding,守住,NOUN,C1
+ojo verde,green eye,碧眼,NOUN,B2
+ojos verdes,green eyes,想碧眼,NOUN,B2
+tecnología verde,green technology,绿色技术,NOUN,B2
+ojiverde,green-eyed,让碧眼,NOUN,B2
+sombrío,grim,严酷的,ADJ,B2
+sonreír,to grin,咧嘴笑,VERB,B2
+moler,to grind,磨碎,VERB,B2
+agarrar,grip,握法,NOUN,B2
+agarrar,to grip,紧握,VERB,B2
+gemir,to groan,呻吟,VERB,B2
+novio,groom,新郎,NOUN,B2
+bruto,gross,总的,ADJ,B2
+suelo,ground,根据,NOUN,B2
+terrenos,grounds,论据,NOUN,B2
+crecer,to grow up,成长,VERB,B2
+rencor,grudge,怨恨,NOUN,B2
+refunfuño,grumbling,抱怨,NOUN,B2
 guardián,guardian,守卫,NOUN,B2
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-guerra mundial,world war,世界大战,NOUN,B2
-guerrear,to wage war,作战,VERB,B2
-guerrilla,guerrilla,词,NOUN,C1
-guess (noun),guess,一猜,NOUN,B2
-guest house,guest house,招待所,NOUN,C1
-guest tester,guest tester,,NOUN,B2
-guidance,guidance,指导,NOUN,B2
-guidebook,guidebook,词,NOUN,B1
-guided tour,guided tour,导游,NOUN,B2
-guideline,guideline,指导方针,NOUN,B2
-guiding light,guiding light,词,NOUN,C1
-guilder,guilder,盾,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-guión,screenplay,剧本,NOUN,B2
-guión teatral,script for play,剧本,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-guru,guru,精神导师,NOUN,B2
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
-gynaecology,gynaecology,妇科,NOUN,B2
-gyroscope,gyroscope,词,NOUN,C1
-género,gender,性别,NOUN,B2
-haber,have,有,AUX,B2
-haber,to there's still time,来得及,VERB,B2
-habit formation,habit formation,词,NOUN,C1
-habitlessness,habitlessness,无习惯,NOUN,B2
+adivinar,guess,猜测,NOUN,B2
+adivinar,to guess,猜,VERB,B2
+chicle,gum,牙龈,NOUN,B2
+pistola,gun,枪,NOUN,B2
+tipo,guy,家伙,NOUN,B2
+gimnasio,gymnasium,体育馆,NOUN,B2
+ja,ha,哈,INTJ,B2
+hábitat,habitat,栖息地,NOUN,B2
+costumbre,habitually in the past,往常,NOUN,B2
 habituación,habituation,习惯化,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-habitus,habitus,词,NOUN,C1
-hablar,talk,谈话,NOUN,B2
-hablar,to talk,谈话,VERB,B2
-habous endowments,habous endowments,词,NOUN,C1
-hacer,to make,制作,VERB,B2
-hacer ruido,to make noise,闹得,VERB,B2
-hacia abajo,downwards,向下,ADV,B2
 hackear,to hack,入侵；盗版,VERB,B2
-hacker,hacker,黑客,NOUN,C1
-hacking,hacking,黑客行为,NOUN,B2
-hackneyed,hackneyed,词,ADJ,C1
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hag,hag,老妇,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-haircut,haircut,词,NOUN,C1
-hairy,hairy,词,ADJ,C1
-hakawati,hakawati,词,NOUN,B2
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half hour,half hour,半小时,NOUN,B2
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
-half-day,half-day,半天,NOUN,B2
-half-year,half-year,半年,NOUN,B2
-halfway,halfway,半途,ADV,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall,hall,殿,PART,B2
-hallazgo,finding,发现,NOUN,B2
-hallelujah,hallelujah,哈利路亚,INTJ,B2
-hallowed,hallowed,词,ADJ,C1
-halo,halo,词,NOUN,B2
-hamburger,hamburger,汉堡包,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
-handbrake,handbrake,手刹,NOUN,C1
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handle (noun),handle,把手,NOUN,B2
-handlebars,handlebars,词,NOUN,C1
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-handyman,handyman,工匠,NOUN,B2
-hanged,hanged,被绞死的,ADJ,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hanging,hanging,绞刑,NOUN,B2
-hangover,hangover,词,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happen to,happen to,词,VERB,C1
-happily,happily,快乐地,ADV,B2
-happy event,happy event,喜事,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-harbour,harbour,港口,NOUN,B2
-hard,hard,努力地,ADV,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-harder,harder,词,ADJ,A2
-hardship,hardship,艰难,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hare,hare,野兔,NOUN,B2
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
-harried,harried,词,ADJ,C1
-harsh,harsh,严厉的,ADJ,B2
-harshly,harshly,词,ADV,C1
-harshness,harshness,词,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hassle,hassle,麻烦,NOUN,B2
-hasta,until,直到,ADP,B2
-hasta,up to,为止,ADP,B2
-hasta ahora,so far,到目前为止,ADV,B2
-hastily,hastily,急忙,ADV,B2
-hatch,hatch,舱口,NOUN,B2
-haughtily,haughtily,词,ADV,C1
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have time,have time,词,VERB,B2
-have to,have to,必须,AUX,B2
-have to (adv),have to,不得不,ADV,A1
-having a birthday,having a birthday,过生日的,ADJ,B2
-having a cold,having a cold,感冒的,ADJ,B2
-having item,having item,有件,NOUN,C1
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-he this one,he this one,他/这位,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headline,headline,标题,NOUN,B2
-headlines,headlines,词,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,医疗保健,NOUN,B2
-healthcare worker,healthcare worker,医护人员,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-heap cluster,heap cluster,词,NOUN,C1
-hearsay,hearsay,词,NOUN,C1
-heart,heart,心,ADV,B2
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt,heartfelt,衷心的,ADJ,B2
-heartfelt (noun),heartfelt,词,NOUN,B2
-hearth,hearth,壁炉,NOUN,B2
-heartlessness,heartlessness,无情,NOUN,B2
-heartrending,heartrending,词,ADJ,C1
-hearts,hearts,心,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavily,heavily,沉重地,ADV,B2
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-hecho,done,事已,NOUN,B2
-hectic,hectic,忙乱,NOUN,B2
-hectic (adj),hectic,词,ADJ,C1
-hedge,hedge,树篱,NOUN,B2
-hedonistic,hedonistic,享乐主义的,ADJ,B2
-heedlessness,heedlessness,词,NOUN,C1
-hefen,hefen,河粉,NOUN,C1
-heinous,heinous,词,ADJ,C1
-helado,ice-cold,冰冷的,ADJ,B2
-helado,icy,冰冷的,ADJ,B2
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello bye,hello bye,词,INTJ,B2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-hem,hem,边缘,NOUN,B2
-hematoma,hematoma,血肿,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemistich,hemistich,词,NOUN,C1
+regatear,to haggle,讨价还价,VERB,B2
+regateo,haggling,计较,NOUN,B2
+peluquero,hairdresser,理发师,NOUN,B2
+peinado,hairstyle,发型,NOUN,B2
+sala,hall,大厅,NOUN,B2
+alucinación,hallucination,幻觉,NOUN,B2
+detener,to halt,停止,VERB,B2
+martillo,hammer,锤子,NOUN,B2
+entregar,to hand over,交付,VERB,B2
+maneta,handcuff,手铐,NOUN,B2
+artesanía,handicraft,工艺品,NOUN,B2
+pañuelo,handkerchief,手帕,NOUN,B2
+manejar,handle,把手,NOUN,B2
+manejar,to handle,处理,VERB,B2
+manejo,handling,处理,NOUN,B2
+entrega,handover,拿给,NOUN,B2
+guapo,handsome guy,帅哥,NOUN,B2
+caligrafía,handwriting,笔迹,NOUN,B2
+caligrafía,handwriting practice,练字,NOUN,B2
+colgar,to hang up,挂断,VERB,B2
+puerto,harbor,港口,NOUN,B2
+difícil,hard to choose,难以抉择,ADJ,B2
+indistinguible,hard to distinguish,难以区分,ADJ,B2
+inmantenible,hard to maintain,难以维持,ADJ,B2
+indecible,hard to speak of,难以启齿,ADJ,B2
+trabajador,hardworking,勤奋的,ADJ,B2
+armonioso,harmonious,和谐的,ADJ,B2
+armonización,harmonization,协调,NOUN,B2
+arpa,harp,竖琴,NOUN,B2
+prisa,haste,匆忙,NOUN,B2
+apresurado,hasty,仓促的,ADJ,B2
+odio,hatred,仇恨,NOUN,B2
+haber,have,有,AUX,B2
+accidentarse,to have an accident,遭遇意外,VERB,B2
+tener,to have only,唯有,VERB,B2
+obligación,have to,还得,NOUN,B2
+avellana,hazelnut,榛子,NOUN,B2
+dolor de cabeza,headache,头痛,NOUN,B2
+auriculares,headphones,耳机,NOUN,B2
+curar,to heal,治愈,VERB,B2
+curación,healing,治愈,NOUN,B2
+oír,to hear a case,审理,VERB,B2
+beile,heard beile,听说贝勒,NOUN,B2
+infarto,heart attack,心脏病发作,NOUN,B2
+ola de calor,heat wave,热浪,NOUN,B2
+cielo,heaven,天堂,NOUN,B2
+aroma celestial,heavenly fragrance,天香,NOUN,B2
+pesadez,heaviness,沉重 / 笨重,NOUN,B2
+etiqueta pesada,heavy etiquette,礼太重,NOUN,B2
+nudo fuerte,heavy knot,重结,NOUN,B2
+máquina pesada,heavy machine,重机,NOUN,B2
+tipo grueso,heavy type,重型,NOUN,B2
+trabajo pesado,heavy work,重功,NOUN,B2
+talón,heel,脚后跟,NOUN,B2
+jeje,hehe,嘿嘿,INTJ,B2
+ayudar,to help assistance,帮助,VERB,B2
+útil,helpful,有帮助的,ADJ,B2
 hemoglobina,hemoglobin,血红蛋白,NOUN,B2
-hemorragia,bleeding,出血,NOUN,B2
-hemostasis,hemostasis,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
-hence,hence,因此,ADV,B2
-henceforth,henceforth,从此以后,ADV,B2
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,DET,B2
-her (pron),her,词,PRON,A1
-her their,her their,词,DET,A1
-herbal tea,herbal tea,花草茶,NOUN,B2
-herbalist,herbalist,词,NOUN,B1
-herbicide,herbicide,除草剂,NOUN,B2
-herbs,herbs,词,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
-here (noun),here,此地,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here hither,here hither,这里/到这里,ADV,B2
-here is,here is,词,ADV,A1
-here you go,here you go,请,INTJ,B2
-hereafter,hereafter,词,NOUN,C1
-herein,herein,词,ADV,B1
-herencia,heredity,遗传,NOUN,B2
-heretical innovation,heretical innovation,词,NOUN,C1
-herido,wounded,受伤的,ADJ,B2
-hermanos,siblings,兄弟姐妹,NOUN,B2
-hermeneutics,hermeneutics,词,NOUN,C1
-hermenéutico,hermeneutic,诠释学的,ADJ,B2
-hermetic,hermetic,词,ADJ,C1
-hernia,hernia,词,NOUN,C1
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroin vapor,heroin vapor,,NOUN,B2
-herrero,blacksmith,铁匠,NOUN,B2
-hervir,steam,蒸汽,NOUN,B2
-hervir,to steam,蒸,VERB,B2
-hesitant,hesitant,犹豫的,ADJ,B2
-heterosexual,heterosexual,词,ADJ,C1
-heuristic,heuristic,词,ADJ,C1
-hexadecimal,hexadecimal,词,ADJ,C1
-heyday,heyday,词,NOUN,C1
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hideous,hideous,丑陋的,ADJ,B2
-hider,hider,词,NOUN,B2
-hiding ambush,hiding ambush,词,NOUN,B2
-hiding place,hiding place,藏身处,NOUN,B2
 hierba,herb,草药,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school student,high school student,词,NOUN,B2
-high tall,high tall,高的,ADJ,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highest,highest,最高的,ADJ,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
-highlight,highlight,亮点,NOUN,B2
-highlighter,highlighter,词,NOUN,C1
-hijack,hijack,词,VERB,C1
-hijacking,hijacking,词,NOUN,C1
-hike,hike,徒步旅行,NOUN,B2
-him,him,他,PRON,B2
-him dative,him dative,词,PRON,A2
-himself herself,himself herself,词,PRON,A1
-hint,hint,暗示,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
-his,his,他的,PRON,B2
-his certainty,his certainty,他定,NOUN,C1
-his her its,his her its,其,PRON,B2
-his her its their,his her its their,他的/她的/它的/他们的,DET,B2
-his her own,his her own,他/她自己的,DET,B2
-his refusal,his refusal,他绝,NOUN,C1
-historia,history,历史,NOUN,B2
-historial médico,medical record,病历,NOUN,B2
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
-historicization,historicization,词,NOUN,C1
-history education,history education,词,NOUN,C1
-history story,history story,历史/故事,NOUN,B2
-histórico,historic,历史性的,ADJ,B2
-hit beat,hit beat,词,VERB,A2
-hitch,hitch,词,NOUN,B2
-hither,hither,到这里,ADV,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hockey sobre hielo,ice hockey,冰球,NOUN,B2
-hoja,blade,刀片,NOUN,B2
-hoja,sheet,床单,NOUN,B2
-hojear,to browse,浏览,VERB,B2
+manada,herd,兽群,NOUN,B2
+pastor,herder,牧民,NOUN,B2
+aquí,here,此地,NOUN,B2
+por la presente,hereby,特此,ADV,B2
+herencia,heredity,遗传,NOUN,B2
+hermenéutico,hermeneutic,诠释学的,ADJ,B2
+oye,hey,嘿,INTJ,B2
 hola,hi,嗨,INTJ,B2
-hold,hold,控制,NOUN,B2
-hold catch,hold catch,词,VERB,A1
-hold together,hold together,词,VERB,C1
-holder,holder,持有者,NOUN,B2
-holding,holding,别放,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holiday feast,holiday feast,词,NOUN,A2
-holidaymaker,holidaymaker,词,NOUN,C1
-holidays,holidays,假期,NOUN,B2
-holism,holism,整体论,NOUN,B2
+ocultarse,to hide oneself,躲藏,VERB,B2
+ocultamiento,hiding,ٱختباء,NOUN,B2
+jerárquico,hierarchical,等级的,ADJ,B2
+alto,high,高的,ADJ,B2
+instituto,high school,高中,NOUN,B2
+pleamar,high tide,涨潮,NOUN,B2
+superior,higher,更高的,ADJ,B2
+destacar,to highlight,强调,VERB,B2
+alteza,highness,殿下,NOUN,B2
+caminar,to hike,徒步旅行,VERB,B2
+senderismo,hiking,徒步,NOUN,B2
+colinas,hills,丘陵,NOUN,B2
+empuñadura,hilt,剑柄,NOUN,B2
+él,him,他吧,NOUN,B2
+contratación,hiring,招聘,NOUN,B2
+su partida,his departure,他走,NOUN,B2
+siseo,hiss,嘶嘶声,NOUN,B2
+histórico,historic,历史性的,ADJ,B2
+historia,history,历史,NOUN,B2
+golpe,hit,击中,NOUN,B2
+mmm,hmm,嗯,INTJ,B2
+aguantar,to hold on,抓住,VERB,B2
+equilibrado,hold the balance of power,举足轻重,ADJ,B2
+vacaciones,holiday,假期,NOUN,B2
+santidad,holiness,神圣,NOUN,B2
 holistic,holistic,整体的,ADJ,B2
-hollowed,hollowed,掏空的,ADJ,B2
 holy,holy,神圣的,ADJ,B2
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-home (adv),home,词,ADV,B1
-home automation,home automation,词,NOUN,B1
 home family,home family,家,NOUN,B2
-home hearth,home hearth,词,NOUN,B1
 homeland,homeland,家乡,NOUN,B2
 homeless,homeless,无家可归的,ADJ,B2
-homelessness,homelessness,词,NOUN,B2
-homenajear,to pay respects,参见,VERB,B2
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homeward,homeward,,NOUN,B2
 homework,homework,家庭作业,NOUN,B2
-homework duty,homework duty,词,NOUN,A2
 homosexual,homosexual,同性恋的,ADJ,B2
-homothety,homothety,位似,NOUN,C1
 honey,honey,蜂蜜,NOUN,B2
 honeymoon,honeymoon,蜜月,NOUN,B2
 honk,to honk,按喇叭,VERB,B2
-honor culture,honor culture,荣誉文化,NOUN,B2
 honored,honored,尊敬的,ADJ,B2
-hood,hood,兜帽,NOUN,B2
-hooray,hooray,万岁,INTJ,B2
 hope,to hope,希望,VERB,B2
 hope to wish,to hope to wish,希望,VERB,B2
-hoped-for,hoped-for,词,ADJ,C1
-hopeful,hopeful,词,ADJ,C1
 hopefully,hopefully,希望,ADV,B2
 hopeless,hopeless,绝望的,ADJ,B2
-hopelessly,hopelessly,绝望地,ADV,B2
-horizontal,horizontal,横,ADJ,B1
-hornear,to bake,烘焙,VERB,B2
-horny,horny,性欲的,ADJ,B2
 horror,horror,恐怖,NOUN,B2
 horse departure,horse departure,马去,NOUN,B2
-horseback riding,horseback riding,骑马,NOUN,B2
-hose,hose,软管,NOUN,B2
 hospital,hospital,医院,NOUN,B2
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
-host of angels,host of angels,天使群,NOUN,B2
-hostess,hostess,女服务员,NOUN,B2
-hosting,hosting,托管,NOUN,C1
 hot air balloon,hot air balloon,热气球,NOUN,B2
-hot dog stand,hot dog stand,小吃摊,NOUN,B2
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
 hotel,hotel,酒店,NOUN,B2
-hotel industry,hotel industry,词,NOUN,C1
 hotel room,hotel room,酒店房间,NOUN,B2
-hothead,hothead,急性子的人,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-house search,house search,词,NOUN,B2
 household,household,家庭,NOUN,B2
-household (adj),household,词,ADJ,B2
-household income,household income,家庭收入,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
 hover,to hover,盘旋,VERB,B2
 how,how,又怎会,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
 how many,how many,多少,NUM,B2
-how many (pron),how many,多少,PRON,A1
-how much,how much,多少,ADV,B2
-how to do it,how to do it,办呢,ADV,B2
 however,however,然而,CCONJ,B2
-hoy,today,今天,NOUN,B2
-hoy en día,nowadays,如今,ADV,B2
-hubris,hubris,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
-huella dactilar,fingerprint,指纹,NOUN,B2
 huge,huge,巨大的,ADJ,B2
 huh,huh,哈,INTJ,B2
-huir,to abscond,潜逃,VERB,B2
 hum,to hum,哼唱,VERB,B2
 human,human,人类,NOUN,B2
-human being,human being,词,NOUN,B1
 human capacity,human capacity,人会,NOUN,B2
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
 human nature,human nature,人性,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humane,humane,人道的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
-humming,humming,词,NOUN,B2
-hunch,hunch,词,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hundreds (num),hundreds,词,NUM,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
 hydro energy,hydro energy,水能,NOUN,B2
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrology,hydrology,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
 hyper-use,hyper-use,超用,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hyperthermia,hyperthermia,体温过高,NOUN,B2
-hypotensive,hypotensive,词,ADJ,C1
-hypothesize,hypothesize,词,VERB,B2
-hypothetically,hypothetically,词,ADV,C1
-hábitat,habitat,栖息地,NOUN,B2
-húmedo,damp,潮湿,ADJ,B2
-húmedo,moist,潮湿的,ADJ,B2
-i,i,我连,NOUN,B2
 i don't deserve your praise,i don't deserve your praise,不敢当,INTJ,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
-ice cold,ice cold,冰冷的,ADJ,B2
-ice cube,ice cube,词,NOUN,A2
-ice pick,ice pick,,NOUN,B2
-iconicity,iconicity,词,NOUN,C1
-iconoclastic,iconoclastic,词,ADJ,C1
+hockey sobre hielo,ice hockey,冰球,NOUN,B2
+pista de hielo,ice rink,溜冰场,NOUN,B2
+helado,ice-cold,冰冷的,ADJ,B2
+helado,icy,冰冷的,ADJ,B2
+ello,id,证件,NOUN,B2
+foto de identidad,id photo,证件照,NOUN,B2
 idea,idea,想法,NOUN,B2
 ideal,ideal,理想,NOUN,B2
-ideal (adj),ideal,ideal,ADJ,B2
-idealization,idealization,理想化,NOUN,B2
-ideally,ideally,理想地,ADV,B2
-idear,to devise,设计,VERB,B2
 identidad,identity,身份,NOUN,B2
-identifier,identifier,词,NOUN,C1
-identitarianism,identitarianism,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
-ideologization,ideologization,词,NOUN,C1
 idioma,idiom,习语,NOUN,B2
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiotic,idiotic,愚蠢的,ADJ,B2
-idyllic,idyllic,词,ADJ,C1
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominious,ignominious,词,ADJ,C1
-ignominy,ignominy,耻辱,NOUN,B2
-ignífugo,fireproof,防火的,ADJ,B2
-igual que en el pasado,just as in the past,一如既往,ADV,B2
-igualdad,equality,平等,NOUN,B2
-illegally,illegally,词,ADV,C1
-illiteracy,illiteracy,词,NOUN,C1
-illuminationism,illuminationism,照明主义,NOUN,C1
-illuminator,illuminator,彩饰画家,NOUN,B2
-illusory,illusory,词,ADJ,C1
-image formation,image formation,形象塑造,NOUN,B2
-imagen,picture,图画,NOUN,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imagined,imagined,想象的,ADJ,C1
+ocioso,idle,懒惰的,ADJ,B2
+cuando,if when,如果,SCONJ,B2
+enfermo,ill,生病的,ADJ,B2
 imaginería,imagery,意象,NOUN,B2
-imaging,imaging,词,NOUN,C1
 imam,imam,伊玛目,NOUN,B2
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
 imitativo,imitative,模仿性,ADJ,B2
-immanence,immanence,内在性,NOUN,B2
-immediacy,immediacy,词,NOUN,C1
-immensely,immensely,词,ADV,B2
-immerse,immerse,词,VERB,C1
-imminence,imminence,就将,NOUN,C1
-immobility,immobility,都无动,NOUN,B2
-impactar,to shock,震惊,VERB,B2
-impacto,impact,影响,NOUN,B2
-impasse,impasse,词,NOUN,C1
-impassively,impassively,无动于衷地,ADV,B2
-impenetrable,impenetrable,不可穿透的,ADJ,B2
-imperatively,imperatively,词,ADV,C1
-imperceptible,imperceptible,词,ADJ,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperial,imperial,帝国的,ADJ,B2
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,太医,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
-impersonal,impersonal,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-imperturbable,unruffled,从容,ADJ,B2
-imperturbably,imperturbably,词,ADV,C1
-impetuosity,impetuosity,词,NOUN,C1
-implacably,implacably,毫不留情地,ADV,B2
-implausible,implausible,词,ADJ,C1
-implicar,to implicate,连累,VERB,B2
-implicated,implicated,牵连的,ADJ,C1
-implicitly,implicitly,含蓄地,ADV,B2
-importación,importation,进口,NOUN,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
-importar,to care,照顾,VERB,B2
-importar,to import,进口,VERB,B2
-imports,imports,词,NOUN,C1
-impostor,impostor,骗子,NOUN,B2
-impound lot,impound lot,词,NOUN,B1
-impoverished,impoverished,贫困的,ADJ,B2
-impresionismo,impressionism,印象主义,NOUN,B2
-impresión tridimensional,three-d printing,3D打印,NOUN,B2
-impressed,impressed,印象深刻的,ADJ,B2
-impressions,impressions,感想,NOUN,B2
-imprisoned,imprisoned,被监禁的,ADJ,B2
-improvised,improvised,即兴的,ADJ,B2
-impudente,impudent,无礼的,ADJ,B2
-impuesto sobre el carbono,carbon tax,碳税,NOUN,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-in,in,进来,ADV,B2
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a hurry (adv),in a hurry,词,ADV,A2
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in addition to,in addition to,除...之外,ADP,B2
-in agreement,in agreement,词,ADV,C1
-in anticipation of,in anticipation of,词,ADV,C1
-in book,in book,书里,NOUN,C1
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in deficit,in deficit,词,ADJ,C1
-in every detail,in every detail,词,ADV,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
-in front of before,in front of before,在...前,ADP,B2
-in here,in here,在这里面,ADV,B2
-in high spirits,in high spirits,兴致勃勃,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
-in its entirety,in its entirety,词,ADV,C1
-in me,in me,我中,NOUN,C1
-in mind,in mind,记住,ADV,B2
-in need,in need,词,ADJ,A2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in peace,in peace,不受打扰地,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in private,in private,私下地,ADV,B2
-in question,in question,词,ADV,C1
-in return,in return,作为回报,NOUN,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,在后面,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in there,in there,在那里面,ADV,B2
-in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
-in time (adj),in time,词,ADJ,B1
-in two,in two,成两半,ADV,B2
-in unison,in unison,齐声,ADV,B2
-in vain,in vain,徒劳,NOUN,B2
-in view of,in view of,鉴于,ADP,B2
-in which,in which,在其中,PRON,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccurate,inaccurate,词,ADJ,C1
-inactivity,inactivity,不活跃,NOUN,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadvertent,inadvertent,词,ADJ,C1
-inadvertently,inadvertently,词,ADV,B2
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inaudible,inaudible,词,ADJ,B2
-inboard,inboard,船内的,ADV,B2
-inborn nature,inborn nature,词,NOUN,C1
-incapacidad,inability,无能,NOUN,B2
-incarceration,incarceration,词,NOUN,C1
-incendiar,to fire,开火,VERB,B2
-incendio,blaze,火焰,NOUN,B2
-incentivization,incentivization,词,NOUN,C1
-incest,incest,词,NOUN,C1
-incidental,incidental,偶然的,ADJ,B2
-incidentalmente,incidentally,顺便地,ADV,B2
-inclined prone,inclined prone,词,ADJ,C1
-including,including,包括,ADP,B2
-including (adv),including,词,ADV,A2
-inclusión inversa,reverse inclusion,反纳,NOUN,B2
-incluso si,even if,即使,SCONJ,B2
-income tax,income tax,所得税,NOUN,B2
-incompatible,incompatible,词,ADJ,C1
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,不完整,NOUN,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-incontable,countless,无数的,ADJ,B2
-incontestably,incontestably,词,ADV,B2
-incorporation,incorporation,纳入,NOUN,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increased,increased,增加的,ADJ,B2
-increases,increases,增加,NOUN,C1
-increasing,increasing,增加的,ADJ,B2
-incredible,incredible,难以置信的,ADJ,B2
-incredulidad,disbelief,不信,NOUN,B2
-incremental,incremental,渐进性,ADJ,B2
-increíble,unbelievable,难以置信的,ADJ,B2
-incubación,incubation,孵化,NOUN,B2
-incubadora,incubator,孵化器,NOUN,B2
-incumbent,incumbent,词,ADJ,C1
-incumplidor,noncompliant,违规,ADJ,B2
-incumplir contrato,to breach contract,违约,VERB,B2
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-incómodo,awkward,尴尬的,ADJ,B2
-indebted,indebted,负债的,ADJ,B2
-indecible,hard to speak of,难以启齿,ADJ,B2
-indecipherable,indecipherable,词,ADJ,C1
-indeed (part),indeed,了吧,PART,B2
-independently,independently,独立地,ADV,B2
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
-indexing,indexing,指数化,NOUN,B2
-indian,indian,印度的,ADJ,B2
-indicador,indicator,指标,NOUN,B2
-indictment,indictment,起诉,NOUN,B2
-indigencia,destitution,贫困,NOUN,B2
-indigenous people,indigenous people,原住民,NOUN,B2
-indignación justa,righteous indignation,义愤,NOUN,B2
-indignity,indignity,词,NOUN,C1
-indigno,unworthy,你不配,NOUN,B2
-indirectly,indirectly,间接地,ADV,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indispensable,indispensable,不可或缺的,ADJ,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinguible,hard to distinguish,难以区分,ADJ,B2
-individual,individual,单独的,ADJ,B2
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualidad,individuality,个性,NOUN,B2
-individualization,individualization,词,NOUN,C1
-individually,individually,词,ADV,C1
-indoctrination,indoctrination,灌输,NOUN,B2
-indolent,indolent,词,ADJ,C1
-indonesian,indonesian,印度尼西亚的,ADJ,B2
-indoors,indoors,在室内,ADV,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-indulge,indulge,词,VERB,C1
-indulgencia,leniency,宽厚,NOUN,B2
-indulgente,lenient,宽大的,ADJ,B2
-industrial,industrial,工业的,ADJ,B2
-industrialization,industrialization,工业化,NOUN,B2
-ineffable,ineffable,词,ADJ,C1
-ineffectiveness,ineffectiveness,! 无效,NOUN,B2
-inequity,inequity,词,NOUN,C1
-inequívoco,clear-cut,明确的,ADJ,B2
-inequívoco,unambiguous,明确的,ADJ,B2
-inercia,inertia,惯性,NOUN,B2
-inertness,inertness,词,NOUN,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inesperadamente,unexpectedly,出乎意料地,ADV,B2
-inestabilidad,unrest,动荡,NOUN,B2
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable,inevitable,不可避免的,ADJ,B2
-inevitable (noun),inevitable,词,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexpressible,inexpressible,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infant,infant,婴儿,NOUN,B2
-infantilism,infantilism,词,NOUN,C1
-infantry,infantry,步兵,NOUN,B2
-infarto,heart attack,心脏病发作,NOUN,B2
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-infected,infected,被感染的,ADJ,B2
-inferencia,inference,推断,NOUN,B2
-inferential,inferential,词,ADJ,C1
-inferior,inferior,低等的,ADJ,B2
-inferir,to infer,推断,VERB,B2
-infertility,infertility,词,NOUN,C1
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infinitely,infinitely,词,ADV,B2
-infinitive marker,infinitive marker,去,PART,B2
-inflammable,inflammable,易燃的,ADJ,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflated,inflated,膨胀的,ADJ,B1
-inflationary,inflationary,词,ADJ,C1
-inflexibility,inflexibility,僵化,NOUN,B2
-influenciador,influencer,网红,NOUN,B2
-influential,influential,词,ADJ,C1
-influential person,influential person,词,NOUN,C1
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
-informal,casual,随意的,ADJ,B2
-informal,informal,非正式的,ADJ,B2
-informant,informant,线人,NOUN,B2
-informar,to report,报告,VERB,B2
-informatics,informatics,词,NOUN,B2
-information desk,information desk,词,NOUN,B1
-information exchange,information exchange,词,NOUN,B2
-informe,brief,近点说,NOUN,B2
-informe anual,annual report,年报,NOUN,B2
-informe de progreso,progress report,进度报告,NOUN,B2
-informe de seguridad,safety report,安全报告,NOUN,B2
-informed,informed,见多识广的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informers,informers,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructural,infrastructural,词,ADJ,C1
-infrastructure,infrastructure,基础设施,NOUN,B2
-infringement,infringement,侵犯,NOUN,C1
-ingenio,wits,心眼,NOUN,B2
-ingenioso,clever,聪明的,ADJ,B2
-ingratitude,ingratitude,词,NOUN,C1
-ingredients,ingredients,词,NOUN,B1
-ingresos y gastos,income and expense,收支,NOUN,B2
-inhabited,inhabited,词,ADJ,C1
-inhale,to inhale,吸入,VERB,B2
-inherence,inherence,固有,NOUN,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inherited,inherited,词,ADJ,C1
-inimaginable,unimaginable,难以想象的,ADJ,B2
-inimitability,inimitability,词,NOUN,C1
-initial,initial,花押字,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
-injerto,graft,嫁接,NOUN,B2
-injunction,injunction,禁令,NOUN,B2
-injure,to injure,使受伤,VERB,B2
-injury recovery,injury recovery,好伤,NOUN,C1
-injustice,injustice,不公,NOUN,B2
-injusto,unfair,不公平的,ADJ,B2
-injusto,unjust,不公正的,ADJ,B2
-ink,ink,墨水,NOUN,B2
-inkstone,inkstone,砚,NOUN,C1
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inmantenible,hard to maintain,难以维持,ADJ,B2
-inmate,inmate,词,NOUN,C1
 inmigrar,to immigrate,移入,VERB,B2
-inmobiliario,real estate,房地产,ADJ,B2
 inmunización,immunization,免疫,NOUN,B2
 inmunoterapia,immunotherapy,免疫治疗,NOUN,B2
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
+impacto,impact,影响,NOUN,B2
+deterioro,impairment,左手废,NOUN,B2
+impenetrable,impenetrable,不可穿透的,ADJ,B2
+imperial,imperial,帝国的,ADJ,B2
+corte imperial,imperial court,朝廷,NOUN,B2
+voluntad del padre imperial,imperial father's will,父皇要,NOUN,B2
+guardia imperial,imperial guard,御林,NOUN,B2
+pariente imperial,imperial relatives,皇亲,NOUN,B2
+implicar,to implicate,连累,VERB,B2
+importar,to import,进口,VERB,B2
+importación,importation,进口,NOUN,B2
+impresionismo,impressionism,印象主义,NOUN,B2
+mejora,improvement,好转,NOUN,B2
+impudente,impudent,无礼的,ADJ,B2
+además,in addition,此外,ADV,B2
+por adelantado,in advance,事先,ADV,B2
+en caso de que,in case,如果,SCONJ,B2
+delante de,in front of,在……前面,ADP,B2
+en ello,in it,在里面,ADV,B2
+para,in order to,以期,SCONJ,B2
+en persona,in person,亲自地,ADV,B2
+en resumen,in short,简而言之,ADV,B2
+a pesar de,to in spite of,不顾,VERB,B2
+en el cielo,in the sky,天上,NOUN,B2
+a tiempo,in time,及时地,ADV,B2
+en vano,in vain,徒劳,ADV,B2
+en el viento,in wind,临风,NOUN,B2
+por escrito,in writing,书面,NOUN,B2
+incapacidad,inability,无能,NOUN,B2
+pulgada,inch,بوصة,NOUN,B2
+incidentalmente,incidentally,顺便地,ADV,B2
+ingresos y gastos,income and expense,收支,NOUN,B2
+entrante,incoming,进来的,ADJ,B2
+aumentar constantemente,to increase steadily,与日俱增,VERB,B2
+crecientemente,increasingly,越来越,ADV,B2
+incubación,incubation,孵化,NOUN,B2
+incubadora,incubator,孵化器,NOUN,B2
+indicador,indicator,指标,NOUN,B2
+indispensable,indispensable,不可或缺的,ADJ,B2
+individual,individual,单独的,ADJ,B2
+asignación individual,individual assignment,个人作业,NOUN,B2
+individualidad,individuality,个性,NOUN,B2
+industrial,industrial,工业的,ADJ,B2
+cadena industrial,industry chain,产业链,NOUN,B2
+inercia,inertia,惯性,NOUN,B2
+inevitable,inevitable,不可避免的,ADJ,B2
+inferir,to infer,推断,VERB,B2
+inferencia,inference,推断,NOUN,B2
+inferior,inferior,低等的,ADJ,B2
+influenciador,influencer,网红,NOUN,B2
+informal,informal,非正式的,ADJ,B2
+informant,informant,线人,NOUN,B2
+inhale,to inhale,吸入,VERB,B2
+injure,to injure,使受伤,VERB,B2
+injustice,injustice,不公,NOUN,B2
+ink,ink,墨水,NOUN,B2
 inner,inner,内部的,ADJ,B2
 inner court,inner court,朝内,NOUN,B2
-inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
-inner side,inner side,内侧,NOUN,B2
-innermost,innermost,最里面的,ADV,B2
-innocent,innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
-innocuous,innocuous,无害的,ADJ,B2
-innuendo,innuendo,词,NOUN,C1
-inorganic,inorganic,词,ADJ,C1
-inoxidable,rust-proof,防锈,ADJ,B2
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
-inquieto,uneasy,不安的,ADJ,B2
 inquire,to inquire,询问,VERB,B2
-insanely,insanely,疯狂地,ADV,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect-proof,insect-proof,防虫,ADJ,C1
 insecticide,insecticide,杀虫剂,NOUN,B2
-insensible,callous,冷酷,ADJ,B2
 inseparable,inseparable,不可分割的,ADJ,B2
-insertion,insertion,词,NOUN,B2
 inside,inside,在内部,ADP,B2
-inside (noun),inside,内,NOUN,B2
 inside city,inside city,城内,NOUN,B2
-inside in,inside in,里,NOUN,B2
-inside of,inside of,在...里面,ADP,B2
 inside story,inside story,内幕,NOUN,B2
 insider,insider,知情者,NOUN,B2
-insidiously,insidiously,词,ADV,B2
 insight,insight,洞察力,NOUN,B2
-insightfulness,insightfulness,洞察,NOUN,B2
-insincere,insincere,词,ADJ,C1
-insipid,insipid,词,ADJ,C1
 insistence,insistence,坚持,NOUN,B2
-insistence persistence,insistence persistence,词,NOUN,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
-insolent conceit,insolent conceit,词,NOUN,C1
 insolvency,insolvency,无偿付能力,NOUN,B2
-insourcing,insourcing,内包,NOUN,C1
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
-inspectorate,inspectorate,词,NOUN,C1
-inspiring,inspiring,鼓舞人心的,ADJ,B2
-instalaciones,facilities,设施,NOUN,B2
-instalación,facility,设施,NOUN,B2
-instalar,to set up,建立,VERB,B2
-installation assembly,installation assembly,词,NOUN,C1
-installed,installed,词,ADJ,C1
 installment,installment,分期付款,NOUN,B2
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
-instance,instance,例子,NOUN,B2
 instant,instant,فور,NOUN,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instantly,instantly,词,ADV,C1
 instead,instead,代替,ADV,B2
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
 instead on the contrary,instead on the contrary,反而,ADV,B2
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instinctuality,instinctuality,词,NOUN,C1
 institutionalization,institutionalization,制度化,NOUN,B2
-institutionalized,institutionalized,词,ADJ,C1
-instituto,high school,高中,NOUN,B2
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructive,instructive,有教育意义的,ADJ,B2
-instructor,instructor,讲师,NOUN,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
 insulation,insulation,绝缘,NOUN,B2
-insulator,insulator,词,NOUN,B2
 insurance,insurance,保险,NOUN,B2
-insurances,insurances,词,NOUN,C1
 insure,to insure,保证,VERB,B2
-insured,insured,词,NOUN,B2
-insurer,insurer,词,NOUN,C1
-insurgency,insurgency,词,NOUN,C1
-intake,intake,词,NOUN,C1
-integer,integer,词,NOUN,C1
 integration,integration,融合,NOUN,B2
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-inteligente,smart,聪明的,ADJ,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intellectual life,intellectual life,精神生活,NOUN,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence service,intelligence service,情报机构,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
-intelligently,intelligently,词,ADV,C1
-intelligible,intelligible,词,ADJ,C1
-intención contraria,contrary intention,反意,NOUN,B2
-intended,intended,预定的,ADJ,B2
-intended (noun),intended,intended,NOUN,B2
-intended meaning,intended meaning,词,NOUN,C1
-intensification,intensification,词,NOUN,C1
-intensive,intensive,强化的,ADJ,B2
-intensive care,intensive care,重症监护,NOUN,B2
 intent,intent,意图,NOUN,B2
-intentionality,intentionality,词,NOUN,C1
-intentionally,intentionally,故意地,ADV,B2
-intentions,intentions,词,NOUN,C1
-intento fallido,failed bid,流标,NOUN,B2
 interaction,interaction,互动,NOUN,B2
 interactive,interactive,交互式的,ADJ,B2
-interactivity,interactivity,词,NOUN,C1
-intercambio de turnos,shift swap,换班,NOUN,B2
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
 intercourse,intercourse,性交,NOUN,B2
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,interdiction,词,NOUN,C1
-interest rate,interest rate,利率,NOUN,B2
-interesting things,interesting things,词,NOUN,C1
-interim (adj),interim,词,ADJ,C1
-interim (noun),interim,词,NOUN,B2
 interior,interior,内部,NOUN,B2
-interior modificado,amended interior,改内,NOUN,B2
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
 interlocutor,interlocutor,对话者,NOUN,B2
 intermediary,intermediary,中间人,NOUN,B2
-intern,intern,词,NOUN,C1
-internado,boarding school,寄宿学校,NOUN,B2
-internal affairs,internal affairs,内政,NOUN,C1
 internal force,internal force,内力,NOUN,B2
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
 international student,international student,留学生,NOUN,B2
-internationalization,internationalization,词,NOUN,C1
 internet,internet,互联网,NOUN,B2
 internship,internship,实习,NOUN,B2
-interpellation,interpellation,词,NOUN,C1
-interpersonal,interpersonal,人际的,ADJ,B2
-interpretive,interpretive,词,ADJ,C1
-interrogation room,interrogation room,审讯室,NOUN,B2
-interrupted,interrupted,词,ADJ,B2
-intertextuality,intertextuality,词,NOUN,C1
-interval,interval,词,NOUN,C1
-intestines,intestines,词,NOUN,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimately,intimately,词,ADV,C1
-into (adp),into,词,ADP,A1
-into (adv),into,词,ADV,B1
-intolerable,intolerable,词,ADJ,C1
-intonational quality,intonational quality,词,NOUN,C1
-intransigence,intransigence,词,NOUN,C1
-intravenous drip,intravenous drip,输液,NOUN,B2
-intrepidity,intrepidity,词,NOUN,C1
 intrinsic,intrinsic,固有的,ADJ,B2
-intrinsically,intrinsically,词,ADV,C1
-introductory,introductory,词,ADJ,C1
 introspection,introspection,内省,NOUN,B2
-introversion,introversion,词,NOUN,B2
 introverted,introverted,内向的,ADJ,B2
-intrusive,intrusive,词,ADJ,C1
-intuitionist,intuitionist,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-inure,inure,词,VERB,C1
-invalidated,invalidated,词,ADJ,C1
-invalidity,invalidity,词,NOUN,C1
-invariable,invariable,词,ADJ,C1
-invariably,invariably,不变地,ADV,B2
-inventar,to think up,构思,VERB,B2
 inventor,inventor,发明家,NOUN,B2
-inventorying,inventorying,清点,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigated,investigated,被调查的,ADJ,B2
-investigative,investigative,词,ADJ,C1
-investment (adj),investment,词,ADJ,C1
 investor,investor,投资者,NOUN,B2
-invincibility,invincibility,不胜,NOUN,C1
-inviolate,inviolate,词,ADJ,C1
 invisible,invisible,看不见的,ADJ,B2
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invite offer,invite offer,词,VERB,A2
-invited,invited,词,ADJ,C1
-invocations,invocations,词,NOUN,C1
-invoicing,invoicing,开票,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
 involved,involved,涉及的,ADJ,B2
-involved party,involved party,词,NOUN,C1
 involvement,involvement,参与,NOUN,B2
-invulnerability,invulnerability,词,NOUN,C1
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-iodine deficiency,iodine deficiency,词,NOUN,C1
-ion,ion,词,NOUN,C1
-ir primero,to go first,先去,VERB,B2
-ir y venir,to rush about,奔波,VERB,B2
-ira,wrath,愤怒,NOUN,B2
-iranian,iranian,伊朗的,ADJ,B2
 irascibility,irascibility,易怒,NOUN,B2
 irascible,irascible,易怒的,ADJ,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰的,ADJ,B2
-irish person,irish person,爱尔兰人,NOUN,B2
-irksome,irksome,词,ADJ,C1
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
 ironic,ironic,讽刺的,ADJ,B2
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
 irrationality,irrationality,非理性,NOUN,B2
-irrazonable,unreasonable,不合理的,ADJ,B2
 irrefutable,irrefutable,无可辩驳的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irregular,irregular,不规则的,ADJ,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irrelevante,unimportant,不重要的,ADJ,B2
-irremediably,irremediably,词,ADV,B2
 irresistible,irresistible,不可抗拒的,ADJ,B2
-irreversibility,irreversibility,词,NOUN,C1
 irreversible,irreversible,不可逆转的,ADJ,B2
-irrigation,irrigation,词,NOUN,B2
 irrigation canal,irrigation canal,灌溉渠,NOUN,B2
-irritability,irritability,词,NOUN,C1
-irritable boredom,irritable boredom,词,NOUN,C1
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-islamization,islamization,词,NOUN,C1
 isolated,isolated,孤立的,ADJ,B2
-isolated reports,isolated reports,词,NOUN,C1
 isotope,isotope,同位素,NOUN,B2
 issue,issue,问题,NOUN,B2
-it,it,对此,ADV,B2
-it (noun),it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it common,it common,它 (通性),PRON,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
-it neuter,it neuter,它 (中性),PRON,B2
 italian,italian,意大利人,NOUN,B2
 itch,to itch,发痒,VERB,B2
 itching,itching,瘙痒,NOUN,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-its,its,它的,PRON,B2
 its details,its details,其详,NOUN,B2
-its doing,its doing,它干,NOUN,B2
-itself,itself,它自己,PRON,B2
-ivory,ivory,象牙,NOUN,C1
-ja,ha,哈,INTJ,B2
-jack plug,jack plug,词,NOUN,C1
-jactancia,boasting,夸耀,NOUN,B2
 jade,jade,这玉,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
 jade ware,jade ware,玉器,NOUN,B2
-jaded,jaded,厌倦的,ADJ,B2
-jadeite,jadeite,翡翠,NOUN,C1
 jail,jail,监狱,NOUN,B2
-jailer,jailer,词,NOUN,B2
 jam,jam,果酱,NOUN,B2
-january,january,一月,NOUN,B2
 japanese,japanese,日本人,NOUN,B2
 jar,jar,广口瓶,NOUN,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jarring,jarring,词,ADJ,C1
-jasmine tea,jasmine tea,词,NOUN,C1
-jeans,jeans,牛仔裤,NOUN,B2
-jefe de aldea,village head,村长,NOUN,B2
-jefe de departamento,department head,厅长,NOUN,B2
-jeje,hehe,嘿嘿,INTJ,B2
-jengibre,ginger,姜,NOUN,B2
-jersey,jersey,词,NOUN,B1
-jerárquico,hierarchical,等级的,ADJ,B2
-jet-black,jet-black,乌黑,ADJ,B2
 jew,jew,犹太人,NOUN,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jeweler,jeweler,词,NOUN,B2
 jewelry,jewelry,珠宝,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewelry set,jewelry set,词,NOUN,C1
-jewish,jewish,犹太的,ADJ,B2
-jews,jews,犹太人,NOUN,B2
 jianghu,jianghu,江湖,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
 jiaolong,jiaolong,娇龙,NOUN,B2
 jin,jin,斤,NOUN,B2
-jinete,rider,骑手,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocular,jocular,词,ADJ,C1
-jog,jog,词,VERB,A1
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,生活乐趣,NOUN,B2
-joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-jointness,jointness,词,NOUN,C1
-joking,joking,词,NOUN,B2
-journal,journal,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
-journalism,journalism,新闻业,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-journeying,journeying,词,NOUN,C1
-jubilado,retired,退休的,ADJ,B2
-jubilant,jubilant,词,ADJ,C1
-judge sentence,judge sentence,词,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
-judicial,judicial,司法的,ADJ,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
-juego,play,剧本,NOUN,B2
-jugo,juice,果汁,NOUN,B2
+común,joint,平等的,ADJ,B2
+copropiedad,joint ownership,共有,NOUN,B2
 juicio,judgment,判断,NOUN,B2
-jujube,jujube,枣子,NOUN,B2
-junction,junction,词,NOUN,C1
-jungles,jungles,词,NOUN,B2
-junior jersey,junior jersey,,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junkie,junkie,词,NOUN,C1
-junta,junta,词,NOUN,C1
-junto con,along with,随着,ADP,B2
+judicial,judicial,司法的,ADJ,B2
+poder judicial,judiciary,司法官,NOUN,B2
+jugo,juice,果汁,NOUN,B2
+selva,jungle,丛林,NOUN,B2
+ámbito de jurisdicción,jurisdiction area,辖区,NOUN,B2
 jurado,juror,陪审员,NOUN,B2
-jurisconsult,jurisconsult,法学专家,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
-jury service,jury service,陪审,NOUN,C1
-just,just,公正,ADJ,B2
-just as,just as,词,ADV,A2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,随便地,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just over,just over,稍微超过,ADV,B2
-just precis,just precis,恰好,ADV,B2
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justifiability,justifiability,正当性,NOUN,C1
-justified,justified,有根据的,ADJ,B2
-justo,righteous,正直的,ADJ,B2
 justo,just,仅仅,ADV,B2
+igual que en el pasado,just as in the past,一如既往,ADV,B2
+ahora mismo,just now,刚刚,ADV,B2
 justo,just right,恰到好处,ADV,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
 karate,karate,空手道,NOUN,B2
-kasbah,kasbah,词,NOUN,B1
-kayaking,kayaking,皮划艇,NOUN,C1
-keen eager,keen eager,渴望的,ADJ,B2
-keenly,keenly,词,ADV,C1
-keenness,keenness,词,NOUN,B2
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kept,kept,词,ADJ,B2
-kerosene,kerosene,火油,NOUN,C1
-key point,key point,要点,NOUN,C1
-khul',khul',女方离婚,NOUN,C1
-kick (noun),kick,词,NOUN,B1
-kickback,kickback,回扣,NOUN,C1
-kidnapped,kidnapped,被绑架的,ADJ,B2
-kidnapper,kidnapper,绑架者,NOUN,B2
-kids,kids,孩子,NOUN,B2
-killed,killed,,NOUN,B2
-killing,killing,词,NOUN,B2
-kin,kin,词,NOUN,B2
-kind sort,kind sort,种类,NOUN,B2
-kind species,kind species,种类/物种,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindly,kindly,亲切地,ADV,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
-king,king,王,PART,B2
-kit,kit,词,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
-kitten,kitten,小猫,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-knack,knack,窍,NOUN,C1
-kneader,kneader,词,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knock,knock,敲击,NOUN,B2
-knocked out,knocked out,被淘汰的,ADJ,B2
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge exchange,knowledge exchange,知识交流,NOUN,B2
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-knowledgeably,knowledgeably,词,ADV,C1
-known famous,known famous,著名的/熟悉的,ADJ,B2
-kohl,kohl,词,NOUN,A1
-laazima,laazima,词,NOUN,B2
-lab,lab,实验室,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,不稳定的,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-laboratory (adj),laboratory,词,ADJ,C1
-laborious striving,laborious striving,词,NOUN,C1
-labour market,labour market,词,NOUN,B1
-labyrinthine,labyrinthine,词,ADJ,C1
-lace,lace,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-laconically,laconically,词,ADV,C1
+teclado,keyboard,键盘,NOUN,B2
+patar,kick,踢,NOUN,B2
+patar,to kick,踢,VERB,B2
+riñón,kidney,肾脏,NOUN,B2
+matar dos pájaros de un tiro,kill two birds with one stone,一举两得,ADJ,B2
+asesino,killer,杀手,NOUN,B2
+tipo,kind,种类,NOUN,B2
+cinético,kinetic,运动的,ADJ,B2
+parentesco,kinship,亲属关系,NOUN,B2
+cometa,kite,风筝,NOUN,B2
+caballero,knight,骑士,NOUN,B2
+golpear,to knock,敲,VERB,B2
+nudo,knot,结,NOUN,B2
+reconocer,to know to recognize,认识,VERB,B2
+conocido,known,已知的,ADJ,B2
+trabajo,labor,劳动,NOUN,B2
 laconico,laconic,简洁的,ADJ,B2
-laconism,laconism,简洁,NOUN,B2
-lacquerware,lacquerware,漆器,NOUN,C1
-lactancia,breastfeeding,母乳喂养,NOUN,B2
-lacunary,lacunary,残缺的,ADJ,B2
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-ladle,ladle,词,NOUN,A2
-lado izquierdo,left side,左侧,NOUN,B2
-ladrón,burglar,窃贼,NOUN,B2
-ladrón,robber,强盗,NOUN,B2
-laicismo,secularism,世俗主义,NOUN,B2
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lament (noun),lament,词,NOUN,C1
-lamentable,lamentable,词,ADJ,C1
-lamer,to lick,舔,VERB,B2
-lamp niche,lamp niche,词,NOUN,C1
-lampoon,lampoon,词,NOUN,C1
-lana,wool,羊毛,NOUN,B2
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
+escalera,ladder,梯子,NOUN,B2
+dama,lady,女士,NOUN,B2
 land,land,土地,NOUN,B2
-land (adj),land,بري,ADJ,B2
-land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,土地政策,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land use,land use,土地利用,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landfill,landfill,填埋,NOUN,C1
 landlord,landlord,房东,NOUN,B2
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landmine,landmine,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
 landslide,landslide,滑坡,NOUN,B2
 lane,lane,小巷,NOUN,B2
-language use,language use,语言使用,NOUN,B2
-languid,languid,词,ADJ,C1
-lanzamiento,throw,投掷,NOUN,B2
 lap,lap,大腿部,NOUN,B2
-lapidary,lapidary,简略的,ADJ,B2
-lapse of time,lapse of time,词,NOUN,C1
-laptop,laptop,笔记本电脑,NOUN,B2
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
 large-scale,large-scale,大规模的,ADJ,B2
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larva,larva,幼虫,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
 last,last,最后,ADV,B2
-last (num),last,词,NUM,A2
 last a period of time,to last a period of time,为期,VERB,B2
-last evening,last evening,,NOUN,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
 last year,last year,去年,NOUN,B2
 late,late,晚的,ADJ,B2
-late (noun),late,晚才,NOUN,B2
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-latent,latent,潜在的,ADJ,B2
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
 lateral,lateral,侧面的,ADJ,B2
-lateral side,lateral side,词,ADJ,C1
-latest,latest,最新的,ADJ,B2
-latest (adv),latest,最迟/最近,ADV,B1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude leeway,latitude leeway,词,NOUN,C1
-laudable,laudable,词,ADJ,C1
-laugh,laugh,笑,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
 launch,to launch,发起,VERB,B2
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,洗钱,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
-laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
 lava,lava,熔岩,NOUN,B2
-lavado,washing,洗涤,NOUN,B2
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
 law enforcement,law enforcement,执法,NOUN,B2
-law team,law team,法律/团队,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
 lawful,lawful,合法的,ADJ,B2
-lawless,lawless,无法的,ADJ,B2
-lawlessness,lawlessness,词,NOUN,C1
-lawnmower,lawnmower,割草机,NOUN,B2
 lawsuit,lawsuit,诉讼,NOUN,B2
-lawyer female,lawyer female,词,NOUN,B2
-lay,lay,叙事短诗,NOUN,B2
 lay,to lay,放置,VERB,B2
-lay (noun),lay,叙事短诗,NOUN,B2
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
-layer storage,layer storage,层/仓库,NOUN,B2
 layman,layman,外行,NOUN,B2
 layoff,layoff,解雇,NOUN,B2
 layout,layout,布局,NOUN,B2
-layperson,layperson,外行,NOUN,B2
-lead actor,lead actor,主演,NOUN,B2
 lead thousand,lead thousand,率千,NOUN,B2
 lead to,to lead to,通向,VERB,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
 leading,leading,领先的,ADJ,B2
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf page,leaf page,叶子,NOUN,B2
 leaflet,leaflet,传单,NOUN,B2
 leak,to leak,泄漏,VERB,B2
-leak escape,leak escape,词,NOUN,B1
 lean,lean,瘦的,ADJ,B2
 lean,to lean,倾斜,VERB,B2
-lean (adj),lean,词,ADJ,B2
 leap,leap,跳跃,NOUN,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
-learning curve,learning curve,学习曲线,NOUN,B2
-leash,leash,词,NOUN,B2
-leasing,leasing,词,NOUN,C1
-least,least,最少,ADV,B2
-least (adj),least,词,ADJ,A1
-leather goods,leather goods,词,NOUN,C1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
 leave,leave,休假,NOUN,B2
 leave behind,to leave behind,留下,VERB,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
 leave out,to leave out,省略,VERB,B2
-lechuga,lettuce,生菜,NOUN,B2
-lector,reader,读者,NOUN,B2
 lecture,lecture,讲座,NOUN,B2
 ledger,ledger,总账,NOUN,B2
-leek,leek,词,NOUN,A2
 left,left,左边,ADV,B2
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
-left-handed,left-handed,词,ADJ,C1
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leftovers,leftovers,剩菜,NOUN,B2
-leg of lamb,leg of lamb,词,NOUN,B1
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal expert,legal expert,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
-legal representative,legal representative,词,NOUN,C1
+lado izquierdo,left side,左侧,NOUN,B2
+abogacía,legal profession,律师业,NOUN,B2
 legalidad,legality,合法性,NOUN,B2
-legalization,legalization,词,NOUN,C1
-legatee,legatee,受遗赠人,NOUN,B2
-legation,legation,公使馆,NOUN,B2
 legendario,legendary,传奇的,ADJ,B2
-legible,legible,词,ADJ,C1
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legion unit,legion unit,,NOUN,B2
 legislación,legislation,立法,NOUN,B2
-legislative elections,legislative elections,词,NOUN,C1
 legislativo,legislative,立法的,ADJ,B2
-legislator,legislator,词,NOUN,C1
-legislature,legislature,立法机关,NOUN,B2
-legitimar,to legitimize,使合法,VERB,B2
 legitimidad,legitimacy,合法性,NOUN,B2
-legitimization,legitimization,词,NOUN,B2
-lejano,far,远的,ADJ,B2
-lejos,away,离开,ADV,B2
-lejía,bleach,漂白剂,NOUN,B2
-lemon verbena,lemon verbena,词,NOUN,B2
-lemonade,lemonade,词,NOUN,A2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-lengthy,lengthy,词,ADJ,C1
-lengua,tongue,舌头,NOUN,B2
-lens,lens,词,NOUN,C1
-lent,lent,大斋期,NOUN,B2
-lentil lens,lentil lens,词,NOUN,C1
-lentils,lentils,词,NOUN,A2
-lentitud,slowness,缓慢,NOUN,B2
-lesbian,lesbian,女同性恋的,ADJ,B2
-lesion,lesion,病变,NOUN,B2
-less,less,较少的,ADJ,B2
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
-let alone (cconj),let alone,何况,CCONJ,B1
-lethality,lethality,词,NOUN,C1
-lethargy,lethargy,词,NOUN,C1
-letrina,outhouse,茅房,NOUN,B2
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
-levantarse,to get up,起床,VERB,B2
-lever,lever,词,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-leverage,leverage,词,NOUN,B2
-levity,levity,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-lexical,lexical,词,ADJ,C1
+legitimar,to legitimize,使合法,VERB,B2
+limón,lemon,柠檬,NOUN,B2
+indulgencia,leniency,宽厚,NOUN,B2
+indulgente,lenient,宽大的,ADJ,B2
+no sea que,lest,唯恐,SCONJ,B2
+dejar,let,让,AUX,B2
+dejar,to let,让,VERB,B2
+mucho menos,let alone,别说,ADV,B2
+lechuga,lettuce,生菜,NOUN,B2
 lexicología,lexicology,词汇学,NOUN,B2
-liabilities,liabilities,词,NOUN,C1
-liable,liable,有责任的,ADJ,B2
-libel,libel,词,NOUN,C1
-liberación,release,释放,NOUN,B2
-liberal,liberal,自由的,ADJ,B2
+responsabilidad,liability,责任,NOUN,B2
+enlace,liaison,联络,NOUN,B2
 liberalismo,liberalism,自由主义,NOUN,B2
 liberalización,liberalization,自由化,NOUN,B2
-liberalize,liberalize,自由化,! VERB,B2
 liberar,to liberate,解放,VERB,B2
-liberating,liberating,解放的,ADJ,B2
-libertad condicional,parole,假释,NOUN,B2
+matrícula,license plate,车牌,NOUN,B2
+restricción de matrícula,license plate restriction,限号,NOUN,B2
 libertinaje,licentiousness,放荡,NOUN,B2
-libertinism,libertinism,放荡,NOUN,B2
-liberty,liberty,词,NOUN,B2
-libra,pound,磅,NOUN,B2
-librarian,librarian,图书管理员,NOUN,B2
-libro de texto,textbook,教科书,NOUN,B2
-licencia de conducir,driver's license,驾驶证,NOUN,B2
-licenciatura,bachelor's degree,学士学位,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licensor,licensor,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
-lichen,lichen,词,NOUN,B2
-life (part),life,生,PART,A2
-life connection,life connection,连命,NOUN,C1
-life sentence,life sentence,无期徒刑,NOUN,B2
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifeguard,lifeguard,词,NOUN,B2
-lifelong,lifelong,终身,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-lifestyle,lifestyle,生活方式,NOUN,B2
+lamer,to lick,舔,VERB,B2
+tapa,lid,盖子,NOUN,B2
+acostarse,to lie down,躺,VERB,B2
+teniente,lieutenant,中尉,NOUN,B2
+vida y muerte,life and death,生死,NOUN,B2
+cadena perpetua,life imprisonment,无期徒刑,NOUN,B2
+retribución vitalicia,life retribution,偿命,NOUN,B2
+vida o muerte,life-and-death,决生,NOUN,B2
+vida,lifetime,一生,NOUN,B2
 ligereza,lightness,轻盈,NOUN,B2
-light blue,light blue,词,ADJ,A1
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light grey,light grey,浅灰色的,ADJ,B2
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-light-year,light-year,,NOUN,B2
-lightbulb,lightbulb,词,NOUN,A1
-lightest,lightest,最轻,NOUN,C1
-lighting,lighting,词,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
 like,like,像,ADP,B2
-like (noun),like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like as,like as,如同/好像,ADV,B2
-like that,like that,像那样,ADV,B2
-like this,like this,,NOUN,B2
-like this (adv),like this,词,ADV,B1
-likeable,likeable,词,ADJ,C1
-likely (adj),likely,词,ADJ,A1
-likely (adv),likely,词,ADV,A1
-likely source,likely source,词,NOUN,C1
 likeness,likeness,就象,NOUN,B2
 likewise,likewise,同样地,ADV,B2
-lily,lily,百合,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
 lime,lime,石灰,NOUN,B2
-liminal,liminal,阈限的,ADJ,B2
 limit,to limit,限制,VERB,B2
-limit border,limit border,界限,NOUN,B2
 limited,limited,有限的,ADJ,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limpiar,to clean up,清理,VERB,B2
-limpidity,limpidity,词,NOUN,C1
-limpieza,cleansing,清洗,NOUN,B2
-limón,lemon,柠檬,NOUN,B2
-line of conduct,line of conduct,行为方针,NOUN,B2
-line queue,line queue,词,NOUN,B1
-line-up,line-up,阵容,NOUN,B2
-lineages,lineages,词,NOUN,C1
 linear,linear,线性的,ADJ,B2
 linen,linen,线麻,NOUN,B2
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,语言的,ADJ,B2
-linguist,linguist,词,NOUN,C1
-linguistic,linguistic,语言的,ADJ,B2
-linguistic intuition,linguistic intuition,词,NOUN,C1
 linguistics,linguistics,语言学,NOUN,B2
-lining understudy,lining understudy,词,NOUN,B1
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linkage (noun),linkage,词,NOUN,C1
-lip service,lip service,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
 lipstick,lipstick,口红,NOUN,B2
-liquid,liquid,液态的,ADJ,B2
 liquidation,liquidation,清算,NOUN,B2
 liquidity,liquidity,流动性,NOUN,B2
 liquor,liquor,烈酒,NOUN,B2
-lisp (noun),lisp,词,NOUN,C1
 list,to list,列举,VERB,B2
-listen (intj),listen,词,INTJ,B2
 listen attentively,to listen attentively,倾听,VERB,B2
-listen up,listen up,听着,INTJ,B2
-listener,listener,听众,NOUN,B2
-listening,listening,也听,NOUN,B2
-listing,listing,词,NOUN,C1
-listless,listless,词,ADJ,C1
-litanies,litanies,词,NOUN,C1
 liter,liter,升,NOUN,B2
 literacy,literacy,读写能力,NOUN,B2
-literal,literal,字面的,ADJ,B2
-literalism,literalism,词,NOUN,C1
-literally,literally,字面上地,ADV,B2
-literariness,literariness,词,NOUN,C1
-literary,literary,文学的,ADJ,B2
-literary thefts,literary thefts,词,NOUN,C1
-lithe,lithe,词,ADJ,C1
-lithography,lithography,词,NOUN,C1
 litigant,litigant,诉讼当事人,NOUN,B2
 litigation,litigation,诉讼,NOUN,B2
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litotes understatement,litotes understatement,词,NOUN,C1
 litre,litre,升,NOUN,B2
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
-little (adj),little,词,ADJ,A1
-little (adv),little,词,ADV,A2
-little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,小男孩,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
 little eleven,little eleven,小十一,NOUN,B2
-little finger,little finger,小指,NOUN,B2
-little girl,little girl,词,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,小心脏,NOUN,B2
 little nine,little nine,小九,NOUN,B2
-little one,little one,小家伙,NOUN,B2
-little sister,little sister,妹妹,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little thing,little thing,词,NOUN,B2
-little town,little town,词,NOUN,C1
-liturgical,liturgical,词,ADJ,C1
-liturgy,liturgy,词,NOUN,C1
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
 lively,lively,热闹的,ADJ,B2
 livestock,livestock,家畜,NOUN,B2
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
 living room,living room,客厅,NOUN,B2
-llama,flame,火焰,NOUN,B2
-llamada,phone call,通话,NOUN,B2
-llamar,to phone,打电话,VERB,B2
-llanto,crying,,NOUN,B2
-llanura,plain,平原,NOUN,B2
-llegada,arrival,到达,NOUN,B2
-llegar tarde,to be late,迟到,VERB,B2
-llenar,to fill in,填写,VERB,B2
-llevar,to take along,带走,VERB,B2
-llevarse,to take away,拿走,VERB,B2
-llover,to rain,下雨,VERB,B2
-llovizna,drizzle,毛毛雨,NOUN,B2
-lluvia congelada,freezing rain,冻雨,NOUN,B2
-lluvia moderada,moderate rain,中雨,NOUN,B2
-load cargo,load cargo,货物/负荷,NOUN,B2
-loaded,loaded,词,ADJ,C1
-loading,loading,词,NOUN,B2
 loan,loan,贷款,NOUN,B2
-loanword,loanword,外来词,NOUN,C1
-loathing,loathing,,NOUN,B2
-loathsome,loathsome,词,ADJ,C1
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
 local,local,当地的,ADJ,B2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
-local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-located,located,位于,ADJ,B2
 lock,to lock,锁上,VERB,B2
 lockdown,to lockdown,封城,VERB,B2
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locked,locked,锁定的,ADJ,B2
-locked in,locked in,被关在里面的,ADJ,B2
-locker,locker,词,NOUN,C1
 locker room,locker room,更衣室,NOUN,B2
-locksmith,locksmith,词,NOUN,C1
-loco,madman,疯子,NOUN,B2
-locomotive,locomotive,词,NOUN,C1
-locuacidad,talkativeness,多嘴,NOUN,B2
-lodges,lodges,道堂,NOUN,C1
-loft,loft,词,NOUN,C1
-loftiness,loftiness,高尚,NOUN,C1
 lofty,lofty,崇高的,ADJ,B2
 log,log,日志,NOUN,B2
-logarithm,logarithm,词,NOUN,C1
-logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logistical,logistical,词,ADJ,C1
 logistics,logistics,后勤,NOUN,B2
-logistics (adj),logistics,词,ADJ,C1
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
-lograr,to accomplish,完成,VERB,B2
-lomo,tenderloin,里脊,NOUN,B2
 lonely,lonely,孤独的,ADJ,B2
-lonely soul,lonely soul,孤魂,NOUN,C1
-long,long,,NOUN,B2
-long absence,long absence,久违,NOUN,C1
 long ago,long ago,早已,ADV,B2
-long lease,long lease,词,NOUN,C1
 long live,long live,万岁,INTJ,B2
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
 long time,long time,长时间,ADV,B2
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
 long-distance bus,long-distance bus,长途车,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longer,longer,更长的,ADJ,B2
-longest,longest,أطول,NOUN,B1
-longevity,longevity,词,NOUN,C1
-loofah,loofah,丝瓜,NOUN,C1
 look after,to look after,照料,VERB,B2
-look around,look around,词,VERB,C1
 look at,to look at,观看,VERB,B2
 look at you,look at you,你看你,NOUN,B2
 look down upon,to look down upon,看不起,VERB,B2
 look for to find,to look for to find,找,VERB,B2
 look up,to look up,查阅,VERB,B2
 lookout,lookout,瞭望,NOUN,B2
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loop,loop,循环,NOUN,B2
 loophole,loophole,漏洞,NOUN,B2
-loopholes,loopholes,词,NOUN,C1
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
 lord,lord,领主,NOUN,B2
-lord god,lord god,上帝,NOUN,B2
 lord yu,lord yu,玉大人,NOUN,B2
 lord's words,lord's words,主说,NOUN,B2
-lordship,lordship,词,NOUN,C1
-loro,parrot,鹦鹉,NOUN,B2
 lose,lose,上丢,NOUN,B2
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
 lose weight,to lose weight,减肥,VERB,B2
 loser,loser,失败者,NOUN,B2
-losses,losses,词,NOUN,B1
-lost tradition,lost tradition,失传,NOUN,C1
-lotar,lotar,词,NOUN,C1
-lots,lots,大量,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
 loud,loud,大声的,ADJ,B2
-loud and clear,loud and clear,响亮,ADJ,B2
-loudly,loudly,大声地,ADV,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
 lounge,lounge,休息室,NOUN,B2
 louse,louse,虱子,NOUN,B2
 lousy,lousy,糟糕的,ADJ,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-loved,loved,被爱的,ADJ,B2
-lovely,lovely,美好的,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
 low tide,low tide,退潮,NOUN,B2
-low-carbon,low-carbon,低碳,ADJ,C1
-lower,lower,较低的,ADJ,B2
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucha,wrestling,摔跤,NOUN,B2
-lucid,lucid,词,ADJ,C1
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck turn,luck turn,词,NOUN,A2
 lucky,lucky,幸运的,ADJ,B2
-lucky (noun),lucky,吉祥,NOUN,B2
 lucky chance,lucky chance,虽侥,NOUN,B2
-lucky find,lucky find,意外发现,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucrative,lucrative,有利可图的,ADJ,B2
-lugar de trabajo,workplace,工作场所,NOUN,B2
-lukewarm,lukewarm,微温的,ADJ,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-lullaby,lullaby,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-luminous,luminous,发光的,ADJ,B2
 lump,lump,块,NOUN,B2
-lump in throat,lump in throat,词,NOUN,C1
-luna del mes,month moon,月,NOUN,B2
-luna llena,full moon,满月,NOUN,B2
-lunar,lunar,词,ADJ,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunatic,lunatic,疯子,NOUN,B2
 lunch,lunch,午餐,NOUN,B2
-lunch break,lunch break,午休,NOUN,B2
 lung,lung,肺,NOUN,B2
-lupini beans,lupini beans,词,NOUN,B2
 lure,lure,诱惑,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
-lurid,lurid,词,ADJ,C1
-lust,lust,欲望,NOUN,B2
 luster,luster,光泽,NOUN,B2
-lute,lute,词,NOUN,C1
 luxurious,luxurious,奢侈的,ADJ,B2
-luz de marcha atrás,backup light,倒车灯,NOUN,B2
-lychee,lychee,荔枝,NOUN,C1
 lymph,lymph,淋巴,NOUN,B2
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyre,lyre,词,NOUN,B2
-lyrical,lyrical,抒情的,ADJ,B2
-lyricism,lyricism,词,NOUN,C1
 lyrics,lyrics,歌词,NOUN,B2
-lágrimas,tears,眼泪,NOUN,B2
-machination,machination,词,NOUN,C1
 machine,machine,机器,NOUN,B2
-machine (adj),machine,词,ADJ,B2
-machine learning,machine learning,机器学习,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
 macroscopic,macroscopic,宏观的,ADJ,B2
-mad,mad,词,ADJ,A1
 madam,madam,夫人,NOUN,B2
-made,made,制成的,ADJ,B2
-madera,wood,木头,NOUN,B2
-madrastra,stepmother,后母,NOUN,B2
-madre,mother,娘,PART,B2
-maduro,mature,成熟的,ADJ,B2
-maduro,ripe,成熟的,ADJ,B2
-mafia,mafia,黑手党,NOUN,B2
-magically,magically,魔法地,ADV,B2
-magnanimidad,magnanimity,宽宏大量,NOUN,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
-magnesium,magnesium,镁,NOUN,B2
-magnetic,magnetic,磁的,ADJ,B2
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
-magnifying glass,magnifying glass,词,NOUN,C1
-magnitude,magnitude,词,NOUN,C1
+loco,madman,疯子,NOUN,B2
 mago,magician,魔术师,NOUN,B2
-magus,magus,词,NOUN,C1
-maieutic,maieutic,词,ADJ,C1
-mail (verb),mail,寄送,VERB,C1
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-main thing,main thing,词,NOUN,B2
-mainstream,mainstream,主流的,ADJ,B2
-majestad,majesty,陛下,NOUN,B2
-major,major,主要的,ADJ,B2
-major case,major case,大案,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
-make amends,make amends,词,VERB,C1
-makeover,makeover,改容,NOUN,C1
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-mala cosa,bad thing,坏事,NOUN,B2
-mala idea,bad idea,坏水,NOUN,B2
-mala suerte,bad luck,倒霉,NOUN,B2
-malaria,malaria,疟疾,NOUN,B2
-malas noticias,bad news,坏消息,NOUN,B2
-maldecir,damn,该死的,ADJ,B2
-maldecir,curse,诅咒,NOUN,B2
-maldecir,to curse,诅咒,VERB,B2
-maldecir,to damn,诅咒,VERB,B2
-male,male,男性,NOUN,B2
-malefic,malefic,邪恶的,ADJ,B2
-malentendido,misunderstanding,误解,NOUN,B2
-malevolence,malevolence,恶意,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malfeasance,malfeasance,渎职,NOUN,B2
-malhun,malhun,词,NOUN,B2
-malicia,malice,恶意,NOUN,B2
-malicious,malicious,恶意的,ADJ,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
-malignity,malignity,词,NOUN,C1
-maligno,malignant,恶性的,ADJ,B2
-maliki school,maliki school,词,NOUN,C1
-malinterpretar,to misunderstand,误解,VERB,B2
-mall,mall,词,NOUN,B2
-malleability,malleability,词,NOUN,C1
-malleable,malleable,词,ADJ,C1
-mallow greens,mallow greens,词,NOUN,B2
-malmo,malmo,马尔默,PROPN,B2
-malpractice,malpractice,弊端,NOUN,C1
-maltratar,to mistreat,أساء,VERB,B2
-mammal,mammal,哺乳动物,NOUN,B2
-mammalian,mammalian,词,ADJ,C1
-manada,herd,兽群,NOUN,B2
-managed,managed,,NOUN,B2
-management pipe,management pipe,管理层/管道,NOUN,B2
-managing director,managing director,总经理,NOUN,B2
-mancha,blemish,瑕疵,NOUN,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-manejar,handle,把手,NOUN,B2
-manejar,to handle,处理,VERB,B2
-manejo,handling,处理,NOUN,B2
-manera,manner,方式,NOUN,B2
-maneta,handcuff,手铐,NOUN,B2
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-manhunt,manhunt,搜捕,NOUN,B2
-mania,mania,狂躁症,NOUN,B2
-manifestante,protester,示威者,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifestly,manifestly,明显地,ADV,B2
-manifold,manifold,多方面的,ADJ,B2
-manija,door handle,门把手,NOUN,B2
-manipulable,manipulable,可操纵的,ADJ,B2
-manipulación,manipulation,操纵,NOUN,B2
-manipulator,manipulator,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
-mannerly,mannerly,有礼貌的,ADJ,B2
-manners,manners,词,NOUN,B2
-manor (part),manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
-mansión,manor,庄园,NOUN,B2
-manslaughter,manslaughter,词,NOUN,C1
-manta,blanket,毯子,NOUN,B2
+magnanimidad,magnanimity,宽宏大量,NOUN,B2
+criada,maidservant,女仆,NOUN,B2
+tierra firme,mainland,大陆,NOUN,B2
+principalmente,mainly,主要地,ADV,B2
+corriente principal,mainstream,主流,NOUN,B2
 mantener,to maintain,维持,VERB,B2
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manually,manually,手动地,ADV,B2
-manufacturing,manufacturing,词,NOUN,B1
-manumission,manumission,词,NOUN,C1
+majestad,majesty,陛下,NOUN,B2
+mayor,major,少校,NOUN,B2
+carrera principal,major course,专业课,NOUN,B2
+hacer,to make,制作,VERB,B2
+dar un discurso,to make a speech,发言,VERB,B2
+arreglárselas,to make do,做,VERB,B2
+error,make mistake,犯错,NOUN,B2
+hacer ruido,to make noise,闹得,VERB,B2
+compensar,to make up for,弥补,VERB,B2
+enfermedad,malady,弊病,NOUN,B2
+masculino,male,男性的,ADJ,B2
+avería,malfunction,故障,NOUN,B2
+malicia,malice,恶意,NOUN,B2
+maligno,malignant,恶性的,ADJ,B2
+obligatorio,mandatory,强制的,ADJ,B2
+manipulación,manipulation,操纵,NOUN,B2
+manera,manner,方式,NOUN,B2
+mansión,manor,庄园,NOUN,B2
+fabricar,to manufacture,制造,VERB,B2
 manuscrito,manuscript,手稿,NOUN,B2
-many,many,许多,DET,B2
-many (noun),many,多……,NOUN,B2
-many (pron),many,词,PRON,B1
-many a,many a,词,ADJ,C1
-many things,many things,许多事物,PRON,B2
-many whips,many whips,好多鞭,NOUN,C1
-mapping,mapping,梳理,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
-mar de sangre,blood sea,血海,NOUN,B2
+muchos,many,许多,ADJ,B2
+muchas veces,many times,多次,ADV,B2
 maratón,marathon,马拉松,NOUN,B2
-maravillar,to marvel,使惊奇,VERB,B2
-maravillarse,wonder,奇迹,NOUN,B2
-maravillarse,to wonder,觉得奇怪,VERB,B2
-marble,marble,大理石,NOUN,B2
-marbly,marbly,大理石般的,ADJ,B2
-marca,mark,标记,NOUN,B2
-marcador de ritmo,pace-setter,标兵,NOUN,B2
-marco,framework,框架,NOUN,B2
-mare,mare,词,NOUN,B2
-marea,tide,潮汐,NOUN,B2
-mareal,tidal,潮汐,ADJ,B2
 marginación,marginalization,边缘化,NOUN,B2
-marginal,marginal,边缘的,ADJ,B2
-marginally,marginally,边缘地,ADV,B2
-marinade,marinade,词,NOUN,B2
 marinar,to marinate,腌制,VERB,B2
-marine,marine,海军陆战队员,NOUN,B2
-marine corps,marine corps,海军陆战队,NOUN,B2
-mariposa,butterfly,蝴蝶,NOUN,B2
-marital conjugal,marital conjugal,词,ADJ,C1
-marker,marker,词,NOUN,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
-marketing,marketing,营销,NOUN,B2
-markets,markets,词,NOUN,C1
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshal,marshal,元帅,NOUN,B2
-marshy,marshy,沼泽般的,ADJ,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martillo,hammer,锤子,NOUN,B2
-martyr,martyr,词,NOUN,C1
-marvel (noun),marvel,词,NOUN,B2
-marvelous,marvelous,极好的,ADJ,B2
 marítimo,maritime,海事的,ADJ,B2
+marca,mark,标记,NOUN,B2
+marketing,marketing,营销,NOUN,B2
+alianza matrimonial,marriage alliance,联姻,NOUN,B2
+casadera,marriageable,适婚,NOUN,B2
+maravillar,to marvel,使惊奇,VERB,B2
 masa,mass,大量,NOUN,B2
 masacre,massacre,大屠杀,NOUN,B2
-mascot,mascot,吉祥物,NOUN,B2
-mascota,pet,宠物,NOUN,B2
-masculine,masculine,男性的,ADJ,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-masculino,male,男性的,ADJ,B2
-mash,mash,泥状食物,NOUN,B2
-masochism,masochism,词,NOUN,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass media,mass media,大众媒体,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,按摩师,NOUN,B2
-massively,massively,大量地,ADV,B2
-mast (noun),mast,词,NOUN,C1
-master (noun),master,主人,NOUN,B2
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
-masterly,masterly,词,ADJ,B2
-mastermind,mastermind,词,NOUN,C1
-masticar,to chew,咀嚼,VERB,B2
-mat,mat,词,NOUN,B2
-matar dos pájaros de un tiro,kill two birds with one stone,一举两得,ADJ,B2
-matches,matches,词,NOUN,C1
-matching use,matching use,配用,NOUN,C1
-mate,mate,词,NOUN,A2
-matemáticas,math,数学,NOUN,B2
-matemáticas,mathematics,数学,NOUN,B2
-matemático,mathematical,数学的,ADJ,B2
-materia prima,raw material,原材料,NOUN,B2
+dominar,master,大师,NOUN,B2
+dominar,to master,掌握,VERB,B2
+máster,master's degree,硕士学位,NOUN,B2
+palabra del maestro,master's word,爷说,NOUN,B2
+obra maestra,masterpiece,杰作,NOUN,B2
+emparejar,to match,相配,VERB,B2
+correspondiente,matching,配套,ADJ,B2
+tiempo de correspondencia,matching time,对时,NOUN,B2
+casamentero,matchmaker,媒,NOUN,B2
 material,material,材料,NOUN,B2
-material (adj),material,词,ADJ,C1
 materialismo,materialism,唯物主义,NOUN,B2
-maternal,maternal,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-mathematician,mathematician,词,NOUN,C1
-matizado,nuanced,细微差别的,ADJ,B2
-matriarchy,matriarchy,词,NOUN,C1
-matrícula,license plate,车牌,NOUN,B2
-matrícula de vehículo,vehicle registration,行驶证,NOUN,B2
-matter affair,matter affair,事情,NOUN,A1
-matter of conscience,matter of conscience,良心问题,NOUN,B2
-matter of time,matter of time,时间问题,NOUN,B2
-matón,bully,欺凌者,NOUN,B2
-mausoleum,mausoleum,词,NOUN,B1
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawkishness,mawkishness,词,NOUN,C1
-mawwal,mawwal,词,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
-maximization,maximization,词,NOUN,C1
-maximum (noun),maximum,词,NOUN,B2
-may (aux),may,词,AUX,A1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe possible,maybe possible,可能,ADV,A1
-mayor,biggest,最大,ADJ,B2
-mayor,major,少校,NOUN,B2
-mayoral,mayoral,市长的,ADJ,B2
-mayormente,mostly,主要地,ADV,B2
-maze,maze,词,NOUN,C1
-maze labyrinth,maze labyrinth,词,NOUN,C1
-maíz,corn,玉米,NOUN,B2
-mañana,morning,早晨,NOUN,B2
-mañana,tomorrow,غد,NOUN,B2
+tía materna,maternal aunt,姨母,NOUN,B2
+tío materno,maternal uncle,舅舅,NOUN,B2
+matemáticas,math,数学,NOUN,B2
+matemático,mathematical,数学的,ADJ,B2
+matemáticas,mathematics,数学,NOUN,B2
+maduro,mature,成熟的,ADJ,B2
+máxima,maxim,格言,NOUN,B2
+quizás,maybe,也许,ADV,B2
 me,me,لي,NOUN,B2
-me (pron),me,我吧,PRON,A1
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-meager,meager,词,ADJ,C1
-mean (noun),mean,词,NOUN,C1
-meandering,meandering,蜿蜒的,ADJ,B2
-meaning content,meaning content,语义内容,NOUN,B2
-meaningful,meaningful,有意义的,ADJ,B2
-meaningless,meaningless,毫无意义的,ADJ,B2
-meanness,meanness,词,NOUN,C1
-measurable,measurable,词,ADJ,C1
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,克制的,ADJ,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-meatballs,meatballs,肉丸,NOUN,B2
-mecanicista,mechanistic,机制性,ADJ,B2
-mecanismo,mechanism,机制,NOUN,B2
-mecanismo alterado,altered mechanism,改机,NOUN,B2
-mechanical,mechanical,机械的,ADJ,B2
-mechanically,mechanically,词,ADV,C1
-mechanics,mechanics,词,NOUN,C1
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
-medal awarding,medal awarding,授勋,NOUN,B2
-medalla,medal,奖牌,NOUN,B2
-medallion,medallion,词,NOUN,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-media (adj),media,词,ADJ,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media professionals,media professionals,词,NOUN,C1
-media-related,media-related,词,ADJ,B2
-mediación,mediation,调解,NOUN,B2
-median (adj),median,词,ADJ,C1
-mediana,median,中位数,NOUN,B2
-mediator,mediator,调解人,NOUN,C1
-medicación,medication,药物,NOUN,B2
-medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical examiner,medical examiner,法医,NOUN,B2
-medical help,medical help,,NOUN,B2
-medical practitioner,medical practitioner,词,NOUN,C1
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
-medieval,medieval,中世纪的,ADJ,B2
+prado,meadow,草地,NOUN,B2
+comida,meal,一餐,NOUN,B2
 medio,mean,刻薄的,ADJ,B2
-medio,by means of,通过,ADP,B2
-medio,media,媒体,NOUN,B2
-medio,medium,媒介,NOUN,B2
-mediocre,mediocre,平庸的,ADJ,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
 medios,means,手段,NOUN,B2
+entretanto,meantime,同时,NOUN,B2
 medir,to measure,测量,VERB,B2
+volumen,measure word for books,本,NUM,B2
+mecanismo,mechanism,机制,NOUN,B2
+mecanicista,mechanistic,机制性,ADJ,B2
+medalla,medal,奖牌,NOUN,B2
+medio,media,媒体,NOUN,B2
+mediana,median,中位数,NOUN,B2
+mediación,mediation,调解,NOUN,B2
+médico,medical,医疗的,ADJ,B2
+historial médico,medical record,病历,NOUN,B2
+medicación,medication,药物,NOUN,B2
+mediocre,mediocre,平庸的,ADJ,B2
 meditación,meditation,冥想,NOUN,B2
 mediterráneo,mediterranean,地中海的,ADJ,B2
-meek,meek,温顺的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meeting hit,meeting hit,会面/击中,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-megabyte,megabyte,词,NOUN,C1
-megalomania,megalomania,狂妄自大,NOUN,B2
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
-mejilla,cheek,脸颊,NOUN,B2
-mejor,best,最好的,ADJ,B2
-mejor,better,越好,NOUN,B2
-mejora,improvement,好转,NOUN,B2
-mejora,upturn,好转,NOUN,B2
-mejorar,to upgrade,升级,VERB,B2
+medio,medium,媒介,NOUN,B2
+reunirse,to meet,遇见,VERB,B2
 melancólico,melancholic,忧郁的,ADJ,B2
 melancólico,melancholy,忧郁,ADJ,B2
-mellifluous,mellifluous,词,ADJ,C1
-mellifluousness,mellifluousness,词,NOUN,C1
-melocotón,peach,桃子,NOUN,B2
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
-melon,melon,香瓜,NOUN,C1
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
+palpación de melón,melon groping,摸瓜,NOUN,B2
 membresía,membership,会员资格,NOUN,B2
-memoir,memoir,回忆录,NOUN,B2
-memorable,memorable,难忘的,ADJ,B2
-memorial,memorial,纪念碑,NOUN,B2
-memorial (adj),memorial,词,ADJ,C1
-memorización,memorization,记忆,NOUN,B2
-memorizer,memorizer,词,NOUN,C1
-memory loss,memory loss,词,NOUN,C1
 memorándum,memorandum,备忘录,NOUN,B2
-men,men,词,NOUN,C1
-menace,menace,词,NOUN,C1
-mencionar,to mention,提及,VERB,B2
-mendacious,mendacious,词,ADJ,C1
-mendicidad,begging,乞讨,NOUN,B2
-mendigo,beggar,乞丐,NOUN,B2
-meninx,meninx,词,NOUN,C1
-mensaje de texto,text message,短信,NOUN,B2
-mensajero,messenger,信使,NOUN,B2
-menses,menses,词,NOUN,B2
-mensualmente,monthly,每月的,ADJ,B2
+memorial,memorial,纪念碑,NOUN,B2
+memorización,memorization,记忆,NOUN,B2
+remendar,to mend,修补,VERB,B2
 mental,mental,精神的,ADJ,B2
-mental hospital,mental hospital,精神病院,NOUN,B2
 mentalidad,mentality,心态,NOUN,B2
-mentally,mentally,精神上地,ADV,B2
-mente,-ly,地,PART,B2
-mentioned,mentioned,词,ADJ,B2
+mencionar,to mention,提及,VERB,B2
 mentor,mentor,导师,NOUN,B2
-mentoring,mentoring,词,NOUN,B2
-mentón,chin,下巴,NOUN,B2
 menú,menu,菜单,NOUN,B2
-meramente,merely,仅仅,ADV,B2
-mercantile,mercantile,词,ADJ,C1
-mercenaries,mercenaries,词,NOUN,C1
-mercenary,mercenary,雇佣兵,NOUN,B2
-merchandise,merchandise,商品,NOUN,B2
-merchant ship,merchant ship,商船,NOUN,C1
-mercilessly,mercilessly,词,ADV,C1
-mercurial,mercurial,词,ADJ,C1
 mercurio,mercury,汞,NOUN,B2
-mercy blow,mercy blow,致命一击,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
-merged,merged,词,ADJ,C1
-merger,merger,合并,NOUN,B2
-merger fusion,merger fusion,词,NOUN,B1
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
-merienda,snack,小吃,NOUN,B2
+meramente,merely,仅仅,ADV,B2
+fusión,merge,合并,NOUN,B2
 meritocracia,meritocracy,精英管理,NOUN,B2
-merits,merits,词,NOUN,C1
-meseta,plateau,高原,NOUN,B2
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-message errand,message errand,消息/差事,NOUN,B2
-messaging,messaging,词,NOUN,C1
-metabolic,metabolic,代谢的,ADJ,B2
+siren,mermaid,美人鱼,NOUN,B2
+mensajero,messenger,信使,NOUN,B2
+desordenado,messy,混乱的,ADJ,B2
 metabolismo,metabolism,新陈代谢,NOUN,B2
 metal,metal,金属,NOUN,B2
-metalepsis,metalepsis,词,NOUN,C1
-metalinguistic,metalinguistic,词,ADJ,C1
-metallurgy,metallurgy,词,NOUN,C1
-metamorphic,metamorphic,变质的,ADJ,B2
-metamorphosis,metamorphosis,词,NOUN,C1
 metaphor,metaphor,隐喻,NOUN,B2
-metaphorical,metaphorical,隐喻的,ADJ,B2
-metaphysical,metaphysical,词,ADJ,C1
 metaphysics,metaphysics,形而上学,NOUN,B2
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological,meteorological,气象的,ADJ,B2
-meteorological observations,meteorological observations,词,NOUN,C1
 meter,meter,米,NOUN,B2
-metering,metering,词,ADJ,C1
-methane,methane,词,NOUN,C1
-methodical,methodical,词,ADJ,C1
-methodological,methodological,方法论的,ADJ,B2
 methodology,methodology,方法论,NOUN,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
 metonymy,metonymy,转喻,NOUN,B2
-metric,metric,公制的,ADJ,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolis,metropolis,大都市,NOUN,B2
-metropolises,metropolises,词,NOUN,C1
-metropolitan,metropolitan,词,ADJ,C1
-mettle,mettle,词,NOUN,C1
 mexican,mexican,墨西哥的,ADJ,B2
-mezclado,mixed,混合的,ADJ,B2
-mezquita,mosque,清真寺,NOUN,B2
-mi grande,my big one,我偌大,NOUN,B2
-mi lugar,my place,我处,NOUN,B2
-mi residencia,my residence,我府,NOUN,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
-microeconomic,microeconomic,微观经济学的,ADJ,B2
 microphone,microphone,麦克风,NOUN,B2
 microscope,microscope,显微镜,NOUN,B2
-microscopic,microscopic,微观的,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-microwave,microwave,微波炉,NOUN,B2
-mid-morning,mid-morning,词,NOUN,C1
-midday heat,midday heat,词,NOUN,B1
-middle,middle,中间,ADV,B2
-middle (adj),middle,词,ADJ,B2
-middle class,middle class,中产阶层,NOUN,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
 midnight,midnight,午夜,NOUN,B2
-midpoint,midpoint,词,NOUN,B2
 midst,midst,中间,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
-miembro de la familia,family member,家庭成员,NOUN,B2
 might,might,威力,NOUN,B2
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty,mighty,词,ADJ,B1
-mighty man,mighty man,强人,NOUN,B2
-mighty very,mighty very,非常,ADJ,B2
-migrant,migrant,词,NOUN,B2
 migrate,to migrate,迁移,VERB,B2
 migration,migration,移民,NOUN,B2
-migratory,migratory,词,ADJ,C1
-mil,thousand,千,NUM,B2
 mild,mild,温和的,ADJ,B2
 mile,mile,英里,NOUN,B2
-militant,militant,词,ADJ,C1
-militaristic,militaristic,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
 military,military,军队,NOUN,B2
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
 military intelligence,military intelligence,军情,NOUN,B2
-military merit,military merit,军功,NOUN,C1
 military order,military order,军令,NOUN,B2
-military pay,military pay,军饷,NOUN,B2
 military power,military power,兵权,NOUN,B2
 militia,militia,民兵,NOUN,B2
-milk tooth,milk tooth,,NOUN,B2
-milking,milking,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
 mill,mill,磨坊,NOUN,B2
-mill (verb),mill,碾磨,VERB,C1
 millennium,millennium,千年,NOUN,B2
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
 million,million,百万,NOUN,B2
-millionaire,millionaire,百万富翁,NOUN,B2
-millions of,millions of,数百万的,NUM,B2
-mime (noun),mime,词,NOUN,C1
-mimicry,mimicry,词,NOUN,B2
-minaret,minaret,词,NOUN,B1
-minatory,minatory,词,ADJ,C1
-minced meat,minced meat,词,NOUN,A2
 mind,mind,精神,NOUN,B2
 mind,to mind,介意,VERB,B2
-mind (noun),mind,头脑,NOUN,B2
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mindset,mindset,词,NOUN,B2
 mine,mine,矿井,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
 mineral,mineral,矿物,NOUN,B2
-mineral (adj),mineral,词,ADJ,C1
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
-minibus,minibus,中巴,NOUN,B2
-minimal,minimal,微小的,ADJ,B2
-minimalism,minimalism,极简主义,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimization,minimization,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
 minister,minister,臣,PART,B2
 ministerial,ministerial,部长的,ADJ,B2
-minivan,minivan,小型货车,NOUN,B2
 minor,minor,未成年人,NOUN,B2
-minor (adj),minor,较小的,ADJ,B2
 minor course,minor course,辅修课,NOUN,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
 minority,minority,少数,NOUN,B2
-minority (adj),minority,少数派的,ADJ,B2
-minority group,minority group,少数群体,NOUN,B2
 mint,mint,薄荷,NOUN,B2
-minuciosidad,thoroughness,彻底,NOUN,B2
-minus,minus,减,NOUN,B2
-minuscule,minuscule,极小的,ADJ,B2
-miraculous,miraculous,词,ADJ,C1
-mirar,to glance,瞥,VERB,B2
-mirar fijamente,to stare,凝视,VERB,B2
-mirthful,mirthful,词,ADJ,C1
-misanthropic,misanthropic,词,ADJ,C1
 misappropriation,misappropriation,挪用,NOUN,B2
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misconception,misconception,误解,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-misdemeanor,misdemeanor,词,NOUN,B2
 miserable,miserable,痛苦的,ADJ,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
+engañoso,misleading,诡辩的,ADJ,B2
+falta,miss,小姐,NOUN,B2
 misión,mission,任务,NOUN,B2
-misjudge,misjudge,词,VERB,C1
-mismatch,mismatch,词,NOUN,C1
-misplaced,misplaced,不合时宜的,ADJ,B2
-miss teacher,miss teacher,小姐/老师,NOUN,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-missile,missile,导弹,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missionizing,missionizing,词,ADJ,C1
-missions,missions,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-missnahme,missnahme,词,NOUN,C1
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
-misterio,mystery,谜,NOUN,B2
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
-mitigating,mitigating,词,ADJ,C1
-mitigation,mitigation,词,NOUN,C1
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mito,myth,神话,NOUN,B2
-mitología,mythology,神话学,NOUN,B2
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mitten,mitten,连指手套,NOUN,B2
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixer,mixer,词,NOUN,C1
-mixing,mixing,词,NOUN,B2
-mmm,hmm,嗯,INTJ,B2
-mob,mob,词,NOUN,B2
-mobile (noun),mobile,词,NOUN,B2
-mobility,mobility,流动性,NOUN,B2
-mochila,backpack,背包,NOUN,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mockery,mockery,词,NOUN,C1
-moco,mucus,黏液,NOUN,B2
-mocos,runny nose,流鼻涕,NOUN,B2
-moda,fashion,时尚,NOUN,B2
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
+bruma,mist,薄雾,NOUN,B2
+equivocarse,to mistake,弄错,VERB,B2
+maltratar,to mistreat,أساء,VERB,B2
+amante,mistress,情妇,NOUN,B2
+malinterpretar,to misunderstand,误解,VERB,B2
+malentendido,misunderstanding,误解,NOUN,B2
+mezclado,mixed,混合的,ADJ,B2
+móvil,mobile,移动的,ADJ,B2
+pago móvil,mobile payment,移动支付,NOUN,B2
+movilización,mobilization,动员,NOUN,B2
+movilizar,to mobilize,动员,VERB,B2
 modelado,modeling,造型,NOUN,B2
-modelo a seguir,role model,榜样,NOUN,B2
-modelo modificado,modified model,改模,NOUN,B2
-modem,modem,词,NOUN,C1
-moderate snow,moderate snow,中雪,NOUN,C1
-moderator,moderator,词,NOUN,C1
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,现代,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
+lluvia moderada,moderate rain,中雨,NOUN,B2
 modernización,modernization,现代化,NOUN,B2
-modestly,modestly,词,ADV,C1
 modesto,modest,谦虚的,ADJ,B2
-modesty,modesty,谦虚,NOUN,B2
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
 modificación,modification,修改,NOUN,B2
+efecto modificado,modified effect,改效,NOUN,B2
+modelo modificado,modified model,改模,NOUN,B2
+sonido modificado,modified sound,改响,NOUN,B2
+sistema modificado,modified system,改系,NOUN,B2
 modificar,to modify,修改,VERB,B2
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified structure,modified structure,改结,NOUN,C1
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
 modular,modular,模块化的,ADJ,B2
-modulation,modulation,词,NOUN,C1
-module,module,词,NOUN,C1
-moisture,moisture,湿气,NOUN,B2
-moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-moldear,to shape,塑造,VERB,B2
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
-moler,to grind,磨碎,VERB,B2
-molestar,to nag,唠叨,VERB,B2
-molestia,nuisance,麻烦事,NOUN,B2
-mollify,mollify,词,VERB,C1
-molten,molten,词,ADJ,C1
-molting,molting,词,NOUN,C1
+húmedo,moist,潮湿的,ADJ,B2
 molécula,molecule,分子,NOUN,B2
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,暂时地,ADV,B2
-momento,point in time,时间点,NOUN,B2
-momentous,momentous,词,ADJ,C1
-mommy,mommy,词,NOUN,B1
-monarchy,monarchy,君主制,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monasticism,monasticism,词,NOUN,C1
-moneda,currency,货币,NOUN,B2
-monetization,monetization,词,NOUN,C1
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
+ímpetu,momentum,势头,NOUN,B2
 monitorear,monitor,显示器,NOUN,B2
 monitorear,to monitor,监控,VERB,B2
 monitoreo,monitoring,监控,NOUN,B2
-monkey ape,monkey ape,猿/猴,NOUN,B2
+sala de monitoreo,monitoring room,监控室,NOUN,B2
 mono,monkey,猴子,NOUN,B2
-monolithic,monolithic,单一的,ADJ,B2
-monologue,monologue,词,NOUN,B2
-monopolio,monopoly,垄断,NOUN,B2
 monopólico,monopolistic,垄断的,ADJ,B2
-monotheism,monotheism,词,NOUN,C1
-monotonic,monotonic,词,ADJ,C1
-monotony,monotony,词,NOUN,C1
-monotonía,dullness,迟钝,NOUN,B2
-monstrous,monstrous,怪异的,ADJ,B2
-montada,ride,行程,NOUN,B2
-month ago,month ago,月前,NOUN,B2
-monthly,monthly,每月的,ADV,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-monumental,monumental,词,ADJ,C1
+monopolio,monopoly,垄断,NOUN,B2
+luna del mes,month moon,月,NOUN,B2
+mensualmente,monthly,每月的,ADJ,B2
+examen mensual,monthly exam,月考,NOUN,B2
 monumento,monument,纪念碑,NOUN,B2
-moodiness,moodiness,词,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-moor,moor,荒野,NOUN,B2
-mooring,mooring,词,NOUN,C1
-moose,moose,驼鹿,NOUN,B2
-mop (noun),mop,词,NOUN,B2
-mora,blackberry,黑莓,NOUN,B2
+pastel de luna,mooncake,月饼,NOUN,B2
 moral,moral,道德,NOUN,B2
-moral,morals,道德,NOUN,B2
-moral (adj),moral,道德的,ADJ,C1
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral portrait,moral portrait,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,人心,NOUN,B2
 moralidad,morality,道德,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralization,moralization,词,NOUN,C1
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morally,morally,词,ADV,C1
-morass,morass,词,NOUN,C1
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
-mordedura,biting,咬人,NOUN,B2
-mordisco,bite,一口,NOUN,B2
-more,more,مزيد,NOUN,B2
-more (adj),more,更多,ADJ,A2
-more beautiful,more beautiful,更美的,ADJ,B2
-more expensive,more expensive,更贵的,ADJ,B2
-more fun,more fun,更有趣的,ADJ,B2
-more important,more important,更重要的,ADJ,B2
-more personal,more personal,词,ADJ,C1
-more pl,more pl,更多,ADJ,B2
-more than,more than,不止,ADV,B2
-moreover,moreover,而且,CCONJ,B2
-moretón,bruise,瘀伤,NOUN,B2
-morfología,morphology,形态学,NOUN,B2
+moral,morals,道德,NOUN,B2
+más,more,更多,ADJ,B2
+con más frecuencia,more often,更频繁,ADV,B2
+además,moreover,此外,ADV,B2
+mañana,morning,早晨,NOUN,B2
+periódico matutino,morning newspaper,晨报,NOUN,B2
 morfológico,morphological,形态的,ADJ,B2
-morgue,morgue,词,NOUN,B1
-morning (adj),morning,词,ADJ,C1
-moroccanization,moroccanization,词,NOUN,C1
-morocco leather,morocco leather,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morpheme,morpheme,语素,NOUN,C1
-morphine,morphine,吗啡,NOUN,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortality,mortality,死亡率,NOUN,B2
-mortar,mortar,词,NOUN,C1
-mortuary,mortuary,词,NOUN,B2
-mosca,fly,苍蝇,NOUN,B2
-moslem,moslem,词,NOUN,C1
+morfología,morphology,形态学,NOUN,B2
+mezquita,mosque,清真寺,NOUN,B2
 mosquito,mosquito,蚊子,NOUN,B2
-mosquito net,mosquito net,蚊帐,NOUN,B2
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-most,most,最,ADV,B2
-most (det),most,词,DET,B2
-most (noun),most,大部分,NOUN,B2
-most (pron),most,词,PRON,C1
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-motel,motel,汽车旅馆,NOUN,B2
-moth,moth,词,NOUN,B2
-mother (part),mother,娘,PART,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
-motif,motif,主题,NOUN,B2
-motion picture,motion picture,词,NOUN,C1
-motive for murder,motive for murder,词,NOUN,C1
+musgo,moss,苔藓,NOUN,B2
+más,most,大多数,ADJ,B2
+mayormente,mostly,主要地,ADV,B2
+madre,mother,娘,PART,B2
+reconforto de la madre,mother's reassurance,娘放心,NOUN,B2
 motivo,motive,动机,NOUN,B2
-motley,motley,词,ADJ,B2
 motor,motor,发动机,NOUN,B2
-motor (adj),motor,运动的,ADJ,C1
-motorist,motorist,词,NOUN,C1
-motorway,motorway,高速公路,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mound,mound,土堆,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-mouth animal,mouth animal,词,NOUN,B1
-move fast,move fast,快搬,NOUN,C1
-movilización,mobilization,动员,NOUN,B2
-movilizar,to mobilize,动员,VERB,B2
-mow,mow,词,VERB,B2
-mp,mp,国会议员,NOUN,B2
-mr master,mr master,先生/主人,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-much,much,很多,ADV,B2
-much (adj),much,词,ADJ,A1
-much many,much many,许多,ADJ,B2
-muchas veces,many times,多次,ADV,B2
-mucho menos,let alone,别说,ADV,B2
-muchos,many,许多,ADJ,B2
-mucous,mucous,词,ADJ,C1
+autocaravana,motorhome,露营车,NOUN,B2
+descenso de montaña,mountain descent,下山,NOUN,B2
+ratón,mouse,老鼠,NOUN,B2
+bocado,mouthful,一口,NOUN,B2
+apartarse,to move aside,移开,VERB,B2
 mudarse,to move in,搬入,VERB,B2
-mudo,dumb,愚蠢的,ADJ,B2
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-mueble,furniture,家具,NOUN,B2
-muelle,quay,码头,NOUN,B2
-muezzin,muezzin,词,NOUN,B2
-muffin,muffin,玛芬蛋糕,NOUN,B2
-mufti,mufti,词,NOUN,C1
-mug (noun),mug,词,NOUN,B2
-mujer,female,女性的,ADJ,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-muleta,crutch,拐杖,NOUN,B2
-multar,fine,好的,ADJ,B2
-multar,to fine,罚款,VERB,B2
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiple,multiple,词,ADJ,B2
+resonancia magnética,mri,核磁共振,NOUN,B2
+moco,mucus,黏液,NOUN,B2
 multiplicar,to multiply,乘；增加,VERB,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-multitud,crowd,人群,NOUN,B2
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
 municipio,municipality,市镇,NOUN,B2
 munificencia,munificence,慷慨,NOUN,B2
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder case,murder case,词,NOUN,B2
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
-murderer female,murderer female,词,NOUN,B2
-murk of dawn,murk of dawn,词,NOUN,C1
-murky,murky,词,ADJ,C1
-murmurar,to mutter,嘟囔,VERB,B2
-murmuring,murmuring,词,NOUN,C1
+arma homicida,murder weapon,凶器,NOUN,B2
 murmurio,murmur,低语,NOUN,B2
-muscle ache,muscle ache,肌肉酸痛,NOUN,B2
-muscular,muscular,词,ADJ,C1
-muse,muse,词,VERB,B2
+dolor muscular,muscle pain,肌肉痛,NOUN,B2
 museo,museum,博物馆,NOUN,B2
-museum piece,museum piece,博物馆藏品,NOUN,B2
-musgo,moss,苔藓,NOUN,B2
-mushroom fungus,mushroom fungus,词,NOUN,C1
-musical,musical,موسيقي,ADJ,B2
-musical (noun),musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
-musicality,musicality,词,NOUN,C1
-muslim,muslim,مسلم,NOUN,B2
-muslo,thigh,大腿,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustache,mustache,胡子,NOUN,B2
-mustard,mustard,词,NOUN,A1
-mutable,mutable,词,ADJ,C1
-mutación,mutation,突变,NOUN,B2
-mutagenic,mutagenic,词,ADJ,C1
-mutazilites,mutazilites,词,NOUN,C1
-mute person,mute person,词,NOUN,B2
-mutiny (noun),mutiny,兵变,NOUN,B2
-muttering,muttering,念叨,NOUN,C1
-mutual affection,mutual affection,词,NOUN,C1
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
-mutual pulling,mutual pulling,词,NOUN,C1
-mutual support,mutual support,互助,NOUN,C1
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
-mutuamente,mutually,相互地,ADV,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
-muñeca,wrist,手腕,NOUN,B2
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-myelin,myelin,词,NOUN,C1
-myriad,myriad,词,ADJ,C1
-myself,myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythical,mythical,神话般的,ADJ,B2
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
-máquina pesada,heavy machine,重机,NOUN,B2
-más,more,更多,ADJ,B2
-más,most,大多数,ADJ,B2
-más allá,beyond,在...之外,ADP,B2
-máster,master's degree,硕士学位,NOUN,B2
-máxima,maxim,格言,NOUN,B2
-médico,medical,医疗的,ADJ,B2
-médico,physician,内科医生,NOUN,B2
-mí,myself,我自,NOUN,B2
-móvil,mobile,移动的,ADJ,B2
 música,music,音乐,NOUN,B2
-música pop,pop music,流行音乐,NOUN,B2
+musical,musical,موسيقي,ADJ,B2
+partitura,musical score,乐谱,NOUN,B2
 músico,musician,音乐家,NOUN,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-nacimiento,birth,出生,NOUN,B2
+deber,must,必须,AUX,B2
+mutación,mutation,突变,NOUN,B2
+murmurar,to mutter,嘟囔,VERB,B2
+cordero,mutton,羊肉,NOUN,B2
+ayuda mutua,mutual aid,互助,NOUN,B2
+generación mutua,mutual generation,相生,NOUN,B2
+seguro mutuo,mutual insurance,互助保险,NOUN,B2
+restricción mutua,mutual restriction,相克,NOUN,B2
+mutuamente,mutually,相互地,ADV,B2
+mi grande,my big one,我偌大,NOUN,B2
+mi lugar,my place,我处,NOUN,B2
+mi residencia,my residence,我府,NOUN,B2
+mí,myself,我自,NOUN,B2
+misterio,mystery,谜,NOUN,B2
+mito,myth,神话,NOUN,B2
+mitología,mythology,神话学,NOUN,B2
+molestar,to nag,唠叨,VERB,B2
+es decir,namely,即,ADV,B2
+niñera,nanny,保姆,NOUN,B2
+nanotecnología,nanotechnology,纳米技术,NOUN,B2
+siesta,nap,午睡,NOUN,B2
+servilleta,napkin,餐巾,NOUN,B2
+narcisismo,narcissism,自恋,NOUN,B2
+narrar,to narrate,叙述,VERB,B2
+narrativa,narrative,叙述；故事,NOUN,B2
+narrador,narrator,叙述者,NOUN,B2
+desagradable,nasty,令人不快的,ADJ,B2
 nacionalismo,nationalism,民族主义,NOUN,B2
 nacionalización,nationalization,国有化,NOUN,B2
 nacionalizar,to nationalize,国有化,VERB,B2
-nación poderosa,powerful nation,强国,NOUN,B2
-nadir,nadir,最低点,NOUN,B2
-nah,nah,不,INTJ,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
-nalgas,buttocks,屁股,NOUN,B2
-name-calling,name-calling,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-named,named,词,ADP,C1
-nanotecnología,nanotechnology,纳米技术,NOUN,B2
-narcisismo,narcissism,自恋,NOUN,B2
-narcissistic,narcissistic,自恋的,ADJ,B2
-narcotics,narcotics,词,NOUN,C1
-narrador,narrator,叙述者,NOUN,B2
-narrar,to narrate,叙述,VERB,B2
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
-narrativa,narrative,叙述；故事,NOUN,B2
-narrative (adj),narrative,词,ADJ,C1
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
-narrators,narrators,词,NOUN,C1
-narrow-minded,narrow-minded,狭隘的,ADJ,B2
-nascent,nascent,词,ADJ,C1
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
-nationalist,nationalist,民族主义者,NOUN,B2
-nationwide,nationwide,全国,NOUN,B2
-native (noun),native,词,NOUN,C1
-native american,native american,印第安人,NOUN,B2
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
 natural,natural,自然的,ADJ,B2
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-naturalization,naturalization,入籍,NOUN,B2
-naturally,naturally,自然地,ADV,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-navaja,razor,剃刀,NOUN,B2
-naval,naval,词,ADJ,C1
-nave espacial,spaceship,宇宙飞船,NOUN,B2
+reserva natural,nature reserve,自然保护区,NOUN,B2
+travieso,naughty,淘气的,ADJ,B2
+náusea,nausea,恶心,NOUN,B2
 navegación,navigation,导航；航行,NOUN,B2
-navegación,sailing,航行,NOUN,B2
-navegador,browser,浏览器,NOUN,B2
-navegar,to sail,航行,VERB,B2
-navel,navel,肚脐,NOUN,B2
-navigational,navigational,词,ADJ,C1
 nazi,nazi,纳粹分子,NOUN,B2
-near,near,在附近,ADP,B2
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,附近,NOUN,B2
-nearest,nearest,最近的,ADJ,B2
-nearest (noun),nearest,词,NOUN,B2
-nearness,nearness,词,NOUN,B2
-neatly,neatly,整洁地,ADV,B2
+cercano,near,近,ADJ,B2
+cercanía,nearby,在附近,ADV,B2
+casi,nearly,几乎,ADV,B2
 nebulosa,nebula,星云,NOUN,B2
-nebulous,nebulous,词,ADJ,C1
 necesariamente,necessarily,必然地,ADV,B2
 necesidad,necessity,必要性；必需品,NOUN,B2
+collar,necklace,项链,NOUN,B2
 necesitar,need,需要,AUX,B2
-necessarily incumbent,necessarily incumbent,词,ADV,C1
-necklace chain,necklace chain,词,NOUN,A1
-necrosis,necrosis,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
-nefarious,nefarious,词,ADJ,C1
-negación,negation,否定,NOUN,B2
 negar,to negate,否定,VERB,B2
-negativity,negativity,消极,NOUN,B2
+negación,negation,否定,NOUN,B2
 negativo,negative,负面的,ADJ,B2
-neglect (noun),neglect,词,NOUN,C1
 negligente,negligent,疏忽的,ADJ,B2
-negociaciones,negotiations,谈判,NOUN,B2
+no despreciable,negligible not,不可忽视,ADJ,B2
 negociación,negotiation,谈判；协商,NOUN,B2
-negotiator,negotiator,词,NOUN,C1
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
-neighbors,neighbors,词,NOUN,B1
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,社区,NOUN,B2
-neither (det),neither,词,DET,A2
-neither nor,neither nor,词,CCONJ,A2
-nemesis,nemesis,词,NOUN,C1
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
-nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerd,nerd,书呆子,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
+negociaciones,negotiations,谈判,NOUN,B2
+relinchar,to neigh,嘶鸣,VERB,B2
+ni,neither,也不,CCONJ,B2
 nerviosismo,nervousness,紧张,NOUN,B2
-nest,nest,巢,NOUN,B2
-nesting box,nesting box,词,NOUN,B1
-nettle,nettle,词,NOUN,C1
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neural,neural,词,ADJ,C1
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neurological,neurological,词,ADJ,C1
-neuron,neuron,神经元,NOUN,B2
-neuroscience,neuroscience,词,NOUN,C1
+red,net,网,NOUN,B2
+red,network,网络,NOUN,B2
 neurosis,neurosis,神经症,NOUN,B2
-neuroticism,neuroticism,词,NOUN,C1
 neutral,neutral,中立的,ADJ,B2
 neutrality,neutrality,中立,NOUN,B2
-neutron,neutron,词,NOUN,C1
-nevertheless,nevertheless,尽管如此,ADV,B2
-new beginning,new beginning,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
 new year's day,new year's day,元旦,NOUN,B2
-newcomer,newcomer,新来者,NOUN,B2
-newly,newly,词,ADV,C1
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
-news bulletin,news bulletin,词,NOUN,B2
-news report,news report,词,NOUN,B1
-news reporting,news reporting,新闻报道,NOUN,B2
-newsletter,newsletter,简报,NOUN,B2
 next,next,接下来,ADV,B2
-next day,next day,词,NOUN,A2
 next door,next door,隔壁,NOUN,B2
-next door (adv),next door,在隔壁,ADV,B2
-next following,next following,词,ADJ,C1
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
 next to,next to,在...旁边,ADP,B2
-next to (adv),next to,词,ADV,B2
-next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
-ni,neither,也不,CCONJ,B2
 nibble,to nibble,啃,VERB,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-nicely nice,nicely nice,美好地,ADV,B2
-niceness,niceness,,NOUN,B2
-nickel,nickel,镍,NOUN,B2
-niebla,fog,雾,NOUN,B2
-nieta,granddaughter,孙女,NOUN,B2
-nieto,grandchild,孙辈,NOUN,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
 night view,night view,夜景,NOUN,B2
 nightclub,nightclub,夜总会,NOUN,B2
 nightingale,nightingale,夜莺,NOUN,B2
 nihilism,nihilism,虚无主义,NOUN,B2
-nihilistic,nihilistic,词,ADJ,C1
-nimble,nimble,敏捷的,ADJ,B2
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-nineteen,nineteen,十九,NUM,B2
 ninety,ninety,九十,NUM,B2
-ninguno,none,没有一个,DET,B2
-ninth,ninth,第九,ADJ,B2
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,氮,NOUN,B2
-niñera,nanny,保姆,NOUN,B2
-niño,child,儿童,NOUN,B2
-no,not,不,ADV,B2
 no,no,毫无,DET,B2
-no,nope,不,INTJ,B2
-no (det),no,毫无,DET,A2
-no (intj),no,词,INTJ,A1
-no (part),no,词,PART,B2
-no attachment,no attachment,无牵,NOUN,C1
-no bastar,won't do,不行,ADJ,B2
-no bastar,to won't do,不成,VERB,B2
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no creer,to can't believe,不敢相信,VERB,B2
-no deber,should not,不该,AUX,B2
-no despreciable,negligible not,不可忽视,ADJ,B2
+no harm,no harm,没事吧,NOUN,B2
+no longer,no longer,不再,ADV,B2
+no matter,no matter,不论,CCONJ,B2
+no need,no need,不用,AUX,B2
+noble,noble,高尚的,ADJ,B2
+nocturnal,nocturnal,夜间的,ADJ,B2
+nod,to nod,点头,VERB,B2
+noisy,noisy,吵闹的,ADJ,B2
+nomadism,nomadism,游牧生活,NOUN,B2
+nominate,to nominate,提名,VERB,B2
+nomination,nomination,提名,NOUN,B2
+non-ability,non-ability,非能,NOUN,B2
+non-abstraction,non-abstraction,非抽,NOUN,B2
+non-action,non-action,非作,NOUN,B2
+non-assistance,non-assistance,勿助,NOUN,B2
+non-belief,non-belief,非信,NOUN,B2
+non-concept,non-concept,非概,NOUN,B2
+non-construction,non-construction,非建,NOUN,B2
+non-contingent,non-contingent,非偶,NOUN,B2
+non-evidence,non-evidence,非据,NOUN,B2
+no inducción,non-induction,非归,NOUN,B2
+no inferencia,non-inference,非推,NOUN,B2
+no nivel,non-level,非级,NOUN,B2
+no gestión,non-management,管不,NOUN,B2
+no mérito,non-merit,非功,NOUN,B2
+no mente,non-mind,非心,NOUN,B2
+no modelo,non-model,非模,NOUN,B2
+no órbita,non-orbit,非轨,NOUN,B2
+no orden,non-order,非序,NOUN,B2
+no sombra,non-shadow,非影,NOUN,B2
+no sonido,non-sound,非响,NOUN,B2
 no específico,non-specific,非殊,NOUN,B2
 no estado,non-state,非态,NOUN,B2
 no estrategia,non-strategy,非略,NOUN,B2
-no gestión,non-management,管不,NOUN,B2
-no guerra,non-war,非战,NOUN,B2
-no harm,no harm,没事吧,NOUN,B2
-no heaven,no heaven,无天,NOUN,C1
-no inducción,non-induction,非归,NOUN,B2
-no inferencia,non-inference,非推,NOUN,B2
-no longer,no longer,不再,ADV,B2
-no matter,no matter,不论,CCONJ,B2
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no mente,non-mind,非心,NOUN,B2
-no modelo,non-model,非模,NOUN,B2
-no mérito,non-merit,非功,NOUN,B2
-no need,no need,不用,AUX,B2
-no nivel,non-level,非级,NOUN,B2
-no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no orden,non-order,非序,NOUN,B2
-no parking zone,no parking zone,禁停区,NOUN,C1
-no pensamiento,non-thought,非念,NOUN,B2
-no permitido,not allowed,不准,ADJ,B2
-no permitir,not allow,不许,AUX,B2
-no poder,cannot,不能,AUX,B2
-no poder evitar,can't help,不由得,ADV,B2
-no poder evitar,to cannot help,忍不住,VERB,B2
-no rastro,non-trace,非迹,NOUN,B2
-no sea que,lest,唯恐,SCONJ,B2
-no solo,not only,不光,CCONJ,B2
-no sombra,non-shadow,非影,NOUN,B2
-no sonido,non-sound,非响,NOUN,B2
-no soportar,to cannot bear,不堪,VERB,B2
 no sustancia,non-substance,非质,NOUN,B2
-no tener,to not have,没,VERB,B2
-no tratar,to not about,不关,VERB,B2
-no venir,to not come,不来,VERB,B2
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-no órbita,non-orbit,非轨,NOUN,B2
-nobility of character,nobility of character,词,NOUN,C1
-noble,noble,高尚的,ADJ,B2
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
-noción,smattering,少量,NOUN,B2
-nocturnal,nocturnal,夜间的,ADJ,B2
-nod,to nod,点头,VERB,B2
-node,node,词,NOUN,C1
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noise row,noise row,词,NOUN,C1
-noises,noises,噪音,NOUN,B2
-noisome,noisome,词,ADJ,C1
-noisy,noisy,吵闹的,ADJ,B2
-nomadism,nomadism,游牧生活,NOUN,B2
-nomads,nomads,词,NOUN,B2
-nombre,first name,名字,NOUN,B2
-nombre completo,full name,大名,NOUN,B2
-nominal,nominal,词,ADJ,C1
-nominate,to nominate,提名,VERB,B2
-nomination,nomination,提名,NOUN,B2
-nominee,nominee,词,NOUN,C1
-non-ability,non-ability,非能,NOUN,B2
-non-above,non-above,非上,NOUN,C1
-non-abstraction,non-abstraction,非抽,NOUN,B2
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-action,non-action,非作,NOUN,B2
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-assistance,non-assistance,勿助,NOUN,B2
-non-belief,non-belief,非信,NOUN,B2
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-concept,non-concept,非概,NOUN,B2
-non-concrete,non-concrete,非具,NOUN,C1
-non-construction,non-construction,非建,NOUN,B2
-non-contingent,non-contingent,非偶,NOUN,B2
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-evidence,non-evidence,非据,NOUN,B2
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
-none (det),none,毫无,DET,B2
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonprofit,nonprofit,非营利的,ADJ,B2
-nonviolence,nonviolence,非暴力,NOUN,B2
-noodle,noodle,面条,NOUN,B2
-noodles,noodles,面条,NOUN,A1
+no pensamiento,non-thought,非念,NOUN,B2
+no rastro,non-trace,非迹,NOUN,B2
+no guerra,non-war,非战,NOUN,B2
+incumplidor,noncompliant,违规,ADJ,B2
+ninguno,none,没有一个,DET,B2
+no,nope,不,INTJ,B2
 norma,norm,规范,NOUN,B2
 normal,normal,正常的,ADJ,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalization,normalization,词,NOUN,C1
 normalmente,normally,通常地,ADV,B2
-normalmente,usually,通常,ADV,B2
-normativity,normativity,词,NOUN,C1
-northeast,northeast,词,NOUN,C1
-northward,northward,向北,ADV,B2
-norwegian,norwegian,挪威的,ADJ,B2
-nosology,nosology,词,NOUN,C1
-nosotros,us,你我,NOUN,B2
-nostalgia,nostalgia,怀旧,NOUN,B2
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
-not,not,不,PART,B2
-not afraid,not afraid,不怕,VERB,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
-not bad,not bad,不错,ADJ,B2
-not care,not care,词,VERB,C1
-not catch up,not catch up,非赶,NOUN,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
-notables,notables,词,NOUN,B2
-notably,notably,显著地,ADV,B2
-notario,notary,公证人,NOUN,B2
+no,not,不,ADV,B2
+no tratar,to not about,不关,VERB,B2
+no permitir,not allow,不许,AUX,B2
+no permitido,not allowed,不准,ADJ,B2
+no venir,to not come,不来,VERB,B2
+no tener,to not have,没,VERB,B2
+no solo,not only,不光,CCONJ,B2
 notarización,notarization,公证,NOUN,B2
-notarized,notarized,经公证的,ADJ,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
-note patch,note patch,词,NOUN,C1
-notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
+notario,notary,公证人,NOUN,B2
+anotar,to note,记录,VERB,B2
+cuaderno,notebook,笔记本,NOUN,B2
 notificación,notification,通知,NOUN,B2
-notifications,notifications,词,NOUN,C1
-notion,notion,词,NOUN,B2
-notoriously,notoriously,词,ADV,C1
-notwithstanding,notwithstanding,词,ADP,C1
-nourishment,nourishment,营养,NOUN,B2
-novelístico,novelistic,小说般的,ADJ,B2
-novia,bride,新娘,NOUN,B2
-novio,fiance,未婚夫,NOUN,B2
-novio,groom,新郎,NOUN,B2
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
 noúmeno,noumenon,本体,NOUN,B2
-nuance,nuance,细微差别,NOUN,B2
-nublado,cloudy,阴沉的,ADJ,B2
-nublado,overcast,阴天的,ADJ,B2
+novelístico,novelistic,小说般的,ADJ,B2
+hoy en día,nowadays,如今,ADV,B2
+en ninguna parte,nowhere,无处,ADV,B2
+matizado,nuanced,细微差别的,ADJ,B2
 nuclear,nuclear,核的,ADJ,B2
-nuclear (noun),nuclear,词,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nuclear power,nuclear power,核能,NOUN,B2
-nuclear war,nuclear war,核战争,NOUN,B2
-nuclear weapon,nuclear weapon,核武器,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudo,knot,结,NOUN,B2
-nudo fuerte,heavy knot,重结,NOUN,B2
-nueva brusquedad,re-abruptness,再骤,NOUN,B2
-nueva estratificación,re-layering,改层,NOUN,B2
-nueva evidencia,re-evidence,重据,NOUN,B2
-nueva fruta,re-fruit,再果,NOUN,B2
-nuevo curso,re-course,重途,NOUN,B2
-nuevo interior,re-inner,再内,NOUN,B2
-nuevo límite,re-boundary,重界,NOUN,B2
-nuez,nut,坚果,NOUN,B2
-nugget,nugget,词,NOUN,C1
+molestia,nuisance,麻烦事,NOUN,B2
 nulidad,nullity,无效；无能,NOUN,B2
-null and void,null and void,无效的,ADJ,C1
-nullify,nullify,词,VERB,C1
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-number one,number one,第一名,NOUN,B2
-numbering,numbering,词,NOUN,C1
-numeral,numeral,词,NOUN,C1
-numerical,numerical,词,ADJ,C1
-numismatic,numismatic,钱币学的,ADJ,B2
-nunation,nunation,词,NOUN,C1
-nursing home,nursing home,养老院,NOUN,C1
-nutrición,nutrition,营养,NOUN,B2
-nutritional,nutritional,词,ADJ,C1
-nuts,nuts,疯狂的,ADJ,B2
-nylon,nylon,尼龙,NOUN,C1
-náusea,nausea,恶心,NOUN,B2
-núcleo,core,核心,NOUN,B2
 número dos,number two,二号,NOUN,B2
-o,o,词,PART,B1
-o'clock (adv),o'clock,词,ADV,B2
-o'clock (noun),o'clock,点,NOUN,B2
-oak,oak,词,NOUN,B1
+guardería,nursery,托儿所,NOUN,B2
+criar,to nurture,养育,VERB,B2
+crianza,nurturing,养好,NOUN,B2
+nuez,nut,坚果,NOUN,B2
+nutrición,nutrition,营养,NOUN,B2
+remo,oar,桨,NOUN,B2
 oasis,oasis,绿洲,NOUN,B2
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
-obdurate,obdurate,词,ADJ,C1
 obediencia,obedience,服从,NOUN,B2
 obediente,obedient,顺从的,ADJ,B2
-obelisk,obelisk,词,NOUN,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obese,obese,肥胖的,ADJ,B2
 obesidad,obesity,肥胖,NOUN,B2
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obispo,bishop,主教,NOUN,B2
 objeción,objection,异议,NOUN,B2
-object marker,object marker,把,ADP,A1
-objective (adj),objective,客观,ADJ,B2
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-objectivism,objectivism,词,NOUN,C1
-objetividad,objectivity,客观性,NOUN,B2
 objetivo,objective,客观的,ADJ,B2
-obligación,have to,还得,NOUN,B2
+objetividad,objectivity,客观性,NOUN,B2
 obligación,obligation,义务,NOUN,B2
-obligatorio,mandatory,强制的,ADJ,B2
-obliged,obliged,被迫的,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-obliteration,obliteration,词,NOUN,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
-obra de teatro,stage play,舞台剧,NOUN,B2
-obra maestra,masterpiece,杰作,NOUN,B2
-obscenity,obscenity,词,NOUN,C1
 obsceno,obscene,淫秽的,ADJ,B2
 obscurantismo,obscurantism,蒙昧主义,NOUN,B2
-obscurantist,obscurantist,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observable,observable,可观测的,ADJ,B2
 observación,observation,观察,NOUN,B2
-observador,observer,观察者,NOUN,B2
-observation skill,observation skill,,NOUN,B2
-observational,observational,词,ADJ,C1
 observatorio,observatory,天文台,NOUN,B2
-observers,observers,词,NOUN,C1
+observador,observer,观察者,NOUN,B2
 obsesionado,obsessed,着迷的,ADJ,B2
 obsesión,obsession,痴迷,NOUN,B2
-obsess,obsess,词,VERB,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstinately,obstinately,词,ADV,C1
-obstreperous,obstreperous,词,ADJ,C1
-obstrucción,obstruction,阻塞,NOUN,B2
 obstruir,to obstruct,阻碍,VERB,B2
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
+obstrucción,obstruction,阻塞,NOUN,B2
+evidente,obvious,明显的,ADJ,B2
 obviously,obviously,显然,ADV,B2
 occasionally,occasionally,偶尔,ADV,B2
-occult,occult,神秘的,ADJ,B2
-occultism,occultism,神秘学,NOUN,B2
-occupational pension,occupational pension,职业养老金,NOUN,B2
 occupied,occupied,被占用的,ADJ,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
 occurrence,occurrence,发生,NOUN,B2
-ocioso,idle,懒惰的,ADJ,B2
-octave,octave,词,NOUN,C1
-october,october,十月,NOUN,B2
-octopus,octopus,词,NOUN,B2
-ocular,ocular,词,ADJ,C1
-ocultamiento,hiding,ٱختباء,NOUN,B2
-ocultarse,to hide oneself,躲藏,VERB,B2
-oddball,oddball,怪人,NOUN,B2
-oddly,oddly,词,ADV,B2
-odds,odds,赔率,NOUN,B2
-odio,hatred,仇恨,NOUN,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
 of,of,之,PART,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of by,of by,的/被,ADP,B2
 of course,of course,理所当然的,ADJ,B2
-of course (adv),of course,当然,ADV,B2
-of course (intj),of course,词,INTJ,C1
-of first instance,of first instance,词,ADJ,C1
-of it,of it,其中,ADV,B2
-of old,of old,词,ADV,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,乌得勒支的,ADJ,B2
-of which,of which,关于哪个,PRON,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
 off-road vehicle,off-road vehicle,越野车,NOUN,B2
-offcuts,offcuts,词,NOUN,C1
-offence,offence,罪行,NOUN,B2
-offense,offense,冒犯,NOUN,B2
-offensive,offensive,冒犯的,ADJ,B2
 offer,offer,报价,NOUN,B2
 offering,offering,祭品,NOUN,B2
-office work,office work,办公室工作,NOUN,B2
 officer,officer,官员,NOUN,B2
 official,official,官员,NOUN,B2
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
 officials,officials,官员,NOUN,B2
-officious,officious,词,ADJ,C1
-offshoring,offshoring,词,NOUN,B2
-oficina,bureau,局,NOUN,B2
-oficina de correos,post office,邮局,NOUN,B2
-oficio,craft,工艺,NOUN,B2
 often,often,经常,ADV,B2
 oh,oh,哦,INTJ,B2
-oh (part),oh,呀,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
 oh my god,oh my god,我的天,INTJ,B2
-oh really,oh really,真的吗,INTJ,B2
-oh well,oh well,算了,INTJ,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oil tanker,oil tanker,词,NOUN,C1
-oilfield,oilfield,词,NOUN,C1
 ointment,ointment,药膏,NOUN,B2
-ojiverde,green-eyed,让碧眼,NOUN,B2
-ojo verde,green eye,碧眼,NOUN,B2
-ojos verdes,green eyes,想碧眼,NOUN,B2
-ok,ok,好的,INTJ,B2
-okay,okay,好的,ADJ,B2
-okay (noun),okay,好啊,NOUN,C1
-ola de calor,heat wave,热浪,NOUN,B2
-ola de frío,cold wave,寒潮,NOUN,B2
-old (noun),old,夙,NOUN,B1
 old age,old age,老年,NOUN,B2
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
 old master,old master,老太爷,NOUN,B2
-old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
 old person,old person,老人,NOUN,B2
 old servant,old servant,老奴,NOUN,B2
-old thief,old thief,老贼,NOUN,C1
 old woman,old woman,老妇人,NOUN,B2
-old-age,old-age,晚年,NOUN,C1
-old-fashioned,old-fashioned,老式的,ADJ,B2
 older brother,older brother,大哥哥,NOUN,B2
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-older woman,older woman,老妇人,NOUN,B2
-oldest,oldest,词,ADJ,C1
-oleada,surge,激增,NOUN,B2
-oleander,oleander,词,NOUN,B2
-oler,smell,气味,NOUN,B2
-oler,to smell,闻,VERB,B2
-olfactory,olfactory,词,ADJ,C1
-oligarchy,oligarchy,寡头政治,NOUN,B2
-oligopoly,oligopoly,寡头垄断,NOUN,B2
-olives,olives,词,NOUN,A2
-olla,cooking pot,炖锅,NOUN,B2
-olla,pot,锅,NOUN,B2
-olympic,olympic,奥林匹克的,ADJ,B2
 omelet,omelet,欧姆蛋,NOUN,B2
-omelette,omelette,煎蛋卷,NOUN,B2
-omnipotent,omnipotent,词,ADJ,C1
-omnipresent,omnipresent,无所不在的,ADJ,B2
-omniscient,omniscient,词,ADJ,C1
 on,on,,NOUN,B2
-on (adv),on,进行中,ADV,A2
-on behalf of,on behalf of,代表,ADP,B2
-on board,on board,在船上,ADV,B2
-on condition,on condition,词,SCONJ,C1
 on head,on head,当头,NOUN,B2
 on it,on it,在上面,ADV,B2
-on one hand,on one hand,一方面,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on that day,on that day,词,ADV,C1
 on the contrary,on the contrary,相反,ADV,B2
-on the one hand,on the one hand,一方面,ADV,B2
 on the other hand,on the other hand,另一方面,ADV,B2
-on the spot,on the spot,当场,ADV,B2
 on the way,on the way,在路上,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,准时,ADV,B2
-on top of,on top of,在...上面,ADP,B2
-on upon,on upon,在...上,ADP,B2
-on what,on what,在什么上面,ADV,B2
-on which,on which,在其上,PRON,B2
 once,once,一次,ADV,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
 once more,once more,再次,ADV,B2
-oncology,oncology,词,NOUN,C1
 one,one,人们,PRON,B2
-one (adj),one,词,ADJ,A2
-one (det),one,词,DET,C1
-one (noun),one,one,NOUN,B2
 one after another,one after another,接连地,ADV,B2
-one and a half,one and a half,一个半,NUM,B2
 one book,one book,一本,NUM,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
 one day,one day,一天,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
 one family,one family,一家,NUM,B2
 one flat,one flat,一张,NUM,B2
-one handful,one handful,一把,NUM,B2
 one head,one head,一头,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
 one night,one night,一晚,NUM,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
 one set,one set,一套,NUM,B2
 one shot,one shot,一枪,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one you,one you,人们,PRON,B2
 one's heart's content,one's heart's content,尽情,ADV,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
 one-sided,one-sided,单方面的,ADJ,B2
-one-sidedness,one-sidedness,片面性,NOUN,B2
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way,one-way,单向的,ADJ,B2
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
-onerous,onerous,词,ADJ,C1
 oneself,oneself,自己,PRON,B2
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-ongoing,ongoing,进行中的,ADJ,B2
-ongoing (noun),ongoing,词,NOUN,B2
-online,online,词,ADJ,B1
-online dating profile,online dating profile,,NOUN,B2
-online store,online store,词,NOUN,C1
 only,only,唯一的,ADJ,B2
-only (adv),only,仅,ADV,A1
-only (det),only,词,DET,B2
-only (sconj),only,而已,SCONJ,B2
-only bringing,only bringing,只带,NOUN,C1
 only just,only just,才,ADV,B2
-only son,only son,独子,NOUN,C1
 only then,only then,才,ADV,B2
 only-me,only-me,只我,NOUN,B2
-onomatopoeia,onomatopoeia,拟声词,NOUN,B2
 ontology,ontology,本体论,NOUN,B2
-oops,oops,词,INTJ,C1
-oozing,oozing,词,NOUN,B2
-opacity,opacity,不透明性,NOUN,B2
-opaque,opaque,词,ADJ,C1
 open,open,开着的,ADJ,B2
-open (adv),open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-minded,open-minded,思想开明的,ADJ,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
 openly,openly,公开地,ADV,B2
-openness,openness,开放,NOUN,B2
 opera,opera,歌剧,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
 operator,operator,经营者,NOUN,B2
-operetta,operetta,词,NOUN,C1
-opium den,opium den,词,NOUN,B2
-oportunista,seeking instant benefit,急功近利,ADJ,B2
-opportune,opportune,词,ADJ,C1
-opportunism,opportunism,词,NOUN,C1
-opportunist,opportunist,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opportunity used,opportunity used,机会,NOUN,B2
-opposing,opposing,词,ADJ,C1
 opposite,opposite,对立面,NOUN,B2
-opposite (adp),opposite,对面,ADP,B2
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
 oppress,to oppress,压迫,VERB,B2
-oppressed,oppressed,词,ADJ,B1
 oppression,oppression,压迫,NOUN,B2
-oppressive,oppressive,压迫的,ADJ,B2
-oppressive weight,oppressive weight,词,NOUN,C1
-opprobrium,opprobrium,词,NOUN,C1
-opt,opt,词,VERB,C1
 optical,optical,光学的,ADJ,B2
-optical illusion,optical illusion,词,NOUN,C1
-optician,optician,词,NOUN,C1
 optics,optics,光学,NOUN,B2
-optics perspective,optics perspective,词,NOUN,C1
-optimal,optimal,最佳的,ADJ,B2
 optimism,optimism,乐观,NOUN,B2
-optimization,optimization,优化,NOUN,B2
 optimize,to optimize,优化,VERB,B2
-optimum,optimum,词,NOUN,C1
 options,options,期权,NOUN,B2
-opulence,opulence,词,NOUN,C1
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
 or rather,or rather,或者,ADV,B2
-or something,or something,词,ADV,C1
-oracular,oracular,词,ADJ,C1
-orador,speaker,发言人,NOUN,B2
 oral,oral,口头的,ADJ,B2
-oral cavity,oral cavity,口腔,NOUN,B2
 oral decree,oral decree,口谕,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange,orange,橙色的,ADJ,B2
-orange color,orange color,词,ADJ,A1
-orange juice,orange juice,橙汁,NOUN,B2
-orator speaker,orator speaker,词,NOUN,C1
-oratory,oratory,词,NOUN,C1
 orbit,orbit,轨道,NOUN,B2
-orbital,orbital,词,ADJ,C1
 orchard,orchard,果园,NOUN,B2
-orchestra,orchestra,管弦乐队,NOUN,B2
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-orden público,public order,治安,NOUN,B2
+prueba,ordeal,苦难,NOUN,B2
 ordenado,orderly,有序的,ADJ,B2
-ordenar,to put in order,收拾,VERB,B2
-ordenar,to tidy up,整理,VERB,B2
-order mission,order mission,词,NOUN,A2
-orderliness,orderliness,有序性,NOUN,B2
 ordinariamente,ordinarily,通常,ADV,B2
 ordinario,ordinary,普通的,ADJ,B2
-ore,ore,矿石,NOUN,B2
-oreja de Judas,wood ear mushroom,木耳,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organically,organically,有机地,ADV,B2
-organism,organism,词,NOUN,C1
+día ordinario,ordinary day,平日,NOUN,B2
+gente ordinaria,ordinary people,老百姓,NOUN,B2
+órgano,organ,器官,NOUN,B2
+orgánico,organic,有机的,ADJ,B2
 organizado,organized,有组织的,ADJ,B2
 organizador,organizer,组织者,NOUN,B2
-organization body,organization body,词,NOUN,B1
-orgulloso,proud,自豪的,ADJ,B2
-orgánico,organic,有机的,ADJ,B2
 orientación,orientation,取向,NOUN,B2
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
-orientation direction,orientation direction,词,NOUN,B1
 origen,origin,起源,NOUN,B2
 original,original,最初的,ADJ,B2
-original (noun),original,正本,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
+documento original,original document,原件,NOUN,B2
 originalidad,originality,独创性,NOUN,B2
-originally (part),originally,原,PART,B2
 originalmente,originally,最初,ADV,B2
 originar,to originate,发源,VERB,B2
-originating,originating,词,ADJ,B1
-originator,originator,词,NOUN,C1
-orinar,to pee,小便,VERB,B2
-orison prayer,orison prayer,词,NOUN,C1
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-orphanage,orphanage,孤儿院,NOUN,C1
-orphaned,orphaned,无父母的,ADJ,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-oscillator,oscillator,振荡器,NOUN,C1
-osseous,osseous,词,ADJ,C1
-ostensible,ostensible,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentation,ostentation,词,NOUN,C1
-ostentatious,ostentatious,词,ADJ,C1
-ostrich,ostrich,词,NOUN,B2
-other,other,其他,NOUN,B2
-other (det),other,词,DET,B2
-other (pron),other,其它,PRON,B2
-other others,other others,其他,DET,B2
-other people,other people,人家,NOUN,B2
-others,others,他人,PRON,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherworldly,otherworldly,词,ADJ,C1
-otorgamiento,bestowal,授予,NOUN,B2
-otorgar,to bestow,授予,VERB,B2
-otredad,otherness,相异性,NOUN,B2
 otro,other,其他的,DET,B2
 otro lado,other side,对面,NOUN,B2
+otredad,otherness,相异性,NOUN,B2
 otros,others,他人,NOUN,B2
-ought,ought,应该,AUX,B2
-ought to,ought to,词,AUX,A2
-ounce,ounce,词,NOUN,C1
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out,out,出,ADP,B2
-out here,out here,这里外面,ADV,B2
-out of control,out of control,失控,VERB,B2
-out there,out there,词,ADV,B2
-outbreak,outbreak,爆发,NOUN,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoor pool,outdoor pool,词,NOUN,C1
-outdoors,outdoors,户外,ADV,B2
-outer,outer,外部的,ADJ,B2
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outermost,outermost,词,ADJ,C1
-outfit,outfit,服装,NOUN,B2
-outgoing,outgoing,外向的,ADJ,C1
-outlast,outlast,词,VERB,B2
-outpatient,outpatient,门诊,NOUN,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outside,outside,在外面,ADP,B2
-outside of,outside of,在...之外,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,外界,NOUN,B2
-outsider,outsider,外人,NOUN,B2
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward,outward,向外,ADV,B2
-outward (adj),outward,词,ADJ,C1
-ovarian,ovarian,词,ADJ,C1
-oveja,sheep,绵羊,NOUN,B2
-over,over,过去,ADV,B2
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overbidding,overbidding,词,NOUN,C1
-overconsumption,overconsumption,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
-overdose,overdose,过量,NOUN,B2
-overdraft,overdraft,透支,NOUN,B2
-overfall,overfall,,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overhead,overhead,词,NOUN,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overlapping,overlapping,重叠的,ADJ,C1
-overload surcharge,overload surcharge,词,NOUN,C1
-overreach,overreach,词,NOUN,C1
-overrule,overrule,词,VERB,C1
-overseas,overseas,词,ADV,B2
-overt,overt,词,ADJ,C1
-overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overview,overview,概览,NOUN,B2
-overweight,overweight,词,ADJ,C1
-overwork,overwork,词,NOUN,C1
-ow,ow,词,INTJ,C1
-owed,owed,欠下的,ADJ,B2
-own,own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-owned,owned,被拥有的,ADJ,A1
-ox,ox,词,NOUN,C1
-oxidation,oxidation,词,NOUN,C1
-oxidized,oxidized,词,ADJ,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oxymoron,oxymoron,矛盾修辞法,NOUN,B2
+de lo contrario,otherwise,否则,ADV,B2
+ay,ouch,哎哟,INTJ,B2
+fuera,out,在外面,ADV,B2
+fuera de,out of,从...出来,ADP,B2
+letrina,outhouse,茅房,NOUN,B2
+revelación,outing,郊游,NOUN,B2
+salida,outlet,出口,NOUN,B2
+esquema,outline,大纲,NOUN,B2
+perspectiva,outlook,前景,NOUN,B2
+exterior,outside,外部,NOUN,B2
+subcontratación,outsourcing,外包,NOUN,B2
+sobresaliente,outstanding,杰出的,ADJ,B2
+encima,over,在...上方,ADP,B2
+sobre-dominio,over-domain,超畴,NOUN,B2
+sobreestrategia,over-strategy,超策,NOUN,B2
+sobretrazo,over-stroke,超程,NOUN,B2
+en general,overall,总体上,ADV,B2
+nublado,overcast,阴天的,ADJ,B2
+sobregirar,to overdraw,透支,VERB,B2
+vencido,overdue,逾期,ADJ,B2
+solapamiento,overlap,重叠,NOUN,B2
+durante la noche,overnight,一夜之间,ADV,B2
+chino de ultramar,overseas chinese,华侨,NOUN,B2
+adelantar,to overtake,超过,VERB,B2
+tiempo extra,overtime,加班,NOUN,B2
+volcar,to overturn,打翻,VERB,B2
+deber,to owe,欠,VERB,B2
+poseer,to own,拥有,VERB,B2
+propiedad,ownership,,NOUN,B2
+óxido,oxide,氧化物,NOUN,B2
 oxígeno,oxygen,氧气,NOUN,B2
-oye,hey,嘿,INTJ,B2
-oyster,oyster,牡蛎,NOUN,B2
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-oír,to hear a case,审理,VERB,B2
-pabellón,pavilion,亭子,NOUN,B2
-paciente,patient,病人,NOUN,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
-pacto,covenant,契约,NOUN,B2
+ritmo,pace,速度,NOUN,B2
+marcador de ritmo,pace-setter,标兵,NOUN,B2
+paquete,packet,小包裹,NOUN,B2
 pacto,pact,协定,NOUN,B2
-pacts,pacts,词,NOUN,C1
-pacífico,peaceful,和平的,ADJ,B2
-padding,padding,词,NOUN,C1
-paddle,paddle,词,VERB,C1
-padecer insomnio,to suffer from insomnia,失眠,VERB,B2
-padre,parent,父母,NOUN,B2
-padre,father,父,PART,B2
-padres,parents,父母,NOUN,B2
-pagar,to pay smilingly,笑付,VERB,B2
-pagar,to pay tax,纳税,VERB,B2
-pagaré,promissory note,本票,NOUN,B2
-pago,payment all,付都,NOUN,B2
-pago móvil,mobile payment,移动支付,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pain hurt,pain hurt,疼痛,ADJ,B2
-pain relief,pain relief,,NOUN,B2
-pained,pained,词,ADJ,C1
-painless,painless,,NOUN,B2
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-painstakingly,painstakingly,细致地,ADV,B2
-paint dye,paint dye,词,VERB,A1
-paintbrush,paintbrush,画笔；毛笔,NOUN,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-paisaje,scenery,风景,NOUN,B2
-pajamas,pajamas,睡衣,NOUN,B2
-pala,shovel,铲子,NOUN,B2
-palabra de carácter,character word,字,NOUN,B2
-palabra del maestro,master's word,爷说,NOUN,B2
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-palatable,palatable,词,ADJ,C1
-paleography,paleography,词,NOUN,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palimpsest,palimpsest,词,NOUN,C1
-paliza,beating,跳动,NOUN,B2
-palliative,palliative,缓和的,ADJ,B2
-pallid,pallid,词,ADJ,C1
-pallor,pallor,苍白,NOUN,B2
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
+almohadilla,pad,垫,NOUN,B2
+analgésico,painkiller,止痛药,NOUN,B2
+pintura,paint,油漆,NOUN,B2
+pintor,painter,画家,NOUN,B2
+pálido,pale,苍白的,ADJ,B2
 palma,palm,手掌,NOUN,B2
 palmera,palm tree,棕榈树,NOUN,B2
-palo,stick,棍子,NOUN,B2
-paloma,pigeon,鸽子,NOUN,B2
-palpable,palpable,词,ADJ,C1
-palpación de melón,melon groping,摸瓜,NOUN,B2
-paltriness,paltriness,词,NOUN,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
-panadero,baker,面包师,NOUN,B2
-panda,panda,熊猫,NOUN,B2
+sartén,pan,平底锅,NOUN,B2
+panqueque,pancake,煎饼,NOUN,B2
+páncreas,pancreas,胰腺,NOUN,B2
 pandemia,pandemic,大流行病,NOUN,B2
-pandilla,gang,帮派,NOUN,B2
 panegírico,panegyric,颂词,NOUN,B2
 panel,panel,小组,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
-panqueque,pancake,煎饼,NOUN,B2
-pantano,swamp,沼泽,NOUN,B2
 panteísmo,pantheism,泛神论,NOUN,B2
-pantheon,pantheon,先贤祠,NOUN,B2
-panther,panther,豹,NOUN,B2
-panties,panties,词,NOUN,C1
-pants,pants,裤子,NOUN,B2
-pants trousers,pants trousers,词,NOUN,A1
-papa,pope,教皇,NOUN,B2
-papa frita,chip,碎片,NOUN,B2
-papas fritas,fries,炸薯条,NOUN,B2
 papaya,papaya,木瓜,NOUN,B2
-papel,role,角色,NOUN,B2
+recorte de papel,paper cutting,剪纸,NOUN,B2
 papeleo,paperwork,文书工作,NOUN,B2
-papelería,stationery,文具,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-paquete,packet,小包裹,NOUN,B2
-par,even,偶数的,ADJ,B2
-par,peer,同龄人,NOUN,B2
-par,a pair,一对,NUM,B2
-para,in order to,以期,SCONJ,B2
-para que,so that,以便,SCONJ,B2
-para siempre,forever,永远,ADV,B2
-parable,parable,寓言,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
-paradise heaven,paradise heaven,词,NOUN,B1
-paradoja,paradox,悖论,NOUN,B2
-paradoxical,paradoxical,矛盾的,ADJ,B2
-paradoxically,paradoxically,词,ADV,C1
-paragraph heel,paragraph heel,词,NOUN,C1
-paraguas,umbrella,雨伞,NOUN,B2
-paralipsis,paralipsis,词,NOUN,C1
-paralizar,to paralyze,使瘫痪,VERB,B2
-parallelism,parallelism,词,NOUN,C1
-paralogism,paralogism,谬误推理,NOUN,B2
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
-paralyzed,paralyzed,瘫痪的,ADJ,B2
-paramount,paramount,词,ADJ,C1
-parangón,paragon,典范,NOUN,B2
-paranoia,paranoia,词,NOUN,C1
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-pararse,to stand,站立,VERB,B2
-pararse lado a lado,to stand side by side,并列,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parataxis,parataxis,意合,NOUN,B2
 paraíso,paradise,天堂,NOUN,B2
-parcel,parcel,包裹,NOUN,B2
-parch,parch,词,VERB,C1
-parche,patch,补丁,NOUN,B2
-parchment,parchment,词,NOUN,C1
-parcialmente,partly,部分地,ADV,B2
-pardoning,pardoning,词,NOUN,C1
-pareja casada,a married couple,夫妇,NOUN,B2
-parent-friendly,parent-friendly,,NOUN,B2
-parentesco,kinship,亲属关系,NOUN,B2
-paresis,paresis,词,NOUN,C1
-pariah,pariah,词,NOUN,C1
+paradoja,paradox,悖论,NOUN,B2
+parangón,paragon,典范,NOUN,B2
+párrafo,paragraph,段落,NOUN,B2
+parálisis,paralysis,瘫痪,NOUN,B2
+paralizar,to paralyze,使瘫痪,VERB,B2
+parámetro,parameter,参数,NOUN,B2
+padre,parent,父母,NOUN,B2
+padres,parents,父母,NOUN,B2
 paridad,parity,平等,NOUN,B2
-pariente imperial,imperial relatives,皇亲,NOUN,B2
-parientes femeninas,female relatives,女眷,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parking,parking,停车,NOUN,B2
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
+aparcamiento,parking lot,停车场,NOUN,B2
 parlamento,parliament,议会,NOUN,B2
-parley,parley,词,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parliamentary,parliamentary,议会的/议员,ADJ,B2
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
-parlor,parlor,词,NOUN,C1
 parodia,parody,戏仿,NOUN,B2
+libertad condicional,parole,假释,NOUN,B2
 paronomasia,paronomasia,近音词双关,NOUN,B2
-paronym,paronym,词,NOUN,C1
-parse,parse,解析,VERB,B2
-parsimonious,parsimonious,吝啬的,ADJ,B2
-part forever,part forever,永别,VERB,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-part-time worker,part-time worker,兼职工,NOUN,B2
-parte,share,股份,NOUN,B2
-parte trasera,rear part,后部,NOUN,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-partially,partially,部分地,ADV,B2
+loro,parrot,鹦鹉,NOUN,B2
+perejil,parsley,欧芹,NOUN,B2
+partir,to part,分离,VERB,B2
+separarse por muerte,to part by death,死别,VERB,B2
+causa parcial,partial cause,分因,NOUN,B2
+significado parcial,partial meaning,分义,NOUN,B2
 participante,participant,参与者,NOUN,B2
 participativo,participatory,参与式的,ADJ,B2
-particle (part),particle,么,PART,B2
+partícula,particle,颗粒,NOUN,B2
 particular,particular,特定的,ADJ,B2
 particularidad,particularity,特点,NOUN,B2
-particularize,particularize,词,VERB,B2
-particularly,particularly,特别地,ADV,B2
-partir,to depart,离开,VERB,B2
-partir,to part,分离,VERB,B2
-partir,to set off,出发,VERB,B2
-partisan (adj),partisan,词,ADJ,C1
-partisan (noun),partisan,词,NOUN,C1
-partisanship,partisanship,党派性,NOUN,C1
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
-partitura,musical score,乐谱,NOUN,B2
-partner female,partner female,词,NOUN,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-partícula,particle,颗粒,NOUN,B2
-parálisis,paralysis,瘫痪,NOUN,B2
-parámetro,parameter,参数,NOUN,B2
-pasado,bygone,过去的,ADJ,B2
-pasado,past,过去,NOUN,B2
-pasar,to come over,顺道来访,VERB,B2
+parcialmente,partly,部分地,ADV,B2
+asociación,partnership,伙伴关系,NOUN,B2
 pasar,to pass,通过,VERB,B2
+fallecer,to pass away,流逝,VERB,B2
 pasar,to pass by,经过,VERB,B2
-pasar hambre,to starve,挨饿,VERB,B2
-paseo,walk,行走,NOUN,B2
-pashalik,pashalik,词,NOUN,C1
-pasivo,passive,被动的,ADJ,B2
+transmitir,to pass on,转交,VERB,B2
 paso,passing,过世,NOUN,B2
-pass (noun),pass,过得,NOUN,C1
-passable,passable,词,ADJ,C1
-passed,passed,递,ADJ,B2
-passerby,passerby,词,NOUN,C1
-passionate,passionate,热情的,ADJ,B2
-passionate love,passionate love,词,NOUN,C1
-passive reliance on others,passive reliance on others,词,NOUN,C1
-past,past,经过,ADV,B2
-past (adp),past,词,ADP,B2
-past (noun),past,过去,NOUN,A1
-past events,past events,往事,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
+pasivo,passive,被动的,ADJ,B2
+pasado,past,过去,NOUN,B2
+examen,past exam papers,真题,NOUN,B2
 pasta,pasta,意大利面,NOUN,B2
 pasta,paste,酱,NOUN,B2
-pastar,to graze,吃草,VERB,B2
-pastel,cake,蛋糕,NOUN,B2
-pastel de luna,mooncake,月饼,NOUN,B2
-pastime,pastime,爱好,NOUN,B2
-pastor,herder,牧民,NOUN,B2
 pastor,pastor,牧师,NOUN,B2
-pastor,shepherd,牧羊人,NOUN,B2
-pastoral (adj),pastoral,词,ADJ,C1
-pastoral (noun),pastoral,词,NOUN,C1
-pastoreo,grazing,放牧,NOUN,B2
-pastry chef,pastry chef,词,NOUN,C1
-patar,kick,踢,NOUN,B2
-patar,to kick,踢,VERB,B2
-patata,potato,土豆,NOUN,B2
-patch tire,patch tire,补胎,VERB,C1
+acariciar,to pat,轻拍,VERB,B2
+parche,patch,补丁,NOUN,B2
 patente,patent,专利,NOUN,B2
-patently,patently,显然地,ADV,B2
-paternal,paternal,父亲的,ADJ,B2
-paternal grandmother,paternal grandmother,祖母,NOUN,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
-pathogenic,pathogenic,致病的,ADJ,B2
-patient (noun),patient,病人,NOUN,A2
-patient female,patient female,词,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patiently,patiently,词,ADV,C1
-pato,duck,鸭子,NOUN,B2
-patológico,pathological,病态的,ADJ,B2
-patriarcado,patriarchy,父权制,NOUN,B2
-patriarch,patriarch,词,NOUN,C1
-patricide,patricide,弑父,NOUN,B2
-patriot,patriot,词,NOUN,B2
-patriotismo,patriotism,爱国主义,NOUN,B2
-patriótico,patriotic,爱国的,ADJ,B2
-patrocinio,sponsorship,赞助,NOUN,B2
-patrol duty,patrol duty,词,NOUN,B2
-patronage,patronage,赞助,NOUN,B2
+tía,paternal aunt,姑母,NOUN,B2
 patético,pathetic,可悲的,ADJ,B2
-paucity,paucity,词,NOUN,C1
-pauper,pauper,词,NOUN,B2
+patológico,pathological,病态的,ADJ,B2
+paciente,patient,病人,NOUN,B2
+patriarcado,patriarchy,父权制,NOUN,B2
+patriótico,patriotic,爱国的,ADJ,B2
+patriotismo,patriotism,爱国主义,NOUN,B2
 pausar,pause,暂停,NOUN,B2
 pausar,to pause,暂停,VERB,B2
-pave,pave,词,VERB,C1
-pavement,pavement,人行道,NOUN,B2
-pavilion (part),pavilion,阁,PART,C1
-paving,paving,铺路,NOUN,B2
-paving stone,paving stone,词,NOUN,A2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-payaso,clown,小丑,NOUN,B2
-payments,payments,词,NOUN,C1
-pañal,diaper,尿布,NOUN,B2
-pañuelo,handkerchief,手帕,NOUN,B2
-peacefully,peacefully,词,ADV,C1
-peat,peat,泥炭,NOUN,B2
-peatón,pedestrian,行人,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
+pabellón,pavilion,亭子,NOUN,B2
+atender,to pay attention,注意,VERB,B2
+homenajear,to pay respects,参见,VERB,B2
+pagar,to pay smilingly,笑付,VERB,B2
+pagar,to pay tax,纳税,VERB,B2
+pago,payment all,付都,NOUN,B2
+pacífico,peaceful,和平的,ADJ,B2
+melocotón,peach,桃子,NOUN,B2
+pera,pear,梨,NOUN,B2
+perla,pearl,珍珠,NOUN,B2
 peculiar,peculiar,奇怪的,ADJ,B2
-peculiarity,peculiarity,词,NOUN,B2
-pecuniary,pecuniary,词,ADJ,C1
-pedagogía,pedagogy,教育学,NOUN,B2
 pedagógico,pedagogical,教学的,ADJ,B2
-pedal,pedal,词,NOUN,B1
-pedantic,pedantic,词,ADJ,C1
-pedantically,pedantically,词,ADV,C1
-pedantry,pedantry,迂腐,NOUN,B2
-peddler,peddler,小贩,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-peek,peek,词,VERB,C1
-peel (noun),peel,词,NOUN,B2
-peephole,peephole,门镜,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-peg,peg,词,NOUN,C1
-pegamento,glue,胶水,NOUN,B2
-peinado,hairstyle,发型,NOUN,B2
-peinar,comb,梳子,NOUN,B2
-peinar,to comb,梳头,VERB,B2
-pejorative,pejorative,词,ADJ,C1
+pedagogía,pedagogy,教育学,NOUN,B2
+peatón,pedestrian,行人,NOUN,B2
+puente peatonal,pedestrian bridge,天桥,NOUN,B2
+orinar,to pee,小便,VERB,B2
 pelar,peel,皮,NOUN,B2
 pelar,to peel,削皮,VERB,B2
-peligro,peril,危险,NOUN,B2
-pellizcar,pinch,捏,NOUN,B2
-pellizcar,to pinch,捏,VERB,B2
-pellucid,pellucid,词,ADJ,C1
-peluche,plush toy,毛绒玩具,NOUN,B2
-peluquero,hairdresser,理发师,NOUN,B2
-pelvis,pelvis,词,NOUN,B2
-pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
-pena de muerte,death penalty,死刑,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalties,penalties,处罚,NOUN,C1
-penalty,penalty,惩罚,NOUN,B2
-penalty payment,penalty payment,词,NOUN,C1
-penance,penance,忏悔,NOUN,B2
-penchant,penchant,词,NOUN,C1
-pencil case,pencil case,词,NOUN,C1
+par,peer,同龄人,NOUN,B2
+bolígrafo,pen,钢笔,NOUN,B2
 penetración,penetration,渗透,NOUN,B2
-penguin,penguin,词,NOUN,A1
-penis,penis,词,NOUN,B2
-penitence,penitence,词,NOUN,C1
-penitent,penitent,词,ADJ,C1
-penitentiary,penitentiary,词,ADJ,C1
-penniless,penniless,词,ADJ,B1
-penoso,pity,可惜,ADJ,B2
-pensamiento,thinking,思维,NOUN,B2
-pensativo,thoughtful,体贴的,ADJ,B2
-pensión,pension,养老金,NOUN,B2
-pensión alimenticia,alimony,赡养费,NOUN,B2
-penury,penury,词,NOUN,C1
 península,peninsula,半岛,NOUN,B2
-people,people,人们,PRON,B2
-people nation,people nation,人民 / 民族,NOUN,B2
-pepino,cucumber,黄瓜,NOUN,B2
-peppermint,peppermint,词,NOUN,C1
-pequeñez,smallness,小小,NOUN,B2
-pequeño,smallest,最小的,ADJ,B2
-per,per,每,ADP,B2
-pera,pear,梨,NOUN,B2
-perceptibly,perceptibly,明显地,ADV,B2
-perception opinion,perception opinion,看法,NOUN,B2
-perceptual,perceptual,词,ADJ,B2
-percibir,to sense,隐约感到,VERB,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-perderse,to get lost,迷路,VERB,B2
-perdón,sorry,抱歉,ADJ,B2
-perdón,forgiveness,宽恕,NOUN,B2
-perejil,parsley,欧芹,NOUN,B2
-peremptorily,peremptorily,词,ADV,C1
-perennial,perennial,长期的,ADJ,B2
-perezoso,sluggish,迟钝的,ADJ,B2
+pensión,pension,养老金,NOUN,B2
+pimienta,pepper,胡椒,NOUN,B2
+por ciento,percent,百分比,NOUN,B2
+porcentaje,percentage,百分比,NOUN,B2
 perfección,perfection,完美,NOUN,B2
-perfectly,perfectly,词,ADV,A2
-perfidious,perfidious,词,ADJ,C1
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-performer,performer,词,NOUN,C1
+actuación,performance,表现,NOUN,B2
 perfume,perfume,香水,NOUN,B2
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-peri-urban,peri-urban,城市周边的,ADJ,B2
-periférico,peripheral,外围的,ADJ,B2
-perilla,perilla,紫苏,NOUN,B2
-perilous,perilous,危险的,ADJ,B2
-period,period,句号,PUNCT,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periodical,periodical,词,NOUN,C1
-periodization,periodization,分期,NOUN,C1
-periphery,periphery,边缘,NOUN,B2
-periphrasis,periphrasis,词,NOUN,C1
-perishing,perishing,,NOUN,B2
-peritoneum,peritoneum,腹膜,NOUN,B2
+peligro,peril,危险,NOUN,B2
+período,period,时期,NOUN,B2
 periódicamente,periodically,定期地,ADV,B2
-periódico diario,daily newspaper,日报,NOUN,B2
-periódico matutino,morning newspaper,晨报,NOUN,B2
-perla,pearl,珍珠,NOUN,B2
+periférico,peripheral,外围的,ADJ,B2
 permanencia,permanence,持久,NOUN,B2
 permanente,permanent,永久的,ADJ,B2
-permanente,standing,站立的,ADJ,B2
-permanently,permanently,词,ADV,C1
-permeability,permeability,词,NOUN,C1
 permeable,permeable,可渗透的,ADJ,B2
 permiso,permit,许可证,NOUN,B2
-permiso de ocultación,allow hiding,许躲,NOUN,B2
-permissible,permissible,词,ADJ,C1
-permitido,allowed,被允许的,ADJ,B2
-permutations,permutations,词,NOUN,C1
-pernicious,pernicious,有害的,ADJ,B2
-pero,but,然而,ADV,B2
-pero tú,but you,但您,NOUN,B2
-pero yo,but i,可我,ADV,B2
-peroration,peroration,结语,NOUN,B2
 perpendicular,perpendicular,垂直的,ADJ,B2
 perpetrador,perpetrator,肇事者,NOUN,B2
-perpetual,perpetual,永久的,ADJ,B2
-perplex,perplex,词,VERB,C1
-persecución,chase,追逐,NOUN,B2
 persecución,persecution,迫害,NOUN,B2
-persecución,pursuit,追求,NOUN,B2
-perseguir,to pursue,追求,VERB,B2
-persiana,blind,百叶窗,NOUN,B2
-persiana,roller blind,卷帘,NOUN,B2
-persimmon,persimmon,柿子,NOUN,C1
-persistence,persistence,坚持,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
+tratamiento,person honorific,位,NOUN,B2
 persona a cargo,person in charge,负责人,NOUN,B2
-personable,personable,词,ADJ,C1
 personal,personal,个人的,ADJ,B2
-personal,personnel,人员,NOUN,B2
-personal,staff,全体员工,NOUN,B2
-personal (noun),personal,私事,NOUN,B2
-personal best,personal best,,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
-personal integrity,personal integrity,个人隐私,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
+enemistad personal,personal enmity,私仇,NOUN,B2
+récord personal,personal record,个人纪录,NOUN,B2
 personalidad,personality,个性,NOUN,B2
-personalization,personalization,词,NOUN,C1
-personalized,personalized,个性化的,ADJ,B2
-personally experience,personally experience,亲历,VERB,C1
 personalmente,personally,就个人而言,ADV,B2
-personification,personification,词,NOUN,C1
-perspectiva,outlook,前景,NOUN,B2
+personal,personnel,人员,NOUN,B2
 perspectiva,perspective,视角,NOUN,B2
-perspectiva,prospect,前景,NOUN,B2
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicacious,perspicacious,词,ADJ,C1
-perspicacity,perspicacity,词,NOUN,B2
 persuadir,to persuade,说服,VERB,B2
-persuasión,coaxing,哄得,NOUN,B2
 persuasión,persuasion,说服,NOUN,B2
-pertenecer,to belong to,属于,VERB,B2
-pertenencia,belonging,归属感,NOUN,B2
-pertenencias,belongings,所属物,NOUN,B2
-pertinent,pertinent,词,ADJ,C1
-pertinently,pertinently,词,ADV,B2
-pervasive,pervasive,词,ADJ,C1
-perverse,perverse,任性的,ADJ,B2
-perversity,perversity,词,NOUN,C1
-período,period,时期,NOUN,B2
-pesadez,heaviness,沉重 / 笨重,NOUN,B2
-pescador,fisherman,渔夫,NOUN,B2
-pescar,to fish,钓鱼,VERB,B2
 pesimismo,pessimism,悲观主义,NOUN,B2
 pesimista,pessimistic,悲观的,ADJ,B2
-pest,pest,词,NOUN,C1
-pestaña,eyelash,睫毛,NOUN,B2
 pesticida,pesticide,杀虫剂,NOUN,B2
-pesticides,pesticides,词,NOUN,C1
-petal,petal,词,NOUN,C1
-petardo,firecracker,鞭炮,NOUN,B2
+mascota,pet,宠物,NOUN,B2
 petición,petition,请愿,NOUN,B2
-petition for review,petition for review,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
 petróleo,petroleum,石油,NOUN,B2
-pettiness,pettiness,词,NOUN,C1
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharynx,pharynx,词,NOUN,B2
-phase,phase,阶段,NOUN,B2
-phased (adv),phased,词,ADV,B1
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-phenomenological,phenomenological,词,ADJ,C1
-phew,phew,词,INTJ,C1
-philanthropic,philanthropic,词,ADJ,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philology,philology,词,NOUN,C1
-philosophizing,philosophizing,词,NOUN,C1
-philosophy of life,philosophy of life,词,NOUN,B2
-phishing,phishing,词,NOUN,B2
-phloem,phloem,词,ADJ,C1
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
-phone credit,phone credit,词,NOUN,B1
-phone number,phone number,电话号码,NOUN,B2
-phoneme,phoneme,词,NOUN,C1
-phosphate,phosphate,词,NOUN,B2
-phosphorus,phosphorus,词,NOUN,C1
-photo album,photo album,影集,NOUN,C1
-photo model,photo model,模特,NOUN,B2
-photographic,photographic,词,ADJ,C1
-photon,photon,光子,NOUN,B2
-phrase,phrase,短语,NOUN,B2
-phrasing,phrasing,措辞,NOUN,B2
-physically,physically,身体上地,ADV,B2
-physicist,physicist,词,NOUN,C1
-physiotherapist,physiotherapist,词,NOUN,B1
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-pianist,pianist,词,NOUN,C1
+farmacéutico,pharmaceutical,制药的,ADJ,B2
+escalonado,phased,阶段性,ADJ,B2
+fenomenología,phenomenology,现象学,NOUN,B2
+fénix,phoenix,拿凤,NOUN,B2
+llamar,to phone,打电话,VERB,B2
+llamada,phone call,通话,NOUN,B2
+fonética,phonetics,语音学,NOUN,B2
+fonología,phonology,音系学,NOUN,B2
+fotocopiar,to photocopy,复印,VERB,B2
+fotografiar,to photograph,拍照,VERB,B2
+fotografía,photography,摄影,NOUN,B2
+fotosíntesis,photosynthesis,光合作用,NOUN,B2
+prueba física,physical evidence,物证,NOUN,B2
+médico,physician,内科医生,NOUN,B2
+física,physics,物理,NOUN,B2
 piano,piano,钢琴,NOUN,B2
-piano music,piano music,词,NOUN,B2
-pick up a car,pick up a car,取车,VERB,B2
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickle (noun),pickle,词,NOUN,C1
-pickles,pickles,词,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
+recoger,to pick,挑选,VERB,B2
 picnic,picnic,野餐,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-pictorial,pictorial,绘画的,ADJ,B2
-picture photo,picture photo,词,NOUN,A2
-picturesque,picturesque,如画的；别致的,ADJ,B2
-pidgin,pidgin,词,NOUN,C1
-pie,pie,派,NOUN,B2
-piece of bread,piece of bread,词,NOUN,B2
+imagen,picture,图画,NOUN,B2
+dato,piece of information,信息,NOUN,B2
 piedad,piety,虔诚,NOUN,B2
-piedra,boulder,巨石,NOUN,B2
-piel,fur,毛皮,NOUN,B2
-piel fina,fine skin,细皮,NOUN,B2
-pier,pier,码头,NOUN,B2
-pieza,classifier for paintings cloth etc.,幅,NUM,B2
+paloma,pigeon,鸽子,NOUN,B2
 pila,pile,堆,NOUN,B2
-pila,a pile,一堆,NUM,B2
-pile heap,pile heap,词,NOUN,C1
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pills,pills,词,NOUN,B2
-pimienta,pepper,胡椒,NOUN,B2
-pimiento,bell pepper,甜椒,NOUN,B2
-pimp,pimp,词,NOUN,C1
-pimple,pimple,词,NOUN,B2
-pinch (noun),pinch,词,NOUN,C1
-pine forest,pine forest,松林,NOUN,B2
-pine needle,pine needle,针叶,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
+amontonar,to pile up,堆积,VERB,B2
+almohada,pillow,枕头,NOUN,B2
+alfilerar,to pin,别住,VERB,B2
+pellizcar,pinch,捏,NOUN,B2
+pellizcar,to pinch,捏,VERB,B2
 pino,pine,松树,NOUN,B2
-pintor,painter,画家,NOUN,B2
-pintura,paint,油漆,NOUN,B2
-pioneer,pioneer,先驱,NOUN,B2
-piously,piously,词,ADV,C1
-pipa,pipa,琵琶,NOUN,B2
-pipe dream,pipe dream,词,NOUN,C1
-piquant,piquant,词,ADJ,C1
-piracy,piracy,词,NOUN,B2
-pirata,pirate,海盗,NOUN,B2
-pirated,pirated,词,ADJ,B2
-pirámide,pyramid,金字塔,NOUN,B2
-piscina,swimming pool,游泳池,NOUN,B2
-piscina,pool,池,PART,B2
-pisotear,to trample,踩踏,VERB,B2
-pista de hielo,ice rink,溜冰场,NOUN,B2
-pistacho,pistachio,开心果,NOUN,B2
-pistola,gun,枪,NOUN,B2
-piston,piston,词,NOUN,C1
-pitch,pitch,词,NOUN,B1
-pitch darkness,pitch darkness,词,NOUN,C1
-pitchfork,pitchfork,叉子,NOUN,B2
-piteous,piteous,词,ADJ,C1
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pitido,beep,吱吱声,NOUN,B2
-pittance,pittance,词,NOUN,C1
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,pivotal,词,ADJ,C1
-pizarra,blackboard,黑板,NOUN,B2
-pizza,pizza,词,NOUN,B1
 piña,pineapple,菠萝,NOUN,B2
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-place value,place value,位值,NOUN,C1
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
-placid,placid,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
+rosado,pink,粉色的,ADJ,B2
+tubería,pipe,管子,NOUN,B2
+pirata,pirate,海盗,NOUN,B2
+pistacho,pistachio,开心果,NOUN,B2
+penoso,pity,可惜,ADJ,B2
+colocación,placement,放置,NOUN,B2
 plaga,plague,瘟疫,NOUN,B2
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plaintive,plaintive,哀伤的,ADJ,C1
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
+llanura,plain,平原,NOUN,B2
+demandante,plaintiff,原告,NOUN,B2
 plan,plan,计划,NOUN,B2
-planning,planning,规划,NOUN,B2
-plano,flat,扁平的,ADJ,B2
-plantación,plantation,人工林,NOUN,B2
-plantación de té,tea plantation,茶园,NOUN,B2
-plantain,plantain,芭蕉,NOUN,B2
 plantar,to plant,种植,VERB,B2
-plaqueta,platelet,血小板,NOUN,B2
-plasma,plasma,血浆,NOUN,B2
-plastic (noun),plastic,词,NOUN,B1
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
-plataforma,platform,平台,NOUN,B2
-plateado,silver,银色,ADJ,B2
-platforms,platforms,词,NOUN,C1
-platillo,cymbal,钹,NOUN,B2
-platinum,platinum,词,NOUN,B2
-platitude,platitude,词,NOUN,C1
-plausibility,plausibility,词,NOUN,B2
-play game,play game,游戏/玩耍,NOUN,B2
-playable,playable,可演奏的,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
-plays,plays,词,NOUN,C1
-playwright,playwright,剧作家,NOUN,B2
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleamar,high tide,涨潮,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please,please,请,INTJ,B2
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-plebiscite,plebiscite,词,NOUN,B2
-pledge (noun),pledge,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plenary,plenary,词,ADJ,C1
-plenitude,plenitude,充足,NOUN,B2
-plenty,plenty,充足地,ADV,B2
-plenty (noun),plenty,大量,NOUN,A2
-pleonasm,pleonasm,赘述,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plot twist,plot twist,词,NOUN,C1
-plow,plow,词,NOUN,B2
-plucky,plucky,勇敢的,ADJ,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-pluma,feather,羽毛,NOUN,B2
-plumb,plumb,词,NOUN,C1
-plump,plump,词,ADJ,C1
-plunge,plunge,词,VERB,C1
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
-pluralismo,pluralism,多元主义,NOUN,B2
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
-plutocracia,plutocracy,财阀政治,NOUN,B2
+trasplantar,to plant out,定植,VERB,B2
+plantación,plantation,人工林,NOUN,B2
+siembra,planting,种植,NOUN,B2
+yeso,plaster,石膏,NOUN,B2
 plástico,plastic,塑料,NOUN,B2
-plátano,banana,香蕉,NOUN,B2
-pneumonia,pneumonia,词,NOUN,C1
-poach,poach,词,VERB,C1
-población,population,人口,NOUN,B2
-poblar,to populate,居住,VERB,B2
-pobreza,poverty,贫困,NOUN,B2
-pocos,few,很少的,ADJ,B2
-podcast,podcast,播客,NOUN,B2
-podcasting,podcasting,词,NOUN,B1
-poder,can,能够,AUX,B2
-poder judicial,judiciary,司法官,NOUN,B2
-poder notarial,power of attorney,委托书,NOUN,B2
-poder solo,can only,只能,AUX,B2
-poderoso,powerful,强大的,ADJ,B2
-podrido,rotten,腐烂的,ADJ,B2
-poesía,poetry,诗歌,NOUN,B2
-poeta,poet,诗人,NOUN,B2
-poetic,poetic,词,ADJ,C1
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
-poignant,poignant,词,ADJ,C1
-point grade,point grade,词,NOUN,A2
-point of view,point of view,词,NOUN,C1
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointlessly,pointlessly,徒劳地,ADV,B2
-pointwise,pointwise,词,ADJ,C1
-poison flow,poison flow,毒走,NOUN,C1
-poison gas,poison gas,毒气,NOUN,B2
-poisoned,poisoned,,NOUN,B2
-poke,poke,词,VERB,B2
-polar,polar,极地的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polarity,polarity,极性,NOUN,C1
-polarización,polarization,两极分化 / 极化,NOUN,B2
-polemic,polemic,词,NOUN,C1
-polemicist,polemicist,词,NOUN,C1
-police chief,police chief,警察局长,NOUN,B2
-police officer,police officer,警察,NOUN,B2
-police officer female,police officer female,词,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police report,police report,,NOUN,B2
-police search,police search,词,NOUN,C1
-policy-related,policy-related,词,ADJ,C1
-policía,cop,警察,NOUN,B2
-policía,policeman,警察,NOUN,B2
-polinización,pollination,授粉,NOUN,B2
-polish,polish,波兰的,ADJ,B2
-polish (noun),polish,精炼,NOUN,C1
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politely,politely,礼貌地,ADV,B2
-politeness,politeness,词,NOUN,C1
-politic,politic,词,ADJ,C1
-political party,political party,政党,NOUN,B2
-politically,politically,在政治上,ADV,B2
-politicization,politicization,词,NOUN,C1
-pollinic,pollinic,词,ADJ,C1
-pollito,chick,小鸡,NOUN,B2
-polo,pole,极,NOUN,B2
-polvo,powder,粉末,NOUN,B2
-polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,连词叠用,NOUN,B2
-polytunnel,polytunnel,大棚,NOUN,B2
-polémico,polemical,论战的,ADJ,B2
-política,policy,政策,NOUN,B2
-política modificada,changed policy,改策,NOUN,B2
-político,politician,政治家,NOUN,B2
-pomelo,pomelo,柚子,NOUN,B2
-pomp,pomp,词,NOUN,C1
-pompously,pompously,词,ADV,C1
-ponderous,ponderous,词,ADJ,C1
-poner,to put down,放下,VERB,B2
-ponerse,to put on,穿上,VERB,B2
-ponerse al día,to catch up,赶上,VERB,B2
-ponerse de pie,to stand up,站起来,VERB,B2
-pool (part),pool,池,PART,B2
-pooled,pooled,词,ADJ,C1
-poor devil,poor devil,可怜虫,NOUN,B2
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-poor wretched,poor wretched,可怜的,ADJ,B2
-poorer,poorer,更穷的,ADJ,B2
-poorest,poorest,最穷的,ADJ,B2
-pop,pop,词,NOUN,B1
-popcorn,popcorn,词,ADJ,C1
-poppy,poppy,词,NOUN,B1
-pops,pops,词,NOUN,C1
-popular,popular,受欢迎的,ADJ,B2
-popularity,popularity,流行,NOUN,B2
-popularizar,to popularize,推广,VERB,B2
-populism,populism,民粹主义,NOUN,C1
-populist,populist,民粹主义者,NOUN,B2
-populous,populous,词,ADJ,C1
-por,because of,因为,ADP,B2
-por,for the sake of,为了,ADP,B2
-por adelantado,in advance,事先,ADV,B2
-por ahora,for now,暂时,ADV,B2
-por ciento,percent,百分比,NOUN,B2
-por cierto,by the way,顺便说一下,ADV,B2
-por ejemplo,for example,例如,ADV,B2
-por ello,for it,为此,ADV,B2
-por escrito,in writing,书面,NOUN,B2
+meseta,plateau,高原,NOUN,B2
+plaqueta,platelet,血小板,NOUN,B2
+plataforma,platform,平台,NOUN,B2
+juego,play,剧本,NOUN,B2
+compañero de juegos,playmate,玩伴,NOUN,B2
+suplicar,to plead,恳求,VERB,B2
 por favor,please,请,ADV,B2
-por la presente,hereby,特此,ADV,B2
-por lo tanto,therefore,因此,ADV,B2
-por medios lícitos o ilícitos,by fair means or foul,不择手段,ADV,B2
-por qué,for what,为了什么,ADV,B2
-porcelain,porcelain,瓷器,NOUN,B2
-porcentaje,percentage,百分比,NOUN,B2
-porche,porch,门廊,NOUN,B2
-porción,portion,部分,NOUN,B2
-pork,pork,词,NOUN,B2
-pornografía,porn,色情,NOUN,B2
-pornography,pornography,色情,NOUN,B2
-pornográfico,pornographic,色情的,ADJ,B2
-porosity,porosity,词,NOUN,C1
-porous,porous,词,ADJ,C1
-porque,because,因为,CCONJ,B2
-port harbor,port harbor,词,NOUN,A1
-portable,portable,词,ADJ,C1
-porte,bearing,轴承,NOUN,B2
-portentous,portentous,词,ADJ,C1
-portero,doorman,门卫,NOUN,B2
-portero,porter,搬运工,NOUN,B2
-portfolios,portfolios,词,NOUN,C1
-portico,portico,词,NOUN,C1
-portion serving,portion serving,部分 / 一份,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portrayal,portrayal,词,NOUN,B2
-portuguese,portuguese,葡萄牙语,NOUN,B2
-poseer,to own,拥有,VERB,B2
-poseer,to possess,拥有,VERB,B2
-posesionarse,to take office,就职,VERB,B2
-posh,posh,上流的,ADJ,B2
-posibilidad,possibility,可能性,NOUN,B2
-posiblemente,possibly,可能地,ADV,B2
-posicionamiento,positioning,定位,NOUN,B2
-posit,posit,词,VERB,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivism,positivism,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-posos,dregs,渣滓,NOUN,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postal code,postal code,邮政编码,NOUN,B2
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-posterioridad,afterward,去后,NOUN,B2
-posterity,posterity,词,NOUN,C1
-posthumous,posthumous,死后的,ADJ,B2
-postmark,postmark,邮戳,NOUN,C1
-postscript,postscript,词,NOUN,C1
-postulado,postulate,假定,NOUN,B2
-postura,stance,立场,NOUN,B2
-posture,posture,作势,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-potencia máxima,full power,全力,NOUN,B2
-potencial,potential,潜力,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
-potential,potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potter,potter,词,NOUN,B2
-pouch,pouch,词,NOUN,C1
-pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power grid,power grid,电网,NOUN,B2
-power outlet,power outlet,插座,NOUN,B1
-power plant,power plant,发电厂,NOUN,B2
-power station,power station,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powers,powers,词,NOUN,C1
-pozo,a well,井,NOUN,B2
-practicante,practitioner,从业者,NOUN,B2
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-prado,meadow,草地,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatismo,pragmatism,实用主义,NOUN,B2
-pragmatist,pragmatist,词,NOUN,C1
-prairie,prairie,词,NOUN,C1
-praise singer,praise singer,词,NOUN,C1
-praiseworthy,praiseworthy,词,ADJ,C1
-prank,prank,恶作剧,NOUN,B2
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer room,prayer room,祈祷室,NOUN,B2
-prayer trap,prayer trap,,NOUN,B2
-pre,pre,,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-preacher,preacher,传教士,NOUN,B2
-precarious,precarious,不稳定的,ADJ,B2
-precarization,precarization,不稳定化,NOUN,B2
-precaución,caution,谨慎,NOUN,B2
-precaución,precaution,预防措施,NOUN,B2
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
-precepto,precept,戒律,NOUN,B2
-precificación,pricing,定价 / 收费,NOUN,B2
-precinct,precinct,辖区,NOUN,B2
-preciosidad,preciousness,珍贵,NOUN,B2
-precioso,gorgeous,华丽的,ADJ,B2
-precioso,precious,珍贵的,ADJ,B2
-precipitación,precipitation,降水,NOUN,B2
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-precision,precision,精确,NOUN,B2
-preclude,preclude,词,VERB,C1
-precocious,precocious,早熟的,ADJ,B2
-precocious talent,precocious talent,词,NOUN,C1
-preconception,preconception,词,NOUN,B2
-precursor,precursor,先驱,NOUN,B2
-predecesor,predecessor,前任,NOUN,B2
-predicación,preaching,劝诫,NOUN,B2
-predicción,prediction,预测,NOUN,B2
-predictable,predictable,可预测的,ADJ,B2
-predilection,predilection,词,NOUN,C1
-predisposition,predisposition,天赋,NOUN,B2
-predominance,predominance,主导地位,NOUN,B2
-predominant,predominant,词,ADJ,B2
-predominantly,predominantly,词,ADV,C1
-preeminence,preeminence,词,NOUN,B2
-preeminent,preeminent,词,ADJ,C1
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
-preescolar,preschool,幼儿园,NOUN,B2
-prefect,prefect,词,NOUN,B1
-prefectura,prefecture,省政府,NOUN,B2
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-preferable,preferable,更可取的,ADJ,B2
-preferencia,preference,偏好,NOUN,B2
-preferencia de gusto,taste preference,口味,NOUN,B2
-preferiblemente,preferably,更愿意,ADV,B2
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-pregunta retórica,rhetorical question,宁非,NOUN,B2
-preguntar,to question,质疑,VERB,B2
-prejudiced,prejudiced,有偏见的,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-prejuicio,prejudice,偏见,NOUN,B2
-prelate,prelate,词,NOUN,C1
-preliminary,preliminary,初步的,ADJ,B2
-preliminary investigation,preliminary investigation,,NOUN,B2
-premature,premature,词,ADJ,C1
-premature baby,premature baby,词,NOUN,B2
-prematurely,prematurely,词,ADV,C1
-prematurity,prematurity,词,NOUN,C1
-premeditate,premeditate,词,VERB,C1
-premeditation,premeditation,预谋,NOUN,B2
-premio,award,奖项,NOUN,B2
-premisa,premise,前提,NOUN,B2
-premium,premium,溢价,NOUN,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
-preocupado,worried,担心的,ADJ,B2
-preparación,preparation,准备,NOUN,B2
-preparación,readiness,准备就绪,NOUN,B2
-preparar,to prepare a lesson,预习,VERB,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
-prepared,prepared,准备好的,ADJ,B2
-preparedness,preparedness,词,NOUN,B1
-preponderance,preponderance,词,NOUN,C1
-preponderant,preponderant,占优势的,ADJ,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-prerogative,prerogative,特权,NOUN,B2
-prerrequisito,prerequisite,前提,NOUN,B2
-prescient,prescient,词,ADJ,C1
-prescribir,to prescribe,开处方,VERB,B2
-prescripción,prescription,处方,NOUN,B2
-presencia,thief presence,有贼,NOUN,B2
-present,present,礼物,NOUN,B2
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-present time,present time,现在,NOUN,B2
-presentador,presenter,主持人,NOUN,B2
-presente,present,在场的,ADJ,B2
-preservación,preservation,保护,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-presidencia,presidency,总统任期,NOUN,B2
-presidencial,presidential,总统的,ADJ,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidente,chairman,主席,NOUN,B2
-presidente,chairperson,主席,NOUN,B2
-presidential election,presidential election,总统选举,NOUN,B2
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
-presionar,to press,按,VERB,B2
-presión arterial,blood pressure,血压,NOUN,B2
-press freedom,press freedom,新闻自由,NOUN,B2
-press release,press release,公报,NOUN,B2
-prestatario,borrower,借款人,NOUN,B2
-prestigious,prestigious,有声望的,ADJ,B2
-presumably,presumably,据推测,ADV,B2
-presumed,presumed,推定的,ADJ,B2
-presumir,to presume,假定,VERB,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-presumptuous,presumptuous,词,ADJ,C1
-presuntamente,allegedly,据称,ADV,B2
-presupuestario,budgetary,预算的,ADJ,B2
-presupuesto,budget,预算,NOUN,B2
-pretender,pretender,词,NOUN,C1
-pretending to forget,pretending to forget,词,VERB,C1
-pretension,pretension,词,NOUN,C1
-pretentious,pretentious,自命不凡的,ADJ,B2
-preterition,preterition,假托,NOUN,B2
-prevalence,prevalence,词,NOUN,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
-prevention,prevention,预防,NOUN,B2
-preventive,preventive,词,ADJ,B2
-prever,to foresee,预见,VERB,B2
-previamente,previously,以前,ADV,B2
-preview,preview,词,NOUN,C1
-previous,previous,,NOUN,B2
-previsión,foresight,远见,NOUN,B2
-prey,prey,猎物,NOUN,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prices,prices,词,NOUN,C1
-prickly,prickly,词,ADJ,C1
-pride arrogance,pride arrogance,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
-primario,primary,主要的,ADJ,B2
-primary school,primary school,小学,NOUN,B2
-primary school teacher,primary school teacher,词,NOUN,C1
-primate,primate,词,NOUN,C1
-prime,prime,首要的,ADJ,B1
-prime matter,prime matter,词,NOUN,C1
-primer borrador,first draft,初稿,NOUN,B2
-primer ministro,premier,总理,NOUN,B2
-primer ministro,prime minister,总理,NOUN,B2
-primer mérito,first merit,首功,NOUN,B2
-primera convocatoria,first capping,首加缁布冠,NOUN,B2
-primero,first,首先,ADV,B2
-primeval forest,primeval forest,原始森林,NOUN,C1
-primitivo,primitive,原始的,ADJ,B2
-primordial chaos,primordial chaos,词,NOUN,C1
-princesa,princess,公主,NOUN,B2
-principal (adj),principal,词,ADJ,B2
-principality,principality,词,NOUN,C1
-principalmente,mainly,主要地,ADV,B2
-principiante,beginner,初学者,NOUN,B2
-principio,principle,原则,NOUN,B2
-printed form,printed form,词,NOUN,B1
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printout,printout,打印件,NOUN,B2
-prior,prior,先前的,ADJ,B2
-priority,priority,优先的,ADJ,B2
-prisa,haste,匆忙,NOUN,B2
-prisma,prism,棱镜,NOUN,B2
-pristine,pristine,词,ADJ,C1
-privacidad,privacy,隐私,NOUN,B2
-privación,deprivation,剥夺,NOUN,B2
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-private life,private life,私生活,NOUN,B2
-privatization,privatization,词,NOUN,B2
-privileged,privileged,词,ADJ,B2
-privilegio,privilege,特权,NOUN,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-proactive,proactive,积极主动的,ADJ,B2
-probabilístico,probabilistic,概率的,ADJ,B2
-probable,probable,可能的,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probar,to prove,证明,VERB,B2
-probar,to test,测试,VERB,B2
-probation,probation,缓刑,NOUN,B2
-probationary,probationary,词,ADJ,B2
-probative,probative,词,ADJ,C1
-probe,probe,探测器,NOUN,B2
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-probity,probity,正直,NOUN,B2
-problema difícil,difficult problem,难题,NOUN,B2
-problematic,problematic,词,ADJ,B2
-problematic issue,problematic issue,词,NOUN,C1
-procedural,procedural,程序的,ADJ,B2
-procedures,procedures,词,NOUN,C1
-procesador,processor,处理器,NOUN,B2
-procesar,to process,处理,VERB,B2
-process technique,process technique,词,NOUN,B1
-processable,processable,词,ADJ,C1
-processing,processing,处理,NOUN,B2
-processing (adj),processing,词,ADJ,C1
-proclamar,to proclaim,宣布,VERB,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
-procrastinación,procrastination,拖延,NOUN,B2
-procrastinar,to procrastinate,拖延,VERB,B2
-procurar,to procure,获取,VERB,B2
-prodigal,prodigal,词,ADJ,C1
-prodigality,prodigality,挥霍,NOUN,C1
-prodigious,prodigious,词,ADJ,C1
-prodigy,prodigy,神童,NOUN,B2
-producción,production,生产,NOUN,B2
-productive,productive,多产的,ADJ,B2
-productividad,productivity,生产力,NOUN,B2
-productivist,productivist,生产至上主义的,ADJ,B2
-productor,producer,生产者,NOUN,B2
-profane,profane,词,ADJ,C1
-profesional,professional,专业人士,NOUN,B2
-profesión,profession,职业,NOUN,B2
-profesor,professor,教授,NOUN,B2
-profess,profess,词,VERB,B2
-professional (noun),professional,词,NOUN,B2
-professional ethics,professional ethics,词,NOUN,C1
-professional formation,professional formation,职业养成,NOUN,B2
-professionalism,professionalism,词,NOUN,B2
-professionally active,professionally active,在职,NOUN,B2
-professorship,professorship,词,NOUN,C1
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
-profitability,profitability,盈利能力,NOUN,B2
-profitable,profitable,词,ADJ,B2
-profits,profits,词,NOUN,B2
-profligate,profligate,词,ADJ,C1
-profundo,profound,深刻的,ADJ,B2
-profuse,profuse,词,ADJ,C1
-profusion,profusion,词,NOUN,C1
-prognosis,prognosis,预后,NOUN,B2
-program schedule,program schedule,词,NOUN,A2
-programación,programming,编程,NOUN,B2
-programador,programmer,程序员,NOUN,B2
-programmed,programmed,词,ADJ,C1
-progresar,to progress,进步,VERB,B2
-progresivamente,progressively,逐渐地,ADV,B2
-progresivo,progressive,渐进的,ADJ,B2
-progression,progression,词,NOUN,C1
-progressive,progressive,进步人士,NOUN,B2
-prohibido,forbidden,被禁止的,ADJ,B2
-prohibir,ban,禁令,NOUN,B2
-prohibir,to ban,禁止,VERB,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
-project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projections,projections,词,NOUN,C1
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
-proletariado,proletariat,无产阶级,NOUN,B2
-proliferate,proliferate,扩散,! VERB,B2
-proliferation,proliferation,增殖,NOUN,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolijidad,prolixity,冗长,NOUN,B2
-prolijo,prolix,冗长的,ADJ,B2
-prolongar,to prolong,延长,VERB,B2
-promedio,average,平均,ADJ,B2
-prometedor,promising,有前途的,ADJ,B2
 prometer,pledge,抵押,NOUN,B2
 prometer,to pledge,保证,VERB,B2
-prominence,prominence,词,NOUN,B2
-prominent family,prominent family,望族,NOUN,C1
-promoted,promoted,词,ADJ,B1
-prompt,prompt,词,ADJ,C1
-promulgar,to promulgate,颁布,VERB,B2
-pronoun,pronoun,词,NOUN,B1
-pronounced,pronounced,显著的,ADJ,B2
+alicates,pliers,钳子,NOUN,B2
+apuro,plight,处境,NOUN,B2
+arado,plowing,犁地,NOUN,B2
+ciruela,plum,李子,NOUN,B2
+fontanero,plumber,水管工,NOUN,B2
+pluralismo,pluralism,多元主义,NOUN,B2
+peluche,plush toy,毛绒玩具,NOUN,B2
+plutocracia,plutocracy,财阀政治,NOUN,B2
+podcast,podcast,播客,NOUN,B2
+poeta,poet,诗人,NOUN,B2
+poesía,poetry,诗歌,NOUN,B2
+antología poética,poetry collection,诗集,NOUN,B2
+señalar,to point,指向,VERB,B2
+momento,point in time,时间点,NOUN,B2
+venenoso,poisonous,有毒的,ADJ,B2
+polarización,polarization,两极分化 / 极化,NOUN,B2
+polo,pole,极,NOUN,B2
+polémico,polemical,论战的,ADJ,B2
+policía,policeman,警察,NOUN,B2
+política,policy,政策,NOUN,B2
+político,politician,政治家,NOUN,B2
+encuesta,poll,民意调查,NOUN,B2
+polinización,pollination,授粉,NOUN,B2
+contaminante,pollutant,污染物,NOUN,B2
+contaminado,polluted,受污染的,ADJ,B2
+granada,pomegranate,石榴,NOUN,B2
+pomelo,pomelo,柚子,NOUN,B2
+piscina,pool,池,PART,B2
+música pop,pop music,流行音乐,NOUN,B2
+papa,pope,教皇,NOUN,B2
+popular,popular,受欢迎的,ADJ,B2
+popularizar,to popularize,推广,VERB,B2
+poblar,to populate,居住,VERB,B2
+población,population,人口,NOUN,B2
+porche,porch,门廊,NOUN,B2
+pornografía,porn,色情,NOUN,B2
+pornográfico,pornographic,色情的,ADJ,B2
+portero,porter,搬运工,NOUN,B2
+porción,portion,部分,NOUN,B2
+retrato,portrait,肖像,NOUN,B2
+retratar,to portray,描绘,VERB,B2
+posicionamiento,positioning,定位,NOUN,B2
+poseer,to possess,拥有,VERB,B2
+posibilidad,possibility,可能性,NOUN,B2
+posiblemente,possibly,可能地,ADV,B2
+correo,post,邮件,NOUN,B2
+oficina de correos,post office,邮局,NOUN,B2
+tarjeta postal,postcard,明信片,NOUN,B2
+postulado,postulate,假定,NOUN,B2
+olla,pot,锅,NOUN,B2
+patata,potato,土豆,NOUN,B2
+potencial,potential,潜力,NOUN,B2
+cerámica,pottery,陶器,NOUN,B2
+aves de corral,poultry,家禽,NOUN,B2
+libra,pound,磅,NOUN,B2
+verter,to pour,倾倒,VERB,B2
+pobreza,poverty,贫困,NOUN,B2
+polvo,powder,粉末,NOUN,B2
+poder notarial,power of attorney,委托书,NOUN,B2
+poderoso,powerful,强大的,ADJ,B2
+nación poderosa,powerful nation,强国,NOUN,B2
+práctico,practical,实际的,ADJ,B2
+prácticamente,practically,几乎,ADV,B2
+practicante,practitioner,从业者,NOUN,B2
+pragmatismo,pragmatism,实用主义,NOUN,B2
+predicación,preaching,劝诫,NOUN,B2
+precaución,precaution,预防措施,NOUN,B2
+precepto,precept,戒律,NOUN,B2
+precioso,precious,珍贵的,ADJ,B2
+preciosidad,preciousness,珍贵,NOUN,B2
+precipitación,precipitation,降水,NOUN,B2
+precursor,precursor,先驱,NOUN,B2
+depredador,predatory,掠夺的,ADJ,B2
+predecesor,predecessor,前任,NOUN,B2
+predicción,prediction,预测,NOUN,B2
+prólogo,preface,序言,NOUN,B2
+prefectura,prefecture,省政府,NOUN,B2
+preferiblemente,preferably,更愿意,ADV,B2
+preferencia,preference,偏好,NOUN,B2
+prejuicio,prejudice,偏见,NOUN,B2
+primer ministro,premier,总理,NOUN,B2
+premisa,premise,前提,NOUN,B2
+preparación,preparation,准备,NOUN,B2
+preparar,to prepare a lesson,预习,VERB,B2
+absurdo,preposterous,荒谬的,ADJ,B2
+prerrequisito,prerequisite,前提,NOUN,B2
+preescolar,preschool,幼儿园,NOUN,B2
+prescribir,to prescribe,开处方,VERB,B2
+prescripción,prescription,处方,NOUN,B2
+presente,present,在场的,ADJ,B2
+presentador,presenter,主持人,NOUN,B2
+preservación,preservation,保护,NOUN,B2
+presidencia,presidency,总统任期,NOUN,B2
+presidencial,presidential,总统的,ADJ,B2
+presionar,to press,按,VERB,B2
+conferencia de prensa,press conference,新闻发布会,NOUN,B2
+presumir,to presume,假定,VERB,B2
+fingir,to pretend to be,冒充,VERB,B2
+previamente,previously,以前,ADV,B2
+precificación,pricing,定价 / 收费,NOUN,B2
+primario,primary,主要的,ADJ,B2
+primer ministro,prime minister,总理,NOUN,B2
+primitivo,primitive,原始的,ADJ,B2
+princesa,princess,公主,NOUN,B2
+director,principal,委托人,NOUN,B2
+principio,principle,原则,NOUN,B2
+prisma,prism,棱镜,NOUN,B2
+privacidad,privacy,隐私,NOUN,B2
+privilegio,privilege,特权,NOUN,B2
+probabilístico,probabilistic,概率的,ADJ,B2
+procesar,to process,处理,VERB,B2
+procesador,processor,处理器,NOUN,B2
+proclamar,to proclaim,宣布,VERB,B2
+procrastinar,to procrastinate,拖延,VERB,B2
+procrastinación,procrastination,拖延,NOUN,B2
+procurar,to procure,获取,VERB,B2
+productor,producer,生产者,NOUN,B2
+producción,production,生产,NOUN,B2
+productividad,productivity,生产力,NOUN,B2
+profesión,profession,职业,NOUN,B2
+profesional,professional,专业人士,NOUN,B2
+profesor,professor,教授,NOUN,B2
+diestro,proficient,熟练的,ADJ,B2
+rentable,profit-making,营利性,ADJ,B2
+profundo,profound,深刻的,ADJ,B2
+programador,programmer,程序员,NOUN,B2
+programación,programming,编程,NOUN,B2
+progresar,to progress,进步,VERB,B2
+informe de progreso,progress report,进度报告,NOUN,B2
+progresivo,progressive,渐进的,ADJ,B2
+progresivamente,progressively,逐渐地,ADV,B2
+proyecto,project,项目,NOUN,B2
+tarea de proyecto,project assignment,项目作业,NOUN,B2
+proyector,projector,投影仪,NOUN,B2
+proletariado,proletariat,无产阶级,NOUN,B2
+prolijo,prolix,冗长的,ADJ,B2
+prolijidad,prolixity,冗长,NOUN,B2
+prolongar,to prolong,延长,VERB,B2
+prometedor,promising,有前途的,ADJ,B2
+pagaré,promissory note,本票,NOUN,B2
 prontamente,promptly,迅速地,ADV,B2
-pronunciación,pronunciation,发音,NOUN,B2
+promulgar,to promulgate,颁布,VERB,B2
 pronunciar,to pronounce,发音,VERB,B2
-pronóstico,forecast,预测,NOUN,B2
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-propaedeutic,propaedeutic,词,ADJ,C1
-propagación,spread,传播,NOUN,B2
+pronunciación,pronunciation,发音,NOUN,B2
+prueba,proof,证据,NOUN,B2
+corrección de pruebas,proofreading,校对,NOUN,B2
+apoyar,to prop,撑,VERB,B2
 propaganda,propaganda,宣传,NOUN,B2
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-property owner,property owner,房主,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophet,prophet,先知,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-propiedad,ownership,,NOUN,B2
-propitious,propitious,词,ADJ,C1
-proponent,proponent,词,NOUN,C1
+adecuado,proper,适当的,ADJ,B2
+adecuadamente,properly,适当地,ADV,B2
+proporción,proportion,比例,NOUN,B2
 proponer,to propose,提议,VERB,B2
+propuesta,proposition,主张,NOUN,B2
+decencia,propriety,分寸,NOUN,B2
+prosaico,prosaic,平淡无奇的,ADJ,B2
+prosa,prose,散文,NOUN,B2
+fiscalía,prosecution,起诉,NOUN,B2
+perspectiva,prospect,前景,NOUN,B2
+prostituta,prostitute,妓女,NOUN,B2
+proteccionismo,protectionism,保护主义,NOUN,B2
+protector,protective,保护的,ADJ,B2
+proteína,protein,蛋白质,NOUN,B2
+protesta,protest,抗议,NOUN,B2
+manifestante,protester,示威者,NOUN,B2
+orgulloso,proud,自豪的,ADJ,B2
+probar,to prove,证明,VERB,B2
+proverbio,proverb,谚语,NOUN,B2
 proporcionar pruebas,to provide evidence,举证,VERB,B2
 proporcionar retroalimentación,to provide feedback,反馈,VERB,B2
-proporción,proportion,比例,NOUN,B2
-proportional,proportional,成比例的,ADJ,B2
-proportionality,proportionality,词,NOUN,C1
-proportionally,proportionally,词,ADV,C1
-proposal suggestion,proposal suggestion,建议,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-propuesta,proposition,主张,NOUN,B2
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
-prosa,prose,散文,NOUN,B2
-prosaico,prosaic,平淡无奇的,ADJ,B2
-prose writer,prose writer,词,NOUN,C1
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutions,prosecutions,词,NOUN,C1
-prosecutor's office,prosecutor's office,词,NOUN,B2
-proselyte,proselyte,词,NOUN,C1
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
-prostituta,prostitute,妓女,NOUN,B2
-prostitution,prostitution,词,NOUN,B2
-proteccionismo,protectionism,保护主义,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protective cover,protective cover,词,NOUN,C1
-protector,protective,保护的,ADJ,B2
-protector,protector,保护者,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
-protesta,protest,抗议,NOUN,B2
-proteína,protein,蛋白质,NOUN,B2
-proton,proton,词,NOUN,C1
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-proudly,proudly,词,ADV,C1
-provable,provable,可证明的,ADJ,B2
-proveedor,provider,提供者,NOUN,B2
-proveedor,supplier,供应商,NOUN,B2
-proveedor de servicios,service provider,服务商,NOUN,B2
 proveer,to provide for,供应,VERB,B2
-provenir,to come from,来自,VERB,B2
-proverbio,proverb,谚语,NOUN,B2
-proverbs,proverbs,词,NOUN,C1
-providential,providential,词,ADJ,C1
-provinces,provinces,词,NOUN,C1
+siempre que,provided that,只要,SCONJ,B2
+proveedor,provider,提供者,NOUN,B2
 provincia,province,省,NOUN,B2
-provincial,provincial,地方的,ADJ,B2
-provision,provision,词,NOUN,C1
-provisional,provisional,临时的,ADJ,B2
-provisionally,provisionally,词,ADV,C1
+carretera provincial,provincial highway,省道,NOUN,B2
 provisiones,provisions,储备,NOUN,B2
 provocación,provocation,挑衅,NOUN,B2
-provocative,provocative,挑衅的,ADJ,B2
-prow,prow,词,NOUN,C1
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-proyectar,to screen,筛选,VERB,B2
-proyecto,project,项目,NOUN,B2
-proyector,projector,投影仪,NOUN,B2
-prudent,prudent,谨慎的,ADJ,B2
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prueba,ordeal,苦难,NOUN,B2
-prueba,proof,证据,NOUN,B2
-prueba física,physical evidence,物证,NOUN,B2
-prune,prune,修剪,VERB,C1
-prácticamente,practically,几乎,ADV,B2
-práctico,practical,实际的,ADJ,B2
-préstamo,borrowing,借贷,NOUN,B2
-prólogo,preface,序言,NOUN,B2
-próximo,upcoming,مقبل,ADJ,B2
-psalm,psalm,诗篇,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
+psiquiatra,psychiatrist,精神科医生,NOUN,B2
 psicología,psychology,心理学,NOUN,B2
 psicosis,psychosis,精神病,NOUN,B2
-psiquiatra,psychiatrist,精神科医生,NOUN,B2
-psoriasis,psoriasis,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychiatric,psychiatric,精神病的,ADJ,B2
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychological,psychological,心理的,ADJ,B2
-psychologically,psychologically,词,ADV,C1
-psychopath,psychopath,精神变态者,NOUN,B2
-psychopathy,psychopathy,词,NOUN,C1
+bar,pub,酒吧,NOUN,B2
 pubertad,puberty,青春期,NOUN,B2
-public (noun),public,公众,NOUN,B1
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publicación,publication,出版物,NOUN,B2
-publicar,to publish,出版,VERB,B2
-publicidad,advertising,广告业,NOUN,B2
-publicity,publicity,宣传,NOUN,B2
-pueblo,folk,民间的,ADJ,B2
-puente peatonal,footbridge,人行天桥,NOUN,B2
-puente peatonal,pedestrian bridge,天桥,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puerperal,puerperal,词,ADJ,C1
-puerta,gate,大门,NOUN,B2
-puerta lateral,side door,侧门,NOUN,B2
-puerta principal,front door,正门,NOUN,B2
-puerta trasera,back door,后门,NOUN,B2
-puerto,harbor,港口,NOUN,B2
-pugnacious,pugnacious,词,ADJ,C1
-pugnacity,pugnacity,词,NOUN,C1
-puissant,puissant,词,ADJ,C1
-pulgada,inch,بوصة,NOUN,B2
-pulgar,thumb,拇指,NOUN,B2
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
-pulling,pulling,拔,NOUN,B2
-pulmonar,pulmonary,肺的,ADJ,B2
-pulpit,pulpit,讲坛,NOUN,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pulsera,bracelet,手镯,NOUN,B2
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
-punch (verb),punch,词,VERB,B2
-punch drink,punch drink,词,NOUN,C1
-punción,puncture,穿刺,NOUN,B2
-punctilious,punctilious,词,ADJ,C1
-punctuality,punctuality,守时,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
-puncture tap,puncture tap,词,NOUN,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
-punishable,punishable,可处罚的,ADJ,B2
-punitive,punitive,惩罚性的,ADJ,B2
-punto de vista,viewpoint,观点,NOUN,B2
-punto muerto,standstill,停滞,NOUN,B2
-puntuación,punctuation,标点符号,NOUN,B2
-puntuación,score,比分,NOUN,B2
-puntual,punctual,准时的,ADJ,B2
-pupil female,pupil female,词,NOUN,C1
-pupila,pupil,学生,NOUN,B2
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-purchase price,purchase price,购买价,NOUN,B2
-purely,purely,纯粹地,ADV,B2
-pureza,purity,纯洁,NOUN,B2
-purifying,purifying,净化的,ADJ,B2
-puritanical,puritanical,词,ADJ,C1
-puro,pure,纯净的,ADJ,B2
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-purse,purse,词,NOUN,B1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-pus,pus,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-puñalada por la espalda,backstab,背刺,NOUN,B2
-puño,fist,拳头,NOUN,B2
-pálido,pale,苍白的,ADJ,B2
-páncreas,pancreas,胰腺,NOUN,B2
-párpado,eyelid,眼皮,NOUN,B2
-párrafo,paragraph,段落,NOUN,B2
-públicamente,publicly,公开地,ADV,B2
 público,public,公众,NOUN,B2
+orden público,public order,治安,NOUN,B2
+bienestar público,public welfare,公益性,NOUN,B2
+publicación,publication,出版物,NOUN,B2
+públicamente,publicly,公开地,ADV,B2
+publicar,to publish,出版,VERB,B2
+editor,publisher,出版商,NOUN,B2
+editorial,publishing house,出版社,NOUN,B2
+pulmonar,pulmonary,肺的,ADJ,B2
+bomba,pump,泵,NOUN,B2
+puntual,punctual,准时的,ADJ,B2
+puntuación,punctuation,标点符号,NOUN,B2
+punción,puncture,穿刺,NOUN,B2
+pupila,pupil,学生,NOUN,B2
+comprar,to purchase,购买,VERB,B2
+puro,pure,纯净的,ADJ,B2
+pureza,purity,纯洁,NOUN,B2
 púrpura,purple,紫色,ADJ,B2
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifying,qualifying,词,ADJ,C1
-quantum,quantum,量子的,ADJ,B2
-quarantine (noun),quarantine,词,NOUN,C1
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarry,quarry,词,NOUN,B1
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quaternary,quaternary,第四的,ADJ,B2
-que,than,比,ADP,B2
-quebrar,to go bankrupt,破产,VERB,B2
-queer,queer,词,ADJ,C1
-quemado,burnt,烧焦的,ADJ,B2
-quemadura,burn,烧伤,NOUN,B2
-quench,quench,词,VERB,C1
-querer,want,想,AUX,B2
-querer,to think to want,想,VERB,B2
-querer necesitar,to want to need will,要,VERB,B2
-querulous,querulous,词,ADJ,C1
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-quibble,quibble,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiescent,quiescent,词,ADJ,C1
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
+yin púrpura,purple yin,紫阴,NOUN,B2
+perseguir,to pursue,追求,VERB,B2
+persecución,pursuit,追求,NOUN,B2
+suerte,push luck,太得寸,NOUN,B2
+poner,to put down,放下,VERB,B2
+ordenar,to put in order,收拾,VERB,B2
+ponerse,to put on,穿上,VERB,B2
+confundir,puzzle,谜题,NOUN,B2
+confundir,to puzzle,使困惑,VERB,B2
+pirámide,pyramid,金字塔,NOUN,B2
+codorniz,quail,鹌鹑,NOUN,B2
+calificación,qualification,资格,NOUN,B2
+calificaciones,qualifications,资格,NOUN,B2
+cualificado,qualified,合格的,ADJ,B2
+cualitativo,qualitative,定性的,ADJ,B2
+cuantitativo,quantitative,定量的,ADJ,B2
+discutir,quarrel,争吵,NOUN,B2
+discutir,to quarrel,争吵,VERB,B2
+discusión,quarreling,再吵,NOUN,B2
+cuarto,quarter,四分之一,NOUN,B2
+trimestre,quarter of a year,季度,NOUN,B2
+revista trimestral,quarterly magazine,季刊,NOUN,B2
+muelle,quay,码头,NOUN,B2
+búsqueda,quest,探索,NOUN,B2
+preguntar,to question,质疑,VERB,B2
+rápido,quick,快的,ADJ,B2
+rápidamente,quickly,迅速地,ADV,B2
 quieto,quiet,安静的,ADJ,B2
-quietude,quietude,词,NOUN,C1
-quill,quill,词,NOUN,C1
-quint,quint,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quinto,fifth,خامس,ADJ,B2
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quita de zapatos,shoe removal,鞋脱,NOUN,B2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quivering,quivering,颤抖的,ADJ,B2
-quixotic,quixotic,词,ADJ,C1
-quizás,maybe,也许,ADV,B2
-quota sharing,quota sharing,配额分享,NOUN,C1
-quote,quote,报价单,NOUN,B2
-quotidian,quotidian,词,ADJ,C1
-química,chemistry,化学,NOUN,B2
-químico,chemical,化学的,ADJ,B2
-rabble,rabble,词,NOUN,C1
-rabiar,to rage,狂怒,VERB,B2
+colcha,quilt,被子,NOUN,B2
+cita,quotation,报价,NOUN,B2
 rabino,rabbi,拉比,NOUN,B2
-racionalidad,rationality,理性,NOUN,B2
-racionalismo,rationalism,理性主义,NOUN,B2
-racionalización,rationalization,合理化,NOUN,B2
+carrera,race,比赛,NOUN,B2
 racismo,racism,种族主义,NOUN,B2
-racist,racist,种族主义者,NOUN,B2
-racist (adj),racist,种族主义的,ADJ,C1
-ración,ration,配给,NOUN,B2
-racketeering,racketeering,词,NOUN,B2
-radar,radar,词,NOUN,B2
-radiación,radiation,辐射,NOUN,B2
-radiactivo,radioactive,放射性的,ADJ,B2
-radiador,radiator,暖气片,NOUN,B2
-radiant,radiant,容光焕发的,ADJ,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radical,radical,激进的,ADJ,B2
-radicalism,radicalism,词,NOUN,C1
-radically,radically,彻底地,ADV,B2
-radio,radio,收音机,NOUN,B2
-radio silence,radio silence,词,NOUN,C1
-radioactivity,radioactivity,词,NOUN,C1
-radiodifusión,broadcasting,广播,NOUN,B2
-radiography rays,radiography rays,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
-radiotherapy,radiotherapy,放疗,NOUN,B2
-radius,radius,半径,NOUN,B2
-rags,rags,词,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-rai,rai,词,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
-railroad,railroad,词,NOUN,B2
-rails,rails,词,NOUN,C1
-rain clouds,rain clouds,词,NOUN,C1
-rain shower,rain shower,阵雨,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy,rainy,多雨的,ADJ,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise (noun),raise,词,NOUN,B1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-rajaz poem,rajaz poem,词,NOUN,C1
-rake,rake,耙子,NOUN,B2
-rally (noun),rally,词,NOUN,B2
-rallying,rallying,词,NOUN,C1
-rambunctious,rambunctious,词,ADJ,C1
-rampa,ramp,坡道,NOUN,B2
-rampart,rampart,词,NOUN,C1
-ramshackle,ramshackle,词,ADJ,C1
-ran,ran,跑,ADJ,B2
-rana,frog,青蛙,NOUN,B2
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancorous,rancorous,词,ADJ,C1
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-range zone,range zone,词,NOUN,C1
-ranger,ranger,词,NOUN,B2
-rango,rank,等级,NOUN,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-ranking classification,ranking classification,词,NOUN,C1
-rapacious,rapacious,词,ADJ,C1
-rapacity,rapacity,词,NOUN,C1
-rapidly,rapidly,词,ADV,B2
-rapper,rapper,说唱歌手,NOUN,B2
-rapporteur,rapporteur,词,NOUN,C1
-rapturous,rapturous,词,ADJ,C1
 raqueta,racket,球拍,NOUN,B2
-raramente,rarely,很少,ADV,B2
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarity,rarity,希罕,NOUN,C1
+radiación,radiation,辐射,NOUN,B2
+radiador,radiator,暖气片,NOUN,B2
+radical,radical,激进的,ADJ,B2
+radio,radio,收音机,NOUN,B2
+emisora,radio station,广播电台,NOUN,B2
+radiactivo,radioactive,放射性的,ADJ,B2
+rábano,radish,小萝卜,NOUN,B2
+rabiar,to rage,狂怒,VERB,B2
+redada,raid,突袭,NOUN,B2
+llover,to rain,下雨,VERB,B2
+arcoíris,rainbow,彩虹,NOUN,B2
+chubasquero,raincoat,雨衣,NOUN,B2
+selva tropical,rainforest,雨林,NOUN,B2
+recaudar,to raise donations,募捐,VERB,B2
+ariete,ram,公羊,NOUN,B2
+rampa,ramp,坡道,NOUN,B2
+tiranía desenfrenada,rampant tyranny,横行,NOUN,B2
+aleatorio,random,随机的,ADJ,B2
+rango,rank,等级,NOUN,B2
+violar,rape,强奸,NOUN,B2
+violar,to rape,强奸,VERB,B2
+rápido,rapid,迅速的,ADJ,B2
+acercamiento,rapprochement,和解,NOUN,B2
 raro,rare,稀有的,ADJ,B2
-raro,freak,怪人,NOUN,B2
-rash,rash,皮疹,NOUN,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-raspy,raspy,词,ADJ,C1
+raramente,rarely,很少,ADV,B2
+sarpullido,rash,轻率的,ADJ,B2
+frambuesa,raspberry,覆盆子,NOUN,B2
 rata,rat,老鼠,NOUN,B2
-rate,rate,比率,NOUN,B2
-rate percentage,rate percentage,词,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
-ratio,ratio,比率,NOUN,B2
-rational,rational,词,ADJ,B2
-rationalist,rationalist,词,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
-rato,a while,一会儿,NOUN,B2
-rattling,rattling,词,NOUN,C1
-ratón,mouse,老鼠,NOUN,B2
-raucous,raucous,词,ADJ,C1
-ravenous,ravenous,词,ADJ,C1
-ravine,ravine,沟壑,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-raw ore,raw ore,词,ADJ,C1
+antirratas,rat-proof,防鼠,ADJ,B2
+bastante,rather,相当,ADV,B2
+calificación,rating,评分,NOUN,B2
+ración,ration,配给,NOUN,B2
+racionalismo,rationalism,理性主义,NOUN,B2
+racionalidad,rationality,理性,NOUN,B2
+racionalización,rationalization,合理化,NOUN,B2
+materia prima,raw material,原材料,NOUN,B2
 rayo,ray,光线,NOUN,B2
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-raza,breed,品种,NOUN,B2
-raze,raze,词,VERB,C1
-razonable,reasonable,合理的,ADJ,B2
-razonamiento,reasoning,论证,NOUN,B2
-razonar,to reason,推理,VERB,B2
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-camino,re-path,重径,NOUN,B2
-re-cantidad,re-quantity,再量,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-enrutamiento,re-routing,改轨,NOUN,B2
-re-envío,re-submission,再上,NOUN,B2
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,再判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
+navaja,razor,剃刀,NOUN,B2
+nueva brusquedad,re-abruptness,再骤,NOUN,B2
+recombate,re-battle,重战,NOUN,B2
+nuevo límite,re-boundary,重界,NOUN,B2
+nuevo curso,re-course,重途,NOUN,B2
+recreación,re-creation,再作,NOUN,B2
+recreación,re-enactment,再演,NOUN,B2
+nueva evidencia,re-evidence,重据,NOUN,B2
+nueva fruta,re-fruit,再果,NOUN,B2
+nuevo interior,re-inner,再内,NOUN,B2
+nueva estratificación,re-layering,改层,NOUN,B2
 re-límite,re-limit,重限,NOUN,B2
 re-lógica,re-logic,再逻,NOUN,B2
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-orden,re-order,重序,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-razón,re-reason,重理,NOUN,B2
-re-reality,re-reality,再实,NOUN,C1
-re-ritmo,re-pace,重骤,NOUN,B2
-re-route,re-route,重路,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-secuenciación,re-sequencing,改骤,NOUN,B2
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-shape,re-shape,重形,NOUN,C1
 re-significado,re-meaning,再义,NOUN,B2
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,再综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach position,reach position,及位,NOUN,B2
-reach suffice,reach suffice,词,VERB,B2
-reactionary,reactionary,反动,ADJ,B2
+re-orden,re-order,重序,NOUN,B2
+re-ritmo,re-pace,重骤,NOUN,B2
+re-camino,re-path,重径,NOUN,B2
+re-cantidad,re-quantity,再量,NOUN,B2
+re-razón,re-reason,重理,NOUN,B2
+re-enrutamiento,re-routing,改轨,NOUN,B2
+re-secuenciación,re-sequencing,改骤,NOUN,B2
+re-envío,re-submission,再上,NOUN,B2
+alcanzar,to reach,到达,VERB,B2
+alcanzable,reachable,可到达的,ADJ,B2
 reactivo,reactive,反应的,ADJ,B2
 reactor,reactor,反应堆,NOUN,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
-readiness to help,readiness to help,词,NOUN,C1
-ready finished,ready finished,准备好的/完成的,ADJ,B2
-reaffirm,reaffirm,词,VERB,B2
+lector,reader,读者,NOUN,B2
+preparación,readiness,准备就绪,NOUN,B2
 real,real,真实的,ADJ,B2
-real,royal,皇家的,ADJ,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
+inmobiliario,real estate,房地产,ADJ,B2
 realismo,realism,现实主义,NOUN,B2
-realist,realist,词,NOUN,C1
-realistic,realistic,现实的,ADJ,B2
-reality TV,reality TV,词,NOUN,C1
 realizar,to realize,意识到,VERB,B2
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reasoned,reasoned,经过推理的,ADJ,B2
-reassuring,reassuring,词,ADJ,B1
-rebab,rebab,列巴布琴,NOUN,B2
+deseo genuino,really want,真要,NOUN,B2
+reino,realm,领域,NOUN,B2
+retaguardia,rear,后部,NOUN,B2
+parte trasera,rear part,后部,NOUN,B2
+razonar,to reason,推理,VERB,B2
+razonable,reasonable,合理的,ADJ,B2
+razonamiento,reasoning,论证,NOUN,B2
+reconforto,reassurance,安抚,NOUN,B2
+reconfortar,to reassure,使安心,VERB,B2
 rebelarse,rebel,反叛者,NOUN,B2
 rebelarse,to rebel,反叛,VERB,B2
 rebelión,rebellion,叛乱,NOUN,B2
-rebirth,rebirth,词,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (noun),rebound,词,NOUN,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recado,errand,差事,NOUN,B2
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recall,recall,回忆,NOUN,B2
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recaudar,to raise donations,募捐,VERB,B2
-recaída,relapse,再犯,NOUN,B2
-recede,recede,词,VERB,C1
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-receptor,receiver,接收器,NOUN,B2
-recesión,recession,衰退,NOUN,B2
-recess,recess,词,NOUN,C1
-recharge (noun),recharge,词,NOUN,B2
-rechazar,to refuse,拒绝,VERB,B2
-rechazo,refusal,拒绝,NOUN,B2
-rechazo,rejection,拒绝,NOUN,B2
-rechazo temporal,temporary refusal,暂不,NOUN,B2
-recibir atención mundial,to receive worldwide attention,举世瞩目,VERB,B2
+corazón rebelde,rebellious heart,反心,NOUN,B2
+reconstruir,to rebuild,重建,VERB,B2
+reproche,rebuke,责备,NOUN,B2
+refutar,to rebut,反驳,VERB,B2
+refutación,rebuttal,反驳,NOUN,B2
+recordar,to recall,回忆,VERB,B2
+recibo,receipt,收据,NOUN,B2
 recibir correo,to receive mail,收件,VERB,B2
 recibir órdenes,to receive orders,受命,VERB,B2
-recibo,receipt,收据,NOUN,B2
-reciclaje,recycling,回收利用,NOUN,B2
-reciclar,to recycle,回收利用,VERB,B2
+recibir atención mundial,to receive worldwide attention,举世瞩目,VERB,B2
+receptor,receiver,接收器,NOUN,B2
 recientemente,recently,最近,ADV,B2
-reciprocally,reciprocally,词,ADV,B2
-reciprocate,reciprocate,词,VERB,C1
+recesión,recession,衰退,NOUN,B2
+recíproco,reciprocal,互惠的,ADJ,B2
 recitar,to recite,背诵,VERB,B2
-recitation,recitation,词,NOUN,C1
-reckoning,reckoning,它算,NOUN,C1
-reclamo,claim,要求,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
 reclinación,reclining,躺下,NOUN,B2
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-reclutamiento,recruitment,招聘,NOUN,B2
-reclutar,to recruit,招募,VERB,B2
-recoger,to pick,挑选,VERB,B2
-recognizable,recognizable,可辨认的,ADJ,B2
-recognized,recognized,词,NOUN,B2
-recombate,re-battle,重战,NOUN,B2
-recombination,recombination,再结,NOUN,C1
+reconocimiento,recognition,认可,NOUN,B2
 recomendación,recommendation,推荐,NOUN,B2
 recomendación de otros,recommendation by others,他荐,NOUN,B2
-recommended,recommended,词,ADJ,C1
-recompensar,to reward,奖励,VERB,B2
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconfortar,to reassure,使安心,VERB,B2
-reconforto,reassurance,安抚,NOUN,B2
-reconforto de la madre,mother's reassurance,娘放心,NOUN,B2
-reconnoiter,reconnoiter,词,VERB,C1
-reconocer,to know to recognize,认识,VERB,B2
-reconocimiento,recognition,认可,NOUN,B2
-reconocimiento facial,face recognition,认人,NOUN,B2
-reconquest,reconquest,词,NOUN,C1
-reconsideración,reconsideration,重思,NOUN,B2
+exploración,reconnaissance,侦察,NOUN,B2
 reconsiderar,to reconsider,重新考虑,VERB,B2
+reconsideración,reconsideration,重思,NOUN,B2
 reconstrucción,reconstruction,重建,NOUN,B2
-reconstruir,to rebuild,重建,VERB,B2
-recontar,to retell,转述,VERB,B2
-recordar,to recall,回忆,VERB,B2
-recordar,to remind,提醒,VERB,B2
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recorte de papel,paper cutting,剪纸,NOUN,B2
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recourse,recourse,求助,NOUN,B2
-recreación,re-creation,再作,NOUN,B2
-recreación,re-enactment,再演,NOUN,B2
-recreation,recreation,娱乐,NOUN,B2
-recruit,recruit,新兵,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectangular,rectangular,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-rectitud,righteousness,亦正,NOUN,B2
-rector,rector,词,NOUN,C1
-recuerdo,remembrance,纪念,NOUN,B2
-recuerdo,souvenir,纪念品,NOUN,B2
-recuperación,retrieval,检索,NOUN,B2
-recuperación de Qingming,retrieve qingming,拿回青冥,NOUN,B2
-recuperar,to retrieve,取回,VERB,B2
+tocadiscos,record player,唱机,NOUN,B2
+relatar,to recount,转述,VERB,B2
+reclutar,to recruit,招募,VERB,B2
+reclutamiento,recruitment,招聘,NOUN,B2
 recuperarse,to recuperate,恢复,VERB,B2
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
 recurrencia,recurrence,往复,NOUN,B2
-recurring,recurring,词,ADJ,C1
-recursive,recursive,词,ADJ,C1
 recusación,recusal,回避,NOUN,B2
-recycled item,recycled item,再物,NOUN,B2
-recíproco,reciprocal,互惠的,ADJ,B2
-red,net,网,NOUN,B2
-red,network,网络,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redact,redact,词,VERB,C1
-redada,raid,突袭,NOUN,B2
+reciclar,to recycle,回收利用,VERB,B2
+reciclaje,recycling,回收利用,NOUN,B2
 redefinición,redefinition,改界,NOUN,B2
-redesign,redesign,词,NOUN,C1
-redevelopment,redevelopment,词,NOUN,C1
-redolent,redolent,词,ADJ,C1
-redondo,round,圆的,ADJ,B2
-redoubtable,redoubtable,词,ADJ,C1
-redrawing,redrawing,重新绘制,NOUN,B2
-redress,redress,词,VERB,B2
 reducir,to reduce,减少,VERB,B2
-reduction,reduction,减少,NOUN,B2
-reductionism,reductionism,词,NOUN,C1
-redundancy,redundancy,冗余,NOUN,B2
-redundant,redundant,多余的,ADJ,B2
-reed pen,reed pen,词,NOUN,C1
-reeditar,to reissue,补办,VERB,B2
-reefs,reefs,词,NOUN,B2
-reel,reel,词,NOUN,C1
-reembolsar,to reimburse,偿还,VERB,B2
-reembolso,refund,退款,NOUN,B2
-reembolso,repayment,偿还,NOUN,B2
-reemplazar,to replace,替换,VERB,B2
-reemplazo,replacement,替代品,NOUN,B2
-refereed,refereed,词,ADJ,C1
-reference framework,reference framework,词,NOUN,C1
-references,references,词,NOUN,C1
-referencia,reference,参考,NOUN,B2
-referendum-related,referendum-related,词,ADJ,B2
 referirse,to refer,参考,VERB,B2
-referral,referral,词,NOUN,C1
+referencia,reference,参考,NOUN,B2
 referéndum,referendum,公民投票,NOUN,B2
 refinado,refined,精炼的,ADJ,B2
 refinamiento,refinement,修养,NOUN,B2
 refinamiento,refining,提炼,NOUN,B2
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
-reflective,reflective,词,ADJ,C1
 reflejar,to reflect,反映,VERB,B2
-reflex,reflex,词,NOUN,C1
 reflexión,reflection,思考,NOUN,B2
-reflexión inversa,reverse reflection,反影,NOUN,B2
-reflujo,backflow,倒流,NOUN,B2
 reforestación,reforestation,重新造林,NOUN,B2
-reform (noun),reform,变革,NOUN,B2
 reformar,reform,改革,NOUN,B2
 reformar,to reform,改革,VERB,B2
-reformatory,reformatory,词,NOUN,C1
 reformismo,reformism,改唯,NOUN,B2
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-reformulation,reformulation,重新表述,NOUN,B2
-reforzar,to reinforce,加强,VERB,B2
-refractory,refractory,词,ADJ,C1
-refreshing,refreshing,令人清爽的,ADJ,B2
-refrigerador,fridge,冰箱,NOUN,B2
-refrigeration,refrigeration,词,NOUN,C1
-refuerzo,reinforcement,增援,NOUN,B2
-refugiado,refugee,难民,NOUN,B2
+abstenerse,to refrain,克制,VERB,B2
 refugio,refuge,避难所,NOUN,B2
-refulgent,refulgent,词,ADJ,C1
-refunfuño,grumbling,抱怨,NOUN,B2
-refurbish,refurbish,词,VERB,C1
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refutable,refutable,可反驳的,ADJ,B2
-refutación,rebuttal,反驳,NOUN,B2
-refutar,to rebut,反驳,VERB,B2
+refugiado,refugee,难民,NOUN,B2
+reembolso,refund,退款,NOUN,B2
+rechazo,refusal,拒绝,NOUN,B2
+rechazar,to refuse,拒绝,VERB,B2
 refutar,to refute,驳斥,VERB,B2
-refutation,refutation,词,NOUN,C1
-regal,regal,词,ADJ,C1
-regar,to water,浇水,VERB,B2
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regardless,regardless,不管,ADP,B2
-regardless (adv),regardless,不管,ADV,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regatear,to haggle,讨价还价,VERB,B2
-regateo,haggling,计较,NOUN,B2
-regañar,to scold,训斥,VERB,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,再生,NOUN,B2
-regent,regent,词,NOUN,C1
-regimen,regimen,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
+respecto a,regarding,关于,ADP,B2
+al respecto,regarding this,对此,ADV,B2
 regional,regional,地区的,ADJ,B2
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-register (noun),register,词,NOUN,B1
-registered,registered,注册的,ADJ,B2
-registered mail,registered mail,挂号信,NOUN,B2
-registration number,registration number,词,NOUN,C1
 registro,registration,注册,NOUN,B2
-regocijarse,to rejoice,欢欣,VERB,B2
-regresar,to go back,回去,VERB,B2
-regresar primero,to return first,先回,VERB,B2
-regresivo,regressive,退步的,ADJ,B2
+retroceder,to regress,倒退,VERB,B2
 regresión,regression,倒退,NOUN,B2
-regrettable,regrettable,词,ADJ,B2
-regulación,regulation,规章,NOUN,B2
+regresivo,regressive,退步的,ADJ,B2
 regular,regular,规律的,ADJ,B2
 regular,to regulate,调节,VERB,B2
-regularity,regularity,规律性,NOUN,B2
-regularization,regularization,词,NOUN,C1
-regularly,regularly,定期地,ADV,B2
-regulated,regulated,词,ADJ,C1
-regulator,regulator,词,NOUN,C1
-regulatory,regulatory,监管的,ADJ,B2
-rehabilitation,rehabilitation,康复,NOUN,B2
-rehabilitative,rehabilitative,词,ADJ,B2
-rehearsal,rehearsal,排练,NOUN,B2
-reification,reification,词,NOUN,C1
-reign,reign,统治,NOUN,B2
-rein,rein,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
-reinforced,reinforced,词,ADJ,C1
-reining,reining,勒马,NOUN,B2
-reino,realm,领域,NOUN,B2
-reins,reins,词,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
-reintroducción,retype,再型,NOUN,B2
-reissue (noun),reissue,词,NOUN,C1
+regulación,regulation,规章,NOUN,B2
+reembolsar,to reimburse,偿还,VERB,B2
+reforzar,to reinforce,加强,VERB,B2
+refuerzo,reinforcement,增援,NOUN,B2
+reeditar,to reissue,补办,VERB,B2
 reiterar,to reiterate,重申,VERB,B2
-relacionado,related,相关的,ADJ,B2
-relajación,relaxation,缓和,NOUN,B2
-relajado,relaxed,放松的,ADJ,B2
-relapse (verb),relapse,词,VERB,B2
-relatar,to recount,转述,VERB,B2
+rechazo,rejection,拒绝,NOUN,B2
+regocijarse,to rejoice,欢欣,VERB,B2
+recaída,relapse,再犯,NOUN,B2
 relatar,to relate to narrate,叙述,VERB,B2
-relating to birth,relating to birth,词,ADJ,C1
-relation,relation,词,NOUN,B1
-relational,relational,词,ADJ,B2
+relacionado,related,相关的,ADJ,B2
+relativo,relative,相对的,ADJ,B2
 relativamente,relatively,相对地,ADV,B2
 relativamente hablando,relatively speaking,相对而言,ADV,B2
 relativismo,relativism,相对主义,NOUN,B2
-relativist,relativist,词,ADJ,C1
-relativity,relativity,词,NOUN,C1
-relativo,relative,相对的,ADJ,B2
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
-relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-released,released,获释的,ADJ,B2
-relentless,relentless,无情的,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+relajación,relaxation,缓和,NOUN,B2
+relajado,relaxed,放松的,ADJ,B2
+liberación,release,释放,NOUN,B2
 relevancia,relevance,相关性,NOUN,B2
-relieved,relieved,宽慰的,ADJ,B2
-religiosity,religiosity,笃信宗教,NOUN,B2
-religious,religious,宗教的,ADJ,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiously,religiously,词,ADV,C1
-religiousness,religiousness,虔诚,NOUN,B2
-relinchar,to neigh,嘶鸣,VERB,B2
-relinquish,relinquish,词,VERB,C1
-reliquia cultural,cultural relic,文物,NOUN,B2
-relocation,relocation,搬家,NOUN,B2
-reloj,watch,手表,NOUN,B2
-reluctance,reluctance,不情愿,NOUN,B2
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
-remains spoils,remains spoils,遗体，战利品,NOUN,B2
-remand,remand,词,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
-remar,to row,划船,VERB,B2
-remark (verb),remark,词,VERB,B2
-remarkable,remarkable,非凡的,ADJ,B2
-remarkably,remarkably,显著地,ADV,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
+confianza,reliance,信赖,NOUN,B2
+reubicar,to relocate,调动,VERB,B2
+a regañadientes,reluctantly,不情愿地,ADV,B2
+confiar,to rely,依赖,VERB,B2
+confiar en,to rely on,依靠,VERB,B2
+resto,remainder,剩余部分,NOUN,B2
+restos,remains,残骸,NOUN,B2
+comentario,remark,评论,NOUN,B2
 remediar,to remedy,补救,VERB,B2
-remediation,remediation,词,NOUN,B2
-remendar,to mend,修补,VERB,B2
-reminder,reminder,提醒物,NOUN,B2
-reminisce,reminisce,词,VERB,C1
-reminiscent,reminiscent,词,ADJ,C1
-remiss,remiss,词,ADJ,C1
-remission,remission,词,NOUN,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remnant,remnant,词,NOUN,C1
-remo,oar,桨,NOUN,B2
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remote work,remote work,远程办公,NOUN,B2
+recuerdo,remembrance,纪念,NOUN,B2
+recordar,to remind,提醒,VERB,B2
 remoto,remote,遥远的,ADJ,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-removal deletion,removal deletion,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,移除的,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
+coche a control remoto,remote-controlled car,遥控车,NOUN,B2
+eliminación,removal,移除,NOUN,B2
 renacimiento,renaissance,复兴,NOUN,B2
 renal,renal,肾脏的,ADJ,B2
-renascent,renascent,词,ADJ,C1
-rencor,grudge,怨恨,NOUN,B2
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
-rendición,surrender,投降,NOUN,B2
-rendirse,to give up,放弃,VERB,B2
-rendition,rendition,词,NOUN,C1
-renegade,renegade,词,NOUN,C1
-renegar,to disavow,否认,VERB,B2
+cita,rendezvous,约会,NOUN,B2
 renegar,to renege,食言,VERB,B2
-renewable energy,renewable energy,可再生能源,NOUN,C1
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
-renminbi,renminbi,人民币,NOUN,B2
-renombre,renown,声誉,NOUN,B2
-renounce,renounce,词,VERB,C1
+renovar,to renew,更新,VERB,B2
 renovable,renewable,可再生的,ADJ,B2
 renovación,renewal,更新,NOUN,B2
+renminbi,renminbi,人民币,NOUN,B2
 renovación,renovation,翻新,NOUN,B2
-renovar,to renew,更新,VERB,B2
-renowned,renowned,著名的,ADJ,B2
-rent a car,rent a car,租车,VERB,C1
-rentable,profit-making,营利性,ADJ,B2
-rental,rental,词,ADJ,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
-reopening,reopening,词,NOUN,C1
+renombre,renown,声誉,NOUN,B2
 reoperación,reoperation,再术,NOUN,B2
-reordering,reordering,改序,NOUN,B2
 reorganización,reorganization,重组,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-repagar,to repay,偿还,VERB,B2
-reparable,reparable,词,ADJ,C1
 reparación,repair,修理,NOUN,B2
 reparación,reparation,赔偿,NOUN,B2
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repatriation,repatriation,词,NOUN,C1
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repelling,repelling,词,VERB,C1
-repentinamente,suddenly,突然地,ADV,B2
-repertoire,repertoire,全部曲目,NOUN,B2
-repetición,again,再次,ADV,B2
-repetición,repetition,重复,NOUN,B2
-repetidamente,repeatedly,反复地,ADV,B2
+repagar,to repay,偿还,VERB,B2
+reembolso,repayment,偿还,NOUN,B2
 repetido,repeated,反复的,ADJ,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
+repetidamente,repeatedly,反复地,ADV,B2
+arrepentirse,to repent,悔改,VERB,B2
+arrepentimiento,repentance,悔恨,NOUN,B2
+repetición,repetition,重复,NOUN,B2
+reemplazar,to replace,替换,VERB,B2
+reemplazo,replacement,替代品,NOUN,B2
 replanificación,replanning,再策,NOUN,B2
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
-reply,reply,回复,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report card,report card,成绩单,NOUN,B2
-report completion,report completion,交差,VERB,C1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
+responder,to reply,回复,VERB,B2
+respuesta a vuestra alteza,reply to your-highness,回殿下,NOUN,B2
+informar,to report,报告,VERB,B2
 reportero,reporter,记者,NOUN,B2
-reporting,reporting,报道,NOUN,B2
 reposicionamiento,repositioning,重新定位,NOUN,B2
-reprecio,reprice,再价,NOUN,B2
 representación,representation,代表,NOUN,B2
-representar,to depict,描绘,VERB,B2
-representational,representational,词,ADJ,C1
-representatividad,representativeness,代表性,NOUN,B2
 representativo,representative,有代表性的,ADJ,B2
-represivo,repressive,压制的,ADJ,B2
-represión,repression,镇压,NOUN,B2
-repressed,repressed,词,ADJ,C1
-reprieve,reprieve,暂缓执行,NOUN,B2
-reprimenda,reprimand,训斥,NOUN,B2
+representatividad,representativeness,代表性,NOUN,B2
 reprimir,to repress,镇压,VERB,B2
-reprint,reprint,词,NOUN,C1
-reprisal,reprisal,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
-reproachable,reproachable,应受责备的,ADJ,B2
-reprobate,reprobate,词,NOUN,C1
-reproche,rebuke,责备,NOUN,B2
+represión,repression,镇压,NOUN,B2
+represivo,repressive,压制的,ADJ,B2
+reprecio,reprice,再价,NOUN,B2
+reprimenda,reprimand,训斥,NOUN,B2
 reproche,reproach,责备,NOUN,B2
 reproducción,reproduction,繁殖,NOUN,B2
-reproducibility,reproducibility,可重复性,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
-reprogramming,reprogramming,改程,NOUN,B2
-reptiles,reptiles,词,NOUN,B2
-republicanism,republicanism,词,NOUN,C1
-republicano,republican,共和的,ADJ,B2
-repudiate,repudiate,词,VERB,C1
-repugnant,repugnant,词,ADJ,C1
-repulsivo,repulsive,令人反感的,ADJ,B2
-repulso,repulse,击退,NOUN,B2
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
 república,republic,共和国,NOUN,B2
-requerido,required,必需的,ADJ,B2
+republicano,republican,共和的,ADJ,B2
+repulso,repulse,击退,NOUN,B2
+repulsivo,repulsive,令人反感的,ADJ,B2
+solicitud,request,请求,NOUN,B2
 requerir,to require,需要,VERB,B2
-request to rest,request to rest,请息,NOUN,C1
-required course,required course,必修课,NOUN,C1
-requirement,requirement,要求,NOUN,B2
-requirements,requirements,词,NOUN,C1
-requisite,requisite,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,重播,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
-rescind,rescind,词,VERB,C1
+requerido,required,必需的,ADJ,B2
+reventa,resale,转售,NOUN,B2
 rescue a-fang,rescue a-fang,救阿方,NOUN,B2
 research,research,研究,NOUN,B2
 research,to research,研究,VERB,B2
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
 researcher,researcher,研究员,NOUN,B2
-resection,resection,切除术,NOUN,B2
 resemblance,resemblance,相似,NOUN,B2
 resemble,to resemble,像,VERB,B2
-resent,resent,词,VERB,C1
 resentful,resentful,充满愤恨的,ADJ,B2
-reserva natural,nature reserve,自然保护区,NOUN,B2
-reservar,to book,预订,VERB,B2
 reserve,reserve,预备,NOUN,B2
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
 reserved,reserved,保留的,ADJ,B2
-reserves,reserves,储备,NOUN,B2
 reservoir,reservoir,水库,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
 reshaping,reshaping,改形,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
 reside,to reside,居住,VERB,B2
 residence,residence,住所,NOUN,B2
-residence housing,residence housing,词,NOUN,A2
 resident,resident,居民,NOUN,B2
-resident (adj),resident,定居的,ADJ,B2
-residential,residential,词,ADJ,B2
-residual,residual,残留的,ADJ,B2
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
-resigned submission,resigned submission,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resin,resin,词,NOUN,C1
-resistance movement,resistance movement,抵抗运动,NOUN,B2
-resistant,resistant,词,ADJ,C1
-resistor,resistor,词,NOUN,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
 resolute,resolute,坚决的,ADJ,B2
 resolution,resolution,决心,NOUN,B2
 resolve,to resolve,解决,VERB,B2
-resolve doubts,resolve doubts,解惑,VERB,B2
-resolver,to work out,成功,VERB,B2
 resonance,resonance,共鸣,NOUN,B2
-resonancia magnética,mri,核磁共振,NOUN,B2
-resonant,resonant,共鸣的,ADJ,B2
 resort,resort,度假胜地,NOUN,B2
 resource,resource,资源,NOUN,B2
-resource shortage,resource shortage,资源短缺,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respaldo,backup,备份,NOUN,B2
-respectful,respectful,恭敬的,ADJ,B2
 respectful deferential,respectful deferential,恭敬,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respective,respective,各自的,ADJ,B2
-respectively,respectively,词,ADV,C1
-respecto a,regarding,关于,ADP,B2
-respiration,respiration,呼吸作用,NOUN,B2
 respiratory,respiratory,呼吸的,ADJ,B2
-respite,respite,喘息,NOUN,B2
-resplandor,glow,光芒,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
 respond,to respond,回应,VERB,B2
 respond to,to respond to,回应,VERB,B2
-respondent,respondent,被上诉人,NOUN,B2
-responder,to answer reply,回答,VERB,B2
-responder,to reply,回复,VERB,B2
-responsabilidad,accountability,问责制,NOUN,B2
-responsabilidad,liability,责任,NOUN,B2
 response,response,回应,NOUN,B2
 responsiveness,responsiveness,反应性,NOUN,B2
-respuesta a vuestra alteza,reply to your-highness,回殿下,NOUN,B2
-rest assured,rest assured,放心的,ADJ,B2
-rest stop,rest stop,词,NOUN,B1
-restate,restate,词,VERB,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-resto,remainder,剩余部分,NOUN,B2
-restock,restock,补货,VERB,C1
 restoration,restoration,恢复,NOUN,B2
 restore,to restore,恢复,VERB,B2
-restos,remains,残骸,NOUN,B2
-restrain,restrain,词,VERB,C1
 restraint,restraint,隐忍,NOUN,B2
-restricción de matrícula,license plate restriction,限号,NOUN,B2
-restricción mutua,mutual restriction,相克,NOUN,B2
 restructuring,restructuring,重组,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
 resume,resume,简历,NOUN,B2
 resume,to resume,重新开始,VERB,B2
-resume (noun),resume,履历,NOUN,B2
-resumption,resumption,恢复,NOUN,B2
-resurgent,resurgent,词,ADJ,C1
 resurrection,resurrection,复活,NOUN,B2
-resuscitate,resuscitate,词,VERB,C1
-resuscitation,resuscitation,复苏,NOUN,B2
-retaguardia,rear,后部,NOUN,B2
 retail,retail,零售,NOUN,B2
-retailer,retailer,零售商,NOUN,B2
 retain,to retain,保留,VERB,B2
-retaliate,retaliate,词,VERB,C1
-retaliation,retaliation,词,NOUN,C1
-retarded,retarded,词,ADJ,C1
-retener,to withhold,扣留,VERB,B2
-retention,retention,我留,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-retina,retina,词,NOUN,B2
+recontar,to retell,转述,VERB,B2
+jubilado,retired,退休的,ADJ,B2
 retirarse,retreat,撤退,NOUN,B2
 retirarse,to retreat,撤退,VERB,B2
-retiree,retiree,退休人员,NOUN,B2
-retirement pension,retirement pension,退休金,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retranslation,retranslation,重译,NOUN,B2
-retratar,to portray,描绘,VERB,B2
-retrato,portrait,肖像,NOUN,B2
-retrato artístico,artistic portrait,艺术照,NOUN,B2
-retrial,retrial,再审,NOUN,B2
-retribución vitalicia,life retribution,偿命,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retroactive,retroactive,词,ADJ,C1
-retroalimentación,feedback,反馈,NOUN,B2
-retroceder,to fall back,回落,VERB,B2
-retroceder,to regress,倒退,VERB,B2
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-retrospective (noun),retrospective,词,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-retórica,rhetoric,修辞,NOUN,B2
-retórico,rhetorical,修辞的,ADJ,B2
-reubicar,to relocate,调动,VERB,B2
-reunification,reunification,重新统一,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunirse,to meet,遇见,VERB,B2
-reunite,reunite,团圆,VERB,B2
-reunión,gathering,聚集,NOUN,B2
+recuperación,retrieval,检索,NOUN,B2
+recuperar,to retrieve,取回,VERB,B2
+recuperación de Qingming,retrieve qingming,拿回青冥,NOUN,B2
+regresar primero,to return first,先回,VERB,B2
+reintroducción,retype,再型,NOUN,B2
 reunión,reunion,重聚,NOUN,B2
-reunión de negocios,business meeting,洽谈会,NOUN,B2
-reunión secreta,secret meeting,密会,NOUN,B2
 reutilización,reuse,重用,NOUN,B2
 revalorización,revaluation,重新评估,NOUN,B2
-revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
-revel,revel,词,VERB,C1
-revelación,outing,郊游,NOUN,B2
 revelar,to reveal,揭示,VERB,B2
-reventa,resale,转售,NOUN,B2
-reventar,to burst,爆发,VERB,B2
-revenue,revenue,收入,NOUN,C1
-revenues,revenues,词,NOUN,C1
-reverberation,reverberation,词,NOUN,C1
-reverentially,reverentially,词,ADV,C1
-reverie,reverie,词,NOUN,C1
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
 reversión,reversal,突变,NOUN,B2
+inclusión inversa,reverse inclusion,反纳,NOUN,B2
+reflexión inversa,reverse reflection,反影,NOUN,B2
 reversión,reversion,重归,NOUN,B2
-revile,revile,词,VERB,C1
-revisar,to revise,修订,VERB,B2
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
 revisión,review,回顾,NOUN,B2
+revisar,to revise,修订,VERB,B2
 revisión,revision,复习,NOUN,B2
-revista trimestral,quarterly magazine,季刊,NOUN,B2
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revival,revival,复兴,NOUN,B2
-revivalism,revivalism,词,NOUN,C1
 revivir,to revive,复兴,VERB,B2
 revocar,to revoke,撤销,VERB,B2
-revocation,revocation,词,NOUN,C1
-revolt,revolt,叛乱,NOUN,B2
-revolucionario,revolutionary,革命的,ADJ,B2
 revolución,revolution,革命,NOUN,B2
-revolver,revolver,词,NOUN,C1
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald,ribald,词,ADJ,C1
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribbon,ribbon,丝带,NOUN,B2
-ribera,riverbank,河岸,NOUN,B2
-ribs,ribs,肋骨,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-richer,richer,更富的,ADJ,B2
-rico en recursos naturales,richly endowed by nature,得天独厚,ADJ,B2
-ricochet,ricochet,词,NOUN,C1
-ride lift,ride lift,搭车,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridicule (noun),ridicule,词,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
-riesgo de muerte,risking death,冒死,NOUN,B2
-rife,rife,词,ADJ,C1
-riffraff,riffraff,词,NOUN,C1
-right,right,右边,ADV,B2
-right (adj),right,正确的,ADJ,A1
-right (intj),right,词,INTJ,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rightly,rightly,正确地,ADV,B2
-rights and interests,rights and interests,权益,NOUN,B2
-rigid,rigid,僵硬的,ADJ,B2
-rigidez,rigidity,僵硬,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
-riguroso,rigorous,严格的,ADJ,B2
-rile,rile,词,VERB,C1
-rim,rim,词,NOUN,C1
+revolucionario,revolutionary,革命的,ADJ,B2
+recompensar,to reward,奖励,VERB,B2
+retórica,rhetoric,修辞,NOUN,B2
+retórico,rhetorical,修辞的,ADJ,B2
+pregunta retórica,rhetorical question,宁非,NOUN,B2
 rima,rhyme,韵脚,NOUN,B2
-rings,rings,词,NOUN,B2
-ringtone,ringtone,词,NOUN,C1
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
-risks,risks,词,NOUN,C1
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
-ritmo,pace,速度,NOUN,B2
+arroz,rice,米饭,NOUN,B2
+rico en recursos naturales,richly endowed by nature,得天独厚,ADJ,B2
+montada,ride,行程,NOUN,B2
+descanso de montada,ride break,骑破,NOUN,B2
+jinete,rider,骑手,NOUN,B2
+grieta,rift,裂痕,NOUN,B2
+derecho,right,正确的,ADJ,B2
+justo,righteous,正直的,ADJ,B2
+indignación justa,righteous indignation,义愤,NOUN,B2
+rectitud,righteousness,亦正,NOUN,B2
+derechos,rights,权利,NOUN,B2
+rigidez,rigidity,僵硬,NOUN,B2
+riguroso,rigorous,严格的,ADJ,B2
+sonar,to ring,鸣响,VERB,B2
+vía de circunvalación,ring road,绕城,NOUN,B2
+sonido,ringing,铃声,NOUN,B2
+tumulto,riot,骚乱,NOUN,B2
+maduro,ripe,成熟的,ADJ,B2
+subir,to rise,上升,VERB,B2
+arriesgar,to risk life,拼命,VERB,B2
+riesgo de muerte,risking death,冒死,NOUN,B2
 ritual,ritual,仪式,NOUN,B2
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
 rivalidad,rivalry,竞争,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-riverside,riverside,河边,NOUN,C1
-riñón,kidney,肾脏,NOUN,B2
-road (adj),road,词,ADJ,B2
-roadblock,roadblock,,NOUN,B2
-roadway,roadway,路面,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
-robe,robe,词,NOUN,B2
+ribera,riverbank,河岸,NOUN,B2
+señal de tráfico,road sign,路标,NOUN,B2
+vagar,to roam,漫游,VERB,B2
+asado,roast,烤肉,NOUN,B2
+asar,to roast lamb,烤羊,VERB,B2
+ladrón,robber,强盗,NOUN,B2
 robo,robbery,抢劫案,NOUN,B2
 robot,robot,机器人,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotics,robotics,词,NOUN,C1
-robotization,robotization,词,NOUN,C1
-robustness,robustness,词,NOUN,C1
 robusto,robust,强健的,ADJ,B2
 rocall,rockery,假山,NOUN,B2
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rock slab,rock slab,岩板,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rocío,dew,露水,NOUN,B2
-rod,rod,词,NOUN,B1
+cohete,rocket,火箭,NOUN,B2
+papel,role,角色,NOUN,B2
+modelo a seguir,role model,榜样,NOUN,B2
 rodar,to roll,滚动,VERB,B2
-rodent,rodent,啮齿动物,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
-rogue,rogue,词,NOUN,B2
-rolled,rolled,词,ADJ,C1
-roller skate,roller skate,词,NOUN,B1
-rolling,rolling,词,NOUN,C1
-roman,roman,罗马的,ADJ,B2
-romance,romance,浪漫,NOUN,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
+persiana,roller blind,卷帘,NOUN,B2
 romano,roman,罗马人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-romper,to break up,破裂,VERB,B2
-romper,to shatter,粉碎,VERB,B2
+romance,romance,浪漫,NOUN,B2
 romántico,romantic,浪漫的,ADJ,B2
-roncar,to snore,打鼾,VERB,B2
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-ropa interior,underwear,内衣,NOUN,B2
+techar,to roof,房顶,VERB,B2
+compañero de piso,roommate,室友,NOUN,B2
+cuerda,rope,绳子,NOUN,B2
 rosa,rose,玫瑰,NOUN,B2
-rosado,pink,粉色的,ADJ,B2
-rose bush,rose bush,词,NOUN,B1
-roster,roster,词,NOUN,C1
-rot decomposition,rot decomposition,词,NOUN,C1
-rotación de turnos,shift rotation,倒班,NOUN,B2
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
+podrido,rotten,腐烂的,ADJ,B2
+aproximadamente,roughly,大约,ADV,B2
+redondo,round,圆的,ADJ,B2
 rotonda,roundabout,环岛,NOUN,B2
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
-rotura,rupture,破裂,NOUN,B2
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
-rout,rout,溃败,NOUN,B2
-rove,rove,词,VERB,C1
-row series,row series,词,NOUN,B1
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal court,royal court,词,NOUN,C1
-royalty,royalty,王室,NOUN,B2
-rubbish,rubbish,垃圾,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubicund,rubicund,词,ADJ,C1
-ruby,ruby,词,NOUN,C1
-rudely,rudely,词,ADV,C1
-rudimentary,rudimentary,词,ADJ,C1
-rueful,rueful,词,ADJ,C1
-rug,rug,地毯,NOUN,B2
-rugby,rugby,橄榄球,NOUN,C1
-ruin relic,ruin relic,词,NOUN,B2
-ruina familiar,family ruin,家破,NOUN,B2
-ruinas,ruins,废墟,NOUN,B2
-ruined,ruined,词,ADJ,B2
-rulebook,rulebook,规则体系,NOUN,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-rumination,rumination,词,NOUN,C1
-ruminative,ruminative,词,ADJ,C1
-rumors,rumors,词,NOUN,B2
-run away fled,run away fled,词,VERB,A1
-run over,run over,被碾过的,ADJ,B2
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,,NOUN,B2
-rung,rung,词,NOUN,C1
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
-runway,runway,词,NOUN,C1
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-ruse,ruse,词,NOUN,C1
-rush (noun),rush,赶往,NOUN,B2
-rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
-ruso,russian,俄罗斯的,ADJ,B2
-russian,russian,俄罗斯人,NOUN,B2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
-rustic,rustic,乡村的,ADJ,B2
+enrutador,router,路由器,NOUN,B2
 rutina,routine,常规,NOUN,B2
-rábano,radish,小萝卜,NOUN,B2
-rápidamente,quickly,迅速地,ADV,B2
-rápido,fast quick,快的,ADJ,B2
-rápido,quick,快的,ADJ,B2
-rápido,rapid,迅速的,ADJ,B2
-récord personal,personal record,个人纪录,NOUN,B2
-rígido,stiff,僵硬的,ADJ,B2
-sabbath,sabbath,安息日,NOUN,B2
-sabbatical,sabbatical,词,NOUN,C1
-saber,saber,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-saccharine,saccharine,词,ADJ,C1
+remar,to row,划船,VERB,B2
+real,royal,皇家的,ADJ,B2
+ruinas,ruins,废墟,NOUN,B2
+estado de derecho,rule of law,法治,NOUN,B2
+carrera,run,跑步,NOUN,B2
+toparse con,to run into,碰见,VERB,B2
+correr,to run quickly,奔驰,VERB,B2
+trotar,to run to jog,跑步,VERB,B2
+corredor,runner,跑步者,NOUN,B2
+carrera,running,进行中的,NOUN,B2
+mocos,runny nose,流鼻涕,NOUN,B2
+rotura,rupture,破裂,NOUN,B2
+apresurarse,rush,赶往,NOUN,B2
+apresurarse,to rush,冲,VERB,B2
+ir y venir,to rush about,奔波,VERB,B2
+ruso,russian,俄罗斯的,ADJ,B2
+óxido,rust,铁锈,NOUN,B2
+inoxidable,rust-proof,防锈,ADJ,B2
+despiadado,ruthlessness,无情,NOUN,B2
 sacrificar,to sacrifice,牺牲,VERB,B2
-sacrifice,sacrifice,牺牲,NOUN,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadistic,sadistic,施虐的,ADJ,B2
-sadly,sadly,词,ADV,B2
-safe container,safe container,词,NOUN,C1
-safe haven,safe haven,避风港,NOUN,B2
-safe secure,safe secure,安全的/可靠的,ADJ,B2
-safely,safely,安然,ADV,C1
-safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-sagacity,sagacity,词,NOUN,B2
-sagaz,sagacious,睿智的,ADJ,B2
-sage,sage,词,NOUN,C1
-sagittarius,sagittarius,射手座,NOUN,B2
-sail,sail,帆,NOUN,B2
-sailboat,sailboat,,NOUN,B2
-sailor,sailor,水手,NOUN,B2
-sailors,sailors,词,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-sake,sake,缘故,NOUN,B2
-sala,hall,大厅,NOUN,B2
-sala,ward,病房,NOUN,B2
-sala de conmutación,switch room,配电室,NOUN,B2
-sala de control,control room,控制室,NOUN,B2
-sala de espera,waiting room,候诊室,NOUN,B2
-sala de monitoreo,monitoring room,监控室,NOUN,B2
-salacious,salacious,词,ADJ,C1
-salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
-salado,salty,咸的,ADJ,B2
-salario,wage,工资,NOUN,B2
-salarios,wages,工资,NOUN,B2
-salesman,salesman,词,NOUN,B2
-salida,departure,离开,NOUN,B2
-salida,outlet,出口,NOUN,B2
-salida de reclusión,seclusion exit,出关,NOUN,B2
-salient,salient,词,ADJ,C1
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-salir,to come out,出来,VERB,B2
-salir,to get off work,下班,VERB,B2
-salir,to go out,出去,VERB,B2
-saliva,saliva,词,NOUN,B2
-salmon,salmon,三文鱼,NOUN,B2
-salon,salon,沙龙,NOUN,B2
-salsa,sauce,酱汁,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salt shaker,salt shaker,,NOUN,B2
-salted,salted,词,ADJ,B2
-salubrious,salubrious,词,ADJ,C1
-salud,cheers,干杯,INTJ,B2
-salutary,salutary,词,ADJ,C1
-salvación,salvation,拯救,NOUN,B2
-salvador,savior,救星,NOUN,B2
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-salón de eventos,affair hall,事殿,NOUN,B2
-sama,sama,词,NOUN,B2
-same (adv),same,一律,ADV,B2
-same (det),same,词,DET,A1
-same (noun),same,同,NOUN,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
-sanctity,sanctity,词,NOUN,C1
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
-sandalia,sandal,凉鞋,NOUN,B2
-sands,sands,词,NOUN,B2
-sandía,watermelon,西瓜,NOUN,B2
-sangre fría,cold blood,冷血,NOUN,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
-santidad,holiness,神圣,NOUN,B2
-santuario,shrine,مشعر,NOUN,B2
-santur,santur,词,NOUN,C1
-sap,sap,词,NOUN,C1
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sardonic,sardonic,词,ADJ,C1
-sargento,sergeant,中士,NOUN,B2
-sarpullido,rash,轻率的,ADJ,B2
-sartén,frying pan,平底锅,NOUN,B2
-sartén,pan,平底锅,NOUN,B2
-sat,sat,词,NOUN,B1
-satchel,satchel,词,NOUN,C1
-satisfacción,contentment,满足,NOUN,B2
-satisfacer,to satisfy,使满意,VERB,B2
-satisfactorio,satisfactory,令人满意的,ADJ,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-satélite,satellite,卫星,NOUN,B2
-satírico,satirical,讽刺的,ADJ,B2
-saucepan,saucepan,平底锅,NOUN,B2
-saucy,saucy,下流的,ADJ,B2
-sauna,sauna,桑拿,NOUN,B2
-saunter,saunter,词,VERB,C1
-savage,savage,savage,NOUN,B2
-savant,savant,词,NOUN,C1
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
-saving the root,saving the root,救本,NOUN,C1
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-sawdust,sawdust,词,NOUN,C1
-say he,say he,说他,NOUN,C1
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,秤,NOUN,B2
-scammer,scammer,词,NOUN,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
-scarf shawl,scarf shawl,词,NOUN,A1
-scathing,scathing,词,ADJ,C1
-scattering,scattering,词,NOUN,B2
-scene stage,scene stage,场景/舞台,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
-sceptical,sceptical,词,ADJ,C1
-scheduling,scheduling,调度；排序,NOUN,B2
-schema,schema,词,NOUN,B2
-scholar learned,scholar learned,词,NOUN,C1
-scholing,scholing,受过训练,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school bag,school bag,词,NOUN,A2
-school bench,school bench,词,NOUN,A1
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-school year,school year,学年,NOUN,B2
-schoolbag,schoolbag,词,NOUN,A1
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schoolyard,schoolyard,词,NOUN,A1
-scientifically,scientifically,科学地,ADV,B2
-scientists,scientists,科学家,NOUN,B2
-scintillate,scintillate,词,VERB,C1
-scoff (noun),scoff,词,NOUN,C1
-scoff (verb),scoff,词,VERB,C1
-scoop,scoop,词,NOUN,B2
-scooter,scooter,踏板摩托车,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scorpion,scorpion,词,NOUN,A1
-scottish,scottish,苏格兰的,ADJ,B2
-scour,scour,词,VERB,C1
-scouting locating,scouting locating,定位 / 侦察,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-scratch,scratch,抓痕,NOUN,B2
-scream (noun),scream,尖叫,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
-screenwriter,screenwriter,编剧,NOUN,B2
-screw (noun),screw,词,NOUN,C1
-screw up,screw up,词,VERB,C1
-scribal misreading,scribal misreading,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulous,scrupulous,一丝不苟的,ADJ,B2
-scrupulousness,scrupulousness,词,NOUN,C1
-scrutiny,scrutiny,明察,NOUN,B2
-scumbag,scumbag,词,NOUN,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scuttle,scuttle,词,VERB,C1
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seam,seam,词,NOUN,C1
-seamless,seamless,无缝的,ADJ,B2
-seaport,seaport,海港,NOUN,C1
-search engine,search engine,搜索引擎,NOUN,B2
-search engine optimization,search engine optimization,词,NOUN,C1
-search warrant,search warrant,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seated,seated,坐着的,ADJ,B2
-seats,seats,词,NOUN,C1
-seaweed,seaweed,词,NOUN,C1
-sección,section,部分,NOUN,B2
-secession,secession,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-second,second,秒,NOUN,B2
-second (adj),second,秒,ADJ,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
-secondment,secondment,词,NOUN,C1
-secret (adj),secret,秘密的,ADJ,B2
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
-secretario,secretary,秘书,NOUN,B2
-secretaría,secretariat,秘书处,NOUN,B2
-secreto,secret,秘密的,ADJ,B2
-secreto,secretly,秘密地,ADV,B2
-secreto,secrecy,保密,NOUN,B2
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-secta,sect,教派,NOUN,B2
-sectarianism,sectarianism,词,NOUN,C1
-sectario,sectarian,宗派的,ADJ,B2
-section chief,section chief,课长,NOUN,B2
-sector,sector,部门,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secuela,aftereffect,后遗症，后果,NOUN,B2
-secuencia,sequence,顺序，片段,NOUN,B2
-secular,secular,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
-secularization,secularization,世俗化,NOUN,C1
-secundario,secondary,次要的,ADJ,B2
-secure (adj),secure,词,ADJ,B1
-securitization,securitization,证券化,NOUN,B2
-security matter,security matter,词,NOUN,C1
-security service,security service,词,NOUN,C1
-security-related,security-related,安全的，安保的,ADJ,B2
-securocratic,securocratic,词,ADJ,C1
-sedate,sedate,词,ADJ,C1
-sedative,sedative,词,NOUN,C1
-sede,venue,场地,NOUN,B2
-sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
-sediento,thirsty,口渴的,ADJ,B2
-sediment,sediment,词,NOUN,C1
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-sedition,sedition,煽动叛乱,NOUN,B2
-seditious,seditious,词,ADJ,C1
-sedulous,sedulous,词,ADJ,C1
-sedán,sedan,轿车,NOUN,B2
-see off (verb),see off,送别,VERB,C1
-see you,see you,词,VERB,A2
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seedy,seedy,词,ADJ,C1
-seeker,seeker,寻求者,NOUN,B2
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking intercession,seeking intercession,词,NOUN,C1
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seen,seen,被看见,ADJ,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-segregation,segregation,隔离，分离,NOUN,B2
-segunda vez,second time,再而,NOUN,B2
-segundo,second,第二,ADJ,B2
-segundo,secondly,其次,ADV,B2
+apenado,sad sorrowful,悲伤,ADJ,B2
+caja fuerte,safe,保险箱,NOUN,B2
 seguridad,safety,安全,NOUN,B2
-seguro,sure,确定的,ADJ,B2
-seguro de automóvil,car insurance,车险,NOUN,B2
-seguro de sí mismo,self-confident,自信的,ADJ,B2
-seguro mutuo,mutual insurance,互助保险,NOUN,B2
-según,according to,根据,ADP,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
-seldom,seldom,很少,ADV,B2
-selección,selection,选择,NOUN,B2
-select seeds,select seeds,选种,VERB,C1
-selected,selected,选中的,ADJ,B2
-selectively,selectively,有选择地,ADV,B2
-selectivo,selective,选择的，挑选的,ADJ,B2
-selector,selector,词,NOUN,C1
-self,self,自己,ADV,B2
-self-abasement,self-abasement,词,NOUN,C1
-self-care,self-care,自我护理,NOUN,B2
-self-concern,self-concern,自顾,NOUN,B2
-self-deception,self-deception,词,NOUN,C1
-self-defense,self-defense,自卫,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-employed person,self-employed person,个体经营者,NOUN,B2
-self-esteem,self-esteem,自尊,NOUN,B2
-self-evident,self-evident,,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-image,self-image,自我形象,NOUN,B2
-self-interest,self-interest,私利,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-worth,self-worth,自我价值,NOUN,B2
-selfie,selfie,自拍,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfless devotion,selfless devotion,词,NOUN,C1
+informe de seguridad,safety report,安全报告,NOUN,B2
+sagaz,sagacious,睿智的,ADJ,B2
+navegar,to sail,航行,VERB,B2
+navegación,sailing,航行,NOUN,B2
+sake,sake,缘故,NOUN,B2
+venta,sale,出售,NOUN,B2
+ventas,sales,打折,NOUN,B2
+vendedor,salesperson,销售人员,NOUN,B2
+salado,salty,咸的,ADJ,B2
+salvación,salvation,拯救,NOUN,B2
+sandalia,sandal,凉鞋,NOUN,B2
+tormenta de arena,sandstorm,沙尘暴,NOUN,B2
+San Nicolás,santa claus,圣诞老人,NOUN,B2
+satélite,satellite,卫星,NOUN,B2
+sátira,satire,讽刺,NOUN,B2
+satírico,satirical,讽刺的,ADJ,B2
+satisfactorio,satisfactory,令人满意的,ADJ,B2
+satisfacer,to satisfy,使满意,VERB,B2
+salsa,sauce,酱汁,NOUN,B2
+ahorro,savings,存款,NOUN,B2
+salvador,savior,救星,NOUN,B2
+sierra,saw,锯子,NOUN,B2
+despedirse,to say goodbye,告别,VERB,B2
+dicho,saying,格言,NOUN,B2
+escaneo,scan,扫描件,NOUN,B2
+asustado,scared,害怕的,ADJ,B2
+bufanda,scarf,围巾,NOUN,B2
+espantoso,scary,可怕的,ADJ,B2
+paisaje,scenery,风景,NOUN,B2
+erudito,scholar,学者,NOUN,B2
+beca,scholarship,奖学金,NOUN,B2
+escolástico,scholastic,经院哲学的,ADJ,B2
+científico,scientific,科学的,ADJ,B2
+tijeras,scissors,剪刀,NOUN,B2
+regañar,to scold,训斥,VERB,B2
+puntuación,score,比分,NOUN,B2
+explorador,scout,侦察员,NOUN,B2
+gritar,scream,尖叫,NOUN,B2
+gritar,to scream,尖叫,VERB,B2
+proyectar,to screen,筛选,VERB,B2
+guión,screenplay,剧本,NOUN,B2
+destornillador,screwdriver,螺丝刀,NOUN,B2
+guión teatral,script for play,剧本,NOUN,B2
+buceo,scuba diving,潜水,NOUN,B2
 sellar,to seal,密封,VERB,B2
-sellou,sellou,塞卢能量膏,NOUN,B2
-selva,jungle,丛林,NOUN,B2
-selva tropical,rainforest,雨林,NOUN,B2
-semantic,semantic,词,ADJ,C1
-semantics,semantics,语义学,NOUN,B2
-semblance,semblance,词,NOUN,C1
-sembrar,to sow,播种,VERB,B2
+buscar,to search,搜索,VERB,B2
+buscar,to search for,寻找,VERB,B2
+estacional,seasonal,季节性的,ADJ,B2
+separarse,to secede,脱离,VERB,B2
+salida de reclusión,seclusion exit,出关,NOUN,B2
+segundo,second,第二,ADJ,B2
+segunda vez,second time,再而,NOUN,B2
+secundario,secondary,次要的,ADJ,B2
+segundo,secondly,其次,ADV,B2
+secreto,secrecy,保密,NOUN,B2
+secreto,secret,秘密的,ADJ,B2
+reunión secreta,secret meeting,密会,NOUN,B2
+secretaría,secretariat,秘书处,NOUN,B2
+secretario,secretary,秘书,NOUN,B2
+secreto,secretly,秘密地,ADV,B2
+secta,sect,教派,NOUN,B2
+sectario,sectarian,宗派的,ADJ,B2
+sección,section,部分,NOUN,B2
+sector,sector,部门,NOUN,B2
+laicismo,secularism,世俗主义,NOUN,B2
+guardia de seguridad,security guard,保安,NOUN,B2
+sedán,sedan,轿车,NOUN,B2
+volver a ver,to see again,再见,VERB,B2
+ver cadáver,to see corpse,见尸,VERB,B2
+despedida,see off,送走,NOUN,B2
+atravesar,to see through,看穿,VERB,B2
+buscar,to seek,寻找,VERB,B2
+solicitar audiencia,to seek audience,求见,VERB,B2
+buscar la verdad en los hechos,to seek truth from facts,实事求是,VERB,B2
+búsqueda,seeking,寻求,NOUN,B2
+oportunista,seeking instant benefit,急功近利,ADJ,B2
+aparentemente,seemingly,表面上,ADV,B2
+sísmico,seismic,地震的,ADJ,B2
+selección,selection,选择,NOUN,B2
+selectivo,selective,选择的，挑选的,ADJ,B2
+sí mismo,self,自我,NOUN,B2
+autoconfianza,self-confidence,自信,NOUN,B2
+seguro de sí mismo,self-confident,自信的,ADJ,B2
+autosacrificio,self-sacrifice,舍己,NOUN,B2
+egoísmo,selfishness,自私,NOUN,B2
 semestre,semester,学期,NOUN,B2
-semicolon,semicolon,分号,PUNCT,B2
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
 seminario,seminar,研讨会,NOUN,B2
-seminary,seminary,词,NOUN,C1
 semiología,semiology,符号学，症状学,NOUN,B2
 semiótica,semiotics,符号学,NOUN,B2
-semolina,semolina,粗面粉,NOUN,B2
-senate,senate,参议院,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-senderismo,hiking,徒步,NOUN,B2
-sending,sending,词,NOUN,B1
-senescence,senescence,衰老,NOUN,B2
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
-seniors,seniors,词,NOUN,C1
-sensationalism,sensationalism,词,NOUN,C1
-sense of duty,sense of duty,责任感,NOUN,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of shame,sense of shame,,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
-sensibilidad,sensitivity,敏感性,NOUN,B2
+antigüedad,seniority,资历,NOUN,B2
+percibir,to sense,隐约感到,VERB,B2
 sensible,sensitive,敏感的,ADJ,B2
-sensibly,sensibly,明智地,ADV,B2
-sensitization,sensitization,词,NOUN,B2
+sensibilidad,sensitivity,敏感性,NOUN,B2
 sensor,sensor,传感器,NOUN,B2
-sensor donor,sensor donor,传感器/捐献者,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensual,sensual,感官的,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentenced,sentenced,被判刑的,ADJ,B2
-sentences,sentences,句子,NOUN,B2
-sentencing,sentencing,量刑,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentient,sentient,词,ADJ,C1
+condenar,to sentence,判决,VERB,B2
 sentimiento,sentiment,情感,NOUN,B2
-sentinel,sentinel,哨兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separarse,to secede,脱离,VERB,B2
-separarse por muerte,to part by death,死别,VERB,B2
-separate,separate,分开的,ADJ,B2
-separated,separated,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
-separatism,separatism,词,NOUN,C1
-separatist,separatist,词,NOUN,C1
-sequential,sequential,词,ADJ,C1
-sequía,drought,干旱,NOUN,B2
-ser así,to be so,然,VERB,B2
-ser bueno en,to be good at,擅长,VERB,B2
-ser elegido,to be elected,当选,VERB,B2
-ser forzado,to be forced,被迫,VERB,B2
-ser golpeado,to be hit,中箭,VERB,B2
-ser requerido,to be required,被要求,VERB,B2
-ser responsable de,to be responsible for,负责,VERB,B2
-ser robado,to be stolen,失窃,VERB,B2
-ser útil,to be useful,有用,VERB,B2
-seraphic,seraphic,词,ADJ,C1
-serendipity,serendipity,词,NOUN,C1
-serenely,serenely,词,ADV,C1
-serenidad,serenity,宁静,NOUN,B2
+centinela,sentry,卫兵,NOUN,B2
+secuencia,sequence,顺序，片段,NOUN,B2
 sereno,serene,宁静的,ADJ,B2
-serial,serial,词,NOUN,B1
-serialized drama,serialized drama,连续剧,NOUN,B2
+serenidad,serenity,宁静,NOUN,B2
+sargento,sergeant,中士,NOUN,B2
+asesino en serie,serial killer,连环杀手,NOUN,B2
 seriedad,seriousness,严肃,NOUN,B2
-series of conversations,series of conversations,系列对话,NOUN,B2
-seriously,seriously,认真地,ADV,B2
-serous,serous,词,ADJ,C1
-serpentine,serpentine,词,ADJ,C1
-serum,serum,词,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
-service counter,service counter,词,NOUN,B1
-service favor,service favor,词,NOUN,A2
-service of process,service of process,词,NOUN,C1
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-service year,service year,,NOUN,B2
-services,services,词,NOUN,C1
 servidor,server,服务器,NOUN,B2
-servile,servile,词,ADJ,C1
-servilely,servilely,奴性地,ADV,B2
+proveedor de servicios,service provider,服务商,NOUN,B2
+carretera de servicio,service road,辅路,NOUN,B2
 servilismo,servility,奴性,NOUN,B2
-servilleta,napkin,餐巾,NOUN,B2
-serving,serving,词,NOUN,B2
-servitude,servitude,奴役,NOUN,C1
-sesgado,biased,有偏见的,ADJ,B2
-sesgo,bias,偏见,NOUN,B2
+sésamo,sesame,芝麻,NOUN,B2
 sesión,session,会议,NOUN,B2
-set a record,set a record,创造纪录,VERB,B2
-set-off,set-off,词,NOUN,C1
+partir,to set off,出发,VERB,B2
+instalar,to set up,建立,VERB,B2
 setenta,seventy,七十,NUM,B2
-setting,setting,词,NOUN,B1
-setting splinting,setting splinting,词,NOUN,C1
-setting sun,setting sun,夕阳,NOUN,B2
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-settlement deal,settlement deal,词,NOUN,C1
-seven (adj),seven,词,ADJ,B2
-seventeen,seventeen,十七,NUM,B2
-seventh,seventh,第七,ADJ,B2
-sever,sever,词,VERB,C1
-several,several,若干,NOUN,B2
-several (det),several,几个,DET,A2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times (adv),several times,词,ADV,C1
-several times (noun),several times,几遍,NOUN,B2
-severance,severance,词,NOUN,C1
-severely,severely,严厉地,ADV,B2
-severidad,severity,严厉,NOUN,B2
+varios,several,几个,DET,B2
 severo,severe,严厉的,ADJ,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
-sewing needle,sewing needle,词,NOUN,C1
-sex appeal,sex appeal,性感,NOUN,B2
-sex gender,sex gender,词,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexily,sexily,性感地,ADV,B2
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
+severidad,severity,严厉,NOUN,B2
 sexual,sexual,性的,ADJ,B2
-sexually,sexually,在性方面,ADV,B2
-sexy,sexy,性感的,ADJ,B2
-señal de dirección,direction sign,指示牌,NOUN,B2
-señal de tráfico,road sign,路标,NOUN,B2
-señalar,signal,信号,NOUN,B2
-señalar,to point,指向,VERB,B2
-señalar,to signal,示意,VERB,B2
-sfouf,sfouf,词,NOUN,B2
-sh,sh,词,INTJ,C1
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
-shading,shading,阴影,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shadows,shadows,词,NOUN,C1
-shady suspicious,shady suspicious,可疑的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shaft,shaft,词,NOUN,B2
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,将要,AUX,B2
-shambles,shambles,词,NOUN,C1
-shame culture,shame culture,羞耻文化,NOUN,B2
-shame disgrace,shame disgrace,词,NOUN,B2
-shame pity,shame pity,遗憾,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-sharply,sharply,词,ADV,B2
-shavings,shavings,刨花,NOUN,C1
-she (noun),she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-sheaf,sheaf,捆,NOUN,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-shedding,shedding,,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift (noun),shift,轮班,NOUN,C1
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
-shirk,shirk,词,VERB,C1
-shit,shit,恐惧,NOUN,B2
-shit (adj),shit,该死的,ADJ,B2
-shit crap,shit crap,废话,NOUN,B2
-shitty,shitty,词,ADJ,B2
-shivers,shivers,词,NOUN,B2
-shocked,shocked,震惊的,ADJ,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoelace,shoelace,词,NOUN,C1
-shoot at,shoot at,词,VERB,C1
-shooter,shooter,射手,NOUN,B2
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shopkeeper,shopkeeper,词,NOUN,C1
-shopping mall,shopping mall,商场,NOUN,B2
-short film,short film,短片,NOUN,B2
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-shortcomings,shortcomings,词,NOUN,C1
-shorter,shorter,更短的,ADJ,B2
-shortest,shortest,词,NOUN,B2
-shortly,shortly,不久,ADV,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-should ought to,should ought to,应该,AUX,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-shred,shred,词,NOUN,B2
-shriek,shriek,词,VERB,C1
-shrimp,shrimp,虾,NOUN,B2
-shrivel,shrivel,词,VERB,C1
-shrub,shrub,词,NOUN,C1
-shrug,shrug,词,VERB,C1
-shrunken,shrunken,词,ADJ,B2
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shutdown,shutdown,词,NOUN,C1
-shuttle,shuttle,穿梭巴士,NOUN,B2
-shyness,shyness,羞怯,NOUN,B2
-sibilant,sibilant,词,ADJ,C1
-sibling,sibling,兄弟姐妹,NOUN,B2
-sibyl,sibyl,词,NOUN,C1
-sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickle,sickle,词,NOUN,B2
-sickness,sickness,词,NOUN,B2
-side,side,骄傲的,ADJ,B2
-side effect,side effect,副作用,NOUN,B2
-side page,side page,侧面/页,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-sideburn,sideburn,词,NOUN,B1
-siege time,siege time,攻城时,NOUN,C1
-siembra,planting,种植,NOUN,B2
-siembra,sowing,播种,NOUN,B2
-siempre,ever,曾经,ADV,B2
-siempre,to ever,里何尝,VERB,B2
-siempre que,as long as,طالما,CCONJ,B2
-siempre que,provided that,只要,SCONJ,B2
-sierra,saw,锯子,NOUN,B2
-siesta,nap,午睡,NOUN,B2
-sighing,sighing,叹息的,ADJ,B2
-sightseeing,sightseeing,词,NOUN,C1
-sign brand,sign brand,词,NOUN,C1
-signatory,signatory,签署者,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signed,signed,词,ADJ,B2
-significado,significance,含义,NOUN,B2
-significado alterado,altered meaning,改义,NOUN,B2
-significado parcial,partial meaning,分义,NOUN,B2
-significar,to signify,意味着,VERB,B2
-significativo,significant,重要的,ADJ,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-silenced,silenced,词,ADJ,C1
-silenciar,to silence,خرس,VERB,B2
-silencing,silencing,词,NOUN,C1
-silencioso,silent,沉默的,ADJ,B2
-silent quiet,silent quiet,词,ADJ,A1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-sillón,armchair,扶手椅,NOUN,B2
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
-silvery,silvery,词,ADJ,C1
-simbolizar,to symbolize,象征,VERB,B2
-simetría,symmetry,对称,NOUN,B2
-simian,simian,词,ADJ,C1
-similarly,similarly,同样地,ADV,B2
-simile,simile,明喻,NOUN,B2
-similitud,similarity,相似,NOUN,B2
-simony,simony,词,NOUN,C1
-simpatizar,to sympathize,同情,VERB,B2
-simpatía,sympathy,同情,NOUN,B2
-simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
-simplicity,simplicity,简单,NOUN,B2
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplify,to simplify,简化,VERB,B2
-simplism,simplism,简单化,NOUN,C1
-simply,simply,简单地,ADV,B2
-simposio,symposium,研讨会,NOUN,B2
-simptomático,symptomatic,症状的,ADJ,B2
-simulation,simulation,模拟,NOUN,B2
-simulator,simulator,词,NOUN,C1
-simultaneous,simultaneous,同时的,ADJ,B2
-simultaneously,simultaneously,同时地,ADV,B2
-simultaneously with,simultaneously with,词,ADV,C1
-sin espada,swordless,剑不,NOUN,B2
-sin refrigeración,uncooled,未寒,NOUN,B2
-since,since,自从,ADP,B2
-since (part),since,以来,PART,B2
-since (sconj),since,既,SCONJ,A2
-since then,since then,从那以后,ADV,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerely,sincerely,真诚地,ADV,B2
-sincerity,sincerity,真诚,NOUN,B2
-sincerity devotion,sincerity devotion,词,NOUN,B2
-sincronización,synchronization,同步,NOUN,B2
-sincrónico,synchronous,同步的,ADJ,B2
-sindicalismo,unionism,工会主义,NOUN,B2
-sindicato,union,工会,NOUN,B2
-sinecure,sinecure,词,NOUN,C1
-sinergia,synergy,协同效应,NOUN,B2
-sinew,sinew,词,NOUN,C1
-sinfonía,symphony,交响乐,NOUN,B2
-singer,singer,歌手,NOUN,B2
-singing,singing,歌唱,NOUN,B2
-single,single,单一的,ADJ,B2
-single (noun),single,单曲,NOUN,B2
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-single thought,single thought,一念,NOUN,B2
-singular (adj),singular,词,ADJ,C1
-singular (noun),singular,词,NOUN,B2
-singularity,singularity,单一性,NOUN,B2
-sinking,sinking,沉?,NOUN,C1
-sinner,sinner,罪人,NOUN,B2
-sinonimia,synonymy,同义关系,NOUN,B2
-sintaxis,syntax,句法,NOUN,B2
-sintetizar,to synthesize,合成,VERB,B2
-sinuous,sinuous,词,ADJ,C1
-sip,sip,小口喝,NOUN,B2
-sip,to sip,小口喝,VERB,B2
-sir,sir,郎,PART,B2
-sir (noun),sir,先生,NOUN,A1
-siren,mermaid,美人鱼,NOUN,B2
-siren,siren,汽笛,NOUN,B2
-siseo,hiss,嘶嘶声,NOUN,B2
-sistema modificado,modified system,改系,NOUN,B2
-sistemático,systematic,系统的,ADJ,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-sistémico,systemic,全身性的,ADJ,B2
-sit,to sit,坐,VERB,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit down,to sit down,坐下,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-site,site,词,NOUN,B1
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-situation circumstances,situation circumstances,情形,NOUN,B2
-six-line stanza,six-line stanza,词,NOUN,C1
-six-year-old,six-year-old,,NOUN,B2
-sixteen,sixteen,十六,NUM,B2
-sixth,sixth,第六,ADJ,B2
-sixth (noun),sixth,sixth,NOUN,B2
-sixty,sixty,六十,NUM,B2
-size measure,size measure,尺寸 / 测量,NOUN,A2
-skate,to skate,滑冰,VERB,B2
-skate (noun),skate,词,NOUN,A2
-skater,skater,,NOUN,B2
-skating,skating,滑冰,NOUN,B2
-skeptic,skeptic,词,NOUN,C1
-sketchiness,sketchiness,词,NOUN,C1
-ski resort,ski resort,滑雪场,NOUN,C1
-skid slip-up,skid slip-up,词,NOUN,C1
-skiff,skiff,词,NOUN,C1
-skiing,skiing,滑雪,NOUN,B2
-skilful,skilful,熟练的,ADJ,B2
-skilled,skilled,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skillfulness,skillfulness,词,NOUN,B2
-skin hide,skin hide,皮肤/皮革,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-sky blue,sky blue,天蓝色,ADJ,B2
-slack,slack,词,ADJ,B2
-slackening dip,slackening dip,词,NOUN,C1
-slackness,slackness,词,NOUN,C1
-slake,slake,词,VERB,C1
-slam,slam,,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slammer jail,slammer jail,词,NOUN,C1
-slang,slang,俚语,NOUN,B2
-slanted,slanted,斜,ADJ,B2
-slaughter,slaughter,屠杀,NOUN,B2
-slaughter,to slaughter,割喉,VERB,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleek,sleek,词,ADJ,C1
-sleep,sleep,睡眠,NOUN,B2
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleeper,sleeper,词,NOUN,C1
-sleeping pill,sleeping pill,安眠药,NOUN,B2
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
-sleeve,sleeve,袖子,NOUN,B2
-sleigh,sleigh,雪橇,NOUN,C1
-slice,slice,薄片,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-slick,slick,词,ADJ,C1
-sliding,sliding,滑动的,ADJ,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
-slightly,slightly,轻微地,ADV,B2
-slim,slim,苗条,ADJ,B2
-slip in,slip in,塞入,VERB,B2
-slipper,slipper,拖鞋,NOUN,B2
-slit,slit,词,NOUN,C1
-slither,slither,词,VERB,C1
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slovenly,slovenly,词,ADJ,C1
-slow down,to slow down,放慢,VERB,B2
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
-slower,slower,更慢,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slum,slum,贫民窟,NOUN,B2
-slur,slur,词,VERB,C1
-slut,slut,荡妇,NOUN,B2
-slyly,slyly,词,ADV,C1
-small bag,small bag,词,NOUN,C1
-small boat,small boat,小船,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small step,small step,词,NOUN,C1
-small things,small things,琐事,NOUN,B2
-small window,small window,词,NOUN,A2
-smart clever,smart clever,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smear,smear,抹,NOUN,C1
-smell (noun),smell,还闻,NOUN,C1
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smelting,smelting,词,NOUN,C1
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoker,smoker,词,NOUN,C1
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
-smoothness,smoothness,词,NOUN,C1
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
-smugness,smugness,词,NOUN,C1
-snap (verb),snap,词,VERB,C1
-snare,snare,词,NOUN,C1
-snazzy,snazzy,时髦的,ADJ,B2
-sneaker,sneaker,词,NOUN,A1
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sneer,sneer,词,VERB,C1
-sneezing,sneezing,词,NOUN,C1
-sniffle,sniffle,词,VERB,C1
-snippet,snippet,词,NOUN,C1
-snore (noun),snore,打呼,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snot,snot,鼻涕,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snow-white,snow-white,词,ADJ,C1
-snowdrift,snowdrift,词,NOUN,B1
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so much (det),so much,那么多,DET,B2
-so much so many,so much so many,词,ADV,C1
-so thus,so thus,所以/如此,ADV,B2
-so to speak,so to speak,可以说,ADV,B2
-so-called,so-called,,NOUN,B2
-soaking,soaking,等你泡,NOUN,B2
-soberano,sovereign,君主,NOUN,B2
-soberanía,sovereignty,主权,NOUN,B2
-sobre,about,关于,ADP,B2
-sobre-dominio,over-domain,超畴,NOUN,B2
-sobreestrategia,over-strategy,超策,NOUN,B2
-sobregirar,to overdraw,透支,VERB,B2
-sobresaliente,outstanding,杰出的,ADJ,B2
-sobretrazo,over-stroke,超程,NOUN,B2
-sobriedad,sobriety,清醒,NOUN,B2
-sobriquet,sobriquet,词,NOUN,C1
-sociable,sociable,好交际的,ADJ,B2
-social,social,社会的,ADJ,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social harmony,social harmony,社会和谐,NOUN,B2
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social identity,social identity,社会身份,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social interaction,social interaction,社会互动,NOUN,B2
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social mobilization,social mobilization,社会动员,NOUN,B2
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social organization,social organization,社会组织,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social practice,social practice,社会实践,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social problem,social problem,社会问题,NOUN,B2
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reconciliation,social reconciliation,社会和解,NOUN,B2
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social stability,social stability,社会稳定,NOUN,B2
-social standard,social standard,社会标准,NOUN,C1
-social statistics,social statistics,社会统计,NOUN,B2
-social status,social status,社会地位,NOUN,C1
-social stratification,social stratification,社会分层,NOUN,B2
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social trend,social trend,社会趋势,NOUN,B2
-social trust,social trust,社会信任,NOUN,B2
-social turmoil,social turmoil,社会动荡,NOUN,C1
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义者,NOUN,B2
-socialist (adj),socialist,社会主义的,ADJ,C1
-socialization,socialization,社会化,NOUN,B2
-socialize,to socialize,交往,VERB,B2
-socializing,socializing,交际,NOUN,B1
-socially,socially,词,ADV,C1
-societal,societal,社会的,ADJ,B2
-sociological,sociological,词,ADJ,C1
-sociologist,sociologist,社会学家,NOUN,B2
-sociology,sociology,社会学,NOUN,B2
-socket,socket,词,NOUN,C1
-soda,soda,苏打,NOUN,B2
-sofa,sofa,沙发,NOUN,B2
-sofistería,sophistry,诡辩,NOUN,B2
-softball,softball,垒球,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software,software,软件,NOUN,B2
-software (adj),software,词,ADJ,C1
-soil,soil,土壤,NOUN,B2
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-sojourn,sojourn,逗留,NOUN,B2
-sol,sunshine,阳光,NOUN,B2
-solace,solace,安慰,NOUN,B2
-solapamiento,overlap,重叠,NOUN,B2
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-solar physics,solar physics,词,NOUN,C1
-soldiers,soldiers,官兵,NOUN,B2
-sole,sole,鞋底,NOUN,B2
-soleado,sunny,晴朗的,ADJ,B2
-solecism,solecism,语法错误,NOUN,B2
-solely,solely,词,ADV,C1
-solemn,solemn,庄严的,ADJ,B2
-solemn (noun),solemn,solemn,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solemnly,solemnly,词,ADV,C1
-solfege,solfege,词,NOUN,C1
-solicit,to solicit,恳求,VERB,B2
-solicit donations,to solicit donations,募捐,VERB,B2
-solicitar audiencia,to seek audience,求见,VERB,B2
-solicitation,solicitation,词,NOUN,C1
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solicitud,request,请求,NOUN,B2
-solicitude,solicitude,关怀,NOUN,B2
-solid,solid,3D模型 / 实体,NOUN,B2
-solid substantial,solid substantial,结实的/大量的,ADJ,B2
-solid-state drive,solid-state drive,固态硬盘,NOUN,B2
-solidarity,solidarity,团结,NOUN,B2
-solidez,soundness,好端端,NOUN,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-soliloquy,soliloquy,独白,NOUN,B2
-solipsism,solipsism,唯我论,NOUN,B2
-solitary,solitary,孤独的,ADJ,B2
-solitude,solitude,孤独,NOUN,B2
-sollozar,to sob,啜泣,VERB,B2
-sollozo,sobbing,抽泣,NOUN,B2
-soloist,soloist,词,NOUN,C1
-solstice,solstice,词,NOUN,C1
-soltero,bachelor,单身汉,NOUN,B2
-solute,solute,词,NOUN,C1
-solve a case,solve a case,破案,VERB,B2
-solvency,solvency,偿付能力,NOUN,B2
-somber,somber,词,ADJ,B2
-sombra de nieve,snow shadow,雪影姐姐,NOUN,B2
-sombrío,gloomy,阴郁的,ADJ,B2
-sombrío,grim,严酷的,ADJ,B2
-some,some,一些,PRON,B2
-some (adj),some,某些,ADJ,A2
-some (noun),some,词,NOUN,B2
-some many a,some many a,词,DET,A2
-some out,some out,出些,NOUN,B2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-somebody,somebody,词,PRON,A1
-somehow,somehow,以某种方式,ADV,B2
-someone stealing,someone stealing,有人偷,NOUN,C1
-someone's,someone's,某人的,PRON,B2
+estrechar la mano,to shake hands,握手,VERB,B2
 somero,shallow,浅的,ADJ,B2
-someter,to submit,提交,VERB,B2
-something,something,شي,NOUN,B2
-something better,something better,词,NOUN,C1
-something like that,something like that,类似的事物,PRON,B2
-sometime,sometime,在某个时候,ADV,B2
-somewhat,somewhat,词,ADV,C1
-somewhere,somewhere,,NOUN,B2
-somewhere else,somewhere else,词,ADV,B1
-somnolent,somnolent,词,ADJ,C1
-son of a bitch,son of a bitch,词,NOUN,B2
-son-in-law,son-in-law,词,NOUN,A2
-sonar,to ring,鸣响,VERB,B2
-sonata,sonata,词,NOUN,C1
-song (part),song,歌,PART,B2
-song festival,song festival,音乐节,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sonido,ringing,铃声,NOUN,B2
-sonido modificado,modified sound,改响,NOUN,B2
-sonorous,sonorous,词,ADJ,C1
-sonreír,to grin,咧嘴笑,VERB,B2
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soothing,soothing,词,ADJ,C1
-soothsayer,soothsayer,词,NOUN,B2
-sopa,clear soup,江瑶清羹,NOUN,B2
-sophist,sophist,诡辩家,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sophisticated,sophisticated,复杂的,ADJ,B2
-sophomoric,sophomoric,词,ADJ,C1
-soplar,to blow,吹,VERB,B2
-soporific,soporific,词,ADJ,C1
-soportable,bearable,可忍受的,ADJ,B2
-soportar,to bear,忍受,VERB,B2
-sordid,sordid,肮脏的,ADJ,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorghum,sorghum,高粱,NOUN,B2
-sorprendente,surprising,令人惊讶的,ADJ,B2
-sorprenderse,to be surprised,感到惊讶,VERB,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry,sorry,抱歉,INTJ,B2
-sorry (adj),sorry,抱歉,ADJ,A1
-sort,sort,种类,NOUN,B2
-sortie,sortie,词,NOUN,C1
-sorting,sorting,分类,NOUN,B2
-sospechoso,suspect,嫌疑人,NOUN,B2
-sostenibilidad,sustainability,可持续性,NOUN,B2
-sostenible,sustainable,可持续的,ADJ,B2
-sought,sought,,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-soul spirit,soul spirit,词,NOUN,B2
-soulmate,soulmate,词,NOUN,C1
-sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,音频片段,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-soundtrack,soundtrack,! 音轨,NOUN,B2
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern,southern,南方的,ADJ,B2
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southward,southward,向南,ADV,B2
-southwest,southwest,西南的,ADJ,B2
-sovereign (adj),sovereign,主权,ADJ,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-sow,sow,母猪,NOUN,B2
-soy,soy,词,NOUN,C1
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
-spaciousness,spaciousness,词,NOUN,C1
-spade,spade,铲子,NOUN,B2
-spadix,spadix,词,NOUN,C1
-spam (noun),spam,词,NOUN,B1
-span cleaner,span cleaner,词,NOUN,B2
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
-spanish (noun),spanish,词,NOUN,B2
-spar,spar,词,VERB,C1
-spare (adj),spare,词,ADJ,B1
-spare (noun),spare,词,NOUN,C1
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spate,spate,词,NOUN,C1
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
-special agent,special agent,特工,NOUN,B2
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special window,special window,词,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
-specifically,specifically,具体地,ADV,B2
-specifications,specifications,词,NOUN,C1
-specificity,specificity,词,NOUN,C1
-specious,specious,似是而非的,ADJ,B2
-spectacle,spectacle,词,NOUN,B2
-specter,specter,词,NOUN,C1
-spectrometer,spectrometer,词,NOUN,C1
-speculative,speculative,词,ADJ,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-spend the night,spend the night,词,VERB,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-spent,spent,词,ADJ,B2
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spiral,spiral,词,NOUN,C1
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit world,spirit world,灵界,NOUN,B2
-spiritual,spiritual,精神的,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
-spittle,spittle,唾沫,NOUN,B2
-splash,splash,扑通,NOUN,B2
-splay,splay,词,VERB,C1
-spleen,spleen,词,NOUN,B2
-split secession,split secession,分裂,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoiled child,spoiled child,词,NOUN,B1
-spoiler,spoiler,词,NOUN,C1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponsor (noun),sponsor,词,NOUN,B2
-spontaneity,spontaneity,词,NOUN,C1
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-sporadic,sporadic,词,ADJ,C1
-sporadically,sporadically,词,ADV,B2
-sports,sports,体育,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,运动公园,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot,spot,地点,NOUN,B2
-spot goods,spot goods,现货,NOUN,C1
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
-spreading,spreading,词,NOUN,C1
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-spry,spry,词,ADJ,C1
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-sputum,sputum,词,NOUN,C1
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-square (adj),square,方,ADJ,B2
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak,squeak,吱吱声,NOUN,B2
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
-stab (noun),stab,捅,NOUN,C1
-stably,stably,稳定地,ADV,B2
-stack (noun),stack,词,NOUN,B2
-staff (verb),staff,词,VERB,B1
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
-staging,staging,上演,NOUN,B2
-staid,staid,词,ADJ,C1
-staircase,staircase,词,NOUN,B1
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalemate,stalemate,词,NOUN,C1
-stalking,stalking,词,NOUN,C1
-stall,stall,包厢座位,NOUN,B2
-stalling,stalling,词,NOUN,B2
-stalwart,stalwart,词,ADJ,C1
-stamina,stamina,词,NOUN,C1
-stammering,stammering,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stanch,stanch,词,VERB,C1
-stand,stand,摊位,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
-standby,standby,待机,VERB,C1
-standing (adv),standing,词,ADV,A1
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-standpoint,standpoint,立场,NOUN,B2
-stands,stands,词,NOUN,B2
-stanza,stanza,词,NOUN,B2
-staple,staple,词,NOUN,C1
-stapler,stapler,词,NOUN,A2
-star celebrity,star celebrity,词,NOUN,B1
-star search,star search,找星,NOUN,B2
-starch,starch,芡,NOUN,C1
-stark,stark,词,ADJ,B2
-starling,starling,词,NOUN,B2
-start of school year,start of school year,词,NOUN,B1
-starting point,starting point,出发点,NOUN,B2
-starting premise,starting premise,词,NOUN,C1
-starved,starved,饥饿的,ADJ,B2
-state federal,state federal,州,NOUN,B2
-state of emergency,state of emergency,词,NOUN,C1
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-statements,statements,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-stationery shop,stationery shop,文具店,NOUN,B2
-statistic,statistic,统计数据,NOUN,B2
-statization,statization,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadfastness,steadfastness,词,NOUN,B2
-steadily,steadily,稳定地,ADV,B2
-steadiness,steadiness,稳倒,NOUN,C1
-steak,steak,牛排,NOUN,B2
-stealth,stealth,秘密行动,NOUN,B2
-stealthily,stealthily,词,ADV,B2
-stealthy,stealthy,词,ADJ,C1
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steering,steering,掌舵的,ADJ,B2
-steering (noun),steering,词,NOUN,C1
-steering control,steering control,词,NOUN,C1
-stem (adj),stem,词,ADJ,C1
-stem cell,stem cell,干细胞,NOUN,C1
-stemming,stemming,词,ADJ,B1
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-stepfather,stepfather,词,NOUN,A1
-steppes,steppes,草原,NOUN,B2
-stepson,stepson,词,NOUN,A2
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-stern (adj),stern,词,ADJ,C1
-stern (noun),stern,词,NOUN,C1
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stiff glove,stiff glove,,NOUN,B2
-stifle,stifle,词,VERB,C1
-stifling,stifling,词,ADJ,B2
-stigmatization,stigmatization,词,NOUN,B2
-still also,still also,还,ADV,A1
-stillness,stillness,静中,NOUN,B2
-stilted,stilted,词,ADJ,C1
-stimulant,stimulant,兴奋剂,NOUN,B2
-sting,sting,刺,NOUN,B2
-stinginess,stinginess,吝啬；小气,NOUN,B2
-stink,stink,恶臭,NOUN,B2
-stinking,stinking,发臭的,ADJ,B2
-stir,stir,搅拌,NOUN,B2
-stir,to stir,搅拌,VERB,B2
-stir (noun),stir,掀不起,NOUN,C1
-stir-fry,stir-fry,炒,VERB,B1
-stitch,stitch,针脚,NOUN,B2
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
-stock,stock,库存,NOUN,B2
-stock exchange,stock exchange,证券交易所,NOUN,B2
-stock market,stock market,股市,NOUN,B2
-stockholm,stockholm,斯德哥尔摩,PROPN,B2
-stocking,stocking,词,NOUN,C1
-stodgy,stodgy,词,ADJ,C1
-stoically,stoically,词,ADV,C1
-stoicism,stoicism,斯多葛主义,NOUN,B2
-stolen,stolen,被偷的,ADJ,B2
-stolen one,stolen one,词,NOUN,B2
-stomach ache,stomach ache,词,NOUN,C1
-stomachache,stomachache,肚子痛,NOUN,B2
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stool,stool,词,NOUN,C1
-stop,stop,停止,NOUN,B2
-stop bleeding,stop bleeding,止血,VERB,B2
-stop me,to stop me,拦我,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-storage,storage,收纳,NOUN,B2
-storage room,storage room,储藏室,NOUN,B2
-store,store,商店,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-stork,stork,词,NOUN,B1
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-storming,storming,词,NOUN,C1
-stormy,stormy,有暴风雨的,ADJ,B2
-stout,stout,词,ADJ,C1
-strabismus,strabismus,词,NOUN,B2
-straight,straight,笔直的,ADJ,B2
-straight (adv),straight,直接地,ADV,B1
-straight (noun),straight,直的,NOUN,B2
-straight ahead,straight ahead,词,ADV,B2
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
-straightforward,straightforward,直率的,ADJ,B2
-strain,to strain,努力,VERB,B2
-strait,strait,海峡,NOUN,B2
-straitened circumstances,straitened circumstances,词,NOUN,C1
-straitjacket,straitjacket,词,NOUN,C1
-strand,strand,词,NOUN,C1
-strange troops,strange troops,怪兵,NOUN,B2
-strangely,strangely,奇怪地,ADV,B2
-strangest,strangest,词,NOUN,C1
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-straw,straw,稻草,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street kid,street kid,词,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-strenuous,strenuous,费力的,ADJ,B2
-stress (noun),stress,压力,NOUN,B1
-stressed,stressed,焦虑的,ADJ,B2
-stressful,stressful,有压力的,ADJ,B2
-stretch,stretch,伸展,NOUN,B2
-stretch out,stretch out,词,VERB,B2
-stretcher,stretcher,担架,NOUN,B2
-strictly,strictly,词,ADV,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-strictness,strictness,词,NOUN,B2
-stride (noun),stride,词,NOUN,C1
-strike,to strike,打击,VERB,B2
-strike-related,strike-related,词,ADJ,C1
-striking,striking,惊人的,ADJ,B2
-string,string,细绳,NOUN,B2
-string instruments,string instruments,词,NOUN,C1
-string music,string music,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-stripe,stripe,条纹,NOUN,B2
-striped,striped,有条纹的,ADJ,B2
-stripping,stripping,剥离的,ADJ,B2
-striving,striving,追求,NOUN,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-stroke,stroke,中风,NOUN,B2
-stroll,to stroll,散步,VERB,B2
-stroller,stroller,婴儿车,NOUN,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
-structural,structural,结构的,ADJ,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structured,structured,词,ADJ,C1
-structuredness,structuredness,结构性,NOUN,B2
-structures,structures,词,NOUN,C1
-stubbornness,stubbornness,固执,NOUN,B2
-stuck,stuck,卡住的,ADJ,B2
-student loan,student loan,助学贷款,NOUN,B2
-student residence,student residence,学生宿舍,NOUN,B2
-studies,studies,学业,NOUN,B2
-studio,studio,工作室,NOUN,B2
-study tour,study tour,游学,NOUN,C1
-stuff,stuff,东西,NOUN,B2
-stuffed,stuffed,词,ADJ,B1
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stumble (noun),stumble,词,NOUN,C1
-stunner,stunner,词,NOUN,B2
-stunt,stunt,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupendous,stupendous,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
-stuttering,stuttering,词,NOUN,C1
-stylish,stylish,雅致的,ADJ,B2
-stylist,stylist,词,NOUN,C1
-stylistics,stylistics,词,NOUN,C1
-stymie,stymie,词,VERB,C1
-su partida,his departure,他走,NOUN,B2
-suave,suave,词,ADJ,C1
-suavemente,smoothly,顺利,ADV,B2
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subconscious,subconscious,潜意识,NOUN,B2
-subcontracting,subcontracting,分包,NOUN,B2
-subcontratación,outsourcing,外包,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subduing object,subduing object,克一物,NOUN,C1
-subestimación,underestimation,小看,NOUN,B2
-subestimar,to underestimate,低估,VERB,B2
-subir,to come up,出现,VERB,B2
-subir,to rise,上升,VERB,B2
-subir,to upload,上传,VERB,B2
-subject field,subject field,科目 / 领域,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,受法律管辖的,ADJ,B2
-subject topic,subject topic,主题/话题,NOUN,B2
-subjection,subjection,词,NOUN,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
-subjetivo,subjective,主观的,ADJ,B2
-sublimation,sublimation,词,NOUN,C1
-subliminal,subliminal,词,ADJ,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submarino,submarine,潜水艇,NOUN,B2
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordinado,subordinate,下属,NOUN,B2
-subordination,subordination,隶属,NOUN,C1
-subsequently,subsequently,词,ADV,C1
-subservient,subservient,词,ADJ,C1
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,辅助性原则,NOUN,B2
-subsidio,subsidy,补贴,NOUN,B2
-subsiguiente,subsequent,随后的,ADJ,B2
-subsistencia,subsistence,生计,NOUN,B2
-substandard,substandard,,NOUN,B2
-substantial,substantial,大量的,ADJ,B2
-substantially,substantially,词,ADV,B2
-substantive,substantive,实质性的,ADJ,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subterráneo,underground,地铁,NOUN,B2
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-subtle,subtle,微妙的,ADJ,B2
-subtlety,subtlety,微妙,NOUN,B2
-subtly,subtly,词,ADV,C1
-subtítulo,subtitle,字幕,NOUN,B2
-suburban,suburban,词,ADJ,C1
-suburbio,suburb,郊区,NOUN,B2
-suburbs,suburbs,郊区,NOUN,B2
-subvención,grant,拨款,NOUN,B2
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
-succinct,succinct,简明的,ADJ,B2
-succinctly,succinctly,简洁地,ADV,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-suceder,to succeed,成功,VERB,B2
-suceder,to take place,举行,VERB,B2
-sucesivamente,successively,连续地,ADV,B2
-sucesión,succession,连续,NOUN,B2
-sucesor,successor,继任者,NOUN,B2
-such (det),such,这样的,DET,A1
-such a,such a,这样的,DET,B2
-such a thing,such a thing,词,PRON,B1
-suciedad,dirt,污垢,NOUN,B2
-sucking,sucking,嗦,NOUN,B2
-sudar,to sweat,出汗,VERB,B2
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suegro,father-in-law,岳父/公公,NOUN,B2
-suelo,ground,根据,NOUN,B2
-suerte,push luck,太得寸,NOUN,B2
-sueño dulce,sweet dream,美梦,NOUN,B2
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-suficiencia,sufficiency,充足,NOUN,B2
-suficiente,sufficient,足够的,ADJ,B2
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugerencia,suggestion,建议,NOUN,B2
-suggestibility,suggestibility,词,NOUN,C1
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal thought,suicidal thought,,NOUN,B2
-suicide candidate,suicide candidate,,NOUN,B2
-suite,suite,套房,NOUN,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
-sulfide,sulfide,词,NOUN,C1
-sulfur,sulfur,硫,NOUN,B2
-sulfuric,sulfuric,词,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sullenness,sullenness,词,NOUN,C1
-sully,sully,词,VERB,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-suma,sum,总和,NOUN,B2
-sumergir,to dip,蘸,VERB,B2
-sumergir,to submerge,淹没,VERB,B2
-suministro,supply,供应,NOUN,B2
-sumisión,submission,顺从,NOUN,B2
-summarily,summarily,草率地,ADV,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
-sun sensitivity,sun sensitivity,,NOUN,B2
-sun-protective,sun-protective,防晒,ADJ,C1
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunglasses,sunglasses,太阳镜,NOUN,B2
-sunny day,sunny day,晴天,NOUN,C1
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super (adv),super,词,ADV,A1
-super dead,super dead,,NOUN,B2
-super high,super high,,NOUN,B2
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-proof,super-proof,超证,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-theory,super-theory,超论,NOUN,C1
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-superb,superb,极好的,ADJ,B2
-supercalidad,super-quality,超质,NOUN,B2
-supercilious,supercilious,词,ADJ,C1
-supercomprensivo,super-comprehensive,超遍,NOUN,B2
-superficial,superficial,表面的,ADJ,B2
-superficiality,superficiality,词,NOUN,C1
-supergrado,super-grade,超级,NOUN,B2
-superhero,superhero,超级英雄,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior,higher,更高的,ADJ,B2
-superior,superior,更好的,ADJ,B2
-superior,upper,上面的,ADJ,B2
-superior (noun),superior,上级,NOUN,B2
-superior upper,superior upper,词,ADJ,C1
-superiority,superiority,优越性/优势,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supermercado,supermarket,超市,NOUN,B2
-supernatural,supernatural,超自然的,ADJ,B2
-supernumerary,supernumerary,词,ADJ,C1
-superpensamiento,super-thought,超思,NOUN,B2
-superprincipio,super-principle,超则,NOUN,B2
-supersede,supersede,词,VERB,C1
-supervisar,to supervise,监督,VERB,B2
-supervisión,supervision,监督,NOUN,B2
-supervisor,supervisor,主管,NOUN,B2
-supervivencia,survival,生存,NOUN,B2
-superviviente,survivor,幸存者,NOUN,B2
-supine,supine,词,ADJ,C1
-suplementar,supplement,补充,NOUN,B2
-suplementar,to supplement,补充,VERB,B2
-suplicar,to plead,恳求,VERB,B2
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplies,supplies,必需品,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
-support medium,support medium,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supported,supported,词,ADJ,B2
-supporter advocate,supporter advocate,词,NOUN,B1
-supporters,supporters,词,NOUN,B2
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,团结的,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-supposition,supposition,词,NOUN,C1
-suppository,suppository,词,NOUN,C1
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
-suppression of us,suppression of us,压咱,NOUN,C1
-suppuration,suppuration,词,NOUN,C1
-supremacy,supremacy,霸权,NOUN,B2
-supreme,supreme,最高的,ADJ,B2
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-supremo,utmost,你尽,NOUN,B2
-supresión,suppression,抑,NOUN,B2
-suprimir,to suppress,压制,VERB,B2
-supsistema,super-system,超制,NOUN,B2
-supuesto,so-called,所谓的,ADJ,B2
-supurar,to fester,溃烂,VERB,B2
-surcharge,surcharge,附加费,NOUN,B2
-sure,sure,当然,ADV,B2
-sure safe,sure safe,确定的,ADJ,B2
-surely safe,surely safe,肯定地,ADV,B2
-surety bond,surety bond,词,NOUN,C1
-suretyship,suretyship,保证,NOUN,C1
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surgical,surgical,外科的,ADJ,B2
-surging effusive,surging effusive,词,ADJ,C1
-surgir,to arise,出现,VERB,B2
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus,surplus,过剩的,ADJ,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
-surprised,surprised,惊讶的,ADJ,B2
-surrealismo,surrealism,超现实主义,NOUN,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrogate,surrogate,词,NOUN,C1
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
-suscribir,to subscribe,订阅,VERB,B2
-suscribir,to underwrite,承保,VERB,B2
-suscripción,subscription,订阅,NOUN,B2
-suscriptor,subscriber,订阅者,NOUN,B2
-susha,susha,夙砂大,NOUN,B2
-suspended,suspended,悬浮的,ADJ,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspensión,suspension,暂停,NOUN,B2
-suspenso,suspense,悬念,NOUN,B2
-suspicions,suspicions,词,NOUN,C1
+farsa,sham,假冒,NOUN,B2
+avergonzar,to shame,使羞愧,VERB,B2
+vergonzoso,shameful,可耻的,ADJ,B2
+champú,shampoo,洗发水,NOUN,B2
+moldear,to shape,塑造,VERB,B2
+parte,share,股份,NOUN,B2
+accionista,shareholder,股东,NOUN,B2
+tiburón,shark,鲨鱼,NOUN,B2
+romper,to shatter,粉碎,VERB,B2
+afeitar,to shave,剃,VERB,B2
+oveja,sheep,绵羊,NOUN,B2
+hoja,sheet,床单,NOUN,B2
+caparazón,shell,壳,NOUN,B2
+pastor,shepherd,牧羊人,NOUN,B2
+cambiar,shift,轮班,NOUN,B2
+cambiar,to shift,改变,VERB,B2
+rotación de turnos,shift rotation,倒班,NOUN,B2
+intercambio de turnos,shift swap,换班,NOUN,B2
+adelantar,to shift to an earlier date,提前,VERB,B2
+enviar,to ship out,出货,VERB,B2
+impactar,to shock,震惊,VERB,B2
+quita de zapatos,shoe removal,鞋脱,NOUN,B2
+zapatos,shoes,鞋子,NOUN,B2
+derribar,to shoot down,击落,VERB,B2
+tiroteo,shooting,射击,NOUN,B2
+comprar,to shop,购物,VERB,B2
+compras,shopping,购物,NOUN,B2
+centro comercial,shopping center,购物中心,NOUN,B2
+a corto plazo,short-term,短期的,ADJ,B2
+escasez,shortage,短缺,NOUN,B2
+defecto,shortcoming,缺点,NOUN,B2
+atajo,shortcut,捷径,NOUN,B2
+acortar,to shorten,缩短,VERB,B2
+deber,should,应该,AUX,B2
+no deber,should not,不该,AUX,B2
+pala,shovel,铲子,NOUN,B2
+santuario,shrine,مشعر,NOUN,B2
+hermanos,siblings,兄弟姐妹,NOUN,B2
+puerta lateral,side door,侧门,NOUN,B2
+acera,sidewalk,人行道,NOUN,B2
 suspirar,sigh,叹息,NOUN,B2
 suspirar,to sigh,叹气,VERB,B2
 suspirar de tristeza,to sigh with sorrow,感慨,VERB,B2
-sustain,sustain,词,VERB,C1
-sustainability policy,sustainability policy,词,NOUN,C1
+vista,sight,视力,NOUN,B2
+firmar por,to sign for,签收,VERB,B2
+señalar,signal,信号,NOUN,B2
+señalar,to signal,示意,VERB,B2
+significado,significance,含义,NOUN,B2
+significativo,significant,重要的,ADJ,B2
+significar,to signify,意味着,VERB,B2
+silenciar,to silence,خرس,VERB,B2
+silencioso,silent,沉默的,ADJ,B2
+tela de seda,silk cloth,丝绸,NOUN,B2
+chica tonta,silly girl,傻丫头,NOUN,B2
+plateado,silver,银色,ADJ,B2
+similitud,similarity,相似,NOUN,B2
+simile,simile,明喻,NOUN,B2
+simplicity,simplicity,简单,NOUN,B2
+simplify,to simplify,简化,VERB,B2
+simply,simply,简单地,ADV,B2
+simulation,simulation,模拟,NOUN,B2
+simultaneous,simultaneous,同时的,ADJ,B2
+since,since,自从,ADP,B2
+sincerity,sincerity,真诚,NOUN,B2
+singer,singer,歌手,NOUN,B2
+singing,singing,歌唱,NOUN,B2
+single,single,单一的,ADJ,B2
+single thought,single thought,一念,NOUN,B2
+sip,sip,小口喝,NOUN,B2
+sip,to sip,小口喝,VERB,B2
+sir,sir,郎,PART,B2
+siren,siren,汽笛,NOUN,B2
+sister-in-law,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
+sit,to sit,坐,VERB,B2
+sit down,to sit down,坐下,VERB,B2
+situation circumstances,situation circumstances,情形,NOUN,B2
+sixth,sixth,第六,ADJ,B2
+sixty,sixty,六十,NUM,B2
+skate,to skate,滑冰,VERB,B2
+skiing,skiing,滑雪,NOUN,B2
+skilled,skilled,熟练的,ADJ,B2
+slaughter,slaughter,屠杀,NOUN,B2
+slaughter,to slaughter,割喉,VERB,B2
+sleep,sleep,睡眠,NOUN,B2
+sleeping pill,sleeping pill,安眠药,NOUN,B2
+sleeve,sleeve,袖子,NOUN,B2
+slice,slice,薄片,NOUN,B2
+slightly,slightly,轻微地,ADV,B2
+slipper,slipper,拖鞋,NOUN,B2
+slow down,to slow down,放慢,VERB,B2
+lentitud,slowness,缓慢,NOUN,B2
+perezoso,sluggish,迟钝的,ADJ,B2
+astucia,slyness,狡猾,NOUN,B2
+pequeño,smallest,最小的,ADJ,B2
+pequeñez,smallness,小小,NOUN,B2
+inteligente,smart,聪明的,ADJ,B2
+aplastar,to smash,粉碎,VERB,B2
+aplastamiento,smashing,砸过,NOUN,B2
+noción,smattering,少量,NOUN,B2
+oler,smell,气味,NOUN,B2
+oler,to smell,闻,VERB,B2
+tabaquismo,smoking,吸烟,NOUN,B2
+alisar,smooth,光滑的,ADJ,B2
+alisar,to smooth,使光滑,VERB,B2
+suavemente,smoothly,顺利,ADV,B2
+contrabando,smuggling,走私,NOUN,B2
+merienda,snack,小吃,NOUN,B2
+colarse,to sneak,潜行,VERB,B2
+roncar,to snore,打鼾,VERB,B2
+sombra de nieve,snow shadow,雪影姐姐,NOUN,B2
+copo de nieve,snowflake,雪花,NOUN,B2
+hasta ahora,so far,到目前为止,ADV,B2
+tanto,so much,那么多,DET,B2
+para que,so that,以便,SCONJ,B2
+supuesto,so-called,所谓的,ADJ,B2
+sollozar,to sob,啜泣,VERB,B2
+sollozo,sobbing,抽泣,NOUN,B2
+sobriedad,sobriety,清醒,NOUN,B2
+sociable,sociable,好交际的,ADJ,B2
+social,social,社会的,ADJ,B2
+arbitraje social,social arbitration,社会仲裁,NOUN,B2
+despertar social,social awakening,社会觉醒,NOUN,B2
+clase social,social class,社会阶层,NOUN,B2
+compromiso social,social compromise,社会妥协,NOUN,B2
+distanciamiento social,social distancing,社交距离,NOUN,B2
+social harmony,social harmony,社会和谐,NOUN,B2
+social identity,social identity,社会身份,NOUN,B2
+social interaction,social interaction,社会互动,NOUN,B2
+social mobilization,social mobilization,社会动员,NOUN,B2
+social organization,social organization,社会组织,NOUN,B2
+social practice,social practice,社会实践,NOUN,B2
+social reconciliation,social reconciliation,社会和解,NOUN,B2
+social stability,social stability,社会稳定,NOUN,B2
+social statistics,social statistics,社会统计,NOUN,B2
+social stratification,social stratification,社会分层,NOUN,B2
+social trend,social trend,社会趋势,NOUN,B2
+social trust,social trust,社会信任,NOUN,B2
+socialize,to socialize,交往,VERB,B2
+sociologist,sociologist,社会学家,NOUN,B2
+sociology,sociology,社会学,NOUN,B2
+sofa,sofa,沙发,NOUN,B2
+softball,softball,垒球,NOUN,B2
+software,software,软件,NOUN,B2
+soil,soil,土壤,NOUN,B2
+sojourn,sojourn,逗留,NOUN,B2
+solace,solace,安慰,NOUN,B2
+soldiers,soldiers,官兵,NOUN,B2
+sole,sole,鞋底,NOUN,B2
+solemn,solemn,庄严的,ADJ,B2
+solicit,to solicit,恳求,VERB,B2
+solicit donations,to solicit donations,募捐,VERB,B2
+solid,solid,3D模型 / 实体,NOUN,B2
+solid-state drive,solid-state drive,固态硬盘,NOUN,B2
+solidarity,solidarity,团结,NOUN,B2
+soliloquy,soliloquy,独白,NOUN,B2
+solitude,solitude,孤独,NOUN,B2
+solvency,solvency,偿付能力,NOUN,B2
+some out,some out,出些,NOUN,B2
+somehow,somehow,以某种方式,ADV,B2
+sometime,sometime,在某个时候,ADV,B2
+a veces,sometimes,有时,ADV,B2
+en alguna parte,somewhere,某处,ADV,B2
+sofistería,sophistry,诡辩,NOUN,B2
+perdón,sorry,抱歉,ADJ,B2
+clasificar,to sort,分类,VERB,B2
+bullicio,sound of activity,动静,NOUN,B2
+solidez,soundness,好端端,NOUN,B2
+agrio,sour,酸的,ADJ,B2
+ejército del sur,southern army,南军,NOUN,B2
+recuerdo,souvenir,纪念品,NOUN,B2
+soberano,sovereign,君主,NOUN,B2
+soberanía,sovereignty,主权,NOUN,B2
+sembrar,to sow,播种,VERB,B2
+siembra,sowing,播种,NOUN,B2
+espacio,space,空间,NOUN,B2
+nave espacial,spaceship,宇宙飞船,NOUN,B2
+español,spanish,西班牙语,NOUN,B2
+ahorrar,to spare,节省,VERB,B2
+tiempo libre,spare time,业余,NOUN,B2
+gorrión,sparrow,麻雀,NOUN,B2
+orador,speaker,发言人,NOUN,B2
+tema especial,special topic,专题,NOUN,B2
+especializado,specialized,专业的,ADJ,B2
+especialidad,specialty,专业,NOUN,B2
+especie,species,物种,NOUN,B2
+entrenamiento espiritual,spirit training,练神,NOUN,B2
+férula,splint,夹板,NOUN,B2
+patrocinio,sponsorship,赞助,NOUN,B2
+espontáneo,spontaneous,自发的,ADJ,B2
+coche deportivo,sports car,跑车,NOUN,B2
+esguince,sprain,扭伤,NOUN,B2
+aerosol,spray,喷雾,NOUN,B2
+propagación,spread,传播,NOUN,B2
+escuadrón,squad,小队,NOUN,B2
+cuadrado,square,平方的,ADJ,B2
+agacharse,to squat,蹲,VERB,B2
+personal,staff,全体员工,NOUN,B2
+obra de teatro,stage play,舞台剧,NOUN,B2
+vacilar,to stagger,蹒跚,VERB,B2
+estancarse,to stagnate,停滞,VERB,B2
+detenerse,to stall,拖延,VERB,B2
+postura,stance,立场,NOUN,B2
+pararse,to stand,站立,VERB,B2
+pararse lado a lado,to stand side by side,并列,VERB,B2
+ponerse de pie,to stand up,站起来,VERB,B2
+estándar,standard,标准,NOUN,B2
+estandarización,standardization,标准化,NOUN,B2
+permanente,standing,站立的,ADJ,B2
+punto muerto,standstill,停滞,NOUN,B2
+anís estrellado,star anise,八角,NOUN,B2
+mirar fijamente,to stare,凝视,VERB,B2
+cielo estrellado,starry sky,星空,NOUN,B2
+pasar hambre,to starve,挨饿,VERB,B2
+declarar,to state,说明,VERB,B2
+papelería,stationery,文具,NOUN,B2
+estatus,status,地位,NOUN,B2
+estable,steady,稳定的,ADJ,B2
+hervir,steam,蒸汽,NOUN,B2
+hervir,to steam,蒸,VERB,B2
+bao,steamed stuffed bun,包子,NOUN,B2
+acero,steel,钢,NOUN,B2
+dirigir,to steer,引导,VERB,B2
+volante,steering wheel,方向盘,NOUN,B2
+tallo,stem,茎,NOUN,B2
+estenosis,stenosis,狭窄,NOUN,B2
+dar un paso,to step,踩,VERB,B2
+madrastra,stepmother,后母,NOUN,B2
+palo,stick,棍子,NOUN,B2
+rígido,stiff,僵硬的,ADJ,B2
+stimulant,stimulant,兴奋剂,NOUN,B2
+stinginess,stinginess,吝啬；小气,NOUN,B2
+stinking,stinking,发臭的,ADJ,B2
+stir,stir,搅拌,NOUN,B2
+stir,to stir,搅拌,VERB,B2
+stitch,stitch,针脚,NOUN,B2
+stock,stock,库存,NOUN,B2
+stock exchange,stock exchange,证券交易所,NOUN,B2
+stock market,stock market,股市,NOUN,B2
+stoicism,stoicism,斯多葛主义,NOUN,B2
+stomachache,stomachache,肚子痛,NOUN,B2
+stop,stop,停止,NOUN,B2
+stop me,to stop me,拦我,VERB,B2
+storage,storage,收纳,NOUN,B2
+store,store,商店,NOUN,B2
+stormy,stormy,有暴风雨的,ADJ,B2
+straight,straight,笔直的,ADJ,B2
+straightforward,straightforward,直率的,ADJ,B2
+strain,to strain,努力,VERB,B2
+strait,strait,海峡,NOUN,B2
+strange troops,strange troops,怪兵,NOUN,B2
+stressed,stressed,焦虑的,ADJ,B2
+stretch,stretch,伸展,NOUN,B2
+stretcher,stretcher,担架,NOUN,B2
+strike,to strike,打击,VERB,B2
+string,string,细绳,NOUN,B2
+stroke,stroke,中风,NOUN,B2
+stroll,to stroll,散步,VERB,B2
+structural,structural,结构的,ADJ,B2
+stuck,stuck,卡住的,ADJ,B2
+studies,studies,学业,NOUN,B2
+studio,studio,工作室,NOUN,B2
+stuff,stuff,东西,NOUN,B2
+stylish,stylish,雅致的,ADJ,B2
+subjetivo,subjective,主观的,ADJ,B2
+submarino,submarine,潜水艇,NOUN,B2
+sumergir,to submerge,淹没,VERB,B2
+sumisión,submission,顺从,NOUN,B2
+someter,to submit,提交,VERB,B2
+subordinado,subordinate,下属,NOUN,B2
+suscribir,to subscribe,订阅,VERB,B2
+suscriptor,subscriber,订阅者,NOUN,B2
+suscripción,subscription,订阅,NOUN,B2
+subsiguiente,subsequent,随后的,ADJ,B2
+subsidio,subsidy,补贴,NOUN,B2
+subsistencia,subsistence,生计,NOUN,B2
 sustanciación,substantiation,论证,NOUN,B2
-sustento,sustenance,食物,NOUN,B2
 sustituto,substitute,替代品,NOUN,B2
+subtítulo,subtitle,字幕,NOUN,B2
+suburbio,suburb,郊区,NOUN,B2
+suceder,to succeed,成功,VERB,B2
+exitoso,successful,成功的,ADJ,B2
+sucesión,succession,连续,NOUN,B2
+sucesivamente,successively,连续地,ADV,B2
+sucesor,successor,继任者,NOUN,B2
+tal,such,如此,DET,B2
+chupar,to suck,吸,VERB,B2
+repentinamente,suddenly,突然地,ADV,B2
+padecer insomnio,to suffer from insomnia,失眠,VERB,B2
+suficiencia,sufficiency,充足,NOUN,B2
+suficiente,sufficient,足够的,ADJ,B2
+asfixiar,to suffocate,窒息,VERB,B2
+asfixia,suffocation,窒息,NOUN,B2
+sugerencia,suggestion,建议,NOUN,B2
+suma,sum,总和,NOUN,B2
+soleado,sunny,晴朗的,ADJ,B2
+amanecer,sunrise,日出,NOUN,B2
+sol,sunshine,阳光,NOUN,B2
+supercomprensivo,super-comprehensive,超遍,NOUN,B2
+supergrado,super-grade,超级,NOUN,B2
+superprincipio,super-principle,超则,NOUN,B2
+supercalidad,super-quality,超质,NOUN,B2
+supsistema,super-system,超制,NOUN,B2
+superpensamiento,super-thought,超思,NOUN,B2
+superficial,superficial,表面的,ADJ,B2
+superior,superior,更好的,ADJ,B2
+supermercado,supermarket,超市,NOUN,B2
+supervisar,to supervise,监督,VERB,B2
+supervisión,supervision,监督,NOUN,B2
+supervisor,supervisor,主管,NOUN,B2
+suplementar,supplement,补充,NOUN,B2
+suplementar,to supplement,补充,VERB,B2
+proveedor,supplier,供应商,NOUN,B2
+suministro,supply,供应,NOUN,B2
+apoyar,to support,支持,VERB,B2
+apoyante,supporter,支持者,NOUN,B2
+suprimir,to suppress,压制,VERB,B2
+supresión,suppression,抑,NOUN,B2
+seguro,sure,确定的,ADJ,B2
+oleada,surge,激增,NOUN,B2
+apellido,surname,姓氏,NOUN,B2
+sorprendente,surprising,令人惊讶的,ADJ,B2
+surrealismo,surrealism,超现实主义,NOUN,B2
+rendición,surrender,投降,NOUN,B2
+alrededores,surroundings,周围,NOUN,B2
+vigilar,to surveil,监视,VERB,B2
+vigilancia,surveillance,监视,NOUN,B2
+topógrafo,surveyor,测量员,NOUN,B2
+supervivencia,survival,生存,NOUN,B2
+superviviente,survivor,幸存者,NOUN,B2
+susha,susha,夙砂大,NOUN,B2
+sospechoso,suspect,嫌疑人,NOUN,B2
+suspenso,suspense,悬念,NOUN,B2
+suspensión,suspension,暂停,NOUN,B2
+sostenibilidad,sustainability,可持续性,NOUN,B2
+sostenible,sustainable,可持续的,ADJ,B2
+sustento,sustenance,食物,NOUN,B2
 suturar,suture,缝合,NOUN,B2
 suturar,to suture,缝合,VERB,B2
-svelte,svelte,词,ADJ,C1
-swab,swab,词,NOUN,B2
-swap,swap,词,VERB,B2
-swarthy,swarthy,词,ADJ,C1
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweatshirt,sweatshirt,词,NOUN,C1
-sweden,sweden,瑞典,PROPN,B2
-swedish,swedish,瑞典语,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-sweetness,sweetness,,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swim training,swim training,,NOUN,B2
-swimmer,swimmer,词,NOUN,C1
-swimming,swimming,游泳,NOUN,B2
-swimwear,swimwear,,NOUN,B2
-swine,swine,猪,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swirl,swirl,词,VERB,C1
-swiss,swiss,瑞士的,ADJ,B2
-switch key,switch key,词,NOUN,C1
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsmanship,swordsmanship,剑术,NOUN,B2
-sycophant,sycophant,词,NOUN,C1
-sycophantic,sycophantic,词,ADJ,B2
-syllabification,syllabification,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
-syllogism,syllogism,三段论,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbolic,symbolic,象征的,ADJ,B2
-symbolism,symbolism,象征主义,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symmetric,symmetric,词,ADJ,C1
-symmetrical,symmetrical,对称的,ADJ,B2
-sympathetic,sympathetic,同情的,ADJ,B2
-sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
-symphonic,symphonic,交响乐的,ADJ,B2
-symptom,symptom,症,PART,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-symptoms,symptoms,词,NOUN,B1
-synaptic,synaptic,词,ADJ,C1
-sync,sync,同步,NOUN,B2
-synchronized,synchronized,词,ADJ,C1
-synchrony,synchrony,词,NOUN,C1
-syncopate,syncopate,词,VERB,C1
-syncretism,syncretism,词,NOUN,C1
-syndicate,syndicate,词,NOUN,C1
-syndrome,syndrome,综合征,NOUN,B2
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,元音合并,NOUN,B2
-synonym,synonym,词,NOUN,C1
-synopsis,synopsis,词,NOUN,C1
-synoptic,synoptic,概要的,ADJ,B2
-syntactic,syntactic,词,ADJ,C1
-synthetic,synthetic,合成的,ADJ,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-syrian,syrian,叙利亚的,ADJ,B2
-systematically,systematically,系统地,ADV,B2
-systemless,systemless,无系统的,ADJ,B2
-sátira,satire,讽刺,NOUN,B2
-sésamo,sesame,芝麻,NOUN,B2
-sí mismo,self,自我,NOUN,B2
-síntesis,synthesis,综合,NOUN,B2
-síntoma,symptom,症状,NOUN,B2
-sísmico,seismic,地震的,ADJ,B2
-tab,tab,词,NOUN,C1
-tabaquismo,smoking,吸烟,NOUN,B2
-taberna,tavern,酒馆,NOUN,B2
-tabernacle,tabernacle,词,NOUN,C1
-tabla,board,木板,NOUN,B2
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tablecloth,tablecloth,词,NOUN,C1
-tablero,dashboard,仪表盘,NOUN,B2
-tablet,tablet,平板电脑,NOUN,B2
-taboo (adj),taboo,词,ADJ,C1
-tabú,taboo,禁忌,NOUN,B2
-tachometer,tachometer,转速表,NOUN,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-taciturno,taciturn,沉默寡言的,ADJ,B2
-tact,tact,词,NOUN,C1
-tactful appeasement,tactful appeasement,词,NOUN,C1
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,不得体的,ADJ,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
-takeover,takeover,词,NOUN,C1
-taking command,taking command,挂帅,NOUN,B2
-tal,such,如此,DET,B2
-taladro,drill,钻头,NOUN,B2
-tale,tale,词,NOUN,A1
-talented,talented,有才华的,ADJ,B2
-talk show,talk show,脱口秀,NOUN,C1
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-taller,workshop,研讨会,NOUN,B2
-tallo,stem,茎,NOUN,B2
-tally,tally,词,VERB,C1
-talón,heel,脚后跟,NOUN,B2
-también,also too,也,ADV,B2
-tambor,drum,鼓,NOUN,B2
-tambourine,tambourine,词,NOUN,B2
-tame (adj),tame,词,ADJ,A1
-tamper,tamper,词,VERB,C1
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tangente,tangent,切线,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible,tangible,有形的,ADJ,B2
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tank cistern,tank cistern,词,NOUN,C1
-tannery,tannery,词,NOUN,B2
-tantamount,tantamount,词,ADJ,C1
-tanto,so much,那么多,DET,B2
-tantrum,tantrum,词,NOUN,C1
-tap,tap,水龙头,NOUN,B2
-tapa,lid,盖子,NOUN,B2
-tapestry,tapestry,词,NOUN,C1
-tarab,tarab,词,NOUN,B2
-tarde,afternoon,下午,NOUN,B2
-tarde,evening,晚上,NOUN,B2
-tarea de proyecto,project assignment,项目作业,NOUN,B2
-target group,target group,词,NOUN,C1
-targeted,targeted,有针对性的,ADJ,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
-tarjeta de crédito,credit card,信用卡,NOUN,B2
-tarjeta postal,postcard,明信片,NOUN,B2
-taro,taro,芋头,NOUN,B2
-tarragon,tarragon,龙蒿,NOUN,B2
-tarry,tarry,词,VERB,C1
-tart pie,tart pie,词,NOUN,C1
-tasteless,tasteless,无味的,ADJ,B2
-tasty,tasty,美味的,ADJ,B2
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tatter,tatter,词,NOUN,C1
-tattoo,tattoo,纹身,NOUN,B2
-tautology,tautology,词,NOUN,C1
-tawdry,tawdry,词,ADJ,C1
-tax (adj),tax,词,ADJ,C1
-tax authorities,tax authorities,税务机关,NOUN,B2
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax rate,tax rate,税率,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax return,tax return,报税,NOUN,B2
-tax revenue,tax revenue,税收,NOUN,B2
-taxable,taxable,应纳税的,ADJ,B2
-taxi,taxi,出租车,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-taxonomy,taxonomy,分类学,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
-teapot,teapot,词,NOUN,C1
-tearing,tearing,tearing,NOUN,B2
-teasing playful,teasing playful,词,ADJ,C1
-techar,to roof,房顶,VERB,B2
-technically,technically,技术上地,ADV,B2
-technocrat,technocrat,词,NOUN,C1
-technocratic,technocratic,技术官僚的,ADJ,B2
-techo,ceiling,天花板,NOUN,B2
-teclado,keyboard,键盘,NOUN,B2
-tecnocracia,technocracy,技术官僚主义,NOUN,B2
-tecnología,technology,技术,NOUN,B2
-tecnología verde,green technology,绿色技术,NOUN,B2
-tecnológico,technological,技术的,ADJ,B2
-tectonic,tectonic,词,ADJ,C1
-teddy bear,teddy bear,词,NOUN,B2
-tedious,tedious,乏味的,ADJ,B2
-tedious painful,tedious painful,词,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-teetotal,teetotal,词,ADJ,C1
-tejido,tissue,组织,NOUN,B2
-tela,cloth,布,NOUN,B2
-tela,fabric,织物,NOUN,B2
-tela de seda,silk cloth,丝绸,NOUN,B2
-telecommunications,telecommunications,词,NOUN,C1
-telegram,telegram,电报,NOUN,B2
-telegraph lightning,telegraph lightning,词,NOUN,C1
-teleological,teleological,目的论的,ADJ,B2
-teleología,teleology,目的论,NOUN,B2
-telepathy,telepathy,词,NOUN,C1
-telephone number,telephone number,电话号码,NOUN,B2
-telephone ringing,telephone ringing,词,NOUN,C1
-telephones,telephones,电话,NOUN,B2
-telephony,telephony,电话学,NOUN,B2
-telescopio,telescope,望远镜,NOUN,B2
-televised,televised,电视播出的,ADJ,B2
-television set,television set,词,NOUN,B1
-televisión,television,电视,NOUN,B2
-teller,teller,词,NOUN,B2
-telling-off,telling-off,词,NOUN,B1
-telltale,telltale,词,ADJ,C1
-teléfono,telephone,电话,NOUN,B2
-teléfono celular,cell phone,手机,NOUN,B2
-telón,backstage,幕后,NOUN,B2
-tema,theme,主题,NOUN,B2
-tema especial,special topic,专题,NOUN,B2
+tragar,to swallow,吞下,VERB,B2
+pantano,swamp,沼泽,NOUN,B2
+balancear,to sway,摇摆,VERB,B2
+sudar,to sweat,出汗,VERB,B2
+barrido,sweep,扫,NOUN,B2
+sueño dulce,sweet dream,美梦,NOUN,B2
+cariño,sweetheart,爱人,NOUN,B2
+dulce,sweetie,亲爱的,NOUN,B2
+dulces,sweets,甜食,NOUN,B2
+piscina,swimming pool,游泳池,NOUN,B2
+columpio,swing,秋千,NOUN,B2
+sala de conmutación,switch room,配电室,NOUN,B2
+conmutador,switchboard,总机,NOUN,B2
+sin espada,swordless,剑不,NOUN,B2
+adulación,sycophancy,阿谀奉承,NOUN,B2
 temario,syllabus,教学大纲,NOUN,B2
-temblor,tremor,颤抖,NOUN,B2
-temer,dread,恐惧,NOUN,B2
-temer,to dread,畏惧,VERB,B2
-temerity,temerity,鲁莽,NOUN,B2
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperamental,temperamental,词,ADJ,C1
-temperamento,temperament,气质,NOUN,B2
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-template,template,词,NOUN,C1
-templo,temple,寺庙,NOUN,B2
-temporal,temporal,时间的,ADJ,B2
-temporal,temporary,暂时的,ADJ,B2
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
-temporalmente,temporarily,临时地,ADV,B2
-temporización,timing,时机,NOUN,B2
-temprano,early,早的,ADJ,B2
-temptation,temptation,词,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-tenable,tenable,词,ADJ,C1
-tenacity,tenacity,坚韧,NOUN,B2
-tend,tend,词,VERB,B2
-tendencia,trend,趋势,NOUN,B2
-tendentious,tendentious,有偏见的,ADJ,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
-tendón,tendon,肌腱,NOUN,B2
-tenedor,fork,叉子,NOUN,B2
-tenement,tenement,词,NOUN,C1
-tener,to have only,唯有,VERB,B2
-tener razón,to be right,正确,VERB,B2
-tenet,tenet,词,NOUN,C1
-teniente,lieutenant,中尉,NOUN,B2
-tenis,tennis,网球,NOUN,B2
-tenor,tenor,男高音,NOUN,B2
-tens,tens,词,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
-tense (noun),tense,词,NOUN,B1
-tense angry,tense angry,词,ADJ,A2
-tense excited,tense excited,词,ADJ,B2
-tensile,tensile,词,ADJ,C1
+simbolizar,to symbolize,象征,VERB,B2
+simetría,symmetry,对称,NOUN,B2
+simpatizar,to sympathize,同情,VERB,B2
+simpatía,sympathy,同情,NOUN,B2
+sinfonía,symphony,交响乐,NOUN,B2
+simposio,symposium,研讨会,NOUN,B2
+síntoma,symptom,症状,NOUN,B2
+simptomático,symptomatic,症状的,ADJ,B2
+sincronización,synchronization,同步,NOUN,B2
+sincrónico,synchronous,同步的,ADJ,B2
+sinergia,synergy,协同效应,NOUN,B2
+sinonimia,synonymy,同义关系,NOUN,B2
+sintaxis,syntax,句法,NOUN,B2
+síntesis,synthesis,综合,NOUN,B2
+sintetizar,to synthesize,合成,VERB,B2
+sistemático,systematic,系统的,ADJ,B2
+sistémico,systemic,全身性的,ADJ,B2
+tabú,taboo,禁忌,NOUN,B2
+tácitamente,tacitly,默不作声地,ADV,B2
+taciturno,taciturn,沉默寡言的,ADJ,B2
+abordar,to tackle,处理,VERB,B2
+diplomático,tactful,圆滑的,ADJ,B2
+táctica,tactics,战术,NOUN,B2
+cola,tail,尾巴,NOUN,B2
+excederse,to take a leave of absence,休学,VERB,B2
+llevar,to take along,带走,VERB,B2
+llevarse,to take away,拿走,VERB,B2
+cuidar,to take care,照顾,VERB,B2
+esquejar,to take cuttings,扦插,VERB,B2
+posesionarse,to take office,就职,VERB,B2
+asumir,to take over,接管,VERB,B2
+suceder,to take place,举行,VERB,B2
+vengarse,to take revenge,报复,VERB,B2
+toma,taking,拍摄,NOUN,B2
+hablar,talk,谈话,NOUN,B2
+hablar,to talk,谈话,VERB,B2
+locuacidad,talkativeness,多嘴,NOUN,B2
+tangente,tangent,切线,NOUN,B2
+tangible,tangible,有形的,ADJ,B2
+bronceado,tanning,晒黑,NOUN,B2
+apuntar,target,目标,NOUN,B2
+apuntar,to target,针对,VERB,B2
+focalización,targeting,定位,NOUN,B2
+preferencia de gusto,taste preference,口味,NOUN,B2
 tenso,taut,绷紧的,ADJ,B2
+taberna,tavern,酒馆,NOUN,B2
+exento de impuestos,tax-exempt,免税,ADJ,B2
+fiscalidad,taxation,征税,NOUN,B2
+taxi,taxi,出租车,NOUN,B2
+plantación de té,tea plantation,茶园,NOUN,B2
+equipo,team,团队,NOUN,B2
+compañero de equipo,teammate,队友,NOUN,B2
+lágrimas,tears,眼泪,NOUN,B2
+técnico,technical,技术的,ADJ,B2
+técnico,technician,技术员,NOUN,B2
+tecnocracia,technocracy,技术官僚主义,NOUN,B2
+tecnológico,technological,技术的,ADJ,B2
+tecnología,technology,技术,NOUN,B2
+teleología,teleology,目的论,NOUN,B2
+teléfono,telephone,电话,NOUN,B2
+telescopio,telescope,望远镜,NOUN,B2
+televisión,television,电视,NOUN,B2
+decir,to tell,告诉,VERB,B2
+genio,temper,脾气,NOUN,B2
+temperamento,temperament,气质,NOUN,B2
+templo,temple,寺庙,NOUN,B2
+temporalmente,temporarily,临时地,ADV,B2
+temporal,temporary,暂时的,ADJ,B2
+rechazo temporal,temporary refusal,暂不,NOUN,B2
+tierno,tender,嫩的,ADJ,B2
+lomo,tenderloin,里脊,NOUN,B2
+tendón,tendon,肌腱,NOUN,B2
+tenis,tennis,网球,NOUN,B2
 tenso,tense,紧张的,ADJ,B2
+tienda,tent,帐篷,NOUN,B2
 tentativo,tentative,暂定的,ADJ,B2
-tenth,tenth,第十,ADJ,B2
-tenth (noun),tenth,词,NOUN,B2
-tenuous,tenuous,词,ADJ,C1
-tenure,tenure,词,NOUN,B2
+terminal,terminal,终点站,NOUN,B2
+terminar,to terminate,终止,VERB,B2
+terminación,termination,解除,NOUN,B2
+terminológico,terminological,术语的,ADJ,B2
+terminología,terminology,术语,NOUN,B2
+terreno,terrain,地形,NOUN,B2
+terrestre,terrestrial,地球的,ADJ,B2
+terrible,terrible,可怕的,ADJ,B2
+territorial,territorial,领土的,ADJ,B2
+terror,terror,恐怖,NOUN,B2
+terrorismo,terrorism,恐怖主义,NOUN,B2
+terrorista,terrorist,恐怖分子,NOUN,B2
+probar,to test,测试,VERB,B2
+testículo,testicle,睾丸,NOUN,B2
+texto,text,文本,NOUN,B2
+mensaje de texto,text message,短信,NOUN,B2
+libro de texto,textbook,教科书,NOUN,B2
+textil,textile,纺织,NOUN,B2
+textual,textual,文本的,ADJ,B2
+que,than,比,ADP,B2
+gracias,thank you,谢谢,INTJ,B2
+gracias,thanks,谢谢,NOUN,B2
+gracias a,thanks to,多亏,ADP,B2
+esa flecha,that arrow,那一箭,NOUN,B2
+es decir,that is,即,ADV,B2
+así,that way,那样,PRON,B2
+el resto,the rest,其余,NOUN,B2
+tema,theme,主题,NOUN,B2
+tú,then you,那你,PRON,B2
 teocracia,theocracy,神权政治,NOUN,B2
 teología,theology,神学,NOUN,B2
 teorema,theorem,定理,NOUN,B2
-tepid,tepid,词,ADJ,C1
-terapéutico,therapeutic,治疗的,ADJ,B2
-teratogenic,teratogenic,致畸的,ADJ,B2
-tercer don,third bestowal,三授,NOUN,B2
-tercero,third,第三,ADJ,B2
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-terminación,termination,解除,NOUN,B2
-terminal,terminal,终点站,NOUN,B2
-terminal (adj),terminal,终末的,ADJ,B2
-terminar,to terminate,终止,VERB,B2
-terminología,terminology,术语,NOUN,B2
-terminológico,terminological,术语的,ADJ,B2
-terminus,terminus,,NOUN,B2
-tern path,tern path,,NOUN,B2
-terrace,terrace,露台,NOUN,B2
-terremoto,earthquake,地震,NOUN,B2
-terreno,terrain,地形,NOUN,B2
-terrenos,grounds,论据,NOUN,B2
-terrestre,terrestrial,地球的,ADJ,B2
-terrible,terrible,可怕的,ADJ,B2
-terribleness,terribleness,,NOUN,B2
-terribly,terribly,可怕地/非常,ADV,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
-territorial,territorial,领土的,ADJ,B2
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
-terror,terror,恐怖,NOUN,B2
-terrorismo,terrorism,恐怖主义,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terrorista,terrorist,恐怖分子,NOUN,B2
-terrorists,terrorists,恐怖分子们,NOUN,B2
-terseness,terseness,词,NOUN,C1
-tertiary,tertiary,第三的,ADJ,B2
-tesis,thesis,论文,NOUN,B2
-test drive,test drive,,NOUN,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testator,testator,词,NOUN,C1
-testicular,testicular,词,ADJ,C1
-testigo ocular,eyewitness,目击,NOUN,B2
-testimonio,witness testimony,人证,NOUN,B2
-testimony deposition,testimony deposition,词,NOUN,C1
-testículo,testicle,睾丸,NOUN,B2
-tether,tether,词,NOUN,C1
-textil,textile,纺织,NOUN,B2
-texto,text,文本,NOUN,B2
-textual,textual,文本的,ADJ,B2
-textuality,textuality,词,NOUN,C1
-texture,texture,词,NOUN,C1
-teóricamente,theoretically,理论上,ADV,B2
 teórico,theoretical,理论的,ADJ,B2
-than (adv),than,词,ADV,A1
-thank god,thank god,谢天谢地,INTJ,B2
-thanks (noun),thanks,谢了,NOUN,A1
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-tharid,tharid,词,NOUN,B2
-that (noun),that,将那,NOUN,C1
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
-that nephew,that nephew,那侄儿,NOUN,B2
-that night,that night,那晚,NOUN,B2
-that one,that one,那个,PRON,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that to,that to,那/去,PART,B2
-that way,that way,往那边,ADV,B2
-that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,复合词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,复合词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,名词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,名词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,名词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,名词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,复合词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,复合词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,复合词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,复合词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the career,the career,职业生涯,NOUN,B2
-the cash register,the cash register,收银台,NOUN,B2
-the casinos,the casinos,赌场,NOUN,B2
-the cavalry,the cavalry,骑兵,NOUN,B2
-the chain,the chain,链条,NOUN,B2
-the chinese,the chinese,中国人,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,ADV,B2
-the day after tomorrow (noun),the day after tomorrow,词,NOUN,B2
-the day before yesterday,the day before yesterday,词,ADV,C1
-the devil bastard,the devil bastard,混蛋,NOUN,B2
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the emperor,the emperor,皇帝,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,复合词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,复合词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the guy,the guy,那个男人,NOUN,B2
-the guy's,the guy's,那个男人的,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,复合词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the it,the it,那,DET,B2
-the masculine,the masculine,词,DET,A2
-the masses,the masses,大众,NOUN,C1
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,复合词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the more,the more,越,ADV,B2
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,复合词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
-the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,词,DET,B1
-the one (pron),the one,那个人,PRON,B1
-the other day,the other day,前几天,ADV,B2
-the other evening,the other evening,前几天晚上,ADV,B2
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the rich,the rich,富人,NOUN,B2
-the safe,the safe,保险箱,NOUN,B2
-the same,the same,相同的,ADJ,B2
-the same (det),the same,词,DET,A2
-the same (pron),the same,词,PRON,C1
-the sick,the sick,病人,NOUN,B2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unseen,the unseen,词,NOUN,C1
-the unstellung,the unstellung,复合词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,复合词,NOUN,B2
-the urbewegung,the urbewegung,复合词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,复合词,NOUN,B2
-the urrechnung,the urrechnung,复合词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,复合词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,复合词,NOUN,B2
-the verminderung,the verminderung,复合词,NOUN,B2
-the verstbindung,the verstbindung,词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,复合词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,复合词,NOUN,B2
-the ververtiefung,the ververtiefung,复合词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the very,the very,正是,ADV,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,复合词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,复合词,NOUN,B2
-the zerordnung,the zerordnung,复合词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-theatrical,theatrical,戏剧的,ADJ,B2
-their,their,他们的,PRON,B2
-their (det),their,词,DET,B2
-them dative,them dative,词,PRON,A2
-thematic,thematic,主题的,ADJ,B2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,神权的,ADJ,B2
-theodicy,theodicy,词,NOUN,C1
-theologian,theologian,神学家,NOUN,B2
-theological,theological,神学的,ADJ,B2
-theorize,theorize,词,VERB,B2
-therapist,therapist,治疗师,NOUN,B2
-there (noun),there,那儿,NOUN,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-thereafter,thereafter,此后,ADV,B2
-therefore (sconj),therefore,所以,SCONJ,B2
-thermal (noun),thermal,词,NOUN,B2
-thermodynamics,thermodynamics,热力学,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-thesaurus,thesaurus,词,NOUN,C1
-these,these,这些,PRON,B2
-thespian,thespian,词,NOUN,C1
-thetic,thetic,正题的,ADJ,B2
-they female,they female,她们,PRON,B2
-they two,they two,词,PRON,A1
-thick fog,thick fog,浓雾,NOUN,C1
-thicker,thicker,更厚的,ADJ,B2
-thickets,thickets,词,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-thinker,thinker,词,NOUN,C1
-thinner,thinner,更薄的,ADJ,B2
-third,third,三分之一,NOUN,B2
-third (adj),third,第三,ADJ,A2
-third place,third place,季军,NOUN,B2
-this,this,这,PRON,B2
-this (noun),this,你这,NOUN,B2
-this afternoon,this afternoon,词,ADV,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this masculine,this masculine,词,DET,A1
-this matter,this matter,这事,NOUN,B2
-this morning,this morning,今天早上,ADV,B2
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
-this way,this way,这边,ADV,B2
-this year,this year,今年,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
-thoroughly,thoroughly,词,ADV,B2
-those,those,那些,PRON,B2
-thoughtfully,thoughtfully,体贴地,ADV,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
-thousand (noun),thousand,词,NOUN,B2
-thousands,thousands,数千,NOUN,B2
-thousands (num),thousands,词,NUM,B1
-thrall,thrall,词,NOUN,C1
-threadbare,threadbare,词,ADJ,C1
-threads,threads,词,NOUN,B2
-threatened,threatened,词,ADJ,C1
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-threshing floor,threshing floor,词,NOUN,B2
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thrilling,thrilling,令人兴奋的,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throng,throng,词,NOUN,C1
-throughout,throughout,词,ADP,B1
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-throwing,throwing,词,NOUN,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thunderstorm,thunderstorm,雷阵雨,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-tiburón,shark,鲨鱼,NOUN,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,检票,NOUN,B2
-ticket window,ticket window,售票窗口,NOUN,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
-tidy (adj),tidy,词,ADJ,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tiempo de correspondencia,matching time,对时,NOUN,B2
-tiempo extra,overtime,加班,NOUN,B2
-tiempo libre,free time,业余时间,NOUN,B2
-tiempo libre,spare time,业余,NOUN,B2
-tienda,tent,帐篷,NOUN,B2
-tier,tier,分阶,NOUN,C1
-tierno,cute,可爱的,ADJ,B2
-tierno,tender,嫩的,ADJ,B2
-tierra firme,mainland,大陆,NOUN,B2
-tierra prohibida,forbidden land,禁地,NOUN,B2
-tifón,typhoon,台风,NOUN,B2
-tight narrow,tight narrow,词,ADJ,B1
-tight-fitting,tight-fitting,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightly,tightly,词,ADV,C1
-tights,tights,词,NOUN,C1
+teóricamente,theoretically,理论上,ADV,B2
+terapéutico,therapeutic,治疗的,ADJ,B2
+allí,there,那儿,NOUN,B2
+haber,to there's still time,来得及,VERB,B2
+de este modo,thereby,从而,ADV,B2
+por lo tanto,therefore,因此,ADV,B2
+entonces,thereupon,随后,ADV,B2
+térmico,thermal,热的,ADJ,B2
+estos,these,这些,DET,B2
+estos tres,these three,这三,NOUN,B2
+tesis,thesis,论文,NOUN,B2
+ellos,they things,它们,PRON,B2
+presencia,thief presence,有贼,NOUN,B2
+muslo,thigh,大腿,NOUN,B2
+delgado,thin,瘦的,ADJ,B2
+querer,to think to want,想,VERB,B2
+inventar,to think up,构思,VERB,B2
+pensamiento,thinking,思维,NOUN,B2
+tercero,third,第三,ADJ,B2
+tercer don,third bestowal,三授,NOUN,B2
+sediento,thirsty,口渴的,ADJ,B2
+trece,thirteen,十三,NUM,B2
+este,this,您这,NOUN,B2
+esta batalla,this battle,此战,NOUN,B2
+este artículo,this item,这件,NOUN,B2
+así,this way,这样,PRON,B2
+este campamento,this-camp,这营,NOUN,B2
+minuciosidad,thoroughness,彻底,NOUN,B2
+esos,those,那些,DET,B2
+pensativo,thoughtful,体贴的,ADJ,B2
+mil,thousand,千,NUM,B2
+amenazador,threatening,具有威胁性的,ADJ,B2
+impresión tridimensional,three-d printing,3D打印,NOUN,B2
+umbral,threshold,门槛,NOUN,B2
+ahorrador,thrifty,节俭的,ADJ,B2
+trono,throne,王座,NOUN,B2
+a través de,through,通过,ADP,B2
+lanzamiento,throw,投掷,NOUN,B2
+empuje,thrust,猛推,NOUN,B2
+empuje hacia,thrust toward,插向,NOUN,B2
+pulgar,thumb,拇指,NOUN,B2
+trueno,thunder,雷,NOUN,B2
+así,thus,因此,ADV,B2
+frustrar,to thwart,阻挠,VERB,B2
+mareal,tidal,潮汐,ADJ,B2
+marea,tide,潮汐,NOUN,B2
+ordenar,to tidy up,整理,VERB,B2
+atar,to tie up,绑,VERB,B2
 tigre,tiger,老虎,NOUN,B2
-tijeras,scissors,剪刀,NOUN,B2
-tilt,tilt,倾斜,NOUN,B2
-timber,timber,词,NOUN,C1
-timbre,doorbell,门铃,NOUN,B2
-timbre,timbre,词,NOUN,C1
-time clock,time clock,打卡机,NOUN,B2
-time era,time era,词,NOUN,A2
-time limit,time limit,词,NOUN,B1
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time out,time out,词,NOUN,B2
-time to go to bed,time to go to bed,该睡觉了,ADV,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
-timetable,timetable,时刻表,NOUN,B2
-timid,timid,词,ADJ,B2
+apretado,tight,紧的,ADJ,B2
+agarre firme,tight grip,手握紧,NOUN,B2
+apretar,to tighten,紧握/收紧,VERB,B2
+baldosa,tile,瓦片,NOUN,B2
+baldosado,tiling,铺瓷砖,NOUN,B2
+veces,times,倍,NOUN,B2
 timidez,timidity,胆怯,NOUN,B2
-timorous,timorous,词,ADJ,C1
-tint (adj),tint,词,ADJ,C1
-tint (noun),tint,词,NOUN,C1
-tiny minute,tiny minute,词,ADJ,C1
-tipo,guy,家伙,NOUN,B2
-tipo,kind,种类,NOUN,B2
-tipo grueso,heavy type,重型,NOUN,B2
-tips,tips,词,NOUN,C1
-tirade,tirade,长篇抨击,NOUN,B2
-tirano,tyrant,暴君,NOUN,B2
-tiranía,tyranny,暴政,NOUN,B2
-tiranía desenfrenada,rampant tyranny,横行,NOUN,B2
-tire (noun),tire,词,NOUN,B1
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tirelessly,tirelessly,词,ADV,C1
-tiring,tiring,令人疲倦的,ADJ,B2
-tiroteo,shooting,射击,NOUN,B2
-tissue (adj),tissue,词,ADJ,C1
-titanic,titanic,词,ADJ,C1
-titillate,titillate,词,VERB,C1
-titling,titling,词,NOUN,C1
-tits,tits,词,NOUN,C1
-titular,titular,词,ADJ,C1
-tiza,chalk,粉笔,NOUN,B2
-to,to,去,PART,B2
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abound,to abound,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,动词,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,动词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abwandeln,to abwandeln,动词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to accentuate,to accentuate,强调,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to account for,to account for,说明,VERB,B2
-to accounting,to accounting,核算,VERB,B2
-to acknowledge,to acknowledge,承认,VERB,B2
-to acquaint,to acquaint,使熟悉,VERB,B2
-to acquiesce,to acquiesce,默许,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adhere join,to adhere join,词,VERB,B2
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to aggravate,to aggravate,加重,VERB,B2
-to agitate,to agitate,鼓动,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to agree with,to agree with,词,VERB,B2
-to aim (verb),to aim,词,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alert,to alert,警告,VERB,B2
-to align,to align,使一致,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to amass,to amass,积聚,VERB,B2
-to amaze,to amaze,使吃惊,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to animate,to animate,词,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to appear in court,to appear in court,词,VERB,B2
-to appear to seem,to appear to seem,出现/显得,VERB,B2
-to apply be valid,to apply be valid,适用/有效,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to archive,to archive,归档,VERB,B2
-to arm,to arm,武装,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ask about,to ask about,打听,VERB,B1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt (verb),to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attest,to attest,证明,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to await orders,to await orders,待命,VERB,B2
-to back up,to back up,后退,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to bandage (verb),to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to banish,to banish,流放,VERB,B2
-to baptize,to baptize,施洗,VERB,B2
-to bare,to bare,暴露,VERB,B2
-to bargain (verb),to bargain,词,VERB,C1
-to bark scold,to bark scold,吠/责骂,VERB,B2
-to barricade (verb),to barricade,词,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be able (aux),to be able,能够,AUX,B1
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be added,to be added,加入,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be content,to be content,词,VERB,C1
-to be contradicted,to be contradicted,词,VERB,B2
-to be correct,to be correct,正确,VERB,B2
-to be counted,to be counted,被算作,VERB,B2
-to be created,to be created,被创造,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be driven,to be driven,被驱动,VERB,B2
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be felled,to be felled,被砍倒,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be forbidden,to be forbidden,词,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be good for,to be good for,词,VERB,B2
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be happy,to be happy,词,VERB,A2
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be included,to be included,包含,VERB,B2
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be liable,to be liable,负责,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be necessary must,to be necessary must,词,VERB,A2
-to be needed,to be needed,被需要,VERB,B2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticeable,to be noticeable,词,VERB,C1
-to be noticed,to be noticed,被注意到,VERB,B2
-to be observed,to be observed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be ongoing,to be ongoing,进行中,VERB,B2
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be punished,to be punished,受罚,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be released,to be released,词,VERB,B2
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be responsible,to be responsible,负责,VERB,B2
-to be said,to be said,词,VERB,B2
-to be saved,to be saved,获救,VERB,B2
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be struck,to be struck,被打击,VERB,B2
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be taken,to be taken,被拿走,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tricked,to be tricked,被欺骗,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be valid,to be valid,有效,VERB,B2
-to be vigilant,to be vigilant,词,VERB,B2
-to be visible,to be visible,可见,VERB,B2
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear to endure,to bear to endure,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become alert,to become alert,词,VERB,B2
-to become certain,to become certain,词,VERB,B2
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to befriend,to befriend,与...交朋友,VERB,B2
-to begin to cut into,to begin to cut into,词,VERB,C1
-to behead,to behead,斩首,VERB,B2
-to behold,to behold,注视,VERB,B2
-to benefit,to benefit,受益,VERB,B2
-to bequeath,to bequeath,遗赠,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to bet invest,to bet invest,下注/投资,VERB,B2
-to betroth,to betroth,词,VERB,C1
-to bevriezen,to bevriezen,词,VERB,C1
-to bicker,to bicker,争吵,VERB,B2
-to bid farewell,to bid farewell,词,VERB,B1
-to bide,to bide,等待,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to blink,to blink,眨眼,VERB,B2
-to bloom,to bloom,开花,VERB,B2
-to blossom,to blossom,开花,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to blow up,to blow up,炸毁,VERB,B2
-to bluff,to bluff,虚张声势,VERB,B2
-to blunder,to blunder,犯大错,VERB,B2
-to blush,to blush,脸红,VERB,B2
-to board (verb),to board,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to box,to box,拳击,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break in,to break in,词,VERB,B2
-to break into,to break into,撬开,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to breathe again,to breathe again,松口气,VERB,B2
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring here,to bring here,词,VERB,C1
-to bring lead,to bring lead,带来/引导,VERB,B2
-to bring to,to bring to,带到,VERB,B2
-to broadcast (verb),to broadcast,词,VERB,B2
-to brood,to brood,沉思,VERB,B2
-to build up,to build up,构建,VERB,B2
-to bullshit,to bullshit,胡扯,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump,to bump,碰撞,VERB,B2
-to bump push,to bump push,推/碰撞,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to burnish,to burnish,擦亮,VERB,B2
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call out,to call out,词,VERB,C1
-to call ring,to call ring,打电话,VERB,B2
-to call to contact,to call to contact,词,VERB,A2
-to camp,to camp,露营,VERB,B2
-to caper,to caper,跳跃,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carry on,to carry on,词,VERB,C1
-to carve,to carve,雕刻,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to cast (verb),to cast,词,VERB,B2
-to castigate,to castigate,严厉批评,VERB,B2
-to catalyze,to catalyze,催化,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,瞥见,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to censor,to censor,审查,VERB,B2
-to center,to center,居中,VERB,B2
-to centralize,to centralize,集中,VERB,B2
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to chair (verb),to chair,词,VERB,C1
-to change clothes,to change clothes,更衣,VERB,B1
-to change trains,to change trains,词,VERB,A1
-to characterize,to characterize,描绘,VERB,B2
-to chastise,to chastise,严惩,VERB,B2
-to chatter,to chatter,喋喋不休,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chill,to chill,使冰冻,VERB,B2
-to chirp,to chirp,啁啾,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,割礼,VERB,B2
-to clean out,to clean out,词,VERB,C1
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to close eyes,to close eyes,闭眼,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to color (verb),to color,着色,VERB,B2
-to comb (verb),to comb,梳,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come loose,to come loose,松脱,VERB,B2
-to come true,to come true,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commission,to commission,委托,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,交融,VERB,B2
-to commute,to commute,通勤,VERB,B2
-to complete finish,to complete finish,词,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to compose (noun),to compose,合成,NOUN,B2
-to compromise (verb),to compromise,妥协,VERB,B2
-to computerize,to computerize,词,VERB,C1
-to concede,to concede,承认,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concoct,to concoct,编造,VERB,B2
-to concretize,to concretize,词,VERB,C1
-to conduct (verb),to conduct,指挥,VERB,B2
-to confer,to confer,授予,VERB,B2
-to confide,to confide,吐露,VERB,B2
-to conform,to conform,符合,VERB,B2
-to conjugate,to conjugate,变位,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to conserve,to conserve,保存,VERB,B2
-to consider think,to consider think,考虑/思考,VERB,B2
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to contest,to contest,质疑,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to cook fix,to cook fix,做/修理,VERB,B2
-to cope,to cope,应付,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to correspond (! verb),to correspond,词,! VERB,C1
-to cough (verb),to cough,咳嗽,VERB,B2
-to counter (verb),to counter,抗辩,VERB,B2
-to countersign,to countersign,副署,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to crack seeds,to crack seeds,嗑,VERB,B2
-to crash into,to crash into,撞击,VERB,B2
-to croak,to croak,呱呱叫,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crumple,to crumple,弄皱,VERB,B2
-to cuddle,to cuddle,拥抱,VERB,B2
-to curl,to curl,卷曲,VERB,B2
-to curse (verb),to curse,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to dam up,to dam up,词,VERB,C1
-to damn (verb),to damn,词,VERB,B2
-to dampen,to dampen,使潮湿,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to dawdle,to dawdle,闲逛,VERB,B2
-to decentralize,to decentralize,去中心化,VERB,B2
-to decide determine,to decide determine,决定/确定,VERB,B2
-to decimate,to decimate,大量削减,VERB,B2
-to declaim,to declaim,慷慨陈词,VERB,B2
-to decouple,to decouple,分离,VERB,B2
-to decry,to decry,谴责,VERB,B2
-to default (verb),to default,拖欠,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to define,to define,定义,VERB,B2
-to defray,to defray,支付,VERB,B2
-to defrost,to defrost,除霜,VERB,B2
-to defuse,to defuse,缓和,VERB,B2
-to dejta,to dejta,约会,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to delude oneself,to delude oneself,词,VERB,B2
-to demilitarize,to demilitarize,非军事化,VERB,B2
-to demonize,to demonize,妖魔化,VERB,B2
-to denominate,to denominate,命名,VERB,B2
-to deploy unfold,to deploy unfold,词,VERB,C1
-to deposit money,to deposit money,储蓄,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,起源于,VERB,B2
-to destock,to destock,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to deviate,to deviate,偏离,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to diet,to diet,减肥,VERB,B2
-to differ,to differ,不同,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to dimension (verb),to dimension,词,VERB,C1
-to diminish,to diminish,减少,VERB,B2
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disenchant,to disenchant,使清醒,VERB,B2
-to disfavor,to disfavor,不利于,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to disjoin,to disjoin,分离,VERB,B2
-to dislodge,to dislodge,逐出,VERB,B2
-to dismiss fire,to dismiss fire,解雇,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disoblige,to disoblige,词,VERB,C1
-to dispel,to dispel,消除,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to disrupt,to disrupt,扰乱,VERB,B2
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to dither,to dither,犹豫不决,VERB,B2
-to divulge,to divulge,泄露,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do hair,to do hair,词,VERB,C1
-to do harm,to do harm,伤害,VERB,B2
-to do justice to,to do justice to,词,VERB,C1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to drape,to drape,悬挂,VERB,B2
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw support from,to draw support from,借助,VERB,B2
-to draw up,to draw up,起草,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drink binge,to drink binge,狂饮,VERB,B2
-to drive herd,to drive herd,驱赶/推动,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,驾驶,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry in the sun (verb),to dry in the sun,晾晒,VERB,B2
-to dry out,to dry out,词,VERB,C1
-to dry up,to dry up,使干枯,VERB,B2
-to duck (verb),to duck,词,VERB,C1
-to dull (verb),to dull,词,VERB,C1
-to dump,to dump,抛弃,VERB,B2
-to dupe,to dupe,欺骗,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dye,to dye,染色,VERB,B2
-to each other (adv),to each other,词,ADV,C1
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eavesdrop,to eavesdrop,偷听,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to elapse,to elapse,流逝,VERB,B2
-to email,to email,发邮件,VERB,B2
-to emasculate,to emasculate,使无力,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emigrate,to emigrate,移居国外,VERB,B2
-to empty,to empty,倒空,VERB,B2
-to encore (verb),to encore,词,VERB,C1
-to encroach,to encroach,侵蚀,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engrave,to engrave,雕刻,VERB,B2
-to enhance,to enhance,增强,VERB,B2
-to enrol,to enrol,注册,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthuse,to enthuse,使热情,VERB,B2
-to equal (verb),to equal,无异,VERB,B2
-to erect behave,to erect behave,建造,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to ever (verb),to ever,何尝,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to execrate,to execrate,痛恨,VERB,B2
-to exemplify,to exemplify,举例说明,VERB,B2
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exist there is,to exist there is,存在/有,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to experiment,to experiment,实验,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to externalize,to externalize,使外在化,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to fake,to fake,伪造,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall crash,to fall crash,坠落/猛冲,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fasten,to fasten,系紧,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign,to feign,假装,VERB,B2
-to fell,to fell,砍倒,VERB,B2
-to ferret,to ferret,搜寻,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to film (verb),to film,拍摄,VERB,B2
-to finalize,to finalize,完成,VERB,B2
-to finally,to finally,你可算,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find oneself,to find oneself,处于,VERB,B2
-to find you,to find you,找你,VERB,B2
-to fine (verb),to fine,罚款,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fit suit,to fit suit,适合,VERB,B2
-to fix to prepare,to fix to prepare,词,VERB,A2
-to fix to set,to fix to set,词,VERB,B1
-to flame,to flame,燃烧,VERB,B2
-to flee escape,to flee escape,逃跑,VERB,B2
-to flock,to flock,群集,VERB,B2
-to flout,to flout,蔑视,VERB,B2
-to flow in,to flow in,词,VERB,C1
-to flush,to flush,冲洗,VERB,B2
-to flush out,to flush out,词,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to food give birth,to food give birth,食物/生育,VERB,B2
-to for example,to for example,比如,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to form to train,to form to train,词,VERB,B1
-to fraction,to fraction,分割,VERB,B2
-to freshen,to freshen,使清新,VERB,B2
-to frolic,to frolic,嬉戏,VERB,B2
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to function to work,to function to work,词,VERB,B1
-to function work,to function work,运作/起作用,VERB,B2
-to furlough,to furlough,临时解雇,VERB,B2
-to fuse (verb),to fuse,融合,VERB,B2
-to gape,to gape,目瞪口呆,VERB,B2
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get acquire,to get acquire,获得/弄到,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get by,to get by,过得去,VERB,B2
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get into,to get into,陷入,VERB,B2
-to get off,to get off,词,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get stuck,to get stuck,卡住,VERB,B2
-to get tired,to get tired,疲劳,VERB,A2
-to get to know,to get to know,词,VERB,B1
-to giggle,to giggle,咯咯笑,VERB,B2
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give a ride,to give a ride,载送一程,VERB,B2
-to give birth,to give birth,分娩,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back and forth,to go back and forth,往返,VERB,B1
-to go blind,to go blind,失明,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go there,to go there,词,VERB,B1
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go travel,to go travel,词,VERB,A1
-to go up again,to go up again,词,VERB,B1
-to go up in smoke,to go up in smoke,化为乌有,VERB,B2
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to graspen,to graspen,抓住,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to grow old,to grow old,词,VERB,A1
-to growl,to growl,咆哮,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to hail inspect,to hail inspect,盘查,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,悬挂/钩住,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harbor,to harbor,怀有,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have strength,to have strength,有力气,VERB,B2
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to hide to disappear,to hide to disappear,词,VERB,A2
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold accountable,to hold accountable,问责,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up stop,to hold up stop,词,VERB,A2
-to hollow out,to hollow out,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to ignite,to ignite,词,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to imprint (verb),to imprint,词,VERB,C1
-to incarcerate,to incarcerate,监禁,VERB,B2
-to incentivize,to incentivize,词,VERB,C1
-to indicate interpret,to indicate interpret,表明/解释,VERB,B2
-to indict,to indict,控告,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to indispose,to indispose,词,VERB,C1
-to induce to lead to,to induce to lead to,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict to impose,to inflict to impose,施加,VERB,B2
-to inform to reach,to inform to reach,词,VERB,A2
-to infuse,to infuse,泡制,VERB,B2
-to innovate,to innovate,词,VERB,C1
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to institutionalize,to institutionalize,制度化,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to interact,to interact,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to internalize,to internalize,词,VERB,C1
-to invalidate,to invalidate,证明无效,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoice,to invoice,开票,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,加入 / 附着,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kidnapped,to kidnapped,绑架,VERB,B2
-to kill you,to kill you,杀你,VERB,B2
-to knead,to knead,词,VERB,A1
-to kneel,to kneel,词,VERB,B1
-to knock to pound,to knock to pound,词,VERB,A2
-to knot (verb),to knot,词,VERB,C1
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know feel,to know feel,认识/感觉,VERB,B2
-to know nothing,to know nothing,一无所知,VERB,B2
-to lack basis,to lack basis,无据,VERB,B2
-to lament,to lament,哀叹,VERB,B2
-to laugh smile,to laugh smile,笑,VERB,A1
-to launder,to launder,洗钱,VERB,B2
-to lay down,to lay down,放下,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to lay put,to lay put,放,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to leap (verb),to leap,跨越,VERB,B2
-to leave stick,to leave stick,离开/刺,VERB,B2
-to leave to,to leave to,词,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to legislate,to legislate,词,VERB,C1
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lengthen,to lengthen,延长,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to levy,to levy,征收,VERB,C1
-to license,to license,许可,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,词,VERB,B2
-to light,to light,照亮,VERB,B2
-to light a fire,to light a fire,生火,VERB,B2
-to light ignite,to light ignite,点燃,VERB,B2
-to like (aux),to like,词,AUX,A2
-to linger,to linger,徘徊,VERB,B2
-to linkage,to linkage,联动,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live in,to live in,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to load charge,to load charge,装载,VERB,B2
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lodge,to lodge,借宿,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to log in,to log in,登录,VERB,B2
-to loiter,to loiter,词,VERB,C1
-to long,to long,渴望,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to loot (verb),to loot,词,VERB,C1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower,to lower,降低,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lure (verb),to lure,词,VERB,B2
-to lurk,to lurk,词,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to maim,to maim,词,VERB,C1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make bland,to make bland,使乏味,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make heavier,to make heavier,加重,VERB,B2
-to make lasting,to make lasting,词,VERB,B2
-to make one's way,to make one's way,词,VERB,B2
-to make out,to make out,接吻,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manifest,to manifest,表明,VERB,B2
-to map out,to map out,摸清,VERB,B2
-to marginalize,to marginalize,使边缘化,VERB,B2
-to mark out,to mark out,标示,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to mash (verb),to mash,词,VERB,A2
-to massacre (verb),to massacre,词,VERB,C1
-to mast,to mast,降伏,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to maximize,to maximize,词,VERB,C1
-to mean entail,to mean entail,意味着,VERB,B2
-to mean to head to,to mean to head to,词,VERB,A2
-to mean to think,to mean to think,词,VERB,C1
-to meant,to meant,意思是,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mention to remember,to mention to remember,词,VERB,A2
-to mess about,to mess about,胡搞,VERB,B2
-to mess around,to mess around,胡闹,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mime (verb),to mime,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to minimize,to minimize,最小化,VERB,B2
-to mirror,to mirror,反映,VERB,B2
-to missed,to missed,错过,VERB,B2
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to model (verb),to model,词,VERB,C1
-to modernize,to modernize,词,VERB,C1
-to modulate,to modulate,调节,VERB,B2
-to monitor (verb),to monitor,监察,VERB,B2
-to moon (verb),to moon,词,VERB,A2
-to mop (verb),to mop,词,VERB,A2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to motivate,to motivate,激励,VERB,B2
-to mourn,to mourn,哀悼,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move house,to move house,搬家,VERB,B2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to move touch,to move touch,使感动,VERB,B2
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to mystify,to mystify,神秘化,VERB,B2
-to navigate,to navigate,导航；航行,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need (aux),to need,还要,AUX,B2
-to need must,to need must,词,VERB,A2
-to neutralize,to neutralize,中和,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to nuance,to nuance,使具有细微差别,VERB,B2
-to number (verb),to number,词,VERB,C1
-to object,to object,反对,VERB,B2
-to objectify,to objectify,客观化,VERB,B2
-to oblige,to oblige,强迫,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occupy oneself,to occupy oneself,从事,VERB,B2
-to occur to,to occur to,词,VERB,B2
-to ogle,to ogle,窥视,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to orient,to orient,定向,VERB,B2
-to orient to guide,to orient to guide,词,VERB,C1
-to ostracize,to ostracize,排斥,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to overestimate,to overestimate,词,VERB,C1
-to overlook,to overlook,忽视,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to paint over,to paint over,重新粉刷,VERB,B2
-to pamper,to pamper,纵容,VERB,B2
-to panic (verb),to panic,词,VERB,C1
-to party,to party,狂欢,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pause (verb),to pause,……,VERB,B2
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to pension off,to pension off,词,VERB,C1
-to perceive,to perceive,察觉,VERB,B2
-to perfect,to perfect,精修,VERB,B2
-to perform umrah,to perform umrah,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to permeate,to permeate,弥漫,VERB,C1
-to perpetuate,to perpetuate,使永存,VERB,B2
-to persecute,to persecute,迫害,VERB,B2
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to persist,to persist,坚持,VERB,B2
-to personify,to personify,词,VERB,C1
-to pick out,to pick out,挑选,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to place put,to place put,放置,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant trees,to plant trees,植树,VERB,B2
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to pledge mutually,to pledge mutually,词,VERB,C1
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to point to clock in,to point to clock in,指 / 打卡,VERB,B2
-to polarize,to polarize,使两极分化,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to polemicize,to polemicize,词,VERB,C1
-to portend,to portend,词,VERB,B2
-to position,to position,定位 / 安置,VERB,B2
-to post,to post,张贴,VERB,B2
-to postpone to carry over,to postpone to carry over,推迟,VERB,B2
-to postulate,to postulate,假定,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to preserve to protect,to preserve to protect,词,VERB,C1
-to preside,to preside,主持,VERB,B2
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to prick,to prick,扎,VERB,B2
-to prioritize,to prioritize,优先考虑,VERB,B2
-to privatize,to privatize,私有化,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to profile (verb),to profile,词,VERB,C1
-to program,to program,编程,VERB,B2
-to project,to project,投射,VERB,B2
-to propagate,to propagate,传播,VERB,B2
-to prosecute,to prosecute,起诉,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pucker,to pucker,噘,VERB,B2
-to pull through,to pull through,词,VERB,B2
-to pump (verb),to pump,词,VERB,C1
-to puncture deflate,to puncture deflate,刺破,VERB,B2
-to purge,to purge,清除,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push through,to push through,推动,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put away,to put away,收拾,VERB,B2
-to put back,to put back,放回,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put set,to put set,放置,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to puzzle (verb),to puzzle,迷惑,VERB,B2
-to quarrel (verb),to quarrel,吵,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to quiver,to quiver,颤抖,VERB,B2
-to race (verb),to race,词,VERB,B1
-to race down,to race down,词,VERB,C1
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise bring up,to raise bring up,抚养,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rape (verb),to rape,词,VERB,B2
-to ratify,to ratify,批准,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to rationalize,to rationalize,合理化,VERB,B2
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to rebel (verb),to rebel,造反,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to recreate,to recreate,重建,VERB,B2
-to rediscover,to rediscover,重新发现,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to refresh,to refresh,使恢复精神,VERB,B2
-to refuel,to refuel,加油,VERB,B2
-to regain,to regain,恢复,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
-to rehabilitate,to rehabilitate,使康复,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to relate,to relate,联系,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relativize,to relativize,词,VERB,C1
-to relaunch,to relaunch,重启,VERB,B2
-to relay,to relay,转达,VERB,B2
-to release let go,to release let go,释放/放手,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remove to pull out,to remove to pull out,词,VERB,A2
-to remunerate,to remunerate,词,VERB,C1
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to renovate,to renovate,翻新,VERB,B2
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,重犯,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to repel,to repel,击退,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to replicate,to replicate,复制,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to reproach,to reproach,责备,VERB,B2
-to reproduce,to reproduce,繁殖,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to research (verb),to research,词,VERB,B2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resonate,to resonate,共鸣,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to result,to result,产生,VERB,B2
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retort,to retort,反驳,VERB,B2
-to retrace,to retrace,追溯,VERB,B2
-to retreat (verb),to retreat,后退,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return home,to return home,词,VERB,B1
-to return something,to return something,词,VERB,A2
-to return to restore,to return to restore,词,VERB,C1
-to revalue,to revalue,重新估值,VERB,B2
-to reverse,to reverse,反转,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to ride along,to ride along,词,VERB,B1
-to ridicule (verb),to ridicule,词,VERB,C1
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to root out,to root out,词,VERB,C1
-to rot,to rot,腐烂,VERB,B2
-to rotate,to rotate,轮,VERB,C1
-to round (verb),to round,词,VERB,A2
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to sabotage,to sabotage,破坏,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanction,to sanction,认可,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to saturate,to saturate,使饱和,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to savor,to savor,品味,VERB,B2
-to saw,to saw,锯,VERB,B2
-to scan,to scan,扫描,VERB,B2
-to scare away,to scare away,惊飞,VERB,B2
-to scent,to scent,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scheme (verb),to scheme,词,VERB,C1
-to score (verb),to score,词,VERB,B2
-to scout,to scout,侦察,VERB,B2
-to scram,to scram,词,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to screw,to screw,拧,VERB,B2
-to scrimp,to scrimp,词,VERB,C1
-to sculpt,to sculpt,词,VERB,C1
-to search apply,to search apply,寻找/申请,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to see emperor,to see emperor,面圣,VERB,C1
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segment,to segment,细分,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to separate divorce,to separate divorce,分离/离婚,VERB,B2
-to sequester,to sequester,隔离,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sew in,to sew in,词,VERB,C1
-to sexualize,to sexualize,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to share divide,to share divide,分享,VERB,B2
-to sharpen,to sharpen,磨快,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shoot dead,to shoot dead,击毙,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop be about,to shop be about,购物,VERB,B2
-to shop for groceries,to shop for groceries,词,VERB,A2
-to show partiality,to show partiality,偏袒,VERB,C1
-to shunt,to shunt,分流,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sigh (verb),to sigh,词,VERB,B2
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to signal (verb),to signal,暗讯,VERB,B2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to simulate,to simulate,模拟,VERB,B2
-to sip (verb),to sip,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to situate,to situate,定位,VERB,B2
-to skim,to skim,轻触,VERB,B2
-to skip,to skip,跳过,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slash,to slash,猛砍,VERB,B2
-to slaughter (verb),to slaughter,宰,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slay,to slay,词,VERB,C1
-to slice (verb),to slice,词,VERB,C1
-to slight (verb),to slight,怠慢,VERB,B2
-to slope down,to slope down,词,VERB,B2
-to smooth (verb),to smooth,抚平,VERB,B2
-to snack (verb),to snack,词,VERB,C1
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to sneak away,to sneak away,溜走,VERB,B2
-to snow,to snow,下雪,VERB,B2
-to soften,to soften,使灵活,VERB,B2
-to solder,to solder,焊接,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort out,to sort out,词,VERB,B2
-to spam,to spam,发垃圾信息,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to specialize,to specialize,专攻,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spell,to spell,拼写,VERB,B2
-to spend time,to spend time,词,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spout,to spout,喷射,VERB,B2
-to spray,to spray,喷洒,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to spy on,to spy on,词,VERB,C1
-to squeak,to squeak,吱吱叫,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay awake,to stay awake,守夜,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steal sword,to steal sword,偷剑,NOUN,B2
-to steam (verb),to steam,蒸煮,VERB,B2
-to steep (verb),to steep,词,VERB,C1
-to steer control,to steer control,控制,VERB,B2
-to stem,to stem,起源于,VERB,B2
-to stem from,to stem from,源于,VERB,B2
-to step down,to step down,辞职,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to stick out,to stick out,伸出,VERB,B2
-to stifle smother,to stifle smother,词,VERB,B2
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop down,to stop down,词,VERB,C1
-to straighten up,to straighten up,词,VERB,B2
-to stride (verb),to stride,词,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string together,to string together,串,VERB,B2
-to strip,to strip,裸露,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strive for,to strive for,争取,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stun,to stun,词,VERB,C1
-to stutter,to stutter,词,VERB,B2
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to subordinate,to subordinate,从属,VERB,B2
-to suborn,to suborn,教唆,VERB,B2
-to subsidize,to subsidize,资助,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to substantiate,to substantiate,证实,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to succeed to pass,to succeed to pass,词,VERB,A2
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to suit agree,to suit agree,词,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplement (verb),to supplement,补充,VERB,B2
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surge (verb),to surge,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture (verb),to suture,缝合,VERB,B2
-to swallow up,to swallow up,词,VERB,B2
-to swarm,to swarm,分群,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to swipe,to swipe,词,VERB,C1
-to switch,to switch,切换,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to synchronize,to synchronize,词,VERB,C1
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to tag (verb),to tag,词,VERB,C1
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take amiss,to take amiss,词,VERB,C1
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,记录,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take on,to take on,词,VERB,C1
-to take one's time,to take one's time,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to talk (verb),to talk,谈,VERB,B2
-to talk chat,to talk chat,聊天/谈论,VERB,B2
-to tap to type,to tap to type,词,VERB,C1
-to target (verb),to target,针对,VERB,B2
-to task (verb),to task,词,VERB,C1
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to tear down,to tear down,拆除,VERB,B2
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to tell to narrate,to tell to narrate,词,VERB,A2
-to tense (verb),to tense,词,VERB,B2
-to text,to text,发短信,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,思考,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think opine,to think opine,认为,VERB,B2
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrive,to thrive,茁壮成长,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrown,to thrown,扔,VERB,B2
-to tidy,to tidy,整理,VERB,B2
-to tinker,to tinker,词,VERB,B1
-to tip,to tip,透露,VERB,B2
-to tip over,to tip over,翻倒,VERB,B2
-to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
-to title,to title,命名,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toil (verb),to toil,词,VERB,C1
-to topple,to topple,词,VERB,C1
-to torture (verb),to torture,拷问,VERB,B2
-to total (verb),to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to tow,to tow,词,VERB,C1
-to trace,to trace,描绘；标出,VERB,B2
-to track (verb),to track,追踪,VERB,B2
-to train exercise,to train exercise,训练/锻炼,VERB,B2
-to transcribe,to transcribe,转录,VERB,B2
-to transfer (verb),to transfer,转移,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transgress,to transgress,违背,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to trap fell,to trap fell,困住/砍倒,VERB,B2
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to trouble (verb),to trouble,困扰,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tumble,to tumble,跌倒,VERB,B2
-to tune,to tune,调谐,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to type,to type,打字,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbend,to unbend,润滑,VERB,B2
-to unblind,to unblind,使醒悟,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to undergo,to undergo,经历,VERB,B2
-to underline,to underline,强调,VERB,B2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhook,to unhook,摘下,VERB,B2
-to unload,to unload,卸货,VERB,B2
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use to usually,to use to usually,通常/习惯于,VERB,B2
-to use up,to use up,用完,VERB,B2
-to vacuum (verb),to vacuum,词,VERB,A2
-to validate,to validate,验证,VERB,B2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vary,to vary,改变,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to vibrate,to vibrate,振动,VERB,B2
-to view,to view,参观,VERB,B2
-to vote (verb),to vote,表决,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to want (aux),to want,欲,AUX,A2
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm,to warm,加热,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to warp,to warp,弯曲,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch out,to watch out,小心,VERB,B2
-to watch tv,to watch tv,看电视,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wave (verb),to wave,挥,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to wear down,to wear down,词,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,使厌倦,VERB,B2
-to wedge,to wedge,卡住,VERB,B2
-to weigh down,to weigh down,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whistle (verb),to whistle,呼啸,VERB,B2
-to wilt,to wilt,枯萎,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wipe out,to wipe out,消灭,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to wither,to wither,,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to worship (verb),to worship,崇拜,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wring,to wring,拧干,VERB,B2
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-to zero out,to zero out,清零,VERB,B2
-toad,toad,蟾蜍,NOUN,B2
-toast,toast,你敬酒,NOUN,B2
-tocadiscos,record player,唱机,NOUN,B2
-tocino,bacon,培根,NOUN,B2
-today (noun),today,今,NOUN,B2
-today's,today's,词,ADJ,C1
-todo,all,全部,ADV,B2
-todo el día,all day long,一整天,NOUN,B2
+temporización,timing,时机,NOUN,B2
+cansar,tire,轮胎,NOUN,B2
+cansar,to tire,使疲倦,VERB,B2
+tejido,tissue,组织,NOUN,B2
+diezmo,tithe,什一税,NOUN,B2
+hoy,today,今天,NOUN,B2
+dedo del pie,toe,脚趾,NOUN,B2
 tofu,tofu,豆腐,NOUN,B2
-tofu seco,dried tofu,豆干,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-toga negra,black robe,黑衣,NOUN,B2
-together,together,共同的,ADJ,B2
-togetherness,togetherness,词,NOUN,C1
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toiling,toiling,词,ADJ,C1
-told instructed,told instructed,被告知的,ADJ,B2
-tolerance dependence,tolerance dependence,词,NOUN,C1
+trabajo,toil,苦工,NOUN,B2
 tolerancia,tolerance,宽容,NOUN,B2
-tolerant,tolerant,宽容的,ADJ,B2
 tolerar,to tolerate,容忍,VERB,B2
-toll,toll,通行费,NOUN,B2
-toma,taking,拍摄,NOUN,B2
-tomar prestado,to borrow,借,VERB,B2
-tomb monument,tomb monument,墓碑,NOUN,B2
-tombstone,tombstone,词,NOUN,C1
-tome,tome,词,NOUN,C1
-tomorrow (noun),tomorrow,明天,NOUN,B2
-tomorrow night,tomorrow night,明晚,ADV,B2
-tonality,tonality,词,NOUN,C1
+mañana,tomorrow,غد,NOUN,B2
 tonelada,ton,吨,NOUN,B2
-tonic (adj),tonic,词,ADJ,C1
-tonic (noun),tonic,词,NOUN,C1
-tonight,tonight,今晚,ADV,B2
 tono,tone,语气,NOUN,B2
-tonsil,tonsil,词,NOUN,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too late,too late,太迟,ADV,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
+lengua,tongue,舌头,NOUN,B2
+esta noche,tonight,今晚,NOUN,B2
+demasiado,too,太,ADV,B2
+blandura excesiva,too soft,太软,NOUN,B2
 tool room,tool room,工具间,NOUN,B2
-tooling,tooling,词,NOUN,C1
 tools,tools,工具,NOUN,B2
 toothache,toothache,牙痛,NOUN,B2
-toothbrush,toothbrush,牙刷,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
 toothpaste,toothpaste,牙膏,NOUN,B2
 top,top,顶部,NOUN,B2
-top (adj),top,顶部的,ADJ,C1
 top dressing,top dressing,追肥,NOUN,B2
-top great,top great,顶部/极好,NOUN,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-toparse con,to run into,碰见,VERB,B2
-topographical,topographical,词,ADJ,C1
 topography,topography,地形,NOUN,B2
-topógrafo,surveyor,测量员,NOUN,B2
-torcido,crooked,弯曲的,ADJ,B2
-torment (noun),torment,词,NOUN,C1
-tormenta de arena,sandstorm,沙尘暴,NOUN,B2
-tormentor,tormentor,词,NOUN,B2
-torments,torments,词,NOUN,B2
 tornado,tornado,龙卷风,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torque,torque,词,NOUN,C1
 torrent,torrent,激流,NOUN,B2
-torrid,torrid,词,ADJ,C1
 torsion,torsion,扭转,NOUN,B2
-torso,torso,躯干,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-tortuous,tortuous,词,ADJ,C1
 torture,torture,酷刑,NOUN,B2
 torture,to torture,折磨,VERB,B2
-torture ordeal,torture ordeal,词,NOUN,C1
-toser,cough,咳嗽,NOUN,B2
-toser,to cough,咳嗽,VERB,B2
-toss,toss,词,VERB,B2
 total,total,总数,NOUN,B2
-total (adj),total,完全的,ADJ,B2
-totalitarian,totalitarian,极权主义的,ADJ,B2
-totalitarianism,totalitarianism,词,NOUN,C1
-totality,totality,词,NOUN,C1
-totem,totem,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
 touchability,touchability,能触摸,NOUN,B2
-touchstone,touchstone,词,NOUN,C1
-touchy,touchy,易怒的,ADJ,B2
 tough,tough,艰难的,ADJ,B2
-tough guy,tough guy,硬汉,NOUN,B2
-tour guide,tour guide,导游,NOUN,A2
-tourist,tourist,旅游的,ADJ,B2
 touristic,touristic,旅游的,ADJ,B2
 tournament,tournament,锦标赛,NOUN,B2
-tout,tout,词,VERB,C1
 toward,toward,朝向,ADP,B2
-towards,towards,迎向,ADV,B2
 towel,towel,毛巾,NOUN,B2
-towering,towering,词,ADJ,B2
 town,town,城镇,NOUN,B2
-town hall,town hall,市政厅,NOUN,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
 township head,township head,乡长,NOUN,B2
-township road,township road,乡道,NOUN,B2
 toxic,toxic,有毒的,ADJ,B2
-toxicity,toxicity,词,NOUN,C1
-toxin,toxin,词,NOUN,C1
-toys,toys,玩具,NOUN,B2
-trabajador,hardworking,勤奋的,ADJ,B2
-trabajador,worker,工人,NOUN,B2
-trabajo,labor,劳动,NOUN,B2
-trabajo,toil,苦工,NOUN,B2
-trabajo pesado,heavy work,重功,NOUN,B2
 trace,trace,痕迹,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
 track,track,轨道,NOUN,B2
 track,to track,追踪,VERB,B2
-track and field,track and field,田径,NOUN,C1
-track trace,track trace,痕迹/轨道,NOUN,B2
-tracking,tracking,词,NOUN,C1
-tracksuit,tracksuit,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
 tractor,tractor,拖拉机,NOUN,B2
-trade (verb),trade,词,VERB,A2
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
 trade union,trade union,工会,NOUN,B2
-trade unionist,trade unionist,词,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
 traditional,traditional,传统的,ADJ,B2
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditionally,traditionally,传统地,ADV,B2
-traditions,traditions,词,NOUN,B1
-traducción,translation,翻译,NOUN,B2
-traduce,traduce,词,VERB,C1
-traductor,translator,译者,NOUN,B2
-traer,to fetch,取来,VERB,B2
-traffic light,traffic light,红绿灯,NOUN,B2
 traffic restriction,traffic restriction,限行,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficker,trafficker,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-tragar,to swallow,吞下,VERB,B2
 tragic,tragic,悲剧的,ADJ,B2
-tragically,tragically,悲剧地,ADV,B2
-tragicness,tragicness,词,NOUN,C1
-traicionero,treacherous,背叛的,ADJ,B2
-traición,treason,叛国罪,NOUN,B2
-trail,trail,词,NOUN,B1
 trailer,trailer,预告片,NOUN,B2
 train of thought,train of thought,思路,NOUN,B2
-train ride,train ride,词,NOUN,A1
 train station,train station,火车站,NOUN,B2
-train ticket,train ticket,词,NOUN,A1
-trained,trained,词,ADJ,C1
 trainee,trainee,实习生,NOUN,B2
-trainer,trainer,教练,NOUN,B2
-trainer bastard,trainer bastard,,NOUN,B2
-training center,training center,培训中心,NOUN,C1
 traitor,traitor,叛徒,NOUN,B2
-traits qualities,traits qualities,词,NOUN,C1
-trajectory,trajectory,轨迹,NOUN,B2
-tram,tram,有轨电车,NOUN,B2
-trance,trance,词,NOUN,C1
+pisotear,to trample,踩踏,VERB,B2
 tranquilo,tranquil,宁静的,ADJ,B2
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transacción,transaction,交易,NOUN,B2
-transatlantic,transatlantic,词,ADJ,C1
-transcend,transcend,词,VERB,C1
-transcript,transcript,词,NOUN,C1
 transdecisión,trans-decision,超断,NOUN,B2
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferee,transferee,词,NOUN,C1
+transhuésped,trans-guest,超客,NOUN,B2
+transmateria,trans-matter,超物,NOUN,B2
+transacción,transaction,交易,NOUN,B2
+trascendencia,transcendence,超越,NOUN,B2
+trascendente,transcendent,卓越的,ADJ,B2
+trascendental,transcendental,先验的,ADJ,B2
 transferir,transfer,转移,NOUN,B2
 transferir,to transfer,转移,VERB,B2
-transferor,transferor,词,NOUN,C1
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
-transfix,transfix,词,VERB,C1
 transformación,transformation,تحول,NOUN,B2
-transformer converter,transformer converter,词,NOUN,C1
-transhumance,transhumance,词,NOUN,B2
-transhuésped,trans-guest,超客,NOUN,B2
-transient,transient,词,ADJ,C1
-transistor,transistor,词,NOUN,C1
-transit,transit,运输,NOUN,C1
-transition,transition,过渡,NOUN,B2
-transitivity,transitivity,及物性,NOUN,C1
 transitorio,transitional,过渡的,ADJ,B2
-transitory,transitory,词,ADJ,C1
-translatology,translatology,词,NOUN,C1
-translucent,translucent,词,ADJ,C1
-transmateria,trans-matter,超物,NOUN,B2
+traducción,translation,翻译,NOUN,B2
+traductor,translator,译者,NOUN,B2
 transmisión,transmission,传输,NOUN,B2
 transmisión a ti,transmission to you,传你,NOUN,B2
-transmisor,transmitter,发射台,NOUN,B2
-transmitir,broadcast,广播,NOUN,B2
-transmitir,to broadcast,播出,VERB,B2
-transmitir,to convey,传达,VERB,B2
-transmitir,to pass on,转交,VERB,B2
 transmitir,to transmit,传输,VERB,B2
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
+transmisor,transmitter,发射台,NOUN,B2
 transparencia,transparency,透明度,NOUN,B2
 transparente,transparent,透明的,ADJ,B2
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport (adj),transport,词,ADJ,C1
-transport service,transport service,词,NOUN,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transportista,carrier,承运人,NOUN,B2
-transpose,transpose,词,VERB,C1
-transregional,transregional,词,ADJ,C1
-trapdoor,trapdoor,活板门,NOUN,B2
-trapping,trapping,词,NOUN,C1
-trascendencia,transcendence,超越,NOUN,B2
-trascendental,transcendental,先验的,ADJ,B2
-trascendente,transcendent,卓越的,ADJ,B2
-trash bag,trash bag,垃圾袋,NOUN,B2
-trash can,trash can,词,NOUN,A2
-trasplantar,to plant out,定植,VERB,B2
+viaje,travel,出行,NOUN,B2
+fatiga de viaje,travel fatigue,车马劳顿,NOUN,B2
+viajero,traveler,旅行家,NOUN,B2
+bandeja,tray,托盘,NOUN,B2
+traicionero,treacherous,背叛的,ADJ,B2
+traición,treason,叛国罪,NOUN,B2
+agasajar,to treat guests,请客,VERB,B2
 tratado,treaty,条约,NOUN,B2
-tratamiento,person honorific,位,NOUN,B2
-tratar,to deal with,处理,VERB,B2
-trauma,trauma,创伤,NOUN,B2
-traumatic,traumatic,创伤的,ADJ,B2
-travail,travail,词,NOUN,C1
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
-travesty,travesty,词,NOUN,C1
-travieso,naughty,淘气的,ADJ,B2
-traída,bringing,جلب,NOUN,B2
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
-treacherousness,treacherousness,阴险,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
-treat,treat,盛宴,NOUN,B2
-treatise,treatise,词,NOUN,C1
-trece,thirteen,十三,NUM,B2
-trek (noun),trek,词,NOUN,C1
-tremendous,tremendous,词,ADJ,B2
-tremulous,tremulous,颤抖的,ADJ,B2
-trenchant,trenchant,词,ADJ,C1
-trending,trending,词,ADJ,C1
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-trial run,trial run,词,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tributo,tribute,贡品,NOUN,B2
-tricky,tricky,词,ADJ,B2
-tricolor,tricolor,词,ADJ,C1
-trigger,to trigger,触发,VERB,B2
-trigger imprint,trigger imprint,印记,NOUN,B2
-trigger mechanism,trigger mechanism,,NOUN,B2
-triggering,triggering,触发,NOUN,B2
-trigo sarraceno,buckwheat,荞麦,NOUN,B2
-trigonometry,trigonometry,词,NOUN,C1
-trilemma,trilemma,三难困境,NOUN,B2
-trilogy,trilogy,三部曲,NOUN,B2
-trim,trim,词,VERB,C1
-trimestre,quarter of a year,季度,NOUN,B2
+temblor,tremor,颤抖,NOUN,B2
 trinchera,trench,沟渠,NOUN,B2
-triple,triple,三倍的,ADJ,B2
-tristeza,gloominess,忧郁,NOUN,B2
-trite,trite,陈腐的,ADJ,B2
-trivia,trivia,词,NOUN,C1
-triviality,triviality,琐碎,NOUN,B2
-trivializable,trivializable,可轻描淡写的,ADJ,B2
-trivialization,trivialization,浅薄化,NOUN,B2
+tendencia,trend,趋势,NOUN,B2
 triángulo,triangle,三角形,NOUN,B2
-trocar,trocar,词,NOUN,C1
-troglodyte,troglodyte,词,NOUN,C1
-trono,throne,王座,NOUN,B2
+tributo,tribute,贡品,NOUN,B2
+engañar,to trick,欺骗,VERB,B2
+trigger,to trigger,触发,VERB,B2
+triple,triple,三倍的,ADJ,B2
+triviality,triviality,琐碎,NOUN,B2
+trivialization,trivialization,浅薄化,NOUN,B2
 troop,troop,部队,NOUN,B2
-troop dispatch,troop dispatch,出兵,NOUN,B2
 troops,troops,部队,NOUN,B2
 trophy,trophy,奖杯,NOUN,B2
-tropic,tropic,词,NOUN,C1
-tropical,tropical,热带的,ADJ,B2
-trotar,to run to jog,跑步,VERB,B2
 trouble,trouble,麻烦,NOUN,B2
 trouble,to trouble,有劳,VERB,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
 troublesome,troublesome,麻烦的,ADJ,B2
-troubling,troubling,令人担忧的,ADJ,B2
 troupe,troupe,剧团,NOUN,B2
 trousers,trousers,裤子,NOUN,B2
-trout,trout,词,NOUN,C1
-trowel,trowel,词,NOUN,B2
 truce,truce,休战,NOUN,B2
-truculent,truculent,词,ADJ,C1
 true concession,true concession,真让,NOUN,B2
 true form,true form,原形,NOUN,B2
 true heart,true heart,本心,NOUN,B2
-true qi,true qi,真气,NOUN,C1
-trueno,thunder,雷,NOUN,B2
-truism,truism,自明之理,NOUN,B2
-truly,truly,确实,ADV,B2
 trumpet,trumpet,小号,NOUN,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trust in God,trust in God,词,NOUN,C1
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
 try hard to,to try hard to,力图,VERB,B2
-try out,try out,词,VERB,C1
-tsunami,tsunami,海啸,NOUN,C1
 tube,tube,أنبوب,NOUN,B2
-tuberculosis,tuberculosis,结核病,NOUN,B2
-tubería,pipe,管子,NOUN,B2
-tug,tug,词,VERB,C1
-tumba,grave,坟墓,NOUN,B2
-tumble (noun),tumble,词,NOUN,C1
-tumor,tumor,肿瘤,NOUN,B2
-tumoral,tumoral,词,ADJ,C1
-tumult,tumult,词,NOUN,C1
-tumulto,riot,骚乱,NOUN,B2
-tumultuous,tumultuous,词,ADJ,C1
 tuna,tuna,金枪鱼,NOUN,B2
 tunic,tunic,束腰外衣,NOUN,B2
-tuning,tuning,词,NOUN,C1
-turban,turban,词,NOUN,B2
-turbid,turbid,词,ADJ,C1
-turbine,turbine,词,NOUN,C1
-turbulence,turbulence,词,NOUN,C1
-turbulent,turbulent,动荡的,ADJ,B2
-turgid,turgid,词,ADJ,C1
-turkey,turkey,火鸡,NOUN,B2
-turkish,turkish,土耳其的,ADJ,B2
-turmeric,turmeric,词,NOUN,B2
 turmoil,turmoil,混乱,NOUN,B2
 turn around,to turn around,转身,VERB,B2
-turn of phrase,turn of phrase,词,NOUN,C1
 turn off,to turn off,关闭,VERB,B2
 turn signal,turn signal,转向灯,NOUN,B2
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
 turning point,turning point,转折点,NOUN,B2
-turnip,turnip,芜菁,NOUN,B2
-turnoff,turnoff,词,NOUN,B2
 turnout,turnout,出席率,NOUN,B2
-turntable,turntable,,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
 tutelage,tutelage,监护,NOUN,B2
-tutelary,tutelary,词,ADJ,C1
-tutor,tutor,导师,NOUN,C1
 tutoring,tutoring,补习,NOUN,B2
-tv,tv,电视,NOUN,B2
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-tweezers,tweezers,词,NOUN,C1
 twelve,twelve,十二,NUM,B2
-twenty-five,twenty-five,词,NUM,C1
-twenty-two-year-old,twenty-two-year-old,,NOUN,B2
 twice,twice,两次,ADV,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
 twist,to twist,扭曲,VERB,B2
-twist (noun),twist,词,NOUN,C1
 twisted,twisted,扭曲的,ADJ,B2
-twitching,twitching,抽搐的,ADJ,B2
 two animals,two animals,两只,NUM,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
 two-way street,two-way street,双行道,NOUN,B2
-twofold,twofold,双重的,ADJ,B2
-type like,type like,类型/比如,NOUN,B2
-typically,typically,词,ADV,C1
-typographical,typographical,排版的,ADJ,B2
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
-tácitamente,tacitly,默不作声地,ADV,B2
-táctica,tactics,战术,NOUN,B2
-técnico,technical,技术的,ADJ,B2
-técnico,technician,技术员,NOUN,B2
-térmico,thermal,热的,ADJ,B2
-tía,paternal aunt,姑母,NOUN,B2
-tía materna,maternal aunt,姨母,NOUN,B2
-tío materno,maternal uncle,舅舅,NOUN,B2
-tú,then you,那你,PRON,B2
-ubiquitous,ubiquitous,词,ADJ,C1
-ukrainian,ukrainian,乌克兰的,ADJ,B2
+tifón,typhoon,台风,NOUN,B2
+tiranía,tyranny,暴政,NOUN,B2
+tirano,tyrant,暴君,NOUN,B2
+úlcera,ulcer,溃疡,NOUN,B2
 ulceración,ulceration,溃疡,NOUN,B2
-ulterior,ulterior,词,ADJ,C1
-ulteriormente,further,进一步的,ADJ,B2
-ultimate,ultimate,最终的,ADJ,B2
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
-um,um,嗯,INTJ,B2
-umbrage,umbrage,词,NOUN,C1
-umbral,threshold,门槛,NOUN,B2
-un poco,a little,一点,ADJ,B2
-un poco,a bit,一点,ADV,B2
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unanimity,unanimity,词,NOUN,C1
-unarmed,unarmed,手无寸铁的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
-uncompromising,uncompromising,词,ADJ,B2
-unconscious (noun),unconscious,词,NOUN,C1
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,不加批判的,ADJ,B2
-unctuous,unctuous,谄媚的,ADJ,B2
-undead,undead,词,NOUN,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under below,under below,在...下方,ADP,A2
-under the,under the,词,ADP,B2
-underclass,underclass,底层,NOUN,B2
-undercover agent,undercover agent,卧底,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
-underground,underground,地下的,ADJ,B2
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underling,underling,词,NOUN,C1
-underlying,underlying,词,ADJ,B2
-undermining authority,undermining authority,削弱权威,NOUN,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-understanding,understanding,体贴的,ADJ,B2
-undervaluing,undervaluing,词,NOUN,C1
-underwater,underwater,词,ADJ,B2
-underworld,underworld,地下世界,NOUN,B2
-undisturbed,undisturbed,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undulate,undulate,词,VERB,C1
-unearned,unearned,浪得,NOUN,C1
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
-unequivocal,unequivocal,词,ADJ,C1
-unerring,unerring,词,ADJ,C1
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unexpected event,unexpected event,变故,NOUN,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfettered,unfettered,词,ADJ,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable (noun),unforgivable,词,NOUN,B2
-unfounded,unfounded,词,ADJ,C1
-unfriendly,unfriendly,不友好的,ADJ,B2
-ungabe,ungabe,词,NOUN,C1
-ungestaltung,ungestaltung,词,NOUN,C1
-ungodliness,ungodliness,词,NOUN,C1
-unhappiness,unhappiness,词,NOUN,C1
-unhealthy,unhealthy,词,ADJ,C1
-unhurried patience,unhurried patience,词,NOUN,C1
-unicidad,uniqueness,独特,NOUN,B2
-unicorn,unicorn,词,NOUN,C1
-unidad,unit,单元,NOUN,B2
-unidad,unity,团结,NOUN,B2
-unidad,classifier for trees,棵,NUM,B2
-unido,united,联合的,ADJ,B2
-unificar,to unify,统一,VERB,B2
-unification,unification,统一,NOUN,B2
-unified examination,unified examination,统考,NOUN,B2
-uniform,uniform,制服,NOUN,B2
-uniformity,uniformity,统一性,NOUN,B2
-unilateral,unilateral,单方面的,ADJ,B2
-unilateralism,unilateralism,词,NOUN,C1
-unimpeachable,unimpeachable,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-union (adj),union,词,ADJ,C1
-unionist,unionist,词,ADJ,B2
-unique (noun),unique,词,NOUN,B2
-universal,universal,普遍的,ADJ,B2
-universal total,universal total,词,ADJ,C1
-universalidad,universality,普遍性,NOUN,B2
-universities,universities,大学,NOUN,B2
-university (adj),university,词,ADJ,C1
-university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
-university student,university student,大学生,NOUN,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlocked,unlocked,词,NOUN,B2
-unmitigated,unmitigated,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unobtrusive,unobtrusive,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpredictable (noun),unpredictable,词,NOUN,B2
-unpublished,unpublished,词,ADJ,B2
-unreasonable,unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
-unrichtung,unrichtung,词,NOUN,C1
-unsafe,unsafe,词,ADJ,B1
-unscathed,unscathed,未受伤害的,ADJ,B2
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unsecured,unsecured,,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unseen realities,unseen realities,词,NOUN,C1
-unsetzung,unsetzung,词,NOUN,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unsprache,unsprache,词,NOUN,C1
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsuccessful,unsuccessful,词,ADJ,C1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untenable,untenable,词,ADJ,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-until,until,直到,SCONJ,B2
-until to,until to,词,ADP,A2
-untouchable,untouchable,不可触碰的,ADJ,B2
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untreibung,untreibung,词,NOUN,B2
-unwandel,unwandel,词,NOUN,B2
-unwanted,unwanted,不受欢迎的,ADJ,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
+finalmente,ultimately,最终,ADV,B2
+paraguas,umbrella,雨伞,NOUN,B2
+inequívoco,unambiguous,明确的,ADJ,B2
 unánime,unanimous,一致的,ADJ,B2
-up above,up above,上,ADP,A1
-up there,up there,在那上面,ADV,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
-upbraid,upbraid,词,VERB,C1
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-upheaval,upheaval,剧变,NOUN,B2
-uphold,uphold,词,VERB,C1
-upholding of rights,upholding of rights,词,NOUN,C1
-upload (noun),upload,词,NOUN,C1
-upper class,upper class,上层,NOUN,B2
-upper floor,upper floor,楼上,NOUN,B2
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-upright,upright,直立地,ADV,B2
-uprightness,uprightness,词,NOUN,B2
-upset,upset,心烦的,ADJ,B2
-upshot,upshot,词,NOUN,C1
-upward,upward,向上,ADV,B2
-upwards,upwards,向上,ADV,B2
-urban area,urban area,词,NOUN,C1
-urbane,urbane,词,ADJ,C1
-urbanidad,urbanity,都市风度,NOUN,B2
-urbanism,urbanism,词,NOUN,B2
-urbanization,urbanization,城市化,NOUN,B2
+increíble,unbelievable,难以置信的,ADJ,B2
+desconcertante,unclear,不清楚的,ADJ,B2
+sin refrigeración,uncooled,未寒,NOUN,B2
+bajo,under,在...下面,ADP,B2
+subestimar,to underestimate,低估,VERB,B2
+subestimación,underestimation,小看,NOUN,B2
+estudiante de pregrado,undergraduate,本科生,NOUN,B2
+subterráneo,underground,地铁,NOUN,B2
+debajo,underneath,在下面,ADV,B2
+bragas,underpants,内裤,NOUN,B2
+comprensible,understandable,可理解的,ADJ,B2
+emprendimiento,undertaking,事业,NOUN,B2
+ropa interior,underwear,内衣,NOUN,B2
+suscribir,to underwrite,承保,VERB,B2
+inquieto,uneasy,不安的,ADJ,B2
+desempleado,unemployed,失业的,ADJ,B2
+inesperadamente,unexpectedly,出乎意料地,ADV,B2
+injusto,unfair,不公平的,ADJ,B2
+unificar,to unify,统一,VERB,B2
+inimaginable,unimaginable,难以想象的,ADJ,B2
+irrelevante,unimportant,不重要的,ADJ,B2
+sindicato,union,工会,NOUN,B2
+sindicalismo,unionism,工会主义,NOUN,B2
+unicidad,uniqueness,独特,NOUN,B2
+unidad,unit,单元,NOUN,B2
+unido,united,联合的,ADJ,B2
+unidad,unity,团结,NOUN,B2
+aplicabilidad universal,universal applicability,普适性,NOUN,B2
+universalidad,universality,普遍性,NOUN,B2
+injusto,unjust,不公正的,ADJ,B2
+a menos que,unless,除非,SCONJ,B2
+desdichado,unlucky,倒霉的,ADJ,B2
+irrazonable,unreasonable,不合理的,ADJ,B2
+inestabilidad,unrest,动荡,NOUN,B2
+imperturbable,unruffled,从容,ADJ,B2
+hasta,until,直到,ADP,B2
+ceremonia de inauguración,unveiling ceremony,揭幕仪式,NOUN,B2
+desvoluntad,unwillingness,不甘,NOUN,B2
+indigno,unworthy,你不配,NOUN,B2
+hasta,up to,为止,ADP,B2
+próximo,upcoming,مقبل,ADJ,B2
+mejorar,to upgrade,升级,VERB,B2
+subir,to upload,上传,VERB,B2
+superior,upper,上面的,ADJ,B2
+mejora,upturn,好转,NOUN,B2
 urbano,urban,城市的,ADJ,B2
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
+urbanidad,urbanity,都市风度,NOUN,B2
 urgente,urgent,紧急的,ADJ,B2
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,C1
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
-usar muletas,to use crutches,拄拐,VERB,B2
-usar palillos,to use chopsticks,动筷,VERB,B2
-usb flash drive,usb flash drive,U盘,NOUN,B2
-used,used,词,ADJ,C1
-usefulness avail,usefulness avail,效用,NOUN,C1
-useless zero,useless zero,词,ADJ,A2
-using this,using this,用这,NOUN,C1
-usual,usual,通常的,ADJ,B2
-usual thing,usual thing,惯例,NOUN,B2
-usuario,user,用户,NOUN,B2
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-usurpar,to usurp,篡夺,VERB,B2
-usurpation,usurpation,词,NOUN,C1
-usury,usury,词,NOUN,C1
-utensil,utensil,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
-utilitarismo,utilitarianism,功利主义,NOUN,B2
-utilitarista,utilitarian,功利的,ADJ,B2
-utility,utility,效用,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
+nosotros,us,你我,NOUN,B2
 utilizable,usable,可用的,ADJ,B2
+usar palillos,to use chopsticks,动筷,VERB,B2
+usar muletas,to use crutches,拄拐,VERB,B2
+usuario,user,用户,NOUN,B2
+usual,usual,通常的,ADJ,B2
+normalmente,usually,通常,ADV,B2
+usurpar,to usurp,篡夺,VERB,B2
+utilitarista,utilitarian,功利的,ADJ,B2
+utilitarismo,utilitarianism,功利主义,NOUN,B2
 utilización,utilization,利用,NOUN,B2
 utilizar,to utilize,利用,VERB,B2
-utmost extreme end,utmost extreme end,词,NOUN,C1
+supremo,utmost,你尽,NOUN,B2
 utopía,utopia,乌托邦,NOUN,B2
-utter,utter,词,ADJ,C1
-utterance-related,utterance-related,词,ADJ,C1
 utópico,utopian,乌托邦式的,ADJ,B2
-uva,grape,葡萄,NOUN,B2
-vacaciones,holiday,假期,NOUN,B2
-vacant lot,vacant lot,空地,NOUN,C1
-vacante,vacant,空缺的,ADJ,B2
+enunciado,utterance,话语,NOUN,B2
 vacante,vacancy,空缺,NOUN,B2
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccinal,vaccinal,词,ADJ,C1
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vacilar,to stagger,蹒跚,VERB,B2
-vacillate,vacillate,词,VERB,C1
-vacuna,vaccine,疫苗,NOUN,B2
-vacunación,vaccination,疫苗接种,NOUN,B2
+vacante,vacant,空缺的,ADJ,B2
 vacunar,to vaccinate,接种疫苗,VERB,B2
-vacuous,vacuous,词,ADJ,C1
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum cleaner,vacuum cleaner,吸尘器,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vagabond,vagabond,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
-vagar,to roam,漫游,VERB,B2
-vagary,vagary,词,NOUN,C1
+vacunación,vaccination,疫苗接种,NOUN,B2
+vacuna,vaccine,疫苗,NOUN,B2
 vago,vague,含糊的,ADJ,B2
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vaguely,vaguely,词,ADV,C1
-vagueness,vagueness,模糊,NOUN,C1
-vain,vain,徒劳的,ADJ,B2
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vainglory,vainglory,词,NOUN,C1
-vale,voucher,代金券,NOUN,B2
-vale of tears,vale of tears,词,NOUN,C1
-valedictory,valedictory,词,ADJ,C1
-valentía,bravery,勇敢,NOUN,B2
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
-valid,valid,有效的,ADJ,B2
-validez,validity,有效期,NOUN,B2
 valiente,valiant,英勇的,ADJ,B2
-valioso,valuable,有价值的,ADJ,B2
+validez,validity,有效期,NOUN,B2
 valor,valor,勇气,NOUN,B2
+valioso,valuable,有价值的,ADJ,B2
 valoración,valuation,估值,NOUN,B2
-valorar,to appraise,评估,VERB,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-values,values,价值观,NOUN,B2
-values base,values base,价值基础,NOUN,B2
-valve,valve,词,NOUN,C1
 vampiro,vampire,吸血鬼,NOUN,B2
 vanguardia,vanguard,先锋,NOUN,B2
-vanguardista,avant-garde,前卫的,ADJ,B2
 vanidad,vanity,虚荣,NOUN,B2
-vanilla,vanilla,词,NOUN,C1
-vanishing,vanishing,词,NOUN,C1
-vanquish,vanquish,词,VERB,C1
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
 variable,variable,变量,NOUN,B2
-variable (adj),variable,词,ADJ,C1
-variables,variables,词,NOUN,C1
-variant,variant,变体,NOUN,B2
 varianza,variance,方差,NOUN,B2
-variation,variation,变化,NOUN,B2
 variedad,variety,种类,NOUN,B2
-variegate,variegate,词,VERB,C1
-varilla de cortina,curtain rod,窗帘杆,NOUN,B2
-varios,several,几个,DET,B2
-various,various,各种各样的,ADJ,B2
-varying,varying,词,ADJ,B2
-vassal,vassal,之臣,NOUN,C1
-vastness,vastness,词,NOUN,B2
+diversos departamentos,various departments,各部,NOUN,B2
 vasto,vast,巨大的,ADJ,B2
-vat,vat,增值税,NOUN,B2
-vaunt,vaunt,词,VERB,C1
-veces,times,倍,NOUN,B2
-vecindad,vicinity,附近,NOUN,B2
-vector,vector,词,NOUN,C1
-veer,veer,词,VERB,C1
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehemence,vehemence,词,NOUN,C1
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiled,veiled,隐晦的,ADJ,B2
-vela,candle,蜡烛,NOUN,B2
-velarization,velarization,词,NOUN,C1
-vencido,overdue,逾期,ADJ,B2
-venda,bandage,绷带,NOUN,B2
-vendedor,salesperson,销售人员,NOUN,B2
-vending machine,vending machine,自动售货机,NOUN,B2
-veneer,veneer,词,NOUN,C1
-venenoso,poisonous,有毒的,ADJ,B2
+matrícula de vehículo,vehicle registration,行驶证,NOUN,B2
 venerable,venerable,值得尊敬的,ADJ,B2
-venereal disease,venereal disease,性病,NOUN,B2
 venganza,vengeance,报复,NOUN,B2
-vengar,to avenge,复仇,VERB,B2
-vengarse,to take revenge,报复,VERB,B2
-venial,venial,词,ADJ,C1
-venir,to come here,来到这里,VERB,B2
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-venta,sale,出售,NOUN,B2
-ventajoso,advantageous,有利的,ADJ,B2
-ventas,sales,打折,NOUN,B2
 ventilación,ventilation,通风,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-ventisca,blizzard,暴风雪,NOUN,B2
-venture (noun),venture,词,NOUN,B2
-ver cadáver,to see corpse,见尸,VERB,B2
-veracity,veracity,词,NOUN,C1
-verbal,verbal,言语的,ADJ,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbalize,verbalize,词,VERB,B2
-verbatim,verbatim,词,ADV,C1
-verbose,verbose,冗长的,ADJ,B2
-verbosely,verbosely,词,ADV,C1
-verdant,verdant,词,ADJ,C1
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-verge,verge,词,NOUN,C1
-vergestaltung,vergestaltung,词,NOUN,C1
-vergonzoso,shameful,可耻的,ADJ,B2
-verifiable,verifiable,词,ADJ,C1
-verification,verification,词,NOUN,C1
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkunft,verkunft,词,NOUN,C1
-vernacular,vernacular,词,NOUN,C1
-vernahme,vernahme,词,NOUN,C1
+sede,venue,场地,NOUN,B2
 vernal,vernal,春季的,ADJ,B2
-vernier,vernier,词,NOUN,C1
-verpflegung,verpflegung,词,NOUN,C1
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
 versado,versed,精通的,ADJ,B2
-versatile,versatile,多才多艺的,ADJ,B2
-versatility,versatility,词,NOUN,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verse,verse,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versification,versification,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-versprache,versprache,词,NOUN,C1
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-versus,versus,对,ADP,B2
-vertebra,vertebra,词,NOUN,B2
-verteilung,verteilung,词,NOUN,C1
-verter,to pour,倾倒,VERB,B2
-vertex,vertex,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
 vertical,vertical,垂直的,ADJ,B2
-vertigo,vertigo,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertreibung,vertreibung,词,NOUN,C1
-verwandel,verwandel,词,NOUN,C1
-verweisung,verweisung,词,NOUN,C1
-verwirkung,verwirkung,词,NOUN,C1
-very best,very best,最好的,ADJ,B2
-very deep,very deep,很深,ADJ,B2
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-vestige,vestige,词,NOUN,C1
-veterinarian,veterinarian,词,NOUN,C1
 veto,veto,否决,NOUN,B2
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-viabilidad,feasibility,可行性,NOUN,B2
-viable,viable,可行的,ADJ,B2
-viaje,travel,出行,NOUN,B2
-viajero,traveler,旅行家,NOUN,B2
-vial,vial,词,NOUN,C1
 vibración,vibration,振动,NOUN,B2
-vibrant,vibrant,词,ADJ,C1
-vicarious,vicarious,词,ADJ,C1
-vice versa,vice versa,反之亦然,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
 viceversa,vice versa,反之亦然,ADV,B2
-vicious,vicious,词,ADJ,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-vida,lifetime,一生,NOUN,B2
-vida o muerte,life-and-death,决生,NOUN,B2
-vida y muerte,life and death,生死,NOUN,B2
-video clip,video clip,词,NOUN,C1
-video on demand,video on demand,点播,NOUN,C1
+vecindad,vicinity,附近,NOUN,B2
+vídeo,video,视频,NOUN,B2
 videodisco,video disc,影碟,NOUN,B2
-videotape,videotape,词,NOUN,C1
-vientre,belly,肚子,NOUN,B2
-viewer,viewer,观众,NOUN,B2
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigilancia,surveillance,监视,NOUN,B2
-vigilancia,vigilance,警惕,NOUN,B2
-vigilar,to surveil,监视,VERB,B2
+grabación de vídeo,video recording,录像,NOUN,B2
+envejecer,to vie,竞争,VERB,B2
+punto de vista,viewpoint,观点,NOUN,B2
 vigilia,vigil,守夜,NOUN,B2
-vignette,vignette,词,NOUN,C1
+vigilancia,vigilance,警惕,NOUN,B2
 vigor,vigor,活力,NOUN,B2
-vigor of prime,vigor of prime,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
 vil,vile,卑鄙的,ADJ,B2
-vile,vile,可憎地,ADV,B2
 villa,villa,别墅,NOUN,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-villainy,villainy,邪恶,NOUN,B2
+jefe de aldea,village head,村长,NOUN,B2
 villano,villain,反派,NOUN,B2
 vinagre,vinegar,醋,NOUN,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vineyard,vineyard,葡萄园,NOUN,C1
-vintage,vintage,佳酿,NOUN,B2
-violación,violation,侵越,NOUN,B2
-violar,rape,强奸,NOUN,B2
-violar,to rape,强奸,VERB,B2
 violar,to violate,违反,VERB,B2
 violar la disciplina,to violate discipline,违纪,VERB,B2
-violate regulations,violate regulations,违规,VERB,C1
-violations,violations,词,NOUN,C1
-violent act,violent act,词,NOUN,C1
-violently,violently,暴力地,ADV,B2
-violet (adj),violet,词,ADJ,C1
-violet (noun),violet,词,NOUN,B2
+violación,violation,侵越,NOUN,B2
 violín,violin,小提琴,NOUN,B2
-viper,viper,词,NOUN,B2
-viral,viral,病毒性的,ADJ,C1
-virginal,virginal,处女的,ADJ,B2
 virtual,virtual,虚拟的,ADJ,B2
-virtual reality,virtual reality,虚拟现实,NOUN,B2
 virtualmente,virtually,几乎,ADV,B2
-virtuoso,virtuoso,词,NOUN,C1
-virtuous,virtuous,有德行的,ADJ,B2
 virus,virus,病毒,NOUN,B2
 visa,visa,签证,NOUN,B2
-viscosity,viscosity,词,NOUN,C1
 viscoso,viscous,黏稠的,ADJ,B2
-viscount,viscount,词,NOUN,C1
-visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
-visionary,visionary,词,NOUN,C1
 visitante,visitor,访客,NOUN,B2
-visiting ban,visiting ban,,NOUN,B2
-visor,visor,词,NOUN,B2
-vista,sight,视力,NOUN,B2
 visual,visual,视觉的,ADJ,B2
-visualize,visualize,词,VERB,C1
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
 vitamina,vitamin,维生素,NOUN,B2
-vitiate,vitiate,词,VERB,C1
-vitriolic,vitriolic,词,ADJ,C1
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
 vivo,vivid,生动的,ADJ,B2
-vocabulary,vocabulary,词,NOUN,C1
 vocal,vocal,直言的,ADJ,B2
-vocal range,vocal range,词,NOUN,C1
-vocalization,vocalization,词,NOUN,C1
-vocation,vocation,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vociferous,vociferous,词,ADJ,C1
-vodka,vodka,词,NOUN,C1
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-voicing,voicing,词,NOUN,C1
-void,void,最无,NOUN,B2
-volante,steering wheel,方向盘,NOUN,B2
-volatility,volatility,词,NOUN,C1
-volcanic,volcanic,词,ADJ,C1
-volcar,to overturn,打翻,VERB,B2
-volcán,volcano,火山,NOUN,B2
-volition,volition,词,NOUN,C1
-volleyball,volleyball,排球,NOUN,B2
-voltage,voltage,词,NOUN,C1
-voluble,voluble,词,ADJ,C1
-volume measure,volume measure,词,NOUN,B2
-volumen,bulk,主体,NOUN,B2
-volumen,volume,体积,NOUN,B2
-volumen,measure word for books,本,NUM,B2
-volumetric,volumetric,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-voluntad del padre imperial,imperial father's will,父皇要,NOUN,B2
-voluntariamente,voluntarily,自愿地,ADV,B2
-voluntariness,voluntariness,词,NOUN,C1
-voluntario,voluntary,自愿的,ADJ,B2
-voluntarist,voluntarist,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
-volunteering,volunteering,志愿服务,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-volver,to come back,回来,VERB,B2
-volver a ver,to see again,再见,VERB,B2
 volátil,volatile,易变的,ADJ,B2
-vomit (noun),vomit,词,NOUN,B2
+volcán,volcano,火山,NOUN,B2
+volumen,volume,体积,NOUN,B2
+voluntariamente,voluntarily,自愿地,ADV,B2
+voluntario,voluntary,自愿的,ADJ,B2
 vomitar,to vomit,呕吐,VERB,B2
-vomiting,vomiting,词,NOUN,C1
-voracious,voracious,词,ADJ,C1
-voracity,voracity,词,NOUN,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorkunft,vorkunft,词,NOUN,C1
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-votación,voting,投票,NOUN,B2
-votante,voter,选民,NOUN,B2
+vórtice,vortex,漩涡,NOUN,B2
 votar,vote,投票,NOUN,B2
 votar,to vote,表决,VERB,B2
-votary,votary,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
+votante,voter,选民,NOUN,B2
+votación,voting,投票,NOUN,B2
+vale,voucher,代金券,NOUN,B2
 voto,vow,誓言,NOUN,B2
-vouch,vouch,词,VERB,C1
-vouchsafe,vouchsafe,词,VERB,C1
-vowel,vowel,词,NOUN,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vs,vs,与...相对,ADP,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulnerable,vulnerable,易受伤害的,ADJ,B2
-vía de circunvalación,ring road,绕城,NOUN,B2
-vídeo,video,视频,NOUN,B2
-vórtice,vortex,漩涡,NOUN,B2
-wading,wading,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-waft,waft,词,VERB,C1
-wage earner,wage earner,词,NOUN,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage murder unit,wage murder unit,词,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-wager,wager,词,NOUN,C1
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wailing,wailing,词,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waive,waive,词,VERB,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-walker,walker,词,NOUN,C1
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wall-mounted,wall-mounted,词,ADJ,C1
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
-wan,wan,词,ADJ,B2
-wanderer,wanderer,词,NOUN,C1
-wandering monk,wandering monk,游方,NOUN,B2
-want (adp),want,我要,ADP,A2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-war cessation,war cessation,战息,NOUN,B2
-warble (verb),warble,词,VERB,C1
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmer,warmer,更暖的,ADJ,B2
-warmly,warmly,热情地,ADV,B2
-warmonger,warmonger,词,NOUN,C1
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrant,warrant,令状,NOUN,B2
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-waste disposal site,waste disposal site,词,NOUN,B1
-waste of time,waste of time,浪费时间,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wastewater,wastewater,废水,NOUN,C1
-watch of the night,watch of the night,词,NOUN,C1
-watch over,watch over,词,VERB,C1
-watched,watched,词,NOUN,B2
-watchmaking,watchmaking,词,NOUN,C1
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water garment,water garment,水衣,NOUN,C1
-water heater,water heater,热水器,NOUN,B2
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-watercourse,watercourse,河道,NOUN,B1
-watering,watering,词,NOUN,B2
+salario,wage,工资,NOUN,B2
+guerrear,to wage war,作战,VERB,B2
+salarios,wages,工资,NOUN,B2
+aullar,to wail,哀号,VERB,B2
+espera,wait,等待,NOUN,B2
+espera,wait for me,等我,NOUN,B2
+esperar mucho,to wait long,久等,VERB,B2
+sala de espera,waiting room,候诊室,NOUN,B2
+camarera,waitress,女服务员,NOUN,B2
+despertar,to wake,唤醒,VERB,B2
+paseo,walk,行走,NOUN,B2
+deambulación,wandering,漫游,NOUN,B2
+querer,want,想,AUX,B2
+deseo de atraer,want to lure,想引,NOUN,B2
+querer necesitar,to want to need will,要,VERB,B2
+buscado,wanted,故意的,ADJ,B2
+sala,ward,病房,NOUN,B2
+alcaide,warden,看守人,NOUN,B2
+almacén,warehouse,仓库,NOUN,B2
+calentamiento,warming,变暖,NOUN,B2
+calor,warmth,温暖,NOUN,B2
+garantía,warranty,保修单,NOUN,B2
+lavado,washing,洗涤,NOUN,B2
+reloj,watch,手表,NOUN,B2
+regar,to water,浇水,VERB,B2
+caída de agua,water falling,水落,NOUN,B2
+espinaca de agua,water spinach,空心菜,NOUN,B2
+acuarela,watercolor,水彩画,NOUN,B2
+cascada,waterfall,瀑布,NOUN,B2
+sandía,watermelon,西瓜,NOUN,B2
 watermelon seed,watermelon seed,西瓜子,NOUN,B2
-watershed,watershed,词,NOUN,C1
-waterskin,waterskin,词,NOUN,B2
-watertight,watertight,,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
 wave,wave,波浪,NOUN,B2
 wave,to wave,挥手,VERB,B2
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-waxen,waxen,词,ADJ,C1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
-waylay,waylay,词,VERB,C1
 we or us including both the speaker and the person s spoken to,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
 we two,we two,我俩,PRON,B2
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weakened,weakened,词,ADJ,C1
-weakening,weakening,减弱,NOUN,B2
-weakly,weakly,词,ADV,C1
-weal,weal,词,NOUN,C1
 wealth,wealth,财富,NOUN,B2
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
 wean,to wean,断奶,VERB,B2
 weaning,weaning,断奶,NOUN,B2
-weapon arms,weapon arms,词,NOUN,A1
-wear tear,wear tear,词,NOUN,C1
-wearisome,wearisome,词,ADJ,C1
 weather,weather,天气,NOUN,B2
-weather forecast,weather forecast,词,NOUN,B1
-weather institute,weather institute,词,NOUN,B2
-weathering,weathering,词,NOUN,C1
 weave,to weave,编织,VERB,B2
-weaver,weaver,词,NOUN,B1
 weaving,weaving,编织,NOUN,B2
 webcam,webcam,网络摄像头,NOUN,B2
 website,website,网站,NOUN,B2
 wedding anniversary,wedding anniversary,结婚纪念日,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
 wedding photo,wedding photo,婚纱照,NOUN,B2
 weed,weed,杂草,NOUN,B2
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
 week number,week number,周次,NOUN,B2
 weekday,weekday,工作日,NOUN,B2
 weekend,weekend,周末,NOUN,B2
-weekly,weekly,每周的,ADJ,B2
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
 weekly test,weekly test,周测,NOUN,B2
 weep,to weep,哭泣,VERB,B2
-weeping,weeping,痛哭,NOUN,C1
-weighing,weighing,词,NOUN,B2
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
 weird,weird,奇怪的,ADJ,B2
 weirdo,weirdo,怪人,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
 welcome,welcome,受欢迎的,ADJ,B2
-welcome (intj),welcome,词,INTJ,A1
 welcome banquet,welcome banquet,欢迎宴,NOUN,B2
-welcome committee,welcome committee,,NOUN,B2
-weld,weld,词,VERB,C1
-welder,welder,词,NOUN,C1
 welding,welding,焊接,NOUN,B2
 welfare,welfare,福利,NOUN,B2
-welfare home,welfare home,福利院,NOUN,C1
 well,well,好吧,INTJ,B2
-well (noun),well,水井,NOUN,B2
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
 well-considered,well-considered,深思熟虑的,ADJ,B2
-well-crafted,well-crafted,词,ADJ,B2
-well-disposed,well-disposed,善意的,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welter,welter,词,NOUN,C1
-wend,wend,词,VERB,C1
-werewolf,werewolf,狼人,NOUN,B2
-western,western,西方的,ADJ,B2
 western regions,western regions,西域,NOUN,B2
-westerner,westerner,词,NOUN,B2
-westward,westward,向西,ADV,B2
-westward (noun),westward,往西,NOUN,B2
 wet,wet,湿的,ADJ,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
 wetland,wetland,湿地,NOUN,B2
 whale,whale,鲸鱼,NOUN,B2
 what,what,什么,ADV,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
 what extent,what extent,在何种程度上,ADV,B2
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what kind of,what kind of,什么样的,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
 wheat,wheat,小麦,NOUN,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
 wheelchair,wheelchair,轮椅,NOUN,B2
-when (adp),when,之时,ADP,B2
-when than,when than,词,SCONJ,A2
-when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where i,where i,,NOUN,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (cconj),whereas,词,CCONJ,B2
-whereas (sconj),whereas,词,SCONJ,C1
-whereas since,whereas since,词,SCONJ,A2
 whereby,whereby,其中,ADV,B2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whet,whet,词,VERB,C1
 whether,whether,能否,NOUN,B2
-whether (part),whether,词,PART,A1
-whether (sconj),whether,是否,SCONJ,A2
 whether or not,whether or not,是否,SCONJ,B2
-whey,whey,乳清,NOUN,B2
 which,which,哪个,DET,B2
 which one,which one,哪一个,PRON,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
 whine,to whine,哀叹,VERB,B2
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
 whirlwind,whirlwind,旋风；漩涡,NOUN,B2
-whirring,whirring,词,NOUN,C1
-whisk,whisk,打蛋器,NOUN,B2
-whisk whip,whisk whip,词,NOUN,B1
 whistle,whistle,口哨,NOUN,B2
 whistle,to whistle,吹口哨,VERB,B2
-whistling,whistling,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whiting,whiting,词,NOUN,B2
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
 whole,whole,整体,NOUN,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
 whole world,whole world,全世界,NOUN,B2
-wholehearted,wholehearted,词,ADJ,C1
 wholesale,wholesale,批发,NOUN,B2
-wholesale (adv),wholesale,词,ADV,B1
-wholesome,wholesome,词,ADJ,C1
 whom,whom,谁,PRON,B2
-whore,whore,妓女,NOUN,B2
 whose,whose,谁的,PRON,B2
-whose (det),whose,词,DET,B2
 why,why,为什么,ADV,B2
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
 widespread,widespread,广泛的,ADJ,B2
-widowhood,widowhood,词,NOUN,C1
 width,width,宽度,NOUN,B2
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
 wife,wife,妻子,NOUN,B2
-wife mrs,wife mrs,妻子/夫人,NOUN,B2
-wig,wig,假发,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
-wilderness,wilderness,荒野,NOUN,B2
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
 will,will,将要,AUX,B2
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will shall,will shall,将要/会,AUX,B2
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
 willful,willful,任性的,ADJ,B2
 willing,willing,肯,AUX,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
 willingness,willingness,乐意,NOUN,B2
-willow,willow,词,NOUN,B2
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-wimp,wimp,懦夫,NOUN,B2
-win,win,胜利,NOUN,B2
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-windfall,windfall,意外之财,NOUN,B2
-windless,windless,无风的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
 window glass,window glass,窗玻璃,NOUN,B2
-windowsill,windowsill,窗台,NOUN,C1
 windproof,windproof,挡风的,ADJ,B2
-windy,windy,有风的,ADJ,B2
-windy day,windy day,风天,NOUN,B2
 wine cup,wine cup,这酒盏,NOUN,B2
 wing,wing,翅膀,NOUN,B2
-wings,wings,翅子,NOUN,C1
 wink,to wink,眨眼,VERB,B2
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
 winnow,to winnow,筛选,VERB,B2
-winsome,winsome,词,ADJ,C1
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
 wiper,wiper,雨刷,NOUN,B2
-wired,wired,词,ADJ,C1
 wireless,wireless,无线的,ADJ,B2
 wisdom,wisdom,智慧,NOUN,B2
-wisely,wisely,明智地,ADV,B2
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wistful,wistful,词,ADJ,C1
-witch hunt,witch hunt,词,NOUN,C1
-with each other,with each other,词,ADV,A2
-with it,with it,在其中,ADV,B2
-with that,with that,以此,ADV,B2
-with the aim of,with the aim of,词,ADP,C1
-with this,with this,以此,ADV,B2
-with what,with what,用什么,ADV,B2
-with which,with which,词,PRON,A2
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawal fold,withdrawal fold,词,NOUN,C1
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without exception,without exception,无例外的,ADV,B2
-without further ado,without further ado,毫不犹豫地,ADV,B2
-withstand,withstand,词,VERB,C1
-witness examination,witness examination,证人询问,NOUN,B2
-witness female,witness female,词,NOUN,B2
-witness protection,witness protection,,NOUN,B2
-witticism,witticism,词,NOUN,C1
-wittiness,wittiness,风趣,NOUN,B2
-wizened,wizened,词,ADJ,C1
-woe (intj),woe,词,INTJ,B2
-woe (noun),woe,词,NOUN,C1
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wonder (noun),wonder,太妙,NOUN,C1
-wonderful,wonderful,极好地,ADV,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-wooden,wooden,木制的,ADJ,B2
-woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
-word choice,word choice,措辞,NOUN,B2
-wording,wording,措辞,NOUN,B2
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work environment,work environment,工作环境,NOUN,B2
-work task,work task,工作任务,NOUN,B2
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working class,working class,工人阶级,NOUN,B2
-working day,working day,工作日,NOUN,B2
-working method,working method,工作方式,NOUN,B2
-workout,workout,词,NOUN,C1
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world champion,world champion,世界冠军,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldliness,worldliness,词,NOUN,C1
-worldly,worldly,世俗的,ADJ,B2
-wormwood,wormwood,词,NOUN,A2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worse,worse,更糟的事,NOUN,B2
-worsening,worsening,词,NOUN,C1
-worst,worst,最坏的,ADJ,B2
-worst (adv),worst,词,ADV,C1
-worst (noun),worst,词,NOUN,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthless,worthless,无价值的,ADJ,B2
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would,would,将要,AUX,B2
-would like,would like,词,AUX,A2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
-wow,wow,哇,INTJ,B2
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wreckage,wreckage,词,NOUN,C1
-wrench,wrench,词,NOUN,C1
-wretched,wretched,词,ADJ,C1
-wretchedness,wretchedness,悲惨,NOUN,C1
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
-writ,writ,词,NOUN,C1
-writhe,writhe,词,VERB,C1
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
-wrongdoer,wrongdoer,罪犯,NOUN,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
-x-ray,x-ray,X光片,NOUN,B2
-xenophobia,xenophobia,排外心理,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
+desear,to wish,希望,VERB,B2
+difícilmente,with difficulty,困难地,ADV,B2
+retener,to withhold,扣留,VERB,B2
+dentro,within,在……之内,ADP,B2
+atestiguar,to witness,目击,VERB,B2
+testimonio,witness testimony,人证,NOUN,B2
+ingenio,wits,心眼,NOUN,B2
+no bastar,won't do,不行,ADJ,B2
+no bastar,to won't do,不成,VERB,B2
+maravillarse,wonder,奇迹,NOUN,B2
+maravillarse,to wonder,觉得奇怪,VERB,B2
+madera,wood,木头,NOUN,B2
+oreja de Judas,wood ear mushroom,木耳,NOUN,B2
+bosque,woodland,林地,NOUN,B2
+lana,wool,羊毛,NOUN,B2
+esforzarse,to work hard for sth to strive for success,争气,VERB,B2
+resolver,to work out,成功,VERB,B2
+trabajador,worker,工人,NOUN,B2
+lugar de trabajo,workplace,工作场所,NOUN,B2
+taller,workshop,研讨会,NOUN,B2
+guerra mundial,world war,世界大战,NOUN,B2
+preocupado,worried,担心的,ADJ,B2
+adorar,worship,崇拜,NOUN,B2
+adorar,to worship,崇拜,VERB,B2
+digno,worth,值得的,ADJ,B2
+herido,wounded,受伤的,ADJ,B2
+ira,wrath,愤怒,NOUN,B2
+desastre,wreck,残骸,NOUN,B2
+arrancar,to wrest,强行夺取,VERB,B2
+lucha,wrestling,摔跤,NOUN,B2
+desgraciado,wretch,令人厌恶的人,NOUN,B2
+antiarrugas,wrinkle-resistant,防皱,ADJ,B2
+muñeca,wrist,手腕,NOUN,B2
+equivocado,wrong mistake,错误,ADJ,B2
+Wudang,wudang,武当,NOUN,B2
 yard,yard,院子,NOUN,B2
-yeah,yeah,词,INTJ,A1
-yeah yeah,yeah yeah,是是是,INTJ,B2
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
 years,years,数年,NOUN,B2
 yeast,yeast,酵母,NOUN,B2
 yell,to yell,大吼,VERB,B2
-yeoman,yeoman,词,NOUN,C1
-yep,yep,是的,INTJ,B2
 yes,yes,是啊,NOUN,B2
-yes (adv),yes,词,ADV,A2
-yes (part),yes,是的,PART,B2
-yes indeed,yes indeed,正是,INTJ,B2
-yes indeed (adv),yes indeed,词,ADV,B2
-yeso,plaster,石膏,NOUN,B2
 yesterday,yesterday,بارحة,NOUN,B2
-yesteryear,yesteryear,词,NOUN,C1
-yet,yet,还,ADV,B2
 yield,yield,产量,NOUN,B2
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yin púrpura,purple yin,紫阴,NOUN,B2
-yo,yo,哟,PART,B2
 yoga,yoga,瑜伽,NOUN,B2
-yoga practice,yoga practice,瑜伽练习,NOUN,B2
 yogurt,yogurt,酸奶,NOUN,B2
-yoke,yoke,枷锁,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
 you can,you can,您能,NOUN,B2
 you cannot live,you cannot live,你也活不,NOUN,B2
-you dative,you dative,词,PRON,A2
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you formal,you formal,您,PRON,B2
-you masculine,you masculine,词,PRON,A1
 you polite,you polite,您,PRON,B2
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
 young lady,young lady,小姐,NOUN,B2
 young man,young man,年轻人,NOUN,B2
 young master,young master,少庄主,NOUN,B2
 young person,young person,年轻人,NOUN,B2
-young wife,young wife,小媳,NOUN,B2
-younger,younger,较年轻的,ADJ,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-youngest,youngest,最年轻的,ADJ,B2
-your,your,你的,PRON,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
 your laugh,your laugh,你笑,NOUN,B2
 your majesty,your majesty,陛下,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your pl,your pl,你们的,DET,B2
-your plural,your plural,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,你的,PRON,B2
-yourself,yourself,你自己,PRON,B2
-youth culture,youth culture,词,NOUN,C1
-youth people,youth people,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful vigor,youthful vigor,词,NOUN,C1
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
 yuanxiao,yuanxiao,元宵,NOUN,B2
-yuca,cassava,木薯,NOUN,B2
-yuck,yuck,呸,INTJ,B2
-zajal,zajal,词,NOUN,B2
-zany,zany,词,ADJ,C1
-zapatos,shoes,鞋子,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zellige tiles,zellige tiles,词,NOUN,A2
-zen master,zen master,禅师,NOUN,B2
 zenith,zenith,顶点,NOUN,B2
-zephyr,zephyr,词,NOUN,C1
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
-zero,zero,零,NOUN,B2
-zeroing,zeroing,词,NOUN,C1
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
 zhuang he,zhuang he,庄郃,NOUN,B2
 zinc,zinc,锌,NOUN,B2
 zodiac sign,zodiac sign,属相,NOUN,B2
 zombie,zombie,僵尸,NOUN,B2
-zongzi,zongzi,粽子,NOUN,B2
-zoo,zoo,动物园,NOUN,B2
-zorro,fox,狐狸,NOUN,B2
 zucchini,zucchini,西葫芦,NOUN,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zukunft,zukunft,词,NOUN,C1
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
+colony,colony,殖民地,NOUN,B2
+cosmic,cosmic,宇宙的,ADJ,B2
+tendentious,tendentious,有偏见的,ADJ,B2
+carrot,carrot,胡萝卜,NOUN,B2
+securitization,securitization,证券化,NOUN,B2
+rigid,rigid,僵硬的,ADJ,B2
+to reproduce,to reproduce,繁殖,VERB,B2
+cupboard,cupboard,橱柜,NOUN,B2
+after,after,تلو,NOUN,B2
+firm,firm,公司,NOUN,B2
+to renovate,to renovate,翻新,VERB,B2
+flora,flora,植物群,NOUN,B2
+realistic,realistic,现实的,ADJ,B2
+to diminish,to diminish,减少,VERB,B2
+again,again,你又,NOUN,B2
+weekly,weekly,每周的,ADJ,B2
+chinese,chinese,中国的,ADJ,B2
+nest,nest,巢,NOUN,B2
+billion,billion,十亿,NUM,B2
+to baptize,to baptize,施洗,VERB,B2
+around,around,到处,ADV,B2
+to confide,to confide,吐露,VERB,B2
+to subsidize,to subsidize,资助,VERB,B2
+archipelago,archipelago,群岛,NOUN,B2
+to centralize,to centralize,集中,VERB,B2
+dull,dull,枯燥的,ADJ,B2
+seventh,seventh,第七,ADJ,B2
+requirement,requirement,要求,NOUN,B2
+to define,to define,定义,VERB,B2
+audiovisual,audiovisual,视听的,ADJ,B2
+bid,bid,出价,NOUN,B2
+verbose,verbose,冗长的,ADJ,B2
+atheism,atheism,无神论,NOUN,B2
+to banish,to banish,流放,VERB,B2
+diabetes,diabetes,糖尿病,NOUN,B2
+ninth,ninth,第九,ADJ,B2
+orchestra,orchestra,管弦乐队,NOUN,B2
+religious,religious,宗教的,ADJ,B2
+empirical,empirical,经验的,ADJ,B2
+senate,senate,参议院,NOUN,B2
+modesty,modesty,谦虚,NOUN,B2
+pulpit,pulpit,讲坛,NOUN,B2
+quote,quote,报价单,NOUN,B2
+academic,academic,学者,NOUN,B2
+guardianship,guardianship,监护,NOUN,B2
+present,present,礼物,NOUN,B2
+to undergo,to undergo,经历,VERB,B2
+to chatter,to chatter,喋喋不休,VERB,B2
+until,until,直到,SCONJ,B2
+arena,arena,竞技场,NOUN,B2
+female,female,雌性,NOUN,B2
+to refresh,to refresh,使恢复精神,VERB,B2
+turnip,turnip,芜菁,NOUN,B2
+salmon,salmon,三文鱼,NOUN,B2
+to characterize,to characterize,描绘,VERB,B2
+to swarm,to swarm,分群,VERB,B2
+parking,parking,停车,NOUN,B2
+popularity,popularity,流行,NOUN,B2
+autonomous,autonomous,自治的,ADJ,B2
+temporal,temporal,时间的,ADJ,B2
+to motivate,to motivate,激励,VERB,B2
+rate,rate,比率,NOUN,B2
+supernatural,supernatural,超自然的,ADJ,B2
+to finalize,to finalize,完成,VERB,B2
+substantial,substantial,大量的,ADJ,B2
+artistic,artistic,艺术的,ADJ,B2
+apocryphal,apocryphal,杜撰的,ADJ,B2
+asian,asian,亚洲的,ADJ,B2
+to light,to light,照亮,VERB,B2
+linguistic,linguistic,语言的,ADJ,B2
+existing,existing,现有的,ADJ,B2
+liberal,liberal,自由的,ADJ,B2
+third,third,三分之一,NOUN,B2
+above,above,上面,ADV,B2
+barrel,barrel,桶,NOUN,B2
+muslim,muslim,مسلم,NOUN,B2
+prevention,prevention,预防,NOUN,B2
+dumping,dumping,倾销,NOUN,B2
+frightening,frightening,令人恐惧的,ADJ,B2
+cottage,cottage,小屋,NOUN,B2
+delighted,delighted,高兴的,ADJ,B2
+intensive,intensive,强化的,ADJ,B2
+to unload,to unload,卸货,VERB,B2
+his,his,他的,PRON,B2
+bankrupt,bankrupt,破产的,ADJ,B2
+worst,worst,最坏的,ADJ,B2
+to simulate,to simulate,模拟,VERB,B2
+disjoint,disjoint,不相交的,ADJ,B2
+most,most,最,ADV,B2
+hedge,hedge,树篱,NOUN,B2
+certain,certain,某些,DET,B2
+fee,fee,费用,NOUN,B2
+southern,southern,南方的,ADJ,B2
+afraid,afraid,害怕的,ADJ,B2
+democrat,democrat,民主主义者,NOUN,B2
+simultaneously,simultaneously,同时地,ADV,B2
+to perceive,to perceive,察觉,VERB,B2
+to enthuse,to enthuse,使热情,VERB,B2
+debut,debut,初次登台,NOUN,B2
+to censor,to censor,审查,VERB,B2
+injunction,injunction,禁令,NOUN,B2
+police officer,police officer,警察,NOUN,B2
+elsewhere,elsewhere,别处,ADV,B2
+chemical,chemical,化学品,NOUN,B2
+tenth,tenth,第十,ADJ,B2
+to marginalize,to marginalize,使边缘化,VERB,B2
+draw,draw,平局,NOUN,B2
+alternative,alternative,替代的,ADJ,B2
+october,october,十月,NOUN,B2
+to sharpen,to sharpen,磨快,VERB,B2
+right,right,右边,ADV,B2
+to chirp,to chirp,啁啾,VERB,B2
+hall,hall,殿,PART,B2
+reign,reign,统治,NOUN,B2
+both,both,两者,PRON,B2
+western,western,西方的,ADJ,B2
+their,their,他们的,PRON,B2
+conceivable,conceivable,可设想的,ADJ,B2
+please,please,请,INTJ,B2
+second,second,秒,NOUN,B2
+monthly,monthly,每月的,ADV,B2
+metropolis,metropolis,大都市,NOUN,B2
+indictment,indictment,起诉,NOUN,B2
+phrase,phrase,短语,NOUN,B2
+shooter,shooter,射手,NOUN,B2
+open-minded,open-minded,思想开明的,ADJ,B2
+january,january,一月,NOUN,B2
+eighth,eighth,第八,ADJ,B2
+improvised,improvised,即兴的,ADJ,B2
+yet,yet,还,ADV,B2
+tattoo,tattoo,纹身,NOUN,B2
+chinese language,chinese language,华文,NOUN,B2
+ditch,ditch,沟渠,NOUN,B2
+tedious,tedious,乏味的,ADJ,B2
+to differ,to differ,不同,VERB,B2
+instance,instance,例子,NOUN,B2
+polish,polish,波兰的,ADJ,B2
+henceforth,henceforth,从此以后,ADV,B2
+wig,wig,假发,NOUN,B2
+of which,of which,关于哪个,PRON,B2
+worthless,worthless,无价值的,ADJ,B2
+monstrous,monstrous,怪异的,ADJ,B2
+carefully,carefully,仔细地,ADV,B2
+to build up,to build up,构建,VERB,B2
+literal,literal,字面的,ADJ,B2
+power grid,power grid,电网,NOUN,B2
+to give birth,to give birth,分娩,VERB,B2
+power plant,power plant,发电厂,NOUN,B2
+focused,focused,专注的,ADJ,B2
+corporal,corporal,下士,NOUN,B2
+nevertheless,nevertheless,尽管如此,ADV,B2
+wisely,wisely,明智地,ADV,B2
+intentionally,intentionally,故意地,ADV,B2
+eighteen,eighteen,十八,NUM,B2
+entropy,entropy,熵,NOUN,B2
+partially,partially,部分地,ADV,B2
+turkey,turkey,火鸡,NOUN,B2
+meteorological,meteorological,气象的,ADJ,B2
+terribly,terribly,可怕地/非常,ADV,B2
+infinitive marker,infinitive marker,去,PART,B2
+sexually,sexually,在性方面,ADV,B2
+paternal,paternal,父亲的,ADJ,B2
+to privatize,to privatize,私有化,VERB,B2
+to alert,to alert,警告,VERB,B2
+air force,air force,空军,NOUN,B2
+canadian,canadian,加拿大的,ADJ,B2
+daddy,daddy,爸爸,NOUN,B2
+least,least,最少,ADV,B2
+reunification,reunification,重新统一,NOUN,B2
+toll,toll,通行费,NOUN,B2
+general practitioner,general practitioner,全科医生,NOUN,B2
+to put back,to put back,放回,VERB,B2
+to refuel,to refuel,加油,VERB,B2
+scientifically,scientifically,科学地,ADV,B2
+yeah yeah,yeah yeah,是是是,INTJ,B2
+draftsman,draftsman,绘图员,NOUN,B2
+family life,family life,家庭生活,NOUN,B2
+competitive,competitive,竞争的,ADJ,B2
+psychological,psychological,心理的,ADJ,B2
+to project,to project,投射,VERB,B2
+break-in,break-in,非法侵入,NOUN,B2
+wording,wording,措辞,NOUN,B2
+wimp,wimp,懦夫,NOUN,B2
+to arm,to arm,武装,VERB,B2
+complex,complex,建筑群,NOUN,B2
+literary,literary,文学的,ADJ,B2
+noodle,noodle,面条,NOUN,B2
+brutality,brutality,残暴,NOUN,B2
+good heavens,good heavens,天哪,INTJ,B2
+administrator,administrator,管理员,NOUN,B2
+catholic,catholic,天主教的,ADJ,B2
+prestigious,prestigious,有声望的,ADJ,B2
+indoctrination,indoctrination,灌输,NOUN,B2
+to gape,to gape,目瞪口呆,VERB,B2
+superiority,superiority,优越性/优势,NOUN,B2
+stand,stand,摊位,NOUN,B2
+rehabilitation,rehabilitation,康复,NOUN,B2
+fire brigade,fire brigade,消防队,NOUN,B2
+distributor,distributor,分销商,NOUN,B2
+horny,horny,性欲的,ADJ,B2
+thematic,thematic,主题的,ADJ,B2
+together,together,共同的,ADJ,B2
+front page,front page,头版,NOUN,B2
+to relaunch,to relaunch,重启,VERB,B2
+fauna,fauna,动物群,NOUN,B2
+instructive,instructive,有教育意义的,ADJ,B2
+sacrifice,sacrifice,牺牲,NOUN,B2
+manhunt,manhunt,搜捕,NOUN,B2
+advent,advent,到来,NOUN,B2
+colored,colored,有色的,ADJ,B2
+gifted,gifted,有天赋的,ADJ,B2
+to experiment,to experiment,实验,VERB,B2
+remarkably,remarkably,显著地,ADV,B2
+tax authorities,tax authorities,税务机关,NOUN,B2
+to title,to title,命名,VERB,B2
+vulnerable,vulnerable,易受伤害的,ADJ,B2
+infected,infected,被感染的,ADJ,B2
+mobility,mobility,流动性,NOUN,B2
+to benefit,to benefit,受益,VERB,B2
+medieval,medieval,中世纪的,ADJ,B2
+admirer,admirer,仰慕者,NOUN,B2
+technically,technically,技术上地,ADV,B2
+private life,private life,私生活,NOUN,B2
+considerably,considerably,相当地,ADV,B2
+to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
+chieftain,chieftain,酋长,NOUN,B2
+rodent,rodent,啮齿动物,NOUN,B2
+past,past,经过,ADV,B2
+favorite,favorite,最爱,NOUN,B2
+tumor,tumor,肿瘤,NOUN,B2
+tonight,tonight,今晚,ADV,B2
+relocation,relocation,搬家,NOUN,B2
+pornography,pornography,色情,NOUN,B2
+trajectory,trajectory,轨迹,NOUN,B2
+broke,broke,破产的,ADJ,B2
+it,it,对此,ADV,B2
+asthmatic,asthmatic,哮喘的,ADJ,B2
+to strip,to strip,裸露,VERB,B2
+to perfect,to perfect,精修,VERB,B2
+ribbon,ribbon,丝带,NOUN,B2
+therapist,therapist,治疗师,NOUN,B2
+pronounced,pronounced,显著的,ADJ,B2
+heavily,heavily,沉重地,ADV,B2
+theological,theological,神学的,ADJ,B2
+to empty,to empty,倒空,VERB,B2
+since then,since then,从那以后,ADV,B2
+located,located,位于,ADJ,B2
+other,other,其他,NOUN,B2
+damages,damages,损害赔偿,NOUN,B2
+yuck,yuck,呸,INTJ,B2
+guided tour,guided tour,导游,NOUN,B2
+in,in,进来,ADV,B2
+jewish,jewish,犹太的,ADJ,B2
+sailor,sailor,水手,NOUN,B2
+to fake,to fake,伪造,VERB,B2
+concerned,concerned,担忧的,ADJ,B2
+further,further,进一步,ADV,B2
+incredible,incredible,难以置信的,ADJ,B2
+old-fashioned,old-fashioned,老式的,ADJ,B2
+targeted,targeted,有针对性的,ADJ,B2
+reporting,reporting,报道,NOUN,B2
+to wedge,to wedge,卡住,VERB,B2
+stroller,stroller,婴儿车,NOUN,B2
+reminder,reminder,提醒物,NOUN,B2
+childbirth,childbirth,分娩,NOUN,B2
+a little,a little,一点儿,ADV,B2
+presumably,presumably,据推测,ADV,B2
+understanding,understanding,体贴的,ADJ,B2
+highlight,highlight,亮点,NOUN,B2
+narrow-minded,narrow-minded,狭隘的,ADJ,B2
+become,become,成为,AUX,B2
+bread roll,bread roll,小圆面包,NOUN,B2
+to thrive,to thrive,茁壮成长,VERB,B2
+olympic,olympic,奥林匹克的,ADJ,B2
+thunderstorm,thunderstorm,雷阵雨,NOUN,B2
+turkish,turkish,土耳其的,ADJ,B2
+bare,bare,赤裸的,ADJ,B2
+tap,tap,水龙头,NOUN,B2
+triggering,triggering,触发,NOUN,B2
+with it,with it,在其中,ADV,B2
+the same,the same,相同的,ADJ,B2
+mentally,mentally,精神上地,ADV,B2
+him,him,他,PRON,B2
+town hall,town hall,市政厅,NOUN,B2
+on top of,on top of,在...上面,ADP,B2
+good morning,good morning,早上好,INTJ,B2
+metric,metric,公制的,ADJ,B2
+vending machine,vending machine,自动售货机,NOUN,B2
+to move touch,to move touch,使感动,VERB,B2
+someone's,someone's,某人的,PRON,B2
+documentary,documentary,纪录片,NOUN,B2
+mitten,mitten,连指手套,NOUN,B2
+mechanical,mechanical,机械的,ADJ,B2
+about it,about it,关于它,ADV,B2
+to minimize,to minimize,最小化,VERB,B2
+tasty,tasty,美味的,ADJ,B2
+to load charge,to load charge,装载,VERB,B2
+stealth,stealth,秘密行动,NOUN,B2
+x-ray,x-ray,X光片,NOUN,B2
+to dump,to dump,抛弃,VERB,B2
+symptom,symptom,症,PART,B2
+little sister,little sister,妹妹,NOUN,B2
+seated,seated,坐着的,ADJ,B2
+this morning,this morning,今天早上,ADV,B2
+autonomy,autonomy,自治,NOUN,B2
+alphabet,alphabet,字母表,NOUN,B2
+over,over,过去,ADV,B2
+to engrave,to engrave,雕刻,VERB,B2
+belgian,belgian,比利时的,ADJ,B2
+cigarette butt,cigarette butt,烟头,NOUN,B2
+those,those,那些,PRON,B2
+symbolic,symbolic,象征的,ADJ,B2
+parliamentary,parliamentary,议会的/议员,ADJ,B2
+villainy,villainy,邪恶,NOUN,B2
+swedish,swedish,瑞典语,NOUN,B2
+metaphorical,metaphorical,隐喻的,ADJ,B2
+psychopath,psychopath,精神变态者,NOUN,B2
+mythical,mythical,神话般的,ADJ,B2
+baton,baton,警棍,NOUN,B2
+eighty,eighty,八十,NUM,B2
+inspiring,inspiring,鼓舞人心的,ADJ,B2
+torso,torso,躯干,NOUN,B2
+uniform,uniform,制服,NOUN,B2
+cyclist,cyclist,骑自行车的人,NOUN,B2
+to giggle,to giggle,咯咯笑,VERB,B2
+overdose,overdose,过量,NOUN,B2
+rubbish,rubbish,垃圾,NOUN,B2
+prey,prey,猎物,NOUN,B2
+to trace,to trace,描绘；标出,VERB,B2
+meaningless,meaningless,毫无意义的,ADJ,B2
+relieved,relieved,宽慰的,ADJ,B2
+alcoholic,alcoholic,酒精的,ADJ,B2
+soda,soda,苏打,NOUN,B2
+hood,hood,兜帽,NOUN,B2
+about,about,大约,ADV,B2
+ultimate,ultimate,最终的,ADJ,B2
+politically,politically,在政治上,ADV,B2
+city council,city council,市议会,NOUN,B2
+separate,separate,分开的,ADJ,B2
+wilderness,wilderness,荒野,NOUN,B2
+artillery,artillery,炮兵,NOUN,B2
+to result,to result,产生,VERB,B2
+chronology,chronology,年表,NOUN,B2
+to wring,to wring,拧干,VERB,B2
+to indict,to indict,控告,VERB,B2
+tv,tv,电视,NOUN,B2
+near,near,在附近,ADP,B2
+tablet,tablet,平板电脑,NOUN,B2
+navel,navel,肚脐,NOUN,B2
+broadcaster,broadcaster,广播公司,NOUN,B2
+regularity,regularity,规律性,NOUN,B2
+daylight,daylight,日光,NOUN,B2
+prior,prior,先前的,ADJ,B2
+diploma,diploma,文凭,NOUN,B2
+sixteen,sixteen,十六,NUM,B2
+revolt,revolt,叛乱,NOUN,B2
+to draw up,to draw up,起草,VERB,B2
+that one,that one,那个,PRON,B2
+exactness,exactness,精确,NOUN,B2
+seriously,seriously,认真地,ADV,B2
+to wilt,to wilt,枯萎,VERB,B2
+categorical,categorical,绝对的,ADJ,B2
+prepared,prepared,准备好的,ADJ,B2
+loved,loved,被爱的,ADJ,B2
+continued,continued,持续的,ADJ,B2
+cylindrical,cylindrical,圆柱形的,ADJ,B2
+the more,the more,越,ADV,B2
+to skim,to skim,轻触,VERB,B2
+have to,have to,必须,AUX,B2
+dying,dying,垂死的,ADJ,B2
+grandpa,grandpa,爷爷,NOUN,B2
+to position,to position,定位 / 安置,VERB,B2
+listener,listener,听众,NOUN,B2
+dangerousness,dangerousness,危险性,NOUN,B2
+hiding place,hiding place,藏身处,NOUN,B2
+holidays,holidays,假期,NOUN,B2
+to neutralize,to neutralize,中和,VERB,B2
+anything,anything,任何事,PRON,B2
+alone,alone,单独的,ADJ,B2
+to snow,to snow,下雪,VERB,B2
+picturesque,picturesque,如画的；别致的,ADJ,B2
+halfway,halfway,半途,ADV,B2
+oh well,oh well,算了,INTJ,B2
+behind it,behind it,在后面,ADV,B2
+subconscious,subconscious,潜意识,NOUN,B2
+to blow up,to blow up,炸毁,VERB,B2
+hose,hose,软管,NOUN,B2
+including,including,包括,ADP,B2
+theatrical,theatrical,戏剧的,ADJ,B2
+marble,marble,大理石,NOUN,B2
+hare,hare,野兔,NOUN,B2
+to sabotage,to sabotage,破坏,VERB,B2
+to back up,to back up,后退,VERB,B2
+ashtray,ashtray,烟灰缸,NOUN,B2
+nearest,nearest,最近的,ADJ,B2
+renowned,renowned,著名的,ADJ,B2
+prophet,prophet,先知,NOUN,B2
+driven,driven,被驾驶的,ADJ,B2
+to infuse,to infuse,泡制,VERB,B2
+lay,lay,叙事短诗,NOUN,B2
+to lengthen,to lengthen,延长,VERB,B2
+industrialization,industrialization,工业化,NOUN,B2
+to recreate,to recreate,重建,VERB,B2
+weakening,weakening,减弱,NOUN,B2
+self-employed person,self-employed person,个体经营者,NOUN,B2
+symmetrical,symmetrical,对称的,ADJ,B2
+physically,physically,身体上地,ADV,B2
+counterargument,counterargument,反论点,NOUN,B2
+surprised,surprised,惊讶的,ADJ,B2
+effectively,effectively,有效地,ADV,B2
+from there,from there,从那里,ADV,B2
+to switch,to switch,切换,VERB,B2
+minimal,minimal,微小的,ADJ,B2
+atmospheric,atmospheric,大气的,ADJ,B2
+phase,phase,阶段,NOUN,B2
+infantry,infantry,步兵,NOUN,B2
+hold,hold,控制,NOUN,B2
+to move house,to move house,搬家,VERB,B2
+glance,glance,一瞥,NOUN,B2
+to post,to post,张贴,VERB,B2
+report card,report card,成绩单,NOUN,B2
+recognizable,recognizable,可辨认的,ADJ,B2
+fussy,fussy,挑剔的,ADJ,B2
+synthetic,synthetic,合成的,ADJ,B2
+to oblige,to oblige,强迫,VERB,B2
+gladly,gladly,乐意地,ADV,B2
+generously,generously,慷慨地,ADV,B2
+decorative,decorative,装饰性的,ADJ,B2
+stripe,stripe,条纹,NOUN,B2
+adjustment,adjustment,调节,NOUN,B2
+overview,overview,概览,NOUN,B2
+warmly,warmly,热情地,ADV,B2
+to program,to program,编程,VERB,B2
+lyrical,lyrical,抒情的,ADJ,B2
+whore,whore,妓女,NOUN,B2
+to prioritize,to prioritize,优先考虑,VERB,B2
+specifically,specifically,具体地,ADV,B2
+to camp,to camp,露营,VERB,B2
+campsite,campsite,露营地,NOUN,B2
+boxer,boxer,拳击手,NOUN,B2
+telephone number,telephone number,电话号码,NOUN,B2
+vat,vat,增值税,NOUN,B2
+grid,grid,网格,NOUN,B2
+wow,wow,哇,INTJ,B2
+english-speaking,english-speaking,讲英语的,ADJ,B2
+by chance,by chance,偶然地,ADV,B2
+good night,good night,晚安,INTJ,B2
+asphalt,asphalt,沥青,NOUN,B2
+canteen,canteen,食堂,NOUN,B2
+muscle ache,muscle ache,肌肉酸痛,NOUN,B2
+pajamas,pajamas,睡衣,NOUN,B2
+condom,condom,避孕套,NOUN,B2
+scooter,scooter,踏板摩托车,NOUN,B2
+downfall,downfall,毁灭,NOUN,B2
+massively,massively,大量地,ADV,B2
+press release,press release,公报,NOUN,B2
+to relate,to relate,联系,VERB,B2
+from where,from where,从哪里,ADV,B2
+highest,highest,最高的,ADJ,B2
+to sanction,to sanction,认可,VERB,B2
+as long as,as long as,只要,SCONJ,B2
+to stem,to stem,起源于,VERB,B2
+to lower,to lower,降低,VERB,B2
+hanging,hanging,绞刑,NOUN,B2
+universal,universal,普遍的,ADJ,B2
+regularly,regularly,定期地,ADV,B2
+terrace,terrace,露台,NOUN,B2
+electronics,electronics,电子学,NOUN,B2
+to divulge,to divulge,泄露,VERB,B2
+offensive,offensive,冒犯的,ADJ,B2
+fort,fort,堡垒,NOUN,B2
+to center,to center,居中,VERB,B2
+find,find,发现物,NOUN,B2
+to mirror,to mirror,反映,VERB,B2
+hemp,hemp,大麻,NOUN,B2
+the anform,the anform,复合词,NOUN,B2
+in view of,in view of,鉴于,ADP,B2
+lucrative,lucrative,有利可图的,ADJ,B2
+profitability,profitability,盈利能力,NOUN,B2
+bump shock,bump shock,碰撞/震惊,NOUN,B2
+peat,peat,泥炭,NOUN,B2
+supremacy,supremacy,霸权,NOUN,B2
+student loan,student loan,助学贷款,NOUN,B2
+terminus,terminus,,NOUN,B2
+further on,further on,更远处,ADV,B2
+windfall,windfall,意外之财,NOUN,B2
+annals,annals,编年史,NOUN,B2
+contractualization,contractualization,契约化,NOUN,B2
+the anbruch,the anbruch,名词,NOUN,B2
+watertight,watertight,,NOUN,B2
+limit border,limit border,界限,NOUN,B2
+nameable,nameable,可命名的,ADJ,B2
+getheilung,getheilung,词,NOUN,B2
+neonatal,neonatal,新生儿的,ADJ,B2
+tourist,tourist,旅游的,ADJ,B2
+where i,where i,,NOUN,B2
+on which,on which,在其上,PRON,B2
+tidal movement,tidal movement,潮汐运动,NOUN,B2
+ground basis,ground basis,基础/理由,NOUN,B2
+fernsucht,fernsucht,词,NOUN,B2
+bare ownership,bare ownership,虚有权,NOUN,B2
+national coach,national coach,国家队教练,NOUN,B2
+burger stand,burger stand,,NOUN,B2
+swine,swine,猪,NOUN,B2
+domestic,domestic,国内,NOUN,B2
+athletic,athletic,运动的,ADJ,B2
+to place put,to place put,放置,VERB,B2
+urbanization,urbanization,城市化,NOUN,B2
+antibiotic,antibiotic,抗生素,NOUN,B2
+here hither,here hither,这里/到这里,ADV,B2
+at the top,at the top,在最上面,ADV,B2
+to cope,to cope,应付,VERB,B2
+the missbildung,the missbildung,复合词,NOUN,B2
+matter of time,matter of time,时间问题,NOUN,B2
+cover blanket,cover blanket,覆盖物,NOUN,B2
+grown,grown,长大的,ADJ,B2
+totalitarian,totalitarian,极权主义的,ADJ,B2
+e-reader,e-reader,电子阅读器,NOUN,B2
+sync,sync,同步,NOUN,B2
+religiosity,religiosity,笃信宗教,NOUN,B2
+ready finished,ready finished,准备好的/完成的,ADJ,B2
+self-care,self-care,自我护理,NOUN,B2
+reformulation,reformulation,重新表述,NOUN,B2
+to encroach,to encroach,侵蚀,VERB,B2
+counterproductivity,counterproductivity,适得其反,NOUN,B2
+liable,liable,有责任的,ADJ,B2
+indexing,indexing,指数化,NOUN,B2
+mighty very,mighty very,非常,ADJ,B2
+unterpflegung,unterpflegung,词,NOUN,B2
+public holiday,public holiday,公共假日,ADJ,B2
+to vary,to vary,改变,VERB,B2
+more pl,more pl,更多,ADJ,B2
+symbolism,symbolism,象征主义,NOUN,B2
+to transgress,to transgress,违背,VERB,B2
+upset,upset,心烦的,ADJ,B2
+listen up,listen up,听着,INTJ,B2
+trade barrier,trade barrier,贸易壁垒,NOUN,B2
+feeble-minded,feeble-minded,弱智的,ADJ,B2
+surely safe,surely safe,肯定地,ADV,B2
+caring,caring,关怀的,ADJ,B2
+viable,viable,可行的,ADJ,B2
+one-way,one-way,单向的,ADJ,B2
+implicitly,implicitly,含蓄地,ADV,B2
+paralympic,paralympic,残奥会的,ADJ,B2
+colder,colder,更冷的,ADJ,B2
+sulfur,sulfur,硫,NOUN,B2
+demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
+fjeld cleft,fjeld cleft,,NOUN,B2
+getreibung,getreibung,词,NOUN,B2
+six-year-old,six-year-old,,NOUN,B2
+emergency doctor,emergency doctor,急诊医生,NOUN,B2
+approximate,approximate,近似的,ADJ,B2
+deceit,deceit,欺骗,NOUN,B2
+hard,hard,努力地,ADV,B2
+bumpy,bumpy,凹凸不平的,ADJ,B2
+intended,intended,预定的,ADJ,B2
+minority group,minority group,少数群体,NOUN,B2
+proposal suggestion,proposal suggestion,建议,NOUN,B2
+more,more,مزيد,NOUN,B2
+scrupulous,scrupulous,一丝不苟的,ADJ,B2
+all everyone,all everyone,所有/大家,PRON,B2
+habitual behavior,habitual behavior,习惯行为,NOUN,B2
+play game,play game,游戏/玩耍,NOUN,B2
+painless,painless,,NOUN,B2
+distorted,distorted,歪曲的,ADJ,B2
+humane,humane,人道的,ADJ,B2
+cerebral,cerebral,大脑的,ADJ,B2
+shrimp,shrimp,虾,NOUN,B2
+to substantiate,to substantiate,证实,VERB,B2
+methodological,methodological,方法论的,ADJ,B2
+connective,connective,连接的,ADJ,B2
+eczema,eczema,湿疹,NOUN,B2
+nineteen,nineteen,十九,NUM,B2
+disposable,disposable,一次性的,ADJ,B2
+cats,cats,猫,NOUN,B2
+tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
+socialization,socialization,社会化,NOUN,B2
+bike basket,bike basket,车筐,NOUN,B2
+prognosis,prognosis,预后,NOUN,B2
+all,all,جميع,NOUN,B2
+to disfavor,to disfavor,不利于,VERB,B2
+not,not,不,PART,B2
+russian,russian,俄罗斯人,NOUN,B2
+antique,antique,古董,NOUN,B2
+sorry,sorry,抱歉,INTJ,B2
+einteilung,einteilung,词,NOUN,B2
+the abmessung,the abmessung,复合词,NOUN,B2
+untersinnung,untersinnung,词,NOUN,B2
+lord god,lord god,上帝,NOUN,B2
+hintersucht,hintersucht,词,NOUN,B2
+gerichtung,gerichtung,词,NOUN,B2
+the adressat,the adressat,名词,NOUN,B2
+the weitmischung,the weitmischung,复合词,NOUN,B2
+nimble,nimble,敏捷的,ADJ,B2
+scratch,scratch,抓痕,NOUN,B2
+the verwandlung,the verwandlung,复合词,NOUN,B2
+creepy,creepy,令人毛骨悚然的,ADJ,B2
+the verstleitung,the verstleitung,复合词,NOUN,B2
+the tiefbindung,the tiefbindung,复合词,NOUN,B2
+einweisung,einweisung,词,NOUN,B2
+the aktnadel,the aktnadel,名词,NOUN,B2
+the auserweiterung,the auserweiterung,复合词,NOUN,B2
+college,college,学院,NOUN,B2
+sting,sting,刺,NOUN,B2
+to anesthetize,to anesthetize,麻醉,VERB,B2
+emerald,emerald,祖母绿,NOUN,B2
+to fell,to fell,砍倒,VERB,B2
+zersucht,zersucht,词,NOUN,B2
+the berechnung,the berechnung,复合词,NOUN,B2
+the anreiz,the anreiz,名词,NOUN,B2
+the erzheilung,the erzheilung,复合词,NOUN,B2
+the akademie,the akademie,名词,NOUN,B2
+guards,guards,警卫,NOUN,B2
+to switch off,to switch off,关掉,VERB,B2
+telegram,telegram,电报,NOUN,B2
+firstly,firstly,首先,ADV,B2
+beteilung,beteilung,词,NOUN,B2
+the anwerk,the anwerk,复合词,NOUN,B2
+concerning,concerning,关于,ADP,B2
+mania,mania,狂躁症,NOUN,B2
+the hochleitung,the hochleitung,复合词,NOUN,B2
+the weitstoff,the weitstoff,复合词,NOUN,B2
+einsprache,einsprache,词,NOUN,B2
+the hochordnung,the hochordnung,复合词,NOUN,B2
+erfahrt,erfahrt,词,NOUN,B2
+eingabe,eingabe,词,NOUN,B2
+the beminderung,the beminderung,复合词,NOUN,B2
+nahfahrt,nahfahrt,词,NOUN,B2
+burdened,burdened,负担重的,ADJ,B2
+the nachleitung,the nachleitung,复合词,NOUN,B2
+oddball,oddball,怪人,NOUN,B2
+to breathe again,to breathe again,松口气,VERB,B2
+the gewendung,the gewendung,复合词,NOUN,B2
+fickleness,fickleness,反复无常,NOUN,B2
+aussinnung,aussinnung,词,NOUN,B2
+the grundstoff,the grundstoff,复合词,NOUN,B2
+to countersign,to countersign,副署,VERB,B2
+bum,bum,流浪汉,NOUN,B2
+aufweisung,aufweisung,词,NOUN,B2
+but rather,but rather,而是,CCONJ,B2
+the erzwendung,the erzwendung,复合词,NOUN,B2
+the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
+the unleitung,the unleitung,复合词,NOUN,B2
+oberleitung,oberleitung,词,NOUN,B2
+the aushandlung,the aushandlung,复合词,NOUN,B2
+einerziehung,einerziehung,词,NOUN,B2
+so to speak,so to speak,可以说,ADV,B2
+the ausstellung,the ausstellung,复合词,NOUN,B2
+the ansage,the ansage,名词,NOUN,B2
+to share divide,to share divide,分享,VERB,B2
+theme music,theme music,主题曲,NOUN,B2
+nachsuchung,nachsuchung,词,NOUN,B2
+christmas tree,christmas tree,圣诞树,NOUN,B2
+thin-walled,thin-walled,隔音差的,ADJ,B2
+the vorrechnung,the vorrechnung,复合词,NOUN,B2
+the mitstellung,the mitstellung,复合词,NOUN,B2
+the tiefleitung,the tiefleitung,复合词,NOUN,B2
+crap,crap,屎,NOUN,B2
+to vibrate,to vibrate,振动,VERB,B2
+einwirkung,einwirkung,词,NOUN,B2
+the untererweiterung,the untererweiterung,复合词,NOUN,B2
+the abweisung,the abweisung,名词,NOUN,B2
+nachsinnung,nachsinnung,词,NOUN,B2
+unfassung,unfassung,词,NOUN,B2
+to break out,to break out,爆发,VERB,B2
+the ursammlung,the ursammlung,复合词,NOUN,B2
+to bump,to bump,碰撞,VERB,B2
+fishing rod,fishing rod,钓竿,NOUN,B2
+the nachbindung,the nachbindung,复合词,NOUN,B2
+from it,from it,从中,ADV,B2
+weitweisung,weitweisung,词,NOUN,B2
+the abkraft,the abkraft,复合词,NOUN,B2
+the aufleitung,the aufleitung,复合词,NOUN,B2
+to queue,to queue,排队,VERB,B2
+annual wage,annual wage,年薪,NOUN,B2
+erzregelung,erzregelung,词,NOUN,B2
+people nation,people nation,人民 / 民族,NOUN,B2
+prank,prank,恶作剧,NOUN,B2
+learning curve,learning curve,学习曲线,NOUN,B2
+the erwendung,the erwendung,复合词,NOUN,B2
+moor,moor,荒野,NOUN,B2
+benahme,benahme,词,NOUN,B2
+to stint,to stint,吝啬,VERB,B2
+the erzwerk,the erzwerk,复合词,NOUN,B2
+thousands,thousands,数千,NOUN,B2
+the erzmischung,the erzmischung,复合词,NOUN,B2
+to lay down,to lay down,放下,VERB,B2
+vorderfassung,vorderfassung,词,NOUN,B2
+everyday life,everyday life,日常生活,NOUN,B2
+city map,city map,城市地图,NOUN,B2
+host of angels,host of angels,天使群,NOUN,B2
+wage labor,wage labor,雇佣劳动,NOUN,B2
+to step in,to step in,介入,VERB,B2
+sort,sort,种类,NOUN,B2
+ausweisung,ausweisung,词,NOUN,B2
+vorwandel,vorwandel,词,NOUN,B2
+the abwert,the abwert,复合词,NOUN,B2
+the vorwert,the vorwert,复合词,NOUN,B2
+german class,german class,德语课,NOUN,B2
+the adoption,the adoption,名词,NOUN,B2
+hearts,hearts,心,NOUN,B2
+crook,crook,骗子,NOUN,B2
+hochweisung,hochweisung,词,NOUN,B2
+to make sense,to make sense,讲得通,VERB,B2
+to keep secret,to keep secret,隐瞒,VERB,B2
+bitch,bitch,母狗,NOUN,B2
+the zurechnung,the zurechnung,复合词,NOUN,B2
+semicolon,semicolon,分号,PUNCT,B2
+the gebindung,the gebindung,复合词,NOUN,B2
+sky blue,sky blue,天蓝色,ADJ,B2
+vegetarian,vegetarian,素食者,NOUN,B2
+she they,she they,她,PRON,B2
+chain mail,chain mail,锁子甲,NOUN,B2
+the missordnung,the missordnung,复合词,NOUN,B2
+the verstwerk,the verstwerk,复合词,NOUN,B2
+twitching,twitching,抽搐的,ADJ,B2
 zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
+urgestaltung,urgestaltung,词,NOUN,B2
+to overlook,to overlook,忽视,VERB,B2
+the mitbildung,the mitbildung,复合词,NOUN,B2
+motherfucker,motherfucker,混蛋,NOUN,B2
+the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
+the alpinismus,the alpinismus,名词,NOUN,B2
+yikes,yikes,哎呀,INTJ,B2
+sow,sow,母猪,NOUN,B2
+urgabe,urgabe,词,NOUN,B2
+erweisung,erweisung,词,NOUN,B2
+virtuous,virtuous,有德行的,ADJ,B2
+to go blind,to go blind,失明,VERB,B2
+zufahrt,zufahrt,词,NOUN,B2
+backdrop,backdrop,背景,NOUN,B2
+probation,probation,缓刑,NOUN,B2
+comma,comma,逗号,PUNCT,B2
+seamless,seamless,无缝的,ADJ,B2
+distorted image,distorted image,扭曲的形象,NOUN,B2
+sagittarius,sagittarius,射手座,NOUN,B2
+to stay here,to stay here,留在这里,VERB,B2
+verschaft,verschaft,词,NOUN,B2
+unweisung,unweisung,词,NOUN,B2
+the abholung,the abholung,名词,NOUN,B2
+gay,gay,快乐的,ADJ,B2
+ausgestaltung,ausgestaltung,词,NOUN,B2
+hinterleitung,hinterleitung,词,NOUN,B2
+to pick out,to pick out,挑选,VERB,B2
+president female,president female,女总统,NOUN,B2
+below,below,下面,ADV,B2
+to abschweifen,to abschweifen,动词,VERB,B2
+the aufwandlung,the aufwandlung,复合词,NOUN,B2
+the erzkraft,the erzkraft,复合词,NOUN,B2
+cleaning,cleaning,清洁,NOUN,B2
+timetable,timetable,时刻表,NOUN,B2
+einnahme,einnahme,词,NOUN,B2
+the zerbildung,the zerbildung,复合词,NOUN,B2
+drinking glass,drinking glass,水杯,NOUN,B2
+weitsuchung,weitsuchung,词,NOUN,B2
+the hochstoff,the hochstoff,复合词,NOUN,B2
+to brood,to brood,沉思,VERB,B2
+the antrag,the antrag,名词,NOUN,B2
+tasteless,tasteless,无味的,ADJ,B2
+sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
+to bullshit,to bullshit,胡扯,VERB,B2
+university student,university student,大学生,NOUN,B2
+to growl,to growl,咆哮,VERB,B2
+the aufwendung,the aufwendung,复合词,NOUN,B2
+serve markup,serve markup,发球/加价,NOUN,B2
+the weitminderung,the weitminderung,复合词,NOUN,B2
+the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
+the einmessung,the einmessung,复合词,NOUN,B2
+the urheilung,the urheilung,复合词,NOUN,B2
+rake,rake,耙子,NOUN,B2
+to spell,to spell,拼写,VERB,B2
+sacrificed,sacrificed,牺牲,ADJ,B2
+to get by,to get by,过得去,VERB,B2
+hintertheilung,hintertheilung,词,NOUN,B2
+the vorordnung,the vorordnung,复合词,NOUN,B2
+to align,to align,使一致,VERB,B2
+geteilung,geteilung,词,NOUN,B2
+urwandel,urwandel,词,NOUN,B2
+the mitheilung,the mitheilung,复合词,NOUN,B2
+precinct,precinct,辖区,NOUN,B2
+the verststoff,the verststoff,复合词,NOUN,B2
+romanian,romanian,罗马尼亚人,NOUN,B2
+the vorstellung,the vorstellung,复合词,NOUN,B2
+helper,helper,助手,NOUN,B2
+the andrang,the andrang,名词,NOUN,B2
+hinterrechnung,hinterrechnung,词,NOUN,B2
+the abhang,the abhang,名词,NOUN,B2
+weitwandel,weitwandel,词,NOUN,B2
+investigated,investigated,被调查的,ADJ,B2
+auswandel,auswandel,词,NOUN,B2
+unnahme,unnahme,词,NOUN,B2
+the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
+hinterrichtung,hinterrichtung,词,NOUN,B2
+the bemessung,the bemessung,复合词,NOUN,B2
+misstreibung,misstreibung,词,NOUN,B2
+bodily harm,bodily harm,人身伤害,NOUN,B2
+that yonder,that yonder,那个,DET,B2
+vortheilung,vortheilung,词,NOUN,B2
+the aktivist,the aktivist,名词,NOUN,B2
+naherziehung,naherziehung,词,NOUN,B2
+pastime,pastime,爱好,NOUN,B2
+the aufstoff,the aufstoff,复合词,NOUN,B2
+refreshing,refreshing,令人清爽的,ADJ,B2
+ausforderung,ausforderung,词,NOUN,B2
+the unmischung,the unmischung,复合词,NOUN,B2
+the beleitung,the beleitung,复合词,NOUN,B2
+the bewendung,the bewendung,复合词,NOUN,B2
+the aufheilung,the aufheilung,复合词,NOUN,B2
+to elapse,to elapse,流逝,VERB,B2
+mortal fear,mortal fear,极度恐惧,NOUN,B2
+the aktion,the aktion,名词,NOUN,B2
+trash bag,trash bag,垃圾袋,NOUN,B2
+the anbeginn,the anbeginn,名词,NOUN,B2
+worst thing,worst thing,最坏的事,NOUN,B2
+usual thing,usual thing,惯例,NOUN,B2
+per,per,每,ADP,B2
+the hochbindung,the hochbindung,复合词,NOUN,B2
+to abtrocken,to abtrocken,动词,VERB,B2
+to pressurize,to pressurize,逼迫,VERB,B2
+at the,at the,在...时,ADP,B2
+the zuwandlung,the zuwandlung,复合词,NOUN,B2
+groan,groan,呻吟,NOUN,B2
+to shunt,to shunt,分流,VERB,B2
+bulldog,bulldog,斗牛犬,NOUN,B2
+to play along,to play along,配合,VERB,B2
+agreed,agreed,一致的,ADJ,B2
+ursicht,ursicht,词,NOUN,B2
+hideous,hideous,丑陋的,ADJ,B2
+the ausbildung,the ausbildung,复合词,NOUN,B2
+the gemischung,the gemischung,复合词,NOUN,B2
+drive,drive,动力,NOUN,B2
+wiedertreibung,wiedertreibung,词,NOUN,B2
+urteilung,urteilung,词,NOUN,B2
+fernrechnung,fernrechnung,词,NOUN,B2
+unfahrt,unfahrt,词,NOUN,B2
+separated,separated,分开的,ADJ,B2
+the unbildung,the unbildung,复合词,NOUN,B2
+the zuhandlung,the zuhandlung,复合词,NOUN,B2
+anteilung,anteilung,词,NOUN,B2
+anrichtung,anrichtung,词,NOUN,B2
+erschaft,erschaft,词,NOUN,B2
+interpersonal,interpersonal,人际的,ADJ,B2
+the allianz,the allianz,名词,NOUN,B2
+the anteil,the anteil,名词,NOUN,B2
+hothead,hothead,急性子的人,NOUN,B2
+tiefsuchung,tiefsuchung,词,NOUN,B2
+the zererweiterung,the zererweiterung,复合词,NOUN,B2
+the aktuar,the aktuar,名词,NOUN,B2
+nahfassung,nahfassung,词,NOUN,B2
+the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
+the anheilung,the anheilung,复合词,NOUN,B2
+to turn away,to turn away,转开,VERB,B2
+to get into,to get into,陷入,VERB,B2
+the abheilung,the abheilung,复合词,NOUN,B2
+without exception,without exception,无例外的,ADV,B2
+to view,to view,参观,VERB,B2
+vordersinnung,vordersinnung,词,NOUN,B2
+to deregister,to deregister,注销,VERB,B2
+how much,how much,多少,ADV,B2
+ran,ran,跑,ADJ,B2
+the day after tomorrow,the day after tomorrow,后天,ADV,B2
+the absteigerung,the absteigerung,复合词,NOUN,B2
+ausschrift,ausschrift,词,NOUN,B2
+the abgrund,the abgrund,名词,NOUN,B2
+to subordinate,to subordinate,从属,VERB,B2
+zersicht,zersicht,词,NOUN,B2
+the urvertiefung,the urvertiefung,复合词,NOUN,B2
+the mitkraft,the mitkraft,复合词,NOUN,B2
+the urverbesserung,the urverbesserung,复合词,NOUN,B2
+deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
+causal,causal,因果的,ADJ,B2
+windy,windy,有风的,ADJ,B2
+office work,office work,办公室工作,NOUN,B2
 zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
-ágil,agile,敏捷的,ADJ,B2
-águila,eagle,鹰,NOUN,B2
-álbum,album,相册,NOUN,B2
-álgebra,algebra,代数,NOUN,B2
-ámbito de jurisdicción,jurisdiction area,辖区,NOUN,B2
-área,area,区域,NOUN,B2
-átomo,atom,原子,NOUN,B2
-él,him,他吧,NOUN,B2
-ética,ethics,伦理学,NOUN,B2
-ímpetu,momentum,势头,NOUN,B2
-órgano,organ,器官,NOUN,B2
-óxido,oxide,氧化物,NOUN,B2
-óxido,rust,铁锈,NOUN,B2
-úlcera,ulcer,溃疡,NOUN,B2
-útil,helpful,有帮助的,ADJ,B2
+the nachbildung,the nachbildung,复合词,NOUN,B2
+untreibung,untreibung,词,NOUN,B2
+besprache,besprache,词,NOUN,B2
+many things,many things,许多事物,PRON,B2
+the bevertiefung,the bevertiefung,复合词,NOUN,B2
+the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
+the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
+unwandel,unwandel,词,NOUN,B2
+hinterfassung,hinterfassung,词,NOUN,B2
+to watch tv,to watch tv,看电视,VERB,B2
+to wait and see,to wait and see,等待观望,VERB,B2
+noises,noises,噪音,NOUN,B2
+grandparents,grandparents,祖父母,NOUN,B2
+to move out,to move out,搬出,VERB,B2
+the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
+the aktpunkt,the aktpunkt,名词,NOUN,B2
+the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
+the akkumulator,the akkumulator,名词,NOUN,B2
+the ererweiterung,the ererweiterung,复合词,NOUN,B2
+mitsetzung,mitsetzung,词,NOUN,B2
+bullshitted,bullshitted,被愚弄的,ADJ,B2
+upbeat,upbeat,轻快的,ADJ,B2
+the einwerk,the einwerk,复合词,NOUN,B2
+vorderweisung,vorderweisung,词,NOUN,B2
+nachrichtung,nachrichtung,词,NOUN,B2
+to abdanken,to abdanken,动词,VERB,B2
+scarce commodity,scarce commodity,紧缺商品,NOUN,B2
+lunch break,lunch break,午休,NOUN,B2
+wiedersprache,wiedersprache,词,NOUN,B2
+the erleitung,the erleitung,复合词,NOUN,B2
+to absagen,to absagen,动词,VERB,B2
+vordersetzung,vordersetzung,词,NOUN,B2
+in front of before,in front of before,在...前,ADP,B2
+misstheilung,misstheilung,词,NOUN,B2
+test of courage,test of courage,勇气测试,NOUN,B2
+the unwandlung,the unwandlung,复合词,NOUN,B2
+gesinnung,gesinnung,词,NOUN,B2
+shit,shit,恐惧,NOUN,B2
+hinterwandel,hinterwandel,词,NOUN,B2
+the anschlag,the anschlag,名词,NOUN,B2
+the altruismus,the altruismus,名词,NOUN,B2
+the verhandlung,the verhandlung,复合词,NOUN,B2
+song of praise,song of praise,赞歌,NOUN,B2
+aufforderung,aufforderung,词,NOUN,B2
+the urstoff,the urstoff,复合词,NOUN,B2
+the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
+on what,on what,在什么上面,ADV,B2
+unpflegung,unpflegung,词,NOUN,B2
+stupid things,stupid things,蠢事,NOUN,B2
+itching powder,itching powder,痒痒粉,NOUN,B2
+to be delayed,to be delayed,迟到,VERB,B2
+urschrift,urschrift,词,NOUN,B2
+to abschlafen,to abschlafen,动词,VERB,B2
+affected,affected,受影响的,ADJ,B2
+hintersuchung,hintersuchung,词,NOUN,B2
+zernahme,zernahme,词,NOUN,B2
+glib,glib,伶牙俐齿的,ADJ,B2
+wiedersucht,wiedersucht,词,NOUN,B2
+to abzwecken,to abzwecken,动词,VERB,B2
+the bekraft,the bekraft,复合词,NOUN,B2
+the alpen,the alpen,名词,NOUN,B2
+besuchung,besuchung,词,NOUN,B2
+interrogation room,interrogation room,审讯室,NOUN,B2
+aussetzung,aussetzung,词,NOUN,B2
+hinterwendung,hinterwendung,词,NOUN,B2
+fernschaft,fernschaft,词,NOUN,B2
+obersuchung,obersuchung,词,NOUN,B2
+the unterordnung,the unterordnung,复合词,NOUN,B2
+most important thing,most important thing,最重要的事,NOUN,B2
+the aufordnung,the aufordnung,复合词,NOUN,B2
+main reason,main reason,主要原因,NOUN,B2
+to play down,to play down,淡化,VERB,B2
+the geverbesserung,the geverbesserung,复合词,NOUN,B2
+oberbildung,oberbildung,词,NOUN,B2
+the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
+weitsicht,weitsicht,词,NOUN,B2
+the aufwert,the aufwert,复合词,NOUN,B2
+to run away,to run away,逃跑,VERB,B2
+delivery van,delivery van,厢式送货车,NOUN,B2
+the amboss,the amboss,名词,NOUN,B2
+einschaft,einschaft,词,NOUN,B2
+the gebildung,the gebildung,复合词,NOUN,B2
+antheilung,antheilung,词,NOUN,B2
+the beerweiterung,the beerweiterung,复合词,NOUN,B2
+the missstoff,the missstoff,复合词,NOUN,B2
+the weitordnung,the weitordnung,复合词,NOUN,B2
+to commission,to commission,委托,VERB,B2
+zersuchung,zersuchung,词,NOUN,B2
+wiedersicht,wiedersicht,词,NOUN,B2
+hochkunft,hochkunft,词,NOUN,B2
+the aufbewegung,the aufbewegung,复合词,NOUN,B2
+of all things,of all things,偏偏,ADV,B2
+the unterleitung,the unterleitung,复合词,NOUN,B2
+nachtheilung,nachtheilung,词,NOUN,B2
+untertreibung,untertreibung,词,NOUN,B2
+the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
+missschrift,missschrift,词,NOUN,B2
+the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
+vorderrichtung,vorderrichtung,词,NOUN,B2
+to abstimmen,to abstimmen,动词,VERB,B2
+wiederordnung,wiederordnung,词,NOUN,B2
+the missbewegung,the missbewegung,复合词,NOUN,B2
+vorteilung,vorteilung,词,NOUN,B2
+unerziehung,unerziehung,词,NOUN,B2
+to do harm,to do harm,伤害,VERB,B2
+the weitheilung,the weitheilung,复合词,NOUN,B2
+the akkord,the akkord,名词,NOUN,B2
+unlawful,unlawful,非法的,ADJ,B2
+oberwandlung,oberwandlung,词,NOUN,B2
+kidnapper,kidnapper,绑架者,NOUN,B2
+the weitwendung,the weitwendung,复合词,NOUN,B2
+clear as day,clear as day,一清二楚的,ADJ,B2
+the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
+to abteilen,to abteilen,动词,VERB,B2
+the ackerbau,the ackerbau,名词,NOUN,B2
+the missvertiefung,the missvertiefung,复合词,NOUN,B2
+geforderung,geforderung,词,NOUN,B2
+to oversleep,to oversleep,睡过头,VERB,B2
+the gestoff,the gestoff,复合词,NOUN,B2
+loudspeaker,loudspeaker,扬声器,NOUN,B2
+the mitordnung,the mitordnung,复合词,NOUN,B2
+goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
+the tiefstoff,the tiefstoff,复合词,NOUN,B2
+erforderung,erforderung,词,NOUN,B2
+missschaft,missschaft,词,NOUN,B2
+wiederkunft,wiederkunft,词,NOUN,B2
+the unminderung,the unminderung,复合词,NOUN,B2
+ausfahrt,ausfahrt,词,NOUN,B2
+oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
+the nachmessung,the nachmessung,复合词,NOUN,B2
+game rule,game rule,游戏规则,NOUN,B2
+aufrichtung,aufrichtung,词,NOUN,B2
+mitfahrt,mitfahrt,词,NOUN,B2
+obererziehung,obererziehung,词,NOUN,B2
+the anbindung,the anbindung,复合词,NOUN,B2
+with what,with what,用什么,ADV,B2
+handyman,handyman,工匠,NOUN,B2
+urnahme,urnahme,词,NOUN,B2
+devices,devices,设备,NOUN,B2
+detective force,detective force,刑警,NOUN,B2
+the alphabet,the alphabet,名词,NOUN,B2
+the vorbindung,the vorbindung,复合词,NOUN,B2
+wiedersinnung,wiedersinnung,词,NOUN,B2
+weitregelung,weitregelung,词,NOUN,B2
+the hochsammlung,the hochsammlung,复合词,NOUN,B2
+zuschaft,zuschaft,词,NOUN,B2
+the anbieter,the anbieter,名词,NOUN,B2
+the albatros,the albatros,名词,NOUN,B2
+letter mail,letter mail,信,NOUN,B2
+once again,once again,再次,ADV,B2
+the abwurf,the abwurf,名词,NOUN,B2
+wiedererziehung,wiedererziehung,词,NOUN,B2
+the verform,the verform,复合词,NOUN,B2
+the nachstoff,the nachstoff,复合词,NOUN,B2
+the misskraft,the misskraft,复合词,NOUN,B2
+ferntheilung,ferntheilung,词,NOUN,B2
+cheers,cheers,欢呼,NOUN,B2
+emergency call,emergency call,紧急呼叫,NOUN,B2
+eleven,eleven,十一,NOUN,B2
+german person,german person,德国人,NOUN,B2
+hectic,hectic,忙乱,NOUN,B2
+to be added,to be added,加入,VERB,B2
+hintersicht,hintersicht,词,NOUN,B2
+to switch on,to switch on,开启,VERB,B2
+the zerrechnung,the zerrechnung,复合词,NOUN,B2
+the verstellung,the verstellung,复合词,NOUN,B2
+wiedersuchung,wiedersuchung,词,NOUN,B2
+sick nauseous,sick nauseous,恶心的,ADJ,B2
+you formal,you formal,您,PRON,B2
+congratulations,congratulations,祝贺,NOUN,B2
+zurichtung,zurichtung,词,NOUN,B2
+bepflegung,bepflegung,词,NOUN,B2
+hinterregelung,hinterregelung,词,NOUN,B2
+gesucht,gesucht,词,NOUN,B2
+zerteilung,zerteilung,词,NOUN,B2
+vorderleitung,vorderleitung,词,NOUN,B2
+nachweisung,nachweisung,词,NOUN,B2
+nachwirkung,nachwirkung,词,NOUN,B2
+the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
+the zerhandlung,the zerhandlung,复合词,NOUN,B2
+the abstoff,the abstoff,复合词,NOUN,B2
+over about,over about,在...上方,ADP,B2
+squeak,squeak,吱吱声,NOUN,B2
+the unterheilung,the unterheilung,复合词,NOUN,B2
+some things,some things,一些事情,PRON,B2
+no not any,no not any,没有,DET,B2
+ursetzung,ursetzung,词,NOUN,B2
+at it,at it,靠近,ADV,B2
+the ausleitung,the ausleitung,复合词,NOUN,B2
+expert opinion,expert opinion,专家意见,NOUN,B2
+the auswendung,the auswendung,复合词,NOUN,B2
+to descend from,to descend from,起源于,VERB,B2
+the hochminderung,the hochminderung,复合词,NOUN,B2
+your pl,your pl,你们的,DET,B2
+yours,yours,你的,PRON,B2
+pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
+erwirkung,erwirkung,词,NOUN,B2
+abfassung,abfassung,词,NOUN,B2
+the abhandlung,the abhandlung,复合词,NOUN,B2
+the alias,the alias,名词,NOUN,B2
+yoga practice,yoga practice,瑜伽练习,NOUN,B2
+the urmischung,the urmischung,复合词,NOUN,B2
+aussuchung,aussuchung,词,NOUN,B2
+nachfassung,nachfassung,词,NOUN,B2
+unschaft,unschaft,词,NOUN,B2
+anschrift,anschrift,词,NOUN,B2
+erztheilung,erztheilung,词,NOUN,B2
+at night,at night,夜间,ADV,B2
+the anordnung,the anordnung,复合词,NOUN,B2
+untersetzung,untersetzung,词,NOUN,B2
+the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
+the nachheilung,the nachheilung,复合词,NOUN,B2
+the missrechnung,the missrechnung,复合词,NOUN,B2
+the unwendung,the unwendung,复合词,NOUN,B2
+hochforderung,hochforderung,词,NOUN,B2
+the beordnung,the beordnung,复合词,NOUN,B2
+to abtun,to abtun,动词,VERB,B2
+vorderwandel,vorderwandel,词,NOUN,B2
+the zerordnung,the zerordnung,复合词,NOUN,B2
+aussucht,aussucht,词,NOUN,B2
+the anbettlung,the anbettlung,名词,NOUN,B2
+wiederleitung,wiederleitung,词,NOUN,B2
+to circumcise,to circumcise,割礼,VERB,B2
+the vermacht,the vermacht,复合词,NOUN,B2
+justified,justified,有根据的,ADJ,B2
+the geform,the geform,复合词,NOUN,B2
+hinterweisung,hinterweisung,词,NOUN,B2
+mitsicht,mitsicht,词,NOUN,B2
+nachsucht,nachsucht,词,NOUN,B2
+passed,passed,递,ADJ,B2
+nachschaft,nachschaft,词,NOUN,B2
+the ververbesserung,the ververbesserung,复合词,NOUN,B2
+vorerziehung,vorerziehung,词,NOUN,B2
+weitteilung,weitteilung,词,NOUN,B2
+the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
+the urrechnung,the urrechnung,复合词,NOUN,B2
+different,different,不同地,ADV,B2
+period,period,句号,PUNCT,B2
+the zerkraft,the zerkraft,复合词,NOUN,B2
+misssicht,misssicht,词,NOUN,B2
+joie de vivre,joie de vivre,生活乐趣,NOUN,B2
+the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
+the urstellung,the urstellung,复合词,NOUN,B2
+for each other,for each other,相互,ADV,B2
+hochgabe,hochgabe,词,NOUN,B2
+kitten,kitten,小猫,NOUN,B2
+outside of,outside of,在...之外,ADP,B2
+fernkunft,fernkunft,词,NOUN,B2
+to be valid,to be valid,有效,VERB,B2
+wiederfahrt,wiederfahrt,词,NOUN,B2
+to be liable,to be liable,负责,VERB,B2
+the vorkraft,the vorkraft,复合词,NOUN,B2
+the verminderung,the verminderung,复合词,NOUN,B2
+to abwandeln,to abwandeln,动词,VERB,B2
+the urbewegung,the urbewegung,复合词,NOUN,B2
+to absichern,to absichern,动词,VERB,B2
+the grundbildung,the grundbildung,复合词,NOUN,B2
+the ververtiefung,the ververtiefung,复合词,NOUN,B2
+ersetzung,ersetzung,词,NOUN,B2
+all the more,all the more,更加,ADV,B2
+to squeak,to squeak,吱吱叫,VERB,B2
+aberziehung,aberziehung,词,NOUN,B2
+mittheilung,mittheilung,词,NOUN,B2
+the altertum,the altertum,名词,NOUN,B2
+zerregelung,zerregelung,词,NOUN,B2
+mitpflegung,mitpflegung,词,NOUN,B2
+worse,worse,更糟的事,NOUN,B2
+the versthandlung,the versthandlung,复合词,NOUN,B2
+gefahrt,gefahrt,词,NOUN,B2
+managing director,managing director,总经理,NOUN,B2
+erzfahrt,erzfahrt,词,NOUN,B2
+coke,coke,可卡因,NOUN,B2
+as possible,as possible,尽可能地,ADV,B2
+waste of time,waste of time,浪费时间,NOUN,B2
+the unstellung,the unstellung,复合词,NOUN,B2
+aufgestaltung,aufgestaltung,词,NOUN,B2
+versinnung,versinnung,词,NOUN,B2
+missfassung,missfassung,词,NOUN,B2
+the erzerweiterung,the erzerweiterung,复合词,NOUN,B2
+the abbindung,the abbindung,复合词,NOUN,B2
+masseur,masseur,按摩师,NOUN,B2
+all saints' day,all saints' day,诸圣节,NOUN,B2
+the angriff,the angriff,名词,NOUN,B2
+doorbell button,doorbell button,门铃按钮,NOUN,B2
+endeavor,endeavor,努力,NOUN,B2
+dearest,dearest,最爱的人,NOUN,B2
+relaxed loose,relaxed loose,放松的 / 松的,ADJ,B2
+nachwandel,nachwandel,词,NOUN,B2
+the career,the career,职业生涯,NOUN,B2
+temerity,temerity,鲁莽,NOUN,B2
+hair bun,hair bun,发髻,NOUN,B2
+complementarity,complementarity,互补性,NOUN,B2
+line of conduct,line of conduct,行为方针,NOUN,B2
+locked,locked,锁定的,ADJ,B2
+layer storage,layer storage,层/仓库,NOUN,B2
+to vegetate,to vegetate,苟活,VERB,B2
+to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
+every,every,每个,PRON,B2
+conductivity,conductivity,导电性,NOUN,B2
+to retrace,to retrace,追溯,VERB,B2
+to perpetuate,to perpetuate,使永存,VERB,B2
+to disenchant,to disenchant,使清醒,VERB,B2
+brawl,brawl,斗殴,NOUN,B2
+tyrannical,tyrannical,专横的,ADJ,B2
+punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
+seldom,seldom,很少,ADV,B2
+to situate,to situate,定位,VERB,B2
+equal treatment,equal treatment,平等待遇,NOUN,B2
+guilt-ridden,guilt-ridden,内疚的,ADJ,B2
+to specialize,to specialize,专攻,VERB,B2
+to vampirize,to vampirize,吸血,VERB,B2
+chief physician,chief physician,主任医师,NOUN,B2
+professionally active,professionally active,在职,NOUN,B2
+premeditation,premeditation,预谋,NOUN,B2
+idiotic,idiotic,愚蠢的,ADJ,B2
+swimming,swimming,游泳,NOUN,B2
+short film,short film,短片,NOUN,B2
+to disrupt,to disrupt,扰乱,VERB,B2
+soundtrack,soundtrack,! 音轨,NOUN,B2
+the casinos,the casinos,赌场,NOUN,B2
+hatch,hatch,舱口,NOUN,B2
+fictional character,fictional character,虚构角色,NOUN,B2
+like that,like that,像那样,ADV,B2
+vain,vain,徒劳的,ADJ,B2
+motif,motif,主题,NOUN,B2
+to bump push,to bump push,推/碰撞,VERB,B2
+costs,costs,费用,NOUN,B2
+shuttle,shuttle,穿梭巴士,NOUN,B2
+junior jersey,junior jersey,,NOUN,B2
+to be felled,to be felled,被砍倒,VERB,B2
+variant,variant,变体,NOUN,B2
+nonprofit,nonprofit,非营利的,ADJ,B2
+news reporting,news reporting,新闻报道,NOUN,B2
+would,would,将要,AUX,B2
+to recharge,to recharge,充电,VERB,B2
+roadway,roadway,路面,NOUN,B2
+precarization,precarization,不稳定化,NOUN,B2
+culture of greed,culture of greed,贪得无厌文化,NOUN,B2
+outdoors,outdoors,户外,ADV,B2
+to buy back,to buy back,赎回,VERB,B2
+meaning content,meaning content,语义内容,NOUN,B2
+chauvinistic,chauvinistic,沙文主义的,ADJ,B2
+to reopen,to reopen,重新开放,VERB,B2
+one you,one you,人们,PRON,B2
+latent,latent,潜在的,ADJ,B2
+omnipresent,omnipresent,无所不在的,ADJ,B2
+slum,slum,贫民窟,NOUN,B2
+co-determination,co-determination,共同决定权,NOUN,B2
+resuscitation,resuscitation,复苏,NOUN,B2
+elementary,elementary,基本的,ADJ,B2
+ace carcass,ace carcass,王牌/尸体,NOUN,B2
+curfew,curfew,宵禁,NOUN,B2
+shyness,shyness,羞怯,NOUN,B2
+from behind,from behind,从后面,ADV,B2
+resource shortage,resource shortage,资源短缺,NOUN,B2
+damageable,damageable,易损的,ADJ,B2
+lunatic,lunatic,疯子,NOUN,B2
+plenitude,plenitude,充足,NOUN,B2
+ferry,ferry,渡轮,NOUN,B2
+nuclear war,nuclear war,核战争,NOUN,B2
+insanely,insanely,疯狂地,ADV,B2
+occupational pension,occupational pension,职业养老金,NOUN,B2
+mp,mp,国会议员,NOUN,B2
+sadistic,sadistic,施虐的,ADJ,B2
+his her its their,his her its their,他的/她的/它的/他们的,DET,B2
+incorporation,incorporation,纳入,NOUN,B2
+to decouple,to decouple,分离,VERB,B2
+group member,group member,群体成员,NOUN,B2
+to bluff,to bluff,虚张声势,VERB,B2
+cloister,cloister,回廊,NOUN,B2
+domain,domain,领域,NOUN,B2
+to put set,to put set,放置,VERB,B2
+selected,selected,选中的,ADJ,B2
+disturbed,disturbed,不安的,ADJ,B2
+palliative,palliative,缓和的,ADJ,B2
+veiled,veiled,隐晦的,ADJ,B2
+obliged,obliged,被迫的,ADJ,B2
+appeasement,appeasement,平息,NOUN,B2
+thetic,thetic,正题的,ADJ,B2
+attributive,attributive,定语的,ADJ,B2
+ideally,ideally,理想地,ADV,B2
+to meant,to meant,意思是,VERB,B2
+should ought to,should ought to,应该,AUX,B2
+crusade,crusade,运动,NOUN,B2
+from within,from within,从内部,ADV,B2
+outcome ending,outcome ending,结局，解决,NOUN,B2
+thicker,thicker,更厚的,ADJ,B2
+shady suspicious,shady suspicious,可疑的,ADJ,B2
+villainous,villainous,恶棍的,ADJ,B2
+playwright,playwright,剧作家,NOUN,B2
+sexy,sexy,性感的,ADJ,B2
+upright,upright,直立地,ADV,B2
+values base,values base,价值基础,NOUN,B2
+acculturation,acculturation,文化涵化,NOUN,B2
+jews,jews,犹太人,NOUN,B2
+to dawdle,to dawdle,闲逛,VERB,B2
+to saturate,to saturate,使饱和,VERB,B2
+mammal,mammal,哺乳动物,NOUN,B2
+sail,sail,帆,NOUN,B2
+irish person,irish person,爱尔兰人,NOUN,B2
+photon,photon,光子,NOUN,B2
+cheapness,cheapness,廉价,NOUN,B2
+autism,autism,自闭症,NOUN,B2
+dator,dator,电脑,NOUN,B2
+superb,superb,极好的,ADJ,B2
+slut,slut,荡妇,NOUN,B2
+numismatic,numismatic,钱币学的,ADJ,B2
+faint,faint,微弱的,ADJ,B2
+demagogy,demagogy,蛊惑,NOUN,B2
+meticulously,meticulously,一丝不苟地,ADV,B2
+to map out,to map out,摸清,VERB,B2
+to do sports,to do sports,运动,VERB,B2
+side,side,骄傲的,ADJ,B2
+to freshen,to freshen,使清新,VERB,B2
+solecism,solecism,语法错误,NOUN,B2
+to log in,to log in,登录,VERB,B2
+iranian,iranian,伊朗的,ADJ,B2
+doctor visit,doctor visit,,NOUN,B2
+dans,dans,舞蹈,NOUN,B2
+to navigate,to navigate,导航；航行,VERB,B2
+family circle,family circle,家庭圈子,NOUN,B2
+ago,ago,以前,ADV,B2
+cooked,cooked,熟的,ADJ,B2
+super dead,super dead,,NOUN,B2
+emotional experience,emotional experience,情感体验,NOUN,B2
+film movie,film movie,电影,NOUN,B2
+to fasten,to fasten,系紧,VERB,B2
+depot,depot,仓库,NOUN,B2
+tropical,tropical,热带的,ADJ,B2
+to stitch,to stitch,缝,VERB,B2
+asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
+racist,racist,种族主义者,NOUN,B2
+to slash,to slash,猛砍,VERB,B2
+detention center,detention center,拘留所,NOUN,B2
+full of life,full of life,充满活力的,ADJ,B2
+deleveraging,deleveraging,去杠杆化,NOUN,B2
+tax exemption,tax exemption,免税,NOUN,B2
+dissatisfaction,dissatisfaction,不满,NOUN,B2
+city centre,city centre,市中心,NOUN,B2
+implacably,implacably,毫不留情地,ADV,B2
+skilful,skilful,熟练的,ADJ,B2
+phone number,phone number,电话号码,NOUN,B2
+splash,splash,扑通,NOUN,B2
+on behalf of,on behalf of,代表,ADP,B2
+lent,lent,大斋期,NOUN,B2
+repertoire,repertoire,全部曲目,NOUN,B2
+win,win,胜利,NOUN,B2
+shocked,shocked,震惊的,ADJ,B2
+instructor,instructor,讲师,NOUN,B2
+clock watch,clock watch,钟表,NOUN,B2
+wait-and-see,wait-and-see,观望的,ADJ,B2
+authoritative,authoritative,权威的,ADJ,B2
+landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
+band tape,band tape,带子,NOUN,B2
+orange juice,orange juice,橙汁,NOUN,B2
+periphery,periphery,边缘,NOUN,B2
+gastronomic,gastronomic,美食的,ADJ,B2
+genital,genital,生殖器,NOUN,B2
+to manifest,to manifest,表明,VERB,B2
+breach of contract,breach of contract,违约,NOUN,B2
+to postulate,to postulate,假定,VERB,B2
+cellulose,cellulose,纤维素,NOUN,B2
+by now,by now,此时,ADV,B2
+basal,basal,基本的,ADJ,B2
+averse,averse,厌恶的,ADJ,B2
+to preside,to preside,主持,VERB,B2
+tremulous,tremulous,颤抖的,ADJ,B2
+syllable,syllable,音节,NOUN,B2
+sanitation,sanitation,卫生,NOUN,B2
+psychoanalysis,psychoanalysis,精神分析,NOUN,B2
+unfriendly,unfriendly,不友好的,ADJ,B2
+graveyard,graveyard,墓地,NOUN,B2
+capital gain,capital gain,增值,NOUN,B2
+fresh,fresh,,NOUN,B2
+increased,increased,增加的,ADJ,B2
+arson,arson,纵火,NOUN,B2
+royalty,royalty,王室,NOUN,B2
+cleanly,cleanly,干净地,ADV,B2
+comparative,comparative,比较的,ADJ,B2
+to know feel,to know feel,认识/感觉,VERB,B2
+evidence bag,evidence bag,,NOUN,B2
+how long,how long,多久,ADV,B2
+optimization,optimization,优化,NOUN,B2
+steak,steak,牛排,NOUN,B2
+little one,little one,小家伙,NOUN,B2
+to type,to type,打字,VERB,B2
+advancement,advancement,晋升,NOUN,B2
+suicide candidate,suicide candidate,,NOUN,B2
+slam,slam,,NOUN,B2
+libertinism,libertinism,放荡,NOUN,B2
+dossier,dossier,档案,NOUN,B2
+journalism,journalism,新闻业,NOUN,B2
+reluctance,reluctance,不情愿,NOUN,B2
+monolithic,monolithic,单一的,ADJ,B2
+duplicate,duplicate,! 副本,NOUN,B2
+surcharge,surcharge,附加费,NOUN,B2
+binoculars,binoculars,双筒望远镜,NOUN,B2
+all kinds,all kinds,各种各样的,DET,B2
+hallelujah,hallelujah,哈利路亚,INTJ,B2
+to attest,to attest,证明,VERB,B2
+declinable,declinable,可变格的,ADJ,B2
+snot,snot,鼻涕,NOUN,B2
+volunteer work,volunteer work,志愿工作,NOUN,B2
+gender equality,gender equality,性别平等,NOUN,B2
+optimal,optimal,最佳的,ADJ,B2
+will shall,will shall,将要/会,AUX,B2
+told instructed,told instructed,被告知的,ADJ,B2
+state secretary,state secretary,国务秘书,NOUN,B2
+articulation,articulation,清晰表达,NOUN,B2
+reduction,reduction,减少,NOUN,B2
+about that,about that,关于那个,ADV,B2
+orange,orange,橙色的,ADJ,B2
+grand duke,grand duke,大公,NOUN,B2
+wooden,wooden,木制的,ADJ,B2
+tired of,tired of,,NOUN,B2
+up there,up there,在那上面,ADV,B2
+retailer,retailer,零售商,NOUN,B2
+longer,longer,更长的,ADJ,B2
+fewer,fewer,较少的,ADJ,B2
+just precis,just precis,恰好,ADV,B2
+determine,determine,确定,VER! B,B2
+to meditate,to meditate,沉思,VERB,B2
+overdraft,overdraft,透支,NOUN,B2
+existentialism,existentialism,存在主义,NOUN,B2
+substandard,substandard,,NOUN,B2
+ratio,ratio,比率,NOUN,B2
+infrastructure,infrastructure,基础设施,NOUN,B2
+to missed,to missed,错过,VERB,B2
+vaccine-related,vaccine-related,疫苗的,ADJ,B2
+in here,in here,在这里面,ADV,B2
+little son,little son,小儿子,NOUN,B2
+pernicious,pernicious,有害的,ADJ,B2
+exceptionality,exceptionality,特殊性,NOUN,B2
+as if,as if,好像,SCONJ,B2
+present time,present time,现在,NOUN,B2
+nuclear weapon,nuclear weapon,核武器,NOUN,B2
+christianity,christianity,基督教,NOUN,B2
+freedom of assembly,freedom of assembly,集会自由,NOUN,B2
+having a birthday,having a birthday,过生日的,ADJ,B2
+speculator,speculator,投机者,NOUN,B2
+field medic,field medic,战地医生,NOUN,B2
+lucidity,lucidity,清醒 / 明晰,NOUN,B2
+synoptic,synoptic,概要的,ADJ,B2
+to asphalt,to asphalt,铺沥青,VERB,B2
+salon,salon,沙龙,NOUN,B2
+infant,infant,婴儿,NOUN,B2
+satisfying,satisfying,令人满意的,ADJ,B2
+to consider think,to consider think,考虑/思考,VERB,B2
+conceptual,conceptual,概念的,ADJ,B2
+to be taken,to be taken,被拿走,VERB,B2
+snazzy,snazzy,时髦的,ADJ,B2
+remaining,remaining,,NOUN,B2
+holder,holder,持有者,NOUN,B2
+fired,fired,被解雇的,ADJ,B2
+danish,danish,丹麦的,ADJ,B2
+grand duchy,grand duchy,大公国,NOUN,B2
+ataxia,ataxia,共济失调,NOUN,B2
+norwegian,norwegian,挪威的,ADJ,B2
+online dating profile,online dating profile,,NOUN,B2
+sibling,sibling,兄弟姐妹,NOUN,B2
+to flee escape,to flee escape,逃跑,VERB,B2
+kidnapped,kidnapped,被绑架的,ADJ,B2
+basic income,basic income,基本收入,NOUN,B2
+exclusionary,exclusionary,排他性的,ADJ,B2
+slowdown,slowdown,减速,NOUN,B2
+concessionary,concessionary,让步的,ADJ,B2
+to flush,to flush,冲洗,VERB,B2
+press freedom,press freedom,新闻自由,NOUN,B2
+demonstrative,demonstrative,演示的,ADJ,B2
+continual,continual,持续的,ADJ,B2
+mosquito net,mosquito net,蚊帐,NOUN,B2
+furrow,furrow,犁沟,NOUN,B2
+underclass,underclass,底层,NOUN,B2
+unscathed,unscathed,未受伤害的,ADJ,B2
+effort bet,effort bet,努力/赌注,NOUN,B2
+prayer room,prayer room,祈祷室,NOUN,B2
+except for,except for,除了,ADP,B2
+thrilling,thrilling,令人兴奋的,ADJ,B2
+observation skill,observation skill,,NOUN,B2
+egyptian,egyptian,埃及的,ADJ,B2
+foal,foal,马驹,NOUN,B2
+diverse,diverse,多样的,ADJ,B2
+gay man,gay man,男同性恋者,NOUN,B2
+gaping,gaping,,NOUN,B2
+depicting,depicting,描绘的,ADJ,B2
+meeting hit,meeting hit,会面/击中,NOUN,B2
+religiousness,religiousness,虔诚,NOUN,B2
+freedom of speech,freedom of speech,言论自由,NOUN,B2
+dissociation,dissociation,解离,NOUN,B2
+ribs,ribs,肋骨,NOUN,B2
+unilateral,unilateral,单方面的,ADJ,B2
+timeline,timeline,时间线,NOUN,B2
+to object,to object,反对,VERB,B2
+much many,much many,许多,ADJ,B2
+of by,of by,的/被,ADP,B2
+nourishment,nourishment,营养,NOUN,B2
+perennial,perennial,长期的,ADJ,B2
+the safe,the safe,保险箱,NOUN,B2
+directorship,directorship,董事职位,NOUN,B2
+bud,bud,芽,NOUN,B2
+bleak,bleak,无望的,ADJ,B2
+bridle,bridle,马勒,NOUN,B2
+millions of,millions of,数百万的,NUM,B2
+philippic,philippic,猛烈的抨击,NOUN,B2
+self-esteem,self-esteem,自尊,NOUN,B2
+orderliness,orderliness,有序性,NOUN,B2
+mapping,mapping,梳理,NOUN,B2
+strangely,strangely,奇怪地,ADV,B2
+freedom of opinion,freedom of opinion,意见自由,NOUN,B2
+to appear to seem,to appear to seem,出现/显得,VERB,B2
+terrorists,terrorists,恐怖分子们,NOUN,B2
+nah,nah,不,INTJ,B2
+bro,bro,哥们,NOUN,B2
+retranslation,retranslation,重译,NOUN,B2
+fascinated,fascinated,着迷的,ADJ,B2
+painstakingly,painstakingly,细致地,ADV,B2
+decor,decor,布景,NOUN,B2
+moose,moose,驼鹿,NOUN,B2
+truthful,truthful,忠于事实的,ADJ,B2
+scheduling,scheduling,调度；排序,NOUN,B2
+to tweet,to tweet,发推文,VERB,B2
+editing,editing,剪辑,NOUN,B2
+citrus,citrus,柑橘,NOUN,B2
+member state,member state,成员国,NOUN,B2
+youth trauma,youth trauma,童年创伤,NOUN,B2
+concave,concave,凹的,ADJ,B2
+attempted murder,attempted murder,谋杀未遂,NOUN,B2
+provincial,provincial,地方的,ADJ,B2
+compulsiveness,compulsiveness,强迫性,NOUN,B2
+windless,windless,无风的,ADJ,B2
+to blossom,to blossom,开花,VERB,B2
+furnishing,furnishing,室内布置,NOUN,B2
+good day,good day,你好,INTJ,B2
+oppressive,oppressive,压迫的,ADJ,B2
+extinct,extinct,灭绝的,ADJ,B2
+kind sort,kind sort,种类,NOUN,B2
+to plane,to plane,刨,VERB,B2
+liquid,liquid,液态的,ADJ,B2
+position of authority,position of authority,! 权威地位,NOUN,B2
+rock slab,rock slab,岩板,NOUN,B2
+care home,care home,,NOUN,B2
+to keep silent,to keep silent,保持沉默,VERB,B2
+sordid,sordid,肮脏的,ADJ,B2
+in which,in which,在其中,PRON,B2
+dismal,dismal,令人失望的,ADJ,B2
+to emasculate,to emasculate,使无力,VERB,B2
+gloriousness,gloriousness,光荣,NOUN,B2
+trusting,trusting,信任的,ADJ,B2
+valid,valid,有效的,ADJ,B2
+keen eager,keen eager,渴望的,ADJ,B2
+witness protection,witness protection,,NOUN,B2
+costly,costly,昂贵的,ADJ,B2
+to warm,to warm,加热,VERB,B2
+to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
+to diet,to diet,减肥,VERB,B2
+to stay awake,to stay awake,守夜,VERB,B2
+male,male,男性,NOUN,B2
+obtaining,obtaining,获得,NOUN,B2
+luminous,luminous,发光的,ADJ,B2
+grandparenthood,grandparenthood,祖父母身份,NOUN,B2
+prodigy,prodigy,神童,NOUN,B2
+multinational,multinational,跨国公司,NOUN,B2
+explicable,explicable,可解释的,ADJ,B2
+one hundred,one hundred,一百,NUM,B2
+to function work,to function work,运作/起作用,VERB,B2
+to externalize,to externalize,使外在化,VERB,B2
+split secession,split secession,分裂,NOUN,B2
+couple pair,couple pair,一对,NOUN,B2
+group culture,group culture,群体文化,NOUN,B2
+civilisation,civilisation,文明,NOUN,B2
+notarized,notarized,经公证的,ADJ,B2
+constructivism,constructivism,建构主义,NOUN,B2
+minuscule,minuscule,极小的,ADJ,B2
+deck tire,deck tire,甲板/轮胎,NOUN,B2
+catalogue,catalogue,目录,NOUN,B2
+psychiatric,psychiatric,精神病的,ADJ,B2
+gosh,gosh,天哪,INTJ,B2
+abroad,abroad,在国外,ADV,B2
+unctuous,unctuous,谄媚的,ADJ,B2
+contaminated,contaminated,受污染的,ADJ,B2
+underworld,underworld,地下世界,NOUN,B2
+fluctuating,fluctuating,波动的,ADJ,B2
+for sale,for sale,待售,ADJ,B2
+to soften,to soften,使灵活,VERB,B2
+to conjugate,to conjugate,变位,VERB,B2
+to bring lead,to bring lead,带来/引导,VERB,B2
+to set rates,to set rates,定价,VERB,B2
+to bully,to bully,欺凌,VERB,B2
+suite,suite,套房,NOUN,B2
+recall,recall,回忆,NOUN,B2
+thoughtfully,thoughtfully,体贴地,ADV,B2
+brain activity,brain activity,,NOUN,B2
+abominable,abominable,可憎的,ADJ,B2
+motel,motel,汽车旅馆,NOUN,B2
+informedness,informedness,知情度,NOUN,B2
+parcel,parcel,包裹,NOUN,B2
+polar,polar,极地的,ADJ,B2
+little hand,little hand,小手,NOUN,B2
+cultural heritage,cultural heritage,文化遗产,NOUN,B2
+kind species,kind species,种类/物种,NOUN,B2
+to be created,to be created,被创造,VERB,B2
+to declaim,to declaim,慷慨陈词,VERB,B2
+arrived present,arrived present,到了,ADV,B2
+respondent,respondent,被上诉人,NOUN,B2
+lust,lust,欲望,NOUN,B2
+enormously,enormously,巨大地,ADV,B2
+light-year,light-year,,NOUN,B2
+metabolic,metabolic,代谢的,ADJ,B2
+to amaze,to amaze,使吃惊,VERB,B2
+inboard,inboard,船内的,ADV,B2
+filled,filled,充满的,ADJ,B2
+younger,younger,较年轻的,ADJ,B2
+southeast,southeast,东南,NOUN,B2
+catachresis,catachresis,词语误用,NOUN,B2
+tv movie,tv movie,电视电影,NOUN,B2
+to commentate,to commentate,评论,VERB,B2
+to come loose,to come loose,松脱,VERB,B2
+gracious,gracious,亲切的,ADJ,B2
+gratuity,gratuity,酬金,NOUN,B2
+sophisticated,sophisticated,复杂的,ADJ,B2
+balsam,balsam,香脂,NOUN,B2
+student residence,student residence,学生宿舍,NOUN,B2
+respectful,respectful,恭敬的,ADJ,B2
+mainstream,mainstream,主流的,ADJ,B2
+steering,steering,掌舵的,ADJ,B2
+roadblock,roadblock,,NOUN,B2
+charismatic,charismatic,有魅力的,ADJ,B2
+dozens,dozens,数十个,NOUN,B2
+constancy,constancy,恒定,NOUN,B2
+decimal,decimal,小数,NOUN,B2
+to mess about,to mess about,胡搞,VERB,B2
+bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
+maximal,maximal,最大的,ADJ,B2
+guilty owes,guilty owes,有罪的/欠钱的,ADJ,B2
+so-called,so-called,,NOUN,B2
+to relay,to relay,转达,VERB,B2
+to reproach,to reproach,责备,VERB,B2
+that to,that to,那/去,PART,B2
+tolerant,tolerant,宽容的,ADJ,B2
+all-clear,all-clear,许可信号,NOUN,B2
+sporty,sporty,运动的,ADJ,B2
+service year,service year,,NOUN,B2
+enforcement policy,enforcement policy,执法政策,NOUN,B2
+australian,australian,澳大利亚的,ADJ,B2
+for this purpose,for this purpose,为此,ADV,B2
+finance,finance,金融,NOUN,B2
+preliminary investigation,preliminary investigation,,NOUN,B2
+shading,shading,阴影,NOUN,B2
+chili,chili,辣椒,NOUN,B2
+reprieve,reprieve,暂缓执行,NOUN,B2
+marvelous,marvelous,极好的,ADJ,B2
+databas,databas,数据库,NOUN,B2
+to objectify,to objectify,客观化,VERB,B2
+systemless,systemless,无系统的,ADJ,B2
+doe,doe,雌鹿,NOUN,B2
+larva,larva,幼虫,NOUN,B2
+bicameral,bicameral,两院制的,ADJ,B2
+to theatricalize,to theatricalize,戏剧化,VERB,B2
+spot,spot,地点,NOUN,B2
+demographic,demographic,人口统计的,ADJ,B2
+anaphora,anaphora,首语重复修辞,NOUN,B2
+showing,showing,表现,NOUN,B2
+opacity,opacity,不透明性,NOUN,B2
+taxonomy,taxonomy,分类学,NOUN,B2
+advertising,advertising,广告的,ADJ,B2
+pathogenic,pathogenic,致病的,ADJ,B2
+malmo,malmo,马尔默,PROPN,B2
+virginal,virginal,处女的,ADJ,B2
+line-up,line-up,阵容,NOUN,B2
+relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+kindred spirit,kindred spirit,志同道合者,NOUN,B2
+attractiveness,attractiveness,吸引力,NOUN,B2
+loathing,loathing,,NOUN,B2
+to use up,to use up,用完,VERB,B2
+selfish,selfish,,NOUN,B2
+tilt,tilt,倾斜,NOUN,B2
+redundant,redundant,多余的,ADJ,B2
+to make stupid,to make stupid,使愚蠢,VERB,B2
+cornice,cornice,檐口,NOUN,B2
+to accentuate,to accentuate,强调,VERB,B2
+budgetable,budgetable,可预算的,ADJ,B2
+darn,darn,哎呀,INTJ,B2
+trapdoor,trapdoor,活板门,NOUN,B2
+colour,colour,颜色,NOUN,B2
+higher professional education,higher professional education,高等专业教育,NOUN,B2
+prosody,prosody,韵律学,NOUN,B2
+best friend,best friend,最好的朋友,NOUN,B2
+others,others,他人,PRON,B2
+reproachable,reproachable,应受责备的,ADJ,B2
+drugs,drugs,毒品,NOUN,B2
+courteous,courteous,有礼貌的,ADJ,B2
+light brown,light brown,浅棕色的,ADJ,B2
+ballot,ballot,选票,NOUN,B2
+minus,minus,减,NOUN,B2
+jointly,jointly,共同地,ADV,B2
+lower,lower,较低的,ADJ,B2
+predominance,predominance,主导地位,NOUN,B2
+to raise bring up,to raise bring up,抚养,VERB,B2
+accessible,accessible,易接近的,ADJ,B2
+balm,balm,香脂,NOUN,B2
+leading role,leading role,主角,NOUN,B2
+viewer,viewer,观众,NOUN,B2
+to revitalize,to revitalize,使复苏,VERB,B2
+masonry,masonry,砌体,NOUN,B2
+to leave stick,to leave stick,离开/刺,VERB,B2
+drug dealer,drug dealer,毒贩,NOUN,B2
+political party,political party,政党,NOUN,B2
+hint,hint,暗示,NOUN,B2
+average,average,平均数,NOUN,B2
+to play football,to play football,踢足球,VERB,B2
+the guy,the guy,那个男人,NOUN,B2
+last evening,last evening,,NOUN,B2
+strenuous,strenuous,费力的,ADJ,B2
+correctness,correctness,正确性,NOUN,B2
+chore,chore,家务,NOUN,B2
+audible,audible,听得见的,ADJ,B2
+to use to usually,to use to usually,通常/习惯于,VERB,B2
+iatrogenic,iatrogenic,医源性的,ADJ,B2
+too late,too late,太迟,ADV,B2
+prerogative,prerogative,特权,NOUN,B2
+to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
+collegial,collegial,同事的,ADJ,B2
+choreographer,choreographer,编舞者,NOUN,B2
+to burnish,to burnish,擦亮,VERB,B2
+amnesia,amnesia,健忘症,NOUN,B2
+to demilitarize,to demilitarize,非军事化,VERB,B2
+prayer trap,prayer trap,,NOUN,B2
+mannerly,mannerly,有礼貌的,ADJ,B2
+to bequeath,to bequeath,遗赠,VERB,B2
+hollowed,hollowed,掏空的,ADJ,B2
+subtle,subtle,微妙的,ADJ,B2
+nerd,nerd,书呆子,NOUN,B2
+crystal clear,crystal clear,清澈的,ADJ,B2
+zoo,zoo,动物园,NOUN,B2
+syndrome,syndrome,综合征,NOUN,B2
+to carve,to carve,雕刻,VERB,B2
+berkeley coach,berkeley coach,,NOUN,B2
+in two,in two,成两半,ADV,B2
+to savor,to savor,品味,VERB,B2
+gynaecology,gynaecology,妇科,NOUN,B2
+border post,border post,边防哨所,NOUN,B2
+paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
+explosives,explosives,炸药,NOUN,B2
+corporatism,corporatism,法团主义,NOUN,B2
+from above,from above,从上方,ADV,B2
+curbing,curbing,遏制,NOUN,B2
+remarkable,remarkable,非凡的,ADJ,B2
+to train exercise,to train exercise,训练/锻炼,VERB,B2
+embargo,embargo,禁运,NOUN,B2
+technocratic,technocratic,技术官僚的,ADJ,B2
+middle class,middle class,中产阶层,NOUN,B2
+resistance movement,resistance movement,抵抗运动,NOUN,B2
+to lament,to lament,哀叹,VERB,B2
+moralizing,moralizing,说教的,ADJ,B2
+minimalism,minimalism,极简主义,NOUN,B2
+expressiveness,expressiveness,表现力,NOUN,B2
+matter of conscience,matter of conscience,良心问题,NOUN,B2
+sympathy empathy,sympathy empathy,同情/共情,NOUN,B2
+ride lift,ride lift,搭车,NOUN,B2
+mafia,mafia,黑手党,NOUN,B2
+security-related,security-related,安全的，安保的,ADJ,B2
+atrophy,atrophy,萎缩,NOUN,B2
+versus,versus,对,ADP,B2
+to play sports,to play sports,做运动,VERB,B2
+sure safe,sure safe,确定的,ADJ,B2
+greetings,greetings,,NOUN,B2
+to frolic,to frolic,嬉戏,VERB,B2
+to defuse,to defuse,缓和,VERB,B2
+delicately,delicately,巧妙地,ADV,B2
+border community,border community,边境社区,NOUN,B2
+entrance ticket,entrance ticket,门票,NOUN,B2
+to fraction,to fraction,分割,VERB,B2
+life's work,life's work,毕生事业,NOUN,B2
+ears,ears,耳朵,NOUN,B2
+to deviate,to deviate,偏离,VERB,B2
+yourself,yourself,你自己,PRON,B2
+parent-friendly,parent-friendly,,NOUN,B2
+certainly,certainly,当然,INTJ,B2
+sliding,sliding,滑动的,ADJ,B2
+personalized,personalized,个性化的,ADJ,B2
+lab,lab,实验室,NOUN,B2
+morphine,morphine,吗啡,NOUN,B2
+fine pretty,fine pretty,美丽的,ADJ,B2
+to drape,to drape,悬挂,VERB,B2
+gladly willingly,gladly willingly,乐意地/宁愿,ADV,B2
+clear,clear,当然,ADV,B2
+fold,fold,折痕,NOUN,B2
+rustic,rustic,乡村的,ADJ,B2
+doubling,doubling,加倍,NOUN,B2
+breast,breast,乳房,NOUN,B2
+to flout,to flout,蔑视,VERB,B2
+particularly,particularly,特别地,ADV,B2
+upheaval,upheaval,剧变,NOUN,B2
+to serve a route,to serve a route,为...提供交通服务,VERB,B2
+mound,mound,土堆,NOUN,B2
+pallor,pallor,苍白,NOUN,B2
+rout,rout,溃败,NOUN,B2
+resourceful,resourceful,机灵的,ADJ,B2
+awareness raising,awareness raising,提高意识,NOUN,B2
+granny,granny,奶奶,NOUN,B2
+sheaf,sheaf,捆,NOUN,B2
+locality,locality,地点,NOUN,B2
+facies,facies,面貌,NOUN,B2
+aphasia,aphasia,失语症,NOUN,B2
+feature film,feature film,故事片,NOUN,B2
+perpetual,perpetual,永久的,ADJ,B2
+probe,probe,探测器,NOUN,B2
+to commute,to commute,通勤,VERB,B2
+to reverse,to reverse,反转,VERB,B2
+water heater,water heater,热水器,NOUN,B2
+proliferation,proliferation,增殖,NOUN,B2
+pantheon,pantheon,先贤祠,NOUN,B2
+detainee,detainee,被拘留者,NOUN,B2
+summarily,summarily,草率地,ADV,B2
+to defrost,to defrost,除霜,VERB,B2
+perilous,perilous,危险的,ADJ,B2
+to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
+to execrate,to execrate,痛恨,VERB,B2
+to resonate,to resonate,共鸣,VERB,B2
+factoring,factoring,保理,NOUN,B2
+detached house,detached house,独栋房屋,NOUN,B2
+to amass,to amass,积聚,VERB,B2
+independently,independently,独立地,ADV,B2
+severely,severely,严厉地,ADV,B2
+traditionally,traditionally,传统地,ADV,B2
+tenacity,tenacity,坚韧,NOUN,B2
+politely,politely,礼貌地,ADV,B2
+paper clip,paper clip,回形针,NOUN,B2
+to unbridle,to unbridle,解开,VERB,B2
+yoke,yoke,枷锁,NOUN,B2
+cohort,cohort,队列,NOUN,B2
+respective,respective,各自的,ADJ,B2
+newcomer,newcomer,新来者,NOUN,B2
+bookplate,bookplate,藏书票,NOUN,B2
+frankly,frankly,坦率地,ADV,B2
+passionate,passionate,热情的,ADJ,B2
+panther,panther,豹,NOUN,B2
+antisemitism,antisemitism,反犹太主义,NOUN,B2
+to generate engender,to generate engender,产生,VERB,B2
+to sequester,to sequester,隔离,VERB,B2
+invariably,invariably,不变地,ADV,B2
+stall,stall,包厢座位,NOUN,B2
+major,major,主要的,ADJ,B2
+expatriate,expatriate,移居国外者,NOUN,B2
+gallop,gallop,疾驰,NOUN,B2
+array,array,排列,NOUN,B2
+malfeasance,malfeasance,渎职,NOUN,B2
+to ratify,to ratify,批准,VERB,B2
+to defray,to defray,支付,VERB,B2
+to gratinate,to gratinate,烤成焦皮,VERB,B2
+various,various,各种各样的,ADJ,B2
+to flock,to flock,群集,VERB,B2
+to appal,to appal,使惊恐,VERB,B2
+to crash into,to crash into,撞击,VERB,B2
+lymphatic,lymphatic,淋巴的,ADJ,B2
+paradoxical,paradoxical,矛盾的,ADJ,B2
+supreme,supreme,最高的,ADJ,B2
+bump,bump,肿块,NOUN,B2
+librarian,librarian,图书管理员,NOUN,B2
+craze,craze,狂热,NOUN,B2
+pedantry,pedantry,迂腐,NOUN,B2
+bulgarian,bulgarian,保加利亚的,ADJ,B2
+syllogism,syllogism,三段论,NOUN,B2
+to conserve,to conserve,保存,VERB,B2
+grumbler,grumbler,爱抱怨的人,NOUN,B2
+prophylaxis,prophylaxis,预防,NOUN,B2
+to invalidate,to invalidate,证明无效,VERB,B2
+to suborn,to suborn,教唆,VERB,B2
+solipsism,solipsism,唯我论,NOUN,B2
+to curl,to curl,卷曲,VERB,B2
+to start again,to start again,重新开始,VERB,B2
+detrimental,detrimental,有害的,ADJ,B2
+mortality,mortality,死亡率,NOUN,B2
+to prosper,to prosper,繁荣,VERB,B2
+televised,televised,电视播出的,ADJ,B2
+tirade,tirade,长篇抨击,NOUN,B2
+rainy,rainy,多雨的,ADJ,B2
+hesitant,hesitant,犹豫的,ADJ,B2
+fit,fit,适合的,ADJ,B2
+preliminary,preliminary,初步的,ADJ,B2
+semantics,semantics,语义学,NOUN,B2
+kindly,kindly,亲切地,ADV,B2
+to tumble,to tumble,跌倒,VERB,B2
+truism,truism,自明之理,NOUN,B2
+civility,civility,礼貌,NOUN,B2
+to dye,to dye,染色,VERB,B2
+respite,respite,喘息,NOUN,B2
+annexation,annexation,吞并,NOUN,B2
+oligarchy,oligarchy,寡头政治,NOUN,B2
+disciplinary,disciplinary,纪律的,ADJ,B2
+to dither,to dither,犹豫不决,VERB,B2
+bailiff,bailiff,法警,NOUN,B2
+to croak,to croak,呱呱叫,VERB,B2
+accuracy,accuracy,准确性,NOUN,B2
+calmly,calmly,平静地,ADV,B2
+predictable,predictable,可预测的,ADJ,B2
+to hail inspect,to hail inspect,盘查,VERB,B2
+narcissistic,narcissistic,自恋的,ADJ,B2
+mash,mash,泥状食物,NOUN,B2
+nostalgia,nostalgia,怀旧,NOUN,B2
+inexorably,inexorably,不可阻挡地,ADV,B2
+vintage,vintage,佳酿,NOUN,B2
+solitary,solitary,孤独的,ADJ,B2
+to make heavier,to make heavier,加重,VERB,B2
+to rally,to rally,团结,VERB,B2
+relentless,relentless,无情的,ADJ,B2
+pioneer,pioneer,先驱,NOUN,B2
+frequently,frequently,经常,ADV,B2
+pleura,pleura,胸膜,NOUN,B2
+mascot,mascot,吉祥物,NOUN,B2
+accessibility,accessibility,可达性,NOUN,B2
+penalty,penalty,惩罚,NOUN,B2
+damaging,damaging,有害的,ADJ,B2
+trauma,trauma,创伤,NOUN,B2
+merchandise,merchandise,商品,NOUN,B2
+to demonize,to demonize,妖魔化,VERB,B2
+not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
+prosecution service,prosecution service,检察院,NOUN,B2
+to ferret,to ferret,搜寻,VERB,B2
+to crumple,to crumple,弄皱,VERB,B2
+to acquiesce,to acquiesce,默许,VERB,B2
+to caper,to caper,跳跃,VERB,B2
+balance sheet,balance sheet,资产负债表,NOUN,B2
+filming,filming,拍摄,NOUN,B2
+separately,separately,分开地，单独地,ADV,B2
+preponderant,preponderant,占优势的,ADJ,B2
+pretentious,pretentious,自命不凡的,ADJ,B2
+hike,hike,徒步旅行,NOUN,B2
+potentially,potentially,潜在地,ADV,B2
+straw,straw,稻草,NOUN,B2
+acoustic,acoustic,声学的,ADJ,B2
+naturally,naturally,自然地,ADV,B2
+know-how,know-how,诀窍,NOUN,B2
+to behead,to behead,斩首,VERB,B2
+to cuddle,to cuddle,拥抱,VERB,B2
+to chastise,to chastise,严惩,VERB,B2
+to decry,to decry,谴责,VERB,B2
+precarious,precarious,不稳定的,ADJ,B2
+flesh,flesh,肉,NOUN,B2
+lubricity,lubricity,好色 / 淫荡,NOUN,B2
+talented,talented,有才华的,ADJ,B2
+apocalyptic,apocalyptic,启示录的,ADJ,B2
+to disjoin,to disjoin,分离,VERB,B2
+offense,offense,冒犯,NOUN,B2
+rain shower,rain shower,阵雨,NOUN,B2
+peritoneum,peritoneum,腹膜,NOUN,B2
+this,this,这,PRON,B2
+hacking,hacking,黑客行为,NOUN,B2
+layperson,layperson,外行,NOUN,B2
+fulfilled,fulfilled,满足的,ADJ,B2
+awful,awful,糟糕的,ADJ,B2
+to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
+braggadocio,braggadocio,吹牛,NOUN,B2
+tertiary,tertiary,第三的,ADJ,B2
+planning,planning,规划,NOUN,B2
+screenwriter,screenwriter,编剧,NOUN,B2
+to concoct,to concoct,编造,VERB,B2
+to dislodge,to dislodge,逐出,VERB,B2
+to dupe,to dupe,欺骗,VERB,B2
+tenor,tenor,男高音,NOUN,B2
+resonant,resonant,共鸣的,ADJ,B2
+supporting document,supporting document,证明文件,NOUN,B2
+touchy,touchy,易怒的,ADJ,B2
+to dispel,to dispel,消除,VERB,B2
+antiquated,antiquated,过时的,ADJ,B2
+unforeseen,unforeseen,意外的,ADJ,B2
+to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
+occult,occult,神秘的,ADJ,B2
+probable likely,probable likely,可能的,ADJ,B2
+to blush,to blush,脸红,VERB,B2
+to bloom,to bloom,开花,VERB,B2
+to feign,to feign,假装,VERB,B2
+notch,notch,刻痕,NOUN,B2
+summer visitor,summer visitor,暑期游客,NOUN,B2
+subcontracting,subcontracting,分包,NOUN,B2
+volunteering,volunteering,志愿服务,NOUN,B2
+to break into,to break into,撬开,VERB,B2
+spade,spade,铲子,NOUN,B2
+subtlety,subtlety,微妙,NOUN,B2
+abusive,abusive,滥用的,ADJ,B2
+persistence,persistence,坚持,NOUN,B2
+cutting,cutting,切割,NOUN,B2
+revival,revival,复兴,NOUN,B2
+to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
+precocious,precocious,早熟的,ADJ,B2
+regulatory,regulatory,监管的,ADJ,B2
+versatile,versatile,多才多艺的,ADJ,B2
+gently,gently,轻轻地,ADV,B2
+microwave,microwave,微波炉,NOUN,B2
+harsh,harsh,严厉的,ADJ,B2
+to purge,to purge,清除,VERB,B2
+taxable,taxable,应纳税的,ADJ,B2
+flow rate,flow rate,流量,NOUN,B2
+financing funding,financing funding,融资,NOUN,B2
+breakup,breakup,分手,NOUN,B2
+historically,historically,历史上,ADV,B2
+preferable,preferable,更可取的,ADJ,B2
+elation,elation,兴高采烈,NOUN,B2
+to pamper,to pamper,纵容,VERB,B2
+to persecute,to persecute,迫害,VERB,B2
+deeply moving,deeply moving,令人感动的,ADJ,B2
+onomatopoeia,onomatopoeia,拟声词,NOUN,B2
+resumption,resumption,恢复,NOUN,B2
+pusillanimous,pusillanimous,怯懦的,ADJ,B2
+decontamination,decontamination,去污,NOUN,B2
+to launder,to launder,洗钱,VERB,B2
+to concede,to concede,承认,VERB,B2
+perceptibly,perceptibly,明显地,ADV,B2
+closing argument,closing argument,辩护词,NOUN,B2
+sentinel,sentinel,哨兵,NOUN,B2
+precision,precision,精确,NOUN,B2
+parsimonious,parsimonious,吝啬的,ADJ,B2
+quiddity,quiddity,本质,NOUN,B2
+bodywork,bodywork,车身,NOUN,B2
+renunciation,renunciation,放弃,NOUN,B2
+canvas,canvas,帆布,NOUN,B2
+formally,formally,正式地,ADV,B2
+loop,loop,循环,NOUN,B2
+mercenary,mercenary,雇佣兵,NOUN,B2
+angelic,angelic,天使般的,ADJ,B2
+disdainfully,disdainfully,轻蔑地,ADV,B2
+lesion,lesion,病变,NOUN,B2
+residual,residual,残留的,ADJ,B2
+cooking,cooking,烹饪,NOUN,B2
+sorting,sorting,分类,NOUN,B2
+to castigate,to castigate,严厉批评,VERB,B2
+innocuous,innocuous,无害的,ADJ,B2
+perverse,perverse,任性的,ADJ,B2
+dishonest,dishonest,不诚实的,ADJ,B2
+to transcribe,to transcribe,转录,VERB,B2
+posthumous,posthumous,死后的,ADJ,B2
+freely,freely,自由地,ADV,B2
+recreation,recreation,娱乐,NOUN,B2
+oxymoron,oxymoron,矛盾修辞法,NOUN,B2
+redundancy,redundancy,冗余,NOUN,B2
+angular,angular,有角的,ADJ,B2
+sedition,sedition,煽动叛乱,NOUN,B2
+to warp,to warp,弯曲,VERB,B2
+pickaxe,pickaxe,镐；锄,NOUN,B2
+notably,notably,显著地,ADV,B2
+semolina,semolina,粗面粉,NOUN,B2
+antecedent,antecedent,先行词,NOUN,B2
+acclimatization,acclimatization,适应环境,NOUN,B2
+probity,probity,正直,NOUN,B2
+sensual,sensual,感官的,ADJ,B2
+malevolence,malevolence,恶意,NOUN,B2
+theologian,theologian,神学家,NOUN,B2
+remote work,remote work,远程办公,NOUN,B2
+specious,specious,似是而非的,ADJ,B2
+drawback,drawback,缺点,NOUN,B2
+to conform,to conform,符合,VERB,B2
+to confer,to confer,授予,VERB,B2
+to strip bare,to strip bare,洗劫,VERB,B2
+practicing believer,practicing believer,信徒,NOUN,B2
+to make bland,to make bland,使乏味,VERB,B2
+pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
+peroration,peroration,结语,NOUN,B2
+indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+food-processing,food-processing,食品加工的,ADJ,B2
+parataxis,parataxis,意合,NOUN,B2
+to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
+hostess,hostess,女服务员,NOUN,B2
+obstetrics,obstetrics,产科学,NOUN,B2
+wrongdoer,wrongdoer,罪犯,NOUN,B2
+to pour out,to pour out,倾诉,VERB,B2
+guru,guru,精神导师,NOUN,B2
+freshly,freshly,新鲜地,ADV,B2
+perfidy,perfidy,背信弃义,NOUN,B2
+cordially,cordially,亲切地,ADV,B2
+street interview,street interview,街头采访,NOUN,B2
+manually,manually,手动地,ADV,B2
+slang,slang,俚语,NOUN,B2
+eight-line stanza,eight-line stanza,八行诗,NOUN,B2
+diagonal,diagonal,对角线,NOUN,B2
+customs officer,customs officer,海关官员,NOUN,B2
+depressive,depressive,抑郁的，压抑的,ADJ,B2
+lawnmower,lawnmower,割草机,NOUN,B2
+proportional,proportional,成比例的,ADJ,B2
+picking,picking,采摘,NOUN,B2
+airfield,airfield,飞机场,NOUN,B2
+apodictic,apodictic,确证的,ADJ,B2
+indirectly,indirectly,间接地,ADV,B2
+to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
+to fall to,to fall to,落到...身上,VERB,B2
+magnesium,magnesium,镁,NOUN,B2
+quashing,quashing,撤销,NOUN,B2
+recruiter,recruiter,招聘人员,NOUN,B2
+toad,toad,蟾蜍,NOUN,B2
+sovereigntist,sovereigntist,主权主义者,NOUN,B2
+clumsiness,clumsiness,笨拙,NOUN,B2
+media library,media library,多媒体图书馆,NOUN,B2
+caterpillar,caterpillar,毛毛虫,NOUN,B2
+sincerely,sincerely,真诚地,ADV,B2
+to move to pity,to move to pity,使怜悯,VERB,B2
+typology,typology,类型学,NOUN,B2
+heatwave,heatwave,热浪,NOUN,B2
+stressful,stressful,有压力的,ADJ,B2
+unofficially,unofficially,非正式地,ADV,B2
+to chill,to chill,使冰冻,VERB,B2
+triangular,triangular,三角形的,ADJ,B2
+pitchfork,pitchfork,叉子,NOUN,B2
+french-speaking,french-speaking,讲法语的,ADJ,B2
+symptomatology,symptomatology,症状学,NOUN,B2
+dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
+to raise awareness,to raise awareness,提高意识,VERB,B2
+about sixty,about sixty,六十来个,NOUN,B2
+indiscriminately,indiscriminately,不加区别地,ADV,B2
+the blues,the blues,忧郁,NOUN,B2
+legatee,legatee,受遗赠人,NOUN,B2
+to resell,to resell,转售,VERB,B2
+juvenile,juvenile,青少年的,ADJ,B2
+consecutive,consecutive,连续的,ADJ,B2
+penal,penal,刑事的,ADJ,B2
+pamphleteer,pamphleteer,小册子作者,NOUN,B2
+segregation,segregation,隔离，分离,NOUN,B2
+moralism,moralism,道德主义,NOUN,B2
+sexism,sexism,性别歧视,NOUN,B2
+case law,case law,判例法,NOUN,B2
+to nuance,to nuance,使具有细微差别,VERB,B2
+setting sun,setting sun,夕阳,NOUN,B2
+to subsist,to subsist,存在,VERB,B2
+coastal,coastal,沿海的,ADJ,B2
+lukewarm,lukewarm,微温的,ADJ,B2
+marrow,marrow,骨髓,NOUN,B2
+bistro,bistro,小酒馆,NOUN,B2
+untouchable,untouchable,不可触碰的,ADJ,B2
+alternatively,alternatively,交替地,ADV,B2
+stage fright,stage fright,怯场,NOUN,B2
+socialist,socialist,社会主义者,NOUN,B2
+obsequiousness,obsequiousness,谄媚,NOUN,B2
+heartening,heartening,令人高兴的,ADJ,B2
+roman,roman,罗马的,ADJ,B2
+heroically,heroically,英勇地,ADV,B2
+flint,flint,燧石,NOUN,B2
+delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
+to maltreat,to maltreat,虐待,VERB,B2
+obsequiously,obsequiously,谄媚地,ADV,B2
+telephony,telephony,电话学,NOUN,B2
+food,food,食品的,ADJ,B2
+carcass,carcass,骨架,NOUN,B2
+faithful loyal,faithful loyal,忠诚的,ADJ,B2
+symphonic,symphonic,交响乐的,ADJ,B2
+undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+treat,treat,盛宴,NOUN,B2
+generational,generational,代际的,ADJ,B2
+alpine,alpine,高山的,ADJ,B2
+servilely,servilely,奴性地,ADV,B2
+checkbook,checkbook,支票簿,NOUN,B2
+productive,productive,多产的,ADJ,B2
+tv viewer,tv viewer,电视观众,NOUN,B2
+release of lien,release of lien,解除扣押,NOUN,B2
+asphyxia,asphyxia,窒息,NOUN,B2
+registered mail,registered mail,挂号信,NOUN,B2
+to push to grow,to push to grow,推/生长,VERB,B2
+a lot,a lot,很多,ADV,B2
+populist,populist,民粹主义者,NOUN,B2
+rapper,rapper,说唱歌手,NOUN,B2
+greek,greek,希腊的,ADJ,B2
+marshal,marshal,元帅,NOUN,B2
+purely,purely,纯粹地,ADV,B2
+currant,currant,醋栗,NOUN,B2
+anarchist,anarchist,无政府主义者,NOUN,B2
+manifestly,manifestly,明显地,ADV,B2
+irregular,irregular,不规则的,ADJ,B2
+jurisconsult,jurisconsult,法学专家,NOUN,B2
+lymph node,lymph node,淋巴结,NOUN,B2
+litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
+worrying,worrying,令人担忧的,ADJ,B2
+to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
+oyster,oyster,牡蛎,NOUN,B2
+underground,underground,地下的,ADJ,B2
+retiree,retiree,退休人员,NOUN,B2
+reproducibility,reproducibility,可重复性,NOUN,B2
+agitated,agitated,焦躁的,ADJ,B2
+nationalist,nationalist,民族主义者,NOUN,B2
+fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+productivist,productivist,生产至上主义的,ADJ,B2
+pictorial,pictorial,绘画的,ADJ,B2
+to taint,to taint,玷污,VERB,B2
+fingernail,fingernail,指甲,NOUN,B2
+marginally,marginally,边缘地,ADV,B2
+biologist,biologist,生物学家,NOUN,B2
+polysyndeton,polysyndeton,连词叠用,NOUN,B2
+recourse,recourse,求助,NOUN,B2
+subject to the law,subject to the law,受法律管辖的,ADJ,B2
+deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
+remains spoils,remains spoils,遗体，战利品,NOUN,B2
+to mark out,to mark out,标示,VERB,B2
+sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
+geriatrics,geriatrics,老年医学,NOUN,B2
+playable,playable,可演奏的,ADJ,B2
+to commune,to commune,交融,VERB,B2
+hyperthermia,hyperthermia,体温过高,NOUN,B2
+to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
+preterition,preterition,假托,NOUN,B2
+nitrogen,nitrogen,氮,NOUN,B2
+preacher,preacher,传教士,NOUN,B2
+about thirty,about thirty,三十左右,NOUN,B2
+to spout,to spout,喷射,VERB,B2
+traumatic,traumatic,创伤的,ADJ,B2
+several,several,若干,NOUN,B2
+parable,parable,寓言,NOUN,B2
+to stem from,to stem from,源于,VERB,B2
+priority,priority,优先的,ADJ,B2
+to tip over,to tip over,翻倒,VERB,B2
+foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
+be tender,be tender,温柔的,ADJ,B2
+fistula,fistula,瘘管,NOUN,B2
+to catch sight of,to catch sight of,瞥见,VERB,B2
+artificially,artificially,人为地,ADV,B2
+forfeiture,forfeiture,丧失,NOUN,B2
+recruit,recruit,新兵,NOUN,B2
+genetically,genetically,遗传地,ADV,B2
+scouting locating,scouting locating,定位 / 侦察,NOUN,B2
+subsidiarity,subsidiarity,辅助性原则,NOUN,B2
+dish towel,dish towel,抹布,NOUN,B2
+co-ownership,co-ownership,共有产权,NOUN,B2
+momentarily,momentarily,暂时地,ADV,B2
+to rediscover,to rediscover,重新发现,VERB,B2
+paralogism,paralogism,谬误推理,NOUN,B2
+cyst,cyst,囊肿,NOUN,B2
+resection,resection,切除术,NOUN,B2
+patently,patently,显然地,ADV,B2
+ticket window,ticket window,售票窗口,NOUN,B2
+to weary to tire,to weary to tire,使厌倦,VERB,B2
+tuberculosis,tuberculosis,结核病,NOUN,B2
+overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
+blender,blender,搅拌机,NOUN,B2
+degenerative,degenerative,退化的,ADJ,B2
+fresco,fresco,壁画,NOUN,B2
+receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
+on upon,on upon,在...上,ADP,B2
+to unhook,to unhook,摘下,VERB,B2
+footage,footage,镜头长度,NOUN,B2
+droppings,droppings,粪便,NOUN,B2
+computer specialist,computer specialist,计算机专家,NOUN,B2
+cruelly,cruelly,残酷地,ADV,B2
+progressive,progressive,进步人士,NOUN,B2
+selectively,selectively,有选择地,ADV,B2
+lily,lily,百合,NOUN,B2
+illuminator,illuminator,彩饰画家,NOUN,B2
+acronym,acronym,首字母缩略词,NOUN,B2
+similarly,similarly,同样地,ADV,B2
+bedsheet,bedsheet,床单,NOUN,B2
+surplus,surplus,过剩的,ADJ,B2
+to mast,to mast,降伏,VERB,B2
+to drive lead,to drive lead,驾驶,VERB,B2
+fishing,fishing,钓鱼,NOUN,B2
+lucky find,lucky find,意外发现,NOUN,B2
+cross-border,cross-border,边境的,ADJ,B2
+community-related,community-related,社区的,ADJ,B2
+dynamism,dynamism,活力,NOUN,B2
+great-grandfather,great-grandfather,曾祖父,NOUN,B2
+supportive,supportive,团结的,ADJ,B2
+tarragon,tarragon,龙蒿,NOUN,B2
+regeneration,regeneration,再生,NOUN,B2
+scales,scales,秤,NOUN,B2
+trilemma,trilemma,三难困境,NOUN,B2
+indebted,indebted,负债的,ADJ,B2
+skating,skating,滑冰,NOUN,B2
+malaria,malaria,疟疾,NOUN,B2
+boastfulness,boastfulness,吹嘘,NOUN,B2
+anagram,anagram,字谜游戏,NOUN,B2
+cinematographic,cinematographic,电影的,ADJ,B2
+fake news,fake news,假新闻,NOUN,B2
+derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
+hematoma,hematoma,血肿,NOUN,B2
+malefic,malefic,邪恶的,ADJ,B2
+enslavement,enslavement,奴役,NOUN,B2
+chauvinism,chauvinism,沙文主义,NOUN,B2
+striped,striped,有条纹的,ADJ,B2
+oligopoly,oligopoly,寡头垄断,NOUN,B2
+breathing,breathing,呼吸,NOUN,B2
+laundering,laundering,洗钱,NOUN,B2
+systematically,systematically,系统地,ADV,B2
+accordion,accordion,手风琴,NOUN,B2
+naturalization,naturalization,入籍,NOUN,B2
+to postpone to carry over,to postpone to carry over,推迟,VERB,B2
+suburbs,suburbs,郊区,NOUN,B2
+ignominy,ignominy,耻辱,NOUN,B2
+neuron,neuron,神经元,NOUN,B2
+psalm,psalm,诗篇,NOUN,B2
+signatory,signatory,签署者,NOUN,B2
+solicitude,solicitude,关怀,NOUN,B2
+teratogenic,teratogenic,致畸的,ADJ,B2
+radically,radically,彻底地,ADV,B2
+masculine,masculine,男性的,ADJ,B2
+to join to adhere,to join to adhere,加入 / 附着,VERB,B2
+ravine,ravine,沟壑,NOUN,B2
+barracks,barracks,兵营,NOUN,B2
+distinctly,distinctly,清楚地,ADV,B2
+presumed,presumed,推定的,ADJ,B2
+to dry up,to dry up,使干枯,VERB,B2
+breach of duty,breach of duty,渎职,NOUN,B2
+occultism,occultism,神秘学,NOUN,B2
+peri-urban,peri-urban,城市周边的,ADJ,B2
+eddy,eddy,漩涡,NOUN,B2
+accused person,accused person,被告,NOUN,B2
+punctuality,punctuality,守时,NOUN,B2
+impostor,impostor,骗子,NOUN,B2
+asyndeton,asyndeton,连词省略,NOUN,B2
+saucepan,saucepan,平底锅,NOUN,B2
+current events,current events,时事,NOUN,B2
+rerun,rerun,重播,NOUN,B2
+laconism,laconism,简洁,NOUN,B2
+shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
+to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
+about fifty,about fifty,五十左右,NOUN,B2
+herbal tea,herbal tea,花草茶,NOUN,B2
+to point to clock in,to point to clock in,指 / 打卡,VERB,B2
+capping,capping,封顶,NOUN,B2
+to incarcerate,to incarcerate,监禁,VERB,B2
+paintbrush,paintbrush,画笔；毛笔,NOUN,B2
+magnetic,magnetic,磁的,ADJ,B2
+clandestinity,clandestinity,秘密状态,NOUN,B2
+beatitude,beatitude,至福,NOUN,B2
+clumsily,clumsily,笨拙地,ADV,B2
+to inflict to impose,to inflict to impose,施加,VERB,B2
+amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
+amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
+small boat,small boat,小船,NOUN,B2
+ok,ok,好的,INTJ,B2
+sophist,sophist,诡辩家,NOUN,B2
+measured,measured,克制的,ADJ,B2
+deeply profoundly,deeply profoundly,深刻地,ADV,B2
+ticket validation,ticket validation,检票,NOUN,B2
+divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
+cosmology,cosmology,宇宙学,NOUN,B2
+funerary,funerary,丧葬的,ADJ,B2
+to unbend,to unbend,润滑,VERB,B2
+bookstore,bookstore,书店,NOUN,B2
+to unblind,to unblind,使醒悟,VERB,B2
+coin purse,coin purse,零钱包,NOUN,B2
+buyer purchaser,buyer purchaser,买方,NOUN,B2
+succinctly,succinctly,简洁地,ADV,B2
+striking,striking,惊人的,ADJ,B2
+activism,activism,激进主义,NOUN,B2
+cider,cider,苹果酒,NOUN,B2
+portion serving,portion serving,部分 / 一份,NOUN,B2
+each one,each one,每人,PRON,B2
+to scare away,to scare away,惊飞,VERB,B2
+duct pipe,duct pipe,管道,NOUN,B2
+continually,continually,不断地,ADV,B2
+award auction,award auction,裁定 / 拍卖,NOUN,B2
+initial,initial,花押字,NOUN,B2
+time clock,time clock,打卡机,NOUN,B2
+legislature,legislature,立法机关,NOUN,B2
+flowering,flowering,开花,NOUN,B2
+quantum,quantum,量子的,ADJ,B2
+stationery shop,stationery shop,文具店,NOUN,B2
+exceptionally,exceptionally,例外地,ADV,B2
+fed up,fed up,受够了,NOUN,B2
+pleonasm,pleonasm,赘述,NOUN,B2
+opportunity used,opportunity used,机会,NOUN,B2
+patronage,patronage,赞助,NOUN,B2
+laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
+millionaire,millionaire,百万富翁,NOUN,B2
+obese,obese,肥胖的,ADJ,B2
+flat rate,flat rate,包干费,NOUN,B2
+amicable out-of-court,amicable out-of-court,友好的 / 庭外和解的,ADJ,B2
+to ogle,to ogle,窥视,VERB,B2
+accessory,accessory,配件,NOUN,B2
+to flame,to flame,燃烧,VERB,B2
+achievable,achievable,可实现的,ADJ,B2
+trilogy,trilogy,三部曲,NOUN,B2
+egg-laying,egg-laying,产卵,NOUN,B2
+allegiance,allegiance,忠诚,NOUN,B2
+refutable,refutable,可反驳的,ADJ,B2
+ore,ore,矿石,NOUN,B2
+syneresis,syneresis,元音合并,NOUN,B2
+beneficial,beneficial,有益的,ADJ,B2
+to contest,to contest,质疑,VERB,B2
+impassively,impassively,无动于衷地,ADV,B2
+comorbidity,comorbidity,共病,NOUN,B2
+exoteric,exoteric,外传的,ADJ,B2
+boarder,boarder,寄宿生,NOUN,B2
+thermodynamics,thermodynamics,热力学,NOUN,B2
+vacuum cleaner,vacuum cleaner,吸尘器,NOUN,B2
+senescence,senescence,衰老,NOUN,B2
+to hang hook,to hang hook,悬挂/钩住,VERB,B2
+endemic disease,endemic disease,地方病,NOUN,B2
+malicious,malicious,恶意的,ADJ,B2
+to revalue,to revalue,重新估值,VERB,B2
+closer,closer,更近的,ADJ,B2
+conspiratorial,conspiratorial,阴谋的,ADJ,B2
+guidance,guidance,指导,NOUN,B2
+benignity,benignity,良性,NOUN,B2
+class struggle,class struggle,阶级斗争,NOUN,B2
+desirability,desirability,可取性,NOUN,B2
+liberalize,liberalize,自由化,! VERB,B2
+group mentality,group mentality,群体心态,NOUN,B2
+member of parliament,member of parliament,议员,NOUN,B2
+grammaticality,grammaticality,合语法性,NOUN,B2
+alienating,alienating,使人疏远的,ADJ,B2
+avoidable,avoidable,可避免的,ADJ,B2
+criminal law,criminal law,刑法,NOUN,B2
+group solidarity,group solidarity,群体团结,NOUN,B2
+surgical,surgical,外科的,ADJ,B2
+to solder,to solder,焊接,VERB,B2
+irish,irish,爱尔兰的,ADJ,B2
+universities,universities,大学,NOUN,B2
+entranced,entranced,痴迷的,ADJ,B2
+aghast,aghast,惊骇的,ADJ,B2
+diction,diction,措辞,NOUN,B2
+to technologize,to technologize,技术化,VERB,B2
+gallows humor,gallows humor,绞刑架幽默,NOUN,B2
+cycle path,cycle path,自行车道,NOUN,B2
+misplaced,misplaced,不合时宜的,ADJ,B2
+presidential election,presidential election,总统选举,NOUN,B2
+marginal,marginal,边缘的,ADJ,B2
+place of residence,place of residence,居住地,NOUN,B2
+to pauperize,to pauperize,使贫困,VERB,B2
+healing power,healing power,疗效,NOUN,B2
+to draw water,to draw water,打水,VERB,B2
+cohort-based,cohort-based,队列的,ADJ,B2
+publicity,publicity,宣传,NOUN,B2
+to walk around,to walk around,四处走动,VERB,B2
+spiritual,spiritual,精神的,ADJ,B2
+towards,towards,迎向,ADV,B2
+physiotherapy,physiotherapy,物理治疗,NOUN,B2
+founding,founding,成立,NOUN,B2
+family reunification,family reunification,家庭团聚,NOUN,B2
+to validate,to validate,验证,VERB,B2
+unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
+exemplary country,exemplary country,模范国家,NOUN,B2
+consolidating,consolidating,巩固的,ADJ,B2
+eclecticism,eclecticism,折衷主义,NOUN,B2
+statistic,statistic,统计数据,NOUN,B2
+hazard report,hazard report,危险报告,NOUN,B2
+dentition,dentition,牙齿,NOUN,B2
+front line,front line,前线,NOUN,B2
+conference-based,conference-based,会议的,ADJ,B2
+court case,court case,诉讼,NOUN,B2
+plucky,plucky,勇敢的,ADJ,B2
+two-dimensional,two-dimensional,二维的,ADJ,B2
+purifying,purifying,净化的,ADJ,B2
+to be correct,to be correct,正确,VERB,B2
+to rehabilitate,to rehabilitate,使康复,VERB,B2
+factual,factual,事实的,ADJ,B2
+sighing,sighing,叹息的,ADJ,B2
+to tune,to tune,调谐,VERB,B2
+collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
+little brother,little brother,小弟弟,NOUN,B2
+one-way traffic,one-way traffic,单向通行,NOUN,B2
+national anthem,national anthem,国歌,NOUN,B2
+to replicate,to replicate,复制,VERB,B2
+to catalyze,to catalyze,催化,VERB,B2
+nauseous,nauseous,恶心的,ADJ,B2
+to modulate,to modulate,调节,VERB,B2
+cult,cult,邪教,NOUN,B2
+grave desecration,grave desecration,亵渎坟墓,NOUN,B2
+effortless,effortless,不费力的,ADJ,B2
+worth mentioning,worth mentioning,值得一提的,ADJ,B2
+to settle up,to settle up,结账,VERB,B2
+portuguese,portuguese,葡萄牙语,NOUN,B2
+meaningful,meaningful,有意义的,ADJ,B2
+moreover,moreover,而且,CCONJ,B2
+contested,contested,有争议的,ADJ,B2
+to instrumentalize,to instrumentalize,工具化,VERB,B2
+labor market,labor market,劳动力市场,NOUN,B2
+to lug,to lug,搬运,VERB,B2
+convertible,convertible,可兑换的,ADJ,B2
+upwards,upwards,向上,ADV,B2
+altruistic,altruistic,利他的,ADJ,B2
+hence,hence,因此,ADV,B2
+new construction,new construction,新建建筑,NOUN,B2
+jaded,jaded,厌倦的,ADJ,B2
+dominance,dominance,威权,NOUN,B2
+immanence,immanence,内在性,NOUN,B2
+well-groomed,well-groomed,整洁的,ADJ,B2
+hassle,hassle,麻烦,NOUN,B2
+to text,to text,发短信,VERB,B2
+headscarf,headscarf,头巾,NOUN,B2
+courageous,courageous,勇敢的,ADJ,B2
+posh,posh,上流的,ADJ,B2
+daft,daft,傻的,ADJ,B2
+abolition,abolition,废除,NOUN,B2
+knowledge transfer,knowledge transfer,知识传授,NOUN,B2
+merger,merger,合并,NOUN,B2
+to stick out,to stick out,伸出,VERB,B2
+emaciating,emaciating,消耗的,ADJ,B2
+bisexual,bisexual,双性恋的,ADJ,B2
+with this,with this,以此,ADV,B2
+to decentralize,to decentralize,去中心化,VERB,B2
+contact person,contact person,联系人,NOUN,B2
+connecting,connecting,连接的,ADJ,B2
+proliferate,proliferate,扩散,! VERB,B2
+milky,milky,乳白色的,ADJ,B2
+to rent out,to rent out,出租,VERB,B2
+to retort,to retort,反驳,VERB,B2
+variation,variation,变化,NOUN,B2
+april,april,四月,NOUN,B2
+mysticism,mysticism,神秘主义,NOUN,B2
+humanities,humanities,人文学科,NOUN,B2
+power station,power station,发电厂,NOUN,B2
+bit,bit,一点,NOUN,B2
+peddler,peddler,小贩,NOUN,B2
+broadening,broadening,拓宽,NOUN,B2
+this evening,this evening,今晚,ADV,B2
+pregnant woman,pregnant woman,孕妇,NOUN,B2
+rest assured,rest assured,放心的,ADJ,B2
+to tax to burden,to tax to burden,征税,VERB,B2
+radius,radius,半径,NOUN,B2
+decibel,decibel,分贝,NOUN,B2
+small gift,small gift,小礼物,NOUN,B2
+museum piece,museum piece,博物馆藏品,NOUN,B2
+florid,florid,辞藻华丽的,ADJ,B2
+crisis situation,crisis situation,危机局势,NOUN,B2
+to ostracize,to ostracize,排斥,VERB,B2
+dislike,dislike,厌恶,NOUN,B2
+syrian,syrian,叙利亚的,ADJ,B2
+to scan,to scan,扫描,VERB,B2
+worldly,worldly,世俗的,ADJ,B2
+contentious,contentious,有争议的,ADJ,B2
+communautarization,communautarization,社群化,NOUN,B2
+connotative,connotative,内涵的,ADJ,B2
+to spam,to spam,发垃圾信息,VERB,B2
+macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+at the back,at the back,在后面,ADV,B2
+neighbour,neighbour,邻居,NOUN,B2
+schoolboy,schoolboy,学生,NOUN,B2
+to sublimate,to sublimate,升华,VERB,B2
+for this,for this,为此,ADV,B2
+witness examination,witness examination,证人询问,NOUN,B2
+climate denial,climate denial,气候否认,NOUN,B2
+turbulent,turbulent,动荡的,ADJ,B2
+to sensitize,to sensitize,提高意识,VERB,B2
+microscopic,microscopic,微观的,ADJ,B2
+toothless,toothless,无齿的,ADJ,B2
+to telework,to telework,远程办公,VERB,B2
+venereal disease,venereal disease,性病,NOUN,B2
+to persevere,to persevere,坚持,VERB,B2
+to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
+heath,heath,石楠荒原,NOUN,B2
+guilder,guilder,盾,NOUN,B2
+financier,financier,资助者,NOUN,B2
+filipino,filipino,菲律宾的,ADJ,B2
+to agitate,to agitate,鼓动,VERB,B2
+multipart,multipart,多部分的,ADJ,B2
+all-round,all-round,全面的,ADJ,B2
+her,her,她的,DET,B2
+vacuum,vacuum,真空的,ADJ,B2
+newsletter,newsletter,简报,NOUN,B2
+whisk,whisk,打蛋器,NOUN,B2
+very hard,very hard,极硬的,ADJ,B2
+to regionalize,to regionalize,区域化,VERB,B2
+suspended,suspended,悬浮的,ADJ,B2
+to plagiarize,to plagiarize,剽窃,VERB,B2
+axiomatic,axiomatic,公理的,ADJ,B2
+antisocial,antisocial,反社会的,ADJ,B2
+transition,transition,过渡,NOUN,B2
+to drop off,to drop off,放下,VERB,B2
+such a,such a,这样的,DET,B2
+noise nuisance,noise nuisance,噪音扰民,NOUN,B2
+amicable,amicable,友好的,ADJ,B2
+fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
+vs,vs,与...相对,ADP,B2
+mayoral,mayoral,市长的,ADJ,B2
+health policy,health policy,健康政策,NOUN,B2
+inheritance law,inheritance law,继承法,NOUN,B2
+bent,bent,弯的,ADJ,B2
+inventorying,inventorying,清点,NOUN,B2
+religious war,religious war,宗教战争,NOUN,B2
+to immunize,to immunize,免疫,VERB,B2
+analytical,analytical,分析的,ADJ,B2
+to invoice,to invoice,开票,VERB,B2
+life-size,life-size,真人大小的,ADJ,B2
+bilateral,bilateral,双边的,ADJ,B2
+little sun,little sun,小太阳,NOUN,B2
+collectomania,collectomania,收藏癖,NOUN,B2
+workable,workable,可加工的,ADJ,B2
+composable,composable,可组合的,ADJ,B2
+disco,disco,迪厅,NOUN,B2
+laptop,laptop,笔记本电脑,NOUN,B2
+legation,legation,公使馆,NOUN,B2
+group norm,group norm,群体规范,NOUN,B2
+inflexibility,inflexibility,僵化,NOUN,B2
+to enrol,to enrol,注册,VERB,B2
+insightfulness,insightfulness,洞察,NOUN,B2
+catastrophic,catastrophic,灾难性的,ADJ,B2
+to industrialize,to industrialize,工业化,VERB,B2
+fossil fuel,fossil fuel,化石燃料,NOUN,B2
+megalomanic,megalomanic,狂妄自大的,ADJ,B2
+contractual,contractual,合同的,ADJ,B2
+school year,school year,学年,NOUN,B2
+to persist,to persist,坚持,VERB,B2
+postal code,postal code,邮政编码,NOUN,B2
+property right,property right,所有权,NOUN,B2
+customer service,customer service,客户服务,NOUN,B2
+aloud,aloud,出声地,ADV,B2
+court fee,court fee,诉讼费,NOUN,B2
+globalization process,globalization process,全球化进程,NOUN,B2
+film star,film star,,NOUN,B2
+memorable,memorable,难忘的,ADJ,B2
+factionalism,factionalism,派系主义,NOUN,B2
+austrian,austrian,奥地利的,ADJ,B2
+family composition,family composition,家庭构成,NOUN,B2
+frictionless,frictionless,无摩擦的,ADJ,B2
+off,off,关,ADP,B2
+fatty,fatty,脂肪的,ADJ,B2
+ceremonial,ceremonial,仪式的,ADJ,B2
+ice cold,ice cold,冰冷的,ADJ,B2
+heated,heated,激昂的,ADJ,B2
+constitutive,constitutive,构成的,ADJ,B2
+character assassination,character assassination,人格谋杀,NOUN,B2
+meek,meek,温顺的,ADJ,B2
+contaminating,contaminating,污染的,ADJ,B2
+conversional,conversional,转换的,ADJ,B2
+federalization,federalization,联邦化,NOUN,B2
+gravitational,gravitational,引力的,ADJ,B2
+amusement,amusement,娱乐,NOUN,B2
+paralysed,paralysed,瘫痪的,ADJ,B2
+energy crisis,energy crisis,能源危机,NOUN,B2
+search engine,search engine,搜索引擎,NOUN,B2
+parliamentary elections,parliamentary elections,议会选举,NOUN,B2
+petrol,petrol,汽油,NOUN,B2
+final score,final score,最终比分,NOUN,B2
+holism,holism,整体论,NOUN,B2
+from which,from which,从中,ADV,B2
+family tension,family tension,家庭紧张,NOUN,B2
+drinking water,drinking water,饮用水,NOUN,B2
+state of mind,state of mind,精神状态,NOUN,B2
+destined,destined,,NOUN,B2
+tens of thousands,tens of thousands,数万,NUM,B2
+licentious,licentious,放荡的,ADJ,B2
+visible,visible,可见的,ADJ,B2
+few,few,几下,NOUN,B2
+schooled person,schooled person,受过培训者,NOUN,B2
+swiss,swiss,瑞士的,ADJ,B2
+to polarize,to polarize,使两极分化,VERB,B2
+atheistic,atheistic,无神论的,ADJ,B2
+accountable,accountable,负责任的,ADJ,B2
+guideline,guideline,指导方针,NOUN,B2
+native american,native american,印第安人,NOUN,B2
+provisional,provisional,临时的,ADJ,B2
+lacunary,lacunary,残缺的,ADJ,B2
+to hold accountable,to hold accountable,问责,VERB,B2
+utility,utility,效用,NOUN,B2
+data processing,data processing,数据处理,NOUN,B2
+irrelevance,irrelevance,无关,NOUN,B2
+to repel,to repel,击退,VERB,B2
+one and a half,one and a half,一个半,NUM,B2
+loyalty to authority,loyalty to authority,服从权威,NOUN,B2
+associated,associated,相关的,ADJ,B2
+southwest,southwest,西南的,ADJ,B2
+emotional expression,emotional expression,! 情感表达,NOUN,B2
+commencement,commencement,开始,NOUN,B2
+to propagate,to propagate,传播,VERB,B2
+religious strife,religious strife,宗教纷争,NOUN,B2
+heartfelt,heartfelt,衷心的,ADJ,B2
+trivializable,trivializable,可轻描淡写的,ADJ,B2
+bombardment,bombardment,轰炸,NOUN,B2
+to mystify,to mystify,神秘化,VERB,B2
+dutchman,dutchman,荷兰人,NOUN,B2
+bicycle repairer,bicycle repairer,修车匠,NOUN,B2
+to,to,去,PART,B2
+egocentrism,egocentrism,自我中心,NOUN,B2
+palestinian,palestinian,巴勒斯坦的,ADJ,B2
+toys,toys,玩具,NOUN,B2
+endowed,endowed,有天赋的,ADJ,B2
+hungarian,hungarian,匈牙利的,ADJ,B2
+expertise center,expertise center,专业中心,NOUN,B2
+sympathetic,sympathetic,同情的,ADJ,B2
+run-up,run-up,助跑,NOUN,B2
+to aggravate,to aggravate,加重,VERB,B2
+manual,manual,手工的,ADJ,B2
+flemish,flemish,佛兰芒的,ADJ,B2
+toothbrush,toothbrush,牙刷,NOUN,B2
+to emigrate,to emigrate,移居国外,VERB,B2
+email address,email address,电子邮件地址,NOUN,B2
+the one,the one,,NOUN,B2
+grand officer,grand officer,大官,NOUN,B2
+ukrainian,ukrainian,乌克兰的,ADJ,B2
+border arrangement,border arrangement,边境安排,NOUN,B2
+metamorphic,metamorphic,变质的,ADJ,B2
+to localize,to localize,本地化,VERB,B2
+undermining authority,undermining authority,削弱权威,NOUN,B2
+group individual,group individual,群体个体,NOUN,B2
+brazilian,brazilian,巴西的,ADJ,B2
+nuts,nuts,疯狂的,ADJ,B2
+coloredness,coloredness,有色性,NOUN,B2
+berlijns,berlijns,柏林的,ADJ,B2
+judgement,judgement,评估,NOUN,B2
+manipulable,manipulable,可操纵的,ADJ,B2
+depicted,depicted,描绘的,ADJ,B2
+many,many,许多,DET,B2
+cosmetics,cosmetics,化妆品,NOUN,B2
+diplomatic relations,diplomatic relations,外交关系,NOUN,B2
+to pucker,to pucker,噘,VERB,B2
+how come,how come,怎么会,INTJ,B2
+structuredness,structuredness,结构性,NOUN,B2
+to break off,to break off,中断,VERB,B2
+to tidy,to tidy,整理,VERB,B2
+habitlessness,habitlessness,无习惯,NOUN,B2
+increasing,increasing,增加的,ADJ,B2
+south african,south african,南非的,ADJ,B2
+your,your,你的,PRON,B2
+folksy,folksy,乡土的,ADJ,B2
+redrawing,redrawing,重新绘制,NOUN,B2
+largely,largely,主要地,ADV,B2
+to contextualize,to contextualize,置于语境,VERB,B2
+editor-in-chief,editor-in-chief,主编,NOUN,B2
+documentation,documentation,文献,NOUN,B2
+outside,outside,在外面,ADP,B2
+traditional costume,traditional costume,传统服饰,NOUN,B2
+special offer,special offer,特价,NOUN,B2
+balancing,balancing,平衡的,ADJ,B2
+dispirited,dispirited,沮丧的,ADJ,B2
+potential,potential,潜在的,ADJ,B2
+ourselves,ourselves,我们自己,PRON,B2
+explanatory,explanatory,解释的,ADJ,B2
+source citation,source citation,出处注明,NOUN,B2
+vice versa,vice versa,反之亦然,ADJ,B2
+bleeding,bleeding,流血的,ADJ,B2
+children's rights,children's rights,儿童权利,NOUN,B2
+arabic,arabic,阿拉伯的,ADJ,B2
+demotion,demotion,降职,NOUN,B2
+to revolutionize,to revolutionize,革命化,VERB,B2
+with that,with that,以此,ADV,B2
+parish priest,parish priest,本堂神父,NOUN,B2
+tram,tram,有轨电车,NOUN,B2
+for a moment,for a moment,片刻,ADV,B2
+provable,provable,可证明的,ADJ,B2
+some,some,一些,PRON,B2
+owed,owed,欠下的,ADJ,B2
+midfielder,midfielder,中场球员,NOUN,B2
+solar panel,solar panel,太阳能电池板,NOUN,B2
+church community,church community,教会,NOUN,B2
+liberating,liberating,解放的,ADJ,B2
+healthcare,healthcare,医疗保健,NOUN,B2
+figuration,figuration,群演,NOUN,B2
+inactivity,inactivity,不活跃,NOUN,B2
+by means of,by means of,凭借,NOUN,B2
+in the back,in the back,在后面,ADV,B2
+series of conversations,series of conversations,系列对话,NOUN,B2
+day after tomorrow,day after tomorrow,后天,NOUN,B2
+plenty,plenty,充足地,ADV,B2
+myself,myself,我自己,PRON,B2
+disharmony,disharmony,不和谐,NOUN,B2
+barbarization,barbarization,野蛮化,NOUN,B2
+land policy,land policy,土地政策,NOUN,B2
+governable,governable,可管理的,ADJ,B2
+just like that,just like that,随便地,ADV,B2
+paving,paving,铺路,NOUN,B2
+fabulist,fabulist,幻想家,NOUN,B2
+regardless,regardless,不管,ADP,B2
+hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
+twofold,twofold,双重的,ADJ,B2
+sentences,sentences,句子,NOUN,B2
+alternating,alternating,交替的,ADJ,B2
+sports park,sports park,运动公园,NOUN,B2
+removed,removed,移除的,ADJ,B2
+nearby,nearby,附近,NOUN,B2
+world champion,world champion,世界冠军,NOUN,B2
+hem,hem,边缘,NOUN,B2
+border check,border check,边境检查,NOUN,B2
+rightly,rightly,正确地,ADV,B2
+brabant,brabant,布拉班特的,ADJ,B2
+group work,group work,群体工作,NOUN,B2
+domineeringness,domineeringness,支配欲,NOUN,B2
+lifelong,lifelong,终身,ADJ,B2
+authority structure,authority structure,权威结构,NOUN,B2
+deputation,deputation,代表团,NOUN,B2
+people,people,人们,PRON,B2
+meandering,meandering,蜿蜒的,ADJ,B2
+dutch,dutch,荷兰语,NOUN,B2
+tomorrow night,tomorrow night,明晚,ADV,B2
+grand master,grand master,大师,NOUN,B2
+to saw,to saw,锯,VERB,B2
+full-time,full-time,全职,ADJ,B2
+subject field,subject field,科目 / 领域,NOUN,B2
+conviviality,conviviality,温馨,NOUN,B2
+film industry,film industry,电影业,NOUN,B2
+primary school,primary school,小学,NOUN,B2
+song festival,song festival,音乐节,NOUN,B2
+little heart,little heart,小心脏,NOUN,B2
+lawless,lawless,无法的,ADJ,B2
+in unison,in unison,齐声,ADV,B2
+neatly,neatly,整洁地,ADV,B2
+contactual,contactual,接触的,ADJ,B2
+compostable,compostable,可堆肥的,ADJ,B2
+as many,as many,一样多,NUM,B2
+century-old,century-old,世纪的,ADJ,B2
+self-interest,self-interest,私利,NOUN,B2
+collectivization,collectivization,集体化,NOUN,B2
+fishery,fishery,渔业,NOUN,B2
+liminal,liminal,阈限的,ADJ,B2
+tactless,tactless,不得体的,ADJ,B2
+without further ado,without further ado,毫不犹豫地,ADV,B2
+as a result of which,as a result of which,由此,ADV,B2
+euphemistic,euphemistic,委婉的,ADJ,B2
+to reoffend,to reoffend,重犯,VERB,B2
+border region,border region,边境地区,NOUN,B2
+patricide,patricide,弑父,NOUN,B2
+on the one hand,on the one hand,一方面,ADV,B2
+duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
+graphic designer,graphic designer,图形设计师,NOUN,B2
+megalomania,megalomania,狂妄自大,NOUN,B2
+to shoot dead,to shoot dead,击毙,VERB,B2
+lingual,lingual,语言的,ADJ,B2
+light grey,light grey,浅灰色的,ADJ,B2
+classicist,classicist,古典主义的,ADJ,B2
+tiring,tiring,令人疲倦的,ADJ,B2
+conformist,conformist,从众的,ADJ,B2
+intellectual life,intellectual life,精神生活,NOUN,B2
+middle,middle,中间,ADV,B2
+nonviolence,nonviolence,非暴力,NOUN,B2
+inherence,inherence,固有,NOUN,B2
+conscientious objection,conscientious objection,良知抗拒,NOUN,B2
+spirit world,spirit world,灵界,NOUN,B2
+convolutional,convolutional,卷积的,ADJ,B2
+argentinian,argentinian,阿根廷的,ADJ,B2
+predisposition,predisposition,天赋,NOUN,B2
+authority figure,authority figure,权威人士,NOUN,B2
+marshy,marshy,沼泽般的,ADJ,B2
+whey,whey,乳清,NOUN,B2
+for that purpose,for that purpose,为此,ADV,B2
+brainy,brainy,聪明的,ADJ,B2
+to archive,to archive,归档,VERB,B2
+collectie,collectie,收藏,NOUN,B2
+unwanted,unwanted,不受欢迎的,ADJ,B2
+good-naturedness,good-naturedness,温和,NOUN,B2
+for what purpose,for what purpose,为了什么目的,ADV,B2
+labile,labile,不稳定的,ADJ,B2
+consumptive,consumptive,消费的,ADJ,B2
+incompleteness,incompleteness,不完整,NOUN,B2
+to take minutes,to take minutes,记录,VERB,B2
+czech,czech,捷克的,ADJ,B2
+backyard,backyard,后院,NOUN,B2
+self,self,自己,ADV,B2
+indonesian,indonesian,印度尼西亚的,ADJ,B2
+processing,processing,处理,NOUN,B2
+outside world,outside world,外界,NOUN,B2
+tomb monument,tomb monument,墓碑,NOUN,B2
+care worker,care worker,护理人员,NOUN,B2
+to email,to email,发邮件,VERB,B2
+mercy blow,mercy blow,致命一击,NOUN,B2
+co-,co-,共同,ADV,B2
+purchase price,purchase price,购买价,NOUN,B2
+campus-like,campus-like,校园式的,ADJ,B2
+well-disposed,well-disposed,善意的,ADJ,B2
+offence,offence,罪行,NOUN,B2
+lapidary,lapidary,简略的,ADJ,B2
+uniformity,uniformity,统一性,NOUN,B2
+to graspen,to graspen,抓住,VERB,B2
+editorial office,editorial office,编辑部,NOUN,B2
+quaternary,quaternary,第四的,ADJ,B2
+marbly,marbly,大理石般的,ADJ,B2
+reasoned,reasoned,经过推理的,ADJ,B2
+out,out,出,ADP,B2
+little finger,little finger,小指,NOUN,B2
+uncritical,uncritical,不加批判的,ADJ,B2
+very best,very best,最好的,ADJ,B2
+family tie,family tie,家庭纽带,NOUN,B2
+impoverished,impoverished,贫困的,ADJ,B2
+little boy,little boy,小男孩,NOUN,B2
+to lodge,to lodge,借宿,VERB,B2
+expression of opinion,expression of opinion,意见表达,NOUN,B2
+cool-headed,cool-headed,冷静的,ADJ,B2
+tax rate,tax rate,税率,NOUN,B2
+genetic modification,genetic modification,基因改造,NOUN,B2
+engrossing,engrossing,引人入胜的,ADJ,B2
+image formation,image formation,形象塑造,NOUN,B2
+sound clip,sound clip,音频片段,NOUN,B2
+film studio,film studio,电影制片厂,NOUN,B2
+manifold,manifold,多方面的,ADJ,B2
+to think it over,to think it over,思考,VERB,B2
+esotericism,esotericism,秘教,NOUN,B2
+averageness,averageness,平庸,NOUN,B2
+microeconomic,microeconomic,微观经济学的,ADJ,B2
+above-mentioned,above-mentioned,上述的,ADJ,B2
+combining,combining,结合的,ADJ,B2
+artwork,artwork,艺术品,NOUN,B2
+unification,unification,统一,NOUN,B2
+heartlessness,heartlessness,无情,NOUN,B2
+of it,of it,其中,ADV,B2
+punishable,punishable,可处罚的,ADJ,B2
+to put away,to put away,收拾,VERB,B2
+troubling,troubling,令人担忧的,ADJ,B2
+laugh,laugh,笑,NOUN,B2
+photo model,photo model,模特,NOUN,B2
+exoticism,exoticism,异国情调,NOUN,B2
+apolitical,apolitical,非政治的,ADJ,B2
+groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
+indian,indian,印度的,ADJ,B2
+cremation,cremation,火化,NOUN,B2
+confronting,confronting,对峙的,ADJ,B2
+appropriation,appropriation,挪用,NOUN,B2
+motorway,motorway,高速公路,NOUN,B2
+border legislation,border legislation,边境立法,NOUN,B2
+blackbird,blackbird,乌鸫,NOUN,B2
+telephones,telephones,电话,NOUN,B2
+divisible,divisible,可分的,ADJ,B2
+professional formation,professional formation,职业养成,NOUN,B2
+scholing,scholing,受过训练,NOUN,B2
+moisture,moisture,湿气,NOUN,B2
+teleological,teleological,目的论的,ADJ,B2
+about which,about which,关于什么,PRON,B2
+economic cycle,economic cycle,经济周期,NOUN,B2
+ineffectiveness,ineffectiveness,! 无效,NOUN,B2
+capital flight,capital flight,资本外逃,NOUN,B2
+scottish,scottish,苏格兰的,ADJ,B2
+alteration,alteration,改变,NOUN,B2
+prejudiced,prejudiced,有偏见的,ADJ,B2
+shall will,shall will,将要,AUX,B2
+one-sidedness,one-sidedness,片面性,NOUN,B2
+to orient,to orient,定向,VERB,B2
+land use,land use,土地利用,NOUN,B2
+university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
+observable,observable,可观测的,ADJ,B2
+crossing the border,crossing the border,越境,NOUN,B2
+working day,working day,工作日,NOUN,B2
+day out,day out,一日游,NOUN,B2
+misconception,misconception,误解,NOUN,B2
+minivan,minivan,小型货车,NOUN,B2
+conforming,conforming,遵从的,ADJ,B2
+of utrecht,of utrecht,乌得勒支的,ADJ,B2
+about this,about this,关于这个,ADV,B2
+something like that,something like that,类似的事物,PRON,B2
+fief,fief,封地,NOUN,B2
+at the bottom,at the bottom,在底部,ADV,B2
+customer orientation,customer orientation,客户导向,NOUN,B2
+to license,to license,许可,VERB,B2
+the rich,the rich,富人,NOUN,B2
+runaway,runaway,,NOUN,B2
+frisian,frisian,弗里斯兰的,ADJ,B2
+to wither,to wither,,VERB,B2
+collected,collected,收集的,ADJ,B2
+civil war,civil war,内战,NOUN,B2
+grey area,grey area,灰色地带,NOUN,B2
+combinatorial,combinatorial,组合的,ADJ,B2
+from this,from this,由此,ADV,B2
+typographical,typographical,排版的,ADJ,B2
+to segment,to segment,细分,VERB,B2
+closely,closely,紧密地,ADV,B2
+mighty man,mighty man,强人,NOUN,B2
+theocratic,theocratic,神权的,ADJ,B2
+goalkeeper,goalkeeper,守门员,NOUN,B2
+harbour,harbour,港口,NOUN,B2
+invoicing,invoicing,开票,NOUN,B2
+societal,societal,社会的,ADJ,B2
+flying,flying,飞行的,ADJ,B2
+genocide,genocide,种族灭绝,NOUN,B2
+verbal,verbal,言语的,ADJ,B2
+self-worth,self-worth,自我价值,NOUN,B2
+household income,household income,家庭收入,NOUN,B2
+incidental,incidental,偶然的,ADJ,B2
+neighbourhood,neighbourhood,社区,NOUN,B2
+idealization,idealization,理想化,NOUN,B2
+cosy,cosy,舒适的,ADJ,B2
+stripping,stripping,剥离的,ADJ,B2
+grail,grail,圣杯,NOUN,B2
+concluding,concluding,推断的,ADJ,B2
+alderman,alderman,市议员,NOUN,B2
+knowledge exchange,knowledge exchange,知识交流,NOUN,B2
+top great,top great,顶部/极好,NOUN,B2
+twenty-two-year-old,twenty-two-year-old,,NOUN,B2
+pier,pier,码头,NOUN,B2
+in peace,in peace,不受打扰地,ADV,B2
+penance,penance,忏悔,NOUN,B2
+to be needed,to be needed,被需要,VERB,B2
+bike helmet,bike helmet,自行车头盔,NOUN,B2
+sailboat,sailboat,,NOUN,B2
+suicidal thought,suicidal thought,,NOUN,B2
+electric motor,electric motor,电动机,NOUN,B2
+family relatives,family relatives,亲属,NOUN,B2
+fast,fast,快地,ADV,B2
+monarchy,monarchy,君主制,NOUN,B2
+pain relief,pain relief,,NOUN,B2
+fair decent,fair decent,公平的/正派的,ADJ,B2
+to zero out,to zero out,清零,VERB,B2
+swim training,swim training,,NOUN,B2
+mental hospital,mental hospital,精神病院,NOUN,B2
+sense of shame,sense of shame,,NOUN,B2
+locked in,locked in,被关在里面的,ADJ,B2
+pants,pants,裤子,NOUN,B2
+stolen,stolen,被偷的,ADJ,B2
+to be included,to be included,包含,VERB,B2
+funniness,funniness,,NOUN,B2
+outbreak,outbreak,爆发,NOUN,B2
+premium,premium,溢价,NOUN,B2
+grille,grille,格栅,NOUN,B2
+medical help,medical help,,NOUN,B2
+gothenburg,gothenburg,哥德堡,PROPN,B2
+managed,managed,,NOUN,B2
+english teacher,english teacher,,NOUN,B2
+literally,literally,字面上地,ADV,B2
+leaf page,leaf page,叶子,NOUN,B2
+to light a fire,to light a fire,生火,VERB,B2
+mr master,mr master,先生/主人,NOUN,B2
+pine needle,pine needle,针叶,NOUN,B2
+funeral home,funeral home,,NOUN,B2
+sweetness,sweetness,,NOUN,B2
+hooray,hooray,万岁,INTJ,B2
+angle of approach,angle of approach,切入点,NOUN,B2
+thereafter,thereafter,此后,ADV,B2
+although,although,尽管,CCONJ,B2
+latest,latest,最新的,ADJ,B2
+change exchange,change exchange,改变/交换,NOUN,B2
+work environment,work environment,工作环境,NOUN,B2
+to fit suit,to fit suit,适合,VERB,B2
+to be driven,to be driven,被驱动,VERB,B2
+to be counted,to be counted,被算作,VERB,B2
+its,its,它的,PRON,B2
+social problem,social problem,社会问题,NOUN,B2
+indigenous people,indigenous people,原住民,NOUN,B2
+bigwig,bigwig,大人物,NOUN,B2
+something,something,شي,NOUN,B2
+magically,magically,魔法地,ADV,B2
+number one,number one,第一名,NOUN,B2
+he this one,he this one,他/这位,PRON,B2
+concussion,concussion,脑震荡,NOUN,B2
+bank card,bank card,银行卡,NOUN,B2
+known famous,known famous,著名的/熟悉的,ADJ,B2
+bigger,bigger,更大的,ADJ,B2
+alive living,alive living,活着的,ADJ,B2
+following page,following page,,NOUN,B2
+more important,more important,更重要的,ADJ,B2
+to screw,to screw,拧,VERB,B2
+fun joke,fun joke,乐趣/玩笑,NOUN,B2
+agree,agree,一致,ADJ,B2
+to step down,to step down,辞职,VERB,B2
+monkey ape,monkey ape,猿/猴,NOUN,B2
+conifer,conifer,针叶树,NOUN,B2
+sure,sure,当然,ADV,B2
+to steer control,to steer control,控制,VERB,B2
+starved,starved,饥饿的,ADJ,B2
+artistry,artistry,,NOUN,B2
+to trap fell,to trap fell,困住/砍倒,VERB,B2
+half-year,half-year,半年,NOUN,B2
+hither,hither,到这里,ADV,B2
+guest tester,guest tester,,NOUN,B2
+contacts,contacts,人脉,NOUN,B2
+computer program,computer program,电脑程序,NOUN,B2
+hanged,hanged,被绞死的,ADJ,B2
+butt,butt,臀部,NOUN,B2
+to bicker,to bicker,争吵,VERB,B2
+violently,violently,暴力地,ADV,B2
+to decide determine,to decide determine,决定/确定,VERB,B2
+so thus,so thus,所以/如此,ADV,B2
+to wipe out,to wipe out,消灭,VERB,B2
+citizenship right,citizenship right,公民权,NOUN,B2
+at once,at once,立刻,ADV,B2
+to drink binge,to drink binge,狂饮,VERB,B2
+to dampen,to dampen,使潮湿,VERB,B2
+to denominate,to denominate,命名,VERB,B2
+these,these,这些,PRON,B2
+test drive,test drive,,NOUN,B2
+disposition,disposition,性情,NOUN,B2
+itself,itself,它自己,PRON,B2
+the sick,the sick,病人,NOUN,B2
+more beautiful,more beautiful,更美的,ADJ,B2
+atomic nucleus,atomic nucleus,原子核,NOUN,B2
+to paint over,to paint over,重新粉刷,VERB,B2
+working class,working class,工人阶级,NOUN,B2
+to harbor,to harbor,怀有,VERB,B2
+sentenced,sentenced,被判刑的,ADJ,B2
+upper floor,upper floor,楼上,NOUN,B2
+salad lettuce,salad lettuce,沙拉/生菜,NOUN,B2
+scientists,scientists,科学家,NOUN,B2
+lots,lots,大量,NOUN,B2
+poor wretched,poor wretched,可怜的,ADJ,B2
+welcome committee,welcome committee,,NOUN,B2
+self-image,self-image,自我形象,NOUN,B2
+to find oneself,to find oneself,处于,VERB,B2
+ace,ace,王牌,NOUN,B2
+your plural,your plural,你们的,DET,B2
+values,values,价值观,NOUN,B2
+goodbye kiss,goodbye kiss,,NOUN,B2
+atm,atm,自动取款机,NOUN,B2
+sun sensitivity,sun sensitivity,,NOUN,B2
+load cargo,load cargo,货物/负荷,NOUN,B2
+egg card,egg card,,NOUN,B2
+wife mrs,wife mrs,妻子/夫人,NOUN,B2
+definite,definite,明确的,ADJ,B2
+evenly,evenly,均匀地,ADV,B2
+determined definite,determined definite,确定的,ADJ,B2
+healthcare worker,healthcare worker,医护人员,NOUN,B2
+to behold,to behold,注视,VERB,B2
+freedom of the press,freedom of the press,出版自由,NOUN,B2
+heroin vapor,heroin vapor,,NOUN,B2
+nuance,nuance,细微差别,NOUN,B2
+bags,bags,包,NOUN,B2
+other others,other others,其他,DET,B2
+degree exam,degree exam,学位/考试,NOUN,B2
+oh really,oh really,真的吗,INTJ,B2
+back side,back side,背面,NOUN,B2
+to quiver,to quiver,颤抖,VERB,B2
+scene stage,scene stage,场景/舞台,NOUN,B2
+long,long,,NOUN,B2
+director manager,director manager,主管/经理,NOUN,B2
+hag,hag,老妇,NOUN,B2
+stably,stably,稳定地,ADV,B2
+electric power,electric power,电力,NOUN,B2
+to rot,to rot,腐烂,VERB,B2
+income tax,income tax,所得税,NOUN,B2
+eating,eating,,NOUN,B2
+mustache,mustache,胡子,NOUN,B2
+safe secure,safe secure,安全的/可靠的,ADJ,B2
+squirrel wheel,squirrel wheel,仓鼠轮,NOUN,B2
+sinner,sinner,罪人,NOUN,B2
+shortly,shortly,不久,ADV,B2
+to enhance,to enhance,增强,VERB,B2
+attacked,attacked,被攻击的,ADJ,B2
+chubby,chubby,胖子,NOUN,B2
+every other,every other,每隔一个,DET,B2
+caught,caught,被捕获的,ADJ,B2
+arrested,arrested,被逮捕的,ADJ,B2
+firearms,firearms,枪支,NOUN,B2
+to food give birth,to food give birth,食物/生育,VERB,B2
+diagonally,diagonally,对角地,ADV,B2
+to occupy oneself,to occupy oneself,从事,VERB,B2
+the guy's,the guy's,那个男人的,NOUN,B2
+good well,good well,好/很好,ADJ,B2
+impressed,impressed,印象深刻的,ADJ,B2
+emotionally,emotionally,情感上,ADV,B2
+innocent,innocent,无辜地,ADV,B2
+experience exchange,experience exchange,经验交流,NOUN,B2
+good behavior,good behavior,,NOUN,B2
+green-clad,green-clad,,NOUN,B2
+broken,broken,破碎的,ADV,B2
+chips,chips,薯片,NOUN,B2
+difficult flirt,difficult flirt,,NOUN,B2
+cognac,cognac,干邑,NOUN,B2
+hot dog stand,hot dog stand,小吃摊,NOUN,B2
+corpse alike,corpse alike,尸体/相似的,NOUN,B2
+big brother,big brother,哥哥,NOUN,B2
+what kind of,what kind of,什么样的,PRON,B2
+ceo,ceo,首席执行官,NOUN,B2
+to call ring,to call ring,打电话,VERB,B2
+confusing,confusing,令人困惑的,ADJ,B2
+loudly,loudly,大声地,ADV,B2
+to be punished,to be punished,受罚,VERB,B2
+like this,like this,,NOUN,B2
+armorer,armorer,,NOUN,B2
+to account for,to account for,说明,VERB,B2
+dejt,dejt,约会,NOUN,B2
+to prosecute,to prosecute,起诉,VERB,B2
+it common,it common,它 (通性),PRON,B2
+self-evident,self-evident,,NOUN,B2
+informed,informed,见多识广的,ADJ,B2
+faster,faster,更快的,ADJ,B2
+action plan,action plan,行动方案,NOUN,B2
+seen,seen,被看见,ADJ,B2
+chill,chill,放松,ADJ,B2
+to mourn,to mourn,哀悼,VERB,B2
+to tear down,to tear down,拆除,VERB,B2
+to furlough,to furlough,临时解雇,VERB,B2
+subject topic,subject topic,主题/话题,NOUN,B2
+out here,out here,这里外面,ADV,B2
+pavement,pavement,人行道,NOUN,B2
+astray,astray,迷路,ADJ,B2
+epoch,epoch,时代,NOUN,B2
+phrasing,phrasing,措辞,NOUN,B2
+older woman,older woman,老妇人,NOUN,B2
+registered,registered,注册的,ADJ,B2
+elite unit,elite unit,,NOUN,B2
+zero,zero,零,NOUN,B2
+to be tricked,to be tricked,被欺骗,VERB,B2
+pre,pre,,NOUN,B2
+upward,upward,向上,ADV,B2
+lifestyle,lifestyle,生活方式,NOUN,B2
+christmas present,christmas present,圣诞礼物,NOUN,B2
+apart from,apart from,除了,ADP,B2
+part-time worker,part-time worker,兼职工,NOUN,B2
+central station,central station,中央车站,NOUN,B2
+based,based,基于,ADJ,B2
+cola,cola,可乐,NOUN,B2
+to be saved,to be saved,获救,VERB,B2
+smart clever,smart clever,聪明的,ADJ,B2
+to underline,to underline,强调,VERB,B2
+date fruit,date fruit,椰枣,NOUN,B2
+civilian,civilian,平民的,ADJ,B2
+trigger mechanism,trigger mechanism,,NOUN,B2
+sought,sought,,NOUN,B2
+to exist there is,to exist there is,存在/有,VERB,B2
+personal integrity,personal integrity,个人隐私,NOUN,B2
+to separate divorce,to separate divorce,分离/离婚,VERB,B2
+history story,history story,历史/故事,NOUN,B2
+away gone,away gone,不在/离开,ADV,B2
+legion unit,legion unit,,NOUN,B2
+the other day,the other day,前几天,ADV,B2
+dear,dear,,NOUN,B2
+xenophobia,xenophobia,排外心理,NOUN,B2
+stockholm,stockholm,斯德哥尔摩,PROPN,B2
+word choice,word choice,措辞,NOUN,B2
+ever,ever,,NOUN,B2
+indoors,indoors,在室内,ADV,B2
+omelette,omelette,煎蛋卷,NOUN,B2
+the it,the it,那,DET,B2
+to blink,to blink,眨眼,VERB,B2
+to acknowledge,to acknowledge,承认,VERB,B2
+cultural encounter,cultural encounter,文化交汇,NOUN,B2
+own,own,自己的,DET,B2
+the very,the very,正是,ADV,B2
+heart,heart,心,ADV,B2
+to mess around,to mess around,胡闹,VERB,B2
+cancelled set,cancelled set,取消的/设定的,ADJ,B2
+innermost,innermost,最里面的,ADV,B2
+sunglasses,sunglasses,太阳镜,NOUN,B2
+furthest,furthest,最远,ADV,B2
+to cook fix,to cook fix,做/修理,VERB,B2
+for because,for because,因为,CCONJ,B2
+pie,pie,派,NOUN,B2
+before previously,before previously,以前,ADV,B2
+beside,beside,在...旁边,ADP,B2
+coworker,coworker,同事,NOUN,B2
+yes indeed,yes indeed,正是,INTJ,B2
+to sneak away,to sneak away,溜走,VERB,B2
+headline,headline,标题,NOUN,B2
+farm yard,farm yard,农场,NOUN,B2
+to shop be about,to shop be about,购物,VERB,B2
+to kidnapped,to kidnapped,绑架,VERB,B2
+language use,language use,语言使用,NOUN,B2
+to watch out,to watch out,小心,VERB,B2
+eidsvold,eidsvold,,NOUN,B2
+to exemplify,to exemplify,举例说明,VERB,B2
+alarm center,alarm center,报警中心,NOUN,B2
+alder,alder,桤木,NOUN,B2
+blood test,blood test,验血,NOUN,B2
+dal,dal,山谷,NOUN,B2
+odds,odds,赔率,NOUN,B2
+to close eyes,to close eyes,闭眼,VERB,B2
+happily,happily,快乐地,ADV,B2
+devil bastard,devil bastard,混蛋,NOUN,B2
+cheaper,cheaper,更便宜的,ADJ,B2
+to bide,to bide,等待,VERB,B2
+capable good,capable good,能干的/优秀的,ADJ,B2
+property owner,property owner,房主,NOUN,B2
+dot,dot,点,NOUN,B2
+to acquaint,to acquaint,使熟悉,VERB,B2
+edging,edging,镶边,NOUN,B2
+the devil bastard,the devil bastard,混蛋,NOUN,B2
+alpha,alpha,阿尔法,NOUN,B2
+super high,super high,,NOUN,B2
+poor devil,poor devil,可怜虫,NOUN,B2
+to puncture deflate,to puncture deflate,刺破,VERB,B2
+sexily,sexily,性感地,ADV,B2
+more fun,more fun,更有趣的,ADJ,B2
+side page,side page,侧面/页,NOUN,B2
+to push through,to push through,推动,VERB,B2
+organically,organically,有机地,ADV,B2
+paralyzed,paralyzed,瘫痪的,ADJ,B2
+to regain,to regain,恢复,VERB,B2
+paternal grandmother,paternal grandmother,祖母,NOUN,B2
+to bark scold,to bark scold,吠/责骂,VERB,B2
+on board,on board,在船上,ADV,B2
+reply,reply,回复,NOUN,B2
+to get acquire,to get acquire,获得/弄到,VERB,B2
+ongoing,ongoing,进行中的,ADJ,B2
+ought,ought,应该,AUX,B2
+baptized,baptized,受洗的,ADJ,B2
+the chinese,the chinese,中国人,NOUN,B2
+free off,free off,空闲的/休假,ADJ,B2
+intelligence service,intelligence service,情报机构,NOUN,B2
+half hour,half hour,半小时,NOUN,B2
+to dismiss fire,to dismiss fire,解雇,VERB,B2
+seventeen,seventeen,十七,NUM,B2
+freedom of religion,freedom of religion,宗教自由,NOUN,B2
+police chief,police chief,警察局长,NOUN,B2
+lesbian,lesbian,女同性恋的,ADJ,B2
+knock,knock,敲击,NOUN,B2
+down there,down there,在那下面,ADV,B2
+high tall,high tall,高的,ADJ,B2
+death,death,致死,ADV,B2
+radiant,radiant,容光焕发的,ADJ,B2
+to have strength,to have strength,有力气,VERB,B2
+sabbath,sabbath,安息日,NOUN,B2
+marine corps,marine corps,海军陆战队,NOUN,B2
+bang,bang,砰,INTJ,B2
+seeker,seeker,寻求者,NOUN,B2
+to fall crash,to fall crash,坠落/猛冲,VERB,B2
+it neuter,it neuter,它 (中性),PRON,B2
+milk tooth,milk tooth,,NOUN,B2
+poison gas,poison gas,毒气,NOUN,B2
+full drunk,full drunk,满的/醉的,ADJ,B2
+tough guy,tough guy,硬汉,NOUN,B2
+to party,to party,狂欢,VERB,B2
+nicely nice,nicely nice,美好地,ADV,B2
+to lay put,to lay put,放,VERB,B2
+werewolf,werewolf,狼人,NOUN,B2
+to scout,to scout,侦察,VERB,B2
+good-looking person,good-looking person,帅哥/美女,NOUN,B2
+gangster,gangster,黑帮成员,NOUN,B2
+girl girlfriend,girl girlfriend,女孩/女朋友,NOUN,B2
+creep,creep,令人厌恶的人,NOUN,B2
+eider hunter,eider hunter,,NOUN,B2
+just over,just over,稍微超过,ADV,B2
+to give a ride,to give a ride,载送一程,VERB,B2
+fiancee,fiancee,未婚妻,NOUN,B2
+law team,law team,法律/团队,NOUN,B2
+quivering,quivering,颤抖的,ADJ,B2
+unarmed,unarmed,手无寸铁的,ADJ,B2
+meatballs,meatballs,肉丸,NOUN,B2
+datum,datum,日期,NOUN,B2
+inflammable,inflammable,易燃的,ADJ,B2
+confounded,confounded,该死的,ADJ,B2
+shedding,shedding,,NOUN,B2
+to blunder,to blunder,犯大错,VERB,B2
+to linger,to linger,徘徊,VERB,B2
+special agent,special agent,特工,NOUN,B2
+to bare,to bare,暴露,VERB,B2
+poorer,poorer,更穷的,ADJ,B2
+thank god,thank god,谢天谢地,INTJ,B2
+delayed,delayed,延误的,ADJ,B2
+hamburger,hamburger,汉堡包,NOUN,B2
+rug,rug,地毯,NOUN,B2
+less,less,较少的,ADJ,B2
+dressed,dressed,穿着的,ADJ,B2
+rash,rash,皮疹,NOUN,B2
+knocked out,knocked out,被淘汰的,ADJ,B2
+earlier,earlier,更早的,ADJ,B2
+all of it,all of it,全部,PRON,B2
+overfall,overfall,,NOUN,B2
+away,away,避开,ADP,B2
+work task,work task,工作任务,NOUN,B2
+to mean entail,to mean entail,意味着,VERB,B2
+slower,slower,更慢,ADJ,B2
+all of them,all of them,大家,PRON,B2
+somewhere,somewhere,,NOUN,B2
+track trace,track trace,痕迹/轨道,NOUN,B2
+deadly,deadly,致命地,ADV,B2
+fair hair,fair hair,,NOUN,B2
+to make out,to make out,接吻,VERB,B2
+skater,skater,,NOUN,B2
+trainer,trainer,教练,NOUN,B2
+backward,backward,向后,ADV,B2
+this way,this way,这边,ADV,B2
+to tire get tired,to tire get tired,疲倦/厌烦,VERB,B2
+retirement pension,retirement pension,退休金,NOUN,B2
+gas flame,gas flame,煤气火焰,NOUN,B2
+europe,europe,欧洲,PROPN,B2
+marine,marine,海军陆战队员,NOUN,B2
+self-defense,self-defense,自卫,NOUN,B2
+closed disabled,closed disabled,关闭的/禁用的,ADJ,B2
+visiting ban,visiting ban,,NOUN,B2
+to think opine,to think opine,认为,VERB,B2
+evening meal,evening meal,晚餐,NOUN,B2
+thinner,thinner,更薄的,ADJ,B2
+westward,westward,向西,ADV,B2
+calming,calming,令人平静的,ADJ,B2
+competition bastard,competition bastard,,NOUN,B2
+damn,damn,该死的,ADV,B2
+attitude setting,attitude setting,态度/设置,NOUN,B2
+turntable,turntable,,NOUN,B2
+okay,okay,好的,ADJ,B2
+convicted,convicted,被判罪的,ADJ,B2
+fifth,fifth,第五,NUM,B2
+shorter,shorter,更短的,ADJ,B2
+bigness,bigness,,NOUN,B2
+starting point,starting point,出发点,NOUN,B2
+beaten,beaten,被打败的,ADJ,B2
+outer,outer,外部的,ADJ,B2
+police report,police report,,NOUN,B2
+steadily,steadily,稳定地,ADV,B2
+superhero,superhero,超级英雄,NOUN,B2
+to dejta,to dejta,约会,VERB,B2
+the cash register,the cash register,收银台,NOUN,B2
+protector,protector,保护者,NOUN,B2
+outward,outward,向外,ADV,B2
+born,born,出生的,ADJ,B2
+cleaner,cleaner,更干净的,ADJ,B2
+cykel,cykel,自行车,NOUN,B2
+destroyed,destroyed,被毁坏的,ADJ,B2
+ice pick,ice pick,,NOUN,B2
+tax return,tax return,报税,NOUN,B2
+dirtier,dirtier,更脏的,ADJ,B2
+sensibly,sensibly,明智地,ADV,B2
+to release let go,to release let go,释放/放手,VERB,B2
+tragically,tragically,悲剧地,ADV,B2
+lovely,lovely,美好的,ADJ,B2
+kids,kids,孩子,NOUN,B2
+sensor donor,sensor donor,传感器/捐献者,NOUN,B2
+sauna,sauna,桑拿,NOUN,B2
+to search apply,to search apply,寻找/申请,VERB,B2
+bow tie,bow tie,领结,NOUN,B2
+here you go,here you go,请,INTJ,B2
+to apply be valid,to apply be valid,适用/有效,VERB,B2
+in vain,in vain,徒劳,NOUN,B2
+shit crap,shit crap,废话,NOUN,B2
+like as,like as,如同/好像,ADV,B2
+upper class,upper class,上层,NOUN,B2
+poorest,poorest,最穷的,ADJ,B2
+sweden,sweden,瑞典,PROPN,B2
+salt shaker,salt shaker,,NOUN,B2
+state federal,state federal,州,NOUN,B2
+del,del,部分,NOUN,B2
+vile,vile,可憎地,ADV,B2
+inside of,inside of,在...里面,ADP,B2
+doughy,doughy,面团状的,ADJ,B2
+exactly just,exactly just,恰好,ADV,B2
+his her own,his her own,他/她自己的,DET,B2
+sentencing,sentencing,量刑,NOUN,B2
+christmas eve,christmas eve,平安夜,NOUN,B2
+time to go to bed,time to go to bed,该睡觉了,ADV,B2
+sense of duty,sense of duty,责任感,NOUN,B2
+that way,that way,往那边,ADV,B2
+giddy,giddy,头晕的,ADJ,B2
+rulebook,rulebook,规则体系,NOUN,B2
+electric guitar,electric guitar,电吉他,NOUN,B2
+richer,richer,更富的,ADJ,B2
+pain hurt,pain hurt,疼痛,ADJ,B2
+corrections,corrections,刑事司法,NOUN,B2
+to erect behave,to erect behave,建造,VERB,B2
+to tip,to tip,透露,VERB,B2
+trigger imprint,trigger imprint,印记,NOUN,B2
+yep,yep,是的,INTJ,B2
+compassion sympathy,compassion sympathy,同情/怜悯,NOUN,B2
+dance floor,dance floor,舞池,NOUN,B2
+to be struck,to be struck,被打击,VERB,B2
+gas meter,gas meter,,NOUN,B2
+cracker,cracker,饼干,NOUN,B2
+corrupted,corrupted,,NOUN,B2
+to thrown,to thrown,扔,VERB,B2
+orphaned,orphaned,无父母的,ADJ,B2
+honor culture,honor culture,荣誉文化,NOUN,B2
+shame culture,shame culture,羞耻文化,NOUN,B2
+muffin,muffin,玛芬蛋糕,NOUN,B2
+saucy,saucy,下流的,ADJ,B2
+wonderful,wonderful,极好地,ADV,B2
+youngest,youngest,最年轻的,ADJ,B2
+personal best,personal best,,NOUN,B2
+life sentence,life sentence,无期徒刑,NOUN,B2
+warmer,warmer,更暖的,ADJ,B2
+pointlessly,pointlessly,徒劳地,ADV,B2
+devastated,devastated,崩溃的,ADJ,B2
+run over,run over,被碾过的,ADJ,B2
+supplies,supplies,必需品,NOUN,B2
+probable,probable,可能的,ADJ,B2
+stink,stink,恶臭,NOUN,B2
+to decimate,to decimate,大量削减,VERB,B2
+to light ignite,to light ignite,点燃,VERB,B2
+equally,equally,同样地,ADV,B2
+attention,attention,立正,INTJ,B2
+chest breast,chest breast,胸部/乳房,NOUN,B2
+terribleness,terribleness,,NOUN,B2
+game play,game play,游戏/比赛,NOUN,B2
+to be responsible,to be responsible,负责,VERB,B2
+in return,in return,作为回报,NOUN,B2
+to be ongoing,to be ongoing,进行中,VERB,B2
+mass media,mass media,大众媒体,NOUN,B2
+imprisoned,imprisoned,被监禁的,ADJ,B2
+swimwear,swimwear,,NOUN,B2
+in addition to,in addition to,除...之外,ADP,B2
+stiff glove,stiff glove,,NOUN,B2
+small things,small things,琐事,NOUN,B2
+message errand,message errand,消息/差事,NOUN,B2
+unsecured,unsecured,,NOUN,B2
+to be noticed,to be noticed,被注意到,VERB,B2
+above all,above all,,NOUN,B2
+hopelessly,hopelessly,绝望地,ADV,B2
+dredge,dredge,,NOUN,B2
+nuclear power,nuclear power,核能,NOUN,B2
+to get stuck,to get stuck,卡住,VERB,B2
+shame pity,shame pity,遗憾,NOUN,B2
+foreign strange,foreign strange,外国的/陌生的,ADJ,B2
+much,much,很多,ADV,B2
+business sector,business sector,商业界,NOUN,B2
+eastward,eastward,向东,ADV,B2
+cartel,cartel,卡特尔,NOUN,B2
+poisoned,poisoned,,NOUN,B2
+trainer bastard,trainer bastard,,NOUN,B2
+chiefly,chiefly,主要地,ADV,B2
+miss teacher,miss teacher,小姐/老师,NOUN,B2
+more expensive,more expensive,更贵的,ADJ,B2
+made,made,制成的,ADJ,B2
+brain damage,brain damage,,NOUN,B2
+the other evening,the other evening,前几天晚上,ADV,B2
+applicable,applicable,适用的,ADJ,B2
+to spray,to spray,喷洒,VERB,B2
+having a cold,having a cold,感冒的,ADJ,B2
+the cavalry,the cavalry,骑兵,NOUN,B2
+easier,easier,更容易的,ADJ,B2
+envious jealous,envious jealous,嫉妒的,ADJ,B2
+northward,northward,向北,ADV,B2
+in there,in there,在那里面,ADV,B2
+working method,working method,工作方式,NOUN,B2
+to box,to box,拳击,VERB,B2
+medical examiner,medical examiner,法医,NOUN,B2
+homeward,homeward,,NOUN,B2
+to be visible,to be visible,可见,VERB,B2
+from here,from here,从这里,ADV,B2
+blockhead,blockhead,笨蛋,NOUN,B2
+damm,damm,池塘,NOUN,B2
+to skip,to skip,跳过,VERB,B2
+backside,backside,臀部,NOUN,B2
+in private,in private,私下地,ADV,B2
+freedom of choice,freedom of choice,选择自由,NOUN,B2
+the emperor,the emperor,皇帝,NOUN,B2
+espresso,espresso,浓缩咖啡,NOUN,B2
+management pipe,management pipe,管理层/管道,NOUN,B2
+type like,type like,类型/比如,NOUN,B2
+southward,southward,向南,ADV,B2
+previous,previous,,NOUN,B2
+christmas porridge,christmas porridge,,NOUN,B2
+skin hide,skin hide,皮肤/皮革,NOUN,B2
+can jar,can jar,罐子,NOUN,B2
+to regret apologize,to regret apologize,遗憾/道歉,VERB,B2
+exam evening,exam evening,,NOUN,B2
+consciously,consciously,有意识地,ADV,B2
+in mind,in mind,记住,ADV,B2
+to indicate interpret,to indicate interpret,表明/解释,VERB,B2
+emotional life,emotional life,情感生活,NOUN,B2
+to long,to long,渴望,VERB,B2
+perception opinion,perception opinion,看法,NOUN,B2
+released,released,获释的,ADJ,B2
+causal link,causal link,因果关系,NOUN,B2
+depressing,depressing,令人沮丧的,ADJ,B2
+standpoint,standpoint,立场,NOUN,B2
+truly,truly,确实,ADV,B2
+perishing,perishing,,NOUN,B2
+abuser,abuser,滥用者,NOUN,B2
+leftovers,leftovers,剩菜,NOUN,B2
+niceness,niceness,,NOUN,B2
+as far as,as far as,就……而言,ADV,B2
+to talk chat,to talk chat,聊天/谈论,VERB,B2
+from home,from home,从家里,ADV,B2
+tern path,tern path,,NOUN,B2
+striving,striving,追求,NOUN,B2
+blow beating,blow beating,殴打,NOUN,B2
+to bet invest,to bet invest,下注/投资,VERB,B2
+killed,killed,,NOUN,B2
+electrical theory,electrical theory,电学,NOUN,B2
+early morning,early morning,清晨,ADV,B2
+to go up in smoke,to go up in smoke,化为乌有,VERB,B2
+the chain,the chain,链条,NOUN,B2
+to drive herd,to drive herd,驱赶/推动,VERB,B2
+solid substantial,solid substantial,结实的/大量的,ADJ,B2
+data protection,data protection,数据保护,NOUN,B2
+partial norm,partial norm,分范,NOUN,B2
+one machine,one machine,一架,NUM,B2
+proactive,proactive,积极主动的,ADJ,B2
+domestic debt,domestic debt,内债,NOUN,B2
+sufficient flight,sufficient flight,飞够,NOUN,B2
+he she,he she,伊,PRON,B2
+mangosteen,mangosteen,山竹,NOUN,B2
+meridian,meridian,经脉,NOUN,B2
+toast,toast,你敬酒,NOUN,B2
+just,just,公正,ADJ,B2
+social custom,social custom,社会习俗,NOUN,B2
+amended generality,amended generality,改般,NOUN,B2
+jeans,jeans,牛仔裤,NOUN,B2
+crafty,crafty,狡猾,ADJ,B2
+trite,trite,陈腐的,ADJ,B2
+to wash with water,to wash with water,水洗,VERB,B2
+half-day,half-day,半天,NOUN,B2
+to extort a bribe,to extort a bribe,索贿,VERB,B2
+sub-reality,sub-reality,分实,NOUN,B2
+hard to measure,hard to measure,难以衡量,ADJ,B2
+to for example,to for example,比如,VERB,B2
+rethinking,rethinking,重想,NOUN,B2
+warrant,warrant,令状,NOUN,B2
+recounting,recounting,再叙,NOUN,B2
+to concern all,to concern all,凡事,VERB,B2
+timely,timely,适时,ADJ,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+foul smell,foul smell,骚味,NOUN,B2
+human life,human life,人命,NOUN,B2
+social value,social value,社会价值,NOUN,B2
+to donate blood,to donate blood,献血,VERB,B2
+hardship,hardship,艰难,NOUN,B2
+rehearsal,rehearsal,排练,NOUN,B2
+otherwise,otherwise,要不,PART,B2
+shooting star,shooting star,流星,NOUN,B2
+changed work,changed work,改工,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+your arrow,your arrow,若非你一箭,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
+amended synthesis,amended synthesis,改综,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+feudal ethics,feudal ethics,礼教,NOUN,B2
+very deep,very deep,很深,ADJ,B2
+bungee jumping,bungee jumping,蹦极,NOUN,B2
+non-knot,non-knot,非结,NOUN,B2
+bizarre case,bizarre case,奇案,NOUN,B2
+provocative,provocative,挑衅的,ADJ,B2
+non-possible,non-possible,非可,NOUN,B2
+main camp,main camp,大营,NOUN,B2
+imperial father,imperial father,父皇,NOUN,B2
+tendering,tendering,招标,NOUN,B2
+characteristic feature,characteristic feature,特点,NOUN,B2
+adversity,adversity,逆境,NOUN,B2
+partial basis,partial basis,分据,NOUN,B2
+waist token,waist token,腰牌,NOUN,B2
+sister yu,sister yu,俞姐,NOUN,B2
+no matter what,no matter what,无论,ADV,B2
+one building,one building,一座,NUM,B2
+to finally,to finally,你可算,VERB,B2
+how enough,how enough,哪够,NOUN,B2
+which seat,which seat,哪座,NOUN,B2
+succinct,succinct,简明的,ADJ,B2
+to seek peace,to seek peace,主和,VERB,B2
+case details,case details,案情,NOUN,B2
+motto,motto,座右铭,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+social activity,social activity,社会活动,NOUN,B2
+survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
+malicious words,malicious words,恶言,NOUN,B2
+social mediation,social mediation,社会调解,NOUN,B2
+gearbox,gearbox,变速箱,NOUN,B2
+hyper-target,hyper-target,超的,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+departure lounge,departure lounge,候机室,NOUN,B2
+social fairness,social fairness,社会公平,NOUN,B2
+to hope for,to hope for,盼望,VERB,B2
+great victory,great victory,大胜,NOUN,B2
+not bad,not bad,不错,ADJ,B2
+amended particular,amended particular,改特,NOUN,B2
+shopping mall,shopping mall,商场,NOUN,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
+wanting you,wanting you,要你,NOUN,B2
+to be afraid,to be afraid,害怕,VERB,B2
+re-criterion,re-criterion,重准,NOUN,B2
+non-technique,non-technique,非术,NOUN,B2
+cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
+earnest sincere,earnest sincere,恳切,ADJ,B2
+town mayor,town mayor,镇长,NOUN,B2
+traditional chinese painting,traditional chinese painting,国画,NOUN,B2
+acrobatics,acrobatics,杂技,NOUN,B2
+disposable diaper,disposable diaper,纸尿裤,NOUN,B2
+prudent,prudent,谨慎的,ADJ,B2
+inner heart,inner heart,内心,NOUN,B2
+walnut,walnut,核桃,NOUN,B2
+affordability,affordability,得起,NOUN,B2
+how dare,how dare,岂敢,NOUN,B2
+non-iron,non-iron,免烫,ADJ,B2
+to do what,to do what,干嘛,VERB,B2
+virtual reality,virtual reality,虚拟现实,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+kneeling,kneeling,跪,NOUN,B2
+reverse result,reverse result,反果,NOUN,B2
+dense forest,dense forest,密林,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+changed route,changed route,改路,NOUN,B2
+to thresh,to thresh,脱粒,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+overthinking,overthinking,你想多,NOUN,B2
+non-necessary,non-necessary,非必,NOUN,B2
+incremental,incremental,渐进性,ADJ,B2
+outer-gate,outer-gate,外门,NOUN,B2
+star search,star search,找星,NOUN,B2
+reverse origin,reverse origin,反原,NOUN,B2
+adequacy,adequacy,也不错,NOUN,B2
+inversion,inversion,反演,NOUN,B2
+from away from,from away from,离,ADP,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+that evening,that evening,当晚,NOUN,B2
+film roll,film roll,胶卷,NOUN,B2
+upper part,upper part,上部,NOUN,B2
+to shut up,to shut up,闭嘴,VERB,B2
+not good,not good,不好,ADJ,B2
+social progress,social progress,社会进步,NOUN,B2
+altogether,altogether,共,ADV,B2
+modified ability,modified ability,改能,NOUN,B2
+sucking,sucking,嗦,NOUN,B2
+not very good,not very good,不太好,ADJ,B2
+spiral pattern,spiral pattern,旋纹,NOUN,B2
+sticky note,sticky note,便签,NOUN,B2
+could it be,could it be,难不成,ADJ,B2
+outfit,outfit,服装,NOUN,B2
+meridians,meridians,筋脉,NOUN,B2
+re-grading,re-grading,改级,NOUN,B2
+my scrutiny,my scrutiny,我看你,NOUN,B2
+it is a pity,it is a pity,可惜,ADJ,B2
+polytunnel,polytunnel,大棚,NOUN,B2
+summer grass,summer grass,夏草,NOUN,B2
+now,now,此刻,NOUN,B2
+brook no delay,brook no delay,刻不容缓,ADJ,B2
+cilantro,cilantro,香菜,NOUN,B2
+further debate,further debate,再辩,NOUN,B2
+to act rashly,to act rashly,妄动,VERB,B2
+will surely,will surely,定会,AUX,B2
+heavy snow,heavy snow,大雪,NOUN,B2
+foot-warming,foot-warming,捂脚,NOUN,B2
+floating dust,floating dust,浮尘,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+cut off,cut off,割下,NOUN,B2
+surfing,surfing,冲浪,NOUN,B2
+well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
+not intentional,not intentional,不是故意,ADJ,B2
+all day,all day,整天,ADV,B2
+modern dance,modern dance,现代舞,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+to ambush,to ambush,埋伏,VERB,B2
+alumnus,alumnus,校友,NOUN,B2
+to transfer schools,to transfer schools,转学,VERB,B2
+um,um,嗯,INTJ,B2
+altered art,altered art,改艺,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+heart disease,heart disease,心脏病,NOUN,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+singularity,singularity,单一性,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+big data,big data,大数据,NOUN,B2
+charades,charades,打哑谜,NOUN,B2
+this matter,this matter,这事,NOUN,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+bloodshed,bloodshed,血腥,NOUN,B2
+re-argument,re-argument,重论,NOUN,B2
+foreign debt,foreign debt,外债,NOUN,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+side effect,side effect,副作用,NOUN,B2
+measure word flat objects,measure word flat objects,张,NOUN,B2
+hyper-origin,hyper-origin,超原,NOUN,B2
+but also,but also,但也,NOUN,B2
+captive,captive,俘虏,NOUN,B2
+cannot stay,cannot stay,不住,PART,B2
+moisture-proof,moisture-proof,防潮,ADJ,B2
+taking command,taking command,挂帅,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+re-concretization,re-concretization,再具,NOUN,B2
+jianghu world,jianghu world,江湖上,NOUN,B2
+as expected,as expected,果然,ADV,B2
+to return a car,to return a car,送车,VERB,B2
+for to,for to,为,ADP,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+entrapment,entrapment,身陷,NOUN,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+running around,running around,跑遍,NOUN,B2
+this indeed,this indeed,这倒,NOUN,B2
+quick lie-down,quick lie-down,快躺,NOUN,B2
+notepad,notepad,记事本,NOUN,B2
+courtyard guard,courtyard guard,护院,NOUN,B2
+major case,major case,大案,NOUN,B2
+elective course,elective course,选修课,NOUN,B2
+tactile paving,tactile paving,盲道,NOUN,B2
+to befriend,to befriend,与...交朋友,VERB,B2
+to not run,to not run,别跑,VERB,B2
+to raise funds,to raise funds,筹资,VERB,B2
+anti-universality,anti-universality,反普,NOUN,B2
+credentials,credentials,国书,NOUN,B2
+enoki mushroom,enoki mushroom,金针菇,NOUN,B2
+gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
+shh,shh,嘘,INTJ,B2
+to file for record,to file for record,备案,VERB,B2
+bound to,bound to,势必,ADV,B2
+grab,grab,揪,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
+sports exercise,sports exercise,运动,NOUN,B2
+red robe,red robe,红衣,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+borrowed knife,borrowed knife,借刀,NOUN,B2
+sound sleep,sound sleep,你踏实睡,NOUN,B2
+reincarnation,reincarnation,再体,NOUN,B2
+express car,express car,快车,NOUN,B2
+non-view,non-view,非观,NOUN,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to lose bid,to lose bid,落标,VERB,B2
+super-form,super-form,超形,NOUN,B2
+car wash,car wash,洗车,NOUN,B2
+can be at,can be at,可在,NOUN,B2
+to fall behind,to fall behind,落后,VERB,B2
+void,void,最无,NOUN,B2
+older sister,older sister,姐姐,NOUN,B2
+fax,fax,传真,NOUN,B2
+sha dynasty,sha dynasty,砂朝,NOUN,B2
+multi-level garage,multi-level garage,立体车库,NOUN,B2
+heaven and earth,heaven and earth,天地,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+to statistics,to statistics,统计,VERB,B2
+dignified manner,dignified manner,威仪,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+emphasize,emphasize,着重,ADV,B2
+to reflect on,to reflect on,思考,VERB,B2
+that pair,that pair,那付,NOUN,B2
+your photo,your photo,照你,NOUN,B2
+loud and clear,loud and clear,响亮,ADJ,B2
+unreasonable,unreasonable,不情,NOUN,B2
+cause of defeat,cause of defeat,败因,NOUN,B2
+good medicine,good medicine,好药,NOUN,B2
+that which,that which,所,PART,B2
+counter-boundary,counter-boundary,反界,NOUN,B2
+classifier for documents portions,classifier for documents portions,份,NOUN,B2
+plain and simple,plain and simple,朴素,ADJ,B2
+too small,too small,太小,ADJ,B2
+all night,all night,通宵,NOUN,B2
+plasma,plasma,血浆,NOUN,B2
+subcategory,subcategory,分目,NOUN,B2
+year by year,year by year,逐年,ADV,B2
+i,i,我连,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+to lack basis,to lack basis,无据,VERB,B2
+cantaloupe,cantaloupe,哈密瓜,NOUN,B2
+to not lose,to not lose,别丢,VERB,B2
+worry-free,worry-free,无忧,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+breakthrough,breakthrough,突破性,ADJ,B2
+lover sweetheart,lover sweetheart,情人,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
+traffic light,traffic light,红绿灯,NOUN,B2
+audio equipment,audio equipment,音响,NOUN,B2
+neighborhood head,neighborhood head,里长,NOUN,B2
+paternity leave,paternity leave,陪产假,NOUN,B2
+exchange goods,exchange goods,换货,NOUN,B2
+next week,next week,下周,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+to linkage,to linkage,联动,VERB,B2
+eyes,eyes,眼中,NOUN,B2
+nadir,nadir,最低点,NOUN,B2
+social morality,social morality,社会公德,NOUN,B2
+to die for,to die for,死要,VERB,B2
+quick removal,quick removal,赶快脱,NOUN,B2
+i'm afraid,i'm afraid,恐怕,ADV,B2
+extreme height,extreme height,极高,NOUN,B2
+marriage leave,marriage leave,婚假,NOUN,B2
+special-purpose trip,special-purpose trip,专程,ADV,B2
+housework,housework,家务,NOUN,B2
+i-than,i-than,我比,NOUN,B2
+mulberry,mulberry,桑葚,NOUN,B2
+inner side,inner side,内侧,NOUN,B2
+sex appeal,sex appeal,性感,NOUN,B2
+trans-idealism,trans-idealism,超唯,NOUN,B2
+to recommend for admission,to recommend for admission,保送,VERB,B2
+usb flash drive,usb flash drive,U盘,NOUN,B2
+holy decree,holy decree,圣令,NOUN,B2
+to study deeply,to study deeply,钻研,VERB,B2
+why not,why not,何不,ADV,B2
+super-distinction,super-distinction,超殊,NOUN,B2
+my taking,my taking,我拿,NOUN,B2
+foe,foe,敌友,NOUN,B2
+explosion-proof,explosion-proof,防爆,ADJ,B2
+this route,this route,这路,NOUN,B2
+birthmark,birthmark,胎记,NOUN,B2
+financial center,financial center,金融中心,NOUN,B2
+pounding,pounding,捶,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+be sorry,be sorry,抱歉,ADJ,B2
+trans-induction,trans-induction,超归,NOUN,B2
+to seek you,to seek you,寻你,VERB,B2
+eldest brother,eldest brother,做大哥,NOUN,B2
+second letter,second letter,再信,NOUN,B2
+counter-belief,counter-belief,反信,NOUN,B2
+past events,past events,往事,NOUN,B2
+swordsmanship,swordsmanship,剑术,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+logic modification,logic modification,改逻,NOUN,B2
+crowded,crowded,拥挤,ADJ,B2
+super-internal,super-internal,超内,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+nuclear energy,nuclear energy,核能,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+law,law,法,PART,B2
+zen master,zen master,禅师,NOUN,B2
+bluntness,bluntness,直说,NOUN,B2
+intravenous drip,intravenous drip,输液,NOUN,B2
+for a time,for a time,一度,ADV,B2
+cause of change,cause of change,改因,NOUN,B2
+equally matched,equally matched,不相上下,ADJ,B2
+external hard drive,external hard drive,移动硬盘,NOUN,B2
+immobility,immobility,都无动,NOUN,B2
+land expansion,land expansion,拓土,NOUN,B2
+pushover,pushover,善茬,NOUN,B2
+family background,family background,出身,NOUN,B2
+on the spot,on the spot,当场,ADV,B2
+sea level rise,sea level rise,海平面上升,NOUN,B2
+no not,no not,不,ADV,B2
+nephews,nephews,子侄,NOUN,B2
+common sense,common sense,常识,NOUN,B2
+capable,capable,有本事,NOUN,B2
+revised image,revised image,改影,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+according to,according to,要照,NOUN,B2
+spending,spending,行用,NOUN,B2
+re-analysis,re-analysis,重析,NOUN,B2
+homestay,homestay,民宿,NOUN,B2
+at worst,at worst,大不了,ADV,B2
+stuffed crab,stuffed crab,蟹酿,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+creditor's rights,creditor's rights,债权,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+sick leave,sick leave,病假,NOUN,B2
+month ago,month ago,月前,NOUN,B2
+altered path,altered path,改径,NOUN,B2
+to pay off,to pay off,清偿,VERB,B2
+medal awarding,medal awarding,授勋,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+in those days,in those days,当年,NOUN,B2
+cutting grass,cutting grass,斩草,NOUN,B2
+main street,main street,大街,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+exchange meeting,exchange meeting,交流会,NOUN,B2
+high-speed,high-speed,高速,ADJ,B2
+senior male student,senior male student,学长,NOUN,B2
+trans-er,trans-er,超而,NOUN,B2
+over-skill,over-skill,超技,NOUN,B2
+can-exit,can-exit,还出得来,NOUN,B2
+polyester,polyester,涤纶,NOUN,B2
+retrial,retrial,再审,NOUN,B2
+then he,then he,那他,NOUN,B2
+to eavesdrop,to eavesdrop,偷听,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+not catch up,not catch up,非赶,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+good faith,good faith,信义,NOUN,B2
+recycled item,recycled item,再物,NOUN,B2
+non-number,non-number,非数,NOUN,B2
+amended possibility,amended possibility,改可,NOUN,B2
+initial stage,initial stage,初期,NOUN,B2
+social awareness,social awareness,社会觉悟,NOUN,B2
+coral reef,coral reef,珊瑚礁,NOUN,B2
+to send mail,to send mail,寄件,VERB,B2
+death news,death news,死讯,NOUN,B2
+able to play,able to play,能下,NOUN,B2
+supreme fate,supreme fate,上缘,NOUN,B2
+re-tolerance,re-tolerance,再容,NOUN,B2
+white blood cell,white blood cell,白细胞,NOUN,B2
+mock exam,mock exam,模拟考,NOUN,B2
+heavy effect,heavy effect,重效,NOUN,B2
+hearth,hearth,壁炉,NOUN,B2
+to wanted,to wanted,通缉,VERB,B2
+to dry clean,to dry clean,干洗,VERB,B2
+return destination,return destination,回哪,NOUN,B2
+historical site,historical site,古迹,NOUN,B2
+patient sufferer,patient sufferer,患者,NOUN,B2
+simple pure,simple pure,单纯,ADJ,B2
+re-basis,re-basis,再据,NOUN,B2
+taro,taro,芋头,NOUN,B2
+re-route,re-route,重路,NOUN,B2
+listening,listening,也听,NOUN,B2
+stone,stone,石,PART,B2
+main road,main road,主路,NOUN,B2
+sub-method,sub-method,分法,NOUN,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+moonlight,moonlight,月色,NOUN,B2
+your word,your word,听你,NOUN,B2
+happy event,happy event,喜事,NOUN,B2
+this sword,this sword,这剑,NOUN,B2
+jujube,jujube,枣子,NOUN,B2
+proclamation,proclamation,宣大,NOUN,B2
+eavesdropping,eavesdropping,偷听,NOUN,B2
+procedural,procedural,程序的,ADJ,B2
+medical care,medical care,医疗,NOUN,B2
+missile,missile,导弹,NOUN,B2
+inside in,inside in,里,NOUN,B2
+great joy,great joy,大喜,NOUN,B2
+direct sales,direct sales,直销,NOUN,B2
+radiotherapy,radiotherapy,放疗,NOUN,B2
+you except,you except,你除,NOUN,B2
+herbicide,herbicide,除草剂,NOUN,B2
+over-degree,over-degree,超阶,NOUN,B2
+core course,core course,核心课,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+non-theory,non-theory,非论,NOUN,B2
+to not seen,to not seen,不见,VERB,B2
+all at once,all at once,一下子,ADV,B2
+re-verification,re-verification,改证,NOUN,B2
+mutual treatment,mutual treatment,相待,NOUN,B2
+too big,too big,太大,ADJ,B2
+to break a record,to break a record,打破纪录,VERB,B2
+final exam,final exam,期末考,NOUN,B2
+anti-static,anti-static,防静电,ADJ,B2
+boundless,boundless,无疆,NOUN,B2
+to serve as,to serve as,充当,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+re-substance,re-substance,再质,NOUN,B2
+light rain,light rain,小雨,NOUN,B2
+undercover agent,undercover agent,卧底,NOUN,B2
+little bitch,little bitch,小婊子,NOUN,B2
+who polite,who polite,哪位,PRON,B2
+to pioneer,to pioneer,首创,VERB,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+over-model,over-model,超模,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+certain fall,certain fall,必倒,NOUN,B2
+anticyclone,anticyclone,反气旋,NOUN,B2
+safe haven,safe haven,避风港,NOUN,B2
+supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
+reordering,reordering,改序,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+air raid,air raid,空袭,NOUN,B2
+to fall down,to fall down,倒下,VERB,B2
+historical record,historical record,历史纪录,NOUN,B2
+re-possibility,re-possibility,重可,NOUN,B2
+larger,larger,再大,NOUN,B2
+wind speed,wind speed,风速,NOUN,B2
+award ceremony,award ceremony,颁奖典礼,NOUN,B2
+super-special,super-special,超特,NOUN,B2
+graduate student,graduate student,研究生,NOUN,B2
+machine learning,machine learning,机器学习,NOUN,B2
+random posting,random posting,乱贴,NOUN,B2
+unwinnable,unwinnable,打不赢,NOUN,B2
+postwar,postwar,战后,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+third place,third place,季军,NOUN,B2
+family happiness,family happiness,天伦之乐,NOUN,B2
+hot water,hot water,热水,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+two days,two days,两天,NUM,B2
+guqin,guqin,古琴,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
+table grape,table grape,提子,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+over-order,over-order,超序,NOUN,B2
+heavy capacity,heavy capacity,重容,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+pipa,pipa,琵琶,NOUN,B2
+so as not to,so as not to,免得,SCONJ,B2
+war cessation,war cessation,战息,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
+perilla,perilla,紫苏,NOUN,B2
+re-specialization,re-specialization,重特,NOUN,B2
+panda,panda,熊猫,NOUN,B2
+sum total,sum total,总而,NOUN,B2
+adolescent,adolescent,青少年,NOUN,B2
+rights and interests,rights and interests,权益,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+unstoppable,unstoppable,不可阻挡,ADJ,B2
+why bother,why bother,何必,ADV,B2
+overthrow,overthrow,扳倒,NOUN,B2
+chest stab,chest stab,胸刺,NOUN,B2
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
+rashly,rashly,轻举,ADV,B2
+social structure,social structure,社会结构,NOUN,B2
+revealing,revealing,现出,NOUN,B2
+amended unity,amended unity,改一,NOUN,B2
+hedonistic,hedonistic,享乐主义的,ADJ,B2
+to strive for,to strive for,争取,VERB,B2
+two people,two people,两名,NUM,B2
+social movement,social movement,社会运动,NOUN,B2
+dare gamble,dare gamble,敢赌,NOUN,B2
+change of mind,change of mind,改念,NOUN,B2
+push further,push further,进尺,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+hyper-intent,hyper-intent,超意,NOUN,B2
+to send back,to send back,传回,VERB,B2
+social ethos,social ethos,社会风气,NOUN,B2
+non-observation,non-observation,非察,NOUN,B2
+ceramic art,ceramic art,陶艺,NOUN,B2
+re-observation,re-observation,再观,NOUN,B2
+young wife,young wife,小媳,NOUN,B2
+visibility,visibility,能见度,NOUN,B2
+excretion,excretion,排泄,NOUN,B2
+eavesdrop,eavesdrop,营听,NOUN,B2
+senior,senior,前辈,NOUN,B2
+to wiretap,to wiretap,监听,VERB,B2
+entering home,entering home,进家,NOUN,B2
+hundred million,hundred million,亿,NUM,B2
+ginseng,ginseng,人参,NOUN,B2
+non-sudden,non-sudden,非骤,NOUN,B2
+later stage,later stage,后期,NOUN,B2
+windy day,windy day,风天,NOUN,B2
+nickel,nickel,镍,NOUN,B2
+scenic spot,scenic spot,名胜,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+super-observation,super-observation,超察,NOUN,B2
+big dipper,big dipper,北斗七星,NOUN,B2
+quite good,quite good,挺好,NOUN,B2
+limbs,limbs,手脚,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+unsolved case,unsolved case,疑案,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to love dearly,to love dearly,心疼,VERB,B2
+military pay,military pay,军饷,NOUN,B2
+over-side,over-side,超方,NOUN,B2
+annual leave,annual leave,年假,NOUN,B2
+to be far from,to be far from,绝非,VERB,B2
+substantive,substantive,实质性的,ADJ,B2
+empress mother,empress mother,你母后,NOUN,B2
+both eyes,both eyes,双眼,NOUN,B2
+rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
+waiter attendant,waiter attendant,服务员,NOUN,B2
+your head,your head,你头上,NOUN,B2
+but majesty,but majesty,可陛,NOUN,B2
+energy saving,energy saving,节能,NOUN,B2
+to use force,to use force,动武,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+national record,national record,全国纪录,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
+to work part-time,to work part-time,打工,VERB,B2
+social phenomenon,social phenomenon,社会现象,NOUN,B2
+super-number,super-number,超数,NOUN,B2
+king,king,王,PART,B2
+flanking,flanking,包抄,NOUN,B2
+coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
+snow lotus,snow lotus,雪莲,NOUN,B2
+personal effort,personal effort,亲力,NOUN,B2
+at the instant sth happens,at the instant sth happens,临时,ADV,B2
+next meeting,next meeting,下回遇,NOUN,B2
+to await orders,to await orders,待命,VERB,B2
+equal size,equal size,等大,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+re-generalization,re-generalization,重般,NOUN,B2
+project report,project report,项目报告,NOUN,B2
+local tyrant,local tyrant,豪强,NOUN,B2
+chinese cabbage,chinese cabbage,白菜,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+peephole,peephole,门镜,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+army morale,army morale,军心,NOUN,B2
+social hierarchy,social hierarchy,社会等级,NOUN,B2
+that is to say,that is to say,也就是说,SCONJ,B2
+value change,value change,改值,NOUN,B2
+what kind,what kind,什么样,PRON,B2
+punitive,punitive,惩罚性的,ADJ,B2
+mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+to follow up,to follow up,追问,VERB,B2
+non-righteousness,non-righteousness,非义,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+your parents,your parents,你爹娘,NOUN,B2
+two sons,two sons,儿俩,NOUN,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+over-form,over-form,超式,NOUN,B2
+hard to determine,hard to determine,难以确定,ADJ,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+don't,don't,可别,AUX,B2
+to be located at,to be located at,位于,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
+amber,amber,琥珀,NOUN,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
+architecture photo,architecture photo,建筑照,NOUN,B2

--- a/swedish/expansion.csv
+++ b/swedish/expansion.csv
@@ -1,3146 +1,888 @@
 Swedish_Lemma,English_Lemma,Chinese_Lemma,POS,CEFR
 -t,-ly,地,PART,B2
-3D-utskrift,three-d printing,3D打印,NOUN,B2
-African,African,词,ADJ,B1
-Ah Fang,Ah Fang,阿方啊,NOUN,C1
-Alawi,Alawi,词,NOUN,C1
-Alice,Alice,词,NOUN,B2
-Alzheimer's disease,Alzheimer's disease,阿尔茨海默病,NOUN,C1
-Amazigh,Amazigh,词,NOUN,C1
-Andalusian,Andalusian,词,ADJ,B2
-Arabic (noun),Arabic,词,NOUN,B1
-Arabic language,Arabic language,词,NOUN,A2
-Arabs,Arabs,词,NOUN,B2
-Atlantean,Atlantean,أطلانطي,ADJ,B1
-Atlantic,Atlantic,词,ADJ,C1
-Balkanization,Balkanization,词,NOUN,C1
-Beijing opera,Beijing opera,京剧,NOUN,A2
-Bitcoin,Bitcoin,比特币,NOUN,C1
-Bluetooth,Bluetooth,蓝牙,NOUN,C1
-Brother He,Brother He,郃弟,NOUN,B2
-Brussels,Brussels,词,ADJ,C1
-Buddhism,Buddhism,词,NOUN,B2
-Buddhist,Buddhist,词,NOUN,B2
-Calvinism,Calvinism,词,NOUN,C1
-Caucasian,Caucasian,词,ADJ,B2
-Celtic,Celtic,词,ADJ,B2
-Changle Marquis,Changle Marquis,长乐小侯,NOUN,C1
-Chengyang,Chengyang,承阳,NOUN,C1
-Chinese chess,Chinese chess,象棋,NOUN,B2
-Chinese person,Chinese person,词,NOUN,B2
-Chinese yam,Chinese yam,山药,NOUN,C1
-Chinese zodiac,Chinese zodiac,生肖,NOUN,B2
-Christian (adj),Christian,词,ADJ,C1
-Christmas Eve dinner,Christmas Eve dinner,词,NOUN,C1
-Chu,Chu,楚,NOUN,C1
-Commander Fu,Commander Fu,付都尉,NOUN,C1
-Common Era,Common Era,公元,NOUN,B1
-Congo,Congo,词,NOUN,C1
-Consort Yuan,Consort Yuan,元妃,NOUN,C1
-Cretaceous,Cretaceous,词,ADJ,B2
-DIY,DIY,词,NOUN,C1
-DNA,DNA,词,NOUN,B2
-ECG,ECG,心电图,NOUN,C1
-Ed,Ed,词,NOUN,B2
-Egyptian (noun),Egyptian,词,NOUN,B2
-English language,English language,词,NOUN,A2
-Etruscan,Etruscan,词,ADJ,C1
-Eucharist,Eucharist,词,NOUN,C1
-Eurasian,Eurasian,词,ADJ,C1
-Fang Wei,Fang Wei,房纬,NOUN,C1
-Fauvism,Fauvism,词,NOUN,C1
-Feng Suige,Feng Suige,凤随歌,NOUN,B2
-France,France,词,NOUN,B1
-Franciscan,Franciscan,词,ADJ,C1
-French language,French language,词,NOUN,A2
-French-speaking world,French-speaking world,词,NOUN,B2
-Frenchification,Frenchification,词,NOUN,C1
-Friday evening,Friday evening,词,NOUN,C1
-Gallic,Gallic,词,ADJ,C1
-German (adj),German,德国人,ADJ,C1
-Gnawa,Gnawa,词,NOUN,B2
-Gothic,Gothic,词,ADJ,C1
-Goyaesque,Goyaesque,词,ADJ,C1
-Gu Yu,Gu Yu,跟辜余,NOUN,C1
-Gypsy,Gypsy,词,NOUN,C1
-Hassaniya Arabic,Hassaniya Arabic,词,NOUN,C1
-Havana cigar,Havana cigar,词,NOUN,C1
-He'er,He'er,郃儿,NOUN,C1
-Hebraic,Hebraic,词,ADJ,C1
-Hebrew,Hebrew,词,NOUN,C1
-Hellenism,Hellenism,词,NOUN,C1
-Hellenist,Hellenist,词,NOUN,C1
-Herculean,Herculean,词,ADJ,C1
-Hindu,Hindu,词,NOUN,C1
-Hinduism,Hinduism,词,NOUN,C1
-Hong Kong licensed goods,Hong Kong licensed goods,港行,NOUN,C1
-Hurufiyya,Hurufiyya,词,NOUN,C1
-I am,I am,我是,PRON,A1
-I come well,I come well,我来好,NOUN,C1
-I hate,I hate,我恨,NOUN,B2
-I only,I only,我光,NOUN,C1
-I see,I see,我见,NOUN,C1
-IT-related,IT-related,词,ADJ,C1
-Iberian,Iberian,词,ADJ,C1
-Indian (noun),Indian,词,NOUN,B1
-Indian summer,Indian summer,秋老虎,NOUN,C1
-Indians,Indians,词,NOUN,C1
-Internet of Things,Internet of Things,物联网,NOUN,C1
-Islamic jurisprudence,Islamic jurisprudence,词,NOUN,C1
-Islamic law,Islamic law,词,NOUN,B2
-Islamism,Islamism,词,NOUN,C1
-Israeli,Israeli,词,ADJ,B2
-January evening,January evening,词,NOUN,B2
-Japanese person,Japanese person,词,NOUN,C1
-Jesuit,Jesuit,词,NOUN,C1
-Jewish quarter,Jewish quarter,词,NOUN,C1
-Kufic,Kufic,词,ADJ,C1
-Lantern Festival,Lantern Festival,元宵节,NOUN,B2
-Latin (noun),Latin,词,NOUN,C1
-Limburgish,Limburgish,词,ADJ,C1
-Ling,Ling,叫凌,NOUN,B2
-Lu Ke,Lu Ke,陆珂,NOUN,B2
-Lu family,Lu family,有鲁家,NOUN,C1
-Machiavellian,Machiavellian,词,ADJ,C1
-Maghrebi,Maghrebi,词,ADJ,C1
-Makhzen,Makhzen,马赫曾,NOUN,C1
-Mandarin,Mandarin,普通话,NOUN,A1
-Marxist,Marxist,词,ADJ,C1
-Mary,Mary,词,NOUN,B2
-Master Gao's wife,Master Gao's wife,高师娘,NOUN,C1
-Master Li,Master Li,李爷,NOUN,C1
-Master Liu,Master Liu,刘爷,NOUN,B2
-Milky Way,Milky Way,银河,NOUN,C1
-Mindfulness Villa,Mindfulness Villa,正念山庄,NOUN,B2
-Ministry of Justice,Ministry of Justice,刑部,NOUN,B1
-Mm,Mm,词,INTJ,C1
-Mon,Mon,词,NOUN,C1
-Moroccan,Moroccan,词,ADJ,B2
-Mr. sir,Mr. sir,先生,NOUN,B2
-Mrs.,Mrs.,词,NOUN,A1
-Ms.,Ms.,词,NOUN,C1
-Murong,Murong,慕容,NOUN,B2
-Muslim (adj),Muslim,词,ADJ,B1
-Natan,Natan,词,NOUN,B2
-National Day,National Day,国庆节,NOUN,B1
-New Year's Eve,New Year's Eve,除夕,NOUN,B2
-New Year's Eve dinner,New Year's Eve dinner,年夜饭,NOUN,B2
-No.,No.,词,NOUN,C1
-Nordic,Nordic,词,ADJ,C1
-Old Jiang,Old Jiang,老江,NOUN,B2
-Old Qin,Old Qin,老秦,NOUN,B2
-Olympics,Olympics,词,NOUN,B1
-Parisian,Parisian,词,ADJ,B1
-Parkinson's disease,Parkinson's disease,词,NOUN,C1
-Philippic (adj),Philippic,词,ADJ,C1
-Pingling,Pingling,等平陵,NOUN,C1
-Polaris,Polaris,北极星,NOUN,B2
-Prophet birthday,Prophet birthday,词,NOUN,B2
-QR code,QR code,二维码,NOUN,C1
-Quran,Quran,词,NOUN,B2
-Rotterdam,Rotterdam,词,ADJ,C1
-SIM card,SIM card,词,NOUN,B1
-SSD,solid-state drive,固态硬盘,NOUN,B2
-Salafism,Salafism,词,NOUN,C1
-Saturday evening,Saturday evening,词,NOUN,C1
-Serbian,Serbian,词,ADJ,C1
-Shiism,Shiism,词,NOUN,C1
-Sichuan pepper,Sichuan pepper,花椒,NOUN,C1
-Song typeface,Song typeface,宋体,NOUN,C1
-Spain,Spain,词,NOUN,B2
-Standard Arabic,Standard Arabic,标准阿拉伯语,NOUN,C1
-Su Sha,Su Sha,夙砂,NOUN,B2
-Sufi,Sufi,词,NOUN,C1
-Sufi order,Sufi order,词,NOUN,B2
-Sufism,Sufism,词,NOUN,C1
-Sunday someone,Sunday someone,词,NOUN,A2
-Surinamese,Surinamese,词,ADJ,C1
-Susha origin,Susha origin,我夙砂本,NOUN,C1
-T-junction,T-junction,丁字路口,NOUN,C1
-TV ratings,TV ratings,词,NOUN,B1
-TV series,TV series,词,NOUN,B1
-Tai Chi,Tai Chi,太极,NOUN,C1
-Tajwid,Tajwid,词,NOUN,C1
-Thai,Thai,词,ADJ,C1
-Tifinagh script,Tifinagh script,词,NOUN,C1
-UV-resistant,UV-resistant,防紫外线,ADJ,C1
-VIP room,VIP room,贵宾室,NOUN,C1
-Whistles,Whistles,词,NOUN,C1
-Wushk,Wushk,词,NOUN,B1
-Xi Yang,Xi Yang,戏阳,NOUN,B1
-Xiang Fengsui,Xiang Fengsui,向凤随,NOUN,C1
-Yama,Yama,阎王,NOUN,C1
-Yay,Yay,词,INTJ,C1
-YouTuber,YouTuber,词,NOUN,B2
-Your Highness,Your Highness,殿下,NOUN,B2
-Youth Welfare Office,Youth Welfare Office,词,NOUN,C1
-Yu family,Yu family,玉家,NOUN,C1
-Zhuang,Zhuang,庄相,NOUN,C1
-Zhuang Hun,Zhuang Hun,庄混,NOUN,B2
-Zhuanghe,zhuang he,庄郃,NOUN,B2
-a an,a an,词,DET,A2
-a big pile,a big pile,一大堆,NUM,B2
-a chat,a chat,一聊,NOUN,B2
-a decade of a century e.g. the Sixties,a decade of a century e.g. the Sixties,年代,NOUN,B1
-a few,a few,بضع,NOUN,B1
-a long time,a long time,词,ADV,A2
-a lot,a lot,很多,ADV,B2
-a mess,a mess,一团糟,ADJ,B2
-a one,a one,词,DET,A1
-a posteriori,a posteriori,词,ADJ,C1
-a priori,a priori,词,ADJ,C1
-a sound,a sound,一声,NUM,B2
-a toast,a toast,我来敬,NOUN,C1
-abate,abate,词,VERB,B2
-abbey,abbey,词,NOUN,B2
-abbot,abbot,词,NOUN,B2
-abdication,abdication,退位,NOUN,C1
-abdominal pain,abdominal pain,腹痛,NOUN,B2
-aberrant,aberrant,词,ADJ,B2
-aberziehung,aberziehung,词,NOUN,B2
-abet,abet,词,VERB,B2
-abfassung,abfassung,词,NOUN,B2
-abforderung,abforderung,词,NOUN,C1
-abgestaltung,abgestaltung,词,NOUN,C1
-abhorrent,abhorrent,词,ADJ,B2
-abject,abject,悲惨的,ADJ,B2
-abjure,abjure,词,VERB,B2
-abkunft,abkunft,词,NOUN,C1
-ablaze keen,ablaze keen,燃烧的/敏锐的,ADJ,C1
-able to play,able to play,能下,NOUN,B2
-ablution,ablution,词,NOUN,B2
+lite,a bit,一点,ADV,B2
+liten,a little,一点,ADJ,B2
+gift par,a married couple,夫妇,NOUN,B2
+par,a pair,一对,NUM,B2
+hög,a pile,一堆,NUM,B2
+brunn,a well,井,NOUN,B2
+stund,a while,一会儿,NOUN,B2
+avsky,to abhor,憎恶,VERB,B2
+förmågen,able,能够的,ADJ,B2
 abnormal,abnormal,异常的,ADJ,B2
-abolition,abolition,废除,NOUN,B2
-abominable,abominable,可憎的,ADJ,B2
-abominate,abominate,词,VERB,B2
-abomination,abomination,词,NOUN,B2
-about,about,大约,ADV,B2
-about fifteen,about fifteen,词,NOUN,B2
-about fifty,about fifty,五十左右,NOUN,B2
-about it,about it,关于它,ADV,B2
-about sixty,about sixty,六十来个,NOUN,B2
-about ten,about ten,词,NOUN,B1
-about that,about that,关于那个,ADV,B2
-about thirty,about thirty,三十左右,NOUN,B2
-about this,about this,关于这个,ADV,B2
-about to,about to,快要,ADV,B2
-about what,about what,词,ADV,B1
-about which,about which,关于什么,PRON,B2
-above (noun),above,重上,NOUN,C1
-above average,above average,词,ADJ,C1
-above over,above over,词,ADP,A2
-above-mentioned,above-mentioned,上述的,ADJ,B2
-abpflegung,abpflegung,词,NOUN,C1
-abrasive,abrasive,词,ADJ,B2
-abregelung,abregelung,词,NOUN,C1
-abrichtung,abrichtung,词,NOUN,C1
-abrogate,abrogate,词,VERB,B2
-abscess,abscess,脓肿,NOUN,B2
-abschaft,abschaft,词,NOUN,C1
-abschrift,abschrift,词,NOUN,C1
-absent-minded,absent-minded,词,ADJ,B2
-absenteeism,absenteeism,词,NOUN,C1
-absetzung,absetzung,词,NOUN,C1
-absinnung,absinnung,词,NOUN,C1
+avskaffa,to abolish,废除,VERB,B2
+erosion,abrasion,擦伤,NOUN,B2
+utlandet,abroad,国外,NOUN,B2
+plötslig,abrupt,突然的,ADJ,B2
+fly,to abscond,潜逃,VERB,B2
+bortavänt,absent-mindedness,心不在焉,NOUN,B2
 absolut,absolute,绝对的,ADJ,B2
-absolutely not,absolutely not,词,ADV,C1
-absolution,absolution,词,NOUN,C1
-absolutist,absolutist,词,ADJ,C1
-absorbed,absorbed,全神贯注的,ADJ,B2
 absorbera,to absorb,吸收,VERB,B2
-absprache,absprache,词,NOUN,C1
-abstemious,abstemious,有节制的,ADJ,B2
-abstinence,abstinence,节制,NOUN,B2
-abstract (noun),abstract,词,NOUN,C1
-abstractionism,abstractionism,词,NOUN,C1
+avstå,to abstain,克制,VERB,B2
 abstraktion,abstraction,抽象,NOUN,B2
-absucht,absucht,词,NOUN,C1
-absuchung,absuchung,词,NOUN,C1
-absurd,preposterous,荒谬的,ADJ,B2
-absurdism,absurdism,词,NOUN,C1
-abtheilung,abtheilung,词,NOUN,C1
-abundantly,abundantly,词,ADV,C1
-abuse case,abuse case,词,NOUN,C1
-abuse of power,abuse of power,词,NOUN,C1
-abuses,abuses,词,NOUN,C1
-abusive,abusive,滥用的,ADJ,B2
-abwandel,abwandel,词,NOUN,C1
-abwirkung,abwirkung,词,NOUN,C1
-abysmal,abysmal,词,ADJ,B2
-academic degree,academic degree,学位,NOUN,C1
-academic proficiency test,academic proficiency test,会考,NOUN,C1
-academician,academician,院士,NOUN,B2
-accede,accede,词,VERB,B2
+obegriplig,abstruse,深奥的,ADJ,B2
+överflödande,abundant,丰富的,ADJ,B2
+missbruka,abuse,滥用,NOUN,B2
+missbruka,to abuse,滥用,VERB,B2
+avgrund,abyss,深渊,NOUN,B2
 acceleration,acceleration,加速,NOUN,B2
 accelerator,accelerator,油门,NOUN,B2
 accent,accent,口音,NOUN,B2
-accept me,accept me,受我,NOUN,B2
-accept orders,accept orders,领命,VERB,C1
-acceptable,acceptable,可接受的,ADJ,B2
 acceptans,acceptance,接受,NOUN,B2
-accessibility,accessibility,可达性,NOUN,B2
-accessibility features,accessibility features,词,NOUN,B2
-accessible,accessible,易接近的,ADJ,B2
 accession,accession,即位,NOUN,B2
-accessory,accessory,词,NOUN,B2
-acclimatization,acclimatization,适应环境,NOUN,B2
-acclimatize,acclimatize,词,VERB,B2
-accommodating,accommodating,词,ADJ,B2
-accompany or not,accompany or not,陪不,NOUN,B2
-accompanying,accompanying,词,ADJ,C1
-according to,according to,要照,NOUN,B2
-according to that,according to that,词,ADV,C1
-accordingly consequently,accordingly consequently,词,ADV,C1
-accordion,accordion,手风琴,NOUN,B2
-accost,accost,词,VERB,B2
-accountable,accountable,负责任的,ADJ,B2
-accounting (adj),accounting,词,ADJ,C1
-accreditation,accreditation,词,NOUN,C1
-acculturation,acculturation,文化涵化,NOUN,B2
-accumulator,accumulator,词,NOUN,C1
-accuracy,accuracy,准确性,NOUN,B2
-accused,accused,词,NOUN,B2
-accused person,accused person,被告,NOUN,B2
-accusing of treason,accusing of treason,词,NOUN,C1
-acedia spiritual sloth,acedia spiritual sloth,词,NOUN,C1
-acerbate,acerbate,词,VERB,B2
-acerbic,acerbic,尖刻的,ADJ,B2
-achievable,achievable,词,ADJ,B2
-achieved,achieved,词,ADJ,B1
-acid (adj),acid,词,ADJ,B1
-acid sour,acid sour,词,ADJ,B2
-acidic,acidic,词,ADJ,B2
-ack,alas,唉,INTJ,B2
+tillfällig,accidental,偶然的,ADJ,B2
+tillfälligt,accidentally,意外地,ADV,B2
+hysa,to accommodate,容纳,VERB,B2
+boende,accommodation,住宿,NOUN,B2
+åtfölja,to accompany,陪伴,VERB,B2
+överensstämmelse,accord with,合乎,NOUN,B2
+ansvarsskyldighet,accountability,问责制,NOUN,B2
+revisor,accountant,会计师,NOUN,B2
+redovisning,accounting,会计,NOUN,B2
 ackreditera,to accredit,认可,VERB,B2
 ackrediterad,accredited,认可的,ADJ,B2
-ackumulation,accumulation,积累,NOUN,B2
+tillfalla,to accrue,积累,VERB,B2
 ackumulera,to accumulate,积累,VERB,B2
-acolyte,acolyte,词,NOUN,B2
-acorn,acorn,词,NOUN,B1
-acoustic,acoustic,声学的,ADJ,B2
-acquired,acquired,词,ADJ,B2
-acquisition of ownership,acquisition of ownership,词,NOUN,C1
-acrid,acrid,词,ADJ,B2
-acrimonious,acrimonious,词,ADJ,B2
-acrobatics,acrobatics,杂技,NOUN,B2
-acronym,acronym,首字母缩略词,NOUN,B2
-acrostic,acrostic,词,NOUN,C1
-act of kneeling,act of kneeling,词,NOUN,C1
-activation,activation,词,NOUN,B2
-active population,active population,词,NOUN,C1
-activism,activism,激进主义,NOUN,B2
-activist,activist,词,NOUN,C1
-activities,activities,词,NOUN,B2
-actor or actress,actor or actress,演员,NOUN,A2
-acts of worship,acts of worship,词,NOUN,C1
-actually (noun),actually,倒也,NOUN,C1
-actuate,actuate,词,VERB,B2
-acumen,acumen,词,NOUN,C1
-acupoint strike,acupoint strike,点穴,NOUN,B2
-acuteness sharpness,acuteness sharpness,词,NOUN,C1
-adaptability,adaptability,词,NOUN,C1
-adaptable,adaptable,词,ADJ,B2
-adaptive,adaptive,词,ADJ,C1
-add-on,add-on,词,NOUN,C1
-addendum,addendum,补遗,NOUN,C1
-addictive,addictive,词,ADJ,B2
-additional extra,additional extra,词,ADJ,C1
-additionally,additionally,另外,ADV,B2
-adel,nobility,贵族气质,NOUN,B2
-adept,adept,词,ADJ,B2
-adequacy,adequacy,也不错,NOUN,B2
-adequate suitable,adequate suitable,词,ADJ,C1
-adherence,adherence,词,NOUN,B2
-adhesive bandage,adhesive bandage,词,NOUN,B2
+ackumulation,accumulation,积累,NOUN,B2
+korrekt,accurate,准确的,ADJ,B2
+syra,acid,酸,NOUN,B2
+surhet,acidity,酸度,NOUN,B2
+akustik,acoustics,声学,NOUN,B2
+förvärv,acquisition,获得,NOUN,B2
+frikänna,to acquit,宣告无罪,VERB,B2
+bitterhet,acrimony,尖刻,NOUN,B2
+akrobat,acrobat,杂技演员,NOUN,B2
+över,across,穿过,ADP,B2
+samverkan,act jointly,合伙,NOUN,B2
+handling,action,行动,NOUN,B2
+beroende,addicted,上瘾的,ADJ,B2
+beroende,addiction,上瘾,NOUN,B2
+tillägg,addition,增加,NOUN,B2
+ytterligare,additional,额外的,ADJ,B2
+tillräcklig,adequate,足够的,ADJ,B2
+närhet,adjacency,邻接,NOUN,B2
+angränsande,adjacent,邻近的,ADJ,B2
 adjektiv,adjective,形容词,NOUN,B2
-adjoin,adjoin,词,VERB,B2
-adjourn,adjourn,词,VERB,B2
-adjournment,adjournment,词,NOUN,C1
-adjudge,adjudge,词,VERB,B2
-adjudicate,adjudicate,裁决,VERB,B2
-adjudication,adjudication,词,NOUN,C1
-adjure,adjure,词,VERB,B2
-adjustability,adjustability,词,NOUN,C1
-adjustment,adjustment,调节,NOUN,B2
+justera,to adjust,调整,VERB,B2
 administration,administration,管理,NOUN,B2
 administrativ,administrative,行政的,ADJ,B2
-administrative offense,administrative offense,词,NOUN,C1
-administrator,administrator,管理员,NOUN,B2
-admirable,admirable,词,ADJ,B2
-admiration,admiration,词,NOUN,B2
-admissibility acceptance,admissibility acceptance,词,NOUN,C1
-admissible,admissible,词,ADJ,B2
-admissible eligible,admissible eligible,词,ADJ,C1
-admission,admission,词,NOUN,B1
-admitted,admitted,词,ADJ,B2
-adolescence,adolescence,词,NOUN,B2
-adolescent,adolescent,青少年,NOUN,B2
-adopted son,adopted son,义子,NOUN,B1
-adopted-son,adopted-son,归义子,NOUN,C1
+visserligen,admittedly,诚然,ADV,B2
+förmana,to admonish,告诫,VERB,B2
 adoption,adoption,收养,NOUN,B2
-adorable,adorable,词,ADJ,B2
-adoration worship,adoration worship,词,NOUN,C1
 adorn,to adorn,装饰,VERB,B2
 adornment,adornment,装饰品,NOUN,B2
-adoul notaries,adoul notaries,词,NOUN,C1
-adrenaline,adrenaline,词,NOUN,C1
-adroit,adroit,词,ADJ,B2
-adulation,adulation,词,NOUN,C1
 adult,adult,成年的,ADJ,B2
 adulterate,to adulterate,掺杂,VERB,B2
-adultery,adultery,词,NOUN,C1
 adulthood,adulthood,成年,NOUN,B2
 advance,advance,进展,NOUN,B2
-advance guard,advance guard,先遣,NOUN,B2
-advance notice,advance notice,词,NOUN,B2
 advanced study,advanced study,深造,NOUN,B2
 advanced technology,advanced technology,先进,ADJ,B2
 advantageous,advantageous,有利的,ADJ,B2
 adventurer,adventurer,冒险家,NOUN,B2
-adventurous,adventurous,词,ADJ,B2
-adversarial,adversarial,词,ADJ,B2
 adversary,adversary,对手,NOUN,B2
-adverse,adverse,不利的,ADJ,B2
-adversity,adversity,逆境,NOUN,B2
 advertise,to advertise,做广告,VERB,B2
 advertisement,advertisement,广告,NOUN,B2
-advertiser,advertiser,词,NOUN,B2
-advertising,advertising,广告的,ADJ,B2
-advisability,advisability,词,NOUN,C1
-advisable,advisable,词,ADJ,B2
 advise,to advise,建议,VERB,B2
 advise against,to advise against,劝阻,VERB,B2
-advisor consultant,advisor consultant,词,NOUN,B2
-advisory,advisory,词,ADJ,C1
-advocacy,advocacy,词,NOUN,C1
-advocate (noun),advocate,词,NOUN,B2
 aerial,aerial,航空的,ADJ,B2
-aerodynamics,aerodynamics,词,NOUN,C1
-aeronautical,aeronautical,词,ADJ,B2
-aesthetic taste,aesthetic taste,词,NOUN,C1
-affability,affability,词,NOUN,C1
 affable,affable,和蔼可亲的,ADJ,B2
 affair,affair,事务,NOUN,B2
 affair hall,affair hall,事殿,NOUN,B2
 affectation,affectation,做作,NOUN,B2
-affected,affected,受影响的,ADJ,B2
-affected eloquence,affected eloquence,词,NOUN,C1
-affected speech,affected speech,词,NOUN,C1
-affectedness,affectedness,词,NOUN,C1
 affectionate,affectionate,深情的,ADJ,B2
-affidavit,affidavit,词,NOUN,B2
 affiliate,affiliate,附属机构,NOUN,B2
 affiliation,affiliation,隶属关系,NOUN,B2
-affinity,affinity,词,NOUN,C1
 affirm,to affirm,断言,VERB,B2
-affirmative,affirmative,词,ADJ,B2
-affix,affix,词,NOUN,B2
 afflict,to afflict,折磨,VERB,B2
-affliction,affliction,灾难,NOUN,C1
-affluent,affluent,词,ADJ,B2
-afford,afford,词,VERB,A2
-affordability,affordability,得起,NOUN,B2
 affordable,affordable,负担得起的,ADJ,B2
 afforestation,afforestation,植树造林,NOUN,B2
-affront,affront,冒犯,NOUN,B2
-affärs,business,商业的,ADJ,B2
-affärsmöte,business meeting,洽谈会,NOUN,B2
-aforementioned,aforementioned,上述的,ADJ,B2
 after,after,تلو,NOUN,B2
-after (adv),after,词,ADV,A1
-after (sconj),after,after,SCONJ,A1
-after all just,after all just,毕竟刚,ADV,C1
 after that,after that,此后,ADV,B2
-after the example of,after the example of,词,NOUN,C1
-after this,after this,词,ADV,B2
-after to,after to,词,ADP,A2
 after which,after which,之后,ADV,B2
-after-class exercises,after-class exercises,课后题,NOUN,C1
 aftereffect,aftereffect,后遗症，后果,NOUN,B2
-aftermath,aftermath,随后,NOUN,C1
-aftertaste,aftertaste,词,NOUN,C1
 afterward,afterward,去后,NOUN,B2
 again,again,你又,NOUN,B2
-against it,against it,词,ADV,A2
-agate,agate,词,NOUN,B1
-age lifetime,age lifetime,词,NOUN,A2
-aged,aged,年老的,ADJ,B2
 agency,agency,代理机构,NOUN,B2
-agenda,agenda,词,NOUN,C1
-agenda item,agenda item,议题,NOUN,C1
 agent,agent,代理人,NOUN,B2
-agg,grudge,怨恨,NOUN,B2
-agglomerate,agglomerate,词,NOUN,B2
-aggrandizement,aggrandizement,词,NOUN,C1
-aggravated,aggravated,词,ADJ,C1
-aggravating,aggravating,词,ADJ,B2
-aggravation,aggravation,词,NOUN,C1
-aggregate (noun),aggregate,词,NOUN,B2
-aggregation,aggregation,词,NOUN,C1
 aggression,aggression,侵略,NOUN,B2
 aggressivitet,aggressiveness,攻击性,NOUN,B2
-aggressor,aggressor,词,NOUN,C1
-aghast,aghast,惊骇的,ADJ,B2
 agil,agile,敏捷的,ADJ,B2
 agilitet,agility,敏捷,NOUN,B2
-aging,aging,老化,NOUN,B2
-agitated,agitated,焦躁的,ADJ,B2
-agitation,agitation,词,NOUN,B2
-agnatic inheritance,agnatic inheritance,词,NOUN,C1
-agnostic (adj),agnostic,词,ADJ,B2
-agnostic (noun),agnostic,词,NOUN,B2
-agnosticism,agnosticism,词,NOUN,C1
-ago,ago,以前,ADV,B2
-agonize,agonize,词,VERB,B2
-agreeable,agreeable,词,ADJ,B2
-agreed,agreed,一致的,ADJ,B2
-ah,ah,水 水,PART,B2
-aha,aha,啊哈,INTJ,B2
-aim destination,aim destination,目的/目的地,NOUN,C1
-aimless,aimless,词,ADJ,C1
-aims,aims,词,NOUN,C1
-air conditioner,air conditioner,词,NOUN,B1
-air leak,air leak,漏气,NOUN,B2
-air pressure,air pressure,气压,NOUN,B2
-air raid,air raid,空袭,NOUN,B2
-air temperature,air temperature,气温,NOUN,C1
-airfield,airfield,飞机场,NOUN,B2
-airline,airline,词,NOUN,C1
-airs,airs,摆架子,NOUN,B2
-airtight,airtight,密封的,ADJ,B2
-aisle,aisle,词,NOUN,B1
-aita song,aita song,词,NOUN,C1
-ajar,ajar,半开的,ADJ,B2
-akin,akin,相似的,ADJ,B2
-akrobat,acrobat,杂技演员,NOUN,B2
-akta,to pay attention,注意,VERB,B2
-aktning,esteem,尊重,NOUN,B2
-akustik,acoustics,声学,NOUN,B2
-alarm system,alarm system,词,NOUN,C1
-alarmant,alarming,令人担忧的,ADJ,B2
-alarmism,alarmism,词,NOUN,C1
+ångest,agony,极度痛苦,NOUN,B2
+jordbruks,agricultural,农业的,ADJ,B2
+jordbruk,agriculture,农业,NOUN,B2
+åh,ah,啊,INTJ,B2
+mål,aim,目标,NOUN,B2
+luftkonditionering,air conditioning,空调,NOUN,B2
+luftförsvar,air defense,防空,NOUN,B2
 alarmklocka,alarm clock,闹钟,NOUN,B2
+alarmant,alarming,令人担忧的,ADJ,B2
+ack,alas,唉,INTJ,B2
 album,album,相册,NOUN,B2
-alchemy,alchemy,词,NOUN,C1
-alderman,alderman,词,NOUN,B2
-alertness,alertness,机敏,NOUN,C1
-algae,algae,词,NOUN,B2
+larm,alert,警报,NOUN,B2
 algebra,algebra,代数,NOUN,B2
-algebraic,algebraic,词,ADJ,C1
 algoritm,algorithm,算法,NOUN,B2
-alibi,alibi,不在场证明,NOUN,B2
-alien,alien,外星人的,ADJ,B2
-alienable,alienable,可转让的,ADJ,B2
-alienating,alienating,使人疏远的,ADJ,B2
-alike,alike,词,ADV,B1
-alkalinity,alkalinity,词,NOUN,C1
-all,all,جميع,NOUN,B2
-all (adj),all,全,ADJ,B2
-all (noun),all,全体,NOUN,B2
-all along,all along,一路上,NOUN,B2
-all at once,all at once,一下子,ADV,B2
-all correct,all correct,都对,NOUN,C1
-all day,all day,整天,ADV,B2
-all day long (adv),all day long,成天,ADV,C1
-all entirely,all entirely,词,DET,B2
-all good,all good,都好,NOUN,B2
-all kinds,all kinds,各种各样的,DET,B2
-all night,all night,通宵,NOUN,B2
-all night (adv),all night,彻夜,ADV,C1
-all not,all not,都别,ADV,C1
-all out,all out,齐出,NOUN,C1
-all over,all over,遍,ADV,A2
-all passed,all passed,都过,NOUN,C1
-all saints' day,all saints' day,词,NOUN,B2
-all the more,all the more,更加,ADV,B2
-all together,all together,词,ADV,C1
-all with,all with,都与,NOUN,B2
-all-round,all-round,全面的,ADJ,B2
-allay,allay,词,VERB,C1
-allegation,allegation,词,NOUN,C1
-alleged presumed,alleged presumed,词,ADJ,C1
-allegiance,allegiance,词,NOUN,B2
-allegorical,allegorical,词,ADJ,C1
-allegory,allegory,词,NOUN,C1
-allergi,allergy,过敏,NOUN,B2
-alleys,alleys,词,NOUN,B2
-allies,allies,盟友,NOUN,C1
-alliteration,alliteration,词,NOUN,C1
-allmän ordning,public order,治安,NOUN,B2
-allmännyttan,public welfare,公益性,NOUN,B2
-allocation,allocation,词,NOUN,C1
-allot,allot,词,VERB,C1
-allotment,allotment,词,NOUN,C1
+främmandegörande,alienation,异化,NOUN,B2
+justering,alignment,结盟,NOUN,B2
+underhåll,alimony,赡养费,NOUN,B2
+levande,alive,活着的,ADJ,B2
 allt,all,全部,ADV,B2
-alltmer,increasingly,越来越,ADV,B2
-alltså,that is,即,ADV,B2
-allure,allure,词,NOUN,C1
-alluring,alluring,诱人的,ADJ,C1
+hela dagen,all day long,一整天,NOUN,B2
+påstådd,alleged,所谓的,ADJ,B2
+påstås,allegedly,据称,ADV,B2
+allergi,allergy,过敏,NOUN,B2
+dold läge,allow hiding,许躲,NOUN,B2
+bidrag,allowance,津贴,NOUN,B2
+legering,alloy,合金,NOUN,B2
 allusion,allusion,暗示,NOUN,B2
 allusive,allusive,暗指的,ADJ,B2
 almond,almond,杏仁,NOUN,B2
-almonds,almonds,词,NOUN,A2
-alms,alms,词,NOUN,B2
-alms zakat,alms zakat,词,NOUN,B2
 alone,alone,独自,ADV,B2
 along with,along with,随着,ADP,B2
-aloof,aloof,词,ADJ,C1
-aloofness,aloofness,冷漠,NOUN,B2
-aloud,aloud,出声地,ADV,B2
 alphabetical,alphabetical,按字母顺序的,ADJ,B2
-alpine,alpine,高山的,ADJ,B2
-already may particle,already may particle,词,PART,A2
 alright,alright,好的,ADV,B2
-alright (noun),alright,好吧,NOUN,B1
-also (adp),also,也对,ADP,B2
-also (aux),also,也要,AUX,B2
-also (noun),also,词,NOUN,A2
-also (sconj),also,也是,SCONJ,B1
-also come,also come,也来,NOUN,B2
-also fixed,also fixed,也定,NOUN,C1
-also good,also good,也好,ADJ,B2
-also will,also will,也会,NOUN,C1
-altar,altar,词,NOUN,B2
-alteration,alteration,改变,NOUN,B2
-altercation,altercation,争执,NOUN,B2
-altered art,altered art,改艺,NOUN,B2
 altered meaning,altered meaning,改义,NOUN,B2
 altered mechanism,altered mechanism,改机,NOUN,B2
-altered outcome,altered outcome,改果,NOUN,C1
-altered path,altered path,改径,NOUN,B2
-altered strategy,altered strategy,改略,NOUN,C1
-altered type,altered type,改型,NOUN,C1
-altered work,altered work,改作,NOUN,C1
 alternate,to alternate,交替,VERB,B2
-alternating,alternating,交替的,ADJ,B2
 alternation,alternation,轮流,NOUN,B2
-alternativ,option,选择,NOUN,B2
-alternativ,options,期权,NOUN,B2
-alternative (noun),alternative,替代,NOUN,B2
-alternatively,alternatively,交替地,ADV,B2
-although (adp),although,虽,ADP,B1
-altitude,altitude,海拔,NOUN,B2
-altogether,altogether,共,ADV,B2
 altruism,altruism,利他主义,NOUN,B2
-altruistic,altruistic,利他的,ADJ,B2
 aluminum,aluminum,铝,NOUN,B2
-alumnus,alumnus,校友,NOUN,B2
-always have,always have,总有,VERB,C1
-amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
-amazed,amazed,惊讶,ADJ,C1
 amazement,amazement,惊愕,NOUN,B2
 amazing,amazing,令人惊叹的,ADJ,B2
-amber,amber,琥珀,NOUN,B2
-ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
-ambient surrounding,ambient surrounding,词,ADJ,C1
 ambiguity,ambiguity,歧义,NOUN,B2
 ambiguous,ambiguous,模棱两可的,ADJ,B2
-ambivalence,ambivalence,词,NOUN,B2
 ambivalent,ambivalent,矛盾的,ADJ,B2
-ameliorate,ameliorate,词,VERB,C1
-amelioration,amelioration,词,NOUN,C1
 amend,to amend,修订,VERB,B2
-amendable,amendable,可修正的,ADJ,B2
-amended abstraction,amended abstraction,改抽,NOUN,B2
-amended analysis,amended analysis,改析,NOUN,C1
-amended classification,amended classification,改归,NOUN,B2
-amended combination,amended combination,改合,NOUN,C1
-amended concrete,amended concrete,改具,NOUN,B2
-amended contingency,amended contingency,改偶,NOUN,C1
-amended difference,amended difference,改殊,NOUN,C1
-amended division,amended division,改分,NOUN,B2
-amended essence,amended essence,改本,NOUN,B2
-amended generality,amended generality,改般,NOUN,B2
-amended inclusion,amended inclusion,改纳,NOUN,B2
-amended inference,amended inference,改推,NOUN,C1
 amended interior,amended interior,改内,NOUN,B2
 amended judgment,amended judgment,改断,NOUN,B2
-amended necessity,amended necessity,改必,NOUN,C1
-amended particular,amended particular,改特,NOUN,B2
-amended possibility,amended possibility,改可,NOUN,B2
-amended synthesis,amended synthesis,改综,NOUN,B2
-amended unity,amended unity,改一,NOUN,B2
-amended universality,amended universality,改普,NOUN,C1
 amendment,amendment,修正案,NOUN,B2
-amendments,amendments,词,NOUN,C1
-amends,amends,补偿,NOUN,B2
 amiable,amiable,和蔼可亲的,ADJ,B2
-amicable,amicable,友好的,ADJ,B2
-amicable out-of-court,amicable out-of-court,词,ADJ,B2
-amino acid,amino acid,氨基酸,NOUN,C1
-amma,to breastfeed,母乳喂养,VERB,B2
-amnesia,amnesia,健忘症,NOUN,B2
 amnesty,amnesty,大赦,NOUN,B2
-amning,breastfeeding,母乳喂养,NOUN,B2
 among them,among them,其中,PRON,B2
-among them (adv),among them,在其中,ADV,B2
-amoral,amoral,词,ADJ,C1
-amorphous,amorphous,无定形的,ADJ,B2
-amortization,amortization,词,NOUN,C1
 amortize,to amortize,摊销,VERB,B2
 amount to,to amount to,总计,VERB,B2
-amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
 ample,ample,充足的,ADJ,B2
-ample loose-fitting,ample loose-fitting,词,ADJ,C1
 amplification,amplification,放大,NOUN,B2
 amplifier,amplifier,放大器,NOUN,B2
-amplitude range,amplitude range,词,NOUN,C1
 amputate,to amputate,截肢,VERB,B2
 amputation,amputation,截肢,NOUN,B2
 amulet,amulet,护身符,NOUN,B2
-amusement,amusement,娱乐,NOUN,B2
 amusing,amusing,有趣的,ADJ,B2
-an,an,词,DET,A1
-an official standard,an official standard,标准,NOUN,B2
-anachronism,anachronism,时代错误,NOUN,B2
-anachronistic,anachronistic,时代错误的,ADJ,B2
-anacoluthon,anacoluthon,词,NOUN,C1
-anadiplosis,anadiplosis,词,NOUN,C1
-anagram,anagram,字谜游戏,NOUN,B2
-analgesia,analgesia,词,NOUN,C1
 analog,analog,模拟的,ADJ,B2
-analogize,analogize,词,VERB,B2
 analogous,analogous,类似的,ADJ,B2
-analogous similar,analogous similar,词,ADJ,C1
 analogy,analogy,类比,NOUN,B2
-analytical,analytical,分析的,ADJ,B2
 analytiker,analyst,分析师,NOUN,B2
-anamnesis case history,anamnesis case history,词,NOUN,C1
-anaphora,anaphora,首语重复修辞,NOUN,B2
-anarchical,anarchical,词,ADJ,C1
-anarchism,anarchism,词,NOUN,C1
-anarchist,anarchist,无政府主义者,NOUN,B2
 anarki,anarchy,无政府状态,NOUN,B2
-anathema,anathema,深恶痛绝之物,NOUN,B2
-anatomy,anatomy,解剖学,NOUN,B2
-anatomy dissection,anatomy dissection,词,NOUN,C1
-anbudssamverkan,bid collusion,串标,NOUN,B2
-anbudsutvärdering,bid evaluation,评标,NOUN,B2
-anbudsöppning,bid opening,开标,NOUN,B2
-ancestral,ancestral,词,ADJ,C1
-anchoring,anchoring,停泊,NOUN,B2
-anchovy,anchovy,词,NOUN,B2
-ancient rootedness,ancient rootedness,词,NOUN,C1
-ancient temple,ancient temple,古寺,NOUN,C1
-ancillary,ancillary,辅助的,ADJ,B2
-and (noun),and,重而,NOUN,B2
-and (sconj),and,我也,SCONJ,B1
-and you,and you,而你…,NOUN,C1
-andlighet,spirituality,灵性,NOUN,B2
-andra,second,第二,ADJ,B2
-andra,others,他人,NOUN,B2
-andra gång,second time,再而,NOUN,B2
-andra sidan,other side,对面,NOUN,B2
-andraledes,secondly,其次,ADV,B2
-androgynous,androgynous,词,ADJ,C1
-anecdotal,anecdotal,词,ADJ,C1
-anekdot,anecdote,轶事,NOUN,B2
-anemic,anemic,词,ADJ,C1
-anerziehung,anerziehung,词,NOUN,C1
-anestesi,anesthesia,麻醉,NOUN,B2
-aneurysm,aneurysm,词,NOUN,C1
-anfahrt,anfahrt,词,NOUN,C1
-anfallare,striker,罢工者,NOUN,B2
-anfassung,anfassung,词,NOUN,C1
-anforderung,anforderung,词,NOUN,C1
-angabe,angabe,词,NOUN,C1
-angelic,angelic,天使般的,ADJ,B2
-angestaltung,angestaltung,词,NOUN,C1
-angränsande,adjacent,邻近的,ADJ,B2
-anguished,anguished,词,ADJ,C1
-angular,angular,有角的,ADJ,B2
-anhängare,fan,粉丝,NOUN,B2
-animal pen,animal pen,词,NOUN,B1
-animated,animated,词,ADJ,C1
-animation,animation,动画,NOUN,B2
-animerad film,animated film,动画片,NOUN,B2
-anise,anise,茴香,NOUN,B2
+förfader,ancestor,祖先,NOUN,B2
 ankra,anchor,锚,NOUN,B2
 ankra,to anchor,抛锚,VERB,B2
-anläggning,facilities,设施,NOUN,B2
-annals,annals,编年史,NOUN,B2
-annex (noun),annex,词,NOUN,B2
-annexation,annexation,吞并,NOUN,B2
+antik,ancient,古老的,ADJ,B2
+forntiden,ancient times,古代,NOUN,B2
+och,and,重而,NOUN,B2
+och så vidare,and so forth,依此类推,ADV,B2
+och så vidare,and so on,之类,NOUN,B2
+anekdot,anecdote,轶事,NOUN,B2
+anestesi,anesthesia,麻醉,NOUN,B2
+bedövningsmedel,anesthetic,麻醉剂,NOUN,B2
+ångest,anguish,痛苦,NOUN,B2
+animerad film,animated film,动画片,NOUN,B2
+animation,animation,动画,NOUN,B2
+fiendskap,animosity,敌意,NOUN,B2
+vrist,ankle,脚踝,NOUN,B2
 annexera,annex,附件,NOUN,B2
 annexera,to annex,兼并,VERB,B2
-annexes,annexes,词,NOUN,C1
-annorlunda,otherness,相异性,NOUN,B2
-annotation,annotation,注释,NOUN,B2
+förintelse,annihilation,寂灭,NOUN,B2
+årsdag,anniversary,周年纪念,NOUN,B2
 annotera,to annotate,注释,VERB,B2
-annual (noun),annual,年度,NOUN,C1
-annual battle,annual battle,年仗,NOUN,C1
-annual inspection,annual inspection,年检,NOUN,C1
-annual leave,annual leave,年假,NOUN,B2
-annual publication,annual publication,年刊,NOUN,C1
-annual wage,annual wage,年薪,NOUN,B2
-annuity private income,annuity private income,词,NOUN,C1
-annulment,annulment,词,NOUN,C1
-anodyne,anodyne,词,ADJ,C1
-anoint,anoint,词,VERB,C1
-anomalous,anomalous,词,ADJ,C1
+kungörelse,announcement,公告,NOUN,B2
+irritera,to annoy,使恼怒,VERB,B2
+irritation,annoyance,烦恼,NOUN,B2
+årsredovisning,annual report,年报,NOUN,B2
+årligen,annually,每年,ADV,B2
 anomi,anomaly,异常,NOUN,B2
-anomie,anomie,词,NOUN,C1
-anonymity,anonymity,词,NOUN,C1
-anonymization,anonymization,词,NOUN,C1
-anorexia,anorexia,词,NOUN,C1
-another day,another day,改日,NOUN,C1
-another time,another time,词,ADV,C1
-anpflegung,anpflegung,词,NOUN,C1
-anregelung,anregelung,词,NOUN,C1
-anrichtung,anrichtung,词,NOUN,B2
-anschaft,anschaft,词,NOUN,C1
-anschrift,anschrift,词,NOUN,B2
-anseende,good reputation,清誉,NOUN,B2
-ansetzung,ansetzung,词,NOUN,C1
-ansicht,ansicht,词,NOUN,C1
-ansiktsigenkänning,face recognition,认人,NOUN,B2
-ansiktsläsning,face reading,面相,NOUN,B2
-ansinnung,ansinnung,词,NOUN,C1
-ansprache,ansprache,词,NOUN,C1
-anstränga sig,to try hard to,力图,VERB,B2
-ansträngning,strain,压力,NOUN,B2
-anställning,appointment,预约,NOUN,B2
-anständighet,decency,体面,NOUN,B2
-anständighet,propriety,分寸,NOUN,B2
-ansucht,ansucht,词,NOUN,C1
-ansuchung,ansuchung,词,NOUN,C1
-ansvar,liability,责任,NOUN,B2
-ansvarig för,to be responsible for,负责,VERB,B2
-ansvarsskyldighet,accountability,问责制,NOUN,B2
-answer questions,answer questions,答疑,VERB,C1
-answers,answers,词,NOUN,C1
-anta,to presume,假定,VERB,B2
-antaga,to suppose,假设,VERB,B2
-antagande,presumption,自负,NOUN,B2
-antagonism,antagonism,对抗,NOUN,B2
-antagonistic,antagonistic,词,ADJ,C1
-antecedent,antecedent,先行词,NOUN,B2
-antediluvian,antediluvian,词,ADJ,C1
-anteilung,anteilung,词,NOUN,B2
+besvara,to answer reply,回答,VERB,B2
+svarmaskin,answering machine,邮箱,NOUN,B2
 antenn,antenna,天线,NOUN,B2
-anteroom,anteroom,词,NOUN,B2
-antheilung,antheilung,词,NOUN,B2
-anthem,anthem,词,NOUN,B2
-anthem song,anthem song,词,NOUN,A1
-anthill,anthill,词,NOUN,C1
-anthropological,anthropological,词,ADJ,C1
-anti-Semitic,anti-Semitic,词,ADJ,C1
-anti-actuality,anti-actuality,反然,NOUN,C1
-anti-analysis,anti-analysis,反析,NOUN,C1
-anti-concretion,anti-concretion,反具,NOUN,C1
-anti-content,anti-content,反容,NOUN,C1
-anti-contingency,anti-contingency,反偶,NOUN,B2
-anti-energy,anti-energy,反能,NOUN,C1
-anti-essence,anti-essence,反本,NOUN,C1
-anti-establishment,anti-establishment,反建,NOUN,C1
-anti-form,anti-form,反形,NOUN,C1
-anti-inwardness,anti-inwardness,反内,NOUN,B2
-anti-law,anti-law,反法,NOUN,C1
-anti-nature,anti-nature,反性,NOUN,B2
-anti-necessity,anti-necessity,反必,NOUN,C1
-anti-particularity,anti-particularity,反特,NOUN,C1
-anti-possibility,anti-possibility,反可,NOUN,C1
-anti-reason,anti-reason,反理,NOUN,C1
-anti-rule,anti-rule,反则,NOUN,C1
-anti-specificity,anti-specificity,反殊,NOUN,B2
-anti-state,anti-state,反态,NOUN,B2
-anti-static,anti-static,防静电,ADJ,B2
-anti-synthesis,anti-synthesis,反综,NOUN,C1
-anti-unity,anti-unity,反一,NOUN,C1
-anti-universality,anti-universality,反普,NOUN,B2
-anti-use,anti-use,反用,NOUN,C1
-anti-work,anti-work,反功,NOUN,C1
-antiabstraktion,anti-abstraction,反抽,NOUN,B2
-antiaktion,anti-action,反作,NOUN,B2
-antibiotic,antibiotic,抗生素,NOUN,B2
-anticipated,anticipated,词,ADJ,C1
-anticipatory,anticipatory,词,ADJ,C1
-anticyclone,anticyclone,反气旋,NOUN,B2
-antidote,antidote,解毒剂,NOUN,B2
-antifreeze,antifreeze,防冻剂,NOUN,B2
-antigen,antigen,抗原,NOUN,B2
-antigen test,antigen test,抗原检测,NOUN,C1
-antigeneralitet,anti-generality,反般,NOUN,B2
-antiintegration,anti-integration,反合,NOUN,B2
-antik,ancient,古老的,ADJ,B2
-antik,antique,古老的,ADJ,B2
-antikrig,anti-war,反战,NOUN,B2
-antikropp,antibody,抗体,NOUN,B2
-antimateri,counter-matter,反物,NOUN,B2
-antimått,anti-measure,反度,NOUN,B2
-antinomy,antinomy,词,NOUN,C1
-antiomnipresens,anti-omnipresence,反遍,NOUN,B2
-antioxidant,antioxidant,抗氧化剂,NOUN,B2
-antiphrasis,antiphrasis,词,NOUN,C1
-antipode,antipode,对跖点,NOUN,B2
-antiquated,antiquated,过时的,ADJ,B2
-antique (adj),antique,古旧的,ADJ,B2
-antiquities ruins,antiquities ruins,词,NOUN,B2
-antiquity,antiquity,词,NOUN,B2
-antisemite,antisemite,词,NOUN,C1
-antisemitism,antisemitism,反犹太主义,NOUN,B2
-antiseptic,antiseptic,防腐,ADJ,B2
-antiseptikum,antiseptic,防腐剂,NOUN,B2
-antisocial,antisocial,反社会的,ADJ,B2
-antites,antithesis,对立面,NOUN,B2
 antologi,anthology,选集,NOUN,B2
-antonomasia,antonomasia,词,NOUN,C1
-antonym,antonym,反义词,NOUN,B2
-antonyms,antonyms,词,NOUN,C1
-antonymy,antonymy,反义关系,NOUN,C1
-antreibung,antreibung,词,NOUN,C1
 antropologi,anthropology,人类学,NOUN,B2
 antropomorfism,anthropomorphism,拟人化,NOUN,B2
-antsy,antsy,词,ADJ,C1
-anvil,anvil,词,NOUN,B2
-använd ej,do not use,别用,NOUN,B2
-använda,to expend,花费,VERB,B2
-använda kryckkor,to use crutches,拄拐,VERB,B2
-använda pinnar,to use chopsticks,动筷,VERB,B2
-användare,user,用户,NOUN,B2
-anwandel,anwandel,词,NOUN,C1
-anweisung,anweisung,词,NOUN,C1
-anwirkung,anwirkung,词,NOUN,C1
-anxious eager,anxious eager,词,ADJ,B1
-any,any,任何,PRON,B2
-any (adj),any,词,ADJ,B1
-any (adv),any,词,ADV,B2
-anybody,anybody,词,PRON,A1
-anymore,anymore,词,ADV,A1
-anything,anything,任何事,PRON,B2
-anyway (pron),anyway,好歹,PRON,B2
-anywhere,anywhere,词,ADV,A1
-apart from (verb),apart from,词,VERB,C1
-apartheid,apartheid,词,NOUN,C1
-apathetic,apathetic,冷漠的,ADJ,B2
-apathy,apathy,冷漠,NOUN,B2
-apex,apex,顶点,NOUN,B2
-aphasia,aphasia,失语症,NOUN,B2
-apiary,apiary,词,NOUN,B2
-apnea,apnea,词,NOUN,C1
-apocalypse,apocalypse,词,NOUN,C1
-apocalyptic,apocalyptic,启示录的,ADJ,B2
-apodictic,apodictic,确证的,ADJ,B2
-apogee,apogee,词,NOUN,C1
+antiabstraktion,anti-abstraction,反抽,NOUN,B2
+antiaktion,anti-action,反作,NOUN,B2
+antigeneralitet,anti-generality,反般,NOUN,B2
+antiintegration,anti-integration,反合,NOUN,B2
+antimått,anti-measure,反度,NOUN,B2
+antiomnipresens,anti-omnipresence,反遍,NOUN,B2
+antikrig,anti-war,反战,NOUN,B2
+antikropp,antibody,抗体,NOUN,B2
+förvänta,to anticipate,预期,VERB,B2
+förväntan,anticipation,预期,NOUN,B2
+antigen,antigen,抗原,NOUN,B2
+antioxidant,antioxidant,抗氧化剂,NOUN,B2
+antik,antique,古老的,ADJ,B2
+antiseptikum,antiseptic,防腐剂,NOUN,B2
+antites,antithesis,对立面,NOUN,B2
+antonym,antonym,反义词,NOUN,B2
+orolig,anxious,焦虑的,ADJ,B2
+någon,any,任何,DET,B2
+någon,anyone,任何人,PRON,B2
 apokryf,apocryphal,杜撰的,ADJ,B2
-apolitical,apolitical,非政治的,ADJ,B2
-apologetic,apologetic,道歉的,ADJ,B2
-apologies,apologies,词,NOUN,B1
-apologist,apologist,辩护者,NOUN,B2
-apology for disrespect,apology for disrespect,失敬……,NOUN,B2
-apophatic,apophatic,词,ADJ,C1
-apophthegm,apophthegm,词,NOUN,C1
-apoplexy,apoplexy,中风,NOUN,B2
-aporetic,aporetic,词,ADJ,C1
-aporia,aporia,词,NOUN,B2
-apostate,apostate,叛教者,NOUN,B2
-apostille,apostille,词,NOUN,B2
-apostle,apostle,词,NOUN,C1
-apostrophize,apostrophize,词,VERB,C1
-apotheosis,apotheosis,神化,NOUN,B2
-apotheotic,apotheotic,神化的,ADJ,B2
-app,app,词,NOUN,B1
-appall,appall,词,VERB,C1
-appalling,appalling,词,ADJ,C1
-apparel,apparel,词,NOUN,C1
-apparent,apparent,词,ADJ,C1
-appeals,appeals,词,NOUN,C1
-appeasement,appeasement,平息,NOUN,B2
+beklama,to apologize,道歉,VERB,B2
+ursäkt,apology,道歉,NOUN,B2
+avfall,apostasy,叛教,NOUN,B2
+beropa,to appeal,呼吁,VERB,B2
+freda,to appease,安抚,VERB,B2
 appellant,appellant,上诉人,NOUN,B2
-appellate,appellate,词,ADJ,C1
-append,append,词,VERB,C1
-appertain,appertain,词,VERB,C1
-appetizers,appetizers,词,NOUN,B2
 applaudera,to applaud,鼓掌,VERB,B2
-appliance,appliance,词,NOUN,B1
-appointments,appointments,词,NOUN,B2
-apportion,apportion,词,VERB,C1
-appraisal,appraisal,估价,NOUN,C1
-appreciable,appreciable,可观的,ADJ,B2
-apprehensive,apprehensive,忧虑的,ADJ,B2
-approachable,approachable,词,ADJ,C1
-appropriate fitting,appropriate fitting,恰当,ADJ,C1
-appropriateness,appropriateness,词,NOUN,C1
-appropriation,appropriation,挪用,NOUN,B2
-approval pleasure,approval pleasure,词,NOUN,C1
-approved,approved,词,ADJ,C1
-approx.,approx.,词,ADV,C1
-approximate,approximate,近似的,ADJ,B2
+tillämplighet,applicability,适用性,NOUN,B2
+sökande,applicant,申请人,NOUN,B2
+gipsa,to apply a cast,打石膏,VERB,B2
+sminka,to apply makeup,化妆,VERB,B2
+anställning,appointment,预约,NOUN,B2
+bedöma,to appraise,评估,VERB,B2
+tackfest,appreciation banquet,答谢宴,NOUN,B2
+gripa,to apprehend,逮捕,VERB,B2
+gripande,apprehension,忧虑,NOUN,B2
+lärling,apprentice,学徒,NOUN,B2
+lärlingskap,apprenticeship,学徒期,NOUN,B2
+lämplig,appropriate,适当的,ADJ,B2
 approximation,approximation,近似值,NOUN,B2
 aprikos,apricot,杏,NOUN,B2
-april,april,四月,NOUN,B2
-apt,apt,词,ADJ,C1
-aptitude,aptitude,天资,NOUN,B2
-aquatic,aquatic,词,ADJ,C1
-aqueduct,aqueduct,词,NOUN,C1
-aqueous,aqueous,词,ADJ,B2
+förkläde,apron,围裙,NOUN,B2
 arabesk,arabesque,阿拉伯式花纹,NOUN,B2
-arabic,arabic,阿拉伯的,ADJ,B2
-arabization,arabization,阿拉伯化,NOUN,C1
-arabized word,arabized word,词,NOUN,C1
-arable land,arable land,耕地,NOUN,C1
-arbete,labor,劳动,NOUN,B2
-arbetsam,hardworking,勤奋的,ADJ,B2
-arbetsam,laborious,费力的,ADJ,B2
-arbitrage,arbitrage,词,NOUN,C1
-arbitral,arbitral,词,ADJ,C1
-arbitrarily,arbitrarily,词,ADV,C1
-arbitrariness,arbitrariness,词,NOUN,C1
-arbitrary (adv),arbitrary,任意,ADV,B2
-arbitrator,arbitrator,仲裁人,NOUN,C1
+godtycklig,arbitrary,任意的,ADJ,B2
 arbitrera,to arbitrate,仲裁,VERB,B2
-arcane,arcane,神秘的,ADJ,B2
-archaeologist,archaeologist,词,NOUN,C1
-archbishop,archbishop,词,NOUN,B2
-archenemy,archenemy,宿敌,NOUN,C1
-archeology,archeology,词,NOUN,C1
-archer,archer,神射,NOUN,C1
-archery,archery,射箭,NOUN,C1
-archetype,archetype,原型,NOUN,B2
-architecture photo,architecture photo,建筑照,NOUN,B2
-archival,archival,词,ADJ,C1
-archived,archived,词,ADJ,C1
-archives,archives,词,NOUN,C1
-archiving,archiving,词,NOUN,B2
-ardent,ardent,热情的,ADJ,B2
-ardent blazing,ardent blazing,词,ADJ,C1
-ardent grief,ardent grief,词,NOUN,C1
-ardent longing,ardent longing,词,NOUN,C1
-argan,argan,词,NOUN,B1
-argentinian,argentinian,阿根廷的,ADJ,B2
-arguable,arguable,词,ADJ,C1
-argumentative,argumentative,词,ADJ,C1
-argumentativeness,argumentativeness,词,NOUN,C1
-arid,arid,干旱的,ADJ,B2
-aridity,aridity,干旱,NOUN,B2
-aristocratic,aristocratic,词,ADJ,C1
-aristokrat,aristocrat,贵族,NOUN,B2
-aristokrati,aristocracy,贵族阶层,NOUN,B2
-arithmetic (adj),arithmetic,词,ADJ,C1
-arithmetic (noun),arithmetic,词,NOUN,C1
+skiljedom,arbitration,仲裁,NOUN,B2
+båge,arch,拱门,NOUN,B2
+arkeologisk,archaeological,考古的,ADJ,B2
+arkeologi,archaeology,考古学,NOUN,B2
 arkaisk,archaic,古老的,ADJ,B2
 arkaism,archaism,古语,NOUN,B2
-arkeologi,archaeology,考古学,NOUN,B2
-arkeologisk,archaeological,考古的,ADJ,B2
+ögrupp,archipelago,群岛,NOUN,B2
 arkitekt,architect,建筑师,NOUN,B2
 arkitektonisk,architectural,建筑的,ADJ,B2
 arkitektur,architecture,建筑,NOUN,B2
-armament,armament,词,NOUN,B2
-armband,armband,词,NOUN,C1
-armed force,armed force,词,NOUN,C1
-armed forces,armed forces,三军,NOUN,C1
-armored,armored,词,ADJ,C1
-army escort,army escort,随军,NOUN,C1
-army morale,army morale,军心,NOUN,B2
-aromatic,aromatic,词,ADJ,C1
-around at,around at,词,ADP,A2
-around the,around the,词,ADP,B1
-arousal,arousal,词,NOUN,C1
-arraign,arraign,词,VERB,C1
-arranged,arranged,词,ADJ,B2
-arrangement of ideas,arrangement of ideas,层次,NOUN,B2
-arrangera,to host,接待,VERB,B2
-array,array,排列,NOUN,B2
-arrest warrant,arrest warrant,词,NOUN,C1
-arrhythmia,arrhythmia,词,NOUN,C1
-arrogance vanity,arrogance vanity,傲慢/虚荣,NOUN,B2
-arrogate,arrogate,词,VERB,C1
-arrow wound,arrow wound,箭伤,NOUN,B1
-arrowhead,arrowhead,茨菇,NOUN,C1
+glöd,ardor,热情,NOUN,B2
+besvärlig,arduous,艰巨的,ADJ,B2
+aristokrati,aristocracy,贵族阶层,NOUN,B2
+aristokrat,aristocrat,贵族,NOUN,B2
+rustning,armor,盔甲,NOUN,B2
+uppväcka,to arouse,引起,VERB,B2
+efterbetalning,arrears,欠款,NOUN,B2
+övermod,arrogance,傲慢,NOUN,B2
+övermodig,arrogant,傲慢的,ADJ,B2
 arsenal,arsenal,军火库,NOUN,B2
-arson,arson,纵火,NOUN,B2
-art,kind,种类,NOUN,B2
-art,species,物种,NOUN,B2
-art collection,art collection,画集,NOUN,C1
-arterial,arterial,词,ADJ,C1
-artful,artful,词,ADJ,C1
-artfully,artfully,词,ADV,C1
-artichoke,artichoke,词,NOUN,B1
-articles,articles,词,NOUN,C1
-articular,articular,词,ADJ,C1
-articulation,articulation,清晰表达,NOUN,B2
-artificial,artificial,人造的,ADJ,B2
-artificial intelligence,artificial intelligence,人工智能,NOUN,B2
-artificially,artificially,人为地,ADV,B2
+konstgalleri,art gallery,美术馆,NOUN,B2
+artär,artery,动脉,NOUN,B2
 artikulera,to articulate,清晰表达,VERB,B2
-artillery,artillery,炮兵,NOUN,B2
+list,artifice,诡计,NOUN,B2
+artificial,artificial,人造的,ADJ,B2
 artistic,artistic,艺术的,ADJ,B2
 artistic portrait,artistic portrait,艺术照,NOUN,B2
-artless,artless,词,ADJ,C1
-artwork,artwork,艺术品,NOUN,B2
-artär,artery,动脉,NOUN,B2
-arv,heritage,遗产,NOUN,B2
-arva,to part by death,死别,VERB,B2
-arvlig,hereditary,遗传的,ADJ,B2
 as,as,作为,SCONJ,B2
-as (cconj),as,词,CCONJ,B1
-as (noun),as,词,NOUN,B2
-as a precaution,as a precaution,词,ADV,C1
-as a result of which,as a result of which,由此,ADV,B2
-as before,as before,依旧,ADV,B2
-as early as possible,as early as possible,趁早,ADV,C1
-as everyone knows,as everyone knows,众所周知,ADJ,B2
-as expected,as expected,果然,ADV,B2
-as for (adp),as for,至于,ADP,B2
-as for (adv),as for,词,ADV,B1
-as for (part),as for,词,PART,B1
 as if,as if,仿佛,ADV,B2
-as if (sconj),as if,as if,SCONJ,B2
 as long as,as long as,طالما,CCONJ,B2
-as long as (sconj),as long as,as long as,SCONJ,B2
-as many,as many,一样多,NUM,B2
-as much,as much,词,ADV,A1
-as much as possible,as much as possible,尽可能,ADV,B2
-as possible,as possible,尽可能地,ADV,B2
-as quickly as possible,as quickly as possible,尽快,ADV,B2
 as soon as,as soon as,一...就,SCONJ,B2
-as soon as (adv),as soon as,一...就,ADV,B2
-as usual,as usual,照常,ADV,B1
-as well as,as well as,以及,SCONJ,B2
-as when,as when,词,SCONJ,A1
-asbestos,asbestos,词,NOUN,C1
 ascend,to ascend,上升,VERB,B2
-ascending,ascending,词,ADJ,C1
 ascension,ascension,升天,NOUN,B2
 ascent,ascent,上升,NOUN,B2
-ascertain,ascertain,词,VERB,C1
-ascetic,ascetic,苦行的,ADJ,B2
-ascetic (noun),ascetic,词,NOUN,C1
 asceticism,asceticism,苦行主义,NOUN,B2
 asexual,asexual,无性的,ADJ,B2
 ashamed,ashamed,羞愧的,ADJ,B2
-asharite school,asharite school,词,NOUN,C1
-ashen,ashen,灰白的,ADJ,B2
-ashes,ashes,词,NOUN,B2
-ashore,ashore,词,ADV,C1
 aside,aside,在旁边,ADV,B2
-aside (noun),aside,词,NOUN,C1
-asinine,asinine,词,ADJ,C1
-asleep,asleep,词,ADJ,A2
-asp,asp,角蝰,NOUN,B2
-asparagus,asparagus,芦笋,NOUN,B2
-aspect particle action in progress,aspect particle action in progress,着,PART,A1
-aspersion,aspersion,词,NOUN,C1
-asphyxia,asphyxia,窒息,NOUN,B2
-aspirant,aspirant,词,NOUN,C1
 aspiration,aspiration,抱负,NOUN,B2
 aspire,to aspire,渴望,VERB,B2
-assail,assail,词,VERB,C1
-assailant,assailant,词,NOUN,C1
 assassinate,to assassinate,暗杀,VERB,B2
 assassination,assassination,暗杀,NOUN,B2
 assemble,to assemble,集合,VERB,B2
 assembly,assembly,集会,NOUN,B2
-assent (noun),assent,词,NOUN,B2
-assertion,assertion,断言,NOUN,B2
-assertiveness,assertiveness,果断,NOUN,C1
 assets,assets,资产,NOUN,B2
-asshole,asshole,词,NOUN,A2
-assiduity,assiduity,词,NOUN,B2
 assiduous,assiduous,勤勉的,ADJ,B2
-assiduous application,assiduous application,词,NOUN,C1
-assiduously,assiduously,词,ADV,C1
-assiduousness,assiduousness,词,NOUN,C1
 assistance,assistance,援助,NOUN,B2
 associate,to associate,联想,VERB,B2
-associate (noun),associate,词,NOUN,B2
-associated,associated,相关的,ADJ,B2
-associative,associative,协会性质的,ADJ,C1
-assort,assort,词,VERB,C1
-assortment,assortment,词,NOUN,C1
-assuage,assuage,词,VERB,C1
-assurance,assurance,保证,NOUN,B2
 asteroid,asteroid,小行星,NOUN,B2
-asthenia,asthenia,词,NOUN,C1
 astonish,to astonish,使惊讶,VERB,B2
-astonished,astonished,惊讶的,ADJ,B2
-astonishing amazing,astonishing amazing,惊人,ADJ,C1
 astonishment,astonishment,惊讶,NOUN,B2
-astonishment amazement,astonishment amazement,词,NOUN,B2
-astound,astound,词,VERB,C1
-astounding,astounding,词,ADJ,C1
-astride (adp),astride,词,ADP,C1
-astride (adv),astride,词,ADV,C1
-astringent (adj),astringent,词,ADJ,C1
-astringent (noun),astringent,词,NOUN,B2
 astrology,astrology,占星术,NOUN,B2
 astronaut,astronaut,宇航员,NOUN,B2
 astute,astute,精明的,ADJ,B2
 asylum,asylum,庇护,NOUN,B2
-asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
-asylum shelter,asylum shelter,词,NOUN,B2
 asymmetrical,asymmetrical,不对称的,ADJ,B2
-asymptomatic,asymptomatic,词,ADJ,C1
 asynchronous,asynchronous,异步的,ADJ,B2
-asyndeton,asyndeton,连词省略,NOUN,B2
-at all absolutely,at all absolutely,根本/绝对,ADV,C1
 at any time,at any time,随时,ADV,B2
 at ease,at ease,安心,ADJ,B2
-at home (noun),at home,家里,NOUN,C1
-at it,at it,靠近,ADV,B2
-at length,at length,词,ADV,B2
-at long last,at long last,总算,ADV,B1
-at most,at most,词,ADV,C1
-at night,at night,夜间,ADV,B2
-at noon,at noon,词,ADV,A1
-at on,at on,词,ADP,A1
-at someone's invitation,at someone's invitation,应邀,ADV,C1
 at that time,at that time,当时/那时,ADV,B2
-at the,at the,在...时,ADP,B2
-at the appointed time,at the appointed time,届时,ADV,B2
-at the back,at the back,在后面,ADV,B2
-at the beginning,at the beginning,词,ADV,C1
-at the bottom,at the bottom,在底部,ADV,B2
-at the earliest possible time,at the earliest possible time,及早,ADV,B2
-at the home of,at the home of,词,ADP,A1
-at the instant sth happens,at the instant sth happens,临时,ADV,B2
-at the latest,at the latest,词,ADV,C1
-at the present time,at the present time,目前,ADV,B1
 at the same time,at the same time,同时,ADV,B2
-at the top,at the top,在最上面,ADV,B2
-at will,at will,任由,NOUN,B2
-at with,at with,在...处,ADP,A2
-at worst,at worst,大不了,ADV,B2
-ataraxia,ataraxia,词,NOUN,C1
-ataxia,ataxia,共济失调,NOUN,B2
 atheism,atheism,无神论,NOUN,B2
-atheist,atheist,无神论者,NOUN,B2
-atheistic,atheistic,无神论的,ADJ,B2
 athlete,athlete,运动员,NOUN,B2
-athletic,athletic,运动的,ADJ,B2
-athletics,athletics,词,NOUN,C1
-atmosphere environment,atmosphere environment,词,NOUN,B1
-atmospheric,atmospheric,大气的,ADJ,B2
 atom,atom,原子,NOUN,B2
 atomic,atomic,原子的,ADJ,B2
 atone,to atone,赎罪,VERB,B2
-atonement,atonement,赎罪,NOUN,B2
-atony,atony,词,NOUN,C1
-atrocious,atrocious,词,ADJ,C1
-atrocious terrible,atrocious terrible,词,ADJ,B2
-atrocity,atrocity,暴行,NOUN,B2
-atrophy,atrophy,萎缩,NOUN,B2
-att,that,那个,PRON,B2
-attache office,attache office,词,NOUN,C1
-attached,attached,词,ADJ,B2
 attachment,attachment,附件,NOUN,B2
 attacker,attacker,攻击者,NOUN,B2
 attain,to attain,达到,VERB,B2
-attainable,attainable,可获得的,ADJ,B2
-attainment,attainment,词,NOUN,C1
-attempt at crime,attempt at crime,词,NOUN,C1
 attend,to attend,出席,VERB,B2
-attend as a non-voting delegate,attend as a non-voting delegate,列席,VERB,C1
 attendance,attendance,出席,NOUN,B2
 attendant,attendant,服务员,NOUN,B2
-attentive listening,attentive listening,专注倾听,NOUN,C1
-attentively,attentively,词,ADV,C1
-attentiveness,attentiveness,用心,NOUN,C1
-attenuation,attenuation,衰减,NOUN,C1
-attestation,attestation,词,NOUN,C1
 attic,attic,阁楼,NOUN,B2
 attire,attire,服装,NOUN,B2
 attorney,attorney,律师,NOUN,B2
 attraction,attraction,吸引力,NOUN,B2
-attractiveness,attractiveness,吸引力,NOUN,B2
-attribution,attribution,归因,NOUN,B2
-attributists,attributists,词,NOUN,C1
-attributive,attributive,定语的,ADJ,B2
 atypical,atypical,非典型的,ADJ,B2
-aubergine,eggplant,茄子,NOUN,B2
-audacious,audacious,大胆的,ADJ,B2
 audacity,audacity,大胆,NOUN,B2
-audibility,audibility,词,NOUN,C1
-audible,audible,听得见的,ADJ,B2
-audio,audio,词,NOUN,B2
-audio equipment,audio equipment,音响,NOUN,B2
 audiovisual,audiovisual,视听的,ADJ,B2
 audit,audit,审计,NOUN,B2
 audit,to audit,审计,VERB,B2
-audition,audition,词,NOUN,B1
-auditory,auditory,词,ADJ,C1
-auferziehung,auferziehung,词,NOUN,C1
-aufforderung,aufforderung,词,NOUN,B2
-aufgabe,aufgabe,词,NOUN,C1
-aufgestaltung,aufgestaltung,词,NOUN,B2
-aufkunft,aufkunft,词,NOUN,C1
-aufnahme,aufnahme,词,NOUN,C1
-aufpflegung,aufpflegung,词,NOUN,C1
-aufregelung,aufregelung,词,NOUN,C1
-aufrichtung,aufrichtung,词,NOUN,B2
-aufschaft,aufschaft,词,NOUN,C1
-aufschrift,aufschrift,词,NOUN,C1
-aufsetzung,aufsetzung,词,NOUN,C1
-aufsicht,aufsicht,词,NOUN,C1
-aufsinnung,aufsinnung,词,NOUN,C1
-aufsprache,aufsprache,词,NOUN,C1
-aufsucht,aufsucht,词,NOUN,C1
-aufsuchung,aufsuchung,词,NOUN,C1
-aufteilung,aufteilung,词,NOUN,C1
-auftheilung,auftheilung,词,NOUN,C1
-auftreibung,auftreibung,词,NOUN,C1
-aufwandel,aufwandel,词,NOUN,C1
-aufweisung,aufweisung,词,NOUN,B2
-aufwirkung,aufwirkung,词,NOUN,C1
-augment,augment,词,VERB,C1
-augmentation,augmentation,词,NOUN,C1
-augmented reality,augmented reality,增强现实,NOUN,C1
-augury,augury,词,NOUN,C1
 aunt,aunt,阿姨,NOUN,B2
-auserziehung,auserziehung,词,NOUN,C1
-ausfahrt,ausfahrt,词,NOUN,B2
-ausfassung,ausfassung,词,NOUN,C1
-ausforderung,ausforderung,词,NOUN,B2
-ausgabe,ausgabe,词,NOUN,C1
-ausgestaltung,ausgestaltung,词,NOUN,B2
-auskunft,auskunft,词,NOUN,C1
-ausnahme,ausnahme,词,NOUN,C1
-auspflegung,auspflegung,词,NOUN,C1
-auspice,auspice,赞助,NOUN,B2
-auspicious,auspicious,词,ADJ,C1
-auspicious month,auspicious month,吉月,NOUN,C1
-auspicious time,auspicious time,令辰,NOUN,C1
-ausregelung,ausregelung,词,NOUN,C1
-ausrichtung,ausrichtung,词,NOUN,C1
-ausschaft,ausschaft,词,NOUN,C1
-ausschrift,ausschrift,词,NOUN,B2
-aussetzung,aussetzung,词,NOUN,B2
-aussicht,aussicht,词,NOUN,C1
-aussinnung,aussinnung,词,NOUN,B2
-aussucht,aussucht,词,NOUN,B2
-aussuchung,aussuchung,词,NOUN,B2
-austeilung,austeilung,词,NOUN,C1
 austere,austere,严厉的,ADJ,B2
 austerity,austerity,紧缩,NOUN,B2
-austheilung,austheilung,词,NOUN,C1
-australian,australian,澳大利亚的,ADJ,B2
-austreibung,austreibung,词,NOUN,C1
-austrian,austrian,奥地利的,ADJ,B2
-auswandel,auswandel,词,NOUN,B2
-ausweisung,ausweisung,词,NOUN,B2
-autarchy,autarchy,词,NOUN,C1
-autarky,autarky,词,NOUN,B2
 authentic,authentic,真实的,ADJ,B2
 authenticate,to authenticate,认证,VERB,B2
-authenticated,authenticated,词,ADJ,C1
 authentication,authentication,认证,NOUN,B2
 authenticity,authenticity,真实性,NOUN,B2
 authoritarian,authoritarian,独裁的,ADJ,B2
-authoritarianism,authoritarianism,词,NOUN,C1
-authority figure,authority figure,权威人士,NOUN,B2
-authority structure,authority structure,权威结构,NOUN,B2
 authorization,authorization,授权,NOUN,B2
 authorized,authorized,有资格的,ADJ,B2
-autism,autism,自闭症,NOUN,B2
-autistic (adj),autistic,词,ADJ,C1
-autistic (noun),autistic,词,NOUN,C1
-autobiographical,autobiographical,词,ADJ,C1
 autobiography,autobiography,自传,NOUN,B2
-autocracy,autocracy,专制,NOUN,B2
-autocratic,autocratic,专制的,ADJ,B2
 automate,to automate,使自动化,VERB,B2
 automated,automated,自动化的,ADJ,B2
 automatically,automatically,自动地,ADV,B2
 automation,automation,自动化,NOUN,B2
 autonomous,autonomous,自治的,ADJ,B2
-autumn start,autumn start,立秋,NOUN,C1
-autumnal,autumnal,词,ADJ,C1
-auxiliary,auxiliary,词,ADJ,C1
-av,of,之,PART,B2
-avail,avail,词,NOUN,C1
 availability,availability,可用性,NOUN,B2
 avalanche,avalanche,雪崩,NOUN,B2
 avant-garde,avant-garde,前卫的,ADJ,B2
-avarice,avarice,词,NOUN,C1
-avaricious,avaricious,词,ADJ,C1
-avbokning,cancellation,取消,NOUN,B2
-avbrott,withdrawal,撤回,NOUN,B2
-avbryta,to discontinue,停止,VERB,B2
-avbryta,to suspend,暂停,VERB,B2
-avbryta,to withdraw,撤回,VERB,B2
-avböja artigt,to decline politely,婉拒,VERB,B2
-avdelning,compartment,隔间,NOUN,B2
-avdelning,ward,病房,NOUN,B2
-avdrag,deduction,扣除,NOUN,B2
-avdraga,to deduct,扣除,VERB,B2
 avenge,to avenge,复仇,VERB,B2
-aver,aver,词,VERB,C1
 average,average,平均,ADJ,B2
-average (noun),average,平均数,NOUN,B2
-averageness,averageness,平庸,NOUN,B2
-averse,averse,厌恶的,ADJ,B2
 aversion,aversion,厌恶,NOUN,B2
-avert,avert,词,VERB,C1
-avfall,apostasy,叛教,NOUN,B2
-avfallshantering,disposal,处理,NOUN,B2
-avgift,fees,酬金,NOUN,B2
-avgifta,to detoxify,解毒,VERB,B2
-avgrund,abyss,深渊,NOUN,B2
-avgränsad,clearly demarcated,分明,ADJ,B2
-avgörande,conclusive,决定性的,ADJ,B2
-avgörande,crucial,至关重要的,ADJ,B2
-avhandling,dissertation,论文,NOUN,B2
-avid,avid,热切的,ADJ,B2
-avkoda,to decipher,破译,VERB,B2
-avkoppla,to disconnect,断开,VERB,B2
-avkryptering,decryption,解密,NOUN,B2
-avkyla,to cool down,冷却,VERB,B2
-avleda,to divert,转移,VERB,B2
-avlägsen,remote,遥远的,ADJ,B2
-avlägsna,to disengage,脱离,VERB,B2
-avmilitarisering,demilitarization,去武,NOUN,B2
-avocado,avocado,牛油果,NOUN,C1
-avoidable,avoidable,可避免的,ADJ,B2
 avoidance,avoidance,避免,NOUN,B2
-avow,avow,词,VERB,C1
-avråda,to dissuade,劝阻,VERB,B2
-avsiktlig,deliberate,深思熟虑的,ADJ,B2
-avsiktligt,deliberately,故意地,ADV,B2
-avskaffa,to abolish,废除,VERB,B2
-avsked,dismissal,解雇,NOUN,B2
-avsked,see off,送走,NOUN,B2
-avskild utgång,seclusion exit,出关,NOUN,B2
-avskilja,to detach,分离,VERB,B2
-avskiljande,detachment,脱落,NOUN,B2
-avskogning,deforestation,森林砍伐,NOUN,B2
-avskräcka,to discourage,使气馁,VERB,B2
-avsky,to abhor,憎恶,VERB,B2
-avskyvärd,detestable,可恶的,ADJ,B2
-avslappning,relaxation,缓和,NOUN,B2
-avsluta,to close account,销户,VERB,B2
-avsluta,to conclude,得出结论,VERB,B2
-avsluta,to terminate,终止,VERB,B2
-avslutning,termination,解除,NOUN,B2
-avslutningsceremoni,closing ceremony,闭幕仪式,NOUN,B2
-avslöja,to disclose,揭露,VERB,B2
-avspänning,detente,缓和,NOUN,B2
-avstängning,suspension,暂停,NOUN,B2
-avstå,to abstain,克制,VERB,B2
-avta,to subside,平息,VERB,B2
-avtagande,decline,衰退,NOUN,B2
-avtala,to contract,收缩,VERB,B2
-avtryckare,trigger,触发器,NOUN,B2
-avundsjuk,envious,嫉妒的,ADJ,B2
-avundsjuk,to be jealous,嫉妒,VERB,B2
-avvapna,to disarm,解除武装,VERB,B2
-avveckling,decommissioning,退役,NOUN,B2
-avvikelse,deviation,偏离,NOUN,B2
-avvisa,to disavow,否认,VERB,B2
-avvisning,court dismissal,退朝,NOUN,B2
-avvänja,to wean,断奶,VERB,B2
-avvänjning,weaning,断奶,NOUN,B2
 awaken,to awaken,唤醒,VERB,B2
 awakening,awakening,觉醒,NOUN,B2
 award,award,奖项,NOUN,B2
 award,to award,分配,VERB,B2
-award auction,award auction,裁定 / 拍卖,NOUN,B2
-award ceremony,award ceremony,颁奖典礼,NOUN,B2
-awarding,awarding,词,NOUN,C1
-awareness raising,awareness raising,提高意识,NOUN,B2
 awe,awe,敬畏,NOUN,B2
-awe-inspiring,awe-inspiring,词,ADJ,C1
-awesome,awesome,词,ADJ,A2
-awful,awful,糟糕的,ADJ,B2
 awkward,awkward,尴尬的,ADJ,B2
-awkwardness,awkwardness,尴尬,NOUN,C1
-awl,awl,词,NOUN,B2
-awning,awning,词,NOUN,B2
-axiological,axiological,词,ADJ,C1
-axiology,axiology,词,NOUN,C1
 axiom,axiom,公理,NOUN,B2
-axiomatic,axiomatic,公理的,ADJ,B2
-axioms,axioms,词,NOUN,C1
 axis,axis,轴,NOUN,B2
-axis axle,axis axle,词,NOUN,C1
 ba zi,ba zi,八字,NOUN,B2
-babble,babble,结巴,NOUN,B2
-babble of voices,babble of voices,词,NOUN,B1
-baby bottle,baby bottle,奶瓶,NOUN,C1
-baby diminutive,baby diminutive,词,NOUN,B1
-baby walker,baby walker,词,NOUN,B1
-baccalaureate,baccalaureate,词,NOUN,B2
-bacchanal,bacchanal,狂欢,NOUN,B2
 bachelor,bachelor,单身汉,NOUN,B2
-bachelor (adj),bachelor,词,ADJ,A2
 bachelor's degree,bachelor's degree,学士学位,NOUN,B2
-back mountain,back mountain,后山,NOUN,C1
-back then,back then,词,ADV,A1
-back-and-forth,back-and-forth,来来回回,NOUN,B2
-backache,backache,背痛,NOUN,B2
 backbone,backbone,脊梁,NOUN,B2
-backdrop,backdrop,背景,NOUN,B2
-backfire,backfire,词,VERB,C1
 backflow,backflow,倒流,NOUN,B2
-backpacker,backpacker,词,NOUN,B1
-backslide,backslide,词,VERB,C1
 backstab,backstab,背刺,NOUN,B2
 backstage,backstage,幕后,NOUN,B2
 backup,backup,备份,NOUN,B2
 backup light,backup light,倒车灯,NOUN,B2
-backyard,backyard,后院,NOUN,B2
 bacon,bacon,培根,NOUN,B2
-bacon bit,bacon bit,词,NOUN,B1
 bacteria,bacteria,细菌,NOUN,B2
-bactericide,bactericide,杀菌剂,NOUN,C1
 bacterium,bacterium,细菌,NOUN,B2
-bad,bath,洗澡,NOUN,B2
-bad guy,bad guy,坏蛋,NOUN,B2
 bad idea,bad idea,坏水,NOUN,B2
 bad news,bad news,坏消息,NOUN,B2
-bad person,bad person,坏人,NOUN,B2
-badge,badge,徽章,NOUN,B2
-badger,badger,词,NOUN,C1
+dålig sak,bad thing,坏事,NOUN,B2
 badminton,badminton,羽毛球,NOUN,B2
-baffle,baffle,词,VERB,C1
 bagare,baker,面包师,NOUN,B2
-bagatell,trifle,琐事,NOUN,B2
-baggage,baggage,行李,NOUN,B2
-bagpiper,bagpiper,风笛手,NOUN,B2
-bailiff,bailiff,法警,NOUN,B2
-bakdel,rear part,后部,NOUN,B2
-bakery,bakery,词,NOUN,A2
-baksida,rear,后部,NOUN,B2
-balance of power,balance of power,均势,NOUN,C1
-balance sheet,balance sheet,资产负债表,NOUN,B2
-balancing,balancing,平衡的,ADJ,B2
 balanserad,balanced,平衡的,ADJ,B2
-baldness,baldness,词,NOUN,B2
-bale,bale,词,NOUN,C1
-balk,balk,词,VERB,C1
-ballad,ballad,词,NOUN,C1
-ballast,ballast,压舱物,NOUN,B2
+skallig,bald,秃头的,ADJ,B2
 ballett,ballet,芭蕾舞,NOUN,B2
-balloon,balloon,气球,NOUN,B2
-ballot,ballot,选票,NOUN,B2
-ballot boxes,ballot boxes,词,NOUN,C1
-ballroom dance,ballroom dance,交谊舞,NOUN,C1
-balm,balm,香脂,NOUN,B2
-balustrade,balustrade,栏杆,NOUN,B2
-bamboo,bamboo,竹子,NOUN,B1
-bamboo forest,bamboo forest,竹林,NOUN,B2
-bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+kugelpenna,ballpoint pen,圆珠笔,NOUN,B2
+förbjuda,to ban,禁止,VERB,B2
 banal,banal,陈腐的,ADJ,B2
 banalitet,banality,陈词滥调,NOUN,B2
-bananas,bananas,词,NOUN,A1
 band,band,乐队,NOUN,B2
-band volume,band volume,词,NOUN,C1
-bandaging,bandaging,词,NOUN,C1
 bandit,bandit,强盗,NOUN,B2
-bandwidth,bandwidth,词,ADJ,C1
-banister,banister,词,NOUN,C1
-bank,banking,银行的,ADJ,B2
-bankett,banquet,宴会,NOUN,B2
+utvisa,to banish,流放,VERB,B2
 bankir,banker,银行家,NOUN,B2
+bank,banking,银行的,ADJ,B2
 banner,banner,横幅,NOUN,B2
-banner headline,banner headline,词,NOUN,C1
-bannlysa,to excommunicate,开除教籍,VERB,B2
-bannlysning,excommunication,绝罚,NOUN,B2
+bankett,banquet,宴会,NOUN,B2
 banter,banter,戏谑,NOUN,B2
-baptism,baptism,词,NOUN,B2
-bar of soap,bar of soap,词,NOUN,B2
-bara,only,而已,SCONJ,B2
-bara då,only then,才,ADV,B2
-bara ha,to have only,唯有,VERB,B2
-bara jag,only-me,只我,NOUN,B2
-bara precis,only just,才,ADV,B2
-barbarian,barbarian,词,NOUN,B2
 barbarism,barbarism,野蛮,NOUN,B2
 barbaritet,barbarity,残暴,NOUN,B2
-barbarization,barbarization,野蛮化,NOUN,B2
 barbecue,barbecue,烧烤,NOUN,B2
-barber,barber,词,NOUN,A2
-barcode,barcode,条形码,NOUN,C1
-bard,bard,吟游诗人,NOUN,B2
-bare ownership,bare ownership,虚有权,NOUN,B2
-bareheaded,bareheaded,词,ADJ,C1
-barely,barely,几乎不,ADV,B2
 barfotad,barefoot,赤脚的,ADJ,B2
-bargain,bargain,便宜货,NOUN,B2
-bargaining,bargaining,词,NOUN,C1
-barge,barge,驳船,NOUN,B2
-bark (noun),bark,词,NOUN,B2
-barking,barking,词,NOUN,B2
-barnbarn,granddaughter,孙女,NOUN,B2
-barnbarn,grandson,孙子,NOUN,B2
-baron,baron,词,NOUN,B2
+bjeffa,to bark,吠叫,VERB,B2
+korn,barley,大麦,NOUN,B2
 baronessa,baroness,女男爵,NOUN,B2
-barracks,barracks,兵营,NOUN,B2
-barrage,barrage,词,NOUN,C1
-barren,barren,词,ADJ,C1
-barrenness,barrenness,词,NOUN,C1
-barricade,barricade,路障,NOUN,B2
-barter (noun),barter,词,NOUN,C1
-barter (verb),barter,词,VERB,C1
-bas,basis,基础,NOUN,B2
-bas,bass,贝斯,NOUN,B2
-basal,basal,基本的,ADJ,B2
-basal,basic,基本的,ADJ,B2
 basalitet,baseness,卑鄙,NOUN,B2
+basal,basic,基本的,ADJ,B2
 basalt,basically,基本上,ADV,B2
-base fertilizer,base fertilizer,基肥,NOUN,B2
-bash,bash,词,VERB,C1
-bashful,bashful,词,ADJ,B2
-bashfulness,bashfulness,词,NOUN,C1
-basic attitude,basic attitude,词,NOUN,C1
-basic essential,basic essential,词,ADJ,B1
-basic income,basic income,基本收入,NOUN,B2
 basilika,basil,罗勒,NOUN,B2
 basilika,basilica,大教堂,NOUN,B2
-basing,basing,词,NOUN,C1
-bask,bask,词,VERB,C1
-baste,baste,词,VERB,C1
-basting,basting,词,NOUN,C1
-bastion,bastion,堡垒,NOUN,B2
+bäcken,basin,盆,NOUN,B2
+bas,basis,基础,NOUN,B2
+korg,basket,篮子,NOUN,B2
+bas,bass,贝斯,NOUN,B2
+fladdermus,bat,蝙蝠,NOUN,B2
+bad,bath,洗澡,NOUN,B2
 bataljon,battalion,营,NOUN,B2
-bath attendant,bath attendant,词,NOUN,C1
-bath mat,bath mat,浴垫,NOUN,C1
-bath scrubber,bath scrubber,词,NOUN,C1
-bath towel,bath towel,浴巾,NOUN,C1
-bathrobe,bathrobe,词,NOUN,A2
-batter,batter,词,NOUN,C1
-battle cry,battle cry,喊打,NOUN,C1
-battle none,battle none,战无,NOUN,C1
-battlement,battlement,城垛,NOUN,B2
-bawdiness,bawdiness,词,NOUN,C1
-bawl,bawl,词,VERB,C1
-bayberry,bayberry,杨梅,NOUN,B2
+vik,bay,海湾,NOUN,B2
 bazaar,bazaar,集市,NOUN,B2
-be allowed,be allowed,允许,AUX,B2
-be assassinated,be assassinated,遇刺,VERB,C1
-be hospitalized,be hospitalized,住院,VERB,C1
-be in prison,be in prison,坐牢,VERB,B2
-be patient,be patient,词,VERB,A1
-be quiet,be quiet,词,VERB,A1
-be shot,be shot,中弹,VERB,C1
-be sorry,be sorry,抱歉,ADJ,B2
-be tender,be tender,温柔的,ADJ,B2
-beak,beak,词,NOUN,B2
-bean sprout,bean sprout,豆芽,NOUN,C1
-beanie,beanie,词,NOUN,A2
-beans,beans,词,NOUN,A1
-bearbeta,to process,处理,VERB,B2
-beatitude,beatitude,至福,NOUN,B2
-beautification,beautification,词,NOUN,C1
-beautifully,beautifully,美丽地,ADV,B2
-beaver,beaver,词,NOUN,C1
-because of this,because of this,词,ADV,A2
-beckon,beckon,词,VERB,C1
-become,become,成为,AUX,B2
-becoming,becoming,词,NOUN,C1
-bed sheet,bed sheet,床单,NOUN,C1
-bedchamber,bedchamber,寝宫,NOUN,C1
-bedra,to defraud,诈骗,VERB,B2
-bedrift,feat,功绩,NOUN,B2
-bedrägeri,deception,欺骗,NOUN,B2
-bedrägeri,scam,骗局,NOUN,B2
-bedsheet,bedsheet,床单,NOUN,B2
-bedside,bedside,词,NOUN,C1
-bedöma,to appraise,评估,VERB,B2
-bedövningsmedel,anesthetic,麻醉剂,NOUN,B2
-beech grove,beech grove,词,NOUN,C1
-beef,beef,词,NOUN,A1
-beehive,beehive,词,NOUN,C1
-beeping,beeping,词,NOUN,C1
-beerziehung,beerziehung,词,NOUN,C1
+kunna,to be able,能,VERB,B2
+kunna,to be able to,能够,VERB,B2
+frånvarande,to be absent,缺席,VERB,B2
+beroende,to be addicted,上瘾,VERB,B2
+modig,to be brave,勇善,VERB,B2
+besegrad,to be defeated,会败,VERB,B2
+iver,to be eager,心切,VERB,B2
+iver efter,to be eager for,巴不得,VERB,B2
+vald,to be elected,当选,VERB,B2
+räcklig,to be enough,足够,VERB,B2
+förtrollad,to be entranced,出神,VERB,B2
+god på,to be good at,擅长,VERB,B2
+tacksam,to be grateful,感激,VERB,B2
+slagen,to be hit,中箭,VERB,B2
+avundsjuk,to be jealous,嫉妒,VERB,B2
+sen,to be late,迟到,VERB,B2
+överbliven,to be left over,剩余,VERB,B2
+på tjänst,to be on duty,值班,VERB,B2
+ansvarig för,to be responsible for,负责,VERB,B2
+rätt,to be right,正确,VERB,B2
+säker,to be safe,安好,VERB,B2
+så,to be so,然,VERB,B2
+stulen,to be stolen,失窃,VERB,B2
+överraskad,to be surprised,感到惊讶,VERB,B2
+nyttig,to be useful,有用,VERB,B2
+värd,to be worth,值得,VERB,B2
+tåla,to bear,忍受,VERB,B2
+uthärdlig,bearable,可忍受的,ADJ,B2
+hållning,bearing,轴承,NOUN,B2
+misshandel,beating,跳动,NOUN,B2
+på grund av,because of,因为,ADP,B2
 beetle,beetle,甲虫,NOUN,B2
-befahrt,befahrt,词,NOUN,C1
-befall,befall,词,VERB,C1
-befassung,befassung,词,NOUN,C1
-befit,befit,词,VERB,C1
-befogen,to empower,授权,VERB,B2
-befolka,to populate,居住,VERB,B2
-befolkning,population,人口,NOUN,B2
-beforderung,beforderung,词,NOUN,C1
 before,before,在...之前,SCONJ,B2
-before (noun),before,以前,NOUN,A1
-before one's eyes,before one's eyes,词,ADV,C1
-before that,before that,词,ADV,B1
 beforehand,beforehand,事先,ADV,B2
-befria,to exempt,免除,VERB,B2
-befrielse,liberation,解放,NOUN,B2
-befruktning,fertilization,施肥,NOUN,B2
-befuddle,befuddle,词,VERB,C1
-befästa,to entrench,巩固,VERB,B2
 beg,to beg,乞求,VERB,B2
-beg for pity,beg for pity,乞怜,VERB,B2
-bega,to implore,恳求,VERB,B2
-begabe,begabe,词,NOUN,C1
-begestaltung,begestaltung,词,NOUN,C1
 beggar,beggar,乞丐,NOUN,B2
 begging,begging,乞讨,NOUN,B2
 begin to start,to begin to start,开始,VERB,B2
-beginning primer,beginning primer,词,NOUN,C1
-begravning,burial,埋葬,NOUN,B2
-begrudge,begrudge,词,VERB,C1
-beguile,beguile,词,VERB,C1
-begära,to solicit,恳求,VERB,B2
-behavioral,behavioral,词,ADJ,B2
-behavioral pattern,behavioral pattern,词,NOUN,C1
-behaviorist,behaviorist,行为主义者,NOUN,B2
-beheading,beheading,按律当斩,NOUN,C1
 behind,behind,在后面,ADV,B2
-behind (noun),behind,词,NOUN,B2
-behind it,behind it,在后面,ADV,B2
-behoove,behoove,词,VERB,C1
-behov,no need,不用,AUX,B2
-behållare,container,容器,NOUN,B2
-being lost,being lost,词,NOUN,C1
-being swept along,being swept along,词,NOUN,C1
-bejeweled,bejeweled,镶满宝石的,ADJ,B2
-bekant,familiar,熟悉的,ADJ,B2
-bekanta sig,to get acquainted,相互认识,VERB,B2
-bekantskap,familiarity,مألوف,NOUN,B2
-beklaga,pity,可惜,ADJ,B2
-beklaga,to pity,同情,VERB,B2
-beklama,to apologize,道歉,VERB,B2
-bekunft,bekunft,词,NOUN,C1
-belabor,belabor,词,VERB,C1
-belated,belated,词,ADJ,C1
-belatedly,belatedly,词,ADV,C1
-belch,belch,词,VERB,C1
-beleaguer,beleaguer,词,VERB,C1
-beleaguered,beleaguered,受围困的,ADJ,B2
-belgian,belgian,比利时的,ADJ,B2
-belgian (noun),belgian,比利时人,NOUN,C1
-belie,belie,词,VERB,C1
-belief creed,belief creed,词,NOUN,B2
-belief in the afterlife,belief in the afterlife,词,NOUN,C1
-believability,believability,词,NOUN,C1
 belittle,to belittle,轻视,VERB,B2
-belittling,belittling,词,NOUN,C1
 bell,bell,铃,NOUN,B2
 bell pepper,bell pepper,甜椒,NOUN,B2
-bell tower,bell tower,词,NOUN,A2
 bellicose,bellicose,好战的,ADJ,B2
-belligerent,belligerent,好战的,ADJ,B2
 bellow,to bellow,吼叫,VERB,B2
-bellows,bellows,词,NOUN,C1
 belly,belly,肚子,NOUN,B2
 belong to,to belong to,属于,VERB,B2
 belonging,belonging,归属感,NOUN,B2
 beloved,beloved,爱人,NOUN,B2
-beloved (adj),beloved,心爱的,ADJ,B1
 below,below,下面,NOUN,B2
-below (adj),below,下面的,ADJ,B1
-below (adv),below,下面,ADV,B2
-belägring,siege,围攻,NOUN,B2
-bemoan,bemoan,词,VERB,C1
-bemuse,bemuse,词,VERB,C1
-ben,bone,骨头,NOUN,B2
-benahme,benahme,词,NOUN,B2
-bench seat,bench seat,词,NOUN,C1
 bend,bend,弯道,NOUN,B2
-bending,bending,弯曲,NOUN,C1
-beneath,beneath,词,ADP,B2
 benefactor,benefactor,恩人,NOUN,B2
-beneficence,beneficence,词,NOUN,C1
-beneficial,beneficial,词,ADJ,B2
 beneficiary,beneficiary,受益人,NOUN,B2
 benevolence,benevolence,仁慈,NOUN,B2
 benevolent,benevolent,仁慈的,ADJ,B2
-benig,bony,瘦骨嶙峋的,ADJ,B2
 benign,benign,良性的,ADJ,B2
-benignity,benignity,良性,NOUN,B2
-bent,bent,弯的,ADJ,B2
-benägenhet,inclination,倾向,NOUN,B2
-benägenhet,propensity,倾向,NOUN,B2
-bepflegung,bepflegung,词,NOUN,B2
-bequest,bequest,词,NOUN,B2
-berate,berate,词,VERB,C1
-bereave,bereave,词,VERB,C1
-bereaved,bereaved,词,ADJ,C1
-bereavement leave,bereavement leave,丧假,NOUN,B2
-beredskap,readiness,准备就绪,NOUN,B2
-beregelung,beregelung,词,NOUN,C1
-bergskedja,mountain range,山脉,NOUN,B2
-bergsnedfart,mountain descent,下山,NOUN,B2
-berichtung,berichtung,词,NOUN,C1
-berikning,enrichment,丰富,NOUN,B2
-berlijns,berlijns,柏林的,ADJ,B2
-beroende,addicted,上瘾的,ADJ,B2
-beroende,addiction,上瘾,NOUN,B2
-beroende,to be addicted,上瘾,VERB,B2
-beropa,to appeal,呼吁,VERB,B2
-berry,berry,词,NOUN,A1
-berth,berth,泊位,NOUN,C1
-beräkna,to calculate,计算,VERB,B2
-beräkna,to compute,计算,VERB,B2
-beräkning,calculation,计算,NOUN,B2
-beräkning,computing,计算机科学,NOUN,B2
-berömmelse,fame,名声,NOUN,B2
-berörbarhet,touchability,能触摸,NOUN,B2
-beröring,touch,接触,NOUN,B2
-beschaft,beschaft,词,NOUN,C1
-beschrift,beschrift,词,NOUN,C1
-beseech,beseech,词,VERB,C1
-besegrad,to be defeated,会败,VERB,B2
-beset,beset,词,VERB,C1
-besetzung,besetzung,词,NOUN,C1
-besicht,besicht,词,NOUN,C1
 beside next to,beside next to,旁边,NOUN,B2
-besides (adp),besides,之外,ADP,B2
-besides (noun),besides,词,NOUN,B2
-besides (part),besides,况,PART,A2
 besiege,to besiege,包围,VERB,B2
-besieged,besieged,词,ADJ,B2
-besieging,besieging,词,NOUN,C1
-besinnung,besinnung,词,NOUN,C1
-besittning,possession,财产,NOUN,B2
-beskatta,to tax,征税,VERB,B2
-beslagta,to seize,抓住,VERB,B2
-beslutsam,determined,下定决心的,ADJ,B2
-beslutsamhet,determination,决心,NOUN,B2
-beslutsfattare,decision-maker,决策者,NOUN,B2
-besmirch,besmirch,词,VERB,C1
-besprache,besprache,词,NOUN,B2
-best (adv),best,最好,ADV,A2
-best (noun),best,最佳,NOUN,C1
-best possible,best possible,词,ADJ,C1
-bestial,bestial,词,ADJ,C1
-bestickning,bribery,贿赂,NOUN,B2
 bestow,to bestow,授予,VERB,B2
 bestowal,bestowal,授予,NOUN,B2
-bestyckning,bribe,贿赂,NOUN,B2
-bestämd,peremptory,专横的,ADJ,B2
-beständighet,permanence,持久,NOUN,B2
-bestå,to ever,里何尝,VERB,B2
-bestå,to last,持续,VERB,B2
-besucht,besucht,词,NOUN,C1
-besuchung,besuchung,词,NOUN,B2
-besvara,to answer reply,回答,VERB,B2
-besvika,to disappoint,使失望,VERB,B2
-besvikande,disappointing,令人失望的,ADJ,B2
-besvär,bother,麻烦,NOUN,B2
-besvära,to trouble,有劳,VERB,B2
-besvärjelse,spell,咒语,NOUN,B2
-besvärlig,arduous,艰巨的,ADJ,B2
 bet,bet,打赌,NOUN,B2
 bet,to bet,打赌,VERB,B2
-bet (noun),bet,赌注,NOUN,B2
-beta,to graze,吃草,VERB,B2
-betala,to pay smilingly,笑付,VERB,B2
-betala,to pay tax,纳税,VERB,B2
-betalning,payment all,付都,NOUN,B2
-bete,pasture,牧场,NOUN,B2
-beteilung,beteilung,词,NOUN,B2
-betheilung,betheilung,词,NOUN,C1
-betong,concrete,具体的,ADJ,B2
-betoning,emphasis,强调,NOUN,B2
-betray one's country,betray one's country,卖国,VERB,B2
-betreibung,betreibung,词,NOUN,C1
-betrothal,betrothal,订婚,NOUN,B2
-betrothal gift,betrothal gift,聘,NOUN,C1
-bett,bite,一口,NOUN,B2
 better,better,越好,NOUN,B2
-better (adv),better,词,ADV,A1
-better-off,better-off,好过,NOUN,C1
-between us,between us,词,ADP,B1
-betyda,to signify,意味着,VERB,B2
-betydande,considerable,相当大的,ADJ,B2
-betydande,negligible not,不可忽视,ADJ,B2
-betydelse,significance,含义,NOUN,B2
-betydelsefull,significant,重要的,ADJ,B2
-betyg,rating,评分,NOUN,B2
-betygssättning,grading,评分；记号,NOUN,B2
-bevarande,conservation,保护,NOUN,B2
-bevarande,preservation,保护,NOUN,B2
-beverage,beverage,词,NOUN,B2
-bevilja,to grant,授予,VERB,B2
-bevisläsning,proofreading,校对,NOUN,B2
-bevisning,substantiation,论证,NOUN,B2
-bewail,bewail,词,VERB,C1
-bewandel,bewandel,词,NOUN,C1
-beware,beware,词,VERB,C1
-beweisung,beweisung,词,NOUN,C1
-bewilder,bewilder,词,VERB,C1
 bewilderment,bewilderment,困惑,NOUN,B2
-bewirkung,bewirkung,词,NOUN,C1
 bianzhong,bianzhong,编钟,NOUN,B2
 bias,bias,偏见,NOUN,B2
 biased,biased,有偏见的,ADJ,B2
 bibel,bible,圣经,NOUN,B2
 bibliografi,bibliography,参考书目,NOUN,B2
-bibliomaniac,bibliomaniac,词,NOUN,C1
-bibliophily,bibliophily,词,NOUN,C1
-bicameral,bicameral,两院制的,ADJ,B2
-bickering,bickering,词,NOUN,C1
-bicycle kick,bicycle kick,词,NOUN,B2
-bicycle repairer,bicycle repairer,修车匠,NOUN,B2
-bid award,bid award,定标,NOUN,C1
-bid awarding,bid awarding,定标会,NOUN,C1
-bid rejection,bid rejection,废标,NOUN,C1
-bid rigging,bid rigging,围标,NOUN,C1
-bidding,bidding,竞标,NOUN,C1
-bidding meeting,bidding meeting,竞标会,NOUN,C1
-bidrag,allowance,津贴,NOUN,B2
-bids,bids,词,NOUN,C1
-biennial,biennial,词,NOUN,C1
-bifurcation,bifurcation,词,NOUN,C1
-big cat,big cat,词,NOUN,C1
-big data,big data,大数据,NOUN,B2
-big dipper,big dipper,北斗七星,NOUN,B2
-big lout,big lout,词,NOUN,C1
-bigotry,bigotry,词,NOUN,C1
-bike lane,bike lane,自行车道,NOUN,B2
-bilateral,bilateral,双边的,ADJ,B2
-bilingual,bilingual,词,ADJ,C1
-bilingualism,bilingualism,词,NOUN,C1
-bilious,bilious,易怒的,ADJ,B2
+bud,bid,出价,NOUN,B2
+anbudssamverkan,bid collusion,串标,NOUN,B2
+anbudsutvärdering,bid evaluation,评标,NOUN,B2
+anbudsöppning,bid opening,开标,NOUN,B2
+galla,bile,胆汁,NOUN,B2
 biljard,billiards,台球,NOUN,B2
-bilk,bilk,词,VERB,C1
-bill of exchange,bill of exchange,词,NOUN,C1
-billion,billion,十亿,NOUN,B2
-billionaire,billionaire,词,NOUN,C1
-billow,billow,词,NOUN,C1
-bin,bin,词,NOUN,B2
-binda,to tie up,绑,VERB,B2
-binder,binder,词,NOUN,A2
-binding (adj),binding,词,ADJ,C1
-bindning,binding,装订,NOUN,B2
-binge,binge,放纵,NOUN,B2
-bingo,bingo,词,NOUN,B2
-binoculars,binoculars,双筒望远镜,NOUN,B2
 binär,binary,二进制的,ADJ,B2
-biografi,biography,传记,NOUN,B2
-biographical,biographical,词,ADJ,C1
-biographies,biographies,词,NOUN,C1
-biologi,biology,生物学,NOUN,B2
+bindning,binding,装订,NOUN,B2
 biologisk mångfald,biodiversity,生物多样性,NOUN,B2
-biologist,biologist,生物学家,NOUN,B2
+biografi,biography,传记,NOUN,B2
+biologi,biology,生物学,NOUN,B2
 biomassa,biomass,生物质,NOUN,B2
 biopsi,biopsy,活检,NOUN,B2
 bioteknik,biotechnology,生物技术,NOUN,B2
-bipartisan,bipartisan,词,ADJ,C1
-bipartisanship,bipartisanship,词,NOUN,C1
-birds,birds,词,NOUN,B1
-birds chirping,birds chirping,词,NOUN,C1
-birdsong,birdsong,词,NOUN,C1
-birth rate,birth rate,词,NOUN,C1
-birthday banquet,birthday banquet,寿宴,NOUN,C1
-birthmark,birthmark,胎记,NOUN,B2
-births,births,词,NOUN,C1
-bisarr,bizarre,奇异的,ADJ,B2
-biscuit,biscuit,饼干,NOUN,A2
-bisexual,bisexual,双性恋的,ADJ,B2
 biskop,bishop,主教,NOUN,B2
-bistro,bistro,小酒馆,NOUN,B2
-bit,bit,一点,NOUN,B2
-bitch,bitch,母狗,NOUN,B2
-biting,biting,咬人,NOUN,B2
+bett,bite,一口,NOUN,B2
 bitning,biting,尖刻的,ADJ,B2
 bitter,bitter,苦的,ADJ,B2
-bitter cold,bitter cold,严寒,NOUN,B2
-bitter decision,bitter decision,痛下,NOUN,B2
-bitter melon,bitter melon,苦瓜,NOUN,C1
-bitter quarrel,bitter quarrel,词,NOUN,C1
-bitterhet,acrimony,尖刻,NOUN,B2
 bitterhet,bitterness,苦涩,NOUN,B2
-biweekly,biweekly,双周的,ADJ,B2
-bizarre (noun),bizarre,离奇,NOUN,C1
-bizarre case,bizarre case,奇案,NOUN,B2
-bjeffa,to bark,吠叫,VERB,B2
+bisarr,bizarre,奇异的,ADJ,B2
+svartmarknad,black market,黑市,NOUN,B2
+svart kåpa,black robe,黑衣,NOUN,B2
 björnbär,blackberry,黑莓,NOUN,B2
-blab,blab,词,VERB,C1
-black (noun),black,أسود,NOUN,C1
-black pepper,black pepper,词,NOUN,B2
-blackbird,blackbird,乌鸫,NOUN,B2
-blackout,blackout,词,NOUN,C1
-blacksmith shop,blacksmith shop,词,NOUN,C1
-blacksmithing,blacksmithing,词,NOUN,B2
+tavla,blackboard,黑板,NOUN,B2
+svärta,to blacken,变黑,VERB,B2
+utpressa,to blackmail,勒索,VERB,B2
+smed,blacksmith,铁匠,NOUN,B2
 blad,blade,刀片,NOUN,B2
-bladder,bladder,词,NOUN,B2
-blade mountain,blade mountain,刀山,NOUN,B2
-blah,blah,词,INTJ,C1
-blanch,blanch,词,VERB,C1
-blandish,blandish,词,VERB,C1
-blank,blank,词,ADJ,B1
-blare,blare,词,NOUN,C1
-blast,blast,词,NOUN,B1
-blatant,blatant,词,ADJ,C1
-blazing,blazing,炽热的,ADJ,B2
-blazing ardor,blazing ardor,词,NOUN,C1
-bleak,bleak,无望的,ADJ,B2
-bleeding,bleeding,流血的,ADJ,B2
+skuld,blame,责备,NOUN,B2
+smaklös,bland,平淡的,ADJ,B2
+brand,blaze,火焰,NOUN,B2
 blekmedel,bleach,漂白剂,NOUN,B2
-blekna,to fade,褪色,VERB,B2
-bleknad,faded,褪色的,ADJ,B2
-blend,blend,词,VERB,B2
-blender,blender,搅拌机,NOUN,B2
-blending,blending,词,NOUN,C1
-bli arg,to get angry,生气,VERB,B2
-bli sjuk,to fall ill,患病,VERB,B2
-blight,blight,词,NOUN,C1
+fläck,blemish,瑕疵,NOUN,B2
 blind,blind,盲的,ADJ,B2
-blind (noun),blind,盲人,NOUN,B2
-blind person,blind person,词,NOUN,B2
-blindfold,blindfold,词,NOUN,C1
-blindness,blindness,无眼,NOUN,C1
-blinds,blinds,百叶窗,NOUN,C1
-blindside,blindside,词,VERB,C1
-blinkers,turn signal,转向灯,NOUN,B2
-blissful wellbeing,blissful wellbeing,词,NOUN,C1
-blister,blister,词,NOUN,C1
-bloat,bloat,词,VERB,C1
-block,boulder,巨石,NOUN,B2
-blockage,blockage,词,NOUN,B2
-blockchain,blockchain,区块链,NOUN,C1
-blocked,blocked,词,ADJ,A1
+salighet,bliss,极乐,NOUN,B2
+snöoväder,blizzard,暴风雪,NOUN,B2
 blockera,blockade,封锁,NOUN,B2
 blockera,to blockade,封锁,VERB,B2
-blocking,blocking,词,NOUN,B2
-blodhav,blood sea,血海,NOUN,B2
-blodplätt,platelet,血小板,NOUN,B2
-blodskuld,blood debt,血债,NOUN,B2
-blog post,blog post,词,NOUN,C1
 blogg,blog,博客,NOUN,B2
-blogger,blogger,词,NOUN,B2
-blood flow,blood flow,血流,NOUN,C1
-blood lipid,blood lipid,血脂,NOUN,C1
-blood money,blood money,词,NOUN,C1
-blood sugar,blood sugar,血糖,NOUN,B2
-blood then,blood then,血就,NOUN,C1
-blood type,blood type,血型,NOUN,B2
-blood-related,blood-related,词,ADJ,C1
-bloodless,bloodless,不流血的,ADJ,B2
-bloodshed,bloodshed,血腥,NOUN,B2
-bloodstain,bloodstain,沾血,NOUN,B2
-bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
-bloom (noun),bloom,词,NOUN,C1
-bloom of youth,bloom of youth,词,NOUN,C1
-blooming,blooming,词,ADJ,C1
-blossoming ripening,blossoming ripening,词,NOUN,C1
-blow of fate,blow of fate,词,NOUN,C1
-blowing sand,blowing sand,扬沙,NOUN,C1
-blowout,blowout,爆胎,NOUN,B2
-blubber,blubber,词,NOUN,C1
-blue (noun),blue,词,NOUN,C1
-blueprint,blueprint,词,NOUN,C1
-blueprint diagram,blueprint diagram,词,NOUN,C1
-bluff,sham,假冒,NOUN,B2
-blunder,blunder,大错,NOUN,B2
-blunt,blunt,词,ADJ,B2
-bluntness,bluntness,直说,NOUN,B2
-blurred,blurred,词,ADJ,C1
-blurriness,blurriness,词,NOUN,C1
-blurry,blurry,词,ADJ,B2
-blurt,blurt,词,VERB,C1
+blodskuld,blood debt,血债,NOUN,B2
+blodhav,blood sea,血海,NOUN,B2
+misslyckande,blot,污点,NOUN,B2
 blus,blouse,女衬衫,NOUN,B2
-bluster,bluster,词,VERB,C1
-blygsam,modest,谦虚的,ADJ,B2
-bläddra,to browse,浏览,VERB,B2
 blåbär,blueberry,蓝莓,NOUN,B2
-blötlägga,to soak,浸透,VERB,B2
-boarder,boarder,词,NOUN,B2
-boarding,boarding,词,NOUN,C1
-boarding pass,boarding pass,登机牌,NOUN,B2
-boast (noun),boast,词,NOUN,B2
-boastful,boastful,自夸的,ADJ,B2
-boastfulness,boastfulness,吹嘘,NOUN,B2
-boatman,boatman,船夫,NOUN,C1
-bock,buck,美元,NOUN,B2
-bode,bode,词,VERB,C1
-bodies,bodies,词,NOUN,C1
-bodily harm,bodily harm,人身伤害,NOUN,B2
-body temperature,body temperature,体温,NOUN,B2
-bodywork,bodywork,车身,NOUN,B2
-boende,accommodation,住宿,NOUN,B2
-bog,bog,沼泽,NOUN,B2
-boggle,boggle,词,VERB,C1
-bohemian,bohemian,放荡不羁的,ADJ,B2
-boil (noun),boil,词,NOUN,C1
-boiled,boiled,词,ADJ,B1
-boiled water,boiled water,开水,NOUN,C1
-boiling (adj),boiling,词,ADJ,C1
-boisterous,boisterous,喧闹的,ADJ,B2
-bojkotta,to boycott,抵制,VERB,B2
-boldness daring,boldness daring,词,NOUN,B2
-bolster (noun),bolster,词,NOUN,C1
-bolster (verb),bolster,词,VERB,C1
-bolstering,bolstering,词,NOUN,C1
-bolt,bolt,词,NOUN,B2
-bolted,bolted,词,ADJ,C1
+rakt,bluntly,直率地,ADV,B2
+slöa,to blur,模糊,VERB,B2
+internat,boarding school,寄宿学校,NOUN,B2
+skryt,boasting,夸耀,NOUN,B2
+kroppslig,bodily,身体上的,ADJ,B2
+panna,boiler,锅炉,NOUN,B2
+kokning,boiling,沸腾,NOUN,B2
+modig,bold,大胆的,ADJ,B2
+mod,boldness,大胆,NOUN,B2
 bombardera,to bombard,轰炸,VERB,B2
-bombardment,bombardment,轰炸,NOUN,B2
-bombast,bombast,词,NOUN,C1
 bombastisk,bombastic,夸大的,ADJ,B2
-bomber,bomber,词,NOUN,C1
 bombning,bombing,轰炸,NOUN,B2
-bonde,commoner,平民,NOUN,B2
-bonde,peasant,农民,NOUN,B2
-bondholder,bondholder,词,NOUN,C1
-bonds,bonds,词,NOUN,C1
-bone-setting,bone-setting,接骨,NOUN,C1
-bonfire,bonfire,篝火,NOUN,B2
-bonhomie,bonhomie,词,NOUN,C1
+ben,bone,骨头,NOUN,B2
 bonus,bonus,奖金,NOUN,B2
-bookcase,bookcase,书柜,NOUN,B2
-booking,booking,词,NOUN,A2
-bookmark,bookmark,词,NOUN,B2
-bookplate,bookplate,藏书票,NOUN,B2
-books,books,书籍,NOUN,B2
-bookseller,bookseller,词,NOUN,C1
-bookshelf,bookshelf,书架,NOUN,B1
-bookstore,bookstore,书店,NOUN,B2
-boom,boom,繁荣,NOUN,B2
-boorish,boorish,词,ADJ,C1
-bordell,brothel,妓院,NOUN,B2
-border (adj),border,border,ADJ,C1
-border area,border area,词,NOUN,C1
-border arrangement,border arrangement,边境安排,NOUN,B2
-border check,border check,边境检查,NOUN,B2
-border community,border community,边境社区,NOUN,B2
-border control,border control,词,NOUN,C1
-border frontier,border frontier,词,NOUN,B1
-border guard,border guard,词,NOUN,C1
-border legislation,border legislation,边境立法,NOUN,B2
-border post,border post,边防哨所,NOUN,B2
-border region,border region,边境地区,NOUN,B2
-bordering,bordering,词,ADJ,C1
-borders,borders,边界,NOUN,A1
-borgensman,guarantor,担保人,NOUN,B2
-borgerligheten,bourgeoisie,资产阶级,NOUN,B2
-born (noun),born,词,NOUN,B2
-born (verb),born,词,VERB,A1
-borr,drill,钻头,NOUN,B2
-borrowed,borrowed,词,ADJ,C1
-borrowed knife,borrowed knife,借刀,NOUN,B2
-borste,brush,刷子,NOUN,B2
-bortavänt,absent-mindedness,心不在焉,NOUN,B2
-borttagande,removal,移除,NOUN,B2
-boskap,livestock,家畜,NOUN,B2
-bosom,bosom,词,NOUN,C1
-boss female,boss female,词,NOUN,B2
-bossism,bossism,老板主义,NOUN,B2
-bostad,dwelling,住宅,NOUN,B2
-bostad,housing,住房,NOUN,B2
-botanical,botanical,词,ADJ,C1
-botany,botany,词,NOUN,C1
-botched job,botched job,词,NOUN,B2
-both,both,两者的,ADJ,B2
-both (noun),both,词,NOUN,B2
-both (pron),both,两者,PRON,B2
-both ears,both ears,两耳,NOUN,C1
-both eyes,both eyes,双眼,NOUN,B2
-both parties,both parties,双方,NOUN,B1
-bottle opener,bottle opener,词,NOUN,B1
-bottleneck,bottleneck,词,NOUN,C1
-bottom out,bottom out,底儿掉,NOUN,C1
-bounce,bounce,词,VERB,B2
-bound to,bound to,势必,ADV,B2
-boundless,boundless,无疆,NOUN,B2
-bounty,bounty,词,NOUN,C1
-bourgeois,bourgeois,资产阶级的,ADJ,B2
-bout,bout,阵,NOUN,B2
-bovine,bovine,词,ADJ,C1
-bow (verb),bow,词,VERB,B1
-bower,bower,凉亭,NOUN,B2
-bowl pouring,bowl pouring,倒碗,NOUN,B2
-bowling,bowling,保龄球,NOUN,C1
-box can,box can,盒子 / 罐,NOUN,A2
-boxning,boxing,拳击,NOUN,B2
-brabant,brabant,布拉班特的,ADJ,B2
-brace,brace,词,NOUN,C1
-bracket,bracket,括号,NOUN,B2
-braggadocio,braggadocio,吹牛,NOUN,B2
-bragging,bragging,吹嘘,NOUN,B2
-braid,braid,辫子,NOUN,C1
-brainstorming,brainstorming,词,NOUN,C1
-brainwasher,brainwasher,洗脑者,NOUN,B2
-brainy,brainy,聪明的,ADJ,B2
-braise,braise,焖烧,VERB,C1
-brakeman,brakeman,刹车员,NOUN,B2
-brakes,brakes,词,NOUN,C1
-braking,braking,词,NOUN,C1
-brakmark,wasteland,荒地,NOUN,B2
-bran,bran,词,NOUN,B2
-branch of study,branch of study,词,NOUN,B1
-branch office,branch office,词,NOUN,C1
-branch road,branch road,支路,NOUN,C1
-branched,branched,词,ADJ,C1
-branching,branching,词,NOUN,C1
-brand,blaze,火焰,NOUN,B2
-brass band,brass band,词,NOUN,B2
-brassware,brassware,词,NOUN,C1
-bravo,bravo,词,NOUN,B2
-brawl,brawl,斗殴,NOUN,B2
-bray,bray,词,VERB,C1
-brazen,brazen,厚颜无耻的,ADJ,B2
-brazier,brazier,词,NOUN,B1
-brazilian,brazilian,巴西的,ADJ,B2
-breach of contract,breach of contract,违约,NOUN,B2
-breach of duty,breach of duty,渎职,NOUN,B2
-breach of promise,breach of promise,词,NOUN,C1
-bread roll,bread roll,小圆面包,NOUN,B2
-breadth,breadth,词,NOUN,C1
-breadth crossing,breadth crossing,词,NOUN,C1
-break fraction,break fraction,词,NOUN,C1
-break out of prison,break out of prison,越狱,VERB,C1
-breakage,breakage,词,NOUN,C1
-breakdown of order,breakdown of order,词,NOUN,C1
-breaker cutter,breaker cutter,词,NOUN,C1
-breakthrough,breakthrough,突破性,ADJ,B2
-breakup,breakup,分手,NOUN,B2
-breast,breast,乳房,NOUN,B2
-breaststroke,breaststroke,词,NOUN,C1
-breath holding,breath holding,住气,NOUN,C1
-breathing,breathing,呼吸,NOUN,B2
-breathing space,breathing space,词,NOUN,C1
-breathlessness,breathlessness,词,NOUN,B1
-bredd,width,宽度,NOUN,B2
-breed (verb),breed,育种,VERB,C1
-breeding,breeding,词,NOUN,C1
-breeding site,breeding site,词,NOUN,C1
-breviary,breviary,词,NOUN,C1
-bribe-taker,bribe-taker,词,NOUN,C1
-bribes,bribes,词,NOUN,C1
-bricks,bricks,词,NOUN,B1
-bridal attire,bridal attire,红妆,NOUN,C1
-bridal trousseau,bridal trousseau,词,NOUN,C1
-bridegroom,bridegroom,词,NOUN,C1
-bridle,bridle,马勒,NOUN,B2
-brief,brief,近点说,NOUN,B2
-brief moment,brief moment,词,NOUN,C1
-briefing,briefing,简报,NOUN,B2
-briefly,briefly,词,ADV,C1
-brigade,brigade,词,NOUN,C1
-brigand poet,brigand poet,词,NOUN,C1
-bright-colored,bright-colored,鲜艳,ADJ,B2
-brighten,brighten,词,VERB,C1
-brightness,brightness,词,NOUN,C1
-briljans,brilliance,辉煌,NOUN,B2
-brilliance of mind,brilliance of mind,词,NOUN,C1
-brilliantly keen,brilliantly keen,词,ADJ,C1
-brim,brim,词,NOUN,C1
-bringing back,bringing back,接回,NOUN,C1
-bringing him,bringing him,带他,NOUN,C1
-bris,breeze,微风,NOUN,B2
-briskness,briskness,轻快,NOUN,B2
-brist,deficiency,缺乏,NOUN,B2
-brist,flaw,缺陷,NOUN,B2
-brist,scarcity,短缺,NOUN,B2
-brist,shortcoming,缺点,NOUN,B2
-brista,to burst,爆发,VERB,B2
-bristfällig,deficient,有缺陷的,ADJ,B2
-bristle (noun),bristle,词,NOUN,C1
-brittle,brittle,易碎的,ADJ,B2
-brittleness,brittleness,词,NOUN,C1
-broach,broach,词,VERB,C1
-broad,broad,词,ADJ,B1
-broad and profound,broad and profound,博大精深,ADJ,B2
-broad bean,broad bean,词,NOUN,C1
-broad beans,broad beans,词,NOUN,B2
-broadcast (adj),broadcast,词,ADJ,C1
-broadcaster,broadcaster,广播公司,NOUN,B2
-broadcasting station,broadcasting station,词,NOUN,C1
-broaden,broaden,词,VERB,C1
-broadening,broadening,拓宽,NOUN,B2
-broadleaf forest,broadleaf forest,阔叶林,NOUN,C1
-brocade (part),brocade,锦,PART,A1
-broccoli,broccoli,西兰花,NOUN,C1
-brochure,brochure,小册子,NOUN,B2
-brodera,to embroider,刺绣,VERB,B2
-broderi,embroidery,刺绣,NOUN,B2
-broil,broil,词,VERB,C1
-brokad,brocade,锦绣,NOUN,B2
-brokenness,brokenness,词,NOUN,C1
-broms,brake,刹车,NOUN,B2
-brons,bronze,青铜,NOUN,B2
-bronze ware,bronze ware,青铜器,NOUN,C1
-bronze-colored,bronze-colored,词,ADJ,B2
-brooch,brooch,词,NOUN,C1
-brooding,brooding,忧思,NOUN,B2
-brooding (adj),brooding,词,ADJ,B2
-brook no delay,brook no delay,刻不容缓,ADJ,B2
-broom blow,broom blow,词,NOUN,C1
+benig,bony,瘦骨嶙峋的,ADJ,B2
 broschyr,booklet,小册子,NOUN,B2
-brother (part),brother,兄,PART,B1
-brotherly heart,brotherly heart,兄心,NOUN,C1
-brott,felony,重罪,NOUN,B2
-brottlighet,delinquency,违法行为,NOUN,B2
-brottslighet,criminality,犯罪,NOUN,B2
-brought back,brought back,逮回,NOUN,C1
-brought to justice,brought to justice,归案,VERB,C1
-brow,brow,眉毛,NOUN,B2
-browbeat,browbeat,词,VERB,C1
-brudgum,groom,新郎,NOUN,B2
-brudkammare,bridal chamber,洞房,NOUN,B2
-bruises,bruises,词,NOUN,B2
-bruk,habitually in the past,往常,NOUN,B2
-brunn,a well,井,NOUN,B2
-brunn,well,井,NOUN,B2
-brusig,noisy,吵闹的,ADJ,B2
-brusqueness,brusqueness,唐突,NOUN,B2
-brut,thug,暴徒,NOUN,B2
-brutal,brutal,词,ADJ,B2
-brutalisera,to brutalize,使变得残忍,VERB,B2
-brutality,brutality,残暴,NOUN,B2
-brutalizing,brutalizing,词,ADJ,C1
-brutally,brutally,词,ADV,C1
-brute,brute,粗野的,ADJ,B2
-brygga,dock,码头,NOUN,B2
-bryggeri,brewery,啤酒厂,NOUN,B2
-bryta,to renege,食言,VERB,B2
+boom,boom,繁荣,NOUN,B2
+gräns,border,边境的,ADJ,B2
+tråka,to bore,使厌烦,VERB,B2
+tråkighet,boredom,无聊,NOUN,B2
+lånare,borrower,借款人,NOUN,B2
+lån,borrowing,借贷,NOUN,B2
+båda,both,两者,PRON,B2
+båda händer,both hands,双手,NOUN,B2
+besvär,bother,麻烦,NOUN,B2
+block,boulder,巨石,NOUN,B2
+bunden,bound,一定的,ADJ,B2
+borgerligheten,bourgeoisie,资产阶级,NOUN,B2
+båge,bow,蝴蝶结,NOUN,B2
+boxning,boxing,拳击,NOUN,B2
+bojkotta,to boycott,抵制,VERB,B2
+skryta,to brag,吹嘘,VERB,B2
+broms,brake,刹车,NOUN,B2
+gren,branch,分支,NOUN,B2
+helt ny,brand new,崭新的,ADJ,B2
+fräckhet,brazenness,厚颜无耻,NOUN,B2
+överträdelse,breach,违反,NOUN,B2
 bryta avtal,to breach contract,违约,VERB,B2
 bryta ihop,to break down,分解,VERB,B2
 bryta upp,to break open,撬开,VERB,B2
-bryting,wrestling,摔跤,NOUN,B2
+slita upp,to break up,破裂,VERB,B2
 brytning,breakdown,故障,NOUN,B2
-bränna,to scorch,烧焦,VERB,B2
-brännande,scorching,灼热的,ADJ,B2
-brännskada,burn,烧伤,NOUN,B2
-brådig,hasty,仓促的,ADJ,B2
-brådska,haste,匆忙,NOUN,B2
-brådska,urgency,紧急,NOUN,B2
-bråk,falling out,反目,NOUN,B2
-bråk,fuss,大惊小怪,NOUN,B2
-brödraskap,brotherhood,兄弟情谊,NOUN,B2
-bröla,to roar,咆哮,VERB,B2
-bröllopsfoto,wedding photo,婚纱照,NOUN,B2
-bröstkorg,chest,胸部,NOUN,B2
-bröstsmärta,chest pain,胸痛,NOUN,B2
-bubbling,bubbling,冒泡的,ADJ,B2
-buccaneer,buccaneer,海盗,NOUN,B2
-buckle,buckle,词,VERB,C1
-bucolic,bucolic,词,ADJ,C1
-bud,bid,出价,NOUN,B2
-bud,bud,芽,NOUN,B2
-buddha,buddha,佛,NOUN,B2
-buddies,buddies,哥们,NOUN,B2
-buddy pal,buddy pal,词,NOUN,B1
-budge,budge,词,VERB,C1
-budgetable,budgetable,可预算的,ADJ,B2
-budgeting,budgeting,词,NOUN,C1
-budgetmässig,budgetary,预算的,ADJ,B2
-buff,buff,词,NOUN,C1
-buffalo,buffalo,词,NOUN,C1
-buffer,buffer,词,NOUN,C1
-buffoon,buffoon,小丑,NOUN,B2
-building blocks,building blocks,积木,NOUN,C1
-building manager,building manager,词,NOUN,B1
-building upon,building upon,基于/以此为基础,ADV,C1
-bukt,gulf,海湾,NOUN,B2
-bulgarian,bulgarian,保加利亚的,ADJ,B2
-bulge,bulge,词,NOUN,C1
+amma,to breastfeed,母乳喂养,VERB,B2
+amning,breastfeeding,母乳喂养,NOUN,B2
+ras,breed,品种,NOUN,B2
+bris,breeze,微风,NOUN,B2
+kortform,brevity,简洁,NOUN,B2
+bryggeri,brewery,啤酒厂,NOUN,B2
+bestyckning,bribe,贿赂,NOUN,B2
+bestickning,bribery,贿赂,NOUN,B2
+tegel,brick,砖,NOUN,B2
+brudkammare,bridal chamber,洞房,NOUN,B2
+skrift,brief,简短的,ADJ,B2
+ljus,bright,明亮的,ADJ,B2
+briljans,brilliance,辉煌,NOUN,B2
+återbringa,to bring back,带回,VERB,B2
+bärande,bringing,جلب,NOUN,B2
+sända,to broadcast,播出,VERB,B2
+sändning,broadcasting,广播,NOUN,B2
+brokad,brocade,锦绣,NOUN,B2
+mäkleri,brokerage,经纪业,NOUN,B2
+brons,bronze,青铜,NOUN,B2
+bäck,brook,小溪,NOUN,B2
+kost,broom,扫帚,NOUN,B2
 buljong,broth,肉汤,NOUN,B2
-bull,bull,词,NOUN,B1
-bulldog,bulldog,斗牛犬,NOUN,B2
-bulldoze,bulldoze,词,VERB,C1
-bulldozer,bulldozer,词,NOUN,C1
-bulletin,bulletin,快报,NOUN,C1
-bullshitted,bullshitted,被愚弄的,ADJ,B2
-bullying,bullying,词,NOUN,B2
-bulwark,bulwark,壁垒,NOUN,B2
-bum,bum,流浪汉,NOUN,B2
-bumble,bumble,词,VERB,C1
-bumblebee,bumblebee,词,NOUN,C1
-bump,bump,肿块,NOUN,B2
-bumper harvest,bumper harvest,丰收,NOUN,B2
-bumping,bumping,碰我,NOUN,B2
-bumpy,bumpy,凹凸不平的,ADJ,B2
-bunch,bunch,一群,NOUN,B2
-bunden,bound,一定的,ADJ,B2
-bundling,bundling,词,NOUN,C1
-bungee jumping,bungee jumping,蹦极,NOUN,B2
-bungler,bungler,笨手笨脚的人,NOUN,B2
-bunker,bunker,词,NOUN,B2
-bunt,bundle,捆,NOUN,B2
-buoy,buoy,词,NOUN,C1
-buoyancy,buoyancy,词,NOUN,C1
-buoyant,buoyant,有浮力的,ADJ,B2
-burdened,burdened,负担重的,ADJ,B2
-burdensome,burdensome,繁重的,ADJ,B2
-bureaucrat,bureaucrat,词,NOUN,C1
-bureaucratic,bureaucratic,官僚的,ADJ,B2
-burglarize,burglarize,词,VERB,C1
-burgle,burgle,词,VERB,C1
-buried,buried,مدفون,ADJ,B1
-burlap,burlap,词,NOUN,B2
-burlesque,burlesque,滑稽的,ADJ,B2
-burlesque (noun),burlesque,词,NOUN,C1
-burned,burned,词,ADJ,B2
-burner,burner,燃烧器,NOUN,B2
-burning (noun),burning,词,NOUN,A1
-burning eagerness,burning eagerness,极度渴望,NOUN,C1
-burns,burns,烧伤,NOUN,C1
-burp (noun),burp,词,NOUN,C1
-burrow (noun),burrow,词,NOUN,C1
-burrow (verb),burrow,词,VERB,C1
-burst in,burst in,词,VERB,C1
-bursting forth,bursting forth,词,NOUN,C1
-bushy,bushy,词,ADJ,C1
-business card,business card,名片,NOUN,B1
-business trade,business trade,买卖,NOUN,B2
-business world,business world,词,NOUN,C1
-buske,bush,灌木,NOUN,B2
+bordell,brothel,妓院,NOUN,B2
+brödraskap,brotherhood,兄弟情谊,NOUN,B2
+bläddra,to browse,浏览,VERB,B2
+webbläsare,browser,浏览器,NOUN,B2
+borste,brush,刷子,NOUN,B2
+brutalisera,to brutalize,使变得残忍,VERB,B2
+bock,buck,美元,NOUN,B2
+hink,bucket,桶,NOUN,B2
+grynhavre,buckwheat,荞麦,NOUN,B2
+budgetmässig,budgetary,预算的,ADJ,B2
+insekt,bug,虫子,NOUN,B2
+massa,bulk,主体,NOUN,B2
 buss,bully,欺凌者,NOUN,B2
-bust,bust,词,NOUN,B1
-bustling with noise and excitement,bustling with noise and excitement,热闹,ADJ,B2
-busy telephone line,busy telephone line,占线,VERB,B1
-but (adv),but,却,ADV,A1
-but (sconj),but,但他,SCONJ,B2
-but also,but also,但也,NOUN,B2
-but difficult,but difficult,但难,NOUN,C1
-but majesty,but majesty,可陛,NOUN,B2
-but on the contrary,but on the contrary,反倒,ADV,B2
-but rather,but rather,而是,CCONJ,B2
-but this,but this,可这,NOUN,C1
-but-for,but-for,词,NOUN,B2
-butcher shop,butcher shop,词,NOUN,A2
-butler,butler,词,NOUN,C1
-buttermilk,buttermilk,词,NOUN,A2
-buttress,buttress,扶壁,NOUN,B2
-buy foreign exchange,buy foreign exchange,购汇,VERB,C1
-buyer purchaser,buyer purchaser,买方,NOUN,B2
-buying and selling,buying and selling,词,NOUN,B2
-buzz (noun),buzz,词,NOUN,B2
-buzzer,buzzer,词,NOUN,C1
-buzzing,buzzing,词,NOUN,C1
-by (aux),by,被,AUX,A2
-by all means,by all means,千方百计,ADV,B2
-by analogy with,by analogy with,词,ADV,C1
-by chance,by chance,偶然地,ADV,B2
-by chance (adj),by chance,词,ADJ,A2
-by doing,by doing,词,SCONJ,B1
-by force,by force,词,ADV,B2
-by hearsay,by hearsay,词,ADV,C1
-by heart,by heart,词,ADV,B2
-by himself,by himself,词,ADV,B2
-by inference,by inference,词,ADV,C1
-by itself,by itself,词,ADV,B2
-by me,by me,以我,NOUN,B2
-by means of,by means of,凭借,NOUN,B2
-by month,by month,以月,NOUN,C1
-by night,by night,趁夜,ADV,B2
-by now,by now,此时,ADV,B2
-by telephone,by telephone,词,ADJ,C1
-by virtue of,by virtue of,词,ADP,C1
-by way of digression,by way of digression,词,ADV,C1
-by way of rectification,by way of rectification,词,ADV,C1
-by year,by year,以岁,NOUN,C1
-by-elections,by-elections,词,NOUN,C1
-byggarbete,construction site,工地,NOUN,B2
-bypass (noun),bypass,词,NOUN,C1
-bypass-operation,bypass surgery,搭桥手术,NOUN,B2
-bypassing,bypassing,词,NOUN,C1
+bunt,bundle,捆,NOUN,B2
 byrå,bureau,局,NOUN,B2
 byråkrati,bureaucracy,官僚主义,NOUN,B2
-byta,to shift,改变,VERB,B2
-byta däck,to change tire,换胎,VERB,B2
-byxor,trousers,裤子,NOUN,B2
-byzantine,byzantine,错综复杂的,ADJ,B2
-bäck,brook,小溪,NOUN,B2
-bäcken,basin,盆,NOUN,B2
-bärande,bringing,جلب,NOUN,B2
-båda,both,两者,PRON,B2
-båda händer,both hands,双手,NOUN,B2
-båge,arch,拱门,NOUN,B2
-båge,bow,蝴蝶结,NOUN,B2
-bör inte,should not,不该,AUX,B2
-cabin boy,cabin boy,词,NOUN,C1
-cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
-cable car,cable car,缆车,NOUN,B1
-cache,cache,词,NOUN,C1
-cachexia,cachexia,词,NOUN,C1
-cackle,cackle,词,VERB,C1
-cacophony,cacophony,刺耳的声音,NOUN,B2
-cactus,cactus,词,NOUN,B1
-cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
-cadence,cadence,词,NOUN,B2
-cadres,cadres,词,NOUN,C1
-caesura,caesura,词,NOUN,C1
-cafeteria,cafeteria,词,NOUN,B1
-caffeine,caffeine,词,NOUN,C1
-caftan,caftan,词,NOUN,A1
-cage (verb),cage,词,VERB,C1
-caid local governor,caid local governor,词,NOUN,C1
-cajole,cajole,词,VERB,C1
-calamitous,calamitous,灾难性的,ADJ,B2
-calcareous,calcareous,词,ADJ,B2
-caliber,caliber,词,NOUN,C1
-calibrated,calibrated,词,ADJ,C1
-calibrator,calibrator,词,NOUN,C1
-caliph,caliph,词,NOUN,B2
-caliphate,caliphate,词,NOUN,C1
-call to prayer,call to prayer,词,NOUN,B2
-caller,caller,词,NOUN,A2
-calligrapher,calligrapher,词,NOUN,C1
-callus,callus,硬茧……,NOUN,C1
-calm (noun),calm,安安,NOUN,A2
-calmly,calmly,平静地,ADV,B2
-calorie,calorie,词,NOUN,C1
-calve,calve,词,VERB,C1
-camouflage (noun),camouflage,词,NOUN,C1
-camp (part),camp,营,PART,A2
-campfire,campfire,词,NOUN,C1
-campsite,campsite,露营地,NOUN,B2
-campus,campus,词,NOUN,B2
-campus-like,campus-like,校园式的,ADJ,B2
-can (noun),can,词,NOUN,B2
-can be at,can be at,可在,NOUN,B2
-can cure,can cure,能解,NOUN,C1
-can may,can may,可以,AUX,A1
-can still,can still,还能,AUX,B1
-can to be able to,can to be able to,会,AUX,A1
-can't help doing sth,can't help doing sth,不禁,ADV,B2
-can-exit,can-exit,还出得来,NOUN,B2
-canadian,canadian,加拿大的,ADJ,B2
-canal belt,canal belt,词,NOUN,C1
-cancerous,cancerous,词,ADJ,C1
-candid,candid,词,ADJ,C1
+inbrytare,burglar,窃贼,NOUN,B2
+inbrott,burglary,入室盗窃罪,NOUN,B2
+begravning,burial,埋葬,NOUN,B2
+brännskada,burn,烧伤,NOUN,B2
+pricka,to burp,打嗝,VERB,B2
+brista,to burst,爆发,VERB,B2
+buske,bush,灌木,NOUN,B2
+affärs,business,商业的,ADJ,B2
+affärsmöte,business meeting,洽谈会,NOUN,B2
+rusning,bustle,喧闹,NOUN,B2
+men,but,然而,ADV,B2
+men jag,but i,可我,ADV,B2
+men du,but you,但您,NOUN,B2
+slaktare,butcher,屠夫,NOUN,B2
+fjäril,butterfly,蝴蝶,NOUN,B2
+skinkor,buttocks,屁股,NOUN,B2
+med alla medel,by fair means or foul,不择手段,ADV,B2
+genom,by means of,通过,ADP,B2
+svunnen,bygone,过去的,ADJ,B2
+bypass-operation,bypass surgery,搭桥手术,NOUN,B2
+kabel,cable,电缆,NOUN,B2
+katastrof,calamity,灾难,NOUN,B2
+beräkna,to calculate,计算,VERB,B2
+beräkning,calculation,计算,NOUN,B2
+miniräknare,calculator,计算器,NOUN,B2
+kalender,calendar,日历,NOUN,B2
+kalv,calf,小腿,NOUN,B2
+kalibrering,calibration,校准,NOUN,B2
+samtal,call,电话,NOUN,B2
+kalligrafi,calligraphy,书法,NOUN,B2
+kallelse,calling,使命,NOUN,B2
+okänslig,callous,冷酷,ADJ,B2
+lugna,calm,平静,NOUN,B2
+lugna,to calm,使平静,VERB,B2
+lugn,calmness,平静,NOUN,B2
+kamel,camel,骆驼,NOUN,B2
+kampanja,to campaign,积极参与活动,VERB,B2
+kan bara,can only,只能,AUX,B2
+kan inte tro,to can't believe,不敢相信,VERB,B2
+kan inte låta bli,can't help,不由得,ADV,B2
+kanal,canal,运河,NOUN,B2
+ställa in,to cancel,取消,VERB,B2
+avbokning,cancellation,取消,NOUN,B2
+kandidatur,candidacy,候选资格,NOUN,B2
 candle,candle,蜡烛,NOUN,B2
-candy shop,candy shop,词,NOUN,B2
-cane,cane,手杖,NOUN,B2
-cannabis,cannabis,大麻,NOUN,B2
 canned food,canned food,罐头食品,NOUN,B2
-canning,canning,词,NOUN,C1
 cannot,cannot,不能,AUX,B2
-cannot afford,cannot afford,不起,VERB,B2
-cannot be quiet,cannot be quiet,静不,NOUN,C1
 cannot bear,to cannot bear,不堪,VERB,B2
 cannot help,to cannot help,忍不住,VERB,B2
-cannot reach,cannot reach,不到,VERB,B2
-cannot stay,cannot stay,不住,PART,B2
-canoe,canoe,词,NOUN,C1
-canonical,canonical,规范的,ADJ,B2
-cantaloupe,cantaloupe,哈密瓜,NOUN,B2
-canteen,canteen,食堂,NOUN,B2
-cantillation,cantillation,词,NOUN,C1
-canvas,canvas,帆布,NOUN,B2
-canvass,canvass,词,VERB,C1
 canyon,canyon,峡谷,NOUN,B2
 cap,cap,帽子,NOUN,B2
 capability,capability,能力,NOUN,B2
-capable,capable,有本事,NOUN,B2
-capacitate,capacitate,词,VERB,C1
-capacitor condenser,capacitor condenser,词,NOUN,C1
 capacity,capacity,容量,NOUN,B2
 cape,cape,海角,NOUN,B2
-caper (noun),caper,词,NOUN,B2
-capillary,capillary,词,ADJ,C1
-capital affairs,capital affairs,京机,NOUN,C1
-capital city,capital city,首都,NOUN,A2
-capital flight,capital flight,资本外逃,NOUN,B2
-capital gain,capital gain,增值,NOUN,B2
-capital letter,capital letter,词,NOUN,C1
-capital loss,capital loss,词,NOUN,C1
 capitalism,capitalism,资本主义,NOUN,B2
-capitalist,capitalist,词,NOUN,C1
-capitalization,capitalization,词,NOUN,C1
 capitalize,to capitalize,利用,VERB,B2
-capitulation,capitulation,词,NOUN,C1
-capping,capping,封顶,NOUN,B2
-capping ceremony,capping ceremony,冠礼,NOUN,B2
-capricious,capricious,词,ADJ,C1
-capsize,capsize,词,VERB,C1
-capsule,capsule,词,NOUN,B1
-captious,captious,词,ADJ,B2
-captivated,captivated,词,ADJ,C1
 captivating,captivating,迷人的,ADJ,B2
-captive,captive,俘虏,NOUN,B2
-captive (adj),captive,词,ADJ,B2
-captive bond,captive bond,词,NOUN,C1
 capture,capture,捕获,NOUN,B2
 capture,to capture,获取,VERB,B2
-car (part),car,车,PART,C1
-car door,car door,词,NOUN,C1
-car hood,car hood,词,NOUN,C1
 car insurance,car insurance,车险,NOUN,B2
-car key,car key,词,NOUN,C1
-car light,car light,车灯,NOUN,C1
-car wash,car wash,洗车,NOUN,B2
-carafe,carafe,词,NOUN,C1
-caramelize,caramelize,词,VERB,C1
-carat,carat,克拉,NOUN,B2
-caravanserai,caravanserai,词,NOUN,C1
-caraway,caraway,词,NOUN,B2
-carbohydrate,carbohydrate,碳水化合物,NOUN,B2
-carbohydrates,carbohydrates,词,NOUN,C1
 carbon,carbon,碳,NOUN,B2
-carbon capture,carbon capture,碳捕获,NOUN,C1
-carbon dioxide,carbon dioxide,二氧化碳,NOUN,B2
-carbon footprint,carbon footprint,碳足迹,NOUN,C1
-carbon neutrality,carbon neutrality,碳中和,NOUN,C1
-carbon peak,carbon peak,碳达峰,NOUN,C1
-carbon sequestration,carbon sequestration,碳封存,NOUN,C1
 carbon tax,carbon tax,碳税,NOUN,B2
-carbon trading,carbon trading,碳交易,NOUN,C1
-carcass,carcass,骨架,NOUN,B2
-carcinoma,carcinoma,词,NOUN,C1
-card map,card map,词,NOUN,A1
-cardboard,cardboard,硬纸板,NOUN,B2
 cardiac,cardiac,心脏的,ADJ,B2
-cardinal,cardinal,枢机主教,NOUN,B2
-care worker,care worker,护理人员,NOUN,B2
-careen,careen,词,VERB,C1
-career leap,career leap,词,NOUN,C1
-careerism,careerism,词,NOUN,C1
-careerist,careerist,词,ADJ,B2
-carefree,carefree,无忧无虑的,ADJ,B2
-careful search,careful search,仔细搜,NOUN,B2
-careful treatment,careful treatment,好生诊治,NOUN,C1
-carefulness,carefulness,细心,NOUN,B2
 caregiver,caregiver,护理人员,NOUN,B2
 careless,careless,粗心的,ADJ,B2
-carelessness,carelessness,词,NOUN,C1
-carer,carer,词,NOUN,C1
 caress,to caress,爱抚,VERB,B2
-caress (noun),caress,词,NOUN,B2
 caretaker,caretaker,房屋管理员,NOUN,B2
 cargo,cargo,货物,NOUN,B2
-cargo rest,cargo rest,货歇,NOUN,C1
 caricatural,caricatural,漫画的,ADJ,B2
 caricature,caricature,讽刺画,NOUN,B2
-caricature (verb),caricature,词,VERB,B2
-caring,caring,关怀的,ADJ,B2
-carnation,carnation,词,NOUN,B2
 carnival,carnival,狂欢节,NOUN,B2
-carnivalesque,carnivalesque,狂欢节式的,ADJ,C1
-carob,carob,词,NOUN,B2
-carol,carol,词,NOUN,B1
-carouse,carouse,词,VERB,C1
-carousel,carousel,词,NOUN,C1
-carp (noun),carp,词,NOUN,C1
-carp (verb),carp,词,VERB,C1
 carpenter,carpenter,木匠,NOUN,B2
 carpentry,carpentry,木工,NOUN,B2
 carpet,carpet,地毯,NOUN,B2
-carpet rug,carpet rug,地毯,NOUN,B2
-carpool,carpool,拼车,NOUN,C1
-carpooling,carpooling,词,NOUN,B1
 carrier,carrier,承运人,NOUN,B2
 carry forward,to carry forward,发扬,VERB,B2
-carrying,carrying,扛,NOUN,C1
-carrying in,carrying in,抬进,NOUN,C1
-carrying porterage,carrying porterage,词,NOUN,C1
 cart,cart,手推车,NOUN,B2
 cartilage,cartilage,软骨,NOUN,B2
-cartography,cartography,词,NOUN,B2
-carton,carton,词,NOUN,C1
-cartoon,cartoon,卡通,NOUN,B2
-cartridge,cartridge,词,NOUN,C1
-cascade,cascade,词,NOUN,C1
-case details,case details,案情,NOUN,B2
-case file,case file,案卷,NOUN,C1
-case inflection,case inflection,词,NOUN,C1
-case law,case law,判例法,NOUN,B2
-cash conversion,cash conversion,改现,NOUN,B2
-cashier,cashier,出纳员,NOUN,B2
-casino,casino,词,NOUN,B2
-casket,casket,词,NOUN,C1
-cassation,cassation,词,NOUN,B2
-cassette tape,cassette tape,磁带,NOUN,B1
-cast,cast,演员阵容,NOUN,B2
-cast (adj),cast,词,ADJ,C1
-cast iron,cast iron,词,NOUN,B2
-castanets,castanets,词,NOUN,B1
-caste,caste,词,NOUN,B2
-casting,casting,词,NOUN,C1
-castrate,castrate,词,VERB,C1
-casual (adv),casual,词,ADV,B2
-casual photo,casual photo,生活照,NOUN,B2
-casualties,casualties,伤亡,NOUN,B2
-casualty,casualty,阵亡,NOUN,C1
-casuistry,casuistry,决疑法,NOUN,B2
-catachresis,catachresis,词语误用,NOUN,B2
-catacomb,catacomb,词,NOUN,B2
-catalepsy,catalepsy,词,NOUN,B2
-catalogue,catalogue,目录,NOUN,B2
-catalysis,catalysis,词,NOUN,C1
-catapult,catapult,投石机,NOUN,B2
-cataract,cataract,词,NOUN,B2
-catastrophic,catastrophic,灾难性的,ADJ,B2
-catch thief,catch thief,抓贼,NOUN,C1
-catching up,catching up,词,NOUN,C1
-catechism,catechism,词,NOUN,C1
-categorical,categorical,绝对的,ADJ,B2
-categorically,categorically,词,ADV,C1
-cater,cater,词,VERB,C1
-caterer,caterer,词,NOUN,C1
-catering,catering,词,NOUN,B1
-caterpillar,caterpillar,毛毛虫,NOUN,B2
-catheter,catheter,词,NOUN,C1
-catheterize,catheterize,词,VERB,C1
-catholic,catholic,天主教的,ADJ,B2
-cattle rancher,cattle rancher,牧场主,NOUN,B2
-caudillism,caudillism,词,NOUN,C1
-cauldron,cauldron,词,NOUN,C1
-causal,causal,因果的,ADJ,B2
-cause of change,cause of change,改因,NOUN,B2
-cause of defeat,cause of defeat,败因,NOUN,B2
-causing harm,causing harm,伤害,NOUN,C1
-caustic,caustic,词,ADJ,B2
-cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
-cavern,cavern,词,NOUN,B2
-cavil,cavil,词,VERB,C1
-cavity,cavity,腔,NOUN,B2
-cavort,cavort,词,VERB,C1
-caw (noun),caw,词,NOUN,C1
-ceasefire,ceasefire,止战,NOUN,C1
-cedar,cedar,词,NOUN,B1
-cede,cede,词,VERB,C1
-celebrant,celebrant,词,NOUN,B2
-celerity,celerity,迅速,NOUN,B2
-celestial (adj),celestial,词,ADJ,B2
-celestial (noun),celestial,词,NOUN,B2
-celestial body,celestial body,词,NOUN,B2
+kassa,cash,现金,ADJ,B2
+kassa,to cash,兑现,VERB,B2
+kassaapparat,cash register,收银机,NOUN,B2
+kashot,cashew,腰果,NOUN,B2
+kasmér,cashmere,羊绒,NOUN,B2
+manoknöl,cassava,木薯,NOUN,B2
+slarvig,casual,随意的,ADJ,B2
+katalog,catalog,目录,NOUN,B2
+katalysator,catalyst,催化剂,NOUN,B2
+katastrof,catastrophe,大灾难,NOUN,B2
+fångst,catch,捕捉,NOUN,B2
+komma ikapp,to catch up,赶上,VERB,B2
+kategorisering,categorization,分类,NOUN,B2
+kategorisera,to categorize,分类,VERB,B2
+kategori,category,类别,NOUN,B2
+katharsis,catharsis,宣泄,NOUN,B2
+katedral,cathedral,大教堂,NOUN,B2
+katolicism,catholicism,天主教,NOUN,B2
+gulröt,cauliflower,花椰菜,NOUN,B2
+kausalitet,causality,因果关系,NOUN,B2
+orsakande,causation,因果关系,NOUN,B2
+försiktighet,caution,谨慎,NOUN,B2
+försiktig,cautious,小心的,ADJ,B2
+försiktig och samvetsgrann,cautious and conscientious,兢兢业业,ADJ,B2
+kavalleri,cavalry,骑兵,NOUN,B2
+gäspa,to caw,呱呱叫,VERB,B2
+tak,ceiling,天花板,NOUN,B2
+firande,celebration,庆祝,NOUN,B2
+selleri,celery,芹菜,NOUN,B2
 celibat,celibacy,独身,NOUN,B2
-celibate,celibate,词,ADJ,B2
 cell,cell,细胞,NOUN,B2
-cell phone ringing,cell phone ringing,词,NOUN,C1
-cello,cello,大提琴,NOUN,C1
-cells,cells,词,NOUN,C1
+mobiltelefon,cell phone,手机,NOUN,B2
+källare,cellar,地窖,NOUN,B2
 cellulär,cellular,细胞的,ADJ,B2
 cementera,to cement,巩固,VERB,B2
-cenotaph,cenotaph,词,NOUN,B2
-censure (noun),censure,词,NOUN,C1
-censure (verb),censure,词,VERB,C1
-census,census,人口普查,NOUN,B2
 cent,cent,分,NOUN,B2
-centenary,centenary,词,NOUN,C1
-centennial,centennial,词,ADJ,B2
-centime,centime,词,NOUN,B2
 centimeter,centimeter,厘米,NOUN,B2
-centipede,centipede,蜈蚣,NOUN,B2
-cento,cento,词,NOUN,C1
 centralisering,centralization,集中化,NOUN,B2
-centrality,centrality,词,NOUN,C1
-centrifug,centrifuge,离心机,NOUN,B2
 centrifugalkraft,centrifugal force,离心力,NOUN,B2
-centripetal force,centripetal force,向心力,NOUN,C1
-centrist,centrist,中间派的,ADJ,C1
-century-old,century-old,世纪的,ADJ,B2
-ceramic art,ceramic art,陶艺,NOUN,B2
-cereal,cereal,词,NOUN,B2
-cerebral,cerebral,大脑的,ADJ,B2
-ceremonial,ceremonial,仪式的,ADJ,B2
-ceremonial protocol,ceremonial protocol,词,NOUN,C1
+centrifug,centrifuge,离心机,NOUN,B2
+keramik,ceramics,陶瓷,NOUN,B2
 ceremonimössa,ceremonial cap,爵弁,NOUN,B2
-ceremoniously,ceremoniously,词,ADV,C1
-ceremony complete,ceremony complete,礼成,NOUN,C1
-certain fall,certain fall,必倒,NOUN,B2
-certification,certification,认证,NOUN,C1
-cessation passing,cessation passing,消亡,NOUN,C1
-chain (adj),chain,词,ADJ,C1
-chain mail,chain mail,锁子甲,NOUN,B2
-chain of transmission,chain of transmission,词,NOUN,C1
-chalet,chalet,词,NOUN,B1
-chalice,chalice,词,NOUN,C1
-challenges,challenges,词,NOUN,C1
-challenging,challenging,词,ADJ,C1
-chamberlain,chamberlain,词,NOUN,C1
-chamois,chamois,词,NOUN,C1
+säker,certain,确定的,ADJ,B2
+säkerhet,certainty,确定性,NOUN,B2
+fortjänstbevis,certificate of merit,奖状,NOUN,B2
+intyga,to certify,证明,VERB,B2
+upphörande,cessation,终止,NOUN,B2
+ordförande,chairman,主席,NOUN,B2
+kreda,chalk,粉笔,NOUN,B2
+kammare,chamber,房间,NOUN,B2
 champagne,champagne,香槟,NOUN,B2
-chance opportunity,chance opportunity,词,NOUN,A2
-chancery,chancery,词,NOUN,C1
-chandelier,chandelier,吊灯,NOUN,B2
-chandelier sheen,chandelier sheen,词,NOUN,C1
-change of faith,change of faith,改信,NOUN,B2
-change of heart,change of heart,改心,NOUN,C1
-change of master,change of master,改主,NOUN,C1
-change of mind,change of mind,改念,NOUN,B2
-change of scenery,change of scenery,词,NOUN,B1
-changed body,changed body,改体,NOUN,C1
-changed function,changed function,改功,NOUN,C1
-changed route,changed route,改路,NOUN,B2
-changed style,changed style,改式,NOUN,C1
-changed technique,changed technique,改术,NOUN,C1
-changed use,changed use,改用,NOUN,C1
-changed work,changed work,改工,NOUN,B2
-changing clothes,changing clothes,换上,NOUN,C1
-chant,chant,词,VERB,C1
-chants,chants,词,NOUN,B2
-chaperon,chaperon,词,NOUN,C1
-chaplain,chaplain,词,NOUN,C1
-chapter of Quran,chapter of Quran,词,NOUN,B2
-character assassination,character assassination,人格谋杀,NOUN,B2
-character trait,character trait,品性,NOUN,C1
-character trait creation,character trait creation,词,NOUN,C1
-characteristic feature,characteristic feature,特点,NOUN,B2
-characterization,characterization,词,NOUN,C1
-characters,characters,词,NOUN,C1
-charade,charade,词,NOUN,B2
-charades,charades,打哑谜,NOUN,B2
-charges,charges,词,NOUN,C1
-charging,charging,词,NOUN,C1
-charismatic,charismatic,有魅力的,ADJ,B2
-charitable,charitable,慈善的,ADJ,B2
-charity hall,charity hall,善堂,NOUN,C1
+mästare,champion,冠军,NOUN,B2
+mästerskap,championship,锦标赛,NOUN,B2
+kansler,chancellor,总理,NOUN,B2
+byta däck,to change tire,换胎,VERB,B2
+ändrad politik,changed policy,改策,NOUN,B2
+kanalisera,to channel,疏导,VERB,B2
+kaotisk,chaotic,混乱的,ADJ,B2
+kapell,chapel,小教堂,NOUN,B2
+tecken,character word,字,NOUN,B2
+karakteristisk,characteristic,典型的,ADJ,B2
+kol,charcoal,木炭,NOUN,B2
+ladda,charge,收费,NOUN,B2
+ladda,to charge,充电,VERB,B2
+laddare,charger,充电器,NOUN,B2
+karisma,charisma,个人魅力,NOUN,B2
 charlatan,charlatan,江湖骗子,NOUN,B2
 charm,charm,魅力,NOUN,B2
-charmer,charmer,词,NOUN,B2
-charter-based,charter-based,词,ADJ,C1
+karta,chart,图表,NOUN,B2
 chartra,to charter,租船,VERB,B2
-chase (noun),chase,追他,NOUN,B2
-chase fast,chase fast,快追,NOUN,C1
-chassis frame,chassis frame,词,NOUN,C1
-chasten,chasten,词,VERB,C1
-chastity probity,chastity probity,词,NOUN,C1
+jaga,chase,追逐,NOUN,B2
+jaga,to chase,追逐,VERB,B2
+kysklighet,chastity,贞洁,NOUN,B2
 chatta,to chat,聊天,VERB,B2
-chatter (noun),chatter,词,NOUN,A2
 chattera,to chatter,喋喋不休,VERB,B2
-chauffeur,chauffeur,词,NOUN,C1
-chauvinism,chauvinism,沙文主义,NOUN,B2
-chauvinistic,chauvinistic,沙文主义的,ADJ,B2
-cheap wine,cheap wine,破酒,NOUN,C1
-cheapen,cheapen,词,VERB,C1
-cheapness,cheapness,廉价,NOUN,B2
-check him,check him,查他,NOUN,C1
-check-in,check-in,词,NOUN,B1
-checkbook,checkbook,支票簿,NOUN,B2
-checked,checked,词,ADJ,C1
-checkers,checkers,词,NOUN,A2
-checkmark,checkmark,词,NOUN,C1
-checkmate,checkmate,词,NOUN,C1
-checkup,checkup,体检,NOUN,B2
-cheekbone,cheekbone,词,NOUN,C1
-cheerful-faced,cheerful-faced,词,ADJ,C1
-cheerfulness,cheerfulness,词,NOUN,C1
-cheering,cheering,欢呼,NOUN,B2
-cheers,cheers,欢呼,NOUN,B2
-chef,chef,厨师,NOUN,B2
-chef,executive,行政主管,NOUN,B2
-chemist,chemist,词,NOUN,C1
-chemotherapy,chemotherapy,化疗,NOUN,B2
-cheque,cheque,词,NOUN,A2
-chermoula,chermoula,词,NOUN,B2
-chermoula-marinated,chermoula-marinated,词,ADJ,B2
-chest of drawers,chest of drawers,词,NOUN,A2
-chest stab,chest stab,胸刺,NOUN,B2
-chest width,chest width,胸宽,NOUN,C1
-chiaroscuro,chiaroscuro,词,NOUN,B2
-chiasmus,chiasmus,词,NOUN,C1
-chic (adj),chic,词,ADJ,C1
-chic (noun),chic,词,NOUN,C1
-chickpeas,chickpeas,词,NOUN,A2
-chide,chide,词,VERB,C1
-child's play,child's play,词,NOUN,C1
-child-rearing,child-rearing,教子,NOUN,C1
-childbirth,childbirth,分娩,NOUN,B2
-childcare,childcare,词,NOUN,C1
-childhood trauma,childhood trauma,词,NOUN,C1
-childish ambition,childish ambition,幼志,NOUN,C1
-childish infantile,childish infantile,词,ADJ,C1
-children,children,儿女,NOUN,C1
-children's rights,children's rights,儿童权利,NOUN,B2
+kassa,checkout,收银台,NOUN,B2
+kind,cheek,脸颊,NOUN,B2
+muntra upp,to cheer up,使高兴,VERB,B2
+skål,cheers,干杯,INTJ,B2
+kemikalie,chemical,化学品,NOUN,B2
+skärja,to cherish,珍爱,VERB,B2
+körsbär,cherry,樱桃,NOUN,B2
+bröstkorg,chest,胸部,NOUN,B2
+bröstsmärta,chest pain,胸痛,NOUN,B2
+kastanj,chestnut,板栗,NOUN,B2
 chilipeppar,chili pepper,辣椒,NOUN,B2
-chill (noun),chill,词,NOUN,B1
-chilling,chilling,词,ADJ,C1
-chime,chime,词,NOUN,C1
-chimera,chimera,词,NOUN,C1
-chimney sweep,chimney sweep,词,NOUN,C1
-chimpanzee,chimpanzee,词,NOUN,B2
-chinese cabbage,chinese cabbage,白菜,NOUN,B2
+skorsten,chimney,烟囱,NOUN,B2
+kinesiska,chinese language,华文,NOUN,B2
 chip,chip,碎片,NOUN,B2
-chirp (noun),chirp,词,NOUN,C1
-chitchat,chitchat,词,NOUN,B2
-chivalrous,chivalrous,词,ADJ,B2
-chive,chive,韭菜,NOUN,C1
-chives,chives,词,NOUN,B1
-chocolate shop,chocolate shop,词,NOUN,B2
-choirboy,choirboy,唱诗班男孩,NOUN,B2
-choke,choke,词,VERB,B2
-cholera,cholera,词,NOUN,C1
-choleric,choleric,易怒的,ADJ,B2
-chomp,chomp,词,VERB,C1
-chopsticks,chopsticks,筷子,NOUN,A1
-chorale,chorale,词,NOUN,C1
-chord,chord,弦,NOUN,C1
-chore,chore,家务,NOUN,B2
-choreograph,choreograph,词,VERB,C1
-choreographer,choreographer,编舞者,NOUN,B2
-choreographic,choreographic,词,ADJ,C1
-choreography,choreography,词,NOUN,C1
-chortle,chortle,词,VERB,C1
-christen,christen,词,VERB,C1
-christianity,christianity,基督教,NOUN,B2
-christianization,christianization,词,NOUN,C1
-christmas tree,christmas tree,圣诞树,NOUN,B2
-chromatic,chromatic,词,ADJ,B2
-chromaticity,chromaticity,词,NOUN,C1
-chromosomal,chromosomal,词,ADJ,C1
-chronic illness,chronic illness,顽疾,NOUN,C1
-chronicle,chronicle,编年史,NOUN,B2
-chronicler,chronicler,词,NOUN,B2
-chronological,chronological,词,ADJ,C1
-chronology,chronology,年表,NOUN,B2
-chuck,chuck,词,VERB,B1
-chuckle,chuckle,词,VERB,B2
-church community,church community,教会,NOUN,B2
-churchgoing,churchgoing,词,NOUN,C1
-churn,churn,词,VERB,C1
-churn skin,churn skin,词,NOUN,B2
-cider,cider,苹果酒,NOUN,B2
-cigarette butt,cigarette butt,烟头,NOUN,B2
-cilantro,cilantro,香菜,NOUN,B2
-cinematic,cinematic,词,ADJ,B1
-cinematographic,cinematographic,电影的,ADJ,B2
-circular (adj),circular,词,ADJ,C1
-circular (noun),circular,词,NOUN,B2
-circulating,circulating,词,ADJ,B2
-circumference,circumference,词,NOUN,C1
-circumlocution,circumlocution,迂回说法,NOUN,B2
-circumscription,circumscription,词,NOUN,C1
-circumspect,circumspect,谨慎的,ADJ,B2
-circumspection,circumspection,词,NOUN,B2
-circumstantial accusative,circumstantial accusative,词,NOUN,C1
-circumvent,circumvent,词,VERB,C1
-circus (adj),circus,词,ADJ,B2
-cirrhosis,cirrhosis,词,NOUN,B2
-cistern,cistern,蓄水池,NOUN,B2
-citadel,citadel,词,NOUN,C1
+kvittra,to chirp,啁啾,VERB,B2
+mejsel,chisel,凿子,NOUN,B2
+ridderlighet,chivalry,骑士精神,NOUN,B2
+kör,choir,合唱团,NOUN,B2
+kolesterol,cholesterol,胆固醇,NOUN,B2
+kromosom,chromosome,染色体,NOUN,B2
+kronisk,chronic,慢性的,ADJ,B2
+kanel,cinnamon,肉桂,NOUN,B2
+krets,circuit,电路,NOUN,B2
+omskärelse,circumcision,割礼,NOUN,B2
+omskriva,to circumscribe,限制,VERB,B2
 citat,citation,引用,NOUN,B2
-citat,quotation,报价,NOUN,B2
 citera,to cite,引用,VERB,B2
-citera,to quote,引用,VERB,B2
-city centre,city centre,市中心,NOUN,B2
-city council,city council,市议会,NOUN,B2
-city dweller,city dweller,词,NOUN,C1
-city gate,city gate,城门,NOUN,B2
-city map,city map,城市地图,NOUN,B2
-civic,civic,词,ADJ,C1
-civic-mindedness,civic-mindedness,词,NOUN,B2
+medborgarskap,citizenship,公民身份,NOUN,B2
 civil,civil,民事的,ADJ,B2
-civil war,civil war,内战,NOUN,B2
-civility,civility,礼貌,NOUN,B2
-civilize,civilize,词,VERB,C1
-clack,clack,词,NOUN,C1
-claim damages,claim damages,索赔,VERB,C1
-claim settlement,claim settlement,理赔,NOUN,C1
-clairvoyance,clairvoyance,词,NOUN,B2
-clairvoyant,clairvoyant,词,ADJ,B2
-clamber,clamber,词,VERB,C1
-clamorous,clamorous,词,ADJ,B2
-clampdown,clampdown,词,NOUN,C1
-clandestine migration,clandestine migration,词,NOUN,B2
-clandestineness,clandestineness,词,NOUN,B2
-clandestinity,clandestinity,秘密状态,NOUN,B2
-clang,clang,词,NOUN,C1
-clank,clank,词,NOUN,C1
-clapping,clapping,词,NOUN,B2
-clarified butter,clarified butter,词,NOUN,A2
-clarify doubts,clarify doubts,释疑,VERB,B2
-clarity evidentness,clarity evidentness,词,NOUN,C1
-clash (noun),clash,词,NOUN,C1
-clasp,clasp,词,NOUN,C1
-class lesson,class lesson,课,NOUN,B2
-class monitor,class monitor,班长,NOUN,C1
-class nature,class nature,阶级性,NOUN,C1
-class session,class session,词,NOUN,B1
-class stratification,class stratification,词,NOUN,C1
-class struggle,class struggle,阶级斗争,NOUN,B2
-class test,class test,词,NOUN,B1
-classical poetry,classical poetry,词,NOUN,C1
-classicist,classicist,古典主义的,ADJ,B2
-classifier for documents portions,classifier for documents portions,份,NOUN,B2
-classifier for flowers,classifier for flowers,朵,NUM,B2
-classifier for horses,classifier for horses,匹,NUM,B2
-classifier for small round objects,classifier for small round objects,颗,NOUN,B2
-classifier for trips,classifier for trips,趟,NUM,A2
-classifier for vehicles,classifier for vehicles,辆,NUM,A1
-classwork,classwork,课堂作业,NOUN,B2
-clatter,clatter,哗啦声,NOUN,C1
-clauses,clauses,词,NOUN,C1
-clay stove,clay stove,词,NOUN,B1
-clean pure,clean pure,纯净的,ADJ,A1
-clean technology,clean technology,清洁技术,NOUN,C1
-cleaner (noun),cleaner,清洁剂,NOUN,B2
-cleaning,cleaning,清洁,NOUN,B2
-cleanliness cleanness,cleanliness cleanness,词,NOUN,C1
-cleanse,cleanse,词,VERB,C1
-cleanup,cleanup,清理,NOUN,C1
-clear as day,clear as day,一清二楚的,ADJ,B2
-clear justice,clear justice,明正,NOUN,C1
-clear limpid,clear limpid,词,ADJ,C1
-clear the throat,clear the throat,词,VERB,B2
-clear view,clear view,明见,NOUN,C1
-clear weather,clear weather,晴,ADJ,A1
-clearance,clearance,词,NOUN,C1
-clearing of the throat,clearing of the throat,词,NOUN,C1
-clemency,clemency,仁慈,NOUN,B2
-clench,clench,词,VERB,C1
-clericalism,clericalism,词,NOUN,B2
-clerk cleric,clerk cleric,词,NOUN,C1
-click (noun),click,词,NOUN,C1
-clickbait,clickbait,词,NOUN,C1
-clientele,clientele,词,NOUN,B2
-cliff fall,cliff fall,坠崖,NOUN,C1
-cliffhanger,cliffhanger,词,NOUN,B1
-climate denial,climate denial,气候否认,NOUN,B2
-climatic,climatic,词,ADJ,C1
-climatology,climatology,词,NOUN,C1
-climbing,climbing,词,NOUN,B1
-clinch,clinch,词,VERB,C1
-clink,clink,词,NOUN,C1
-clinking,clinking,词,NOUN,C1
-clipping,clipping,词,NOUN,C1
-clobber,clobber,词,VERB,C1
-clog (noun),clog,词,NOUN,B2
-clog (verb),clog,词,VERB,C1
-cloister,cloister,回廊,NOUN,B2
-cloned,cloned,词,ADJ,C1
-cloning,cloning,词,NOUN,C1
-close a case,close a case,结案,VERB,B2
-close scrutiny,close scrutiny,词,NOUN,C1
-close well,close well,关好,NOUN,C1
-closedness,closedness,封闭,NOUN,C1
-closely,closely,词,ADV,B2
-closer,closer,更近的,ADJ,B2
-closer (adv),closer,词,ADV,B2
-closing,closing,词,NOUN,B2
-closing argument,closing argument,辩护词,NOUN,B2
-clothe,clothe,词,VERB,C1
-cloud (adj),cloud,词,ADJ,C1
-cloud computing,cloud computing,云计算,NOUN,B2
-cloud of smoke,cloud of smoke,词,NOUN,C1
-clouds,clouds,云,NOUN,B1
-cloudy day,cloudy day,阴天,NOUN,B2
-clout,clout,词,NOUN,C1
-clove,clove,丁香,NOUN,C1
-clover,clover,词,NOUN,C1
-cloying,cloying,词,ADJ,C1
-club blow,club blow,词,NOUN,C1
-cluck,cluck,词,NOUN,C1
-clueless,clueless,词,ADJ,C1
-clump,clump,词,NOUN,C1
-clumsily,clumsily,笨拙地,ADV,B2
-clumsiness,clumsiness,笨拙,NOUN,B2
-clunky,clunky,词,ADJ,C1
-clutter,clutter,词,NOUN,C1
-co-,co-,共同,ADV,B2
-co-conspirator,co-conspirator,同谋,NOUN,B2
-co-founder,co-founder,词,NOUN,C1
-co-occurrence,co-occurrence,词,NOUN,C1
-co-ownership,co-ownership,共有产权,NOUN,B2
+tjänsteman,civil servant,公务员,NOUN,B2
+oväsen,clamor,喧嚣,NOUN,B2
+klemma,clamp,夹钳,NOUN,B2
+hemlig,clandestine,秘密的,ADJ,B2
+klappa,to clap,拍手,VERB,B2
+klargörande,clarification,澄清,NOUN,B2
+tydlighet,clarity,清晰,NOUN,B2
+klassisk,classical,古典的,ADJ,B2
+klassicism,classicism,古典主义,NOUN,B2
+klassificering,classification,分类,NOUN,B2
+stycke,classifier for paintings cloth etc.,幅,NUM,B2
+stam,classifier for trees,棵,NUM,B2
+klassificera,to classify,分类,VERB,B2
+klasskamrat,classmate,同学,NOUN,B2
+klassrum,classroom,教室,NOUN,B2
+städa,to clean up,清理,VERB,B2
+renlighet,cleanliness,清洁,NOUN,B2
+rengöring,cleansing,清洗,NOUN,B2
+insikt,clear knowledge,明知,NOUN,B2
+klarsoppa,clear soup,江瑶清羹,NOUN,B2
+tydlig,clear-cut,明确的,ADJ,B2
+rydning,clearing,林中空地,NOUN,B2
+tydligt,clearly,清楚地,ADV,B2
+avgränsad,clearly demarcated,分明,ADJ,B2
+klyva,to cleave,劈开,VERB,B2
+klerus,clergy,神职人员,NOUN,B2
+klok,clever,聪明的,ADJ,B2
+kliché,cliche,陈词滥调,NOUN,B2
+klicka,to click,点击,VERB,B2
+klientelism,clientelism,庇护主义,NOUN,B2
+klimat,climate,气候,NOUN,B2
+klimatförändring,climate change,气候变化,NOUN,B2
+klimax,climax,高潮,NOUN,B2
+fästa,to cling,紧贴,VERB,B2
+klinisk,clinical,临床的,ADJ,B2
+klipp,clip,夹子,NOUN,B2
+kappa,cloak,斗篷,NOUN,B2
+garderob,cloakroom,衣帽间,NOUN,B2
+klon,clone,克隆体,NOUN,B2
+tät,close,近的,ADJ,B2
+avsluta,to close account,销户,VERB,B2
+stänga,to close the door,关门,VERB,B2
+skåp,closet,壁橱,NOUN,B2
+avslutningsceremoni,closing ceremony,闭幕仪式,NOUN,B2
+stängning,closure,关闭,NOUN,B2
+propp,clot,凝块,NOUN,B2
+tyg,cloth,布,NOUN,B2
+kläder,clothing,服装,NOUN,B2
+molnig,cloudy,阴沉的,ADJ,B2
+klovne,clown,小丑,NOUN,B2
+klumpig,clumsy,笨拙的,ADJ,B2
+kluster,cluster,簇,NOUN,B2
+koppling,clutch,离合器,NOUN,B2
 coacha,coach,教练,NOUN,B2
 coacha,to coach,辅导,VERB,B2
-coagulated,coagulated,词,ADJ,C1
-coagulation,coagulation,词,NOUN,B2
-coalesce,coalesce,词,VERB,C1
-coast road,coast road,词,NOUN,B2
-coastal,coastal,沿海的,ADJ,B2
-coastal (noun),coastal,词,NOUN,B2
-coastline,coastline,词,NOUN,B2
-coat of arms,coat of arms,纹章,NOUN,B2
-coating,coating,词,NOUN,C1
-coating plaster,coating plaster,词,NOUN,C1
-cobble,cobble,词,VERB,C1
-cobbler,cobbler,词,NOUN,B2
-cock,cock,词,NOUN,B2
-cockroach,cockroach,词,NOUN,A1
-cocoa,cocoa,词,NOUN,C1
-coconut,coconut,椰子,NOUN,B2
-cod,cod,词,NOUN,B1
-coddle,coddle,词,VERB,C1
-code of conduct,code of conduct,词,NOUN,C1
-codicil,codicil,词,NOUN,C1
-codicology,codicology,词,NOUN,C1
-codification,codification,法典化,NOUN,C1
-codified,codified,词,ADJ,C1
-coding,coding,词,NOUN,B2
-coffee maker,coffee maker,词,NOUN,A2
-cog,cog,词,NOUN,C1
-cogency,cogency,词,NOUN,C1
-cogitate,cogitate,词,VERB,C1
-cogito,cogito,词,NOUN,C1
-cognate,cognate,词,NOUN,B2
-cognition,cognition,认知,NOUN,B2
-cognitive,cognitive,认知的,ADJ,B2
-cognizance,cognizance,词,NOUN,C1
-cogwheel,cogwheel,词,NOUN,C1
-cohabitation,cohabitation,词,NOUN,C1
-cohere,cohere,词,VERB,C1
-cohort,cohort,队列,NOUN,B2
-cohort-based,cohort-based,队列的,ADJ,B2
-coil (noun),coil,词,NOUN,C1
-coin purse,coin purse,零钱包,NOUN,B2
-coincidence of ideas,coincidence of ideas,词,NOUN,C1
-coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
-coining,coining,词,NOUN,B2
-coins,coins,词,NOUN,C1
-coitus,coitus,词,NOUN,B2
-coke,coke,可卡因,NOUN,B2
-cold arrow,cold arrow,冷箭,NOUN,C1
-cold case,cold case,悬案,NOUN,B2
-cold hands,cold hands,手冰,NOUN,C1
-cold weather,cold weather,天冷,NOUN,C1
-coldness,coldness,词,NOUN,B2
-colic,colic,词,NOUN,C1
-coliseum,coliseum,词,NOUN,B2
+grov,coarse,粗糙的,ADJ,B2
+övertalning,coaxing,哄得,NOUN,B2
+koefficient,coefficient,系数,NOUN,B2
+tvång,coercion,胁迫,NOUN,B2
+koexistera,to coexist,共存,VERB,B2
+koexistens,coexistence,共存,NOUN,B2
+sammanhang,coherence,连贯性,NOUN,B2
+sammanhängande,coherent,连贯的,ADJ,B2
+sammanhållning,cohesion,凝聚力,NOUN,B2
+sammanfalla,to coincide,同时发生,VERB,B2
+sil,colander,漏勺,NOUN,B2
+kallt blod,cold blood,冷血,NOUN,B2
+kallvåg,cold wave,寒潮,NOUN,B2
+kallt,coldly,冷淡地,ADV,B2
+samarbeta,to collaborate,合作,VERB,B2
+samarbete,collaboration,合作,NOUN,B2
+samarbetare,collaborator,合作者,NOUN,B2
 collapse,collapse,倒塌,NOUN,B2
 collar,collar,衣领,NOUN,B2
-collarbone,collarbone,词,NOUN,B2
 collateral,collateral,附属的,ADJ,B2
-collation,collation,词,NOUN,B2
-colleague female,colleague female,词,NOUN,B2
 collect,to collect,收集,VERB,B2
-collect evidence,collect evidence,取证,VERB,C1
-collect seeds,collect seeds,采种,VERB,C1
-collected,collected,收集的,ADJ,B2
-collectie,collectie,收藏,NOUN,B2
-collections,collections,词,NOUN,C1
 collective,collective,集体的,ADJ,B2
-collective (noun),collective,集体,NOUN,B2
-collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
-collectivism,collectivism,词,NOUN,C1
-collectivization,collectivization,集体化,NOUN,B2
-collectomania,collectomania,收藏癖,NOUN,B2
 collector,collector,收藏家,NOUN,B2
-college,college,学院,NOUN,B2
-college entrance examination,college entrance examination,高考,NOUN,B2
-collegial,collegial,同事的,ADJ,B2
-collegiality,collegiality,词,NOUN,C1
-collegiate,collegiate,词,ADJ,B2
 collide,to collide,碰撞,VERB,B2
 collision,collision,碰撞,NOUN,B2
-collocation,collocation,词,NOUN,C1
-colloidal,colloidal,胶体的,ADJ,C1
-colloquial,colloquial,词,ADJ,B2
-colloquial language,colloquial language,词,NOUN,C1
-colloquium,colloquium,词,NOUN,B2
 collude,to collude,勾结,VERB,B2
-collusion,collusion,串通,NOUN,B2
 colon,colon,冒号,NOUN,B2
-colon (punct),colon,词,PUNCT,A2
-colonial,colonial,词,ADJ,C1
-colonial settlers,colonial settlers,词,NOUN,C1
 colonialism,colonialism,殖民主义,NOUN,B2
-colonist,colonist,词,NOUN,B2
 colonization,colonization,殖民化,NOUN,B2
 colonize,to colonize,殖民,VERB,B2
-colonizing,colonizing,词,ADJ,C1
-colonnade,colonnade,词,NOUN,C1
-colonoscopy,colonoscopy,肠镜,NOUN,C1
 colony,colony,殖民地,NOUN,B2
-colophon,colophon,词,NOUN,B2
 color,to color,着色,VERB,B2
-coloration,coloration,词,NOUN,B2
-colorblind,colorblind,词,ADJ,B2
-coloredness,coloredness,有色性,NOUN,B2
 colorful,colorful,五颜六色的,ADJ,B2
-coloring,coloring,词,NOUN,B2
-colorless,colorless,词,ADJ,C1
-colossal,colossal,巨大的,ADJ,B2
-colossus,colossus,词,NOUN,B2
-colour,colour,颜色,NOUN,B2
-columnar,columnar,词,ADJ,C1
-columnist,columnist,词,NOUN,C1
 comb,comb,梳子,NOUN,B2
 combat,combat,战斗,NOUN,B2
-combatant,combatant,词,NOUN,B2
 combating,combating,打击,NOUN,B2
-combative,combative,词,ADJ,B2
-combativeness,combativeness,好斗性,NOUN,B2
-combinations,combinations,词,NOUN,C1
-combinatorial,combinatorial,组合的,ADJ,B2
-combinatorics,combinatorics,词,NOUN,C1
-combing,combing,词,NOUN,C1
-combining,combining,结合的,ADJ,B2
-combustibility,combustibility,词,NOUN,C1
-combustion,combustion,词,NOUN,C1
-come (sconj),come,来 来,SCONJ,B2
-come again,come again,再来,VERB,B2
 come along,to come along,一起来,VERB,B2
-come and take,come and take,有本事来拿,NOUN,C1
 come back,to come back,回来,VERB,B2
 come from,to come from,来自,VERB,B2
 come here,to come here,来到这里,VERB,B2
@@ -3149,3980 +891,1252 @@ come out,to come out,出来,VERB,B2
 come over,to come over,顺道来访,VERB,B2
 come up,to come up,出现,VERB,B2
 comedy,comedy,喜剧,NOUN,B2
-comer,comer,词,NOUN,C1
 comet,comet,彗星,NOUN,B2
-comfortable tranquility,comfortable tranquility,词,NOUN,C1
-comfortably,comfortably,词,ADV,C1
-comforted,comforted,宽慰,ADJ,B2
-comforting,comforting,词,ADJ,B2
 comic,comic,喜剧的,ADJ,B2
-comic (noun),comic,词,NOUN,B2
-comic strip,comic strip,连环画,NOUN,B2
-comicness,comicness,词,NOUN,C1
 coming,coming,مجيء,NOUN,B2
 coming and going,coming and going,往来,NOUN,B2
-coming-of-age attire,coming-of-age attire,元服,NOUN,C1
-comma,comma,逗号,PUNCT,B2
-comma (noun),comma,词,NOUN,B1
 command room,command room,指挥室,NOUN,B2
-commandeer,commandeer,词,VERB,C1
-commanding officer,commanding officer,司令,NOUN,B2
-commanding presence,commanding presence,威严,NOUN,C1
-commandment,commandment,词,NOUN,C1
 commemorate,to commemorate,纪念,VERB,B2
 commemoration,commemoration,纪念,NOUN,B2
-commence,commence,词,VERB,B2
-commencement,commencement,开始,NOUN,B2
-commend,commend,词,VERB,C1
-commendable,commendable,词,ADJ,C1
-commendation,commendation,词,NOUN,C1
-commensalism,commensalism,词,NOUN,B2
-commensurability,commensurability,词,NOUN,C1
-commentaries,commentaries,词,NOUN,C1
-commercial (noun),commercial,词,NOUN,B2
-commercial center,commercial center,商业中心,NOUN,C1
-commercialization,commercialization,词,NOUN,C1
-commiserate,commiserate,词,VERB,C1
-commiseration,commiseration,同情,NOUN,B2
-commitments,commitments,词,NOUN,C1
-committee member,committee member,委员,NOUN,C1
-committees,committees,词,NOUN,C1
-commodatum,commodatum,词,NOUN,C1
-commodification,commodification,词,NOUN,C1
-common good,common good,词,NOUN,B2
-common opinion,common opinion,词,NOUN,C1
-common saying,common saying,俗话,NOUN,B2
-common sense,common sense,常识,NOUN,B2
-common shared,common shared,词,ADJ,B1
-commonly,commonly,词,ADV,C1
-commonplace,commonplace,词,ADJ,C1
-communal work,communal work,词,NOUN,C1
-communautarization,communautarization,社群化,NOUN,B2
-communes,communes,词,NOUN,C1
-communicativeness,communicativeness,词,NOUN,C1
-communion rail,communion rail,词,NOUN,B2
-communitarian,communitarian,词,ADJ,C1
-community-related,community-related,社区的,ADJ,B2
-commuter,commuter,词,NOUN,A2
-comorbidity,comorbidity,词,NOUN,B2
-compact disc,compact disc,光盘,NOUN,B1
-compactness,compactness,词,NOUN,C1
-comparability,comparability,词,NOUN,C1
-comparable,comparable,可比较的,ADJ,B2
-comparative,comparative,比较的,ADJ,B2
-comparative weighing,comparative weighing,词,NOUN,C1
-compared to than,compared to than,比,ADP,A1
-compartmental,compartmental,词,ADJ,C1
-compatible,compatible,词,ADJ,C1
-compelling,compelling,词,ADJ,C1
-compendious,compendious,词,ADJ,B2
-compendium,compendium,纲要,NOUN,B2
-competencies,competencies,词,NOUN,B2
-competing,competing,词,ADJ,C1
-competitive,competitive,竞争的,ADJ,B2
-competitive exam,competitive exam,词,NOUN,B2
-complacency,complacency,词,NOUN,B2
-complaints,complaints,词,NOUN,C1
-complement,complement,补充物,NOUN,B2
-complementarity,complementarity,互补性,NOUN,B2
-complete (noun),complete,具,NOUN,C1
-complete idiot,complete idiot,词,NOUN,C1
-complete works,complete works,全集,NOUN,B2
-completed-action particle,completed-action particle,了,PART,A1
-completeness,completeness,completeness,NOUN,B2
-completion ceremony,completion ceremony,竣工仪式,NOUN,C1
-complex (noun),complex,建筑群,NOUN,B2
-complexion,complexion,肤色,NOUN,B2
-complication,complication,周折,NOUN,B2
-complications,complications,词,NOUN,C1
-composable,composable,可组合的,ADJ,B2
-compositional,compositional,词,ADJ,C1
-compostable,compostable,可堆肥的,ADJ,B2
-compound,compound,化合物,NOUN,B2
-compound fertilizer,compound fertilizer,复合肥,NOUN,C1
-comprehensibility,comprehensibility,词,NOUN,C1
-compressed,compressed,词,ADJ,C1
-compressibility,compressibility,词,NOUN,C1
-compressible,compressible,词,ADJ,C1
-comprise,comprise,词,VERB,C1
-compulsion,compulsion,词,NOUN,C1
-compulsiveness,compulsiveness,强迫性,NOUN,B2
-compulsorily,compulsorily,词,ADV,C1
-compunction,compunction,词,NOUN,B2
-compurgation oath,compurgation oath,词,NOUN,C1
-computability,computability,词,NOUN,C1
-computer mouse,computer mouse,词,NOUN,B1
-computer science,computer science,词,NOUN,C1
-computer specialist,computer specialist,计算机专家,NOUN,B2
-con artist,con artist,词,NOUN,B1
-concatenation,concatenation,词,NOUN,B2
-concave,concave,凹的,ADJ,B2
-concavity,concavity,词,NOUN,B2
-concealed,concealed,词,ADJ,C1
-conceit,conceit,词,NOUN,C1
-concentrated,concentrated,浓,ADJ,B1
-concentric,concentric,词,ADJ,C1
-conception,conception,概念,NOUN,B2
-concepts,concepts,词,NOUN,C1
-conceptual,conceptual,概念的,ADJ,B2
-conceptualize,conceptualize,词,VERB,C1
-concerned,concerned,担忧的,ADJ,B2
-concerning,concerning,关于,ADP,B2
-concerning (adj),concerning,词,ADJ,B2
-concerns,concerns,词,NOUN,C1
-concert hall,concert hall,音乐厅,NOUN,C1
-concerto,concerto,词,NOUN,C1
-concessionary,concessionary,让步的,ADJ,B2
-conch,conch,海螺壳,NOUN,B2
-conciliation,conciliation,词,NOUN,B2
-conciliatory,conciliatory,调和的,ADJ,B2
-conciseness,conciseness,简洁,NOUN,B2
-concision,concision,简洁,NOUN,C1
-conclave,conclave,词,NOUN,B2
-conclude treaty,conclude treaty,缔约,VERB,B2
-concluding,concluding,词,ADJ,B2
-conclusion of contract,conclusion of contract,词,NOUN,C1
-concomitantly,concomitantly,词,ADV,B2
-concord,concord,和谐,NOUN,B2
-concordance,concordance,一致,NOUN,B2
-concordat,concordat,政教协定,NOUN,B2
-concrete,concrete,混凝土,NOUN,B2
-concretization,concretization,词,NOUN,C1
-concubine dismissal,concubine dismissal,让妾,NOUN,B2
-concupiscence,concupiscence,词,NOUN,B2
-concur,concur,词,VERB,C1
-concurrence,concurrence,词,NOUN,B2
-concurrently,concurrently,词,ADV,C1
+kommentator,commentator,评论员,NOUN,B2
+handel,commerce,商业,NOUN,B2
+komersiell,commercial,商业的,ADJ,B2
+kommission,commission,委员会,NOUN,B2
+göra ett brott,to commit a crime,犯罪,VERB,B2
+engagerad,committed,投入的,ADJ,B2
+vara,commodity,商品,NOUN,B2
+gemensamhet,commonality,共同点,NOUN,B2
+bonde,commoner,平民,NOUN,B2
+upprör,commotion,骚动,NOUN,B2
+kommuniké,communique,公报,NOUN,B2
+kommunism,communism,共产主义,NOUN,B2
+kommunistisk,communist,شيوعي,ADJ,B2
+kommunitarism,communitarianism,社群主义,NOUN,B2
+gemenskap,community,社区,NOUN,B2
+kompakt,compact,紧凑的,ADJ,B2
+kamratskap,companionship,陪伴,NOUN,B2
+avdelning,compartment,隔间,NOUN,B2
+kompass,compass,指南针,NOUN,B2
+medkänsla,compassion,同情,NOUN,B2
+medkännande,compassionate,有同情心的,ADJ,B2
+kompatibilitet,compatibility,兼容性,NOUN,B2
+landsman,compatriot,同胞,NOUN,B2
+tvinga,to compel,强迫,VERB,B2
+ersättningsledighet,compensatory leave,调休,NOUN,B2
+kompetent,competent,胜任的,ADJ,B2
+konkurrenskraft,competitiveness,竞争力,NOUN,B2
+konkurrent,competitor,竞争者,NOUN,B2
+sammanställning,compilation,汇编,NOUN,B2
+komplementär,complementary,互补的,ADJ,B2
+slutförande,completion,完成,NOUN,B2
+komplex,complex,复杂的,ADJ,B2
+komplexitet,complexity,复杂性,NOUN,B2
+efterlevnad,compliance,合规,NOUN,B2
+efterlevande,compliant,符合的,ADJ,B2
+komplikera,to complicate,使复杂化,VERB,B2
+medskyldig,complicit,共谋的,ADJ,B2
+medskyldighet,complicity,共犯,NOUN,B2
+lyda,to comply,遵守,VERB,B2
+följa,to comply with,遵守,VERB,B2
+komponent,component,组成部分,NOUN,B2
+komponera,to compose,组成,VERB,B2
+samlad,composed,稳重的,ADJ,B2
+kompositör,composer,作曲家,NOUN,B2
+komposition,composition,作文,NOUN,B2
+kompost,compost,堆肥,NOUN,B2
+samladhet,composure,镇定,NOUN,B2
+förening,compound,复合性,ADJ,B2
+förstå,to comprehend,理解,VERB,B2
+förståelse,comprehension,理解,NOUN,B2
+komprimera,to compress,压缩,VERB,B2
+kompressor,compressor,压缩机,NOUN,B2
+kompromissa,to compromise,危及,VERB,B2
+kompulsiv,compulsive,强迫性的,ADJ,B2
+beräkna,to compute,计算,VERB,B2
+beräkning,computing,计算机科学,NOUN,B2
+dölja,to conceal,隐藏,VERB,B2
+doldhet,concealment,隐瞒,NOUN,B2
+självbelåten,conceited,自负的,ADJ,B2
+tanka,to conceive,构想,VERB,B2
+gälla,concern,担忧,NOUN,B2
+gälla,to concern,涉及,VERB,B2
+koncession,concession,让步,NOUN,B2
+koncis,concise,简洁的,ADJ,B2
+avsluta,to conclude,得出结论,VERB,B2
+avgörande,conclusive,决定性的,ADJ,B2
+betong,concrete,具体的,ADJ,B2
+konkubin,concubine,妾,NOUN,B2
 condemn,to condemn,谴责,VERB,B2
 condemnation,condemnation,谴责,NOUN,B2
-condemned,condemned,被定罪的,ADJ,B2
 condensation,condensation,凝结,NOUN,B2
 condense,to condense,浓缩,VERB,B2
-condenser,condenser,词,NOUN,C1
-condescension,condescension,屈尊,NOUN,B2
 conditional,conditional,条件的,ADJ,B2
-conditioning (adj),conditioning,词,ADJ,B2
-conditioning (noun),conditioning,词,NOUN,C1
-conditioning adaptation air conditioning,conditioning adaptation air conditioning,词,NOUN,C1
 condole,to condole,哀悼,VERB,B2
 condolence,condolence,哀悼,NOUN,B2
 condolences,condolences,哀悼,NOUN,B2
-conducive,conducive,词,ADJ,B2
-conduciveness,conduciveness,词,NOUN,C1
 conduct,to conduct,أجرى,VERB,B2
-conductivity,conductivity,导电性,NOUN,B2
-conductor,conductor,词,NOUN,C1
-conduit,conduit,词,NOUN,B2
 cone,cone,圆锥体,NOUN,B2
-confederal,confederal,词,ADJ,C1
-confederate,confederate,同盟者,NOUN,B2
 confederation,confederation,邦联,NOUN,B2
-conference center,conference center,会议中心,NOUN,C1
-conference paper,conference paper,会议论文,NOUN,C1
-conference talk,conference talk,词,NOUN,C1
-conference-based,conference-based,会议的,ADJ,B2
-confessional,confessional,宗派的,ADJ,B2
-confetti,confetti,词,NOUN,C1
-confidant,confidant,知己,NOUN,B2
 confidence,confidence,信心,NOUN,B2
 confidential,confidential,机密的,ADJ,B2
 confidentiality,confidentiality,保密性,NOUN,B2
-confiding,confiding,词,NOUN,C1
 configuration,configuration,配置,NOUN,B2
-configure,configure,词,VERB,C1
-configured,configured,词,ADJ,C1
-confinement,confinement,禁闭,NOUN,B2
-confines edges,confines edges,词,NOUN,C1
 confiscate,to confiscate,没收,VERB,B2
 confiscation,confiscation,没收,NOUN,B2
-conflictual,conflictual,词,ADJ,C1
-confluence,confluence,词,NOUN,B2
-conform to,conform to,符合,VERB,A2
-conforming,conforming,遵从的,ADJ,B2
 conformism,conformism,因循守旧,NOUN,B2
-conformist,conformist,墨守成规者,NOUN,B2
-conformist (adj),conformist,词,ADJ,B2
-conformity,conformity,词,NOUN,B2
-confound,confound,词,VERB,C1
 confrontation,confrontation,对抗,NOUN,B2
-confronted,confronted,词,ADJ,B2
-confronting,confronting,对峙的,ADJ,B2
 confuse,to confuse,混淆,VERB,B2
-confused (adv),confused,词,ADV,B1
-confused embarrassed,confused embarrassed,词,ADJ,C1
-confused hesitant,confused hesitant,词,ADJ,A2
-confusedly,confusedly,词,ADV,C1
-congeal,congeal,词,VERB,C1
-congenital,congenital,先天的,ADJ,B2
 congestion,congestion,拥堵,NOUN,B2
-conglomerate,conglomerate,词,NOUN,B2
 congratulation,congratulation,祝贺,NOUN,B2
-congratulations,congratulations,祝贺,NOUN,B2
-congregate,congregate,词,VERB,C1
-congressperson,congressperson,词,NOUN,B2
-congruence,congruence,词,NOUN,B2
-congruent,congruent,一致的,ADJ,B2
-conic,conic,圆锥曲线,NOUN,B2
 coniferous forest,coniferous forest,针叶林,NOUN,B2
-conjoin,conjoin,词,VERB,C1
-conjugal,conjugal,词,ADJ,B2
 conjugation,conjugation,变位,NOUN,B2
 conjunction,conjunction,连词,NOUN,B2
-conjunctural,conjunctural,词,ADJ,C1
 conjure,to conjure,变魔术,VERB,B2
 connected,connected,连接的,ADJ,B2
-connectedness,connectedness,词,NOUN,C1
-connecting,connecting,连接的,ADJ,B2
-connective,connective,连接的,ADJ,B2
-connector,connector,词,NOUN,B2
-connivance,connivance,词,NOUN,B2
-connive,connive,词,VERB,C1
-conniving,conniving,词,ADJ,C1
 connoisseur,connoisseur,行家,NOUN,B2
 connotation,connotation,内涵,NOUN,B2
-connotative,connotative,内涵的,ADJ,B2
 conqueror,conqueror,征服者,NOUN,B2
-conquests,conquests,征服,NOUN,C1
-consanguineous,consanguineous,词,ADJ,B2
-consanguinity,consanguinity,血缘,NOUN,B2
 conscientious,conscientious,认真的,ADJ,B2
-conscientious objection,conscientious objection,良知抗拒,NOUN,B2
-conscientiously,conscientiously,词,ADV,C1
 conscious,conscious,有意识的,ADJ,B2
-conscript,conscript,词,NOUN,C1
-conscription,conscription,词,NOUN,C1
 consecrate,to consecrate,奉献,VERB,B2
-consecration,consecration,词,NOUN,C1
-consecutive,consecutive,连续的,ADJ,B2
 consecutive cards,consecutive cards,连牌,NOUN,B2
-consecutive falls,consecutive falls,连下,NOUN,C1
-consecutively,consecutively,连续地,ADV,B2
-consensualism,consensualism,词,NOUN,C1
 consensus,consensus,共识,NOUN,B2
-consequences,consequences,后果,NOUN,B1
-consequent,consequent,随之发生的,ADJ,B2
-conservatism,conservatism,词,NOUN,C1
-conservatory,conservatory,音乐学院,NOUN,B2
-considerable (noun),considerable,不小,NOUN,C1
-considered,considered,词,ADJ,B1
-console (noun),console,词,NOUN,B2
-consolidable,consolidable,词,ADJ,C1
-consolidating,consolidating,巩固的,ADJ,B2
-consolidation,consolidation,词,NOUN,C1
-consonance,consonance,词,NOUN,B2
-consortium,consortium,词,NOUN,B2
-conspirator,conspirator,词,NOUN,B2
-conspiratorial,conspiratorial,阴谋的,ADJ,B2
-constancy,constancy,恒定,NOUN,B2
-constants,constants,词,NOUN,C1
-constative,constative,词,ADJ,C1
-consternation,consternation,词,NOUN,B2
-constituencies,constituencies,词,NOUN,C1
-constituent,constituent,成分,NOUN,B2
-constitutional amendment,constitutional amendment,词,NOUN,C1
-constitutional article,constitutional article,词,NOUN,C1
-constitutionalization,constitutionalization,词,NOUN,B2
-constitutive,constitutive,构成的,ADJ,B2
-constraints,constraints,词,NOUN,C1
-constrict,constrict,词,VERB,C1
-constructiveness,constructiveness,词,NOUN,C1
-constructivism,constructivism,建构主义,NOUN,B2
-construe,construe,词,VERB,C1
-consultations,consultations,磋商,NOUN,C1
-consultative,consultative,咨询的,ADJ,B2
-consumerist,consumerist,词,ADJ,B2
-consummate,consummate,熟练的,ADJ,B2
-consummation,consummation,词,NOUN,B2
-consumptive,consumptive,消费的,ADJ,B2
-contact person,contact person,联系人,NOUN,B2
-contactual,contactual,接触的,ADJ,B2
-contagion,contagion,词,NOUN,B2
-containment,containment,词,NOUN,C1
-contaminated,contaminated,受污染的,ADJ,B2
-contaminating,contaminating,污染的,ADJ,B2
-contemn,contemn,蔑视,VERB,C1
-contemplation,contemplation,沉思,NOUN,B2
-contemporaneity,contemporaneity,词,NOUN,C1
-contemporary (noun),contemporary,当代,NOUN,B1
-contemptuously,contemptuously,词,ADV,C1
-contender,contender,词,NOUN,B2
-content (adj),content,词,ADJ,B2
-contentious,contentious,有争议的,ADJ,B2
-contents,contents,内有,NOUN,B2
-contestable,contestable,可质疑的,ADJ,B2
-contested,contested,有争议的,ADJ,B2
-contextuality,contextuality,语境性,NOUN,C1
-contextualization,contextualization,词,NOUN,C1
-contiguity,contiguity,词,NOUN,B2
-contiguous,contiguous,相邻的,ADJ,B2
-continence,continence,词,NOUN,B2
-continental,continental,词,ADJ,B2
-contingent,contingent,偶然的,ADJ,B2
-continual,continual,持续的,ADJ,B2
-continually,continually,不断地,ADV,B2
-continuously,continuously,一直,ADV,A1
-contort,contort,词,VERB,C1
-contortion,contortion,词,NOUN,B2
-contour,contour,词,NOUN,B2
-contraband,contraband,违禁品,NOUN,B2
-contracted,contracted,词,ADJ,B2
-contracting,contracting,词,NOUN,C1
-contraction,contraction,收缩,NOUN,C1
-contractor,contractor,词,NOUN,B1
-contractual,contractual,合同的,ADJ,B2
-contractual nature,contractual nature,词,NOUN,C1
-contractuality,contractuality,词,NOUN,C1
-contractualization,contractualization,契约化,NOUN,B2
-contradictoriness,contradictoriness,词,NOUN,C1
-contraindicate,contraindicate,词,VERB,C1
-contraindication,contraindication,词,NOUN,C1
-contrary (adj),contrary,词,ADJ,C1
-contrary to expectations,contrary to expectations,偏偏,ADV,B2
-contrast,contrast,对比,NOUN,B2
-contrastive,contrastive,词,ADJ,C1
-contributions,contributions,词,NOUN,C1
-contrite,contrite,词,ADJ,B2
-contrition,contrition,悔罪,NOUN,B2
-contrive,contrive,词,VERB,C1
-controllability,controllability,词,NOUN,C1
-controllable,controllable,可控制的,ADJ,B2
-controller,controller,词,NOUN,C1
-controlling,controlling,词,ADJ,C1
-contumacy,contumacy,词,NOUN,C1
-contusion,contusion,词,NOUN,B2
-contusion trauma,contusion trauma,挫伤 / 外伤,NOUN,C1
-convalesce,convalesce,词,VERB,B2
-convalescence,convalescence,词,NOUN,C1
-convalescent,convalescent,词,ADJ,B2
-convenant,convenant,词,NOUN,C1
-convenience,convenience,词,NOUN,B2
-convenience store,convenience store,便利店,NOUN,C1
-convening,convening,召集,NOUN,C1
-convent,convent,词,NOUN,B2
-conventionality,conventionality,词,NOUN,C1
-convergent,convergent,词,ADJ,C1
-conversation technique,conversation technique,词,NOUN,C1
-conversion,conversion,转换,NOUN,B2
-conversional,conversional,转换的,ADJ,B2
-convert (noun),convert,词,NOUN,B2
-convertibility,convertibility,可兑换性,NOUN,B2
-convertible,convertible,可兑换的,ADJ,B2
-convex,convex,词,ADJ,B2
-convexity,convexity,词,NOUN,B2
-conveyance,conveyance,词,NOUN,C1
-conveyance routing,conveyance routing,词,NOUN,B2
-convict (adj),convict,词,ADJ,B2
-convict (noun),convict,词,NOUN,C1
-conviviality,conviviality,温馨,NOUN,B2
-convoke,convoke,词,VERB,C1
-convoluted,convoluted,词,ADJ,B2
-convolutional,convolutional,卷积的,ADJ,B2
-convoy,convoy,词,NOUN,B2
-convulse,convulse,词,VERB,C1
-convulsive,convulsive,词,ADJ,B2
-cookbook,cookbook,词,NOUN,C1
-cooked,cooked,熟的,ADJ,B2
-cooking,cooking,烹饪,NOUN,B2
-cooking wine,cooking wine,料酒,NOUN,B2
-cool-headed,cool-headed,冷静的,ADJ,B2
-cooler,cooler,词,ADJ,C1
-cooler coolant,cooler coolant,冷却器 / 冷却液,NOUN,C1
-coop,coop,词,VERB,C1
-cooperative (adj),cooperative,词,ADJ,C1
-cooperative (noun),cooperative,词,NOUN,B1
-coordinated,coordinated,词,ADJ,C1
-coordinates,coordinates,词,NOUN,C1
-coordination,coordination,词,NOUN,B2
-cope with,cope with,应对,VERB,B2
-copious,copious,丰富的,ADJ,B2
-coproduction,coproduction,联合制作,NOUN,B2
-coquettish,coquettish,词,ADJ,C1
-coral (adj),coral,词,ADJ,C1
-coral reef,coral reef,珊瑚礁,NOUN,B2
-cord,cord,绳索,NOUN,B2
-cordial,cordial,词,ADJ,B2
-cordiality,cordiality,词,NOUN,C1
-cordially,cordially,亲切地,ADV,B2
-cordoning,cordoning,词,NOUN,C1
-core course,core course,核心课,NOUN,B2
-coriander,coriander,词,NOUN,B2
-cornea,cornea,角膜,NOUN,B2
-cornice,cornice,檐口,NOUN,B2
-corniche,corniche,词,NOUN,C1
-corollary,corollary,推论,NOUN,B2
-corporate,corporate,公司的,ADJ,B2
-corporation,corporation,公司,NOUN,B2
-corporatism,corporatism,法团主义,NOUN,B2
-corporeal,corporeal,词,ADJ,B2
-corpulent,corpulent,词,ADJ,B2
-corpuscle,corpuscle,词,NOUN,C1
-correct deviation,correct deviation,纠偏,VERB,C1
-correct errors,correct errors,纠错,VERB,C1
-correctional,correctional,词,ADJ,C1
-correctness,correctness,正确性,NOUN,B2
-correlate,correlate,词,VERB,C1
-correlative,correlative,词,ADJ,B2
-correlatively,correlatively,词,ADV,B2
-correspondence course,correspondence course,函授,NOUN,C1
-correspondents,correspondents,词,NOUN,C1
-corridors,corridors,词,NOUN,C1
-corrigible,corrigible,可改正的,ADJ,B2
-corroboration,corroboration,证实,NOUN,B2
-corrosive,corrosive,腐蚀性的,ADJ,B2
-corruptibility,corruptibility,词,NOUN,C1
-cortical,cortical,皮层的,ADJ,C1
-cosmetic,cosmetic,化妆品的,ADJ,B2
-cosmetics,cosmetics,化妆品,NOUN,B2
-cosmogony,cosmogony,词,NOUN,C1
-cosmology,cosmology,宇宙学,NOUN,B2
-cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
-cosmopolitanism,cosmopolitanism,词,NOUN,B2
-cosmos,cosmos,词,NOUN,C1
-costly,costly,昂贵的,ADJ,B2
-costs,costs,费用,NOUN,B2
-costumbrism,costumbrism,词,NOUN,B2
-costumes,costumes,词,NOUN,B2
-cosy,cosy,词,ADJ,B2
-cotton cloth,cotton cloth,棉布,NOUN,C1
-couch,couch,词,NOUN,B1
-cough (noun),cough,词,NOUN,B2
-could,could,词,AUX,A1
-could it be,could it be,难不成,ADJ,B2
-could it be that,could it be that,难道,ADV,A2
-council-related,council-related,词,ADJ,C1
-councilor,councilor,市议员,NOUN,B2
-councils,councils,委员会,NOUN,C1
-counsel,counsel,词,NOUN,B2
-counselor,counselor,词,NOUN,C1
-countability,countability,屈指可数,NOUN,B2
-countenance,countenance,面容,NOUN,B2
-counter clerk,counter clerk,词,NOUN,B1
-counter-argument,counter-argument,反辩,NOUN,B2
-counter-art,counter-art,反艺,NOUN,C1
-counter-belief,counter-belief,反信,NOUN,B2
-counter-body,counter-body,反体,NOUN,C1
-counter-boundary,counter-boundary,反界,NOUN,B2
-counter-cause,counter-cause,反因,NOUN,C1
-counter-class,counter-class,反类,NOUN,C1
-counter-criterion,counter-criterion,反准,NOUN,C1
-counter-domain,counter-domain,反畴,NOUN,B2
-counter-evidence,counter-evidence,反据,NOUN,B2
-counter-grade,counter-grade,反级,NOUN,C1
-counter-image,counter-image,反象,NOUN,B2
-counter-layer,counter-layer,反层,NOUN,B2
-counter-level,counter-level,反阶,NOUN,C1
-counter-limit,counter-limit,反限,NOUN,B2
-counter-number,counter-number,反数,NOUN,C1
-counter-path,counter-path,反径,NOUN,C1
-counter-price,counter-price,反价,NOUN,C1
-counter-process,counter-process,反程,NOUN,C1
-counter-quantity,counter-quantity,反量,NOUN,B2
-counter-segment,counter-segment,反段,NOUN,B2
-counter-standard,counter-standard,反标,NOUN,C1
-counter-step,counter-step,反步,NOUN,C1
-counter-strategy,counter-strategy,反略,NOUN,C1
-counter-thought,counter-thought,反想,NOUN,C1
-counter-trace,counter-trace,反迹,NOUN,C1
-counter-track,counter-track,反轨,NOUN,C1
-counter-value,counter-value,反值,NOUN,C1
-counter-work,counter-work,反工,NOUN,C1
-counteract,counteract,词,VERB,C1
-counterbalance,counterbalance,词,VERB,C1
-counterclaim,counterclaim,反诉,VERB,C1
-countercurrent,countercurrent,逆流,NOUN,B2
-counterfactual,counterfactual,反实,NOUN,C1
-counterfeiting,counterfeiting,伪造,NOUN,B2
-countermand,countermand,词,VERB,C1
-countermeasure,countermeasure,反制,NOUN,C1
-counterproductive,counterproductive,适得其反的,ADJ,B2
-counterproductivity,counterproductivity,适得其反,NOUN,B2
-counterweight,counterweight,词,NOUN,B2
-country land,country land,词,NOUN,A1
-county magistrate,county magistrate,县长,NOUN,C1
-county road,county road,县道,NOUN,B2
-courageous,courageous,勇敢的,ADJ,B2
-courageously,courageously,词,ADV,C1
-court and country,court and country,朝野,NOUN,C1
-court appearance,court appearance,词,NOUN,C1
-court case,court case,诉讼,NOUN,B2
-court clerk,court clerk,词,NOUN,C1
-court costs,court costs,词,NOUN,C1
-court fee,court fee,诉讼费,NOUN,B2
-court hearing,court hearing,庭审,NOUN,C1
-courteous,courteous,有礼貌的,ADJ,B2
-courtier,courtier,词,NOUN,B2
-courtly,courtly,词,ADJ,B2
-courtyard guard,courtyard guard,护院,NOUN,B2
-couscous,couscous,词,NOUN,A1
-couscous steamer,couscous steamer,古斯古斯蒸锅,NOUN,B1
-cousin female,cousin female,词,NOUN,B2
-cove,cove,小海湾,NOUN,B2
-cover a shift,cover a shift,替班,VERB,B2
-cover-up,cover-up,词,NOUN,C1
-coward (adj),coward,词,ADJ,A2
-cower,cower,词,VERB,C1
-cowpeas,cowpeas,词,NOUN,B2
-crackdown,crackdown,词,NOUN,C1
-cracking,cracking,词,NOUN,B2
-cradle,cradle,摇篮,NOUN,B2
-crafty,crafty,狡猾,ADJ,B2
-cramp,cramp,抽筋,NOUN,B2
-cranberry,cranberry,蔓越莓,NOUN,C1
-crank,crank,词,NOUN,C1
-crap,crap,屎,NOUN,B2
-crash bang,crash bang,词,NOUN,C1
-crass,crass,词,ADJ,B2
-cravenly,cravenly,词,ADV,C1
-craving,craving,渴求,NOUN,B2
-crayon,crayon,词,NOUN,C1
-craze,craze,狂热,NOUN,B2
-crazy nutcase,crazy nutcase,词,NOUN,C1
-creak (noun),creak,词,NOUN,B2
-creamy,creamy,词,ADJ,C1
-crease,crease,词,NOUN,C1
-credentials,credentials,国书,NOUN,B2
-credible,credible,词,ADJ,C1
-creditor's rights,creditor's rights,债权,NOUN,B2
-credulity,credulity,轻信,NOUN,B2
-credulous,credulous,词,ADJ,B2
-creep (verb),creep,词,VERB,B2
-creepy,creepy,令人毛骨悚然的,ADJ,B2
-cremate,cremate,词,VERB,C1
-cremation,cremation,火化,NOUN,B2
-crenelate,crenelate,词,VERB,C1
-crescendo,crescendo,词,NOUN,C1
-crescent,crescent,crescent,NOUN,B2
-crib,crib,词,NOUN,C1
-crick,crick,词,NOUN,C1
-cricket,cricket,板球,NOUN,B2
-crime novel,crime novel,词,NOUN,B1
-crime occur,crime occur,案发,VERB,B2
-crime rate,crime rate,词,NOUN,B2
-criminal (adj),criminal,刑事,ADJ,C1
-criminal law,criminal law,刑法,NOUN,B2
-criminal lawyer,criminal lawyer,词,NOUN,B2
-criminal record,criminal record,词,NOUN,B2
-criminalization,criminalization,词,NOUN,C1
-crimson,crimson,词,ADJ,C1
-cringe,cringe,词,VERB,C1
-crinkle,crinkle,词,VERB,C1
-cripple,cripple,词,VERB,C1
-crisis deepening,crisis deepening,词,NOUN,C1
-crisis of conscience,crisis of conscience,词,NOUN,C1
-crisis situation,crisis situation,危机局势,NOUN,B2
-crisis-ridden,crisis-ridden,词,ADJ,C1
-crisp,crisp,词,ADJ,C1
-criticizable,criticizable,词,ADJ,B2
-critique,critique,词,NOUN,C1
-crochet,crochet,词,NOUN,C1
-crocodile,crocodile,词,NOUN,A1
-cronyism,cronyism,词,NOUN,C1
-crook,crook,骗子,NOUN,B2
-cross-border,cross-border,边境的,ADJ,B2
-cross-cultural exchange,cross-cultural exchange,词,NOUN,C1
-cross-cutting,cross-cutting,词,ADJ,C1
-crossbow,crossbow,弓弩,NOUN,C1
-crossing the border,crossing the border,越境,NOUN,B2
-crosstalk,crosstalk,相声,NOUN,B2
-crosswalk,crosswalk,斑马线,NOUN,B2
-crosswise,crosswise,词,ADJ,C1
-crouch (noun),crouch,词,NOUN,B2
-croup,croup,词,NOUN,C1
-crowbar,crowbar,词,NOUN,B2
-crowded,crowded,拥挤,ADJ,B2
-crowdfunding,crowdfunding,众筹,NOUN,B2
-crowdsourcing,crowdsourcing,众包,NOUN,C1
-crucible,crucible,词,NOUN,B2
-crucifixion,crucifixion,词,NOUN,C1
-crucify,crucify,词,VERB,C1
-crude,crude,简陋,ADJ,B2
-crude oil,crude oil,原油,NOUN,B2
-cruelly,cruelly,残酷地,ADV,B2
-cruelty harshness,cruelty harshness,词,NOUN,B2
-cruise passenger,cruise passenger,词,NOUN,B1
-crumb,crumb,词,NOUN,C1
-crumbs,crumbs,词,NOUN,B2
-crunching,crunching,词,NOUN,C1
-crunchy,crunchy,脆的,ADJ,B1
-crusade,crusade,运动,NOUN,B2
-crushing,crushing,词,NOUN,B2
-crusty,crusty,词,ADJ,B2
-cry weep,cry weep,词,VERB,A1
-crying shouting,crying shouting,词,NOUN,B1
-cryptic,cryptic,词,ADJ,C1
-cryptocurrency,cryptocurrency,加密货币,NOUN,C1
-crystal clear,crystal clear,清澈的,ADJ,B2
-crystal glass,crystal glass,词,NOUN,B1
-crystalline,crystalline,水晶般的,ADJ,B2
-crystallization,crystallization,词,NOUN,C1
-crystallize,crystallize,词,VERB,C1
-cubit,cubit,词,NOUN,B2
-cuckold,cuckold,词,VERB,C1
-cuddle (noun),cuddle,词,NOUN,C1
-cudgel,cudgel,棍棒,NOUN,B2
-cue,cue,词,NOUN,B2
-cuff,cuff,词,NOUN,C1
-cuisine,cuisine,词,NOUN,C1
-cull,cull,词,VERB,C1
-culminating,culminating,词,ADJ,C1
-culmination,culmination,词,NOUN,B2
-culprit,culprit,谁让,NOUN,C1
-cult,cult,邪教,NOUN,B2
-cultivation,cultivation,培养,NOUN,B2
-cultural center,cultural center,文化馆,NOUN,C1
-culturalism,culturalism,词,NOUN,C1
-culture of greed,culture of greed,贪得无厌文化,NOUN,B2
-cultured,cultured,词,ADJ,B2
-cumber,cumber,词,VERB,C1
-cumbersome,cumbersome,笨重的,ADJ,B2
-cumin,cumin,词,NOUN,B1
-cumulative,cumulative,词,ADJ,B2
-cunning shrewdness,cunning shrewdness,词,NOUN,B2
-cunningly,cunningly,词,ADV,C1
-cupboard wardrobe,cupboard wardrobe,词,NOUN,A2
-cupola,cupola,词,NOUN,C1
-cupping,cupping,词,NOUN,B1
-curable,curable,有解,NOUN,C1
-curate,curate,词,VERB,C1
-curative,curative,有疗效的,ADJ,B2
-curator,curator,策展人,NOUN,B2
-curatorship,curatorship,词,NOUN,C1
-curbing,curbing,遏制,NOUN,B2
-curd,curd,词,NOUN,B2
-curdle,curdle,词,VERB,C1
-curdled milk,curdled milk,词,NOUN,A2
-cure (noun),cure,给治好,NOUN,C1
-curiously,curiously,词,ADV,C1
-curly,curly,卷曲的,ADJ,B2
-currant,currant,醋栗,NOUN,B2
-currency exchange,currency exchange,词,NOUN,B2
-current events,current events,时事,NOUN,B2
-current times,current times,词,NOUN,B2
-curriculum vitae,curriculum vitae,词,NOUN,B2
-curry,curry,词,NOUN,B2
-cursing,cursing,骂人,NOUN,C1
-curvature,curvature,词,NOUN,B2
-curved,curved,词,ADJ,B2
-cusp,cusp,词,NOUN,B2
-custodian,custodian,词,NOUN,B2
-customary law,customary law,词,NOUN,C1
-customer orientation,customer orientation,客户导向,NOUN,B2
-customer service,customer service,客户服务,NOUN,B2
-customization,customization,词,NOUN,C1
-customs (adj),customs,词,ADJ,C1
-customs officer,customs officer,海关官员,NOUN,B2
-cut off,cut off,割下,NOUN,B2
+följaktligen,consequently,因此,ADV,B2
+bevarande,conservation,保护,NOUN,B2
+konservativ,conservative,保守的,ADJ,B2
+betydande,considerable,相当大的,ADJ,B2
+omsorgsfull,considerate,体贴,ADJ,B2
+konsignation,consignment,托运,NOUN,B2
+konsistens,consistency,一致性,NOUN,B2
+konsekvent,consistent,一致的,ADJ,B2
+tröst,consolation,安慰,NOUN,B2
+trösta,to console,安慰,VERB,B2
+konsolidera,to consolidate,巩固,VERB,B2
+konsort,consort,福晋,NOUN,B2
+framträdande,conspicuous,显著的,ADJ,B2
+samspira,to conspire,密谋,VERB,B2
+stjärnbild,constellation,星座,NOUN,B2
+förstoppning,constipation,便秘,NOUN,B2
+konstitutionell,constitutional,宪法的,ADJ,B2
+konstitutionalitet,constitutionality,合宪性,NOUN,B2
+inskränka,to constrain,限制,VERB,B2
+inskränkning,constraint,约束,NOUN,B2
+konstruktion,construction,建造,NOUN,B2
+byggarbete,construction site,工地,NOUN,B2
+konstruktiv,constructive,建设性的,ADJ,B2
+konsul,consul,领事,NOUN,B2
+konsulär,consular,领事的,ADJ,B2
+konsulat,consulate,领事馆,NOUN,B2
+konsultera,to consult reference,参考,VERB,B2
+konsult,consultant,顾问,NOUN,B2
+konsultation,consultation,咨询,NOUN,B2
+konsumera,to consume,消费,VERB,B2
+konsumtion,consumption,消费,NOUN,B2
+smittsam,contagious,传染性的,ADJ,B2
+behållare,container,容器,NOUN,B2
+förorena,to contaminate,污染,VERB,B2
+överväga,to contemplate,沉思,VERB,B2
+tänksam,contemplative,沉思的,ADJ,B2
+samtidig,contemporary,当代的,ADJ,B2
+tillfredsställelse,contentment,满足,NOUN,B2
+tävling,contest,比赛,NOUN,B2
+kontextuell,contextual,语境的,ADJ,B2
+kontinent,continent,大陆,NOUN,B2
+kontingens,contingency,偶然性,NOUN,B2
+fortsättning,continuation,延续,NOUN,B2
+kontinuitet,continuity,连续性,NOUN,B2
+kontinuerlig,continuous,连续的,ADJ,B2
+avtala,to contract,收缩,VERB,B2
+motsägelse,contradiction,矛盾,NOUN,B2
+motsägelsefull,contradictory,矛盾的,ADJ,B2
+motsats,contrary,反而,NOUN,B2
+motsatt avsikt,contrary intention,反意,NOUN,B2
+kontrastera,to contrast,对比,VERB,B2
+överträda,to contravene,违反,VERB,B2
+kontroversiell,controversial,有争议的,ADJ,B2
+kontrovers,controversy,争议,NOUN,B2
+sammanträffa,to convene,召集,VERB,B2
+praktisk,convenient,方便的,ADJ,B2
+konventionell,conventional,传统的,ADJ,B2
+konvergera,to converge,汇聚,VERB,B2
+konvergens,convergence,汇聚,NOUN,B2
+konversera,to converse,交谈,VERB,B2
+tvärtom,conversely,相反地,ADV,B2
+konvertera,to convert,转换,VERB,B2
+döma,to convict,定罪,VERB,B2
+kramp,convulsion,抽搐,NOUN,B2
+kokt köttbulle,cooked meatball,丸子熟,NOUN,B2
+kokt ris,cooked rice,米饭,NOUN,B2
+kex,cookie,饼干,NOUN,B2
+kokpanna,cooking pot,炖锅,NOUN,B2
+avkyla,to cool down,冷却,VERB,B2
+kylning,cooling,冷却,NOUN,B2
+koordinator,coordinator,协调员,NOUN,B2
+koppar,copper,铜,NOUN,B2
+kopist,copyist,抄写员,NOUN,B2
+upphovsrätt,copyright,版权,NOUN,B2
+korall,coral,珊瑚,NOUN,B2
+kork,cork,软木塞,NOUN,B2
+kröningsceremoni,coronation,加冕,NOUN,B2
+lik,corpse,尸体,NOUN,B2
+korrigering,correction,纠正,NOUN,B2
+korrelation,correlation,相关性,NOUN,B2
+korrespondera,to correspond,符合,VERB,B2
+korrespondens,correspondence,通信,NOUN,B2
+korrosion,corrosion,腐蚀,NOUN,B2
+korrumpera,corrupt,腐败的,ADJ,B2
+korrumpera,to corrupt,腐败,VERB,B2
+korruption,corruption,腐败,NOUN,B2
+kosmisk,cosmic,宇宙的,ADJ,B2
+kostym,costume,戏服,NOUN,B2
+hosta,cough,咳嗽,NOUN,B2
+råd,council,委员会,NOUN,B2
+rådgivning,counseling,咨询,NOUN,B2
+räkna,to count as,算,VERB,B2
+motverka,to counter,反击,VERB,B2
+motform,counter-form,反式,NOUN,B2
+motlogik,counter-logic,反逻,NOUN,B2
+antimateri,counter-matter,反物,NOUN,B2
+motmekanism,counter-mechanism,反机,NOUN,B2
+motmodell,counter-model,反模,NOUN,B2
+motobservation,counter-observation,反察,NOUN,B2
+motkvalitet,counter-quality,反质,NOUN,B2
+motrutt,counter-route,反途,NOUN,B2
+motfärdighet,counter-skill,反技,NOUN,B2
+motsula,counter-sole,反唯,NOUN,B2
+motstruktur,counter-structure,反结,NOUN,B2
+motsystem,counter-system,反系,NOUN,B2
+motteknik,counter-technique,反术,NOUN,B2
+motström,counter-trend,反势,NOUN,B2
+mottyp,counter-type,反型,NOUN,B2
+motattack,counterattack,反击,NOUN,B2
+falsk,counterfeit,假冒,ADJ,B2
+motpart,counterpart,对应的人或物,NOUN,B2
+otalig,countless,无数的,ADJ,B2
+land,countryside,乡村,NOUN,B2
+kupp,coup,政变,NOUN,B2
+par,couple,一对,NOUN,B2
+distikon,couplet,对联,NOUN,B2
+avvisning,court dismissal,退朝,NOUN,B2
+hövlighet,courtesy,礼貌,NOUN,B2
+gård,courtyard,庭院,NOUN,B2
+förbund,covenant,契约,NOUN,B2
+girighet,covetousness,贪欲,NOUN,B2
+krabba,crab,螃蟹,NOUN,B2
+knakka,to crackle,噼啪作响,VERB,B2
+hantverk,craft,工艺,NOUN,B2
+hantverkare,craftsman,工匠,NOUN,B2
+hantverkskonst,craftsmanship,手工艺,NOUN,B2
+kran,crane,起重机,NOUN,B2
+kassa,crate,板条箱,NOUN,B2
+krater,crater,火山口,NOUN,B2
+längta,to crave,渴望,VERB,B2
+kreativ,creative,有创造力的,ADJ,B2
+kreativitet,creativity,创造力,NOUN,B2
+trovärdighet,credibility,可信度,NOUN,B2
+fordringshavare,creditor,债权人,NOUN,B2
+fordringsrätt,creditor's right,债权,NOUN,B2
+trosbekännelse,creed,信条,NOUN,B2
+våga,crest,顶峰,NOUN,B2
+brottslighet,criminality,犯罪,NOUN,B2
+kriminalisera,to criminalize,定罪,VERB,B2
+kritiker,critic,评论家,NOUN,B2
+kritisk,critical,关键的,ADJ,B2
+kritikalitet,criticality,临界性,NOUN,B2
+kritisera,to criticize,批评,VERB,B2
+sned,crooked,弯曲的,ADJ,B2
+gröda,crop,庄稼,NOUN,B2
+korsning,crossing,交叉口,NOUN,B2
+korsväg,crossroads,十字路口,NOUN,B2
+knäböja,to crouch,蹲下,VERB,B2
+kråka,crow,乌鸦,NOUN,B2
+folkmassa,crowd,人群,NOUN,B2
+kröna,to crown,加冕,VERB,B2
+avgörande,crucial,至关重要的,ADJ,B2
+härskamma,cruelty,残忍,NOUN,B2
+kryssning,cruise,巡航,NOUN,B2
+knäcka,to crunch,嘎吱作响,VERB,B2
+knäckande nederlag,crushing defeat,惨败,NOUN,B2
+skorpa,crust,外壳,NOUN,B2
+kräftdjur,crustacean,甲壳类动物,NOUN,B2
+kryck,crutch,拐杖,NOUN,B2
+kristall,crystal,水晶,NOUN,B2
+unge,cub,幼兽,NOUN,B2
+kub,cube,立方体,NOUN,B2
+kubism,cubism,立体主义,NOUN,B2
+kulturell,cultural,文化的,ADJ,B2
+kulturrelikv,cultural relic,文物,NOUN,B2
+list,cunning,诡计,NOUN,B2
+inskränka,to curb,抑制,VERB,B2
+nuvarande dynasti,current dynasty,当朝,NOUN,B2
+för närvarande,currently,目前,ADV,B2
+förbannad,cursed,被诅咒的,ADJ,B2
+gardinstång,curtain rod,窗帘杆,NOUN,B2
+kurva,curve,曲线,NOUN,B2
+kudde,cushion,垫子,NOUN,B2
+vårdnad,custody,监护,NOUN,B2
+sedvanlig,customary,习惯的,ADJ,B2
 cut off,to cut off,切断,VERB,B2
-cut off (noun),cut off,割下,NOUN,B2
 cut short,to cut short,截断,VERB,B2
-cutaneous,cutaneous,词,ADJ,C1
-cutlet,cutlet,词,NOUN,B1
-cutting,cutting,切割,NOUN,B2
-cutting grass,cutting grass,斩草,NOUN,B2
-cuttlefish,cuttlefish,词,NOUN,B2
 cyanosis,cyanosis,发绀,NOUN,B2
 cyber,cyber,网络的,ADJ,B2
-cybernetics,cybernetics,词,NOUN,C1
 cybersecurity,cybersecurity,网络安全,NOUN,B2
-cyborg,cyborg,词,NOUN,C1
 cycle,cycle,循环,NOUN,B2
-cycle path,cycle path,自行车道,NOUN,B2
 cyclical,cyclical,周期的,ADJ,B2
-cycling,cycling,词,NOUN,C1
-cyclist,cyclist,骑自行车的人,NOUN,B2
 cyclone,cyclone,气旋,NOUN,B2
-cynicism,cynicism,犬儒主义,NOUN,B2
-cyst,cyst,囊肿,NOUN,B2
-czech,czech,捷克的,ADJ,B2
-dab,dab,词,VERB,C1
-dabble,dabble,词,VERB,C1
-dachshund,dachshund,词,NOUN,A1
-dad father,dad father,爸爸,NOUN,A1
-dadaism,dadaism,词,NOUN,C1
-daddy,daddy,爸爸,NOUN,B2
-daft,daft,傻的,ADJ,B2
-dagg,dew,露水,NOUN,B2
 dagger,dagger,匕首,NOUN,B2
 daily,daily,每日的,ADJ,B2
-daily (noun),daily,词,NOUN,B2
 daily increase,daily increase,日渐,NOUN,B2
-daily necessities,daily necessities,日用品,NOUN,B1
 daily newspaper,daily newspaper,日报,NOUN,B2
-daily wage,daily wage,词,NOUN,C1
-dairy,dairy,词,ADJ,C1
-dal,valley,山谷,NOUN,B2
-dally,dally,词,VERB,C1
 dam,dam,水坝,NOUN,B2
 damage,to damage,损坏,VERB,B2
-damageable,damageable,易损的,ADJ,B2
-damaging,damaging,有害的,ADJ,B2
-damask,damask,词,NOUN,B2
 damn,damn,该死的,ADJ,B2
 damn,to damn,诅咒,VERB,B2
 damp,damp,潮湿,ADJ,B2
-damping,damping,词,NOUN,C1
-dandelion,dandelion,词,NOUN,B1
-dandle,dandle,词,VERB,C1
-dandruff,dandruff,词,NOUN,B2
-dangle,dangle,词,VERB,C1
-danish,danish,丹麦的,ADJ,B2
 danmei,danmei,但没,NOUN,B2
-dapper,dapper,整洁的,ADJ,B2
-darbuka,darbuka,词,NOUN,C1
-dare (noun),dare,我敢说,NOUN,C1
-dare gamble,dare gamble,敢赌,NOUN,B2
-dare not,dare not,不敢,VERB,B2
-dare to ruin,dare to ruin,敢坏,NOUN,C1
-daring,daring,词,ADJ,B2
-daring bold,daring bold,词,ADJ,B2
-dark blue,dark blue,词,ADJ,A1
-dark depths,dark depths,词,NOUN,C1
-dark-colored,dark-colored,词,ADJ,A2
 darken,to darken,变暗,VERB,B2
-darkness of night,darkness of night,词,NOUN,C1
-darn (verb),darn,词,VERB,B2
-dart (noun),dart,词,NOUN,B2
-dart (verb),dart,词,VERB,C1
-dash (noun),dash,点跑,NOUN,C1
-dash (verb),dash,词,VERB,C1
 dashboard,dashboard,仪表盘,NOUN,B2
-dashing (adj),dashing,潇洒,ADJ,B2
-dashing (noun),dashing,风流倜傥,NOUN,C1
-data leak,data leak,词,NOUN,C1
-data processing,data processing,数据处理,NOUN,B2
-date history,date history,词,NOUN,A2
-dates,dates,词,NOUN,A2
-daub,daub,词,VERB,C1
-daughter-in-law,daughter-in-law,媳妇,NOUN,C1
-dawning,dawning,破晓,NOUN,B2
-day after day,day after day,日复一日,ADV,B2
-day after tomorrow,day after tomorrow,后天,NOUN,B2
-day by day,day by day,日日,ADV,B2
 day laborer,day laborer,日工,NOUN,B2
-day off,day off,词,NOUN,B2
-day out,day out,一日游,NOUN,B2
-day school,day school,词,NOUN,C1
-day sun,day sun,日,NOUN,B2
-daybreak,daybreak,拂晓,NOUN,C1
-daycare,daycare,托儿所,NOUN,B2
 daydream,to daydream,幻想,VERB,B2
-daydream (noun),daydream,词,NOUN,C1
-daydreaming,daydreaming,词,NOUN,C1
-daytime,daytime,白天,NOUN,C1
-daze (noun),daze,别愣,NOUN,C1
-dazed,dazed,词,ADJ,C1
-dazed one,dazed one,词,NOUN,B2
-dazzled,dazzled,词,ADJ,C1
-de,those,那些,DET,B2
-de,they things,它们,PRON,B2
-de facto,de facto,词,ADJ,C1
-de-escalation,de-escalation,词,NOUN,C1
-deacon,deacon,词,NOUN,C1
-dead body,dead body,尸体,NOUN,C1
-dead person,dead person,词,NOUN,B1
-deaden,deaden,词,VERB,C1
 deadline,deadline,截止日期,NOUN,B2
-deadlock,deadlock,词,NOUN,C1
-deaf person,deaf person,词,NOUN,B2
-deafening,deafening,词,ADJ,C1
-deafness,deafness,听不,NOUN,C1
 deal,deal,交易,NOUN,B2
 dealer,dealer,经销商,NOUN,B2
-deals,deals,词,NOUN,C1
 dean,dean,院长,NOUN,B2
-deanship,deanship,词,NOUN,C1
-dearest,dearest,词,NOUN,B2
-death anniversary,death anniversary,忌日,NOUN,B2
-death news,death news,死讯,NOUN,B2
-death rattle,death rattle,词,NOUN,C1
-death trap,death trap,死地,NOUN,B2
-death warrior,death warrior,死士,NOUN,C1
 death wish,death wish,找死,NOUN,B2
-deaths,deaths,词,NOUN,C1
-debasement,debasement,词,NOUN,C1
 debatable,debatable,有争议的,ADJ,B2
-debauch,debauch,词,VERB,C1
 debauchery,debauchery,放荡,NOUN,B2
-debilitate,debilitate,词,VERB,C1
-debility,debility,虚弱,NOUN,C1
-debit,debit,词,VERB,C1
-debrief,debrief,词,VERB,C1
-debris,debris,词,NOUN,B2
-debris rubble,debris rubble,词,NOUN,C1
 debtor,debtor,债务人,NOUN,B2
 debts,debts,债务,NOUN,B2
-debug,debug,词,VERB,C1
-debunk,debunk,词,VERB,C1
 decadence,decadence,衰落,NOUN,B2
 decadent,decadent,颓废,ADJ,B2
-decalogue,decalogue,词,NOUN,B2
-decamp,decamp,词,VERB,C1
-decapitate,decapitate,词,VERB,C1
-decay,decay,词,VERB,C1
-decease,decease,词,NOUN,C1
 deceased,deceased,死者,NOUN,B2
-deceased (adj),deceased,已故的,ADJ,B2
-deceit,deceit,欺骗,NOUN,B2
 deceitful,deceitful,欺诈的,ADJ,B2
-deceived,deceived,词,ADJ,A2
-decelerate,decelerate,词,VERB,C1
+anständighet,decency,体面,NOUN,B2
 decentralisering,decentralization,权力下放,NOUN,B2
-decentralized,decentralized,词,ADJ,C1
-deceptive,deceptive,欺骗性的,ADJ,B2
-decibel,decibel,分贝,NOUN,B2
-decidedly,decidedly,坚决地,ADV,B2
-decimal (adj),decimal,词,ADJ,C1
-deciphering,deciphering,词,NOUN,C1
-decision-making,decision-making,决策,NOUN,B2
-decisiveness,decisiveness,决断,NOUN,B2
-deck,deck,词,NOUN,B1
-declamatory style,declamatory style,词,NOUN,C1
-declarant,declarant,词,NOUN,B2
-declarative,declarative,词,ADJ,C1
-declare war,declare war,宣战,VERB,B2
-declension,declension,词,NOUN,C1
-declinable,declinable,可变格的,ADJ,B2
-decline setting,decline setting,词,NOUN,C1
-decoding,decoding,词,NOUN,B2
-decommission,decommission,词,VERB,C1
-decompensation,decompensation,词,NOUN,C1
-decomposed,decomposed,词,ADJ,C1
-decomposition,decomposition,词,NOUN,C1
-decomposition degradation,decomposition degradation,分解 / 降解,NOUN,C1
-deconcentration,deconcentration,词,NOUN,C1
-deconsecrate,deconsecrate,词,VERB,C1
-deconstructionist,deconstructionist,词,ADJ,C1
-decontaminate,decontaminate,词,VERB,C1
-decontamination,decontamination,去污,NOUN,B2
-decor,decor,布景,NOUN,B2
-decorated,decorated,词,ADJ,B1
-decorous,decorous,词,ADJ,B2
-decorous modesty,decorous modesty,词,NOUN,C1
-decorum,decorum,礼仪,NOUN,B2
-decoy,decoy,词,NOUN,C1
-decrease (noun),decrease,减,NOUN,B2
-decreasing,decreasing,词,ADJ,B2
-decrepit,decrepit,词,ADJ,B2
-dedikera,to dedicate,致力于,VERB,B2
-deducera,to deduce,推断,VERB,B2
-deduct points,deduct points,扣分,VERB,C1
-deductions,deductions,词,NOUN,C1
-deductive,deductive,词,ADJ,C1
-deem,deem,词,VERB,C1
-deep darkness,deep darkness,词,NOUN,C1
-deep love,deep love,深爱,NOUN,C1
-deep measure,deep measure,丈深,NOUN,C1
-deep sea technology,deep sea technology,深海技术,NOUN,C1
-deep thought,deep thought,思深沉,NOUN,C1
-deep-frying,deep-frying,干炸,NOUN,B2
-deep-rooted,deep-rooted,词,ADJ,B2
-deeply learned,deeply learned,学识渊博的,ADJ,C1
-deeply moving,deeply moving,令人感动的,ADJ,B2
-deeply profoundly,deeply profoundly,深刻地,ADV,B2
-deface,deface,词,VERB,C1
-defamatory,defamatory,词,ADJ,C1
-defamiliarization,defamiliarization,词,NOUN,C1
-defeated general,defeated general,败将,NOUN,B2
-defeated soldier,defeated soldier,败兵,NOUN,B2
-defeatist,defeatist,词,ADJ,C1
-defection,defection,词,NOUN,B2
-defective,defective,有缺陷的,ADJ,B2
-defectiveness,defectiveness,词,NOUN,C1
-defense deployment,defense deployment,布防,NOUN,C1
-defense to death,defense to death,死守,NOUN,B2
-defenseless,defenseless,无防御的,ADJ,B2
-defensive,defensive,防御的,ADJ,B2
-deference,deference,敬意,NOUN,B2
-deferential,deferential,词,ADJ,C1
-defetism,defeatism,失败主义,NOUN,B2
-deficitary,deficitary,词,ADJ,C1
-defile,defile,词,VERB,C1
-definable,definable,词,ADJ,C1
-definitiv,definitive,决定性的,ADJ,B2
-deflated,deflated,词,ADJ,B1
-deflation,deflation,通货紧缩,NOUN,B2
-deflationary,deflationary,词,ADJ,C1
-deflect,deflect,词,VERB,C1
-deflower,deflower,词,VERB,C1
-defoliate,defoliate,词,VERB,C1
-deforest,deforest,词,VERB,C1
-deformation,deformation,变形,NOUN,B2
-deformity,deformity,词,NOUN,C1
-defunct,defunct,词,ADJ,C1
-degeneration,degeneration,退化,NOUN,B2
-degenerative,degenerative,退化的,ADJ,B2
-degenerera,to degenerate,退化,VERB,B2
-degradation,degradation,降级,NOUN,B2
-degradera,to degrade,贬低,VERB,B2
-degrading,degrading,词,ADJ,C1
-degrease,degrease,词,VERB,C1
-degree graduation,degree graduation,词,NOUN,B2
-degree of fit,degree of fit,吻合度,NOUN,C1
-degrowth,degrowth,词,NOUN,C1
-dehumanize,dehumanize,词,VERB,C1
-dehydrate,dehydrate,词,VERB,C1
-dehydration dryness,dehydration dryness,词,NOUN,C1
-dehydrering,dehydration,脱水,NOUN,B2
-deice,deice,词,VERB,C1
-deification,deification,词,NOUN,C1
-deism,deism,自然神论,NOUN,B2
+bedrägeri,deception,欺骗,NOUN,B2
+fuskmod,deception dare,你敢骗我,NOUN,B2
+avkoda,to decipher,破译,VERB,B2
+beslutsfattare,decision-maker,决策者,NOUN,B2
 deklaration,declaration,宣言,NOUN,B2
+förklara,to declare,宣布,VERB,B2
+avtagande,decline,衰退,NOUN,B2
+avböja artigt,to decline politely,婉拒,VERB,B2
+avveckling,decommissioning,退役,NOUN,B2
+nedbryta,to decompose,分解,VERB,B2
 dekonstruera,to deconstruct,解构,VERB,B2
 dekonstruktion,deconstruction,解构主义,NOUN,B2
-dela,split,分裂,NOUN,B2
-dela,to split,分裂,VERB,B2
-delbetydelse,partial meaning,分义,NOUN,B2
+minska,decrease,减少,NOUN,B2
+minska,to decrease,减少,VERB,B2
+förordna,decree,法令,NOUN,B2
+förordna,to decree,颁布法令,VERB,B2
+avkryptering,decryption,解密,NOUN,B2
+dedikera,to dedicate,致力于,VERB,B2
+deducera,to deduce,推断,VERB,B2
+avdraga,to deduct,扣除,VERB,B2
+avdrag,deduction,扣除,NOUN,B2
+djupsteka,to deep-fry,油炸,VERB,B2
+fördjupa,to deepen,加深,VERB,B2
+standard,default,违约,NOUN,B2
+defetism,defeatism,失败主义,NOUN,B2
+övergå,to defect,叛变,VERB,B2
+försvara sitt land,to defend one's country,卫国,VERB,B2
+åtalad,defendant,被告,NOUN,B2
+uppror,defiance,挑衅,NOUN,B2
+upprorisk,defiant,挑衅的,ADJ,B2
+brist,deficiency,缺乏,NOUN,B2
+bristfällig,deficient,有缺陷的,ADJ,B2
+underskott,deficit,赤字,NOUN,B2
+definitiv,definitive,决定性的,ADJ,B2
+deflation,deflation,通货紧缩,NOUN,B2
+avskogning,deforestation,森林砍伐,NOUN,B2
+deformation,deformation,变形,NOUN,B2
+bedra,to defraud,诈骗,VERB,B2
+trotta,to defy,违抗,VERB,B2
+degenerera,to degenerate,退化,VERB,B2
+degeneration,degeneration,退化,NOUN,B2
+degradation,degradation,降级,NOUN,B2
+degradera,to degrade,贬低,VERB,B2
+dehydrering,dehydration,脱水,NOUN,B2
+deism,deism,自然神论,NOUN,B2
+gudom,deity,神,NOUN,B2
+nedslagen,dejected,沮丧的,ADJ,B2
+nedslagenhet,dejection,沮丧,NOUN,B2
+försening,delay,延迟,NOUN,B2
 delegat,delegate,代表,NOUN,B2
-delegation of authority,delegation of authority,词,NOUN,C1
-delegations,delegations,词,NOUN,C1
-deleterious,deleterious,词,ADJ,B2
-deletion,deletion,词,NOUN,B2
-deleveraging,deleveraging,去杠杆化,NOUN,B2
-delfin,dolphin,海豚,NOUN,B2
-deli meats,deli meats,词,NOUN,C1
-deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
-deliberateness,deliberateness,词,NOUN,C1
-deliberations,deliberations,词,NOUN,C1
-deliberatively,deliberatively,词,ADV,C1
-delicately,delicately,巧妙地,ADV,B2
-delicious tasty,delicious tasty,词,ADJ,A1
-deliciousness,deliciousness,词,NOUN,B2
-delimitation,delimitation,词,NOUN,C1
-delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
-deliquesce,deliquesce,词,VERB,C1
-delirious,delirious,谵妄的,ADJ,B2
+avsiktlig,deliberate,深思熟虑的,ADJ,B2
+avsiktligt,deliberately,故意地,ADV,B2
+smaklig,delicious,美味的,ADJ,B2
+glädje,delight,高兴,NOUN,B2
+brottlighet,delinquency,违法行为,NOUN,B2
+förbrytare,delinquent,罪犯,NOUN,B2
 delirium,delirium,精神错乱,NOUN,B2
-deliverance issuance,deliverance issuance,词,NOUN,C1
-delivery person,delivery person,词,NOUN,C1
-delivery van,delivery van,厢式送货车,NOUN,B2
-delorsak,partial cause,分因,NOUN,B2
-delouse,delouse,词,VERB,C1
-delta,delta,delta,NOUN,B2
-deltagande,participatory,参与式的,ADJ,B2
-deltagande,turnout,出席率,NOUN,B2
-delude,delude,词,VERB,C1
-deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
-delve,delve,词,VERB,C1
-demagogic,demagogic,词,ADJ,C1
-demagogue,demagogue,词,NOUN,C1
-demagoguery,demagoguery,煽动性,NOUN,B2
-demagogy,demagogy,蛊惑,NOUN,B2
-demand-based activism,demand-based activism,词,NOUN,C1
-demean,demean,词,VERB,C1
-demeanor,demeanor,仪态,NOUN,B2
+översvämning,deluge,洪水,NOUN,B2
+sken,delusion,幻想,NOUN,B2
+krävande,demanding,要求高的,ADJ,B2
 demens,dementia,痴呆,NOUN,B2
-dement,dement,词,VERB,C1
-demented,demented,词,ADJ,C1
-dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
-demijohn,demijohn,词,NOUN,B2
-demobilize,demobilize,词,VERB,C1
-demografi,demography,人口学,NOUN,B2
-demographic,demographic,人口统计的,ADJ,B2
+avmilitarisering,demilitarization,去武,NOUN,B2
 demokratisering,democratization,民主化,NOUN,B2
-demon devil,demon devil,恶魔,NOUN,C1
-demonic,demonic,词,ADJ,C1
-demonization,demonization,词,NOUN,C1
-demons,demons,词,NOUN,C1
-demonstrable,demonstrable,词,ADJ,C1
-demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
-demonstrator,demonstrator,词,NOUN,C1
-demontera,to disassemble,拆卸,VERB,B2
+demografi,demography,人口学,NOUN,B2
+riva,to demolish,拆除,VERB,B2
+rivning,demolition,拆除,NOUN,B2
 demoralisera,to demoralize,使士气低落,VERB,B2
-demoralization,demoralization,词,NOUN,C1
-demote,demote,词,VERB,C1
-demotion,demotion,降职,NOUN,B2
-demur,demur,词,VERB,C1
-demystify,demystify,词,VERB,C1
-den,the,这,DET,B2
-den,den,兽穴,NOUN,B2
-denationalize,denationalize,词,VERB,C1
-denial contradiction,denial contradiction,词,NOUN,C1
-denim jacket,denim jacket,词,NOUN,C1
-denna,this,您这,NOUN,B2
-denomination,denomination,词,NOUN,C1
-denominator,denominator,词,NOUN,C1
 denotation,denotation,外延,NOUN,B2
 denounce,to denounce,谴责,VERB,B2
 dense,dense,密集的,ADJ,B2
-dense forest,dense forest,密林,NOUN,B2
 density,density,密度,NOUN,B2
-dent,dent,凹痕,NOUN,B2
-dental,dental,词,ADJ,C1
-dentition,dentition,牙齿,NOUN,B2
-denude,denude,词,VERB,C1
 denunciation,denunciation,告发,NOUN,B2
-deodorize,deodorize,词,VERB,C1
-deontology,deontology,词,NOUN,C1
 depart,to depart,离开,VERB,B2
-department director,department director,司长,NOUN,C1
 department head,department head,厅长,NOUN,B2
 department store,department store,百货商店,NOUN,B2
-departmental,departmental,词,ADJ,B2
 departure,departure,离开,NOUN,B2
-departure lounge,departure lounge,候机室,NOUN,B2
 depend on,to depend on,依赖,VERB,B2
-dependence,dependence,依赖,NOUN,B2
-dependency,dependency,词,NOUN,B2
-dependent passivity,dependent passivity,词,NOUN,C1
-depicted,depicted,描绘的,ADJ,B2
-depicting,depicting,描绘的,ADJ,B2
-deplete,deplete,词,VERB,C1
-depletion,depletion,词,NOUN,C1
-deplorable,deplorable,可悲的,ADJ,B2
 deplore,to deplore,谴责,VERB,B2
 deploy,to deploy,部署,VERB,B2
 deployment,deployment,部署,NOUN,B2
-depone,depone,词,VERB,C1
-depopulation,depopulation,词,NOUN,B2
-deportation,deportation,驱逐出境,NOUN,B2
-deposed,deposed,词,ADJ,C1
 deposit,deposit,存款,NOUN,B2
 deposit,to deposit,存放,VERB,B2
-deposition,deposition,证词,NOUN,B2
-depositional,depositional,词,ADJ,C1
-deposits,deposits,词,NOUN,C1
-depot,depot,仓库,NOUN,B2
-depravity,depravity,堕落,NOUN,B2
-deprecate,deprecate,词,VERB,C1
-deprecation,deprecation,词,NOUN,C1
 depreciation,depreciation,贬值,NOUN,B2
-depredate,depredate,词,VERB,C1
-depredation,depredation,词,NOUN,C1
 depression,depression,抑郁,NOUN,B2
-depressive,depressive,抑郁的，压抑的,ADJ,B2
 deprivation,deprivation,剥夺,NOUN,B2
 deprive,to deprive,剥夺,VERB,B2
-deputation,deputation,代表团,NOUN,B2
-depute,depute,词,VERB,C1
 deputy,deputy,议员,NOUN,B2
-deracinate,deracinate,词,VERB,C1
 derail,to derail,使脱轨,VERB,B2
-derailment,derailment,词,NOUN,C1
-derange,derange,词,VERB,C1
-derby,derby,词,NOUN,B2
-deregulate,deregulate,词,VERB,C1
-deregulation,deregulation,词,NOUN,B2
-dereliction,dereliction,词,NOUN,C1
-deride,deride,词,VERB,C1
-derision mockery,derision mockery,词,NOUN,C1
-derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
-derivation,derivation,词,NOUN,C1
 derivative,derivative,衍生物,NOUN,B2
 derive,to derive,源于,VERB,B2
-dermal,dermal,词,ADJ,C1
 derogate,to derogate,贬损,VERB,B2
-derogation,derogation,词,NOUN,C1
-derogatory,derogatory,词,ADJ,C1
-desalination,desalination,词,NOUN,C1
-descant,descant,词,VERB,C1
 descend,to descend,下降,VERB,B2
-descend go down,descend go down,词,VERB,A1
 descendant,descendant,后代,NOUN,B2
-descendants,descendants,词,NOUN,C1
-descending,descending,词,ADJ,C1
-describable,describable,词,ADJ,C1
-descriptive,descriptive,描述性的,ADJ,B2
-descriptiveness,descriptiveness,词,NOUN,C1
-descry,descry,词,VERB,C1
-desecrate,desecrate,词,VERB,C1
-desecration,desecration,词,NOUN,C1
-desegregate,desegregate,词,VERB,C1
 desert,desert,沙漠,NOUN,B2
-deserter,deserter,逃兵,NOUN,B2
 desertification,desertification,荒漠化,NOUN,B2
-desertion,desertion,逃亡,NOUN,B2
-deserved,deserved,词,ADJ,B2
-deserving,deserving,才配得,NOUN,C1
-desiccant,desiccant,干燥剂,NOUN,C1
-desiccate,desiccate,词,VERB,C1
-desiccation,desiccation,词,NOUN,C1
 design,design,设计,NOUN,B2
 design,to design,设计,VERB,B2
 designate,to designate,指定,VERB,B2
 designated driver,designated driver,代驾,NOUN,B2
 designation,designation,指定,NOUN,B2
 designer,designer,设计者,NOUN,B2
-desinfektionsmedel,disinfectant,消毒剂,NOUN,B2
-desinficera,to disinfect,消毒,VERB,B2
-desinformation,disinformation,虚假信息,NOUN,B2
-desirability,desirability,可取性,NOUN,B2
-desirable,desirable,可取的,ADJ,B2
 desire,to desire,渴望,VERB,B2
-desire for release,desire for release,思放,NOUN,B2
-desired aim,desired aim,期望的目标,NOUN,C1
-desirous,desirous,词,ADJ,C1
 desist,to desist,停止,VERB,B2
-desolate loneliness,desolate loneliness,词,NOUN,C1
-desolation,desolation,荒凉,NOUN,B2
-despatch,despatch,词,VERB,C1
-desperately serious,desperately serious,不得了,ADJ,B2
-despite (adv),despite,词,ADV,B2
-despite (noun),despite,虽有,NOUN,C1
-despoliation,despoliation,词,NOUN,C1
-despond,despond,词,VERB,C1
-despondency,despondency,词,NOUN,C1
+öde,desolate,荒凉的,ADJ,B2
+föraktlig,despicable,可鄙的,ADJ,B2
 despot,despot,暴君,NOUN,B2
-despotic,despotic,词,ADJ,C1
 despotism,despotism,专制,NOUN,B2
-desquamation,desquamation,词,NOUN,C1
-dessa,these,这些,PRON,B2
-dessutom,furthermore,此外,ADV,B2
-dessutom,in addition,此外,ADV,B2
-dessutom,moreover,此外,ADV,B2
-destabilisera,to destabilize,使不稳定,VERB,B2
 destabilisering,destabilization,动摇,NOUN,B2
+destabilisera,to destabilize,使不稳定,VERB,B2
 destination,destination,目的地,NOUN,B2
-destine,destine,词,VERB,C1
-destined,destined,,NOUN,B2
-destitute,destitute,词,ADJ,C1
-destroyer,destroyer,词,NOUN,C1
-destruction of property,destruction of property,毁坏财物,NOUN,C1
+öde,destiny,命运,NOUN,B2
+utblottning,destitution,贫困,NOUN,B2
+förstörelse,destruction,破坏,NOUN,B2
 destruktiv,destructive,مدمر,ADJ,B2
-detachable,detachable,词,ADJ,C1
-detached house,detached house,独栋房屋,NOUN,B2
-details,details,细细,NOUN,C1
-detainee,detainee,被拘留者,NOUN,B2
-detaljerat,in detail,详细地,ADV,B2
-detection,detection,检测,NOUN,B2
-detective force,detective force,刑警,NOUN,B2
-detector,detector,词,NOUN,C1
-deter,deter,词,VERB,C1
-detergent,detergent,洗涤剂,NOUN,B2
-deteriorated,deteriorated,恶化的,ADJ,B2
-deterioration,deterioration,恶化,NOUN,B2
-determinant,determinant,词,NOUN,C1
-determine,determine,确定,VER! B,B2
+avskilja,to detach,分离,VERB,B2
+avskiljande,detachment,脱落,NOUN,B2
+upptäcka,to detect,探测,VERB,B2
+avspänning,detente,缓和,NOUN,B2
+försämras,to deteriorate,恶化,VERB,B2
+beslutsamhet,determination,决心,NOUN,B2
+beslutsam,determined,下定决心的,ADJ,B2
 determinism,determinism,决定论,NOUN,B2
-determinist,determinist,词,ADJ,C1
 deterministisk,deterministic,决定论的,ADJ,B2
-deterrence,deterrence,词,NOUN,C1
-deterrent,deterrent,词,NOUN,C1
-detonation,detonation,爆炸,NOUN,B2
+avskyvärd,detestable,可恶的,ADJ,B2
 detonera,to detonate,引爆,VERB,B2
-detractor,detractor,词,NOUN,C1
-detriment,detriment,损害,NOUN,B2
-detrimental,detrimental,有害的,ADJ,B2
-detritus,detritus,词,NOUN,C1
-devaluation,devaluation,贬值,NOUN,B2
+detonation,detonation,爆炸,NOUN,B2
+omväg,detour,绕道,NOUN,B2
+avgifta,to detoxify,解毒,VERB,B2
 devalvera,to devalue,贬值,VERB,B2
-devastating,devastating,毁灭性的,ADJ,B2
-development works,development works,词,NOUN,B2
-development zone,development zone,开发区,NOUN,C1
-developments,developments,词,NOUN,B2
-deviance,deviance,词,NOUN,B2
-device system,device system,词,NOUN,B1
-devices,devices,设备,NOUN,B2
-devilish,devilish,恶魔般的,ADJ,B2
-devious,devious,词,ADJ,B2
-devoice,devoice,词,VERB,C1
-devoid,devoid,词,ADJ,C1
-devoid lacking,devoid lacking,词,ADJ,C1
-devolution,devolution,词,NOUN,C1
-devolve,devolve,词,VERB,C1
-devoted (adv),devoted,尽心,ADV,B2
-devotion to duty,devotion to duty,词,NOUN,C1
-devotional humility,devotional humility,词,NOUN,C1
-devotional worship,devotional worship,词,NOUN,C1
-devourer,devourer,吞噬者,NOUN,B2
-devouring,devouring,必噬,NOUN,C1
-devout,devout,词,ADJ,B2
-devoutly,devoutly,词,ADV,C1
-dexterity,dexterity,灵巧,NOUN,B2
-dexterous,dexterous,词,ADJ,C1
+ödelägga,to devastate,摧毁,VERB,B2
+förödelse,devastation,破坏,NOUN,B2
+utvecklad,developed,发达的,ADJ,B2
+utvecklare,developer,开发商,NOUN,B2
+avvikelse,deviation,偏离,NOUN,B2
+utforma,to devise,设计,VERB,B2
+hängivenhet,devotion,奉献,NOUN,B2
+dagg,dew,露水,NOUN,B2
 diabetes,diabetes,糖尿病,NOUN,B2
-diabetic,diabetic,词,ADJ,C1
-diabolical,diabolical,恶魔般的,ADJ,B2
-diachrony,diachrony,词,NOUN,C1
-diaeresis,diaeresis,词,NOUN,C1
 diagnostisera,to diagnose,诊断,VERB,B2
-diagonal,diagonal,对角线,NOUN,B2
 diagram,diagram,图表,NOUN,B2
-dial (noun),dial,词,NOUN,C1
-dial (verb),dial,词,VERB,B2
-dialectic (adj),dialectic,词,ADJ,C1
-dialectic (noun),dialectic,辩证法,NOUN,C1
-dialectician,dialectician,词,NOUN,C1
 dialekt,dialect,方言,NOUN,B2
-dialing code,dialing code,词,NOUN,C1
 dialoga,to dialogue,对话,VERB,B2
-dialogism,dialogism,词,NOUN,C1
-diameter,diameter,词,NOUN,C1
-diametrically,diametrically,词,ADV,C1
-diapers,diapers,词,NOUN,B1
-diaphanous,diaphanous,词,ADJ,C1
-diaphragm,diaphragm,横膈膜,NOUN,B2
 diarré,diarrhea,腹泻,NOUN,B2
 diaspora,diaspora,流散,NOUN,B2
-diaspora community,diaspora community,词,NOUN,C1
-diatribe,diatribe,词,NOUN,C1
-dichotomy,dichotomy,二分法,NOUN,B2
-dictation,dictation,dictation,NOUN,B2
-dictator,dictator,独裁者,NOUN,B2
-diction,diction,措辞,NOUN,B2
-didactic,didactic,教学的,ADJ,B2
-didactics,didactics,词,NOUN,C1
-die,die,骰子,NOUN,B2
-dietary,dietary,词,ADJ,C1
-different,different,不同地,ADV,B2
-differentiable,differentiable,词,ADJ,C1
-differentiating,differentiating,词,ADJ,C1
+tärning,dice,骰子,NOUN,B2
+diktera,to dictate,口述,VERB,B2
+ordbok,dictionary,词典,NOUN,B2
+kost,diet,饮食,NOUN,B2
 differentiera,to differentiate,区分,VERB,B2
 differentiering,differentiation,区分,NOUN,B2
-difficult to handle,difficult to handle,难办,NOUN,C1
-difficulty resolution,difficulty resolution,解难,NOUN,C1
+svår attack,difficult attack,难攻,NOUN,B2
+svårt problem,difficult problem,难题,NOUN,B2
 diffunda,to diffuse,扩散,VERB,B2
-diffuse,diffuse,模糊的,ADJ,B2
-diffusely,diffusely,词,ADV,C1
-diffusion,diffusion,传播,NOUN,B2
-diffusion spread,diffusion spread,词,NOUN,C1
-dig up,dig up,词,VERB,B2
-digestible,digestible,词,ADJ,C1
+smälta,to digest,消化,VERB,B2
+smältning,digestion,消化,NOUN,B2
+smältande,digestive,消化的,ADJ,B2
+grävning,digging,挖掘,NOUN,B2
+siffra,digit,数字,NOUN,B2
 digital,digital,数字的,ADJ,B2
-digital currency,digital currency,数字货币,NOUN,C1
 digitalisering,digitization,数字化,NOUN,B2
-digitized,digitized,词,ADJ,C1
-diglossia,diglossia,词,NOUN,C1
-dignified,dignified,词,ADJ,C1
-dignified manner,dignified manner,威仪,NOUN,B2
-dignifiedly,dignifiedly,词,ADV,C1
-dignify,dignify,词,VERB,C1
-dignitaries,dignitaries,词,NOUN,C1
-dignitary,dignitary,高官,NOUN,B2
 digrediera,to digress,离题,VERB,B2
-digression,digression,词,NOUN,C1
-dike,dike,词,NOUN,B2
-diktera,to dictate,口述,VERB,B2
-dilatation,dilation,扩张,NOUN,B2
-dilated,dilated,词,ADJ,C1
 dilatera,to dilate,膨胀,VERB,B2
-dilatory,dilatory,拖延的,ADJ,B2
+dilatation,dilation,扩张,NOUN,B2
 dilemma,dilemma,困境,NOUN,B2
-dilution,dilution,词,NOUN,C1
-dim,dim,词,ADJ,C1
-dim sum,dim sum,点心,NOUN,B1
-diminutive,diminutive,指小词,NOUN,B2
-dimmed,dimmed,词,ADJ,C1
-dimple,dimple,词,NOUN,C1
-din,din,喧嚣,NOUN,B2
-dine,dine,词,VERB,C1
-dinghy,dinghy,词,NOUN,C1
-dining room,dining room,词,NOUN,B1
-dining table,dining table,词,NOUN,B2
-dinner party,dinner party,聚餐,NOUN,C1
+flitig,diligent,勤奋的,ADJ,B2
 dinosaurie,dinosaur,恐龙,NOUN,B2
-diocesan,diocesan,词,ADJ,C1
-diocese,diocese,词,NOUN,B2
-dioxide,dioxide,词,NOUN,C1
-diplomat,diplomat,词,NOUN,C1
-diplomati,diplomacy,外交,NOUN,B2
-diplomatic relations,diplomatic relations,外交关系,NOUN,B2
-diplomatisk,diplomatic,外交的,ADJ,B2
 dippa,to dip,蘸,VERB,B2
-dipsomaniac,dipsomaniac,词,NOUN,C1
-direct hit,direct hit,词,NOUN,C1
-direct message,direct message,私信,NOUN,C1
-direct sales,direct sales,直销,NOUN,B2
-direct shot,direct shot,面射,NOUN,B2
-directing,directing,导演,NOUN,B2
-directionality,directionality,词,NOUN,C1
-directive (adj),directive,词,ADJ,C1
-directness,directness,词,NOUN,C1
-directorate,directorate,局,NOUN,C1
-directorship,directorship,董事职位,NOUN,B2
-directory,directory,词,NOUN,C1
+diplomati,diplomacy,外交,NOUN,B2
+diplomatisk,diplomatic,外交的,ADJ,B2
+riktningsskylt,direction sign,指示牌,NOUN,B2
 direkt,directly,直接地,ADV,B2
-dirham,dirham,词,NOUN,A1
-dirt filth,dirt filth,词,NOUN,C1
-dirt soil,dirt soil,词,NOUN,A1
-dirty bastard,dirty bastard,词,NOUN,C1
-dirty trick,dirty trick,词,NOUN,B2
-disable,disable,词,VERB,C1
-disadvantaged,disadvantaged,词,ADJ,C1
-disadvantageous,disadvantageous,不利的,ADJ,B2
-disaffect,disaffect,词,VERB,C1
-disaffected,disaffected,词,ADJ,C1
-disaffection,disaffection,词,NOUN,C1
-disagreeing,disagreeing,不同意的,ADJ,B2
-disallow,disallow,词,VERB,C1
-disapproval,disapproval,词,NOUN,C1
-disarmament,disarmament,裁军,NOUN,B2
-disarray (noun),disarray,词,NOUN,C1
-disassembly,disassembly,词,NOUN,C1
-disassociate,disassociate,词,VERB,C1
-disaster relief,disaster relief,救灾,NOUN,C1
-disband,disband,词,VERB,C1
-disbar,disbar,词,VERB,C1
-disbelieve,disbelieve,词,VERB,C1
-disburden,disburden,词,VERB,C1
-disburse,disburse,词,VERB,C1
-disbursement,disbursement,词,NOUN,C1
-disc,disc,光盘,NOUN,B2
-discernment,discernment,洞察力,NOUN,B2
+funktionsnedsättning,disability,残疾,NOUN,B2
+funktionsnedsatt,disabled,残疾的,ADJ,B2
+nackdel,disadvantage,劣势,NOUN,B2
+disputera,to disagree,不同意,VERB,B2
+oense,disagreement,不和,NOUN,B2
+försvinnande,disappearance,消失,NOUN,B2
+besvika,to disappoint,使失望,VERB,B2
+besvikande,disappointing,令人失望的,ADJ,B2
+missbilliga,to disapprove,不赞成,VERB,B2
+avvapna,to disarm,解除武装,VERB,B2
+demontera,to disassemble,拆卸,VERB,B2
+katastrofal,disastrous,灾难性的,ADJ,B2
+avvisa,to disavow,否认,VERB,B2
+otro,disbelief,不信,NOUN,B2
+förkasta,to discard,丢弃,VERB,B2
+utsläpp,discharge,放电,NOUN,B2
 discipel,disciple,门徒,NOUN,B2
-discipleship,discipleship,词,NOUN,C1
-disciplinary,disciplinary,纪律的,ADJ,B2
-disciplined,disciplined,词,ADJ,C1
 disciplinera,to discipline,管教,VERB,B2
-disclaim,disclaim,词,VERB,C1
-disclosure,disclosure,泄露,NOUN,C1
-disco,disco,迪厅,NOUN,B2
-discolor,discolor,词,VERB,C1
-discomfit,discomfit,词,VERB,C1
-discompose,discompose,词,VERB,C1
-disconnection,disconnection,词,NOUN,C1
-disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
-disconsolation,disconsolation,词,NOUN,C1
-discontent,discontent,不满,NOUN,B2
-discontinuity,discontinuity,词,NOUN,B2
-discordant,discordant,词,ADJ,C1
-discounts,discounts,折扣,NOUN,B2
-discouragement,discouragement,词,NOUN,C1
-discourteous,discourteous,词,ADJ,C1
-discourtesy,discourtesy,失礼,NOUN,B2
-discoverer,discoverer,发现者,NOUN,C1
-discredit,discredit,丧失信誉,NOUN,B2
-discrediting,discrediting,词,NOUN,C1
-discreetly,discreetly,词,ADV,B2
-discrepancy,discrepancy,差异,NOUN,B2
-discrete,discrete,词,ADJ,C1
-discretionary,discretionary,自由裁量的,ADJ,B2
-discretionary punishment,discretionary punishment,词,NOUN,C1
-discursive,discursive,词,ADJ,C1
-disdainful,disdainful,词,ADJ,C1
-disdainfully,disdainfully,轻蔑地,ADV,B2
-disembarkation,disembarkation,词,NOUN,C1
-disembarrass,disembarrass,词,VERB,C1
-disembody,disembody,词,VERB,C1
-disembowel,disembowel,词,VERB,C1
-disenchantment,disenchantment,幻灭,NOUN,B2
-disenfranchise,disenfranchise,词,VERB,C1
-disenfranchised,disenfranchised,词,ADJ,C1
-disengagement,disengagement,词,NOUN,B2
-disestablish,disestablish,词,VERB,C1
-disesteem,disesteem,词,VERB,C1
-disfavor (noun),disfavor,词,NOUN,C1
-disfranchise,disfranchise,词,VERB,C1
-disgorge,disgorge,词,VERB,C1
-disgruntle,disgruntle,词,VERB,C1
-dish towel,dish towel,抹布,NOUN,B2
-disharmony,disharmony,不和谐,NOUN,B2
-disheartened,disheartened,词,ADJ,C1
-disheartening,disheartening,词,ADJ,C1
-dishes,dishes,词,NOUN,C1
-disheveled,disheveled,蓬乱的,ADJ,B2
-dishonest,dishonest,不诚实的,ADJ,B2
-dishonor,dishonor,耻辱,NOUN,B2
-dishonorable,dishonorable,词,ADJ,C1
-disillusion,disillusion,词,VERB,C1
-disillusionment,disillusionment,词,NOUN,C1
-disincline,disincline,词,VERB,C1
-disinflation,disinflation,词,NOUN,B2
-disinhibited,disinhibited,词,ADJ,C1
-disintegration,disintegration,词,NOUN,B2
-disinter,disinter,词,VERB,C1
-disinvestment,disinvestment,词,NOUN,C1
-disjointed,disjointed,词,ADJ,C1
-disjunkt,disjoint,不相交的,ADJ,B2
+avslöja,to disclose,揭露,VERB,B2
+obehag,discomfort,不适,NOUN,B2
+avkoppla,to disconnect,断开,VERB,B2
+avbryta,to discontinue,停止,VERB,B2
+strid,discord,不和,NOUN,B2
 diskordans,discordance,不一致,NOUN,B2
+avskräcka,to discourage,使气馁,VERB,B2
+diskutera,discourse,论述,NOUN,B2
+diskutera,to discourse,论述,VERB,B2
 diskreditera,to discredit,败坏名声,VERB,B2
 diskretion,discretion,谨慎,NOUN,B2
 diskriminera,to discriminate,歧视,VERB,B2
-diskutera,discourse,论述,NOUN,B2
-diskutera,to discourse,论述,VERB,B2
-dislike,dislike,厌恶,NOUN,B2
-disloyal,disloyal,不忠的,ADJ,B2
-disloyalty,disloyalty,不忠,NOUN,B2
-dismal,dismal,令人失望的,ADJ,B2
-dismay (noun),dismay,词,NOUN,C1
-dismember,dismember,词,VERB,C1
-dismissal of charges,dismissal of charges,词,NOUN,C1
-dismissal referral,dismissal referral,词,NOUN,C1
-disobedient,disobedient,不服从的,ADJ,B2
-disorganization,disorganization,无组织,NOUN,B2
-disorganize,disorganize,词,VERB,C1
-disoriented,disoriented,词,ADJ,C1
-disown,disown,词,VERB,C1
-disparage,disparage,词,VERB,C1
-disparagement,disparagement,词,NOUN,C1
-disparate,disparate,截然不同的,ADJ,B2
-dispassionate,dispassionate,词,ADJ,C1
-dispatch (noun),dispatch,我派,NOUN,B2
-dispatch room,dispatch room,调度室,NOUN,C1
-dispensary,dispensary,词,NOUN,C1
-dispense ceremony,dispense ceremony,免礼,NOUN,B2
-dispersal,dispersal,全散,NOUN,C1
-dispersion,dispersion,词,NOUN,C1
-dispirit,dispirit,词,VERB,C1
-dispirited,dispirited,沮丧的,ADJ,B2
-displace,displace,词,VERB,C1
-displaced person,displaced person,词,NOUN,C1
-displacement,displacement,位移,NOUN,B2
-displeased,displeased,词,ADJ,C1
-disport,disport,词,VERB,C1
-disposable diaper,disposable diaper,纸尿裤,NOUN,B2
-disposed,disposed,词,ADJ,C1
-dispossessed,dispossessed,词,ADJ,C1
-disproportion,disproportion,不成比例,NOUN,B2
-disproportionate,disproportionate,词,ADJ,C1
-disprove,disprove,词,VERB,C1
-disputation,disputation,词,NOUN,C1
-dispute lawsuit,dispute lawsuit,词,NOUN,C1
-disputed,disputed,有争议的,ADJ,B2
-disputed case,disputed case,词,NOUN,C1
-disputera,to disagree,不同意,VERB,B2
-disqualification,disqualification,词,NOUN,C1
-disquiet,disquiet,词,NOUN,C1
-disquisition,disquisition,论述,NOUN,B2
-disrepair,disrepair,词,NOUN,C1
-disrepute,disrepute,坏名声,NOUN,B2
-disrespect,disrespect,不敬,NOUN,B2
-disrespectful,disrespectful,无礼的,ADJ,B2
-disrobe,disrobe,词,VERB,C1
-disruption,disruption,词,NOUN,C1
-disruptive,disruptive,颠覆性,ADJ,C1
-dissatisfy,dissatisfy,词,VERB,C1
-dissemble,dissemble,词,VERB,C1
-dissembling,dissembling,词,ADJ,C1
-dissemination,dissemination,词,NOUN,C1
-disseminator,disseminator,传播者,NOUN,C1
+förfärlighet,disdain,蔑视,NOUN,B2
+lämna,to disembark,下船,VERB,B2
+avlägsna,to disengage,脱离,VERB,B2
+skam,disgrace,耻辱,NOUN,B2
+dölja,disguise,伪装,NOUN,B2
+dölja,to disguise,伪装,VERB,B2
+tallrik,dish,盘子,NOUN,B2
+desinficera,to disinfect,消毒,VERB,B2
+desinfektionsmedel,disinfectant,消毒剂,NOUN,B2
+desinformation,disinformation,虚假信息,NOUN,B2
+intressebrist,disinterest,公正;不感兴趣,NOUN,B2
+opartisk,disinterested,公正的,ADJ,B2
+disjunkt,disjoint,不相交的,ADJ,B2
+luxera,to dislocate,使脱臼,VERB,B2
+luxation,dislocation,脱臼,NOUN,B2
+nedmontering,dismantling,拆除，瓦解,NOUN,B2
+avsked,dismissal,解雇,NOUN,B2
+stiga av,to dismount,下马,VERB,B2
+lydnadsbrist,disobedience,不服从,NOUN,B2
+lyda inte,to disobey,违抗,VERB,B2
+oordningsam,disorderly,杂乱的,ADJ,B2
+orientera bort,to disorient,使迷失方向,VERB,B2
+orienteringsstörning,disorientation,迷失方向,NOUN,B2
+obalans,disparity,差异,NOUN,B2
+skicka,to dispatch,派遣,VERB,B2
+utdela medicin,to dispense medicine,配药,VERB,B2
+utställning,display,展示,NOUN,B2
+missnöja,to displease,使不快,VERB,B2
+missnöje,displeasure,不悦,NOUN,B2
+avfallshantering,disposal,处理,NOUN,B2
+tvist,dispute,争论,NOUN,B2
+ignorera,to disregard,忽视,VERB,B2
+sektionera,to dissect,解剖,VERB,B2
+sprida,to disseminate,传播,VERB,B2
 dissens,dissent,异议,NOUN,B2
-dissert,dissert,词,VERB,C1
-disserve,disserve,词,VERB,C1
-dissever,dissever,词,VERB,C1
-dissident,dissident,异见者,NOUN,B2
-dissimilar,dissimilar,词,ADJ,C1
-dissimilarity,dissimilarity,相异性,NOUN,B2
-dissimulation,dissimulation,词,NOUN,C1
+avhandling,dissertation,论文,NOUN,B2
 dissipation,dissipation,挥霍,NOUN,B2
-dissociate,dissociate,词,VERB,C1
-dissociation,dissociation,解离,NOUN,B2
-dissolute,dissolute,放荡的,ADJ,B2
+upplösning,dissolution,溶解,NOUN,B2
+upplösa,to dissolve,溶解,VERB,B2
 dissonans,dissonance,不和谐,NOUN,B2
-dissonant,dissonant,词,ADJ,C1
-dissuasion,dissuasion,词,NOUN,C1
-dissuasive,dissuasive,词,ADJ,C1
-distaste,distaste,词,NOUN,C1
-distend,distend,词,VERB,C1
-distich,distich,词,NOUN,C1
-distikon,couplet,对联,NOUN,B2
-distil,distil,词,VERB,C1
-distillation,distillation,词,NOUN,C1
-distinctive,distinctive,独特的,ADJ,B2
-distinctly,distinctly,清楚地,ADV,B2
-distinguishable,distinguishable,词,ADJ,C1
+avråda,to dissuade,劝阻,VERB,B2
 distinkt,distinct,明显的,ADJ,B2
-distinkt,distinguished,杰出,ADJ,B2
 distinktion,distinction,区别,NOUN,B2
-distorted,distorted,歪曲的,ADJ,B2
-distorted image,distorted image,扭曲的形象,NOUN,B2
+distinkt,distinguished,杰出,ADJ,B2
+förvränga,to distort,扭曲,VERB,B2
+förvrängning,distortion,扭曲,NOUN,B2
 distraction,distraction,分心,NOUN,B2
-distrain,distrain,词,VERB,C1
-distressing,distressing,词,ADJ,B1
-distributed,distributed,词,ADJ,C1
 distribution,distribution,分布,NOUN,B2
-districting,districting,词,NOUN,C1
-districts,districts,词,NOUN,C1
 distriktchef,district head,区长,NOUN,B2
-distrustful,distrustful,词,ADJ,C1
-disuse,disuse,废弃,NOUN,B2
-ditch,ditch,沟渠,NOUN,B2
-dithyramb,dithyramb,词,NOUN,C1
-ditt skratt,your laugh,你笑,NOUN,B2
-dive (noun),dive,词,NOUN,B2
-diver,diver,词,NOUN,B2
-divergence,divergence,分歧,NOUN,B2
+dyka,dive,跳水,NOUN,B2
+dyka,to dive,潜水,VERB,B2
 divergent,divergent,分歧的,ADJ,B2
-diverging,diverging,词,ADJ,C1
-diverse,diverse,多样的,ADJ,B2
-diversifiera,to diversify,使多样化,VERB,B2
 diversifiering,diversification,多样化,NOUN,B2
-divestment,divestment,词,NOUN,C1
-divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
-divider,divider,词,NOUN,C1
-divin,divine,神圣的,ADJ,B2
+diversifiera,to diversify,使多样化,VERB,B2
+avleda,to divert,转移,VERB,B2
 divination,divination,占卜,NOUN,B2
-divinatory,divinatory,词,ADJ,C1
-divine,divine,如神,NOUN,B2
-divine fist,divine fist,神拳,NOUN,B2
-divine physician,divine physician,医仙,NOUN,C1
-divine reward,divine reward,词,NOUN,C1
-divine trial,divine trial,词,NOUN,C1
-divisibility,divisibility,词,NOUN,C1
-divisible,divisible,可分的,ADJ,B2
-divisive,divisive,词,ADJ,C1
-divisor,divisor,词,NOUN,C1
-divorced,divorced,词,ADJ,B2
-divorced woman,divorced woman,词,NOUN,B2
-djellaba,djellaba,词,NOUN,B2
-djup,profound,深刻的,ADJ,B2
-djupsteka,to deep-fry,油炸,VERB,B2
-do not (aux),do not,不要,AUX,B2
-do not (part),do not,勿,PART,B2
-do not know,do not know,不知,VERB,B2
-do not want,do not want,不想,VERB,B2
-do one's best (adv),do one's best,竭力,ADV,B2
-do one's best (noun),do one's best,愿尽心尽力,NOUN,C1
-docile,docile,温顺的,ADJ,B2
-docilely,docilely,词,ADV,C1
-dock,however,然而,CCONJ,B2
-docka,puppet,木偶,NOUN,B2
-doctoral degree,doctoral degree,博士学位,NOUN,C1
-doctoral student,doctoral student,博士生,NOUN,C1
-doctrinaire,doctrinaire,教条主义的,ADJ,B2
-doctrine,doctrine,词,NOUN,B2
-documentary,documentary,纪录片,NOUN,B2
-documentation,documentation,文献,NOUN,B2
-documented,documented,词,ADJ,C1
-documents,documents,词,NOUN,B2
-dodge (noun),dodge,一躲,NOUN,C1
-doe,doe,雌鹿,NOUN,B2
-doesn't work,doesn't work,不通,ADJ,B2
-doff,doff,词,VERB,C1
-doggedly,doggedly,词,ADV,C1
+divin,divine,神圣的,ADJ,B2
+dykning,diving,潜水,NOUN,B2
+gudomlighet,divinity,神性,NOUN,B2
+skilja,to divorce,离婚,VERB,B2
+svimning,dizziness,眩晕,NOUN,B2
+svimmande,dizzy,头晕的,ADJ,B2
+inte,do not,莫,ADV,B2
+använd ej,do not use,别用,NOUN,B2
+göra,to do one's best,尽力,VERB,B2
+göra,to do to make,做,VERB,B2
+lydnad,docility,温顺,NOUN,B2
+brygga,dock,码头,NOUN,B2
+doktorat,doctorate,博士学位,NOUN,B2
+dokumentär,documentary,纪录片的,ADJ,B2
+undvika,to dodge,躲避,VERB,B2
 dogma,dogma,教条,NOUN,B2
 dogmatisk,dogmatic,教条的,ADJ,B2
 dogmatism,dogmatism,教条主义,NOUN,B2
-doktorat,doctorate,博士学位,NOUN,B2
-dokumentär,documentary,纪录片的,ADJ,B2
-dold läge,allow hiding,许躲,NOUN,B2
-doldhet,concealment,隐瞒,NOUN,B2
-doldis,hideout,藏身处,NOUN,B2
-dollar,dollar,词,NOUN,C1
-domain,domain,领域,NOUN,B2
-domare,referee,裁判,NOUN,B2
+delfin,dolphin,海豚,NOUN,B2
 domestic,domestic,国内的,ADJ,B2
-domestic (noun),domestic,国内,NOUN,B2
-domestic currency,domestic currency,本币,NOUN,C1
-domestic debt,domestic debt,内债,NOUN,B2
-domestic licensed goods,domestic licensed goods,国行,NOUN,B2
-domesticate,domesticate,词,VERB,C1
 domestication,domestication,驯化,NOUN,B2
-dominance,dominance,威权,NOUN,B2
 dominant,dominant,占主导地位的,ADJ,B2
 dominate,to dominate,支配,VERB,B2
-domineering,domineering,词,ADJ,C1
-domineeringness,domineeringness,支配欲,NOUN,B2
-don,don,词,VERB,C1
-don't,don't,可别,AUX,B2
-don't believe,don't believe,不信,VERB,B2
-don't care,don't care,不在乎,VERB,B2
-don't eat,don't eat,不吃,VERB,B2
-don't give a fuck,don't give a fuck,词,ADJ,C1
-don't let,don't let,不让,VERB,B2
-don't mind,don't mind,不介意,VERB,B2
 donate,to donate,捐赠,VERB,B2
 donation,donation,捐款,NOUN,B2
-donation of goods,donation of goods,捐物,NOUN,C1
 done,done,事已,NOUN,B2
-donera,to endow,赋予,VERB,B2
-donkey foal,donkey foal,词,NOUN,B2
 donor,donor,捐赠者,NOUN,B2
-doom,doom,词,VERB,C1
-door chain,door chain,门链,NOUN,C1
-door gate,door gate,门,NOUN,A1
 door handle,door handle,门把手,NOUN,B2
-door lock,door lock,门锁,NOUN,C1
 doorbell,doorbell,门铃,NOUN,B2
-doorbell button,doorbell button,词,NOUN,B2
-doorkeeper,doorkeeper,词,NOUN,B1
 doorman,doorman,门卫,NOUN,B2
 doormat,doormat,门垫,NOUN,B2
-doorway,doorway,门口,NOUN,C1
-dope (noun),dope,词,NOUN,B2
-doping,doping,词,NOUN,C1
-doping agents,doping agents,词,NOUN,B2
-dorm,dorm,词,NOUN,B2
-dormant,dormant,词,ADJ,C1
 dormitory,dormitory,宿舍,NOUN,B2
 dosage,dosage,剂量,NOUN,B2
-dossier,dossier,档案,NOUN,B2
-dotterbolag,subsidiary,子公司,NOUN,B2
-dotting,dotting,词,NOUN,C1
 double,to double,加倍,VERB,B2
-double (noun),double,词,NOUN,C1
-double degree,double degree,双学位,NOUN,C1
-double entendre,double entendre,词,NOUN,C1
-double image,double image,重影,NOUN,C1
-doubling,doubling,加倍,NOUN,B2
-doubtful,doubtful,可疑的,ADJ,B2
-douse,douse,词,VERB,C1
-down (noun),down,下…,NOUN,C1
-down payment,down payment,词,NOUN,B1
-down to,down to,以至,SCONJ,B2
-downgrade,downgrade,词,VERB,C1
 download,download,下载,NOUN,B2
 download,to download,下载,VERB,B2
-download (noun),download,词,NOUN,B2
-downplay,downplay,词,VERB,C1
-downplaying,downplaying,词,NOUN,C1
 downpour,downpour,倾盆大雨,NOUN,B2
-downright,downright,词,ADV,B1
-downsize,downsize,词,VERB,C1
-downstairs,downstairs,词,ADV,B1
 downstream,downstream,下游,NOUN,B2
 dowry,dowry,嫁妆,NOUN,B2
-doze (noun),doze,词,NOUN,C1
-doze (verb),doze,词,VERB,C1
-doze off,doze off,词,VERB,B2
-dra sig tillbaka,to fall back,回落,VERB,B2
-draconian,draconian,词,ADJ,C1
 draft,draft,草稿,NOUN,B2
-draftsman,draftsman,绘图员,NOUN,B2
-drag,drag,拖曳,NOUN,B2
-dragon fruit,dragon fruit,火龙果,NOUN,B2
-dragonfly,dragonfly,词,NOUN,C1
-dragoon,dragoon,词,VERB,C1
 drain,drain,排水沟,NOUN,B2
-drainage,drainage,词,NOUN,C1
-drainage sewage,drainage sewage,词,NOUN,C1
-drake,kite,风筝,NOUN,B2
 drama,drama,戏剧,NOUN,B2
-dramatization,dramatization,词,NOUN,C1
 dramatize,to dramatize,戏剧化,VERB,B2
 dramaturgy,dramaturgy,戏剧艺术,NOUN,B2
-drastic,drastic,词,ADJ,C1
-draught,draught,词,NOUN,C1
 draw,draw,平局,NOUN,B2
-draw blood,draw blood,抽血,VERB,B2
 draw on the experience of,to draw on the experience of,借鉴,VERB,B2
 draw out,draw out,引出,NOUN,B2
-drawback,drawback,缺点,NOUN,B2
 drawer,drawer,抽屉,NOUN,B2
-drawl,drawl,词,VERB,C1
 dread,dread,恐惧,NOUN,B2
 dread,to dread,畏惧,VERB,B2
-dread (noun),dread,胆战,NOUN,B2
-dreamer,dreamer,词,NOUN,C1
-dreamlike,dreamlike,梦幻,ADJ,C1
-dreamy dreamer,dreamy dreamer,爱做梦的/空想家,ADJ,C1
-dreary,dreary,词,ADJ,B2
-dredge (verb),dredge,词,VERB,C1
 dregs,dregs,渣滓,NOUN,B2
-drench,drench,词,VERB,C1
 dress up,to dress up,盛装打扮,VERB,B2
-dressing room,dressing room,词,NOUN,B2
-dribble,dribble,词,VERB,C1
-dribbling,dribbling,词,NOUN,B2
-dried,dried,词,ADJ,B1
-dried curd,dried curd,词,NOUN,B2
-dried cured,dried cured,词,ADJ,B2
-dried meat,dried meat,词,NOUN,B2
 dried tofu,dried tofu,豆干,NOUN,B2
 drift,drift,漂移,NOUN,B2
 drift,drifting,漂泊,NOUN,B2
-drift (verb),drift,词,VERB,B2
-drift excess,drift excess,词,NOUN,C1
-drift mot,thrust toward,插向,NOUN,B2
-drinking,drinking,喝水,NOUN,C1
-drinking glass,drinking glass,水杯,NOUN,B2
-drinking water,drinking water,饮用水,NOUN,B2
-drinks,drinks,词,NOUN,C1
-dripping (adj),dripping,词,ADJ,C1
-dripping (noun),dripping,词,NOUN,C1
-drive,drive,动力,NOUN,B2
-drive mad,drive mad,词,VERB,C1
-drivel,drivel,词,NOUN,C1
-driving,driving,你来驾车,NOUN,C1
-drizzly,drizzly,词,ADJ,C1
-drool,drool,口水,NOUN,B2
-droop,droop,词,VERB,C1
-drop cap,drop cap,词,NOUN,C1
-drop out,drop out,退学,VERB,C1
-dropout,dropout,词,NOUN,B2
+borr,drill,钻头,NOUN,B2
+infart,driveway,车道,NOUN,B2
 droppa,to drop,掉落,VERB,B2
-dropper,dropper,词,NOUN,C1
-droppings,droppings,粪便,NOUN,B2
-drops,drops,词,NOUN,B1
-drowning,drowning,词,NOUN,C1
-drub,drub,词,VERB,C1
-drudge,drudge,词,NOUN,C1
-drug addict,drug addict,词,NOUN,C1
-drug addiction,drug addiction,词,NOUN,C1
-drug medication,drug medication,词,NOUN,C1
-drummer,drummer,词,NOUN,B1
-drunkard,drunkard,醉翁,NOUN,C1
-drunkenness,drunkenness,醉酒,NOUN,B2
-dry cleaner,dry cleaner,词,NOUN,A2
-dry land,dry land,词,NOUN,B2
-dry sausage,dry sausage,词,NOUN,B2
-drying,drying,词,NOUN,C1
-drying up,drying up,词,NOUN,C1
-dryness,dryness,词,NOUN,A1
-du,then you,那你,PRON,B2
-du,you polite,您,PRON,B2
-du kan,you can,您能,NOUN,B2
-du kan inte leva,you cannot live,你也活不,NOUN,B2
-dual,dual,词,ADJ,C1
-dual form,dual form,词,NOUN,C1
+tork,drought,干旱,NOUN,B2
+sömnighet,drowsiness,昏睡,NOUN,B2
+trummor,drum,鼓,NOUN,B2
 dualism,dualism,二元论,NOUN,B2
 dualitet,duality,二元性,NOUN,B2
-dub,dub,词,VERB,C1
 dubbing,dubbing,配音,NOUN,B2
-duchess,duchess,公爵夫人,NOUN,B2
-duct pipe,duct pipe,管道,NOUN,B2
-ductile,ductile,词,ADJ,C1
-dude,dude,词,NOUN,A2
-due date maturity,due date maturity,词,NOUN,B2
-duel,duel,词,NOUN,C1
-duet,duet,二重奏,NOUN,B2
-duka under,to succumb,屈服,VERB,B2
-dull-witted,dull-witted,词,ADJ,B2
-duly,duly,词,ADV,C1
+förfallen,due,到期的,ADJ,B2
+på grund av,due to,由于,ADP,B2
+tristess,dullness,迟钝,NOUN,B2
 dum,dumb,愚蠢的,ADJ,B2
-dum,foolish,愚蠢的,ADJ,B2
-dumbfound,dumbfound,词,VERB,C1
-dummy,dummy,词,NOUN,B2
-dump (noun),dump,词,NOUN,B1
-dump site,dump site,词,NOUN,B2
 dumping,dumping,倾销,NOUN,B2
-dunes,dunes,词,NOUN,B2
-dung,dung,词,NOUN,B2
-dungeon,dungeon,地牢,NOUN,B2
-dunghill,dunghill,词,NOUN,C1
-duo,duo,词,NOUN,C1
-duplex,duplex,词,NOUN,C1
-duplicate,duplicate,! 副本,NOUN,B2
-duplication,duplication,词,NOUN,C1
-duplicera,to duplicate,复制,VERB,B2
-duplicity,duplicity,口是心非,NOUN,B2
-durable,durable,词,ADJ,C1
-durian,durian,榴莲,NOUN,C1
-dust coat,dust coat,词,NOUN,C1
-duster,duster,词,NOUN,C1
-dustproof,dustproof,防尘,ADJ,C1
-dutch,dutch,荷兰语,NOUN,B2
-dutchman,dutchman,荷兰人,NOUN,B2
-duty of care,duty of care,词,NOUN,C1
-duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
-duva,pigeon,鸽子,NOUN,B2
-duvet,duvet,羽绒被,NOUN,B2
-dwell,dwell,词,VERB,C1
-dwindle,dwindle,词,VERB,C1
-dwindling,dwindling,词,NOUN,C1
-dyed,dyed,词,ADJ,B1
-dying without,dying without,将死无,NOUN,C1
-dyka,dive,跳水,NOUN,B2
-dyka,to dive,潜水,VERB,B2
-dykning,diving,潜水,NOUN,B2
-dykning,scuba diving,潜水,NOUN,B2
+knytpudde,dumpling,丸子,NOUN,B2
 dyna,dune,沙丘,NOUN,B2
-dynamics,dynamics,词,NOUN,C1
+duplicera,to duplicate,复制,VERB,B2
+hållbarhet,durability,耐用性,NOUN,B2
+varaktighet,duration,持续时间,NOUN,B2
+under,during,在...期间,ADP,B2
+under dagen,during the day,在白天,ADV,B2
+skymning,dusk,黄昏,NOUN,B2
+nederländsk,dutch,荷兰的,ADJ,B2
+bostad,dwelling,住宅,NOUN,B2
 dynamisk,dynamic,动态的,ADJ,B2
-dynamism,dynamism,活力,NOUN,B2
 dynasti,dynasty,王朝,NOUN,B2
-dysfunctional,dysfunctional,词,ADJ,C1
 dysfunktion,dysfunction,功能障碍,NOUN,B2
 dystopi,dystopia,反乌托邦,NOUN,B2
-dålig sak,bad thing,坏事,NOUN,B2
-dö,to pass away,流逝,VERB,B2
-dödlig,fatal,致命的,ADJ,B2
-dödsrisk,risking death,冒死,NOUN,B2
-dölja,disguise,伪装,NOUN,B2
-dölja,to conceal,隐藏,VERB,B2
-dölja,to disguise,伪装,VERB,B2
-dölja,to hide oneself,躲藏,VERB,B2
-döljande,hiding,ٱختباء,NOUN,B2
-döma,to convict,定罪,VERB,B2
-e-reader,e-reader,电子阅读器,NOUN,B2
-each,each,每个,PRON,B2
-each (noun),each,一一,NOUN,C1
-each every,each every,每,DET,A1
-each one,each one,每人,PRON,B2
-eager anticipation,eager anticipation,词,NOUN,C1
-eagerness,eagerness,词,NOUN,B2
-earlier (adv),earlier,更早,ADV,B2
-earliness,earliness,你早,NOUN,C1
-early (noun),early,词,NOUN,B2
-early nourishment,early nourishment,先养,NOUN,C1
-early phase,early phase,前期,NOUN,C1
-early sign,early sign,词,NOUN,C1
-early stage,early stage,早期,NOUN,C1
-earnest,earnest,词,ADJ,B1
-earnest sincere,earnest sincere,恳切,ADJ,B2
-earnestly,earnestly,词,ADV,C1
-earnestness,earnestness,着实,NOUN,C1
-earnings,earnings,词,NOUN,C1
-earrings,earrings,词,NOUN,B1
-ears of wheat,ears of wheat,词,NOUN,B2
-ease affluence,ease affluence,词,NOUN,C1
-ease of circumstances,ease of circumstances,词,NOUN,C1
-easement,easement,词,NOUN,C1
-easily,easily,词,ADV,B2
-easing,easing,词,NOUN,C1
-east bank,east bank,东岸,NOUN,C1
-easy defense,easy defense,易守,NOUN,C1
-eating habit,eating habit,词,NOUN,C1
-eavesdrop,eavesdrop,营听,NOUN,B2
-eavesdropping,eavesdropping,偷听,NOUN,B2
-ebb,ebb,词,VERB,C1
-ebb tide,ebb tide,词,NOUN,B1
-eccentric person,eccentric person,词,NOUN,C1
-eccentricity,eccentricity,古怪,NOUN,B2
-ecclesial,ecclesial,词,ADJ,C1
-echoes,echoes,词,NOUN,C1
-eclectic,eclectic,词,ADJ,C1
-eclecticism,eclecticism,折衷主义,NOUN,B2
-ecliptic,ecliptic,黄道,NOUN,C1
-economic climate,economic climate,词,NOUN,B2
-economic cycle,economic cycle,经济周期,NOUN,B2
-economic forecaster,economic forecaster,词,NOUN,C1
-economical,economical,词,ADJ,A1
-economize,economize,词,VERB,C1
-ecosystem chain,ecosystem chain,生态链,NOUN,B2
-ecstatic,ecstatic,词,ADJ,C1
-eczema,eczema,湿疹,NOUN,B2
-eddy,eddy,漩涡,NOUN,B2
-edge border,edge border,词,NOUN,C1
-edible,edible,词,ADJ,C1
-edifying,edifying,词,ADJ,C1
-edikt,edict,法令,NOUN,B2
-edit (noun),edit,重辑,NOUN,B2
-editing,editing,剪辑,NOUN,B2
-editor-in-chief,editor-in-chief,主编,NOUN,B2
-editorial office,editorial office,编辑部,NOUN,B2
-educational,educational,教育的,ADJ,B2
-educational background,educational background,学历,NOUN,C1
-eeg,eeg,脑电图,NOUN,B2
-efface,efface,词,VERB,C1
-effect and traces,effect and traces,词,NOUN,C1
-effect-seeking,effect-seeking,词,NOUN,C1
-effects,effects,词,NOUN,B2
-effectuate,effectuate,词,VERB,C1
-effektiv,efficient,高效的,ADJ,B2
-effektivitet,effectiveness,功效,NOUN,B2
-effervesce,effervesce,词,VERB,C1
-effervescence,effervescence,词,NOUN,C1
-effervescent,effervescent,沸腾的,ADJ,B2
-effigy,effigy,词,NOUN,C1
-effortless,effortless,不费力的,ADJ,B2
-effuse,effuse,词,VERB,C1
-efterbetalning,arrears,欠款,NOUN,B2
-efterföljande,subsequent,随后的,ADJ,B2
-efterlevande,compliant,符合的,ADJ,B2
-efterlevnad,compliance,合规,NOUN,B2
-efterträdare,successor,继任者,NOUN,B2
-egalitarian,egalitarian,平等主义的,ADJ,B2
-egendomlighet,strangeness,奇怪,NOUN,B2
-egg carton,egg carton,词,NOUN,C1
-egg-laying,egg-laying,词,NOUN,B2
-ego,ego,词,NOUN,C1
-egocentrism,egocentrism,自我中心,NOUN,B2
-egoism,egoism,词,NOUN,C1
-egolatry,egolatry,词,NOUN,C1
-egomaniac,egomaniac,词,NOUN,C1
-egyptian,egyptian,埃及的,ADJ,B2
-eh,eh,词,INTJ,C1
-eight (noun),eight,词,NOUN,B2
-eight-line stanza,eight-line stanza,八行诗,NOUN,B2
-einerziehung,einerziehung,词,NOUN,B2
-einfahrt,einfahrt,词,NOUN,C1
-einfassung,einfassung,词,NOUN,C1
-einforderung,einforderung,词,NOUN,C1
-eingabe,eingabe,词,NOUN,B2
-eingestaltung,eingestaltung,词,NOUN,C1
-einkunft,einkunft,词,NOUN,C1
-einnahme,einnahme,词,NOUN,B2
-einpflegung,einpflegung,词,NOUN,C1
-einregelung,einregelung,词,NOUN,C1
-einrichtung,einrichtung,词,NOUN,C1
-einschaft,einschaft,词,NOUN,B2
-einschrift,einschrift,词,NOUN,C1
-einsetzung,einsetzung,词,NOUN,C1
-einsinnung,einsinnung,词,NOUN,C1
-einsprache,einsprache,词,NOUN,B2
-einsucht,einsucht,词,NOUN,C1
-einsuchung,einsuchung,词,NOUN,C1
-einteilung,einteilung,词,NOUN,B2
-eintheilung,eintheilung,词,NOUN,C1
-eintreibung,eintreibung,词,NOUN,C1
-einwandel,einwandel,词,NOUN,C1
-einweisung,einweisung,词,NOUN,B2
-einwirkung,einwirkung,词,NOUN,B2
-either,either,或者,ADV,B2
+varje,each,每个,DET,B2
+örn,eagle,鹰,NOUN,B2
+tidigare,earlier,刚才,ADV,B2
+morgon,early morning,凌晨,NOUN,B2
+tidsig varning,early warning,预警,NOUN,B2
+jordbävning,earthquake,地震,NOUN,B2
+lätthet,ease,轻松,NOUN,B2
+lätt sagt,easy to say,好说,NOUN,B2
+excentrisk,eccentric,古怪的,ADJ,B2
+kyrklig,ecclesiastical,教会的,ADJ,B2
+formörkelse,eclipse,日食,NOUN,B2
 ekologi,ecology,生态学,NOUN,B2
-ekorre,squirrel,松鼠,NOUN,B2
 ekosystem,ecosystem,生态系统,NOUN,B2
-ekvation,equation,方程,NOUN,B2
-elaboration,elaboration,词,NOUN,C1
-elak,spiteful,怀恨的,ADJ,B2
+extas,ecstasy,狂喜,NOUN,B2
+kant,edge,边缘,NOUN,B2
+edikt,edict,法令,NOUN,B2
+redigera,to edit,编辑,VERB,B2
+upplaga,edition,版本,NOUN,B2
+redaktörsartikel,editorial,社论,NOUN,B2
+utbilda,to educate,教育,VERB,B2
+eeg,eeg,脑电图,NOUN,B2
+effektivitet,effectiveness,功效,NOUN,B2
+verkan,efficacy,功效,NOUN,B2
+effektiv,efficient,高效的,ADJ,B2
+aubergine,eggplant,茄子,NOUN,B2
+utveckla,elaborate,详尽的,ADJ,B2
+utveckla,to elaborate,制定,VERB,B2
 elasticitet,elasticity,弹性,NOUN,B2
-elation,elation,兴高采烈,NOUN,B2
-elda,to stoke,添燃料,VERB,B2
-elder brother,elder brother,兄长,NOUN,B1
-elderly,elderly,老年人,NOUN,B2
-eldest,eldest,词,ADJ,A2
-eldest brother,eldest brother,做大哥,NOUN,B2
-eldest sister,eldest sister,大姐,NOUN,B2
-elected officials,elected officials,词,NOUN,C1
-elections,elections,词,NOUN,B1
-elective,elective,词,ADJ,C1
-elective course,elective course,选修课,NOUN,B2
-electivity,electivity,词,NOUN,C1
-electoral,electoral,词,ADJ,C1
-electoralist,electoralist,词,ADJ,C1
-electric (noun),electric,词,NOUN,B2
-electric plug,electric plug,词,NOUN,B1
-electrical engineering,electrical engineering,词,NOUN,C1
-electrification,electrification,词,NOUN,C1
-electrify,electrify,词,VERB,C1
-electrocute,electrocute,词,VERB,C1
-electron,electron,词,NOUN,B2
-electronic bracelet,electronic bracelet,词,NOUN,C1
-elegance,elegance,词,NOUN,C1
-elegant,elegant,优雅的,ADJ,B2
-elegi,elegy,挽歌,NOUN,B2
+upprymd,elated,兴高采烈的,ADJ,B2
+äldre,elderly,年长的,ADJ,B2
+äldste son,eldest son,长子,NOUN,B2
+välja,to elect,选举,VERB,B2
+väljarkår,electorate,选民,NOUN,B2
 elektronisk,electronic,电子的,ADJ,B2
 elektronisk betalning,electronic payment,电子支付,NOUN,B2
-elemental,elemental,词,ADJ,B2
-elements of an offense,elements of an offense,词,NOUN,C1
-elevated,elevated,词,ADJ,C1
-eleven,eleven,十一,NOUN,B2
-elf,elf,词,NOUN,C1
-elicit,elicit,词,VERB,C1
-eligible,eligible,词,ADJ,C1
+elegant,elegant,优雅的,ADJ,B2
+elegi,elegy,挽歌,NOUN,B2
+höjd,elevation,提升,NOUN,B2
 eliminering,elimination,消除,NOUN,B2
-elitism,elitism,词,NOUN,C1
-ellipsis,ellipsis,省略,NOUN,B2
-ellipsis (part),ellipsis,…,PART,C1
-elocution,elocution,演讲术,NOUN,B2
-elongate,elongate,词,VERB,C1
-elope,elope,词,VERB,C1
 eloquens,eloquence,口才,NOUN,B2
 eloquent,eloquent,雄辩的,ADJ,B2
-else,else,词,ADV,A1
-elucidation,elucidation,词,NOUN,C1
-elusive,elusive,难以捉摸的,ADJ,B2
-elusiveness,elusiveness,神来无影去,NOUN,C1
-emaciate,emaciate,词,VERB,C1
-emaciated,emaciated,词,ADJ,C1
-emaciating,emaciating,消耗的,ADJ,B2
-emaciation,emaciation,词,NOUN,C1
-email address,email address,电子邮件地址,NOUN,B2
-emanation,emanation,散发物,NOUN,B2
-emancipation,emancipation,解放,NOUN,B2
-emancipera,to emancipate,解放,VERB,B2
 emanera,to emanate,散发,VERB,B2
-ematisera,to empathize,共情,VERB,B2
-embalm,embalm,词,VERB,C1
-embargo,embargo,禁运,NOUN,B2
-embattle,embattle,词,VERB,C1
-embers,embers,词,NOUN,B1
-embitter,embitter,词,VERB,C1
-emblazon,emblazon,词,VERB,C1
-emblem,emblem,徽章,NOUN,B2
-emblematic,emblematic,象征性的,ADJ,B2
-embodiment,embodiment,词,NOUN,B2
-embolism,embolism,栓塞,NOUN,B2
-emboss,emboss,词,VERB,C1
-embrace each other,embrace each other,词,VERB,B2
-embroil,embroil,词,VERB,C1
-embryo,embryo,胚胎,NOUN,B2
-embryonic,embryonic,词,ADJ,C1
-emend,emend,词,VERB,B2
-emerald,emerald,祖母绿,NOUN,B2
-emergence emanation,emergence emanation,词,NOUN,C1
-emergency call,emergency call,紧急呼叫,NOUN,B2
-emergency doctor,emergency doctor,急诊医生,NOUN,B2
-emerging,emerging,词,ADJ,C1
-eminence,eminence,词,NOUN,C1
-eminent,eminent,杰出的,ADJ,B2
-emirate,emirate,词,NOUN,C1
-emiri,emiri,埃米尔的,ADJ,C1
+emanation,emanation,散发物,NOUN,B2
+emancipera,to emancipate,解放,VERB,B2
+emancipation,emancipation,解放,NOUN,B2
+inbädda,to embed,嵌入,VERB,B2
+pryda,to embellish,装饰,VERB,B2
+försloka,to embezzle,贪污,VERB,B2
+förslokning,embezzlement,贪污,NOUN,B2
+kroppslita,to embody,体现,VERB,B2
+brodera,to embroider,刺绣,VERB,B2
+broderi,embroidery,刺绣,NOUN,B2
+uppkomst,emergence,涌现,NOUN,B2
 emission,emission,排放,NOUN,B2
-emission reduction,emission reduction,减排,NOUN,C1
-emissions,emissions,词,NOUN,C1
-emitter,emitter,词,NOUN,C1
 emittera,to emit,发出,VERB,B2
-emolument,emolument,词,NOUN,C1
-emote,emote,词,VERB,C1
-emoticon,emoticon,词,NOUN,C1
-emotion feeling,emotion feeling,情感,NOUN,C1
-emotional experience,emotional experience,情感体验,NOUN,B2
-emotional expression,emotional expression,! 情感表达,NOUN,B2
 emotionalitet,emotionality,感性/情绪化,NOUN,B2
-emotionality lyricism,emotionality lyricism,词,NOUN,C1
-emphasize,emphasize,着重,ADV,B2
-emphatic,emphatic,词,ADJ,C1
-emphatically,emphatically,词,ADV,C1
-empirically,empirically,凭经验地,ADV,B2
+ematisera,to empathize,共情,VERB,B2
+betoning,emphasis,强调,NOUN,B2
+rike,empire,帝国,NOUN,B2
 empiricism,empiricism,经验主义,NOUN,B2
-employability,employability,词,NOUN,B2
-employers,employers,词,NOUN,B1
-emporium,emporium,词,NOUN,C1
-empowerment,empowerment,词,NOUN,C1
-empress dowager,empress dowager,母后,NOUN,B2
-empress mother,empress mother,你母后,NOUN,B2
-emptying,emptying,词,NOUN,B2
-empyrean,empyrean,词,ADJ,C1
-emulation,emulation,模仿,NOUN,B2
-emulator,emulator,词,NOUN,C1
+befogen,to empower,授权,VERB,B2
+kejsarinna,empress,女皇,NOUN,B2
+tomhet,emptiness,空虚,NOUN,B2
+tomt rykte,empty fame,虚名,NOUN,B2
 emulera,to emulate,效仿,VERB,B2
-emulsify,emulsify,词,VERB,C1
-emulsion,emulsion,词,NOUN,C1
-en,one,人们,PRON,B2
-en bok,one book,一本,NUM,B2
-en dag,one day,一天,NUM,B2
-en efter en,one after another,接连地,ADV,B2
-en familj,one family,一家,NUM,B2
-en gång,once,一次,ADV,B2
-en gång till,once more,再次,ADV,B2
-en lägenhet,one flat,一张,NUM,B2
-en natt,one night,一晚,NUM,B2
-enamel,enamel,珐琅,NOUN,B2
-enamel (verb),enamel,词,VERB,C1
-enamor,enamor,词,VERB,C1
-encage,encage,词,VERB,C1
-encamp,encamp,词,VERB,C1
-encampment,encampment,词,NOUN,C1
-encampments,encampments,词,NOUN,C1
-encapsulate,encapsulate,词,VERB,C1
-encase,encase,词,VERB,C1
-encephalic,encephalic,词,ADJ,C1
-enchain,enchain,词,VERB,C1
-encirclement,encirclement,环绕,NOUN,B2
-enclosed,enclosed,词,ADJ,B2
-enclosure pen,enclosure pen,词,NOUN,C1
-encoding,encoding,编码,NOUN,C1
-encomium,encomium,词,NOUN,C1
-encore (noun),encore,词,NOUN,C1
-encouraging,encouraging,词,ADJ,C1
-encroachment,encroachment,词,NOUN,C1
-encrust,encrust,词,VERB,C1
-encrypt,encrypt,词,VERB,C1
-encrypted,encrypted,词,ADJ,B2
-encumber,encumber,词,VERB,C1
+möjliggöra,to enable,使能够,VERB,B2
+verkställa,to enact,颁布,VERB,B2
+förtrylla,to enchant,使着迷,VERB,B2
+förtryllande,enchanting,迷人的,ADJ,B2
+inluta,to enclose,围住,VERB,B2
+omfatta,to encompass,包含,VERB,B2
+möte,encounter,相遇,NOUN,B2
+uppmuntra,to encourage,鼓励,VERB,B2
+kryptering,encryption,加密,NOUN,B2
 encyklopedi,encyclopedia,百科全书,NOUN,B2
 encyklopedisk,encyclopedic,百科全书式的,ADJ,B2
-end (part),end,端,PART,B2
-end of the working day,end of the working day,词,NOUN,C1
-end of the year,end of the year,词,NOUN,C1
-endear,endear,词,VERB,C1
-endeavor (noun),endeavor,词,NOUN,B2
-endeavor (verb),endeavor,词,VERB,C1
-endemic,endemic,地方性的,ADJ,B2
-endemic disease,endemic disease,词,NOUN,B2
-ending,ending,了头,NOUN,C1
-endogamy,endogamy,词,NOUN,C1
-endogenous,endogenous,内生的,ADJ,B2
-endoscope,endoscope,词,NOUN,C1
-endoscopy,endoscopy,词,NOUN,C1
-endowed,endowed,有天赋的,ADJ,B2
-endowment,endowment,配备,NOUN,B2
-endue,endue,词,VERB,C1
-enduring hardship,enduring hardship,词,NOUN,C1
-enemy army,enemy army,敌军,NOUN,C1
-enemy of the state,enemy of the state,词,NOUN,C1
-energize,energize,词,VERB,C1
-energy crisis,energy crisis,能源危机,NOUN,B2
-energy saving,energy saving,节能,NOUN,B2
-enfeeble,enfeeble,词,VERB,C1
-enfeoffment,enfeoffment,封王,NOUN,C1
-enfold,enfold,词,VERB,C1
-enforceability,enforceability,词,NOUN,C1
-enforcement policy,enforcement policy,执法政策,NOUN,B2
-enfranchise,enfranchise,词,VERB,C1
-engagemang,engagement,订婚,NOUN,B2
-engagerad,committed,投入的,ADJ,B2
-engender,engender,词,VERB,C1
-engine motor,engine motor,词,NOUN,C1
-english-speaking,english-speaking,讲英语的,ADJ,B2
-engraft,engraft,词,VERB,C1
-engrave in mind,engrave in mind,铭记,VERB,C1
-engraver,engraver,词,NOUN,C1
-engrossing,engrossing,引人入胜的,ADJ,B2
-engulf,engulf,词,VERB,C1
-enigma,enigma,词,NOUN,C1
-enigmatic,enigmatic,神秘的,ADJ,B2
-enjambment,enjambment,词,NOUN,C1
-enjoin,enjoin,词,VERB,C1
-enjoyable,enjoyable,词,ADJ,B1
-enjoyed,enjoyed,词,ADJ,C1
-enkelhet,simplicity,简单,NOUN,B2
-enkelt,simply,简单地,ADV,B2
-enkindle,enkindle,词,VERB,C1
-enlargement,enlargement,词,NOUN,C1
-enlightening,enlightening,词,ADJ,C1
-enlistment,enlistment,入伍,NOUN,C1
-enliven,enliven,词,VERB,C1
-enmesh,enmesh,词,VERB,C1
-enoki mushroom,enoki mushroom,金针菇,NOUN,B2
-enorm,huge,巨大的,ADJ,B2
-enormitet,enormity,极恶,NOUN,B2
-enough (noun),enough,就够,NOUN,C1
-enough okay,enough okay,词,ADJ,A1
-enquire,enquire,词,VERB,C1
-enraged,enraged,词,ADJ,C1
-enriching,enriching,词,ADJ,C1
-enrolled,enrolled,词,ADJ,B2
-ensam,lonely,孤独的,ADJ,B2
-ensamhet,solitude,孤独,NOUN,B2
-ensconce,ensconce,词,VERB,C1
-enshrine,enshrine,词,VERB,C1
-enshrinement,enshrinement,词,NOUN,C1
-enshroud,enshroud,词,VERB,C1
-ensidig,one-sided,单方面的,ADJ,B2
-enslavement,enslavement,奴役,NOUN,B2
-enslavement by love,enslavement by love,词,NOUN,C1
-ensue,ensue,词,VERB,B2
-entanglement,entanglement,缠,NOUN,C1
-entelechy,entelechy,词,NOUN,C1
-entering city,entering city,入城,NOUN,C1
-entering home,entering home,进家,NOUN,B2
-enterprising,enterprising,词,ADJ,C1
-entertainer,entertainer,词,NOUN,B2
-entertaining,entertaining,有趣的,ADJ,B2
-enticement,enticement,词,NOUN,C1
-entitle,entitle,词,VERB,C1
-entitled to exist,entitled to exist,词,ADJ,C1
-entitlement,entitlement,权利,NOUN,C1
-entitlements,entitlements,词,NOUN,B2
-entomb,entomb,词,VERB,C1
-entomology,entomology,词,NOUN,C1
-entrails,entrails,内脏,NOUN,B2
-entranced,entranced,痴迷的,ADJ,B2
-entrancing,entrancing,词,ADJ,C1
-entrap,entrap,词,VERB,C1
-entrapment,entrapment,身陷,NOUN,B2
-entreat,entreat,词,VERB,C1
-entrenchment,entrenchment,词,NOUN,C1
-entrepreneurship,entrepreneurship,词,NOUN,C1
-entropy,entropy,熵,NOUN,B2
-entusiasm,enthusiasm,热情,NOUN,B2
-entwine,entwine,词,VERB,C1
-enumeration,enumeration,列举,NOUN,B2
-enunciative,enunciative,词,ADJ,C1
-envelop,envelop,词,VERB,C1
-envenom,envenom,词,VERB,C1
-envetna,tenacious,顽强的,ADJ,B2
-enviable,enviable,令人羡慕的,ADJ,B2
-environ,environ,词,VERB,C1
-environmental technology,environmental technology,环保技术,NOUN,B2
-envisage,envisage,词,VERB,C1
-envist,obstinate,固执的,ADJ,B2
-envoy,envoy,词,NOUN,B2
-enwetens,enwetens,词,ADV,C1
-enzym,enzyme,酶,NOUN,B2
-eon age,eon age,词,NOUN,C1
-ephemeral,ephemeral,短暂的,ADJ,B2
-epic quality,epic quality,词,NOUN,C1
-epidermal,epidermal,词,ADJ,C1
-epigram,epigram,词,NOUN,C1
-epigraph,epigraph,题词,NOUN,B2
-epikureisk,epicurean,享乐主义的,ADJ,B2
-epilepsy,epilepsy,词,NOUN,C1
-epilogue,epilogue,词,NOUN,C1
-episodic,episodic,词,ADJ,C1
-epistolary,epistolary,词,ADJ,C1
-epitaph,epitaph,墓志铭,NOUN,B2
-epithet,epithet,绰号,NOUN,B2
-epitomize,epitomize,词,VERB,C1
-eponymous,eponymous,词,ADJ,C1
-epos,epic,史诗,NOUN,B2
-equal same,equal same,词,ADJ,A1
-equal size,equal size,等大,NOUN,B2
-equalization,equalization,词,NOUN,B2
-equally matched,equally matched,不相上下,ADJ,B2
-equanimity,equanimity,词,NOUN,C1
-equatorial,equatorial,词,ADJ,C1
-equestrian,equestrian,马术的,ADJ,B2
-equidistant,equidistant,词,ADJ,C1
-equilateral,equilateral,等边的,ADJ,B2
-equilibrate,equilibrate,词,VERB,C1
-equity,equity,公平,NOUN,B2
-equivalent,equivalent,相等的,ADJ,B2
-equivalent to,equivalent to,相当,ADJ,B1
-equivocal,equivocal,词,ADJ,C1
-equivocate,equivocate,词,VERB,C1
-er majestät,your majesty,陛下,NOUN,B2
-erbjudande,offering,祭品,NOUN,B2
-erection,erection,词,NOUN,C1
-ererziehung,ererziehung,词,NOUN,C1
-erfahrt,erfahrt,词,NOUN,B2
-erfassung,erfassung,词,NOUN,C1
-erforderung,erforderung,词,NOUN,B2
-ergabe,ergabe,词,NOUN,C1
-ergestaltung,ergestaltung,词,NOUN,C1
-ergonomics,ergonomics,词,NOUN,C1
-erhu,erhu,二胡,NOUN,B2
-erkunft,erkunft,词,NOUN,C1
-ernahme,ernahme,词,NOUN,C1
-erosion,abrasion,擦伤,NOUN,B2
-erosion,erosion,侵蚀,NOUN,B2
-erotic,erotic,色情的,ADJ,B2
-eroticism,eroticism,色情,NOUN,B2
-erpflegung,erpflegung,词,NOUN,C1
-errant,errant,词,ADJ,C1
-errata,errata,勘误,NOUN,B2
-erratic,erratic,不稳定的,ADJ,B2
-erregelung,erregelung,词,NOUN,C1
-erroneous,erroneous,词,ADJ,C1
-erschaft,erschaft,词,NOUN,B2
-erschrift,erschrift,词,NOUN,C1
-ersetzung,ersetzung,词,NOUN,B2
-ersicht,ersicht,词,NOUN,C1
-ersinnung,ersinnung,词,NOUN,C1
-ersprache,ersprache,词,NOUN,C1
-ersucht,ersucht,词,NOUN,C1
-ersuchung,ersuchung,词,NOUN,C1
-ersättare,substitute,替代品,NOUN,B2
-ersättning,remuneration,报酬,NOUN,B2
-ersättning,reparation,赔偿,NOUN,B2
-ersättningsledighet,compensatory leave,调休,NOUN,B2
-erteilung,erteilung,词,NOUN,C1
-ertheilung,ertheilung,词,NOUN,C1
-ertreibung,ertreibung,词,NOUN,C1
-erudite,erudite,博学的,ADJ,B2
-erudition,erudition,博学,NOUN,B2
-erupt,erupt,词,VERB,C1
-erwandel,erwandel,词,NOUN,C1
-erweisung,erweisung,词,NOUN,B2
-erwirkung,erwirkung,词,NOUN,B2
-erzerziehung,erzerziehung,词,NOUN,C1
-erzfahrt,erzfahrt,词,NOUN,B2
-erzfassung,erzfassung,词,NOUN,C1
-erzforderung,erzforderung,词,NOUN,C1
-erzgabe,erzgabe,词,NOUN,C1
-erzgestaltung,erzgestaltung,词,NOUN,C1
-erzkunft,erzkunft,词,NOUN,C1
-erznahme,erznahme,词,NOUN,C1
-erzpflegung,erzpflegung,词,NOUN,C1
-erzregelung,erzregelung,词,NOUN,B2
-erzrichtung,erzrichtung,词,NOUN,C1
-erzschaft,erzschaft,词,NOUN,C1
-erzschrift,erzschrift,词,NOUN,C1
-erzsetzung,erzsetzung,词,NOUN,C1
-erzsicht,erzsicht,词,NOUN,C1
-erzsinnung,erzsinnung,词,NOUN,C1
-erzsprache,erzsprache,词,NOUN,C1
-erzsucht,erzsucht,词,NOUN,C1
-erzsuchung,erzsuchung,词,NOUN,C1
-erzteilung,erzteilung,词,NOUN,C1
-erztheilung,erztheilung,词,NOUN,B2
-erztreibung,erztreibung,词,NOUN,C1
-erzwandel,erzwandel,词,NOUN,C1
-erzweisung,erzweisung,词,NOUN,C1
-erzwirkung,erzwirkung,词,NOUN,C1
-escaping,escaping,词,NOUN,C1
-eschatological,eschatological,词,ADJ,C1
-eschatology,eschatology,词,NOUN,C1
-escheat,escheat,词,VERB,C1
-eschew,eschew,词,VERB,C1
-escort agency,escort agency,镖局,NOUN,B2
-escort mission,escort mission,跑镖,NOUN,C1
-escort request,escort request,镖要,NOUN,C1
-eskalation,escalation,升级,NOUN,B2
-eskalera,to escalate,升级,VERB,B2
-eskort,escort guard,镖师,NOUN,B2
-esophagus,esophagus,词,NOUN,B2
-esoteric,esoteric,词,ADJ,C1
-esotericism,esotericism,秘教,NOUN,B2
-essayist,essayist,词,NOUN,C1
-essayistic,essayistic,词,ADJ,C1
-essayistic quality,essayistic quality,词,NOUN,C1
-essence core,essence core,词,NOUN,B2
-essens,essence,本质,NOUN,B2
-essentiality,essentiality,词,NOUN,C1
-esteemed guest,esteemed guest,嘉宾,NOUN,B2
-estimation,estimation,词,NOUN,C1
-estrange,estrange,词,VERB,C1
-etc,etc,等等,NOUN,B2
-etch,etch,词,VERB,C1
-eternally receive,eternally receive,永受,NOUN,C1
-eternity without beginning,eternity without beginning,词,NOUN,C1
-eternity without end,eternity without end,词,NOUN,C1
-ethereal,ethereal,飘渺的,ADJ,B2
-ethereum,ethereum,以太坊,NOUN,B2
-ethnic Chinese,ethnic Chinese,华裔,NOUN,B1
-ethnic group,ethnic group,词,NOUN,C1
-etnicitet,ethnicity,种族,NOUN,B2
-etnologi,ethnology,民族学,NOUN,B2
-ett huvud,one head,一头,NUM,B2
-ett set,one set,一套,NUM,B2
-ett skott,one shot,一枪,NUM,B2
-etymology,etymology,词源学,NOUN,B2
-eufemism,euphemism,委婉语,NOUN,B2
-eufori,euphoria,欣快感,NOUN,B2
-eulogize,eulogize,词,VERB,C1
-eunuch,eunuch,词,NOUN,C1
-euphemistic,euphemistic,委婉的,ADJ,B2
-euphonic,euphonic,悦耳的,ADJ,B2
-euphoric,euphoric,词,ADJ,C1
-euthanasia,euthanasia,词,NOUN,C1
-evanesce,evanesce,词,VERB,C1
-evangelical,evangelical,词,ADJ,C1
-evangelisera,to evangelize,传福音,VERB,B2
-evangelist,evangelist,词,NOUN,C1
-evangelization,evangelization,词,NOUN,C1
-evaporating,evaporating,词,ADJ,C1
-evasion,evasion,逃避,NOUN,B2
-eve,eve,前夕,NOUN,C1
-even if (adp),even if,就算,ADP,A2
-even me,even me,连我,NOUN,C1
-even pulse,even pulse,脉象平,NOUN,C1
-even you,even you,连你,PRON,B2
-evening chat,evening chat,晚间闲谈,NOUN,B2
-evening gathering,evening gathering,词,NOUN,C1
-evening newspaper,evening newspaper,晚报,NOUN,C1
-evening night,evening night,晚上,NOUN,A1
-evening party,evening party,词,NOUN,B1
-events,events,事件,NOUN,C1
-eventual,eventual,词,ADJ,C1
-eventual outcome,eventual outcome,词,NOUN,C1
-eventuate,eventuate,词,VERB,C1
-everlasting,everlasting,词,ADJ,C1
-everlastingness,everlastingness,词,NOUN,C1
-every,every,每个,PRON,B2
-every day (noun),every day,每天,NOUN,C1
-every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
-every time,every time,每次,NOUN,C1
-everybody,everybody,词,PRON,A1
-everyday family life,everyday family life,家常,NOUN,C1
-everyday life,everyday life,日常生活,NOUN,B2
-everydayness,everydayness,词,NOUN,B2
-everyone,everyone,各位,NOUN,B2
-everyone gives their own view,everyone gives their own view,各抒己见,NOUN,B2
-evidentiary weight,evidentiary weight,词,NOUN,C1
-evig allians,eternal alliance,永结,NOUN,B2
-evil (part),evil,邪,PART,B2
-evil move,evil move,邪招,NOUN,C1
-evince,evince,词,VERB,C1
-eviscerate,eviscerate,词,VERB,C1
-evocation,evocation,唤起,NOUN,B2
-evocative,evocative,引起回忆的,ADJ,B2
-evolution,evolution,进化,NOUN,B2
-evolutionary,evolutionary,词,ADJ,C1
-exact change,exact change,词,NOUN,C1
-exactitude,exactitude,词,NOUN,C1
-exactly the same,exactly the same,一模一样,ADJ,B2
-exakt,exactly,确切地,ADV,B2
-exaltation,exaltation,狂热,NOUN,B2
-exalted,exalted,狂热的,ADJ,B2
-exam paper,exam paper,试卷,NOUN,B2
-exam to take an exam,exam to take an exam,考试,NOUN,A1
-examinera,graduate,毕业生,NOUN,B2
-examinera,to graduate,毕业,VERB,B2
-excavated,excavated,词,ADJ,B1
-excavation,excavation,词,NOUN,B2
-excavator,excavator,挖掘机,NOUN,B2
-excentrisk,eccentric,古怪的,ADJ,B2
-except for,except for,除了,ADP,B2
-except unless,except unless,词,ADP,A2
-exceptionality,exceptionality,特殊性,NOUN,B2
-exceptionally,exceptionally,例外地,ADV,B2
-excess weight,excess weight,词,NOUN,C1
-excessively,excessively,词,ADV,C1
-excessiveness,excessiveness,词,NOUN,C1
-exchange fee,exchange fee,词,NOUN,C1
-exchange goods,exchange goods,换货,NOUN,B2
-exchange greetings,exchange greetings,寒暄,VERB,C1
-exchange meeting,exchange meeting,交流会,NOUN,B2
-exchange money,exchange money,词,NOUN,A1
-exchange of accusations,exchange of accusations,词,NOUN,C1
-exchange of verses,exchange of verses,词,NOUN,C1
-exchange rate,exchange rate,汇率,NOUN,B1
-exchange student,exchange student,交流生,NOUN,C1
-exchanger,exchanger,词,NOUN,C1
-exchanges,exchanges,词,NOUN,C1
-excise (noun),excise,词,NOUN,C1
-excise (verb),excise,词,VERB,C1
-excision,excision,词,NOUN,C1
-excitability,excitability,兴奋性,NOUN,B2
-exclamation (punct),exclamation,词,PUNCT,A2
-exclusionary,exclusionary,排他性的,ADJ,B2
-exclusive dedication,exclusive dedication,词,NOUN,C1
-exclusivism,exclusivism,词,NOUN,C1
-excrement,excrement,排泄物,NOUN,B2
-excrescence,excrescence,词,NOUN,C1
-excrete,excrete,词,VERB,C1
-excretion,excretion,排泄,NOUN,B2
-exculpation,exculpation,开脱,NOUN,B2
-excursion,excursion,郊游,NOUN,B2
-excuse me (intj),excuse me,劳驾,INTJ,B1
-excuse me (verb),excuse me,失陪,VERB,B2
-execution by firing squad,execution by firing squad,词,NOUN,C1
-executive board,executive board,词,NOUN,C1
-executory,executory,词,ADJ,C1
-exeges,exegesis,注释,NOUN,B2
-exegete,exegete,注释家,NOUN,B2
-exemplar,exemplar,楷模,NOUN,C1
-exemplar,measure word for books,本,NUM,B2
-exemplary country,exemplary country,模范国家,NOUN,B2
-exemption from admission exam,exemption from admission exam,推免,NOUN,C1
-exercise book,exercise book,词,NOUN,C1
-exercises,exercises,词,NOUN,B2
-exert,exert,词,VERB,C1
-exhalation,exhalation,词,NOUN,C1
-exhaust gas,exhaust gas,废气,NOUN,C1
-exhausting,exhausting,词,ADJ,B2
-exhibit (noun),exhibit,证物,NOUN,B2
-exhibition center,exhibition center,展览中心,NOUN,C1
-exhibition match,exhibition match,表演赛,NOUN,C1
-exhibitor,exhibitor,词,NOUN,C1
-exhilarate,exhilarate,词,VERB,C1
-exhortation,exhortation,词,NOUN,C1
-exhumation,exhumation,掘墓,NOUN,B2
-exhumera,to exhume,掘出,VERB,B2
-exigent,exigent,词,ADJ,C1
-exile (noun),exile,词,NOUN,B2
-exiled,exiled,词,ADJ,C1
-existensminimum,subsistence,生计,NOUN,B2
-existential,existential,存在主义的,ADJ,B2
-existentialism,existentialism,存在主义,NOUN,B2
-exit (verb),exit,词,VERB,A1
-exklusiv,exclusive,独有的,ADJ,B2
-exklusivitet,exclusivity,排他性,NOUN,B2
-exklusivt,exclusively,专门地,ADV,B2
-exodus,exodus,词,NOUN,C1
-exoneration,exoneration,词,NOUN,C1
-exorbitant,exorbitant,过高的,ADJ,B2
-exorcism,exorcism,词,NOUN,C1
-exordium,exordium,词,NOUN,C1
-exoteric,exoteric,词,ADJ,B2
-exotic,exotic,异国情调的,ADJ,B2
-exoticism,exoticism,异国情调,NOUN,B2
-expanse,expanse,词,NOUN,B2
-expansionism,expansionism,扩张主义,NOUN,C1
-expatiate,expatiate,词,VERB,C1
-expatriate,expatriate,移居国外者,NOUN,B2
-expatriation,expatriation,词,NOUN,C1
-expectant,expectant,词,ADJ,C1
-expectoration,expectoration,词,NOUN,C1
-expedite,expedite,词,VERB,C1
-expedition,expedition,探险,NOUN,B2
-expeditionary,expeditionary,词,ADJ,C1
-expeditious,expeditious,迅速的,ADJ,B2
-expenditures,expenditures,支出,NOUN,C1
-expensiveness,expensiveness,词,NOUN,B2
-experiences,experiences,经验,NOUN,C1
-experiential marker,experiential marker,过,PART,A2
-experimentation,experimentation,词,NOUN,C1
-expert opinion,expert opinion,专家意见,NOUN,B2
-expertise center,expertise center,专业中心,NOUN,B2
-expiate,expiate,词,VERB,C1
-expiration,expiration,词,NOUN,C1
-explanatory,explanatory,解释的,ADJ,B2
-expletive,expletive,词,NOUN,C1
-explicable,explicable,可解释的,ADJ,B2
-explicate,explicate,词,VERB,C1
-explicitly,explicitly,明确地,ADV,B2
-exploatering,exploitation,利用,NOUN,B2
-exploit (noun),exploit,词,NOUN,C1
-exploitable,exploitable,词,ADJ,C1
-exploits,exploits,词,NOUN,C1
-exploration,exploration,探索,NOUN,B2
-exploratory,exploratory,词,ADJ,C1
-explosion-proof,explosion-proof,防爆,ADJ,B2
-explosiv,explosive,爆炸性的,ADJ,B2
-explosive,explosive,炸药,NOUN,B2
-exponent,exponent,指数,NOUN,B2
-exponential,exponential,指数的,ADJ,B2
-exponering,exposure,暴露,NOUN,B2
-exportation,exportation,词,NOUN,C1
-exports,exports,词,NOUN,C1
-exposition,exposition,阐述,NOUN,B2
-expostulate,expostulate,词,VERB,C1
-express,express,明确的,ADJ,B2
-express car,express car,快车,NOUN,B2
-express delivery,express delivery,快递,NOUN,C1
-expression of opinion,expression of opinion,意见表达,NOUN,B2
-expressionism,expressionism,词,NOUN,C1
-expressiveness,expressiveness,表现力,NOUN,B2
-expropriation,expropriation,征用,NOUN,B2
-expropriera,to expropriate,征用,VERB,B2
-expunge,expunge,词,VERB,C1
-exquisiteness,exquisiteness,词,NOUN,C1
-extas,ecstasy,狂喜,NOUN,B2
-extemporize,extemporize,词,VERB,C1
-extended,extended,广泛的,ADJ,B2
-extended reality,extended reality,扩展现实,NOUN,C1
-extension cord,extension cord,词,NOUN,C1
-extenuate,extenuate,词,VERB,C1
-extenuating,extenuating,词,ADJ,C1
-exterior,exterior,在外,NOUN,B2
-extern,external,外部的,ADJ,B2
-external hard drive,external hard drive,移动硬盘,NOUN,B2
-extinct,extinct,灭绝的,ADJ,B2
-extinguishable,extinguishable,词,ADJ,C1
-extinguished listless,extinguished listless,熄灭的/无精打采的,ADJ,C1
-extinguishing,extinguishing,词,NOUN,C1
-extirpation,extirpation,切除,NOUN,B2
-extolling,extolling,词,NOUN,C1
-extort a confession,extort a confession,逼供,VERB,C1
-extra,extra,群众演员,NOUN,B2
-extra (adv),extra,词,ADV,A1
-extra (noun),extra,群众演员,NOUN,B2
-extra drink,extra drink,多喝,NOUN,C1
-extract,extract,摘录,NOUN,B2
-extrahera,to extract,提取,VERB,B2
-extraktion,extraction,提取,NOUN,B2
-extramarital,extramarital,词,ADJ,C1
-extraordinarie,extraordinary,非凡的,ADJ,B2
-extrapolation,extrapolation,词,NOUN,C1
-extrapolera,to extrapolate,推断,VERB,B2
-extraterrestrial,extraterrestrial,外星的,ADJ,B2
-extravagans,extravagance,奢侈,NOUN,B2
-extravagant,extravagant,奢侈的,ADJ,B2
-extraversion,extraversion,词,NOUN,C1
-extrem,extreme,أقصى,NOUN,B2
-extreme (noun),extreme,至极,NOUN,B2
-extreme cold,extreme cold,极寒,NOUN,C1
-extreme height,extreme height,极高,NOUN,B2
-extreme unction,extreme unction,词,NOUN,C1
-extreme weather,extreme weather,极端天气,NOUN,C1
-extremism,extremism,词,NOUN,C1
-extremist,extremist,极端主义者,NOUN,B2
-extremity,extremity,极为,NOUN,B2
-extrinsic,extrinsic,词,ADJ,C1
-extroversion,extroversion,外向,NOUN,B2
-extrovert,extrovert,词,ADJ,C1
-extroverted,extroverted,外向,ADJ,B2
-extrude,extrude,词,VERB,C1
-exuberance,exuberance,繁茂,NOUN,B2
-exuberant,exuberant,繁茂的,ADJ,B2
-exudation,exudation,词,NOUN,C1
-eye (part),eye,眼,PART,A2
-eye-care,eye-care,目养,NOUN,C1
-eyebrows,eyebrows,词,NOUN,A1
-eyes,eyes,眼中,NOUN,B2
-eyesight,eyesight,视力,NOUN,B1
-fabel,fable,寓言,NOUN,B2
-fabricated,fabricated,词,ADJ,B2
-fabulist,fabulist,幻想家,NOUN,B2
-fabulous,fabulous,极好的,ADJ,B2
-face towel,face towel,面巾,NOUN,C1
-face veil,face veil,词,NOUN,B2
-facies,facies,面貌,NOUN,B2
-facilitation,facilitation,词,NOUN,C1
-fackförening,trade union,工会,NOUN,B2
-fackla,torch,手电筒,NOUN,B2
-facticity,facticity,词,NOUN,C1
-factionalism,factionalism,派系主义,NOUN,B2
-factious,factious,词,ADJ,C1
-factoring,factoring,保理,NOUN,B2
-factotum,factotum,词,NOUN,C1
-factual,factual,事实的,ADJ,B2
-fad,fad,词,NOUN,C1
-fade away,fade away,词,VERB,C1
-fading away,fading away,词,NOUN,C1
-fag,fag,词,NOUN,C1
-faggot,faggot,词,NOUN,C1
-failing an exam,failing an exam,不及格,NOUN,B2
-failing student,failing student,词,NOUN,B2
-failure to act,failure to act,词,NOUN,C1
-faint,faint,微弱的,ADJ,B2
-faint (noun),faint,词,NOUN,C1
-fair-haired,fair-haired,词,ADJ,B1
-fairly,fairly,词,ADV,C1
-fairness,fairness,词,NOUN,B2
-faithful loyal,faithful loyal,忠诚的,ADJ,B2
-faithfully,faithfully,词,ADV,C1
-faithlessness,faithlessness,弃义,NOUN,C1
-fake and inferior,fake and inferior,伪劣,ADJ,C1
-fake goods,fake goods,假货,NOUN,C1
-fake news,fake news,假新闻,NOUN,B2
-faksimil,facsimile,副本,NOUN,B2
-faktor,factor,因素,NOUN,B2
-fakultet,faculty,学院,NOUN,B2
-falconry,falconry,猎鹰术,NOUN,B2
-falk,falcon,猎鹰,NOUN,B2
-fall collapse,fall collapse,词,NOUN,C1
-fall on,fall on,落在,NOUN,C1
-fallacious,fallacious,词,ADJ,B2
-fallibility,fallibility,易错性,NOUN,B2
-fallible,fallible,词,ADJ,C1
-falling into,falling into,落进,NOUN,C1
-falling off horse,falling off horse,坠马,NOUN,C1
-fallout,fallout,词,NOUN,C1
-fallow land,fallow land,词,NOUN,B2
-false oath,false oath,词,NOUN,C1
-falsely,falsely,词,ADV,C1
-falseness,falseness,词,NOUN,C1
-falsifiability,falsifiability,词,NOUN,C1
-falsification,falsification,词,NOUN,C1
-falsk,counterfeit,假冒,ADJ,B2
-falsk,fake,假的,ADJ,B2
-falskhet,falsity,虚假,NOUN,B2
-falskt vittnesmål,perjury,伪证,NOUN,B2
-falter,falter,词,VERB,C1
-faltering,faltering,词,ADJ,C1
-familial,familial,词,ADJ,B2
-familiar with,familiar with,熟悉,ADJ,A2
-familjeförfall,family ruin,家破,NOUN,B2
-familjemedlem,family member,家庭成员,NOUN,B2
-family (adj),family,词,ADJ,B1
-family background,family background,出身,NOUN,B2
-family circle,family circle,家庭圈子,NOUN,B2
-family composition,family composition,家庭构成,NOUN,B2
-family happiness,family happiness,天伦之乐,NOUN,B2
-family has,family has,家有,NOUN,C1
-family portrait,family portrait,全家福,NOUN,B2
-family reunification,family reunification,家庭团聚,NOUN,B2
-family situation,family situation,词,NOUN,C1
-family tension,family tension,家庭紧张,NOUN,B2
-family therapy,family therapy,词,NOUN,C1
-family tie,family tie,家庭纽带,NOUN,B2
-famine,famine,饥荒,NOUN,B2
-famish,famish,词,VERB,C1
-famished,famished,词,ADJ,C1
-famous brand,famous brand,名牌,NOUN,B2
-famous catcher,famous catcher,名捕,NOUN,C1
-famous family,famous family,名门,NOUN,B2
-fanatic,fanatic,狂热的,ADJ,B2
-fanatical,fanatical,词,ADJ,C1
-fanatism,fanaticism,狂热,NOUN,B2
-fancy,fancy,词,ADJ,B1
-fancy decoration,fancy decoration,词,NOUN,C1
-fang,fang,犬齿,NOUN,B2
-fantasize,fantasize,词,VERB,C1
-fantasizing,fantasizing,词,NOUN,C1
-far,far,远,ADV,B2
-far,father,父,PART,B2
-far away,far away,远远,ADV,B2
-far from,far from,远非,NOUN,B2
-fara,peril,危险,NOUN,B2
-fare,fare,车费,NOUN,B2
-farewell banquet,farewell banquet,告别宴,NOUN,C1
-farmland,farmland,农田,NOUN,C1
-farmor,grandma,奶奶,NOUN,B2
-farrow,farrow,词,VERB,C1
-farsighted,farsighted,词,ADJ,C1
-fart (noun),fart,屁,NOUN,C1
-fascination,fascination,魅力,NOUN,B2
-fascism,fascism,法西斯主义,NOUN,B2
-fascist (adj),fascist,词,ADJ,C1
-fascist (noun),fascist,词,NOUN,C1
-fashion designer,fashion designer,词,NOUN,C1
-fashion plate,fashion plate,词,NOUN,C1
-fashionable,fashionable,时髦,ADJ,B2
-fast,stuck,卡住的,ADJ,B2
-fast forward,fast forward,快进,VERB,C1
-fast grepp,tight grip,手握紧,NOUN,B2
-fast ämne,solid,3D模型 / 实体,NOUN,B2
-fasta,fasting,禁食,NOUN,B2
-fastening,fastening,要扎紧,NOUN,B2
-fastighet,real estate,房地产,ADJ,B2
-fastighet,estate,地产,NOUN,B2
-fatalism,fatalism,宿命论,NOUN,B2
-fatalist (adj),fatalist,宿命论的,ADJ,C1
-fatalist (noun),fatalist,词,NOUN,C1
-fatality,fatality,致命性,NOUN,B2
-fatally,fatally,词,ADV,C1
-fateful,fateful,词,ADJ,C1
-father (part),father,父,PART,B2
-father and daughter,father and daughter,父女俩,NOUN,C1
-fathom,fathom,词,VERB,C1
-fatness,fatness,词,NOUN,C1
-fats,fats,词,NOUN,C1
-fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
-fatty,fatty,脂肪的,ADJ,B2
-fatty acid,fatty acid,词,NOUN,C1
-fatuity,fatuity,愚昧,NOUN,B2
-fatuous,fatuous,词,ADJ,C1
-fatwa,fatwa,词,NOUN,B2
-faucet,faucet,词,NOUN,C1
-faulty,faulty,词,ADJ,C1
-fauna,fauna,动物群,NOUN,B2
-favor kindness,favor kindness,恩,NOUN,C1
-favorable,favorable,词,ADJ,C1
-favorit,favorite,最喜欢的,ADJ,B2
-favorite (noun),favorite,最爱,NOUN,B2
-favoritism,favoritism,偏袒,NOUN,B2
-favourite,favourite,词,ADJ,B1
-fawn,fawn,词,VERB,C1
-fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
-fax,fax,传真,NOUN,B2
-fear book,fear book,怕本,NOUN,B2
-fearlessness,fearlessness,词,NOUN,C1
-feast,feast,盛宴,NOUN,B2
-feature film,feature film,故事片,NOUN,B2
-febrile,febrile,词,ADJ,C1
-feces,feces,屎,NOUN,C1
-fecundate,fecundate,词,VERB,C1
-fecundity,fecundity,词,NOUN,C1
-fed up,fed up,受够了,NOUN,B2
-fed up (adj),fed up,词,ADJ,B1
-federal,federal,联邦的,ADJ,B2
-federalism,federalism,联邦主义,NOUN,B2
-federalization,federalization,联邦化,NOUN,B2
-federalize,federalize,词,VERB,C1
-feeble,feeble,虚弱的,ADJ,B2
-feeble-minded,feeble-minded,弱智的,ADJ,B2
-feeding,feeding,词,NOUN,C1
-feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
-feel unwell,feel unwell,难受,ADJ,B2
-feeling emotion love,feeling emotion love,情,NOUN,C1
-feghet,timidity,胆怯,NOUN,B2
-feigning ignorance,feigning ignorance,词,VERB,C1
-feigning youthfulness,feigning youthfulness,装嫩,VERB,C1
-fejd,feud,世仇,NOUN,B2
-fel,wrong,错误的,ADJ,B2
-fel,error,错误,NOUN,B2
-fel,fault,错误,NOUN,B2
-fela,to err,犯错,VERB,B2
-felföljd,fallacy,谬误,NOUN,B2
-felicitate,felicitate,词,VERB,C1
-felicity,felicity,词,NOUN,C1
-feline,feline,词,ADJ,C1
-fellow citizen,fellow citizen,同胞,NOUN,B2
-felt,felt,词,NOUN,C1
-female general,female general,女将,NOUN,C1
-female judge,female judge,词,NOUN,C1
-female neighbor,female neighbor,词,NOUN,C1
-female prosecutor,female prosecutor,词,NOUN,C1
-female student,female student,词,NOUN,C1
-female teacher,female teacher,词,NOUN,C1
-female thief,female thief,女贼,NOUN,C1
-females,females,词,NOUN,B2
-feminine,feminine,女性的,ADJ,B2
-feminism,feminism,女权主义,NOUN,B2
-feminist,feminist,女权主义者,NOUN,B2
-feminization,feminization,词,NOUN,C1
-fend,fend,词,VERB,C1
-fender,fender,词,NOUN,C1
-feng shui,feng shui,风水,NOUN,C1
-fennec fox,fennec fox,词,NOUN,B2
-fenugreek,fenugreek,词,NOUN,B2
-feodal,feudal,封建,ADJ,B2
-feodalism,feudalism,封建主义,NOUN,B2
-feral,feral,词,ADJ,C1
-fermata,fermata,词,NOUN,B2
-fermented bean,fermented bean,豆豉,NOUN,C1
-fern,fern,蕨类植物,NOUN,B2
-fernbildung,fernbildung,词,NOUN,C1
-fernerziehung,fernerziehung,词,NOUN,C1
-fernfahrt,fernfahrt,词,NOUN,C1
-fernfassung,fernfassung,词,NOUN,C1
-fernforderung,fernforderung,词,NOUN,C1
-ferngabe,ferngabe,词,NOUN,C1
-ferngestaltung,ferngestaltung,词,NOUN,C1
-fernkunft,fernkunft,词,NOUN,B2
-fernleitung,fernleitung,词,NOUN,C1
-fernmessung,fernmessung,词,NOUN,C1
-fernnahme,fernnahme,词,NOUN,C1
-fernordnung,fernordnung,词,NOUN,C1
-fernpflegung,fernpflegung,词,NOUN,C1
-fernrechnung,fernrechnung,词,NOUN,B2
-fernregelung,fernregelung,词,NOUN,C1
-fernrichtung,fernrichtung,词,NOUN,C1
-fernschaft,fernschaft,词,NOUN,B2
-fernschrift,fernschrift,词,NOUN,C1
-fernsetzung,fernsetzung,词,NOUN,C1
-fernsicht,fernsicht,词,NOUN,C1
-fernsinnung,fernsinnung,词,NOUN,C1
-fernsprache,fernsprache,词,NOUN,C1
-fernstellung,fernstellung,词,NOUN,C1
-fernsucht,fernsucht,词,NOUN,B2
-fernsuchung,fernsuchung,词,NOUN,C1
-fernteilung,fernteilung,词,NOUN,C1
-ferntheilung,ferntheilung,词,NOUN,B2
-ferntreibung,ferntreibung,词,NOUN,C1
-fernwandel,fernwandel,词,NOUN,C1
-fernwandlung,fernwandlung,词,NOUN,C1
-fernweisung,fernweisung,词,NOUN,C1
-fernwendung,fernwendung,词,NOUN,C1
-fernwirkung,fernwirkung,词,NOUN,C1
-ferociously,ferociously,词,ADV,C1
-ferret,ferret,雪貂,NOUN,B2
-ferrule,ferrule,箍,NOUN,B2
-fervent,fervent,词,ADJ,C1
-fervor,fervor,词,NOUN,C1
-festival,festival,节日,NOUN,B2
-festivals,festivals,词,NOUN,C1
-festive,festive,节日的,ADJ,B2
-festivity,festivity,词,NOUN,C1
-fete,fete,词,VERB,C1
-fetid,fetid,词,ADJ,C1
-fetig,greasy,油腻的,ADJ,B2
-fetish,fetish,恋物,NOUN,B2
-fetishism,fetishism,词,NOUN,B2
-fetma,obesity,肥胖,NOUN,B2
-fetter,fetter,词,VERB,C1
-feud end,feud end,仇终,NOUN,C1
-feudal ethics,feudal ethics,礼教,NOUN,B2
-feverish,feverish,词,ADJ,C1
-few,few,几下,NOUN,B2
-fez,fez,词,NOUN,B2
-fib,fib,词,VERB,C1
-fiber,fiber,纤维,NOUN,B2
-fibrosis,fibrosis,纤维化,NOUN,B2
-fibrous,fibrous,词,ADJ,C1
-fickleness,fickleness,反复无常,NOUN,B2
-fiction,fiction,小说,NOUN,B2
-fictional,fictional,虚构的,ADJ,B2
-fictional character,fictional character,虚构角色,NOUN,B2
-fictionalization,fictionalization,词,NOUN,C1
-fictionalize,fictionalize,词,VERB,C1
-fictitious,fictitious,虚构的,ADJ,B2
-fiddle (noun),fiddle,词,NOUN,B2
-fiddle (verb),fiddle,词,VERB,C1
-fidelity,fidelity,忠诚,NOUN,B2
-fidget,fidget,词,VERB,C1
-fiduciary,fiduciary,词,ADJ,C1
-fief,fief,封地,NOUN,B2
-field (adj),field,词,ADJ,C1
-fiend,fiend,词,NOUN,C1
+slut,end,端,PART,B2
+äventyra,to endanger,危及,VERB,B2
+hotad,endangered,濒危的,ADJ,B2
+godkänna,to endorse,支持,VERB,B2
+godkännande,endorsement,背书,NOUN,B2
+donera,to endow,赋予,VERB,B2
+uthållighet,endurance,坚忍,NOUN,B2
+uthärda,to endure,忍受,VERB,B2
 fiende,enemy must,仇必,NOUN,B2
 fiendestat,enemy state,敌国,NOUN,B2
-fiendskap,animosity,敌意,NOUN,B2
-fientlig,hostile,敌对的,ADJ,B2
+upprätthålla,to enforce,执行,VERB,B2
+verkställighet,enforcement,执行,NOUN,B2
+engagemang,engagement,订婚,NOUN,B2
+ingenjörskonst,engineering,工程学,NOUN,B2
+gravyr,engraving,版画,NOUN,B2
+förstora,to enlarge,扩大,VERB,B2
+upplysa,to enlighten,启发,VERB,B2
+upplyst,enlightened,开明的,ADJ,B2
+upplysning,enlightenment,澄清,NOUN,B2
+värva,to enlist,征募,VERB,B2
 fientlighet,enmity,敌意,NOUN,B2
-fientlighet,hostility,敌意,NOUN,B2
+förädla,to ennoble,使高贵,VERB,B2
+enormitet,enormity,极恶,NOUN,B2
+tillräcklig,enough,足够的,ADJ,B2
+berikning,enrichment,丰富,NOUN,B2
+skriva in,to enroll,注册,VERB,B2
+inskrivning,enrollment,注册,NOUN,B2
+medföra,to entail,牵涉,VERB,B2
+trassla in,to entangle,使纠缠,VERB,B2
+träda in,to enter,进入,VERB,B2
+inträda i stad,to enter city,进城,VERB,B2
+företag,enterprise,企业,NOUN,B2
+underhålla,to entertain,娱乐,VERB,B2
+underhållningscenter,entertainment center,娱乐中心,NOUN,B2
+tronbestigning,enthronement,登基,NOUN,B2
+entusiasm,enthusiasm,热情,NOUN,B2
+locka,to entice,引诱,VERB,B2
+hel,entire,整个的,ADJ,B2
+helhet,entirety,全部,NOUN,B2
+följe,entourage,随从,NOUN,B2
+befästa,to entrench,巩固,VERB,B2
+ingång,entry,入口,NOUN,B2
+räkna upp,to enumerate,列举,VERB,B2
+uttal,enunciation,发音,NOUN,B2
+avundsjuk,envious,嫉妒的,ADJ,B2
+miljö-,environmental,环境的,ADJ,B2
+miljöskydd,environmental protection,环境保护,NOUN,B2
+miljörapport,environmental report,环境报告,NOUN,B2
+föreställa sig,to envision,展望,VERB,B2
+enzym,enzyme,酶,NOUN,B2
+epos,epic,史诗,NOUN,B2
+epikureisk,epicurean,享乐主义的,ADJ,B2
+kunskapsteori,epistemology,认识论,NOUN,B2
+personifiering,epitome,化身,NOUN,B2
+lika,equal,相等的,ADJ,B2
+ekvation,equation,方程,NOUN,B2
+ridsport,equestrianism,马术,NOUN,B2
+jämvikt,equilibrium,平衡,NOUN,B2
+utrusta,to equip,装备,VERB,B2
+utrustad,equipped,配备的,ADJ,B2
+motsvarighet,equivalent,等价物,NOUN,B2
+utrota,to eradicate,根除,VERB,B2
+utrotning,eradication,根除,NOUN,B2
+radera,to erase,擦除,VERB,B2
+suddgummi,eraser,橡皮擦,NOUN,B2
+radering,erasure,擦除,NOUN,B2
+erhu,erhu,二胡,NOUN,B2
+erosion,erosion,侵蚀,NOUN,B2
+fela,to err,犯错,VERB,B2
+ärende,errand,差事,NOUN,B2
+errata,errata,勘误,NOUN,B2
+fel,error,错误,NOUN,B2
+utbrott,eruption,爆发,NOUN,B2
+eskalera,to escalate,升级,VERB,B2
+eskalation,escalation,升级,NOUN,B2
+rulltrappa,escalator,自动扶梯,NOUN,B2
+eskort,escort guard,镖师,NOUN,B2
+spioneri,espionage,间谍活动,NOUN,B2
+essens,essence,本质,NOUN,B2
+väsentlig,essential,必要的,ADJ,B2
+grundutrustning,essential equipment,要置,NOUN,B2
+väsentligen,essentially,主要地,ADV,B2
+fastighet,estate,地产,NOUN,B2
+aktning,esteem,尊重,NOUN,B2
+uppskatta,estimate,估计,NOUN,B2
+uppskatta,to estimate,估计,VERB,B2
+frånmärdhet,estrangement,疏离,NOUN,B2
+mynning,estuary,河口,NOUN,B2
+evig allians,eternal alliance,永结,NOUN,B2
+ethereum,ethereum,以太坊,NOUN,B2
+etnicitet,ethnicity,种族,NOUN,B2
+etnologi,ethnology,民族学,NOUN,B2
+minnestal,eulogy,赞辞,NOUN,B2
+eufemism,euphemism,委婉语,NOUN,B2
+eufori,euphoria,欣快感,NOUN,B2
+undvika,to evade,逃避,VERB,B2
+utvärdering,evaluation,评估,NOUN,B2
+evangelisera,to evangelize,传福音,VERB,B2
+fördunsta,to evaporate,蒸发,VERB,B2
+fördunstning,evaporation,蒸发,NOUN,B2
+undvikande,evasive,回避的,ADJ,B2
+jämn,even,偶数的,ADJ,B2
+även om,even if,即使,SCONJ,B2
+slutligen,eventually,最终,ADV,B2
+bestå,to ever,里何尝,VERB,B2
+vardag,every day,天天,ADV,B2
+utvisa,to evict,驱逐,VERB,B2
+utvisning,eviction,驱逐,NOUN,B2
+tydlig,evident,明显的,ADJ,B2
+ond,evil,邪,PART,B2
+evolution,evolution,进化,NOUN,B2
+utvecklas,to evolve,进化,VERB,B2
+förvärra,to exacerbate,加剧,VERB,B2
+förvärring,exacerbation,加剧,NOUN,B2
+exakt,exactly,确切地,ADV,B2
+överdriven,exaggerated,夸张的,ADJ,B2
+överdrift,exaggeration,夸张,NOUN,B2
+irritera,to exasperate,激怒,VERB,B2
+irritation,exasperation,恼怒,NOUN,B2
+utgräva,to excavate,挖掘,VERB,B2
+överskrida,to exceed,超过,VERB,B2
+utmärka,to excel,擅长,VERB,B2
+undantagslös,exceptional,杰出的,ADJ,B2
+urval,excerpt,摘录,NOUN,B2
+överskott,excess,过量,NOUN,B2
+överdriven,excessive,过度的,ADJ,B2
+utbyta,to exchange,交换,VERB,B2
+uppröra,to excite,使兴奋,VERB,B2
+upprörhet,excitement,兴奋,NOUN,B2
+utrop,exclamation,感叹,NOUN,B2
+utesluten,excluded,排除在外的,ADJ,B2
+uteslutning,exclusion,排除,NOUN,B2
+exklusiv,exclusive,独有的,ADJ,B2
+exklusivt,exclusively,专门地,ADV,B2
+exklusivitet,exclusivity,排他性,NOUN,B2
+bannlysa,to excommunicate,开除教籍,VERB,B2
+bannlysning,excommunication,绝罚,NOUN,B2
+skada,to excoriate,严厉批评,VERB,B2
+rättare,executioner,刽子手,NOUN,B2
+chef,executive,行政主管,NOUN,B2
+testamentsförvaltare,executor,遗嘱执行人,NOUN,B2
+exeges,exegesis,注释,NOUN,B2
+befria,to exempt,免除,VERB,B2
+undantag,exemption,豁免,NOUN,B2
+utandas,to exhale,呼气,VERB,B2
+utmatta,to exhaust,耗尽,VERB,B2
+utmattning,exhaustion,疲惫,NOUN,B2
+omfattande,exhaustive,详尽的,ADJ,B2
+visa,to exhibit,展览,VERB,B2
+mana,to exhort,劝告,VERB,B2
+exhumera,to exhume,掘出,VERB,B2
+fördriva,exile,流亡,NOUN,B2
+fördriva,to exile,流放,VERB,B2
+friklara,to exonerate,使无罪,VERB,B2
+expedition,expedition,探险,NOUN,B2
+utvisa,to expel,开除,VERB,B2
+använda,to expend,花费,VERB,B2
+utgift,expenditure,支出,NOUN,B2
+utgifter,expenses,费用,NOUN,B2
+utgång,expiry,失效,NOUN,B2
+uttrycklig,explicit,明确的,ADJ,B2
+exploatering,exploitation,利用,NOUN,B2
+upptäckare,explorer,探险家,NOUN,B2
+explosiv,explosive,爆炸性的,ADJ,B2
+exposition,exposition,阐述,NOUN,B2
+exponering,exposure,暴露,NOUN,B2
+redogöra,to expound,阐述,VERB,B2
+expropriera,to expropriate,征用,VERB,B2
+expropriation,expropriation,征用,NOUN,B2
+utvisning,expulsion,驱逐,NOUN,B2
+förlängning,extension,延伸,NOUN,B2
+omfattande,extensive,广泛的,ADJ,B2
+utrota,to exterminate,消灭,VERB,B2
+utrotning,extermination,灭绝,NOUN,B2
+extern,external,外部的,ADJ,B2
+utdöende,extinction,灭绝,NOUN,B2
+utpressa,to extort,敲诈,VERB,B2
+utpressning,extortion,勒索,NOUN,B2
+extra,extra,群众演员,NOUN,B2
+extrahera,to extract,提取,VERB,B2
+extraktion,extraction,提取,NOUN,B2
+utlämna,to extradite,引渡,VERB,B2
+utlämning,extradition,引渡,NOUN,B2
+extraordinarie,extraordinary,非凡的,ADJ,B2
+extrapolera,to extrapolate,推断,VERB,B2
+extravagans,extravagance,奢侈,NOUN,B2
+extrem,extreme,أقصى,NOUN,B2
+extroversion,extroversion,外向,NOUN,B2
+jubla,to exult,狂喜,VERB,B2
+jubel,exultation,欢腾,NOUN,B2
+ögonbryn,eyebrow,眉毛,NOUN,B2
+ögonfrans,eyelash,睫毛,NOUN,B2
+ögonvittne,eyewitness,目击,NOUN,B2
+fabel,fable,寓言,NOUN,B2
+tyg,fabric,织物,NOUN,B2
+förfalska,to fabricate,捏造,VERB,B2
+förfalskning,fabrication,捏造,NOUN,B2
+möta,to face,面对,VERB,B2
+ansiktsläsning,face reading,面相,NOUN,B2
+ansiktsigenkänning,face recognition,认人,NOUN,B2
+underlätta,to facilitate,促进,VERB,B2
+anläggning,facilities,设施,NOUN,B2
+faksimil,facsimile,副本,NOUN,B2
+fraktion,faction,派,NOUN,B2
+faktor,factor,因素,NOUN,B2
+fakultet,faculty,学院,NOUN,B2
+blekna,to fade,褪色,VERB,B2
+bleknad,faded,褪色的,ADJ,B2
+misslyckat bud,failed bid,流标,NOUN,B2
+svimning,fainting,晕厥,NOUN,B2
+mässa,fair,交易会,NOUN,B2
+fä,fairy,仙女,NOUN,B2
+saga,fairy tale,童话,NOUN,B2
+tro,faith,信仰,NOUN,B2
+falsk,fake,假的,ADJ,B2
+falk,falcon,猎鹰,NOUN,B2
+höst,fall,瀑布,NOUN,B2
+dra sig tillbaka,to fall back,回落,VERB,B2
+bli sjuk,to fall ill,患病,VERB,B2
+förälska sig,to fall in love,坠入爱河,VERB,B2
+felföljd,fallacy,谬误,NOUN,B2
+bråk,falling out,反目,NOUN,B2
+genomfall,falling though,虽坠,NOUN,B2
+lögn,falsehood,谎言,NOUN,B2
+förfalska,to falsify,伪造,VERB,B2
+falskhet,falsity,虚假,NOUN,B2
+berömmelse,fame,名声,NOUN,B2
+bekant,familiar,熟悉的,ADJ,B2
+bekantskap,familiarity,مألوف,NOUN,B2
+familjemedlem,family member,家庭成员,NOUN,B2
+familjeförfall,family ruin,家破,NOUN,B2
+anhängare,fan,粉丝,NOUN,B2
+fanatism,fanaticism,狂热,NOUN,B2
+långt,far,远的,ADJ,B2
+jordbruk,farming,农业,NOUN,B2
+fascination,fascination,魅力,NOUN,B2
+snabb,fast quick,快的,ADJ,B2
+fasta,fasting,禁食,NOUN,B2
+dödlig,fatal,致命的,ADJ,B2
+far,father,父,PART,B2
+utmattning,fatigue,疲劳,NOUN,B2
+fel,fault,错误,NOUN,B2
+gunst,favor,恩惠,NOUN,B2
+förmånliga omständigheter,favorable circumstances,顺境,NOUN,B2
+favorit,favorite,最喜欢的,ADJ,B2
+genomförbarhet,feasibility,可行性,NOUN,B2
+genomförbar,feasible,可行的,ADJ,B2
+bedrift,feat,功绩,NOUN,B2
+federal,federal,联邦的,ADJ,B2
+federalism,federalism,联邦主义,NOUN,B2
+foder,feed,饲料,NOUN,B2
+återkoppling,feedback,反馈,NOUN,B2
+avgift,fees,酬金,NOUN,B2
+kamrat,fellow,家伙,NOUN,B2
+brott,felony,重罪,NOUN,B2
+kvinna,female,雌性,NOUN,B2
+kvinnliga släktingar,female relatives,女眷,NOUN,B2
+kvinnlighet,femininity,女性气质,NOUN,B2
+feminism,feminism,女权主义,NOUN,B2
+fäktning,fencing,击剑,NOUN,B2
+fänkål,fennel,茴香,NOUN,B2
+jäsa,to ferment,发酵,VERB,B2
+jästning,fermentation,发酵,NOUN,B2
+vildhet,ferocity,凶猛,NOUN,B2
+fruktbarhet,fertility,肥沃,NOUN,B2
+befruktning,fertilization,施肥,NOUN,B2
+gödselmedel,fertilizer,肥料,NOUN,B2
+söndra,to fester,溃烂,VERB,B2
+festival,festival,节日,NOUN,B2
+foster,fetus,胎儿,NOUN,B2
+fejd,feud,世仇,NOUN,B2
+feodal,feudal,封建,ADJ,B2
+feodalism,feudalism,封建主义,NOUN,B2
+få,few,很少的,ADJ,B2
+fiber,fiber,纤维,NOUN,B2
+fibrosis,fibrosis,纤维化,NOUN,B2
+fiction,fiction,小说,NOUN,B2
+fictional,fictional,虚构的,ADJ,B2
 fierce,fierce,凶猛的,ADJ,B2
-fierce one,fierce one,词,NOUN,B2
 fierceness,fierceness,凶猛,NOUN,B2
 fifth,fifth,خامس,ADJ,B2
-fig,fig,词,NOUN,C1
-fig tree,fig tree,词,NOUN,C1
-fight back,fight back,抗击,VERB,C1
-fighting,fighting,词,NOUN,B2
-figuration,figuration,群演,NOUN,B2
-figurative,figurative,比喻的,ADJ,B2
-figurative language,figurative language,词,NOUN,C1
-figuratively,figuratively,比喻地,ADV,B2
-figure skating,figure skating,花样滑冰,NOUN,C1
-fil,lane,小巷,NOUN,B2
-filament,filament,词,NOUN,C1
-filch,filch,词,VERB,C1
-file a case,file a case,立案,VERB,B2
-file expense,file expense,报账,VERB,B2
 filial,filial,孝顺,ADJ,B2
-filibuster,filibuster,词,NOUN,C1
-filigree,filigree,词,NOUN,C1
-filings,filings,词,NOUN,C1
-filipino,filipino,菲律宾的,ADJ,B2
 fill in,to fill in,填写,VERB,B2
-fill pack,fill pack,装满,VERB,B2
-fillet (noun),fillet,词,NOUN,C1
-fillet (verb),fillet,词,VERB,C1
-filling,filling,词,NOUN,B2
 film,film,电影,NOUN,B2
-film,movie,电影,NOUN,B2
-film art,film art,词,NOUN,C1
-film director,film director,词,NOUN,B2
-film industry,film industry,电影业,NOUN,B2
-film roll,film roll,胶卷,NOUN,B2
-film star,film star,,NOUN,B2
-film studio,film studio,电影制片厂,NOUN,B2
-filming,filming,拍摄,NOUN,B2
-filmmaker,filmmaker,词,NOUN,C1
 filter,filter,过滤器,NOUN,B2
 filter,to filter,过滤,VERB,B2
-filter (noun),filter,词,NOUN,B2
-filth garbage,filth garbage,词,NOUN,C1
-filthy,filthy,肮脏的,ADJ,B2
-fin,pretty,漂亮的,ADJ,B2
-fin,fin,词,NOUN,B2
 final,final,最终的,ADJ,B2
-final (noun),final,决赛,NOUN,B1
-final account,final account,决算,NOUN,B2
-final accounts,final accounts,决算,NOUN,C1
-final exam,final exam,期末考,NOUN,B2
-final gathering,final gathering,末日集合,NOUN,C1
-final judgment,final judgment,终审,NOUN,C1
-final score,final score,最终比分,NOUN,B2
 final stage,final stage,末期,NOUN,B2
-finality,finality,词,NOUN,C1
-finals,finals,决赛,NOUN,B1
-finance,finance,金融,NOUN,B2
 financial,financial,财务的,ADJ,B2
-financial center,financial center,金融中心,NOUN,B2
-financial liability,financial liability,词,NOUN,C1
-financial loss,financial loss,赔本,NOUN,C1
-financially,financially,词,ADV,B2
-financier,financier,资助者,NOUN,B2
-financing funding,financing funding,融资,NOUN,B2
-find back,find back,找回来,NOUN,C1
 find out,to find out,找出,VERB,B2
 finding,finding,发现,NOUN,B2
-finding comfort in company,finding comfort in company,寻得陪伴,NOUN,C1
 fine,fine,好的,ADJ,B2
-fine arts,fine arts,美术,NOUN,B1
-fine print,fine print,词,NOUN,C1
 fine skin,fine skin,细皮,NOUN,B2
-fine well,fine well,词,ADJ,A1
-finely,finely,词,ADV,C1
-finger toe,finger toe,手指/脚趾,NOUN,A1
-fingernail,fingernail,指甲,NOUN,B2
-finial,finial,词,NOUN,C1
-finish end,finish end,词,VERB,A1
-finished,finished,完蛋,VERB,C1
-finished laughter,finished laughter,笑完,NOUN,B2
 finishing,finishing,装修,NOUN,B2
 finite,finite,有限的,ADJ,B2
-finnas,to there's still time,来得及,VERB,B2
-finnish,finnish,芬兰的,ADJ,B2
-fint,pretense,假装,NOUN,B2
-fir forest,fir forest,杉林,NOUN,C1
-fir tree,fir tree,词,NOUN,B2
-firande,celebration,庆祝,NOUN,B2
-fire a gun,fire a gun,开枪,VERB,B2
-fire department,fire department,词,NOUN,B2
-fire extinguisher,fire extinguisher,词,NOUN,C1
-fire station,fire station,词,NOUN,C1
 firecracker,firecracker,鞭炮,NOUN,B2
-firedamp,firedamp,词,NOUN,C1
 firefighter,firefighter,消防员,NOUN,B2
 fireplace,fireplace,壁炉,NOUN,B2
-firework,firework,词,NOUN,B2
 fireworks,fireworks,烟花,NOUN,B2
 firm,firm,坚固的,ADJ,B2
-firm entrenchment,firm entrenchment,词,NOUN,C1
-firmament,firmament,词,NOUN,C1
-firmly,firmly,词,ADV,C1
 firmness,firmness,坚定,NOUN,B2
-first (noun),first,先将,NOUN,C1
-first (num),first,词,NUM,A2
-first aid,first aid,词,NOUN,B2
 first capping,first capping,首加缁布冠,NOUN,B2
 first draft,first draft,初稿,NOUN,B2
-first fruit,first fruit,初熟果实,NOUN,C1
-first instance,first instance,初审,NOUN,C1
 first merit,first merit,首功,NOUN,B2
 first of all,first of all,首先,ADV,B2
-first-class,first-class,一流,ADJ,B2
-firstly,firstly,首先,ADV,B2
-firstly (noun),firstly,先是,NOUN,C1
-fiscal,fiscal,词,ADJ,C1
-fiscal tax,fiscal tax,词,ADJ,B1
-fish bone,fish bone,词,NOUN,C1
-fish shop,fish shop,词,NOUN,A2
-fisheries,fisheries,词,NOUN,B2
 fisherman,fisherman,渔夫,NOUN,B2
-fishery,fishery,渔业,NOUN,B2
-fishhook,fishhook,词,NOUN,B2
-fishing,fishing,钓鱼,NOUN,B2
-fishing rod,fishing rod,钓竿,NOUN,B2
-fishmonger,fishmonger,词,NOUN,B2
 fission,fission,裂变,NOUN,B2
-fissure,fissure,裂缝,NOUN,B2
 fist,fist,拳头,NOUN,B2
-fistula,fistula,瘘管,NOUN,B2
-fit,fit,适合的,ADJ,B2
-fit (noun),fit,词,NOUN,B2
-fitting out,fitting out,词,NOUN,B2
-fittings,fittings,水龙头配件,NOUN,B2
-five (adj),five,词,ADJ,C1
-five organs,five organs,五脏,NOUN,B2
-five-year term,five-year term,词,NOUN,C1
-fixation,fixation,词,NOUN,C1
-fixed-term imprisonment,fixed-term imprisonment,有期徒刑,NOUN,C1
-fizz,fizz,词,VERB,C1
-fizzle,fizzle,词,VERB,C1
-fjolla,silly girl,傻丫头,NOUN,B2
-fjäril,butterfly,蝴蝶,NOUN,B2
-fjärrstyrd bil,remote-controlled car,遥控车,NOUN,B2
-flabbergast,flabbergast,词,VERB,C1
-flabby,flabby,词,ADJ,B2
-flaccid,flaccid,松弛的,ADJ,B2
-flaccidity,flaccidity,词,NOUN,C1
-fladdermus,bat,蝙蝠,NOUN,B2
-fladdra,to flutter,飘动,VERB,B2
-flag (part),flag,旗,PART,C1
-flagellation,flagellation,词,NOUN,C1
-flagrancy,flagrancy,现行,NOUN,B2
-flagrant,flagrant,词,ADJ,C1
-flagrante delicto,flagrante delicto,词,NOUN,C1
-flail,flail,词,VERB,C1
-flair,flair,词,NOUN,C1
-flake (noun),flake,词,NOUN,C1
-flake (verb),flake,词,VERB,C1
-flakig,flimsy,脆弱的,ADJ,B2
-flame retardant,flame retardant,阻燃剂,NOUN,C1
-flaming,flaming,词,ADJ,C1
-flammable,flammable,易燃的,ADJ,B2
-flammable ice,flammable ice,可燃冰,NOUN,C1
-flange,flange,词,NOUN,C1
+passa,to fit,适合,VERB,B2
+kondition,fitness,健康,NOUN,B2
 flank,flank,侧翼,NOUN,B2
-flank (verb),flank,词,VERB,C1
-flanking,flanking,包抄,NOUN,B2
-flare,flare,词,VERB,C1
-flash (noun),flash,词,NOUN,B2
-flashback,flashback,词,NOUN,C1
-flashlight,flashlight,手电筒,NOUN,B2
 flaska,flask,小瓶,NOUN,B2
-flat (noun),flat,词,NOUN,B1
-flat rate,flat rate,词,NOUN,B2
-flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
-flat-rate,flat-rate,词,ADJ,C1
-flatterer,flatterer,词,NOUN,C1
-flattering,flattering,词,ADJ,C1
-flaunt,flaunt,词,VERB,C1
-flawed,flawed,词,ADJ,C1
-flay,flay,词,VERB,C1
-flea,flea,蚤,NOUN,C1
-flea chip,flea chip,词,NOUN,B2
-fleck,fleck,词,NOUN,C1
-fleece (noun),fleece,词,NOUN,C1
-flemish,flemish,佛兰芒的,ADJ,B2
-flesh,flesh,肉,NOUN,B2
-flex,flex,词,VERB,C1
-flexibel,flexible,灵活的,ADJ,B2
+smickeri,flattery,奉承,NOUN,B2
+smak,flavor,味道,NOUN,B2
+brist,flaw,缺陷,NOUN,B2
+fly,to flee,逃跑,VERB,B2
+flyktig,fleeting,短暂的,ADJ,B2
 flexibilitet,flexibility,灵活性,NOUN,B2
-flexion,flexion,词,NOUN,C1
-flick,flick,词,VERB,C1
-flicker,flicker,词,VERB,C1
-flina,to grin,咧嘴笑,VERB,B2
-flinch,flinch,词,VERB,C1
-fling (noun),fling,词,NOUN,C1
-fling (verb),fling,词,VERB,C1
-flint,flint,燧石,NOUN,B2
-flip,flip,词,VERB,B2
-flirt (noun),flirt,词,NOUN,B2
-flirt (verb),flirt,词,VERB,B2
-flirtation,flirtation,词,NOUN,C1
-flirting,flirting,词,NOUN,C1
-flit,flit,词,VERB,C1
-flitig,diligent,勤奋的,ADJ,B2
-float (noun),float,词,NOUN,B2
-floating,floating,漂浮的,ADJ,B2
-floating (noun),floating,词,NOUN,C1
-floating dust,floating dust,浮尘,NOUN,B2
+flexibel,flexible,灵活的,ADJ,B2
+flakig,flimsy,脆弱的,ADJ,B2
 flock,flock,兽群,NOUN,B2
-flodbank,riverbank,河岸,NOUN,B2
-flogging,flogging,词,NOUN,C1
-flooded,flooded,词,ADJ,B2
-floor mat,floor mat,地垫,NOUN,C1
-floor projectile,floor projectile,词,NOUN,C1
-floor story,floor story,词,NOUN,A2
-floorboard,floorboard,木地板,NOUN,B2
-flop,flop,词,VERB,C1
+översvämning,flood,洪水,NOUN,B2
 flora,flora,植物群,NOUN,B2
 flora,to flourish,繁荣,VERB,B2
-floral,floral,词,ADJ,C1
-florid,florid,辞藻华丽的,ADJ,B2
-florist,florist,词,NOUN,C1
-flotation,flotation,词,NOUN,C1
-flounce,flounce,词,VERB,C1
-flounder,flounder,词,VERB,C1
-floundering,floundering,词,NOUN,C1
-flourishing,flourishing,繁荣的,ADJ,B2
-flourishing (noun),flourishing,词,NOUN,C1
-flow rate,flow rate,流量,NOUN,B2
-flower arranging,flower arranging,整花,NOUN,C1
-flower bed,flower bed,花圃,NOUN,C1
-flower shadow,flower shadow,花影,NOUN,C1
-flowerbed stalls,flowerbed stalls,词,NOUN,C1
-flowering,flowering,开花,NOUN,B2
-flowery,flowery,华丽的,ADJ,B2
-fluctuating,fluctuating,波动的,ADJ,B2
-fluency,fluency,流利,NOUN,B2
-fluently,fluently,词,ADV,C1
-fluff,fluff,词,NOUN,C1
-flug,fly,苍蝇,NOUN,B2
-fluid,fluid,液体,NOUN,B2
-fluid (adj),fluid,词,ADJ,B2
-fluidity,fluidity,词,NOUN,C1
-fluidize,fluidize,词,VERB,C1
-fluids,fluids,词,NOUN,C1
-fluke,fluke,词,NOUN,B2
-fluktuation,fluctuation,波动,NOUN,B2
-flunk,flunk,词,VERB,C1
-fluorescence,fluorescence,词,NOUN,C1
-fluorescent,fluorescent,词,ADJ,C1
-fluorine,fluorine,词,NOUN,C1
-flushing,flushing,潮红,NOUN,C1
-fluster (noun),fluster,词,NOUN,C1
-flustered,flustered,慌张,ADJ,B2
-flutist,flutist,词,NOUN,C1
-flutter (noun),flutter,词,NOUN,B2
-flux,flux,变迁,NOUN,B2
-fly,to abscond,潜逃,VERB,B2
-fly,to flee,逃跑,VERB,B2
-flying,flying,词,ADJ,B2
-flyktig,fleeting,短暂的,ADJ,B2
-flyover,flyover,词,NOUN,C1
-flytande,fluent,流利的,ADJ,B2
-flyting poems,flyting poems,词,NOUN,C1
-flytta,to move aside,移开,VERB,B2
-flytta,to move in,搬入,VERB,B2
-flytta,to relocate,调动,VERB,B2
-fläck,blemish,瑕疵,NOUN,B2
 flöde,flow,流动,NOUN,B2
+spenning,flu,流感,NOUN,B2
+fluktuation,fluctuation,波动,NOUN,B2
+flytande,fluent,流利的,ADJ,B2
 flöjt,flute,长笛,NOUN,B2
-foal,foal,马驹,NOUN,B2
-fob,fob,词,NOUN,C1
-focalization,focalization,词,NOUN,C1
-foder,feed,饲料,NOUN,B2
+fladdra,to flutter,飘动,VERB,B2
+flux,flux,变迁,NOUN,B2
+flug,fly,苍蝇,NOUN,B2
+skumig,foamy,多泡沫的,ADJ,B2
 foder,fodder,饲料,NOUN,B2
-foe,foe,敌友,NOUN,B2
-fog light,fog light,雾灯,NOUN,C1
-foggy,foggy,词,ADJ,C1
-foggy day,foggy day,雾天,NOUN,C1
-foil (noun),foil,词,NOUN,C1
-fold,fold,折痕,NOUN,B2
-fold over,fold over,词,VERB,C1
-foldable,foldable,词,ADJ,C1
-foliaceous,foliaceous,词,ADJ,C1
-foliage,foliage,枝叶,NOUN,B2
-foliar,foliar,词,ADJ,C1
-foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+mapp,folder,文件夹,NOUN,B2
 folk,folk,民间的,ADJ,B2
-folk (noun),folk,苍生,NOUN,B2
-folk oboe,folk oboe,词,NOUN,B2
-folk singer,folk singer,词,NOUN,C1
 folkliv,folklore,民俗,NOUN,B2
-folkloric,folkloric,词,ADJ,C1
-folkmassa,crowd,人群,NOUN,B2
-folksy,folksy,乡土的,ADJ,B2
-follower enthusiast,follower enthusiast,词,NOUN,C1
-followers,followers,词,NOUN,C1
-following (adp),following,词,ADP,C1
-following next,following next,词,ADJ,A2
-following the example of,following the example of,词,NOUN,C1
-folly,folly,愚妄,NOUN,C1
-foment,foment,词,VERB,C1
-fond,fund,基金,NOUN,B2
-fond of food,fond of food,词,ADJ,B1
-fondle,fondle,词,VERB,C1
-fondness,fondness,词,NOUN,B2
-fontän,fountain,喷泉,NOUN,B2
-food,food,食品的,ADJ,B2
-food chain,food chain,食物链,NOUN,C1
-food dish,food dish,菜,NOUN,A1
-food-processing,food-processing,食品加工的,ADJ,B2
-foolhardiness,foolhardiness,词,NOUN,C1
-foolishness,foolishness,词,NOUN,B1
-foot-warming,foot-warming,捂脚,NOUN,B2
-footage,footage,镜头长度,NOUN,B2
-football player,football player,词,NOUN,C1
-foothill,foothill,词,NOUN,B2
-footnote,footnote,词,NOUN,C1
-footsteps,footsteps,后尘,NOUN,C1
-footstool,footstool,词,NOUN,C1
-for a lifetime,for a lifetime,一辈子,ADV,A2
-for a long time,for a long time,很久,ADV,C1
-for a moment,for a moment,片刻,ADV,B2
-for a time,for a time,一度,ADV,B2
-for each other,for each other,相互,ADV,B2
-for guidance orientation,for guidance orientation,词,ADV,C1
-for hours,for hours,词,ADJ,B2
-for my sake,for my sake,词,ADV,C1
-for now (part),for now,权,PART,C1
-for that,for that,词,ADV,A2
-for that purpose,for that purpose,为此,ADV,B2
-for the,for the,词,ADP,A2
-for the sake of argument,for the sake of argument,词,ADV,C1
-for this,for this,为此,ADV,B2
-for this purpose,for this purpose,为此,ADV,B2
-for to,for to,为,ADP,B2
-for what purpose,for what purpose,为了什么目的,ADV,B2
-for your sake,for your sake,词,ADV,B2
-forage,forage,词,VERB,C1
-foray,foray,词,NOUN,C1
-forbear,forbear,词,VERB,C1
-forbearance,forbearance,词,NOUN,C1
-forbearing,forbearing,词,ADJ,C1
-forced labor,forced labor,词,NOUN,C1
-forceful,forceful,词,ADJ,B2
-forcing submission,forcing submission,词,NOUN,C1
-ford,ford,词,NOUN,B2
-fordringshavare,creditor,债权人,NOUN,B2
-fordringsrätt,creditor's right,债权,NOUN,B2
-forearm,forearm,词,NOUN,C1
-foreboding,foreboding,词,NOUN,C1
-forecast (verb),forecast,词,VERB,B2
-foreclose,foreclose,词,VERB,C1
-foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
-forecourt,forecourt,词,NOUN,C1
-foredoom,foredoom,词,VERB,C1
-forego,forego,词,VERB,C1
-foreground,foreground,词,NOUN,C1
-foreign currency,foreign currency,外币,NOUN,C1
-foreign debt,foreign debt,外债,NOUN,B2
-foreign exchange,foreign exchange,外汇,NOUN,B2
-foreknow,foreknow,词,VERB,C1
-foreman,foreman,词,NOUN,B2
-forenoon,forenoon,词,NOUN,A1
-forensic,forensic,法医的,ADJ,B2
-forensic evidence collection,forensic evidence collection,词,NOUN,C1
-foreshadow,foreshadow,词,VERB,C1
-foreshadowing,foreshadowing,词,NOUN,C1
-foreshorten,foreshorten,词,VERB,C1
-forest (adj),forest,词,ADJ,C1
-forest ranger,forest ranger,词,NOUN,C1
-forest-related,forest-related,词,ADJ,B2
-forestall,forestall,词,VERB,C1
-forestry,forestry,词,ADJ,C1
-foretell,foretell,词,VERB,C1
-forewarn,forewarn,词,VERB,C1
-foreword,foreword,词,NOUN,C1
-forfeit,forfeit,词,VERB,C1
-forfeiture,forfeiture,丧失,NOUN,B2
-forge (noun),forge,词,NOUN,C1
-forge ahead,forge ahead,进取,VERB,C1
-forged,forged,词,ADJ,C1
-forger,forger,词,NOUN,C1
-forgetfulness,forgetfulness,词,NOUN,B2
-forgetting,forgetting,你忘,NOUN,C1
-forging,forging,词,NOUN,C1
-forgiving,forgiving,词,ADJ,C1
-forgo,forgo,词,VERB,C1
-form,shape,形状,NOUN,B2
-formal notice,formal notice,词,NOUN,C1
-formalisera,to formalize,使正式化,VERB,B2
-formalism,formalism,形式主义,NOUN,B2
-formalist (adj),formalist,词,ADJ,C1
-formalist (noun),formalist,词,NOUN,C1
-formalitet,formality,礼节,NOUN,B2
-formally,formally,正式地,ADV,B2
-format,format,格式,NOUN,B2
-formation,formation,组建,NOUN,B2
-formell,formal,正式的,ADJ,B2
-former subordinates,former subordinates,旧部,NOUN,C1
-formulation,formulation,配方,NOUN,B2
-formörkelse,eclipse,日食,NOUN,B2
-fornicate,fornicate,词,VERB,C1
-forntiden,ancient times,古代,NOUN,B2
-forsake,forsake,词,VERB,C1
-forswear,forswear,词,VERB,C1
-fort,fort,堡垒,NOUN,B2
-forthcoming,forthcoming,词,ADJ,C1
-fortid,past,过去,NOUN,B2
-fortification,fortification,词,NOUN,C1
-fortjänstbevis,certificate of merit,奖状,NOUN,B2
-fortlet,fortlet,词,NOUN,C1
-fortsätta,to proceed,继续进行,VERB,B2
-fortsättning,continuation,延续,NOUN,B2
-fortuitous,fortuitous,偶然的,ADJ,B2
-fortune teller,fortune teller,占卜者,NOUN,B2
-forums,forums,词,NOUN,C1
-fossil,fossil,化石,NOUN,B2
-fossil fuel,fossil fuel,化石燃料,NOUN,B2
-fossilization,fossilization,词,NOUN,B2
-fossilized,fossilized,词,ADJ,C1
-fossils,fossils,化石,NOUN,C1
-foster,fetus,胎儿,NOUN,B2
-foster,foster,词,VERB,B2
+uppföljning,follow-up,跟进,NOUN,B2
+följare,follower,追随者,NOUN,B2
+livsmedel,foodstuff,食品,NOUN,B2
+dum,foolish,愚蠢的,ADJ,B2
 fotbrygga,footbridge,人行天桥,NOUN,B2
-fotgängarbro,pedestrian bridge,天桥,NOUN,B2
-fotgängare,pedestrian,行人,NOUN,B2
-foul,foul,词,NOUN,B2
-foul smell,foul smell,骚味,NOUN,B2
-foul-mouthed,foul-mouthed,词,ADJ,C1
-found a country,found a country,建国,VERB,B2
-foundation base,foundation base,基础,NOUN,B2
-foundation course,foundation course,基础课,NOUN,C1
-foundations,foundations,词,NOUN,C1
-founding,founding,成立,NOUN,B2
-four (adj),four,词,ADJ,C1
-four limbs,four limbs,四肢,NOUN,B2
-fourth (num),fourth,词,NUM,B1
-fowl,fowl,词,NOUN,C1
-foyer,foyer,词,NOUN,C1
-fractal,fractal,分形,NOUN,B2
+skor,footwear,鞋穿,NOUN,B2
+gratis,for free,免费,ADV,B2
+för det,for it,为此,ADV,B2
+för tillfället,for now,暂时,ADV,B2
+för ... skull,for the sake of,为了,ADP,B2
+för vad,for what,为了什么,ADV,B2
+i många år,for years,多年,ADV,B2
+förbjudet land,forbidden land,禁地,NOUN,B2
+kraft,force,力量,NOUN,B2
+tvångsvis,forcibly,强制地,ADV,B2
+prognos,forecast,预测,NOUN,B2
+utlänning,foreigner,外国人,NOUN,B2
+försyn,foresight,远见,NOUN,B2
+för alltid,forever,永远,ADV,B2
+förfalska,to forge,伪造,VERB,B2
+förfalskning,forgery,伪造品,NOUN,B2
+glömsk,forgetful,健忘的,ADJ,B2
+gaffel,fork,叉子,NOUN,B2
+formell,formal,正式的,ADJ,B2
+formalism,formalism,形式主义,NOUN,B2
+formalitet,formality,礼节,NOUN,B2
+formalisera,to formalize,使正式化,VERB,B2
+formation,formation,组建,NOUN,B2
+tidigare,former,以前的,ADJ,B2
+tidigare,formerly,以前,ADV,B2
+framåt,forth,向前,ADV,B2
+fästning,fortress,堡垒,NOUN,B2
+lycklig,fortunate,幸运的,ADJ,B2
+lycka,fortune,运气,NOUN,B2
+spådom,fortune telling,算命,NOUN,B2
+fossil,fossil,化石,NOUN,B2
+grundare,founder,创始人,NOUN,B2
+funnen,foundling,弃婴,NOUN,B2
+gjuteri,foundry,铸造厂,NOUN,B2
+fontän,fountain,喷泉,NOUN,B2
 fraction,fraction,分数,NOUN,B2
 fraction marker,fraction marker,分之,PART,B2
-fractional,fractional,分数的,ADJ,B2
 fracture,fracture,骨折,NOUN,B2
-fractured,fractured,词,ADJ,C1
 fragile,fragile,易碎的,ADJ,B2
-fragility,fragility,脆弱,NOUN,B2
 fragment,fragment,碎片,NOUN,B2
-fragmentary,fragmentary,零碎的,ADJ,B2
 fragmentation,fragmentation,碎片化,NOUN,B2
 fragrance,fragrance,香味,NOUN,B2
 fragrant,fragrant,芬芳的,ADJ,B2
-fraktion,faction,派,NOUN,B2
 frame,to frame,装框,VERB,B2
-frame of reference,frame of reference,词,NOUN,C1
-framework-related,framework-related,词,ADJ,C1
-framför,in front,在前面,ADV,B2
-framing,framing,词,NOUN,C1
-framträdande,conspicuous,显著的,ADJ,B2
-framåt,forth,向前,ADV,B2
 franchise,franchise,特许经营权,NOUN,B2
 frank,frank,坦率的,ADJ,B2
-frankly,frankly,坦率地,ADV,B2
 frankness,frankness,坦率,NOUN,B2
-frantic,frantic,狂乱的,ADJ,B2
-fraternal,fraternal,词,ADJ,C1
-fraternity,fraternity,词,NOUN,C1
-fratricide,fratricide,杀兄弟,NOUN,B2
-fraud prevention,fraud prevention,词,NOUN,C1
-fraudster,fraudster,词,NOUN,C1
-fraudulent,fraudulent,词,ADJ,C1
-fraudulent concealment,fraudulent concealment,词,NOUN,C1
-fray,fray,词,VERB,C1
-frayed,frayed,词,ADJ,C1
-frazzle,frazzle,词,VERB,C1
 freak,freak,怪人,NOUN,B2
-freckles,freckles,词,NOUN,B2
-freda,to appease,安抚,VERB,B2
-fredfull,peaceful,和平的,ADJ,B2
 free,to free,释放,VERB,B2
-free association,free association,词,NOUN,C1
-free of charge,free of charge,免费,NOUN,B2
-free of charge (adj),free of charge,免费,ADJ,A2
-free of charge (adv),free of charge,词,ADV,B1
 free time,free time,业余时间,NOUN,B2
-free trade,free trade,词,NOUN,C1
-free will,free will,词,NOUN,B2
-freedmen clients,freedmen clients,词,NOUN,C1
-freely,freely,自由地,ADV,B2
 freezing,freezing,冻结,NOUN,B2
-freezing (adj),freezing,极冷的,ADJ,B2
 freezing rain,freezing rain,冻雨,NOUN,B2
-freight,freight,货物,NOUN,B2
-french fry,french fry,词,NOUN,B2
-french-speaking,french-speaking,讲法语的,ADJ,B2
 frenzy,frenzy,疯狂,NOUN,B2
-frequencies,frequencies,词,NOUN,B2
-frequency (adj),frequency,词,ADJ,C1
 frequent,frequent,频繁的,ADJ,B2
 frequent,to frequent,常去,VERB,B2
-frequent (adj),frequent,词,ADJ,B2
-frequently,frequently,经常,ADV,B2
-fresco,fresco,壁画,NOUN,B2
-fresh soft,fresh soft,词,ADJ,A1
-freshly,freshly,新鲜地,ADV,B2
 freshness,freshness,新鲜,NOUN,B2
-freshness bloom,freshness bloom,清新/鲜艳,NOUN,C1
-fret,fret,词,VERB,C1
-friar,friar,词,NOUN,C1
 friction,friction,摩擦,NOUN,B2
-frictionless,frictionless,无摩擦的,ADJ,B2
-fried,fried,词,ADJ,B1
-fried food,fried food,词,NOUN,C1
-friend female,friend female,词,NOUN,A1
-friend male,friend male,词,NOUN,A1
-friends,friends,词,NOUN,B1
-friends with,friends with,词,ADJ,B2
-frieze,frieze,檐壁,NOUN,B2
-frigate,frigate,护卫舰,NOUN,B2
 fright,fright,惊吓,NOUN,B2
 frighten,to frighten,使害怕,VERB,B2
-frightful,frightful,词,ADJ,B1
-frigid,frigid,寒冷的,ADJ,B2
-frigöra,to release,释放,VERB,B2
-friklara,to exonerate,使无罪,VERB,B2
-frikänna,to acquit,宣告无罪,VERB,B2
-frill,frill,词,NOUN,C1
 fringe,fringe,边缘,NOUN,B2
-frisian,frisian,弗里斯兰的,ADJ,B2
-frisk,frisk,词,VERB,C1
-frisör,hairdresser,理发师,NOUN,B2
-fritid,leisure,闲暇,NOUN,B2
-fritid,spare time,业余,NOUN,B2
-fritter,fritter,词,VERB,C1
-frivol,frivol,词,VERB,C1
-frivolous,frivolous,轻浮的,ADJ,B2
-frizz,frizz,词,VERB,C1
-frock,frock,词,NOUN,C1
-from Cadiz,from Cadiz,词,ADJ,C1
-from Granada,from Granada,词,ADJ,C1
-from Havana,from Havana,词,ADJ,C1
-from Seville,from Seville,词,ADJ,C1
-from as of,from as of,词,ADP,A2
-from away from,from away from,离,ADP,B2
-from beginning to end,from beginning to end,始终,ADV,B2
-from brocade,from brocade,从锦,NOUN,C1
 from childhood,from childhood,从小,ADV,B2
-from day,from day,日起,NOUN,B2
-from each other,from each other,词,ADV,C1
-from it,from it,从中,ADV,B2
 from now on,from now on,今后,ADV,B2
-from one,from one,从一,NOUN,C1
-from onward,from onward,词,ADP,A1
-from tavern,from tavern,从醉仙楼,NOUN,C1
-from the,from the,词,ADP,C1
-from then on,from then on,从此,ADV,B2
-from this,from this,由此,ADV,B2
-from time to time,from time to time,不时,ADV,B2
-from what,from what,词,ADV,B2
-from which,from which,从中,ADV,B2
-fromhet,piety,虔诚,NOUN,B2
 front,front,前面,NOUN,B2
-front line,front line,前线,NOUN,B2
-front part,front part,前部,NOUN,C1
-front scout,front scout,前方探子来,NOUN,C1
-frontier,frontier,前沿,NOUN,B2
-frontiers,frontiers,词,NOUN,C1
-frontispiece,frontispiece,词,NOUN,C1
-frontrunner,frontrunner,词,NOUN,C1
 frost,frost,霜,NOUN,B2
-frostbite,frostbite,冻伤,NOUN,B2
-frosted,frosted,词,ADJ,C1
-frosty,frosty,词,ADJ,A1
-froth,froth,泡沫,NOUN,B2
-frown (noun),frown,frown,NOUN,B2
-frown (verb),frown,词,VERB,C1
-frowning,frowning,词,NOUN,C1
-frozen (noun),frozen,词,NOUN,B2
-fructify,fructify,词,VERB,C1
 frugal,frugal,节俭的,ADJ,B2
-frugality,frugality,节俭,NOUN,B2
-fruit juice,fruit juice,果汁,NOUN,A1
-fruit tree,fruit tree,果树的,ADJ,B2
-fruitful,fruitful,词,ADJ,C1
-fruitfully,fruitfully,词,ADV,C1
-fruiting,fruiting,词,ADJ,C1
-fruitless,fruitless,词,ADJ,C1
-frukosta,to have breakfast,吃早餐,VERB,B2
-fruktbarhet,fertility,肥沃,NOUN,B2
-fruktodling,orchard,果园,NOUN,B2
 frustrate,to frustrate,挫败,VERB,B2
 frustrating,frustrating,令人沮丧的,ADJ,B2
 frustration,frustration,挫折,NOUN,B2
-fryer,fryer,词,NOUN,C1
 frying pan,frying pan,平底锅,NOUN,B2
-fräckhet,brazenness,厚颜无耻,NOUN,B2
-främmande trupper,strange troops,怪兵,NOUN,B2
-främmandegörande,alienation,异化,NOUN,B2
-frånmärdhet,estrangement,疏离,NOUN,B2
-frånvarande,to be absent,缺席,VERB,B2
-frö,seed,种子,NOUN,B2
-fuchsia,fuchsia,词,NOUN,C1
-fuddle,fuddle,词,VERB,C1
-fudge,fudge,词,NOUN,C1
-fuel gauge,fuel gauge,油表,NOUN,C1
-fuels,fuels,词,NOUN,B2
-fuels hydrocarbons,fuels hydrocarbons,词,NOUN,C1
-fugitive (adj),fugitive,词,ADJ,B2
-fugitive (noun),fugitive,词,NOUN,B2
-fuktig,moist,潮湿的,ADJ,B2
-fuktighet,humidity,湿度,NOUN,B2
-fulcrum,fulcrum,词,NOUN,C1
-fulfil,fulfil,词,VERB,C1
-fulfilled,fulfilled,满足的,ADJ,B2
-fulfillment,fulfillment,满足,NOUN,B2
-full amount,full amount,足足,NOUN,C1
-full fed up,full fed up,词,ADJ,B1
-full makt,full power,全力,NOUN,B2
-full moon banquet,full moon banquet,满月酒,NOUN,C1
 full name,full name,大名,NOUN,B2
-full of life,full of life,充满活力的,ADJ,B2
-full payment,full payment,全款,NOUN,C1
-full satiated,full satiated,词,ADJ,A2
-full-fledged,full-fledged,词,ADJ,C1
-full-time,full-time,全职,ADJ,B2
-fullness,fullness,词,NOUN,C1
-fully,fully,词,ADV,C1
-fulminate,fulminate,词,VERB,C1
-fumarole,fumarole,词,NOUN,C1
-fumble,fumble,词,VERB,C1
-fume,fume,词,NOUN,C1
-fumigation,fumigation,词,NOUN,C1
-functionalism,functionalism,功能主义,NOUN,B2
-functioning operation,functioning operation,词,NOUN,B1
-fundamental rights,fundamental rights,词,NOUN,C1
-fundamentalism,fundamentalism,原教旨主义,NOUN,B2
-fundamentally,fundamentally,词,ADV,C1
-fundera,to ponder,沉思,VERB,B2
-fundraise,fundraise,募款,VERB,C1
-fundraiser,fundraiser,词,NOUN,C1
-fundraising,fundraising,集资,NOUN,C1
-funds,funds,经费,NOUN,C1
-funeral (adj),funeral,词,ADJ,C1
-funeral rites,funeral rites,词,NOUN,C1
-funerary,funerary,丧葬的,ADJ,B2
-funereal,funereal,丧葬的,ADJ,B2
-fungal,fungal,词,ADJ,C1
-fungera,to work out,成功,VERB,B2
-fungi,fungi,词,NOUN,B2
-fungibility,fungibility,词,NOUN,C1
-fungus,fungus,真菌,NOUN,C1
-funktionalitet,functionality,功能性,NOUN,B2
+full makt,full power,全力,NOUN,B2
 funktionell,functional,功能的,ADJ,B2
-funktionsnedsatt,disabled,残疾的,ADJ,B2
-funktionsnedsättning,disability,残疾,NOUN,B2
-funnel,funnel,漏斗,NOUN,B2
-funnen,foundling,弃婴,NOUN,B2
-furbish,furbish,词,VERB,C1
+functionalism,functionalism,功能主义,NOUN,B2
+funktionalitet,functionality,功能性,NOUN,B2
+fond,fund,基金,NOUN,B2
+fundamentalism,fundamentalism,原教旨主义,NOUN,B2
+utrusta,to furnish,提供,VERB,B2
+vidare,further,进一步的,ADJ,B2
+dessutom,furthermore,此外,ADV,B2
 furi,fury,狂怒,NOUN,B2
-furl,furl,词,VERB,C1
-furlough (noun),furlough,词,NOUN,C1
-furnished,furnished,词,ADJ,B2
-furnishing,furnishing,室内布置,NOUN,B2
-furrow,furrow,犁沟,NOUN,B2
-further (adj),further,进一步,ADJ,A2
-further debate,further debate,再辩,NOUN,B2
-further on,further on,更远处,ADV,B2
-further study,further study,进修,NOUN,C1
-further to in reference,further to in reference,词,ADV,C1
-furtive,furtive,鬼鬼祟祟的,ADJ,B2
-furtively,furtively,词,ADV,C1
-furuncle,furuncle,词,NOUN,C1
+smyga,fuse,保险丝,NOUN,B2
 fuselå,fuselage,机身,NOUN,B2
 fusion,fusion,融合,NOUN,B2
-fuskmod,deception dare,你敢骗我,NOUN,B2
-fussy,fussy,挑剔的,ADJ,B2
-futile,futile,词,ADJ,C1
+bråk,fuss,大惊小怪,NOUN,B2
 futilitet,futility,无用,NOUN,B2
-future prospects,future prospects,出息,AUX,B2
-futures,futures,期货,NOUN,C1
 futurism,futurism,未来主义,NOUN,B2
-futurist,futurist,词,NOUN,C1
-futuristic,futuristic,词,ADJ,C1
-fuzzy,fuzzy,词,ADJ,C1
-fyrkantig,square,平方的,ADJ,B2
-fysiologi,physiology,生理学,NOUN,B2
-fä,fairy,仙女,NOUN,B2
-fäktning,fencing,击剑,NOUN,B2
-fängsla,to imprison,监禁,VERB,B2
-fängslande,imprisonment,监禁,NOUN,B2
-fänkål,fennel,茴香,NOUN,B2
-fästa,to cling,紧贴,VERB,B2
-fästning,fortress,堡垒,NOUN,B2
-få,few,很少的,ADJ,B2
-få,to obtain,获得,VERB,B2
-få post,to receive mail,收件,VERB,B2
-få världsomspännande uppmärksamhet,to receive worldwide attention,举世瞩目,VERB,B2
-fågelkött,poultry,家禽,NOUN,B2
-fångst,catch,捕捉,NOUN,B2
-föda,sustenance,食物,NOUN,B2
-följa,to comply with,遵守,VERB,B2
-följaktligen,consequently,因此,ADV,B2
-följare,follower,追随者,NOUN,B2
-följe,entourage,随从,NOUN,B2
-fönsterruta,window glass,窗玻璃,NOUN,B2
-för ... skull,for the sake of,为了,ADP,B2
-för alltid,forever,永远,ADV,B2
-för att,in order to,以期,SCONJ,B2
-för att inte,lest,唯恐,SCONJ,B2
-för att inte tala om,let alone,别说,ADV,B2
-för det,for it,为此,ADV,B2
-för länge sedan,long ago,早已,ADV,B2
-för mjuk,too soft,太软,NOUN,B2
-för mycket,too much,太,ADV,B2
-för närvarande,currently,目前,ADV,B2
-för tillfället,for now,暂时,ADV,B2
-för vad,for what,为了什么,ADV,B2
-föraktlig,despicable,可鄙的,ADJ,B2
-förbannad,cursed,被诅咒的,ADJ,B2
-förbereda,to prepare a lesson,预习,VERB,B2
-förberedelse,preparation,准备,NOUN,B2
-förbindelse,liaison,联络,NOUN,B2
-förbjuda,to ban,禁止,VERB,B2
-förbjuda,to prohibit,禁止,VERB,B2
-förbjudet land,forbidden land,禁地,NOUN,B2
-förbluffande,stunning,极好的,ADJ,B2
-förbrylla,puzzle,谜题,NOUN,B2
-förbrylla,to puzzle,使困惑,VERB,B2
-förbrytare,delinquent,罪犯,NOUN,B2
-förbud,prohibition,禁止,NOUN,B2
-förbund,covenant,契约,NOUN,B2
-förbättring,improvement,好转,NOUN,B2
-fördjupa,to deepen,加深,VERB,B2
-fördriva,exile,流亡,NOUN,B2
-fördriva,to exile,流放,VERB,B2
-fördunsta,to evaporate,蒸发,VERB,B2
-fördunstning,evaporation,蒸发,NOUN,B2
-föregå,to precede,在...之前,VERB,B2
-föregå,to progress,进步,VERB,B2
-föregångare,precursor,先驱,NOUN,B2
-föregångare,predecessor,前任,NOUN,B2
-förekomst,occurrence,发生,NOUN,B2
-förening,compound,复合性,ADJ,B2
-förenkla,to simplify,简化,VERB,B2
-föreskriva,to prescribe,开处方,VERB,B2
-föreställa sig,to envision,展望,VERB,B2
-företag,enterprise,企业,NOUN,B2
-förevändning,pretext,借口,NOUN,B2
-förfader,ancestor,祖先,NOUN,B2
-förfallen,due,到期的,ADJ,B2
-förfalska,to fabricate,捏造,VERB,B2
-förfalska,to falsify,伪造,VERB,B2
-förfalska,to forge,伪造,VERB,B2
-förfalskning,fabrication,捏造,NOUN,B2
-förfalskning,forgery,伪造品,NOUN,B2
-författare,writer,作家,NOUN,B2
-förfolgelse,persecution,迫害,NOUN,B2
-förfära,to horrify,使惊骇,VERB,B2
-förfärande,horrifying,令人毛骨悚然的,ADJ,B2
-förfärlighet,disdain,蔑视,NOUN,B2
-förhandling,negotiations,谈判,NOUN,B2
-förhör,questioning,质问,NOUN,B2
-förintelse,annihilation,寂灭,NOUN,B2
-förkasta,to discard,丢弃,VERB,B2
-förklara,to declare,宣布,VERB,B2
-förkläde,apron,围裙,NOUN,B2
-förlag,publishing house,出版社,NOUN,B2
-förlänga,to prolong,延长,VERB,B2
-förlängning,extension,延伸,NOUN,B2
-förmana,to admonish,告诫,VERB,B2
-förmyndare,guardian,守卫,NOUN,B2
-förmyndarskap,guardianship,监护,NOUN,B2
-förmyndarskap,tutelage,监护,NOUN,B2
-förmågen,able,能够的,ADJ,B2
-förmånliga omständigheter,favorable circumstances,顺境,NOUN,B2
-förnedra,to humiliate,羞辱,VERB,B2
-förnedring,humiliation,羞辱,NOUN,B2
-förnya,to renew,更新,VERB,B2
-förnybar,renewable,可再生的,ADJ,B2
-förord,preface,序言,NOUN,B2
-förordna,decree,法令,NOUN,B2
-förordna,to decree,颁布法令,VERB,B2
-förorena,to contaminate,污染,VERB,B2
-försegla,to seal,密封,VERB,B2
-försenad,overdue,逾期,ADJ,B2
-försening,delay,延迟,NOUN,B2
-försiktig,cautious,小心的,ADJ,B2
-försiktig och samvetsgrann,cautious and conscientious,兢兢业业,ADJ,B2
-försiktighet,caution,谨慎,NOUN,B2
-försiktighet,prudence,谨慎,NOUN,B2
-försiktighetsåtgärd,precaution,预防措施,NOUN,B2
-förslag,proposal,提议,NOUN,B2
-förslag,suggestion,建议,NOUN,B2
-försloka,to embezzle,贪污,VERB,B2
-förslokning,embezzlement,贪污,NOUN,B2
-försoning,reconciliation,和解,NOUN,B2
-förstoppning,constipation,便秘,NOUN,B2
-förstora,to enlarge,扩大,VERB,B2
-förstå,to comprehend,理解,VERB,B2
-förståelse,comprehension,理解,NOUN,B2
-förstöra,to spoil,损坏,VERB,B2
-förstöras,to perish,死亡,VERB,B2
-förstörelse,destruction,破坏,NOUN,B2
-försumma,to neglect,忽视,VERB,B2
-försvara sitt land,to defend one's country,卫国,VERB,B2
-försvinnande,disappearance,消失,NOUN,B2
-försyn,foresight,远见,NOUN,B2
-försäkran,reassurance,安抚,NOUN,B2
-försämras,to deteriorate,恶化,VERB,B2
-försörjningsmedel,provisions,储备,NOUN,B2
-förtroende,reliance,信赖,NOUN,B2
-förtrollad,to be entranced,出神,VERB,B2
-förtrupp,vanguard,先锋,NOUN,B2
-förtryck,oppression,压迫,NOUN,B2
-förtrycka,to oppress,压迫,VERB,B2
-förtrylla,to enchant,使着迷,VERB,B2
-förtryllande,enchanting,迷人的,ADJ,B2
-förundras,to marvel,使惊奇,VERB,B2
-förutsatt att,provided that,只要,SCONJ,B2
-förutsäga,to predict,预测,VERB,B2
-förutsägelse,prediction,预测,NOUN,B2
-förvränga,to distort,扭曲,VERB,B2
-förvrängning,distortion,扭曲,NOUN,B2
-förvänta,to anticipate,预期,VERB,B2
-förväntan,anticipation,预期,NOUN,B2
-förvärra,to exacerbate,加剧,VERB,B2
-förvärra,to worsen,恶化,VERB,B2
-förvärring,exacerbation,加剧,NOUN,B2
-förvärv,acquisition,获得,NOUN,B2
-förädla,to ennoble,使高贵,VERB,B2
-föräldralöst barn,orphan,孤儿,NOUN,B2
-förälska sig,to fall in love,坠入爱河,VERB,B2
-förälskelse,infatuation,迷恋,NOUN,B2
-föråldrad,obsolete,过时的,ADJ,B2
-föråldrad,outdated,过时的,ADJ,B2
-förödelse,devastation,破坏,NOUN,B2
-gad,gad,词,VERB,C1
-gaffel,fork,叉子,NOUN,B2
-gag,gag,词,NOUN,C1
-gainsay,gainsay,词,VERB,C1
-gala,gala,晚会,NOUN,C1
-galactic,galactic,词,ADJ,C1
-galician,galician,加利西亚的,ADJ,B2
-galla,bile,胆汁,NOUN,B2
-gallant,gallant,英勇的,ADJ,B2
+vinst,gain,收益,NOUN,B2
 gallanteri,gallantry,英勇,NOUN,B2
-gallbladder,gallbladder,词,NOUN,C1
 galleri,gallery,画廊,NOUN,B2
-gallery owner,gallery owner,词,NOUN,C1
-galley,galley,词,NOUN,C1
-gallon,gallon,词,NOUN,C1
-gallop,gallop,疾驰,NOUN,B2
-galloping,galloping,词,ADJ,C1
-gallows,gallows,词,NOUN,C1
-gallows humor,gallows humor,绞刑架幽默,NOUN,B2
 galoppa,to gallop,飞奔,VERB,B2
-galvanization,galvanization,词,NOUN,C1
-galvanized,galvanized,词,ADJ,C1
 gambla,gamble,赌博,NOUN,B2
 gambla,to gamble,赌博,VERB,B2
-gamble (noun),gamble,就赌,NOUN,C1
-gambling,gambling,词,NOUN,C1
-gambol,gambol,词,VERB,C1
-game rule,game rule,游戏规则,NOUN,B2
-gamete,gamete,配子,NOUN,B2
-gamla mästaren,old master,老太爷,NOUN,B2
-gammal tjänare,old servant,老奴,NOUN,B2
-gangrene,gangrene,坏疽,NOUN,B2
-gantry portal,gantry portal,词,NOUN,C1
-gaol,gaol,词,NOUN,C1
-garanti,guarantee,保证,NOUN,B2
-garanti,warranty,保修单,NOUN,B2
-garb,garb,词,NOUN,C1
-garbage,garbage,词,NOUN,B2
-garble,garble,词,VERB,C1
-gardening,gardening,园艺,NOUN,B2
-garderob,cloakroom,衣帽间,NOUN,B2
-gardinstång,curtain rod,窗帘杆,NOUN,B2
-gargle (noun),gargle,词,NOUN,C1
-gargle (verb),gargle,词,VERB,C1
-gargoyle,gargoyle,滴水嘴兽,NOUN,B2
-garland,garland,花环,NOUN,B2
-garment (part),garment,衣,PART,B2
-garment making,garment making,词,NOUN,C1
-garner,garner,词,VERB,C1
+trädgårdsmästare,gardener,园丁,NOUN,B2
+plagg,garment,服装,NOUN,B2
 garnera,to garnish,装饰,VERB,B2
 garnison,garrison,驻军,NOUN,B2
-garrison towns,garrison towns,词,NOUN,C1
-garvare,tanner,制革工,NOUN,B2
-garvning,tanning,晒黑,NOUN,B2
-gas pipeline,gas pipeline,词,NOUN,C1
-gash,gash,词,NOUN,C1
-gasket,gasket,词,NOUN,B1
-gasp (noun),gasp,词,NOUN,B2
-gasp (verb),gasp,词,VERB,B2
-gastronome,gastronome,词,NOUN,C1
-gastronomy,gastronomy,美食学,NOUN,B2
-gastroscopy,gastroscopy,胃镜,NOUN,B2
-gatekeeper,gatekeeper,道口看守员,NOUN,B2
-gateway,gateway,词,NOUN,C1
-gather (noun),gather,词,NOUN,C1
-gather happily,gather happily,欢聚,VERB,C1
-gauge (noun),gauge,词,NOUN,C1
-gauge meter,gauge meter,词,NOUN,C1
-gaunt,gaunt,词,ADJ,C1
-gauze,gauze,纱布,NOUN,C1
-gay,gay,快乐的,ADJ,B2
-gay man,gay man,男同性恋者,NOUN,B2
-gaze (noun),gaze,目视,NOUN,B2
-gazelle,gazelle,词,NOUN,B1
-gazette,gazette,词,NOUN,C1
-ge,yield,产量,NOUN,B2
-ge,to yield,产出,VERB,B2
-ge återkoppling,to provide feedback,反馈,VERB,B2
-gearbox,gearbox,变速箱,NOUN,B2
-geek,geek,极客,NOUN,C1
-geerziehung,geerziehung,词,NOUN,C1
-gefahrt,gefahrt,词,NOUN,B2
-gefassung,gefassung,词,NOUN,C1
-geforderung,geforderung,词,NOUN,B2
-gegabe,gegabe,词,NOUN,C1
-gegestaltung,gegestaltung,词,NOUN,C1
-gekunft,gekunft,词,NOUN,C1
-gel,gel,词,NOUN,C1
-gelatin,gelatin,词,NOUN,C1
-gelatinous,gelatinous,胶状的,ADJ,C1
-geld,geld,词,VERB,C1
-gem,gem,宝石,NOUN,B2
-gemensamhet,commonality,共同点,NOUN,B2
-gemenskap,community,社区,NOUN,B2
-gemstone,gemstone,词,NOUN,C1
+pratsam,garrulous,喋喋不休的,ADJ,B2
+mack,gas station,加油站,NOUN,B2
+sammankomst,gathering,聚集,NOUN,B2
+skåda,gaze,目视,NOUN,B2
+skåda,to gaze,凝视,VERB,B2
+utrustning,gear,齿轮,NOUN,B2
+kön,gender,性别,NOUN,B2
 gen,gene,基因,NOUN,B2
-genahme,genahme,词,NOUN,C1
-gendarme,gendarme,词,NOUN,B1
-gendarmerie,gendarmerie,词,NOUN,C1
-gender parity,gender parity,词,NOUN,C1
-gene therapy,gene therapy,基因治疗,NOUN,C1
 genealogi,genealogy,家谱学,NOUN,B2
-genealogical,genealogical,词,ADJ,C1
-genealogies,genealogies,家谱,NOUN,C1
-genealogist,genealogist,词,NOUN,C1
 general,general,将军,NOUN,B2
-general assembly,general assembly,词,NOUN,C1
-general course,general course,公共课,NOUN,B2
-general manager,general manager,总经理,NOUN,C1
-general practitioner,general practitioner,全科医生,NOUN,B2
-generalisera,to generalize,概括,VERB,B2
 generalisering,generalization,概括,NOUN,B2
-generality,generality,普遍性,NOUN,B2
-generally accepted,generally accepted,公认,ADJ,B2
-generally speaking,generally speaking,一般而言,ADV,B2
-generation,generation,一代人,NOUN,B2
-generation change,generation change,换代,NOUN,C1
-generational,generational,代际的,ADJ,B2
-generations,generations,词,NOUN,B2
-generative grammar,generative grammar,生成语法,NOUN,C1
-generator,generator,发电机,NOUN,B2
-generatrix,generatrix,母线,NOUN,B2
+generalisera,to generalize,概括,VERB,B2
 generellt,generally,通常,ADV,B2
 generera,to generate,产生,VERB,B2
-generic,generic,通用的,ADJ,B2
+generation,generation,一代人,NOUN,B2
+generator,generator,发电机,NOUN,B2
 generositet,generosity,慷慨,NOUN,B2
 genes,genesis,起源,NOUN,B2
-genesis emergence,genesis emergence,词,NOUN,C1
-genetic modification,genetic modification,基因改造,NOUN,B2
-genetically,genetically,遗传地,ADV,B2
-genetik,genetics,遗传学,NOUN,B2
 genetisk,genetic,基因的,ADJ,B2
-genial,genial,词,ADJ,C1
-genialisk,ingenious,灵巧的,ADJ,B2
-genital,genital,生殖器,NOUN,B2
-genocide,genocide,词,NOUN,B2
-genom,by means of,通过,ADP,B2
+genetik,genetics,遗传学,NOUN,B2
 genom,genome,基因组,NOUN,B2
-genomfall,falling though,虽坠,NOUN,B2
-genomförbar,feasible,可行的,ADJ,B2
-genomförbarhet,feasibility,可行性,NOUN,B2
-genomskåda,to see through,看穿,VERB,B2
-genomtränga,to penetrate,穿透,VERB,B2
-genomtränglig,permeable,可渗透的,ADJ,B2
-genomträngning,penetration,渗透,NOUN,B2
 genre,genre,类型,NOUN,B2
-genre classification,genre classification,词,NOUN,C1
-gentle reproach,gentle reproach,词,NOUN,C1
-gentlemen,gentlemen,词,NOUN,C1
-gentleness,gentleness,词,NOUN,C1
-gently,gently,轻轻地,ADV,B2
-gentrification,gentrification,词,NOUN,C1
-genuflect,genuflect,词,VERB,C1
-genuflection,genuflection,词,NOUN,C1
-genuine article,genuine article,真品,NOUN,C1
-genuine goods,genuine goods,真货,NOUN,C1
-genuine product,genuine product,正品,NOUN,B2
-genuineness,genuineness,真成,NOUN,C1
-genus,genus,词,NOUN,C1
-geocentric,geocentric,词,ADJ,C1
-geografi,geography,地理,NOUN,B2
+mjuk,gentle,温柔的,ADJ,B2
+herre,gentleman,绅士,NOUN,B2
 geografisk,geographical,地理的,ADJ,B2
-geographer,geographer,词,NOUN,C1
-geographically,geographically,词,ADV,C1
-geolocation,geolocation,词,NOUN,C1
-geologi,geology,地质学,NOUN,B2
+geografi,geography,地理,NOUN,B2
 geologisk,geological,地质的,ADJ,B2
-geometer,geometer,几何学家,NOUN,B2
-geometri,geometry,几何学,NOUN,B2
+geologi,geology,地质学,NOUN,B2
 geometrisk,geometric,几何的,ADJ,B2
-geophysics,geophysics,词,NOUN,C1
-geopolitik,geopolitics,地缘政治,NOUN,B2
+geometri,geometry,几何学,NOUN,B2
 geopolitisk,geopolitical,地缘政治的,ADJ,B2
-geostrategic,geostrategic,词,ADJ,C1
-geothermal,geothermal,地热,ADJ,C1
-gepflegung,gepflegung,词,NOUN,C1
-geregelung,geregelung,词,NOUN,C1
-geriatric,geriatric,词,ADJ,C1
-geriatrics,geriatrics,老年医学,NOUN,B2
-gerichtung,gerichtung,词,NOUN,B2
-german class,german class,德语课,NOUN,B2
-german person,german person,德国人,NOUN,B2
-germanic,germanic,日耳曼的,ADJ,B2
-germicidal,germicidal,杀菌的,ADJ,B2
-gerontocracy,gerontocracy,老人政治,NOUN,B2
-geschaft,geschaft,词,NOUN,C1
-geschrift,geschrift,词,NOUN,C1
-gesetzung,gesetzung,词,NOUN,C1
-gesicht,gesicht,词,NOUN,C1
-gesinnung,gesinnung,词,NOUN,B2
-gesprache,gesprache,词,NOUN,C1
-gestation,gestation,词,NOUN,C1
+geopolitik,geopolitics,地缘政治,NOUN,B2
+spora,germ,病菌,NOUN,B2
+spiring,germination,发芽,NOUN,B2
 gestikulera,to gesticulate,做手势,VERB,B2
-gestural,gestural,词,ADJ,C1
-gesucht,gesucht,词,NOUN,B2
-gesuchung,gesuchung,词,NOUN,C1
-get off car,get off car,下车,VERB,B2
-get out,get out,词,VERB,C1
-getaway,getaway,词,NOUN,C1
-geteilung,geteilung,词,NOUN,B2
-getheilung,getheilung,词,NOUN,B2
-getreibung,getreibung,词,NOUN,B2
-getting rich,getting rich,词,NOUN,C1
-gewandel,gewandel,词,NOUN,C1
-geweisung,geweisung,词,NOUN,C1
-gewirkung,gewirkung,词,NOUN,C1
-ghaita,ghaita,词,NOUN,B2
-gharar,gharar,词,NOUN,C1
-gherkin,gherkin,词,NOUN,B1
-ghoriba cookie,ghoriba cookie,词,NOUN,B2
-ghostly,ghostly,词,ADJ,C1
-ghostly look,ghostly look,鬼样子,NOUN,B2
-gibber,gibber,词,VERB,C1
-gibberish,gibberish,词,NOUN,C1
-gibe,gibe,词,VERB,C1
-gift par,a married couple,夫妇,NOUN,B2
-giftedness,giftedness,词,NOUN,C1
+bekanta sig,to get acquainted,相互认识,VERB,B2
+bli arg,to get angry,生气,VERB,B2
+gå vilse,to get lost,迷路,VERB,B2
+sluta,to get off work,下班,VERB,B2
+slippa,to get rid of,摆脱,VERB,B2
+stiga upp,to get up,起床,VERB,B2
+vana sig vid,to get used to,习惯于,VERB,B2
+jättestor,giant,巨大的,ADJ,B2
 gigantisk,gigantic,巨大的,ADJ,B2
 gigolo,gigolo,面首,NOUN,B2
 gild,to gild,镀金,VERB,B2
-gilding,gilding,词,NOUN,C1
-giljotin,guillotine,断头台,NOUN,B2
-gills,gills,词,NOUN,B2
-giltighet,validity,有效期,NOUN,B2
-gin,gin,金酒,NOUN,B2
 ginger,ginger,姜,NOUN,B2
-ginseng,ginseng,人参,NOUN,B2
-gipsa,to apply a cast,打石膏,VERB,B2
 giraffe,giraffe,长颈鹿,NOUN,B2
-girdle,girdle,词,NOUN,C1
-girighet,covetousness,贪欲,NOUN,B2
-girl daughter,girl daughter,词,NOUN,A1
-gissel,scourge,灾祸,NOUN,B2
-gitarrist,guitarist,吉他手,NOUN,B2
-give a farewell dinner,give a farewell dinner,饯行,VERB,C1
 give back,to give back,归还,VERB,B2
-give change,give change,找零,VERB,C1
-give mother,give mother,给娘,NOUN,C1
 give to grant,to give to grant,予以,VERB,B2
 give up,to give up,放弃,VERB,B2
-give you (noun),give you,送你,NOUN,C1
 given,given,给定,NOUN,B2
-given datum,given datum,词,NOUN,C1
-given that,given that,鉴于,SCONJ,B2
-giving,giving,给人,NOUN,C1
-giving of oneself,giving of oneself,词,NOUN,C1
-gjuteri,foundry,铸造厂,NOUN,B2
-glacial,glacial,词,ADJ,C1
 glacier,glacier,冰川,NOUN,B2
-gladden,gladden,词,VERB,C1
-gladiator,gladiator,词,NOUN,C1
-gladly,gladly,乐意地,ADV,B2
-gladness,gladness,欢喜,NOUN,C1
-glamour,glamour,词,NOUN,C1
 gland,gland,腺体,NOUN,B2
-glare,glare,词,VERB,C1
-glass bottle,glass bottle,词,NOUN,B1
-glass noodles,glass noodles,粉丝,NOUN,B2
-glasses spectacles,glasses spectacles,词,NOUN,A1
-glasögon,spectacles,眼镜,NOUN,B2
-glaze,glaze,词,VERB,C1
-gleam,gleam,词,NOUN,C1
-glebe,glebe,词,NOUN,C1
-gleeful,gleeful,词,ADJ,C1
-glib,glib,伶牙俐齿的,ADJ,B2
-gliding,gliding,滑翔,NOUN,B2
-glimmer,glimmer,词,NOUN,C1
-glimpse,glimpse,一瞥,NOUN,B2
 glimpse,to glimpse,瞥见,VERB,B2
-glint,glint,词,NOUN,C1
-glisten,glisten,词,VERB,C1
-glitch,glitch,故障,NOUN,C1
-glitter (noun),glitter,词,NOUN,B2
-glitter (verb),glitter,词,VERB,C1
-gloat,gloat,词,VERB,C1
-gloating,gloating,词,NOUN,C1
 global,global,全球的,ADJ,B2
-global (noun),global,全球,NOUN,B2
 global warming,global warming,气候变暖,NOUN,B2
 globalization,globalization,全球化,NOUN,B2
-globalization process,globalization process,全球化进程,NOUN,B2
-glomerulus,glomerulus,词,NOUN,C1
 gloominess,gloominess,忧郁,NOUN,B2
 gloomy,gloomy,阴郁的,ADJ,B2
 glorification,glorification,赞美,NOUN,B2
 glorify,to glorify,赞美,VERB,B2
 glorious,glorious,辉煌的,ADJ,B2
-gloriously,gloriously,词,ADV,C1
-gloriousness,gloriousness,光荣,NOUN,B2
 glory,glory,荣耀,NOUN,B2
 gloss,gloss,光泽,NOUN,B2
-glossary,glossary,词汇表,NOUN,B2
-glossator,glossator,词,NOUN,C1
-gloves,gloves,词,NOUN,B2
 glow,glow,光芒,NOUN,B2
-glow (verb),glow,词,VERB,B2
-glow glimmer,glow glimmer,词,NOUN,C1
-glower,glower,词,VERB,C1
-glucose,glucose,词,NOUN,C1
 glue,glue,胶水,NOUN,B2
-glut,glut,词,NOUN,C1
-gluteal,gluteal,词,ADJ,C1
-glutinous rice,glutinous rice,糯米,NOUN,C1
-glutinous rice ball,glutinous rice ball,汤圆,NOUN,C1
-glutton,glutton,词,NOUN,C1
 gluttony,gluttony,暴食,NOUN,B2
-glyph,glyph,词,NOUN,C1
-glädje,delight,高兴,NOUN,B2
-glöd,ardor,热情,NOUN,B2
-glömsk,forgetful,健忘的,ADJ,B2
-gnash,gnash,词,VERB,C1
-gnash one's teeth,gnash one's teeth,咬牙切齿,VERB,B2
 gnaw,to gnaw,啃,VERB,B2
-gnista,spark,火花,NOUN,B2
 gnosis,gnosis,灵知,NOUN,B2
-gnosticism,gnosticism,灵知主义,NOUN,C1
-go away,go away,词,VERB,C1
 go back,to go back,回去,VERB,B2
 go bankrupt,to go bankrupt,破产,VERB,B2
 go crazy,to go crazy,发疯,VERB,B2
@@ -7132,14825 +2146,7213 @@ go help,go help,去帮,NOUN,B2
 go in,to go in,进去,VERB,B2
 go online,to go online,上网,VERB,B2
 go out,to go out,出去,VERB,B2
-go wrong,go wrong,词,VERB,C1
-goalkeeper,goalkeeper,词,NOUN,B2
-gobble,gobble,词,VERB,C1
-goblin,goblin,词,NOUN,C1
-god of death,god of death,杀神,NOUN,C1
-god of exams,god of exams,魁星,NOUN,C1
-god på,to be good at,擅长,VERB,B2
-godis,sweets,甜食,NOUN,B2
-godkänna,to endorse,支持,VERB,B2
-godkännande,endorsement,背书,NOUN,B2
-godliness,godliness,词,NOUN,C1
-godmother,godmother,词,NOUN,C1
-gods,good,خير,NOUN,B2
-godson,godson,词,NOUN,A2
-godtrogen,gullible,易受骗的,ADJ,B2
-godtycklig,arbitrary,任意的,ADJ,B2
-goggle,goggle,词,VERB,C1
-going,going,词,NOUN,B2
-going with me,going with me,跟我去,NOUN,C1
-golf,golf,高尔夫,NOUN,B2
-gondolier,gondolier,词,NOUN,C1
-gong,gong,锣,NOUN,B2
-good cooked,good cooked,词,ADJ,A1
-good evening,good evening,词,INTJ,A1
-good faith,good faith,信义,NOUN,B2
-good hall,good hall,好殿,NOUN,B2
-good medicine,good medicine,好药,NOUN,B2
-good nature,good nature,词,NOUN,B2
-good news,good news,有好事,NOUN,C1
-good offices,good offices,词,NOUN,C1
-good thing,good thing,好事,NOUN,B2
-good-natured,good-natured,词,ADJ,B2
-good-naturedness,good-naturedness,温和,NOUN,B2
-goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
-gorge,gorge,词,NOUN,C1
-gosh,gosh,天哪,INTJ,B2
-gospel,gospel,词,NOUN,C1
-gossipmonger,gossipmonger,词,NOUN,B2
-gossipy,gossipy,爱传流言的,ADJ,B2
-gouge,gouge,词,VERB,C1
-gourmet,gourmet,美食家,NOUN,B2
-govern a country,govern a country,治国,VERB,C1
-governability,governability,可治理性,NOUN,B2
-governable,governable,可管理的,ADJ,B2
-governess,governess,词,NOUN,C1
-governorate,governorate,词,NOUN,C1
-grab,grab,揪,NOUN,B2
-grabba,to grab,抓,VERB,B2
-gracefulness,gracefulness,词,NOUN,C1
-gracious,gracious,亲切的,ADJ,B2
-graciös,graceful,优雅的,ADJ,B2
-grade (verb),grade,分级,VERB,C1
-gradering,gradation,渐变,NOUN,B2
-graduate school,graduate school,研究生院,NOUN,C1
-graduate student,graduate student,研究生,NOUN,B2
-graduation,graduation,毕业,NOUN,B2
-graduation photo,graduation photo,毕业照,NOUN,C1
-graduation thesis,graduation thesis,毕业论文,NOUN,C1
-gradvis,gradual,逐渐的,ADJ,B2
-graffiti,graffiti,涂鸦,NOUN,C1
-grafisk,graphic,图形的,ADJ,B2
-grail,grail,词,NOUN,B2
-gram,gram,克,NOUN,B2
-grammatical,grammatical,词,ADJ,C1
-grammaticality,grammaticality,合语法性,NOUN,B2
-grammatik,grammar,语法,NOUN,B2
-gramophone,gramophone,词,NOUN,C1
-granary,granary,词,NOUN,C1
-grand duchy,grand duchy,大公国,NOUN,B2
-grand duke,grand duke,大公,NOUN,B2
-grand master,grand master,大师,NOUN,B2
-grand officer,grand officer,大官,NOUN,B2
-grand plan,grand plan,大计,NOUN,C1
-grand theater,grand theater,大剧院,NOUN,B2
-grandiloquence,grandiloquence,词,NOUN,C1
-grandiloquent,grandiloquent,夸张的,ADJ,B2
-grandiloquently,grandiloquently,词,ADV,C1
-grandios,grandiose,浮夸的,ADJ,B2
-grandiosity,grandiosity,宏伟,NOUN,B2
-grandpa,grandpa,爷爷,NOUN,B2
-grandparent,grandparent,词,NOUN,B2
-grandparenthood,grandparenthood,祖父母身份,NOUN,B2
-grandparents,grandparents,祖父母,NOUN,B2
-granit,granite,花岗岩,NOUN,B2
-granitic,granitic,词,ADJ,C1
-grann,next door,隔壁,NOUN,B2
-grannliggande,neighboring,邻近的,ADJ,B2
-grannskapet,neighborhood,社区,NOUN,B2
-granny,granny,奶奶,NOUN,B2
-granska,to scrutinize,仔细检查,VERB,B2
-granting of respite,granting of respite,词,NOUN,C1
-grants,grants,词,NOUN,C1
-granular,granular,词,ADJ,C1
-granule,granule,词,NOUN,C1
-grapefruit,grapefruit,词,NOUN,A2
-grapes,grapes,词,NOUN,A1
-graph,graph,词,NOUN,C1
-graphic artist,graphic artist,词,NOUN,C1
-graphic design,graphic design,词,NOUN,C1
-graphic designer,graphic designer,图形设计师,NOUN,B2
-graphics card,graphics card,显卡,NOUN,B2
-graphology,graphology,笔迹学,NOUN,B2
-grapple,grapple,词,VERB,C1
-grasp (noun),grasp,把及,NOUN,C1
-grasshopper,grasshopper,词,NOUN,B1
-grassroots,grassroots,词,ADJ,C1
-grate,grate,词,VERB,C1
-grater,grater,词,NOUN,B2
-gratification,gratification,词,NOUN,C1
-gratified,gratified,欣慰,ADJ,C1
-gratis,for free,免费,ADV,B2
-gratitude and enmity,gratitude and enmity,恩仇,NOUN,C1
-gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
-gratuity,gratuity,酬金,NOUN,B2
-grave desecration,grave desecration,亵渎坟墓,NOUN,B2
-gravely,gravely,严重地,ADV,B2
-graveyard,graveyard,墓地,NOUN,B2
-gravid,gravid,怀孕的,ADJ,B2
-graviditet,pregnancy,怀孕,NOUN,B2
-gravitas,gravitas,词,NOUN,C1
-gravitation,gravitation,引力,NOUN,B2
-gravitational,gravitational,引力的,ADJ,B2
-gravity of loss,gravity of loss,词,NOUN,C1
-gravkammare,tomb,坟墓,NOUN,B2
-gravyr,engraving,版画,NOUN,B2
-gray hair,gray hair,词,NOUN,B2
-grayish,grayish,词,ADJ,C1
-grease (noun),grease,词,NOUN,C1
-great chaos,great chaos,大乱,NOUN,C1
-great joy,great joy,大喜,NOUN,B2
-great merit,great merit,大功,NOUN,B2
-great victory,great victory,大胜,NOUN,B2
-great-grandfather,great-grandfather,曾祖父,NOUN,B2
-greaten,greaten,词,VERB,C1
-greatest,greatest,词,NOUN,B2
-greedy ambition,greedy ambition,贪欲,NOUN,C1
-greek,greek,希腊的,ADJ,B2
-green blue,green blue,青,ADJ,B2
-green pepper,green pepper,青椒,NOUN,C1
-green rice ball,green rice ball,青团,NOUN,C1
-greenhouse gas,greenhouse gas,温室气体,NOUN,B2
-greening,greening,绿化,NOUN,C1
-greeter,greeter,迎宾,NOUN,C1
-gregarious,gregarious,爱社交的,ADJ,B2
-gren,branch,分支,NOUN,B2
-grenadier,grenadier,词,NOUN,C1
-grey area,grey area,灰色地带,NOUN,B2
-grid,grid,网格,NOUN,B2
-griddle flatbread,griddle flatbread,词,NOUN,B2
-grieve,grieve,词,VERB,C1
-grieved,grieved,词,ADJ,B2
-grievously unjust,grievously unjust,词,ADJ,C1
-grill (noun),grill,词,NOUN,B2
-grilled,grilled,词,ADJ,B1
-grilling,grilling,烧烤,NOUN,B2
-grimace,grimace,词,NOUN,C1
-grimness,grimness,词,NOUN,C1
-grinder,grinder,词,NOUN,C1
-grip adhesion,grip adhesion,词,NOUN,C1
-gripa,to apprehend,逮捕,VERB,B2
-gripa,to grip,紧握,VERB,B2
-gripa fast,to grasp firmly,抓紧,VERB,B2
-gripande,apprehension,忧虑,NOUN,B2
-gripe,gripe,词,VERB,C1
-grit,grit,词,NOUN,C1
-groan,groan,呻吟,NOUN,B2
-grocer,grocer,词,NOUN,A2
-grocery,grocery,词,NOUN,B2
-grooming,grooming,词,NOUN,C1
-grooved,grooved,词,ADJ,C1
-grop,pit,坑,NOUN,B2
-grope,grope,词,VERB,C1
-grosshandel,wholesale,批发,NOUN,B2
-grotesque,grotesque,怪诞的,ADJ,B2
-ground (adj),ground,磨碎的,ADJ,B1
-groundbreaking ceremony,groundbreaking ceremony,奠基仪式,NOUN,C1
-grounding,grounding,扎根,NOUN,C1
-grounds of judgment,grounds of judgment,词,NOUN,C1
-groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
-group assignment,group assignment,小组作业,NOUN,C1
-group chat,group chat,群聊,NOUN,C1
-group cohesion,group cohesion,词,NOUN,C1
-group culture,group culture,群体文化,NOUN,B2
-group dynamics,group dynamics,词,NOUN,C1
-group harmony,group harmony,词,NOUN,C1
-group identity,group identity,词,NOUN,C1
-group individual,group individual,群体个体,NOUN,B2
-group leader,group leader,组长,NOUN,C1
-group member,group member,群体成员,NOUN,B2
-group mentality,group mentality,群体心态,NOUN,B2
-group norm,group norm,群体规范,NOUN,B2
-group photo,group photo,合影,NOUN,B1
-group solidarity,group solidarity,群体团结,NOUN,B2
-group weakness,group weakness,词,NOUN,C1
-group work,group work,群体工作,NOUN,B2
-grouping,grouping,词,NOUN,B2
-grouse,grouse,词,VERB,C1
-grov,coarse,粗糙的,ADJ,B2
-grovel,grovel,词,VERB,C1
-growing,growing,词,ADJ,B2
-grown,grown,长大的,ADJ,B2
-growth rate,growth rate,词,NOUN,C1
-grub,grub,词,NOUN,C1
-grueling,grueling,词,ADJ,C1
-gruff,gruff,阴沉的,ADJ,B2
-grumbler,grumbler,爱抱怨的人,NOUN,B2
-grumpy,grumpy,脾气坏的,ADJ,B2
-grund,shallow,浅的,ADJ,B2
-grundare,founder,创始人,NOUN,B2
-grundlig,thorough,彻底的,ADJ,B2
-grundutrustning,essential equipment,要置,NOUN,B2
-grunt,grunt,词,VERB,B2
-grus,gravel,砾石,NOUN,B2
-grym,grim,严酷的,ADJ,B2
-grynhavre,buckwheat,荞麦,NOUN,B2
-gräl,quarreling,再吵,NOUN,B2
-gräns,border,边境的,ADJ,B2
-gräns,limit,限制,NOUN,B2
-gräns,re-boundary,重界,NOUN,B2
-gräsmark,grassland,草地,NOUN,B2
-grävning,digging,挖掘,NOUN,B2
-grå,gray,灰色的,ADJ,B2
-gråta,to weep,哭泣,VERB,B2
-gröda,crop,庄稼,NOUN,B2
-grön teknik,green technology,绿色技术,NOUN,B2
-gröna ögon,green eyes,想碧眼,NOUN,B2
-grönt öga,green eye,碧眼,NOUN,B2
-grönögd,green-eyed,让碧眼,NOUN,B2
-gröt,porridge,粥,NOUN,B2
-guarantees,guarantees,词,NOUN,C1
-guarding,guarding,守住,NOUN,C1
-guardrail,guardrail,词,NOUN,C1
-guards,guards,警卫,NOUN,B2
-gudfar,godfather,教父,NOUN,B2
-gudinna,goddess,女神,NOUN,B2
-gudom,deity,神,NOUN,B2
-gudomlighet,divinity,神性,NOUN,B2
-guerrilla,guerrilla,词,NOUN,C1
-guerrilla fighter,guerrilla fighter,词,NOUN,C1
-guest house,guest house,招待所,NOUN,C1
-guffaw,guffaw,哄笑,NOUN,B2
-guida,guide,导游,NOUN,B2
-guida,to guide,引导,VERB,B2
-guidance,guidance,指导,NOUN,B2
-guidebook,guidebook,词,NOUN,B1
-guided tour,guided tour,导游,NOUN,B2
-guideline,guideline,指导方针,NOUN,B2
-guiding light,guiding light,词,NOUN,C1
-guild,guild,行会,NOUN,B2
-guild (adj),guild,词,ADJ,C1
-guilder,guilder,盾,NOUN,B2
-guilt-ridden,guilt-ridden,内疚的,ADJ,B2
-guitar music,guitar music,词,NOUN,C1
-gulröt,cauliflower,花椰菜,NOUN,B2
-gunshot,gunshot,枪声,NOUN,B2
-gunst,favor,恩惠,NOUN,B2
-guqin,guqin,古琴,NOUN,B2
-gurgle (noun),gurgle,词,NOUN,C1
-guru,guru,精神导师,NOUN,B2
-gush (noun),gush,词,NOUN,B2
-gustatory,gustatory,词,ADJ,C1
-gutter,gutter,路沟,NOUN,B2
-guttural,guttural,词,ADJ,C1
-guzheng,guzheng,古筝,NOUN,C1
-guzzle,guzzle,词,VERB,C1
-gym,gym,健身房,NOUN,B2
-gymnast,gymnast,体操运动员,NOUN,B2
-gymnastic,gymnastic,词,ADJ,C1
-gymnastik,gymnastics,体操,NOUN,B2
-gymnastiksal,gymnasium,体育馆,NOUN,B2
-gynaecology,gynaecology,妇科,NOUN,B2
-gynecologist,gynecologist,词,NOUN,C1
-gyroscope,gyroscope,词,NOUN,C1
-gälla,concern,担忧,NOUN,B2
-gälla,to concern,涉及,VERB,B2
-gäspa,to caw,呱呱叫,VERB,B2
-gäspa,to yawn,打哈欠,VERB,B2
-gästvänlig,hospitable,好客的,ADJ,B2
-gästvänlighet,hospitality,好客,NOUN,B2
-gävnhet,munificence,慷慨,NOUN,B2
-gå,won't do,不行,ADJ,B2
-gå,to won't do,不成,VERB,B2
 gå igenom,to go through,经历,VERB,B2
 gå upp,to go up,上升,VERB,B2
-gå vilse,to get lost,迷路,VERB,B2
-gård,courtyard,庭院,NOUN,B2
-gård,yard,院子,NOUN,B2
+krigsgud,god of war,战神,NOUN,B2
+gudinna,goddess,女神,NOUN,B2
+gudfar,godfather,教父,NOUN,B2
+gods,good,خير,NOUN,B2
+tur,good luck,好运,NOUN,B2
+anseende,good reputation,清誉,NOUN,B2
 gås,goose,鹅,NOUN,B2
-gåva,third bestowal,三授,NOUN,B2
-gödselmedel,fertilizer,肥料,NOUN,B2
-göra,to do one's best,尽力,VERB,B2
-göra,to do to make,做,VERB,B2
-göra ett brott,to commit a crime,犯罪,VERB,B2
-göra sig till,to pretend to be,冒充,VERB,B2
-ha,ha,哈,INTJ,B2
-habit formation,habit formation,词,NOUN,C1
-habitability,habitability,词,NOUN,C1
-habitat,habitat,栖息地,NOUN,B2
-habitlessness,habitlessness,无习惯,NOUN,B2
-habitual behavior,habitual behavior,习惯行为,NOUN,B2
-habitus,habitus,词,NOUN,C1
-habous endowments,habous endowments,词,NOUN,C1
-hacka,to hack,入侵；盗版,VERB,B2
-hacker,hacker,黑客,NOUN,C1
-hacking,hacking,黑客行为,NOUN,B2
-hackneyed,hackneyed,词,ADJ,C1
-hadith prophetic saying,hadith prophetic saying,圣训,NOUN,B2
-hadra,hadra,词,NOUN,B2
-hagel,hail,冰雹,NOUN,B2
-haha,haha,哈哈,INTJ,B2
-hair bun,hair bun,发髻,NOUN,B2
-hair dryer,hair dryer,词,NOUN,C1
-hair-raising,hair-raising,词,ADJ,B2
-haircut,haircut,词,NOUN,C1
-hairy,hairy,词,ADJ,C1
-hakawati,hakawati,词,NOUN,B2
-half (num),half,半,NUM,A1
-half board,half board,词,NOUN,B1
-half inch,half inch,半寸,NOUN,C1
-half of a match,half of a match,半场,NOUN,B1
-half-day,half-day,半天,NOUN,B2
-halfway (noun),halfway,中途,NOUN,C1
-hall,hall,殿,PART,B2
-hallon,raspberry,覆盆子,NOUN,B2
-hallowed,hallowed,词,ADJ,C1
-hallucination,hallucination,幻觉,NOUN,B2
-halo,halo,词,NOUN,B2
+praktfull,gorgeous,华丽的,ADJ,B2
+gourmet,gourmet,美食家,NOUN,B2
+styra,to govern,统治,VERB,B2
+styre,governance,治理,NOUN,B2
+statlig,governmental,政府的,ADJ,B2
+grabba,to grab,抓,VERB,B2
+graciös,graceful,优雅的,ADJ,B2
+gradering,gradation,渐变,NOUN,B2
+betygssättning,grading,评分；记号,NOUN,B2
+gradvis,gradual,逐渐的,ADJ,B2
+examinera,graduate,毕业生,NOUN,B2
+examinera,to graduate,毕业,VERB,B2
+ymp,graft,嫁接,NOUN,B2
+gram,gram,克,NOUN,B2
+grammatik,grammar,语法,NOUN,B2
+storslagen,grand,宏伟的,ADJ,B2
+stort avstånd,grand distance,雄远,NOUN,B2
+barnbarn,granddaughter,孙女,NOUN,B2
+storhet,grandeur,宏伟,NOUN,B2
+grandios,grandiose,浮夸的,ADJ,B2
+farmor,grandma,奶奶,NOUN,B2
+barnbarn,grandson,孙子,NOUN,B2
+granit,granite,花岗岩,NOUN,B2
+bevilja,to grant,授予,VERB,B2
+vindruva,grape,葡萄,NOUN,B2
+grafisk,graphic,图形的,ADJ,B2
+gripa fast,to grasp firmly,抓紧,VERB,B2
+gräsmark,grassland,草地,NOUN,B2
+grus,gravel,砾石,NOUN,B2
+tyngdkraft,gravity,重力,NOUN,B2
+grå,gray,灰色的,ADJ,B2
+beta,to graze,吃草,VERB,B2
+fetig,greasy,油腻的,ADJ,B2
+stor,great,伟大的,ADJ,B2
+stor tjänst,great favor,大恩,NOUN,B2
+stor förolämpning,great offense,冒犯大,NOUN,B2
+stormakt,great power,大国,NOUN,B2
+storhet,greatness,伟大,NOUN,B2
+grönt öga,green eye,碧眼,NOUN,B2
+gröna ögon,green eyes,想碧眼,NOUN,B2
+grön teknik,green technology,绿色技术,NOUN,B2
+grönögd,green-eyed,让碧眼,NOUN,B2
+växthus,greenhouse,温室,NOUN,B2
+sorg,grief,悲伤,NOUN,B2
+klagomål,grievance,弊端,NOUN,B2
+grym,grim,严酷的,ADJ,B2
+smuts,grime,污垢,NOUN,B2
+flina,to grin,咧嘴笑,VERB,B2
+mala,to grind,磨碎,VERB,B2
+gripa,to grip,紧握,VERB,B2
+stöna,to groan,呻吟,VERB,B2
+brudgum,groom,新郎,NOUN,B2
+vidrig,gross,总的,ADJ,B2
+mark,grounds,论据,NOUN,B2
+växa upp,to grow up,成长,VERB,B2
+morrande,growl,低吼,NOUN,B2
+tillväxt,growth,增长,NOUN,B2
+agg,grudge,怨恨,NOUN,B2
+muttra,to grumble,抱怨,VERB,B2
+muttrande,grumbling,抱怨,NOUN,B2
+garanti,guarantee,保证,NOUN,B2
+borgensman,guarantor,担保人,NOUN,B2
+förmyndare,guardian,守卫,NOUN,B2
+förmyndarskap,guardianship,监护,NOUN,B2
+guida,guide,导游,NOUN,B2
+guida,to guide,引导,VERB,B2
+giljotin,guillotine,断头台,NOUN,B2
+skyldig,guilty,有罪的,ADJ,B2
+gitarrist,guitarist,吉他手,NOUN,B2
+bukt,gulf,海湾,NOUN,B2
+godtrogen,gullible,易受骗的,ADJ,B2
 halsa,to gulp,吞咽,VERB,B2
-halvö,peninsula,半岛,NOUN,B2
-hand wash,hand wash,手洗,VERB,C1
-hand wound,hand wound,手伤,NOUN,B1
-handball,handball,手球,NOUN,C1
+tandkött,gum,牙龈,NOUN,B2
+gym,gym,健身房,NOUN,B2
+gymnastiksal,gymnasium,体育馆,NOUN,B2
+gymnastik,gymnastics,体操,NOUN,B2
+ha,ha,哈,INTJ,B2
+habitat,habitat,栖息地,NOUN,B2
+bruk,habitually in the past,往常,NOUN,B2
+tillvänjning,habituation,习惯化,NOUN,B2
+hacka,to hack,入侵；盗版,VERB,B2
+pruta,to haggle,讨价还价,VERB,B2
+prutande,haggling,计较,NOUN,B2
+hagel,hail,冰雹,NOUN,B2
+frisör,hairdresser,理发师,NOUN,B2
+hall,hall,殿,PART,B2
+hallucination,hallucination,幻觉,NOUN,B2
+korridor,hallway,走廊,NOUN,B2
 handboja,handcuff,手铐,NOUN,B2
-handbrake,handbrake,手刹,NOUN,C1
-handel,commerce,商业,NOUN,B2
-handful,handful,词,NOUN,B2
-handguard,handguard,护手,NOUN,B2
-handicap,handicap,词,NOUN,C1
-handiness,handiness,趁手,NOUN,C1
-handlebars,handlebars,词,NOUN,C1
-handled,wrist,手腕,NOUN,B2
-handledning,tutoring,补习,NOUN,B2
-handling,action,行动,NOUN,B2
+näsduk,handkerchief,手帕,NOUN,B2
 handtag,handle,把手,NOUN,B2
-handwritten document,handwritten document,手写件,NOUN,C1
-handy,handy,词,ADJ,B1
-handyman,handyman,工匠,NOUN,B2
-hanged man,hanged man,词,NOUN,C1
-hanger,hanger,词,NOUN,A2
-hangover,hangover,词,NOUN,B2
 hantering,handling,处理,NOUN,B2
-hantverk,craft,工艺,NOUN,B2
-hantverkare,craftsman,工匠,NOUN,B2
-hantverkskonst,craftsmanship,手工艺,NOUN,B2
-haphazard,haphazard,词,ADJ,C1
-hapless,hapless,词,ADJ,C1
-happy cheerful,happy cheerful,词,ADJ,B1
-happy event,happy event,喜事,NOUN,B2
-harangue (noun),harangue,词,NOUN,B2
-harassed,harassed,词,ADJ,C1
-harassments,harassments,词,NOUN,C1
-harbinger,harbinger,词,NOUN,C1
-harbour,harbour,词,NOUN,B2
-hard and soft,hard and soft,刚柔,NOUN,B2
-hard drive,hard drive,硬盘,NOUN,C1
-hard to achieve,hard to achieve,难以实现,ADJ,C1
-hard to adapt,hard to adapt,难以适应,ADJ,B2
-hard to adjust,hard to adjust,难以调整,ADJ,C1
-hard to complete,hard to complete,难以完成,ADJ,B2
-hard to confirm,hard to confirm,难以确认,ADJ,C1
-hard to decide,hard to decide,难以决定,ADJ,B2
-hard to determine,hard to determine,难以确定,ADJ,B2
-hard to execute,hard to execute,难以执行,ADJ,B2
-hard to identify,hard to identify,难以辨别,ADJ,C1
-hard to implement,hard to implement,难以实施,ADJ,B2
-hard to judge,hard to judge,难以判断,ADJ,B2
-hard to manage,hard to manage,难以管理,ADJ,C1
-hard to measure,hard to measure,难以衡量,ADJ,B2
-hard to operate,hard to operate,难以操作,ADJ,B2
-hard to part with,hard to part with,难以割舍,ADJ,C1
-hard to please,hard to please,词,ADJ,C1
-hard to promote,hard to promote,难以推行,ADJ,B2
-hard to reach,hard to reach,难以达成,ADJ,C1
-hard to satisfy,hard to satisfy,难以满足,ADJ,B2
-hard to spread,hard to spread,难以推广,ADJ,B2
-hard training,hard training,苦练,NOUN,C1
-hard-working,hard-working,辛苦,ADJ,A2
-hardening,hardening,词,NOUN,C1
-hardship,hardship,艰难,NOUN,B2
-hardship of circumstances,hardship of circumstances,词,NOUN,C1
-hardship of life,hardship of life,词,NOUN,C1
-hardware (adj),hardware,词,ADJ,C1
-hardware (noun),hardware,硬件,NOUN,B1
-hardware store,hardware store,词,NOUN,C1
-harm intention,harm intention,想害,NOUN,C1
-harm strength might,harm strength might,词,NOUN,C1
-harmoni,harmony,和谐,NOUN,B2
-harmonisering,harmonization,协调,NOUN,B2
+stilig man,handsome guy,帅哥,NOUN,B2
+skrivövning,handwriting practice,练字,NOUN,B2
+hänga upp,to hang up,挂断,VERB,B2
+trakassera,to harass,骚扰,VERB,B2
+kränkning,harassment,骚扰,NOUN,B2
+svårvald,hard to choose,难以抉择,ADJ,B2
+svårskild,hard to distinguish,难以区分,ADJ,B2
+svårupprätthållen,hard to maintain,难以维持,ADJ,B2
+svårtalad,hard to speak of,难以启齿,ADJ,B2
+hårdhet,hardness,硬度,NOUN,B2
+arbetsam,hardworking,勤奋的,ADJ,B2
+skada,harm,伤害,NOUN,B2
+skada,to harm,损害,VERB,B2
+skadlig,harmful,有害的,ADJ,B2
+oskadlig,harmless,无害的,ADJ,B2
 harmonisk,harmonious,和谐的,ADJ,B2
+harmonisering,harmonization,协调,NOUN,B2
+harmoni,harmony,和谐,NOUN,B2
 harp,harp,竖琴,NOUN,B2
-harried,harried,词,ADJ,C1
-harsh,harsh,严厉的,ADJ,B2
-harshly,harshly,词,ADV,C1
-harshness,harshness,词,NOUN,B2
-harvest crop,harvest crop,词,NOUN,B2
-hashtag,hashtag,词,NOUN,B2
-hasselnot,hazelnut,榛子,NOUN,B2
-hassle,hassle,麻烦,NOUN,B2
-hastily,hastily,急忙,ADV,B2
+skörd,harvest,收获,NOUN,B2
+brådska,haste,匆忙,NOUN,B2
+brådig,hasty,仓促的,ADJ,B2
 hat,hate,仇恨,NOUN,B2
-hatch,hatch,舱口,NOUN,B2
-hatching,hatching,词,NOUN,C1
-haughtily,haughtily,词,ADV,C1
-haughty,haughty,傲慢的,ADJ,B2
-haul,haul,词,VERB,B2
-haunt,haunt,词,VERB,C1
-hav,ocean,海洋,NOUN,B2
-have a look,have a look,看一看啦,NOUN,C1
-have back,have back,词,VERB,C1
-have to,have to,必须,AUX,B2
-have to (adv),have to,不得不,ADV,A1
-having a birthday,having a birthday,过生日的,ADJ,B2
-having item,having item,有件,NOUN,C1
-hazard lights,hazard lights,双闪,NOUN,C1
-hazard report,hazard report,危险报告,NOUN,B2
-he him,he him,他,PRON,B2
-he she,he she,伊,PRON,B2
-head cold,head cold,词,NOUN,B1
-head falls,head falls,立马人头落地,NOUN,C1
-head of state,head of state,元首,NOUN,B2
-head office,head office,词,NOUN,C1
-head teacher,head teacher,班主任,NOUN,B1
-headband,headband,词,NOUN,C1
-headdress,headdress,词,NOUN,C1
-headed by,headed by,为首,VERB,B2
-header,header,头球,NOUN,B2
-headlight,headlight,大灯,NOUN,C1
-headlines,headlines,词,NOUN,B2
-headscarf,headscarf,头巾,NOUN,B2
-headstrong,headstrong,词,ADJ,C1
-healer,healer,词,NOUN,B2
-healing power,healing power,疗效,NOUN,B2
-health care,health care,词,NOUN,B2
-health policy,health policy,健康政策,NOUN,B2
-healthcare,healthcare,医疗保健,NOUN,B2
-healthy correct strong,healthy correct strong,词,ADJ,A1
-heap cluster,heap cluster,词,NOUN,C1
-hearing aid,hearing aid,词,NOUN,B2
-hearsay,hearsay,词,NOUN,C1
-heart disease,heart disease,心脏病,NOUN,B2
-heart meridian,heart meridian,心脉……,NOUN,B2
-heart's blood,heart's blood,心血,NOUN,C1
-heart-to-heart disclosure,heart-to-heart disclosure,词,NOUN,C1
-heartbreaking,heartbreaking,词,ADJ,C1
-heartbroken,heartbroken,词,ADJ,C1
-heartburn,heartburn,词,NOUN,B1
-heartening,heartening,令人高兴的,ADJ,B2
-heartfelt,heartfelt,衷心的,ADJ,B2
-hearth,hearth,壁炉,NOUN,B2
-heartless,heartless,词,ADJ,C1
-heartlessness,heartlessness,无情,NOUN,B2
-heartrending,heartrending,词,ADJ,C1
-hearts,hearts,心,NOUN,B2
-heated,heated,激昂的,ADJ,B2
-heath,heath,石楠荒原,NOUN,B2
-heatsink,heatsink,散热器,NOUN,C1
-heatstroke,heatstroke,中暑,NOUN,C1
-heatwave,heatwave,热浪,NOUN,B2
-heaven and earth,heaven and earth,天地,NOUN,B2
-heaven's blessing,heaven's blessing,受天之庆,NOUN,C1
-heavenly body,heavenly body,词,NOUN,B2
-heavenly kingdom,heavenly kingdom,词,NOUN,C1
-heavy body,heavy body,重体,NOUN,B2
-heavy capacity,heavy capacity,重容,NOUN,B2
-heavy class,heavy class,重类,NOUN,B2
-heavy effect,heavy effect,重效,NOUN,B2
-heavy energy,heavy energy,重能,NOUN,C1
-heavy fog,heavy fog,大雾,NOUN,C1
-heavy form,heavy form,重式,NOUN,C1
-heavy industry,heavy industry,重工,NOUN,C1
-heavy method,heavy method,重法,NOUN,C1
-heavy mold,heavy mold,重模,NOUN,C1
-heavy rain,heavy rain,大雨,NOUN,B2
-heavy result,heavy result,重果,NOUN,C1
-heavy rule,heavy rule,重则,NOUN,C1
-heavy snow,heavy snow,大雪,NOUN,B2
-heavy substance,heavy substance,重实,NOUN,C1
-heavy system,heavy system,重系,NOUN,B2
-hectare,hectare,词,NOUN,C1
-hectic,hectic,忙乱,NOUN,B2
-hectic (adj),hectic,词,ADJ,C1
-heders-,honorary,名誉的,ADJ,B2
-hedonism,hedonism,享乐主义,NOUN,B2
-hedonist,hedonist,词,NOUN,C1
-hedonistic,hedonistic,享乐主义的,ADJ,B2
-hedrad,honored,尊敬的,ADJ,B2
-heedlessness,heedlessness,词,NOUN,C1
-hefen,hefen,河粉,NOUN,C1
+högmod,haughtiness,傲慢,NOUN,B2
+olyckas,to have an accident,遭遇意外,VERB,B2
+frukosta,to have breakfast,吃早餐,VERB,B2
+middaga,to have dinner,吃晚餐,VERB,B2
+luncha,to have lunch,吃午餐,VERB,B2
+bara ha,to have only,唯有,VERB,B2
+nödvändighet,have to,还得,NOUN,B2
+hö,hay,干草,NOUN,B2
+hasselnot,hazelnut,榛子,NOUN,B2
+hörlurar,headphones,耳机,NOUN,B2
+läkning,healing,治愈,NOUN,B2
+hop,heap,堆,NOUN,B2
+höra,to hear a case,审理,VERB,B2
+hörselbeile,heard beile,听说贝勒,NOUN,B2
+hörsel,hearing,听证会,NOUN,B2
+hjärtklapp,heartbeat,心跳,NOUN,B2
+värma,to heat,加热,VERB,B2
+hettbölja,heat wave,热浪,NOUN,B2
+uppvärmning,heating,供暖,NOUN,B2
+himmel,heaven,天堂,NOUN,B2
+himmelsk doft,heavenly fragrance,天香,NOUN,B2
+tyngd,heaviness,沉重 / 笨重,NOUN,B2
+tung etikett,heavy etiquette,礼太重,NOUN,B2
+tung knut,heavy knot,重结,NOUN,B2
+tung maskin,heavy machine,重机,NOUN,B2
+tung typ,heavy type,重型,NOUN,B2
+tungt arbete,heavy work,重功,NOUN,B2
+igelkott,hedgehog,刺猬,NOUN,B2
+häla,heel,脚后跟,NOUN,B2
 hegemoni,hegemony,霸权,NOUN,B2
 hehe,hehe,嘿嘿,INTJ,B2
-heinous,heinous,词,ADJ,C1
-hej,hey,嘿,INTJ,B2
-hel,entire,整个的,ADJ,B2
-hela dagen,all day long,一整天,NOUN,B2
-hela världen,whole world,全世界,NOUN,B2
-helhet,entirety,全部,NOUN,B2
-hello (adv),hello,词,ADV,B1
-hello (part),hello,词,PART,A2
-hello bye,hello bye,词,INTJ,B2
-hello peace,hello peace,词,NOUN,A1
-hello polite,hello polite,您好,INTJ,C1
-helper,helper,助手,NOUN,B2
-helplessly,helplessly,无力,ADV,C1
-helt ny,brand new,崭新的,ADJ,B2
-hem,hem,边缘,NOUN,B2
-hematoma,hematoma,血肿,NOUN,B2
-hemicycle,hemicycle,词,NOUN,C1
-hemiplegia,hemiplegia,词,NOUN,C1
-hemisphere,hemisphere,半球,NOUN,B2
-hemistich,hemistich,词,NOUN,C1
-hemlig,clandestine,秘密的,ADJ,B2
-hemlig sammankomst,secret meeting,密会,NOUN,B2
+hjälpa,to help assistance,帮助,VERB,B2
+hjälpsam,helpful,有帮助的,ADJ,B2
 hemoglobin,hemoglobin,血红蛋白,NOUN,B2
 hemorragi,hemorrhage,出血,NOUN,B2
-hemorrhoid,hemorrhoid,词,NOUN,C1
-hemostasis,hemostasis,词,NOUN,C1
-hemostat,hemostat,词,NOUN,C1
-hemp,hemp,大麻,NOUN,B2
-hemsk,horrible,可怕的,ADJ,B2
-hence,hence,因此,ADV,B2
-henchman,henchman,词,NOUN,C1
-henhouse,henhouse,词,NOUN,C1
-hepatic,hepatic,肝脏的,ADJ,B2
-hepatitis,hepatitis,词,NOUN,C1
-her,her,她的,DET,B2
-her their,her their,词,DET,A1
-herald,herald,词,NOUN,C1
-heraldry,heraldry,词,NOUN,C1
-herbaceous,herbaceous,草本的,ADJ,B2
-herbal tea,herbal tea,花草茶,NOUN,B2
-herbalism,herbalism,词,NOUN,C1
-herbalist,herbalist,词,NOUN,B1
-herbarium,herbarium,词,NOUN,C1
-herbicide,herbicide,除草剂,NOUN,B2
-herbs,herbs,词,NOUN,B2
-herd mentality,herd mentality,从众心理,NOUN,C1
+ört,herb,草药,NOUN,B2
+hjord,herd,兽群,NOUN,B2
 herde,herder,牧民,NOUN,B2
-herde,shepherd,牧羊人,NOUN,B2
-here (pron),here,这儿,PRON,A1
-here is,here is,词,ADV,A1
-hereafter,hereafter,词,NOUN,C1
-herein,herein,词,ADV,B1
-heresiarch,heresiarch,词,NOUN,C1
-heretical,heretical,词,ADJ,C1
-heretical innovation,heretical innovation,词,NOUN,C1
-hermeneutics,hermeneutics,词,NOUN,C1
+arvlig,hereditary,遗传的,ADJ,B2
+ärvlighet,heredity,遗传,NOUN,B2
+kätteri,heresy,异端,NOUN,B2
+kättare,heretic,异端,NOUN,B2
+arv,heritage,遗产,NOUN,B2
 hermeneutisk,hermeneutic,诠释学的,ADJ,B2
-hermetic,hermetic,词,ADJ,C1
-hermit,hermit,隐士,NOUN,B2
-hermitage,hermitage,词,NOUN,B2
-hernia,hernia,词,NOUN,C1
-heroic deeds,heroic deeds,词,NOUN,C1
-heroic feat,heroic feat,壮举,NOUN,C1
-heroic poetry,heroic poetry,词,NOUN,C1
-heroically,heroically,英勇地,ADV,B2
-heroine,heroine,词,NOUN,B1
 heroisk,heroic,英勇的,ADJ,B2
 heroism,heroism,英雄主义,NOUN,B2
-heron,heron,词,NOUN,C1
-herr,mr.,先生,NOUN,B2
-herre,gentleman,绅士,NOUN,B2
-herre,sir,先生,NOUN,B2
-hesitant,hesitant,犹豫的,ADJ,B2
-heterodox,heterodox,异端的,ADJ,B2
-heterodoxy,heterodoxy,词,NOUN,C1
 heterogen,heterogeneous,异质的,ADJ,B2
-heterogeneity,heterogeneity,异质性,NOUN,B2
-heterosexual,heterosexual,词,ADJ,C1
-hettbölja,heat wave,热浪,NOUN,B2
-heuristic,heuristic,词,ADJ,C1
-hexadecimal,hexadecimal,词,ADJ,C1
-hexagon,hexagon,六边形,NOUN,B2
-heyday,heyday,词,NOUN,C1
-hidden arrow,hidden arrow,暗箭,NOUN,C1
-hidden edge,hidden edge,揣而锐,NOUN,C1
-hidden intentions,hidden intentions,词,NOUN,C1
-hidden master,hidden master,江湖里卧虎,NOUN,B2
-hidden matters,hidden matters,词,NOUN,C1
-hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
-hideous,hideous,丑陋的,ADJ,B2
-hider,hider,词,NOUN,B2
-hiding ambush,hiding ambush,词,NOUN,B2
+hej,hey,嘿,INTJ,B2
+dölja,to hide oneself,躲藏,VERB,B2
+doldis,hideout,藏身处,NOUN,B2
+döljande,hiding,ٱختباء,NOUN,B2
 hierarchical,hierarchical,等级的,ADJ,B2
 hierarchy,hierarchy,等级制度,NOUN,B2
-hieratic,hieratic,词,ADJ,C1
-hieroglyphic,hieroglyphic,词,NOUN,C1
 high,high,高的,ADJ,B2
-high cost of living,high cost of living,词,NOUN,B2
-high level,high level,高级,ADJ,A2
-high morale,high morale,高昂,NOUN,C1
-high official,high official,大官,NOUN,C1
-high pressure,high pressure,高气压,NOUN,C1
-high quality,high quality,优质,ADJ,C1
-high school diploma,high school diploma,词,NOUN,C1
-high school entrance examination,high school entrance examination,中考,NOUN,C1
-high school graduate,high school graduate,高中毕业生,NOUN,B2
-high school student,high school student,词,NOUN,B2
 high tide,high tide,涨潮,NOUN,B2
-high-grade,high-grade,高档,ADJ,B2
-high-speed,high-speed,高速,ADJ,B2
-higher professional education,higher professional education,高等专业教育,NOUN,B2
-highland,highland,山地,NOUN,C1
-highlands,highlands,词,NOUN,B2
 highlight,to highlight,强调,VERB,B2
-highlighter,highlighter,词,NOUN,C1
-hijack,hijack,词,VERB,C1
-hijacking,hijacking,词,NOUN,C1
-hike,hike,徒步旅行,NOUN,B2
 hike,to hike,徒步旅行,VERB,B2
 hiking,hiking,徒步,NOUN,B2
 hilarious,hilarious,滑稽的,ADJ,B2
 hills,hills,丘陵,NOUN,B2
 hilt,hilt,剑柄,NOUN,B2
 him,him,他吧,NOUN,B2
-him dative,him dative,词,PRON,A2
-him her,him her,他/她,PRON,B2
-himmel,heaven,天堂,NOUN,B2
-himmelsk doft,heavenly fragrance,天香,NOUN,B2
-hindra,to thwart,阻挠,VERB,B2
 hindrance,hindrance,障碍,NOUN,B2
-hinge,hinge,合页,NOUN,B2
-hink,bucket,桶,NOUN,B2
-hinterbildung,hinterbildung,词,NOUN,C1
-hintererziehung,hintererziehung,词,NOUN,C1
-hinterfahrt,hinterfahrt,词,NOUN,C1
-hinterfassung,hinterfassung,词,NOUN,B2
-hinterforderung,hinterforderung,词,NOUN,C1
-hintergabe,hintergabe,词,NOUN,C1
-hintergestaltung,hintergestaltung,词,NOUN,C1
-hinterkunft,hinterkunft,词,NOUN,C1
-hinterleitung,hinterleitung,词,NOUN,B2
-hintermessung,hintermessung,词,NOUN,C1
-hinternahme,hinternahme,词,NOUN,C1
-hinterordnung,hinterordnung,词,NOUN,C1
-hinterpflegung,hinterpflegung,词,NOUN,C1
-hinterrechnung,hinterrechnung,词,NOUN,B2
-hinterregelung,hinterregelung,词,NOUN,B2
-hinterrichtung,hinterrichtung,词,NOUN,B2
-hinterschaft,hinterschaft,词,NOUN,C1
-hinterschrift,hinterschrift,词,NOUN,C1
-hintersetzung,hintersetzung,词,NOUN,C1
-hintersicht,hintersicht,词,NOUN,B2
-hintersinnung,hintersinnung,词,NOUN,C1
-hintersprache,hintersprache,词,NOUN,C1
-hinterstellung,hinterstellung,词,NOUN,C1
-hintersucht,hintersucht,词,NOUN,B2
-hintersuchung,hintersuchung,词,NOUN,B2
-hinterteilung,hinterteilung,词,NOUN,C1
-hintertheilung,hintertheilung,词,NOUN,B2
-hintertreibung,hintertreibung,词,NOUN,C1
-hinterwandel,hinterwandel,词,NOUN,B2
-hinterwandlung,hinterwandlung,词,NOUN,C1
-hinterweisung,hinterweisung,词,NOUN,B2
-hinterwendung,hinterwendung,词,NOUN,B2
-hinterwirkung,hinterwirkung,词,NOUN,C1
 hiring,hiring,招聘,NOUN,B2
-hirsute,hirsute,词,ADJ,C1
 his,his,他的,DET,B2
-his certainty,his certainty,他定,NOUN,C1
 his departure,his departure,他走,NOUN,B2
-his her its,his her its,其,PRON,B2
-his hers theirs,his hers theirs,词,PRON,A2
-his refusal,his refusal,他绝,NOUN,C1
-hispanic,hispanic,西班牙的,ADJ,B2
 hiss,hiss,嘶嘶声,NOUN,B2
 historian,historian,历史学家,NOUN,B2
 historic,historic,历史性的,ADJ,B2
-historical record,historical record,历史纪录,NOUN,B2
-historical site,historical site,古迹,NOUN,B2
-historically,historically,历史上,ADV,B2
-historicism,historicism,历史主义,NOUN,B2
-historicist,historicist,历史主义者,NOUN,B2
-historicity,historicity,历史性,NOUN,B2
-historicization,historicization,词,NOUN,C1
 historiography,historiography,史学,NOUN,B2
 history,history,历史,NOUN,B2
-history education,history education,词,NOUN,C1
-histrionic,histrionic,词,ADJ,C1
 hit,hit,击中,NOUN,B2
 hit,to hit,打,VERB,B2
-hit (noun),hit,必中,NOUN,B2
-hitch,hitch,词,NOUN,B2
-hjord,herd,兽群,NOUN,B2
-hjälpa,to help assistance,帮助,VERB,B2
-hjälpsam,helpful,有帮助的,ADJ,B2
-hjärtklapp,heartbeat,心跳,NOUN,B2
 hmm,hmm,嗯,INTJ,B2
-hoarding,hoarding,词,NOUN,C1
-hoax,hoax,词,NOUN,C1
-hoax deception,hoax deception,词,NOUN,C1
 hobby,hobby,爱好,NOUN,B2
-hocherziehung,hocherziehung,词,NOUN,C1
-hochfahrt,hochfahrt,词,NOUN,C1
-hochfassung,hochfassung,词,NOUN,C1
-hochforderung,hochforderung,词,NOUN,B2
-hochgabe,hochgabe,词,NOUN,B2
-hochgestaltung,hochgestaltung,词,NOUN,C1
-hochkunft,hochkunft,词,NOUN,B2
-hochnahme,hochnahme,词,NOUN,C1
-hochpflegung,hochpflegung,词,NOUN,C1
-hochregelung,hochregelung,词,NOUN,C1
-hochrichtung,hochrichtung,词,NOUN,C1
-hochschaft,hochschaft,词,NOUN,C1
-hochschrift,hochschrift,词,NOUN,C1
-hochsetzung,hochsetzung,词,NOUN,C1
-hochsicht,hochsicht,词,NOUN,C1
-hochsinnung,hochsinnung,词,NOUN,C1
-hochsprache,hochsprache,词,NOUN,C1
-hochsucht,hochsucht,词,NOUN,C1
-hochsuchung,hochsuchung,词,NOUN,C1
-hochteilung,hochteilung,词,NOUN,C1
-hochtheilung,hochtheilung,词,NOUN,C1
-hochtreibung,hochtreibung,词,NOUN,C1
-hochwandel,hochwandel,词,NOUN,C1
-hochweisung,hochweisung,词,NOUN,B2
-hochwirkung,hochwirkung,词,NOUN,C1
-hock,hock,词,NOUN,C1
-hockey,hockey,曲棍球,NOUN,C1
-hold catch,hold catch,词,VERB,A1
 hold on,to hold on,抓住,VERB,B2
 hold the balance of power,hold the balance of power,举足轻重,ADJ,B2
-hold together,hold together,词,VERB,C1
-holder,holder,持有者,NOUN,B2
-holding,holding,别放,NOUN,B2
-holding company,holding company,词,NOUN,C1
-holdup,holdup,词,NOUN,B2
 holiday,holiday,假期,NOUN,B2
-holiday feast,holiday feast,词,NOUN,A2
-holidaymaker,holidaymaker,词,NOUN,C1
-holidays,holidays,假期,NOUN,B2
 holiness,holiness,神圣,NOUN,B2
-holism,holism,整体论,NOUN,B2
 holistic,holistic,整体的,ADJ,B2
-hollowed,hollowed,掏空的,ADJ,B2
-holm oak,holm oak,词,NOUN,C1
-holocaust,holocaust,浩劫,NOUN,B2
-hologram,hologram,词,NOUN,C1
-holy decree,holy decree,圣令,NOUN,B2
-holy empress,holy empress,圣后,NOUN,C1
-homage,homage,词,NOUN,C1
-home (adv),home,词,ADV,B1
-home automation,home automation,词,NOUN,B1
 home family,home family,家,NOUN,B2
-home hearth,home hearth,词,NOUN,B1
-home-based,home-based,词,ADJ,C1
-home-loving,home-loving,顾家的,ADJ,B2
 homeland,homeland,家乡,NOUN,B2
-homelessness,homelessness,词,NOUN,B2
-homemade,homemade,词,ADJ,B2
-homeopathy,homeopathy,词,NOUN,C1
-homestay,homestay,民宿,NOUN,B2
-hometown,hometown,家乡,NOUN,B1
-homework duty,homework duty,词,NOUN,A2
 homicide,homicide,杀人,NOUN,B2
-homiletic,homiletic,词,ADJ,C1
-homily,homily,布道,NOUN,B2
-hominization,hominization,词,NOUN,C1
-homogeneity,homogeneity,同质性,NOUN,B2
 homogeneous,homogeneous,同质的,ADJ,B2
-homonym,homonym,词,NOUN,C1
-homonymy,homonymy,同音异义,NOUN,B2
 homosexuality,homosexuality,同性恋,NOUN,B2
-homothety,homothety,位似,NOUN,C1
 honk,to honk,按喇叭,VERB,B2
-honorability,honorability,词,NOUN,C1
-honorable,honorable,可敬的,ADJ,B2
-honoree,honoree,词,NOUN,C1
-honorific,honorific,词,ADJ,C1
-hood,hood,兜帽,NOUN,B2
-hooligan,hooligan,流氓,NOUN,B2
-hop,heap,堆,NOUN,B2
-hopa,to pile up,堆积,VERB,B2
-hoped-for,hoped-for,词,ADJ,C1
-hopeful,hopeful,词,ADJ,C1
-hopelessness,hopelessness,词,NOUN,C1
+heders-,honorary,名誉的,ADJ,B2
+hedrad,honored,尊敬的,ADJ,B2
 hoppas,to hope to wish,希望,VERB,B2
-horde,horde,词,NOUN,B2
 horisont,horizon,地平线,NOUN,B2
-horizontal,horizontal,横,ADJ,B1
 hormon,hormone,激素,NOUN,B2
 horn,horn,号角,NOUN,B2
-horoscope,horoscope,星座运势,NOUN,B2
-horrified,horrified,惊骇的,ADJ,B2
-hors d'oeuvre,hors d'oeuvre,词,NOUN,C1
-horseback riding,horseback riding,骑马,NOUN,B2
-horseshoe,horseshoe,词,NOUN,C1
-hose,hose,软管,NOUN,B2
-hospice,hospice,词,NOUN,C1
-hospital bed,hospital bed,病床,NOUN,C1
-hospital-acquired,hospital-acquired,词,ADJ,C1
-hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
-hospitalization,hospitalization,词,NOUN,C1
-host of angels,host of angels,天使群,NOUN,B2
-hosta,cough,咳嗽,NOUN,B2
-hostel,hostel,词,NOUN,C1
-hostess,hostess,女服务员,NOUN,B2
-hosting,hosting,托管,NOUN,C1
-hot dry wind,hot dry wind,词,NOUN,B2
-hot spring,hot spring,温泉,NOUN,C1
-hot water,hot water,热水,NOUN,B2
-hotad,endangered,濒危的,ADJ,B2
-hotbed,hotbed,词,NOUN,C1
-hotel industry,hotel industry,词,NOUN,C1
-hotelier,hotelier,旅馆老板,NOUN,B2
-hotfull,ominous,不祥的,ADJ,B2
-hotfull,threatening,具有威胁性的,ADJ,B2
-hothead,hothead,急性子的人,NOUN,B2
-hourly,hourly,按小时,ADV,C1
-house arrest,house arrest,软禁,NOUN,B2
-house call,house call,词,NOUN,C1
-household,household,家庭的,ADJ,B2
-household income,household income,词,NOUN,B2
-housekeeper,housekeeper,词,NOUN,C1
-housework,housework,家务,NOUN,B2
-how (aux),how,怎会,AUX,B2
-how (noun),how,又怎会,NOUN,B2
-how (pron),how,怎么,PRON,A1
-how about,how about,怎么样,PRON,A1
-how come,how come,怎么会,INTJ,B2
-how could there be,how could there be,哪有,PRON,B2
-how dare,how dare,岂敢,NOUN,B2
-how enough,how enough,哪够,NOUN,B2
-how long,how long,多久,ADV,B2
-how many (pron),how many,多少,PRON,A1
-how much,how much,多少,ADV,B2
-how to do it,how to do it,办呢,ADV,B2
-however (cconj),however,然而,CCONJ,B2
-howl (noun),howl,词,NOUN,B2
-hubbub,hubbub,词,NOUN,C1
-hubris,hubris,词,NOUN,C1
-hudud punishments,hudud punishments,词,NOUN,C1
-huka,to squat,蹲,VERB,B2
-human being,human being,词,NOUN,B1
-human law,human law,人法,NOUN,C1
-human life,human life,人命,NOUN,B2
-human need,human need,人要,NOUN,B2
-human rights (adj),human rights,词,ADJ,C1
-human rights (noun),human rights,人权,NOUN,C1
-human rights work,human rights work,词,NOUN,C1
-humane,humane,人道的,ADJ,B2
-humanisering,humanization,人性化,NOUN,B2
-humanism,humanism,人文主义,NOUN,B2
-humanist,humanist,人文主义者,NOUN,B2
-humanitarian,humanitarian,人道主义的,ADJ,B2
-humanities,humanities,人文学科,NOUN,B2
-humble,humble,谦逊的,ADJ,B2
-humble send-off,humble send-off,恭送,NOUN,C1
-humble servant,humble servant,卑职,NOUN,C1
-humbly,humbly,词,ADV,C1
-humid,humid,潮湿的,ADJ,B2
-humid weather after cold spell,humid weather after cold spell,回南天,NOUN,B2
-humiliating,humiliating,令人羞辱的,ADJ,B2
-humma,to hum,哼唱,VERB,B2
-humming,humming,词,NOUN,B2
-hummingbird,hummingbird,词,NOUN,B2
-humor,humor,幽默,NOUN,B2
-humorist,humorist,词,NOUN,C1
-humorous,humorous,幽默的,ADJ,B2
-hump,hump,词,NOUN,C1
-humör,temper,脾气,NOUN,B2
-hunch,hunch,词,NOUN,B2
-hundred,hundred,一百,NOUN,B2
-hundred million,hundred million,亿,NUM,B2
-hundreds (noun),hundreds,词,NOUN,B2
-hungarian,hungarian,匈牙利的,ADJ,B2
-hur,how,又怎会,NOUN,B2
-hur mycket,how much,多少,PRON,B2
-hur många,how many,多少,NUM,B2
-hurrah,hurrah,万岁,INTJ,B2
-hurriedly,hurriedly,赶紧,ADV,B2
-husband's parents,husband's parents,公婆,NOUN,B2
-husband-slaying,husband-slaying,手刃亲夫,NOUN,C1
+hemsk,horrible,可怕的,ADJ,B2
+förfära,to horrify,使惊骇,VERB,B2
+förfärande,horrifying,令人毛骨悚然的,ADJ,B2
+hästavgång,horse departure,马去,NOUN,B2
+gästvänlig,hospitable,好客的,ADJ,B2
+gästvänlighet,hospitality,好客,NOUN,B2
+sjukhusvårdas,to hospitalize,使住院,VERB,B2
+arrangera,to host,接待,VERB,B2
+fientlig,hostile,敌对的,ADJ,B2
+fientlighet,hostility,敌意,NOUN,B2
+varmluftballong,hot air balloon,热气球,NOUN,B2
 hushåll,household,家庭,NOUN,B2
-husvagn,motorhome,露营车,NOUN,B2
-huvud,on head,当头,NOUN,B2
-hyaline,hyaline,词,ADJ,C1
+bostad,housing,住房,NOUN,B2
+hur,how,又怎会,NOUN,B2
+hur många,how many,多少,NUM,B2
+hur mycket,how much,多少,PRON,B2
+dock,however,然而,CCONJ,B2
+yla,to howl,嚎叫,VERB,B2
+enorm,huge,巨大的,ADJ,B2
+va,huh,哈,INTJ,B2
+humma,to hum,哼唱,VERB,B2
+mänsklig kapacitet,human capacity,人会,NOUN,B2
+människonatur,human nature,人性,NOUN,B2
+humanism,humanism,人文主义,NOUN,B2
+humanisering,humanization,人性化,NOUN,B2
+fuktighet,humidity,湿度,NOUN,B2
+förnedra,to humiliate,羞辱,VERB,B2
+förnedring,humiliation,羞辱,NOUN,B2
+ödmjukhet,humility,谦逊,NOUN,B2
+humor,humor,幽默,NOUN,B2
+kryckryggad,hunchbacked,驼背的,ADJ,B2
+svält,hunger,饥饿,NOUN,B2
+jakt,hunting,狩猎,NOUN,B2
+orkan,hurricane,飓风,NOUN,B2
+hydda,hut,小屋,NOUN,B2
 hybrid,hybrid,杂交的,ADJ,B2
 hybridisering,hybridization,杂交,NOUN,B2
-hybridism,hybridism,词,NOUN,C1
-hybridity,hybridity,词,NOUN,C1
-hydda,hut,小屋,NOUN,B2
-hydrant,hydrant,词,NOUN,C1
-hydration,hydration,词,NOUN,C1
-hydraulic,hydraulic,液压的,ADJ,B2
-hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
-hydroelectric,hydroelectric,水力发电的,ADJ,C1
-hydrogen energy,hydrogen energy,氢能,NOUN,B2
-hydrography,hydrography,词,NOUN,C1
-hydrology,hydrology,词,NOUN,C1
-hydrophobia,hydrophobia,词,NOUN,C1
-hydropic,hydropic,词,ADJ,C1
-hydrosphere,hydrosphere,词,NOUN,C1
-hydrotherapy,hydrotherapy,词,NOUN,C1
-hyena,hyena,鬣狗,NOUN,B2
+vattenkraft,hydro energy,水能,NOUN,B2
+väte,hydrogen,氢,NOUN,B2
 hygien,hygiene,卫生,NOUN,B2
-hygienic,hygienic,卫生的,ADJ,B2
-hymnal,hymnal,词,NOUN,C1
-hyper-category,hyper-category,超目,NOUN,C1
-hyper-cause,hyper-cause,超因,NOUN,C1
-hyper-effect,hyper-effect,超果,NOUN,C1
-hyper-efficacy,hyper-efficacy,超效,NOUN,B2
-hyper-idea,hyper-idea,超念,NOUN,C1
-hyper-intent,hyper-intent,超意,NOUN,B2
-hyper-meaning,hyper-meaning,超义,NOUN,C1
-hyper-origin,hyper-origin,超原,NOUN,B2
-hyper-price,hyper-price,超价,NOUN,C1
-hyper-shadow,hyper-shadow,超影,NOUN,C1
-hyper-sound,hyper-sound,超响,NOUN,C1
-hyper-target,hyper-target,超的,NOUN,B2
-hyper-value,hyper-value,超值,NOUN,C1
-hyper-view,hyper-view,超观,NOUN,C1
-hyperbaton,hyperbaton,词,NOUN,C1
-hyperbole,hyperbole,夸张,NOUN,B2
-hyperbolic,hyperbolic,词,ADJ,C1
-hypertension,hypertension,词,NOUN,C1
-hypertensive,hypertensive,词,ADJ,C1
-hyperthermia,hyperthermia,体温过高,NOUN,B2
-hypertrophy,hypertrophy,肥大,NOUN,B2
+psalm,hymn,赞美诗,NOUN,B2
+överanvändning,hyper-use,超用,NOUN,B2
 hypnos,hypnosis,催眠,NOUN,B2
-hypochondria,hypochondria,词,NOUN,C1
-hypochondriac,hypochondriac,词,NOUN,C1
 hypokrisi,hypocrisy,虚伪,NOUN,B2
-hypotension,hypotension,词,NOUN,C1
-hypotensive,hypotensive,词,ADJ,C1
 hypotermi,hypothermia,体温过低,NOUN,B2
 hypotetisk,hypothetical,假设的,ADJ,B2
-hypothesize,hypothesize,词,VERB,B2
-hypothetically,hypothetically,词,ADV,C1
-hyresgäst,tenant,租户,NOUN,B2
-hyresvärd,landlord,房东,NOUN,B2
-hysa,to accommodate,容纳,VERB,B2
-hysa,to pay respects,参见,VERB,B2
-hysterectomy,hysterectomy,词,NOUN,C1
-hysteria,hysteria,词,NOUN,C1
-häla,heel,脚后跟,NOUN,B2
-hänga upp,to hang up,挂断,VERB,B2
-hängivenhet,devotion,奉献,NOUN,B2
-härskamma,cruelty,残忍,NOUN,B2
-härstamma,to originate,发源,VERB,B2
-hästavgång,horse departure,马去,NOUN,B2
-hålla i sig,to last a period of time,为期,VERB,B2
-hållbar,sustainable,可持续的,ADJ,B2
-hållbarhet,durability,耐用性,NOUN,B2
-hållbarhet,sustainability,可持续性,NOUN,B2
-hållning,bearing,轴承,NOUN,B2
-hårdhet,hardness,硬度,NOUN,B2
-hö,hay,干草,NOUN,B2
-hög,lofty,崇高的,ADJ,B2
-hög,pile,堆,NOUN,B2
-hög,a pile,一堆,NUM,B2
-högmod,haughtiness,傲慢,NOUN,B2
-högtidlig,solemn,庄严的,ADJ,B2
-höjd,elevation,提升,NOUN,B2
-höra,to hear a case,审理,VERB,B2
-hörlurar,headphones,耳机,NOUN,B2
-hörsel,hearing,听证会,NOUN,B2
-hörselbeile,heard beile,听说贝勒,NOUN,B2
-höst,fall,瀑布,NOUN,B2
-hövlighet,courtesy,礼貌,NOUN,B2
-i,i,我连,NOUN,B2
-i det,in it,在里面,ADV,B2
-i förväg,in advance,事先,ADV,B2
-i hemlighet,secretly,秘密地,ADV,B2
-i himlen,in the sky,天上,NOUN,B2
-i många år,for years,多年,ADV,B2
-i tid,in time,及时地,ADV,B2
-i vilken utsträckning,what extent,在何种程度上,ADV,B2
-i övrigt,incidentally,顺便地,ADV,B2
-i'm afraid,i'm afraid,恐怕,ADV,B2
-i-than,i-than,我比,NOUN,B2
-iatrogenic,iatrogenic,医源性的,ADJ,B2
-ibland,occasionally,偶尔,ADV,B2
-ice cold,ice cold,冰冷的,ADJ,B2
-ice cube,ice cube,词,NOUN,A2
-icicle,icicle,词,NOUN,B2
-icke-abstraktion,non-abstraction,非抽,NOUN,B2
-icke-bana,non-orbit,非轨,NOUN,B2
-icke-begrepp,non-concept,非概,NOUN,B2
-icke-bevis,non-evidence,非据,NOUN,B2
-icke-förtjänst,non-merit,非功,NOUN,B2
-icke-handling,non-action,非作,NOUN,B2
-icke-hjälp,non-assistance,勿助,NOUN,B2
-icke-induktion,non-induction,非归,NOUN,B2
-icke-inferens,non-inference,非推,NOUN,B2
-icke-konstruktion,non-construction,非建,NOUN,B2
-icke-kontingent,non-contingent,非偶,NOUN,B2
-icke-ljud,non-sound,非响,NOUN,B2
-icke-medvetande,non-mind,非心,NOUN,B2
-icke-modell,non-model,非模,NOUN,B2
-icke-nivå,non-level,非级,NOUN,B2
-icke-ordning,non-order,非序,NOUN,B2
-icke-skugga,non-shadow,非影,NOUN,B2
-icke-specifik,non-specific,非殊,NOUN,B2
-icke-spår,non-trace,非迹,NOUN,B2
-icke-stad,non-state,非态,NOUN,B2
-icke-strategi,non-strategy,非略,NOUN,B2
-icke-styrning,non-management,管不,NOUN,B2
-icke-substans,non-substance,非质,NOUN,B2
-icke-tanke,non-thought,非念,NOUN,B2
-icke-tron,non-belief,非信,NOUN,B2
-iconic,iconic,词,ADJ,C1
-iconicity,iconicity,词,NOUN,C1
-iconoclast,iconoclast,偶像破坏者,NOUN,B2
-iconoclastic,iconoclastic,词,ADJ,C1
-iconographic,iconographic,词,ADJ,C1
+jag förtjänar inte din berömelse,i don't deserve your praise,不敢当,INTJ,B2
+ishockey,ice hockey,冰球,NOUN,B2
+isbana,ice rink,溜冰场,NOUN,B2
+ikon,icon,偶像,NOUN,B2
+isig,icy,冰冷的,ADJ,B2
 id,id,证件,NOUN,B2
-id-foto,id photo,证件照,NOUN,B2
 id-kort,id card,身份证,NOUN,B2
-idag,today,今天,NOUN,B2
-idag kväll,tonight,今晚,NOUN,B2
+id-foto,id photo,证件照,NOUN,B2
 idealisk,ideal,理想的,ADJ,B2
 idealism,idealism,理想主义,NOUN,B2
 idealism,idealist,理想主义者,NOUN,B2
-idealization,idealization,词,NOUN,B2
-ideally,ideally,理想地,ADV,B2
-ideational,ideational,词,ADJ,C1
-identifier,identifier,词,NOUN,C1
-identitarianism,identitarianism,词,NOUN,C1
-identity-related,identity-related,词,ADJ,C1
-ideologi,ideology,意识形态,NOUN,B2
 ideologisk,ideological,意识形态的,ADJ,B2
-ideologization,ideologization,词,NOUN,C1
-idiom,idiom,习语,NOUN,B2
-idiomatic,idiomatic,词,ADJ,C1
-idiopathic,idiopathic,词,ADJ,C1
-idiosyncrasy,idiosyncrasy,特质,NOUN,B2
-idiosyncratic,idiosyncratic,词,ADJ,C1
-idiot,idiot,傻瓜,ADJ,B2
-idiot (adj),idiot,词,ADJ,A2
+ideologi,ideology,意识形态,NOUN,B2
 idioti,idiocy,愚蠢,NOUN,B2
-idolatry,idolatry,词,NOUN,B2
+idiom,idiom,习语,NOUN,B2
+ledig,idle,懒惰的,ADJ,B2
 idyll,idyll,田园诗,NOUN,B2
-idyllic,idyllic,词,ADJ,C1
-if (adp),if,若,ADP,A2
-if (aux),if,若要,AUX,B2
-if (noun),if,若就,NOUN,C1
-if (part),if,的话,PART,A2
-if I,if I,我若,SCONJ,B2
-if counterfactual,if counterfactual,词,SCONJ,A2
-if necessary,if necessary,词,ADV,C1
-if only,if only,但愿,VERB,B2
-igelkott,hedgehog,刺猬,NOUN,B2
-igneous,igneous,火成的,ADJ,B2
+om när,if when,如果,SCONJ,B2
 ignition,ignition,点火,NOUN,B2
-ignoble malice,ignoble malice,词,NOUN,C1
-ignominious,ignominious,词,ADJ,C1
-ignominy,ignominy,耻辱,NOUN,B2
 ignorance,ignorance,无知,NOUN,B2
 ignorant,ignorant,无知的,ADJ,B2
-ignorera,to disregard,忽视,VERB,B2
-igår,yesterday,بارحة,NOUN,B2
-ikon,icon,偶像,NOUN,B2
-iliac,iliac,词,ADJ,C1
 ill,ill,生病的,ADJ,B2
 illegality,illegality,非法,NOUN,B2
-illegally,illegally,词,ADV,C1
 illegitimate,illegitimate,非法的,ADJ,B2
-illicit,illicit,违禁的,ADJ,B2
-illiteracy,illiteracy,词,NOUN,C1
-illiterate,illiterate,词,ADJ,B2
 illness,illness,疾病,NOUN,B2
-illogical,illogical,不合逻辑的,ADJ,B2
 illuminate,to illuminate,照亮,VERB,B2
-illumination,illumination,照明,NOUN,B2
-illuminationism,illuminationism,照明主义,NOUN,C1
-illuminator,illuminator,彩饰画家,NOUN,B2
-illusory,illusory,词,ADJ,C1
-illustration,illustration,插图,NOUN,B2
-illustrative,illustrative,词,ADJ,C1
-illustrious,illustrious,著名的,ADJ,B2
 image,image,形象,NOUN,B2
-image formation,image formation,形象塑造,NOUN,B2
 imagery,imagery,意象,NOUN,B2
 imaginary,imaginary,虚构的,ADJ,B2
-imaginary (noun),imaginary,词,NOUN,C1
-imagined,imagined,想象的,ADJ,C1
-imaging,imaging,词,NOUN,C1
 imam,imam,伊玛目,NOUN,B2
-imamate,imamate,词,NOUN,C1
-imbalanced,imbalanced,失衡,ADJ,C1
-imbecile,imbecile,词,NOUN,C1
-imbecility,imbecility,愚蠢,NOUN,B2
 imitate,to imitate,模仿,VERB,B2
 imitation,imitation,模仿,NOUN,B2
 imitative,imitative,模仿性,ADJ,B2
-immaculate,immaculate,词,ADJ,C1
-immanence,immanence,内在性,NOUN,B2
-immanent,immanent,词,ADJ,C1
-immature,immature,不成熟的,ADJ,B2
 immeasurable,immeasurable,不可估量的,ADJ,B2
-immediacy,immediacy,词,NOUN,C1
-immemorial,immemorial,词,ADJ,C1
-immense,immense,巨大的,ADJ,B2
-immensity,immensity,词,NOUN,C1
-immerse,immerse,词,VERB,C1
-immersed,immersed,词,ADJ,C1
 immersion,immersion,沉浸,NOUN,B2
 immigrate,to immigrate,移入,VERB,B2
-imminence,imminence,就将,NOUN,C1
 imminent,imminent,即将来临的,ADJ,B2
-immobility,immobility,都无动,NOUN,B2
-immoderate,immoderate,词,ADJ,C1
-immoderation,immoderation,词,NOUN,C1
-immodesty,immodesty,不贞,NOUN,B2
-immoral,immoral,不道德的,ADJ,B2
-immorality,immorality,词,NOUN,C1
 immortality,immortality,不朽,NOUN,B2
-immovable,immovable,不可移动的,ADJ,B2
 immune,immune,免疫的,ADJ,B2
 immunization,immunization,免疫,NOUN,B2
 immunotherapy,immunotherapy,免疫治疗,NOUN,B2
-imorgon,tomorrow,غد,NOUN,B2
 impact,impact,影响,NOUN,B2
 impairment,impairment,左手废,NOUN,B2
 impart,to impart,传授,VERB,B2
-impartial,impartial,词,ADJ,C1
-impartiality,impartiality,公正,NOUN,B2
-impasse,impasse,词,NOUN,C1
-impassive,impassive,词,ADJ,C1
-impassively,impassively,词,ADV,B2
-impatience,impatience,词,NOUN,C1
 impatient,impatient,不耐烦的,ADJ,B2
-impeccable,impeccable,无瑕疵的,ADJ,B2
 impediment,impediment,障碍,NOUN,B2
 impel,to impel,推动,VERB,B2
 impenetrable,impenetrable,不可穿透的,ADJ,B2
 imperative,imperative,必要的,ADJ,B2
-imperatively,imperatively,词,ADV,C1
-imperceptible,imperceptible,词,ADJ,C1
-imperceptibly,imperceptibly,词,ADV,C1
-imperfect,imperfect,不完美的,ADJ,B2
-imperfection,imperfection,词,NOUN,C1
 imperial,imperial,帝国的,ADJ,B2
-imperial brother,imperial brother,你皇弟,NOUN,C1
-imperial consort,imperial consort,皇妃,NOUN,C1
 imperial court,imperial court,朝廷,NOUN,B2
-imperial decree,imperial decree,御令,NOUN,C1
-imperial face,imperial face,朕面,NOUN,C1
-imperial family,imperial family,皇室,NOUN,B2
-imperial father,imperial father,父皇,NOUN,B2
 imperial father's will,imperial father's will,父皇要,NOUN,B2
-imperial gaze,imperial gaze,朕看,NOUN,B2
 imperial guard,imperial guard,御林,NOUN,B2
-imperial or royal court,imperial or royal court,朝,NOUN,B1
-imperial physician,imperial physician,太医,NOUN,B2
-imperial share,imperial share,皇分,NOUN,C1
-imperial son-in-law,imperial son-in-law,驸马,NOUN,C1
-imperial use,imperial use,朕以,NOUN,C1
+kejsarlig släkting,imperial relatives,皇亲,NOUN,B2
 imperialism,imperialism,帝国主义,NOUN,B2
-imperialist,imperialist,帝国主义的,ADJ,B2
-imperious,imperious,词,ADJ,C1
-impersonal,impersonal,词,ADJ,C1
-impersonation,impersonation,词,NOUN,B2
-impertinence,impertinence,词,NOUN,C1
-impertinent,impertinent,词,ADJ,C1
-imperturbability,imperturbability,词,NOUN,C1
-imperturbably,imperturbably,词,ADV,C1
-impetuosity,impetuosity,词,NOUN,C1
-impetuous,impetuous,词,ADJ,B2
-impetus,impetus,词,NOUN,C1
-impiety,impiety,词,NOUN,C1
-impious,impious,词,ADJ,B2
-implacably,implacably,毫不留情地,ADV,B2
-implantation,implantation,词,NOUN,C1
-implausible,implausible,词,ADJ,C1
 implementera,to implement,实施,VERB,B2
 implementering,implementation,实施,NOUN,B2
-implicated,implicated,牵连的,ADJ,C1
+inblandas,to implicate,连累,VERB,B2
 implication,implication,含义,NOUN,B2
 implicit,implicit,含蓄的,ADJ,B2
-implicitly,implicitly,含蓄地,ADV,B2
-impoliteness,impoliteness,词,NOUN,C1
-import,import,进口,NOUN,B2
+bega,to implore,恳求,VERB,B2
+oförskamfull,impolite,不礼貌的,ADJ,B2
 import,importation,进口,NOUN,B2
-important case,important case,要案,NOUN,B2
-important matter,important matter,事要,NOUN,C1
-important thing,important thing,词,NOUN,C1
-imports,imports,词,NOUN,C1
-imposing,imposing,宏伟的,ADJ,B2
-imposition,imposition,词,NOUN,C1
-impostor,impostor,骗子,NOUN,B2
-imposture,imposture,词,NOUN,C1
-impotence,impotence,无力,NOUN,B2
-impotent,impotent,词,ADJ,C1
-impound lot,impound lot,词,NOUN,B1
-impoverished,impoverished,贫困的,ADJ,B2
-impoverishment,impoverishment,词,NOUN,C1
-imprecation,imprecation,词,NOUN,C1
-imprecise,imprecise,词,ADJ,C1
-impregnation,impregnation,词,NOUN,C1
+påbuda,to impose,强加,VERB,B2
+omöjlighet,impossibility,不可能,NOUN,B2
 impressionism,impressionism,印象主义,NOUN,B2
-impressions,impressions,感想,NOUN,B2
-imprint,imprint,印记,NOUN,B2
-impromptu,impromptu,即兴的,ADJ,B2
-improvidence,improvidence,词,NOUN,C1
+fängsla,to imprison,监禁,VERB,B2
+fängslande,imprisonment,监禁,NOUN,B2
+opassande,improper,不合适的,ADJ,B2
+förbättring,improvement,好转,NOUN,B2
 improvisation,improvisation,即兴创作,NOUN,B2
 improvisera,to improvise,即兴创作,VERB,B2
 improviserad,improvised,即兴的,ADJ,B2
-imprudence,imprudence,词,NOUN,C1
-imprudent,imprudent,词,ADJ,C1
+oförskämhet,impudence,厚颜无耻,NOUN,B2
+oförskamfull,impudent,无礼的,ADJ,B2
 impuls,impulse,冲动,NOUN,B2
 impulsiv,impulsive,冲动的,ADJ,B2
-impulsiveness,impulsiveness,冲动,NOUN,B2
-impulsivity,impulsivity,词,NOUN,C1
-impunity,impunity,逍遥法外,NOUN,B2
-impure,impure,词,ADJ,C1
-imputation,imputation,词,NOUN,C1
-in a great rush,in a great rush,慌忙,ADJ,C1
-in a hurry (adj),in a hurry,词,ADJ,B1
-in a while,in a while,待会儿,ADV,C1
-in a word,in a word,总之,ADV,B1
-in absentia (adj),in absentia,词,ADJ,C1
-in absentia (adv),in absentia,词,ADV,B2
-in accordance (adj),in accordance,词,ADJ,B2
-in accordance (noun),in accordance,依照,NOUN,C1
-in agreement,in agreement,词,ADV,C1
-in anticipation of,in anticipation of,词,ADV,C1
-in between,in between,在中间,ADV,B2
-in book,in book,书里,NOUN,C1
-in case sth happens,in case sth happens,一旦,SCONJ,B2
-in cash,in cash,词,ADV,B2
-in conclusion,in conclusion,词,ADV,C1
-in continuous succession,in continuous succession,词,ADV,C1
-in deficit,in deficit,词,ADJ,C1
-in every detail,in every detail,词,ADV,C1
-in exchange for,in exchange for,词,ADP,C1
-in fact,in fact,事实上,ADV,B2
-in front of before,in front of before,在...前,ADP,B2
-in high spirits,in high spirits,兴致勃勃,ADJ,B2
-in installments,in installments,分期付款,ADV,B1
-in its entirety,in its entirety,词,ADV,C1
-in me,in me,我中,NOUN,C1
-in need,in need,词,ADJ,A2
-in no way,in no way,词,ADV,C1
-in one's heart,in one's heart,心里,NOUN,C1
-in order,in order,依次,ADV,B2
-in order to (adp),in order to,为了,ADP,A1
-in order to avoid,in order to avoid,以免,SCONJ,B2
-in order to so that,in order to so that,以便,SCONJ,A2
-in other words,in other words,换言之,ADV,B2
-in parallel,in parallel,词,ADV,B2
-in parallel with,in parallel with,词,ADV,C1
-in particular,in particular,词,ADV,B2
-in passing,in passing,顺便,ADV,B2
-in presence of parties,in presence of parties,词,ADJ,C1
-in question,in question,词,ADV,C1
+orenhet,impurity,不纯,NOUN,B2
+dessutom,in addition,此外,ADV,B2
+i förväg,in advance,事先,ADV,B2
+detaljerat,in detail,详细地,ADV,B2
+framför,in front,在前面,ADV,B2
+i det,in it,在里面,ADV,B2
+för att,in order to,以期,SCONJ,B2
+personligen,in person,亲自地,ADV,B2
 in short,in short,简而言之,ADV,B2
-in street,in street,当街,NOUN,C1
-in summary,in summary,综上所述,ADV,B2
-in the back,in the back,在后面,ADV,B2
-in the body,in the body,体内,NOUN,B2
-in the end,in the end,到底,ADV,A2
-in the evening,in the evening,词,ADV,B2
-in the final analysis,in the final analysis,归根结底,ADV,B2
-in the future,in the future,词,ADV,B2
-in the middle,in the middle,词,ADV,B1
-in the middle of doing,in the middle of doing,正在,ADV,B2
-in the morning,in the morning,词,ADV,C1
-in the mouth,in the mouth,嘴里,NOUN,B2
-in the past (adv),in the past,词,ADV,B2
-in the past (noun),in the past,以往,NOUN,B2
-in the world,in the world,世上,NOUN,B2
-in those days,in those days,当年,NOUN,B2
-in those days (adv),in those days,在那些日子/当时,ADV,C1
-in time (adj),in time,词,ADJ,B1
-in unison,in unison,齐声,ADV,B2
-in view of,in view of,鉴于,ADP,B2
-in which,in which,在其中,PRON,B2
-in writing (adv),in writing,词,ADV,B2
-in-law,in-law,词,NOUN,A2
-inaccessible,inaccessible,词,ADJ,C1
-inaccurate,inaccurate,词,ADJ,C1
-inaction,inaction,词,NOUN,C1
-inactive,inactive,词,ADJ,C1
-inactivity,inactivity,不活跃,NOUN,B2
-inadequate,inadequate,不足的,ADJ,B2
-inadmissibility,inadmissibility,词,NOUN,C1
-inadmissible,inadmissible,不可接受的,ADJ,B2
-inadvertent,inadvertent,词,ADJ,C1
-inadvertently,inadvertently,词,ADV,B2
-inalienable,inalienable,词,ADJ,C1
-inane,inane,词,ADJ,C1
-inanimate,inanimate,词,ADJ,C1
-inappreciable,inappreciable,词,ADJ,C1
-inappropriateness,inappropriateness,不妥,NOUN,B2
-inattentive,inattentive,词,ADJ,C1
-inaudible,inaudible,词,ADJ,B2
-inblandas,to implicate,连累,VERB,B2
-inborn nature,inborn nature,词,NOUN,C1
-inbrott,burglary,入室盗窃罪,NOUN,B2
-inbrytare,burglar,窃贼,NOUN,B2
-inbädda,to embed,嵌入,VERB,B2
-incandescence,incandescence,词,NOUN,C1
-incandescent,incandescent,白炽的,ADJ,B2
+trotts,to in spite of,不顾,VERB,B2
+i himlen,in the sky,天上,NOUN,B2
+i tid,in time,及时地,ADV,B2
+vind,in wind,临风,NOUN,B2
+skrift,in writing,书面,NOUN,B2
+oförmåga,inability,无能,NOUN,B2
+inviga,to inaugurate,启用,VERB,B2
+invigning,inauguration,开幕,NOUN,B2
 incantation,incantation,咒语,NOUN,B2
-incapable,incapable,词,ADJ,B1
-incapacity,incapacity,词,NOUN,C1
-incarceration,incarceration,词,NOUN,C1
-incarnation,incarnation,词,NOUN,C1
-incendiary,incendiary,词,ADJ,C1
-incentivization,incentivization,词,NOUN,C1
-inceptive,inceptive,词,ADJ,C1
-incessant,incessant,持续的,ADJ,B2
-incest,incest,词,NOUN,C1
-inchoative,inchoative,词,ADJ,C1
-incidence,incidence,发生率,NOUN,B2
-incident,incident,事件,NOUN,B2
-incidental,incidental,词,ADJ,B2
-incinera,to incinerate,焚烧,VERB,B2
-incineration,incineration,词,NOUN,C1
-incinerator,incinerator,词,NOUN,C1
-incipient,incipient,初期的,ADJ,B2
-incision,incision,切口,NOUN,B2
-incisive,incisive,深刻的,ADJ,B2
+rökelse,incense,香,NOUN,B2
 incitament,incentive,激励,NOUN,B2
-inciting,inciting,词,ADJ,C1
-inclemency,inclemency,词,NOUN,C1
-inclement,inclement,严酷的,ADJ,B2
-inclined prone,inclined prone,词,ADJ,C1
-including (adv),including,词,ADV,A2
-inclusion,inclusion,包含,NOUN,B2
-incognito,incognito,词,ADJ,C1
-incoherence,incoherence,不连贯,NOUN,B2
-incoherent,incoherent,不连贯的,ADJ,B2
-incommunicado,incommunicado,词,ADJ,C1
-incompatible,incompatible,词,ADJ,C1
-incompetence,incompetence,词,NOUN,C1
-incompetent,incompetent,无能的,ADJ,B2
-incomplete (noun),incomplete,不全,NOUN,C1
-incompleteness,incompleteness,不完整,NOUN,B2
-incomprehension,incomprehension,词,NOUN,C1
-inconceivable,inconceivable,不可想象的,ADJ,B2
-inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
-incongruity,incongruity,不协调,NOUN,B2
-incongruous,incongruous,不协调的,ADJ,B2
-inconsiderate,inconsiderate,词,ADJ,C1
-inconsolable,inconsolable,词,ADJ,C1
-inconspicuous,inconspicuous,词,ADJ,C1
-inconstant,inconstant,词,ADJ,C1
-incontestably,incontestably,词,ADV,B2
-inconvenience (noun),inconvenience,词,NOUN,C1
-inconvenient,inconvenient,词,ADJ,C1
-incorporation,incorporation,纳入,NOUN,B2
-incorrect,incorrect,不正确的,ADJ,B2
-incorrectness,incorrectness,词,NOUN,C1
-incorruptible,incorruptible,廉洁,ADJ,C1
-increase excess,increase excess,词,NOUN,C1
-increase growth,increase growth,词,NOUN,C1
-increased,increased,增加的,ADJ,B2
-increases,increases,增加,NOUN,C1
-increasing,increasing,增加的,ADJ,B2
-incredible amazing,incredible amazing,词,ADJ,A1
-incredulous,incredulous,词,ADJ,C1
-incremental,incremental,渐进性,ADJ,B2
-inculcate,inculcate,词,VERB,C1
-incumbent,incumbent,词,ADJ,C1
-incurable,incurable,不可救药,ADJ,B2
-incurable (noun),incurable,难治,NOUN,C1
-incursion,incursion,词,NOUN,C1
-indebted,indebted,负债的,ADJ,B2
-indecent,indecent,词,ADJ,C1
-indecipherable,indecipherable,词,ADJ,C1
-indecision,indecision,词,NOUN,C1
-indeed (part),indeed,了吧,PART,B2
-indefinite,indefinite,词,ADJ,C1
-independently,independently,独立地,ADV,B2
-indeterminate,indeterminate,词,ADJ,C1
-indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
-index,index,索引,NOUN,B2
-indexed,indexed,词,ADJ,C1
-indexes,indexes,词,NOUN,C1
-indexing,indexing,指数化,NOUN,B2
-indian,indian,印度的,ADJ,B2
-indictment,indictment,起诉,NOUN,B2
-indigent,indigent,词,ADJ,C1
-indignation,indignation,愤慨,NOUN,B2
-indignerad,indignant,愤慨的,ADJ,B2
-indignity,indignity,词,NOUN,C1
-indikator,indicator,指标,NOUN,B2
-indikera,to indicate,表明,VERB,B2
-indirect,indirect,词,ADJ,C1
-indirectly,indirectly,间接地,ADV,B2
-indiscreet,indiscreet,词,ADJ,C1
-indiscretion,indiscretion,轻率,NOUN,B2
-indiscriminately,indiscriminately,不加区别地,ADV,B2
-indisputable,indisputable,词,ADJ,C1
-indisputably,indisputably,词,ADV,C1
-indistinct,indistinct,模糊的,ADJ,B2
-indistinguishable,indistinguishable,词,ADJ,C1
-individual personal,individual personal,个人,NOUN,B1
-individual specific,individual specific,个别,ADJ,B2
-individualism,individualism,个人主义,NOUN,B2
-individualitet,individuality,个性,NOUN,B2
-individualization,individualization,词,NOUN,C1
-individually,individually,词,ADV,C1
-individuell,individual,单独的,ADJ,B2
-individuell uppgift,individual assignment,个人作业,NOUN,B2
-indoctrination,indoctrination,灌输,NOUN,B2
-indolent,indolent,词,ADJ,C1
-indomitable,indomitable,词,ADJ,C1
-indonesian,indonesian,印度尼西亚的,ADJ,B2
-inducera,to induce,引起,VERB,B2
-induction,induction,词,NOUN,C1
-inductive,inductive,词,ADJ,C1
-indulge,indulge,词,VERB,C1
-indulgence,indulgence,词,NOUN,C1
-indulgent,indulgent,词,ADJ,C1
-industrialization,industrialization,工业化,NOUN,B2
-industriell,industrial,工业的,ADJ,B2
-industrikedja,industry chain,产业链,NOUN,B2
-industrious,industrious,勤劳的,ADJ,B2
-inedible,inedible,词,ADJ,C1
-ineffable,ineffable,词,ADJ,C1
-ineffective,ineffective,词,ADJ,C1
-ineffectiveness,ineffectiveness,! 无效,NOUN,B2
-ineffektiv,inefficient,低效的,ADJ,B2
-inefficiency,inefficiency,低效,NOUN,B2
-inept,inept,词,ADJ,C1
-ineptitude,ineptitude,词,NOUN,C1
-inequity,inequity,词,NOUN,C1
-inert,inert,惰性的,ADJ,B2
-inertness,inertness,词,NOUN,B2
-inescapable,inescapable,词,ADJ,C1
-inescapable blame,inescapable blame,难辞其咎,NOUN,C1
-inestimable,inestimable,难以估量,ADJ,C1
-inevitable (noun),inevitable,词,NOUN,B2
-inevitably,inevitably,不免,ADV,B1
-inexact,inexact,词,ADJ,C1
-inexhaustible,inexhaustible,词,ADJ,C1
-inexorably,inexorably,不可阻挡地,ADV,B2
-inexpressible,inexpressible,词,ADJ,C1
-inexpressive,inexpressive,词,ADJ,C1
-infallible,infallible,词,ADJ,C1
-infamous,infamous,声名狼藉的,ADJ,B2
-infamy,infamy,恶名,NOUN,B2
-infant,infant,婴儿,NOUN,B2
-infantilism,infantilism,词,NOUN,C1
-infantry,infantry,步兵,NOUN,B2
-infart,driveway,车道,NOUN,B2
-infatuated,infatuated,词,ADJ,B2
-infeasibility,infeasibility,不可行性,NOUN,C1
-inferential,inferential,词,ADJ,C1
-infertility,infertility,词,NOUN,C1
-infidelity,infidelity,不忠,NOUN,B2
-infiltration,infiltration,混进,NOUN,C1
-infiltrator,infiltrator,词,NOUN,C1
-infiltrera,to infiltrate,渗透,VERB,B2
-infinitely,infinitely,词,ADV,B2
-infinity,infinity,词,NOUN,C1
-infirmary,infirmary,医务室,NOUN,B2
-inflamed,inflamed,激烈的,ADJ,B2
-inflammation,inflammation,炎症,NOUN,B2
-inflammatory,inflammatory,词,ADJ,C1
-inflated,inflated,膨胀的,ADJ,B1
-inflatera,to inflate,使膨胀,VERB,B2
-inflation,inflation,通货膨胀,NOUN,B2
-inflationary,inflationary,词,ADJ,C1
-inflection,inflection,词尾,NOUN,B2
-inflexibility,inflexibility,僵化,NOUN,B2
-influencer,influencer,网红,NOUN,B2
-influential,influential,词,ADJ,C1
-influential person,influential person,词,NOUN,C1
-influx,influx,涌入,NOUN,B2
-infographic computer graphics,infographic computer graphics,词,NOUN,C1
-informant,informant,线人,NOUN,B2
-informatics,informatics,词,NOUN,B2
-information,information,信息,NOUN,B2
-information desk,information desk,词,NOUN,B1
-informative,informative,提供信息的,ADJ,B2
-informedness,informedness,知情度,NOUN,B2
-informell,informal,非正式的,ADJ,B2
-informer,informer,词,NOUN,C1
-informers,informers,词,NOUN,C1
-infraction,infraction,词,NOUN,C1
-infractions,infractions,词,NOUN,C1
-infrared,infrared,词,ADJ,C1
-infrastructural,infrastructural,词,ADJ,C1
-infrastructure,infrastructure,基础设施,NOUN,B2
-infringement,infringement,侵犯,NOUN,C1
-ingen,nobody,没有人,PRON,B2
-ingenjörskonst,engineering,工程学,NOUN,B2
-ingest,to ingest,服用,VERB,B2
-ingratitude,ingratitude,词,NOUN,C1
-ingredient,ingredient,成分,NOUN,B2
-ingredients,ingredients,词,NOUN,B1
-ingång,entry,入口,NOUN,B2
-inhabited,inhabited,词,ADJ,C1
-inhale,to inhale,吸入,VERB,B2
-inhamta,to overtake,超过,VERB,B2
-inharmonious,inharmonious,词,ADJ,C1
-inhemsk,indigenous,本土的,ADJ,B2
-inherence,inherence,固有,NOUN,B2
-inherent,inherent,固有的,ADJ,B2
-inherent (noun),inherent,自有,NOUN,C1
-inheritance law,inheritance law,继承法,NOUN,B2
-inherited,inherited,词,ADJ,C1
-inhibited,inhibited,词,ADJ,B2
-inhibition,inhibition,抑制,NOUN,B2
-inhospitable,inhospitable,词,ADJ,C1
-inhuman,inhuman,不人道的,ADJ,B2
-inhumanity,inhumanity,词,NOUN,C1
-inimitability,inimitability,词,NOUN,C1
-initial,initial,最初的,ADJ,B2
-initial (noun),initial,词,NOUN,B2
-initial capping,initial capping,始加,NOUN,C1
-initial stage,initial stage,初期,NOUN,B2
-initial suffering,initial suffering,先受,NOUN,C1
-initialization,initialization,词,NOUN,C1
-initially,initially,首先,ADV,B2
-initiation,initiation,词,NOUN,C1
-initiative,initiative,主动权,NOUN,B2
-injection,injection,注射,NOUN,B2
-injunction,injunction,禁令,NOUN,B2
-injure,to injure,使受伤,VERB,B2
-injury,injury,伤害,NOUN,B2
-injury recovery,injury recovery,好伤,NOUN,C1
-injustice,injustice,不公,NOUN,B2
+tum,inch,بوصة,NOUN,B2
+incident,incident,事件,NOUN,B2
+i övrigt,incidentally,顺便地,ADV,B2
+incinera,to incinerate,焚烧,VERB,B2
+uppvigla,to incite,煽动,VERB,B2
+uppvigling,incitement,煽动,NOUN,B2
+benägenhet,inclination,倾向,NOUN,B2
+luta,to incline,使倾斜,VERB,B2
+intäkt och utgift,income and expense,收支,NOUN,B2
+oförenlighet,incompatibility,不兼容,NOUN,B2
+ofullständig,incomplete,不完整的,ADJ,B2
 inkonsekvens,inconsistency,不一致,NOUN,B2
 inkonsekvent,inconsistent,不一致的,ADJ,B2
 inkorporera,to incorporate,包含,VERB,B2
-inkstone,inkstone,砚,NOUN,C1
+ökning,increase,增加,NOUN,B2
+öka stadigt,to increase steadily,与日俱增,VERB,B2
+alltmer,increasingly,越来越,ADV,B2
 inkubation,incubation,孵化,NOUN,B2
 inkubator,incubator,孵化器,NOUN,B2
-inkwell,inkwell,词,NOUN,C1
-inlay,inlay,镶,NOUN,C1
-inledning,preamble,序言,NOUN,B2
-inluta,to enclose,围住,VERB,B2
-inlägga,to pickle,腌渍,VERB,B2
-inmate,inmate,词,NOUN,C1
+skuldsättning,indebtedness,负债,NOUN,B2
+obeslutsam,indecisive,犹豫不决的,ADJ,B2
+outplånlig,indelible,不可磨灭的,ADJ,B2
+oberoende,independence,独立,NOUN,B2
+obeskrivlig,indescribable,难以形容的,ADJ,B2
+index,index,索引,NOUN,B2
+indikera,to indicate,表明,VERB,B2
+indikator,indicator,指标,NOUN,B2
+likgiltighet,indifference,冷漠,NOUN,B2
+likgiltig,indifferent,冷漠的,ADJ,B2
+inhemsk,indigenous,本土的,ADJ,B2
+matsmältningsstörning,indigestion,消化不良,NOUN,B2
+indignerad,indignant,愤慨的,ADJ,B2
+indignation,indignation,愤慨,NOUN,B2
+omrörlig,indispensable,不可或缺的,ADJ,B2
+individuell,individual,单独的,ADJ,B2
+individuell uppgift,individual assignment,个人作业,NOUN,B2
+individualism,individualism,个人主义,NOUN,B2
+individualitet,individuality,个性,NOUN,B2
+inducera,to induce,引起,VERB,B2
+industriell,industrial,工业的,ADJ,B2
+industrikedja,industry chain,产业链,NOUN,B2
+ineffektiv,inefficient,低效的,ADJ,B2
+ojämlikhet,inequality,不平等,NOUN,B2
+tröghet,inertia,惯性,NOUN,B2
+obergad,inexperienced,生疏的,ADJ,B2
+förälskelse,infatuation,迷恋,NOUN,B2
+sluta,to infer,推断,VERB,B2
+slutsats,inference,推断,NOUN,B2
+underlägsen,inferior,低等的,ADJ,B2
+underlägsenhet,inferiority,劣势,NOUN,B2
+infiltrera,to infiltrate,渗透,VERB,B2
+oändlig,infinite,无限的,ADJ,B2
+inflatera,to inflate,使膨胀,VERB,B2
+inflation,inflation,通货膨胀,NOUN,B2
+påverka,to influence,影响,VERB,B2
+influencer,influencer,网红,NOUN,B2
+informell,informal,非正式的,ADJ,B2
+informant,informant,线人,NOUN,B2
+information,information,信息,NOUN,B2
+kränka,to infringe,侵犯,VERB,B2
+genialisk,ingenious,灵巧的,ADJ,B2
+ingest,to ingest,服用,VERB,B2
+ingredient,ingredient,成分,NOUN,B2
+inhale,to inhale,吸入,VERB,B2
+inherent,inherent,固有的,ADJ,B2
+initial,initial,最初的,ADJ,B2
+initially,initially,首先,ADV,B2
+initiative,initiative,主动权,NOUN,B2
+injection,injection,注射,NOUN,B2
+injure,to injure,使受伤,VERB,B2
+injury,injury,伤害,NOUN,B2
+injustice,injustice,不公,NOUN,B2
 inn,inn,小旅馆,NOUN,B2
 innate,innate,天生的,ADJ,B2
-innate disposition,innate disposition,词,NOUN,C1
-innate nature,innate nature,词,NOUN,B2
-innate qualities,innate qualities,词,NOUN,C1
 inner court,inner court,朝内,NOUN,B2
-inner heart,inner heart,内心,NOUN,B2
-inner self,inner self,词,NOUN,C1
-inner side,inner side,内侧,NOUN,B2
-inner workings,inner workings,词,NOUN,C1
-innocent (adv),innocent,无辜地,ADV,B2
-innocent person,innocent person,词,NOUN,C1
-innocuous,innocuous,无害的,ADJ,B2
 innovation,innovation,创新,NOUN,B2
 innovative,innovative,创新的,ADJ,B2
-innuendo,innuendo,词,NOUN,C1
-inopportune,inopportune,词,ADJ,C1
-inorganic,inorganic,词,ADJ,C1
-inpackning,wrapping,包装,NOUN,B2
-inpatient department,inpatient department,住院部,NOUN,B2
-inputs,inputs,词,NOUN,C1
 inquire,to inquire,询问,VERB,B2
 inquiry,inquiry,调查,NOUN,B2
-inquisition,inquisition,宗教裁判所,NOUN,B2
-inquisitive,inquisitive,好奇的,ADJ,B2
-insamla donationer,to raise donations,募捐,VERB,B2
-insatiable,insatiable,不知足的,ADJ,B2
-inscription,inscription,刻有,NOUN,B2
-inscrutable,inscrutable,词,ADJ,C1
-insect-proof,insect-proof,防虫,ADJ,C1
 insecticide,insecticide,杀虫剂,NOUN,B2
 insecure,insecure,不安全的,ADJ,B2
-insecurity,insecurity,不安全感,NOUN,B2
-insekt,bug,虫子,NOUN,B2
-insemination,insemination,词,NOUN,C1
-insensitive,insensitive,麻木的,ADJ,B2
-insensitivity,insensitivity,词,NOUN,C1
 inseparable,inseparable,不可分割的,ADJ,B2
 insert,to insert,插入,VERB,B2
-insertion,insertion,词,NOUN,B2
 inside city,inside city,城内,NOUN,B2
-inside in,inside in,里,NOUN,B2
 inside story,inside story,内幕,NOUN,B2
 insider,insider,知情者,NOUN,B2
 insidious,insidious,潜伏的,ADJ,B2
-insidiously,insidiously,词,ADV,B2
-insightfulness,insightfulness,洞察,NOUN,B2
 insignificant,insignificant,微不足道的,ADJ,B2
-insikt,clear knowledge,明知,NOUN,B2
-insiktsfull,perceptive,敏锐的,ADJ,B2
-insincere,insincere,词,ADJ,C1
-insinuation,insinuation,暗示,NOUN,B2
-insipid,insipid,词,ADJ,C1
 insistence,insistence,坚持,NOUN,B2
-insistence persistence,insistence persistence,词,NOUN,B2
-inskrivning,enrollment,注册,NOUN,B2
-inskränka,to constrain,限制,VERB,B2
-inskränka,to curb,抑制,VERB,B2
-inskränkning,constraint,约束,NOUN,B2
 insolence,insolence,无礼,NOUN,B2
-insolence rudeness,insolence rudeness,词,NOUN,B2
 insolent,insolent,傲慢的,ADJ,B2
-insolent conceit,insolent conceit,词,NOUN,C1
 insolvency,insolvency,无偿付能力,NOUN,B2
-insolvent,insolvent,无偿还能力的,ADJ,B2
 insomnia,insomnia,失眠,NOUN,B2
-insourcing,insourcing,内包,NOUN,C1
 inspect,to inspect,检查,VERB,B2
-inspect and accept,inspect and accept,验收,VERB,C1
-inspect goods,inspect goods,验货,VERB,C1
 inspection,inspection,检查,NOUN,B2
-inspectorate,inspectorate,词,NOUN,C1
 inspiration,inspiration,灵感,NOUN,B2
 inspire,to inspire,鼓舞,VERB,B2
-inspired,inspired,受启发的,ADJ,B2
 instability,instability,不稳定,NOUN,B2
 install,to install,安装,VERB,B2
 installation,installation,安装,NOUN,B2
-installation assembly,installation assembly,词,NOUN,C1
-installed,installed,词,ADJ,C1
 installment,installment,分期付款,NOUN,B2
-installment plan,installment plan,词,NOUN,B2
-installments,installments,词,NOUN,B2
 instant,instant,فور,NOUN,B2
-instantaneous,instantaneous,瞬间的,ADJ,B2
-instantaneously,instantaneously,瞬间地,ADV,C1
-instantly,instantly,词,ADV,C1
-instead (adp),instead,词,ADP,C1
-instead of,instead of,词,ADP,A2
 instead on the contrary,instead on the contrary,反而,ADV,B2
-instigation,instigation,怂恿,NOUN,C1
-instigator,instigator,词,NOUN,C1
-instinctively,instinctively,词,ADV,C1
-instinctuality,instinctuality,词,NOUN,C1
 institute,institute,机构,NOUN,B2
 institutional,institutional,机构的,ADJ,B2
 institutionalization,institutionalization,制度化,NOUN,B2
-institutionalized,institutionalized,词,ADJ,C1
-instruction deposit,instruction deposit,词,NOUN,C1
-instruction leaflet,instruction leaflet,词,NOUN,B2
-instructive,instructive,有教育意义的,ADJ,B2
-instructor,instructor,讲师,NOUN,B2
 instrument,instrument,乐器,NOUN,B2
-instrumental improvisation,instrumental improvisation,器乐即兴演奏,NOUN,C1
-instrumental piece,instrumental piece,词,NOUN,C1
-instrumentalist (adj),instrumentalist,词,ADJ,C1
-instrumentalist (noun),instrumentalist,词,NOUN,B2
-insufferable,insufferable,词,ADJ,C1
-insufficiency,insufficiency,不足,NOUN,B2
 insufficient,insufficient,不足的,ADJ,B2
-insulator,insulator,词,NOUN,B2
-insulin,insulin,胰岛素,NOUN,B2
-insurances,insurances,词,NOUN,C1
 insure,to insure,保证,VERB,B2
-insured,insured,词,NOUN,B2
-insurer,insurer,词,NOUN,C1
-insurgency,insurgency,词,NOUN,C1
 insurmountable,insurmountable,不可逾越的,ADJ,B2
 insurrection,insurrection,起义,NOUN,B2
-intake,intake,词,NOUN,C1
-intangible,intangible,无形的,ADJ,B2
-inte,do not,莫,ADV,B2
-inte längre,no longer,不再,ADV,B2
-inteckna,mortgage,抵押贷款,NOUN,B2
-inteckna,to mortgage,抵押,VERB,B2
-integer,integer,词,NOUN,C1
-integral,integral,不可或缺的,ADJ,B2
-integrity trustworthiness,integrity trustworthiness,诚实/正直,NOUN,B2
-intellect,intellect,智力,NOUN,B2
 intellectual,intellectual,知识的,ADJ,B2
-intellectual (noun),intellectual,词,NOUN,B2
-intellectual life,intellectual life,精神生活,NOUN,B2
-intelligence information,intelligence information,情报,NOUN,B2
-intelligence-related,intelligence-related,词,ADJ,C1
 intelligent,intelligent,聪明的,ADJ,B2
-intelligently,intelligently,词,ADV,C1
-intelligible,intelligible,词,ADJ,C1
-intemperate,intemperate,词,ADJ,C1
 intend,to intend,打算,VERB,B2
-intended,intended,预定的,ADJ,B2
-intended meaning,intended meaning,词,NOUN,C1
-intensification,intensification,词,NOUN,C1
 intensify,to intensify,加剧,VERB,B2
 intensity,intensity,强度,NOUN,B2
-intensive care,intensive care,重症监护,NOUN,B2
 intent,intent,意图,NOUN,B2
 intentional,intentional,故意的,ADJ,B2
-intentionality,intentionality,词,NOUN,C1
-intentions,intentions,词,NOUN,C1
 interactive,interactive,交互式的,ADJ,B2
-interactivity,interactivity,词,NOUN,C1
 intercept,to intercept,拦截,VERB,B2
-intercession,intercession,词,NOUN,C1
-intercity bus,intercity bus,词,NOUN,B2
-interconnection,interconnection,词,NOUN,C1
 intercourse,intercourse,性交,NOUN,B2
-interdicted person,interdicted person,词,NOUN,C1
-interdiction,interdiction,词,NOUN,C1
 interest,to interest,使感兴趣,VERB,B2
-interest rate,interest rate,利率,NOUN,B2
-interesting things,interesting things,词,NOUN,C1
 interface,interface,接口,NOUN,B2
 interfere,to interfere,干涉,VERB,B2
 interference,interference,干扰,NOUN,B2
-interim (adj),interim,词,ADJ,C1
-interim (noun),interim,词,NOUN,B2
 interior,interior,内部,NOUN,B2
-interjection,interjection,词,NOUN,C1
-interlaced,interlaced,词,ADJ,C1
-interlocked,interlocked,词,ADJ,C1
 interlocutor,interlocutor,对话者,NOUN,B2
 intermediary,intermediary,中间人,NOUN,B2
-intermediate,intermediate,中级的,ADJ,B2
-intermission,intermission,词,NOUN,C1
 intermittent,intermittent,间歇的,ADJ,B2
-intern,intern,词,NOUN,C1
 internal,internal,内部的,ADJ,B2
-internal affairs,internal affairs,内政,NOUN,C1
 internal force,internal force,内力,NOUN,B2
-internal medicine,internal medicine,内科,NOUN,B1
-internal rhyme,internal rhyme,词,NOUN,C1
-internat,boarding school,寄宿学校,NOUN,B2
 international student,international student,留学生,NOUN,B2
-internationalization,internationalization,词,NOUN,C1
 internet,internet,互联网,NOUN,B2
 internship,internship,实习,NOUN,B2
-interpellation,interpellation,词,NOUN,C1
-interpersonal,interpersonal,人际的,ADJ,B2
 interpreter,interpreter,口译员,NOUN,B2
-interpretive,interpretive,词,ADJ,C1
-interrogation room,interrogation room,审讯室,NOUN,B2
-interrupted,interrupted,词,ADJ,B2
 intersection,intersection,交叉点,NOUN,B2
-intertextuality,intertextuality,词,NOUN,C1
-intertwined,intertwined,词,ADJ,C1
-interval,interval,词,NOUN,C1
 intervention,intervention,干预,NOUN,B2
-interviewer,interviewer,词,NOUN,C1
 intestine,intestine,肠,NOUN,B2
-intestines,intestines,词,NOUN,B2
 intimacy,intimacy,亲密,NOUN,B2
 intimate,intimate,亲密的,ADJ,B2
-intimate (noun),intimate,词,NOUN,B2
-intimate friendship,intimate friendship,词,NOUN,C1
-intimately,intimately,词,ADV,C1
 intimidate,to intimidate,恐吓,VERB,B2
 intimidation,intimidation,恐吓,NOUN,B2
-into (adp),into,词,ADP,A1
-into (adv),into,词,ADV,B1
-intolerable,intolerable,词,ADJ,C1
 intolerance,intolerance,不容忍,NOUN,B2
-intolerant,intolerant,不容忍的,ADJ,B2
-intonational quality,intonational quality,词,NOUN,C1
-intoxication,intoxication,词,NOUN,C1
 intractable,intractable,难处理的,ADJ,B2
-intransigence,intransigence,词,NOUN,C1
-intransigent,intransigent,不妥协的,ADJ,B2
-intravenous drip,intravenous drip,输液,NOUN,B2
 intrepid,intrepid,无畏的,ADJ,B2
-intrepidity,intrepidity,词,NOUN,C1
-intressebrist,disinterest,公正;不感兴趣,NOUN,B2
-intricacy,intricacy,词,NOUN,C1
-intricate,intricate,错综复杂的,ADJ,B2
 intrigue,to intrigue,激起兴趣,VERB,B2
-intrigue (noun),intrigue,词,NOUN,C1
-intriguing,intriguing,词,ADJ,C1
 intrinsic,intrinsic,固有的,ADJ,B2
-intrinsically,intrinsically,词,ADV,C1
 introduction,introduction,介绍,NOUN,B2
-introductory,introductory,词,ADJ,C1
 introspection,introspection,内省,NOUN,B2
-introversion,introversion,词,NOUN,B2
 introverted,introverted,内向的,ADJ,B2
-intrusive,intrusive,词,ADJ,C1
-inträda i stad,to enter city,进城,VERB,B2
 intuition,intuition,直觉,NOUN,B2
-intuitionist,intuitionist,词,ADJ,C1
-intuitive,intuitive,词,ADJ,C1
-intyga,to certify,证明,VERB,B2
-intäkt och utgift,income and expense,收支,NOUN,B2
-inure,inure,词,VERB,C1
 invade,to invade,入侵,VERB,B2
-invader,invader,入侵者,NOUN,B2
-invalidated,invalidated,词,ADJ,C1
-invalidity,invalidity,词,NOUN,C1
-invariable,invariable,词,ADJ,C1
-invariably,invariably,不变地,ADV,B2
 invasion,invasion,入侵,NOUN,B2
 inventor,inventor,发明家,NOUN,B2
-inventorying,inventorying,清点,NOUN,B2
-inverse,inverse,词,NOUN,C1
-inversion,inversion,反演,NOUN,B2
-inverted,inverted,词,ADJ,C1
-investigated,investigated,被调查的,ADJ,B2
-investigative,investigative,词,ADJ,C1
-investment (adj),investment,词,ADJ,C1
-inviga,to inaugurate,启用,VERB,B2
-invigning,inauguration,开幕,NOUN,B2
-invincibility,invincibility,不胜,NOUN,C1
-invincible,invincible,无敌的,ADJ,B2
-inviolate,inviolate,词,ADJ,C1
-invitational tournament,invitational tournament,邀请赛,NOUN,C1
-invited,invited,词,ADJ,C1
-invocation,invocation,词,NOUN,C1
-invocations,invocations,词,NOUN,C1
 invoice,invoice,发票,NOUN,B2
-invoicing,invoicing,词,NOUN,B2
-involuntarily,involuntarily,词,ADV,C1
-involuntary,involuntary,无意识的,ADJ,B2
 involve,to involve,涉及,VERB,B2
-involved party,involved party,词,NOUN,C1
-invulnerability,invulnerability,词,NOUN,C1
-invändning,objection,异议,NOUN,B2
-inward,inward,词,ADJ,C1
-inwardly,inwardly,内在地,ADV,C1
-iodine deficiency,iodine deficiency,词,NOUN,C1
-ion,ion,词,NOUN,C1
-iranian,iranian,伊朗的,ADJ,B2
 irascibility,irascibility,易怒,NOUN,B2
 irascible,irascible,易怒的,ADJ,B2
-iris,iris,词,NOUN,B2
-irish,irish,爱尔兰的,ADJ,B2
-irksome,irksome,词,ADJ,C1
 iron,iron,铁的,ADJ,B2
-iron arm,iron arm,铁臂,NOUN,C1
-ironclad case,ironclad case,铁案,NOUN,C1
-ironically,ironically,词,ADV,C1
-ironing,ironing,词,NOUN,B1
 irony,irony,讽刺,NOUN,B2
-irrational,irrational,非理性的,ADJ,B2
 irrationality,irrationality,非理性,NOUN,B2
 irreconcilable,irreconcilable,不可调和的,ADJ,B2
 irrefutable,irrefutable,无可辩驳的,ADJ,B2
-irrefutably,irrefutably,词,ADV,C1
-irregular,irregular,不规则的,ADJ,B2
-irregularity,irregularity,不规则,NOUN,B2
-irrelevance,irrelevance,无关,NOUN,B2
-irreligious,irreligious,词,ADJ,C1
-irremediably,irremediably,词,ADV,B2
 irreplaceable,irreplaceable,不可替代的,ADJ,B2
 irreproachable,irreproachable,无可指责的,ADJ,B2
 irresistible,irresistible,不可抗拒的,ADJ,B2
 irresponsible,irresponsible,不负责任的,ADJ,B2
-irretrievable,irretrievable,词,ADJ,C1
-irreversibility,irreversibility,词,NOUN,C1
 irreversible,irreversible,不可逆转的,ADJ,B2
-irrigation,irrigation,词,NOUN,B2
 irrigation canal,irrigation canal,灌溉渠,NOUN,B2
-irritability,irritability,词,NOUN,C1
 irritable,irritable,易怒的,ADJ,B2
-irritable boredom,irritable boredom,词,NOUN,C1
 irritate,to irritate,激怒,VERB,B2
-irritating,irritating,令人恼火的,ADJ,B2
-irritation,annoyance,烦恼,NOUN,B2
-irritation,exasperation,恼怒,NOUN,B2
 irritation,irritation,刺激,NOUN,B2
-irritera,to annoy,使恼怒,VERB,B2
-irritera,to exasperate,激怒,VERB,B2
-is not (adv),is not,并非,ADV,C1
-is not (verb),is not,不是,VERB,B2
-isbana,ice rink,溜冰场,NOUN,B2
-ishockey,ice hockey,冰球,NOUN,B2
-isig,icy,冰冷的,ADJ,B2
-islamic,islamic,伊斯兰的,ADJ,B2
-islamization,islamization,词,NOUN,C1
-islander,islander,词,NOUN,C1
 isolated,isolated,孤立的,ADJ,B2
-isolated reports,isolated reports,词,NOUN,C1
 isolation,isolation,隔绝,NOUN,B2
 isotope,isotope,同位素,NOUN,B2
 issue,issue,问题,NOUN,B2
 issue,to issue,颁布,VERB,B2
-isthmus,isthmus,词,NOUN,C1
 it,it,它,PRON,B2
-it (noun),it,信息技术,NOUN,B2
-it can be seen,it can be seen,可见,ADV,B2
-it doesn't matter,it doesn't matter,没关系,ADJ,A1
-it goes without saying,it goes without saying,不言而喻,VERB,B2
-it is a pity,it is a pity,可惜,ADJ,B2
-it is said that,it is said that,据说,VERB,B2
 itch,itch,痒,NOUN,B2
 itching,itching,瘙痒,NOUN,B2
-itching powder,itching powder,痒痒粉,NOUN,B2
-item,item,重目,NOUN,C1
-iterative,iterative,词,ADJ,C1
-itinerant,itinerant,巡回的,ADJ,B2
-itinerary,itinerary,行程,NOUN,B2
 its details,its details,其详,NOUN,B2
-its doing,its doing,它干,NOUN,B2
-iver,to be eager,心切,VERB,B2
-iver efter,to be eager for,巴不得,VERB,B2
-ivory,ivory,象牙,NOUN,C1
-ja,yes,是啊,NOUN,B2
-jack plug,jack plug,词,NOUN,C1
-jackal,jackal,词,NOUN,B2
 jade,jade,这玉,NOUN,B2
-jade palace,jade palace,玉府,NOUN,B2
-jade tree,jade tree,玉树,NOUN,C1
 jade ware,jade ware,玉器,NOUN,B2
-jaded,jaded,厌倦的,ADJ,B2
-jadeite,jadeite,翡翠,NOUN,C1
-jag,me,لي,NOUN,B2
-jag förtjänar inte din berömelse,i don't deserve your praise,不敢当,INTJ,B2
-jaga,chase,追逐,NOUN,B2
-jaga,to chase,追逐,VERB,B2
-jail,jail,监狱,NOUN,B2
-jailer,jailer,词,NOUN,B2
-jakt,hunting,狩猎,NOUN,B2
-jakt,pursuit,追求,NOUN,B2
 jam,jam,果酱,NOUN,B2
-janitor,janitor,词,NOUN,B2
 jar,jar,广口瓶,NOUN,B2
 jargon,jargon,行话,NOUN,B2
-jargon-heavy,jargon-heavy,词,ADJ,C1
-jarring,jarring,词,ADJ,C1
-jasmine,jasmine,词,NOUN,C1
-jasmine tea,jasmine tea,词,NOUN,C1
 jaundice,jaundice,黄疸,NOUN,B2
-jaws,jaws,词,NOUN,C1
-jeans,jeans,牛仔裤,NOUN,B2
-jersey,jersey,词,NOUN,B1
-jest,jest,词,NOUN,C1
-jet,jet,喷气式飞机,NOUN,B2
-jet-black,jet-black,乌黑,ADJ,B2
 jewel,jewel,宝石,NOUN,B2
-jewel robbery,jewel robbery,词,NOUN,C1
-jeweler,jeweler,词,NOUN,B2
-jewelry making,jewelry making,词,NOUN,B2
-jewelry set,jewelry set,词,NOUN,C1
-jewelry store,jewelry store,珠宝店,NOUN,B2
 jianghu,jianghu,江湖,NOUN,B2
-jianghu world,jianghu world,江湖上,NOUN,B2
 jiaolong,jiaolong,娇龙,NOUN,B2
 jin,jin,斤,NOUN,B2
-jinn,jinn,词,NOUN,B2
-jizya tax,jizya tax,词,NOUN,C1
-job interview,job interview,词,NOUN,B2
-job position,job position,词,NOUN,A1
-jocular,jocular,词,ADJ,C1
-jocularity,jocularity,词,NOUN,B2
-jog,jog,词,VERB,A1
-jogging,jogging,词,NOUN,C1
-joie de vivre,joie de vivre,生活乐趣,NOUN,B2
 joint,joint,平等的,ADJ,B2
-joint examination,joint examination,联考,NOUN,B2
-joint liability,joint liability,词,NOUN,C1
 joint ownership,joint ownership,共有,NOUN,B2
-joint pain,joint pain,关节痛,NOUN,C1
-jointly,jointly,共同地,ADV,B2
-jointness,jointness,词,NOUN,C1
-joker,joker,词,NOUN,C1
-joking,joking,词,NOUN,B2
-jord,soil,土壤,NOUN,B2
-jordbruk,agriculture,农业,NOUN,B2
-jordbruk,farming,农业,NOUN,B2
-jordbruks,agricultural,农业的,ADJ,B2
-jordbävning,earthquake,地震,NOUN,B2
-jordgubbe,strawberry,草莓,NOUN,B2
-jordisk,terrestrial,地球的,ADJ,B2
-jordskred,landslide,滑坡,NOUN,B2
-journal,journal,词,NOUN,C1
-journal article,journal article,期刊论文,NOUN,B2
-journalism,journalism,新闻业,NOUN,B2
-journalistic,journalistic,词,ADJ,C1
-journeying,journeying,词,NOUN,C1
-joust,joust,词,NOUN,B1
-jubel,exultation,欢腾,NOUN,B2
-jubilant,jubilant,词,ADJ,C1
-jubilation,jubilation,欢欣,NOUN,B2
 jubilee,jubilee,禧年,NOUN,B2
-jubla,to exult,狂喜,VERB,B2
 judge,to judge,判断,VERB,B2
-judgeable,judgeable,词,ADJ,C1
-judgement,judgement,评估,NOUN,B2
 judicial,judicial,司法的,ADJ,B2
-judicial (noun),judicial,司法,NOUN,B2
-judicious,judicious,词,ADJ,C1
-judiciously,judiciously,词,ADV,B2
-judo,judo,柔道,NOUN,C1
-jujube,jujube,枣子,NOUN,B2
-jumble,jumble,词,NOUN,B2
 jump,jump,跳跃,NOUN,B2
-junction,junction,词,NOUN,C1
-juncture,juncture,词,NOUN,B2
-jungles,jungles,词,NOUN,B2
-juniper,juniper,词,NOUN,B2
-junk,junk,破烂货,NOUN,B2
-junta,junta,词,NOUN,C1
-jurisconsult,jurisconsult,法学专家,NOUN,B2
 jurisdiction area,jurisdiction area,辖区,NOUN,B2
-jurisprudence,jurisprudence,法理学,NOUN,B2
-jurist,jurist,法学家,NOUN,B2
-juristic preference,juristic preference,词,NOUN,C1
 juror,juror,陪审员,NOUN,B2
-jury,jury,陪审团,NOUN,B2
-jury service,jury service,陪审,NOUN,C1
 just,just,仅仅,ADV,B2
-just (adj),just,公正,ADJ,B2
-just as,just as,词,ADV,A2
 just as in the past,just as in the past,一如既往,ADV,B2
-just enough,just enough,便够,NOUN,C1
-just in case,just in case,万一,SCONJ,A2
-just in time,just in time,正好,ADV,A2
-just like that,just like that,随便地,ADV,B2
-just now (noun),just now,我刚才,NOUN,C1
-just right perfect,just right perfect,恰到好处,ADJ,C1
-justera,to adjust,调整,VERB,B2
-justering,alignment,结盟,NOUN,B2
-justifiability,justifiability,正当性,NOUN,C1
-justifiable,justifiable,词,ADJ,C1
-justified,justified,有根据的,ADJ,B2
-justness,justness,公正,NOUN,B2
-juvenile,juvenile,青少年的,ADJ,B2
-juvenile delinquency,juvenile delinquency,词,NOUN,B2
-juxtapose,juxtapose,词,VERB,C1
-jämlik,peer,同龄人,NOUN,B2
-jämn,even,偶数的,ADJ,B2
-jämvikt,equilibrium,平衡,NOUN,B2
-jäsa,to ferment,发酵,VERB,B2
-jäst,yeast,酵母,NOUN,B2
-jästning,fermentation,发酵,NOUN,B2
-jättestor,giant,巨大的,ADJ,B2
-jävsförklaring,recusal,回避,NOUN,B2
-kabel,cable,电缆,NOUN,B2
-kaj,quay,码头,NOUN,B2
-kaleidoscope,kaleidoscope,词,NOUN,B2
-kalender,calendar,日历,NOUN,B2
-kalibrering,calibration,校准,NOUN,B2
-kalla,to summon,召唤,VERB,B2
-kallelse,calling,使命,NOUN,B2
-kallelse,summons,传票,NOUN,B2
-kalligrafi,calligraphy,书法,NOUN,B2
-kallt,coldly,冷淡地,ADV,B2
-kallt blod,cold blood,冷血,NOUN,B2
-kallvåg,cold wave,寒潮,NOUN,B2
-kalv,calf,小腿,NOUN,B2
-kamel,camel,骆驼,NOUN,B2
-kammare,chamber,房间,NOUN,B2
-kampanja,to campaign,积极参与活动,VERB,B2
-kamrat,fellow,家伙,NOUN,B2
-kamratskap,companionship,陪伴,NOUN,B2
-kan bara,can only,只能,AUX,B2
-kan inte låta bli,can't help,不由得,ADV,B2
-kan inte tro,to can't believe,不敢相信,VERB,B2
-kanal,canal,运河,NOUN,B2
-kanalisera,to channel,疏导,VERB,B2
-kandidatur,candidacy,候选资格,NOUN,B2
-kanel,cinnamon,肉桂,NOUN,B2
-kanske,perhaps,也许,ADV,B2
-kansler,chancellor,总理,NOUN,B2
-kant,edge,边缘,NOUN,B2
-kaotisk,chaotic,混乱的,ADJ,B2
-kapell,chapel,小教堂,NOUN,B2
-kappa,cloak,斗篷,NOUN,B2
-kaprice,whim,突发奇想,NOUN,B2
-karakteristisk,characteristic,典型的,ADJ,B2
+rättfärdigande,justification,理由,NOUN,B2
 karate,karate,空手道,NOUN,B2
-karisma,charisma,个人魅力,NOUN,B2
-karta,chart,图表,NOUN,B2
-kasbah,kasbah,词,NOUN,B1
-kashot,cashew,腰果,NOUN,B2
-kasmér,cashmere,羊绒,NOUN,B2
-kassa,cash,现金,ADJ,B2
-kassa,checkout,收银台,NOUN,B2
-kassa,crate,板条箱,NOUN,B2
-kassa,to cash,兑现,VERB,B2
-kassaapparat,cash register,收银机,NOUN,B2
-kastanj,chestnut,板栗,NOUN,B2
-kastrull,pot,锅,NOUN,B2
-katalog,catalog,目录,NOUN,B2
-katalysator,catalyst,催化剂,NOUN,B2
-katastrof,calamity,灾难,NOUN,B2
-katastrof,catastrophe,大灾难,NOUN,B2
-katastrofal,disastrous,灾难性的,ADJ,B2
-katedral,cathedral,大教堂,NOUN,B2
-kategori,category,类别,NOUN,B2
-kategorisera,to categorize,分类,VERB,B2
-kategorisering,categorization,分类,NOUN,B2
-katharsis,catharsis,宣泄,NOUN,B2
-katolicism,catholicism,天主教,NOUN,B2
-kausalitet,causality,因果关系,NOUN,B2
-kavalleri,cavalry,骑兵,NOUN,B2
-kayaking,kayaking,皮划艇,NOUN,C1
-keenly,keenly,词,ADV,C1
-keenness,keenness,词,NOUN,B2
-keep away,keep away,词,VERB,C1
-keeping,keeping,娘存,NOUN,C1
-keeping up with,keeping up with,词,NOUN,B2
-kejsarinna,empress,女皇,NOUN,B2
-kejsarlig släkting,imperial relatives,皇亲,NOUN,B2
-kemikalie,chemical,化学品,NOUN,B2
-kendo,kendo,剑道,NOUN,C1
-kept,kept,词,ADJ,B2
-keramik,ceramics,陶瓷,NOUN,B2
-keramik,pottery,陶器,NOUN,B2
-kerosene,kerosene,火油,NOUN,C1
-kex,cookie,饼干,NOUN,B2
-key point,key point,要点,NOUN,C1
-khul',khul',女方离婚,NOUN,C1
-kickback,kickback,回扣,NOUN,C1
-kidnapper,kidnapper,绑架者,NOUN,B2
-killing,killing,词,NOUN,B2
-kilometer,kilometer,公里,NOUN,B2
-kind,cheek,脸颊,NOUN,B2
-kind type,kind type,词,NOUN,A1
-kind words,kind words,好言,NOUN,C1
-kindergarten,kindergarten,幼儿园,NOUN,B1
-kindheartedness,kindheartedness,词,NOUN,B2
-kindly,kindly,亲切地,ADV,B2
-kindly (adj),kindly,慈祥,ADJ,C1
-kindly (verb),kindly,敬请,VERB,B2
-kindness gentleness,kindness gentleness,词,NOUN,B2
-kindred spirit,kindred spirit,志同道合者,NOUN,B2
-kinesiska,chinese language,华文,NOUN,B2
-kinetisk,kinetic,运动的,ADJ,B2
-king,king,王,PART,B2
-kiosk,kiosk,亭子,NOUN,B2
-kit,kit,词,NOUN,B2
-kitchen annex,kitchen annex,词,NOUN,B1
 kittel,kettle,水壶,NOUN,B2
-kitten,kitten,小猫,NOUN,B2
-kiwi,kiwi,猕猴桃,NOUN,C1
-klagomål,grievance,弊端,NOUN,B2
-klappa,to clap,拍手,VERB,B2
-klargörande,clarification,澄清,NOUN,B2
-klarsoppa,clear soup,江瑶清羹,NOUN,B2
-klassicism,classicism,古典主义,NOUN,B2
-klassificera,to classify,分类,VERB,B2
-klassificering,classification,分类,NOUN,B2
-klassisk,classical,古典的,ADJ,B2
-klasskamrat,classmate,同学,NOUN,B2
-klassrum,classroom,教室,NOUN,B2
-klemma,clamp,夹钳,NOUN,B2
-klerus,clergy,神职人员,NOUN,B2
-klia,to scratch,抓,VERB,B2
-kliché,cliche,陈词滥调,NOUN,B2
-klicka,to click,点击,VERB,B2
-klientelism,clientelism,庇护主义,NOUN,B2
-klimat,climate,气候,NOUN,B2
-klimatförändring,climate change,气候变化,NOUN,B2
-klimax,climax,高潮,NOUN,B2
-klinisk,clinical,临床的,ADJ,B2
-klinka,tile,瓦片,NOUN,B2
-klinkning,tiling,铺瓷砖,NOUN,B2
-klipp,clip,夹子,NOUN,B2
-klok,clever,聪明的,ADJ,B2
-klon,clone,克隆体,NOUN,B2
-klovne,clown,小丑,NOUN,B2
-klumpig,clumsy,笨拙的,ADJ,B2
-kluster,cluster,簇,NOUN,B2
-klyva,to cleave,劈开,VERB,B2
-kläder,clothing,服装,NOUN,B2
-klåda,tingling,麻木感,NOUN,B2
-knack,knack,窍,NOUN,C1
-knakka,to crackle,噼啪作响,VERB,B2
-knapp,scarce,稀少的,ADJ,B2
-kneader,kneader,词,NOUN,C1
-kneeling,kneeling,跪,NOUN,B2
-kneeling (adj),kneeling,词,ADJ,C1
-knife wound,knife wound,词,NOUN,B2
-knight-errant,knight-errant,侠,NOUN,C1
-knocking,knocking,词,NOUN,B1
-knockout match,knockout match,淘汰赛,NOUN,B2
-know-how,know-how,诀窍,NOUN,B2
-knowingly,knowingly,词,ADV,C1
-knowledge gained,knowledge gained,心得,NOUN,C1
-knowledge of human nature,knowledge of human nature,词,NOUN,C1
-knowledge transfer,knowledge transfer,知识传授,NOUN,B2
-knowledgeably,knowledgeably,词,ADV,C1
-knut,knot,结,NOUN,B2
-knytpudde,dumpling,丸子,NOUN,B2
-knäböja,to crouch,蹲下,VERB,B2
-knäcka,to crunch,嘎吱作响,VERB,B2
-knäckande nederlag,crushing defeat,惨败,NOUN,B2
-koefficient,coefficient,系数,NOUN,B2
-koexistens,coexistence,共存,NOUN,B2
-koexistera,to coexist,共存,VERB,B2
-kohl,kohl,词,NOUN,A1
-kokning,boiling,沸腾,NOUN,B2
-kokpanna,cooking pot,炖锅,NOUN,B2
-kokt köttbulle,cooked meatball,丸子熟,NOUN,B2
-kokt ris,cooked rice,米饭,NOUN,B2
-kol,charcoal,木炭,NOUN,B2
-kolesterol,cholesterol,胆固醇,NOUN,B2
-komersiell,commercial,商业的,ADJ,B2
-komma ikapp,to catch up,赶上,VERB,B2
-kommentator,commentator,评论员,NOUN,B2
-kommission,commission,委员会,NOUN,B2
-kommunal,municipal,市政的,ADJ,B2
-kommunchef,township head,乡长,NOUN,B2
-kommuniké,communique,公报,NOUN,B2
-kommunism,communism,共产主义,NOUN,B2
-kommunistisk,communist,شيوعي,ADJ,B2
-kommunitarism,communitarianism,社群主义,NOUN,B2
-kompakt,compact,紧凑的,ADJ,B2
-kompass,compass,指南针,NOUN,B2
-kompatibilitet,compatibility,兼容性,NOUN,B2
-kompetent,competent,胜任的,ADJ,B2
-komplementär,complementary,互补的,ADJ,B2
-komplex,complex,复杂的,ADJ,B2
-komplexitet,complexity,复杂性,NOUN,B2
-komplikera,to complicate,使复杂化,VERB,B2
-komponent,component,组成部分,NOUN,B2
-komponera,to compose,组成,VERB,B2
-komposition,composition,作文,NOUN,B2
-kompositör,composer,作曲家,NOUN,B2
-kompost,compost,堆肥,NOUN,B2
-kompressor,compressor,压缩机,NOUN,B2
-komprimera,to compress,压缩,VERB,B2
-kompromissa,to compromise,危及,VERB,B2
-kompulsiv,compulsive,强迫性的,ADJ,B2
-koncession,concession,让步,NOUN,B2
-koncis,concise,简洁的,ADJ,B2
-kondition,fitness,健康,NOUN,B2
-konkubin,concubine,妾,NOUN,B2
-konkurrenskraft,competitiveness,竞争力,NOUN,B2
-konkurrent,competitor,竞争者,NOUN,B2
-konsekvent,consistent,一致的,ADJ,B2
-konservativ,conservative,保守的,ADJ,B2
-konsignation,consignment,托运,NOUN,B2
-konsistens,consistency,一致性,NOUN,B2
-konsolidera,to consolidate,巩固,VERB,B2
-konsort,consort,福晋,NOUN,B2
-konstgalleri,art gallery,美术馆,NOUN,B2
-konstitutionalitet,constitutionality,合宪性,NOUN,B2
-konstitutionell,constitutional,宪法的,ADJ,B2
-konstruktion,construction,建造,NOUN,B2
-konstruktiv,constructive,建设性的,ADJ,B2
-konsul,consul,领事,NOUN,B2
-konsulat,consulate,领事馆,NOUN,B2
-konsult,consultant,顾问,NOUN,B2
-konsultation,consultation,咨询,NOUN,B2
-konsultera,to consult reference,参考,VERB,B2
-konsulär,consular,领事的,ADJ,B2
-konsumera,to consume,消费,VERB,B2
-konsumtion,consumption,消费,NOUN,B2
-kontextuell,contextual,语境的,ADJ,B2
-kontinent,continent,大陆,NOUN,B2
-kontingens,contingency,偶然性,NOUN,B2
-kontinuerlig,continuous,连续的,ADJ,B2
-kontinuitet,continuity,连续性,NOUN,B2
-kontrastera,to contrast,对比,VERB,B2
-kontrovers,controversy,争议,NOUN,B2
-kontroversiell,controversial,有争议的,ADJ,B2
-konventionell,conventional,传统的,ADJ,B2
-konvergens,convergence,汇聚,NOUN,B2
-konvergera,to converge,汇聚,VERB,B2
-konversera,to converse,交谈,VERB,B2
-konvertera,to convert,转换,VERB,B2
-koordinator,coordinator,协调员,NOUN,B2
-kopist,copyist,抄写员,NOUN,B2
-koppar,copper,铜,NOUN,B2
-koppling,clutch,离合器,NOUN,B2
-korall,coral,珊瑚,NOUN,B2
-korg,basket,篮子,NOUN,B2
-kork,cork,软木塞,NOUN,B2
-korn,barley,大麦,NOUN,B2
-korp,raven,乌鸦,NOUN,B2
-korrekt,accurate,准确的,ADJ,B2
-korrelation,correlation,相关性,NOUN,B2
-korrespondens,correspondence,通信,NOUN,B2
-korrespondera,to correspond,符合,VERB,B2
-korridor,hallway,走廊,NOUN,B2
-korrigering,correction,纠正,NOUN,B2
-korrosion,corrosion,腐蚀,NOUN,B2
-korrumpera,corrupt,腐败的,ADJ,B2
-korrumpera,to corrupt,腐败,VERB,B2
-korruption,corruption,腐败,NOUN,B2
-korsning,crossing,交叉口,NOUN,B2
-korsväg,crossroads,十字路口,NOUN,B2
-kortform,brevity,简洁,NOUN,B2
-kortsiktig,seeking instant benefit,急功近利,ADJ,B2
-kortsiktig,short-term,短期的,ADJ,B2
-kosmisk,cosmic,宇宙的,ADJ,B2
-kost,broom,扫帚,NOUN,B2
-kost,diet,饮食,NOUN,B2
-kostym,costume,戏服,NOUN,B2
-krabba,crab,螃蟹,NOUN,B2
-kraft,force,力量,NOUN,B2
-kramp,convulsion,抽搐,NOUN,B2
-kramp,spasm,痉挛,NOUN,B2
-kran,crane,起重机,NOUN,B2
-krater,crater,火山口,NOUN,B2
-kreativ,creative,有创造力的,ADJ,B2
-kreativitet,creativity,创造力,NOUN,B2
-kreda,chalk,粉笔,NOUN,B2
-krets,circuit,电路,NOUN,B2
-krigsgud,god of war,战神,NOUN,B2
-kriminalisera,to criminalize,定罪,VERB,B2
-kristall,crystal,水晶,NOUN,B2
-kritikalitet,criticality,临界性,NOUN,B2
-kritiker,critic,评论家,NOUN,B2
-kritisera,to criticize,批评,VERB,B2
-kritisk,critical,关键的,ADJ,B2
-krog,tavern,酒馆,NOUN,B2
-kromosom,chromosome,染色体,NOUN,B2
-kronisk,chronic,慢性的,ADJ,B2
-kroppslig,bodily,身体上的,ADJ,B2
-kroppslita,to embody,体现,VERB,B2
-krossa,to shatter,粉碎,VERB,B2
-kryck,crutch,拐杖,NOUN,B2
-kryckryggad,hunchbacked,驼背的,ADJ,B2
-krydda,to season,调味,VERB,B2
-krympa,to shrink,收缩,VERB,B2
-kryptering,encryption,加密,NOUN,B2
-kryssning,cruise,巡航,NOUN,B2
-kräftdjur,crustacean,甲壳类动物,NOUN,B2
-kränka,to infringe,侵犯,VERB,B2
-kränka,to offend,冒犯,VERB,B2
-kränkning,harassment,骚扰,NOUN,B2
-krävande,demanding,要求高的,ADJ,B2
-kråka,crow,乌鸦,NOUN,B2
-kröna,to crown,加冕,VERB,B2
-kröningsceremoni,coronation,加冕,NOUN,B2
-kub,cube,立方体,NOUN,B2
-kubism,cubism,立体主义,NOUN,B2
-kudde,cushion,垫子,NOUN,B2
-kugelpenna,ballpoint pen,圆珠笔,NOUN,B2
-kulturell,cultural,文化的,ADJ,B2
-kulturrelikv,cultural relic,文物,NOUN,B2
-kungörelse,announcement,公告,NOUN,B2
-kunna,to be able,能,VERB,B2
-kunna,to be able to,能够,VERB,B2
-kunskapsteori,epistemology,认识论,NOUN,B2
-kupp,coup,政变,NOUN,B2
-kurva,curve,曲线,NOUN,B2
-kvalificera,to qualify,使合格,VERB,B2
-kvalificerad,qualified,合格的,ADJ,B2
-kvalifikation,qualifications,资格,NOUN,B2
-kvalitativ,qualitative,定性的,ADJ,B2
-kvantitativ,quantitative,定量的,ADJ,B2
-kvartal,quarter of a year,季度,NOUN,B2
-kvartalstidskrift,quarterly magazine,季刊,NOUN,B2
-kvinna,female,雌性,NOUN,B2
-kvinnliga släktingar,female relatives,女眷,NOUN,B2
-kvinnlighet,femininity,女性气质,NOUN,B2
-kvittera,to sign for,签收,VERB,B2
-kvitto,receipt,收据,NOUN,B2
-kvittra,to chirp,啁啾,VERB,B2
-kvot,quota,配额,NOUN,B2
-kvävas,to suffocate,窒息,VERB,B2
-kvävning,suffocation,窒息,NOUN,B2
-kylning,cooling,冷却,NOUN,B2
-kyrklig,ecclesiastical,教会的,ADJ,B2
-kysklighet,chastity,贞洁,NOUN,B2
+tangentbord,keyboard,键盘,NOUN,B2
+njur,kidney,肾脏,NOUN,B2
+slå två flugor i en smäll,kill two birds with one stone,一举两得,ADJ,B2
+mördare,killer,杀手,NOUN,B2
+kilometer,kilometer,公里,NOUN,B2
+art,kind,种类,NOUN,B2
+kinetisk,kinetic,运动的,ADJ,B2
+rike,kingdom,王国,NOUN,B2
+släktskap,kinship,亲属关系,NOUN,B2
 kyssa,to kiss,亲吻,VERB,B2
-källare,cellar,地窖,NOUN,B2
-känd,known,已知的,ADJ,B2
+drake,kite,风筝,NOUN,B2
+knut,knot,结,NOUN,B2
 känna igen,to know to recognize,认识,VERB,B2
-känna igen,to recognize,认出,VERB,B2
-kännbar,tangible,有形的,ADJ,B2
-kärande,plaintiff,原告,NOUN,B2
-kärlek,tenderness,柔情,NOUN,B2
-kättare,heretic,异端,NOUN,B2
-kätteri,heresy,异端,NOUN,B2
-kålrot,turnip,芜菁,NOUN,B2
-kön,gender,性别,NOUN,B2
-köpa,to purchase,购买,VERB,B2
-köpcentrum,shopping center,购物中心,NOUN,B2
-kör,choir,合唱团,NOUN,B2
-körsbär,cherry,樱桃,NOUN,B2
-laazima,laazima,词,NOUN,B2
-laba porridge,laba porridge,腊八粥,NOUN,C1
-labile,labile,不稳定的,ADJ,B2
-labor market,labor market,劳动力市场,NOUN,B2
-labor-related,labor-related,词,ADJ,C1
+känd,known,已知的,ADJ,B2
+arbete,labor,劳动,NOUN,B2
 laboratorium,laboratory,实验室,NOUN,B2
-laboratory (adj),laboratory,词,ADJ,C1
-laborer,laborer,词,NOUN,B2
-laborious striving,laborious striving,词,NOUN,C1
-laboriously,laboriously,词,ADV,C1
-labyrinth,labyrinth,词,NOUN,C1
-labyrinthine,labyrinthine,词,ADJ,C1
-lace,lace,词,NOUN,C1
-lack of affection,lack of affection,词,NOUN,C1
-lack of appetite,lack of appetite,词,NOUN,C1
-lack of awareness,lack of awareness,词,NOUN,C1
-lack of knowledge,lack of knowledge,词,NOUN,C1
-laconically,laconically,词,ADV,C1
-laconism,laconism,简洁,NOUN,B2
-lacquer,lacquer,词,NOUN,C1
-lacquerware,lacquerware,漆器,NOUN,C1
-lacunary,lacunary,残缺的,ADJ,B2
-ladda,charge,收费,NOUN,B2
-ladda,to charge,充电,VERB,B2
-laddare,charger,充电器,NOUN,B2
-ladies and gentlemen,ladies and gentlemen,词,NOUN,C1
-ladle,ladle,词,NOUN,A2
-lager,stock,库存,NOUN,B2
-lager,warehouse,仓库,NOUN,B2
-lagkamrat,teammate,队友,NOUN,B2
-lagoon,lagoon,词,NOUN,C1
-lagra,store,商店,NOUN,B2
-lagra,to store,储存,VERB,B2
-lagstiftande,legislative,立法的,ADJ,B2
-lair,lair,词,NOUN,C1
-lair den,lair den,词,NOUN,C1
-lake (part),lake,湖,PART,A2
-lakeside,lakeside,湖上,NOUN,B2
+arbetsam,laborious,费力的,ADJ,B2
+sakna,to lack,缺乏,VERB,B2
 lakonisk,laconic,简洁的,ADJ,B2
+stege,ladder,梯子,NOUN,B2
 lam,lame,跛的,ADJ,B2
-lamb leg,lamb leg,羊腿,NOUN,C1
-lame person,lame person,词,NOUN,B2
-lament (noun),lament,词,NOUN,C1
-lamentable,lamentable,词,ADJ,C1
-lamp niche,lamp niche,词,NOUN,C1
-lampoon,lampoon,词,NOUN,C1
-lancet,lancet,柳叶刀 / 刺血针,NOUN,C1
-land,countryside,乡村,NOUN,B2
-land (adj),land,بري,ADJ,B2
-land expansion,land expansion,拓土,NOUN,B2
-land ownership,land ownership,词,NOUN,C1
-land policy,land policy,土地政策,NOUN,B2
-land register,land register,地籍,NOUN,B2
-land tax,land tax,词,NOUN,C1
-land titling,land titling,词,NOUN,B2
-land use,land use,土地利用,NOUN,B2
-land-related,land-related,词,ADJ,C1
-landfill,landfill,填埋,NOUN,C1
-landmark (adj),landmark,标志性,ADJ,C1
-landmark (noun),landmark,词,NOUN,C1
-landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
-landmine,landmine,词,NOUN,C1
 landning,landing,着陆,NOUN,B2
-landowner,landowner,词,NOUN,C1
-landscape photo,landscape photo,风景照,NOUN,C1
+hyresvärd,landlord,房东,NOUN,B2
 landskap,landscape,风景,NOUN,B2
-landskap,scenery,风景,NOUN,B2
-landsman,compatriot,同胞,NOUN,B2
-languid,languid,词,ADJ,C1
-languor,languor,倦怠,NOUN,B2
-lapidary,lapidary,简略的,ADJ,B2
-lapp,patch,补丁,NOUN,B2
-lapptäcke,quilt,被子,NOUN,B2
-lapse,lapse,疏忽,NOUN,B2
-lapse of time,lapse of time,词,NOUN,C1
-laptop,laptop,笔记本电脑,NOUN,B2
-large,large,词,ADJ,A2
-large amount,large amount,大量,NOUN,B2
-large clay jar,large clay jar,词,NOUN,B1
-large estate,large estate,词,NOUN,C1
-large landowner,large landowner,词,NOUN,C1
-large place used for a specific purpose,large place used for a specific purpose,场,NOUN,A2
-large serving bowl,large serving bowl,词,NOUN,B1
-large-scale (noun),large-scale,大举,NOUN,C1
-largely,largely,主要地,ADV,B2
-larger,larger,再大,NOUN,B2
-larm,alert,警报,NOUN,B2
-larva,larva,幼虫,NOUN,B2
-lascivious,lascivious,词,ADJ,C1
-lasciviousness,lasciviousness,词,NOUN,C1
-lassitude,lassitude,词,NOUN,C1
-last,load,负载,NOUN,B2
-last (num),last,词,NUM,A2
-last name,last name,姓,NOUN,B2
-last time,last time,上次,NOUN,B2
-last week,last week,上周,NOUN,B2
-lasting,lasting,词,ADJ,C1
-late afternoon,late afternoon,词,NOUN,C1
-late arrival,late arrival,去晚,NOUN,C1
-late behind,late behind,词,ADJ,B2
-late belated,late belated,词,ADJ,C1
-late night,late night,深夜,NOUN,C1
-late spring cold snap,late spring cold snap,倒春寒,NOUN,B2
-late stage,late stage,晚期,NOUN,C1
-lately,lately,词,ADV,A2
-latent,latent,潜在的,ADJ,B2
-later (adj),later,词,ADJ,C1
-later earlier,later earlier,词,ADV,C1
-later stage,later stage,后期,NOUN,B2
+jordskred,landslide,滑坡,NOUN,B2
+fil,lane,小巷,NOUN,B2
+lykta,lantern,灯笼,NOUN,B2
+storskalig,large-scale,大规模的,ADJ,B2
+struphuvud,larynx,喉,NOUN,B2
+bestå,to last,持续,VERB,B2
+hålla i sig,to last a period of time,为期,VERB,B2
+senhet,late,晚才,NOUN,B2
 lateral,lateral,侧面的,ADJ,B2
-lateral side,lateral side,词,ADJ,C1
-lathe,lathe,词,NOUN,C1
-lathing turning,lathing turning,词,NOUN,C1
-latin,latin,拉丁的,ADJ,B2
-latin dance,latin dance,拉丁舞,NOUN,B2
-latitude,latitude,词,NOUN,C1
-latitude leeway,latitude leeway,词,NOUN,C1
-laudable,laudable,词,ADJ,C1
-laugh,laugh,笑,NOUN,B2
-laugh again,laugh again,又笑,NOUN,C1
-laughing,laughing,词,ADJ,C1
 launch,launch,发射,NOUN,B2
 launch,to launch,发起,VERB,B2
-launch (noun),launch,词,NOUN,B1
-launch ceremony,launch ceremony,启动仪式,NOUN,C1
-launcher,launcher,词,NOUN,C1
-laundering,laundering,洗钱,NOUN,B2
-laundromat,laundromat,词,NOUN,A2
-laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
 laundry room,laundry room,洗衣房,NOUN,B2
-laureate winner,laureate winner,词,NOUN,C1
-laurel,laurel,词,NOUN,C1
 lava,lava,熔岩,NOUN,B2
-lavish,lavish,词,ADJ,C1
-law,law,法,PART,B2
 law enforcement,law enforcement,执法,NOUN,B2
-law firm,law firm,律师事务所,NOUN,B2
-law-abiding,law-abiding,守法,ADJ,C1
 lawful,lawful,合法的,ADJ,B2
-lawless,lawless,无法的,ADJ,B2
-lawlessness,lawlessness,词,NOUN,C1
 lawn,lawn,草坪,NOUN,B2
-lawnmower,lawnmower,割草机,NOUN,B2
-lawsuit demand,lawsuit demand,词,NOUN,B1
-lawyer female,lawyer female,词,NOUN,B2
 lax,lax,松懈的,ADJ,B2
-laxative,laxative,词,NOUN,C1
-laxity,laxity,松弛,NOUN,B2
 lay,to lay,放置,VERB,B2
-lay (adj),lay,词,ADJ,C1
 layer,layer,层,NOUN,B2
-layer (verb),layer,压条,VERB,C1
-layer shift,layer shift,词,NOUN,B2
 layman,layman,外行,NOUN,B2
 layoff,layoff,解雇,NOUN,B2
 layout,layout,布局,NOUN,B2
-layperson,layperson,外行,NOUN,B2
 laziness,laziness,懒惰,NOUN,B2
-lazybones,lazybones,词,NOUN,C1
-lead actor,lead actor,主演,NOUN,B2
 lead thousand,lead thousand,率千,NOUN,B2
 lead to,to lead to,通向,VERB,B2
-leader female,leader female,词,NOUN,C1
-leader ladder,leader ladder,词,NOUN,B1
-leading (noun),leading,正带,NOUN,C1
-leading role,leading role,主角,NOUN,B2
-leaf litter,leaf litter,词,NOUN,C1
-leafiness,leafiness,词,NOUN,C1
 leaflet,leaflet,传单,NOUN,B2
-leafy,leafy,枝叶茂密的,ADJ,B2
 league,league,联盟,NOUN,B2
 leak,leak,泄漏,NOUN,B2
-leak escape,leak escape,词,NOUN,B1
 lean,lean,瘦的,ADJ,B2
 leap,leap,跳跃,NOUN,B2
-leapfrog,leapfrog,跳跃式,ADJ,C1
-learned,learned,词,ADJ,C1
-learnedly,learnedly,词,ADV,C1
-learner,learner,词,NOUN,C1
-learning curve,learning curve,学习曲线,NOUN,B2
 lease,lease,租约,NOUN,B2
-leash,leash,词,NOUN,B2
-leasing,leasing,词,NOUN,C1
-least (adj),least,词,ADJ,A1
 leather,leather,皮革,NOUN,B2
-leather goods,leather goods,词,NOUN,C1
-leather jacket,leather jacket,词,NOUN,C1
-leather shoes,leather shoes,皮鞋,NOUN,B1
-leathery,leathery,词,ADJ,B2
 leave behind,to leave behind,留下,VERB,B2
-leave hospital,leave hospital,出院,VERB,C1
-leave office,leave office,卸任,VERB,C1
 leave out,to leave out,省略,VERB,B2
 lecture,lecture,讲座,NOUN,B2
 lecture,to lecture,教导,VERB,B2
 lecturer,lecturer,演讲者,NOUN,B2
-led astray,led astray,词,ADJ,C1
 ledger,ledger,总账,NOUN,B2
-ledig,idle,懒惰的,ADJ,B2
-ledsen,sorry,抱歉,ADJ,B2
-leek,leek,词,NOUN,A2
-left (adj),left,向左,ADJ,B1
-left hand,left hand,左手,NOUN,C1
-left over,left over,词,ADJ,A2
 left side,left side,左侧,NOUN,B2
-left-handed,left-handed,词,ADJ,C1
-leftism,leftism,词,NOUN,C1
-leftist,leftist,词,ADJ,C1
-leg of lamb,leg of lamb,词,NOUN,B1
 legacy,legacy,遗产,NOUN,B2
-legal capacity,legal capacity,词,NOUN,C1
-legal challenge,legal challenge,词,NOUN,B2
-legal consideration,legal consideration,词,NOUN,C1
-legal expert,legal expert,词,NOUN,C1
-legal fees,legal fees,词,NOUN,C1
-legal guardian,legal guardian,词,NOUN,C1
 legal profession,legal profession,律师业,NOUN,B2
-legal representative,legal representative,词,NOUN,C1
 legality,legality,合法性,NOUN,B2
-legalization,legalization,词,NOUN,C1
-legatee,legatee,受遗赠人,NOUN,B2
-legation,legation,公使馆,NOUN,B2
 legend,legend,传说,NOUN,B2
 legendarisk,legendary,传奇的,ADJ,B2
-legering,alloy,合金,NOUN,B2
-legible,legible,词,ADJ,C1
-legible readable,legible readable,词,ADJ,C1
-legion,legion,词,NOUN,B2
-legislative elections,legislative elections,词,NOUN,C1
-legislator,legislator,词,NOUN,C1
-legislature,legislature,立法机关,NOUN,B2
-legitim,legitimate,合法的,ADJ,B2
+lagstiftande,legislative,立法的,ADJ,B2
 legitimitet,legitimacy,合法性,NOUN,B2
-legitimization,legitimization,词,NOUN,B2
-leisurely,leisurely,词,ADJ,C1
-lemon verbena,lemon verbena,词,NOUN,B2
-lemonade,lemonade,词,NOUN,A2
-lender,lender,词,NOUN,B2
-lending,lending,词,NOUN,C1
-lengthy,lengthy,词,ADJ,C1
-lens,lens,词,NOUN,C1
-lentil lens,lentil lens,词,NOUN,C1
-lentils,lentils,词,NOUN,A2
-ler,mud,泥,NOUN,B2
-lesion,lesion,病变,NOUN,B2
-less (adv),less,较少,ADV,A1
-less starch,less starch,粉少,NOUN,C1
-lessor,lessor,词,NOUN,C1
-let alone (cconj),let alone,何况,CCONJ,B1
-leta efter,to look for to find,找,VERB,B2
-lethal,lethal,致命的,ADJ,B2
-lethality,lethality,词,NOUN,C1
-lethargic,lethargic,昏睡的,ADJ,B2
-lethargy,lethargy,词,NOUN,C1
-letter mail,letter mail,信,NOUN,B2
-letter of the alphabet,letter of the alphabet,字母,NOUN,C1
-letter paper,letter paper,信纸,NOUN,B2
-levande,alive,活着的,ADJ,B2
-lever,lever,词,NOUN,B2
-lever crane,lever crane,词,NOUN,C1
-leverage,leverage,词,NOUN,B2
-leverantör,provider,提供者,NOUN,B2
-levity,levity,词,NOUN,C1
-levy sample,levy sample,词,NOUN,B2
-lexical,lexical,词,ADJ,C1
-lexikologi,lexicology,词汇学,NOUN,B2
-liabilities,liabilities,词,NOUN,C1
-liable,liable,有责任的,ADJ,B2
-libel,libel,词,NOUN,C1
-liberal,liberal,自由的,ADJ,B2
-liberalisering,liberalization,自由化,NOUN,B2
-liberalism,liberalism,自由主义,NOUN,B2
-liberalize,liberalize,自由化,! VERB,B2
-liberating,liberating,解放的,ADJ,B2
-libertinism,libertinism,放荡,NOUN,B2
-liberty,liberty,词,NOUN,B2
-librarian,librarian,图书管理员,NOUN,B2
-licensed goods,licensed goods,行货,NOUN,C1
-licenses,licenses,词,NOUN,C1
-licensor,licensor,词,NOUN,C1
-licentious,licentious,放荡的,ADJ,B2
-lichen,lichen,词,NOUN,B2
-lida av sömnlöshet,to suffer from insomnia,失眠,VERB,B2
-life (part),life,生,PART,A2
-life connection,life connection,连命,NOUN,C1
-life span,life span,寿命,NOUN,B1
-life's work,life's work,毕生事业,NOUN,B2
-life-size,life-size,真人大小的,ADJ,B2
-lifeguard,lifeguard,词,NOUN,B2
-lifeless,lifeless,无生命的,ADJ,B2
-lifelong,lifelong,终身,ADJ,B2
-lifelong promise,lifelong promise,许白首不离,NOUN,B2
-liggande,reclining,躺下,NOUN,B2
-light (adj),light,清淡,ADJ,B1
-light blue,light blue,词,ADJ,A1
-light brown,light brown,浅棕色的,ADJ,B2
-light bulb,light bulb,词,NOUN,B2
-light bulb blister,light bulb blister,词,NOUN,C1
-light grey,light grey,浅灰色的,ADJ,B2
-light load,light load,轻装,NOUN,C1
-light rain,light rain,小雨,NOUN,B2
-light sleep,light sleep,词,NOUN,C1
-light snow,light snow,小雪,NOUN,B2
-light up turn on,light up turn on,词,VERB,A1
-light-colored,light-colored,词,ADJ,A2
-lightbulb,lightbulb,词,NOUN,A1
-lightest,lightest,最轻,NOUN,C1
-lighting,lighting,词,NOUN,B2
-lightning flash,lightning flash,词,NOUN,B1
-lik,corpse,尸体,NOUN,B2
-lika,equal,相等的,ADJ,B2
-likaså,likewise,同样地,ADV,B2
-like,like,点赞,NOUN,B2
-like (part),like,似的,PART,B1
-like this (adv),like this,词,ADV,B1
-likeable,likeable,词,ADJ,C1
-likely (adj),likely,词,ADJ,A1
-likely (adv),likely,词,ADV,A1
-likely source,likely source,词,NOUN,C1
-likgiltig,indifferent,冷漠的,ADJ,B2
-likgiltighet,indifference,冷漠,NOUN,B2
-likhet,likeness,就象,NOUN,B2
-likhet,similarity,相似,NOUN,B2
-liknelse,simile,明喻,NOUN,B2
-likvidation,liquidation,清算,NOUN,B2
-likviditet,liquidity,流动性,NOUN,B2
-lila yin,purple yin,紫阴,NOUN,B2
-lilla elva,little eleven,小十一,NOUN,B2
-lilla nia,little nine,小九,NOUN,B2
-lily,lily,百合,NOUN,B2
-lim,paste,酱,NOUN,B2
-limb,limb,肢体,NOUN,B2
-limbo,limbo,limbo,NOUN,B2
-limbs,limbs,手脚,NOUN,B2
-limbs faculties,limbs faculties,词,NOUN,C1
-lime,lime,石灰,NOUN,B2
-liminal,liminal,阈限的,ADJ,B2
-limited liability company,limited liability company,词,NOUN,C1
-limitless,limitless,不可限量,ADJ,C1
-limits,limits,词,NOUN,B2
-limpa,loaf,一条面包,NOUN,B2
-limpidity,limpidity,词,NOUN,C1
-lindra,to relieve,缓解,VERB,B2
-line of conduct,line of conduct,行为方针,NOUN,B2
-line queue,line queue,词,NOUN,B1
-line-up,line-up,阵容,NOUN,B2
-lineages,lineages,词,NOUN,C1
-liner,liner,词,NOUN,C1
-lines,lines,台词,NOUN,B2
-lingering stun,lingering stun,还愣,NOUN,C1
-lingual,lingual,语言的,ADJ,B2
-linguist,linguist,词,NOUN,C1
-linguistic,linguistic,语言的,ADJ,B2
-linguistic intuition,linguistic intuition,词,NOUN,C1
-lining understudy,lining understudy,词,NOUN,B1
-linjär,linear,线性的,ADJ,B2
-link (adj),link,词,ADJ,C1
-link connector,link connector,词,NOUN,C1
-linkage (noun),linkage,词,NOUN,C1
-linking,linking,词,NOUN,C1
-linne,linen,线麻,NOUN,B2
-lip service,lip service,词,NOUN,C1
-lipless,lipless,词,ADJ,C1
-liquid,liquid,液态的,ADJ,B2
-lisp (noun),lisp,词,NOUN,C1
-list,artifice,诡计,NOUN,B2
-list,cunning,诡计,NOUN,B2
-lista,to list,列举,VERB,B2
-listening,listening,也听,NOUN,B2
-listig,shrewd,精明的,ADJ,B2
-listing,listing,词,NOUN,C1
-listless,listless,词,ADJ,C1
-lita,to rely,依赖,VERB,B2
-lita på,to rely on,依靠,VERB,B2
-litanies,litanies,词,NOUN,C1
-lite,a bit,一点,ADV,B2
-liten,a little,一点,ADJ,B2
-liten,tiny,微小的,ADJ,B2
-liter,liter,升,NOUN,B2
-literal,literal,字面的,ADJ,B2
-literalism,literalism,词,NOUN,C1
-literariness,literariness,词,NOUN,C1
-literary,literary,文学的,ADJ,B2
-literary thefts,literary thefts,词,NOUN,C1
-lithe,lithe,词,ADJ,C1
-lithography,lithography,词,NOUN,C1
-litigation against a judge,litigation against a judge,词,NOUN,C1
-litotes understatement,litotes understatement,词,NOUN,C1
-litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
-litterateur,litterateur,词,NOUN,C1
-little,little,少,DET,B2
-little (adj),little,词,ADJ,A1
-little (adv),little,词,ADV,A2
-little bitch,little bitch,小婊子,NOUN,B2
-little boy,little boy,小男孩,NOUN,B2
-little brother,little brother,小弟弟,NOUN,B2
-little dragon,little dragon,小龙……,NOUN,C1
-little finger,little finger,小指,NOUN,B2
-little girl,little girl,词,NOUN,B2
-little hand,little hand,小手,NOUN,B2
-little heart,little heart,小心脏,NOUN,B2
-little son,little son,小儿子,NOUN,B2
-little sun,little sun,小太阳,NOUN,B2
-little thing,little thing,词,NOUN,B2
-little town,little town,词,NOUN,C1
-liturgical,liturgical,词,ADJ,C1
-liturgy,liturgy,词,NOUN,C1
-liv och död,life and death,生死,NOUN,B2
-liv och död,life-and-death,决生,NOUN,B2
-live (adj),live,词,ADJ,B1
-live in peace and work happily,live in peace and work happily,安居乐业,VERB,C1
-live stream,live stream,词,NOUN,B2
-live to,live to,活到,NOUN,C1
-livelihood,livelihood,词,NOUN,C1
-liveliness,liveliness,词,NOUN,B1
-livestock farming,livestock farming,词,NOUN,C1
-livestream,livestream,直播,NOUN,C1
-living being,living being,词,NOUN,C1
-livlig,lively,热闹的,ADJ,B2
-livsmedel,foodstuff,食品,NOUN,B2
-livstid,lifetime,一生,NOUN,B2
-livstids fängelse,life imprisonment,无期徒刑,NOUN,B2
-livstids straff,life retribution,偿命,NOUN,B2
-lizard,lizard,蜥蜴,NOUN,B2
-ljus,bright,明亮的,ADJ,B2
-loading,loading,词,NOUN,B2
-loanword,loanword,外来词,NOUN,C1
-loathsome,loathsome,词,ADJ,C1
-lobby,lobby,词,NOUN,C1
-lobe,lobe,词,NOUN,A2
-local (noun),local,当地,NOUN,A2
-local elections,local elections,地方选举,NOUN,C1
-local tyrant,local tyrant,豪强,NOUN,B2
-localism,localism,词,NOUN,C1
-locality,locality,地点,NOUN,B2
-locally,locally,词,ADV,C1
-located,located,位于,ADJ,B2
-locka,to entice,引诱,VERB,B2
-lockbete,want to lure,想引,NOUN,B2
-lockdown confinement,lockdown confinement,词,NOUN,C1
-locker,locker,词,NOUN,C1
-locksmith,locksmith,词,NOUN,C1
-locomotive,locomotive,词,NOUN,C1
-lodges,lodges,道堂,NOUN,C1
-loft,loft,词,NOUN,C1
-loftiness,loftiness,高尚,NOUN,C1
-logarithm,logarithm,词,NOUN,C1
-logi,lodging,住宿,NOUN,B2
-logic modification,logic modification,改逻,NOUN,B2
-logically,logically,词,ADV,B2
-logistical,logistical,词,ADJ,C1
-logistics (adj),logistics,词,ADJ,C1
-logistik,logistics,后勤,NOUN,B2
-logo,logo,标识,NOUN,C1
-logomachy,logomachy,词,NOUN,C1
-logorrhea,logorrhea,词,NOUN,C1
-lokalisera,to locate,定位,VERB,B2
-lonely soul,lonely soul,孤魂,NOUN,C1
-long absence,long absence,久违,NOUN,C1
-long lease,long lease,词,NOUN,C1
-long pipe,long pipe,词,NOUN,B2
-long poem,long poem,词,NOUN,C1
-long story,long story,话长,NOUN,C1
-long stretch of time,long stretch of time,词,NOUN,C1
-long time (noun),long time,许久,NOUN,C1
-long-distance,long-distance,长途,ADJ,B2
-long-distance runner,long-distance runner,长跑运动员,NOUN,B2
-long-established,long-established,词,ADJ,C1
-long-lasting,long-lasting,持久的,ADJ,B2
-long-running,long-running,词,ADJ,C1
-long-term,long-term,长期性,ADJ,C1
-long-winded,long-winded,啰唆,ADJ,B2
-longan,longan,龙眼,NOUN,C1
-longest,longest,أطول,NOUN,B1
-longevity,longevity,词,NOUN,C1
-loofah,loofah,丝瓜,NOUN,C1
-look around,look around,词,VERB,C1
-loom,loom,词,NOUN,B2
-looming,looming,词,ADJ,C1
-loop,loop,循环,NOUN,B2
-loophole,loophole,漏洞,NOUN,B2
-loopholes,loopholes,词,NOUN,C1
-loose thread,loose thread,线头,NOUN,B2
-loosen,to loosen,放松,VERB,B2
-looseness,looseness,词,NOUN,C1
-loot,loot,战利品,NOUN,B2
-looting,looting,掠夺,NOUN,B2
-loquacious,loquacious,词,ADJ,C1
-loquat,loquat,枇杷,NOUN,C1
-lord,lord,领主,NOUN,B2
-lord god,lord god,上帝,NOUN,B2
-lord yu,lord yu,玉大人,NOUN,B2
-lord's words,lord's words,主说,NOUN,B2
-lordship,lordship,词,NOUN,C1
-lose,lose,上丢,NOUN,B2
-lose an election,lose an election,落选,VERB,C1
-lose face,lose face,丢脸,VERB,B2
-lose heart,lose heart,灰心,VERB,B2
-lose weight,to lose weight,减肥,VERB,B2
-losses,losses,词,NOUN,B1
-lost tradition,lost tradition,失传,NOUN,C1
-lot,lot,许多,NOUN,B2
-lotar,lotar,词,NOUN,C1
-lottery,lottery,彩票,NOUN,B2
-lottery ticket,lottery ticket,彩票,NOUN,C1
-lotus root,lotus root,莲藕,NOUN,C1
-loud,loud,大声的,ADJ,B2
-loud and clear,loud and clear,响亮,ADJ,B2
-loudspeaker,loudspeaker,扬声器,NOUN,B2
-lounge,lounge,休息室,NOUN,B2
-louse,louse,虱子,NOUN,B2
-lousy servant,lousy servant,臭当差,NOUN,C1
-love and esteem,love and esteem,爱戴,VERB,C1
-love ardently,love ardently,热爱,VERB,B1
-love at first sight,love at first sight,词,NOUN,C1
-loved,loved,被爱的,ADJ,B2
-lover sweetheart,lover sweetheart,情人,NOUN,B2
-lovesickness,lovesickness,词,NOUN,C1
-lovestruck,lovestruck,词,ADJ,C1
-low blow,low blow,词,NOUN,C1
-low point,low point,词,NOUN,C1
-low pressure,low pressure,低气压,NOUN,C1
-low tide,low tide,退潮,NOUN,B2
-low-carbon,low-carbon,低碳,ADJ,C1
-lower (noun),lower,词,NOUN,B2
-lower part,lower part,下部,NOUN,C1
-lowering,lowering,词,NOUN,C1
-lowest,lowest,最低的,ADJ,B2
-lowland,lowland,低地,NOUN,B2
-lowly,lowly,词,ADJ,B2
-loyalism,loyalism,词,NOUN,C1
-loyalty fidelity,loyalty fidelity,词,NOUN,B2
-loyalty to authority,loyalty to authority,服从权威,NOUN,B2
-lubrication,lubrication,词,NOUN,C1
-lubricity,lubricity,好色 / 淫荡,NOUN,B2
-lucid,lucid,词,ADJ,C1
-lucidity,lucidity,清醒 / 明晰,NOUN,B2
-luck,luck,运气,NOUN,B2
-lucky,lucky,幸运的,ADJ,B2
-lucky (noun),lucky,吉祥,NOUN,B2
-lucky chance,lucky chance,虽侥,NOUN,B2
-lucky find,lucky find,意外发现,NOUN,B2
-lucky money,lucky money,压岁钱,NOUN,B2
-lucky one,lucky one,词,NOUN,B2
-lucrative,lucrative,有利可图的,ADJ,B2
-lucubrate,lucubrate,词,VERB,C1
-lucubration,lucubration,词,NOUN,C1
-luftförsvar,air defense,防空,NOUN,B2
-luftkonditionering,air conditioning,空调,NOUN,B2
-lugn,calmness,平静,NOUN,B2
-lugna,calm,平静,NOUN,B2
-lugna,to calm,使平静,VERB,B2
-lugna,to reassure,使安心,VERB,B2
-lukewarm,lukewarm,微温的,ADJ,B2
-lukewarmness,lukewarmness,词,NOUN,C1
-lullaby,lullaby,词,NOUN,C1
-luminosity,luminosity,词,NOUN,C1
-luminous,luminous,发光的,ADJ,B2
-lump,lump,块,NOUN,B2
-lump in throat,lump in throat,词,NOUN,C1
-lunar,lunar,词,ADJ,C1
-lunar calendar,lunar calendar,农历,NOUN,B2
-lunar phase,lunar phase,月相,NOUN,C1
-lunch break,lunch break,午休,NOUN,B2
-luncha,to have lunch,吃午餐,VERB,B2
-lunga,pulmonary,肺的,ADJ,B2
-lupini beans,lupini beans,词,NOUN,B2
-lure,lure,诱惑,NOUN,B2
-lure decoy,lure decoy,词,NOUN,C1
-lurid,lurid,词,ADJ,C1
-lust,lust,欲望,NOUN,B2
-luster,luster,光泽,NOUN,B2
-luta,to incline,使倾斜,VERB,B2
-lute,lute,词,NOUN,C1
-luxation,dislocation,脱臼,NOUN,B2
-luxera,to dislocate,使脱臼,VERB,B2
-luxurious,luxurious,奢侈的,ADJ,B2
-luxury,luxury,奢侈,NOUN,B2
-lychee,lychee,荔枝,NOUN,C1
-lycka,fortune,运气,NOUN,B2
-lycklig,fortunate,幸运的,ADJ,B2
-lyda,to comply,遵守,VERB,B2
-lyda inte,to disobey,违抗,VERB,B2
-lydnad,docility,温顺,NOUN,B2
-lydnadsbrist,disobedience,不服从,NOUN,B2
-lykta,lantern,灯笼,NOUN,B2
-lymph,lymph,淋巴,NOUN,B2
-lymph node,lymph node,淋巴结,NOUN,B2
-lymphatic,lymphatic,淋巴的,ADJ,B2
-lyre,lyre,词,NOUN,B2
-lyrical,lyrical,抒情的,ADJ,B2
-lyricism,lyricism,词,NOUN,C1
-lyssna uppmärksamt,to listen attentively,倾听,VERB,B2
-läger,this-camp,这营,NOUN,B2
-lägesrapport,progress report,进度报告,NOUN,B2
-lägga ner,to put down,放下,VERB,B2
-läkning,healing,治愈,NOUN,B2
-lämna,to disembark,下船,VERB,B2
-lämplig,appropriate,适当的,ADJ,B2
-lämplighet,suitability,适宜性,NOUN,B2
-längta,to crave,渴望,VERB,B2
-längta,to yearn for,渴望,VERB,B2
-längtan,yearning,向往,NOUN,B2
-lärd,scholar,学者,NOUN,B2
-lärling,apprentice,学徒,NOUN,B2
-lärlingskap,apprenticeship,学徒期,NOUN,B2
-lärobok,textbook,教科书,NOUN,B2
-läsare,reader,读者,NOUN,B2
-läskunnighet,literacy,读写能力,NOUN,B2
-läsning,reading,阅读,NOUN,B2
-lätt sagt,easy to say,好说,NOUN,B2
-lätthet,ease,轻松,NOUN,B2
-lätthet,lightness,轻盈,NOUN,B2
-lån,borrowing,借贷,NOUN,B2
+legitim,legitimate,合法的,ADJ,B2
+fritid,leisure,闲暇,NOUN,B2
 låna,to lend,借出,VERB,B2
-lånare,borrower,借款人,NOUN,B2
-lång,tall,高的,ADJ,B2
-långfärdsbuss,long-distance bus,长途车,NOUN,B2
-långt,far,远的,ADJ,B2
-lår,thigh,大腿,NOUN,B2
-låsa in,to lock up,关押,VERB,B2
-låsa ner,to lockdown,封城,VERB,B2
+mildhet,leniency,宽厚,NOUN,B2
+mild,lenient,宽大的,ADJ,B2
+mindre,less,更少,ADV,B2
+för att inte,lest,唯恐,SCONJ,B2
 låta,let,让,AUX,B2
 låta,to let,让,VERB,B2
-lögn,falsehood,谎言,NOUN,B2
+för att inte tala om,let alone,别说,ADV,B2
+släppa,to let go,放开,VERB,B2
+sallad,lettuce,生菜,NOUN,B2
+lexikologi,lexicology,词汇学,NOUN,B2
+ansvar,liability,责任,NOUN,B2
+förbindelse,liaison,联络,NOUN,B2
+liberalism,liberalism,自由主义,NOUN,B2
+liberalisering,liberalization,自由化,NOUN,B2
+befrielse,liberation,解放,NOUN,B2
+registreringsskylt,license plate,车牌,NOUN,B2
+registreringsskyltsrestriktion,license plate restriction,限号,NOUN,B2
 lösaktighet,licentiousness,放荡,NOUN,B2
-lösesumma,ransom,赎金,NOUN,B2
-lösningsmedel,solvent,溶剂,NOUN,B2
-macabre,macabre,词,ADJ,C1
-macaw,macaw,词,NOUN,C1
-macerate,macerate,词,VERB,C1
-machination,machination,词,NOUN,C1
-machine,machine,机械的,ADJ,B2
-machine learning,machine learning,机器学习,NOUN,B2
-machine wash,machine wash,机洗,VERB,B2
-machinery,machinery,词,NOUN,C1
-mack,gas station,加油站,NOUN,B2
-macro,macro,宏观,ADJ,C1
-macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+liv och död,life and death,生死,NOUN,B2
+livstids fängelse,life imprisonment,无期徒刑,NOUN,B2
+livstids straff,life retribution,偿命,NOUN,B2
+liv och död,life-and-death,决生,NOUN,B2
+livstid,lifetime,一生,NOUN,B2
+lätthet,lightness,轻盈,NOUN,B2
+likhet,likeness,就象,NOUN,B2
+likaså,likewise,同样地,ADV,B2
+lime,lime,石灰,NOUN,B2
+gräns,limit,限制,NOUN,B2
+ställa upp,to line up,排成一行,VERB,B2
+släktlinje,lineage,血统,NOUN,B2
+linjär,linear,线性的,ADJ,B2
+linne,linen,线麻,NOUN,B2
+likvidation,liquidation,清算,NOUN,B2
+likviditet,liquidity,流动性,NOUN,B2
+lista,to list,列举,VERB,B2
+lyssna uppmärksamt,to listen attentively,倾听,VERB,B2
+liter,liter,升,NOUN,B2
+läskunnighet,literacy,读写能力,NOUN,B2
+processförande,litigant,诉讼当事人,NOUN,B2
+rättsprocess,litigation,诉讼,NOUN,B2
+lilla elva,little eleven,小十一,NOUN,B2
+lilla nia,little nine,小九,NOUN,B2
+livlig,lively,热闹的,ADJ,B2
+boskap,livestock,家畜,NOUN,B2
+last,load,负载,NOUN,B2
+limpa,loaf,一条面包,NOUN,B2
+lokalisera,to locate,定位,VERB,B2
+plats,location,地点,NOUN,B2
+låsa in,to lock up,关押,VERB,B2
+låsa ner,to lockdown,封城,VERB,B2
+omklädningsrum,locker room,更衣室,NOUN,B2
+logi,lodging,住宿,NOUN,B2
+hög,lofty,崇高的,ADJ,B2
+stock,log,日志,NOUN,B2
+logistik,logistics,后勤,NOUN,B2
+ensam,lonely,孤独的,ADJ,B2
+för länge sedan,long ago,早已,ADV,B2
+långfärdsbuss,long-distance bus,长途车,NOUN,B2
+ta hand om,to look after,照料,VERB,B2
+titta på,to look at,观看,VERB,B2
+titta på dig,look at you,你看你,NOUN,B2
+se ner på,to look down upon,看不起,VERB,B2
+leta efter,to look for to find,找,VERB,B2
+slå upp,to look up,查阅,VERB,B2
+loophole,loophole,漏洞,NOUN,B2
+loosen,to loosen,放松,VERB,B2
+loot,loot,战利品,NOUN,B2
+lord,lord,领主,NOUN,B2
+lord yu,lord yu,玉大人,NOUN,B2
+lord's words,lord's words,主说,NOUN,B2
+lose,lose,上丢,NOUN,B2
+lose weight,to lose weight,减肥,VERB,B2
+lot,lot,许多,NOUN,B2
+lottery,lottery,彩票,NOUN,B2
+loud,loud,大声的,ADJ,B2
+lounge,lounge,休息室,NOUN,B2
+louse,louse,虱子,NOUN,B2
+low tide,low tide,退潮,NOUN,B2
+luck,luck,运气,NOUN,B2
+lucky,lucky,幸运的,ADJ,B2
+lucky chance,lucky chance,虽侥,NOUN,B2
+lump,lump,块,NOUN,B2
+lure,lure,诱惑,NOUN,B2
+luster,luster,光泽,NOUN,B2
+luxurious,luxurious,奢侈的,ADJ,B2
+luxury,luxury,奢侈,NOUN,B2
+lymph,lymph,淋巴,NOUN,B2
 macroscopic,macroscopic,宏观的,ADJ,B2
-mad,mad,词,ADJ,A1
 madam,madam,夫人,NOUN,B2
 madman,madman,疯子,NOUN,B2
-madrass,mattress,床垫,NOUN,B2
-maelstrom,maelstrom,词,NOUN,C1
-magistrate,magistrate,法官,NOUN,B2
 magnanimity,magnanimity,宽宏大量,NOUN,B2
-magnanimous,magnanimous,宽宏大量的,ADJ,B2
-magnanimous pardon,magnanimous pardon,词,NOUN,C1
-magnesium,magnesium,镁,NOUN,B2
 magnet,magnet,磁铁,NOUN,B2
-magnetic,magnetic,磁的,ADJ,B2
-magnetism,magnetism,词,NOUN,C1
-magnification,magnification,增大,NOUN,C1
 magnificent,magnificent,壮丽的,ADJ,B2
 magnify,to magnify,放大,VERB,B2
-magnifying glass,magnifying glass,词,NOUN,C1
-magnitude,magnitude,词,NOUN,C1
-magont,stomachache,肚子痛,NOUN,B2
-magus,magus,词,NOUN,C1
 maid,maid,女仆,NOUN,B2
 maiden,maiden,少女,NOUN,B2
 maidservant,maidservant,女仆,NOUN,B2
-maieutic,maieutic,词,ADJ,C1
-mail (verb),mail,寄送,VERB,C1
 mailbox,mailbox,邮箱,NOUN,B2
 main,main,主要的,ADJ,B2
-main camp,main camp,大营,NOUN,B2
-main reason,main reason,主要原因,NOUN,B2
-main road,main road,主路,NOUN,B2
-main street,main street,大街,NOUN,B2
-main text,main text,词,NOUN,C1
-main thing,main thing,词,NOUN,B2
 mainland,mainland,大陆,NOUN,B2
 mainly,mainly,主要地,ADV,B2
 mainstream,mainstream,主流,NOUN,B2
-mainstream (adj),mainstream,主流的,ADJ,B2
 majestic,majestic,宏伟的,ADJ,B2
 major,major,少校,NOUN,B2
-major (adj),major,主要的,ADJ,A2
-major case,major case,大案,NOUN,B2
 major course,major course,专业课,NOUN,B2
-major defense,major defense,大防,NOUN,C1
-major event,major event,大事,NOUN,B2
-majority (adj),majority,词,ADJ,B2
 make,to make,制作,VERB,B2
 make a mistake,to make a mistake,弄错,VERB,B2
 make a speech,to make a speech,发言,VERB,B2
-make amends,make amends,词,VERB,C1
 make do,to make do,做,VERB,B2
-make flexible,make flexible,词,VERB,C1
 make mistake,make mistake,犯错,NOUN,B2
 make noise,to make noise,闹得,VERB,B2
 make sure,to make sure,确保,VERB,B2
 make up for,to make up for,弥补,VERB,B2
-makeover,makeover,改容,NOUN,C1
 maker,maker,制造者,NOUN,B2
-makeshift solution,makeshift solution,词,NOUN,B2
-makeup leave,makeup leave,补休,NOUN,B2
-makhzen-related,makhzen-related,词,ADJ,C1
-making,making,词,NOUN,B2
-maktpotens,powerful nation,强国,NOUN,B2
-mala,to grind,磨碎,VERB,B2
-maladjusted,maladjusted,适应不良的,ADJ,B2
-maladjustment,maladjustment,词,NOUN,C1
 malady,malady,弊病,NOUN,B2
-malaria,malaria,疟疾,NOUN,B2
-male,male,男性,NOUN,B2
-male goat,male goat,词,NOUN,B2
-malefic,malefic,邪恶的,ADJ,B2
-malevolence,malevolence,恶意,NOUN,B2
-malevolent,malevolent,词,ADJ,C1
-malfeasance,malfeasance,渎职,NOUN,B2
 malfunction,malfunction,故障,NOUN,B2
-malhun,malhun,词,NOUN,B2
-malicious,malicious,恶意的,ADJ,B2
-malicious words,malicious words,恶言,NOUN,B2
-malignancy,malignancy,词,NOUN,C1
 malignant,malignant,恶性的,ADJ,B2
-malignity,malignity,词,NOUN,C1
-maliki school,maliki school,词,NOUN,C1
-mall,mall,词,NOUN,B2
-malleability,malleability,词,NOUN,C1
-malleable,malleable,词,ADJ,C1
-mallow greens,mallow greens,词,NOUN,B2
-malnutrition,malnutrition,营养不良,NOUN,B2
-malpractice,malpractice,弊端,NOUN,C1
-mamma,mother,娘,PART,B2
-mammal,mammal,哺乳动物,NOUN,B2
-mammalian,mammalian,词,ADJ,C1
-mana,to exhort,劝告,VERB,B2
 management,management,管理,NOUN,B2
 manager,manager,经理,NOUN,B2
-managing director,managing director,总经理,NOUN,B2
 mandatory,mandatory,强制的,ADJ,B2
-mandatory compulsory,mandatory compulsory,词,ADJ,B1
-mane,mane,词,NOUN,C1
 maneuver,maneuver,策略,NOUN,B2
-mango,mango,芒果,NOUN,B2
-mangosteen,mangosteen,山竹,NOUN,B2
-mangrove,mangrove,红树林,NOUN,B2
-manhunt,manhunt,搜捕,NOUN,B2
-mania,mania,狂躁症,NOUN,B2
-manifestation,manifestation,词,NOUN,C1
-manifestly,manifestly,明显地,ADV,B2
-manifesto,manifesto,宣言,NOUN,B2
-manifold,manifold,多方面的,ADJ,B2
-manipulable,manipulable,可操纵的,ADJ,B2
 manipulation,manipulation,操纵,NOUN,B2
-manipulator,manipulator,词,NOUN,C1
-manliness,manliness,词,NOUN,C1
-manly deed,manly deed,词,NOUN,C1
-manly virtue,manly virtue,词,NOUN,C1
 manner,manner,方式,NOUN,B2
-mannerly,mannerly,有礼貌的,ADJ,B2
-manners,manners,词,NOUN,B2
-mannish,mannish,像男人的,ADJ,B2
-manoknöl,cassava,木薯,NOUN,B2
 manor,manor,庄园,NOUN,B2
-manor (part),manor,庄,PART,B2
-manor lord,manor lord,庄主,NOUN,B2
 mansion,mansion,豪宅,NOUN,B2
-manslaughter,manslaughter,词,NOUN,C1
-mantra,mantra,心诀,NOUN,B2
-manual,manual,手工的,ADJ,B2
-manual (noun),manual,词,NOUN,B1
-manually,manually,手动地,ADV,B2
-manufacture,manufacture,制造,NOUN,B2
-manufacturing,manufacturing,词,NOUN,B1
-manumission,manumission,词,NOUN,C1
-manure (noun),manure,词,NOUN,C1
-manus,screenplay,剧本,NOUN,B2
-manus,script for play,剧本,NOUN,B2
 manuscript,manuscript,手稿,NOUN,B2
 many,many,多……,NOUN,B2
-many (det),many,词,DET,B2
-many (pron),many,词,PRON,B1
-many a,many a,词,ADJ,C1
-many things,many things,许多事物,PRON,B2
 many times,many times,多次,ADV,B2
-many whips,many whips,好多鞭,NOUN,C1
-maple,maple,词,NOUN,B2
-mapp,folder,文件夹,NOUN,B2
-maqam,maqam,词,NOUN,B2
-maqama,maqama,词,NOUN,C1
 marathon,marathon,马拉松,NOUN,B2
-marble,marble,大理石,NOUN,B2
-marbly,marbly,大理石般的,ADJ,B2
-mare,mare,词,NOUN,B2
 margin,margin,边缘,NOUN,B2
-marginal,marginal,边缘的,ADJ,B2
 marginalization,marginalization,边缘化,NOUN,B2
-marginally,marginally,边缘地,ADV,B2
-marin,navy,海军,NOUN,B2
-marinade,marinade,词,NOUN,B2
 marinate,to marinate,腌制,VERB,B2
-marital conjugal,marital conjugal,词,ADJ,C1
 maritime,maritime,海事的,ADJ,B2
-mark,grounds,论据,NOUN,B2
 mark,to mark,标记,VERB,B2
-marker,marker,词,NOUN,B2
-market (adj),market,词,ADJ,C1
-market inspection,market inspection,词,NOUN,C1
-market inspector,market inspector,词,NOUN,C1
-markets,markets,词,NOUN,C1
-maroon,maroon,深红色,ADJ,B2
-marriage contract,marriage contract,婚约,NOUN,C1
-marriage leave,marriage leave,婚假,NOUN,B2
-marrow,marrow,骨髓,NOUN,B2
-marsh,marsh,词,NOUN,C1
-marshal,marshal,元帅,NOUN,B2
-marshy,marshy,沼泽般的,ADJ,B2
-martial (adj),martial,词,ADJ,B2
-martial (part),martial,武,PART,B2
-martial arts,martial arts,武术,NOUN,B1
-martyr,martyr,词,NOUN,C1
+äktenskapsallians,marriage alliance,联姻,NOUN,B2
+äktenskapsbar,marriageable,适婚,NOUN,B2
 martyrium,martyrdom,殉难,NOUN,B2
-marvel (noun),marvel,词,NOUN,B2
-marvelous,marvelous,极好的,ADJ,B2
-mascot,mascot,吉祥物,NOUN,B2
-masculine,masculine,男性的,ADJ,B2
-masculine (noun),masculine,masculine,NOUN,B2
-masculinity,masculinity,词,NOUN,C1
-masculinization,masculinization,词,NOUN,C1
-mash,mash,泥状食物,NOUN,B2
+förundras,to marvel,使惊奇,VERB,B2
 mask,mask,面具,NOUN,B2
-mask (verb),mask,词,VERB,C1
-masochism,masochism,词,NOUN,C1
-mason,mason,词,NOUN,C1
-masonry,masonry,砌体,NOUN,B2
-masquerade,masquerade,词,NOUN,C1
-mass (adj),mass,词,ADJ,C1
-mass appeal,mass appeal,词,NOUN,C1
-mass innovation,mass innovation,众创,NOUN,B2
-mass-transmitted,mass-transmitted,词,ADJ,C1
-massa,bulk,主体,NOUN,B2
-massage (noun),massage,词,NOUN,B2
-massage (verb),massage,词,VERB,B2
 massakr,massacre,大屠杀,NOUN,B2
-masses,masses,群众,NOUN,C1
-masseur,masseur,词,NOUN,B2
 massiv,massive,巨大的,ADJ,B2
-massively,massively,大量地,ADV,B2
-mast (noun),mast,词,NOUN,C1
-master (part),master,爷,PART,A2
-master and disciple,master and disciple,师徒,NOUN,C1
-master copy,master copy,底本,NOUN,C1
-master gives,master gives,爷给,NOUN,C1
-master's grudge,master's grudge,师仇,NOUN,B2
-master's possession,master's possession,爷有,NOUN,B2
-master's wife,master's wife,师娘,NOUN,B1
-master's wife sits,master's wife sits,师娘坐,NOUN,C1
+mästra,to master,掌握,VERB,B2
 masterexamen,master's degree,硕士学位,NOUN,B2
-masterly,masterly,词,ADJ,B2
-mastermind,mastermind,词,NOUN,C1
-mat,mat,词,NOUN,B2
+mästarens ord,master's word,爷说,NOUN,B2
+mästerskap,mastery,精通,NOUN,B2
 match,match,火柴,NOUN,B2
 matchande,matching,配套,ADJ,B2
-matches,matches,词,NOUN,C1
-matching use,matching use,配用,NOUN,C1
-matchmakare,matchmaker,媒,NOUN,B2
 matchtid,matching time,对时,NOUN,B2
-mate,mate,词,NOUN,A2
-matematisk,mathematical,数学的,ADJ,B2
+matchmakare,matchmaker,媒,NOUN,B2
 material,material,材料,NOUN,B2
-material (adj),material,词,ADJ,C1
 materialism,materialism,唯物主义,NOUN,B2
-maternal,maternal,词,ADJ,C1
-maternal grace,maternal grace,母恩难,NOUN,B2
-maternal grandmother,maternal grandmother,外婆,NOUN,B2
-maternity leave,maternity leave,产假,NOUN,C1
-maternity matron,maternity matron,月嫂,NOUN,C1
-mathematician,mathematician,词,NOUN,C1
-matriarch,matriarch,女家长,NOUN,B2
-matriarchy,matriarchy,词,NOUN,C1
+morbror,maternal uncle,舅舅,NOUN,B2
+matematisk,mathematical,数学的,ADJ,B2
 matris,matrix,矩阵,NOUN,B2
-matsmältningsstörning,indigestion,消化不良,NOUN,B2
-matter affair,matter affair,事情,NOUN,A1
-mausoleum,mausoleum,词,NOUN,B1
-maverick,maverick,词,NOUN,C1
-mawkish,mawkish,词,ADJ,C1
-mawkishness,mawkishness,词,NOUN,C1
-mawwal,mawwal,词,NOUN,B2
+sake,matter,事情,NOUN,B2
+madrass,mattress,床垫,NOUN,B2
+mognad,maturity,成熟,NOUN,B2
 maxim,maxim,格言,NOUN,B2
-maximal,maximal,最大的,ADJ,B2
 maximal,maximum,最大,ADJ,B2
-maximization,maximization,词,NOUN,C1
-maximum (noun),maximum,词,NOUN,B2
-may (aux),may,词,AUX,A1
-may be allowed,may be allowed,词,AUX,A2
-may subjunctive,may subjunctive,词,AUX,C1
-maybe possible,maybe possible,可能,ADV,A1
-mayoral,mayoral,市长的,ADJ,B2
-maze,maze,词,NOUN,C1
-maze labyrinth,maze labyrinth,词,NOUN,C1
-me accusative,me accusative,词,PRON,A2
-me dative,me dative,词,PRON,A2
-mead,mead,词,NOUN,C1
-meager,meager,词,ADJ,C1
-mean (noun),mean,词,NOUN,C1
-meander,meander,词,NOUN,C1
-meandering,meandering,蜿蜒的,ADJ,B2
-meaningful,meaningful,有意义的,ADJ,B2
-meanness,meanness,词,NOUN,C1
-measurable,measurable,词,ADJ,C1
-measure word events items,measure word events items,件,NOUN,A1
-measure word flat objects,measure word flat objects,张,NOUN,B2
-measure word general,measure word general,个,NUM,B2
-measured,measured,克制的,ADJ,B2
-measurements,measurements,词,NOUN,C1
-meat-eating,meat-eating,开荤,NOUN,C1
-mechanical,mechanical,机械的,ADJ,B2
-mechanically,mechanically,词,ADV,C1
-mechanics,mechanics,词,NOUN,C1
-mechanization,mechanization,词,NOUN,C1
-mechanized,mechanized,词,ADJ,C1
-med alla medel,by fair means or foul,不择手段,ADV,B2
-med svårighet,with difficulty,困难地,ADV,B2
-medal awarding,medal awarding,授勋,NOUN,B2
-medallion,medallion,词,NOUN,C1
-medborgarskap,citizenship,公民身份,NOUN,B2
-meddlesome (adj),meddlesome,词,ADJ,C1
-meddlesome (noun),meddlesome,多事,NOUN,C1
-meddling,meddling,掺和,NOUN,C1
-medföra,to entail,牵涉,VERB,B2
-media (adj),media,词,ADJ,C1
-media library,media library,多媒体图书馆,NOUN,B2
-media professionals,media professionals,词,NOUN,C1
-media-related,media-related,词,ADJ,B2
+jag,me,لي,NOUN,B2
+äng,meadow,草地,NOUN,B2
+mellan,meantime,同时,NOUN,B2
+samtidigt,meanwhile,同时,ADV,B2
+exemplar,measure word for books,本,NUM,B2
+mekanism,mechanism,机制,NOUN,B2
+mekanistisk,mechanistic,机制性,ADJ,B2
 median,median,中位数,NOUN,B2
-median (adj),median,词,ADJ,C1
-mediator,mediator,调解人,NOUN,C1
-medical care,medical care,医疗,NOUN,B2
-medical checkup,medical checkup,词,NOUN,A2
-medical practitioner,medical practitioner,词,NOUN,C1
-medical test,medical test,词,NOUN,B1
-medical tests,medical tests,词,NOUN,B2
-medical visit,medical visit,看病,NOUN,C1
+medling,mediation,调解,NOUN,B2
+patientjournal,medical record,病历,NOUN,B2
 medication,medication,药物,NOUN,B2
-medication completion,medication completion,完药,NOUN,C1
-medicine pool,medicine pool,药池,NOUN,B2
-medieval,medieval,中世纪的,ADJ,B2
 mediocre,mediocre,平庸的,ADJ,B2
-mediocrity,mediocrity,庸庸碌碌,NOUN,B2
 meditation,meditation,冥想,NOUN,B2
 mediterranean,mediterranean,地中海的,ADJ,B2
 medium,medium,媒介,NOUN,B2
-medium-sized,medium-sized,词,ADJ,C1
-medkännande,compassionate,有同情心的,ADJ,B2
-medkänsla,compassion,同情,NOUN,B2
-medling,mediation,调解,NOUN,B2
-medskyldig,complicit,共谋的,ADJ,B2
-medskyldighet,complicity,共犯,NOUN,B2
-meek,meek,温顺的,ADJ,B2
-meekness,meekness,词,NOUN,B2
-meeting point,meeting point,词,NOUN,C1
-megabyte,megabyte,词,NOUN,C1
-megalomania,megalomania,狂妄自大,NOUN,B2
-megalomaniac,megalomaniac,词,ADJ,C1
-megalomanic,megalomanic,狂妄自大的,ADJ,B2
-megaphone,megaphone,扩音器,NOUN,C1
-mejsel,chisel,凿子,NOUN,B2
-mekanism,mechanism,机制,NOUN,B2
-mekanistisk,mechanistic,机制性,ADJ,B2
 melancholic,melancholic,忧郁的,ADJ,B2
 melancholy,melancholy,忧郁,ADJ,B2
-melancholy (noun),melancholy,忧郁,NOUN,C1
-mellan,meantime,同时,NOUN,B2
-mellifluous,mellifluous,词,ADJ,C1
-mellifluousness,mellifluousness,词,NOUN,C1
-melodious,melodious,词,ADJ,C1
-melodiousness,melodiousness,词,NOUN,C1
-melodrama,melodrama,词,NOUN,C1
 melody,melody,旋律,NOUN,B2
-melon,melon,香瓜,NOUN,C1
 melon groping,melon groping,摸瓜,NOUN,B2
-melted,melted,词,ADJ,C1
-melting,melting,词,NOUN,B2
-member of parliament,member of parliament,议员,NOUN,B2
-member state,member state,成员国,NOUN,B2
 membership,membership,会员资格,NOUN,B2
-membrane,membrane,词,NOUN,C1
-memoir,memoir,回忆录,NOUN,B2
-memorable,memorable,难忘的,ADJ,B2
 memorandum,memorandum,备忘录,NOUN,B2
 memorial,memorial,纪念碑,NOUN,B2
-memorial (adj),memorial,词,ADJ,C1
 memorization,memorization,记忆,NOUN,B2
-memorizer,memorizer,词,NOUN,C1
-memory loss,memory loss,词,NOUN,C1
-men,but,然而,ADV,B2
-men du,but you,但您,NOUN,B2
-men jag,but i,可我,ADV,B2
-menace,menace,词,NOUN,C1
 mend,to mend,修补,VERB,B2
-mendacious,mendacious,词,ADJ,C1
-meninx,meninx,词,NOUN,C1
-menses,menses,词,NOUN,B2
 mentality,mentality,心态,NOUN,B2
 mention,mention,提及,NOUN,B2
-mentioned,mentioned,词,ADJ,B2
 mentor,mentor,导师,NOUN,B2
-mentoring,mentoring,词,NOUN,B2
-mer,more,مزيد,NOUN,B2
-mercantile,mercantile,词,ADJ,C1
-mercenaries,mercenaries,词,NOUN,C1
-mercenary,mercenary,雇佣兵,NOUN,B2
-mercenary (adj),mercenary,词,ADJ,C1
-merchandise,merchandise,商品,NOUN,B2
 merchant,merchant,商人,NOUN,B2
-merchant ship,merchant ship,商船,NOUN,C1
-merciful,merciful,词,ADJ,B2
-mercilessly,mercilessly,词,ADV,C1
-mercurial,mercurial,词,ADJ,C1
 mercury,mercury,汞,NOUN,B2
-mercy blow,mercy blow,致命一击,NOUN,B2
-merely (noun),merely,不就,NOUN,C1
 merge,merge,合并,NOUN,B2
 merge,to merge,合并,VERB,B2
-merged,merged,词,ADJ,C1
-merger,merger,合并,NOUN,B2
-merger fusion,merger fusion,词,NOUN,B1
-meridian,meridian,经脉,NOUN,B2
-meridians,meridians,筋脉,NOUN,B2
 meritocracy,meritocracy,精英管理,NOUN,B2
-merits,merits,词,NOUN,C1
 mermaid,mermaid,美人鱼,NOUN,B2
-merriment,merriment,词,NOUN,C1
-mesh,mesh,词,NOUN,C1
-mesmerizing,mesmerizing,词,ADJ,C1
-messaging,messaging,词,NOUN,C1
-metabolic,metabolic,代谢的,ADJ,B2
 metabolism,metabolism,新陈代谢,NOUN,B2
-metalepsis,metalepsis,词,NOUN,C1
-metalinguistic,metalinguistic,词,ADJ,C1
-metallic,metallic,金属的,ADJ,B2
-metallurgy,metallurgy,词,NOUN,C1
-metamorphic,metamorphic,变质的,ADJ,B2
-metamorphosis,metamorphosis,词,NOUN,C1
 metaphor,metaphor,隐喻,NOUN,B2
-metaphorical,metaphorical,隐喻的,ADJ,B2
-metaphysical,metaphysical,词,ADJ,C1
 metaphysics,metaphysics,形而上学,NOUN,B2
-metastasis,metastasis,词,NOUN,C1
-metaverse,metaverse,元宇宙,NOUN,C1
-metempsychosis,metempsychosis,词,NOUN,C1
-meteor,meteor,词,NOUN,B2
-meteorite,meteorite,词,NOUN,C1
-meteorological,meteorological,气象的,ADJ,B2
-meteorological observations,meteorological observations,词,NOUN,C1
 meter,meter,米,NOUN,B2
-metering,metering,词,ADJ,C1
-methane,methane,词,NOUN,C1
-methodical,methodical,词,ADJ,C1
-methodological,methodological,方法论的,ADJ,B2
 meticulous,meticulous,一丝不苟的,ADJ,B2
-meticulously,meticulously,一丝不苟地,ADV,B2
 metonymy,metonymy,转喻,NOUN,B2
-metric,metric,公制的,ADJ,B2
-metrical foot,metrical foot,词,NOUN,C1
-metropolises,metropolises,词,NOUN,C1
-metropolitan,metropolitan,词,ADJ,C1
-mettle,mettle,词,NOUN,C1
-mezzanine,mezzanine,夹层,NOUN,B2
-microbe,microbe,词,NOUN,C1
-microchip,microchip,词,NOUN,C1
-microeconomic,microeconomic,微观经济学的,ADJ,B2
 microscope,microscope,显微镜,NOUN,B2
-microscopic,microscopic,微观的,ADJ,B2
-microscopic (noun),microscopic,微观,NOUN,C1
-microwave,microwave,微波炉,NOUN,B2
-mid-morning,mid-morning,词,NOUN,C1
-middaga,to have dinner,吃晚餐,VERB,B2
-midday heat,midday heat,词,NOUN,B1
-middle,middle,中间,ADV,B2
-middle (adj),middle,词,ADJ,B2
-middle part,middle part,中部,NOUN,B2
-middle school,middle school,词,NOUN,B1
-middle stage,middle stage,中期,NOUN,B2
-middle third of a month,middle third of a month,中旬,NOUN,B2
-middle-school student,middle-school student,词,NOUN,C1
-middleman,middleman,中间人,NOUN,C1
-midfielder,midfielder,中场球员,NOUN,B2
-midpoint,midpoint,词,NOUN,B2
 midst,midst,中间,NOUN,B2
-midterm exam,midterm exam,期中考,NOUN,B2
-midwife,midwife,词,NOUN,C1
 might,might,威力,NOUN,B2
-might as well,might as well,不妨,ADV,B2
-mightily,mightily,词,ADV,C1
-mighty,mighty,词,ADJ,B1
-mighty man,mighty man,词,NOUN,B2
 migraine,migraine,偏头痛,NOUN,B2
-migrant,migrant,词,NOUN,B2
 migrate,to migrate,迁移,VERB,B2
 migration,migration,移民,NOUN,B2
-migratory,migratory,词,ADJ,C1
-mild,lenient,宽大的,ADJ,B2
 mild,mild,温和的,ADJ,B2
-mildew,mildew,词,VERB,C1
-mildhet,leniency,宽厚,NOUN,B2
-militant,militant,词,ADJ,C1
-militaristic,militaristic,词,ADJ,C1
-militarization,militarization,词,NOUN,C1
-military (noun),military,词,NOUN,B2
-military affairs,military affairs,军事,NOUN,B1
-military camp,military camp,军营,NOUN,C1
-military campaign,military campaign,战役,NOUN,B2
 military intelligence,military intelligence,军情,NOUN,B2
-military merit,military merit,军功,NOUN,C1
 military order,military order,军令,NOUN,B2
-military pay,military pay,军饷,NOUN,B2
 military power,military power,兵权,NOUN,B2
 militia,militia,民兵,NOUN,B2
-miljö-,environmental,环境的,ADJ,B2
-miljörapport,environmental report,环境报告,NOUN,B2
-miljöskydd,environmental protection,环境保护,NOUN,B2
-milking,milking,词,NOUN,C1
-milkman,milkman,词,NOUN,C1
-milky,milky,乳白色的,ADJ,B2
 mill,mill,磨坊,NOUN,B2
-mill (verb),mill,碾磨,VERB,C1
-millenary,millenary,词,ADJ,C1
 millennium,millennium,千年,NOUN,B2
-miller,miller,词,NOUN,B2
-millet,millet,小米,NOUN,C1
-millimeter,millimeter,词,NOUN,C1
-million (num),million,词,NUM,A1
-millionaire,millionaire,百万富翁,NOUN,B2
-mime (noun),mime,词,NOUN,C1
-mimicry,mimicry,词,NOUN,B2
-minaret,minaret,词,NOUN,B1
-minatory,minatory,词,ADJ,C1
-minced meat,minced meat,词,NOUN,A2
 mind,to mind,介意,VERB,B2
-mind-blowing,mind-blowing,词,ADJ,C1
-mindfulness,mindfulness,从正念,NOUN,C1
-mindre,less,更少,ADV,B2
-mindset,mindset,词,NOUN,B2
-mine (pron),mine,词,PRON,C1
-mine (verb),mine,开采,VERB,C1
 mineral,mineral,矿物,NOUN,B2
-mineral (adj),mineral,词,ADJ,C1
-mineral metal,mineral metal,词,NOUN,C1
-mineral spring,mineral spring,矿泉,NOUN,C1
-mineral water,mineral water,矿泉水,NOUN,B2
-miniature painting,miniature painting,词,NOUN,C1
-minibus,minibus,中巴,NOUN,B2
-minimal,minimal,微小的,ADJ,B2
-minimalism,minimalism,极简主义,NOUN,B2
-minimalist,minimalist,词,NOUN,C1
-minimization,minimization,词,NOUN,C1
-minimum,minimum,词,NOUN,B2
-minimum-wage earner,minimum-wage earner,词,NOUN,B2
-mining,mining,词,ADJ,C1
-miniräknare,calculator,计算器,NOUN,B2
 minister,minister,部长,NOUN,B2
-minister (part),minister,臣,PART,B2
 ministerial,ministerial,部长的,ADJ,B2
 ministry,ministry,部,NOUN,B2
-minivan,minivan,小型货车,NOUN,B2
-minnestal,eulogy,赞辞,NOUN,B2
 minor,minor,未成年人,NOUN,B2
-minor (adj),minor,较小的,ADJ,B2
 minor course,minor course,辅修课,NOUN,B2
-minor pilgrimage,minor pilgrimage,副朝,NOUN,B2
-minority,minority,少数派的,ADJ,B2
-minska,decrease,减少,NOUN,B2
-minska,to decrease,减少,VERB,B2
 mint,mint,薄荷,NOUN,B2
-minus,minus,减,NOUN,B2
-minuscule,minuscule,极小的,ADJ,B2
-minutes,minutes,词,NOUN,B2
-miraculous,miraculous,词,ADJ,C1
-mirage,mirage,词,NOUN,C1
-mirthful,mirthful,词,ADJ,C1
-misanthrope,misanthrope,厌世者,NOUN,B2
-misanthropic,misanthropic,词,ADJ,C1
 misappropriation,misappropriation,挪用,NOUN,B2
-miscarriage of justice,miscarriage of justice,错案,NOUN,C1
-mischief,mischief,词,NOUN,C1
-misconception,misconception,误解,NOUN,B2
-misdeed,misdeed,词,NOUN,C1
-misdemeanor,misdemeanor,词,NOUN,B2
-miserable tragic,miserable tragic,悲惨,ADJ,C1
-miserliness,miserliness,词,NOUN,C1
-miserly,miserly,吝啬的,ADJ,B2
-mishap,mishap,词,NOUN,C1
-mishearing,mishearing,听错,NOUN,C1
-misjudge,misjudge,词,VERB,C1
 mislead,to mislead,误导,VERB,B2
 misleading,misleading,诡辩的,ADJ,B2
-mismatch,mismatch,词,NOUN,C1
-misplaced,misplaced,不合时宜的,ADJ,B2
 miss,miss,小姐,NOUN,B2
-missbilliga,to disapprove,不赞成,VERB,B2
-missbruka,abuse,滥用,NOUN,B2
-missbruka,to abuse,滥用,VERB,B2
-misserziehung,misserziehung,词,NOUN,C1
-missfahrt,missfahrt,词,NOUN,C1
-missfassung,missfassung,词,NOUN,B2
-missforderung,missforderung,词,NOUN,C1
-missgabe,missgabe,词,NOUN,C1
-missgestaltung,missgestaltung,词,NOUN,C1
-misshandel,beating,跳动,NOUN,B2
-missile,missile,导弹,NOUN,B2
-missionary,missionary,词,NOUN,C1
-missionizing,missionizing,词,ADJ,C1
-missions,missions,词,NOUN,C1
-missive,missive,词,NOUN,C1
-misskunft,misskunft,词,NOUN,C1
-misslyckande,blot,污点,NOUN,B2
-misslyckat bud,failed bid,流标,NOUN,B2
-missnahme,missnahme,词,NOUN,C1
-missnöja,to displease,使不快,VERB,B2
-missnöje,displeasure,不悦,NOUN,B2
-misspflegung,misspflegung,词,NOUN,C1
-missregelung,missregelung,词,NOUN,C1
-missrichtung,missrichtung,词,NOUN,C1
-missschaft,missschaft,词,NOUN,B2
-missschrift,missschrift,词,NOUN,B2
-misssetzung,misssetzung,词,NOUN,C1
-misssicht,misssicht,词,NOUN,B2
-misssinnung,misssinnung,词,NOUN,C1
-misssprache,misssprache,词,NOUN,C1
-misssucht,misssucht,词,NOUN,C1
-misssuchung,misssuchung,词,NOUN,C1
-missteilung,missteilung,词,NOUN,C1
-misstep,misstep,失足,NOUN,B2
-misstheilung,misstheilung,词,NOUN,B2
-misstreibung,misstreibung,词,NOUN,B2
-misstänkt,suspect,嫌疑人,NOUN,B2
-misswandel,misswandel,词,NOUN,C1
-missweisung,missweisung,词,NOUN,C1
-misswirkung,misswirkung,词,NOUN,C1
 mist,mist,薄雾,NOUN,B2
-mistaken,mistaken,错误的,ADJ,B2
 mistreat,to mistreat,أساء,VERB,B2
-mistreatment,mistreatment,虐待,NOUN,B2
-misunderstood,misunderstood,词,ADJ,C1
-miterziehung,miterziehung,词,NOUN,C1
-mitfahrt,mitfahrt,词,NOUN,B2
-mitfassung,mitfassung,词,NOUN,C1
-mitforderung,mitforderung,词,NOUN,C1
-mitgabe,mitgabe,词,NOUN,C1
-mitgestaltung,mitgestaltung,词,NOUN,C1
 mitigate,to mitigate,减轻,VERB,B2
-mitigating,mitigating,词,ADJ,C1
-mitigating factor,mitigating factor,词,NOUN,B2
-mitigation,mitigation,词,NOUN,C1
-mitkunft,mitkunft,词,NOUN,C1
-mitnahme,mitnahme,词,NOUN,C1
-mitpflegung,mitpflegung,词,NOUN,B2
-mitregelung,mitregelung,词,NOUN,C1
-mitrichtung,mitrichtung,词,NOUN,C1
-mitschaft,mitschaft,词,NOUN,C1
-mitschrift,mitschrift,词,NOUN,C1
-mitsetzung,mitsetzung,词,NOUN,B2
-mitsicht,mitsicht,词,NOUN,B2
-mitsinnung,mitsinnung,词,NOUN,C1
-mitsprache,mitsprache,词,NOUN,C1
-mitsucht,mitsucht,词,NOUN,C1
-mitsuchung,mitsuchung,词,NOUN,C1
-mitteilung,mitteilung,词,NOUN,C1
-mittheilung,mittheilung,词,NOUN,B2
-mittreibung,mittreibung,词,NOUN,C1
-mitwandel,mitwandel,词,NOUN,C1
-mitweisung,mitweisung,词,NOUN,C1
-mitwirkung,mitwirkung,词,NOUN,C1
-mix bar,mix bar,混吧,NOUN,B2
 mixed,mixed,混合的,ADJ,B2
-mixed forest,mixed forest,混交林,NOUN,B2
-mixed reality,mixed reality,混合现实,NOUN,C1
-mixed-race,mixed-race,词,ADJ,C1
-mixer,mixer,词,NOUN,C1
-mixing,mixing,词,NOUN,B2
-mjuk,gentle,温柔的,ADJ,B2
-mjukvara,software,软件,NOUN,B2
 moan,moan,呻吟,NOUN,B2
 moan,to moan,呻吟,VERB,B2
-mob,mob,词,NOUN,B2
 mobile,mobile,移动的,ADJ,B2
-mobile (noun),mobile,词,NOUN,B2
 mobile payment,mobile payment,移动支付,NOUN,B2
-mobility,mobility,流动性,NOUN,B2
 mobilization,mobilization,动员,NOUN,B2
 mobilize,to mobilize,动员,VERB,B2
-mobiltelefon,cell phone,手机,NOUN,B2
 mock,to mock,嘲笑,VERB,B2
-mock exam,mock exam,模拟考,NOUN,B2
-mock exam questions,mock exam questions,模拟题,NOUN,C1
-mocker,mocker,词,NOUN,B2
-mockery,mockery,词,NOUN,C1
-mod,boldness,大胆,NOUN,B2
-modal particle,modal particle,呢,PART,B2
-modal particle suggestion,modal particle suggestion,吧,PART,B2
-modality,modality,词,NOUN,B2
-modder,modder,改客,NOUN,B2
 mode,mode,方式,NOUN,B2
-model prototype,model prototype,词,NOUN,C1
 modeling,modeling,造型,NOUN,B2
-modem,modem,词,NOUN,C1
 moderate,moderate,适度的,ADJ,B2
-moderate snow,moderate snow,中雪,NOUN,C1
+måttligt regn,moderate rain,中雨,NOUN,B2
 moderation,moderation,克制,NOUN,B2
-moderator,moderator,词,NOUN,C1
 modern,modern,现代的,ADJ,B2
-modern dance,modern dance,现代舞,NOUN,B2
-modern times,modern times,现代,NOUN,B2
 modernisering,modernization,现代化,NOUN,B2
-modernist,modernist,词,ADJ,C1
-modernity,modernity,词,NOUN,C1
-modestly,modestly,词,ADV,C1
-modesty bashfulness,modesty bashfulness,词,NOUN,B2
-modified ability,modified ability,改能,NOUN,B2
-modified category,modified category,改类,NOUN,B2
-modified one,modified one,改的,NOUN,C1
-modified route,modified route,改途,NOUN,C1
-modified skill,modified skill,改技,NOUN,C1
-modified structure,modified structure,改结,NOUN,C1
-modified track,modified track,改迹,NOUN,C1
-modified warfare,modified warfare,改战,NOUN,C1
-modifiera,to modify,修改,VERB,B2
+blygsam,modest,谦虚的,ADJ,B2
+modifiering,modification,修改,NOUN,B2
 modifierad effekt,modified effect,改效,NOUN,B2
 modifierad modell,modified model,改模,NOUN,B2
 modifierat ljud,modified sound,改响,NOUN,B2
 modifierat system,modified system,改系,NOUN,B2
-modifiering,modification,修改,NOUN,B2
-modig,bold,大胆的,ADJ,B2
-modig,to be brave,勇善,VERB,B2
-modulation,modulation,词,NOUN,C1
-module,module,词,NOUN,C1
+modifiera,to modify,修改,VERB,B2
 modulär,modular,模块化的,ADJ,B2
-mogen,ripe,成熟的,ADJ,B2
-mognad,maturity,成熟,NOUN,B2
-moisten,moisten,词,VERB,C1
-moisture,moisture,湿气,NOUN,B2
-moisture-proof,moisture-proof,防潮,ADJ,B2
-moisturizer,moisturizer,词,NOUN,B2
-molar,molar,词,NOUN,A2
-mold-resistant,mold-resistant,防霉,ADJ,C1
-molding,molding,词,NOUN,C1
-moldy,moldy,发霉的,ADJ,B1
-molecular,molecular,词,ADJ,C1
+fuktig,moist,潮湿的,ADJ,B2
+mögel,mold,鞋楦,NOUN,B2
+möl,mole,鼹鼠,NOUN,B2
 molekyl,molecule,分子,NOUN,B2
-mollify,mollify,词,VERB,C1
-molnig,cloudy,阴沉的,ADJ,B2
-molnigt,overcast,阴天的,ADJ,B2
-molten,molten,词,ADJ,C1
-molting,molting,词,NOUN,C1
-mom mother,mom mother,妈妈,NOUN,A1
-momentarily,momentarily,暂时地,ADV,B2
-momentous,momentous,词,ADJ,C1
 momentum,momentum,势头,NOUN,B2
-mommy,mommy,词,NOUN,B1
-monarch,monarch,君主,NOUN,B2
-monark,sovereign,君主,NOUN,B2
-monastic community,monastic community,词,NOUN,C1
-monasticism,monasticism,词,NOUN,C1
-monetization,monetization,词,NOUN,C1
 monetär,monetary,金钱的,ADJ,B2
-money laundering,money laundering,洗钱,NOUN,B2
-money transfer,money transfer,词,NOUN,B1
-mongoose,mongoose,词,NOUN,B2
-monism,monism,词,NOUN,C1
 monitor,monitor,显示器,NOUN,B2
-monolithic,monolithic,单一的,ADJ,B2
-monolog,soliloquy,独白,NOUN,B2
-monologue,monologue,词,NOUN,B2
-monopolisera,to monopolize,垄断,VERB,B2
+övervakning,monitoring,监控,NOUN,B2
+övervakningsrum,monitoring room,监控室,NOUN,B2
 monopolistisk,monopolistic,垄断的,ADJ,B2
-monotheism,monotheism,词,NOUN,C1
+monopolisera,to monopolize,垄断,VERB,B2
 monoton,monotonous,单调的,ADJ,B2
-monotonic,monotonic,词,ADJ,C1
-monotony,monotony,词,NOUN,C1
-monstrous,monstrous,怪异的,ADJ,B2
-month ago,month ago,月前,NOUN,B2
-monthly,monthly,每月的,ADV,B2
-monthly magazine,monthly magazine,月刊,NOUN,B2
-monthly report,monthly report,月报,NOUN,C1
-monument,monument,纪念碑,NOUN,B2
-monumental,monumental,词,ADJ,C1
-moodiness,moodiness,词,NOUN,B2
-moonlight,moonlight,月色,NOUN,B2
-moor,moor,荒野,NOUN,B2
-mooring,mooring,词,NOUN,C1
-mop (noun),mop,词,NOUN,B2
-moral,moral,道德,NOUN,B2
-moral character,moral character,品德,NOUN,B2
-moral defect,moral defect,词,NOUN,C1
-moral fable,moral fable,词,NOUN,C1
-moral portrait,moral portrait,词,NOUN,C1
-moral restraint,moral restraint,词,NOUN,C1
-morale,morale,人心,NOUN,B2
-moralism,moralism,道德主义,NOUN,B2
-moralitet,morality,道德,NOUN,B2
-moralization,moralization,词,NOUN,C1
-moralizing,moralizing,说教的,ADJ,B2
-moralizing (noun),moralizing,词,NOUN,C1
-morally,morally,词,ADV,C1
-morass,morass,词,NOUN,C1
-moratorium,moratorium,暂停,NOUN,B2
-morbid,morbid,词,ADJ,C1
-morbidity,morbidity,词,NOUN,C1
-morbror,maternal uncle,舅舅,NOUN,B2
-more (noun),more,你越,NOUN,B2
-more personal,more personal,词,ADJ,C1
-more than,more than,不止,ADV,B2
-moreover,moreover,而且,CCONJ,B2
-morfologi,morphology,形态学,NOUN,B2
-morfologisk,morphological,形态的,ADJ,B2
-morgon,early morning,凌晨,NOUN,B2
-morgontidning,morning newspaper,晨报,NOUN,B2
-morning (adj),morning,词,ADJ,C1
-moroccanization,moroccanization,词,NOUN,C1
-morocco leather,morocco leather,词,NOUN,C1
-moron,moron,词,NOUN,C1
-morose,morose,词,ADJ,C1
-morpheme,morpheme,语素,NOUN,C1
-morrande,growl,低吼,NOUN,B2
-mors,mother-in-law,岳母,NOUN,B2
-mors trygghet,mother's reassurance,娘放心,NOUN,B2
-mortal (adj),mortal,词,ADJ,B2
-mortal (noun),mortal,词,NOUN,B2
-mortal fear,mortal fear,极度恐惧,NOUN,B2
-mortality,mortality,死亡率,NOUN,B2
-mortar,mortar,词,NOUN,C1
-mortuary,mortuary,词,NOUN,B2
-mosaik,mosaic,马赛克,NOUN,B2
-moské,mosque,清真寺,NOUN,B2
-moslem,moslem,词,NOUN,C1
-mosquito net,mosquito net,蚊帐,NOUN,B2
-mosquito-proof,mosquito-proof,防蚊,ADJ,C1
-moss,moss,苔藓,NOUN,B2
-most,most,大多数,DET,B2
-most (noun),most,大部分,NOUN,B2
-most (pron),most,词,PRON,C1
-most famous,most famous,词,ADJ,B2
-most important,most important,最要紧,NOUN,C1
-most important thing,most important thing,最重要的事,NOUN,B2
-most like,most like,最像,NOUN,C1
-mot,toward,朝向,ADP,B2
-motattack,counterattack,反击,NOUN,B2
-motform,counter-form,反式,NOUN,B2
-motfärdighet,counter-skill,反技,NOUN,B2
-moth,moth,词,NOUN,B2
-mother's words,mother's words,娘说,NOUN,B2
-motherboard,motherboard,主板,NOUN,C1
-motherfucker,motherfucker,混蛋,NOUN,B2
-motherland,motherland,祖国,NOUN,B2
-motif,motif,主题,NOUN,B2
-motinlägg,rebuttal,反驳,NOUN,B2
-motion,motion,运动,NOUN,B2
-motion picture,motion picture,词,NOUN,C1
-motionless,motionless,静止的,ADJ,B2
-motivation,motivation,动机,NOUN,B2
-motive for murder,motive for murder,词,NOUN,C1
-motkvalitet,counter-quality,反质,NOUN,B2
-motley,motley,词,ADJ,B2
-motlogik,counter-logic,反逻,NOUN,B2
-motmekanism,counter-mechanism,反机,NOUN,B2
-motmodell,counter-model,反模,NOUN,B2
-motobservation,counter-observation,反察,NOUN,B2
-motor,motor,发动机,NOUN,B2
-motor (adj),motor,运动的,ADJ,C1
-motorist,motorist,词,NOUN,C1
-motorway,motorway,高速公路,NOUN,B2
-motpart,counterpart,对应的人或物,NOUN,B2
-motrutt,counter-route,反途,NOUN,B2
-motsats,contrary,反而,NOUN,B2
-motsatt,opposite,相反的,ADJ,B2
-motsatt avsikt,contrary intention,反意,NOUN,B2
-motstruktur,counter-structure,反结,NOUN,B2
-motström,counter-trend,反势,NOUN,B2
-motsula,counter-sole,反唯,NOUN,B2
-motsvarighet,equivalent,等价物,NOUN,B2
-motsystem,counter-system,反系,NOUN,B2
-motsägelse,contradiction,矛盾,NOUN,B2
-motsägelsefull,contradictory,矛盾的,ADJ,B2
-mottagare,recipient,接受者,NOUN,B2
-motteknik,counter-technique,反术,NOUN,B2
-motto,motto,座右铭,NOUN,B2
-mottyp,counter-type,反型,NOUN,B2
-motverka,to counter,反击,VERB,B2
-motverka,to oppose,反对,VERB,B2
-mound,mound,土堆,NOUN,B2
-mount,mount,词,NOUN,A1
-mountain closure,mountain closure,山闭,NOUN,C1
-mountaineer,mountaineer,词,NOUN,C1
-mountaineering,mountaineering,登山,NOUN,B2
-mountains and rivers,mountains and rivers,山川,NOUN,C1
-mourning,mourning,词,NOUN,B2
-mouth animal,mouth animal,词,NOUN,B1
-move fast,move fast,快搬,NOUN,C1
-mow,mow,词,VERB,B2
-mp,mp,国会议员,NOUN,B2
-mrouzia,mrouzia,词,NOUN,B2
-mrt,mri,核磁共振,NOUN,B2
-much (adj),much,词,ADJ,A1
-much (det),much,许多,DET,A1
-mucous,mucous,词,ADJ,C1
-muddied,muddied,词,ADJ,C1
-muddy (adj),muddy,词,ADJ,C1
-mudslide,mudslide,泥石流,NOUN,B2
-mudslinging,mudslinging,词,NOUN,C1
-mudslinging exchanges,mudslinging exchanges,词,NOUN,C1
-muezzin,muezzin,词,NOUN,B2
-mufti,mufti,词,NOUN,C1
-mug (noun),mug,词,NOUN,B2
-mulberry,mulberry,桑葚,NOUN,B2
-mulberry thread,mulberry thread,桑皮线,NOUN,C1
-mulch,mulch,词,NOUN,C1
-multi-level garage,multi-level garage,立体车库,NOUN,B2
-multinational,multinational,跨国公司,NOUN,B2
-multipart,multipart,多部分的,ADJ,B2
-multiple,multiple,词,ADJ,B2
-multiplicera,to multiply,乘；增加,VERB,B2
-multiplicity,multiplicity,词,NOUN,C1
-multiplier,multiplier,词,NOUN,C1
-mum,mum,词,NOUN,A2
-mundane,mundane,词,ADJ,C1
-munfull,mouthful,一口,NOUN,B2
-munificent,munificent,词,ADJ,C1
-munitions,munitions,军械,NOUN,C1
-muntlig,oral,口头的,ADJ,B2
-muntligt påbud,oral decree,口谕,NOUN,B2
-muntra upp,to cheer up,使高兴,VERB,B2
-muqarnas,muqarnas,词,NOUN,C1
-murabaha,murabaha,成本加成销售,NOUN,C1
-mural,mural,词,NOUN,C1
-murder case,murder case,词,NOUN,B2
-murder scene,murder scene,词,NOUN,C1
-murder victim,murder victim,词,NOUN,C1
-murderer female,murderer female,词,NOUN,B2
-murk of dawn,murk of dawn,词,NOUN,C1
-murky,murky,词,ADJ,C1
-murmur,murmur,低语,NOUN,B2
-murmuring,murmuring,词,NOUN,C1
-muscular,muscular,词,ADJ,C1
-muse,muse,词,VERB,B2
-museum piece,museum piece,博物馆藏品,NOUN,B2
-musical,musical,موسيقي,ADJ,B2
-musical (noun),musical,音乐剧,NOUN,B2
-musical composition,musical composition,词,NOUN,C1
-musical instrument,musical instrument,乐器,NOUN,C1
-musical note,musical note,词,NOUN,C1
-musical score,musical score,乐谱,NOUN,B2
-musicality,musicality,词,NOUN,C1
-musk,musk,麝香,NOUN,B2
-muskelsmärta,muscle pain,肌肉痛,NOUN,B2
-muslim,muslim,مسلم,NOUN,B2
-must (adv),must,务必,ADV,B2
-must (noun),must,必呢,NOUN,C1
-must (verb),must,词,VERB,A1
-must listen,must listen,得听,NOUN,B2
-must not,must not,不得,AUX,B2
-mustard,mustard,词,NOUN,A1
-mutable,mutable,词,ADJ,C1
-mutagenic,mutagenic,词,ADJ,C1
-mutation,mutation,突变,NOUN,B2
-mutazilites,mutazilites,词,NOUN,C1
-mute,mute,沉默的；哑的,ADJ,B2
-mute person,mute person,词,NOUN,B2
-mutilate,mutilate,词,VERB,C1
-mutiny (noun),mutiny,兵变,NOUN,B2
-mutter,to mutter,嘟囔,VERB,B2
-muttering,muttering,念叨,NOUN,C1
-mutton,mutton,羊肉,NOUN,B2
-muttra,to grumble,抱怨,VERB,B2
-muttrande,grumbling,抱怨,NOUN,B2
-mutual,mutual,相互的,ADJ,B2
-mutual affection,mutual affection,词,NOUN,C1
-mutual aid,mutual aid,互助,NOUN,B2
-mutual compassion,mutual compassion,互悯,NOUN,C1
-mutual consent,mutual consent,词,NOUN,C1
-mutual dependence,mutual dependence,相依,NOUN,B2
-mutual forgiveness,mutual forgiveness,词,NOUN,C1
-mutual generation,mutual generation,相生,NOUN,B2
-mutual insurance,mutual insurance,互助保险,NOUN,B2
-mutual pulling,mutual pulling,词,NOUN,C1
-mutual restriction,mutual restriction,相克,NOUN,B2
-mutual support,mutual support,互助,NOUN,C1
-mutual treatment,mutual treatment,相待,NOUN,B2
-mutual understanding,mutual understanding,词,NOUN,B1
-mutual visit,mutual visit,互访,NOUN,B2
-mutually,mutually,相互地,ADV,B2
-muwashshah,muwashshah,词,NOUN,B2
-muzzle,muzzle,口套,NOUN,B2
-muzzling,muzzling,词,NOUN,C1
-my (pron),my,词,PRON,A1
-my audience,my audience,我要见,NOUN,B2
-my big one,my big one,我偌大,NOUN,B2
-my break,my break,我破,NOUN,C1
-my calculation,my calculation,我算,NOUN,C1
-my death,my death,我死,NOUN,B2
-my envoy,my envoy,我使,NOUN,C1
-my exit,my exit,我出,NOUN,B2
-my name,my name,我叫,NOUN,C1
-my place,my place,我处,NOUN,B2
-my residence,my residence,我府,NOUN,B2
-my scrutiny,my scrutiny,我看你,NOUN,B2
-my support,my support,我撑,NOUN,B2
-my take,my take,待我拿,NOUN,C1
-my taking,my taking,我拿,NOUN,B2
-my turn,my turn,我来吧,NOUN,C1
-my writing,my writing,我写,NOUN,C1
-mycket,much,多,DET,B2
-myelin,myelin,词,NOUN,C1
-mygga,mosquito,蚊子,NOUN,B2
-mynning,estuary,河口,NOUN,B2
-myriad,myriad,词,ADJ,C1
-myself,myself,我自,NOUN,B2
-myself (pron),myself,我自己,PRON,B2
-mystic female,mystic female,玄牝,NOUN,C1
-mysticism,mysticism,神秘主义,NOUN,B2
-mythical,mythical,神话般的,ADJ,B2
-mythicality,mythicality,神话性,NOUN,C1
-mythologization,mythologization,神话化,NOUN,C1
-mythology,mythology,神话学,NOUN,B2
-mäkleri,brokerage,经纪业,NOUN,B2
-människonatur,human nature,人性,NOUN,B2
-mänsklig kapacitet,human capacity,人会,NOUN,B2
-mässa,fair,交易会,NOUN,B2
-mästare,champion,冠军,NOUN,B2
-mästarens ord,master's word,爷说,NOUN,B2
-mästerskap,championship,锦标赛,NOUN,B2
-mästerskap,mastery,精通,NOUN,B2
-mästra,to master,掌握,VERB,B2
-mätare,surveyor,测量员,NOUN,B2
-mål,objective,客观的,ADJ,B2
-mål,aim,目标,NOUN,B2
-målning,targeting,定位,NOUN,B2
-månadskontroll,monthly exam,月考,NOUN,B2
 månadsmåne,month moon,月,NOUN,B2
 månadsvis,monthly,每月的,ADJ,B2
+månadskontroll,monthly exam,月考,NOUN,B2
+monument,monument,纪念碑,NOUN,B2
 månmunk,mooncake,月饼,NOUN,B2
-mås,seagull,海鸥,NOUN,B2
-måttligt regn,moderate rain,中雨,NOUN,B2
-mögel,mold,鞋楦,NOUN,B2
-möjliggöra,to enable,使能够,VERB,B2
-möjlighet,opportunity,机会,NOUN,B2
-möl,mole,鼹鼠,NOUN,B2
-mördare,killer,杀手,NOUN,B2
-möta,to face,面对,VERB,B2
-möte,encounter,相遇,NOUN,B2
-nacherziehung,nacherziehung,词,NOUN,C1
-nachfahrt,nachfahrt,词,NOUN,C1
-nachfassung,nachfassung,词,NOUN,B2
-nachforderung,nachforderung,词,NOUN,C1
-nachgabe,nachgabe,词,NOUN,C1
-nachgestaltung,nachgestaltung,词,NOUN,C1
-nachkunft,nachkunft,词,NOUN,C1
-nachnahme,nachnahme,词,NOUN,C1
-nachpflegung,nachpflegung,词,NOUN,C1
-nachregelung,nachregelung,词,NOUN,C1
-nachrichtung,nachrichtung,词,NOUN,B2
-nachschaft,nachschaft,词,NOUN,B2
-nachschrift,nachschrift,词,NOUN,C1
-nachsetzung,nachsetzung,词,NOUN,C1
-nachsicht,nachsicht,词,NOUN,C1
-nachsinnung,nachsinnung,词,NOUN,B2
-nachsprache,nachsprache,词,NOUN,C1
-nachsucht,nachsucht,词,NOUN,B2
-nachsuchung,nachsuchung,词,NOUN,B2
-nachteilung,nachteilung,词,NOUN,C1
-nachtheilung,nachtheilung,词,NOUN,B2
-nachtreibung,nachtreibung,词,NOUN,C1
-nachwandel,nachwandel,词,NOUN,B2
-nachweisung,nachweisung,词,NOUN,B2
-nachwirkung,nachwirkung,词,NOUN,B2
-nackdel,disadvantage,劣势,NOUN,B2
-nadir,nadir,最低点,NOUN,B2
-nahbildung,nahbildung,词,NOUN,C1
-naherziehung,naherziehung,词,NOUN,B2
-nahfahrt,nahfahrt,词,NOUN,B2
-nahfassung,nahfassung,词,NOUN,B2
-nahforderung,nahforderung,词,NOUN,C1
-nahgabe,nahgabe,词,NOUN,C1
-nahgestaltung,nahgestaltung,词,NOUN,C1
-nahkunft,nahkunft,词,NOUN,C1
-nahleitung,nahleitung,词,NOUN,C1
-nahmessung,nahmessung,词,NOUN,C1
-nahnahme,nahnahme,词,NOUN,C1
-nahordnung,nahordnung,词,NOUN,C1
-nahpflegung,nahpflegung,词,NOUN,C1
-nahrechnung,nahrechnung,词,NOUN,C1
-nahregelung,nahregelung,词,NOUN,C1
-nahrichtung,nahrichtung,词,NOUN,C1
-nahschaft,nahschaft,词,NOUN,C1
-nahschrift,nahschrift,词,NOUN,C1
-nahsetzung,nahsetzung,词,NOUN,C1
-nahsicht,nahsicht,词,NOUN,C1
-nahsinnung,nahsinnung,词,NOUN,C1
-nahsprache,nahsprache,词,NOUN,C1
-nahstellung,nahstellung,词,NOUN,C1
-nahsucht,nahsucht,词,NOUN,C1
-nahsuchung,nahsuchung,词,NOUN,C1
-nahteilung,nahteilung,词,NOUN,C1
-nahtheilung,nahtheilung,词,NOUN,C1
-nahtreibung,nahtreibung,词,NOUN,C1
-nahwandel,nahwandel,词,NOUN,C1
-nahwandlung,nahwandlung,词,NOUN,C1
-nahweisung,nahweisung,词,NOUN,C1
-nahwendung,nahwendung,词,NOUN,C1
-nahwirkung,nahwirkung,词,NOUN,C1
+moral,moral,道德,NOUN,B2
+moralitet,morality,道德,NOUN,B2
+mer,more,مزيد,NOUN,B2
+oftare,more often,更频繁,ADV,B2
+dessutom,moreover,此外,ADV,B2
+morgontidning,morning newspaper,晨报,NOUN,B2
+morfologisk,morphological,形态的,ADJ,B2
+morfologi,morphology,形态学,NOUN,B2
+inteckna,mortgage,抵押贷款,NOUN,B2
+inteckna,to mortgage,抵押,VERB,B2
+mosaik,mosaic,马赛克,NOUN,B2
+moské,mosque,清真寺,NOUN,B2
+mygga,mosquito,蚊子,NOUN,B2
+moss,moss,苔藓,NOUN,B2
+mamma,mother,娘,PART,B2
+mors trygghet,mother's reassurance,娘放心,NOUN,B2
+mors,mother-in-law,岳母,NOUN,B2
+motion,motion,运动,NOUN,B2
+motivation,motivation,动机,NOUN,B2
+motor,motor,发动机,NOUN,B2
+husvagn,motorhome,露营车,NOUN,B2
+bergsnedfart,mountain descent,下山,NOUN,B2
+bergskedja,mountain range,山脉,NOUN,B2
+munfull,mouthful,一口,NOUN,B2
+flytta,to move aside,移开,VERB,B2
+flytta,to move in,搬入,VERB,B2
+film,movie,电影,NOUN,B2
+herr,mr.,先生,NOUN,B2
+mrt,mri,核磁共振,NOUN,B2
+mycket,much,多,DET,B2
+slem,mucus,黏液,NOUN,B2
+ler,mud,泥,NOUN,B2
+virrig,muddled,混乱的,ADJ,B2
+multiplicera,to multiply,乘；增加,VERB,B2
+kommunal,municipal,市政的,ADJ,B2
+gävnhet,munificence,慷慨,NOUN,B2
+murmur,murmur,低语,NOUN,B2
+muskelsmärta,muscle pain,肌肉痛,NOUN,B2
+svamp,mushroom,蘑菇,NOUN,B2
+musical,musical,موسيقي,ADJ,B2
+musical score,musical score,乐谱,NOUN,B2
+muslim,muslim,مسلم,NOUN,B2
+mutation,mutation,突变,NOUN,B2
+mute,mute,沉默的；哑的,ADJ,B2
+mutter,to mutter,嘟囔,VERB,B2
+mutton,mutton,羊肉,NOUN,B2
+mutual,mutual,相互的,ADJ,B2
+mutual aid,mutual aid,互助,NOUN,B2
+mutual generation,mutual generation,相生,NOUN,B2
+mutual insurance,mutual insurance,互助保险,NOUN,B2
+mutual restriction,mutual restriction,相克,NOUN,B2
+mutually,mutually,相互地,ADV,B2
+my big one,my big one,我偌大,NOUN,B2
+my place,my place,我处,NOUN,B2
+my residence,my residence,我府,NOUN,B2
+myself,myself,我自,NOUN,B2
+mythology,mythology,神话学,NOUN,B2
 naivety,naivety,天真,NOUN,B2
 name,to name,命名,VERB,B2
-name-calling,name-calling,词,NOUN,C1
-nameable,nameable,可命名的,ADJ,B2
-named,named,词,ADP,C1
 nanny,nanny,保姆,NOUN,B2
 nanotechnology,nanotechnology,纳米技术,NOUN,B2
-nape,nape,后颈,NOUN,B2
 napkin,napkin,餐巾,NOUN,B2
 narcissism,narcissism,自恋,NOUN,B2
-narcissistic,narcissistic,自恋的,ADJ,B2
 narrate,to narrate,叙述,VERB,B2
-narrated,narrated,词,ADJ,C1
-narration,narration,词,NOUN,B2
 narrative,narrative,叙述；故事,NOUN,B2
-narrative (adj),narrative,词,ADJ,C1
-narratives,narratives,词,NOUN,C1
-narrativity,narrativity,词,NOUN,C1
 narrator,narrator,叙述者,NOUN,B2
-narrators,narrators,词,NOUN,C1
-narrow-minded,narrow-minded,狭隘的,ADJ,B2
-narrowing,narrowing,变窄,NOUN,B2
 narrowness,narrowness,狭窄,NOUN,B2
-nascent,nascent,词,ADJ,C1
 nation,nation,国家,NOUN,B2
-national anthem,national anthem,国歌,NOUN,B2
-national character,national character,民族性,NOUN,C1
-national citizen,national citizen,词,NOUN,C1
-national coach,national coach,国家队教练,NOUN,B2
-national currency,national currency,国币,NOUN,C1
-national debt,national debt,国债,NOUN,C1
-national defense,national defense,国防,NOUN,B2
-national highway,national highway,国道,NOUN,B2
-national record,national record,全国纪录,NOUN,B2
-national team,national team,词,NOUN,B1
 nationalism,nationalism,民族主义,NOUN,B2
-nationalist,nationalist,民族主义者,NOUN,B2
 nationality,nationality,国籍,NOUN,B2
 nationalization,nationalization,国有化,NOUN,B2
 nationalize,to nationalize,国有化,VERB,B2
-nationwide,nationwide,全国,NOUN,B2
 native,native,本地的,ADJ,B2
-native (noun),native,词,NOUN,C1
-native american,native american,印第安人,NOUN,B2
-natives inhabitants,natives inhabitants,当地人,NOUN,C1
-nattklubb,nightclub,夜总会,NOUN,B2
-nattlig,nocturnal,夜间的,ADJ,B2
-nattskärr,nightingale,夜莺,NOUN,B2
-nattvy,night view,夜景,NOUN,B2
-natural gas,natural gas,天然气,NOUN,B2
-natural law,natural law,自然法则,NOUN,C1
-naturalism,naturalism,词,NOUN,C1
-naturalization,naturalization,入籍,NOUN,B2
-naturally,naturally,自然地,ADV,B2
 nature reserve,nature reserve,自然保护区,NOUN,B2
-naturgynnad,richly endowed by nature,得天独厚,ADJ,B2
-nauseous,nauseous,恶心的,ADJ,B2
-nauseous disgusting,nauseous disgusting,恶心,ADJ,B2
-nautical,nautical,词,ADJ,C1
-naval,naval,词,ADJ,C1
-navel,navel,肚脐,NOUN,B2
 navigation,navigation,导航；航行,NOUN,B2
-navigational,navigational,词,ADJ,C1
-near (adj),near,近,ADJ,B2
-near (adv),near,词,ADV,A1
-near-dry,near-dry,近干,NOUN,B2
-nearby,nearby,附近,NOUN,B2
-nearest (noun),nearest,词,NOUN,B2
-nearness,nearness,词,NOUN,B2
-neatly,neatly,整洁地,ADV,B2
+marin,navy,海军,NOUN,B2
+nära,near,靠近,ADV,B2
+närheten,nearby,在附近,ADV,B2
+nästan,nearly,几乎,ADV,B2
+nysn,neat,整洁的,ADJ,B2
 nebula,nebula,星云,NOUN,B2
-nebulous,nebulous,词,ADJ,C1
-necessarily incumbent,necessarily incumbent,词,ADV,C1
-necklace chain,necklace chain,词,NOUN,A1
-neckline,neckline,词,NOUN,C1
-necrosis,necrosis,词,NOUN,C1
-nectar,nectar,词,NOUN,C1
-nedbryta,to decompose,分解,VERB,B2
-nederbörd,precipitation,降水,NOUN,B2
-nederländsk,dutch,荷兰的,ADJ,B2
-nedgradera,to relegate,降级,VERB,B2
-nedmontering,dismantling,拆除，瓦解,NOUN,B2
-nedslagen,dejected,沮丧的,ADJ,B2
-nedslagenhet,dejection,沮丧,NOUN,B2
-need not (adv),need not,不必,ADV,B1
-need not (aux),need not,无须,AUX,C1
-needlessly,needlessly,词,ADV,C1
-nefarious,nefarious,词,ADJ,C1
-negation,negation,否定,NOUN,B2
-negativity,negativity,消极,NOUN,B2
+nödvändighet,necessity,必要性；必需品,NOUN,B2
 negera,to negate,否定,VERB,B2
-neglect (noun),neglect,词,NOUN,C1
-negotiator,negotiator,词,NOUN,C1
-neigh (noun),neigh,词,NOUN,C1
-neighbor female,neighbor female,词,NOUN,B2
-neighborhood head,neighborhood head,里长,NOUN,B2
-neighbors,neighbors,词,NOUN,B1
-neighbour,neighbour,邻居,NOUN,B2
-neighbourhood,neighbourhood,词,NOUN,B2
-neither (adv),neither,词,ADV,A1
-neither (det),neither,词,DET,A2
-neither nor,neither nor,词,CCONJ,A2
-nej,no,不,ADV,B2
-nemesis,nemesis,词,NOUN,C1
-neologism,neologism,词,NOUN,C1
-neonatal,neonatal,新生儿的,ADJ,B2
-neophyte,neophyte,新手；初学者,NOUN,B2
-nephews,nephews,子侄,NOUN,B2
-nepotism,nepotism,词,NOUN,B2
-nerve impulse,nerve impulse,词,NOUN,C1
-nerve pain,nerve pain,神经痛,NOUN,C1
+negation,negation,否定,NOUN,B2
+försumma,to neglect,忽视,VERB,B2
+vårdslöshet,negligence,疏忽；过失,NOUN,B2
+vårdslös,negligent,疏忽的,ADJ,B2
+obetydlig,negligible,微不足道的,ADJ,B2
+betydande,negligible not,不可忽视,ADJ,B2
+förhandling,negotiations,谈判,NOUN,B2
+snyta,to neigh,嘶鸣,VERB,B2
+grannskapet,neighborhood,社区,NOUN,B2
+grannliggande,neighboring,邻近的,ADJ,B2
 nervositet,nervousness,紧张,NOUN,B2
-nesting box,nesting box,词,NOUN,B1
-nettle,nettle,词,NOUN,C1
-network card,network card,网卡,NOUN,B2
-networked,networked,联网的,ADJ,C1
-networking,networking,词,NOUN,C1
-neural,neural,词,ADJ,C1
-neuralgia,neuralgia,词,NOUN,C1
-neurasthenia,neurasthenia,词,NOUN,C1
-neurological,neurological,词,ADJ,C1
-neuron,neuron,神经元,NOUN,B2
 neuros,neurosis,神经症,NOUN,B2
-neuroscience,neuroscience,词,NOUN,C1
-neuroticism,neuroticism,词,NOUN,C1
 neutral,neutral,中立的,ADJ,B2
 neutralitet,neutrality,中立,NOUN,B2
-neutron,neutron,词,NOUN,C1
-nevertheless,nevertheless,尽管如此,ADV,B2
-new beginning,new beginning,词,NOUN,C1
-new construction,new construction,新建建筑,NOUN,B2
-new development,new development,词,NOUN,C1
-new moon,new moon,新月,NOUN,B2
-newcomer,newcomer,新来者,NOUN,B2
-newly,newly,词,ADV,C1
-newly acquired,newly acquired,词,ADJ,C1
-newly introduced,newly introduced,词,ADJ,C1
-news bulletin,news bulletin,词,NOUN,B2
-news report,news report,词,NOUN,B1
-newsletter,newsletter,简报,NOUN,B2
-next day,next day,词,NOUN,A2
-next door,next door,在隔壁,ADV,B2
-next following,next following,词,ADJ,C1
-next meeting,next meeting,下回遇,NOUN,B2
-next time,next time,下次,NOUN,B2
-next to (adv),next to,词,ADV,B2
-next week,next week,下周,NOUN,B2
-ney,ney,词,NOUN,B2
-nice to meet you,nice to meet you,幸会,INTJ,C1
-niche,niche,词,NOUN,C1
-nickel,nickel,镍,NOUN,B2
-nigella seeds,nigella seeds,词,NOUN,B2
-night school,night school,夜校,NOUN,C1
+nyårsdag,new year's day,元旦,NOUN,B2
+grann,next door,隔壁,NOUN,B2
+nypa,to nibble,啃,VERB,B2
+nattvy,night view,夜景,NOUN,B2
+nattklubb,nightclub,夜总会,NOUN,B2
+nattskärr,nightingale,夜莺,NOUN,B2
 nihilism,nihilism,虚无主义,NOUN,B2
-nihilistic,nihilistic,词,ADJ,C1
-nimble,nimble,敏捷的,ADJ,B2
-nine (noun),nine,词,NOUN,B2
-nine schools,nine schools,九流,NOUN,C1
-ninth (noun),ninth,词,NOUN,B2
-nirvana,nirvana,元寂,NOUN,C1
-nitrogen,nitrogen,氮,NOUN,B2
+nej,no,不,ADV,B2
+skadeslöshet,no harm,没事吧,NOUN,B2
+inte längre,no longer,不再,ADV,B2
+oavsett,no matter,不论,CCONJ,B2
+behov,no need,不用,AUX,B2
+adel,nobility,贵族气质,NOUN,B2
+ingen,nobody,没有人,PRON,B2
+nattlig,nocturnal,夜间的,ADJ,B2
 nixa,to nod,点头,VERB,B2
-njur,kidney,肾脏,NOUN,B2
-njur-,renal,肾脏的,ADJ,B2
-no,no,不,PART,B2
-no (adv),no,不,ADV,A1
-no attachment,no attachment,无牵,NOUN,C1
-no benefit,no benefit,无一利,NOUN,B2
-no burial place,no burial place,无葬身,NOUN,C1
-no heaven,no heaven,无天,NOUN,C1
-no matter (adj),no matter,词,ADJ,C1
-no matter (sconj),no matter,不拘,SCONJ,B2
-no matter what,no matter what,无论,ADV,B2
-no not,no not,不,ADV,B2
-no not any,no not any,没有,DET,B2
-no one (noun),no one,谁都不,NOUN,C1
-no one (pron),no one,词,PRON,A1
-no parking zone,no parking zone,禁停区,NOUN,C1
-no wonder,no wonder,难怪,ADV,B2
-no worry,no worry,无挂,NOUN,C1
-nobility of character,nobility of character,词,NOUN,C1
-noble qualities,noble qualities,词,NOUN,C1
-noble trait,noble trait,词,NOUN,C1
-node,node,词,NOUN,C1
-noise nuisance,noise nuisance,噪音扰民,NOUN,B2
-noise row,noise row,词,NOUN,C1
-noises,noises,噪音,NOUN,B2
-noisome,noisome,词,ADJ,C1
-nomad,nomad,游牧者,NOUN,B2
+brusig,noisy,吵闹的,ADJ,B2
 nomadism,nomadism,游牧生活,NOUN,B2
-nomads,nomads,词,NOUN,B2
-nominal,nominal,词,ADJ,C1
-nominee,nominee,词,NOUN,C1
 nominera,to nominate,提名,VERB,B2
 nominering,nomination,提名,NOUN,B2
-non-above,non-above,非上,NOUN,C1
-non-acceptance,non-acceptance,非纳,NOUN,C1
-non-analysis,non-analysis,非分,NOUN,C1
-non-argument,non-argument,非辩,NOUN,B2
-non-art,non-art,非艺,NOUN,C1
-non-body,non-body,非体,NOUN,C1
-non-but,non-but,非而,NOUN,C1
-non-cause,non-cause,非因,NOUN,C1
-non-class,non-class,非类,NOUN,C1
-non-compliance,non-compliance,词,NOUN,C1
-non-concrete,non-concrete,非具,NOUN,C1
-non-criterion,non-criterion,非准,NOUN,C1
-non-decision,non-decision,非断,NOUN,C1
-non-deduction,non-deduction,非演,NOUN,C1
-non-direction,non-direction,非方,NOUN,C1
-non-domain,non-domain,非畴,NOUN,B2
-non-edit,non-edit,非辑,NOUN,C1
-non-effect,non-effect,非效,NOUN,B2
-non-essential,non-essential,非本,NOUN,B2
-non-extendable,non-extendable,词,ADJ,C1
-non-form,non-form,非式,NOUN,B2
-non-general,non-general,非般,NOUN,B2
-non-goal,non-goal,非目,NOUN,C1
-non-growth,non-growth,勿长,NOUN,C1
-non-image,non-image,非象,NOUN,C1
-non-institution,non-institution,非制,NOUN,B2
-non-intent,non-intent,非意,NOUN,C1
-non-internal,non-internal,非内,NOUN,C1
-non-iron,non-iron,免烫,ADJ,B2
-non-judgment,non-judgment,非判,NOUN,C1
-non-knot,non-knot,非结,NOUN,B2
-non-layer,non-layer,非层,NOUN,C1
-non-limit,non-limit,非限,NOUN,C1
-non-logic,non-logic,非逻,NOUN,C1
-non-machine,non-machine,非机,NOUN,B2
-non-measure,non-measure,非度,NOUN,C1
-non-momentum,non-momentum,非势,NOUN,C1
-non-nature,non-nature,非性,NOUN,B2
-non-necessary,non-necessary,非必,NOUN,B2
-non-number,non-number,非数,NOUN,B2
-non-object,non-object,非客,NOUN,C1
-non-observation,non-observation,非察,NOUN,B2
-non-orientation,non-orientation,非向,NOUN,C1
-non-origin,non-origin,非原,NOUN,B2
-non-paradigm,non-paradigm,非范,NOUN,C1
-non-path,non-path,非径,NOUN,C1
-non-perception,non-perception,非想,NOUN,C1
-non-possible,non-possible,非可,NOUN,B2
-non-present,non-present,非现,NOUN,C1
-non-price,non-price,非价,NOUN,C1
-non-principle,non-principle,非则,NOUN,C1
-non-process,non-process,非程,NOUN,C1
-non-profit,non-profit,非营利性,ADJ,C1
-non-purpose,non-purpose,非的,NOUN,C1
-non-quantity,non-quantity,非量,NOUN,C1
-non-reality,non-reality,非实,NOUN,B2
-non-realm,non-realm,非界,NOUN,C1
-non-renewable,non-renewable,不可再生,ADJ,C1
-non-result,non-result,非果,NOUN,C1
-non-righteousness,non-righteousness,非义,NOUN,B2
-non-road,non-road,非路,NOUN,C1
-non-route,non-route,非途,NOUN,C1
-non-segment,non-segment,非段,NOUN,C1
-non-shape,non-shape,非形,NOUN,C1
-non-skill,non-skill,非技,NOUN,B2
-non-slip,non-slip,防滑,ADJ,C1
-non-so,non-so,非然,NOUN,B2
-non-sole,non-sole,非唯,NOUN,B2
-non-stage,non-stage,非阶,NOUN,C1
-non-standard,non-standard,非标,NOUN,B2
-non-step,non-step,非步,NOUN,B2
-non-stop,non-stop,不停,ADJ,B2
-non-structure,non-structure,非构,NOUN,C1
-non-subject,non-subject,非主,NOUN,B2
-non-sudden,non-sudden,非骤,NOUN,B2
-non-surface,non-surface,非面,NOUN,C1
-non-synthesis,non-synthesis,非合,NOUN,C1
-non-system,non-system,非系,NOUN,C1
-non-technique,non-technique,非术,NOUN,B2
-non-theory,non-theory,非论,NOUN,B2
-non-thing,non-thing,非物,NOUN,B2
-non-tolerance,non-tolerance,非容,NOUN,C1
-non-type,non-type,非型,NOUN,B2
-non-universal,non-universal,非一,NOUN,C1
-non-use,non-use,非用,NOUN,C1
-non-value,non-value,非值,NOUN,C1
-non-view,non-view,非观,NOUN,B2
+oförmåga,non-ability,非能,NOUN,B2
+icke-abstraktion,non-abstraction,非抽,NOUN,B2
+icke-handling,non-action,非作,NOUN,B2
+icke-hjälp,non-assistance,勿助,NOUN,B2
+icke-tron,non-belief,非信,NOUN,B2
+icke-begrepp,non-concept,非概,NOUN,B2
+icke-konstruktion,non-construction,非建,NOUN,B2
+icke-kontingent,non-contingent,非偶,NOUN,B2
+icke-bevis,non-evidence,非据,NOUN,B2
+icke-induktion,non-induction,非归,NOUN,B2
+icke-inferens,non-inference,非推,NOUN,B2
+icke-nivå,non-level,非级,NOUN,B2
+icke-styrning,non-management,管不,NOUN,B2
+icke-förtjänst,non-merit,非功,NOUN,B2
+icke-medvetande,non-mind,非心,NOUN,B2
+icke-modell,non-model,非模,NOUN,B2
+icke-bana,non-orbit,非轨,NOUN,B2
+icke-ordning,non-order,非序,NOUN,B2
+icke-skugga,non-shadow,非影,NOUN,B2
+icke-ljud,non-sound,非响,NOUN,B2
+icke-specifik,non-specific,非殊,NOUN,B2
+icke-stad,non-state,非态,NOUN,B2
+icke-strategi,non-strategy,非略,NOUN,B2
+icke-substans,non-substance,非质,NOUN,B2
+icke-tanke,non-thought,非念,NOUN,B2
+icke-spår,non-trace,非迹,NOUN,B2
 non-war,non-war,非战,NOUN,B2
-non-work,non-work,非工,NOUN,B2
-nonchalant,nonchalant,词,ADJ,C1
 noncompliant,noncompliant,违规,ADJ,B2
-nonconformist,nonconformist,词,NOUN,C1
 none,none,没有一个,DET,B2
-none (pron),none,没有一个,PRON,A2
-nonexistent,nonexistent,词,ADJ,C1
-nonlinear,nonlinear,词,ADJ,C1
-nonmetal,nonmetal,词,NOUN,C1
-nonprofit,nonprofit,非营利的,ADJ,B2
-nonviolence,nonviolence,非暴力,NOUN,B2
-noodle,noodle,面条,NOUN,B2
-noodles,noodles,面条,NOUN,A1
 noon,noon,正午,NOUN,B2
-nor,nor,也不,CCONJ,B2
 normal,normal,正常的,ADJ,B2
-normal ordinary,normal ordinary,词,ADJ,A2
-normalization,normalization,词,NOUN,C1
-normativity,normativity,词,NOUN,C1
-northeast,northeast,词,NOUN,C1
-norwegian,norwegian,挪威的,ADJ,B2
-nos,snout,口鼻,NOUN,B2
-nosology,nosology,词,NOUN,C1
-nostalgia,nostalgia,怀旧,NOUN,B2
-nostalgic,nostalgic,词,ADJ,C1
-nostril,nostril,词,NOUN,C1
-nosy,nosy,爱打听的,ADJ,B2
 not about,to not about,不关,VERB,B2
-not afraid,not afraid,不怕,VERB,B2
 not allow,not allow,不许,AUX,B2
 not allowed,not allowed,不准,ADJ,B2
-not as good as,not as good as,不如,VERB,B1
-not at all,not at all,词,ADV,C1
-not bad,not bad,不错,ADJ,B2
-not catch up,not catch up,非赶,NOUN,B2
 not come,to not come,不来,VERB,B2
-not count,not count,不算,VERB,B2
-not enough,not enough,不够,ADJ,B2
-not far,not far,不远,ADJ,B2
-not go,not go,不去,VERB,B2
-not good,not good,不好,ADJ,B2
-not hard,not hard,不难,ADV,B2
 not have,to not have,没,VERB,B2
-not intentional,not intentional,不是故意,ADJ,B2
-not necessarily,not necessarily,不见得,ADV,B2
 not only,not only,不光,CCONJ,B2
-not only (adv),not only,不仅,ADV,A1
-not say,not say,不说,VERB,B2
-not stint,not stint,不惜,VERB,B2
-not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
-not to have,not to have,无,VERB,A2
-not very,not very,不太,ADV,B2
-not very good,not very good,不太好,ADJ,B2
-not yet,not yet,未,ADV,B2
 notable,notable,显著的,ADJ,B2
-notables,notables,词,NOUN,B2
-notably,notably,显著地,ADV,B2
 notarization,notarization,公证,NOUN,B2
-notarized,notarized,经公证的,ADJ,B2
 notary,notary,公证人,NOUN,B2
-notch,notch,刻痕,NOUN,B2
-note mark,note mark,词,NOUN,A2
 notebook,notebook,笔记本,NOUN,B2
-notepad,notepad,记事本,NOUN,B2
-noteworthy,noteworthy,词,ADJ,C1
-nothing but,nothing but,无非,NOUN,C1
-nothingness,nothingness,词,NOUN,C1
-nothingness nonexistence,nothingness nonexistence,词,NOUN,C1
 notice,notice,通知,NOUN,B2
 notification,notification,通知,NOUN,B2
-notifications,notifications,词,NOUN,C1
 notify,to notify,通知,VERB,B2
-notion,notion,词,NOUN,B2
 notorious,notorious,臭名昭著的,ADJ,B2
-notoriously,notoriously,词,ADV,C1
-notwithstanding,notwithstanding,词,ADP,C1
 noumenon,noumenon,本体,NOUN,B2
 novelistic,novelistic,小说般的,ADJ,B2
-novelty,novelty,新奇事物,NOUN,B2
 november,november,十一月,NOUN,B2
-novice,novice,词,NOUN,C1
-now,now,此刻,NOUN,B2
-noxious,noxious,词,ADJ,C1
-nuanced,nuanced,细微差别的,ADJ,B2
 nuclear,nuclear,核的,ADJ,B2
-nuclear (noun),nuclear,词,NOUN,B2
-nuclear energy,nuclear energy,核能,NOUN,B2
-nucleic acid test,nucleic acid test,核酸检测,NOUN,C1
-nucleus,nucleus,词,NOUN,B2
-nudge,nudge,词,NOUN,B2
-nudity,nudity,词,NOUN,C1
-nugget,nugget,词,NOUN,C1
 nuisance,nuisance,麻烦事,NOUN,B2
-null and void,null and void,无效的,ADJ,C1
-nullify,nullify,词,VERB,C1
 nullity,nullity,无效；无能,NOUN,B2
-numb,numb,麻木的,ADJ,B2
-numb powder,numb powder,五麻散,NOUN,B2
-number date,number date,号,NOUN,B2
-number of people,number of people,人数,NOUN,B2
-numbering,numbering,词,NOUN,C1
 numbness,numbness,麻木,NOUN,B2
-numeral,numeral,词,NOUN,C1
-numerical,numerical,词,ADJ,C1
 numerous,numerous,众多的,ADJ,B2
-numismatic,numismatic,钱币学的,ADJ,B2
-nunation,nunation,词,NOUN,C1
 nursery,nursery,托儿所,NOUN,B2
-nursing home,nursing home,养老院,NOUN,C1
 nurture,to nurture,养育,VERB,B2
 nurturing,nurturing,养好,NOUN,B2
 nutrition,nutrition,营养,NOUN,B2
-nutritional,nutritional,词,ADJ,C1
-nuts,nuts,疯狂的,ADJ,B2
-nuvarande dynasti,current dynasty,当朝,NOUN,B2
-nykterhet,sobriety,清醒,NOUN,B2
-nylon,nylon,尼龙,NOUN,C1
-nypa,to nibble,啃,VERB,B2
-nysn,neat,整洁的,ADJ,B2
-nyttig,to be useful,有用,VERB,B2
-nyttjanderätt,usufruct,用益权,NOUN,B2
-nyårsdag,new year's day,元旦,NOUN,B2
-när,when,当...时,SCONJ,B2
-nära,near,靠近,ADV,B2
-närhet,adjacency,邻接,NOUN,B2
-närhet,proximity,邻近,NOUN,B2
-närheten,nearby,在附近,ADV,B2
-näsduk,handkerchief,手帕,NOUN,B2
-nästan,nearly,几乎,ADV,B2
-nåbar,reachable,可到达的,ADJ,B2
-någon,any,任何,DET,B2
-någon,anyone,任何人,PRON,B2
-någon gång,sometime,在某个时候,ADV,B2
-några ut,some out,出些,NOUN,B2
-nåla,to pin,别住,VERB,B2
-nödvändighet,have to,还得,NOUN,B2
-nödvändighet,necessity,必要性；必需品,NOUN,B2
-nörd,weirdo,怪人,NOUN,B2
-o,o,词,PART,B1
-o'clock (noun),o'clock,点,NOUN,B2
-oak,oak,词,NOUN,B1
 oar,oar,桨,NOUN,B2
 oasis,oasis,绿洲,NOUN,B2
-oath of allegiance,oath of allegiance,词,NOUN,C1
-oats,oats,燕麦,NOUN,C1
-oavsett,no matter,不论,CCONJ,B2
-obalans,disparity,差异,NOUN,B2
-obdurate,obdurate,词,ADJ,C1
 obedience,obedience,服从,NOUN,B2
-obegriplig,abstruse,深奥的,ADJ,B2
-obehag,discomfort,不适,NOUN,B2
-obelisk,obelisk,词,NOUN,C1
-oberbildung,oberbildung,词,NOUN,B2
-obererziehung,obererziehung,词,NOUN,B2
-oberfahrt,oberfahrt,词,NOUN,C1
-oberfassung,oberfassung,词,NOUN,C1
-oberforderung,oberforderung,词,NOUN,C1
-obergabe,obergabe,词,NOUN,C1
-obergad,inexperienced,生疏的,ADJ,B2
-obergestaltung,obergestaltung,词,NOUN,C1
-oberkunft,oberkunft,词,NOUN,C1
-oberleitung,oberleitung,词,NOUN,B2
-obermessung,obermessung,词,NOUN,C1
-obernahme,obernahme,词,NOUN,C1
-oberoende,independence,独立,NOUN,B2
-oberordnung,oberordnung,词,NOUN,C1
-oberpflegung,oberpflegung,词,NOUN,C1
-oberrechnung,oberrechnung,词,NOUN,C1
-oberregelung,oberregelung,词,NOUN,C1
-oberrichtung,oberrichtung,词,NOUN,C1
-oberschaft,oberschaft,词,NOUN,C1
-oberschrift,oberschrift,词,NOUN,C1
-obersetzung,obersetzung,词,NOUN,C1
-obersicht,obersicht,词,NOUN,C1
-obersinnung,obersinnung,词,NOUN,C1
-obersprache,obersprache,词,NOUN,C1
-oberstellung,oberstellung,词,NOUN,C1
-obersucht,obersucht,词,NOUN,C1
-obersuchung,obersuchung,词,NOUN,B2
-oberteilung,oberteilung,词,NOUN,C1
-obertheilung,obertheilung,词,NOUN,C1
-obertreibung,obertreibung,词,NOUN,C1
-oberwandel,oberwandel,词,NOUN,C1
-oberwandlung,oberwandlung,词,NOUN,B2
-oberweisung,oberweisung,词,NOUN,C1
-oberwendung,oberwendung,词,NOUN,C1
-oberwirkung,oberwirkung,词,NOUN,C1
-obese,obese,肥胖的,ADJ,B2
-obeskrivlig,indescribable,难以形容的,ADJ,B2
-obeslutsam,indecisive,犹豫不决的,ADJ,B2
-obetydlig,negligible,微不足道的,ADJ,B2
-obey orders,obey orders,听命,VERB,C1
-obfuscate,obfuscate,词,VERB,C1
-obituary notice,obituary notice,词,NOUN,C1
-object marker,object marker,把,ADP,A1
-objective,objective,目标,NOUN,B2
-objective goal,objective goal,词,NOUN,A2
-objectively,objectively,词,ADV,C1
-objectivism,objectivism,词,NOUN,C1
+ohörlydande,obedient,顺从的,ADJ,B2
+fetma,obesity,肥胖,NOUN,B2
+invändning,objection,异议,NOUN,B2
+mål,objective,客观的,ADJ,B2
 objektivitet,objectivity,客观性,NOUN,B2
-obligatory,obligatory,词,ADJ,C1
-obliged,obliged,被迫的,ADJ,B2
-obliging,obliging,词,ADJ,B2
-oblique,oblique,斜的,ADJ,B2
-oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
-obliterate,obliterate,词,VERB,C1
-obliteration,obliteration,词,NOUN,C1
-oblivion,oblivion,词,NOUN,C1
-oblivious,oblivious,词,ADJ,C1
 obscen,obscene,淫秽的,ADJ,B2
-obscenity,obscenity,词,NOUN,C1
 obscurantism,obscurantism,蒙昧主义,NOUN,B2
-obscurantist,obscurantist,词,ADJ,C1
-obscure (adj),obscure,词,ADJ,C1
-obsequious,obsequious,词,ADJ,C1
-obsequiously,obsequiously,谄媚地,ADV,B2
-obsequiousness,obsequiousness,谄媚,NOUN,B2
-observable,observable,可观测的,ADJ,B2
-observational,observational,词,ADJ,C1
 observatorium,observatory,天文台,NOUN,B2
 observatör,observer,观察者,NOUN,B2
-observers,observers,词,NOUN,C1
-obsess,obsess,词,VERB,B2
-obsession with youth,obsession with youth,词,NOUN,C1
-obstacle hindrance,obstacle hindrance,词,NOUN,C1
-obstetrics,obstetrics,产科学,NOUN,B2
-obstinacy,obstinacy,顽固,NOUN,C1
-obstinately,obstinately,词,ADV,C1
-obstreperous,obstreperous,词,ADJ,C1
-obtaining,obtaining,获得,NOUN,B2
-obtaining governance,obtaining governance,得治道,NOUN,C1
-obtrusive,obtrusive,词,ADJ,C1
-obtuse,obtuse,词,ADJ,C1
-obviate,obviate,词,VERB,C1
-obvious at a glance,obvious at a glance,一目了然,ADJ,B2
-occasional,occasional,词,ADJ,C1
-occult,occult,神秘的,ADJ,B2
-occultism,occultism,神秘学,NOUN,B2
-occupying strategic point,occupying strategic point,踞险,NOUN,C1
-och,and,重而,NOUN,B2
-och så vidare,and so forth,依此类推,ADV,B2
-och så vidare,and so on,之类,NOUN,B2
-octave,octave,词,NOUN,C1
-octopus,octopus,词,NOUN,B2
-ocular,ocular,词,ADJ,C1
-oddball,oddball,怪人,NOUN,B2
-oddly,oddly,词,ADV,B2
-odious,odious,词,ADJ,C1
-odometer,odometer,里程表,NOUN,C1
-odor,odor,词,NOUN,C1
-odorlessness,odorlessness,词,NOUN,C1
-odyssey,odyssey,词,NOUN,C1
-oense,disagreement,不和,NOUN,B2
-of a woman to marry,of a woman to marry,嫁,VERB,B1
-of all things,of all things,偏偏,ADV,B2
-of first instance,of first instance,词,ADJ,C1
-of it,of it,其中,ADV,B2
-of old,of old,词,ADV,C1
-of the,of the,词,ADP,A1
-of the noose,of the noose,词,ADJ,C1
-of this,of this,词,ADV,B1
-of utrecht,of utrecht,乌得勒支的,ADJ,B2
-of which,of which,关于哪个,PRON,B2
-off,off,关,ADP,B2
-off (adv),off,词,ADV,B2
-off-center,off-center,词,ADJ,C1
-off-track,off-track,词,ADJ,C1
-offcuts,offcuts,词,NOUN,C1
-offence,offence,罪行,NOUN,B2
-offense,offense,冒犯,NOUN,B2
-offensive,offensive,冒犯的,ADJ,B2
-offensive (noun),offensive,词,NOUN,C1
-offentligt,publicly,公开地,ADV,B2
-office work,office work,办公室工作,NOUN,B2
-official approval,official approval,词,NOUN,C1
-official business,official business,公事,NOUN,C1
-official report,official report,词,NOUN,B1
-official statement,official statement,词,NOUN,B2
+föråldrad,obsolete,过时的,ADJ,B2
+envist,obstinate,固执的,ADJ,B2
+spärra,to obstruct,阻碍,VERB,B2
+spärrning,obstruction,阻塞,NOUN,B2
+få,to obtain,获得,VERB,B2
+ibland,occasionally,偶尔,ADV,B2
+yrke,occupation,职业,NOUN,B2
+upptagen,occupied,被占用的,ADJ,B2
+förekomst,occurrence,发生,NOUN,B2
+hav,ocean,海洋,NOUN,B2
+av,of,之,PART,B2
+självfallet,of course,理所当然的,ADJ,B2
+terrängbil,off-road vehicle,越野车,NOUN,B2
+kränka,to offend,冒犯,VERB,B2
+erbjudande,offering,祭品,NOUN,B2
+tjänsteman,official,官员,NOUN,B2
 officiellt,officially,正式地,ADV,B2
-officious,officious,词,ADJ,C1
-offshoring,offshoring,词,NOUN,B2
-offspring,offspring,幼崽,NOUN,B2
-oftare,more often,更频繁,ADV,B2
-ofullständig,incomplete,不完整的,ADJ,B2
-oförenlighet,incompatibility,不兼容,NOUN,B2
-oförmåga,inability,无能,NOUN,B2
-oförmåga,non-ability,非能,NOUN,B2
-oförskamfull,impolite,不礼貌的,ADJ,B2
-oförskamfull,impudent,无礼的,ADJ,B2
-oförskämhet,impudence,厚颜无耻,NOUN,B2
-ogräs,weed,杂草,NOUN,B2
-oh (part),oh,呀,PART,B2
-oh I see,oh I see,词,INTJ,A1
-oh my,oh my,哎呀,INTJ,B2
-ohörlydande,obedient,顺从的,ADJ,B2
-oil lamp,oil lamp,词,NOUN,C1
-oil painting,oil painting,油画,NOUN,C1
-oil petroleum,oil petroleum,词,NOUN,C1
-oil press,oil press,榨油机,NOUN,B2
-oil tanker,oil tanker,词,NOUN,C1
-oilfield,oilfield,词,NOUN,C1
-ojämlikhet,inequality,不平等,NOUN,B2
-ok,ok,好的,INTJ,B2
-okay (intj),okay,好的,INTJ,A1
-okay (noun),okay,好啊,NOUN,C1
+tjänsteman,officials,官员,NOUN,B2
+åh,oh,哇,PART,B2
+salva,ointment,药膏,NOUN,B2
 okej,okay,好的,INTJ,B2
-okomplicerad,straightforward,直率的,ADJ,B2
-okänslig,callous,冷酷,ADJ,B2
-old (noun),old,夙,NOUN,B1
-old dog,old dog,蔡老狗,NOUN,C1
-old friend,old friend,旧友,NOUN,C1
-old grudge,old grudge,旧恨,NOUN,C1
-old minister,old minister,老臣,NOUN,B2
-old people,old people,词,ADJ,A1
-old thief,old thief,老贼,NOUN,C1
-old-age,old-age,晚年,NOUN,C1
-older brother's wife,older brother's wife,嫂子,NOUN,C1
-older sister,older sister,姐姐,NOUN,B2
-oldest,oldest,词,ADJ,C1
-oleander,oleander,词,NOUN,B2
-olfactory,olfactory,词,ADJ,C1
-oligarchy,oligarchy,寡头政治,NOUN,B2
-oligopoly,oligopoly,寡头垄断,NOUN,B2
-olives,olives,词,NOUN,A2
-olyckas,to have an accident,遭遇意外,VERB,B2
-olympic,olympic,奥林匹克的,ADJ,B2
-om,whether,能否,NOUN,B2
-om eller inte,whether or not,是否,SCONJ,B2
-om när,if when,如果,SCONJ,B2
-ombud,proxy,代理人,NOUN,B2
-omdefinition,redefinition,改界,NOUN,B2
-omdirigering,re-routing,改轨,NOUN,B2
-omedelbart,promptly,迅速地,ADV,B2
+ålderdom,old age,老年,NOUN,B2
+gamla mästaren,old master,老太爷,NOUN,B2
+gammal tjänare,old servant,老奴,NOUN,B2
+äldre bror,older brother,大哥哥,NOUN,B2
 omelett,omelet,欧姆蛋,NOUN,B2
-omfatta,to encompass,包含,VERB,B2
-omfattande,exhaustive,详尽的,ADJ,B2
-omfattande,extensive,广泛的,ADJ,B2
-omfång,range,范围,NOUN,B2
-omfång,scope,范围,NOUN,B2
-omgivningar,surroundings,周围,NOUN,B2
-omgång,re-course,重途,NOUN,B2
-omkamp,re-battle,重战,NOUN,B2
-omklädningsrum,locker room,更衣室,NOUN,B2
-omlagering,re-layering,改层,NOUN,B2
-omloppsbana,orbit,轨道,NOUN,B2
-omnipotent,omnipotent,词,ADJ,C1
-omnipresent,omnipresent,无所不在的,ADJ,B2
-omniscient,omniscient,词,ADJ,C1
-omordning,re-order,重序,NOUN,B2
-omorganisation,reorganization,重组,NOUN,B2
-ompröva,to reconsider,重新考虑,VERB,B2
-omprövning,reconsideration,重思,NOUN,B2
-omrörlig,indispensable,不可或缺的,ADJ,B2
-omsekvensering,re-sequencing,改骤,NOUN,B2
-omskapelse,re-creation,再作,NOUN,B2
-omskriva,to circumscribe,限制,VERB,B2
-omskärelse,circumcision,割礼,NOUN,B2
-omsorgsfull,considerate,体贴,ADJ,B2
-omuppförande,re-enactment,再演,NOUN,B2
-omväg,detour,绕道,NOUN,B2
-omöjlighet,impossibility,不可能,NOUN,B2
-on behalf of,on behalf of,代表,ADP,B2
-on condition,on condition,词,SCONJ,C1
-on one hand,on one hand,一方面,ADV,B2
-on purpose,on purpose,故意地,ADV,B2
-on shift,on shift,当班,VERB,C1
-on that,on that,词,ADV,B1
-on that day,on that day,词,ADV,C1
-on the one hand,on the one hand,一方面,ADV,B2
-on the spot,on the spot,当场,ADV,B2
-on this,on this,词,ADV,C1
-on time,on time,准时,ADV,B2
-on top,on top,在上面,ADV,B2
-on upon,on upon,在...上,ADP,B2
-on what,on what,在什么上面,ADV,B2
-on which,on which,在其上,PRON,B2
-once (num),once,一次,NUM,B2
-once again,once again,再次,ADV,B2
-oncology,oncology,词,NOUN,C1
-ond,evil,邪,PART,B2
-one (adj),one,词,ADJ,A2
-one (det),one,词,DET,C1
-one (noun),one,one,NOUN,B2
-one and a half,one and a half,一个半,NUM,B2
-one building,one building,一座,NUM,B2
-one cup,one cup,一杯,NUM,B2
-one day (adv),one day,总有一天,ADV,C1
-one event,one event,一场,NUM,B2
-one handful,one handful,一把,NUM,B2
-one hundred,one hundred,一百,NUM,B2
-one impersonal,one impersonal,词,PRON,A2
-one long,one long,一条,NUM,B2
-one machine,one machine,一架,NUM,B2
-one matter,one matter,一事,NOUN,B2
-one of,one of,之一,NOUN,B2
-one person,one person,一人,NOUN,C1
-one piece,one piece,一块,NUM,B2
-one side,one side,一边,NOUN,A1
-one step,one step,一步,NUM,B2
-one stick,one stick,一支,NUM,B2
-one who,one who,者,PART,B1
-one year,one year,一年,NUM,B2
-one's thoughts,one's thoughts,心眼儿,NOUN,C1
-one-sidedness,one-sidedness,片面性,NOUN,B2
-one-upmanship,one-upmanship,词,NOUN,C1
-one-way street,one-way street,单行道,NOUN,C1
-one-way traffic,one-way traffic,单向通行,NOUN,B2
-onerous,onerous,词,ADJ,C1
-oneself (adv),oneself,词,ADV,A1
-oneself reflexive,oneself reflexive,词,PRON,A2
-online,online,词,ADJ,B1
-online store,online store,词,NOUN,C1
-only (det),only,词,DET,B2
-only (sconj),only,而已,SCONJ,B2
-only bringing,only bringing,只带,NOUN,C1
-only son,only son,独子,NOUN,C1
-onomatopoeia,onomatopoeia,拟声词,NOUN,B2
+hotfull,ominous,不祥的,ADJ,B2
+utelämna,to omit,省略,VERB,B2
+huvud,on head,当头,NOUN,B2
+på det,on it,在上面,ADV,B2
+å andra sidan,on the other hand,另一方面,ADV,B2
+på väg,on the way,在路上,ADV,B2
+en gång,once,一次,ADV,B2
+en gång till,once more,再次,ADV,B2
+en,one,人们,PRON,B2
+en efter en,one after another,接连地,ADV,B2
+en bok,one book,一本,NUM,B2
+en dag,one day,一天,NUM,B2
+en familj,one family,一家,NUM,B2
+en lägenhet,one flat,一张,NUM,B2
+ett huvud,one head,一头,NUM,B2
+en natt,one night,一晚,NUM,B2
+ett set,one set,一套,NUM,B2
+ett skott,one shot,一枪,NUM,B2
+till hjärtats nöje,one's heart's content,尽情,ADV,B2
+ensidig,one-sided,单方面的,ADJ,B2
+bara,only,而已,SCONJ,B2
+bara precis,only just,才,ADV,B2
+bara då,only then,才,ADV,B2
+bara jag,only-me,只我,NOUN,B2
 ontologi,ontology,本体论,NOUN,B2
-oops,oops,词,INTJ,C1
-oordningsam,disorderly,杂乱的,ADJ,B2
-oozing,oozing,词,NOUN,B2
-opacity,opacity,不透明性,NOUN,B2
-opaque,opaque,词,ADJ,C1
-opartisk,disinterested,公正的,ADJ,B2
-opassande,improper,不合适的,ADJ,B2
-open (adv),open,开放地,ADV,B2
-open account,open account,开户,VERB,C1
-open air,open air,词,NOUN,C1
-open class,open class,公开课,NOUN,B2
-open fire,open fire,开火,VERB,C1
-open ground,open ground,词,NOUN,C1
-open theft,open theft,明拿,NOUN,B2
-open tournament,open tournament,公开赛,NOUN,B2
-open up,open up,开拓,VERB,B2
-open-mindedness,open-mindedness,词,NOUN,C1
-opening ceremony,opening ceremony,开幕仪式,NOUN,B2
-openness,openness,开放,NOUN,B2
+öppensinnad,open-minded,思想开明的,ADJ,B2
+öppning,opening,开口,NOUN,B2
+öppet,openly,公开地,ADV,B2
 opera,opera,歌剧,NOUN,B2
-operating room,operating room,手术室,NOUN,C1
-operating system,operating system,操作系统,NOUN,C1
 operation,operation,操作,NOUN,B2
-operation,surgery,手术,NOUN,B2
-operation business,operation business,词,NOUN,B2
-operation room,operation room,操作室,NOUN,C1
-operational,operational,词,ADJ,C1
-operationalization,operationalization,词,NOUN,B2
-operative part,operative part,词,NOUN,C1
 operatör,operator,经营者,NOUN,B2
-operetta,operetta,词,NOUN,C1
-opium den,opium den,词,NOUN,B2
-opportune,opportune,词,ADJ,C1
-opportunism,opportunism,词,NOUN,C1
-opportunist,opportunist,词,NOUN,C1
-opportunistic,opportunistic,词,ADJ,B2
-opportunity used,opportunity used,机会,NOUN,B2
-opposing,opposing,词,ADJ,C1
-opposite,opposite,对面,ADP,B2
-opposite side,opposite side,对面,NOUN,A2
-opposite-side,opposite-side,反方,NOUN,C1
-oppressed,oppressed,词,ADJ,B1
-oppressive,oppressive,压迫的,ADJ,B2
-oppressive weight,oppressive weight,词,NOUN,C1
-opprobrium,opprobrium,词,NOUN,C1
-opt,opt,词,VERB,C1
-optical illusion,optical illusion,词,NOUN,C1
-optician,optician,词,NOUN,C1
-optics perspective,optics perspective,词,NOUN,C1
+möjlighet,opportunity,机会,NOUN,B2
+motverka,to oppose,反对,VERB,B2
+motsatt,opposite,相反的,ADJ,B2
+förtrycka,to oppress,压迫,VERB,B2
+förtryck,oppression,压迫,NOUN,B2
+optisk,optical,光学的,ADJ,B2
 optik,optics,光学,NOUN,B2
-optimal,optimal,最佳的,ADJ,B2
-optimera,to optimize,优化,VERB,B2
 optimism,optimism,乐观,NOUN,B2
 optimistisk,optimistic,乐观的,ADJ,B2
-optimization,optimization,优化,NOUN,B2
-optimum,optimum,词,NOUN,C1
-optisk,optical,光学的,ADJ,B2
-opulence,opulence,词,NOUN,C1
-opulent,opulent,豪华的,ADJ,B2
-or (noun),or,或是,NOUN,B2
-or (part),or,或,PART,C1
-or rather,or rather,或者,ADV,B2
-or something,or something,词,ADV,C1
-oracle,oracle,神谕,NOUN,B2
-oracular,oracular,词,ADJ,C1
-oral cavity,oral cavity,口腔,NOUN,B2
-oral narratives,oral narratives,词,NOUN,C1
-oral transmission,oral transmission,词,NOUN,C1
-orality,orality,词,NOUN,C1
-orally,orally,词,ADV,B2
-orange,orange,橙色的,ADJ,B2
-orange color,orange color,词,ADJ,A1
-orator speaker,orator speaker,词,NOUN,C1
-oratory,oratory,词,NOUN,C1
-orbital,orbital,词,ADJ,C1
-orchestrate,orchestrate,词,VERB,C1
-orchestration,orchestration,词,NOUN,C1
-orchid,orchid,兰,NOUN,B2
-ordain,ordain,词,VERB,C1
-ordbok,dictionary,词典,NOUN,B2
-order mission,order mission,词,NOUN,A2
-orderliness,orderliness,有序性,NOUN,B2
-ordförande,chairman,主席,NOUN,B2
-ordna,to put in order,收拾,VERB,B2
+optimera,to optimize,优化,VERB,B2
+alternativ,option,选择,NOUN,B2
+valfri,optional,可选的,ADJ,B2
+alternativ,options,期权,NOUN,B2
+muntlig,oral,口头的,ADJ,B2
+muntligt påbud,oral decree,口谕,NOUN,B2
+omloppsbana,orbit,轨道,NOUN,B2
+fruktodling,orchard,果园,NOUN,B2
+orkester,orchestra,管弦乐队,NOUN,B2
+prövning,ordeal,苦难,NOUN,B2
 ordnad,orderly,有序的,ADJ,B2
-ordspråk,proverb,谚语,NOUN,B2
-ore,ore,词,NOUN,B2
-orenhet,impurity,不纯,NOUN,B2
+vanligtvis,ordinarily,通常,ADV,B2
+vanlig,ordinary,普通的,ADJ,B2
+vanlig dag,ordinary day,平日,NOUN,B2
+vanliga människor,ordinary people,老百姓,NOUN,B2
 organ,organ,器官,NOUN,B2
-organic fertilizer,organic fertilizer,有机肥,NOUN,C1
-organisatör,organizer,组织者,NOUN,B2
-organiserad,organized,有组织的,ADJ,B2
 organisk,organic,有机的,ADJ,B2
-organism,organism,词,NOUN,C1
-organization body,organization body,词,NOUN,B1
-orientalism,orientalism,词,NOUN,C1
-orientalist,orientalist,词,NOUN,C1
-orientation direction,orientation direction,词,NOUN,B1
-orientera bort,to disorient,使迷失方向,VERB,B2
+organiserad,organized,有组织的,ADJ,B2
+organisatör,organizer,组织者,NOUN,B2
 orientering,orientation,取向,NOUN,B2
-orienteringsstörning,disorientation,迷失方向,NOUN,B2
 original,original,重原,NOUN,B2
-original edition,original edition,原版,NOUN,C1
-original manufacturer,original manufacturer,原厂,NOUN,C1
-original owner,original owner,原主,NOUN,C1
-original state,original state,本就,NOUN,B2
 originaldokument,original document,原件,NOUN,B2
 originalitet,originality,独创性,NOUN,B2
-originally (part),originally,原,PART,B2
-originating,originating,词,ADJ,B1
-originator,originator,词,NOUN,C1
-orison prayer,orison prayer,词,NOUN,C1
-orkan,hurricane,飓风,NOUN,B2
-orkester,orchestra,管弦乐队,NOUN,B2
+ursprungligen,originally,最初,ADV,B2
+härstamma,to originate,发源,VERB,B2
 ornament,ornament,装饰,NOUN,B2
-ornamental,ornamental,词,ADJ,C1
-ornamentation,ornamentation,词,NOUN,C1
-ornate,ornate,词,ADJ,C1
-oro,turmoil,混乱,NOUN,B2
-orolig,anxious,焦虑的,ADJ,B2
-orphanage,orphanage,孤儿院,NOUN,C1
-orsakande,causation,因果关系,NOUN,B2
-orthodoxy,orthodoxy,至正,NOUN,C1
-orthogonality,orthogonality,词,NOUN,C1
-orthographic,orthographic,词,ADJ,C1
+föräldralöst barn,orphan,孤儿,NOUN,B2
 ortodox,orthodox,正统的,ADJ,B2
-oscillating,oscillating,词,ADJ,C1
-oscillation,oscillation,词,NOUN,C1
-oscillator,oscillator,振荡器,NOUN,C1
 oscillera,to oscillate,振荡,VERB,B2
-oskadlig,harmless,无害的,ADJ,B2
-osseous,osseous,词,ADJ,C1
-ostensible,ostensible,词,ADJ,C1
-ostensibly,ostensibly,词,ADV,B2
-ostentation,ostentation,词,NOUN,C1
-ostentatious,ostentatious,词,ADJ,C1
-ostracism,ostracism,词,NOUN,C1
-ostrich,ostrich,词,NOUN,B2
-osäkerhet,precariousness,不稳定性,NOUN,B2
-otalig,countless,无数的,ADJ,B2
-other (det),other,词,DET,B2
-other (pron),other,其它,PRON,B2
-other people,other people,人家,NOUN,B2
-others,others,他人,PRON,B2
-otherwise,otherwise,要不,PART,B2
-otherwise (cconj),otherwise,否则,CCONJ,A2
-otherworldly,otherworldly,词,ADJ,C1
-otro,disbelief,不信,NOUN,B2
-ought to,ought to,词,AUX,A2
-ounce,ounce,词,NOUN,C1
-our (pron),our,词,PRON,A1
-our this,our this,咱这,NOUN,C1
-ourselves,ourselves,我们自己,PRON,B2
-out,out,出,ADP,B2
-out of control,out of control,失控,VERB,B2
-out of place,out of place,格格不入的,ADJ,B2
-outcome ending,outcome ending,结局，解决,NOUN,B2
-outdoor,outdoor,词,ADJ,C1
-outdoor pool,outdoor pool,词,NOUN,C1
-outer frontier,outer frontier,塞外,NOUN,B2
-outer side,outer side,外侧,NOUN,C1
-outer space,outer space,太空,NOUN,B2
-outer-gate,outer-gate,外门,NOUN,B2
-outfit,outfit,服装,NOUN,B2
-outgoing,outgoing,外向的,ADJ,C1
+andra sidan,other side,对面,NOUN,B2
+annorlunda,otherness,相异性,NOUN,B2
+andra,others,他人,NOUN,B2
+utbrott,outburst,迸发,NOUN,B2
+utstött,outcast,被遗弃者,NOUN,B2
+föråldrad,outdated,过时的,ADJ,B2
+utettoalett,outhouse,茅房,NOUN,B2
 outing,outing,郊游,NOUN,B2
-outlandish,outlandish,古怪的,ADJ,B2
-outlast,outlast,词,VERB,B2
-outlaw,outlaw,歹徒,NOUN,B2
-outpatient,outpatient,门诊,NOUN,B2
-outplånlig,indelible,不可磨灭的,ADJ,B2
-outpost,outpost,前哨,NOUN,C1
-output,output,词,NOUN,B2
-output value,output value,产值,NOUN,C1
-outputs,outputs,词,NOUN,C1
-outrageous,outrageous,词,ADJ,B2
-outright,outright,词,ADV,C1
-outset,outset,词,NOUN,C1
-outside (adv),outside,在外面,ADV,A1
-outside of,outside of,在...之外,ADP,B2
-outside place,outside place,外地,NOUN,B2
-outside this,outside this,这外,NOUN,C1
-outside world,outside world,外界,NOUN,B2
-outsider,outsider,外人,NOUN,B2
-outskirts,outskirts,词,NOUN,B1
-outstanding merit,outstanding merit,奇功,NOUN,B2
-outward (adj),outward,词,ADJ,C1
-outward journey,outward journey,词,NOUN,C1
-ovarian,ovarian,词,ADJ,C1
-over about,over about,在...上方,ADP,B2
-over it,over it,词,ADV,B1
-over-accuracy,over-accuracy,超准,NOUN,C1
-over-art,over-art,超艺,NOUN,C1
-over-body,over-body,超体,NOUN,C1
-over-boundary,over-boundary,超界,NOUN,C1
-over-class,over-class,超类,NOUN,C1
-over-degree,over-degree,超阶,NOUN,B2
-over-diameter,over-diameter,超径,NOUN,C1
-over-direction,over-direction,超向,NOUN,C1
-over-energy,over-energy,超能,NOUN,C1
-over-form,over-form,超式,NOUN,B2
-over-function,over-function,超功,NOUN,C1
-over-indebtedness,over-indebtedness,词,NOUN,C1
-over-layer,over-layer,超层,NOUN,C1
-over-limit,over-limit,超限,NOUN,C1
-over-machine,over-machine,超机,NOUN,C1
-over-model,over-model,超模,NOUN,B2
-over-operation,over-operation,超作,NOUN,C1
-over-order,over-order,超序,NOUN,B2
-over-path,over-path,超路,NOUN,C1
-over-plan,over-plan,超略,NOUN,C1
-over-range,over-range,超范,NOUN,C1
-over-route,over-route,超途,NOUN,C1
-over-segment,over-segment,超段,NOUN,C1
-over-side,over-side,超方,NOUN,B2
-over-skill,over-skill,超技,NOUN,B2
-over-standard,over-standard,超标,NOUN,C1
-over-step,over-step,超步,NOUN,C1
-over-structure,over-structure,超结,NOUN,C1
-over-surface,over-surface,超面,NOUN,B2
-over-surge,over-surge,超骤,NOUN,C1
-over-system,over-system,超系,NOUN,C1
-over-technique,over-technique,超术,NOUN,C1
-over-trace,over-trace,超迹,NOUN,C1
-over-track,over-track,超轨,NOUN,C1
-over-type,over-type,超型,NOUN,C1
-over-war,over-war,超战,NOUN,B2
-over-work,over-work,超工,NOUN,C1
-overabundant,overabundant,词,ADJ,B2
-overall (adj),overall,全局性,ADJ,C1
-overall situation,overall situation,全局,NOUN,B2
-overbearing arrogance,overbearing arrogance,词,NOUN,C1
-overbidding,overbidding,词,NOUN,C1
-overconsumption,overconsumption,词,NOUN,C1
-overcrowding,overcrowding,词,NOUN,C1
-overdraft,overdraft,透支,NOUN,B2
-overflowing exuberant,overflowing exuberant,词,ADJ,C1
-overhead,overhead,词,NOUN,C1
-overheating,overheating,词,NOUN,C1
-overjoyed,overjoyed,痛快,ADJ,B1
-overlapping,overlapping,重叠的,ADJ,C1
-overload surcharge,overload surcharge,词,NOUN,C1
-overly familiar,overly familiar,词,ADJ,B2
-overreach,overreach,词,NOUN,C1
-overrule,overrule,词,VERB,C1
-overseas,overseas,词,ADV,B2
-oversight,oversight,疏忽,NOUN,B2
-overt,overt,词,ADJ,C1
-overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
-overthinking,overthinking,你想多,NOUN,B2
-overthrow,overthrow,扳倒,NOUN,B2
-overthrow projection,overthrow projection,词,NOUN,C1
-overthrow reversal,overthrow reversal,词,NOUN,C1
-overview,overview,概览,NOUN,B2
-overweight,overweight,词,ADJ,C1
-overwork,overwork,词,NOUN,C1
-ovilligt,reluctantly,不情愿地,ADV,B2
-oväsen,clamor,喧嚣,NOUN,B2
-ow,ow,词,INTJ,C1
-owed,owed,欠下的,ADJ,B2
-own (det),own,自己的,DET,B2
-own clean,own clean,词,ADJ,B1
-owned,owned,被拥有的,ADJ,A1
-ox,ox,词,NOUN,C1
+utlopp,outlet,出口,NOUN,B2
+skissera,outline,大纲,NOUN,B2
+skissera,to outline,勾勒,VERB,B2
+utsikt,outlook,前景,NOUN,B2
+upprörande,outrage,愤怒,NOUN,B2
+utanför,outside,在外面,ADV,B2
+utkontraktering,outsourcing,外包,NOUN,B2
+överdomän,over-domain,超畴,NOUN,B2
+överstrategi,over-strategy,超策,NOUN,B2
+överstryk,over-stroke,超程,NOUN,B2
+överlag,overall,总体上,ADV,B2
+molnigt,overcast,阴天的,ADJ,B2
+övervinna,to overcome,克服,VERB,B2
+överdra,to overdraw,透支,VERB,B2
+försenad,overdue,逾期,ADJ,B2
+överflöde,overflow,溢出,NOUN,B2
+överlappning,overlap,重叠,NOUN,B2
+över natten,overnight,一夜之间,ADV,B2
+utlandskineser,overseas chinese,华侨,NOUN,B2
+inhamta,to overtake,超过,VERB,B2
+övervända,to overturn,打翻,VERB,B2
+överrumpla,to overwhelm,使不知所措,VERB,B2
+skulda,to owe,欠,VERB,B2
+uggla,owl,猫头鹰,NOUN,B2
 oxid,oxide,氧化物,NOUN,B2
-oxidation,oxidation,词,NOUN,C1
-oxidized,oxidized,词,ADJ,C1
-oxygen-rich,oxygen-rich,词,ADJ,C1
-oxymoron,oxymoron,矛盾修辞法,NOUN,B2
-oyster,oyster,牡蛎,NOUN,B2
-oysters,oysters,词,NOUN,B2
-ozone,ozone,词,NOUN,B2
-oändlig,infinite,无限的,ADJ,B2
-pacific,pacific,词,ADJ,B2
-pacifier,pacifier,奶嘴,NOUN,B2
-pack (noun),pack,词,NOUN,C1
-package packet,package packet,词,NOUN,B1
+tempomakare,pace-setter,标兵,NOUN,B2
 packaging,packaging,包装,NOUN,B2
 packet,packet,小包裹,NOUN,B2
-pacts,pacts,词,NOUN,C1
 pad,pad,垫,NOUN,B2
-padding,padding,词,NOUN,C1
-paddle,paddle,词,VERB,C1
-padlock,padlock,词,NOUN,B2
 page,page,页,NOUN,B2
-pagoda,pagoda,塔,NOUN,B1
-paid,paid,词,ADJ,B2
-pained,pained,词,ADJ,C1
-pains,pains,苦心,NOUN,C1
-painstaking,painstaking,词,ADJ,C1
-painstakingly,painstakingly,细致地,ADV,B2
 paint,paint,油漆,NOUN,B2
-paint dye,paint dye,词,VERB,A1
-paintbrush,paintbrush,画笔；毛笔,NOUN,B2
 painter,painter,画家,NOUN,B2
 pair,pair,一对,NOUN,B2
-paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
-pairing,pairing,可配,NOUN,C1
-palace maid,palace maid,宫女,NOUN,C1
-palanquin,palanquin,词,NOUN,B1
-palatable,palatable,词,ADJ,C1
-paleography,paleography,词,NOUN,C1
-palestinian,palestinian,巴勒斯坦的,ADJ,B2
-palimpsest,palimpsest,词,NOUN,C1
-palisade,palisade,词,NOUN,C1
-palliative,palliative,缓和的,ADJ,B2
-pallid,pallid,词,ADJ,C1
-pallor,pallor,苍白,NOUN,B2
 palm,palm,手掌,NOUN,B2
-palm grove,palm grove,词,NOUN,B2
-palm reading,palm reading,手相,NOUN,C1
-palpable,palpable,词,ADJ,C1
-paltriness,paltriness,词,NOUN,C1
-paltry,paltry,词,ADJ,C1
-pamphlet,pamphlet,词,NOUN,C1
-pamphleteer,pamphleteer,小册子作者,NOUN,B2
 pan,pan,平底锅,NOUN,B2
-pan-fry,pan-fry,煎,VERB,B1
-panacea,panacea,词,NOUN,C1
 pancreas,pancreas,胰腺,NOUN,B2
-panda,panda,熊猫,NOUN,B2
 pandemic,pandemic,大流行病,NOUN,B2
 panegyric,panegyric,颂词,NOUN,B2
-panel of judges,panel of judges,词,NOUN,B2
-panna,boiler,锅炉,NOUN,B2
-panoramic,panoramic,词,ADJ,C1
 pant,to pant,喘气,VERB,B2
 pantheism,pantheism,泛神论,NOUN,B2
-pantheon,pantheon,先贤祠,NOUN,B2
-panther,panther,豹,NOUN,B2
-pants trousers,pants trousers,词,NOUN,A1
-papal bull,papal bull,词,NOUN,B2
 papaya,papaya,木瓜,NOUN,B2
-paper clip,paper clip,回形针,NOUN,B2
 paper cutting,paper cutting,剪纸,NOUN,B2
-paper napkin,paper napkin,餐巾纸,NOUN,C1
-paper-based,paper-based,词,ADJ,C1
-paperless,paperless,词,ADJ,C1
-pappersvaror,stationery,文具,NOUN,B2
-par,couple,一对,NOUN,B2
-par,a pair,一对,NUM,B2
-parable,parable,寓言,NOUN,B2
-parachuting,parachuting,跳伞,NOUN,C1
 parade,parade,游行,NOUN,B2
 paradigm,paradigm,范例,NOUN,B2
-paradise heaven,paradise heaven,词,NOUN,B1
 paradox,paradox,悖论,NOUN,B2
-paradoxical,paradoxical,矛盾的,ADJ,B2
-paradoxically,paradoxically,词,ADV,C1
 paragon,paragon,典范,NOUN,B2
-paragraph heel,paragraph heel,词,NOUN,C1
-paralipsis,paralipsis,词,NOUN,C1
 parallel,parallel,平行的,ADJ,B2
-parallelism,parallelism,词,NOUN,C1
-paralogism,paralogism,谬误推理,NOUN,B2
-paralympic,paralympic,残奥会的,ADJ,B2
-paralysed,paralysed,瘫痪的,ADJ,B2
 paralysis,paralysis,瘫痪,NOUN,B2
 paralyze,to paralyze,使瘫痪,VERB,B2
 paramedic,paramedic,急救人员,NOUN,B2
 parameter,parameter,参数,NOUN,B2
-paramount,paramount,词,ADJ,C1
-paranoia,paranoia,词,NOUN,C1
-paranoid,paranoid,词,ADJ,B2
-parapet,parapet,词,NOUN,C1
-paraphrase,paraphrase,词,VERB,B2
-parasite,parasite,寄生虫,NOUN,C1
-parasol,parasol,词,NOUN,B1
-parataxis,parataxis,意合,NOUN,B2
-parch,parch,词,VERB,C1
-parchment,parchment,词,NOUN,C1
 pardon,pardon,赦免,NOUN,B2
 pardon,to pardon,赦免,VERB,B2
-pardon (noun),pardon,莫怪,NOUN,B2
-pardoning,pardoning,词,NOUN,C1
-parenthesis,parenthesis,词,NOUN,C1
 parents,parents,父母,NOUN,B2
-paresis,paresis,词,NOUN,C1
-pariah,pariah,词,NOUN,C1
-parish,parish,词,NOUN,B2
-parish priest,parish priest,本堂神父,NOUN,B2
-parishioner,parishioner,教区居民,NOUN,B2
-parishioners,parishioners,词,NOUN,C1
 parity,parity,平等,NOUN,B2
 park,park,公园,NOUN,B2
 parking lot,parking lot,停车场,NOUN,B2
-parking meter,parking meter,词,NOUN,B1
-parking space,parking space,停车位,NOUN,C1
-parley,parley,词,NOUN,C1
-parliamentarism,parliamentarism,议会制,NOUN,C1
-parliamentary,parliamentary,议会的/议员,ADJ,B2
-parliamentary elections,parliamentary elections,议会选举,NOUN,B2
-parlor,parlor,词,NOUN,C1
 parody,parody,戏仿,NOUN,B2
 parole,parole,假释,NOUN,B2
 paronomasia,paronomasia,近音词双关,NOUN,B2
-paronym,paronym,词,NOUN,C1
-paroxysm,paroxysm,发作,NOUN,B2
-parquet,parquet,词,NOUN,C1
 parrot,parrot,鹦鹉,NOUN,B2
-parse,parse,解析,VERB,B2
-parsimonious,parsimonious,吝啬的,ADJ,B2
-parsimony,parsimony,吝啬,NOUN,B2
-part forever,part forever,永别,VERB,B2
-part-time,part-time,词,NOUN,B1
-part-time job,part-time job,兼职,NOUN,B2
-partial,partial,部分的,ADJ,B2
-partial basis,partial basis,分据,NOUN,B2
-partial category,partial category,分畴,NOUN,C1
-partial idea,partial idea,分想,NOUN,C1
-partial image,partial image,分象,NOUN,B2
-partial mark,partial mark,分标,NOUN,C1
-partial nature,partial nature,分性,NOUN,C1
-partial norm,partial norm,分范,NOUN,B2
-partial potential,partial potential,分势,NOUN,C1
-partial price,partial price,分价,NOUN,C1
-partial quality,partial quality,分质,NOUN,C1
-partial standard,partial standard,分准,NOUN,C1
-partial state,partial state,分态,NOUN,C1
-partial target,partial target,分的,NOUN,C1
-partial thought,partial thought,分思,NOUN,C1
-partial value,partial value,分值,NOUN,C1
-partial view,partial view,分观,NOUN,C1
-partially,partially,部分地,ADV,B2
-particle (part),particle,么,PART,B2
-particularize,particularize,词,VERB,B2
-particularly,particularly,特别地,ADV,B2
+persilja,parsley,欧芹,NOUN,B2
+arva,to part by death,死别,VERB,B2
+delorsak,partial cause,分因,NOUN,B2
+delbetydelse,partial meaning,分义,NOUN,B2
+deltagande,participatory,参与式的,ADJ,B2
 partikel,particle,颗粒,NOUN,B2
-partisan (adj),partisan,词,ADJ,C1
-partisan (noun),partisan,词,NOUN,C1
-partisanship,partisanship,党派性,NOUN,C1
-partisk,tendentious,有偏见的,ADJ,B2
-partition,partition,词,NOUN,C1
-partitioning,partitioning,词,NOUN,C1
-partner female,partner female,词,NOUN,B2
+speciell,particular,特定的,ADJ,B2
 partnerskap,partnership,伙伴关系,NOUN,B2
-partridge,partridge,词,NOUN,B2
-party concert,party concert,词,NOUN,B1
-party to the contract,party to the contract,词,NOUN,B2
-pashalik,pashalik,词,NOUN,C1
-pass (noun),pass,过得,NOUN,C1
-passa,to fit,适合,VERB,B2
-passa,to suit,适合,VERB,B2
-passable,passable,词,ADJ,C1
-passage,passage,段落,NOUN,B2
-passed,passed,递,ADJ,B2
+dö,to pass away,流逝,VERB,B2
 passera,to pass by,经过,VERB,B2
-passerby,passerby,词,NOUN,C1
-passionate,passionate,热情的,ADJ,B2
-passionate love,passionate love,词,NOUN,C1
+överlåta,to pass on,转交,VERB,B2
+passage,passage,段落,NOUN,B2
 passiv,passive,被动的,ADJ,B2
-passive reliance on others,passive reliance on others,词,NOUN,C1
-past,past,过去,ADP,B2
-past events,past events,往事,NOUN,B2
-past matter,past matter,这夙,NOUN,C1
-past moment,past moment,我方才,NOUN,C1
-pastime,pastime,爱好,NOUN,B2
+fortid,past,过去,NOUN,B2
+tentor,past exam papers,真题,NOUN,B2
+lim,paste,酱,NOUN,B2
 pastor,pastor,牧师,NOUN,B2
-pastoral (adj),pastoral,词,ADJ,C1
-pastoral (noun),pastoral,词,NOUN,C1
-pastry chef,pastry chef,词,NOUN,C1
-patch tire,patch tire,补胎,VERB,C1
+bete,pasture,牧场,NOUN,B2
+lapp,patch,补丁,NOUN,B2
 patent,patent,专利,NOUN,B2
-patently,patently,显然地,ADV,B2
-paternal,paternal,父亲的,ADJ,B2
-paternity leave,paternity leave,陪产假,NOUN,B2
-pathogenic,pathogenic,致病的,ADJ,B2
-pathology,pathology,病理学,NOUN,B2
-patient,patient,耐心的,ADJ,B2
-patient (noun),patient,病人,NOUN,A2
-patient female,patient female,词,NOUN,B2
-patient sufferer,patient sufferer,患者,NOUN,B2
-patientjournal,medical record,病历,NOUN,B2
-patiently,patiently,词,ADV,C1
 patologisk,pathological,病态的,ADJ,B2
-patriarch,patriarch,词,NOUN,C1
+patient,patient,耐心的,ADJ,B2
 patriarkat,patriarchy,父权制,NOUN,B2
-patricide,patricide,弑父,NOUN,B2
-patriot,patriot,词,NOUN,B2
 patriotisk,patriotic,爱国的,ADJ,B2
 patriotism,patriotism,爱国主义,NOUN,B2
-patrol,patrol,巡逻,NOUN,B2
 patron,patron,赞助人,NOUN,B2
-patronage,patronage,赞助,NOUN,B2
-paucity,paucity,词,NOUN,C1
-pauper,pauper,词,NOUN,B2
 pausa,to pause,暂停,VERB,B2
-pave,pave,词,VERB,C1
-pave with bricks,pave with bricks,词,VERB,C1
-pave with flags,pave with flags,词,VERB,C1
-pavilion (part),pavilion,阁,PART,C1
 paviljong,pavilion,亭子,NOUN,B2
-paving,paving,铺路,NOUN,B2
-paving stone,paving stone,词,NOUN,A2
-pawn (noun),pawn,词,NOUN,C1
-pay foreign exchange,pay foreign exchange,付汇,VERB,C1
-payments,payments,词,NOUN,C1
-pea,pea,词,NOUN,C1
-peacefully,peacefully,词,ADV,C1
-peach tree,peach tree,词,NOUN,C1
-peanut field,peanut field,词,NOUN,B2
-peanöt,peanut,花生,NOUN,B2
-peat,peat,泥炭,NOUN,B2
-peccadillo,peccadillo,词,NOUN,C1
-pecuniary,pecuniary,词,ADJ,C1
-pedagogik,pedagogy,教育学,NOUN,B2
-pedagogisk,pedagogical,教学的,ADJ,B2
-pedal,pedal,词,NOUN,B1
-pedantic,pedantic,词,ADJ,C1
-pedantically,pedantically,词,ADV,C1
-pedantry,pedantry,迂腐,NOUN,B2
-peddler,peddler,小贩,NOUN,B2
-pedestrian tunnel,pedestrian tunnel,过街隧道,NOUN,B2
-pediatrics,pediatrics,词,NOUN,C1
-pediment,pediment,词,NOUN,C1
-peephole,peephole,门镜,NOUN,B2
-peer review,peer review,词,NOUN,C1
-peerless,peerless,词,ADJ,C1
-peg,peg,词,NOUN,C1
-pejorative,pejorative,词,ADJ,C1
-pelare,pillar,柱子,NOUN,B2
-pellucid,pellucid,词,ADJ,C1
-pelvis,pelvis,词,NOUN,B2
-pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
-penal,penal,刑事的,ADJ,B2
-penalties,penalties,处罚,NOUN,C1
-penalty,penalty,惩罚,NOUN,B2
-penalty payment,penalty payment,词,NOUN,C1
-penchant,penchant,词,NOUN,C1
-pencil case,pencil case,词,NOUN,C1
-pending,pending,词,ADJ,B1
-penguin,penguin,词,NOUN,A1
-penis,penis,词,NOUN,B2
-penitence,penitence,词,NOUN,C1
-penitent,penitent,词,ADJ,C1
-penitentiary,penitentiary,词,ADJ,C1
-penna,pencil,铅笔,NOUN,B2
-pennant,pennant,词,NOUN,C1
-penniless,penniless,词,ADJ,B1
-pensive,pensive,沉思的,ADJ,B2
-penury,penury,词,NOUN,C1
-people,people,人们,PRON,B2
-people nation,people nation,人民 / 民族,NOUN,B2
-peppermint,peppermint,词,NOUN,C1
-per,per,每,ADP,B2
-perceptibly,perceptibly,明显地,ADV,B2
-perceptual,perceptual,词,ADJ,B2
-percussion instruments,percussion instruments,词,NOUN,C1
-peremptorily,peremptorily,词,ADV,C1
-perennial,perennial,长期的,ADJ,B2
-perfectly,perfectly,词,ADV,A2
-perfektion,perfection,完美,NOUN,B2
-perfidious,perfidious,词,ADJ,C1
-perfidiously,perfidiously,词,ADV,C1
-perfidy,perfidy,背信弃义,NOUN,B2
-performative,performative,词,ADJ,C1
-performativity,performativity,词,NOUN,C1
-performer,performer,词,NOUN,C1
-perfunctory,perfunctory,词,ADJ,C1
-perhaps (noun),perhaps,或許,NOUN,C1
-perhaps (part),perhaps,词,PART,C1
-perhaps maybe,perhaps maybe,词,SCONJ,A2
-peri-urban,peri-urban,城市周边的,ADJ,B2
-perifer,peripheral,外围的,ADJ,B2
-perilla,perilla,紫苏,NOUN,B2
-perilous,perilous,危险的,ADJ,B2
-period,period,句号,PUNCT,B2
-period epoch,period epoch,词,NOUN,B2
-period of time,period of time,期间,NOUN,B1
-periodic,periodic,词,ADJ,C1
-periodical,periodical,词,NOUN,C1
-periodiskt,periodically,定期地,ADV,B2
-periodization,periodization,分期,NOUN,C1
-periphrasis,periphrasis,词,NOUN,C1
-peritoneum,peritoneum,腹膜,NOUN,B2
-perks,perks,词,NOUN,C1
-permanent,permanent,永久的,ADJ,B2
-permanently,permanently,词,ADV,C1
-permeability,permeability,词,NOUN,C1
-permissible,permissible,词,ADJ,C1
-permutations,permutations,词,NOUN,C1
-pernicious,pernicious,有害的,ADJ,B2
-peroration,peroration,结语,NOUN,B2
-perpetual,perpetual,永久的,ADJ,B2
-perplex,perplex,词,VERB,C1
-perplexed,perplexed,困惑的,ADJ,B2
-perseverance,perseverance,毅力,NOUN,B2
+akta,to pay attention,注意,VERB,B2
+hysa,to pay respects,参见,VERB,B2
+betala,to pay smilingly,笑付,VERB,B2
+betala,to pay tax,纳税,VERB,B2
+betalning,payment all,付都,NOUN,B2
+fredfull,peaceful,和平的,ADJ,B2
 persika,peach,桃子,NOUN,B2
-persilja,parsley,欧芹,NOUN,B2
-persimmon,persimmon,柿子,NOUN,C1
-persistence,persistence,坚持,NOUN,B2
+topp,peak,顶峰,NOUN,B2
+peanöt,peanut,花生,NOUN,B2
+päron,pear,梨,NOUN,B2
+pärla,pearl,珍珠,NOUN,B2
+bonde,peasant,农民,NOUN,B2
+sten,pebble,卵石,NOUN,B2
+pedagogisk,pedagogical,教学的,ADJ,B2
+pedagogik,pedagogy,教育学,NOUN,B2
+fotgängare,pedestrian,行人,NOUN,B2
+fotgängarbro,pedestrian bridge,天桥,NOUN,B2
+skal,peel,皮,NOUN,B2
+jämlik,peer,同龄人,NOUN,B2
+penna,pencil,铅笔,NOUN,B2
+genomtränga,to penetrate,穿透,VERB,B2
+genomträngning,penetration,渗透,NOUN,B2
+halvö,peninsula,半岛,NOUN,B2
+procentandel,percentage,百分比,NOUN,B2
+insiktsfull,perceptive,敏锐的,ADJ,B2
+bestämd,peremptory,专横的,ADJ,B2
+perfektion,perfection,完美,NOUN,B2
+kanske,perhaps,也许,ADV,B2
+fara,peril,危险,NOUN,B2
+periodiskt,periodically,定期地,ADV,B2
+perifer,peripheral,外围的,ADJ,B2
+förstöras,to perish,死亡,VERB,B2
+falskt vittnesmål,perjury,伪证,NOUN,B2
+beständighet,permanence,持久,NOUN,B2
+permanent,permanent,永久的,ADJ,B2
+genomtränglig,permeable,可渗透的,ADJ,B2
+tillåta,permit,许可证,NOUN,B2
+tillåta,to permit,允许,VERB,B2
+vinkelrät,perpendicular,垂直的,ADJ,B2
+förfolgelse,persecution,迫害,NOUN,B2
+perseverance,perseverance,毅力,NOUN,B2
 persistent,persistent,坚持不懈的,ADJ,B2
 person,person,人,NOUN,B2
 person honorific,person honorific,位,NOUN,B2
 person in charge,person in charge,负责人,NOUN,B2
-person involved,person involved,当事人,NOUN,C1
-person of independent means,person of independent means,词,NOUN,C1
-personable,personable,词,ADJ,C1
-personal,personal,私事,NOUN,B2
-personal effort,personal effort,亲力,NOUN,B2
 personal enmity,personal enmity,私仇,NOUN,B2
-personal leave,personal leave,事假,NOUN,C1
 personal record,personal record,个人纪录,NOUN,B2
-personalization,personalization,词,NOUN,C1
-personalized,personalized,个性化的,ADJ,B2
-personally experience,personally experience,亲历,VERB,C1
-personification,personification,词,NOUN,C1
-personifiering,epitome,化身,NOUN,B2
-personligen,in person,亲自地,ADV,B2
 personnel,personnel,人员,NOUN,B2
-perspectives,perspectives,词,NOUN,C1
-perspectivism,perspectivism,词,NOUN,C1
-perspicacious,perspicacious,词,ADJ,C1
-perspicacity,perspicacity,词,NOUN,B2
 persuasion,persuasion,说服,NOUN,B2
-pertinent,pertinent,词,ADJ,C1
-pertinently,pertinently,词,ADV,B2
-pervasive,pervasive,词,ADJ,C1
-perverse,perverse,任性的,ADJ,B2
-perversity,perversity,词,NOUN,C1
 pessimism,pessimism,悲观主义,NOUN,B2
 pessimistic,pessimistic,悲观的,ADJ,B2
-pest,pest,词,NOUN,C1
 pesticide,pesticide,杀虫剂,NOUN,B2
-pesticides,pesticides,词,NOUN,C1
-pestilent,pestilent,词,ADJ,C1
-petal,petal,词,NOUN,C1
 petition,petition,请愿,NOUN,B2
-petition for review,petition for review,词,NOUN,C1
-petitioner claimant,petitioner claimant,词,NOUN,C1
-petrochemicals,petrochemicals,词,NOUN,C1
-petrol,petrol,汽油,NOUN,B2
 petroleum,petroleum,石油,NOUN,B2
-pettiness,pettiness,词,NOUN,C1
-petty,petty,词,ADJ,B2
-petulant,petulant,词,ADJ,C1
-phantasmagorical,phantasmagorical,词,ADJ,C1
-phantom,phantom,词,NOUN,C1
-pharaoh,pharaoh,法老,NOUN,B2
-pharisee,pharisee,法利赛人,NOUN,B2
 pharmaceutical,pharmaceutical,制药的,ADJ,B2
-pharynx,pharynx,词,NOUN,B2
 phased,phased,阶段性,ADJ,B2
-phased nature,phased nature,词,NOUN,C1
-phasic,phasic,词,ADJ,C1
-pheasant,pheasant,词,NOUN,C1
-phenomenal,phenomenal,非凡的,ADJ,B2
-phenomenological,phenomenological,词,ADJ,C1
 phenomenology,phenomenology,现象学,NOUN,B2
-phew,phew,词,INTJ,C1
-philanthropic,philanthropic,词,ADJ,C1
 philanthropist,philanthropist,慈善家,NOUN,B2
 philanthropy,philanthropy,慈善,NOUN,B2
-philatelist,philatelist,词,NOUN,C1
-philately,philately,词,NOUN,C1
-philharmonic,philharmonic,词,NOUN,C1
-philippic,philippic,猛烈的抨击,NOUN,B2
-philologist,philologist,语言学家,NOUN,B2
-philology,philology,词,NOUN,C1
 philosopher,philosopher,哲学家,NOUN,B2
-philosophical,philosophical,哲学的,ADJ,B2
-philosophizing,philosophizing,词,NOUN,C1
-phishing,phishing,词,NOUN,B2
-phlebitis,phlebitis,静脉炎,NOUN,B2
 phlegm,phlegm,痰,NOUN,B2
-phlegmatic,phlegmatic,冷静的,ADJ,B2
-phloem,phloem,词,ADJ,C1
 phobia,phobia,恐惧症,NOUN,B2
 phoenix,phoenix,拿凤,NOUN,B2
-phoenix camp,phoenix camp,凤字营,NOUN,B2
-phoenix character,phoenix character,凤字,NOUN,B2
-phoenix coronet,phoenix coronet,凤冠,NOUN,B2
 phone,to phone,打电话,VERB,B2
-phone credit,phone credit,词,NOUN,B1
-phoneme,phoneme,词,NOUN,C1
 phonetics,phonetics,语音学,NOUN,B2
 phonology,phonology,音系学,NOUN,B2
-phony,phony,假的,ADJ,B2
-phosphate,phosphate,词,NOUN,B2
-phosphorescence,phosphorescence,词,NOUN,C1
-phosphorescent,phosphorescent,词,ADJ,C1
-phosphorus,phosphorus,词,NOUN,C1
-photo album,photo album,影集,NOUN,C1
-photo model,photo model,模特,NOUN,B2
 photocopy,photocopy,复印件,NOUN,B2
 photocopy,to photocopy,复印,VERB,B2
-photogenic,photogenic,词,ADJ,C1
 photograph,photograph,照片,NOUN,B2
 photograph,to photograph,拍照,VERB,B2
-photographic,photographic,词,ADJ,C1
 photography,photography,摄影,NOUN,B2
-photogravure,photogravure,词,NOUN,C1
-photon,photon,光子,NOUN,B2
-photophobia,photophobia,词,NOUN,C1
 photosynthesis,photosynthesis,光合作用,NOUN,B2
-phototypy,phototypy,词,NOUN,C1
-phraseology,phraseology,词,NOUN,C1
 physical evidence,physical evidence,物证,NOUN,B2
 physician,physician,内科医生,NOUN,B2
-physicist,physicist,词,NOUN,C1
 physiognomy,physiognomy,面相,NOUN,B2
-physiological,physiological,生理的,ADJ,B2
-physiotherapist,physiotherapist,词,NOUN,B1
-physiotherapy,physiotherapy,物理治疗,NOUN,B2
-pianist,pianist,词,NOUN,C1
+fysiologi,physiology,生理学,NOUN,B2
 piano,piano,钢琴,NOUN,B2
-piano music,piano music,词,NOUN,B2
-picaresque,picaresque,词,ADJ,C1
-pick up a car,pick up a car,取车,VERB,B2
-pickaxe,pickaxe,镐；锄,NOUN,B2
-picking,picking,采摘,NOUN,B2
-pickle (noun),pickle,词,NOUN,C1
-pickles,pickles,词,NOUN,B2
-pickup,pickup,拾音器,NOUN,C1
-pickup truck,pickup truck,皮卡,NOUN,B2
-pictogram,pictogram,词,NOUN,C1
-pictorial,pictorial,绘画的,ADJ,B2
-picture photo,picture photo,词,NOUN,A2
-picturesque,picturesque,如画的；别致的,ADJ,B2
-pidgin,pidgin,词,NOUN,C1
-piece of bread,piece of bread,词,NOUN,B2
-piecework,piecework,词,NOUN,C1
-piety pity,piety pity,词,NOUN,B2
-pil,that arrow,那一箭,NOUN,B2
-pile heap,pile heap,词,NOUN,C1
+plocka upp,to pick up,捡起,VERB,B2
+inlägga,to pickle,腌渍,VERB,B2
+upplysning,piece of information,信息,NOUN,B2
+fromhet,piety,虔诚,NOUN,B2
+duva,pigeon,鸽子,NOUN,B2
+hög,pile,堆,NOUN,B2
+hopa,to pile up,堆积,VERB,B2
 pilgrim,pilgrim,朝圣者,NOUN,B2
-piling up,piling up,堆砌,NOUN,B2
-pillowcase,pillowcase,词,NOUN,C1
-pills,pills,词,NOUN,B2
+vallfart,pilgrimage,朝圣,NOUN,B2
+pelare,pillar,柱子,NOUN,B2
 pilot,pilot,飞行员,NOUN,B2
-pimple,pimple,词,NOUN,B2
-pine forest,pine forest,松林,NOUN,B2
-pine nut,pine nut,松子,NOUN,C1
-pink (noun),pink,词,NOUN,B1
-pioneer,pioneer,先驱,NOUN,B2
-pious,pious,虔诚的,ADJ,B2
-piously,piously,词,ADV,C1
-pipa,pipa,琵琶,NOUN,B2
-pipa,whistle,口哨,NOUN,B2
-pipa,to whistle,吹口哨,VERB,B2
-pipe dream,pipe dream,词,NOUN,C1
-piquant,piquant,词,ADJ,C1
-piracy,piracy,词,NOUN,B2
-pirated,pirated,词,ADJ,B2
-piska,to whip,鞭打,VERB,B2
+nåla,to pin,别住,VERB,B2
+tall,pine,松树,NOUN,B2
 pistaschnöt,pistachio,开心果,NOUN,B2
 pistol,pistol,手枪,NOUN,B2
-piston,piston,词,NOUN,C1
-pitch,pitch,词,NOUN,B1
-pitch darkness,pitch darkness,词,NOUN,C1
-pitchfork,pitchfork,叉子,NOUN,B2
-piteous,piteous,词,ADJ,C1
-pithy,pithy,词,ADJ,C1
-pitiable,pitiable,词,ADJ,C1
-pittance,pittance,词,NOUN,C1
-pity,pity,遗憾,NOUN,B2
-pity compassion,pity compassion,词,NOUN,B2
-pivot,pivot,词,NOUN,B2
-pivotal,pivotal,词,ADJ,C1
-pizza,pizza,词,NOUN,B1
-place of,place of,之地,NOUN,B2
-place of origin,place of origin,原产,NOUN,C1
-place of residence,place of residence,居住地,NOUN,B2
-place value,place value,位值,NOUN,C1
-placed before,placed before,词,ADJ,B2
-placenta,placenta,词,NOUN,B2
-placental,placental,词,ADJ,C1
+grop,pit,坑,NOUN,B2
+ömklig,pitiful,可怜的,ADJ,B2
+beklaga,pity,可惜,ADJ,B2
+beklaga,to pity,同情,VERB,B2
 placering,placement,放置,NOUN,B2
-placid,placid,词,ADJ,C1
-placidity,placidity,词,NOUN,C1
-plagg,garment,服装,NOUN,B2
 plagiat,plagiarism,剽窃,NOUN,B2
-plain (adj),plain,词,ADJ,B1
-plain and simple,plain and simple,朴素,ADJ,B2
-plaintive,plaintive,哀伤的,ADJ,C1
-plaintive sorrow,plaintive sorrow,词,NOUN,C1
-plakat,poster,海报,NOUN,B2
+slätt,plain,平原,NOUN,B2
+kärande,plaintiff,原告,NOUN,B2
 plan,plan,计划,NOUN,B2
 planet,planet,行星,NOUN,B2
-planning,planning,规划,NOUN,B2
-plantage,plantation,人工林,NOUN,B2
-plantain,plantain,芭蕉,NOUN,B2
 plantera ut,to plant out,定植,VERB,B2
+plantage,plantation,人工林,NOUN,B2
 plantering,planting,种植,NOUN,B2
-plasma,plasma,血浆,NOUN,B2
-plastic arts,plastic arts,词,NOUN,C1
-plastic bag,plastic bag,塑料袋,NOUN,A2
 plastisk,plastic,塑料的,ADJ,B2
-platforms,platforms,词,NOUN,C1
-platinum,platinum,词,NOUN,B2
-platitude,platitude,词,NOUN,C1
-plats,location,地点,NOUN,B2
 platå,plateau,高原,NOUN,B2
-plausibility,plausibility,词,NOUN,B2
-plausible,plausible,似是而非的,ADJ,B2
-playable,playable,可演奏的,ADJ,B2
-playback,playback,回放,NOUN,C1
-playful,playful,词,ADJ,C1
-playfulness,playfulness,词,NOUN,B2
-playground,playground,操场,NOUN,B2
-playing,playing,词,NOUN,B2
+pläterad,plated,镀层的,ADJ,B2
+blodplätt,platelet,血小板,NOUN,B2
 playmate,playmate,玩伴,NOUN,B2
-plays,plays,词,NOUN,C1
-playwright,playwright,剧作家,NOUN,B2
 plea,plea,辩护,NOUN,B2
 plead,to plead,恳求,VERB,B2
-pleader,pleader,辩护人,NOUN,C1
-pleading,pleading,词,NOUN,B2
-pleasant surprise,pleasant surprise,惊喜,NOUN,C1
-pleasant to listen to,pleasant to listen to,好听,ADJ,B2
-pleasantly,pleasantly,词,ADV,C1
-please come in,please come in,请进,NOUN,C1
-please to invite,please to invite,请,VERB,A1
-please you're welcome,please you're welcome,词,INTJ,A2
-pleased,pleased,词,ADJ,B1
-plebeian,plebeian,词,ADJ,C1
-plebiscite,plebiscite,词,NOUN,B2
 pledge,pledge,抵押,NOUN,B2
 pledge,to pledge,保证,VERB,B2
-pledge (noun),pledge,词,NOUN,B2
-pledge allegiance,pledge allegiance,效忠,VERB,C1
-plenary,plenary,词,ADJ,C1
-plenitude,plenitude,充足,NOUN,B2
-plentiful,plentiful,词,ADJ,B2
-plenty,plenty,充足地,ADV,B2
-plenty (noun),plenty,大量,NOUN,A2
-pleonasm,pleonasm,赘述,NOUN,B2
-pleura,pleura,胸膜,NOUN,B2
-pliable,pliable,词,ADJ,C1
-pliant,pliant,词,ADJ,C1
 pliers,pliers,钳子,NOUN,B2
 plight,plight,处境,NOUN,B2
-plocka upp,to pick up,捡起,VERB,B2
-plot episode,plot episode,情节,NOUN,C1
-plot of land,plot of land,词,NOUN,B2
-plot twist,plot twist,词,NOUN,C1
-plow,plow,词,NOUN,B2
-plow handle,plow handle,词,NOUN,C1
 plowing,plowing,犁地,NOUN,B2
-plucky,plucky,勇敢的,ADJ,B2
 plug,plug,插头,NOUN,B2
 plum,plum,李子,NOUN,B2
-plum rain season,plum rain season,梅雨,NOUN,B2
-plumb,plumb,词,NOUN,C1
 plumber,plumber,水管工,NOUN,B2
 plumbing,plumbing,管道工程,NOUN,B2
-plump,plump,词,ADJ,C1
 plunder,plunder,掠夺,NOUN,B2
-plundering,plundering,掠夺,NOUN,B2
-plunge,plunge,词,VERB,C1
-plural (noun),plural,词,NOUN,C1
-plural (part),plural,们,PART,A1
 pluralism,pluralism,多元主义,NOUN,B2
-plurality,plurality,词,NOUN,C1
-plus,plus,加上,VERB,B2
 plush toy,plush toy,毛绒玩具,NOUN,B2
 plutocracy,plutocracy,财阀政治,NOUN,B2
-pläterad,plated,镀层的,ADJ,B2
-plötslig,abrupt,突然的,ADJ,B2
-plötslig,sudden,突然的,ADJ,B2
-plötslighet,re-abruptness,再骤,NOUN,B2
-pneumonia,pneumonia,词,NOUN,C1
-poach,poach,词,VERB,C1
 podcast,podcast,播客,NOUN,B2
-podcasting,podcasting,词,NOUN,B1
 poet,poet,诗人,NOUN,B2
-poetic,poetic,词,ADJ,C1
-poetic imitations,poetic imitations,词,NOUN,C1
-poetic mastery,poetic mastery,词,NOUN,C1
-poetic quality,poetic quality,诗意,NOUN,C1
-poetic talent,poetic talent,词,NOUN,C1
-poetics,poetics,词,NOUN,C1
 poetry collection,poetry collection,诗集,NOUN,B2
-poignant,poignant,词,ADJ,C1
-point grade,point grade,词,NOUN,A2
-point of view,point of view,词,NOUN,C1
 point out,to point out,指出,VERB,B2
-pointed specialized,pointed specialized,词,ADJ,C1
-pointless,pointless,词,ADJ,C1
-pointless effort,pointless effort,干吗费神费力,NOUN,C1
-pointwise,pointwise,词,ADJ,C1
-poison flow,poison flow,毒走,NOUN,C1
 poisoning,poisoning,中毒,NOUN,B2
 poisonous,poisonous,有毒的,ADJ,B2
-poke,poke,词,VERB,B2
-polar,polar,极地的,ADJ,B2
-polar technology,polar technology,极地技术,NOUN,B2
-polarity,polarity,极性,NOUN,C1
 polarization,polarization,两极分化 / 极化,NOUN,B2
 pole,pole,极,NOUN,B2
-polemic,polemic,词,NOUN,C1
 polemical,polemical,论战的,ADJ,B2
-polemicist,polemicist,词,NOUN,C1
-police officer female,police officer female,词,NOUN,B2
-police questioning,police questioning,词,NOUN,C1
-police search,police search,词,NOUN,C1
 policeman,policeman,警察,NOUN,B2
 policy,policy,政策,NOUN,B2
-policy-related,policy-related,词,ADJ,C1
-polish,polish,波兰的,ADJ,B2
-polish (noun),polish,精炼,NOUN,C1
-polished,polished,词,ADJ,C1
-polishing,polishing,词,NOUN,B2
-politely,politely,礼貌地,ADV,B2
-politeness,politeness,词,NOUN,C1
-politic,politic,词,ADJ,C1
-political party,political party,政党,NOUN,B2
-politicization,politicization,词,NOUN,C1
 poll,poll,民意调查,NOUN,B2
 pollination,pollination,授粉,NOUN,B2
-pollinic,pollinic,词,ADJ,C1
-pollster,pollster,词,NOUN,C1
 pollutant,pollutant,污染物,NOUN,B2
 polluted,polluted,受污染的,ADJ,B2
 pollution,pollution,污染,NOUN,B2
-polyester,polyester,涤纶,NOUN,B2
-polygon,polygon,多边形,NOUN,C1
-polyphony,polyphony,词,NOUN,B2
-polyptoton,polyptoton,词,NOUN,C1
-polysemy,polysemy,词,NOUN,C1
-polysyndeton,polysyndeton,连词叠用,NOUN,B2
-polytunnel,polytunnel,大棚,NOUN,B2
 pomegranate,pomegranate,石榴,NOUN,B2
 pomelo,pomelo,柚子,NOUN,B2
-pomp,pomp,词,NOUN,C1
-pompous,pompous,浮夸的,ADJ,B2
-pompously,pompously,词,ADV,C1
 pond,pond,池塘,NOUN,B2
-ponderous,ponderous,词,ADJ,C1
+fundera,to ponder,沉思,VERB,B2
 pool,pool,池,PART,B2
-pooled,pooled,词,ADJ,C1
-poor person,poor person,词,NOUN,B2
-poor quality,poor quality,劣质,ADJ,B2
-poor style,poor style,词,NOUN,C1
-pop,pop,词,NOUN,B1
-pop music,pop music,流行音乐,NOUN,B2
-popcorn,popcorn,词,ADJ,C1
-poppy,poppy,词,NOUN,B1
-pops,pops,词,NOUN,C1
-popularisera,to popularize,推广,VERB,B2
 popularitet,popularity,流行,NOUN,B2
-populism,populism,民粹主义,NOUN,C1
-populist,populist,民粹主义者,NOUN,B2
-populous,populous,词,ADJ,C1
-porcelain,porcelain,瓷器,NOUN,B2
-pork,pork,词,NOUN,B2
+popularisera,to popularize,推广,VERB,B2
+befolka,to populate,居住,VERB,B2
+befolkning,population,人口,NOUN,B2
+veranda,porch,门廊,NOUN,B2
 pornografisk,pornographic,色情的,ADJ,B2
-pornography,pornography,色情,NOUN,B2
-porosity,porosity,词,NOUN,C1
-porous,porous,词,ADJ,C1
+gröt,porridge,粥,NOUN,B2
 port,port,港口,NOUN,B2
-port harbor,port harbor,词,NOUN,A1
-portable,portable,词,ADJ,C1
-portentous,portentous,词,ADJ,C1
-portfolios,portfolios,词,NOUN,C1
-portico,portico,词,NOUN,C1
-portion,portion,部分,NOUN,B2
-portion serving,portion serving,部分 / 一份,NOUN,B2
-portrait subject,portrait subject,词,NOUN,C1
-portuguese,portuguese,葡萄牙语,NOUN,B2
 portvakt,porter,搬运工,NOUN,B2
-posh,posh,上流的,ADJ,B2
-posit,posit,词,VERB,B2
-position of authority,position of authority,! 权威地位,NOUN,B2
+portion,portion,部分,NOUN,B2
 positionering,positioning,定位,NOUN,B2
-positions,positions,词,NOUN,C1
-positivism,positivism,词,NOUN,C1
-positivist,positivist,词,ADJ,C1
-positivity,positivity,词,NOUN,B2
-possessive,possessive,词,ADJ,C1
-possessive particle,possessive particle,的,PART,A1
-possible future,possible future,词,ADJ,C1
+besittning,possession,财产,NOUN,B2
 post,post,邮件,NOUN,B2
-postage,postage,邮资,NOUN,B2
-postage stamp,postage stamp,邮票,NOUN,C1
-postal,postal,词,ADJ,C1
-postal code,postal code,邮政编码,NOUN,B2
-postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
-posterity,posterity,词,NOUN,C1
-posthumous,posthumous,死后的,ADJ,B2
 postkontor,post office,邮局,NOUN,B2
-postman,postman,词,NOUN,B2
-postmark,postmark,邮戳,NOUN,C1
-postponement,postponement,延期,NOUN,B2
-postscript,postscript,词,NOUN,C1
+plakat,poster,海报,NOUN,B2
 postulat,postulate,假定,NOUN,B2
-posture,posture,作势,NOUN,B2
-postwar,postwar,战后,NOUN,B2
-potency,potency,药效,NOUN,B2
-potent,potent,词,ADJ,C1
+kastrull,pot,锅,NOUN,B2
 potential,potential,潜力,NOUN,B2
-potential (adj),potential,潜在的,ADJ,B2
-potentially,potentially,潜在地,ADV,B2
-potion,potion,词,NOUN,B2
-potter,potter,词,NOUN,B2
-pouch,pouch,词,NOUN,C1
-poultice,poultice,词,NOUN,B2
-pounding,pounding,捶,NOUN,B2
-pour into,pour into,倾注,VERB,B2
-power outlet,power outlet,插座,NOUN,B1
-power station,power station,发电厂,NOUN,B2
-power struggle,power struggle,词,NOUN,C1
-power supply,power supply,电源,NOUN,C1
-power tilt,power tilt,权倾,NOUN,C1
-powers,powers,词,NOUN,C1
-practice exercises,practice exercises,练习题,NOUN,C1
-practicing,practicing,词,ADJ,C1
-practicing believer,practicing believer,信徒,NOUN,B2
-pragmatic,pragmatic,务实,ADJ,B2
-pragmatics,pragmatics,词,NOUN,C1
-pragmatism,pragmatism,实用主义,NOUN,B2
-pragmatist,pragmatist,词,NOUN,C1
-prairie,prairie,词,NOUN,C1
-praise singer,praise singer,词,NOUN,C1
-praiseworthy,praiseworthy,词,ADJ,C1
-prakt,splendor,辉煌,NOUN,B2
-praktfull,gorgeous,华丽的,ADJ,B2
-praktfull,splendid,极好的,ADJ,B2
-praktfull,sumptuous,奢华的,ADJ,B2
+keramik,pottery,陶器,NOUN,B2
+fågelkött,poultry,家禽,NOUN,B2
+rycka,to pounce,猛扑,VERB,B2
+pulver,powder,粉末,NOUN,B2
+maktpotens,powerful nation,强国,NOUN,B2
+praktiskt,practically,几乎,ADV,B2
 praktik,practice,练习,NOUN,B2
 praktiker,practitioner,从业者,NOUN,B2
-praktisk,convenient,方便的,ADJ,B2
-praktiskt,practically,几乎,ADV,B2
-prank,prank,恶作剧,NOUN,B2
-prata nonsens,to talk nonsense,胡言乱语,VERB,B2
-pratsam,garrulous,喋喋不休的,ADJ,B2
-pratsam,talkative,健谈的,ADJ,B2
-pratsamhet,talkativeness,多嘴,NOUN,B2
-prawn,prawn,词,NOUN,C1
-prayer beads,prayer beads,词,NOUN,C1
-prayer niche,prayer niche,词,NOUN,B2
-prayer room,prayer room,祈祷室,NOUN,B2
-pre-Islamic era,pre-Islamic era,词,NOUN,C1
-pre-dawn meal,pre-dawn meal,词,NOUN,B1
-pre-eternity,pre-eternity,词,NOUN,C1
-preacher,preacher,传教士,NOUN,B2
-precarious,precarious,不稳定的,ADJ,B2
-precarization,precarization,不稳定化,NOUN,B2
-precautionary,precautionary,词,ADJ,C1
-precedence,precedence,也先,NOUN,C1
+pragmatism,pragmatism,实用主义,NOUN,B2
+predika,to preach,布道,VERB,B2
+predikan,preaching,劝诫,NOUN,B2
+inledning,preamble,序言,NOUN,B2
+osäkerhet,precariousness,不稳定性,NOUN,B2
+försiktighetsåtgärd,precaution,预防措施,NOUN,B2
+föregå,to precede,在...之前,VERB,B2
 precedent,precedent,先例,NOUN,B2
 precept,precept,戒律,NOUN,B2
-precinct,precinct,辖区,NOUN,B2
-precipice,precipice,词,NOUN,C1
-precipitate,precipitate,词,VERB,C1
-precipitous,precipitous,词,ADJ,C1
-precis,precise,精确的,ADJ,B2
-precisely,precisely,确切地; 正好,ADV,B2
-precision,precision,精确,NOUN,B2
-preclude,preclude,词,VERB,C1
-precocious,precocious,早熟的,ADJ,B2
-precocious talent,precocious talent,词,NOUN,C1
-predatorisk,predatory,掠夺的,ADJ,B2
-predictable,predictable,可预测的,ADJ,B2
-predika,to preach,布道,VERB,B2
-predikament,predicament,困境,NOUN,B2
-predikan,preaching,劝诫,NOUN,B2
-predikstol,pulpit,讲坛,NOUN,B2
-predilection,predilection,词,NOUN,C1
-predisposition,predisposition,天赋,NOUN,B2
-predominance,predominance,主导地位,NOUN,B2
-predominant,predominant,词,ADJ,B2
-predominantly,predominantly,词,ADV,C1
-preeminence,preeminence,词,NOUN,B2
-preeminent,preeminent,词,ADJ,C1
-preemption,preemption,先发制人,NOUN,C1
-preemption right,preemption right,词,NOUN,C1
-preemptively,preemptively,词,ADV,C1
-prefect,prefect,词,NOUN,B1
-prefectural registrar,prefectural registrar,府典,NOUN,B2
-prefectures,prefectures,词,NOUN,C1
-prefektur,prefecture,省政府,NOUN,B2
-preferable,preferable,更可取的,ADJ,B2
-pregnant woman,pregnant woman,孕妇,NOUN,B2
-prejudiced,prejudiced,有偏见的,ADJ,B2
-prejudicial,prejudicial,词,ADJ,C1
-prelate,prelate,词,NOUN,C1
-preliminary,preliminary,初步的,ADJ,B2
-premature,premature,词,ADJ,C1
-premature baby,premature baby,词,NOUN,B2
-prematurely,prematurely,词,ADV,C1
-prematurity,prematurity,词,NOUN,C1
-premeditate,premeditate,词,VERB,C1
-premeditation,premeditation,预谋,NOUN,B2
-premiss,premise,前提,NOUN,B2
-premiär,premier,总理,NOUN,B2
-premiär,premiere,首演,NOUN,B2
-premonition,premonition,预感,NOUN,B2
-prenumerant,subscriber,订阅者,NOUN,B2
-preoccupation,preoccupation,preoccupation,NOUN,B2
-preparations,preparations,词,NOUN,C1
-preparatory (adj),preparatory,词,ADJ,C1
-preparatory (noun),preparatory,词,NOUN,B2
-prepare (noun),prepare,备上,NOUN,C1
-preponderance,preponderance,词,NOUN,C1
-preponderant,preponderant,占优势的,ADJ,B2
-prerequisite course,prerequisite course,先修课,NOUN,C1
-prerogative,prerogative,特权,NOUN,B2
-prescient,prescient,词,ADJ,C1
-present,present,礼物,NOUN,B2
-present available,present available,存在的 / 可获得的,ADJ,A2
-present knowledge,present knowledge,通今,NOUN,C1
-presentation,presentation,展示,NOUN,B2
-presentatör,presenter,主持人,NOUN,B2
-preservative,preservative,防腐剂,NOUN,B2
-president,president,总统,NOUN,B2
-president female,president female,女总统,NOUN,B2
-president of a country,president of a country,总统,NOUN,B1
-presidential election,presidential election,总统选举,NOUN,B2
-presidential elections,presidential elections,词,NOUN,C1
-presidentialism,presidentialism,词,NOUN,C1
-presidentiell,presidential,总统的,ADJ,B2
-presidentskap,presidency,总统任期,NOUN,B2
-press release,press release,公报,NOUN,B2
-pressande,pressing,紧迫的,ADJ,B2
-prestige,prestige,声望,NOUN,B2
-prestigious,prestigious,有声望的,ADJ,B2
-presumably,presumably,据推测,ADV,B2
-presumed,presumed,推定的,ADJ,B2
-presumption of continuity,presumption of continuity,词,NOUN,C1
-presumptuous,presumptuous,词,ADJ,C1
-pretender,pretender,词,NOUN,C1
-pretending to forget,pretending to forget,词,VERB,C1
-pretension,pretension,词,NOUN,C1
-pretentious,pretentious,自命不凡的,ADJ,B2
-preterition,preterition,假托,NOUN,B2
-prevailing,prevailing,词,ADJ,C1
-prevalence,prevalence,词,NOUN,C1
-prevalent,prevalent,词,ADJ,C1
-prevaricate,prevaricate,词,VERB,C1
-prevention,prevention,预防,NOUN,B2
-preventive,preventive,词,ADJ,B2
-preview,preview,词,NOUN,C1
-prey,prey,猎物,NOUN,B2
-price capping,price capping,词,NOUN,C1
-price change,price change,改价,NOUN,C1
-price increase,price increase,词,NOUN,C1
-prices,prices,词,NOUN,C1
-pricka,to burp,打嗝,VERB,B2
-prickly,prickly,词,ADJ,C1
-pride arrogance,pride arrogance,词,NOUN,C1
-priesthood,priesthood,词,NOUN,C1
-primal,primal,词,ADJ,C1
-primarily,primarily,词,ADV,C1
-primary school,primary school,小学,NOUN,B2
-primary school teacher,primary school teacher,词,NOUN,C1
-primate,primate,词,NOUN,C1
-prime,prime,首要的,ADJ,B1
-prime matter,prime matter,词,NOUN,C1
-primeval forest,primeval forest,原始森林,NOUN,C1
-primitiv,primitive,原始的,ADJ,B2
-primordial chaos,primordial chaos,词,NOUN,C1
-primär,primary,主要的,ADJ,B2
-principal (adj),principal,词,ADJ,B2
-principality,principality,词,NOUN,C1
-print (noun),print,版画,NOUN,C1
-printed,printed,词,ADJ,C1
-printed form,printed form,词,NOUN,B1
-printing,printing,词,NOUN,C1
-printing house,printing house,词,NOUN,B2
-printing press,printing press,词,NOUN,C1
-printout,printout,打印件,NOUN,B2
-prior,prior,先前的,ADJ,B2
-priority,priority,优先的,ADJ,B2
-prisma,prism,棱镜,NOUN,B2
 pristig,precious,珍贵的,ADJ,B2
 pristighet,preciousness,珍贵,NOUN,B2
-pristine,pristine,词,ADJ,C1
-private accessory prosecution,private accessory prosecution,词,NOUN,C1
-private car service,private car service,专车,NOUN,C1
-private debt,private debt,私债,NOUN,B2
-privatization,privatization,词,NOUN,B2
+nederbörd,precipitation,降水,NOUN,B2
+precis,precise,精确的,ADJ,B2
+föregångare,precursor,先驱,NOUN,B2
+predatorisk,predatory,掠夺的,ADJ,B2
+föregångare,predecessor,前任,NOUN,B2
+predikament,predicament,困境,NOUN,B2
+förutsäga,to predict,预测,VERB,B2
+förutsägelse,prediction,预测,NOUN,B2
+förord,preface,序言,NOUN,B2
+prefektur,prefecture,省政府,NOUN,B2
+graviditet,pregnancy,怀孕,NOUN,B2
+premiär,premier,总理,NOUN,B2
+premiär,premiere,首演,NOUN,B2
+premiss,premise,前提,NOUN,B2
+förberedelse,preparation,准备,NOUN,B2
+förbereda,to prepare a lesson,预习,VERB,B2
+absurd,preposterous,荒谬的,ADJ,B2
+föreskriva,to prescribe,开处方,VERB,B2
+recept,prescription,处方,NOUN,B2
+present,present,礼物,NOUN,B2
+presentation,presentation,展示,NOUN,B2
+presentatör,presenter,主持人,NOUN,B2
+bevarande,preservation,保护,NOUN,B2
+presidentskap,presidency,总统任期,NOUN,B2
+president,president,总统,NOUN,B2
+presidentiell,presidential,总统的,ADJ,B2
+pressande,pressing,紧迫的,ADJ,B2
+prestige,prestige,声望,NOUN,B2
+anta,to presume,假定,VERB,B2
+antagande,presumption,自负,NOUN,B2
+göra sig till,to pretend to be,冒充,VERB,B2
+fint,pretense,假装,NOUN,B2
+förevändning,pretext,借口,NOUN,B2
+fin,pretty,漂亮的,ADJ,B2
+tidigare,previous,先前的,ADJ,B2
+tidigare,previously,以前,ADV,B2
+primär,primary,主要的,ADJ,B2
+primitiv,primitive,原始的,ADJ,B2
+trycka,print,印记,NOUN,B2
+trycka,to print,打印,VERB,B2
+skrivare,printer,打印机,NOUN,B2
+prisma,prism,棱镜,NOUN,B2
 privatliv,privacy,隐私,NOUN,B2
-privileged,privileged,词,ADJ,B2
 privilegium,privilege,特权,NOUN,B2
-prize,prize,奖品,NOUN,B2
-pro-natalist,pro-natalist,词,ADJ,B2
-pro-war,pro-war,主战,NOUN,C1
-proactive,proactive,积极主动的,ADJ,B2
 probabilistisk,probabilistic,概率的,ADJ,B2
-probable likely,probable likely,可能的,ADJ,B2
-probation,probation,缓刑,NOUN,B2
-probationary,probationary,词,ADJ,B2
-probative,probative,词,ADJ,C1
-probe,probe,探测器,NOUN,B2
-probing the depths,probing the depths,词,NOUN,C1
-probiotic,probiotic,益生菌,NOUN,C1
-probity,probity,正直,NOUN,B2
-problematic,problematic,词,ADJ,B2
-problematic issue,problematic issue,词,NOUN,C1
-procedural,procedural,程序的,ADJ,B2
-procedures,procedures,词,NOUN,C1
-procentandel,percentage,百分比,NOUN,B2
-process technique,process technique,词,NOUN,B1
-processable,processable,词,ADJ,C1
-processförande,litigant,诉讼当事人,NOUN,B2
-processing,processing,处理,NOUN,B2
-processing (adj),processing,词,ADJ,C1
+sannolikhet,probability,概率,NOUN,B2
+fortsätta,to proceed,继续进行,VERB,B2
+bearbeta,to process,处理,VERB,B2
 procession,procession,行列,NOUN,B2
 processor,processor,处理器,NOUN,B2
-proclamation,proclamation,宣大,NOUN,B2
-proclivity,proclivity,词,NOUN,C1
-prodigal,prodigal,词,ADJ,C1
-prodigality,prodigality,挥霍,NOUN,C1
-prodigious,prodigious,词,ADJ,C1
-prodigy,prodigy,神童,NOUN,B2
-productive,productive,多产的,ADJ,B2
-productivist,productivist,生产至上主义的,ADJ,B2
-produktion,production,生产,NOUN,B2
-produktivitet,productivity,生产力,NOUN,B2
-profane,profane,词,ADJ,C1
-profess,profess,词,VERB,B2
-professional ethics,professional ethics,词,NOUN,C1
-professional formation,professional formation,职业养成,NOUN,B2
-professionalism,professionalism,词,NOUN,B2
-professor,professor,教授,NOUN,B2
-professorship,professorship,词,NOUN,C1
-profetera,to prophesy,预言,VERB,B2
-profetia,prophecy,预言,NOUN,B2
-proffer,proffer,词,VERB,C1
-proficiency,proficiency,词,NOUN,C1
-profitability,profitability,盈利能力,NOUN,B2
-profitable,profitable,词,ADJ,B2
-profits,profits,词,NOUN,B2
-profligate,profligate,词,ADJ,C1
-profuse,profuse,词,ADJ,C1
-profusion,profusion,词,NOUN,C1
-prognos,forecast,预测,NOUN,B2
-prognosis,prognosis,预后,NOUN,B2
-program,program,节目,NOUN,B2
-program schedule,program schedule,词,NOUN,A2
-programmed,programmed,词,ADJ,C1
-programmerare,programmer,程序员,NOUN,B2
-programmering,programming,编程,NOUN,B2
-progression,progression,词,NOUN,C1
-progressiv,progressive,渐进的,ADJ,B2
-progressive,progressive,进步人士,NOUN,B2
-progressivt,progressively,逐渐地,ADV,B2
-prohibited,prohibited,词,ADJ,C1
-prohibited items,prohibited items,词,NOUN,B2
-prohibition sign,prohibition sign,禁令牌,NOUN,C1
-prohibitive,prohibitive,词,ADJ,C1
-project report,project report,项目报告,NOUN,B2
-projectile,projectile,词,NOUN,C1
-projection,projection,词,NOUN,C1
-projections,projections,词,NOUN,C1
-projektor,projector,投影仪,NOUN,B2
-projektuppgift,project assignment,项目作业,NOUN,B2
 prokrastinera,to procrastinate,拖延,VERB,B2
 prokrastinering,procrastination,拖延,NOUN,B2
-prolapse,prolapse,词,NOUN,C1
-prolegomena,prolegomena,词,NOUN,C1
+produktion,production,生产,NOUN,B2
+produktivitet,productivity,生产力,NOUN,B2
+professor,professor,教授,NOUN,B2
+skicklig,proficient,熟练的,ADJ,B2
+vinstgivande,profit-making,营利性,ADJ,B2
+djup,profound,深刻的,ADJ,B2
+program,program,节目,NOUN,B2
+programmerare,programmer,程序员,NOUN,B2
+programmering,programming,编程,NOUN,B2
+föregå,to progress,进步,VERB,B2
+lägesrapport,progress report,进度报告,NOUN,B2
+progressiv,progressive,渐进的,ADJ,B2
+progressivt,progressively,逐渐地,ADV,B2
+förbjuda,to prohibit,禁止,VERB,B2
+förbud,prohibition,禁止,NOUN,B2
+projektuppgift,project assignment,项目作业,NOUN,B2
+projektor,projector,投影仪,NOUN,B2
 proletariat,proletariat,无产阶级,NOUN,B2
-proliferate,proliferate,扩散,! VERB,B2
-proliferation,proliferation,增殖,NOUN,B2
-proliferation of evil,proliferation of evil,蔓延,NOUN,C1
-prolific,prolific,多产的,ADJ,B2
 prolix,prolix,冗长的,ADJ,B2
 prolixitet,prolixity,冗长,NOUN,B2
-prominence,prominence,词,NOUN,B2
-prominent family,prominent family,望族,NOUN,C1
-promiscuous,promiscuous,滥交的,ADJ,B2
+förlänga,to prolong,延长,VERB,B2
 promiss,promissory note,本票,NOUN,B2
 promotör,promoter,推动者,NOUN,B2
-prompt,prompt,词,ADJ,C1
-promptness,promptness,词,NOUN,C1
+omedelbart,promptly,迅速地,ADV,B2
 promulgera,to promulgate,颁布,VERB,B2
-prone,prone,词,ADJ,C1
-pronoun,pronoun,词,NOUN,B1
-pronounced,pronounced,显著的,ADJ,B2
-proofread,proofread,校对,VERB,C1
-proofreader,proofreader,词,NOUN,C1
-propaedeutic,propaedeutic,词,ADJ,C1
+uttal,pronunciation,发音,NOUN,B2
+bevisläsning,proofreading,校对,NOUN,B2
+stötta,to prop,撑,VERB,B2
 propaganda,propaganda,宣传,NOUN,B2
-propel,propel,推动,VERB,B2
-propellant,propellant,词,NOUN,C1
-propeller,propeller,螺旋桨,NOUN,B2
-property right,property right,所有权,NOUN,B2
-prophet,prophet,先知,NOUN,B2
-prophethood,prophethood,词,NOUN,C1
-prophylactic,prophylactic,词,ADJ,C1
-prophylaxis,prophylaxis,预防,NOUN,B2
-propitious,propitious,词,ADJ,C1
-proponent,proponent,词,NOUN,C1
+benägenhet,propensity,倾向,NOUN,B2
+profetia,prophecy,预言,NOUN,B2
+profetera,to prophesy,预言,VERB,B2
 proportion,proportion,比例,NOUN,B2
-proportional,proportional,成比例的,ADJ,B2
-proportionality,proportionality,词,NOUN,C1
-proportionally,proportionally,词,ADV,C1
+förslag,proposal,提议,NOUN,B2
 proposition,proposition,主张,NOUN,B2
-propp,clot,凝块,NOUN,B2
-proprietor,proprietor,词,NOUN,C1
-propulsion,propulsion,词,NOUN,C1
-pros and cons,pros and cons,利害,NOUN,B2
-prosa,prose,散文,NOUN,B2
+anständighet,propriety,分寸,NOUN,B2
 prosaisk,prosaic,平淡无奇的,ADJ,B2
-prose writer,prose writer,词,NOUN,C1
-prosecution service,prosecution service,检察院,NOUN,B2
-prosecutions,prosecutions,词,NOUN,C1
-prosecutor's office,prosecutor's office,词,NOUN,B2
-proselyte,proselyte,词,NOUN,C1
-proselytism,proselytism,传教,NOUN,B2
-prosody,prosody,韵律学,NOUN,B2
-prosopopoeia,prosopopoeia,词,NOUN,C1
-prospecting,prospecting,词,NOUN,C1
-prospecting drilling,prospecting drilling,词,NOUN,C1
-prospects,prospects,前途,NOUN,B1
-prosthesis,prosthesis,词,NOUN,C1
-prostitution,prostitution,词,NOUN,B2
+prosa,prose,散文,NOUN,B2
+utsikt,prospect,前景,NOUN,B2
+välfärd,prosperity,繁荣,NOUN,B2
+välmående,prosperous,繁荣的,ADJ,B2
 protagonist,protagonist,主角,NOUN,B2
-protection of Majesty,protection of Majesty,保陛,NOUN,C1
-protective cover,protective cover,词,NOUN,C1
-protein,protein,蛋白质,NOUN,B2
 protektionism,protectionism,保护主义,NOUN,B2
+skyddande,protective,保护的,ADJ,B2
+protein,protein,蛋白质,NOUN,B2
 protest,protest,抗议,NOUN,B2
-protest movement,protest movement,词,NOUN,C1
 protestant,protester,示威者,NOUN,B2
-proton,proton,词,NOUN,C1
-prototype,prototype,词,NOUN,C1
-protract,protract,词,VERB,C1
-protracted,protracted,词,ADJ,C1
-protractor,protractor,量角器,NOUN,C1
-proud of oneself,proud of oneself,得意,ADJ,A2
-proud refusal,proud refusal,词,NOUN,C1
-proudly,proudly,词,ADV,C1
-provable,provable,可证明的,ADJ,B2
-proverbs,proverbs,词,NOUN,C1
-providential,providential,词,ADJ,C1
-provinces,provinces,词,NOUN,C1
-provincial,provincial,地方的,ADJ,B2
+ordspråk,proverb,谚语,NOUN,B2
+tillhandahålla bevis,to provide evidence,举证,VERB,B2
+ge återkoppling,to provide feedback,反馈,VERB,B2
+förutsatt att,provided that,只要,SCONJ,B2
+leverantör,provider,提供者,NOUN,B2
 provinsväg,provincial highway,省道,NOUN,B2
-provision,provision,词,NOUN,C1
-provisional,provisional,临时的,ADJ,B2
-provisionally,provisionally,词,ADV,C1
-provocative,provocative,挑衅的,ADJ,B2
-provocera,to provoke,激怒,VERB,B2
+försörjningsmedel,provisions,储备,NOUN,B2
 provokation,provocation,挑衅,NOUN,B2
-prow,prow,词,NOUN,C1
-prowess,prowess,词,NOUN,C1
-prowl,prowl,词,VERB,C1
-prudent,prudent,谨慎的,ADJ,B2
-prudently,prudently,词,ADV,C1
-prudishness,prudishness,词,NOUN,C1
-prune,prune,修剪,VERB,C1
-pruning,pruning,词,NOUN,C1
-pruta,to haggle,讨价还价,VERB,B2
-prutande,haggling,计较,NOUN,B2
-pryda,to embellish,装饰,VERB,B2
-pryk,rascal,无赖,NOUN,B2
-prövning,ordeal,苦难,NOUN,B2
-psalm,hymn,赞美诗,NOUN,B2
-psalm,psalm,诗篇,NOUN,B2
-psalter,psalter,词,NOUN,C1
-pseudonym,pseudonym,词,NOUN,C1
-psoriasis,psoriasis,词,NOUN,C1
-psst,psst,词,INTJ,C1
-psychiatric,psychiatric,精神病的,ADJ,B2
-psychic,psychic,词,ADJ,C1
-psychoanalysis,psychoanalysis,精神分析,NOUN,B2
-psychoanalyst,psychoanalyst,词,NOUN,C1
-psychological,psychological,心理的,ADJ,B2
-psychologically,psychologically,词,ADV,C1
-psychopathy,psychopathy,词,NOUN,C1
+provocera,to provoke,激怒,VERB,B2
+närhet,proximity,邻近,NOUN,B2
+ombud,proxy,代理人,NOUN,B2
+försiktighet,prudence,谨慎,NOUN,B2
 psykos,psychosis,精神病,NOUN,B2
 pub,pub,酒吧,NOUN,B2
 pubertet,puberty,青春期,NOUN,B2
-public bath,public bath,公共浴室,NOUN,A2
-public debt,public debt,公债,NOUN,C1
-public fountain,public fountain,公共喷泉,NOUN,C1
-public holiday,public holiday,公共假日,ADJ,B2
-public holiday (noun),public holiday,词,NOUN,C1
-public opinion,public opinion,社会舆论,NOUN,C1
-public relations,public relations,公关,NOUN,B2
-public security,public security,社会治安,NOUN,C1
-public security bureau,public security bureau,公安局,NOUN,B2
-public square,public square,广场,NOUN,B1
-publicera,to publish,出版,VERB,B2
-publicity,publicity,宣传,NOUN,B2
+allmän ordning,public order,治安,NOUN,B2
+allmännyttan,public welfare,公益性,NOUN,B2
 publikation,publication,出版物,NOUN,B2
-puddle,puddle,水坑,NOUN,B2
-puerile,puerile,词,ADJ,C1
-puerperal,puerperal,词,ADJ,C1
-puff,puff,一口烟,NOUN,B2
-puff pastry,puff pastry,词,NOUN,C1
-pugnacious,pugnacious,词,ADJ,C1
-pugnacity,pugnacity,词,NOUN,C1
-puissant,puissant,词,ADJ,C1
-pull (noun),pull,别拉,NOUN,C1
-pulley,pulley,词,NOUN,C1
-pulling,pulling,拔,NOUN,B2
-pulpy,pulpy,髓质的,ADJ,C1
-pulver,powder,粉末,NOUN,B2
-pummel,pummel,词,VERB,C1
-pump air,pump air,打气,VERB,C1
-pumping,pumping,词,NOUN,C1
-pumpkin,pumpkin,南瓜,NOUN,C1
-pumpkin seed,pumpkin seed,南瓜子,NOUN,B2
-pun,pun,词,NOUN,C1
+offentligt,publicly,公开地,ADV,B2
+publicera,to publish,出版,VERB,B2
+förlag,publishing house,出版社,NOUN,B2
+lunga,pulmonary,肺的,ADJ,B2
+predikstol,pulpit,讲坛,NOUN,B2
 punch,punch,拳击,NOUN,B2
-punch (verb),punch,词,VERB,B2
-punch drink,punch drink,词,NOUN,C1
-punctilious,punctilious,词,ADJ,C1
-punctuality,punctuality,守时,NOUN,B2
-punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
-punctuation,punctuation,标点符号,NOUN,B2
 punctuel,punctual,准时的,ADJ,B2
-puncture tap,puncture tap,词,NOUN,C1
-pundit,pundit,词,NOUN,C1
-pungent,pungent,词,ADJ,C1
+punctuation,punctuation,标点符号,NOUN,B2
 pungtur,puncture,穿刺,NOUN,B2
-punishable,punishable,可处罚的,ADJ,B2
-punitive,punitive,惩罚性的,ADJ,B2
-punkt,this item,这件,NOUN,B2
-puny,puny,词,ADJ,C1
-pupil female,pupil female,词,NOUN,C1
-puppet show,puppet show,木偶戏,NOUN,C1
-puppets,puppets,词,NOUN,B2
-purchase price,purchase price,购买价,NOUN,B2
-purely,purely,纯粹地,ADV,B2
-purifying,purifying,净化的,ADJ,B2
-puritanical,puritanical,词,ADJ,C1
-purple (noun),purple,词,NOUN,A2
-purple needle,purple needle,紫阴针,NOUN,B2
-purpose design,purpose design,词,NOUN,C1
-purse,purse,词,NOUN,B1
-pursuant to (adp),pursuant to,词,ADP,C1
-pursuant to (adv),pursuant to,依照/根据,ADV,C1
-pursuer,pursuer,追兵,NOUN,B2
-pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
-purveyor,purveyor,词,NOUN,C1
-pus,pus,词,NOUN,C1
-push (noun),push,词,NOUN,C1
-push further,push further,进尺,NOUN,B2
+docka,puppet,木偶,NOUN,B2
+köpa,to purchase,购买,VERB,B2
+ren,pure,纯净的,ADJ,B2
+rening,purification,净化,NOUN,B2
+renhet,purity,纯洁,NOUN,B2
+lila yin,purple yin,紫阴,NOUN,B2
+jakt,pursuit,追求,NOUN,B2
 push luck,push luck,太得寸,NOUN,B2
-pushover,pushover,善茬,NOUN,B2
-pusillanimity,pusillanimity,词,NOUN,C1
-pusillanimous,pusillanimous,怯懦的,ADJ,B2
-put forward,put forward,提出,VERB,B2
-putative,putative,词,ADJ,C1
-putrid,putrid,词,ADJ,C1
+lägga ner,to put down,放下,VERB,B2
+ordna,to put in order,收拾,VERB,B2
+ta på sig,to put on,穿上,VERB,B2
+förbrylla,puzzle,谜题,NOUN,B2
+förbrylla,to puzzle,使困惑,VERB,B2
 pyramid,pyramid,金字塔,NOUN,B2
-pärla,pearl,珍珠,NOUN,B2
-päron,pear,梨,NOUN,B2
-på det,on it,在上面,ADV,B2
-på grund av,because of,因为,ADP,B2
-på grund av,due to,由于,ADP,B2
-på något sätt,somehow,以某种方式,ADV,B2
-på tjänst,to be on duty,值班,VERB,B2
-på väg,on the way,在路上,ADV,B2
-påbuda,to impose,强加,VERB,B2
-pålitlig,trustworthy,值得信赖的,ADJ,B2
-påstådd,alleged,所谓的,ADJ,B2
-påstås,allegedly,据称,ADV,B2
-påverka,to influence,影响,VERB,B2
-qasida form,qasida form,词,NOUN,C1
-qraqeb,qraqeb,克拉克斯布,NOUN,B2
-quackery,quackery,词,NOUN,B2
-quaint,quaint,词,ADJ,C1
-qualifier,qualifier,资格赛,NOUN,C1
-qualifiers,qualifiers,词,NOUN,B2
-qualifying,qualifying,词,ADJ,C1
-quandary,quandary,词,NOUN,B2
-quantifiable,quantifiable,词,ADJ,B2
-quantum,quantum,量子的,ADJ,B2
-quarantine (verb),quarantine,隔离,VERB,C1
-quarrelsome,quarrelsome,词,ADJ,C1
-quarry,quarry,词,NOUN,B1
-quarter of an hour,quarter of an hour,词,NOUN,C1
-quarterly report,quarterly report,季报,NOUN,C1
-quartz,quartz,词,NOUN,C1
-quashing,quashing,撤销,NOUN,B2
-quasi,quasi,词,ADV,B2
-quaternary,quaternary,第四的,ADJ,B2
-queer,queer,词,ADJ,C1
-quench,quench,词,VERB,C1
-querulous,querulous,词,ADJ,C1
-question mark,question mark,词,PUNCT,A2
-question particle,question particle,吗,PART,A1
-questioning (adj),questioning,词,ADJ,C1
-questionnaire,questionnaire,词,NOUN,C1
-questions,questions,词,NOUN,C1
-quibble,quibble,词,NOUN,C1
-quibbling,quibbling,词,NOUN,C1
-quick arrival,quick arrival,赶紧到,NOUN,B2
-quick departure,quick departure,快去,NOUN,C1
-quick lie-down,quick lie-down,快躺,NOUN,B2
-quick removal,quick removal,赶快脱,NOUN,B2
-quick speech,quick speech,快说,NOUN,B2
-quick thought,quick thought,快想,NOUN,C1
-quick wit,quick wit,机智,NOUN,B2
-quick-frying,quick-frying,溜,NOUN,C1
-quick-witted,quick-witted,词,ADJ,C1
-quickly (part),quickly,速,PART,C1
-quiddity,quiddity,本质,NOUN,B2
-quiescent,quiescent,词,ADJ,C1
-quiet (noun),quiet,词,NOUN,A1
-quietly,quietly,悄悄,ADV,B1
-quietude,quietude,词,NOUN,C1
-quill,quill,词,NOUN,C1
-quint,quint,词,NOUN,C1
-quintain,quintain,五联诗,NOUN,C1
-quintessential,quintessential,词,ADJ,C1
-quip,quip,词,NOUN,C1
-quirk,quirk,词,NOUN,C1
-quirky,quirky,词,ADJ,C1
-quit,quit,词,VERB,A2
-quite (noun),quite,还挺,NOUN,C1
-quite a few,quite a few,不少,ADJ,B2
-quite good,quite good,挺好,NOUN,B2
-quits,quits,词,ADJ,C1
-quixotic,quixotic,词,ADJ,C1
-quota sharing,quota sharing,配额分享,NOUN,C1
-quotable,quotable,可估价的,ADJ,B2
-quotidian,quotidian,词,ADJ,C1
-quotient,quotient,词,NOUN,B2
+vaktel,quail,鹌鹑,NOUN,B2
+kvalifikation,qualifications,资格,NOUN,B2
+kvalificerad,qualified,合格的,ADJ,B2
+kvalificera,to qualify,使合格,VERB,B2
+kvalitativ,qualitative,定性的,ADJ,B2
+kvantitativ,quantitative,定量的,ADJ,B2
+gräl,quarreling,再吵,NOUN,B2
+kvartal,quarter of a year,季度,NOUN,B2
+kvartalstidskrift,quarterly magazine,季刊,NOUN,B2
+kaj,quay,码头,NOUN,B2
+sökande,quest,探索,NOUN,B2
+tvivelaktig,questionable,可疑的,ADJ,B2
+förhör,questioning,质问,NOUN,B2
+snabb,quick,快的,ADJ,B2
+snabbt,quickly,迅速地,ADV,B2
+lapptäcke,quilt,被子,NOUN,B2
+kvot,quota,配额,NOUN,B2
+citat,quotation,报价,NOUN,B2
+citera,to quote,引用,VERB,B2
 rabbin,rabbi,拉比,NOUN,B2
-rabble,rabble,词,NOUN,C1
-racist,racist,种族主义者,NOUN,B2
-racist (adj),racist,种族主义的,ADJ,C1
 racket,racket,球拍,NOUN,B2
-racketeering,racketeering,词,NOUN,B2
-radar,radar,词,NOUN,B2
-radera,to erase,擦除,VERB,B2
-radering,erasure,擦除,NOUN,B2
-radiation-proof,radiation-proof,防辐射,ADJ,C1
-radicalism,radicalism,词,NOUN,C1
-radically,radically,彻底地,ADV,B2
+strålglans,radiance,光辉,NOUN,B2
 radikal,radical,激进的,ADJ,B2
 radio,radio,收音机,NOUN,B2
-radio silence,radio silence,词,NOUN,C1
-radioactivity,radioactivity,词,NOUN,C1
-radioaktiv,radioactive,放射性的,ADJ,B2
-radiography rays,radiography rays,词,NOUN,C1
-radiology,radiology,词,NOUN,C1
 radiostation,radio station,广播电台,NOUN,B2
-radiotherapy,radiotherapy,放疗,NOUN,B2
-radius,radius,半径,NOUN,B2
-rag,rag,破布,NOUN,B2
-rags,rags,词,NOUN,B2
-ragtag,ragtag,词,ADJ,C1
-rai,rai,词,NOUN,B2
-raider,raider,词,NOUN,C1
-raids,raids,词,NOUN,C1
-railroad,railroad,词,NOUN,B2
-rails,rails,词,NOUN,C1
-railway,railway,铁路的,ADJ,B2
-rain clouds,rain clouds,词,NOUN,C1
-rain shower,rain shower,阵雨,NOUN,B2
-rainstorm,rainstorm,暴雨,NOUN,B2
-rainy,rainy,多雨的,ADJ,B2
-rainy day,rainy day,雨天,NOUN,C1
-raise (noun),raise,词,NOUN,B1
-raisin,raisin,词,NOUN,A1
-raising tiger,raising tiger,养虎,NOUN,C1
-raisins,raisins,词,NOUN,A2
-rajaz poem,rajaz poem,词,NOUN,C1
-rake,rake,耙子,NOUN,B2
-rakt,bluntly,直率地,ADV,B2
-rally (noun),rally,词,NOUN,B2
-rallying,rallying,词,NOUN,C1
-ram,ram,公羊,NOUN,B2
-rambunctious,rambunctious,词,ADJ,C1
-ramp,ramp,坡道,NOUN,B2
-rampart,rampart,词,NOUN,C1
-ramshackle,ramshackle,词,ADJ,C1
-ran,ran,跑,ADJ,B2
-ranch,ranch,词,NOUN,B2
-rancher,rancher,词,NOUN,C1
-rancor,rancor,怨恨,NOUN,B2
-rancorous,rancorous,词,ADJ,C1
-random movement,random movement,乱动,NOUN,C1
-random posting,random posting,乱贴,NOUN,B2
-randomly,randomly,词,ADV,B2
-rang,rank,等级,NOUN,B2
-range zone,range zone,词,NOUN,C1
-ranger,ranger,词,NOUN,B2
-rank conferral,rank conferral,授衔,NOUN,C1
-ranking classification,ranking classification,词,NOUN,C1
-rankning,ranking,等级,NOUN,B2
-rapacious,rapacious,词,ADJ,C1
-rapacity,rapacity,词,NOUN,C1
-rapidly,rapidly,词,ADV,B2
-rapier,rapier,词,NOUN,C1
-rapper,rapper,说唱歌手,NOUN,B2
-rapporteur,rapporteur,词,NOUN,C1
-rapprochement,rapprochement,和解,NOUN,B2
-rapture,rapture,狂喜,NOUN,B2
-rapturous,rapturous,词,ADJ,C1
-rare earth,rare earth,稀土,NOUN,B2
-rare sight,rare sight,少见,NOUN,B2
-rarefaction,rarefaction,词,NOUN,C1
-rarity,rarity,希罕,NOUN,C1
-ras,breed,品种,NOUN,B2
+radioaktiv,radioactive,放射性的,ADJ,B2
+rädisa,radish,小萝卜,NOUN,B2
 rasa,rage,愤怒,NOUN,B2
 rasa,to rage,狂怒,VERB,B2
-rasande,rash,轻率的,ADJ,B2
-rashly,rashly,轻举,ADV,B2
-rashness,rashness,你贸然,NOUN,C1
-raspy,raspy,词,ADJ,C1
-rasör,razor,剃刀,NOUN,B2
-rate percentage,rate percentage,词,NOUN,B2
-rate price,rate price,词,NOUN,C1
-rather but,rather but,词,CCONJ,A2
-rather more precisely,rather more precisely,词,ADV,C1
-rather on the contrary,rather on the contrary,词,CCONJ,B2
-rather than,rather than,与其,CCONJ,B1
-ratio,ratio,比率,NOUN,B2
-ration,ration,配给,NOUN,B2
-rational,rational,词,ADJ,B2
-rationalisering,rationalization,合理化,NOUN,B2
-rationalism,rationalism,理性主义,NOUN,B2
-rationalist,rationalist,词,NOUN,B2
-rationalitet,rationality,理性,NOUN,B2
-rationalization conservation,rationalization conservation,词,NOUN,C1
-rattling,rattling,词,NOUN,C1
-raucous,raucous,词,ADJ,C1
-ravage (noun),ravage,词,NOUN,C1
-ravenous,ravenous,词,ADJ,C1
-ravine,ravine,沟壑,NOUN,B2
-raw material scarcity,raw material scarcity,词,NOUN,C1
-raw ore,raw ore,词,ADJ,C1
-rays,rays,词,NOUN,B2
-rays of light,rays of light,光芒,NOUN,B2
-raze,raze,词,VERB,C1
-razor blade,razor blade,词,NOUN,B1
-re-ability,re-ability,再能,NOUN,C1
-re-accident,re-accident,重偶,NOUN,C1
-re-admission,re-admission,重纳,NOUN,B2
-re-analysis,re-analysis,重析,NOUN,B2
-re-argument,re-argument,重论,NOUN,B2
-re-art,re-art,再艺,NOUN,C1
-re-attribution,re-attribution,再归,NOUN,C1
-re-basis,re-basis,再据,NOUN,B2
-re-categorization,re-categorization,改畴,NOUN,C1
-re-cause,re-cause,再因,NOUN,C1
-re-combination,re-combination,再合,NOUN,C1
-re-concretization,re-concretization,再具,NOUN,B2
-re-contingency,re-contingency,再偶,NOUN,C1
-re-count,re-count,重数,NOUN,B2
-re-criterion,re-criterion,重准,NOUN,B2
-re-decision,re-decision,再断,NOUN,C1
-re-differentiation,re-differentiation,再殊,NOUN,C1
-re-direction,re-direction,再方,NOUN,C1
-re-distinction,re-distinction,重殊,NOUN,C1
-re-division,re-division,再分,NOUN,C1
-re-domain,re-domain,再畴,NOUN,C1
-re-echo,re-echo,再响,NOUN,B2
-re-edited collection,re-edited collection,再辑,NOUN,C1
-re-editing,re-editing,改辑,NOUN,C1
-re-efficacy,re-efficacy,再效,NOUN,C1
-re-elect,re-elect,连任,VERB,C1
-re-equipment,re-equipment,重具,NOUN,C1
-re-essence,re-essence,重本,NOUN,C1
-re-essentialization,re-essentialization,再本,NOUN,C1
-re-examination,re-examination,改察,NOUN,C1
-re-extraction,re-extraction,再抽,NOUN,C1
-re-face,re-face,重面,NOUN,B2
-re-form,re-form,再形,NOUN,C1
-re-generalization,re-generalization,重般,NOUN,B2
-re-grade,re-grade,再级,NOUN,C1
-re-grading,re-grading,改级,NOUN,B2
-re-image,re-image,再象,NOUN,C1
-re-imagination,re-imagination,再想,NOUN,C1
-re-imaging,re-imaging,改象,NOUN,C1
-re-inclusion,re-inclusion,再纳,NOUN,C1
-re-inference,re-inference,再推,NOUN,C1
-re-interior,re-interior,重内,NOUN,B2
-re-interpretation,re-interpretation,再绎,NOUN,B2
-re-iteration,re-iteration,重遍,NOUN,C1
-re-judgment,re-judgment,再判,NOUN,B2
-re-layer,re-layer,再层,NOUN,C1
-re-limitation,re-limitation,改限,NOUN,C1
-re-lineage,re-lineage,再系,NOUN,C1
-re-mark,re-mark,再标,NOUN,C1
-re-marking,re-marking,改标,NOUN,C1
-re-measurement,re-measurement,改量,NOUN,C1
-re-merit,re-merit,再功,NOUN,C1
-re-method,re-method,再法,NOUN,C1
-re-model,re-model,再范,NOUN,C1
-re-momentum,re-momentum,再势,NOUN,C1
-re-naturalization,re-naturalization,再然,NOUN,C1
-re-nature,re-nature,再性,NOUN,C1
-re-necessitation,re-necessitation,再必,NOUN,C1
-re-necessity,re-necessity,重必,NOUN,C1
-re-number,re-number,再数,NOUN,C1
-re-observation,re-observation,再观,NOUN,B2
-re-opportunity,re-opportunity,再机,NOUN,B2
-re-orientation,re-orientation,再向,NOUN,C1
-re-origin,re-origin,再原,NOUN,C1
-re-popularization,re-popularization,再普,NOUN,B2
-re-possibility,re-possibility,重可,NOUN,B2
-re-process,re-process,再程,NOUN,B2
-re-proof,re-proof,再证,NOUN,C1
-re-quality,re-quality,重质,NOUN,C1
-re-reality,re-reality,再实,NOUN,C1
-re-route,re-route,重路,NOUN,B2
-re-rule,re-rule,再则,NOUN,C1
-re-sampling,re-sampling,重抽,NOUN,C1
-re-search,re-search,我再搜一,NOUN,C1
-re-segment,re-segment,再段,NOUN,C1
-re-segmentation,re-segmentation,改段,NOUN,C1
-re-shape,re-shape,重形,NOUN,C1
-re-skill,re-skill,再技,NOUN,C1
-re-sole,re-sole,再唯,NOUN,B2
-re-specialization,re-specialization,重特,NOUN,B2
-re-staging,re-staging,改阶,NOUN,B2
-re-standardization,re-standardization,改范,NOUN,C1
-re-state,re-state,再态,NOUN,C1
-re-step,re-step,再步,NOUN,C1
-re-stepping,re-stepping,改步,NOUN,C1
-re-strategy,re-strategy,再略,NOUN,C1
-re-substance,re-substance,再质,NOUN,B2
-re-suffering,re-suffering,再受,NOUN,B2
-re-surface,re-surface,再面,NOUN,C1
-re-surfacing,re-surfacing,改面,NOUN,C1
-re-synthesis,re-synthesis,再综,NOUN,B2
-re-system,re-system,重制,NOUN,C1
-re-technique,re-technique,重术,NOUN,C1
-re-thought,re-thought,再思,NOUN,C1
-re-tier,re-tier,再阶,NOUN,C1
-re-tolerance,re-tolerance,再容,NOUN,B2
-re-trace,re-trace,再迹,NOUN,C1
-re-track,re-track,再轨,NOUN,C1
-re-traversal,re-traversal,再遍,NOUN,B2
-re-unification,re-unification,再一,NOUN,C1
-re-universalization,re-universalization,重普,NOUN,C1
-re-verification,re-verification,改证,NOUN,B2
-reach position,reach position,及位,NOUN,B2
-reactionary,reactionary,反动,ADJ,B2
-read out,read out,宣读,VERB,C1
-readability,readability,词,NOUN,C1
-readiness to help,readiness to help,词,NOUN,C1
-reaffirm,reaffirm,词,VERB,B2
-reaktiv,reactive,反应的,ADJ,B2
-reaktor,reactor,反应堆,NOUN,B2
-real estate,real estate,不动产,NOUN,B2
-real estate agent,real estate agent,词,NOUN,C1
-real person,real person,真人,NOUN,C1
-real trouble,real trouble,真麻烦,NOUN,C1
-realism,realism,现实主义,NOUN,B2
-realist,realist,词,NOUN,C1
-realistisk,realistic,现实的,ADJ,B2
-reality TV,reality TV,词,NOUN,C1
-realization,realization,后知,NOUN,C1
-really (noun),really,真是,NOUN,C1
-really not,really not,真不,ADV,A2
-really pass,really pass,真过,NOUN,C1
-really should,really should,真该,NOUN,C1
-really true,really true,真,ADV,A1
-reaper,reaper,词,NOUN,C1
-reappearance,reappearance,再现,NOUN,C1
-rearing,rearing,养有,NOUN,C1
-rearmament,rearmament,词,NOUN,C1
-rearview mirror,rearview mirror,后视镜,NOUN,C1
-reason and justice common sense,reason and justice common sense,情理,NOUN,B2
-reasonably,reasonably,词,ADV,C1
-reasoned,reasoned,经过推理的,ADJ,B2
-reassuring,reassuring,词,ADJ,B1
-rebab,rebab,列巴布琴,NOUN,B2
-rebellera,to rebel,反叛,VERB,B2
-rebellious,rebellious,叛逆的,ADJ,B2
-rebirth,rebirth,词,NOUN,B2
-reboot,reboot,词,VERB,C1
-rebound (noun),rebound,词,NOUN,C1
-rebound (verb),rebound,词,VERB,C1
-rebuff,rebuff,词,VERB,C1
-recalcitrant,recalcitrant,词,ADJ,C1
-recalibrate,recalibrate,词,VERB,B2
-recalibration,recalibration,改准,NOUN,C1
-recant,recant,词,VERB,C1
-recapitulate,recapitulate,词,VERB,C1
-recede,recede,词,VERB,C1
-receding ebbing,receding ebbing,衰退/退潮,NOUN,C1
-receipt discharge,receipt discharge,词,NOUN,C1
-receipts,receipts,词,NOUN,C1
-receivables,receivables,词,NOUN,C1
-receive foreign exchange,receive foreign exchange,收汇,VERB,C1
-receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
-recent,recent,词,ADJ,B2
-recent past,recent past,前些,NOUN,C1
-recept,prescription,处方,NOUN,B2
-recess,recess,词,NOUN,C1
-recession,recession,衰退,NOUN,B2
-recharge (noun),recharge,词,NOUN,B2
-recidivism,recidivism,词,NOUN,B2
-reciprocally,reciprocally,词,ADV,B2
-reciprocate,reciprocate,词,VERB,C1
-recitation,recitation,词,NOUN,C1
-recitera,to recite,背诵,VERB,B2
-reckoning,reckoning,它算,NOUN,C1
-reclamation,reclamation,收复,NOUN,B2
-reclassification,reclassification,再类,NOUN,C1
-recline,recline,词,VERB,C1
-reclusive,reclusive,词,ADJ,C1
-recognizable,recognizable,可辨认的,ADJ,B2
-recombination,recombination,再结,NOUN,C1
-recommended,recommended,词,ADJ,C1
-recompense,recompense,词,VERB,C1
-recondite,recondite,词,ADJ,C1
-reconfiguration,reconfiguration,再构,NOUN,C1
-reconnoiter,reconnoiter,词,VERB,C1
-reconquest,reconquest,词,NOUN,C1
-recorded broadcast,recorded broadcast,录播,NOUN,C1
-recorder,recorder,记录者,NOUN,C1
-recounting,recounting,再叙,NOUN,B2
-recoup,recoup,词,VERB,C1
-recourse,recourse,求助,NOUN,B2
-recreation,recreation,娱乐,NOUN,B2
-recruit,recruit,新兵,NOUN,B2
-recruiter,recruiter,招聘人员,NOUN,B2
-recruitment-related,recruitment-related,词,ADJ,C1
-rectangular,rectangular,词,ADJ,C1
-rectifier,rectifier,词,NOUN,C1
-rector,rector,词,NOUN,C1
-recuperation,recuperation,养伤,NOUN,B2
-recur,recur,词,VERB,B2
-recurring,recurring,词,ADJ,C1
-recursive,recursive,词,ADJ,C1
-recycled item,recycled item,再物,NOUN,B2
-red blood cell,red blood cell,红细胞,NOUN,C1
-red robe,red robe,红衣,NOUN,B2
-red-haired,red-haired,词,ADJ,B2
-redact,redact,词,VERB,C1
-redaktörsartikel,editorial,社论,NOUN,B2
-redemption,redemption,救赎,NOUN,B2
-redesign,redesign,词,NOUN,C1
-redevelopment,redevelopment,词,NOUN,C1
-redigera,to edit,编辑,VERB,B2
-redogöra,to expound,阐述,VERB,B2
-redolent,redolent,词,ADJ,C1
-redoubtable,redoubtable,词,ADJ,C1
-redovisning,accounting,会计,NOUN,B2
-redrawing,redrawing,重新绘制,NOUN,B2
-redress,redress,词,VERB,B2
-reduction,reduction,减少,NOUN,B2
-reductionism,reductionism,词,NOUN,C1
-redundancy,redundancy,冗余,NOUN,B2
-redundant,redundant,多余的,ADJ,B2
-reed bed,reed bed,词,NOUN,B2
-reed pen,reed pen,词,NOUN,C1
-reef,reef,词,NOUN,B2
-reefs,reefs,词,NOUN,B2
-reel,reel,词,NOUN,C1
-refereed,refereed,词,ADJ,C1
-reference framework,reference framework,词,NOUN,C1
-references,references,词,NOUN,C1
-referendum,referendum,公民投票,NOUN,B2
-referendum-related,referendum-related,词,ADJ,B2
-referens,reference,参考,NOUN,B2
-referral,referral,词,NOUN,C1
-refined,refined,精炼的,ADJ,B2
-refinement,refinement,修养,NOUN,B2
-refinement elevation,refinement elevation,词,NOUN,C1
-refinery,refinery,词,NOUN,C1
-refining,refining,提炼,NOUN,B2
-reflection,reflection,思考,NOUN,B2
-reflective,reflective,词,ADJ,C1
-reflex,reflex,词,NOUN,C1
-reforestation,reforestation,重新造林,NOUN,B2
-reform,reform,改革,NOUN,B2
-reform,to reform,改革,VERB,B2
-reform (noun),reform,变革,NOUN,B2
-reformatory,reformatory,词,NOUN,C1
-reformism,reformism,改唯,NOUN,B2
-reformist,reformist,改良型,ADJ,C1
-reforms,reforms,词,NOUN,C1
-reformulation,reformulation,重新表述,NOUN,B2
-refractory,refractory,词,ADJ,C1
-refrain,refrain,副歌,NOUN,B2
-refresh,to refresh,使恢复精神,VERB,B2
-refreshing,refreshing,令人清爽的,ADJ,B2
-refrigeration,refrigeration,词,NOUN,C1
-refugee,refugee,难民,NOUN,B2
-refulgent,refulgent,词,ADJ,C1
-refund,refund,退款,NOUN,B2
-refurbish,refurbish,词,VERB,C1
-refusal,refusal,拒绝,NOUN,B2
-refusal to take oath,refusal to take oath,词,NOUN,C1
-refutable,refutable,词,ADJ,B2
-refutation,refutation,词,NOUN,C1
-refute,to refute,驳斥,VERB,B2
-regal,regal,词,ADJ,C1
-regard (noun),regard,得顾,NOUN,C1
-regard (verb),regard,词,VERB,B2
-regarding this,regarding this,对此,ADV,B2
-regardless,regardless,不管,ADP,B2
-regardless (sconj),regardless,任凭,SCONJ,B2
-regenerate,regenerate,再生,VERB,C1
-regeneration,regeneration,再生,NOUN,B2
-regent,regent,词,NOUN,C1
-regime,regime,政权,NOUN,B2
-regimen,regimen,词,NOUN,C1
-regiment,regiment,词,NOUN,B2
-regional,regional,地区的,ADJ,B2
-regionalism,regionalism,区域主义,NOUN,C1
-regionalization,regionalization,词,NOUN,C1
-regions,regions,地区,NOUN,C1
-register (noun),register,词,NOUN,B1
-registered mail,registered mail,挂号信,NOUN,B2
-registration,registration,注册,NOUN,B2
-registration number,registration number,词,NOUN,C1
-registrera,to record,记录,VERB,B2
-registreringsskylt,license plate,车牌,NOUN,B2
-registreringsskyltsrestriktion,license plate restriction,限号,NOUN,B2
+trasig,ragged,破烂的,ADJ,B2
+räd,raid,突袭,NOUN,B2
+räcke,railing,栏杆,NOUN,B2
 regnbåge,rainbow,彩虹,NOUN,B2
 regnjacka,raincoat,雨衣,NOUN,B2
 regnskog,rainforest,雨林,NOUN,B2
+insamla donationer,to raise donations,募捐,VERB,B2
+ram,ram,公羊,NOUN,B2
+ramp,ramp,坡道,NOUN,B2
+rående tyranni,rampant tyranny,横行,NOUN,B2
+rancor,rancor,怨恨,NOUN,B2
+slumpmässig,random,随机的,ADJ,B2
+omfång,range,范围,NOUN,B2
+rang,rank,等级,NOUN,B2
+rankning,ranking,等级,NOUN,B2
+lösesumma,ransom,赎金,NOUN,B2
+snabb,rapid,迅速的,ADJ,B2
+rapprochement,rapprochement,和解,NOUN,B2
+pryk,rascal,无赖,NOUN,B2
+rasande,rash,轻率的,ADJ,B2
+hallon,raspberry,覆盆子,NOUN,B2
+råtttät,rat-proof,防鼠,ADJ,B2
+taxa,rate,比率,NOUN,B2
+betyg,rating,评分,NOUN,B2
+ration,ration,配给,NOUN,B2
+rationalism,rationalism,理性主义,NOUN,B2
+rationalitet,rationality,理性,NOUN,B2
+rationalisering,rationalization,合理化,NOUN,B2
+korp,raven,乌鸦,NOUN,B2
+råvara,raw material,原材料,NOUN,B2
+rasör,razor,剃刀,NOUN,B2
+plötslighet,re-abruptness,再骤,NOUN,B2
+omkamp,re-battle,重战,NOUN,B2
+gräns,re-boundary,重界,NOUN,B2
+omgång,re-course,重途,NOUN,B2
+omskapelse,re-creation,再作,NOUN,B2
+omuppförande,re-enactment,再演,NOUN,B2
+återbevisning,re-evidence,重据,NOUN,B2
+återfrukt,re-fruit,再果,NOUN,B2
+återinner,re-inner,再内,NOUN,B2
+omlagering,re-layering,改层,NOUN,B2
+återbegränsning,re-limit,重限,NOUN,B2
+återlogik,re-logic,再逻,NOUN,B2
+återbetydelse,re-meaning,再义,NOUN,B2
+omordning,re-order,重序,NOUN,B2
+återtakt,re-pace,重骤,NOUN,B2
+återbana,re-path,重径,NOUN,B2
+återkvantitet,re-quantity,再量,NOUN,B2
+återresonemang,re-reason,重理,NOUN,B2
+omdirigering,re-routing,改轨,NOUN,B2
+omsekvensering,re-sequencing,改骤,NOUN,B2
+återinlämning,re-submission,再上,NOUN,B2
+nåbar,reachable,可到达的,ADJ,B2
+reaktiv,reactive,反应的,ADJ,B2
+reaktor,reactor,反应堆,NOUN,B2
+läsare,reader,读者,NOUN,B2
+beredskap,readiness,准备就绪,NOUN,B2
+läsning,reading,阅读,NOUN,B2
+fastighet,real estate,房地产,ADJ,B2
+realism,realism,现实主义,NOUN,B2
+realistisk,realistic,现实的,ADJ,B2
+verklig önskan,really want,真要,NOUN,B2
+baksida,rear,后部,NOUN,B2
+bakdel,rear part,后部,NOUN,B2
+resonera,to reason,推理,VERB,B2
+försäkran,reassurance,安抚,NOUN,B2
+lugna,to reassure,使安心,VERB,B2
+rebellera,to rebel,反叛,VERB,B2
+upproriskt hjärta,rebellious heart,反心,NOUN,B2
+återbygga,to rebuild,重建,VERB,B2
+vederlägga,to rebut,反驳,VERB,B2
+motinlägg,rebuttal,反驳,NOUN,B2
+kvitto,receipt,收据,NOUN,B2
+få post,to receive mail,收件,VERB,B2
+ta emot beställningar,to receive orders,受命,VERB,B2
+få världsomspännande uppmärksamhet,to receive worldwide attention,举世瞩目,VERB,B2
+recession,recession,衰退,NOUN,B2
+mottagare,recipient,接受者,NOUN,B2
+ömsesidig,reciprocal,互惠的,ADJ,B2
+recitera,to recite,背诵,VERB,B2
+vårdslös,reckless,鲁莽的,ADJ,B2
+vårdslöshet,recklessness,轻率,NOUN,B2
+återkräva,to reclaim,收回,VERB,B2
+liggande,reclining,躺下,NOUN,B2
+känna igen,to recognize,认出,VERB,B2
+rekommendation,recommendation,推荐,NOUN,B2
+rekommendation av andra,recommendation by others,他荐,NOUN,B2
+försoning,reconciliation,和解,NOUN,B2
+spaning,reconnaissance,侦察,NOUN,B2
+ompröva,to reconsider,重新考虑,VERB,B2
+omprövning,reconsideration,重思,NOUN,B2
+rekonstruera,to reconstruct,重建,VERB,B2
+rekonstruktion,reconstruction,重建,NOUN,B2
+registrera,to record,记录,VERB,B2
+skivspelare,record player,唱机,NOUN,B2
+räkna om,to recount,转述,VERB,B2
+återhämtning,recovery,恢复,NOUN,B2
+rätta till,to rectify,纠正,VERB,B2
+återhämta sig,to recuperate,恢复,VERB,B2
+återfall,recurrence,往复,NOUN,B2
+jävsförklaring,recusal,回避,NOUN,B2
+återvinna,to recycle,回收利用,VERB,B2
+återvinning,recycling,回收利用,NOUN,B2
+omdefinition,redefinition,改界,NOUN,B2
+domare,referee,裁判,NOUN,B2
+referens,reference,参考,NOUN,B2
+referendum,referendum,公民投票,NOUN,B2
+refined,refined,精炼的,ADJ,B2
+refinement,refinement,修养,NOUN,B2
+refining,refining,提炼,NOUN,B2
+reflection,reflection,思考,NOUN,B2
+reforestation,reforestation,重新造林,NOUN,B2
+reform,reform,改革,NOUN,B2
+reform,to reform,改革,VERB,B2
+reformism,reformism,改唯,NOUN,B2
+refrain,refrain,副歌,NOUN,B2
+refresh,to refresh,使恢复精神,VERB,B2
+refugee,refugee,难民,NOUN,B2
+refund,refund,退款,NOUN,B2
+refusal,refusal,拒绝,NOUN,B2
+refute,to refute,驳斥,VERB,B2
+regarding this,regarding this,对此,ADV,B2
+regime,regime,政权,NOUN,B2
+regional,regional,地区的,ADJ,B2
+registration,registration,注册,NOUN,B2
 regress,to regress,倒退,VERB,B2
 regression,regression,倒退,NOUN,B2
 regressive,regressive,退步的,ADJ,B2
 regret,regret,后悔,NOUN,B2
-regrettable,regrettable,词,ADJ,B2
 regular,regular,规律的,ADJ,B2
-regularity,regularity,规律性,NOUN,B2
-regularization,regularization,词,NOUN,C1
 regulate,to regulate,调节,VERB,B2
-regulated,regulated,词,ADJ,C1
 regulations,regulations,法规,NOUN,B2
-regulator,regulator,词,NOUN,C1
-regulatory,regulatory,监管的,ADJ,B2
-rehabilitation,rehabilitation,康复,NOUN,B2
-rehabilitative,rehabilitative,词,ADJ,B2
-rehearsal,rehearsal,排练,NOUN,B2
 rehearse,to rehearse,排练,VERB,B2
-reification,reification,词,NOUN,C1
-reign,reign,统治,NOUN,B2
 reimburse,to reimburse,偿还,VERB,B2
-rein,rein,词,NOUN,C1
-reincarnation,reincarnation,再体,NOUN,B2
 reinforce,to reinforce,加强,VERB,B2
-reinforced,reinforced,词,ADJ,C1
-reining,reining,勒马,NOUN,B2
-reins,reins,词,NOUN,B2
-reintegration,reintegration,词,NOUN,C1
 reissue,to reissue,补办,VERB,B2
-reissue (noun),reissue,词,NOUN,C1
 reiterate,to reiterate,重申,VERB,B2
 rejection,rejection,拒绝,NOUN,B2
-rekommendation,recommendation,推荐,NOUN,B2
-rekommendation av andra,recommendation by others,他荐,NOUN,B2
-rekonstruera,to reconstruct,重建,VERB,B2
-rekonstruktion,reconstruction,重建,NOUN,B2
 relapse,relapse,再犯,NOUN,B2
-relapse (verb),relapse,词,VERB,B2
 relate to narrate,to relate to narrate,叙述,VERB,B2
-relating to birth,relating to birth,词,ADJ,C1
-relation,relation,词,NOUN,B1
-relational,relational,词,ADJ,B2
 relative,relative,相对的,ADJ,B2
-relativism,relativism,相对主义,NOUN,B2
-relativist,relativist,词,ADJ,C1
-relativity,relativity,词,NOUN,C1
 relativt,relatively,相对地,ADV,B2
 relativt sett,relatively speaking,相对而言,ADV,B2
-relaxed comfortable,relaxed comfortable,词,ADJ,A2
-relaxed loose,relaxed loose,词,ADJ,B2
-release after serving sentence,release after serving sentence,刑满释放,VERB,C1
-release of lien,release of lien,解除扣押,NOUN,B2
-relentless,relentless,无情的,ADJ,B2
-relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+relativism,relativism,相对主义,NOUN,B2
+avslappning,relaxation,缓和,NOUN,B2
+frigöra,to release,释放,VERB,B2
+nedgradera,to relegate,降级,VERB,B2
 relevans,relevance,相关性,NOUN,B2
 relevant,relevant,相关的,ADJ,B2
-religiosity,religiosity,笃信宗教,NOUN,B2
-religious chanter,religious chanter,词,NOUN,C1
-religious chanting,religious chanting,词,NOUN,C1
-religious scholar,religious scholar,词,NOUN,B1
-religious strife,religious strife,宗教纷争,NOUN,B2
-religious war,religious war,宗教战争,NOUN,B2
-religiously,religiously,词,ADV,C1
-religiousness,religiousness,虔诚,NOUN,B2
+tillförlitlighet,reliability,可靠性,NOUN,B2
+förtroende,reliance,信赖,NOUN,B2
 relik,relic,圣物,NOUN,B2
-relinquish,relinquish,词,VERB,C1
-relinquishment,relinquishment,词,NOUN,C1
-relocation,relocation,搬家,NOUN,B2
-reluctance,reluctance,不情愿,NOUN,B2
-reluctant,reluctant,不情愿的,ADJ,B2
-rem,strap,带子,NOUN,B2
-remaining,remaining,,NOUN,B2
-remaining (adj),remaining,词,ADJ,C1
-remains spoils,remains spoils,遗体，战利品,NOUN,B2
-remanufacture,remanufacture,再制,NOUN,B2
-remark (verb),remark,词,VERB,B2
-remarkable,remarkable,非凡的,ADJ,B2
-remarks,remarks,说些,NOUN,C1
-rematch,rematch,再战,NOUN,C1
-remedial,remedial,词,ADJ,C1
-remediation,remediation,词,NOUN,B2
-reminisce,reminisce,词,VERB,C1
-reminiscence,reminiscence,词,NOUN,C1
-reminiscent,reminiscent,词,ADJ,C1
-remiss,remiss,词,ADJ,C1
-remission,remission,词,NOUN,C1
-remit,remit,词,VERB,C1
-remittance,remittance,汇款,NOUN,C1
-remnant,remnant,词,NOUN,C1
-remodel,remodel,再模,NOUN,C1
-remorse regret,remorse regret,悔恨,NOUN,C1
-remorseful,remorseful,悔恨的,ADJ,B2
-remote control,remote control,遥控器,NOUN,B2
-remote work,remote work,远程办公,NOUN,B2
-removal deforestation,removal deforestation,词,NOUN,C1
-removal deletion,removal deletion,词,NOUN,C1
-remove stitches,remove stitches,拆线,VERB,C1
-removed,removed,移除的,ADJ,B2
-removing roots,removing roots,除根,NOUN,C1
-remsa,strip,条带,NOUN,B2
-ren,pure,纯净的,ADJ,B2
-renascent,renascent,词,ADJ,C1
-rend,rend,词,VERB,C1
-render,render,词,VERB,C1
-rendition,rendition,词,NOUN,C1
-renegade,renegade,词,NOUN,C1
-renewable energy,renewable energy,可再生能源,NOUN,C1
-renewalism,renewalism,革新主义,NOUN,C1
-renewed heart,renewed heart,再心,NOUN,C1
-renewed respect,renewed respect,刮目相看,NOUN,C1
-renewer,renewer,词,NOUN,C1
-rengöring,cleansing,清洗,NOUN,B2
-renhet,purity,纯洁,NOUN,B2
-rening,purification,净化,NOUN,B2
-renlighet,cleanliness,清洁,NOUN,B2
-renminbi,renminbi,人民币,NOUN,B2
-renounce,renounce,词,VERB,C1
-renovering,renovation,翻新,NOUN,B2
-renowned,renowned,著名的,ADJ,B2
-rent (noun),rent,房租,NOUN,B1
-rent a car,rent a car,租车,VERB,C1
-rental,rental,词,ADJ,C1
-rentierism,rentierism,词,NOUN,C1
-renumbering,renumbering,改数,NOUN,C1
-renunciation,renunciation,放弃,NOUN,B2
+lindra,to relieve,缓解,VERB,B2
+flytta,to relocate,调动,VERB,B2
+ovilligt,reluctantly,不情愿地,ADV,B2
+lita,to rely,依赖,VERB,B2
+lita på,to rely on,依靠,VERB,B2
+rest,remainder,剩余部分,NOUN,B2
+rester,remains,残骸,NOUN,B2
+avlägsen,remote,遥远的,ADJ,B2
+fjärrstyrd bil,remote-controlled car,遥控车,NOUN,B2
+borttagande,removal,移除,NOUN,B2
+ersättning,remuneration,报酬,NOUN,B2
 renässans,renaissance,复兴,NOUN,B2
-reopening,reopening,词,NOUN,C1
-reordering,reordering,改序,NOUN,B2
-reorientation,reorientation,改态,NOUN,C1
-reparable,reparable,词,ADJ,C1
+njur-,renal,肾脏的,ADJ,B2
+träff,rendezvous,约会,NOUN,B2
+bryta,to renege,食言,VERB,B2
+förnya,to renew,更新,VERB,B2
+förnybar,renewable,可再生的,ADJ,B2
+renminbi,renminbi,人民币,NOUN,B2
+renovering,renovation,翻新,NOUN,B2
+rykte,renown,声誉,NOUN,B2
+återoperation,reoperation,再术,NOUN,B2
+omorganisation,reorganization,重组,NOUN,B2
 reparation,repair,修理,NOUN,B2
-repast,repast,词,NOUN,C1
-repatriate,repatriate,词,VERB,C1
-repatriation,repatriation,词,NOUN,C1
+ersättning,reparation,赔偿,NOUN,B2
 repayment,repayment,偿还,NOUN,B2
-repayment time,repayment time,还时,NOUN,C1
-repeal (noun),repeal,词,NOUN,C1
-repeat customer,repeat customer,再客,NOUN,C1
-repeat offender,repeat offender,词,NOUN,B2
 repeated,repeated,反复的,ADJ,B2
 repeatedly,repeatedly,反复地,ADV,B2
-repelling,repelling,词,VERB,C1
 repent,to repent,悔改,VERB,B2
 repentance,repentance,悔恨,NOUN,B2
 repercussion,repercussion,反响,NOUN,B2
-repertoire,repertoire,全部曲目,NOUN,B2
 repetition,repetition,重复,NOUN,B2
-repetitive,repetitive,词,ADJ,C1
-rephotography,rephotography,再影,NOUN,C1
-replacement for Jin,replacement for Jin,替锦,NOUN,C1
 replanning,replanning,再策,NOUN,B2
-replenish,replenish,词,VERB,C1
-replica,replica,词,NOUN,C1
 reply,to reply,回复,VERB,B2
 reply to your-highness,reply to your-highness,回殿下,NOUN,B2
-report a crime,report a crime,报案,VERB,C1
-report an offense,report an offense,检举,VERB,C1
-report back,report back,复命,VERB,B2
-report card,report card,成绩单,NOUN,B2
-report completion,report completion,交差,VERB,C1
-report denunciation,report denunciation,词,NOUN,B1
-report loss,report loss,挂失,VERB,C1
-reportage,reportage,词,NOUN,C1
 repositioning,repositioning,重新定位,NOUN,B2
 reprehensible,reprehensible,应受谴责的,ADJ,B2
 representation,representation,代表,NOUN,B2
-representational,representational,词,ADJ,C1
 representative,representative,有代表性的,ADJ,B2
-representative (noun),representative,代表,NOUN,B2
 representativeness,representativeness,代表性,NOUN,B2
 repress,to repress,镇压,VERB,B2
-repressed,repressed,词,ADJ,C1
 repression,repression,镇压,NOUN,B2
 repressive,repressive,压制的,ADJ,B2
 reprice,reprice,再价,NOUN,B2
-reprieve,reprieve,暂缓执行,NOUN,B2
-reprint,reprint,词,NOUN,C1
-reprisal,reprisal,词,NOUN,C1
-reprisals,reprisals,词,NOUN,C1
 reproach,reproach,责备,NOUN,B2
-reproachable,reproachable,应受责备的,ADJ,B2
-reprobate,reprobate,词,NOUN,C1
 reproduce,to reproduce,繁殖,VERB,B2
-reproducibility,reproducibility,可重复性,NOUN,B2
 reproduction,reproduction,繁殖,NOUN,B2
-reproductive,reproductive,词,ADJ,C1
-reprogramming,reprogramming,改程,NOUN,B2
-reptiles,reptiles,词,NOUN,B2
 republican,republican,共和的,ADJ,B2
-republicanism,republicanism,词,NOUN,C1
-repudiate,repudiate,词,VERB,C1
-repudiation,repudiation,词,NOUN,C1
-repugnant,repugnant,词,ADJ,C1
 repulse,repulse,击退,NOUN,B2
-reputable,reputable,词,ADJ,C1
-repute,repute,词,NOUN,C1
-request to rest,request to rest,请息,NOUN,C1
-required course,required course,必修课,NOUN,C1
-requirements,requirements,词,NOUN,C1
-requisite,requisite,词,NOUN,C1
-requisition,requisition,词,NOUN,C1
-rerun,rerun,重播,NOUN,B2
-resa,to stand up,站起来,VERB,B2
 resale,resale,转售,NOUN,B2
-rescheduling,rescheduling,词,NOUN,C1
-rescind,rescind,词,VERB,C1
 rescue,to rescue,拯救,VERB,B2
 rescue a-fang,rescue a-fang,救阿方,NOUN,B2
-research center,research center,研究中心,NOUN,C1
-research topic,research topic,课题,NOUN,B2
-resection,resection,切除术,NOUN,B2
 resemblance,resemblance,相似,NOUN,B2
-resent,resent,词,VERB,C1
 resentful,resentful,充满愤恨的,ADJ,B2
 resentment,resentment,愤恨,NOUN,B2
 reserve,reserve,预备,NOUN,B2
 reserve,to reserve,预订,VERB,B2
-reserve (noun),reserve,保护区,NOUN,B2
-reserve price,reserve price,底价,NOUN,C1
-reserve protected area,reserve protected area,词,NOUN,C1
 reserved,reserved,保留的,ADJ,B2
-reserves,reserves,储备,NOUN,B2
 reservoir,reservoir,水库,NOUN,B2
-resettlement,resettlement,重新安置,NOUN,B2
 reshaping,reshaping,改形,NOUN,B2
-reshoring,reshoring,词,NOUN,B2
-reshuffle,reshuffle,词,NOUN,C1
 reside,to reside,居住,VERB,B2
-residence housing,residence housing,词,NOUN,A2
 resident,resident,居民,NOUN,B2
-resident (adj),resident,定居的,ADJ,B2
-residential,residential,词,ADJ,B2
-residual,residual,残留的,ADJ,B2
-residue,residue,词,NOUN,C1
-residues waste,residues waste,残留物 / 废弃物,NOUN,C1
 resignation,resignation,辞职,NOUN,B2
-resigned submission,resigned submission,词,NOUN,C1
-resilience,resilience,词,NOUN,C1
-resilient,resilient,词,ADJ,C1
-resin,resin,词,NOUN,C1
-resistant,resistant,词,ADJ,C1
-resistor,resistor,词,NOUN,C1
-reskilling,reskilling,词,NOUN,B2
-resocialization,resocialization,词,NOUN,B2
 resolute,resolute,坚决的,ADJ,B2
 resolution,resolution,决心,NOUN,B2
 resolve,to resolve,解决,VERB,B2
-resolve doubts,resolve doubts,解惑,VERB,B2
 resonance,resonance,共鸣,NOUN,B2
-resonant,resonant,共鸣的,ADJ,B2
-resonera,to reason,推理,VERB,B2
 resort,resort,度假胜地,NOUN,B2
-resourceful,resourceful,机灵的,ADJ,B2
-resourcefulness,resourcefulness,想方设法地,NOUN,C1
-respectful,respectful,恭敬的,ADJ,B2
 respectful deferential,respectful deferential,恭敬,ADJ,B2
-respectful welcome,respectful welcome,恭迎,NOUN,C1
-respectfully,respectfully,词,ADV,C1
-respective,respective,各自的,ADJ,B2
-respectively,respectively,词,ADV,C1
-respiration,respiration,呼吸作用,NOUN,B2
 respiratory,respiratory,呼吸的,ADJ,B2
-respite,respite,喘息,NOUN,B2
-resplendent,resplendent,词,ADJ,C1
-respondent,respondent,被上诉人,NOUN,B2
 response,response,回应,NOUN,B2
 responsiveness,responsiveness,反应性,NOUN,B2
-rest,remainder,剩余部分,NOUN,B2
-rest assured,rest assured,放心的,ADJ,B2
-rest stop,rest stop,词,NOUN,B1
-restate,restate,词,VERB,B2
-rester,remains,残骸,NOUN,B2
-restitution,restitution,词,NOUN,C1
-restive,restive,词,ADJ,C1
-restless,restless,词,ADJ,B2
-restock,restock,补货,VERB,C1
-restrain,restrain,词,VERB,C1
 restraint,restraint,隐忍,NOUN,B2
 restructuring,restructuring,重组,NOUN,B2
-restyle,restyle,再式,NOUN,C1
-results,results,词,NOUN,C1
 resume,resume,简历,NOUN,B2
-resumption,resumption,恢复,NOUN,B2
-resurgent,resurgent,词,ADJ,C1
 resurrection,resurrection,复活,NOUN,B2
-resuscitate,resuscitate,词,VERB,C1
-resuscitation,resuscitation,复苏,NOUN,B2
-resväska,suitcase,手提箱,NOUN,B2
 retail,retail,零售,NOUN,B2
 retain,to retain,保留,VERB,B2
-retaliate,retaliate,词,VERB,C1
-retaliation,retaliation,词,NOUN,C1
-retarded,retarded,词,ADJ,C1
 retell,to retell,转述,VERB,B2
-retention,retention,我留,NOUN,B2
-rethinking,rethinking,重想,NOUN,B2
-reticent,reticent,沉默寡言的,ADJ,B2
-retina,retina,词,NOUN,B2
-retinue,retinue,词,NOUN,B2
 retire,to retire,退休,VERB,B2
-retiree,retiree,退休人员,NOUN,B2
 retirement,retirement,退休,NOUN,B2
+retreat,to retreat,撤退,VERB,B2
+retrieve,to retrieve,取回,VERB,B2
+retrieve qingming,retrieve qingming,拿回青冥,NOUN,B2
+return first,to return first,先回,VERB,B2
+retype,retype,再型,NOUN,B2
+reunion,reunion,重聚,NOUN,B2
+reuse,reuse,重用,NOUN,B2
+revaluation,revaluation,重新评估,NOUN,B2
+revere,to revere,尊敬,VERB,B2
+reverence,reverence,尊敬,NOUN,B2
+reverse inclusion,reverse inclusion,反纳,NOUN,B2
+reverse reflection,reverse reflection,反影,NOUN,B2
+reverse side,reverse side,反面,NOUN,B2
+reversion,reversion,重归,NOUN,B2
+revidera,to revise,修订,VERB,B2
+revision,revision,复习,NOUN,B2
+upphäva,to revoke,撤销,VERB,B2
+revolution,revolution,革命,NOUN,B2
+revolutionär,revolutionary,革命的,ADJ,B2
 retorik,rhetoric,修辞,NOUN,B2
 retorisk,rhetorical,修辞的,ADJ,B2
 retorisk fråga,rhetorical question,宁非,NOUN,B2
-retort (noun),retort,词,NOUN,C1
-retraining,retraining,词,NOUN,C1
-retranslation,retranslation,重译,NOUN,B2
-retreat,to retreat,撤退,VERB,B2
-retrial,retrial,再审,NOUN,B2
-retribution,retribution,报应,NOUN,C1
-retrieve,to retrieve,取回,VERB,B2
-retrieve qingming,retrieve qingming,拿回青冥,NOUN,B2
-retroactive,retroactive,词,ADJ,C1
-retrospect,retrospect,词,NOUN,C1
-retrospective (adj),retrospective,词,ADJ,C1
-retrospective (noun),retrospective,词,NOUN,C1
-return Susha,return Susha,回夙砂,NOUN,C1
-return destination,return destination,回哪,NOUN,B2
-return first,to return first,先回,VERB,B2
-return goods,return goods,退货,NOUN,C1
-return mansion first,return mansion first,先回府,NOUN,B2
-return property,return property,物归,NOUN,C1
-return to,return to,回到,VERB,B2
-return visit,return visit,回访,VERB,B2
-returning farmland to forest,returning farmland to forest,退耕还林,NOUN,B2
-retype,retype,再型,NOUN,B2
-reunification,reunification,重新统一,NOUN,B2
-reunion,reunion,重聚,NOUN,B2
-reunion dinner,reunion dinner,团圆饭,NOUN,C1
-reunite,reunite,团圆,VERB,B2
-reuse,reuse,重用,NOUN,B2
-revaluation,revaluation,重新评估,NOUN,B2
-revealing,revealing,现出,NOUN,B2
-revealing (adj),revealing,词,ADJ,C1
-revel,revel,词,VERB,C1
-revelry,revelry,狂欢,NOUN,B2
-revenue,revenue,收入,NOUN,C1
-revenues,revenues,词,NOUN,C1
-reverberation,reverberation,词,NOUN,C1
-revere,to revere,尊敬,VERB,B2
-reverence,reverence,尊敬,NOUN,B2
-reverent,reverent,虔诚的,ADJ,B2
-reverentially,reverentially,词,ADV,C1
-reverie,reverie,词,NOUN,C1
-reverse (adj),reverse,反,ADJ,B2
-reverse (noun),reverse,词,NOUN,C1
-reverse compilation,reverse compilation,反辑,NOUN,B2
-reverse deduction,reverse deduction,反绎,NOUN,C1
-reverse division,reverse division,反分,NOUN,C1
-reverse effect,reverse effect,反效,NOUN,C1
-reverse generalization,reverse generalization,反概,NOUN,C1
-reverse guest,reverse guest,反客,NOUN,C1
-reverse host,reverse host,反主,NOUN,C1
-reverse inclusion,reverse inclusion,反纳,NOUN,B2
-reverse induction,reverse induction,反归,NOUN,C1
-reverse inference,reverse inference,反推,NOUN,C1
-reverse judgment,reverse judgment,反判,NOUN,C1
-reverse manifestation,reverse manifestation,反现,NOUN,C1
-reverse origin,reverse origin,反原,NOUN,B2
-reverse reflection,reverse reflection,反影,NOUN,B2
-reverse result,reverse result,反果,NOUN,B2
-reverse side,reverse side,反面,NOUN,B2
-reverse thought,reverse thought,反念,NOUN,B2
-reverse up,reverse up,反上,NOUN,C1
-reverse-direction,reverse-direction,反向,NOUN,C1
-reverse-order,reverse-order,反序,NOUN,C1
-reversion,reversion,重归,NOUN,B2
-revidera,to revise,修订,VERB,B2
-revile,revile,词,VERB,C1
-revised deduction,revised deduction,改演,NOUN,C1
-revised estimate,revised estimate,改概,NOUN,C1
-revised image,revised image,改影,NOUN,B2
-revised item,revised item,改目,NOUN,C1
-revision,revision,复习,NOUN,B2
-revisor,accountant,会计师,NOUN,B2
-revitalize a nation,revitalize a nation,兴国,VERB,C1
-revival,revival,复兴,NOUN,B2
-revivalism,revivalism,词,NOUN,C1
-revocation,revocation,词,NOUN,C1
-revolt,revolt,叛乱,NOUN,B2
-revolution,revolution,革命,NOUN,B2
-revolutionär,revolutionary,革命的,ADJ,B2
-revolver,revolver,词,NOUN,C1
-revulsion,revulsion,词,NOUN,C1
-rewatch,rewatch,回看,VERB,C1
-rewind,rewind,快退,VERB,C1
-rework,rework,再工,NOUN,C1
-rhetorical clarity,rhetorical clarity,词,NOUN,C1
-rhetorical embellishment,rhetorical embellishment,词,NOUN,C1
-rhetorical shift of person,rhetorical shift of person,词,NOUN,C1
-rhetorician,rhetorician,词,NOUN,C1
-rheumatism,rheumatism,词,NOUN,C1
-rhinoceros horn,rhinoceros horn,犀角,NOUN,C1
-rhymed prose,rhymed prose,词,NOUN,C1
-rhythmic,rhythmic,词,ADJ,C1
-rhythmicity,rhythmicity,节奏性,NOUN,C1
-riad,riad,词,NOUN,B1
-rial,rial,词,NOUN,A2
-ribald,ribald,词,ADJ,C1
-ribald joke,ribald joke,词,NOUN,C1
-ribaldry,ribaldry,词,NOUN,C1
-ribat fortified convent,ribat fortified convent,词,NOUN,C1
-ribbon,ribbon,丝带,NOUN,B2
-rice cake,rice cake,年糕,NOUN,C1
-rice noodles,rice noodles,米粉,NOUN,B2
-rice vermicelli,rice vermicelli,米线,NOUN,C1
-rich man,rich man,词,NOUN,C1
-rickety,rickety,词,ADJ,C1
-ricochet,ricochet,词,NOUN,C1
-ridderlighet,chivalry,骑士精神,NOUN,B2
-ride-hailing service,ride-hailing service,网约车,NOUN,C1
-ridiculing,ridiculing,词,NOUN,C1
-riding,riding,词,NOUN,B2
-riding me,riding me,骑我,NOUN,C1
+rim,rhyme,韵脚,NOUN,B2
+rytm,rhythm,节奏,NOUN,B2
+naturgynnad,richly endowed by nature,得天独厚,ADJ,B2
 ridpaus,ride break,骑破,NOUN,B2
-ridsport,equestrianism,马术,NOUN,B2
-rife,rife,词,ADJ,C1
-riffraff,riffraff,词,NOUN,C1
-right,right,右边,ADV,B2
-right (intj),right,词,INTJ,C1
-right or wrong,right or wrong,对不对,NOUN,C1
-right path,right path,正道,NOUN,C1
-right side,right side,右侧,NOUN,C1
-rightism,rightism,词,NOUN,C1
-rightist,rightist,词,ADJ,C1
-rightly,rightly,正确地,ADV,B2
-rights and interests,rights and interests,权益,NOUN,B2
+spricka,rift,裂痕,NOUN,B2
+rättfärdig förargelse,righteous indignation,义愤,NOUN,B2
+rättfärdighet,righteousness,亦正,NOUN,B2
+rättigheter,rights,权利,NOUN,B2
 rigid,rigid,僵硬的,ADJ,B2
 rigiditet,rigidity,僵硬,NOUN,B2
-rigidly moral,rigidly moral,词,ADJ,C1
-rigor,rigor,词,NOUN,B2
-rigorously,rigorously,词,ADV,C1
 rigorös,rigorous,严格的,ADJ,B2
-rike,empire,帝国,NOUN,B2
-rike,kingdom,王国,NOUN,B2
-rikta,to target,针对,VERB,B2
-riktningsskylt,direction sign,指示牌,NOUN,B2
-rile,rile,词,VERB,C1
-rim,rhyme,韵脚,NOUN,B2
-rim,rim,词,NOUN,C1
 ringa,ring,戒指,NOUN,B2
 ringa,to ring,鸣响,VERB,B2
-ringning,ringing,铃声,NOUN,B2
-rings,rings,词,NOUN,B2
-ringtone,ringtone,词,NOUN,C1
 ringväg,ring road,绕城,NOUN,B2
-rioter,rioter,词,NOUN,C1
-ripeness,ripeness,该熟,NOUN,B2
-ripple,ripple,词,NOUN,C1
-rising (adj),rising,词,ADJ,C1
-rising (noun),rising,词,NOUN,B2
-rising above pettiness,rising above pettiness,词,NOUN,C1
+ringning,ringing,铃声,NOUN,B2
+mogen,ripe,成熟的,ADJ,B2
+uppgång,rise,上涨,NOUN,B2
 riskera,to risk life,拼命,VERB,B2
-risks,risks,词,NOUN,C1
-risque,risque,有伤风化的,ADJ,B2
-rite,rite,词,NOUN,C1
-rites,rites,词,NOUN,C1
+dödsrisk,risking death,冒死,NOUN,B2
 ritual,ritual,仪式,NOUN,B2
-ritual handwashing,ritual handwashing,奉匜沃盥,NOUN,C1
-ritual impurity,ritual impurity,词,NOUN,C1
-ritualism,ritualism,词,NOUN,C1
-rituals,rituals,仪式,NOUN,B2
-riv upp,to tear up,流泪,VERB,B2
-riva,to demolish,拆除,VERB,B2
-rival,rival,对手,NOUN,B2
 rivalisering,rivalry,竞争,NOUN,B2
-river bank,river bank,河岸,NOUN,B2
-river mouth,river mouth,词,NOUN,C1
-river-gauging,river-gauging,词,ADJ,C1
-riverbed,riverbed,词,NOUN,B2
-riverside,riverside,河边,NOUN,C1
-rivning,demolition,拆除,NOUN,B2
-road (adj),road,词,ADJ,B2
-roadway,roadway,路面,NOUN,B2
-roaming,roaming,词,NOUN,C1
-roar (noun),roar,词,NOUN,B2
-roast (noun),roast,烤透呢,NOUN,B2
-roast lamb,to roast lamb,烤羊,VERB,B2
-roast lamb (noun),roast lamb,烤全羊,NOUN,C1
-roasted,roasted,词,ADJ,B2
-robber,robber,强盗,NOUN,B2
-robe,robe,词,NOUN,B2
-robot,robot,机器人,NOUN,B2
-robotic,robotic,词,ADJ,C1
-robotics,robotics,词,NOUN,C1
-robotization,robotization,词,NOUN,C1
-robust,robust,强健的,ADJ,B2
-robust,sturdy,坚固的,ADJ,B2
-robustness,robustness,词,NOUN,C1
-rock,rock,岩石,NOUN,B2
-rock cliff,rock cliff,词,NOUN,A1
-rock climbing,rock climbing,攀岩,NOUN,C1
-rock music,rock music,词,NOUN,B2
-rockery,rockery,假山,NOUN,B2
-rocket (adj),rocket,词,ADJ,C1
-rocky,rocky,词,ADJ,C1
-rocky desertification,rocky desertification,石漠化,NOUN,C1
-rococo,rococo,词,ADJ,C1
-rod,rod,词,NOUN,B1
-rodent,rodent,啮齿动物,NOUN,B2
-rogatory,rogatory,词,ADJ,C1
-rogue,rogue,词,NOUN,B2
-rolled,rolled,词,ADJ,C1
-roller blind,roller blind,卷帘,NOUN,B2
-roller skate,roller skate,词,NOUN,B1
-rolling,rolling,词,NOUN,C1
-roman,roman,罗马的,ADJ,B2
-romance,romance,浪漫,NOUN,B2
-romanian,romanian,罗马尼亚人,NOUN,B2
-romantic love,romantic love,恋爱,NOUN,B1
-romanticism,romanticism,词,NOUN,C1
-roof,to roof,房顶,VERB,B2
-roof terrace,roof terrace,词,NOUN,A2
-roof tiles,roof tiles,词,NOUN,B1
-roof top,roof top,上房顶,NOUN,C1
-roominess,roominess,词,NOUN,C1
-rooster,rooster,公鸡,NOUN,B2
-roots,roots,词,NOUN,C1
-rop,shout,喊叫,NOUN,B2
-rose bush,rose bush,词,NOUN,B1
+flodbank,riverbank,河岸,NOUN,B2
+vägskylt,road sign,路标,NOUN,B2
+vandra,to roam,漫游,VERB,B2
+bröla,to roar,咆哮,VERB,B2
 rost,roast,烤肉,NOUN,B2
 rost,to roast,煎烤,VERB,B2
-roster,roster,词,NOUN,C1
-rot decomposition,rot decomposition,词,NOUN,C1
-rotating,rotating,词,ADJ,C1
-rotating leave,rotating leave,轮休,NOUN,B2
-rotation,rotation,词,NOUN,C1
-rote learning,rote learning,词,NOUN,B2
-rote teaching,rote teaching,词,NOUN,C1
-rotund,rotund,词,ADJ,C1
-rotunda,rotunda,词,NOUN,C1
+roast lamb,to roast lamb,烤羊,VERB,B2
+robber,robber,强盗,NOUN,B2
+robot,robot,机器人,NOUN,B2
+robust,robust,强健的,ADJ,B2
+rock,rock,岩石,NOUN,B2
+rockery,rockery,假山,NOUN,B2
+roller blind,roller blind,卷帘,NOUN,B2
+romance,romance,浪漫,NOUN,B2
+roof,to roof,房顶,VERB,B2
+rooster,rooster,公鸡,NOUN,B2
 rough,rough,粗糙的,ADJ,B2
 roughly,roughly,大约,ADV,B2
 roughness,roughness,粗糙,NOUN,B2
-round trip,round trip,词,NOUN,B1
-round-robin tournament,round-robin tournament,循环赛,NOUN,B2
 roundabout,roundabout,环岛,NOUN,B2
 rouse,to rouse,唤醒,VERB,B2
-rout,rout,溃败,NOUN,B2
 route,route,路线,NOUN,B2
 router,router,路由器,NOUN,B2
-routing,routing,词,NOUN,C1
-rove,rove,词,VERB,C1
 row,to row,划船,VERB,B2
-row series,row series,词,NOUN,B1
-rowboat,rowboat,词,NOUN,B2
-rowdiness,rowdiness,撒酒疯,NOUN,C1
-rowing,rowing,赛艇,NOUN,C1
-royal court,royal court,词,NOUN,C1
-royalty,royalty,王室,NOUN,B2
 rub,to rub,摩擦,VERB,B2
-rubber,rubber,橡胶,NOUN,B2
 rubbing,rubbing,摩擦,NOUN,B2
-rubbish bin,rubbish bin,垃圾桶,NOUN,A2
-rubble,rubble,瓦砾,NOUN,B2
-rubicund,rubicund,词,ADJ,C1
-ruby,ruby,词,NOUN,C1
-ruckus,ruckus,词,NOUN,C1
-rudely,rudely,词,ADV,C1
 rudeness,rudeness,粗鲁,NOUN,B2
-rudimentary,rudimentary,词,ADJ,C1
-rueful,rueful,词,ADJ,C1
-rugby,rugby,橄榄球,NOUN,C1
 ruin,ruin,废墟,NOUN,B2
 ruin,to ruin,毁灭,VERB,B2
-ruin (noun),ruin,词,NOUN,B2
-ruin relic,ruin relic,词,NOUN,B2
-ruined,ruined,词,ADJ,B2
 ruins,ruins,废墟,NOUN,B2
 rule,to rule,统治,VERB,B2
-ruling (adj),ruling,词,ADJ,C1
-ruling (noun),ruling,裁决,NOUN,C1
-rulltrappa,escalator,自动扶梯,NOUN,B2
-rumble,rumble,咕,NOUN,C1
-rumbling,rumbling,词,NOUN,C1
-ruminant,ruminant,词,NOUN,C1
-ruminate,ruminate,词,VERB,C1
-rumination,rumination,词,NOUN,C1
-ruminative,ruminative,词,ADJ,C1
-rummage,rummage,词,VERB,C1
-rumors,rumors,词,NOUN,B2
 run,run,跑步,NOUN,B2
-run away fled,run away fled,词,VERB,A1
 run into,to run into,碰见,VERB,B2
 run over,to run over,碾过,VERB,B2
 run quickly,to run quickly,奔驰,VERB,B2
 run to jog,to run to jog,跑步,VERB,B2
-run-down,run-down,词,ADJ,C1
-run-up,run-up,助跑,NOUN,B2
-runaway,runaway,,NOUN,B2
-rung,rung,词,NOUN,C1
 runner,runner,跑步者,NOUN,B2
 running,running,进行中的,NOUN,B2
-running around,running around,跑遍,NOUN,B2
-running away,running away,出走,NOUN,C1
-running over,running over,词,NOUN,C1
 runny nose,runny nose,流鼻涕,NOUN,B2
-runway,runway,词,NOUN,C1
 rupture,rupture,破裂,NOUN,B2
 rural,rural,乡村的,ADJ,B2
-rural (noun),rural,词,NOUN,B2
-rural area,rural area,农村,NOUN,A2
-rurality,rurality,词,NOUN,C1
-ruralization,ruralization,词,NOUN,C1
-ruse,ruse,词,NOUN,C1
 rush,rush,赶往,NOUN,B2
 rush about,to rush about,奔波,VERB,B2
-rushing,rushing,居赶,NOUN,B2
-rusk,rusk,词,NOUN,A2
-rusning,bustle,喧闹,NOUN,B2
 rust,rust,铁锈,NOUN,B2
-rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
 rust-proof,rust-proof,防锈,ADJ,B2
-rustic,rustic,乡村的,ADJ,B2
-rustning,armor,盔甲,NOUN,B2
-rusty,rusty,词,ADJ,C1
-ruthless,ruthless,无情的,ADJ,B2
 ruthlessness,ruthlessness,无情,NOUN,B2
-rycka,to pounce,猛扑,VERB,B2
-rycka,to wrest,强行夺取,VERB,B2
-rydning,clearing,林中空地,NOUN,B2
-rykte,renown,声誉,NOUN,B2
-rymlig,spacious,宽敞的,ADJ,B2
-rynka,wrinkle,皱纹,NOUN,B2
-rynkresistent,wrinkle-resistant,防皱,ADJ,B2
-rysning,shudder,战栗,NOUN,B2
-rytm,rhythm,节奏,NOUN,B2
-räcke,railing,栏杆,NOUN,B2
-räcklig,to be enough,足够,VERB,B2
-räd,raid,突袭,NOUN,B2
-rädd,scared,害怕的,ADJ,B2
-rädisa,radish,小萝卜,NOUN,B2
-räkna,to count as,算,VERB,B2
-räkna om,to recount,转述,VERB,B2
-räkna upp,to enumerate,列举,VERB,B2
-räta,to straighten,弄直,VERB,B2
-rätt,to be right,正确,VERB,B2
-rätta till,to rectify,纠正,VERB,B2
-rättare,executioner,刽子手,NOUN,B2
-rättfärdig förargelse,righteous indignation,义愤,NOUN,B2
-rättfärdigande,justification,理由,NOUN,B2
-rättfärdighet,righteousness,亦正,NOUN,B2
-rättigheter,rights,权利,NOUN,B2
-rättsprocess,litigation,诉讼,NOUN,B2
-råd,council,委员会,NOUN,B2
-rådgivning,counseling,咨询,NOUN,B2
-rående tyranni,rampant tyranny,横行,NOUN,B2
-råtttät,rat-proof,防鼠,ADJ,B2
-råvara,raw material,原材料,NOUN,B2
-rökelse,incense,香,NOUN,B2
-röra,stir,搅拌,NOUN,B2
-röra,to stir,搅拌,VERB,B2
-sabbatical,sabbatical,词,NOUN,C1
-saber,saber,词,NOUN,C1
-sabotage (adj),sabotage,词,ADJ,C1
-saboteur,saboteur,词,NOUN,B2
-saccharine,saccharine,词,ADJ,C1
 sacred,sacred,神圣的,ADJ,B2
-sacrificed,sacrificed,牺牲,ADJ,B2
-sacrilege,sacrilege,亵渎,NOUN,B2
-sacrilegious,sacrilegious,词,ADJ,B2
-sacrosanct,sacrosanct,词,ADJ,C1
 sad sorrowful,sad sorrowful,悲伤,ADJ,B2
-saddening,saddening,词,ADJ,C1
-saddle,saddle,词,NOUN,B2
-saddle pad,saddle pad,词,NOUN,B2
-saddlebags,saddlebags,词,NOUN,B2
-sadism,sadism,词,NOUN,C1
-sadistic,sadistic,施虐的,ADJ,B2
 safe,safe,安全的,ADJ,B2
-safe (noun),safe,保险箱,NOUN,B2
-safe container,safe container,词,NOUN,C1
-safe haven,safe haven,避风港,NOUN,B2
-safely,safely,安然,ADV,C1
 safety,safety,安全,NOUN,B2
 safety report,safety report,安全报告,NOUN,B2
-safflower,safflower,红花,NOUN,B2
-saffron,saffron,词,NOUN,A2
-saga,fairy tale,童话,NOUN,B2
 sagacious,sagacious,睿智的,ADJ,B2
-sagacity,sagacity,词,NOUN,B2
-sage,sage,词,NOUN,C1
-sagittarius,sagittarius,射手座,NOUN,B2
 sailing,sailing,航行,NOUN,B2
-sailors,sailors,词,NOUN,B2
-saintly miracles,saintly miracles,圣徒奇迹,NOUN,C1
-saints,saints,词,NOUN,C1
-sake,matter,事情,NOUN,B2
 sake,sake,缘故,NOUN,B2
-sakna,to lack,缺乏,VERB,B2
-salacious,salacious,词,ADJ,C1
-salaried,salaried,词,ADJ,B2
 sales,sales,打折,NOUN,B2
-salesman,salesman,词,NOUN,B2
-salient,salient,词,ADJ,C1
-salighet,bliss,极乐,NOUN,B2
-salinity,salinity,词,NOUN,B2
-salinization,salinization,盐碱化,NOUN,C1
-saliva,saliva,词,NOUN,B2
-sallad,lettuce,生菜,NOUN,B2
-salt flat,salt flat,词,NOUN,B2
-salted,salted,词,ADJ,B2
 salty,salty,咸的,ADJ,B2
-salubrious,salubrious,词,ADJ,C1
-salutary,salutary,词,ADJ,C1
-salva,ointment,药膏,NOUN,B2
-salvage,salvage,词,NOUN,C1
-salve,salve,词,NOUN,C1
-sama,sama,词,NOUN,B2
-samarbeta,to collaborate,合作,VERB,B2
-samarbetare,collaborator,合作者,NOUN,B2
-samarbete,collaboration,合作,NOUN,B2
 same,same,相同的,ADJ,B2
-same (adv),same,一律,ADV,B2
-same (noun),same,同,NOUN,B2
-samla in donationer,to solicit donations,募捐,VERB,B2
-samlad,composed,稳重的,ADJ,B2
-samladhet,composure,镇定,NOUN,B2
-sammanfalla,to coincide,同时发生,VERB,B2
-sammanfattning,summary,摘要,NOUN,B2
-sammanhang,coherence,连贯性,NOUN,B2
-sammanhängande,coherent,连贯的,ADJ,B2
-sammanhållning,cohesion,凝聚力,NOUN,B2
-sammankomst,gathering,聚集,NOUN,B2
-sammanställning,compilation,汇编,NOUN,B2
-sammanträffa,to convene,召集,VERB,B2
 sample,sample,样本,NOUN,B2
-sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
-samspira,to conspire,密谋,VERB,B2
-samtal,call,电话,NOUN,B2
-samtidig,contemporary,当代的,ADJ,B2
-samtidig,simultaneous,同时的,ADJ,B2
-samtidigt,meanwhile,同时,ADV,B2
-samverkan,act jointly,合伙,NOUN,B2
-sanctification,sanctification,词,NOUN,C1
-sanctimonious,sanctimonious,伪善的,ADJ,B2
-sanctimoniousness,sanctimoniousness,词,NOUN,C1
 sanction,sanction,制裁,NOUN,B2
-sanctity,sanctity,词,NOUN,C1
 sanctuary,sanctuary,避难所,NOUN,B2
 sand,sand,沙子,NOUN,B2
-sand and dust,sand and dust,沙尘,NOUN,B2
-sand size,sand size,砂大,NOUN,C1
 sandal,sandal,凉鞋,NOUN,B2
-sands,sands,词,NOUN,B2
 sandstorm,sandstorm,沙尘暴,NOUN,B2
-sandy,sandy,词,ADJ,B2
-sane,sane,神志正常的,ADJ,B2
-sanguinary,sanguinary,词,ADJ,C1
-sanguine,sanguine,词,ADJ,C1
-sanitary,sanitary,词,ADJ,B2
-sanitary pad,sanitary pad,卫生巾,NOUN,C1
-sanitation,sanitation,卫生,NOUN,B2
 sanity,sanity,理智,NOUN,B2
-sann form,true form,原形,NOUN,B2
-sannolikhet,probability,概率,NOUN,B2
-sant hjärta,true heart,本心,NOUN,B2
-santur,santur,词,NOUN,C1
-sap,sap,词,NOUN,C1
-saplings,saplings,词,NOUN,C1
-sarcasm,sarcasm,词,NOUN,C1
-sarcastic,sarcastic,词,ADJ,C1
-sardonic,sardonic,词,ADJ,C1
-sat,sat,词,NOUN,B1
-satchel,satchel,词,NOUN,C1
-sated,sated,词,ADJ,B2
 satiety,satiety,饱足,NOUN,B2
 satire,satire,讽刺,NOUN,B2
 satirical,satirical,讽刺的,ADJ,B2
 satisfactory,satisfactory,令人满意的,ADJ,B2
-satisfying,satisfying,令人满意的,ADJ,B2
-sats,theorem,定理,NOUN,B2
-saturated (adj),saturated,饱和,ADJ,B2
-saturated (noun),saturated,浇满,NOUN,C1
-saucepan,saucepan,平底锅,NOUN,B2
-saunter,saunter,词,VERB,C1
-savage,savage,savage,NOUN,B2
-savant,savant,词,NOUN,C1
-save me,save me,救我,NOUN,C1
-saver,saver,词,NOUN,C1
-saving,saving,储蓄,NOUN,B2
-saving the root,saving the root,救本,NOUN,C1
 savings,savings,存款,NOUN,B2
-savory,savory,词,ADJ,C1
-savvy,savvy,词,ADJ,C1
-sawdust,sawdust,词,NOUN,C1
 say goodbye,to say goodbye,告别,VERB,B2
-say he,say he,说他,NOUN,C1
 saying,saying,格言,NOUN,B2
-sayings,sayings,词,NOUN,C1
-sayings and traditions,sayings and traditions,词,NOUN,C1
 scaffold,scaffold,脚手架,NOUN,B2
-scaffolding,scaffolding,词,NOUN,C1
-scalar,scalar,词,ADJ,C1
 scald,to scald,烫伤,VERB,B2
-scald (noun),scald,烫伤,NOUN,C1
-scale model,scale model,词,NOUN,C1
-scales,scales,秤,NOUN,B2
-scallion,scallion,词,NOUN,B2
 scalpel,scalpel,手术刀,NOUN,B2
-scaly,scaly,有鳞的,ADJ,B2
-scammer,scammer,词,NOUN,B2
-scandalous,scandalous,可耻的,ADJ,B2
-scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
-scanner,scanner,扫描仪,NOUN,C1
-scanning,scanning,词,NOUN,C1
-scant,scant,词,ADJ,C1
-scantily,scantily,词,ADV,C1
-scapegoat,scapegoat,词,NOUN,C1
-scarce commodity,scarce commodity,紧缺商品,NOUN,B2
-scarcely,scarcely,几乎不,ADV,B2
-scarecrow,scarecrow,词,NOUN,C1
-scarf shawl,scarf shawl,词,NOUN,A1
-scathing,scathing,词,ADJ,C1
-scatterbrained,scatterbrained,词,ADJ,B2
-scattering,scattering,词,NOUN,B2
+bedrägeri,scam,骗局,NOUN,B2
+skanning,scan,扫描件,NOUN,B2
+knapp,scarce,稀少的,ADJ,B2
+brist,scarcity,短缺,NOUN,B2
+rädd,scared,害怕的,ADJ,B2
+sprida,to scatter,分散,VERB,B2
+utspridd,scattered,分散的,ADJ,B2
 scen,scene,场景,NOUN,B2
-scen,stage,阶段,NOUN,B2
-scenic spot,scenic spot,名胜,NOUN,B2
-scenography,scenography,词,NOUN,C1
-sceptical,sceptical,词,ADJ,C1
-schampo,shampoo,洗发水,NOUN,B2
-scheduling,scheduling,调度；排序,NOUN,B2
-schema,schema,词,NOUN,B2
+landskap,scenery,风景,NOUN,B2
 schema,scheme,计划,NOUN,B2
-schematic,schematic,概要的,ADJ,B2
-schism,schism,分裂,NOUN,B2
 schizofreni,schizophrenia,精神分裂症,NOUN,B2
-schizophrenic,schizophrenic,词,ADJ,C1
-scholar learned,scholar learned,词,NOUN,C1
-scholarship holder,scholarship holder,奖学金生,NOUN,B2
-scholing,scholing,受过训练,NOUN,B2
-scholium,scholium,词,NOUN,C1
-school,school,学校的,ADJ,B2
-school bag,school bag,词,NOUN,A2
-school bench,school bench,词,NOUN,A1
-school leaving exam,school leaving exam,词,NOUN,B1
-school principal,school principal,词,NOUN,C1
-school year,school year,学年,NOUN,B2
-schoolbag,schoolbag,词,NOUN,A1
-schoolboy,schoolboy,学生,NOUN,B2
-schooled person,schooled person,受过培训者,NOUN,B2
-schooling,schooling,词,NOUN,C1
-schoolyard,schoolyard,词,NOUN,A1
-scintillate,scintillate,词,VERB,C1
-scoff (noun),scoff,词,NOUN,C1
-scoff (verb),scoff,词,VERB,C1
-scoop,scoop,词,NOUN,B2
-scooter,scooter,踏板摩托车,NOUN,B2
-scorn,scorn,轻蔑,NOUN,B2
-scorn (verb),scorn,藐视,VERB,C1
-scornful,scornful,词,ADJ,C1
-scorpion,scorpion,词,NOUN,A1
-scottish,scottish,苏格兰的,ADJ,B2
-scour,scour,词,VERB,C1
-scouting locating,scouting locating,定位 / 侦察,NOUN,B2
-scrappy,scrappy,词,ADJ,C1
-scraps,scraps,屑,NOUN,C1
-scratch,scratch,抓痕,NOUN,B2
-screaming,screaming,词,NOUN,B2
-screen window,screen window,纱窗,NOUN,C1
-screening,screening,词,NOUN,B1
-screenwriter,screenwriter,编剧,NOUN,B2
-screw (noun),screw,词,NOUN,C1
-screw up,screw up,词,VERB,C1
-scribal misreading,scribal misreading,词,NOUN,C1
-scribble (noun),scribble,词,NOUN,C1
-scribe,scribe,词,NOUN,C1
-scripture,scripture,经,NOUN,B2
-scrubland,scrubland,词,NOUN,C1
-scrupulosity,scrupulosity,词,NOUN,C1
-scrupulous,scrupulous,一丝不苟的,ADJ,B2
-scrupulously,scrupulously,一丝不苟地,ADV,B2
-scrupulousness,scrupulousness,词,NOUN,C1
-scrutiny,scrutiny,明察,NOUN,B2
-sculptural,sculptural,词,ADJ,C1
-scumbag,scumbag,词,NOUN,C1
-scurrilous,scurrilous,词,ADJ,C1
-scurry,scurry,词,VERB,C1
-scurvy,scurvy,词,NOUN,C1
-scuttle,scuttle,词,VERB,C1
-scythe,scythe,镰刀,NOUN,B2
-se lik,to see corpse,见尸,VERB,B2
-se ner på,to look down upon,看不起,VERB,B2
-sea level rise,sea level rise,海平面上升,NOUN,B2
-sea of fire,sea of fire,火海,NOUN,C1
-seafood,seafood,海鲜,NOUN,B1
-seal,seal,海豹,NOUN,B2
-seam,seam,词,NOUN,C1
-seamless,seamless,无缝的,ADJ,B2
-seaplane,seaplane,水上飞机,NOUN,B2
-seaport,seaport,海港,NOUN,C1
-search engine,search engine,搜索引擎,NOUN,B2
-search engine optimization,search engine optimization,词,NOUN,C1
-search warrant,search warrant,词,NOUN,C1
-searing,searing,词,NOUN,B2
-seashell,seashell,词,NOUN,B2
-seaside,seaside,海滨,NOUN,C1
-seasonal pasture camp,seasonal pasture camp,词,NOUN,B2
-seasoned,seasoned,词,ADJ,B2
-seasoned experience,seasoned experience,词,NOUN,C1
-seasoning,seasoning,词,NOUN,C1
-seat belt,seat belt,安全带,NOUN,C1
-seated,seated,坐着的,ADJ,B2
-seats,seats,词,NOUN,C1
-seaweed,seaweed,词,NOUN,C1
-secession,secession,词,NOUN,C1
-seclusion,seclusion,闭关,NOUN,B2
-second (num),second,词,NUM,A1
-second again,second again,词,ADJ,A1
-second brother,second brother,二弟,NOUN,B2
-second capping,second capping,次加皮弁,NOUN,C1
-second chance dredging,second chance dredging,词,NOUN,C1
-second cousin,second cousin,再从,NOUN,C1
-second letter,second letter,再信,NOUN,B2
-second look,second look,再目,NOUN,B2
-second master,second master,再主,NOUN,C1
-second place in a sports contest,second place in a sports contest,亚军,NOUN,B2
-second unit of time,second unit of time,秒,NOUN,B2
-second-hand,second-hand,词,ADJ,C1
-secondary sword,secondary sword,从剑,NOUN,C1
-secondment,secondment,词,NOUN,C1
-secret (part),secret,诀,PART,B2
-secret alliance,secret alliance,暗通锦,NOUN,B2
-secret confidence,secret confidence,词,NOUN,C1
-secret recipe,secret recipe,秘制,NOUN,C1
-secret service,secret service,词,NOUN,B2
-secrets,secrets,词,NOUN,C1
-sect taifa,sect taifa,词,NOUN,C1
-sectarianism,sectarianism,词,NOUN,C1
-section chief,section chief,课长,NOUN,B2
-sectoral,sectoral,词,ADJ,C1
-secular,secular,词,ADJ,C1
-secular layperson,secular layperson,词,ADJ,C1
-secularization,secularization,世俗化,NOUN,C1
-secure (adj),secure,词,ADJ,B1
-securitisering,securitization,证券化,NOUN,B2
-security matter,security matter,词,NOUN,C1
-security service,security service,词,NOUN,C1
-security-related,security-related,安全的，安保的,ADJ,B2
-securocratic,securocratic,词,ADJ,C1
-sedanbil,sedan,轿车,NOUN,B2
-sedate,sedate,词,ADJ,C1
-sedative,sedative,词,NOUN,C1
-sedentary,sedentary,久坐的,ADJ,B2
-sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
-sediment,sediment,词,NOUN,C1
-sedimentary,sedimentary,沉积的,ADJ,C1
-sedimentation,sedimentation,词,NOUN,C1
-sediments deposits,sediments deposits,词,NOUN,C1
-sedition,sedition,煽动叛乱,NOUN,B2
-seditious,seditious,词,ADJ,C1
-sedulous,sedulous,词,ADJ,C1
-sedvanlig,customary,习惯的,ADJ,B2
-see off (verb),see off,送别,VERB,C1
-seedling,seedling,词,NOUN,B2
-seeds,seeds,词,NOUN,B2
-seedy,seedy,词,ADJ,C1
-seeking blessing,seeking blessing,词,NOUN,C1
-seeking foreign backing,seeking foreign backing,词,NOUN,C1
-seeking forgiveness,seeking forgiveness,词,NOUN,C1
-seeking intercession,seeking intercession,词,NOUN,C1
-seemly,seemly,词,ADJ,C1
-seems like,seems like,像是,VERB,B2
-seethe,seethe,词,VERB,C1
-segment (noun),segment,词,NOUN,B2
-segregation,segregation,隔离，分离,NOUN,B2
-seismisk,seismic,地震的,ADJ,B2
-seize heir,seize heir,夺嫡,NOUN,C1
-seizing opportunity,seizing opportunity,借机,NOUN,C1
+lärd,scholar,学者,NOUN,B2
+skol-,scholastic,经院哲学的,ADJ,B2
+skälla,to scold,训斥,VERB,B2
+omfång,scope,范围,NOUN,B2
+bränna,to scorch,烧焦,VERB,B2
+brännande,scorching,灼热的,ADJ,B2
+gissel,scourge,灾祸,NOUN,B2
+spejare,scout,侦察员,NOUN,B2
+skrot,scrap,碎屑,NOUN,B2
+klia,to scratch,抓,VERB,B2
+manus,screenplay,剧本,NOUN,B2
+skruvmejsel,screwdriver,螺丝刀,NOUN,B2
+manus,script for play,剧本,NOUN,B2
+skrupel,scruple,顾虑,NOUN,B2
+granska,to scrutinize,仔细检查,VERB,B2
+dykning,scuba diving,潜水,NOUN,B2
+skulptör,sculptor,雕塑家,NOUN,B2
+skulptur,sculpture,雕塑,NOUN,B2
+mås,seagull,海鸥,NOUN,B2
+försegla,to seal,密封,VERB,B2
+krydda,to season,调味,VERB,B2
+säsongsbetonad,seasonal,季节性的,ADJ,B2
+utträda,to secede,脱离,VERB,B2
+avskild utgång,seclusion exit,出关,NOUN,B2
+andra,second,第二,ADJ,B2
+andra gång,second time,再而,NOUN,B2
+sekundär,secondary,次要的,ADJ,B2
+andraledes,secondly,其次,ADV,B2
+hemlig sammankomst,secret meeting,密会,NOUN,B2
 sekretariat,secretariat,秘书处,NOUN,B2
+i hemlighet,secretly,秘密地,ADV,B2
 sekt,sect,教派,NOUN,B2
 sekteristisk,sectarian,宗派的,ADJ,B2
-sektionera,to dissect,解剖,VERB,B2
 sekularism,secularism,世俗主义,NOUN,B2
-sekundär,secondary,次要的,ADJ,B2
-seldom,seldom,很少,ADV,B2
-select seeds,select seeds,选种,VERB,C1
-selectively,selectively,有选择地,ADV,B2
-selector,selector,词,NOUN,C1
+securitisering,securitization,证券化,NOUN,B2
+säkerhetsvakt,security guard,保安,NOUN,B2
+sedanbil,sedan,轿车,NOUN,B2
+återse,to see again,再见,VERB,B2
+se lik,to see corpse,见尸,VERB,B2
+avsked,see off,送走,NOUN,B2
+genomskåda,to see through,看穿,VERB,B2
+frö,seed,种子,NOUN,B2
+söka audiens,to seek audience,求见,VERB,B2
+söka sanningen i fakta,to seek truth from facts,实事求是,VERB,B2
+kortsiktig,seeking instant benefit,急功近利,ADJ,B2
+till synes,seemingly,表面上,ADV,B2
+seismisk,seismic,地震的,ADJ,B2
+beslagta,to seize,抓住,VERB,B2
+urval,selection,选择,NOUN,B2
 selektiv,selective,选择的，挑选的,ADJ,B2
-self,self,自己,ADV,B2
-self (noun),self,我可,NOUN,B1
-self-abasement,self-abasement,词,NOUN,C1
-self-concern,self-concern,自顾,NOUN,B2
-self-deception,self-deception,词,NOUN,C1
-self-denial,self-denial,自我牺牲,NOUN,B2
-self-diminishment,self-diminishment,词,NOUN,C1
-self-drive,self-drive,自驾,VERB,C1
-self-employed person,self-employed person,个体经营者,NOUN,B2
-self-evident (adj),self-evident,词,ADJ,C1
-self-interest,self-interest,私利,NOUN,B2
-self-made,self-made,词,ADJ,C1
-self-recommendation,self-recommendation,自荐,NOUN,C1
-self-reliance,self-reliance,自食,NOUN,C1
-self-respect,self-respect,词,NOUN,B2
-self-satisfaction,self-satisfaction,词,NOUN,C1
-self-taught,self-taught,自学的,ADJ,B2
-self-worth,self-worth,词,NOUN,B2
-selfie,selfie,自拍,NOUN,B2
-selfish,selfish,,NOUN,B2
-selfless,selfless,词,ADJ,B2
-selfless devotion,selfless devotion,词,NOUN,C1
-selleri,celery,芹菜,NOUN,B2
-sellou,sellou,塞卢能量膏,NOUN,B2
-semantic,semantic,词,ADJ,C1
-semantics,semantics,语义学,NOUN,B2
-semblance,semblance,词,NOUN,C1
-semicolon,semicolon,分号,PUNCT,B2
-semiconductor,semiconductor,半导体,NOUN,B2
-semifinal,semifinal,半决赛,NOUN,C1
-seminal,seminal,词,ADJ,C1
-seminary,seminary,词,NOUN,C1
+själv,self,自我,NOUN,B2
+självsäker,self-confident,自信的,ADJ,B2
+självuppoffring,self-sacrifice,舍己,NOUN,B2
+själviskhet,selfishness,自私,NOUN,B2
+säljare,seller,售货员,NOUN,B2
+termin,semester,学期,NOUN,B2
 semiologi,semiology,符号学，症状学,NOUN,B2
 semiotik,semiotics,符号学,NOUN,B2
-semolina,semolina,粗面粉,NOUN,B2
-sen,to be late,迟到,VERB,B2
-sena,tendon,肌腱,NOUN,B2
-senator,senator,参议员,NOUN,B2
-send off,send off,欢送,VERB,C1
-sending,sending,词,NOUN,B1
-senescence,senescence,词,NOUN,B2
-senhet,late,晚才,NOUN,B2
-senile,senile,词,ADJ,C1
-senior,senior,前辈,NOUN,B2
-senior female student,senior female student,学姐,NOUN,C1
-senior male student,senior male student,学长,NOUN,B2
 senioritet,seniority,资历,NOUN,B2
-seniors,seniors,词,NOUN,C1
 sensation,sensation,感觉,NOUN,B2
-sensationalism,sensationalism,词,NOUN,C1
 sense,to sense,隐约感到,VERB,B2
-sense of humor,sense of humor,词,NOUN,B2
-sense of smell,sense of smell,嗅觉,NOUN,B2
 senseless,senseless,无意义的,ADJ,B2
-sensitive to cold,sensitive to cold,词,ADJ,C1
 sensitivity,sensitivity,敏感性,NOUN,B2
-sensitization,sensitization,词,NOUN,B2
 sensor,sensor,传感器,NOUN,B2
-sensors,sensors,词,NOUN,B2
-sensory,sensory,词,ADJ,B2
-sensual,sensual,感官的,ADJ,B2
-sensuality,sensuality,词,NOUN,C1
 sentence,to sentence,判决,VERB,B2
-sentence enforcement,sentence enforcement,判决执行,NOUN,C1
-sentence verdict,sentence verdict,词,NOUN,B2
-sentences,sentences,句子,NOUN,B2
-sententiously,sententiously,词,ADV,C1
-sentient,sentient,词,ADJ,C1
 sentiment,sentiment,情感,NOUN,B2
-sentinel,sentinel,哨兵,NOUN,B2
 sentry,sentry,卫兵,NOUN,B2
-sentry post,sentry post,哨所,NOUN,C1
-separated,separated,分开的,ADJ,B2
-separately,separately,分开地，单独地,ADV,B2
 separation,separation,分离,NOUN,B2
-separatism,separatism,词,NOUN,C1
-separatist,separatist,词,NOUN,C1
 sequence,sequence,顺序，片段,NOUN,B2
-sequential,sequential,词,ADJ,C1
-seraphic,seraphic,词,ADJ,C1
-serendipity,serendipity,词,NOUN,C1
 serene,serene,宁静的,ADJ,B2
-serenely,serenely,词,ADV,C1
 serenity,serenity,宁静,NOUN,B2
 sergeant,sergeant,中士,NOUN,B2
-serial,serial,词,NOUN,B1
-serialized drama,serialized drama,连续剧,NOUN,B2
-series of conversations,series of conversations,系列对话,NOUN,B2
 sermon,sermon,布道,NOUN,B2
-serous,serous,词,ADJ,C1
-serpentine,serpentine,词,ADJ,C1
-serum,serum,词,NOUN,B2
-serve as dog,serve as dog,效犬,NOUN,C1
-serve markup,serve markup,发球/加价,NOUN,B2
-serve one's country,serve one's country,报国,VERB,C1
 server,server,服务器,NOUN,B2
-service counter,service counter,词,NOUN,B1
-service of process,service of process,词,NOUN,C1
 service provider,service provider,服务商,NOUN,B2
 service road,service road,辅路,NOUN,B2
-service user,service user,词,NOUN,C1
-service users,service users,词,NOUN,C1
-services,services,词,NOUN,C1
-servile,servile,词,ADJ,C1
-servilely,servilely,奴性地,ADV,B2
 servility,servility,奴性,NOUN,B2
-serving,serving,词,NOUN,B2
-servitude,servitude,奴役,NOUN,C1
 sesame,sesame,芝麻,NOUN,B2
 session,session,会议,NOUN,B2
 set,set,一套,NOUN,B2
 set,to set,设置,VERB,B2
-set (noun),set,集合,NOUN,B1
-set a record,set a record,创造纪录,VERB,B2
-set of ideals,set of ideals,思想体系,NOUN,B2
 set off,to set off,出发,VERB,B2
-set square,set square,词,NOUN,B2
 set up,to set up,建立,VERB,B2
-set-off,set-off,词,NOUN,C1
 setback,setback,挫折,NOUN,B2
-setting,setting,词,NOUN,B1
-setting splinting,setting splinting,词,NOUN,C1
-setting sun,setting sun,夕阳,NOUN,B2
-settings,settings,词,NOUN,C1
-settle foreign exchange,settle foreign exchange,结汇,VERB,C1
-seven (adj),seven,词,ADJ,B2
-sever,sever,词,VERB,C1
 several,several,几个,DET,B2
-several (noun),several,若干,NOUN,B2
-several (part),several,数,PART,B2
-several (pron),several,词,PRON,A2
-several times (adv),several times,词,ADV,C1
-several times (noun),several times,几遍,NOUN,B2
-severance,severance,词,NOUN,C1
 severe,severe,严厉的,ADJ,B2
-severely,severely,严厉地,ADV,B2
 severity,severity,严厉,NOUN,B2
-sewage,sewage,词,NOUN,C1
-sewer,sewer,词,NOUN,C1
 sewing,sewing,缝纫,NOUN,B2
-sewing needle,sewing needle,词,NOUN,C1
 sex,sex,性别,NOUN,B2
-sex appeal,sex appeal,性感,NOUN,B2
-sexagesimal,sexagesimal,词,ADJ,C1
-sexism,sexism,性别歧视,NOUN,B2
-sexist,sexist,词,ADJ,C1
-sfouf,sfouf,词,NOUN,B2
-sfär,sphere,领域,NOUN,B2
-sh,sh,词,INTJ,C1
-sha dynasty,sha dynasty,砂朝,NOUN,B2
-shabby,shabby,词,ADJ,B2
 shack,shack,棚屋,NOUN,B2
 shackle,shackle,镣铐,NOUN,B2
-shading,shading,阴影,NOUN,B2
-shadow guard,shadow guard,暗卫,NOUN,B2
-shadow play,shadow play,皮影戏,NOUN,C1
-shadow shade,shadow shade,词,NOUN,B1
-shadows,shadows,词,NOUN,C1
 shady,shady,阴凉的,ADJ,B2
-shafii school,shafii school,词,NOUN,C1
-shaft,shaft,词,NOUN,B2
 shake hands,to shake hands,握手,VERB,B2
-shake off,shake off,词,VERB,B2
-shale gas,shale gas,页岩气,NOUN,C1
-shall will,shall will,将要,AUX,B2
-shambles,shambles,词,NOUN,C1
-shame disgrace,shame disgrace,词,NOUN,B2
-shameless person,shameless person,厚颜无耻的人,NOUN,B2
-shamelessness,shamelessness,无耻,NOUN,B2
-shantytown,shantytown,词,NOUN,B2
-shards,shards,词,NOUN,B2
-shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
-shareholding,shareholding,词,NOUN,B2
-shares,shares,词,NOUN,C1
-sharifs,sharifs,词,NOUN,C1
-sharing,sharing,分享,NOUN,B2
-sharp acute,sharp acute,词,ADJ,C1
-sharp object,sharp object,锐之物,NOUN,C1
-sharp pointed end,sharp pointed end,尖端,NOUN,C1
-sharp-witted,sharp-witted,词,ADJ,C1
-sharply,sharply,词,ADV,B2
-shavings,shavings,刨花,NOUN,C1
-she (noun),she,可她,NOUN,B2
-she they,she they,她,PRON,B2
-sheaf,sheaf,捆,NOUN,B2
-shear,shear,词,NOUN,C1
-shearing,shearing,词,NOUN,C1
-sheepskin,sheepskin,词,NOUN,B2
-sheer cliffs precipitous rocks,sheer cliffs precipitous rocks,悬崖峭壁,NOUN,C1
-sheet of paper,sheet of paper,词,NOUN,B2
-sheikh,sheikh,词,NOUN,C1
-sheikhdom,sheikhdom,词,NOUN,C1
-sheltered one,sheltered one,词,NOUN,B2
-shenanigan,shenanigan,词,NOUN,C1
-sheng,sheng,笙,NOUN,C1
-sheriff,sheriff,词,NOUN,B1
-shh,shh,嘘,INTJ,B2
-shibboleth,shibboleth,词,NOUN,C1
-shift work,shift work,轮班,NOUN,B2
-shiitake mushroom,shiitake mushroom,香菇,NOUN,C1
-shimmer,shimmer,词,VERB,C1
-shining,shining,词,ADJ,C1
-shiny,shiny,词,ADJ,B2
-ship (verb),ship,发货,VERB,C1
-ship captain,ship captain,词,NOUN,C1
-shipment,shipment,货物,NOUN,B2
-shirk,shirk,词,VERB,C1
-shit,shit,恐惧,NOUN,B2
-shit (adj),shit,该死的,ADJ,B2
-shitty,shitty,词,ADJ,B2
-shiver,shiver,寒战,NOUN,B2
-shivers,shivers,词,NOUN,B2
-shockproof,shockproof,防震,ADJ,C1
-shoddy,shoddy,词,ADJ,C1
-shoe polish,shoe polish,词,NOUN,B2
-shoelace,shoelace,词,NOUN,C1
-shoot at,shoot at,词,VERB,C1
-shooting down,shooting down,射落马下,NOUN,C1
-shooting star,shooting star,流星,NOUN,B2
-shopkeeper,shopkeeper,词,NOUN,C1
-shopping,shopping,购物,NOUN,B2
-shopping mall,shopping mall,商场,NOUN,B2
-short circuit,short circuit,词,NOUN,B2
-short film,short film,短片,NOUN,B2
-short news item,short news item,短新闻,NOUN,B2
-short piece,short piece,词,NOUN,C1
-short rest,short rest,歇一,NOUN,B2
-short story,short story,词,NOUN,C1
-short while,short while,词,NOUN,C1
-short work,short work,词,NOUN,C1
-short-tempered,short-tempered,易怒,ADJ,C1
-shortcomings,shortcomings,词,NOUN,C1
-shortest,shortest,词,NOUN,B2
-shotgun,shotgun,猎枪,NOUN,B2
-should (adv),should,你该,ADV,B2
-should must,should must,词,AUX,A2
-show,show,表演,NOUN,B2
-show (part),show,秀,PART,C1
-show favoritism,show favoritism,徇私,VERB,B2
-show of hands,show of hands,举手,NOUN,B2
-showing,showing,表现,NOUN,B2
-showing off,showing off,词,NOUN,C1
-showy,showy,词,ADJ,B2
-shred,shred,词,NOUN,B2
-shriek,shriek,词,VERB,C1
-shrill,shrill,尖锐的,ADJ,B2
-shrimp,shrimp,虾,NOUN,B2
-shrinkage,shrinkage,词,NOUN,C1
-shrivel,shrivel,词,VERB,C1
-shrub,shrub,词,NOUN,C1
-shrug,shrug,词,VERB,C1
-shrunken,shrunken,词,ADJ,B2
-shun,shun,词,VERB,C1
-shut,shut,词,VERB,A1
-shutdown,shutdown,词,NOUN,C1
-shuttle,shuttle,穿梭巴士,NOUN,B2
-shyness,shyness,羞怯,NOUN,B2
-sibilant,sibilant,词,ADJ,C1
-sibyl,sibyl,词,NOUN,C1
-sick leave,sick leave,病假,NOUN,B2
-sick nauseous,sick nauseous,恶心的,ADJ,B2
-sickle,sickle,词,NOUN,B2
-sickly,sickly,词,ADJ,C1
-sickness,sickness,词,NOUN,B2
-sida,side,侧面,NOUN,B2
-side,side,骄傲的,ADJ,B2
-side effect,side effect,副作用,NOUN,B2
-sideboard,sideboard,词,NOUN,C1
-sideburn,sideburn,词,NOUN,B1
-siden,silk,丝绸,NOUN,B2
-sidentyg,silk cloth,丝绸,NOUN,B2
-siege time,siege time,攻城时,NOUN,C1
-siffra,digit,数字,NOUN,B2
-sifted,sifted,词,ADJ,C1
-sighing,sighing,叹息的,ADJ,B2
-sightseeing,sightseeing,词,NOUN,C1
-sign brand,sign brand,词,NOUN,C1
-signalera,signal,信号,NOUN,B2
-signalera,to signal,示意,VERB,B2
-signatory,signatory,签署者,NOUN,B2
-signboard,signboard,招牌,NOUN,B2
-signed,signed,词,ADJ,B2
-signified,signified,词,NOUN,C1
-signifier,signifier,词,NOUN,C1
-signing ceremony,signing ceremony,签约仪式,NOUN,B2
-siheyuan,siheyuan,四合院,NOUN,C1
-sik,sieve,筛子,NOUN,B2
-sikta,to sift,筛选,VERB,B2
-sil,colander,漏勺,NOUN,B2
-silenced,silenced,词,ADJ,C1
-silencing,silencing,词,NOUN,C1
-silent quiet,silent quiet,词,ADJ,A1
-silently,silently,词,ADV,C1
-silk material,silk material,丝料,NOUN,C1
-silly thing,silly thing,词,NOUN,C1
-silos,silos,词,NOUN,C1
-silt,silt,词,NOUN,C1
-silta,to winnow,筛选,VERB,B2
-silver,silver,银色,ADJ,B2
-silver (noun),silver,戴银,NOUN,B1
-silvery,silvery,词,ADJ,C1
-simbassäng,swimming pool,游泳池,NOUN,B2
-simian,simian,词,ADJ,C1
-similarly,similarly,同样地,ADV,B2
-simony,simony,词,NOUN,C1
-simple pure,simple pure,单纯,ADJ,B2
-simple-minded,simple-minded,词,ADJ,C1
-simplification,simplification,简化,NOUN,C1
-simplified,simplified,词,ADJ,B2
-simplism,simplism,简单化,NOUN,C1
-simulator,simulator,词,NOUN,C1
-simulering,simulation,模拟,NOUN,B2
-simultaneously with,simultaneously with,词,ADV,C1
-since (part),since,以来,PART,B2
-since then,since then,从那以后,ADV,B2
-since then (sconj),since then,词,SCONJ,A2
-sincerely,sincerely,真诚地,ADV,B2
-sincerity devotion,sincerity devotion,词,NOUN,B2
-sinecure,sinecure,词,NOUN,C1
-sinew,sinew,词,NOUN,C1
-single person,single person,词,NOUN,B2
-single stroke,single stroke,一举,NOUN,C1
-singular (adj),singular,词,ADJ,C1
-singular (noun),singular,词,NOUN,B2
-singularity,singularity,单一性,NOUN,B2
-sinister,sinister,不祥的,ADJ,B2
-sinking,sinking,沉?,NOUN,C1
-sinnesövning,spirit training,练神,NOUN,B2
-sinuous,sinuous,词,ADJ,C1
-sir,sir,郎,PART,B2
-siren,siren,汽笛,NOUN,B2
-sister yu,sister yu,俞姐,NOUN,B2
-sister-in-law (part),sister-in-law,嫂,PART,B1
-sisters,sisters,姊妹,NOUN,B2
-sit cross-legged,sit cross-legged,词,VERB,B2
-sit-in,sit-in,词,NOUN,B2
-sit-in participant,sit-in participant,词,NOUN,C1
-site,site,词,NOUN,B1
-sitter,sitter,词,NOUN,B1
-sitting,sitting,词,NOUN,B2
-sitting stably,sitting stably,坐得,NOUN,C1
-situation,situation circumstances,情形,NOUN,B2
-six-line stanza,six-line stanza,词,NOUN,C1
-size measure,size measure,尺寸 / 测量,NOUN,A2
-sjukhusvårdas,to hospitalize,使住院,VERB,B2
-själv,self,自我,NOUN,B2
-självbelåten,conceited,自负的,ADJ,B2
-självfallet,of course,理所当然的,ADJ,B2
-själviskhet,selfishness,自私,NOUN,B2
-självsäker,self-confident,自信的,ADJ,B2
-självuppoffring,self-sacrifice,舍己,NOUN,B2
-ska,will,将要,AUX,B2
-skada,harm,伤害,NOUN,B2
-skada,to excoriate,严厉批评,VERB,B2
-skada,to harm,损害,VERB,B2
-skadeslöshet,no harm,没事吧,NOUN,B2
-skadlig,harmful,有害的,ADJ,B2
-skal,peel,皮,NOUN,B2
-skallig,bald,秃头的,ADJ,B2
-skam,disgrace,耻辱,NOUN,B2
+grund,shallow,浅的,ADJ,B2
+bluff,sham,假冒,NOUN,B2
 skamlig,shameful,可耻的,ADJ,B2
 skamlös,shameless,无耻的,ADJ,B2
-skanning,scan,扫描件,NOUN,B2
-skate,to skate,滑冰,VERB,B2
-skate (noun),skate,词,NOUN,A2
-skating,skating,滑冰,NOUN,B2
-skattefri,tax-exempt,免税,ADJ,B2
-skeletal,skeletal,词,ADJ,C1
-sken,delusion,幻想,NOUN,B2
+schampo,shampoo,洗发水,NOUN,B2
+form,shape,形状,NOUN,B2
+vass,sharp,锋利的,ADJ,B2
+krossa,to shatter,粉碎,VERB,B2
+skjul,shed,棚屋,NOUN,B2
+skydd,shelter,庇护所,NOUN,B2
+herde,shepherd,牧羊人,NOUN,B2
+byta,to shift,改变,VERB,B2
+skiftesrotation,shift rotation,倒班,NOUN,B2
+skiftesbyte,shift swap,换班,NOUN,B2
+tidigarelägga,to shift to an earlier date,提前,VERB,B2
 skeppa ut,to ship out,出货,VERB,B2
-skeptic,skeptic,词,NOUN,C1
+varv,shipyard,造船厂,NOUN,B2
+skoavtagning,shoe removal,鞋脱,NOUN,B2
+skjuta ner,to shoot down,击落,VERB,B2
+skottlossning,shootout,枪战,NOUN,B2
+shopping,shopping,购物,NOUN,B2
+köpcentrum,shopping center,购物中心,NOUN,B2
+strand,shore,岸,NOUN,B2
+kortsiktig,short-term,短期的,ADJ,B2
+brist,shortcoming,缺点,NOUN,B2
+bör inte,should not,不该,AUX,B2
+rop,shout,喊叫,NOUN,B2
+spade,shovel,铲子,NOUN,B2
+listig,shrewd,精明的,ADJ,B2
+krympa,to shrink,收缩,VERB,B2
+rysning,shudder,战栗,NOUN,B2
+syskon,siblings,兄弟姐妹,NOUN,B2
+sida,side,侧面,NOUN,B2
+trottoar,sidewalk,人行道,NOUN,B2
+belägring,siege,围攻,NOUN,B2
+sik,sieve,筛子,NOUN,B2
+sikta,to sift,筛选,VERB,B2
+sucka,sigh,叹息,NOUN,B2
+sucka,to sigh,叹气,VERB,B2
+sucka,to sigh with sorrow,感慨,VERB,B2
+kvittera,to sign for,签收,VERB,B2
+signalera,signal,信号,NOUN,B2
+signalera,to signal,示意,VERB,B2
+betydelse,significance,含义,NOUN,B2
+betydelsefull,significant,重要的,ADJ,B2
+betyda,to signify,意味着,VERB,B2
+tysta,to silence,خرس,VERB,B2
+tyst,silent,沉默的,ADJ,B2
+siden,silk,丝绸,NOUN,B2
+sidentyg,silk cloth,丝绸,NOUN,B2
+fjolla,silly girl,傻丫头,NOUN,B2
+silver,silver,银色,ADJ,B2
+likhet,similarity,相似,NOUN,B2
+liknelse,simile,明喻,NOUN,B2
+enkelhet,simplicity,简单,NOUN,B2
+förenkla,to simplify,简化,VERB,B2
+enkelt,simply,简单地,ADV,B2
+simulering,simulation,模拟,NOUN,B2
+samtidig,simultaneous,同时的,ADJ,B2
+ärlighet,sincerity,真诚,NOUN,B2
+tanke,single thought,一念,NOUN,B2
+vask,sink,水槽,NOUN,B2
+smutta,to sip,小口喝,VERB,B2
+herre,sir,先生,NOUN,B2
+siren,siren,汽笛,NOUN,B2
+svägerska,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
+sätta sig,to sit down,坐下,VERB,B2
+situation,situation circumstances,情形,NOUN,B2
+skate,to skate,滑冰,VERB,B2
 skeptical,skeptical,怀疑的,ADJ,B2
 skepticism,skepticism,怀疑主义,NOUN,B2
 sketch,sketch,素描,NOUN,B2
-sketchiness,sketchiness,词,NOUN,C1
-ski,ski,滑雪板,NOUN,B2
 ski,to ski,滑雪,VERB,B2
-ski (noun),ski,词,NOUN,C1
-ski resort,ski resort,滑雪场,NOUN,C1
-skicka,to dispatch,派遣,VERB,B2
-skicka,to submit,提交,VERB,B2
-skicklig,proficient,熟练的,ADJ,B2
-skid slip-up,skid slip-up,词,NOUN,C1
-skiff,skiff,词,NOUN,C1
-skiftesbyte,shift swap,换班,NOUN,B2
-skiftesrotation,shift rotation,倒班,NOUN,B2
 skiing,skiing,滑雪,NOUN,B2
-skilful,skilful,熟练的,ADJ,B2
-skilja,to divorce,离婚,VERB,B2
-skiljedom,arbitration,仲裁,NOUN,B2
-skillful,skillful,熟练的,ADJ,B2
-skillfully,skillfully,词,ADV,B2
-skillfulness,skillfulness,词,NOUN,B2
-skinkor,buttocks,屁股,NOUN,B2
-skinny,skinny,词,ADJ,B2
-skip a grade,skip a grade,跳级,VERB,C1
-skirmish,skirmish,小规模战斗,NOUN,B2
-skissera,outline,大纲,NOUN,B2
-skissera,to outline,勾勒,VERB,B2
-skivspelare,record player,唱机,NOUN,B2
-skjul,shed,棚屋,NOUN,B2
-skjuta ner,to shoot down,击落,VERB,B2
-skoavtagning,shoe removal,鞋脱,NOUN,B2
-skog,woodland,林地,NOUN,B2
-skol-,scholastic,经院哲学的,ADJ,B2
-skor,footwear,鞋穿,NOUN,B2
-skorpa,crust,外壳,NOUN,B2
-skorsten,chimney,烟囱,NOUN,B2
-skottlossning,shootout,枪战,NOUN,B2
-skrift,brief,简短的,ADJ,B2
-skrift,in writing,书面,NOUN,B2
-skrift,writing,文字,NOUN,B2
-skrika,to yell,大吼,VERB,B2
-skriva in,to enroll,注册,VERB,B2
-skrivare,printer,打印机,NOUN,B2
-skriven,written,书面的,ADJ,B2
-skrivövning,handwriting practice,练字,NOUN,B2
-skrot,scrap,碎屑,NOUN,B2
-skrupel,scruple,顾虑,NOUN,B2
-skruvmejsel,screwdriver,螺丝刀,NOUN,B2
-skryt,boasting,夸耀,NOUN,B2
-skryta,to brag,吹嘘,VERB,B2
-skräckinjagande,terrifying,令人恐惧的,ADJ,B2
-skräddare,tailor,裁缝,NOUN,B2
-skrämma,to terrify,使恐惧,VERB,B2
-skuld,blame,责备,NOUN,B2
-skulda,to owe,欠,VERB,B2
-skuldsättning,indebtedness,负债,NOUN,B2
-skulptur,sculpture,雕塑,NOUN,B2
-skulptör,sculptor,雕塑家,NOUN,B2
-skumig,foamy,多泡沫的,ADJ,B2
-sky blue,sky blue,天蓝色,ADJ,B2
-skydd,shelter,庇护所,NOUN,B2
-skyddande,protective,保护的,ADJ,B2
-skyldig,guilty,有罪的,ADJ,B2
-skylight,skylight,天窗,NOUN,B2
-skymning,dusk,黄昏,NOUN,B2
-skälla,to scold,训斥,VERB,B2
-skärja,to cherish,珍爱,VERB,B2
-skåda,gaze,目视,NOUN,B2
-skåda,to gaze,凝视,VERB,B2
-skål,cheers,干杯,INTJ,B2
-skåp,closet,壁橱,NOUN,B2
-sköldpadda,turtle,海龟,NOUN,B2
-skörd,harvest,收获,NOUN,B2
-slack,slack,词,ADJ,B2
-slack off,slack off,词,VERB,C1
-slackening dip,slackening dip,词,NOUN,C1
-slackness,slackness,词,NOUN,C1
-slag,stroke,中风,NOUN,B2
-slagen,to be hit,中箭,VERB,B2
-slake,slake,词,VERB,C1
-slaktare,butcher,屠夫,NOUN,B2
-slam (verb),slam,词,VERB,B2
-slammer jail,slammer jail,词,NOUN,C1
 slander,to slander,诽谤,VERB,B2
-slang,slang,俚语,NOUN,B2
-slanted,slanted,斜,ADJ,B2
 slap,slap,拍击,NOUN,B2
 slap,to slap,打耳光,VERB,B2
-slarvig,casual,随意的,ADJ,B2
 slaughter,slaughter,屠杀,NOUN,B2
-slaughterhouse,slaughterhouse,词,NOUN,C1
 slavery,slavery,奴隶制,NOUN,B2
-slavery bondage,slavery bondage,词,NOUN,C1
-slaying,slaying,杀掉,NOUN,C1
-sleek,sleek,词,ADJ,C1
-sleep bar,sleep bar,睡吧,NOUN,B2
-sleep sleepiness,sleep sleepiness,词,NOUN,A2
-sleeper,sleeper,词,NOUN,C1
 sleeplessness,sleeplessness,失眠,NOUN,B2
-sleepy,sleepy,困,ADJ,A2
-sleet,sleet,雨夹雪,NOUN,C1
 sleeve,sleeve,袖子,NOUN,B2
-sleigh,sleigh,雪橇,NOUN,C1
-slem,mucus,黏液,NOUN,B2
-slender,slender,纤细的,ADJ,B2
-slenderness,slenderness,纤细,NOUN,B2
 slice,slice,薄片,NOUN,B2
-slice of bread,slice of bread,词,NOUN,C1
-slick,slick,词,ADJ,C1
 slide,slide,滑动,NOUN,B2
-slight (adj),slight,词,ADJ,B2
-slight chill,slight chill,点凉,NOUN,C1
 slightly,slightly,轻微地,ADV,B2
-slim,slim,苗条,ADJ,B2
-slimy,slimy,粘滑的,ADJ,B2
-sling,sling,词,NOUN,C1
-slip (noun),slip,词,NOUN,C1
-slip in,slip in,塞入,VERB,B2
-slippa,to get rid of,摆脱,VERB,B2
 slipper,slipper,拖鞋,NOUN,B2
-slit,slit,词,NOUN,C1
-slit,toil,苦工,NOUN,B2
-slita upp,to break up,破裂,VERB,B2
-slither,slither,词,VERB,C1
 slogan,slogan,口号,NOUN,B2
-sloppy,sloppy,词,ADJ,B1
-slot,slot,词,NOUN,C1
-slothful,slothful,懒惰的,ADJ,B2
-slovenly,slovenly,词,ADJ,C1
 slow down,to slow down,放慢,VERB,B2
-slow pace,slow pace,你慢点,NOUN,C1
-slowdown,slowdown,减速,NOUN,B2
 slowness,slowness,缓慢,NOUN,B2
 sluggish,sluggish,迟钝的,ADJ,B2
-sluice,sluice,水闸,NOUN,C1
-slum,slum,贫民窟,NOUN,B2
-slumpmässig,random,随机的,ADJ,B2
-slur,slur,词,VERB,C1
-slut,end,端,PART,B2
-sluta,to get off work,下班,VERB,B2
-sluta,to infer,推断,VERB,B2
-slutförande,completion,完成,NOUN,B2
-slutligen,eventually,最终,ADV,B2
-slutsats,inference,推断,NOUN,B2
 sly,sly,狡猾的,ADJ,B2
-slyly,slyly,词,ADV,C1
 slyness,slyness,狡猾,NOUN,B2
-släktlinje,lineage,血统,NOUN,B2
-släktskap,kinship,亲属关系,NOUN,B2
-släppa,to let go,放开,VERB,B2
-släpvagn,trailer,预告片,NOUN,B2
-slätt,plain,平原,NOUN,B2
-slå på,to turn on,打开,VERB,B2
-slå två flugor i en smäll,kill two birds with one stone,一举两得,ADJ,B2
-slå upp,to look up,查阅,VERB,B2
-slöa,to blur,模糊,VERB,B2
-slösa,to squander,浪费,VERB,B2
-slöseri,squandering,挥霍,NOUN,B2
-slöserig,wasteful,浪费的,ADJ,B2
-smak,flavor,味道,NOUN,B2
-smaklig,delicious,美味的,ADJ,B2
-smaklös,bland,平淡的,ADJ,B2
-smakpreferens,taste preference,口味,NOUN,B2
-small bag,small bag,词,NOUN,C1
-small basket,small basket,词,NOUN,C1
-small boat,small boat,小船,NOUN,B2
-small box casket,small box casket,词,NOUN,C1
-small cave,small cave,词,NOUN,B2
-small dog,small dog,词,NOUN,C1
-small forge,small forge,词,NOUN,C1
-small gift,small gift,小礼物,NOUN,B2
-small loaf,small loaf,词,NOUN,B2
-small room,small room,词,NOUN,B1
-small step,small step,词,NOUN,C1
-small sword,small sword,词,NOUN,C1
-small window,small window,词,NOUN,A2
 smart,smart,聪明的,ADJ,B2
-smart contract,smart contract,智能合约,NOUN,C1
-smarting,smarting,词,NOUN,C1
 smash,to smash,粉碎,VERB,B2
 smashing,smashing,砸过,NOUN,B2
 smattering,smattering,少量,NOUN,B2
-smear,smear,抹,NOUN,C1
-smed,blacksmith,铁匠,NOUN,B2
-smelly,smelly,臭,ADJ,B2
-smelt,smelt,词,VERB,C1
-smelting,smelting,词,NOUN,C1
-smickeri,flattery,奉承,NOUN,B2
-smickeri,sycophancy,阿谀奉承,NOUN,B2
-sminka,to apply makeup,化妆,VERB,B2
-smirk,smirk,词,VERB,C1
-smitten,smitten,词,ADJ,C1
-smittsam,contagious,传染性的,ADJ,B2
-smock,smock,词,NOUN,B2
-smog,smog,雾霾,NOUN,C1
-smoked,smoked,词,ADJ,C1
-smoker,smoker,词,NOUN,C1
-smoking (adj),smoking,词,ADJ,C1
 smooth,smooth,光滑的,ADJ,B2
 smooth,to smooth,使光滑,VERB,B2
-smooth (noun),smooth,能磨平,NOUN,C1
-smooth sailing,smooth sailing,一帆风顺,ADJ,B2
 smoothly,smoothly,顺利,ADV,B2
-smoothness,smoothness,词,NOUN,C1
-smuggle,smuggle,词,VERB,C1
-smuggled goods,smuggled goods,水货,NOUN,C1
 smuggler,smuggler,走私者,NOUN,B2
 smuggling,smuggling,走私,NOUN,B2
-smugness,smugness,词,NOUN,C1
-smuts,grime,污垢,NOUN,B2
-smutta,to sip,小口喝,VERB,B2
-smyga,fuse,保险丝,NOUN,B2
-smälta,to digest,消化,VERB,B2
-smältande,digestive,消化的,ADJ,B2
-smältning,digestion,消化,NOUN,B2
-snabb,fast quick,快的,ADJ,B2
-snabb,quick,快的,ADJ,B2
-snabb,rapid,迅速的,ADJ,B2
-snabbt,quickly,迅速地,ADV,B2
-snaffle,snaffle,词,NOUN,B2
-snap (noun),snap,词,NOUN,B2
-snare,snare,词,NOUN,C1
-snarka,to snore,打鼾,VERB,B2
 snatch,to snatch,抢夺,VERB,B2
-sneaker,sneaker,词,NOUN,A1
-sneakers,sneakers,词,NOUN,B2
-sneaking,sneaking,词,NOUN,B2
-sned,crooked,弯曲的,ADJ,B2
-sneer,sneer,词,VERB,C1
 sneeze,to sneeze,打喷嚏,VERB,B2
-sneeze (noun),sneeze,词,NOUN,C1
-sneezing,sneezing,词,NOUN,C1
 sniff,to sniff,嗅,VERB,B2
-sniffle,sniffle,词,VERB,C1
-sniper,sniper,狙击手,NOUN,B2
-snippet,snippet,词,NOUN,C1
-snob,snob,词,NOUN,C1
-snobbery,snobbery,词,NOUN,C1
-snooping,snooping,词,NOUN,C1
-snore (noun),snore,打呼,NOUN,B2
-snoring,snoring,词,NOUN,B2
-snort (noun),snort,词,NOUN,B2
-snow fungus,snow fungus,银耳,NOUN,B2
-snow lotus,snow lotus,雪莲,NOUN,B2
-snowdrift,snowdrift,词,NOUN,B1
-snowy,snowy,词,ADJ,C1
-snowy day,snowy day,雪天,NOUN,C1
-snub (noun),snub,词,NOUN,C1
-snubbla,to stumble,绊倒,VERB,B2
+snarka,to snore,打鼾,VERB,B2
+nos,snout,口鼻,NOUN,B2
+snöskugga,snow shadow,雪影姐姐,NOUN,B2
+snöflinga,snowflake,雪花,NOUN,B2
+så,so,所以,ADV,B2
+så mycket,so much,这么多,ADV,B2
+så att,so that,以便,SCONJ,B2
+så kallad,so-called,所谓的,ADJ,B2
+blötlägga,to soak,浸透,VERB,B2
 snyfta,to sob,啜泣,VERB,B2
 snyftande,sobbing,抽泣,NOUN,B2
-snyta,to neigh,嘶鸣,VERB,B2
-snål,stingy,吝啬的,ADJ,B2
-snålhet,stinginess,吝啬；小气,NOUN,B2
-snöflinga,snowflake,雪花,NOUN,B2
-snöoväder,blizzard,暴风雪,NOUN,B2
-snöskugga,snow shadow,雪影姐姐,NOUN,B2
-so (sconj),so,遂,SCONJ,B2
-so as not to,so as not to,免得,SCONJ,B2
-so as to,so as to,俾使,SCONJ,B2
-so much,so much,那么多,DET,B2
-so much so many,so much so many,词,ADV,C1
-so to speak,so to speak,可以说,ADV,B2
-so-and-so,so-and-so,词,PRON,C1
-soaking,soaking,等你泡,NOUN,B2
-soap (verb),soap,词,VERB,C1
-sobriquet,sobriquet,词,NOUN,C1
-soccer,soccer,足球,NOUN,B2
+nykterhet,sobriety,清醒,NOUN,B2
+umgänglig,sociable,好交际的,ADJ,B2
 social,social,社会的,ADJ,B2
-social action,social action,社会行动,NOUN,C1
-social activity,social activity,社会活动,NOUN,B2
-social analysis,social analysis,社会分析,NOUN,C1
-social appeal,social appeal,社会呼吁,NOUN,B2
-social assessment,social assessment,社会评估,NOUN,C1
-social awareness,social awareness,社会觉悟,NOUN,B2
-social benefit,social benefit,社会效益,NOUN,C1
-social change,social change,社会变迁,NOUN,C1
-social collaboration,social collaboration,社会协作,NOUN,C1
-social commentary,social commentary,社会评论,NOUN,C1
-social communication,social communication,社会沟通,NOUN,C1
-social competition,social competition,社会竞争,NOUN,B2
-social conflict,social conflict,社会冲突,NOUN,C1
-social consensus,social consensus,社会共识,NOUN,B2
-social contract,social contract,社会契约,NOUN,C1
-social contribution,social contribution,社会贡献,NOUN,C1
-social cooperation,social cooperation,社会合作,NOUN,C1
-social cost,social cost,社会成本,NOUN,C1
-social credit,social credit,社会信用,NOUN,B2
-social crisis,social crisis,社会危机,NOUN,C1
-social criticism,social criticism,社会批评,NOUN,C1
-social custom,social custom,社会习俗,NOUN,B2
-social development,social development,社会发展,NOUN,B2
-social discrimination,social discrimination,社会歧视,NOUN,C1
-social distansering,social distancing,社交距离,NOUN,B2
-social enlightenment,social enlightenment,社会启蒙,NOUN,C1
-social equality,social equality,社会平等,NOUN,B2
-social ethos,social ethos,社会风气,NOUN,B2
-social event,social event,社会事件,NOUN,C1
-social evolution,social evolution,社会演变,NOUN,C1
-social exclusion,social exclusion,社会排斥,NOUN,C1
-social expectation,social expectation,社会期望,NOUN,C1
-social experiment,social experiment,社会实验,NOUN,B2
-social fairness,social fairness,社会公平,NOUN,B2
-social försoning,social reconciliation,社会和解,NOUN,B2
-social habit,social habit,社会习惯,NOUN,C1
-social harmoni,social harmony,社会和谐,NOUN,B2
-social hierarchy,social hierarchy,社会等级,NOUN,B2
-social identitet,social identity,社会身份,NOUN,B2
-social inclusion,social inclusion,社会包容,NOUN,B2
-social inequality,social inequality,社会不平等,NOUN,C1
-social initiative,social initiative,社会倡议,NOUN,C1
-social insurance,social insurance,社会保险,NOUN,C1
-social integration,social integration,社会融入,NOUN,C1
-social interaktion,social interaction,社会互动,NOUN,B2
-social issue,social issue,社会问题,NOUN,C1
-social justice,social justice,社会正义,NOUN,B2
-social kompromiss,social compromise,社会妥协,NOUN,B2
-social mediation,social mediation,社会调解,NOUN,B2
-social mobilisering,social mobilization,社会动员,NOUN,B2
-social mobility,social mobility,社会流动,NOUN,C1
-social morality,social morality,社会公德,NOUN,B2
-social movement,social movement,社会运动,NOUN,B2
-social network,social network,社会网络,NOUN,C1
-social news,social news,社会新闻,NOUN,B2
-social norm,social norm,社会规范,NOUN,C1
-social obligation,social obligation,社会义务,NOUN,C1
-social order,social order,社会秩序,NOUN,B2
-social organisation,social organization,社会组织,NOUN,B2
-social participation,social participation,社会参与,NOUN,C1
-social phenomenon,social phenomenon,社会现象,NOUN,B2
-social praktik,social practice,社会实践,NOUN,B2
-social prejudice,social prejudice,社会偏见,NOUN,C1
-social pressure,social pressure,社会压力,NOUN,B2
-social prestige,social prestige,社会声望,NOUN,C1
-social progress,social progress,社会进步,NOUN,B2
-social recognition,social recognition,社会认可,NOUN,C1
-social reflection,social reflection,社会反思,NOUN,C1
-social reform,social reform,社会改革,NOUN,C1
-social relations,social relations,社会关系,NOUN,C1
-social research,social research,社会研究,NOUN,C1
-social responsibility,social responsibility,社会责任,NOUN,C1
-social revolution,social revolution,社会革命,NOUN,B2
-social rights,social rights,社会权利,NOUN,C1
-social role,social role,社会角色,NOUN,B2
-social science,social science,社会科学,NOUN,B2
-social security,social security,社会保障,NOUN,C1
-social skiktning,social stratification,社会分层,NOUN,B2
 social skiljedom,social arbitration,社会仲裁,NOUN,B2
-social stabilitet,social stability,社会稳定,NOUN,B2
-social standard,social standard,社会标准,NOUN,C1
-social status,social status,社会地位,NOUN,C1
-social structure,social structure,社会结构,NOUN,B2
-social survey,social survey,社会调查,NOUN,C1
-social system,social system,社会制度,NOUN,C1
-social tension,social tension,词,NOUN,C1
-social tillit,social trust,社会信任,NOUN,B2
-social tradition,social tradition,社会传统,NOUN,B2
-social transformation,social transformation,社会转型,NOUN,C1
-social trend,social trend,社会趋势,NOUN,B2
-social turmoil,social turmoil,社会动荡,NOUN,C1
 social uppvaknande,social awakening,社会觉醒,NOUN,B2
-social value,social value,社会价值,NOUN,B2
-social welfare,social welfare,社会福利,NOUN,C1
-social worker,social worker,社工,NOUN,C1
-socialism,socialism,词,NOUN,C1
-socialist,socialist,社会主义者,NOUN,B2
-socialist (adj),socialist,社会主义的,ADJ,C1
-socialization,socialization,社会化,NOUN,B2
-socializing,socializing,交际,NOUN,B1
+social kompromiss,social compromise,社会妥协,NOUN,B2
+social distansering,social distancing,社交距离,NOUN,B2
+social harmoni,social harmony,社会和谐,NOUN,B2
+social identitet,social identity,社会身份,NOUN,B2
+social interaktion,social interaction,社会互动,NOUN,B2
+social mobilisering,social mobilization,社会动员,NOUN,B2
+social organisation,social organization,社会组织,NOUN,B2
+social praktik,social practice,社会实践,NOUN,B2
+social försoning,social reconciliation,社会和解,NOUN,B2
+social stabilitet,social stability,社会稳定,NOUN,B2
 socialstatistik,social statistics,社会统计,NOUN,B2
-societal,societal,词,ADJ,B2
+social skiktning,social stratification,社会分层,NOUN,B2
+social trend,social trend,社会趋势,NOUN,B2
+social tillit,social trust,社会信任,NOUN,B2
 sociolog,sociologist,社会学家,NOUN,B2
 sociologi,sociology,社会学,NOUN,B2
-sociological,sociological,词,ADJ,C1
-socket,socket,词,NOUN,C1
+softboll,softball,垒球,NOUN,B2
+mjukvara,software,软件,NOUN,B2
+jord,soil,土壤,NOUN,B2
+vistelse,sojourn,逗留,NOUN,B2
+tröst,solace,安慰,NOUN,B2
+soldat,soldiers,官兵,NOUN,B2
+sula,sole,鞋底,NOUN,B2
+högtidlig,solemn,庄严的,ADJ,B2
+begära,to solicit,恳求,VERB,B2
+samla in donationer,to solicit donations,募捐,VERB,B2
+fast ämne,solid,3D模型 / 实体,NOUN,B2
+SSD,solid-state drive,固态硬盘,NOUN,B2
+monolog,soliloquy,独白,NOUN,B2
+ensamhet,solitude,孤独,NOUN,B2
+solvens,solvency,偿付能力,NOUN,B2
+lösningsmedel,solvent,溶剂,NOUN,B2
+några ut,some out,出些,NOUN,B2
+på något sätt,somehow,以某种方式,ADV,B2
+någon gång,sometime,在某个时候,ADV,B2
+son,son,儿子,NOUN,B2
+sot,soot,烟灰,NOUN,B2
 sofism,sophism,诡辩,NOUN,B2
 sofisteri,sophistry,诡辩,NOUN,B2
-softboll,softball,垒球,NOUN,B2
-softness,softness,词,NOUN,B2
-softness pliancy,softness pliancy,词,NOUN,C1
-software (adj),software,词,ADJ,C1
-soil erosion,soil erosion,水土流失,NOUN,C1
-soil investigation,soil investigation,词,NOUN,C1
-solar (adj),solar,词,ADJ,B1
-solar (noun),solar,词,NOUN,B2
-solar energy,solar energy,太阳能,NOUN,C1
-solar panel,solar panel,太阳能电池板,NOUN,B2
-solar physics,solar physics,词,NOUN,C1
-solbränna,to tan,晒黑,VERB,B2
-soldat,soldiers,官兵,NOUN,B2
-solecism,solecism,语法错误,NOUN,B2
-solely,solely,词,ADV,C1
-solemn,solemn,,NOUN,B2
-solemnity,solemnity,词,NOUN,C1
-solemnly,solemnly,词,ADV,C1
-solfege,solfege,词,NOUN,C1
-solicitation,solicitation,词,NOUN,C1
-solicitor,solicitor,词,NOUN,C1
-solicitous,solicitous,词,ADJ,C1
-solicitude,solicitude,关怀,NOUN,B2
-solidifying,solidifying,词,ADJ,C1
-solidity,solidity,固,NOUN,C1
-solig,sunny,晴朗的,ADJ,B2
-solipsism,solipsism,唯我论,NOUN,B2
-solitary,solitary,孤独的,ADJ,B2
-soloist,soloist,词,NOUN,C1
-solstice,solstice,词,NOUN,C1
-solute,solute,词,NOUN,C1
-solve a case,solve a case,破案,VERB,B2
-solvens,solvency,偿付能力,NOUN,B2
-somber,somber,词,ADJ,B2
-some many a,some many a,词,DET,A2
-some stink,some stink,些臭,NOUN,C1
-some things,some things,一些事情,PRON,B2
-somebody,somebody,词,PRON,A1
-someone stealing,someone stealing,有人偷,NOUN,C1
-something better,something better,词,NOUN,C1
-something like that,something like that,类似的事物,PRON,B2
-somewhat,somewhat,词,ADV,C1
-somewhere else,somewhere else,词,ADV,B1
-somnolent,somnolent,词,ADJ,C1
-son,son,儿子,NOUN,B2
-son of a bitch,son of a bitch,词,NOUN,B2
-son-in-law,son-in-law,词,NOUN,A2
-sonata,sonata,词,NOUN,C1
-song (part),song,歌,PART,B2
-song festival,song festival,音乐节,NOUN,B2
-song grass,song grass,歌草,NOUN,C1
-song of praise,song of praise,赞歌,NOUN,B2
-sonorous,sonorous,词,ADJ,C1
-sooner or later (adv),sooner or later,早晚,ADV,C1
-sooner or later (noun),sooner or later,我迟早,NOUN,C1
-soothing,soothing,词,ADJ,C1
-soothsayer,soothsayer,词,NOUN,B2
-sophist,sophist,诡辩家,NOUN,B2
-sophistic,sophistic,词,ADJ,C1
-sophisticated,sophisticated,复杂的,ADJ,B2
-sophomoric,sophomoric,词,ADJ,C1
-soporific,soporific,词,ADJ,C1
-sorcerer,sorcerer,巫师,NOUN,B2
-sorcery,sorcery,巫术,NOUN,B2
-sordid,sordid,肮脏的,ADJ,B2
-sore,sore,疼痛的,ADJ,B2
-sore (adv),sore,词,ADV,A2
-sore throat,sore throat,喉咙痛,NOUN,C1
-sorg,grief,悲伤,NOUN,B2
-sorghum,sorghum,高粱,NOUN,B2
-sorl,sound of activity,动静,NOUN,B2
-sorrow and indignation,sorrow and indignation,悲愤,NOUN,C1
-sorrowful pitiful,sorrowful pitiful,悲哀,ADJ,C1
-sorry (noun),sorry,词,NOUN,A1
-sort,sort,种类,NOUN,B2
+ledsen,sorry,抱歉,ADJ,B2
 sortera,to sort,分类,VERB,B2
-sortie,sortie,词,NOUN,C1
-sorting,sorting,分类,NOUN,B2
-sot,soot,烟灰,NOUN,B2
-sought-after,sought-after,词,ADJ,C1
-soul spirit,soul spirit,词,NOUN,B2
-soulmate,soulmate,词,NOUN,C1
-sound card,sound card,声卡,NOUN,B2
-sound clip,sound clip,音频片段,NOUN,B2
-sound judgment,sound judgment,词,NOUN,C1
-sound sleep,sound sleep,你踏实睡,NOUN,B2
-soundness of judgment,soundness of judgment,词,NOUN,C1
-soundtrack,soundtrack,! 音轨,NOUN,B2
-sour cherry,sour cherry,词,NOUN,C1
-source citation,source citation,出处注明,NOUN,B2
-source material,source material,素材,NOUN,C1
-sources,sources,词,NOUN,C1
-sourdough,sourdough,词,NOUN,C1
-south african,south african,南非的,ADJ,B2
-south gate,south gate,南关,NOUN,B2
-southeast,southeast,东南,NOUN,B2
-southeast (adj),southeast,词,ADJ,C1
-southern part,southern part,南部,NOUN,B2
-southerner,southerner,词,NOUN,B2
-southwest,southwest,西南的,ADJ,B2
+sorl,sound of activity,动静,NOUN,B2
+sundhet,soundness,好端端,NOUN,B2
+sydarmé,southern army,南军,NOUN,B2
 souvenir,souvenir,纪念品,NOUN,B2
-sovereigntist,sovereigntist,主权主义者,NOUN,B2
-sow,sow,母猪,NOUN,B2
-soy,soy,词,NOUN,C1
-soy milk,soy milk,豆浆,NOUN,B2
-soy sauce,soy sauce,酱油,NOUN,B2
-space (adj),space,词,ADJ,C1
-space technology,space technology,航天技术,NOUN,C1
-spaciousness,spaciousness,词,NOUN,C1
-spade,shovel,铲子,NOUN,B2
-spade,spade,铲子,NOUN,B2
-spadix,spadix,词,NOUN,C1
-spam (noun),spam,词,NOUN,B1
-span duration,span duration,词,NOUN,C1
-spandex,spandex,氨纶,NOUN,C1
-spaning,reconnaissance,侦察,NOUN,B2
-spanking,spanking,词,NOUN,B2
+monark,sovereign,君主,NOUN,B2
+så,to sow,播种,VERB,B2
+sådd,sowing,播种,NOUN,B2
+rymlig,spacious,宽敞的,ADJ,B2
 spansk,spanish,西班牙的,ADJ,B2
-spar,spar,词,VERB,C1
-spare (adj),spare,词,ADJ,B1
-spare (noun),spare,词,NOUN,C1
-sparkle (noun),sparkle,词,NOUN,C1
-sparkling,sparkling,词,ADJ,B2
-sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
-sparsam,thrifty,节俭的,ADJ,B2
-sparse,sparse,词,ADJ,C1
-sparse forest,sparse forest,疏林,NOUN,C1
+fritid,spare time,业余,NOUN,B2
+gnista,spark,火花,NOUN,B2
 sparv,sparrow,麻雀,NOUN,B2
-spasm convulsion,spasm convulsion,词,NOUN,C1
-spasmodic,spasmodic,词,ADJ,C1
-spate,spate,词,NOUN,C1
-spatial,spatial,空间的,ADJ,B2
-spatula,spatula,刮刀,NOUN,B2
-speaking,speaking,说京,NOUN,B2
-speaking of,speaking of,说起,NOUN,C1
-speaking of which,speaking of which,词,ADV,C1
-special issue,special issue,特刊,NOUN,C1
-special offer,special offer,特价,NOUN,B2
-special zone,special zone,特区,NOUN,B2
-special-purpose trip,special-purpose trip,专程,ADV,B2
-specialiserad,specialized,专业的,ADJ,B2
-specialisering,specialization,专业化,NOUN,B2
-specialist,specialist,专家,NOUN,B2
-specialized subject,specialized subject,专科,NOUN,B2
-specially,specially,特意,ADV,B1
+kramp,spasm,痉挛,NOUN,B2
+spjut,spear,长矛,NOUN,B2
 specialämne,special topic,专题,NOUN,B2
-speciell,particular,特定的,ADJ,B2
-specifications,specifications,词,NOUN,C1
-specificity,specificity,词,NOUN,C1
+specialist,specialist,专家,NOUN,B2
+specialisering,specialization,专业化,NOUN,B2
+specialiserad,specialized,专业的,ADJ,B2
+art,species,物种,NOUN,B2
 specifikation,specification,规格,NOUN,B2
-specimen,specimen,标本,NOUN,B2
-specious,specious,似是而非的,ADJ,B2
-spectacle,spectacle,词,NOUN,B2
-specter,specter,词,NOUN,C1
-spectrometer,spectrometer,词,NOUN,C1
-speculative,speculative,词,ADJ,B2
-speculator,speculator,投机者,NOUN,B2
-speech (part),speech,语,PART,C1
-speed bumps,speed bumps,词,NOUN,C1
-speed limit sign,speed limit sign,限速牌,NOUN,B2
-speed measurement,speed measurement,测速,NOUN,B2
-speed radar,speed radar,词,NOUN,B1
-speed skating,speed skating,速度滑冰,NOUN,C1
-speeding,speeding,超速,NOUN,C1
-spejare,scout,侦察员,NOUN,B2
+glasögon,spectacles,眼镜,NOUN,B2
 spektakulär,spectacular,壮观的,ADJ,B2
 spektral,spectral,幽灵般的,ADJ,B2
 spektrum,spectrum,光谱,NOUN,B2
 spekulation,speculation,推测,NOUN,B2
-spelling,spelling,拼写,NOUN,B2
-spend the night,spend the night,词,VERB,B2
-spending,spending,行用,NOUN,B2
-spendthrift,spendthrift,词,NOUN,C1
-spenning,flu,流感,NOUN,B2
-spent,spent,词,ADJ,B2
-spherical,spherical,词,ADJ,C1
-sphincter,sphincter,词,NOUN,C1
-spice,spice,香料,NOUN,B2
-spices,spices,词,NOUN,B1
-spicy,spicy,辣,ADJ,A2
-spike,spike,词,NOUN,B2
-spill (noun),spill,词,NOUN,C1
-spilling,spilling,词,NOUN,C1
-spin (noun),spin,词,NOUN,C1
-spinach,spinach,菠菜,NOUN,B2
-spinal cord,spinal cord,脊髓,NOUN,B2
-spine,spine,脊柱,NOUN,B2
-spinning,spinning,纺纱,NOUN,B2
-spinning mill,spinning mill,纺纱厂,NOUN,B2
-spinsterhood,spinsterhood,词,NOUN,B2
-spioneri,espionage,间谍活动,NOUN,B2
-spiral,spiral,词,NOUN,C1
-spiral pattern,spiral pattern,旋纹,NOUN,B2
-spiring,germination,发芽,NOUN,B2
-spirit (part),spirit,神,PART,A2
-spirit world,spirit world,灵界,NOUN,B2
-spirited,spirited,词,ADJ,B2
-spiritual,spiritual,精神的,ADJ,B2
-spiritual retreat,spiritual retreat,词,NOUN,C1
-spiritual striving,spiritual striving,精神奋斗,NOUN,C1
-spite,spite,恶意,NOUN,B2
-spittle,spittle,唾沫,NOUN,B2
-spjut,spear,长矛,NOUN,B2
-splash,splash,扑通,NOUN,B2
-splay,splay,词,VERB,C1
-spleen,spleen,词,NOUN,B2
+besvärjelse,spell,咒语,NOUN,B2
+sfär,sphere,领域,NOUN,B2
+sinnesövning,spirit training,练神,NOUN,B2
+andlighet,spirituality,灵性,NOUN,B2
+elak,spiteful,怀恨的,ADJ,B2
+praktfull,splendid,极好的,ADJ,B2
+prakt,splendor,辉煌,NOUN,B2
 splint,splint,夹板,NOUN,B2
-splinter (noun),splinter,词,NOUN,B2
-split (noun),split,词,NOUN,C1
-split secession,split secession,分裂,NOUN,B2
-splitter,splitter,词,NOUN,C1
-spoiled,spoiled,词,ADJ,B2
-spoiled child,spoiled child,词,NOUN,B1
-spoiler,spoiler,词,NOUN,C1
-spoils,spoils,词,NOUN,C1
-spoils of war,spoils of war,词,NOUN,C1
-spoliation,spoliation,词,NOUN,C1
-sponge,sponge,词,NOUN,B2
-sponger,sponger,词,NOUN,C1
-spongy,spongy,词,ADJ,C1
-sponsor (noun),sponsor,词,NOUN,B2
+dela,split,分裂,NOUN,B2
+dela,to split,分裂,VERB,B2
+förstöra,to spoil,损坏,VERB,B2
+talesperson,spokesperson,发言人,NOUN,B2
 sponsring,sponsorship,赞助,NOUN,B2
 spontan,spontaneous,自发的,ADJ,B2
-spontaneity,spontaneity,词,NOUN,C1
-spontaneously,spontaneously,词,ADV,C1
-spoonerism,spoonerism,词,NOUN,C1
-spoonful,spoonful,词,NOUN,B2
-spora,germ,病菌,NOUN,B2
-sporadic,sporadic,词,ADJ,C1
-sporadically,sporadically,词,ADV,B2
-sporra,to spur,激励,VERB,B2
 sport,sport,运动,NOUN,B2
 sportbil,sports car,跑车,NOUN,B2
-sports,sports,体育,NOUN,B2
-sports exercise,sports exercise,运动,NOUN,B2
-sports field,sports field,运动场,NOUN,C1
-sports park,sports park,运动公园,NOUN,B2
-sporty,sporty,运动的,ADJ,B2
-spot,spot,地点,NOUN,B2
-spot goods,spot goods,现货,NOUN,C1
-sprayer sprinkler,sprayer sprinkler,词,NOUN,C1
-spreading,spreading,词,NOUN,C1
-spree,spree,词,NOUN,C1
+stukning,sprain,扭伤,NOUN,B2
 sprej,spray,喷雾,NOUN,B2
-spricka,rift,裂痕,NOUN,B2
-sprida,to disseminate,传播,VERB,B2
-sprida,to scatter,分散,VERB,B2
 spridning,spread,传播,NOUN,B2
-spring eye,spring eye,泉,NOUN,B1
-spring water,spring water,泉水,NOUN,C1
-springboard,springboard,词,NOUN,C1
-sprinkling,sprinkling,词,NOUN,B2
-sprite,sprite,词,NOUN,C1
-spry,spry,词,ADJ,C1
-spurious,spurious,虚假的,ADJ,B2
-spurn,spurn,词,VERB,C1
-spurt,spurt,词,VERB,C1
-sputum,sputum,词,NOUN,C1
-spänd,taut,绷紧的,ADJ,B2
-spänning,suspense,悬念,NOUN,B2
-spärra,to obstruct,阻碍,VERB,B2
-spärrning,obstruction,阻塞,NOUN,B2
-spådom,fortune telling,算命,NOUN,B2
-spår,trace,痕迹,NOUN,B2
-squabble (noun),squabble,词,NOUN,B2
-squabble (verb),squabble,词,VERB,C1
-squad leader,squad leader,伍长,NOUN,C1
-squadron,squadron,词,NOUN,B1
-squall,squall,骤雨,NOUN,B2
-squander (noun),squander,词,NOUN,C1
-squanderer,squanderer,词,NOUN,C1
-square as in square foot,square as in square foot,平方,NOUN,B1
-square dance,square dance,广场舞,NOUN,C1
-squeak,squeak,吱吱声,NOUN,B2
-squeal,squeal,词,VERB,C1
-squelch,squelch,词,VERB,C1
-squid,squid,鱿鱼,NOUN,B2
-squire,squire,词,NOUN,C1
-stab (noun),stab,捅,NOUN,C1
-stabilisera,to stabilize,使稳定,VERB,B2
-stabilitet,stability,稳定,NOUN,B2
-stabilization,stabilization,稳定化,NOUN,B2
-stack (noun),stack,词,NOUN,B2
-stad,town,城镇,NOUN,B2
-stadion,stadium,体育场,NOUN,B2
-staff officer,staff officer,参谋,NOUN,B2
-stage design,stage design,词,NOUN,B2
-stage fright,stage fright,怯场,NOUN,B2
-staging,staging,上演,NOUN,B2
-stagnant,stagnant,停滞的,ADJ,B2
-stagnation,stagnation,停滞,NOUN,B2
-stagnera,to stagnate,停滞,VERB,B2
-staid,staid,词,ADJ,C1
-staircase,staircase,词,NOUN,B1
-stairwell,stairwell,楼梯间,NOUN,C1
-stakes,stakes,词,NOUN,B2
-stalemate,stalemate,词,NOUN,C1
-stalking,stalking,词,NOUN,C1
-stall,stall,包厢座位,NOUN,B2
-stalling,stalling,词,NOUN,B2
-stalwart,stalwart,词,ADJ,C1
-stam,classifier for trees,棵,NUM,B2
-stamina,stamina,词,NOUN,C1
-stammering,stammering,词,NOUN,C1
-stamp buffer,stamp buffer,词,NOUN,C1
-stampede,stampede,溃逃,NOUN,B2
-stanch,stanch,词,VERB,C1
-standard,default,违约,NOUN,B2
-standard (adj),standard,词,ADJ,C1
-standard criterion,standard criterion,词,NOUN,C1
-standardisering,standardization,标准化,NOUN,B2
-standby,standby,待机,VERB,C1
-standing (adv),standing,词,ADV,A1
-standing (noun),standing,就站,NOUN,B2
-standoffish,standoffish,词,ADJ,B2
-stands,stands,词,NOUN,B2
-stank,stench,恶臭,NOUN,B2
-stanna,to stall,拖延,VERB,B2
-stanza,stanza,词,NOUN,B2
-staple,staple,词,NOUN,C1
-stapler,stapler,词,NOUN,A2
-star celebrity,star celebrity,词,NOUN,B1
-star search,star search,找星,NOUN,B2
-starboard,starboard,词,NOUN,C1
-starch,starch,芡,NOUN,C1
-stark,stark,词,ADJ,B2
-starling,starling,词,NOUN,B2
-start,start,开始,NOUN,B2
-start,takeoff,起飞,NOUN,B2
-start of school year,start of school year,词,NOUN,B1
-starter,starter,词,NOUN,C1
-starting premise,starting premise,词,NOUN,C1
-startling,startling,词,ADJ,C1
-starvation,starvation,词,NOUN,C1
-state (adj),state,词,ADJ,B1
-state of emergency,state of emergency,词,NOUN,C1
-state of mind,state of mind,精神状态,NOUN,B2
-state relatives,state relatives,国戚,NOUN,B2
-state secretary,state secretary,国务秘书,NOUN,B2
-state truce,state truce,国罢,NOUN,B2
-state-run,state-run,公办,NOUN,C1
-stateless person,stateless person,词,NOUN,C1
-statement of the obvious,statement of the obvious,词,NOUN,C1
-statements,statements,词,NOUN,C1
-static (noun),static,词,NOUN,B2
-statics,statics,词,NOUN,C1
-station,station,车站,NOUN,B2
-stationery shop,stationery shop,文具店,NOUN,B2
-statisk,static,静态的,ADJ,B2
-statism,statism,词,NOUN,C1
-statistic,statistic,统计数据,NOUN,B2
-statistik,statistics,统计学,NOUN,B2
-statistisk,statistical,统计的,ADJ,B2
-statization,statization,词,NOUN,C1
-statlig,governmental,政府的,ADJ,B2
-statute,statute,词,NOUN,C1
-statute of limitations,statute of limitations,词,NOUN,B2
-statutory rape,statutory rape,词,NOUN,C1
-staty,statue,雕像,NOUN,B2
-staunch,staunch,坚定的,ADJ,B2
-stave,stave,词,NOUN,C1
-stay remain,stay remain,词,VERB,A1
-staying,staying,得留,NOUN,C1
-staying behind,staying behind,我留下,NOUN,B2
-steadfast,steadfast,词,ADJ,C1
-steadfastness,steadfastness,词,NOUN,B2
-steadiness,steadiness,稳倒,NOUN,C1
-stealthily,stealthily,词,ADV,B2
-stealthy,stealthy,词,ADJ,C1
-steamed,steamed,词,ADJ,B2
-steamed bun,steamed bun,馒头,NOUN,B2
-steamed fish,steamed fish,花雕蒸鳜,NOUN,B2
-steep,steep,陡峭的,ADJ,B2
-steering,steering,掌舵的,ADJ,B2
-steering (noun),steering,词,NOUN,C1
-steering control,steering control,词,NOUN,C1
-steg,steps,台阶,NOUN,B2
-stege,ladder,梯子,NOUN,B2
-stelhet,stiffness,僵硬,NOUN,B2
-stem (adj),stem,词,ADJ,C1
-stem cell,stem cell,干细胞,NOUN,C1
-stemming,stemming,词,ADJ,B1
-sten,pebble,卵石,NOUN,B2
-stenos,stenosis,狭窄,NOUN,B2
-stent,stent,支架,NOUN,C1
-stentorian,stentorian,词,ADJ,C1
-stepfather,stepfather,词,NOUN,A1
-steppe,steppe,词,NOUN,C1
-steppes,steppes,草原,NOUN,B2
-stepson,stepson,词,NOUN,A2
-stereotypical,stereotypical,词,ADJ,C1
-stereotyping,stereotyping,词,NOUN,C1
-stereotypy routineness,stereotypy routineness,词,NOUN,C1
-steril,sterile,无菌的,ADJ,B2
-sterility,sterility,词,NOUN,C1
-sterilization,sterilization,词,NOUN,B2
-sterilizer,sterilizer,词,NOUN,C1
-stern (adj),stern,词,ADJ,C1
-stern (noun),stern,词,NOUN,C1
-stevedore,stevedore,词,NOUN,C1
-stew,stew,炖菜,NOUN,B2
+strö,to sprinkle,撒,VERB,B2
+sporra,to spur,激励,VERB,B2
+trupp,squad,小队,NOUN,B2
+slösa,to squander,浪费,VERB,B2
+slöseri,squandering,挥霍,NOUN,B2
+fyrkantig,square,平方的,ADJ,B2
+huka,to squat,蹲,VERB,B2
+ekorre,squirrel,松鼠,NOUN,B2
 sticka,to stab,刺,VERB,B2
-sticka,to stick,插入,VERB,B2
-sticka,to sting,刺,VERB,B2
-sticker,sticker,贴,NOUN,C1
-sticking point,sticking point,词,NOUN,C1
-stickler,stickler,词,NOUN,C1
-sticky note,sticky note,便签,NOUN,B2
-stifle,stifle,词,VERB,C1
-stifling,stifling,词,ADJ,B2
-stiga av,to dismount,下马,VERB,B2
-stiga upp,to get up,起床,VERB,B2
-stigmatisera,to stigmatize,污名化,VERB,B2
-stigmatization,stigmatization,词,NOUN,B2
-stiletto,stiletto,词,NOUN,C1
-stilfull,stylish,雅致的,ADJ,B2
-stilig man,handsome guy,帅哥,NOUN,B2
-still also,still also,还,ADV,A1
+stabilitet,stability,稳定,NOUN,B2
+stabilisera,to stabilize,使稳定,VERB,B2
+stadion,stadium,体育场,NOUN,B2
+scen,stage,阶段,NOUN,B2
+teaterpjäs,stage play,舞台剧,NOUN,B2
+vackla,to stagger,蹒跚,VERB,B2
+stagnera,to stagnate,停滞,VERB,B2
+stagnation,stagnation,停滞,NOUN,B2
+stanna,to stall,拖延,VERB,B2
+utmärka,to stand out,引人注目,VERB,B2
+stå,to stand side by side,并列,VERB,B2
+resa,to stand up,站起来,VERB,B2
+standardisering,standardization,标准化,NOUN,B2
 stillastående,standstill,停滞,NOUN,B2
-stillness,stillness,静中,NOUN,B2
-stilted,stilted,词,ADJ,C1
-stimulans,stimulant,兴奋剂,NOUN,B2
-stimulating,stimulating,词,ADJ,C1
-stimulera,to stimulate,激发,VERB,B2
-stimulus,stimulus,刺激,NOUN,B2
-sting,sting,刺,NOUN,B2
-stinka,to stink,发臭,VERB,B2
-stipend,stipend,津贴,NOUN,B2
-stipulation,stipulation,词,NOUN,C1
-stipulera,to stipulate,规定,VERB,B2
-stir (noun),stir,掀不起,NOUN,C1
-stir-fry,stir-fry,炒,VERB,B1
-stitches,stitches,词,NOUN,B1
-stitching,stitching,缝合,NOUN,B2
-stjälk,stem,茎,NOUN,B2
-stjärn-,stellar,杰出的,ADJ,B2
 stjärnanis,star anise,八角,NOUN,B2
-stjärnbild,constellation,星座,NOUN,B2
 stjärnhimmel,starry sky,星空,NOUN,B2
-stjärntecken,zodiac sign,属相,NOUN,B2
-stochastic,stochastic,词,ADJ,B2
-stock,log,日志,NOUN,B2
-stock-market,stock-market,词,ADJ,B2
-stocking,stocking,词,NOUN,C1
-stodgy,stodgy,词,ADJ,C1
-stoic,stoic,坚忍的,ADJ,B2
-stoically,stoically,词,ADV,C1
+start,start,开始,NOUN,B2
+statisk,static,静态的,ADJ,B2
+station,station,车站,NOUN,B2
+pappersvaror,stationery,文具,NOUN,B2
+statistisk,statistical,统计的,ADJ,B2
+statistik,statistics,统计学,NOUN,B2
+staty,statue,雕像,NOUN,B2
+ånga,to steam,蒸,VERB,B2
+ångad bulle,steamed stuffed bun,包子,NOUN,B2
+stjärn-,stellar,杰出的,ADJ,B2
+stjälk,stem,茎,NOUN,B2
+stank,stench,恶臭,NOUN,B2
+stenos,stenosis,狭窄,NOUN,B2
+styvmor,stepmother,后母,NOUN,B2
+steg,steps,台阶,NOUN,B2
+steril,sterile,无菌的,ADJ,B2
+stuva,to stew,炖,VERB,B2
+sticka,to stick,插入,VERB,B2
+stelhet,stiffness,僵硬,NOUN,B2
+stigmatisera,to stigmatize,污名化,VERB,B2
+stimulans,stimulant,兴奋剂,NOUN,B2
+stimulera,to stimulate,激发,VERB,B2
+sticka,to sting,刺,VERB,B2
+snålhet,stinginess,吝啬；小气,NOUN,B2
+snål,stingy,吝啬的,ADJ,B2
+stinka,to stink,发臭,VERB,B2
+stipulera,to stipulate,规定,VERB,B2
+röra,stir,搅拌,NOUN,B2
+röra,to stir,搅拌,VERB,B2
+stygn,stitch,针脚,NOUN,B2
+lager,stock,库存,NOUN,B2
+upplag,stockpile,储备,NOUN,B2
 stoicism,stoicism,斯多葛主义,NOUN,B2
-stolen one,stolen one,词,NOUN,B2
-stolid,stolid,冷漠的,ADJ,B2
-stomach ache,stomach ache,词,NOUN,C1
-stone,stone,石,PART,B2
-stone emerging,stone emerging,石出,NOUN,C1
-stoning,stoning,石刑,NOUN,C1
-stool,stool,词,NOUN,C1
-stop bleeding,stop bleeding,止血,VERB,B2
-stop-arguing,stop-arguing,都别争,NOUN,C1
-stopover,stopover,中途停留,NOUN,B2
+elda,to stoke,添燃料,VERB,B2
+magont,stomachache,肚子痛,NOUN,B2
+stoppa mig,to stop me,拦我,VERB,B2
+lagra,store,商店,NOUN,B2
+lagra,to store,储存,VERB,B2
+storm,storm,风暴,NOUN,B2
+stormig,stormy,有暴风雨的,ADJ,B2
+räta,to straighten,弄直,VERB,B2
+okomplicerad,straightforward,直率的,ADJ,B2
+ansträngning,strain,压力,NOUN,B2
+sund,strait,海峡,NOUN,B2
+främmande trupper,strange troops,怪兵,NOUN,B2
+egendomlighet,strangeness,奇怪,NOUN,B2
+rem,strap,带子,NOUN,B2
+strategisk,strategic,战略的,ADJ,B2
+jordgubbe,strawberry,草莓,NOUN,B2
+ström,stream,溪流,NOUN,B2
+strikt,strict,严格的,ADJ,B2
+strejk,strike,罢工,NOUN,B2
+anfallare,striker,罢工者,NOUN,B2
+sträng,string,细绳,NOUN,B2
+remsa,strip,条带,NOUN,B2
+slag,stroke,中风,NOUN,B2
+strosa,to stroll,散步,VERB,B2
+strukturell,structural,结构的,ADJ,B2
+fast,stuck,卡住的,ADJ,B2
+studio,studio,工作室,NOUN,B2
+studie,study,研究,NOUN,B2
 stoppa,stuff,东西,NOUN,B2
 stoppa,to stuff,填塞,VERB,B2
-stoppa mig,to stop me,拦我,VERB,B2
-stor,great,伟大的,ADJ,B2
-stor förolämpning,great offense,冒犯大,NOUN,B2
-stor tjänst,great favor,大恩,NOUN,B2
-storage room,storage room,储藏室,NOUN,B2
-storehouse,storehouse,库房,NOUN,C1
-storhet,grandeur,宏伟,NOUN,B2
-storhet,greatness,伟大,NOUN,B2
-stork,stork,词,NOUN,B1
-storm,storm,风暴,NOUN,B2
-storm (verb),storm,强袭,VERB,C1
-storm surge,storm surge,风暴潮,NOUN,C1
-stormakt,great power,大国,NOUN,B2
-stormarknad,supermarket,超市,NOUN,B2
-stormig,stormy,有暴风雨的,ADJ,B2
-storming,storming,词,NOUN,C1
-storskalig,large-scale,大规模的,ADJ,B2
-storslagen,grand,宏伟的,ADJ,B2
-stort avstånd,grand distance,雄远,NOUN,B2
-story history,story history,词,NOUN,A1
-stout,stout,词,ADJ,C1
-stowage,stowage,词,NOUN,C1
-strabismus,strabismus,词,NOUN,B2
-straight,straight,直的,NOUN,B2
-straight ahead,straight ahead,词,ADV,B2
-straight direct,straight direct,词,ADJ,A1
-straight line,straight line,词,NOUN,C1
-straitened circumstances,straitened circumstances,词,NOUN,C1
-straitjacket,straitjacket,词,NOUN,C1
-stram,tight,紧的,ADJ,B2
-strand,shore,岸,NOUN,B2
-strand,strand,词,NOUN,C1
-strangest,strangest,词,NOUN,C1
-strangulation,strangulation,词,NOUN,C1
-strapping,strapping,词,ADJ,C1
-stratagem,stratagem,策略,NOUN,B2
-strategisk,strategic,战略的,ADJ,B2
-strategist,strategist,词,NOUN,C1
-strategize,strategize,运筹,VERB,C1
-stratification,stratification,词,NOUN,C1
-stratigraphic,stratigraphic,词,ADJ,C1
-straw,straw,稻草,NOUN,B2
-straying,straying,跑丢,NOUN,C1
-street dance,street dance,街舞,NOUN,C1
-street interview,street interview,街头采访,NOUN,B2
-street kid,street kid,词,NOUN,B2
-street lamp,street lamp,词,NOUN,B1
-street lighting,street lighting,词,NOUN,B1
-street parking,street parking,路边停车,NOUN,C1
-strejk,strike,罢工,NOUN,B2
-strengthening,strengthening,词,NOUN,C1
-stress (noun),stress,压力,NOUN,B1
-stressful,stressful,有压力的,ADJ,B2
-stretch out,stretch out,词,VERB,B2
-stretched,stretched,词,ADJ,C1
-strictly,strictly,词,ADV,B2
-strictly prohibit,strictly prohibit,严禁,VERB,B2
-strictness,strictness,词,NOUN,B2
-strid,discord,不和,NOUN,B2
-strid,this battle,此战,NOUN,B2
-stride (noun),stride,词,NOUN,C1
-strident,strident,刺耳的,ADJ,B2
-strife,strife,词,NOUN,B2
-strike-related,strike-related,词,ADJ,C1
-strikebreaker,strikebreaker,词,NOUN,C1
-striking,striking,惊人的,ADJ,B2
-strikt,strict,严格的,ADJ,B2
-string instruments,string instruments,词,NOUN,C1
-string music,string music,词,NOUN,C1
-stringent,stringent,词,ADJ,C1
-stripe,stripe,条纹,NOUN,B2
-striped,striped,有条纹的,ADJ,B2
-stripping,stripping,词,ADJ,B2
-striving to be first and fearing to be last,striving to be first and fearing to be last,争先恐后,VERB,B2
-strong will,strong will,毅力,NOUN,C1
-strongest,strongest,词,NOUN,B2
-strosa,to stroll,散步,VERB,B2
-structural particle after verb,structural particle after verb,得,PART,A1
-structuralism,structuralism,词,NOUN,C1
-structuralist,structuralist,词,ADJ,C1
-structured,structured,词,ADJ,C1
-structuredness,structuredness,结构性,NOUN,B2
-structures,structures,词,NOUN,C1
-strukturell,structural,结构的,ADJ,B2
-struphuvud,larynx,喉,NOUN,B2
-sträng,string,细绳,NOUN,B2
-sträva,to work hard for sth to strive for success,争气,VERB,B2
-strålglans,radiance,光辉,NOUN,B2
-strö,to sprinkle,撒,VERB,B2
-ström,stream,溪流,NOUN,B2
-ström,surge,激增,NOUN,B2
-ström,torrent,激流,NOUN,B2
-stubbornness,stubbornness,固执,NOUN,B2
-studie,study,研究,NOUN,B2
-studio,studio,工作室,NOUN,B2
-studious,studious,词,ADJ,C1
-study tour,study tour,游学,NOUN,C1
-stuffed,stuffed,词,ADJ,B1
-stuffed crab,stuffed crab,蟹酿,NOUN,B2
-stuffy nose,stuffy nose,鼻塞,NOUN,C1
-stukning,sprain,扭伤,NOUN,B2
-stulen,to be stolen,失窃,VERB,B2
-stumble (noun),stumble,词,NOUN,C1
-stund,a while,一会儿,NOUN,B2
-stund,while,一会儿,NOUN,B2
-stunner,stunner,词,NOUN,B2
-stunt,stunt,词,NOUN,B2
-stupefaction,stupefaction,词,NOUN,C1
-stupefied,stupefied,词,ADJ,C1
-stupendous,stupendous,词,ADJ,C1
-stupid things,stupid things,蠢事,NOUN,B2
-stupor,stupor,昏迷,NOUN,B2
-stuttering,stuttering,词,NOUN,C1
-stuva,to stew,炖,VERB,B2
-stycke,classifier for paintings cloth etc.,幅,NUM,B2
-stygn,stitch,针脚,NOUN,B2
-stylist,stylist,词,NOUN,C1
-stylistics,stylistics,词,NOUN,C1
-stymie,stymie,词,VERB,C1
-styra,to govern,统治,VERB,B2
-styre,governance,治理,NOUN,B2
-styvmor,stepmother,后母,NOUN,B2
-städa,to clean up,清理,VERB,B2
-ställa in,to cancel,取消,VERB,B2
-ställa upp,to line up,排成一行,VERB,B2
-stänga,to close the door,关门,VERB,B2
-stänga av,to turn off,关闭,VERB,B2
-stängning,closure,关闭,NOUN,B2
-stå,to stand side by side,并列,VERB,B2
-stöna,to groan,呻吟,VERB,B2
-stöt,thrust,猛推,NOUN,B2
-stötta,to prop,撑,VERB,B2
-suave,suave,词,ADJ,C1
-sub-construction,sub-construction,分建,NOUN,C1
-sub-degree,sub-degree,分度,NOUN,C1
-sub-method,sub-method,分法,NOUN,B2
-sub-observation,sub-observation,分察,NOUN,C1
-sub-principle,sub-principle,分理,NOUN,C1
-sub-proof,sub-proof,分证,NOUN,C1
-sub-reality,sub-reality,分实,NOUN,B2
-sub-rule,sub-rule,分则,NOUN,C1
-sub-structure,sub-structure,分构,NOUN,C1
-sub-system,sub-system,分制,NOUN,C1
-sub-theory,sub-theory,分论,NOUN,C1
-subaltern,subaltern,词,NOUN,C1
-subcategory,subcategory,分目,NOUN,B2
-subcontracting,subcontracting,分包,NOUN,B2
-subdivision,subdivision,词,NOUN,B2
-subduing object,subduing object,克一物,NOUN,C1
-subject field,subject field,科目 / 领域,NOUN,B2
-subject matter,subject matter,题材,NOUN,C1
-subject to the law,subject to the law,受法律管辖的,ADJ,B2
-subjection,subjection,词,NOUN,B2
-subjectivism,subjectivism,词,NOUN,C1
-subjectivity,subjectivity,词,NOUN,B2
+snubbla,to stumble,绊倒,VERB,B2
+förbluffande,stunning,极好的,ADJ,B2
+robust,sturdy,坚固的,ADJ,B2
+stilfull,stylish,雅致的,ADJ,B2
+underkuva,to subdue,制服,VERB,B2
 subjektiv,subjective,主观的,ADJ,B2
-sublimation,sublimation,词,NOUN,C1
-sublime,sublime,崇高的,ADJ,B2
-subliminal,subliminal,词,ADJ,C1
-subliming,subliming,词,ADJ,C1
-sublimity,sublimity,词,NOUN,C1
-submissive,submissive,词,ADJ,C1
-submit bid,submit bid,投标,VERB,C1
-submit to,submit to,顺从,VERB,B2
-subordination,subordination,隶属,NOUN,C1
-subpoena,subpoena,词,NOUN,B2
-subsequently,subsequently,词,ADV,C1
-subservient,subservient,词,ADJ,C1
-subsidiarily,subsidiarily,词,ADV,C1
-subsidiarity,subsidiarity,辅助性原则,NOUN,B2
-substans,substance,物质,NOUN,B2
-substantially,substantially,词,ADV,B2
-substantive,substantive,实质性的,ADJ,B2
-substitute (verb),substitute,代换,VERB,C1
-substitute deputy,substitute deputy,词,NOUN,C1
-substitutes,substitutes,词,NOUN,C1
-substitution,substitution,词,NOUN,C1
-subterfuge,subterfuge,词,NOUN,C1
-subterranean,subterranean,词,ADJ,C1
-subtitles,subtitles,词,NOUN,A2
-subtitling,subtitling,词,NOUN,C1
-subtle,subtle,微妙的,ADJ,B2
-subtlety,subtlety,微妙,NOUN,B2
-subtly,subtly,词,ADV,C1
-suburban,suburban,词,ADJ,C1
-suburbs,suburbs,郊区,NOUN,B2
+underkuva,to subjugate,征服,VERB,B2
+sänka,to submerge,淹没,VERB,B2
+underkastelse,submission,顺从,NOUN,B2
+skicka,to submit,提交,VERB,B2
+underordnad,subordinate,下属,NOUN,B2
+prenumerant,subscriber,订阅者,NOUN,B2
+efterföljande,subsequent,随后的,ADJ,B2
+avta,to subside,平息,VERB,B2
+dotterbolag,subsidiary,子公司,NOUN,B2
 subventionera,to subsidize,资助,VERB,B2
-subversion,subversion,词,NOUN,C1
-subversive,subversive,词,ADJ,C1
-subvert,subvert,词,VERB,C1
+existensminimum,subsistence,生计,NOUN,B2
+substans,substance,物质,NOUN,B2
+väsentlig,substantial,大量的,ADJ,B2
+bevisning,substantiation,论证,NOUN,B2
+ersättare,substitute,替代品,NOUN,B2
+undertext,subtitle,字幕,NOUN,B2
 succession,succession,连续,NOUN,B2
-successive,successive,词,ADJ,C1
-successive generations,successive generations,历代,NOUN,B2
 successivt,successively,连续地,ADV,B2
-succinct,succinct,简明的,ADJ,B2
-succinctly,succinctly,简洁地,ADV,B2
-succor,succor,词,NOUN,C1
-succulent,succulent,词,ADJ,C1
-such (adj),such,样,ADJ,A1
-such a,such a,这样的,DET,B2
-such a thing,such a thing,词,PRON,B1
-sucka,sigh,叹息,NOUN,B2
-sucka,to sigh,叹气,VERB,B2
-sucka,to sigh with sorrow,感慨,VERB,B2
-sucking,sucking,嗦,NOUN,B2
-sudden braking,sudden braking,词,NOUN,C1
-sudden death,sudden death,暴毙,NOUN,C1
-sudden shower,sudden shower,词,NOUN,B1
-suddgummi,eraser,橡皮擦,NOUN,B2
-suffering (adj),suffering,词,ADJ,C1
-sufficient flight,sufficient flight,飞够,NOUN,B2
-sufficient matter,sufficient matter,事足,NOUN,C1
-sufficiently,sufficiently,词,ADV,C1
-suffocating,suffocating,词,ADJ,B2
-suffrage,suffrage,词,NOUN,C1
-suffuse,suffuse,词,VERB,C1
-sugarcane,sugarcane,甘蔗,NOUN,C1
-sugarcane juice,sugarcane juice,词,NOUN,C1
-suggestibility,suggestibility,词,NOUN,C1
-suggestiveness,suggestiveness,词,NOUN,C1
-suicidal,suicidal,自杀的,ADJ,B2
-sukuk,sukuk,词,NOUN,C1
-sukuk issuance,sukuk issuance,词,NOUN,C1
-sula,sole,鞋底,NOUN,B2
-sulfide,sulfide,词,NOUN,C1
-sulfur,sulfur,硫,NOUN,B2
-sulfuric,sulfuric,词,NOUN,B2
-sullen,sullen,词,ADJ,C1
-sullenness,sullenness,词,NOUN,C1
-sully,sully,词,VERB,C1
-sultan,sultan,苏丹,NOUN,B2
-sultanate,sultanate,苏丹国,NOUN,C1
-sultanic,sultanic,词,ADJ,C1
-sultriness,sultriness,词,NOUN,B2
-sultry,sultry,词,ADJ,C1
-sum total,sum total,总而,NOUN,B2
-summarily,summarily,草率地,ADV,B2
-summarization,summarization,词,NOUN,B2
-summarizing,summarizing,词,NOUN,C1
-summer camp,summer camp,夏令营,NOUN,B2
-summer grass,summer grass,夏草,NOUN,B2
-summer vacationers,summer vacationers,词,NOUN,B2
-summer visitor,summer visitor,暑期游客,NOUN,B2
-summery,summery,词,ADJ,C1
-sumptuousness,sumptuousness,词,NOUN,C1
-sun-protective,sun-protective,防晒,ADJ,C1
-sund,strait,海峡,NOUN,B2
-sundae,sundae,词,NOUN,C1
-sunder,sunder,词,VERB,C1
-sundhet,soundness,好端端,NOUN,B2
-sundown,sundown,日暮,NOUN,C1
-sundry,sundry,词,ADJ,C1
-sunflower,sunflower,向日葵,NOUN,B2
-sunflower seed,sunflower seed,葵花籽,NOUN,C1
-sunny day,sunny day,晴天,NOUN,C1
-suona,suona,唢呐,NOUN,C1
-super (adj),super,词,ADJ,A2
-super (adv),super,词,ADV,A1
-super-basis,super-basis,超据,NOUN,B2
-super-capacity,super-capacity,超容,NOUN,C1
-super-construction,super-construction,超建,NOUN,C1
-super-dimension,super-dimension,超度,NOUN,C1
-super-distinction,super-distinction,超殊,NOUN,B2
-super-even,super-even,超偶,NOUN,C1
-super-form,super-form,超形,NOUN,B2
-super-general,super-general,超般,NOUN,C1
-super-image,super-image,超象,NOUN,C1
-super-imagination,super-imagination,超想,NOUN,C1
-super-instrument,super-instrument,超具,NOUN,C1
-super-internal,super-internal,超内,NOUN,B2
-super-method,super-method,超法,NOUN,C1
-super-nature,super-nature,超性,NOUN,C1
-super-necessity,super-necessity,超必,NOUN,B2
-super-number,super-number,超数,NOUN,B2
-super-observation,super-observation,超察,NOUN,B2
-super-possibility,super-possibility,超可,NOUN,C1
-super-proof,super-proof,超证,NOUN,B2
-super-quantity,super-quantity,超量,NOUN,B2
-super-reality,super-reality,超实,NOUN,C1
-super-reason,super-reason,超理,NOUN,C1
-super-root,super-root,超本,NOUN,B2
-super-special,super-special,超特,NOUN,B2
-super-state,super-state,超态,NOUN,B2
-super-structure,super-structure,超构,NOUN,C1
-super-theory,super-theory,超论,NOUN,C1
-super-trend,super-trend,超势,NOUN,C1
-super-unity,super-unity,超一,NOUN,B2
-super-universal,super-universal,超普,NOUN,C1
-superannuated,superannuated,词,ADJ,C1
-superb,superb,极好的,ADJ,B2
-supercilious,supercilious,词,ADJ,C1
-superficiality,superficiality,词,NOUN,C1
-supergrad,super-grade,超级,NOUN,B2
-superintendent,superintendent,词,NOUN,C1
-superior (adj),superior,优越,ADJ,B2
-superior upper,superior upper,词,ADJ,C1
+efterträdare,successor,继任者,NOUN,B2
+duka under,to succumb,屈服,VERB,B2
+sådan,such,这样的,ADJ,B2
+plötslig,sudden,突然的,ADJ,B2
+lida av sömnlöshet,to suffer from insomnia,失眠,VERB,B2
+tillräcklig,sufficient,足够的,ADJ,B2
+kvävas,to suffocate,窒息,VERB,B2
+kvävning,suffocation,窒息,NOUN,B2
+förslag,suggestion,建议,NOUN,B2
+passa,to suit,适合,VERB,B2
+lämplighet,suitability,适宜性,NOUN,B2
+resväska,suitcase,手提箱,NOUN,B2
+sammanfattning,summary,摘要,NOUN,B2
+topp,summit,顶峰,NOUN,B2
+kalla,to summon,召唤,VERB,B2
+kallelse,summons,传票,NOUN,B2
+praktfull,sumptuous,奢华的,ADJ,B2
+solig,sunny,晴朗的,ADJ,B2
 superkomprehensiv,super-comprehensive,超遍,NOUN,B2
-superkvalitet,super-quality,超质,NOUN,B2
-superlative,superlative,词,ADJ,C1
-supernumerary,supernumerary,词,ADJ,C1
+supergrad,super-grade,超级,NOUN,B2
 superprincip,super-principle,超则,NOUN,B2
-supersede,supersede,词,VERB,C1
-superstitious,superstitious,迷信的,ADJ,B2
+superkvalitet,super-quality,超质,NOUN,B2
 supersystem,super-system,超制,NOUN,B2
 supertanke,super-thought,超思,NOUN,B2
-supine,supine,词,ADJ,C1
-supplant,supplant,词,VERB,C1
-supple,supple,词,ADJ,C1
-supplement extra charge,supplement extra charge,词,NOUN,C1
-supplication,supplication,恳求,NOUN,B2
-supply chain,supply chain,供应链,NOUN,C1
-supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
-supplying,supplying,词,NOUN,C1
-support medium,support medium,词,NOUN,C1
-support pillar,support pillar,词,NOUN,C1
-supported,supported,词,ADJ,B2
-supporter advocate,supporter advocate,词,NOUN,B1
-supporters,supporters,词,NOUN,B2
-supporting document,supporting document,证明文件,NOUN,B2
-supportive,supportive,团结的,ADJ,B2
-supposed to,supposed to,词,ADJ,B1
-supposition,supposition,词,NOUN,C1
-suppository,suppository,词,NOUN,C1
-suppressed grief,suppressed grief,压抑的悲伤,NOUN,C1
-suppression of us,suppression of us,压咱,NOUN,C1
-suppuration,suppuration,词,NOUN,C1
-supremacy,supremacy,霸权,NOUN,B2
-supreme,supreme,最高的,ADJ,B2
-supreme court,supreme court,最高法院,NOUN,C1
-supreme fate,supreme fate,上缘,NOUN,B2
-surcharge,surcharge,附加费,NOUN,B2
-surety bond,surety bond,词,NOUN,C1
-suretyship,suretyship,保证,NOUN,C1
-surfeit,surfeit,词,NOUN,C1
-surfing,surfing,冲浪,NOUN,B2
-surgical,surgical,外科的,ADJ,B2
-surging effusive,surging effusive,词,ADJ,C1
-surhet,acidity,酸度,NOUN,B2
-surly,surly,词,ADJ,C1
-surmise,surmise,词,VERB,C1
-surmount,surmount,词,VERB,C1
-surname Zhuang,surname Zhuang,姓庄,NOUN,C1
-surpassing,surpassing,可越,NOUN,C1
-surplus,surplus,过剩的,ADJ,B2
-surprise attack,surprise attack,偷袭,NOUN,C1
+ytlig,superficial,表面的,ADJ,B2
+överflödig,superfluous,多余的,ADJ,B2
+överordnad,superior,上级,NOUN,B2
+stormarknad,supermarket,超市,NOUN,B2
+vidskepelse,superstition,迷信,NOUN,B2
+tillsyn,supervision,监督,NOUN,B2
+tillägg,supplement,补充,NOUN,B2
+tillägg,to supplement,补充,VERB,B2
+tillhandahålla,to supply,供货,VERB,B2
+antaga,to suppose,假设,VERB,B2
+undertrycka,to suppress,压制,VERB,B2
+undertryckning,suppression,抑,NOUN,B2
+säker,sure,确定的,ADJ,B2
+ström,surge,激增,NOUN,B2
+operation,surgery,手术,NOUN,B2
+överträffa,to surpass,超过,VERB,B2
+överskott,surplus,过剩,NOUN,B2
 surrealism,surrealism,超现实主义,NOUN,B2
-surrender (noun),surrender,就交,NOUN,B2
-surreptitious,surreptitious,秘密的,ADJ,B2
-surreptitiously,surreptitiously,词,ADV,B2
-surrogate,surrogate,词,NOUN,C1
-surrounding,surrounding,词,ADJ,C1
-surrounding area,surrounding area,周边,NOUN,B2
-survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
-susceptible,susceptible,词,ADJ,C1
+överge,surrender,投降,NOUN,B2
+överge,to surrender,投降,VERB,B2
+omgivningar,surroundings,周围,NOUN,B2
+övervaka,to surveil,监视,VERB,B2
+undersökning,survey,调查,NOUN,B2
+mätare,surveyor,测量员,NOUN,B2
 susha,susha,夙砂大,NOUN,B2
-suspended,suspended,悬浮的,ADJ,B2
-suspended sentence,suspended sentence,缓刑,NOUN,C1
-suspicions,suspicions,词,NOUN,C1
-sustain,sustain,词,VERB,C1
-sustainability policy,sustainability policy,词,NOUN,C1
-svaja,to sway,摇摆,VERB,B2
-svamp,mushroom,蘑菇,NOUN,B2
-svan,swan,天鹅,NOUN,B2
-svarmaskin,answering machine,邮箱,NOUN,B2
-svart kåpa,black robe,黑衣,NOUN,B2
-svartmarknad,black market,黑市,NOUN,B2
-svelte,svelte,词,ADJ,C1
-svep,sweep,扫,NOUN,B2
-svetsning,welding,焊接,NOUN,B2
-svimmande,dizzy,头晕的,ADJ,B2
-svimning,dizziness,眩晕,NOUN,B2
-svimning,fainting,晕厥,NOUN,B2
-svindla,to swindle,诈骗,VERB,B2
-svullen,swollen,肿胀的,ADJ,B2
-svunnen,bygone,过去的,ADJ,B2
-svägerska,sister-in-law,嫂子/弟媳/大姑子/小姑子,NOUN,B2
-svält,hunger,饥饿,NOUN,B2
-sväng,swing,秋千,NOUN,B2
-svärdlöshet,swordless,剑不,NOUN,B2
-svärdsmann,swordsman,剑客,NOUN,B2
-svärta,to blacken,变黑,VERB,B2
-svår attack,difficult attack,难攻,NOUN,B2
-svårskild,hard to distinguish,难以区分,ADJ,B2
-svårt problem,difficult problem,难题,NOUN,B2
-svårtalad,hard to speak of,难以启齿,ADJ,B2
-svårupprätthållen,hard to maintain,难以维持,ADJ,B2
-svårvald,hard to choose,难以抉择,ADJ,B2
-swab,swab,词,NOUN,B2
-swagger (noun),swagger,词,NOUN,B2
-swap,swap,词,VERB,B2
-swarm,swarm,蜂群,NOUN,B2
-swarthy,swarthy,词,ADJ,C1
-sweater knitwear,sweater knitwear,词,NOUN,A1
-sweatshirt,sweatshirt,词,NOUN,C1
-sweepings,sweepings,扫出的垃圾,NOUN,B2
-sweet potato,sweet potato,红薯,NOUN,B2
-swelling,swelling,词,NOUN,B2
-swelter,swelter,词,VERB,C1
-swift,swift,词,ADJ,C1
-swiftness,swiftness,词,NOUN,C1
-swimmer,swimmer,词,NOUN,C1
-swimming,swimming,游泳,NOUN,B2
-swinging,swinging,swinging,NOUN,B2
-swirl,swirl,词,VERB,C1
-swiss,swiss,瑞士的,ADJ,B2
-switch key,switch key,词,NOUN,C1
-switchman,switchman,词,NOUN,C1
-sword entrustment,sword entrustment,剑就托,NOUN,C1
-sword placement,sword placement,剑放,NOUN,B2
-sword practice,sword practice,练刀练,NOUN,C1
-sword provocation,sword provocation,剑惹,NOUN,B2
-sword recognition,sword recognition,认剑,NOUN,B2
-sword return,sword return,来还剑,NOUN,C1
-sword strike,sword strike,看剑,NOUN,B2
-swordplay,swordplay,剑走,NOUN,B2
-swords,swords,刀剑,NOUN,C1
-swordsmanship,swordsmanship,剑术,NOUN,B2
+misstänkt,suspect,嫌疑人,NOUN,B2
+avbryta,to suspend,暂停,VERB,B2
+spänning,suspense,悬念,NOUN,B2
+avstängning,suspension,暂停,NOUN,B2
+hållbarhet,sustainability,可持续性,NOUN,B2
+hållbar,sustainable,可持续的,ADJ,B2
+föda,sustenance,食物,NOUN,B2
 sy,suture,缝合,NOUN,B2
 sy,to suture,缝合,VERB,B2
-sycophant,sycophant,词,NOUN,C1
-sycophantic,sycophantic,词,ADJ,B2
-sydarmé,southern army,南军,NOUN,B2
-syllabification,syllabification,词,NOUN,C1
-syllable,syllable,音节,NOUN,B2
-syllogism,syllogism,三段论,NOUN,B2
-symbiosis,symbiosis,词,NOUN,C1
-symbol,symbol,象征,NOUN,B2
-symbolic,symbolic,象征的,ADJ,B2
-symbolisera,to symbolize,象征,VERB,B2
-symbolism,symbolism,象征主义,NOUN,B2
-symbolization,symbolization,词,NOUN,C1
-symfoni,symphony,交响乐,NOUN,B2
-symmetri,symmetry,对称,NOUN,B2
-symmetric,symmetric,词,ADJ,C1
-symmetrical,symmetrical,对称的,ADJ,B2
-sympathetic,sympathetic,同情的,ADJ,B2
-sympatisera,to sympathize,同情,VERB,B2
-symphonic,symphonic,交响乐的,ADJ,B2
-symptom,symptom,症,PART,B2
-symptomatisk,symptomatic,症状的,ADJ,B2
-symptomatology,symptomatology,症状学,NOUN,B2
-symptoms,symptoms,词,NOUN,B1
-synaptic,synaptic,词,ADJ,C1
-synchronized,synchronized,词,ADJ,C1
-synchrony,synchrony,词,NOUN,C1
-syncopate,syncopate,词,VERB,C1
-syncretism,syncretism,词,NOUN,C1
-syndicate,syndicate,词,NOUN,C1
-syndrome,syndrome,综合征,NOUN,B2
-synecdoche,synecdoche,词,NOUN,C1
-syneresis,syneresis,词,NOUN,B2
-synergi,synergy,协同效应,NOUN,B2
-synkron,synchronous,同步的,ADJ,B2
-synkronisering,synchronization,同步,NOUN,B2
-synonym,synonym,词,NOUN,C1
-synonymi,synonymy,同义关系,NOUN,B2
-synopsis,synopsis,词,NOUN,C1
-synoptic,synoptic,概要的,ADJ,B2
-syntactic,syntactic,词,ADJ,C1
-syntax,syntax,句法,NOUN,B2
-syntetisera,to synthesize,合成,VERB,B2
-synthetic,synthetic,合成的,ADJ,B2
-synthetic fiber,synthetic fiber,化纤,NOUN,B2
-syra,acid,酸,NOUN,B2
-syrian,syrian,叙利亚的,ADJ,B2
-syrup,syrup,糖浆,NOUN,B2
-syskon,siblings,兄弟姐妹,NOUN,B2
-systematically,systematically,系统地,ADV,B2
-systematisk,systematic,系统的,ADJ,B2
-systemisk,systemic,全身性的,ADJ,B2
-systemless,systemless,无系统的,ADJ,B2
-säker,certain,确定的,ADJ,B2
-säker,sure,确定的,ADJ,B2
-säker,to be safe,安好,VERB,B2
-säkerhet,certainty,确定性,NOUN,B2
-säkerhetsvakt,security guard,保安,NOUN,B2
-säljare,seller,售货员,NOUN,B2
-sända,to broadcast,播出,VERB,B2
-sändning,broadcasting,广播,NOUN,B2
-sänka,to submerge,淹没,VERB,B2
-sär,to wound,使受伤,VERB,B2
-säsongsbetonad,seasonal,季节性的,ADJ,B2
-sätta sig,to sit down,坐下,VERB,B2
-så,so,所以,ADV,B2
-så,thus,因此,ADV,B2
-så,that way,那样,PRON,B2
-så,this way,这样,PRON,B2
-så,to be so,然,VERB,B2
-så,to sow,播种,VERB,B2
-så att,so that,以便,SCONJ,B2
-så kallad,so-called,所谓的,ADJ,B2
-så mycket,so much,这么多,ADV,B2
-sådan,such,这样的,ADJ,B2
-sådd,sowing,播种,NOUN,B2
-söka audiens,to seek audience,求见,VERB,B2
-söka sanningen i fakta,to seek truth from facts,实事求是,VERB,B2
-sökande,applicant,申请人,NOUN,B2
-sökande,quest,探索,NOUN,B2
-sömnighet,drowsiness,昏睡,NOUN,B2
-söndra,to fester,溃烂,VERB,B2
+svan,swan,天鹅,NOUN,B2
+svaja,to sway,摇摆,VERB,B2
+svep,sweep,扫,NOUN,B2
+sötma,sweet,糖果,NOUN,B2
 söt dröm,sweet dream,美梦,NOUN,B2
 söta,to sweeten,使变甜,VERB,B2
 sötis,sweetie,亲爱的,NOUN,B2
-sötma,sweet,糖果,NOUN,B2
-t-shirt,t-shirt,T 恤衫,NOUN,B2
-ta av sig,to take off,起飞,VERB,B2
-ta bort,to take away,拿走,VERB,B2
-ta emot beställningar,to receive orders,受命,VERB,B2
-ta hand om,to look after,照料,VERB,B2
-ta hand om,to take care of,照顾,VERB,B2
+godis,sweets,甜食,NOUN,B2
+simbassäng,swimming pool,游泳池,NOUN,B2
+svindla,to swindle,诈骗,VERB,B2
+sväng,swing,秋千,NOUN,B2
+växel,switch,开关,NOUN,B2
+växlingsal,switch room,配电室,NOUN,B2
+svullen,swollen,肿胀的,ADJ,B2
+svärdlöshet,swordless,剑不,NOUN,B2
+svärdsmann,swordsman,剑客,NOUN,B2
+smickeri,sycophancy,阿谀奉承,NOUN,B2
+symbol,symbol,象征,NOUN,B2
+symbolisera,to symbolize,象征,VERB,B2
+symmetri,symmetry,对称,NOUN,B2
+sympatisera,to sympathize,同情,VERB,B2
+symfoni,symphony,交响乐,NOUN,B2
+symptom,symptom,症,PART,B2
+symptomatisk,symptomatic,症状的,ADJ,B2
+synkronisering,synchronization,同步,NOUN,B2
+synkron,synchronous,同步的,ADJ,B2
+synergi,synergy,协同效应,NOUN,B2
+synonymi,synonymy,同义关系,NOUN,B2
+syntax,syntax,句法,NOUN,B2
+syntetisera,to synthesize,合成,VERB,B2
+syrup,syrup,糖浆,NOUN,B2
+systematisk,systematic,系统的,ADJ,B2
+systemisk,systemic,全身性的,ADJ,B2
+tabu,taboo,禁忌,NOUN,B2
+underförstådd,tacit,心照不宣的,ADJ,B2
+underförstått,tacitly,默不作声地,ADV,B2
+tyst,taciturn,沉默寡言的,ADJ,B2
+tackla,to tackle,处理,VERB,B2
+tactfull,tactful,圆滑的,ADJ,B2
+skräddare,tailor,裁缝,NOUN,B2
 ta ledigt,to take a leave of absence,休学,VERB,B2
 ta med,to take along,带走,VERB,B2
-ta på sig,to put on,穿上,VERB,B2
+ta bort,to take away,拿走,VERB,B2
+vara försiktig,to take care,照顾,VERB,B2
+ta hand om,to take care of,照顾,VERB,B2
 ta sticklingar,to take cuttings,扦插,VERB,B2
+ta av sig,to take off,起飞,VERB,B2
+träda in,to take office,就职,VERB,B2
 ta ut,to take out,拿出,VERB,B2
-tab,tab,词,NOUN,C1
-tabernacle,tabernacle,词,NOUN,C1
-table grape,table grape,提子,NOUN,B2
-table tennis,table tennis,乒乓球,NOUN,A2
-tableau,tableau,词,NOUN,C1
-tablecloth,tablecloth,词,NOUN,C1
-taboo (adj),taboo,词,ADJ,C1
-tabu,taboo,禁忌,NOUN,B2
-tachometer,tachometer,转速表,NOUN,B2
-tacitly accept,tacitly accept,默认,VERB,C1
-tack,thank you,谢谢,INTJ,B2
-tack,thanks,谢谢,NOUN,B2
-tack vare,thanks to,多亏,ADP,B2
-tackfest,appreciation banquet,答谢宴,NOUN,B2
-tackla,to tackle,处理,VERB,B2
-tackling,tackling,马具,NOUN,B2
-tacksam,to be grateful,感激,VERB,B2
-tacky,tacky,词,ADJ,B2
-tacky thing,tacky thing,俗气的事,NOUN,B2
-tact,tact,词,NOUN,C1
-tactful appeasement,tactful appeasement,词,NOUN,C1
-tactfull,tactful,圆滑的,ADJ,B2
-tactical,tactical,词,ADJ,C1
-tactician,tactician,词,NOUN,C1
-tactile,tactile,词,ADJ,C1
-tactile paving,tactile paving,盲道,NOUN,B2
-tactless,tactless,不得体的,ADJ,B2
-taekwondo,taekwondo,跆拳道,NOUN,B2
-tag (noun),tag,词,NOUN,B2
-taillight,taillight,尾灯,NOUN,B2
-tak,ceiling,天花板,NOUN,B2
-take a bribe,take a bribe,受贿,VERB,C1
-take a look,take a look,瞧一瞧,NOUN,C1
-take a photo,take a photo,照相,VERB,B2
-take a stand,take a stand,表态,VERB,C1
-take advantage of Feng,take advantage of Feng,趁凤,NOUN,C1
-take an x-ray,take an x-ray,拍片,VERB,C1
-take medicine,take medicine,服药,VERB,C1
-take refuge,take refuge,避难,VERB,C1
-taken,taken,词,ADJ,C1
-taken away,taken away,拿去,NOUN,C1
-takeover,takeover,词,NOUN,C1
-taking command,taking command,挂帅,NOUN,B2
-tale,tale,词,NOUN,A1
-talented,talented,有才华的,ADJ,B2
-talesperson,spokesperson,发言人,NOUN,B2
-talisman,talisman,词,NOUN,B2
-talk show,talk show,脱口秀,NOUN,C1
-talked,talked,词,ADJ,C1
-talks,talks,会谈,NOUN,C1
-tall,pine,松树,NOUN,B2
-tall and slender,tall and slender,词,ADJ,C1
-tallrik,dish,盘子,NOUN,B2
-tally,tally,词,VERB,C1
+start,takeoff,起飞,NOUN,B2
+prata nonsens,to talk nonsense,胡言乱语,VERB,B2
+pratsam,talkative,健谈的,ADJ,B2
+pratsamhet,talkativeness,多嘴,NOUN,B2
+lång,tall,高的,ADJ,B2
 tam,to tame,驯服,VERB,B2
-tamable,tamable,词,ADJ,C1
-tambourine,tambourine,词,NOUN,B2
-tame (adj),tame,词,ADJ,A1
-taming,taming,词,NOUN,C1
-tamper,tamper,词,VERB,C1
-tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
-tandkräm,toothpaste,牙膏,NOUN,B2
-tandkött,gum,牙龈,NOUN,B2
-tandvärk,toothache,牙痛,NOUN,B2
+solbränna,to tan,晒黑,VERB,B2
 tangent,tangent,切线,NOUN,B2
-tangentbord,keyboard,键盘,NOUN,B2
-tangential,tangential,词,ADJ,C1
-tangerine,tangerine,桔子,NOUN,B1
-tangibility,tangibility,词,NOUN,C1
-tangible benefit,tangible benefit,实惠,NOUN,C1
-tank cistern,tank cistern,词,NOUN,C1
-tanka,to conceive,构想,VERB,B2
-tanke,single thought,一念,NOUN,B2
-tanned,tanned,词,ADJ,B2
-tannery,tannery,词,NOUN,B2
-tantamount,tantamount,词,ADJ,C1
-tantrum,tantrum,词,NOUN,C1
-tap,tap,水龙头,NOUN,B2
-tape,tape,词,NOUN,A2
-tapestry,tapestry,词,NOUN,C1
-tapper,valiant,英勇的,ADJ,B2
-tapperhet,valor,勇气,NOUN,B2
-tarab,tarab,词,NOUN,B2
-target group,target group,词,NOUN,C1
-targeted,targeted,有针对性的,ADJ,B2
-targeted therapy,targeted therapy,靶向治疗,NOUN,C1
-taro,taro,芋头,NOUN,B2
-tarragon,tarragon,龙蒿,NOUN,B2
-tarry,tarry,词,VERB,C1
-tart pie,tart pie,词,NOUN,C1
-tasteless,tasteless,无味的,ADJ,B2
-tasting,tasting,词,NOUN,C1
-tasty delicious,tasty delicious,好吃,ADJ,B2
-tasty delightful,tasty delightful,词,ADJ,C1
-tatter,tatter,词,NOUN,C1
-tautology,tautology,词,NOUN,C1
-tavla,blackboard,黑板,NOUN,B2
-tawdry,tawdry,词,ADJ,C1
-tax (adj),tax,词,ADJ,C1
-tax authorities,tax authorities,税务机关,NOUN,B2
-tax duty,tax duty,词,NOUN,C1
-tax evasion,tax evasion,逃税,NOUN,B2
-tax exemption,tax exemption,免税,NOUN,B2
-tax rate,tax rate,税率,NOUN,B2
-tax relief,tax relief,词,NOUN,C1
-tax revenue,tax revenue,税收,NOUN,B2
-taxa,rate,比率,NOUN,B2
-taxable,taxable,应纳税的,ADJ,B2
+kännbar,tangible,有形的,ADJ,B2
+garvare,tanner,制革工,NOUN,B2
+garvning,tanning,晒黑,NOUN,B2
+rikta,to target,针对,VERB,B2
+målning,targeting,定位,NOUN,B2
+smakpreferens,taste preference,口味,NOUN,B2
+spänd,taut,绷紧的,ADJ,B2
+krog,tavern,酒馆,NOUN,B2
+beskatta,to tax,征税,VERB,B2
+skattefri,tax-exempt,免税,ADJ,B2
 taxi,taxi,出租车,NOUN,B2
-taxi driver,taxi driver,词,NOUN,C1
-taxi ride,taxi ride,词,NOUN,A2
-taxonomy,taxonomy,分类学,NOUN,B2
-taxpayer,taxpayer,纳税人,NOUN,B2
-tea bar,tea bar,茶吧,NOUN,C1
-tea party,tea party,茶话会,NOUN,B2
-teacher female,teacher female,词,NOUN,B2
-teacher training,teacher training,师范,NOUN,C1
-teaching,teaching,教学的,ADJ,B2
-teaching material,teaching material,教材,NOUN,B1
-team leader,team leader,领队,NOUN,C1
-team member,team member,队员,NOUN,C1
-teapot,teapot,词,NOUN,C1
-tearing,tearing,tearing,NOUN,B2
-teasing playful,teasing playful,词,ADJ,C1
-teaterpjäs,stage play,舞台剧,NOUN,B2
-technocrat,technocrat,词,NOUN,C1
-technocratic,technocratic,技术官僚的,ADJ,B2
-tecken,character word,字,NOUN,B2
-tectonic,tectonic,词,ADJ,C1
-teddy bear,teddy bear,词,NOUN,B2
-tedious painful,tedious painful,词,ADJ,B2
-tedium,tedium,词,NOUN,C1
-teem,teem,词,VERB,C1
-teeter,teeter,词,VERB,C1
-teeth,teeth,词,NOUN,A1
-teething,teething,词,NOUN,B1
-teetotal,teetotal,词,ADJ,C1
-tegel,brick,砖,NOUN,B2
+teplantage,tea plantation,茶园,NOUN,B2
+lagkamrat,teammate,队友,NOUN,B2
+tåra,to tear,撕碎,VERB,B2
+riv upp,to tear up,流泪,VERB,B2
 teknik,technique,技巧,NOUN,B2
 teknokrati,technocracy,技术官僚主义,NOUN,B2
 teknologisk,technological,技术的,ADJ,B2
-telecommunications,telecommunications,词,NOUN,C1
-telefon,telephone,电话,NOUN,B2
-telegram,telegram,电报,NOUN,B2
-telegraph lightning,telegraph lightning,词,NOUN,C1
+tråkig,tedious,乏味的,ADJ,B2
 teleologi,teleology,目的论,NOUN,B2
-teleological,teleological,目的论的,ADJ,B2
-telepathy,telepathy,词,NOUN,C1
-telephone number,telephone number,电话号码,NOUN,B2
-telephone ringing,telephone ringing,词,NOUN,C1
-telephones,telephones,电话,NOUN,B2
-telephony,telephony,电话学,NOUN,B2
+telefon,telephone,电话,NOUN,B2
 teleskop,telescope,望远镜,NOUN,B2
-televised,televised,电视播出的,ADJ,B2
 television,television,电视,NOUN,B2
-television set,television set,词,NOUN,B1
-teller,teller,词,NOUN,B2
-telling-off,telling-off,词,NOUN,B1
-telltale,telltale,词,ADJ,C1
-tema,theme,主题,NOUN,B2
-temerity,temerity,鲁莽,NOUN,B2
-temperament dispositions,temperament dispositions,词,NOUN,C1
-temperamental,temperamental,词,ADJ,C1
-temperance,temperance,词,NOUN,C1
-temperate,temperate,词,ADJ,C1
-temperature gauge,temperature gauge,温度表,NOUN,C1
-tempest,tempest,词,NOUN,C1
-tempestuous,tempestuous,词,ADJ,C1
-template,template,词,NOUN,C1
-tempomakare,pace-setter,标兵,NOUN,B2
+humör,temper,脾气,NOUN,B2
 temporal,temporal,时间的,ADJ,B2
-temporal (noun),temporal,词,NOUN,B2
-temporality,temporality,时间性,NOUN,C1
-temptation,temptation,词,NOUN,B2
-ten (noun),ten,词,NOUN,B2
-ten million,ten million,千万,NUM,B2
-ten reishi,ten reishi,灵芝十株,NOUN,C1
-ten thousand (noun),ten thousand,你万,NOUN,C1
-ten thousand (num),ten thousand,万,NUM,A1
-ten thousand years,ten thousand years,万年,NOUN,B2
-tenable,tenable,词,ADJ,C1
-tenacity,tenacity,坚韧,NOUN,B2
-tend,tend,词,VERB,B2
+tillfällig vägran,temporary refusal,暂不,NOUN,B2
+envetna,tenacious,顽强的,ADJ,B2
+hyresgäst,tenant,租户,NOUN,B2
 tendens,tendency,趋势,NOUN,B2
-tender (noun),tender,词,NOUN,C1
-tender affection,tender affection,词,NOUN,C1
-tender mercy,tender mercy,词,NOUN,C1
-tender-hearted,tender-hearted,词,ADJ,C1
-tendering,tendering,招标,NOUN,B2
-tendering meeting,tendering meeting,招标会,NOUN,B2
+partisk,tendentious,有偏见的,ADJ,B2
 tenderloin,tenderloin,里脊,NOUN,B2
-tenement,tenement,词,NOUN,C1
-tenet,tenet,词,NOUN,C1
-tenn,tin,锡,NOUN,B2
+kärlek,tenderness,柔情,NOUN,B2
+sena,tendon,肌腱,NOUN,B2
 tennis,tennis,网球,NOUN,B2
-tenor,tenor,男高音,NOUN,B2
-tens,tens,词,NOUN,B2
-tens of thousands,tens of thousands,数万,NUM,B2
-tense (noun),tense,词,NOUN,B1
-tense angry,tense angry,词,ADJ,A2
-tense excited,tense excited,词,ADJ,B2
-tensile,tensile,词,ADJ,C1
 tentativ,tentative,暂定的,ADJ,B2
-tenth (noun),tenth,词,NOUN,B2
-tentor,past exam papers,真题,NOUN,B2
-tenuous,tenuous,词,ADJ,C1
-tenure,tenure,词,NOUN,B2
-teokrati,theocracy,神权政治,NOUN,B2
-teologi,theology,神学,NOUN,B2
-teoretisk,theoretical,理论的,ADJ,B2
-teoretiskt,theoretically,理论上,ADV,B2
-tepid,tepid,词,ADJ,C1
-teplantage,tea plantation,茶园,NOUN,B2
-terapeutisk,therapeutic,治疗的,ADJ,B2
-teratogenic,teratogenic,致畸的,ADJ,B2
-term of office,term of office,词,NOUN,C1
-term transition,term transition,换届,NOUN,C1
-termin,semester,学期,NOUN,B2
 terminal,terminal,终点站,NOUN,B2
-terminal (adj),terminal,终末的,ADJ,B2
-terminologi,terminology,术语,NOUN,B2
+avsluta,to terminate,终止,VERB,B2
+avslutning,termination,解除,NOUN,B2
 terminologisk,terminological,术语的,ADJ,B2
-termisk,thermal,热的,ADJ,B2
-terrace,terrace,露台,NOUN,B2
-terrifying terrible,terrifying terrible,恐怖,ADJ,B1
+terminologi,terminology,术语,NOUN,B2
+terräng,terrain,地形,NOUN,B2
+jordisk,terrestrial,地球的,ADJ,B2
+skrämma,to terrify,使恐惧,VERB,B2
+skräckinjagande,terrifying,令人恐惧的,ADJ,B2
 territorial,territorial,领土的,ADJ,B2
-territoriality,territoriality,词,NOUN,C1
-territory expansion,territory expansion,开疆,NOUN,B2
 terror,terror,恐怖,NOUN,B2
 terrorism,terrorism,恐怖主义,NOUN,B2
 terrorist,terrorist,恐怖分子,NOUN,B2
-terrorist (adj),terrorist,词,ADJ,C1
-terräng,terrain,地形,NOUN,B2
-terrängbil,off-road vehicle,越野车,NOUN,B2
-terse,terse,简练的,ADJ,B2
-terseness,terseness,词,NOUN,C1
-tertiary,tertiary,第三的,ADJ,B2
-test of courage,test of courage,勇气测试,NOUN,B2
-test tube,test tube,词,NOUN,C1
-testamentary substitution,testamentary substitution,词,NOUN,C1
-testamentsförvaltare,executor,遗嘱执行人,NOUN,B2
-testator,testator,词,NOUN,C1
-testicular,testicular,词,ADJ,C1
 testikel,testicle,睾丸,NOUN,B2
-testimony deposition,testimony deposition,词,NOUN,C1
-tether,tether,词,NOUN,C1
+lärobok,textbook,教科书,NOUN,B2
 textil,textile,纺织,NOUN,B2
-textuality,textuality,词,NOUN,C1
 textuell,textual,文本的,ADJ,B2
-texture,texture,词,NOUN,C1
-than (adv),than,词,ADV,A1
-thanks (noun),thanks,谢了,NOUN,A1
-thanks a lot,thanks a lot,多谢,INTJ,B2
-thanks sir,thanks sir,谢过大人,NOUN,C1
-tharid,tharid,词,NOUN,B2
-that,that,（引导从句）,SCONJ,B2
-that (det),that,那个,DET,A2
-that (noun),that,将那,NOUN,C1
-that cliff,that cliff,那山崖,NOUN,C1
-that conjunction,that conjunction,词,SCONJ,A2
-that day,that day,那日,NOUN,B2
-that evening,that evening,当晚,NOUN,B2
-that feminine,that feminine,词,DET,A1
-that is (sconj),that is,就是,SCONJ,B2
-that is (verb),that is,便是,VERB,B2
-that is good,that is good,那就好,NOUN,C1
-that is to say,that is to say,也就是说,SCONJ,B2
-that is to say (cconj),that is to say,即,CCONJ,C1
-that little bit,that little bit,那点,NOUN,C1
-that masculine,that masculine,词,DET,A1
-that nephew,that nephew,那侄儿,NOUN,B2
-that neutral over there,that neutral over there,词,PRON,B1
-that night,that night,那晚,NOUN,B2
-that one,that one,那个,PRON,B2
-that pair,that pair,那付,NOUN,B2
-that place,that place,在那,NOUN,B2
-that stretch,that stretch,那片,NOUN,B2
-that sword,that sword,那剑,NOUN,C1
-that time,that time,那时,NOUN,C1
-that which,that which,所,PART,B2
-that yonder,that yonder,那个,DET,B2
-the Abbewegung,the Abbewegung,词,NOUN,C1
-the Abbildung,the Abbildung,词,NOUN,C1
-the Abbruch,the Abbruch,词,NOUN,C1
-the Abend,the Abend,词,NOUN,C1
-the Abendessen,the Abendessen,词,NOUN,C1
-the Abendrot,the Abendrot,词,NOUN,C1
-the Abenteuer,the Abenteuer,词,NOUN,C1
-the Aber,the Aber,词,NOUN,C1
-the Aberweiterung,the Aberweiterung,词,NOUN,C1
-the Abfahrt,the Abfahrt,词,NOUN,C1
-the Abfall,the Abfall,词,NOUN,C1
-the Abflug,the Abflug,词,NOUN,C1
-the Abform,the Abform,词,NOUN,C1
-the Abgabe,the Abgabe,词,NOUN,C1
-the Abhalt,the Abhalt,词,NOUN,C1
-the Abkehr,the Abkehr,词,NOUN,C1
-the Abkopplung,the Abkopplung,词,NOUN,C1
-the Ablauf,the Ablauf,词,NOUN,C1
-the Ablehnung,the Ablehnung,词,NOUN,C1
-the Ableitung,the Ableitung,词,NOUN,C1
-the Ablesung,the Ablesung,词,NOUN,C1
-the Abmacht,the Abmacht,词,NOUN,C1
-the Abmachung,the Abmachung,词,NOUN,C1
-the Abminderung,the Abminderung,词,NOUN,C1
-the Abmischung,the Abmischung,词,NOUN,C1
-the Abnahme,the Abnahme,词,NOUN,C1
-the Abneigung,the Abneigung,词,NOUN,C1
-the Abrechnung,the Abrechnung,词,NOUN,C1
-the Absammlung,the Absammlung,词,NOUN,C1
-the Abschied,the Abschied,词,NOUN,C1
-the Abschluss,the Abschluss,词,NOUN,C1
-the Absicht,the Absicht,词,NOUN,C1
-the Absolvent,the Absolvent,词,NOUN,C1
-the Abstammung,the Abstammung,词,NOUN,C1
-the Abstand,the Abstand,词,NOUN,C1
-the Abstellung,the Abstellung,词,NOUN,C1
-the Abstieg,the Abstieg,词,NOUN,C1
-the Abstrich,the Abstrich,词,NOUN,C1
-the Absturz,the Absturz,词,NOUN,C1
-the Abteilung,the Abteilung,词,NOUN,C1
-the Abtreibung,the Abtreibung,词,NOUN,C1
-the Abverbesserung,the Abverbesserung,词,NOUN,C1
-the Abvereinfachung,the Abvereinfachung,词,NOUN,C1
-the Abvertiefung,the Abvertiefung,词,NOUN,C1
-the Abwanderung,the Abwanderung,词,NOUN,C1
-the Abwandlung,the Abwandlung,词,NOUN,C1
-the Abwehr,the Abwehr,词,NOUN,C1
-the Abwendung,the Abwendung,词,NOUN,C1
-the Abwerk,the Abwerk,词,NOUN,C1
-the Abwertung,the Abwertung,词,NOUN,C1
-the Abzahlung,the Abzahlung,词,NOUN,C1
-the Abzweigung,the Abzweigung,词,NOUN,C1
-the Achtung,the Achtung,词,NOUN,C1
-the Acker,the Acker,词,NOUN,C1
-the Adel,the Adel,词,NOUN,C1
-the Adelsitz,the Adelsitz,词,NOUN,C1
-the Adelstitel,the Adelstitel,词,NOUN,C1
-the Adern,the Adern,词,NOUN,C1
-the Adler,the Adler,词,NOUN,C1
-the Admiral,the Admiral,词,NOUN,C1
-the Adresse,the Adresse,词,NOUN,C1
-the Advokat,the Advokat,词,NOUN,C1
-the Affe,the Affe,词,NOUN,C1
-the Affekt,the Affekt,词,NOUN,C1
-the Aggression,the Aggression,词,NOUN,C1
-the Agrar,the Agrar,词,NOUN,C1
-the Ahne,the Ahne,词,NOUN,C1
-the Ahnen,the Ahnen,词,NOUN,C1
-the Akrobat,the Akrobat,词,NOUN,C1
-the Akt,the Akt,词,NOUN,C1
-the Akteur,the Akteur,词,NOUN,C1
-the Aktie,the Aktie,词,NOUN,C1
-the Akzent,the Akzent,词,NOUN,C1
-the Alchimie,the Alchimie,词,NOUN,C1
-the Algebra,the Algebra,词,NOUN,C1
-the Algorithmus,the Algorithmus,词,NOUN,C1
-the Alleinherrschaft,the Alleinherrschaft,词,NOUN,C1
-the Allergie,the Allergie,词,NOUN,C1
-the Allmende,the Allmende,词,NOUN,C1
-the Almanach,the Almanach,词,NOUN,C1
-the Almosen,the Almosen,词,NOUN,C1
-the Alp,the Alp,词,NOUN,C1
-the Alpdruck,the Alpdruck,词,NOUN,C1
-the Alter,the Alter,词,NOUN,C1
-the Altmetall,the Altmetall,词,NOUN,C1
-the Altpapier,the Altpapier,词,NOUN,C1
-the Aluminium,the Aluminium,词,NOUN,C1
-the Amateur,the Amateur,词,NOUN,C1
-the Ameise,the Ameise,词,NOUN,C1
-the Amme,the Amme,词,NOUN,C1
-the Amtes,the Amtes,词,NOUN,C1
-the Amtszeit,the Amtszeit,词,NOUN,C1
-the Anbau,the Anbau,词,NOUN,C1
-the Anbewegung,the Anbewegung,词,NOUN,C1
-the Anbiederung,the Anbiederung,词,NOUN,C1
-the Anbildung,the Anbildung,词,NOUN,C1
-the Anbindng,the Anbindng,词,NOUN,C1
-the Anbohrung,the Anbohrung,词,NOUN,C1
-the Anerweiterung,the Anerweiterung,词,NOUN,C1
-the Anfall,the Anfall,词,NOUN,C1
-the Anfang,the Anfang,词,NOUN,C1
-the Anflug,the Anflug,词,NOUN,C1
-the Anfrage,the Anfrage,词,NOUN,C1
-the Angebot,the Angebot,词,NOUN,C1
-the Angeklagte,the Angeklagte,词,NOUN,C1
-the Angelpunkt,the Angelpunkt,词,NOUN,C1
-the Angestellte,the Angestellte,词,NOUN,C1
-the Angleichung,the Angleichung,词,NOUN,C1
-the Anhalt,the Anhalt,词,NOUN,C1
-the Anhandlung,the Anhandlung,词,NOUN,C1
-the Ankraft,the Ankraft,词,NOUN,C1
-the Ankunft,the Ankunft,词,NOUN,C1
-the Anlage,the Anlage,词,NOUN,C1
-the Anleitung,the Anleitung,词,NOUN,C1
-the Anliegen,the Anliegen,词,NOUN,C1
-the Anmacht,the Anmacht,词,NOUN,C1
-the Anmerkung,the Anmerkung,词,NOUN,C1
-the Anmessung,the Anmessung,词,NOUN,C1
-the Anminderung,the Anminderung,词,NOUN,C1
-the Anmischung,the Anmischung,词,NOUN,C1
-the Anrechnung,the Anrechnung,词,NOUN,C1
-the Anruf,the Anruf,词,NOUN,C1
-the Ansammlung,the Ansammlung,词,NOUN,C1
-the Anschein,the Anschein,词,NOUN,C1
-the Anspruch,the Anspruch,词,NOUN,C1
-the Anstalt,the Anstalt,词,NOUN,C1
-the Ansteigerung,the Ansteigerung,词,NOUN,C1
-the Anstieg,the Anstieg,词,NOUN,C1
-the Anstoff,the Anstoff,词,NOUN,C1
-the Antenne,the Antenne,词,NOUN,C1
-the Anthropologie,the Anthropologie,词,NOUN,C1
-the Antibiotikum,the Antibiotikum,词,NOUN,C1
-the Anverbesserung,the Anverbesserung,词,NOUN,C1
-the Anvertiefung,the Anvertiefung,词,NOUN,C1
-the Anverwandte,the Anverwandte,词,NOUN,C1
-the Anwandlung,the Anwandlung,词,NOUN,C1
-the Anwendung,the Anwendung,词,NOUN,C1
-the Anwert,the Anwert,词,NOUN,C1
-the Aufbildung,the Aufbildung,词,NOUN,C1
-the Aufbindung,the Aufbindung,词,NOUN,C1
-the Auferweiterung,the Auferweiterung,词,NOUN,C1
-the Aufform,the Aufform,词,NOUN,C1
-the Aufhandlung,the Aufhandlung,词,NOUN,C1
-the Aufkraft,the Aufkraft,词,NOUN,C1
-the Aufmacht,the Aufmacht,词,NOUN,C1
-the Aufmessung,the Aufmessung,词,NOUN,C1
-the Aufminderung,the Aufminderung,词,NOUN,C1
-the Aufmischung,the Aufmischung,词,NOUN,C1
-the Aufrechnung,the Aufrechnung,词,NOUN,C1
-the Aufsammlung,the Aufsammlung,词,NOUN,C1
-the Aufsteigerung,the Aufsteigerung,词,NOUN,C1
-the Aufstellung,the Aufstellung,词,NOUN,C1
-the Aufverbesserung,the Aufverbesserung,词,NOUN,C1
-the Aufvereinfachung,the Aufvereinfachung,词,NOUN,C1
-the Aufvertiefung,the Aufvertiefung,词,NOUN,C1
-the Aufwerk,the Aufwerk,词,NOUN,C1
-the Ausbewegung,the Ausbewegung,词,NOUN,C1
-the Ausbindung,the Ausbindung,词,NOUN,C1
-the Ausform,the Ausform,词,NOUN,C1
-the Ausheilung,the Ausheilung,词,NOUN,C1
-the Auskraft,the Auskraft,词,NOUN,C1
-the Ausmacht,the Ausmacht,词,NOUN,C1
-the Ausmessung,the Ausmessung,词,NOUN,C1
-the Ausminderung,the Ausminderung,词,NOUN,C1
-the Ausmischung,the Ausmischung,词,NOUN,C1
-the Ausordnung,the Ausordnung,词,NOUN,C1
-the Ausrechnung,the Ausrechnung,词,NOUN,C1
-the Aussammlung,the Aussammlung,词,NOUN,C1
-the Aussteigerung,the Aussteigerung,词,NOUN,C1
-the Ausstoff,the Ausstoff,词,NOUN,C1
-the Ausverbesserung,the Ausverbesserung,词,NOUN,C1
-the Ausvereinfachung,the Ausvereinfachung,词,NOUN,C1
-the Auswandlung,the Auswandlung,词,NOUN,C1
-the Auswerk,the Auswerk,词,NOUN,C1
-the Auswert,the Auswert,词,NOUN,C1
-the Bebewegung,the Bebewegung,词,NOUN,C1
-the Bebildung,the Bebildung,词,NOUN,C1
-the Bebindung,the Bebindung,词,NOUN,C1
-the Beform,the Beform,词,NOUN,C1
-the Behandlung,the Behandlung,词,NOUN,C1
-the Beheilung,the Beheilung,词,NOUN,C1
-the Bemacht,the Bemacht,词,NOUN,C1
-the Bemischung,the Bemischung,词,NOUN,C1
-the Besammlung,the Besammlung,词,NOUN,C1
-the Besteigerung,the Besteigerung,词,NOUN,C1
-the Bestoff,the Bestoff,词,NOUN,C1
-the Beverbesserung,the Beverbesserung,词,NOUN,C1
-the Bewandlung,the Bewandlung,词,NOUN,C1
-the Bewerk,the Bewerk,词,NOUN,C1
-the Bewert,the Bewert,词,NOUN,C1
-the Earth,the Earth,地球,NOUN,A2
-the Einbewegung,the Einbewegung,词,NOUN,C1
-the Einbildung,the Einbildung,词,NOUN,C1
-the Einbindung,the Einbindung,词,NOUN,C1
-the Einerweiterung,the Einerweiterung,词,NOUN,C1
-the Einform,the Einform,词,NOUN,C1
-the Einhandlung,the Einhandlung,词,NOUN,C1
-the Einheilung,the Einheilung,词,NOUN,C1
-the Einkraft,the Einkraft,词,NOUN,C1
-the Einmacht,the Einmacht,词,NOUN,C1
-the Einminderung,the Einminderung,词,NOUN,C1
-the Einmischung,the Einmischung,词,NOUN,C1
-the Einordnung,the Einordnung,词,NOUN,C1
-the Einrechnung,the Einrechnung,词,NOUN,C1
-the Einsammlung,the Einsammlung,词,NOUN,C1
-the Einsteigerung,the Einsteigerung,词,NOUN,C1
-the Einstellung,the Einstellung,词,NOUN,C1
-the Einstoff,the Einstoff,词,NOUN,C1
-the Einverbesserung,the Einverbesserung,词,NOUN,C1
-the Einvereinfachung,the Einvereinfachung,词,NOUN,C1
-the Einvertiefung,the Einvertiefung,词,NOUN,C1
-the Einwandlung,the Einwandlung,词,NOUN,C1
-the Einwendung,the Einwendung,词,NOUN,C1
-the Einwert,the Einwert,词,NOUN,C1
-the Erbewegung,the Erbewegung,词,NOUN,C1
-the Erbildung,the Erbildung,词,NOUN,C1
-the Erbindung,the Erbindung,词,NOUN,C1
-the Erform,the Erform,词,NOUN,C1
-the Erhandlung,the Erhandlung,词,NOUN,C1
-the Erheilung,the Erheilung,词,NOUN,C1
-the Erkraft,the Erkraft,词,NOUN,C1
-the Ermacht,the Ermacht,词,NOUN,C1
-the Ermessung,the Ermessung,词,NOUN,C1
-the Erminderung,the Erminderung,词,NOUN,C1
-the Ermischung,the Ermischung,词,NOUN,C1
-the Erordnung,the Erordnung,词,NOUN,C1
-the Errechnung,the Errechnung,词,NOUN,C1
-the Ersammlung,the Ersammlung,词,NOUN,C1
-the Ersteigerung,the Ersteigerung,词,NOUN,C1
-the Erstellung,the Erstellung,词,NOUN,C1
-the Erstoff,the Erstoff,词,NOUN,C1
-the Erverbesserung,the Erverbesserung,词,NOUN,C1
-the Ervertiefung,the Ervertiefung,词,NOUN,C1
-the Erwandlung,the Erwandlung,词,NOUN,C1
-the Erwerk,the Erwerk,词,NOUN,C1
-the Erwert,the Erwert,词,NOUN,C1
-the Erzbewegung,the Erzbewegung,词,NOUN,C1
-the Erzbildung,the Erzbildung,词,NOUN,C1
-the Erzbindung,the Erzbindung,词,NOUN,C1
-the Erzform,the Erzform,词,NOUN,C1
-the Erzhandlung,the Erzhandlung,词,NOUN,C1
-the Erzleitung,the Erzleitung,词,NOUN,C1
-the Erzmacht,the Erzmacht,词,NOUN,C1
-the Erzmessung,the Erzmessung,词,NOUN,C1
-the Erzminderung,the Erzminderung,词,NOUN,C1
-the Erzordnung,the Erzordnung,词,NOUN,C1
-the Erzrechnung,the Erzrechnung,词,NOUN,C1
-the Erzsammlung,the Erzsammlung,词,NOUN,C1
-the Erzstellung,the Erzstellung,词,NOUN,C1
-the Erzstoff,the Erzstoff,词,NOUN,C1
-the Erzverbesserung,the Erzverbesserung,词,NOUN,C1
-the Erzvereinfachung,the Erzvereinfachung,词,NOUN,C1
-the Erzwandlung,the Erzwandlung,词,NOUN,C1
-the Erzwert,the Erzwert,词,NOUN,C1
-the Gebewegung,the Gebewegung,词,NOUN,C1
-the Geerweiterung,the Geerweiterung,词,NOUN,C1
-the Gehandlung,the Gehandlung,词,NOUN,C1
-the Geheilung,the Geheilung,词,NOUN,C1
-the Gekraft,the Gekraft,词,NOUN,C1
-the Geleitung,the Geleitung,词,NOUN,C1
-the Gemacht,the Gemacht,词,NOUN,C1
-the Gemessung,the Gemessung,词,NOUN,C1
-the Geminderung,the Geminderung,词,NOUN,C1
-the Geordnung,the Geordnung,词,NOUN,C1
-the Gerechnung,the Gerechnung,词,NOUN,C1
-the Gesammlung,the Gesammlung,词,NOUN,C1
-the Gesteigerung,the Gesteigerung,词,NOUN,C1
-the Gestellung,the Gestellung,词,NOUN,C1
-the Gevereinfachung,the Gevereinfachung,词,NOUN,C1
-the Gevertiefung,the Gevertiefung,词,NOUN,C1
-the Gewandlung,the Gewandlung,词,NOUN,C1
-the Gewerk,the Gewerk,词,NOUN,C1
-the Gewert,the Gewert,词,NOUN,C1
-the Grundbewegung,the Grundbewegung,词,NOUN,C1
-the Grundbindung,the Grundbindung,词,NOUN,C1
-the Grunderweiterung,the Grunderweiterung,词,NOUN,C1
-the Grundform,the Grundform,词,NOUN,C1
-the Grundhandlung,the Grundhandlung,词,NOUN,C1
-the Grundheilung,the Grundheilung,词,NOUN,C1
-the Grundkraft,the Grundkraft,词,NOUN,C1
-the Grundleitung,the Grundleitung,词,NOUN,C1
-the Grundmacht,the Grundmacht,词,NOUN,C1
-the Grundmessung,the Grundmessung,词,NOUN,C1
-the Grundminderung,the Grundminderung,词,NOUN,C1
-the Grundmischung,the Grundmischung,词,NOUN,C1
-the Grundordnung,the Grundordnung,词,NOUN,C1
-the Grundrechnung,the Grundrechnung,词,NOUN,C1
-the Grundsammlung,the Grundsammlung,词,NOUN,C1
-the Grundsteigerung,the Grundsteigerung,词,NOUN,C1
-the Grundstellung,the Grundstellung,词,NOUN,C1
-the Grundvereinfachung,the Grundvereinfachung,词,NOUN,C1
-the Grundvertiefung,the Grundvertiefung,词,NOUN,C1
-the Grundwandlung,the Grundwandlung,词,NOUN,C1
-the Grundwendung,the Grundwendung,词,NOUN,C1
-the Grundwerk,the Grundwerk,词,NOUN,C1
-the Grundwert,the Grundwert,词,NOUN,C1
-the Hochbewegung,the Hochbewegung,词,NOUN,C1
-the Hochbildung,the Hochbildung,词,NOUN,C1
-the Hocherweiterung,the Hocherweiterung,词,NOUN,C1
-the Hochform,the Hochform,词,NOUN,C1
-the Hochhandlung,the Hochhandlung,词,NOUN,C1
-the Hochheilung,the Hochheilung,词,NOUN,C1
-the Hochkraft,the Hochkraft,词,NOUN,C1
-the Hochmacht,the Hochmacht,词,NOUN,C1
-the Hochmessung,the Hochmessung,词,NOUN,C1
-the Hochmischung,the Hochmischung,词,NOUN,C1
-the Hochrechnung,the Hochrechnung,词,NOUN,C1
-the Hochstellung,the Hochstellung,词,NOUN,C1
-the Hochverbesserung,the Hochverbesserung,词,NOUN,C1
-the Hochvereinfachung,the Hochvereinfachung,词,NOUN,C1
-the Hochwandlung,the Hochwandlung,词,NOUN,C1
-the Hochwendung,the Hochwendung,词,NOUN,C1
-the Hochwerk,the Hochwerk,词,NOUN,C1
-the Hochwert,the Hochwert,词,NOUN,C1
-the Internet,the Internet,互联网,NOUN,B2
-the Missbindung,the Missbindung,词,NOUN,C1
-the Misserweiterung,the Misserweiterung,词,NOUN,C1
-the Missform,the Missform,词,NOUN,C1
-the Misshandlung,the Misshandlung,词,NOUN,C1
-the Missheilung,the Missheilung,词,NOUN,C1
-the Missleitung,the Missleitung,词,NOUN,C1
-the Missmacht,the Missmacht,词,NOUN,C1
-the Missmessung,the Missmessung,词,NOUN,C1
-the Missminderung,the Missminderung,词,NOUN,C1
-the Missmischung,the Missmischung,词,NOUN,C1
-the Misssammlung,the Misssammlung,词,NOUN,C1
-the Misssteigerung,the Misssteigerung,词,NOUN,C1
-the Missstellung,the Missstellung,词,NOUN,C1
-the Missverbesserung,the Missverbesserung,词,NOUN,C1
-the Missvereinfachung,the Missvereinfachung,词,NOUN,C1
-the Misswandlung,the Misswandlung,词,NOUN,C1
-the Misswendung,the Misswendung,词,NOUN,C1
-the Misswerk,the Misswerk,词,NOUN,C1
-the Misswert,the Misswert,词,NOUN,C1
-the Mitbewegung,the Mitbewegung,词,NOUN,C1
-the Mitbindung,the Mitbindung,词,NOUN,C1
-the Miterweiterung,the Miterweiterung,词,NOUN,C1
-the Mitform,the Mitform,词,NOUN,C1
-the Mithandlung,the Mithandlung,词,NOUN,C1
-the Mitleitung,the Mitleitung,词,NOUN,C1
-the Mitmacht,the Mitmacht,词,NOUN,C1
-the Mitmessung,the Mitmessung,词,NOUN,C1
-the Mitminderung,the Mitminderung,词,NOUN,C1
-the Mitmischung,the Mitmischung,词,NOUN,C1
-the Mitrechnung,the Mitrechnung,词,NOUN,C1
-the Mitsammlung,the Mitsammlung,词,NOUN,C1
-the Mitsteigerung,the Mitsteigerung,词,NOUN,C1
-the Mitstoff,the Mitstoff,词,NOUN,C1
-the Mitvereinfachung,the Mitvereinfachung,词,NOUN,C1
-the Mitvertiefung,the Mitvertiefung,词,NOUN,C1
-the Mitwandlung,the Mitwandlung,词,NOUN,C1
-the Mitwendung,the Mitwendung,词,NOUN,C1
-the Mitwerk,the Mitwerk,词,NOUN,C1
-the Mitwert,the Mitwert,词,NOUN,C1
-the Nachbewegung,the Nachbewegung,词,NOUN,C1
-the Nacherweiterung,the Nacherweiterung,词,NOUN,C1
-the Nachform,the Nachform,词,NOUN,C1
-the Nachhandlung,the Nachhandlung,词,NOUN,C1
-the Nachkraft,the Nachkraft,词,NOUN,C1
-the Nachmacht,the Nachmacht,词,NOUN,C1
-the Nachminderung,the Nachminderung,词,NOUN,C1
-the Nachmischung,the Nachmischung,词,NOUN,C1
-the Nachordnung,the Nachordnung,词,NOUN,C1
-the Nachrechnung,the Nachrechnung,词,NOUN,C1
-the Nachsammlung,the Nachsammlung,词,NOUN,C1
-the Nachsteigerung,the Nachsteigerung,词,NOUN,C1
-the Nachstellung,the Nachstellung,词,NOUN,C1
-the Nachverbesserung,the Nachverbesserung,词,NOUN,C1
-the Nachvereinfachung,the Nachvereinfachung,词,NOUN,C1
-the Nachvertiefung,the Nachvertiefung,词,NOUN,C1
-the Nachwandlung,the Nachwandlung,词,NOUN,C1
-the Nachwendung,the Nachwendung,词,NOUN,C1
-the Nachwerk,the Nachwerk,词,NOUN,C1
-the Nachwert,the Nachwert,词,NOUN,C1
-the Tiefbewegung,the Tiefbewegung,词,NOUN,C1
-the Tiefbildung,the Tiefbildung,词,NOUN,C1
-the Tieferweiterung,the Tieferweiterung,词,NOUN,C1
-the Tiefform,the Tiefform,词,NOUN,C1
-the Tiefhandlung,the Tiefhandlung,词,NOUN,C1
-the Tiefheilung,the Tiefheilung,词,NOUN,C1
-the Tiefkraft,the Tiefkraft,词,NOUN,C1
-the Tiefmacht,the Tiefmacht,词,NOUN,C1
-the Tiefmessung,the Tiefmessung,词,NOUN,C1
-the Tiefminderung,the Tiefminderung,词,NOUN,C1
-the Tiefmischung,the Tiefmischung,词,NOUN,C1
-the Tiefordnung,the Tiefordnung,词,NOUN,C1
-the Tiefsammlung,the Tiefsammlung,词,NOUN,C1
-the Tiefsteigerung,the Tiefsteigerung,词,NOUN,C1
-the Tiefstellung,the Tiefstellung,词,NOUN,C1
-the Tiefvereinfachung,the Tiefvereinfachung,词,NOUN,C1
-the Tiefvertiefung,the Tiefvertiefung,词,NOUN,C1
-the Tiefwandlung,the Tiefwandlung,词,NOUN,C1
-the Tiefwendung,the Tiefwendung,词,NOUN,C1
-the Tiefwerk,the Tiefwerk,词,NOUN,C1
-the Tiefwert,the Tiefwert,词,NOUN,C1
-the Unbewegung,the Unbewegung,词,NOUN,C1
-the Unbindung,the Unbindung,词,NOUN,C1
-the Unerweiterung,the Unerweiterung,词,NOUN,C1
-the Unform,the Unform,词,NOUN,C1
-the Unhandlung,the Unhandlung,词,NOUN,C1
-the Unheilung,the Unheilung,词,NOUN,C1
-the Unkraft,the Unkraft,词,NOUN,C1
-the Unmacht,the Unmacht,词,NOUN,C1
-the Unmessung,the Unmessung,词,NOUN,C1
-the Unordnung,the Unordnung,词,NOUN,C1
-the Unrechnung,the Unrechnung,词,NOUN,C1
-the Unsammlung,the Unsammlung,词,NOUN,C1
-the Unsteigerung,the Unsteigerung,词,NOUN,C1
-the Unstoff,the Unstoff,词,NOUN,C1
-the Unterbewegung,the Unterbewegung,词,NOUN,C1
-the Unterbildung,the Unterbildung,词,NOUN,C1
-the Unterbindung,the Unterbindung,词,NOUN,C1
-the Unterform,the Unterform,词,NOUN,C1
-the Unterhandlung,the Unterhandlung,词,NOUN,C1
-the Unterkraft,the Unterkraft,词,NOUN,C1
-the Untermacht,the Untermacht,词,NOUN,C1
-the Untermessung,the Untermessung,词,NOUN,C1
-the Unterminderung,the Unterminderung,词,NOUN,C1
-the Untermischung,the Untermischung,词,NOUN,C1
-the Unterrechnung,the Unterrechnung,词,NOUN,C1
-the Untersammlung,the Untersammlung,词,NOUN,C1
-the Untersteigerung,the Untersteigerung,词,NOUN,C1
-the Unterstellung,the Unterstellung,词,NOUN,C1
-the Unterstoff,the Unterstoff,词,NOUN,C1
-the Unterverbesserung,the Unterverbesserung,词,NOUN,C1
-the Untervereinfachung,the Untervereinfachung,词,NOUN,C1
-the Untervertiefung,the Untervertiefung,词,NOUN,C1
-the Unterwandlung,the Unterwandlung,词,NOUN,C1
-the Unterwendung,the Unterwendung,词,NOUN,C1
-the Unterwerk,the Unterwerk,词,NOUN,C1
-the Unterwert,the Unterwert,词,NOUN,C1
-the Unverbesserung,the Unverbesserung,词,NOUN,C1
-the Unvereinfachung,the Unvereinfachung,词,NOUN,C1
-the Unvertiefung,the Unvertiefung,词,NOUN,C1
-the Unwerk,the Unwerk,词,NOUN,C1
-the Unwert,the Unwert,词,NOUN,C1
-the Urbildung,the Urbildung,词,NOUN,C1
-the Urbindung,the Urbindung,词,NOUN,C1
-the Urerweiterung,the Urerweiterung,词,NOUN,C1
-the Urform,the Urform,词,NOUN,C1
-the Urhandlung,the Urhandlung,词,NOUN,C1
-the Urkraft,the Urkraft,词,NOUN,C1
-the Urleitung,the Urleitung,词,NOUN,C1
-the Urmacht,the Urmacht,词,NOUN,C1
-the Urmessung,the Urmessung,词,NOUN,C1
-the Urminderung,the Urminderung,词,NOUN,C1
-the Urordnung,the Urordnung,词,NOUN,C1
-the Ursteigerung,the Ursteigerung,词,NOUN,C1
-the Urvereinfachung,the Urvereinfachung,词,NOUN,C1
-the Urwandlung,the Urwandlung,词,NOUN,C1
-the Urwendung,the Urwendung,词,NOUN,C1
-the Urwerk,the Urwerk,词,NOUN,C1
-the Urwert,the Urwert,词,NOUN,C1
-the Verbewegung,the Verbewegung,词,NOUN,C1
-the Verbildung,the Verbildung,词,NOUN,C1
-the Verbindung,the Verbindung,词,NOUN,C1
-the Vererweiterung,the Vererweiterung,词,NOUN,C1
-the Verheilung,the Verheilung,词,NOUN,C1
-the Verkraft,the Verkraft,词,NOUN,C1
-the Verleitung,the Verleitung,词,NOUN,C1
-the Vermessung,the Vermessung,词,NOUN,C1
-the Vermischung,the Vermischung,词,NOUN,C1
-the Verordnung,the Verordnung,词,NOUN,C1
-the Verrechnung,the Verrechnung,词,NOUN,C1
-the Verstbewegung,the Verstbewegung,词,NOUN,C1
-the Verstbildung,the Verstbildung,词,NOUN,C1
-the Versteigerung,the Versteigerung,词,NOUN,C1
-the Versterweiterung,the Versterweiterung,词,NOUN,C1
-the Verstform,the Verstform,词,NOUN,C1
-the Verstheilung,the Verstheilung,词,NOUN,C1
-the Verstkraft,the Verstkraft,词,NOUN,C1
-the Verstmacht,the Verstmacht,词,NOUN,C1
-the Verstmessung,the Verstmessung,词,NOUN,C1
-the Verstminderung,the Verstminderung,词,NOUN,C1
-the Verstmischung,the Verstmischung,词,NOUN,C1
-the Verstoff,the Verstoff,词,NOUN,C1
-the Verstordnung,the Verstordnung,词,NOUN,C1
-the Verstrechnung,the Verstrechnung,词,NOUN,C1
-the Verstsammlung,the Verstsammlung,词,NOUN,C1
-the Verststeigerung,the Verststeigerung,词,NOUN,C1
-the Verststellung,the Verststellung,词,NOUN,C1
-the Verstverbesserung,the Verstverbesserung,词,NOUN,C1
-the Verstvertiefung,the Verstvertiefung,词,NOUN,C1
-the Verstwandlung,the Verstwandlung,词,NOUN,C1
-the Verstwendung,the Verstwendung,词,NOUN,C1
-the Verstwert,the Verstwert,词,NOUN,C1
-the Ververeinfachung,the Ververeinfachung,词,NOUN,C1
-the Verwendung,the Verwendung,词,NOUN,C1
-the Verwerk,the Verwerk,词,NOUN,C1
-the Verwert,the Verwert,词,NOUN,C1
-the Vorbewegung,the Vorbewegung,词,NOUN,C1
-the Vorbildung,the Vorbildung,词,NOUN,C1
-the Vorform,the Vorform,词,NOUN,C1
-the Vorhandlung,the Vorhandlung,词,NOUN,C1
-the Vorheilung,the Vorheilung,词,NOUN,C1
-the Vorleitung,the Vorleitung,词,NOUN,C1
-the Vormacht,the Vormacht,词,NOUN,C1
-the Vormessung,the Vormessung,词,NOUN,C1
-the Vorminderung,the Vorminderung,词,NOUN,C1
-the Vormischung,the Vormischung,词,NOUN,C1
-the Vorsammlung,the Vorsammlung,词,NOUN,C1
-the Vorsteigerung,the Vorsteigerung,词,NOUN,C1
-the Vorstoff,the Vorstoff,词,NOUN,C1
-the Vorvereinfachung,the Vorvereinfachung,词,NOUN,C1
-the Vorvertiefung,the Vorvertiefung,词,NOUN,C1
-the Vorwandlung,the Vorwandlung,词,NOUN,C1
-the Vorwendung,the Vorwendung,词,NOUN,C1
-the Vorwerk,the Vorwerk,词,NOUN,C1
-the Weitbewegung,the Weitbewegung,词,NOUN,C1
-the Weitbildung,the Weitbildung,词,NOUN,C1
-the Weitbindung,the Weitbindung,词,NOUN,C1
-the Weiterweiterung,the Weiterweiterung,词,NOUN,C1
-the Weitform,the Weitform,词,NOUN,C1
-the Weithandlung,the Weithandlung,词,NOUN,C1
-the Weitkraft,the Weitkraft,词,NOUN,C1
-the Weitleitung,the Weitleitung,词,NOUN,C1
-the Weitmacht,the Weitmacht,词,NOUN,C1
-the Weitmessung,the Weitmessung,词,NOUN,C1
-the Weitrechnung,the Weitrechnung,词,NOUN,C1
-the Weitsammlung,the Weitsammlung,词,NOUN,C1
-the Weitstellung,the Weitstellung,词,NOUN,C1
-the Weitvereinfachung,the Weitvereinfachung,词,NOUN,C1
-the Weitvertiefung,the Weitvertiefung,词,NOUN,C1
-the Weitwandlung,the Weitwandlung,词,NOUN,C1
-the Weitwerk,the Weitwerk,词,NOUN,C1
-the Weitwert,the Weitwert,词,NOUN,C1
-the Zerbewegung,the Zerbewegung,词,NOUN,C1
-the Zerbindung,the Zerbindung,词,NOUN,C1
-the Zerform,the Zerform,词,NOUN,C1
-the Zerheilung,the Zerheilung,词,NOUN,C1
-the Zerleitung,the Zerleitung,词,NOUN,C1
-the Zermacht,the Zermacht,词,NOUN,C1
-the Zermessung,the Zermessung,词,NOUN,C1
-the Zerminderung,the Zerminderung,词,NOUN,C1
-the Zermischung,the Zermischung,词,NOUN,C1
-the Zersammlung,the Zersammlung,词,NOUN,C1
-the Zersteigerung,the Zersteigerung,词,NOUN,C1
-the Zerstellung,the Zerstellung,词,NOUN,C1
-the Zerstoff,the Zerstoff,词,NOUN,C1
-the Zerverbesserung,the Zerverbesserung,词,NOUN,C1
-the Zervertiefung,the Zervertiefung,词,NOUN,C1
-the Zerwandlung,the Zerwandlung,词,NOUN,C1
-the Zerwendung,the Zerwendung,词,NOUN,C1
-the Zerwerk,the Zerwerk,词,NOUN,C1
-the Zerwert,the Zerwert,词,NOUN,C1
-the Zubewegung,the Zubewegung,词,NOUN,C1
-the Zubildung,the Zubildung,词,NOUN,C1
-the Zubindung,the Zubindung,词,NOUN,C1
-the Zuerweiterung,the Zuerweiterung,词,NOUN,C1
-the Zuform,the Zuform,词,NOUN,C1
-the Zuheilung,the Zuheilung,词,NOUN,C1
-the Zukraft,the Zukraft,词,NOUN,C1
-the Zuleitung,the Zuleitung,词,NOUN,C1
-the Zumacht,the Zumacht,词,NOUN,C1
-the Zumessung,the Zumessung,词,NOUN,C1
-the Zuminderung,the Zuminderung,词,NOUN,C1
-the Zumischung,the Zumischung,词,NOUN,C1
-the Zuordnung,the Zuordnung,词,NOUN,C1
-the Zusammlung,the Zusammlung,词,NOUN,C1
-the Zusteigerung,the Zusteigerung,词,NOUN,C1
-the Zustellung,the Zustellung,词,NOUN,C1
-the Zustoff,the Zustoff,词,NOUN,C1
-the Zuverbesserung,the Zuverbesserung,词,NOUN,C1
-the Zuvereinfachung,the Zuvereinfachung,词,NOUN,C1
-the Zuvertiefung,the Zuvertiefung,词,NOUN,C1
-the Zuwendung,the Zuwendung,词,NOUN,C1
-the Zuwerk,the Zuwerk,词,NOUN,C1
-the Zuwert,the Zuwert,词,NOUN,C1
-the abbindung,the abbindung,词,NOUN,B2
-the abgrund,the abgrund,名词,NOUN,B2
-the abhandlung,the abhandlung,复合词,NOUN,B2
-the abhang,the abhang,名词,NOUN,B2
-the abheilung,the abheilung,复合词,NOUN,B2
-the abholung,the abholung,名词,NOUN,B2
-the abkraft,the abkraft,复合词,NOUN,B2
-the abmessung,the abmessung,复合词,NOUN,B2
-the abordnung,the abordnung,词,NOUN,B2
-the absteigerung,the absteigerung,复合词,NOUN,B2
-the abstoff,the abstoff,复合词,NOUN,B2
-the abweisung,the abweisung,名词,NOUN,B2
-the abwert,the abwert,复合词,NOUN,B2
-the abwurf,the abwurf,名词,NOUN,B2
-the ackerbau,the ackerbau,名词,NOUN,B2
-the adoption,the adoption,名词,NOUN,B2
-the adressat,the adressat,名词,NOUN,B2
-the akademie,the akademie,名词,NOUN,B2
-the akkord,the akkord,名词,NOUN,B2
-the akkumulator,the akkumulator,名词,NOUN,B2
-the aktion,the aktion,名词,NOUN,B2
-the aktivist,the aktivist,名词,NOUN,B2
-the aktnadel,the aktnadel,名词,NOUN,B2
-the aktpunkt,the aktpunkt,名词,NOUN,B2
-the aktuar,the aktuar,名词,NOUN,B2
-the albatros,the albatros,名词,NOUN,B2
-the alias,the alias,名词,NOUN,B2
-the allianz,the allianz,名词,NOUN,B2
-the alpen,the alpen,名词,NOUN,B2
-the alphabet,the alphabet,名词,NOUN,B2
-the alpinismus,the alpinismus,名词,NOUN,B2
-the altertum,the altertum,名词,NOUN,B2
-the altruismus,the altruismus,名词,NOUN,B2
-the amboss,the amboss,名词,NOUN,B2
-the anbeginn,the anbeginn,名词,NOUN,B2
-the anbettlung,the anbettlung,名词,NOUN,B2
-the anbieter,the anbieter,名词,NOUN,B2
-the anbindung,the anbindung,复合词,NOUN,B2
-the anbruch,the anbruch,名词,NOUN,B2
-the andrang,the andrang,名词,NOUN,B2
-the anform,the anform,复合词,NOUN,B2
-the angriff,the angriff,词,NOUN,B2
-the anheilung,the anheilung,复合词,NOUN,B2
-the anordnung,the anordnung,复合词,NOUN,B2
-the anreiz,the anreiz,名词,NOUN,B2
-the ansage,the ansage,名词,NOUN,B2
-the anschlag,the anschlag,名词,NOUN,B2
-the anteil,the anteil,名词,NOUN,B2
-the antrag,the antrag,名词,NOUN,B2
-the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
-the anwerk,the anwerk,复合词,NOUN,B2
-the aufbewegung,the aufbewegung,复合词,NOUN,B2
-the aufheilung,the aufheilung,复合词,NOUN,B2
-the aufleitung,the aufleitung,复合词,NOUN,B2
-the aufordnung,the aufordnung,复合词,NOUN,B2
-the aufstoff,the aufstoff,复合词,NOUN,B2
-the aufwandlung,the aufwandlung,复合词,NOUN,B2
-the aufwendung,the aufwendung,复合词,NOUN,B2
-the aufwert,the aufwert,复合词,NOUN,B2
-the ausbildung,the ausbildung,复合词,NOUN,B2
-the auserweiterung,the auserweiterung,复合词,NOUN,B2
-the aushandlung,the aushandlung,复合词,NOUN,B2
-the ausleitung,the ausleitung,复合词,NOUN,B2
-the ausstellung,the ausstellung,复合词,NOUN,B2
-the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
-the auswendung,the auswendung,复合词,NOUN,B2
-the beerweiterung,the beerweiterung,复合词,NOUN,B2
-the bekraft,the bekraft,复合词,NOUN,B2
-the beleitung,the beleitung,复合词,NOUN,B2
-the bemessung,the bemessung,复合词,NOUN,B2
-the beminderung,the beminderung,复合词,NOUN,B2
-the beordnung,the beordnung,复合词,NOUN,B2
-the berechnung,the berechnung,复合词,NOUN,B2
-the best,the best,词,NOUN,C1
-the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
-the bevertiefung,the bevertiefung,复合词,NOUN,B2
-the bewendung,the bewendung,复合词,NOUN,B2
-the blues,the blues,忧郁,NOUN,B2
-the day after tomorrow,the day after tomorrow,后天,ADV,B2
-the day before yesterday,the day before yesterday,词,ADV,C1
-the einmessung,the einmessung,复合词,NOUN,B2
-the einwerk,the einwerk,复合词,NOUN,B2
-the end,the end,尽头,NOUN,B2
-the ererweiterung,the ererweiterung,复合词,NOUN,B2
-the erleitung,the erleitung,复合词,NOUN,B2
-the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
-the erwendung,the erwendung,复合词,NOUN,B2
-the erzerweiterung,the erzerweiterung,词,NOUN,B2
-the erzheilung,the erzheilung,复合词,NOUN,B2
-the erzkraft,the erzkraft,复合词,NOUN,B2
-the erzmischung,the erzmischung,复合词,NOUN,B2
-the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
-the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
-the erzwendung,the erzwendung,复合词,NOUN,B2
-the erzwerk,the erzwerk,复合词,NOUN,B2
-the following,the following,词,PRON,C1
-the gains do not make up for the losses,the gains do not make up for the losses,得不偿失,VERB,C1
-the gebildung,the gebildung,复合词,NOUN,B2
-the gebindung,the gebindung,复合词,NOUN,B2
-the geform,the geform,复合词,NOUN,B2
-the gemischung,the gemischung,复合词,NOUN,B2
-the gestoff,the gestoff,复合词,NOUN,B2
-the geverbesserung,the geverbesserung,复合词,NOUN,B2
-the gewendung,the gewendung,复合词,NOUN,B2
-the grundbildung,the grundbildung,复合词,NOUN,B2
-the grundstoff,the grundstoff,复合词,NOUN,B2
-the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
-the hochbindung,the hochbindung,复合词,NOUN,B2
-the hochleitung,the hochleitung,复合词,NOUN,B2
-the hochminderung,the hochminderung,复合词,NOUN,B2
-the hochordnung,the hochordnung,复合词,NOUN,B2
-the hochsammlung,the hochsammlung,复合词,NOUN,B2
-the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
-the hochstoff,the hochstoff,复合词,NOUN,B2
-the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
-the house,the house,庄家,NOUN,C1
-the human world,the human world,人间,NOUN,B2
-the masculine,the masculine,词,DET,A2
-the masses,the masses,大众,NOUN,C1
-the missbewegung,the missbewegung,复合词,NOUN,B2
-the missbildung,the missbildung,复合词,NOUN,B2
-the misskraft,the misskraft,复合词,NOUN,B2
-the missordnung,the missordnung,复合词,NOUN,B2
-the missrechnung,the missrechnung,复合词,NOUN,B2
-the missstoff,the missstoff,复合词,NOUN,B2
-the missvertiefung,the missvertiefung,复合词,NOUN,B2
-the mitbildung,the mitbildung,复合词,NOUN,B2
-the mitheilung,the mitheilung,复合词,NOUN,B2
-the mitkraft,the mitkraft,复合词,NOUN,B2
-the mitordnung,the mitordnung,复合词,NOUN,B2
-the mitstellung,the mitstellung,复合词,NOUN,B2
-the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
-the morning after,the morning after,词,NOUN,C1
-the morning of,the morning of,词,NOUN,C1
-the nachbildung,the nachbildung,复合词,NOUN,B2
-the nachbindung,the nachbindung,复合词,NOUN,B2
-the nachheilung,the nachheilung,复合词,NOUN,B2
-the nachleitung,the nachleitung,复合词,NOUN,B2
-the nachmessung,the nachmessung,复合词,NOUN,B2
-the nachstoff,the nachstoff,复合词,NOUN,B2
-the north pole,the north pole,北极,NOUN,B2
-the one,the one,,NOUN,B2
-the one (det),the one,词,DET,B1
-the one (pron),the one,那个人,PRON,B1
-the outside world,the outside world,外界,NOUN,B2
-the reason why,the reason why,之所以,SCONJ,B2
-the rich,the rich,富人,NOUN,B2
-the same (det),the same,词,DET,A2
-the slightest amount or degree,the slightest amount or degree,丝毫,ADV,B1
-the tiefbindung,the tiefbindung,复合词,NOUN,B2
-the tiefleitung,the tiefleitung,复合词,NOUN,B2
-the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
-the tiefstoff,the tiefstoff,复合词,NOUN,B2
-the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
-the unbildung,the unbildung,复合词,NOUN,B2
-the unleitung,the unleitung,复合词,NOUN,B2
-the unminderung,the unminderung,复合词,NOUN,B2
-the unmischung,the unmischung,复合词,NOUN,B2
-the unseen,the unseen,词,NOUN,C1
-the unstellung,the unstellung,复合词,NOUN,B2
-the untererweiterung,the untererweiterung,复合词,NOUN,B2
-the unterheilung,the unterheilung,复合词,NOUN,B2
-the unterleitung,the unterleitung,复合词,NOUN,B2
-the unterordnung,the unterordnung,复合词,NOUN,B2
-the unwandlung,the unwandlung,复合词,NOUN,B2
-the unwendung,the unwendung,复合词,NOUN,B2
-the urbewegung,the urbewegung,复合词,NOUN,B2
-the urheilung,the urheilung,复合词,NOUN,B2
-the urmischung,the urmischung,复合词,NOUN,B2
-the urrechnung,the urrechnung,复合词,NOUN,B2
-the ursammlung,the ursammlung,复合词,NOUN,B2
-the urstellung,the urstellung,复合词,NOUN,B2
-the urstoff,the urstoff,复合词,NOUN,B2
-the urverbesserung,the urverbesserung,复合词,NOUN,B2
-the urvertiefung,the urvertiefung,复合词,NOUN,B2
-the verform,the verform,复合词,NOUN,B2
-the verhandlung,the verhandlung,复合词,NOUN,B2
-the vermacht,the vermacht,复合词,NOUN,B2
-the verminderung,the verminderung,复合词,NOUN,B2
-the verstbindung,the verstbindung,词,NOUN,B2
-the verstellung,the verstellung,复合词,NOUN,B2
-the versthandlung,the versthandlung,复合词,NOUN,B2
-the verstleitung,the verstleitung,复合词,NOUN,B2
-the verststoff,the verststoff,复合词,NOUN,B2
-the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
-the verstwerk,the verstwerk,复合词,NOUN,B2
-the ververbesserung,the ververbesserung,复合词,NOUN,B2
-the ververtiefung,the ververtiefung,复合词,NOUN,B2
-the verwandlung,the verwandlung,复合词,NOUN,B2
-the vorbindung,the vorbindung,复合词,NOUN,B2
-the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
-the vorkraft,the vorkraft,复合词,NOUN,B2
-the vorordnung,the vorordnung,复合词,NOUN,B2
-the vorrechnung,the vorrechnung,复合词,NOUN,B2
-the vorstellung,the vorstellung,复合词,NOUN,B2
-the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
-the vorwert,the vorwert,复合词,NOUN,B2
-the weitheilung,the weitheilung,复合词,NOUN,B2
-the weitminderung,the weitminderung,复合词,NOUN,B2
-the weitmischung,the weitmischung,复合词,NOUN,B2
-the weitordnung,the weitordnung,复合词,NOUN,B2
-the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
-the weitstoff,the weitstoff,复合词,NOUN,B2
-the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
-the weitwendung,the weitwendung,复合词,NOUN,B2
-the whole journey,the whole journey,一路,ADV,A2
-the world,the world,天下,NOUN,B2
-the zerbildung,the zerbildung,复合词,NOUN,B2
-the zererweiterung,the zererweiterung,复合词,NOUN,B2
-the zerhandlung,the zerhandlung,复合词,NOUN,B2
-the zerkraft,the zerkraft,复合词,NOUN,B2
-the zerordnung,the zerordnung,复合词,NOUN,B2
-the zerrechnung,the zerrechnung,复合词,NOUN,B2
-the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
-the zuhandlung,the zuhandlung,复合词,NOUN,B2
-the zurechnung,the zurechnung,复合词,NOUN,B2
-the zuwandlung,the zuwandlung,复合词,NOUN,B2
-theatrical,theatrical,戏剧的,ADJ,B2
-their (det),their,词,DET,B2
-them dative,them dative,词,PRON,A2
-thematic,thematic,主题的,ADJ,B2
-theme music,theme music,主题曲,NOUN,B2
-then (noun),then,当时,NOUN,A2
-then (sconj),then,我就,SCONJ,B2
-then break,then break,便破,NOUN,C1
-then he,then he,那他,NOUN,B2
-then just,then just,就,ADV,A1
-then mixed,then mixed,就杂,NOUN,C1
-then-current,then-current,词,ADJ,C1
-theocratic,theocratic,词,ADJ,B2
-theodicy,theodicy,词,NOUN,C1
-theologian,theologian,神学家,NOUN,B2
-theological,theological,神学的,ADJ,B2
-theorize,theorize,词,VERB,B2
-there (pron),there,那里,PRON,B1
-there direction,there direction,词,ADV,B1
-there is there are,there is there are,词,VERB,A1
-there's not enough time to do sth,there's not enough time to do sth,来不及,VERB,A2
-therefore (sconj),therefore,所以,SCONJ,B2
-thermal (noun),thermal,词,NOUN,B2
-thermodynamics,thermodynamics,词,NOUN,B2
-thermometer,thermometer,词,NOUN,C1
-thesaurus,thesaurus,词,NOUN,C1
-these (pron),these,词,PRON,A1
-thespian,thespian,词,NOUN,C1
-thetic,thetic,正题的,ADJ,B2
-they female,they female,她们,PRON,B2
-they two,they two,词,PRON,A1
-thick fog,thick fog,浓雾,NOUN,C1
-thicket,thicket,灌木丛,NOUN,B2
-thickets,thickets,词,NOUN,B2
-thief here,thief here,有贼呀,NOUN,C1
-thimble,thimble,顶针,NOUN,B2
-thin iron,thin iron,薄铁,NOUN,C1
-thin-walled,thin-walled,隔音差的,ADJ,B2
-think about,think about,词,VERB,B1
-thinker,thinker,词,NOUN,C1
-third (noun),third,三分之一,NOUN,B2
-third (num),third,词,NUM,B1
-third place,third place,季军,NOUN,B2
-this,this,这,PRON,B2
-this (noun),this,你这,NOUN,B2
-this afternoon,this afternoon,词,ADV,B2
-this capital,this capital,这京,NOUN,C1
-this evening,this evening,今晚,ADV,B2
-this feminine,this feminine,词,DET,A1
-this heart,this heart,这心,NOUN,C1
-this indeed,this indeed,这倒,NOUN,B2
-this is,this is,这是,ADP,B2
-this masculine,this masculine,词,DET,A1
-this matter,this matter,这事,NOUN,B2
-this neutral,this neutral,词,PRON,A1
-this piece,this piece,这块,NOUN,C1
-this poison,this poison,这毒,NOUN,B2
-this room,this room,这屋里,NOUN,C1
-this route,this route,这路,NOUN,B2
-this sword,this sword,这剑,NOUN,B2
-this time,this time,词,ADV,B1
-this trick,this trick,这招,NOUN,C1
-this year,this year,今年,NOUN,B2
-thoracic,thoracic,词,ADJ,C1
-thorny,thorny,词,ADJ,C1
-thoroughly,thoroughly,词,ADV,B2
-those,those,那些,PRON,B2
-thoughtfulness,thoughtfulness,词,NOUN,C1
-thousand (noun),thousand,词,NOUN,B2
-thousands,thousands,数千,NOUN,B2
-thrall,thrall,词,NOUN,C1
-thread (verb),thread,词,VERB,C1
-threadbare,threadbare,词,ADJ,C1
-threads,threads,词,NOUN,B2
-threats,threats,词,NOUN,C1
-three (adj),three,ثلاث,ADJ,C1
-three moves,three moves,三招,NOUN,C1
-three times,three times,词,ADV,B2
-three-edged needle,three-edged needle,三棱针,NOUN,C1
-three-sided siege,three-sided siege,三面围,NOUN,B2
-threnody,threnody,词,NOUN,C1
-threshing floor,threshing floor,词,NOUN,B2
-thrill (noun),thrill,词,NOUN,B2
-thrilled,thrilled,词,ADJ,B2
-thrilling,thrilling,令人兴奋的,ADJ,B2
-thriving one,thriving one,词,NOUN,B2
-throes,throes,词,NOUN,C1
-thrombosis,thrombosis,词,NOUN,C1
-throng,throng,词,NOUN,C1
-throughout,throughout,词,ADP,B1
-throw away,throw away,词,VERB,C1
-throw out,throw out,词,VERB,C1
-throwing,throwing,词,NOUN,B2
-thunderous,thunderous,词,ADJ,B2
-thundershower,thundershower,雷阵雨,NOUN,B2
-thunderstorm,thunderstorm,雷阵雨,NOUN,B2
-thus (cconj),thus,因此,CCONJ,A2
-thus (noun),thus,那就索,NOUN,C1
-thus it can be seen,thus it can be seen,由此可见,ADV,B2
-thyme,thyme,词,NOUN,B2
-thyroid,thyroid,词,ADJ,B2
-tick,tick,滴答声,NOUN,B2
-ticket office,ticket office,词,NOUN,C1
-ticket validation,ticket validation,检票,NOUN,B2
-ticket window,ticket window,售票窗口,NOUN,B2
-tickle,tickle,发痒,NOUN,B2
-tidal flat,tidal flat,滩涂,NOUN,C1
-tidal movement,tidal movement,潮汐运动,NOUN,B2
-tider,times,倍,NOUN,B2
-tidigare,former,以前的,ADJ,B2
-tidigare,previous,先前的,ADJ,B2
-tidigare,earlier,刚才,ADV,B2
-tidigare,formerly,以前,ADV,B2
-tidigare,previously,以前,ADV,B2
-tidigarelägga,to shift to an earlier date,提前,VERB,B2
-tidsig varning,early warning,预警,NOUN,B2
-tidvatten,tidal,潮汐,ADJ,B2
-tidvatten,tide,潮汐,NOUN,B2
-tidy (adj),tidy,词,ADJ,B2
-tie mansion,tie mansion,铁府,NOUN,B2
-tiebreaker,tiebreaker,词,NOUN,C1
-tied hands,tied hands,束手,NOUN,C1
-tieferziehung,tieferziehung,词,NOUN,C1
-tieffahrt,tieffahrt,词,NOUN,C1
-tieffassung,tieffassung,词,NOUN,C1
-tiefforderung,tiefforderung,词,NOUN,C1
-tiefgabe,tiefgabe,词,NOUN,C1
-tiefgestaltung,tiefgestaltung,词,NOUN,C1
-tiefkunft,tiefkunft,词,NOUN,C1
-tiefnahme,tiefnahme,词,NOUN,C1
-tiefpflegung,tiefpflegung,词,NOUN,C1
-tiefregelung,tiefregelung,词,NOUN,C1
-tiefrichtung,tiefrichtung,词,NOUN,C1
-tiefschaft,tiefschaft,词,NOUN,C1
-tiefschrift,tiefschrift,词,NOUN,C1
-tiefsetzung,tiefsetzung,词,NOUN,C1
-tiefsicht,tiefsicht,词,NOUN,C1
-tiefsinnung,tiefsinnung,词,NOUN,C1
-tiefsprache,tiefsprache,词,NOUN,C1
-tiefsucht,tiefsucht,词,NOUN,C1
-tiefsuchung,tiefsuchung,词,NOUN,B2
-tiefteilung,tiefteilung,词,NOUN,C1
-tieftheilung,tieftheilung,词,NOUN,C1
-tieftreibung,tieftreibung,词,NOUN,C1
-tiefwandel,tiefwandel,词,NOUN,C1
-tiefweisung,tiefweisung,词,NOUN,C1
-tiefwirkung,tiefwirkung,词,NOUN,C1
-tier,tier,分阶,NOUN,C1
-tight narrow,tight narrow,词,ADJ,B1
-tight-fitting,tight-fitting,词,ADJ,B1
-tight-lipped,tight-lipped,词,ADJ,B2
-tightfisted,tightfisted,词,ADJ,C1
-tightrope walker,tightrope walker,词,NOUN,C1
-tights,tights,词,NOUN,C1
-till hjärtats nöje,one's heart's content,尽情,ADV,B2
-till synes,seemingly,表面上,ADV,B2
-tillbedjan,worship,崇拜,NOUN,B2
-tillfalla,to accrue,积累,VERB,B2
-tillfredsställelse,contentment,满足,NOUN,B2
-tillfällig,accidental,偶然的,ADJ,B2
-tillfällig vägran,temporary refusal,暂不,NOUN,B2
-tillfälligt,accidentally,意外地,ADV,B2
-tillförlitlighet,reliability,可靠性,NOUN,B2
-tillhandahålla,to supply,供货,VERB,B2
-tillhandahålla bevis,to provide evidence,举证,VERB,B2
-tillräcklig,adequate,足够的,ADJ,B2
-tillräcklig,enough,足够的,ADJ,B2
-tillräcklig,sufficient,足够的,ADJ,B2
-tillsyn,supervision,监督,NOUN,B2
-tillvänjning,habituation,习惯化,NOUN,B2
-tillväxt,growth,增长,NOUN,B2
-tillägg,addition,增加,NOUN,B2
-tillägg,supplement,补充,NOUN,B2
-tillägg,to supplement,补充,VERB,B2
-tilläggsgödsel,top dressing,追肥,NOUN,B2
-tillämplighet,applicability,适用性,NOUN,B2
-tillåta,permit,许可证,NOUN,B2
-tillåta,to permit,允许,VERB,B2
-tilt,tilt,倾斜,NOUN,B2
-timber,timber,词,NOUN,C1
-timbre,timbre,词,NOUN,C1
-time clock,time clock,打卡机,NOUN,B2
-time era,time era,词,NOUN,A2
-time limit,time limit,词,NOUN,B1
-time occurrence measure word,time occurrence measure word,次,NOUN,A1
-time once,time once,词,NOUN,A2
-time out,time out,词,NOUN,B2
-timeline,timeline,时间线,NOUN,B2
-timely,timely,适时,ADJ,B2
-timely opportune,timely opportune,词,ADJ,C1
-timetable,timetable,时刻表,NOUN,B2
-timid,timid,词,ADJ,B2
-timing,timing,时机,NOUN,B2
-timorous,timorous,词,ADJ,C1
+tack,thank you,谢谢,INTJ,B2
+tack,thanks,谢谢,NOUN,B2
+tack vare,thanks to,多亏,ADP,B2
+att,that,那个,PRON,B2
+pil,that arrow,那一箭,NOUN,B2
+alltså,that is,即,ADV,B2
+så,that way,那样,PRON,B2
 tina,to thaw,解冻,VERB,B2
-tingling (adj),tingling,词,ADJ,C1
-tinplate,tinplate,词,NOUN,C1
-tinsmith,tinsmith,词,NOUN,C1
-tint (adj),tint,词,ADJ,C1
-tint (noun),tint,词,NOUN,C1
-tiny minute,tiny minute,词,ADJ,C1
-tiodel,tithe,什一税,NOUN,B2
-tips,tips,词,NOUN,C1
-tirade,tirade,长篇抨击,NOUN,B2
-tire (noun),tire,词,NOUN,B1
-tire pressure,tire pressure,胎压,NOUN,B2
-tire tread,tire tread,胎纹,NOUN,C1
-tired of,tired of,,NOUN,B2
-tireless,tireless,不知疲倦的,ADJ,B2
-tirelessly,tirelessly,词,ADV,C1
-tiring,tiring,令人疲倦的,ADJ,B2
-tissue (adj),tissue,词,ADJ,C1
-titanic,titanic,词,ADJ,C1
-titillate,titillate,词,VERB,C1
-titling,titling,词,NOUN,C1
-tits,tits,词,NOUN,C1
-titta,watch,手表,NOUN,B2
-titta,to watch,观看,VERB,B2
-titta på,to look at,观看,VERB,B2
-titta på dig,look at you,你看你,NOUN,B2
-titular,titular,词,ADJ,C1
+den,the,这,DET,B2
+tema,theme,主题,NOUN,B2
+du,then you,那你,PRON,B2
+teokrati,theocracy,神权政治,NOUN,B2
+teologi,theology,神学,NOUN,B2
+sats,theorem,定理,NOUN,B2
+teoretisk,theoretical,理论的,ADJ,B2
+teoretiskt,theoretically,理论上,ADV,B2
+terapeutisk,therapeutic,治疗的,ADJ,B2
+finnas,to there's still time,来得及,VERB,B2
+termisk,thermal,热的,ADJ,B2
+dessa,these,这些,PRON,B2
+tre,these three,这三,NOUN,B2
+de,they things,它们,PRON,B2
 tjocklek,thickness,厚度,NOUN,B2
 tjuv,thief presence,有贼,NOUN,B2
-tjänsteman,civil servant,公务员,NOUN,B2
-tjänsteman,official,官员,NOUN,B2
-tjänsteman,officials,官员,NOUN,B2
-to,to,去,PART,B2
-to abbauen,to abbauen,词,VERB,C1
-to abbilden,to abbilden,词,VERB,C1
-to abbinden,to abbinden,词,VERB,C1
-to abbrechen,to abbrechen,词,VERB,C1
-to abdanken,to abdanken,动词,VERB,B2
-to abdicate,to abdicate,退位,VERB,B2
-to abdichten,to abdichten,词,VERB,C1
-to abfallen,to abfallen,词,VERB,C1
-to abfassen,to abfassen,词,VERB,C1
-to abfedern,to abfedern,词,VERB,C1
-to abfinden,to abfinden,词,VERB,C1
-to abflachen,to abflachen,词,VERB,C1
-to abfragen,to abfragen,词,VERB,C1
-to abgelten,to abgelten,词,VERB,C1
-to abgrenzen,to abgrenzen,词,VERB,C1
-to abhalten,to abhalten,词,VERB,C1
-to abhandeln,to abhandeln,词,VERB,C1
-to abheben,to abheben,词,VERB,C1
-to abkapseln,to abkapseln,词,VERB,C1
-to abklingen,to abklingen,词,VERB,C1
-to abkoppeln,to abkoppeln,词,VERB,C1
-to ablehnen,to ablehnen,词,VERB,C1
-to ableiten,to ableiten,词,VERB,C1
-to abliefern,to abliefern,词,VERB,C1
-to abmildern,to abmildern,词,VERB,C1
-to abnehmen,to abnehmen,词,VERB,C1
-to abnicken,to abnicken,词,VERB,C1
-to abort,to abort,流产,VERB,B2
-to abound,to abound,词,VERB,C1
-to abrangieren,to abrangieren,词,VERB,C1
-to absagen,to absagen,动词,VERB,B2
-to absaufen,to absaufen,词,VERB,C1
-to absaugen,to absaugen,词,VERB,C1
-to abschaffen,to abschaffen,词,VERB,C1
-to abschatten,to abschatten,词,VERB,C1
-to abschauen,to abschauen,词,VERB,C1
-to abschieben,to abschieben,词,VERB,C1
-to abschirmen,to abschirmen,词,VERB,C1
-to abschlafen,to abschlafen,动词,VERB,B2
-to abschlagen,to abschlagen,词,VERB,C1
-to abschleifen,to abschleifen,词,VERB,C1
-to abschrecken,to abschrecken,词,VERB,C1
-to abschreiben,to abschreiben,词,VERB,C1
-to abschweifen,to abschweifen,动词,VERB,B2
-to abschwenken,to abschwenken,词,VERB,C1
-to absenden,to absenden,词,VERB,C1
-to absichern,to absichern,动词,VERB,B2
-to absolve,to absolve,赦免,VERB,B2
-to absolvieren,to absolvieren,词,VERB,C1
-to absondern,to absondern,词,VERB,C1
-to absorbieren,to absorbieren,词,VERB,C1
-to abspannen,to abspannen,词,VERB,C1
-to abspeisen,to abspeisen,词,VERB,C1
-to absprechen,to absprechen,词,VERB,C1
-to abstatten,to abstatten,词,VERB,C1
-to abstehen,to abstehen,词,VERB,C1
-to absteigen,to absteigen,词,VERB,C1
-to abstellen,to abstellen,词,VERB,C1
-to abstimmen,to abstimmen,动词,VERB,B2
-to abstract,to abstract,抽象,VERB,B2
-to abtasten,to abtasten,词,VERB,C1
-to abtauchen,to abtauchen,词,VERB,C1
-to abteilen,to abteilen,动词,VERB,B2
-to abtippen,to abtippen,词,VERB,C1
-to abtragen,to abtragen,词,VERB,C1
-to abtrainieren,to abtrainieren,词,VERB,C1
-to abtreiben,to abtreiben,词,VERB,C1
-to abtrennen,to abtrennen,词,VERB,C1
-to abtrocken,to abtrocken,动词,VERB,B2
-to abtun,to abtun,动词,VERB,B2
-to abturnen,to abturnen,词,VERB,C1
-to abuse (verb),to abuse,词,VERB,B2
-to abwandeln,to abwandeln,动词,VERB,B2
-to abwarten,to abwarten,词,VERB,C1
-to abwaschen,to abwaschen,词,VERB,C1
-to abwechseln,to abwechseln,词,VERB,C1
-to abwehren,to abwehren,词,VERB,C1
-to abweisen,to abweisen,词,VERB,C1
-to abwenden,to abwenden,词,VERB,C1
-to abwerfen,to abwerfen,词,VERB,C1
-to abwickeln,to abwickeln,词,VERB,C1
-to abwiegen,to abwiegen,词,VERB,C1
-to abwinken,to abwinken,词,VERB,C1
-to abwirken,to abwirken,词,VERB,C1
-to abwischen,to abwischen,词,VERB,C1
-to abzahlen,to abzahlen,词,VERB,C1
-to abzeichnen,to abzeichnen,词,VERB,C1
-to abzocken,to abzocken,词,VERB,C1
-to abzwecken,to abzwecken,动词,VERB,B2
-to abzweigen,to abzweigen,词,VERB,C1
-to accentuate,to accentuate,强调,VERB,B2
-to access,to access,进入,VERB,B2
-to acclaim,to acclaim,称赞,VERB,B2
-to accommodate to prepare,to accommodate to prepare,词,VERB,C1
-to accompany you,to accompany you,陪你,VERB,C1
-to accounting,to accounting,核算,VERB,B2
-to acquiesce,to acquiesce,默许,VERB,B2
-to acquit to settle,to acquit to settle,词,VERB,C1
-to act as host,to act as host,做东,VERB,B2
-to act as intermediary,to act as intermediary,中介,NOUN,B1
-to act despotically,to act despotically,词,VERB,C1
-to act on,to act on,词,VERB,B2
-to act on behalf of sb in a responsible position,to act on behalf of sb in a responsible position,代理,VERB,B2
-to act pitiful,to act pitiful,词,VERB,B1
-to act rashly,to act rashly,妄动,VERB,B2
-to act wildly to act recklessly,to act wildly to act recklessly,乱来,VERB,B2
-to address informally,to address informally,词,VERB,C1
-to adduce,to adduce,引证,VERB,B2
-to adhere,to adhere,坚持,VERB,B2
-to adhere join,to adhere join,词,VERB,B2
-to administer an oath,to administer an oath,词,VERB,C1
-to admit fault,to admit fault,知错,VERB,C1
-to admit to confess,to admit to confess,词,VERB,A2
-to adore,to adore,爱慕,VERB,B2
-to afforest,to afforest,造林,VERB,B2
-to aggravate,to aggravate,加重,VERB,B2
-to aggregate (verb),to aggregate,词,VERB,B2
-to agitate,to agitate,鼓动,VERB,B2
-to agree to approve,to agree to approve,词,VERB,A2
-to agree with,to agree with,词,VERB,B2
-to ail,to ail,使苦恼,VERB,B2
-to aim steer,to aim steer,词,VERB,B2
-to alert,to alert,警告,VERB,B2
-to alienate,to alienate,使疏远,VERB,B2
-to align,to align,使一致,VERB,B2
-to allege,to allege,宣称,VERB,B2
-to alleviate,to alleviate,缓解,VERB,B2
-to allocate,to allocate,分配,VERB,B2
-to allude,to allude,暗指,VERB,B2
-to ally,to ally,结盟,VERB,B2
-to almost (verb),to almost,词,VERB,B2
-to alter,to alter,改变,VERB,B2
-to alter to spoil,to alter to spoil,词,VERB,C1
-to amalgamate,to amalgamate,合并,VERB,B2
-to amass,to amass,积聚,VERB,B2
-to amaze,to amaze,使吃惊,VERB,B2
-to ambush,to ambush,埋伏,VERB,B2
-to amnesty (verb),to amnesty,词,VERB,C1
-to amplify,to amplify,放大,VERB,B2
-to anathematize,to anathematize,词,VERB,C1
-to anchor (verb),to anchor,停泊,VERB,B2
-to anesthetize,to anesthetize,麻醉,VERB,B2
-to anger,to anger,使生气,VERB,B2
-to animate,to animate,词,VERB,B2
-to annul,to annul,废除,VERB,B2
-to answer to reply,to answer to reply,词,VERB,A2
-to antagonize,to antagonize,使对立,VERB,B2
-to antedate,to antedate,词,VERB,B2
-to anxious for quick results,to anxious for quick results,急于求成,VERB,B2
-to apostatize,to apostatize,叛教,VERB,B2
-to appal,to appal,使惊恐,VERB,B2
-to appeal to,to appeal to,词,VERB,C1
-to appear in court,to appear in court,词,VERB,B2
-to appear to seem,to appear to seem,出现/显得,VERB,B2
-to apply for,to apply for,词,VERB,B1
-to apply for a job,to apply for a job,应聘,VERB,B2
-to appoint add,to appoint add,词,VERB,B2
-to appoint and nominate,to appoint and nominate,任命,VERB,B2
-to appoint official,to appoint official,命官,VERB,C1
-to archive,to archive,归档,VERB,B2
-to armor,to armor,装甲,VERB,B2
-to arrange a meeting,to arrange a meeting,词,VERB,B1
-to arrange develop,to arrange develop,词,VERB,B2
-to arrive to,to arrive to,到,VERB,A1
-to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
-to ascribe,to ascribe,归因于,VERB,B2
-to ask about,to ask about,打听,VERB,B1
-to ask for,to ask for,词,VERB,A1
-to ask rhetorically,to ask rhetorically,反问,VERB,B2
-to asphalt,to asphalt,铺沥青,VERB,B2
-to asphyxiate,to asphyxiate,使窒息,VERB,B2
-to assault,to assault,袭击,VERB,B2
-to assent,to assent,同意,VERB,B2
-to assume to think,to assume to think,词,VERB,A2
-to atrophy (verb),to atrophy,词,VERB,B2
-to attach importance to,to attach importance to,重视,VERB,A2
-to attain enlightenment,to attain enlightenment,得道,VERB,B2
-to attempt (verb),to attempt,企图,VERB,B2
-to attend class,to attend class,上课,VERB,B2
-to attend to prepare,to attend to prepare,词,VERB,A2
-to attenuate,to attenuate,减弱,VERB,B2
-to attest,to attest,证明,VERB,B2
-to attribute,to attribute,归因于,VERB,B2
-to audit (verb),to audit,审核,VERB,B2
-to augur,to augur,预言,VERB,B2
-to auscultate,to auscultate,听诊,VERB,B2
-to avail oneself of,to avail oneself of,趁,ADP,B2
-to avenge oneself,to avenge oneself,词,VERB,C1
-to await orders,to await orders,待命,VERB,B2
-to award (verb),to award,词,VERB,B2
-to badmouth,to badmouth,词,VERB,C1
-to bandage (verb),to bandage,包扎,VERB,B2
-to bang (verb),to bang,词,VERB,C1
-to bargain (verb),to bargain,词,VERB,C1
-to barricade (verb),to barricade,词,VERB,B2
-to battle (verb),to battle,之战,VERB,B2
-to be able (aux),to be able,能够,AUX,B1
-to be able to (verb),to be able to,词,VERB,B2
-to be absent-minded,to be absent-minded,词,VERB,B2
-to be accused,to be accused,词,VERB,B2
-to be acknowledged,to be acknowledged,词,VERB,B2
-to be added,to be added,加入,VERB,B2
-to be addressed,to be addressed,词,VERB,B2
-to be admitted,to be admitted,词,VERB,B2
-to be adopted,to be adopted,词,VERB,B2
-to be afraid,to be afraid,害怕,VERB,B2
-to be alleged,to be alleged,被声称,VERB,B2
-to be allergic,to be allergic,过敏,VERB,B2
-to be allowed (verb),to be allowed,词,VERB,B2
-to be allowed to,to be allowed to,词,AUX,B1
-to be allowed to may,to be allowed to may,词,AUX,A1
-to be amazed surprised,to be amazed surprised,惊奇,ADJ,C1
-to be analyzed,to be analyzed,词,VERB,B2
-to be approved,to be approved,词,VERB,B2
-to be arrested,to be arrested,词,VERB,B2
-to be ascribed,to be ascribed,词,VERB,B2
-to be assumed,to be assumed,词,VERB,B2
-to be astonished,to be astonished,词,VERB,B2
-to be attempted,to be attempted,词,VERB,B2
-to be attributed,to be attributed,词,VERB,B2
-to be banned,to be banned,词,VERB,B2
-to be based on,to be based on,基于,VERB,B2
-to be believed,to be believed,词,VERB,B2
-to be broadcast,to be broadcast,词,VERB,B2
-to be buried,to be buried,葬身,VERB,C1
-to be calculated,to be calculated,词,VERB,B2
-to be cancelled,to be cancelled,词,VERB,B2
-to be careful,to be careful,小心,VERB,B2
-to be classified,to be classified,词,VERB,B2
-to be concluded,to be concluded,词,VERB,B2
-to be confirmed,to be confirmed,被证实,VERB,B2
-to be considered,to be considered,词,VERB,B2
-to be content,to be content,词,VERB,C1
-to be contradicted,to be contradicted,词,VERB,B2
-to be correct,to be correct,正确,VERB,B2
-to be dazzled,to be dazzled,词,VERB,B2
-to be deduced,to be deduced,词,VERB,B2
-to be deemed bad,to be deemed bad,词,VERB,B2
-to be deemed likely,to be deemed likely,词,VERB,B2
-to be defined,to be defined,词,VERB,B2
-to be delayed,to be delayed,迟到,VERB,B2
-to be demanded,to be demanded,词,VERB,B2
-to be denied,to be denied,词,VERB,B2
-to be derived,to be derived,词,VERB,B2
-to be described,to be described,词,VERB,B2
-to be detained,to be detained,词,VERB,B2
-to be discovered,to be discovered,词,VERB,C1
-to be discussed,to be discussed,词,VERB,B2
-to be disgusted with,to be disgusted with,反感,VERB,B2
-to be disillusioned,to be disillusioned,词,VERB,C1
-to be dissonant,to be dissonant,词,VERB,C1
-to be equivalent,to be equivalent,词,VERB,C1
-to be estimated,to be estimated,词,VERB,B2
-to be evaluated,to be evaluated,词,VERB,B2
-to be expected,to be expected,词,VERB,B2
-to be far from,to be far from,绝非,VERB,B2
-to be fooled,to be fooled,词,VERB,C1
-to be forbidden,to be forbidden,词,VERB,B2
-to be fortunate,to be fortunate,词,VERB,B1
-to be full of,to be full of,充满,VERB,B1
-to be good for,to be good for,词,VERB,B2
-to be grandiloquent,to be grandiloquent,词,VERB,C1
-to be happy,to be happy,词,VERB,A2
-to be heedless,to be heedless,词,VERB,B2
-to be held,to be held,词,VERB,B2
-to be here,to be here,在此,VERB,B2
-to be honest,to be honest,诚实,VERB,A2
-to be humiliated,to be humiliated,受辱,VERB,B1
-to be imagined,to be imagined,词,VERB,B2
-to be in,to be in,身处,VERB,C1
-to be in a state,to be in a state,处于,VERB,B2
-to be in contact with,to be in contact with,相处,VERB,B2
-to be in position,to be in position,就位,VERB,C1
-to be infatuated,to be infatuated,词,VERB,B2
-to be inferred,to be inferred,词,VERB,B2
-to be inspected,to be inspected,词,VERB,B2
-to be interrelated,to be interrelated,相关,ADJ,B1
-to be judged,to be judged,词,VERB,B2
-to be justified,to be justified,词,VERB,B2
-to be kidnapped,to be kidnapped,词,VERB,B2
-to be known,to be known,词,VERB,B2
-to be liable,to be liable,负责,VERB,B2
-to be located at,to be located at,位于,VERB,B2
-to be location,to be location,词,VERB,A1
-to be lost,to be lost,词,VERB,B1
-to be made available,to be made available,词,VERB,B2
-to be measured,to be measured,词,VERB,B2
-to be mentioned,to be mentioned,词,VERB,B2
-to be named,to be named,词,VERB,B2
-to be necessary,to be necessary,词,VERB,A1
-to be necessary must,to be necessary must,词,VERB,A2
-to be nicknamed,to be nicknamed,词,VERB,B2
-to be not,to be not,词,VERB,A1
-to be noticeable,to be noticeable,词,VERB,C1
-to be observed,to be observed,词,VERB,B2
-to be on person,to be on person,在身,VERB,C1
-to be open for business,to be open for business,营业,VERB,B2
-to be out,to be out,出局,VERB,B2
-to be out of tune,to be out of tune,词,VERB,C1
-to be overdue,to be overdue,过期,VERB,B2
-to be pardoned,to be pardoned,词,VERB,B2
-to be pedantic,to be pedantic,词,VERB,C1
-to be possible,to be possible,词,VERB,A1
-to be predicted,to be predicted,词,VERB,B2
-to be pregnant,to be pregnant,怀孕,VERB,B2
-to be preoccupied,to be preoccupied,词,VERB,B2
-to be presented,to be presented,词,VERB,B2
-to be proper,to be proper,体统,VERB,B2
-to be prosecuted,to be prosecuted,词,VERB,B2
-to be proven,to be proven,被证明,VERB,B2
-to be published,to be published,词,VERB,B2
-to be puzzled,to be puzzled,困惑,VERB,B2
-to be reborn,to be reborn,词,VERB,C1
-to be received,to be received,词,VERB,B2
-to be reckless,to be reckless,肆,VERB,B1
-to be refuted,to be refuted,词,VERB,B2
-to be related,to be related,词,VERB,C1
-to be released,to be released,词,VERB,B2
-to be relentless,to be relentless,词,VERB,C1
-to be reluctant to part with,to be reluctant to part with,舍不得,VERB,B2
-to be renowned,to be renowned,词,VERB,B2
-to be requested,to be requested,词,VERB,B2
-to be researched,to be researched,词,VERB,B2
-to be said,to be said,词,VERB,B2
-to be scarce,to be scarce,词,VERB,C1
-to be seen,to be seen,词,VERB,B2
-to be shy,to be shy,词,VERB,A2
-to be skeptical,to be skeptical,怀疑,VERB,B2
-to be sleepy,to be sleepy,我困,VERB,B2
-to be sought,to be sought,词,VERB,B2
-to be startled,to be startled,词,VERB,C1
-to be stuck,to be stuck,卡住,VERB,B2
-to be studied,to be studied,词,VERB,B2
-to be subject to,to be subject to,词,VERB,B2
-to be suited,to be suited,词,VERB,B2
-to be summoned,to be summoned,词,VERB,B2
-to be taken in,to be taken in,上当,VERB,B2
-to be tested,to be tested,词,VERB,B2
-to be tired of,to be tired of,厌倦,VERB,B2
-to be transferred,to be transferred,词,VERB,B2
-to be translated,to be translated,词,VERB,B2
-to be treated,to be treated,词,VERB,B2
-to be tried,to be tried,词,VERB,B2
-to be unable,to be unable,无法,VERB,B1
-to be unaware,to be unaware,不知道,VERB,B2
-to be understood,to be understood,词,VERB,B2
-to be unharmed,to be unharmed,无恙,VERB,B2
-to be unnecessary,to be unnecessary,词,VERB,C1
-to be unworthy,to be unworthy,词,VERB,C1
-to be valid,to be valid,有效,VERB,B2
-to be vigilant,to be vigilant,词,VERB,B2
-to be widowed,to be widowed,词,VERB,C1
-to be willing (aux),to be willing,愿意,AUX,B2
-to be willing (verb),to be willing,能心,VERB,C1
-to be with,to be with,和你,VERB,B2
-to be worthy,to be worthy,词,VERB,B2
-to be worthy of,to be worthy of,不愧,ADV,B2
-to bear fruit,to bear fruit,词,VERB,C1
-to bear to endure,to bear to endure,词,VERB,C1
-to beat up,to beat up,词,VERB,C1
-to beatify,to beatify,宣福,VERB,B2
-to beautify,to beautify,美化,VERB,B2
-to become absorbed,to become absorbed,词,VERB,C1
-to become again,to become again,词,VERB,B1
-to become alert,to become alert,词,VERB,B2
-to become bold,to become bold,词,VERB,C1
-to become certain,to become certain,词,VERB,B2
-to become gangrenous,to become gangrenous,词,VERB,C1
-to become independent,to become independent,词,VERB,C1
-to become inflamed,to become inflamed,发炎,VERB,B2
-to become invalid,to become invalid,作废,VERB,B2
-to become minister,to become minister,词,VERB,C1
-to become poor,to become poor,词,VERB,B2
-to beep (verb),to beep,词,VERB,C1
-to befriend,to befriend,与...交朋友,VERB,B2
-to beget,to beget,引起,VERB,B2
-to begin to cut into,to begin to cut into,词,VERB,C1
-to behave rudely,to behave rudely,词,VERB,C1
-to behead,to behead,斩首,VERB,B2
-to benefit,to benefit,受益,VERB,B2
-to bequeath,to bequeath,遗赠,VERB,B2
-to beschieten,to beschieten,词,VERB,C1
-to betroth,to betroth,词,VERB,C1
-to bevriezen,to bevriezen,词,VERB,C1
-to bewitch,to bewitch,迷住,VERB,B2
-to bid farewell,to bid farewell,词,VERB,B1
-to bifurcate,to bifurcate,分叉,VERB,B2
-to bisect,to bisect,平分,VERB,B2
-to blaspheme,to blaspheme,亵渎,VERB,B2
-to blaze (verb),to blaze,词,VERB,B2
-to blazon,to blazon,词,VERB,C1
-to bleat,to bleat,哀叫,VERB,B2
-to blind (verb),to blind,词,VERB,B2
-to blockade (verb),to blockade,词,VERB,B2
-to bloom,to bloom,开花,VERB,B2
-to blossom,to blossom,开花,VERB,B2
-to blow one's nose,to blow one's nose,词,VERB,B1
-to blush,to blush,脸红,VERB,B2
-to board (verb),to board,词,VERB,C1
-to boil cook,to boil cook,词,VERB,B1
-to boost,to boost,促进,VERB,B2
-to border,to border,接壤,VERB,B2
-to border on,to border on,词,VERB,C1
-to botch,to botch,搞砸,VERB,B2
-to bottle (verb),to bottle,词,VERB,C1
-to bound (verb),to bound,词,VERB,C1
-to bound leap,to bound leap,词,VERB,B2
-to brandish,to brandish,挥舞,VERB,B2
-to brawl (verb),to brawl,词,VERB,B1
-to breach (verb),to breach,词,VERB,C1
-to break a pledge,to break a pledge,词,VERB,C1
-to break a record,to break a record,打破纪录,VERB,B2
-to break away,to break away,词,VERB,C1
-to break in,to break in,词,VERB,B2
-to break into,to break into,撬开,VERB,B2
-to break off,to break off,中断,VERB,B2
-to break out,to break out,爆发,VERB,B2
-to break the back,to break the back,词,VERB,C1
-to breathe again,to breathe again,松口气,VERB,B2
-to bridle (verb),to bridle,词,VERB,C1
-to bring about,to bring about,促成,VERB,B2
-to bring along,to bring along,词,VERB,B1
-to bring closer,to bring closer,靠近,VERB,B2
-to bring here,to bring here,词,VERB,C1
-to bring to,to bring to,带到,VERB,B2
-to bristle,to bristle,使竖起,VERB,B2
-to brood,to brood,沉思,VERB,B2
-to build up,to build up,构建,VERB,B2
-to bullshit,to bullshit,胡扯,VERB,B2
-to bully,to bully,欺凌,VERB,B2
-to bump,to bump,碰撞,VERB,B2
-to bungle,to bungle,搞砸,VERB,B2
-to burden (verb),to burden,词,VERB,B2
-to burn food,to burn food,词,VERB,C1
-to burnish,to burnish,擦亮,VERB,B2
-to buy back,to buy back,赎回,VERB,B2
-to buzz (verb),to buzz,词,VERB,C1
-to bypass (verb),to bypass,词,VERB,C1
-to cadge,to cadge,词,VERB,C1
-to calcify,to calcify,词,VERB,C1
-to calibrate,to calibrate,校准,VERB,B2
-to call back,to call back,词,VERB,B2
-to call name,to call name,词,VERB,A2
-to call out,to call out,词,VERB,C1
-to call to contact,to call to contact,词,VERB,A2
-to calm down,to calm down,使平静,VERB,B2
-to camouflage,to camouflage,伪装,VERB,B2
-to camp,to camp,露营,VERB,B2
-to canonize,to canonize,词,VERB,B2
-to caper,to caper,跳跃,VERB,B2
-to capitulate,to capitulate,投降,VERB,B2
-to captain (verb),to captain,词,VERB,B2
-to captivate,to captivate,迷住,VERB,B2
-to capture (verb),to capture,攻下,VERB,B2
-to care about,to care about,关心,VERB,A1
-to carry on,to carry on,词,VERB,C1
-to carve,to carve,雕刻,VERB,B2
-to cash (verb),to cash,兑现,VERB,B2
-to cash to take a blow,to cash to take a blow,词,VERB,C1
-to cast (verb),to cast,词,VERB,B2
-to castigate,to castigate,严厉批评,VERB,B2
-to catalyze,to catalyze,催化,VERB,B2
-to catch a cold,to catch a cold,感冒,VERB,A1
-to catch cold,to catch cold,着凉,VERB,B1
-to catch sight of,to catch sight of,瞥见,VERB,B2
-to catch up with,to catch up with,词,VERB,B2
-to catechize,to catechize,词,VERB,B2
-to cause death,to cause death,害死,VERB,C1
-to cause remorse,to cause remorse,词,VERB,B2
-to cauterize,to cauterize,烧灼,VERB,B2
-to chain (verb),to chain,词,VERB,C1
-to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
-to chair (verb),to chair,词,VERB,C1
-to change clothes,to change clothes,更衣,VERB,B1
-to change trains,to change trains,词,VERB,A1
-to charge (verb),to charge,充电,VERB,B2
-to chastise,to chastise,严惩,VERB,B2
-to cheer on,to cheer on,加油,VERB,B2
-to chill,to chill,使冰冻,VERB,B2
-to chisel (verb),to chisel,词,VERB,B2
-to circle (verb),to circle,词,VERB,B2
-to circumcise,to circumcise,割礼,VERB,B2
-to clash (verb),to clash,词,VERB,C1
-to clean out,to clean out,词,VERB,C1
-to clear customs,to clear customs,词,VERB,C1
-to clear land,to clear land,词,VERB,C1
-to clear one's throat,to clear one's throat,词,VERB,C1
-to clear up,to clear up,词,VERB,C1
-to climb a mountain,to climb a mountain,爬山,VERB,B2
-to climb mountain,to climb mountain,上山,VERB,C1
-to climb rise,to climb rise,词,VERB,C1
-to cling to,to cling to,词,VERB,B2
-to cloister (verb),to cloister,词,VERB,C1
-to clone (verb),to clone,词,VERB,C1
-to close a deal,to close a deal,成交,VERB,C1
-to cloy,to cloy,使厌烦,VERB,B2
-to cluster (verb),to cluster,词,VERB,B2
-to coach (verb),to coach,辅导,VERB,B2
-to coagulate,to coagulate,词,VERB,B2
-to coat (verb),to coat,词,VERB,C1
-to coax,to coax,哄骗,VERB,B2
-to codify,to codify,编纂,VERB,B2
-to coerce,to coerce,强迫,VERB,B2
-to cohabit,to cohabit,词,VERB,B2
-to coil (verb),to coil,词,VERB,C1
-to coin (verb),to coin,词,VERB,B2
-to collate,to collate,核对,VERB,B2
-to come (aux),to come,就来,AUX,C1
-to come down,to come down,下来,VERB,B2
-to come forward,to come forward,前来,VERB,B2
-to come true,to come true,词,VERB,B2
-to comment (verb),to comment,词,VERB,B2
-to comment on,to comment on,词,VERB,C1
-to commentate,to commentate,评论,VERB,B2
-to commercialize,to commercialize,商业化,VERB,B2
-to commission,to commission,委托,VERB,B2
-to commit fraud,to commit fraud,舞弊,VERB,B2
-to commune,to commune,交融,VERB,B2
-to commute,to commute,通勤,VERB,B2
-to compact (verb),to compact,词,VERB,C1
-to complement,to complement,补充,VERB,B2
-to complete finish,to complete finish,词,VERB,B2
-to compliment (verb),to compliment,词,VERB,C1
-to compose (noun),to compose,合成,NOUN,B2
-to computerize,to computerize,词,VERB,C1
-to concede,to concede,承认,VERB,B2
-to concern (verb),to concern,关乎,VERB,B2
-to concern all,to concern all,凡事,VERB,B2
-to conclude an agreement,to conclude an agreement,词,VERB,C1
-to concoct,to concoct,编造,VERB,B2
-to concretize,to concretize,词,VERB,C1
-to condescend,to condescend,屈尊,VERB,B2
-to condone,to condone,宽恕,VERB,B2
-to confer,to confer,授予,VERB,B2
-to confine,to confine,限制,VERB,B2
-to conform,to conform,符合,VERB,B2
-to conjecture,to conjecture,猜测,VERB,B2
-to conjugate,to conjugate,变位,VERB,B2
-to conjure away,to conjure away,词,VERB,B2
-to connote,to connote,暗示,VERB,B2
-to consent,to consent,同意,VERB,B2
-to conserve,to conserve,保存,VERB,B2
-to consign,to consign,移交,VERB,B2
-to constipate,to constipate,词,VERB,C1
-to constitutionalize,to constitutionalize,词,VERB,C1
-to consult a reference,to consult a reference,参照,VERB,B2
-to consummate,to consummate,完成,VERB,B2
-to contend,to contend,主张,VERB,B2
-to contest (verb),to contest,词,VERB,B2
-to contextualize,to contextualize,置于语境,VERB,B2
-to cope,to cope,应付,VERB,B2
-to corner (verb),to corner,词,VERB,C1
-to correspond (! verb),to correspond,词,! VERB,C1
-to corroborate,to corroborate,证实,VERB,B2
-to corrode,to corrode,腐蚀,VERB,B2
-to corrupt (verb),to corrupt,词,VERB,B2
-to countersign,to countersign,副署,VERB,B2
-to couple pair (verb),to couple pair,词,VERB,B2
-to court (verb),to court,词,VERB,B2
-to cover retreat,to cover retreat,断后,VERB,C1
-to cover up,to cover up,词,VERB,C1
-to covet,to covet,觊觎,VERB,B2
-to crack seeds,to crack seeds,嗑,VERB,B2
-to cram,to cram,填鸭式学习,VERB,B2
-to crash into,to crash into,撞击,VERB,B2
-to creak,to creak,嘎吱作响,VERB,B2
-to croak,to croak,呱呱叫,VERB,B2
-to cross out,to cross out,词,VERB,C1
-to cross-check,to cross-check,词,VERB,B2
-to crossbreed,to crossbreed,杂交,VERB,B2
-to crow (verb),to crow,词,VERB,C1
-to crowd together,to crowd together,挤在一起,VERB,B2
-to crumple,to crumple,弄皱,VERB,B2
-to cry out,to cry out,词,VERB,B2
-to cuddle,to cuddle,拥抱,VERB,B2
-to culminate,to culminate,达到顶点,VERB,B2
-to curl,to curl,卷曲,VERB,B2
-to curtail,to curtail,削减,VERB,B2
-to curve,to curve,弯曲,VERB,B2
-to cushion (verb),to cushion,词,VERB,B2
-to cut robe,to cut robe,割袍,VERB,B2
-to cut the ribbon,to cut the ribbon,剪彩,VERB,B2
-to cut up,to cut up,词,VERB,C1
-to dam up,to dam up,词,VERB,C1
-to damn (verb),to damn,词,VERB,B2
-to dare to,to dare to,勇于,VERB,B2
-to daunt,to daunt,使气馁,VERB,B2
-to dawdle,to dawdle,闲逛,VERB,B2
-to dawn (verb),to dawn,词,VERB,C1
-to daze,to daze,使茫然,VERB,B2
-to deactivate,to deactivate,词,VERB,C1
-to deafen,to deafen,使聋,VERB,B2
-to deal,to deal,处理,VERB,B2
-to debase,to debase,贬低,VERB,B2
-to decant,to decant,倾析,VERB,B2
-to decentralize,to decentralize,去中心化,VERB,B2
-to declaim,to declaim,慷慨陈词,VERB,B2
-to declare oneself,to declare oneself,词,VERB,B2
-to declassify,to declassify,解密,VERB,B2
-to decode,to decode,解码,VERB,B2
-to decompress,to decompress,解压,VERB,B2
-to decontextualize,to decontextualize,词,VERB,C1
-to decouple,to decouple,分离,VERB,B2
-to decree (verb),to decree,旨,VERB,B2
-to decry,to decry,谴责,VERB,B2
-to defame,to defame,诽谤,VERB,B2
-to default (verb),to default,拖欠,VERB,B2
-to defect to the enemy,to defect to the enemy,投敌,VERB,B2
-to defend oneself,to defend oneself,词,VERB,B2
-to defer,to defer,推迟,VERB,B2
-to deflate,to deflate,使泄气,VERB,B2
-to defray,to defray,支付,VERB,B2
-to defrost,to defrost,除霜,VERB,B2
-to defuse,to defuse,缓和,VERB,B2
-to deify,to deify,神化,VERB,B2
-to deign,to deign,屈尊,VERB,B2
-to delay to take long,to delay to take long,词,VERB,C1
-to delegitimize,to delegitimize,词,VERB,C1
-to delete to remove,to delete to remove,词,VERB,C1
-to delight,to delight,使高兴,VERB,B2
-to delimit,to delimit,词,VERB,C1
-to delineate,to delineate,描绘,VERB,B2
-to deliver to give as gift,to deliver to give as gift,送,VERB,B2
-to deliver to issue,to deliver to issue,词,VERB,C1
-to delude oneself,to delude oneself,词,VERB,B2
-to demarcate,to demarcate,划定界限,VERB,B2
-to demilitarize,to demilitarize,非军事化,VERB,B2
-to democratize,to democratize,民主化,VERB,B2
-to demonize,to demonize,妖魔化,VERB,B2
-to denature,to denature,使变性,VERB,B2
-to denigrate,to denigrate,诋毁,VERB,B2
-to denote,to denote,表示,VERB,B2
-to densify,to densify,词,VERB,C1
-to depersonalize,to depersonalize,词,VERB,C1
-to depilate,to depilate,脱毛,VERB,B2
-to deploy unfold,to deploy unfold,词,VERB,C1
-to depopulate,to depopulate,使人口减少,VERB,B2
-to deport,to deport,驱逐出境,VERB,B2
-to deposit (verb),to deposit,存放,VERB,B2
-to deposit money,to deposit money,储蓄,VERB,B2
-to deprave,to deprave,使堕落,VERB,B2
-to depreciate,to depreciate,贬值,VERB,B2
-to depress,to depress,使沮丧,VERB,B2
-to deputize,to deputize,词,VERB,C1
-to deregister,to deregister,注销,VERB,B2
-to descend from,to descend from,起源于,VERB,B2
-to desert,to desert,擅离职守,VERB,B2
-to desertify,to desertify,词,VERB,C1
-to design (verb),to design,词,VERB,B2
-to desolate (verb),to desolate,词,VERB,C1
-to despair (verb),to despair,词,VERB,C1
-to despoil,to despoil,掠夺,VERB,B2
-to destock,to destock,词,VERB,C1
-to destroy (noun),to destroy,毁掉,NOUN,B2
-to detail,to detail,详述,VERB,B2
-to dethrone,to dethrone,废黜,VERB,B2
-to detract,to detract,贬低,VERB,B2
-to deviate,to deviate,偏离,VERB,B2
-to devour,to devour,吞食,VERB,B2
-to dialyze,to dialyze,词,VERB,C1
-to die for,to die for,死要,VERB,B2
-to differ,to differ,不同,VERB,B2
-to digitalize,to digitalize,词,VERB,C1
-to digitize,to digitize,数字化,VERB,B2
-to dilute,to dilute,稀释,VERB,B2
-to dimension (verb),to dimension,词,VERB,C1
-to dirty (verb),to dirty,词,VERB,C1
-to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
-to disabuse,to disabuse,纠正错误想法,VERB,B2
-to disappear to vanish,to disappear to vanish,词,VERB,A2
-to disarrange,to disarrange,弄乱,VERB,B2
-to disarray (verb),to disarray,词,VERB,C1
-to discern,to discern,辨别,VERB,B2
-to disconcert,to disconcert,使惊慌,VERB,B2
-to disconsole,to disconsole,词,VERB,C1
-to discourse (verb),to discourse,论述,VERB,B2
-to disdain (verb),to disdain,词,VERB,C1
-to disdain as beneath contempt,to disdain as beneath contempt,不屑一顾,VERB,B2
-to disenchant,to disenchant,使清醒,VERB,B2
-to disentail,to disentail,词,VERB,C1
-to disentangle,to disentangle,解开,VERB,B2
-to disfigure,to disfigure,毁容,VERB,B2
-to disguise (verb),to disguise,伪装,VERB,B2
-to disgust (verb),to disgust,词,VERB,B2
-to dishearten,to dishearten,使沮丧,VERB,B2
-to dishevel,to dishevel,弄乱,VERB,B2
-to dishonor,to dishonor,使蒙羞,VERB,B2
-to disinherit,to disinherit,剥夺继承权,VERB,B2
-to disintegrate,to disintegrate,瓦解,VERB,B2
-to disjoin,to disjoin,分离,VERB,B2
-to disjoint (verb),to disjoint,词,VERB,C1
-to dislodge,to dislodge,逐出,VERB,B2
-to dismay,to dismay,使沮丧,VERB,B2
-to dismiss from office,to dismiss from office,词,VERB,C1
-to disoblige,to disoblige,词,VERB,C1
-to dispel,to dispel,消除,VERB,B2
-to dispense,to dispense,分发,VERB,B2
-to disperse,to disperse,分散,VERB,B2
-to display to bring into play,to display to bring into play,发挥,VERB,B1
-to dispose,to dispose,处理,VERB,B2
-to dispossess,to dispossess,剥夺,VERB,B2
-to disproportion (verb),to disproportion,词,VERB,C1
-to disqualify,to disqualify,取消资格,VERB,B2
-to disrespect (verb),to disrespect,词,VERB,C1
-to disrupt,to disrupt,扰乱,VERB,B2
-to dissent (verb),to dissent,词,VERB,C1
-to dissipate,to dissipate,消散,VERB,B2
-to distance (verb),to distance,词,VERB,C1
-to distill,to distill,蒸馏,VERB,B2
-to distress (verb),to distress,词,VERB,B2
-to distrust (verb),to distrust,词,VERB,C1
-to disturb to alarm,to disturb to alarm,惊动,VERB,C1
-to disunite,to disunite,使分裂,VERB,B2
-to dither,to dither,犹豫不决,VERB,B2
-to diverge,to diverge,分歧,VERB,B2
-to divest,to divest,剥夺,VERB,B2
-to divulge,to divulge,泄露,VERB,B2
-to do crafts,to do crafts,词,VERB,B1
-to do hair,to do hair,词,VERB,C1
-to do harm,to do harm,伤害,VERB,B2
-to do justice to,to do justice to,词,VERB,C1
-to do make,to do make,词,VERB,A1
-to do one's utmost,to do one's utmost,全力以赴,VERB,B2
-to do sports,to do sports,运动,VERB,B2
-to do what,to do what,干嘛,VERB,B2
-to do wrong,to do wrong,词,VERB,B2
-to domicile,to domicile,词,VERB,C1
-to donate blood,to donate blood,献血,VERB,B2
-to dope (verb),to dope,词,VERB,B2
-to dote,to dote,词,VERB,B2
-to drain (verb),to drain,词,VERB,C1
-to drape,to drape,悬挂,VERB,B2
-to drape over one's shoulders,to drape over one's shoulders,披,VERB,B1
-to draw back,to draw back,词,VERB,C1
-to draw support from,to draw support from,借助,VERB,B2
-to draw up,to draw up,起草,VERB,B2
-to draw water,to draw water,打水,VERB,B2
-to drill (verb),to drill,词,VERB,B2
-to drink a toast,to drink a toast,干杯,VERB,B2
-to drip,to drip,滴,VERB,B2
-to drive in to break down,to drive in to break down,词,VERB,C1
-to drive lead,to drive lead,驾驶,VERB,B2
-to drive there,to drive there,词,VERB,B2
-to drop off,to drop off,放下,VERB,B2
-to drown to sink,to drown to sink,词,VERB,A2
-to dry clean,to dry clean,干洗,VERB,B2
-to dry in the sun (aux),to dry in the sun,晒,AUX,B1
-to dry in the sun (verb),to dry in the sun,晾晒,VERB,B2
-to dry out,to dry out,词,VERB,C1
-to dry up,to dry up,使干枯,VERB,B2
-to dull (verb),to dull,词,VERB,C1
-to dupe,to dupe,欺骗,VERB,B2
-to dust (verb),to dust,词,VERB,C1
-to dust off,to dust off,词,VERB,C1
-to dye,to dye,染色,VERB,B2
-to each other (adv),to each other,词,ADV,C1
-to earmark,to earmark,词,VERB,C1
-to earn money,to earn money,挣钱,VERB,B2
-to earnestly request,to earnestly request,恳请,VERB,B2
-to eat animals,to eat animals,词,VERB,A2
-to eavesdrop,to eavesdrop,偷听,VERB,B2
-to eclipse,to eclipse,使失色,VERB,B2
-to edge (verb),to edge,词,VERB,C1
-to edify,to edify,启发,VERB,B2
-to eject,to eject,弹出,VERB,B2
-to elaborate (verb),to elaborate,阐发,VERB,B2
-to elapse,to elapse,流逝,VERB,B2
-to elbow (verb),to elbow,词,VERB,B2
-to elevate,to elevate,提升,VERB,B2
-to elide,to elide,省略,VERB,B2
-to elucidate,to elucidate,阐明,VERB,B2
-to elude,to elude,逃避,VERB,B2
-to email,to email,发邮件,VERB,B2
-to emasculate,to emasculate,使无力,VERB,B2
-to embark,to embark,上船,VERB,B2
-to embarrass,to embarrass,使尴尬,VERB,B2
-to embolden,to embolden,使大胆,VERB,B2
-to emerge,to emerge,出现,VERB,B2
-to emerge one after another,to emerge one after another,层出不穷,ADJ,C1
-to emigrate,to emigrate,移居国外,VERB,B2
-to encircle,to encircle,环绕,VERB,B2
-to encode,to encode,编码,VERB,B2
-to encore (verb),to encore,词,VERB,C1
-to encroach,to encroach,侵蚀,VERB,B2
-to enervate,to enervate,使衰弱,VERB,B2
-to engage in,to engage in,从事,VERB,B2
-to engrave,to engrave,雕刻,VERB,B2
-to engross,to engross,使全神贯注,VERB,B2
-to enrage,to enrage,激怒,VERB,B2
-to enrapture,to enrapture,使狂喜,VERB,B2
-to enrol,to enrol,注册,VERB,B2
-to enslave,to enslave,奴役,VERB,B2
-to ensnare,to ensnare,诱捕,VERB,B2
-to entail strenuous effort,to entail strenuous effort,吃力,NOUN,B2
-to enter into,to enter into,词,VERB,B2
-to enter palace,to enter palace,进宫,VERB,B1
-to enter to advance,to enter to advance,进,VERB,A1
-to enthrall,to enthrall,迷住,VERB,B2
-to enthrone,to enthrone,立为王,VERB,B2
-to enunciate,to enunciate,阐明,VERB,B2
-to equal (verb),to equal,无异,VERB,B2
-to equalize,to equalize,使相等,VERB,B2
-to equate,to equate,等同,VERB,B2
-to erode,to erode,侵蚀,VERB,B2
-to espy,to espy,窥探,VERB,B2
-to esteem,to esteem,推崇,VERB,B2
-to estimate (verb),to estimate,估算,VERB,B2
-to eternalize,to eternalize,使永恒,VERB,B2
-to evidence (verb),to evidence,词,VERB,C1
-to evoke,to evoke,唤起,VERB,B2
-to exalt,to exalt,颂扬,VERB,B2
-to exchange currency,to exchange currency,换汇,VERB,B2
-to exchange to replace,to exchange to replace,词,VERB,A2
-to exclaim,to exclaim,呼喊,VERB,B2
-to exculpate,to exculpate,开脱,VERB,B2
-to execrate,to execrate,痛恨,VERB,B2
-to execute by firing squad,to execute by firing squad,词,VERB,C1
-to exert effort,to exert effort,使劲儿,VERB,B1
-to exfoliate,to exfoliate,去角质,VERB,B2
-to exit to go out,to exit to go out,出去,VERB,A2
-to exorcise,to exorcise,驱魔,VERB,B2
-to expatriate,to expatriate,使移居国外,VERB,B2
-to expectorate,to expectorate,吐痰,VERB,B2
-to experiment,to experiment,实验,VERB,B2
-to express sympathy,to express sympathy,慰问,VERB,C1
-to expurgate,to expurgate,删节,VERB,B2
-to externalize,to externalize,使外在化,VERB,B2
-to extirpate,to extirpate,根除,VERB,B2
-to extol,to extol,赞美,VERB,B2
-to extort a bribe,to extort a bribe,索贿,VERB,B2
-to extricate,to extricate,使摆脱,VERB,B2
-to exude,to exude,散发,VERB,B2
-to fail to fulfill,to fail to fulfill,未履行,VERB,B2
-to fall behind,to fall behind,落后,VERB,B2
-to fall down,to fall down,倒下,VERB,B2
-to fall into,to fall into,陷入,VERB,B2
-to fall silent,to fall silent,沉默,VERB,B2
-to fall to,to fall to,落到...身上,VERB,B2
-to familiarize,to familiarize,使熟悉,VERB,B2
-to fart (verb),to fart,放屁,VERB,B2
-to fatten,to fatten,养肥,VERB,B2
-to fawn on,to fawn on,巴结,VERB,C1
-to federate,to federate,词,VERB,C1
-to feel cold,to feel cold,寒,VERB,C1
-to feel dizzy,to feel dizzy,词,VERB,A2
-to feel relieved,to feel relieved,放心,VERB,B2
-to feel sorry for,to feel sorry for,惋惜,VERB,B2
-to feel to think,to feel to think,觉得,VERB,A1
-to feel wronged,to feel wronged,委屈,VERB,B2
-to feign,to feign,假装,VERB,B2
-to feign ignorance,to feign ignorance,词,VERB,C1
-to fell,to fell,砍倒,VERB,B2
-to ferret,to ferret,搜寻,VERB,B2
-to fertilize,to fertilize,施肥,VERB,B2
-to festoon,to festoon,词,VERB,C1
-to fight over to vie for,to fight over to vie for,争夺,VERB,B2
-to figure (verb),to figure,词,VERB,C1
-to file (verb),to file,词,VERB,C1
-to file for record,to file for record,备案,VERB,B2
-to fill in a blank,to fill in a blank,填空,VERB,A2
-to finally,to finally,你可算,VERB,B2
-to finance to fund,to finance to fund,词,VERB,B1
-to find employment,to find employment,就业,VERB,C1
-to find medicine,to find medicine,找药,VERB,C1
-to find you,to find you,找你,VERB,B2
-to fit out to develop,to fit out to develop,词,VERB,C1
-to fix to prepare,to fix to prepare,词,VERB,A2
-to fix to set,to fix to set,词,VERB,B1
-to flame (verb),to flame,词,VERB,B2
-to flap,to flap,拍打,VERB,B2
-to flash,to flash,闪烁,VERB,B2
-to flatten,to flatten,使平坦,VERB,B2
-to fleece (verb),to fleece,词,VERB,C1
-to flock,to flock,群集,VERB,B2
-to flog,to flog,鞭打,VERB,B2
-to flood (verb),to flood,词,VERB,C1
-to flout,to flout,蔑视,VERB,B2
-to flow in,to flow in,词,VERB,C1
-to flow into,to flow into,词,VERB,C1
-to fluctuate,to fluctuate,波动,VERB,B2
-to flush out,to flush out,词,VERB,B2
-to fluster,to fluster,使慌乱,VERB,B2
-to foam (verb),to foam,词,VERB,B2
-to foil (verb),to foil,词,VERB,C1
-to foist,to foist,强加,VERB,B2
-to fold back to withdraw,to fold back to withdraw,词,VERB,C1
-to follow up,to follow up,追问,VERB,B2
-to for example,to for example,比如,VERB,B2
-to force-feed,to force-feed,词,VERB,C1
-to forebode,to forebode,预兆,VERB,B2
-to form a coalition,to form a coalition,词,VERB,C1
-to form to train,to form to train,词,VERB,B1
-to fortify,to fortify,加强,VERB,B2
-to fossilize,to fossilize,石化,VERB,B2
-to fraction,to fraction,分割,VERB,B2
-to fractionate,to fractionate,词,VERB,C1
-to fracture (verb),to fracture,词,VERB,C1
-to fragment (verb),to fragment,词,VERB,C1
-to fraternize,to fraternize,勾结,VERB,B2
-to freshen,to freshen,使清新,VERB,B2
-to frighten away,to frighten away,词,VERB,C1
-to frolic,to frolic,嬉戏,VERB,B2
-to fuck,to fuck,词,VERB,B2
-to fuck off,to fuck off,词,VERB,C1
-to fumigate,to fumigate,熏蒸,VERB,B2
-to function to work,to function to work,词,VERB,B1
-to fuse (verb),to fuse,融合,VERB,B2
-to gain,to gain,获得,VERB,B2
-to gain weight,to gain weight,变胖,VERB,B2
-to galvanize,to galvanize,激励,VERB,B2
-to gasify,to gasify,词,VERB,C1
-to gather herbs,to gather herbs,采药,VERB,C1
-to gather to collect,to gather to collect,词,VERB,A2
-to gather to meet,to gather to meet,词,VERB,A2
-to gauge,to gauge,测量,VERB,B2
-to generate engender,to generate engender,产生,VERB,B2
-to generate to beget,to generate to beget,词,VERB,C1
-to germinate,to germinate,发芽,VERB,B2
-to gestate,to gestate,词,VERB,C1
-to get a haircut,to get a haircut,理发,VERB,A2
-to get along,to get along,词,VERB,B2
-to get angry annoyed,to get angry annoyed,恼火,ADJ,C1
-to get better,to get better,词,VERB,A2
-to get bored,to get bored,词,VERB,B1
-to get by,to get by,过得去,VERB,B2
-to get cheaper,to get cheaper,词,VERB,A2
-to get engaged,to get engaged,词,VERB,B1
-to get expensive,to get expensive,词,VERB,A2
-to get fond of,to get fond of,词,VERB,C1
-to get into,to get into,陷入,VERB,B2
-to get into debt,to get into debt,词,VERB,C1
-to get off,to get off,词,VERB,B2
-to get on,to get on,词,VERB,B2
-to get on a vehicle,to get on a vehicle,上车,VERB,B2
-to get rich,to get rich,发财,VERB,B2
-to get sick,to get sick,生病,VERB,A1
-to get started,to get started,词,VERB,C1
-to get stoned,to get stoned,词,VERB,C1
-to get tired,to get tired,疲劳,VERB,A2
-to get to know,to get to know,词,VERB,B1
-to gift (verb),to gift,词,VERB,B1
-to giggle,to giggle,咯咯笑,VERB,B2
-to gird,to gird,束紧,VERB,B2
-to give a discount,to give a discount,打折,VERB,A2
-to give a gift,to give a gift,词,VERB,A2
-to give as a gift,to give as a gift,赠送,VERB,B2
-to give birth,to give birth,分娩,VERB,B2
-to give in,to give in,词,VERB,B2
-to give oneself up,to give oneself up,投案,VERB,B2
-to give or have an injection,to give or have an injection,打针,VERB,A2
-to give rise to,to give rise to,引起,VERB,A2
-to give up halfway,to give up halfway,半途而废,VERB,B2
-to give you (verb),to give you,给你,VERB,B1
-to glean,to glean,搜集,VERB,B2
-to glimpse (verb),to glimpse,瞥见,VERB,B2
-to globalize,to globalize,使全球化,VERB,B2
-to gloss,to gloss,注释,VERB,B2
-to gloss over,to gloss over,词,VERB,B2
-to glue (verb),to glue,词,VERB,C1
-to go along,to go along,词,VERB,C1
-to go back and forth,to go back and forth,往返,VERB,B1
-to go bald,to go bald,词,VERB,C1
-to go blind,to go blind,失明,VERB,B2
-to go deep into,to go deep into,深入,VERB,B2
-to go down to descend,to go down to descend,词,VERB,A2
-to go forward,to go forward,往后,VERB,B2
-to go home,to go home,回家,VERB,B2
-to go in a direction,to go in a direction,往,VERB,A2
-to go numb,to go numb,麻木,VERB,B2
-to go on a business trip,to go on a business trip,出差,VERB,B2
-to go on stage,to go on stage,上场,VERB,B2
-to go there,to go there,词,VERB,B1
-to go to bed,to go to bed,上床,VERB,B2
-to go to school,to go to school,上学,VERB,B2
-to go to work,to go to work,上班,VERB,A1
-to go up again,to go up again,词,VERB,B1
-to go up to climb,to go up to climb,词,VERB,A2
-to go upstairs,to go upstairs,上楼,VERB,B2
-to goad,to goad,刺激,VERB,B2
-to graduate (verb),to graduate,毕业,VERB,B2
-to graspen,to graspen,抓住,VERB,B2
-to gratify,to gratify,使满足,VERB,B2
-to gratinate,to gratinate,烤成焦皮,VERB,B2
-to gravitate,to gravitate,受吸引,VERB,B2
-to gray,to gray,变白,VERB,B2
-to grill (verb),to grill,词,VERB,A2
-to group,to group,分组,VERB,B2
-to grow fond of,to grow fond of,词,VERB,C1
-to grow old,to grow old,词,VERB,A1
-to growl,to growl,咆哮,VERB,B2
-to guess divine,to guess divine,词,VERB,B2
-to guess right,to guess right,猜中,VERB,B2
-to guide (verb),to guide,导向,VERB,B2
-to guillotine,to guillotine,斩首,VERB,B2
-to gulp down,to gulp down,词,VERB,C1
-to gurgle (verb),to gurgle,词,VERB,C1
-to gush,to gush,涌出,VERB,B2
-to hail,to hail,下冰雹,VERB,B2
-to hail inspect,to hail inspect,盘查,VERB,B2
-to half-close,to half-close,词,VERB,C1
-to half-hear,to half-hear,词,VERB,C1
-to half-open,to half-open,词,VERB,C1
-to hallucinate,to hallucinate,词,VERB,B2
-to hand in,to hand in,词,VERB,B2
-to handcuff,to handcuff,给…戴手铐,VERB,B2
-to handle affairs,to handle affairs,办事,VERB,B2
-to hang hook,to hang hook,词,VERB,B2
-to hang to suspend,to hang to suspend,悬挂,VERB,C1
-to harangue (verb),to harangue,词,VERB,B2
-to harden,to harden,使经受锻炼,VERB,B2
-to harm (verb),to harm,害,VERB,B2
-to harm you,to harm you,害你,VERB,B2
-to harmonize,to harmonize,使和谐,VERB,B2
-to hasten,to hasten,词,VERB,C1
-to hatch bloom,to hatch bloom,词,VERB,B2
-to have a fever,to have a fever,发烧,VERB,B2
-to have an attack,to have an attack,发作,VERB,B2
-to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
-to have auxiliary,to have auxiliary,词,AUX,A1
-to have had enough,to have had enough,受够了,VERB,B2
-to have no choice,to have no choice,不得已,ADJ,B2
-to have seen,to have seen,看过,VERB,B2
-to have some,to have some,有些,VERB,B1
-to have summer vacation,to have summer vacation,放暑假,VERB,A2
-to have supper,to have supper,词,VERB,C1
-to have to,to have to,必须,VERB,B2
-to head (verb),to head,词,VERB,B2
-to head for,to head for,前往,VERB,B2
-to hear of,to hear of,词,VERB,B1
-to hear that,to hear that,听说,VERB,B2
-to help out repair,to help out repair,词,VERB,B2
-to herniate,to herniate,词,VERB,C1
-to hide to disappear,to hide to disappear,词,VERB,A2
-to hike (verb),to hike,远足,VERB,B2
-to hit the mark,to hit the mark,词,VERB,B2
-to hoard,to hoard,词,VERB,C1
-to hoist,to hoist,词,VERB,C1
-to hold a meeting,to hold a meeting,开会,VERB,B2
-to hold a record,to hold a record,保持纪录,VERB,B2
-to hold accountable,to hold accountable,问责,VERB,B2
-to hold back,to hold back,憋,VERB,B2
-to hold in the mouth,to hold in the mouth,叼,NOUN,B2
-to hold keep,to hold keep,词,VERB,B2
-to hold talks,to hold talks,词,VERB,C1
-to hold up,to hold up,词,VERB,B2
-to hold up stop,to hold up stop,词,VERB,A2
-to hollow out,to hollow out,词,VERB,C1
-to homogenize,to homogenize,词,VERB,C1
-to homologate,to homologate,词,VERB,C1
-to hook (verb),to hook,词,VERB,C1
-to hop,to hop,词,VERB,A1
-to hope for,to hope for,盼望,VERB,B2
-to house (verb),to house,词,VERB,B2
-to huddle,to huddle,词,VERB,C1
-to humanize,to humanize,使人性化,VERB,B2
-to hunt down,to hunt down,追杀,VERB,B2
-to hurry back,to hurry back,急回,VERB,C1
-to hurt (adj),to hurt,疼,ADJ,A1
-to hush,to hush,别吵,VERB,B2
-to hypnotize,to hypnotize,词,VERB,C1
-to idealize,to idealize,理想化,VERB,B2
-to idolize,to idolize,崇拜,VERB,B2
-to ignite,to ignite,词,VERB,B2
-to ignite to inflame,to ignite to inflame,词,VERB,C1
-to imbue,to imbue,词,VERB,C1
-to immobilize,to immobilize,词,VERB,C1
-to immunize,to immunize,免疫,VERB,B2
-to implant,to implant,植入,VERB,B2
-to impoverish,to impoverish,词,VERB,C1
-to imprecate,to imprecate,词,VERB,C1
-to impregnate,to impregnate,词,VERB,C1
-to imprint (verb),to imprint,词,VERB,C1
-to impute,to impute,归咎,VERB,B2
-to incapacitate,to incapacitate,词,VERB,C1
-to incarcerate,to incarcerate,监禁,VERB,B2
-to incentivize,to incentivize,词,VERB,C1
-to inconvenience,to inconvenience,使不便,VERB,B2
-to incriminate,to incriminate,归罪,VERB,B2
-to incur,to incur,招致,VERB,B2
-to indict,to indict,控告,VERB,B2
-to indignate,to indignate,词,VERB,C1
-to indispose,to indispose,词,VERB,C1
-to indoctrinate,to indoctrinate,灌输,VERB,B2
-to induce to lead to,to induce to lead to,词,VERB,C1
-to industrialize,to industrialize,工业化,VERB,B2
-to infest,to infest,滋生,VERB,B2
-to inflame,to inflame,使发炎,VERB,B2
-to inflate to blow,to inflate to blow,词,VERB,A2
-to inflict,to inflict,词,VERB,C1
-to inflict to impose,to inflict to impose,施加,VERB,B2
-to inform to reach,to inform to reach,词,VERB,A2
-to infuse,to infuse,泡制,VERB,B2
-to innovate,to innovate,词,VERB,C1
-to inoculate,to inoculate,词,VERB,C1
-to input,to input,输入,VERB,B2
-to insinuate,to insinuate,暗示,VERB,B2
-to insist to design,to insist to design,词,VERB,A2
-to instill,to instill,灌输,VERB,B2
-to institute (verb),to institute,词,VERB,C1
-to institutionalize,to institutionalize,制度化,VERB,C1
-to instrumentalize,to instrumentalize,工具化,VERB,B2
-to interact,to interact,词,VERB,C1
-to intercede,to intercede,调停,VERB,B2
-to interlace,to interlace,词,VERB,C1
-to interleave,to interleave,词,VERB,C1
-to interlock,to interlock,词,VERB,C1
-to intermarry,to intermarry,联姻,VERB,B2
-to intermix,to intermix,词,VERB,C1
-to internalize,to internalize,词,VERB,C1
-to interpolate,to interpolate,词,VERB,C1
-to interweave,to interweave,词,VERB,C1
-to intone,to intone,词,VERB,C1
-to intoxicate,to intoxicate,使中毒,VERB,B2
-to intuit,to intuit,词,VERB,C1
-to invalidate,to invalidate,证明无效,VERB,B2
-to inventory,to inventory,盘点,VERB,B2
-to investigate (noun),to investigate,追究,NOUN,C1
-to invite to bless,to invite to bless,词,VERB,A2
-to invoice,to invoice,开票,VERB,B2
-to invoke,to invoke,援引,VERB,B2
-to ironize,to ironize,讽刺,VERB,B2
-to irrigate,to irrigate,灌溉,VERB,B2
-to issue (verb),to issue,发行,VERB,B2
-to issue a fatwa,to issue a fatwa,词,VERB,C1
-to issue exhibit,to issue exhibit,词,VERB,C1
-to issue to publish,to issue to publish,发表,VERB,B1
-to it (adv),to it,对此,ADV,B2
-to jam,to jam,堵塞,VERB,B2
-to jeopardize to harm,to jeopardize to harm,危害,VERB,B1
-to jest ironically,to jest ironically,词,VERB,C1
-to join to adhere,to join to adhere,加入 / 附着,VERB,B2
-to jostle,to jostle,词,VERB,C1
-to jostle shove,to jostle shove,词,VERB,B2
-to juggle,to juggle,词,VERB,C1
-to keep confidential,to keep confidential,保密,VERB,B2
-to keep pace with,to keep pace with,词,VERB,C1
-to keep secret,to keep secret,隐瞒,VERB,B2
-to keep silent,to keep silent,保持沉默,VERB,B2
-to keep thinking about,to keep thinking about,惦记,VERB,C1
-to kill you,to kill you,杀你,VERB,B2
-to knead,to knead,词,VERB,A1
-to kneel,to kneel,词,VERB,B1
-to knit,to knit,编织,VERB,B2
-to knock down,to knock down,词,VERB,B2
-to knock to pound,to knock to pound,词,VERB,A2
-to knot (verb),to knot,词,VERB,C1
-to know a fact,to know a fact,词,VERB,A2
-to know be acquainted,to know be acquainted,词,VERB,A2
-to know nothing,to know nothing,一无所知,VERB,B2
-to label (verb),to label,词,VERB,C1
-to lack basis,to lack basis,无据,VERB,B2
-to lament,to lament,哀叹,VERB,B2
-to languish,to languish,词,VERB,C1
-to laugh smile,to laugh smile,笑,VERB,A1
-to launder,to launder,洗钱,VERB,B2
-to lay down,to lay down,放下,VERB,B2
-to lay eggs,to lay eggs,词,VERB,C1
-to lay off to dismiss,to lay off to dismiss,词,VERB,C1
-to laze,to laze,词,VERB,C1
-to lead astray,to lead astray,使入歧途,VERB,B2
-to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
-to lead to succeed,to lead to succeed,词,VERB,B2
-to leaf through,to leaf through,翻阅,VERB,B2
-to lean against,to lean against,词,VERB,B2
-to lean out,to lean out,探出身体,VERB,B2
-to leap (verb),to leap,跨越,VERB,B2
-to learn a lesson,to learn a lesson,词,VERB,C1
-to leave to,to leave to,词,VERB,B2
-to leave to abandon,to leave to abandon,词,VERB,A2
-to lecture (verb),to lecture,宣讲,VERB,B2
-to legislate,to legislate,词,VERB,C1
-to lend to borrow,to lend to borrow,词,VERB,A2
-to lessen,to lessen,词,VERB,B2
-to let (aux),to let,让你,AUX,B2
-to let alone (verb),to let alone,更何况,VERB,B2
-to let in,to let in,词,VERB,C1
-to let out,to let out,词,VERB,B1
-to let to allow,to let to allow,让,VERB,B2
-to lethargize,to lethargize,词,VERB,C1
-to levy,to levy,征收,VERB,C1
-to license,to license,许可,VERB,B2
-to lie in,to lie in,在于,VERB,B2
-to lie tell untruth,to lie tell untruth,词,VERB,A2
-to lie to,to lie to,词,VERB,B2
-to lift oneself up,to lift oneself up,词,VERB,B2
-to lighten,to lighten,减轻,VERB,B2
-to like (aux),to like,词,AUX,A2
-to linkage,to linkage,联动,VERB,B2
-to liquefy,to liquefy,词,VERB,C1
-to lisp (verb),to lisp,词,VERB,B2
-to list (verb),to list,列举,VERB,B2
-to listen to,to listen to,词,VERB,B2
-to litigate,to litigate,词,VERB,C1
-to live in,to live in,词,VERB,C1
-to live on,to live on,词,VERB,C1
-to loathe,to loathe,厌恶,VERB,B2
-to localize,to localize,本地化,VERB,B2
-to lock conclude,to lock conclude,词,VERB,B2
-to lock in,to lock in,词,VERB,B2
-to lodge,to lodge,借宿,VERB,B2
-to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
-to lodge in,to lodge in,词,VERB,C1
-to log in,to log in,登录,VERB,B2
-to loiter,to loiter,词,VERB,C1
-to long for,to long for,渴望,VERB,B2
-to look forward to,to look forward to,期待,VERB,B1
-to look in all directions idiom,to look in all directions idiom,东张西望,VERB,B2
-to look like,to look like,词,VERB,A2
-to look quickly,to look quickly,快看,VERB,C1
-to look to see to read,to look to see to read,看,VERB,A1
-to loot (verb),to loot,词,VERB,C1
-to lose bid,to lose bid,落标,VERB,B2
-to lose one's job,to lose one's job,失业,VERB,B2
-to lose one's temper,to lose one's temper,发火,VERB,B2
-to lose one's way,to lose one's way,迷路,VERB,B2
-to love dearly,to love dearly,心疼,VERB,B2
-to lower the price of,to lower the price of,词,VERB,B2
-to lug,to lug,搬运,VERB,B2
-to lukewarm (verb),to lukewarm,词,VERB,C1
-to lull,to lull,词,VERB,B2
-to lull a baby,to lull a baby,哄婴儿,VERB,B1
-to lunge,to lunge,词,VERB,C1
-to lure (verb),to lure,词,VERB,B2
-to lurk,to lurk,词,VERB,B2
-to magnetize,to magnetize,词,VERB,C1
-to maim,to maim,词,VERB,C1
-to maintain oneself,to maintain oneself,词,VERB,B1
-to make a decision,to make a decision,做主,VERB,B2
-to make a fool of oneself,to make a fool of oneself,出洋相,VERB,B2
-to make a phone call,to make a phone call,打电话,VERB,A1
-to make bland,to make bland,使乏味,VERB,B2
-to make drowsy,to make drowsy,词,VERB,B2
-to make excuses,to make excuses,词,VERB,B2
-to make explicit,to make explicit,词,VERB,B2
-to make fail,to make fail,词,VERB,C1
-to make fall in love,to make fall in love,词,VERB,C1
-to make happy,to make happy,词,VERB,B2
-to make heavier,to make heavier,加重,VERB,B2
-to make impossible,to make impossible,词,VERB,C1
-to make independent,to make independent,使独立,VERB,B2
-to make lasting,to make lasting,词,VERB,B2
-to make more expensive,to make more expensive,词,VERB,C1
-to make one's way,to make one's way,词,VERB,B2
-to make peace,to make peace,和亲,VERB,A2
-to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
-to make proud,to make proud,使自豪,VERB,B2
-to make resemble,to make resemble,弄得像,NOUN,C1
-to make sense,to make sense,讲得通,VERB,B2
-to make stupid,to make stupid,使愚蠢,VERB,B2
-to make uneasy,to make uneasy,词,VERB,C1
-to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
-to maltreat,to maltreat,虐待,VERB,B2
-to mandate (verb),to mandate,词,VERB,B2
-to maneuver (verb),to maneuver,词,VERB,C1
-to manifest,to manifest,表明,VERB,B2
-to manure (verb),to manure,词,VERB,C1
-to marginalize,to marginalize,使边缘化,VERB,B2
-to mark out,to mark out,标示,VERB,B2
-to marry (noun),to marry,出阁,NOUN,C1
-to marry a woman,to marry a woman,娶,VERB,B1
-to marry daughter,to marry daughter,嫁闺,NOUN,C1
-to mash (verb),to mash,词,VERB,A2
-to massacre (verb),to massacre,词,VERB,C1
-to mast,to mast,降伏,VERB,B2
-to mature (verb),to mature,词,VERB,B2
-to maximize,to maximize,词,VERB,C1
-to mean to head to,to mean to head to,词,VERB,A2
-to mean to think,to mean to think,词,VERB,C1
-to meddle,to meddle,干涉,VERB,B2
-to medicalize,to medicalize,词,VERB,C1
-to meditate,to meditate,沉思,VERB,B2
-to memorize,to memorize,词,VERB,A2
-to mention to remember,to mention to remember,词,VERB,A2
-to merge (noun),to merge,词,NOUN,B2
-to mess about,to mess about,胡搞,VERB,B2
-to militarize,to militarize,词,VERB,C1
-to mime (verb),to mime,词,VERB,C1
-to mince,to mince,词,VERB,B1
-to minimize,to minimize,最小化,VERB,B2
-to misplace,to misplace,词,VERB,C1
-to mix in,to mix in,词,VERB,B2
-to mix together disparate substances,to mix together disparate substances,夹杂,VERB,B2
-to mix up,to mix up,词,VERB,C1
-to moan (verb),to moan,词,VERB,B2
-to model (verb),to model,词,VERB,C1
-to modernize,to modernize,词,VERB,C1
-to modulate,to modulate,调节,VERB,B2
-to moon (verb),to moon,词,VERB,A2
-to moor (verb),to moor,词,VERB,B2
-to mop (verb),to mop,词,VERB,A2
-to mop to rinse,to mop to rinse,词,VERB,A2
-to mortgage (verb),to mortgage,抵押,VERB,B2
-to move away,to move away,移开,VERB,B2
-to move forward,to move forward,词,VERB,A2
-to move house,to move house,搬家,VERB,B2
-to move on,to move on,词,VERB,C1
-to move out,to move out,搬出,VERB,B2
-to move sb emotionally,to move sb emotionally,感动,VERB,B2
-to move to pity,to move to pity,使怜悯,VERB,B2
-to mud,to mud,弄脏,VERB,B2
-to muddle,to muddle,词,VERB,C1
-to muddy (verb),to muddy,词,VERB,C1
-to muffle,to muffle,词,VERB,C1
-to mug (verb),to mug,词,VERB,C1
-to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
-to mumble,to mumble,词,VERB,C1
-to mutiny,to mutiny,煽动叛乱,VERB,B2
-to mystify,to mystify,神秘化,VERB,B2
-to nail,to nail,钉,VERB,B2
-to narrow,to narrow,使变窄,VERB,B2
-to navigate,to navigate,导航；航行,VERB,B2
-to nearly succeed,to nearly succeed,垂成,VERB,B2
-to need (aux),to need,还要,AUX,B2
-to need must,to need must,词,VERB,A2
-to neutralize,to neutralize,中和,VERB,B2
-to nickname,to nickname,给...起绰号,VERB,B2
-to not abandon,to not abandon,别丢下,VERB,B2
-to not cry,to not cry,别哭,VERB,B2
-to not fear,to not fear,别怕,VERB,B2
-to not look,to not look,别看,VERB,C1
-to not lose,to not lose,别丢,VERB,B2
-to not run,to not run,别跑,VERB,B2
-to not seen,to not seen,不见,VERB,B2
-to not sleep,to not sleep,睡不,VERB,B2
-to note down,to note down,词,VERB,B2
-to nourish,to nourish,词,VERB,C1
-to nuance,to nuance,使具有细微差别,VERB,B2
-to numb,to numb,使麻木,VERB,B2
-to number (verb),to number,词,VERB,C1
-to objectify,to objectify,客观化,VERB,B2
-to oblige,to oblige,强迫,VERB,B2
-to obscure (verb),to obscure,词,VERB,B2
-to observe to watch,to observe to watch,词,VERB,B1
-to obtain issuance,to obtain issuance,词,VERB,C1
-to occur to,to occur to,词,VERB,B2
-to ogle,to ogle,词,VERB,B2
-to open one's eyes,to open one's eyes,睁,VERB,B1
-to operate manually,to operate manually,手动,VERB,C1
-to operationalize,to operationalize,词,VERB,C1
-to opt to choose,to opt to choose,词,VERB,C1
-to orient,to orient,定向,VERB,B2
-to orient to guide,to orient to guide,词,VERB,C1
-to ostracize,to ostracize,排斥,VERB,B2
-to oust,to oust,推翻,VERB,B2
-to outdistance,to outdistance,词,VERB,C1
-to outline (verb),to outline,勾勒,VERB,B2
-to outrage (verb),to outrage,词,VERB,C1
-to overcast (verb),to overcast,词,VERB,C1
-to overestimate,to overestimate,词,VERB,C1
-to overflow,to overflow,溢出,VERB,B2
-to overlook,to overlook,忽视,VERB,B2
-to overshadow,to overshadow,使黯然失色,VERB,B2
-to oversleep,to oversleep,睡过头,VERB,B2
-to overstep,to overstep,越权,VERB,B2
-to overthrow,to overthrow,推翻,VERB,B2
-to pace back and forth,to pace back and forth,徘徊,VERB,C1
-to pacify,to pacify,平息,VERB,B2
-to package (verb),to package,词,VERB,C1
-to pair,to pair,配对,VERB,B2
-to pamper,to pamper,纵容,VERB,B2
-to panic (verb),to panic,词,VERB,C1
-to parade,to parade,游行,VERB,B2
-to pass an exam,to pass an exam,及格,VERB,B1
-to pass through,to pass through,通,VERB,B2
-to pass time,to pass time,度过,VERB,B1
-to paste (verb),to paste,粘贴,VERB,B1
-to patch (verb),to patch,词,VERB,A2
-to patrol,to patrol,巡逻,VERB,B2
-to pauperize,to pauperize,使贫困,VERB,B2
-to pawn (verb),to pawn,词,VERB,C1
-to pay attention to,to pay attention to,关注,VERB,B2
-to pay homage to,to pay homage to,词,VERB,C1
-to pay off,to pay off,清偿,VERB,B2
-to pay out,to pay out,词,VERB,C1
-to pay the bill,to pay the bill,买单,VERB,C1
-to pay tribute,to pay tribute,致敬,VERB,B2
-to peddle,to peddle,词,VERB,C1
-to pension off,to pension off,词,VERB,C1
-to perfect,to perfect,精修,VERB,B2
-to perforate,to perforate,词,VERB,C1
-to perform umrah,to perform umrah,词,VERB,C1
-to perfume (verb),to perfume,词,VERB,B1
-to perjure,to perjure,词,VERB,B2
-to permeate,to permeate,弥漫,VERB,C1
-to permit (verb),to permit,允许,VERB,B2
-to perpetrate,to perpetrate,词,VERB,C1
-to perpetuate,to perpetuate,使永存,VERB,B2
-to persecute,to persecute,迫害,VERB,B2
-to persevere,to persevere,坚持,VERB,B2
-to persevere with,to persevere with,坚持,VERB,A2
-to persist,to persist,坚持,VERB,B2
-to personify,to personify,词,VERB,C1
-to pester,to pester,词,VERB,C1
-to phagocytize,to phagocytize,词,VERB,C1
-to philosophize,to philosophize,词,VERB,C1
-to photocopy (verb),to photocopy,复印,VERB,B2
-to photograph (verb),to photograph,拍照,VERB,B2
-to pick out,to pick out,挑选,VERB,B2
-to pierce,to pierce,词,VERB,B2
-to pigeonhole,to pigeonhole,词,VERB,C1
-to pilgrimage (verb),to pilgrimage,词,VERB,B2
-to pioneer,to pioneer,首创,VERB,B2
-to pipe (verb),to pipe,词,VERB,A2
-to pity (verb),to pity,词,VERB,B2
-to placate,to placate,安抚,VERB,B2
-to plagiarize,to plagiarize,剽窃,VERB,B2
-to plane,to plane,刨,VERB,B2
-to plant beans,to plant beans,词,VERB,C1
-to plant trees,to plant trees,植树,VERB,B2
-to plaster (verb),to plaster,词,VERB,C1
-to play a joke,to play a joke,开玩笑,VERB,A2
-to play along,to play along,配合,VERB,B2
-to play down,to play down,淡化,VERB,B2
-to play football,to play football,踢足球,VERB,B2
-to play sports,to play sports,做运动,VERB,B2
-to plead guilty,to plead guilty,认罪,VERB,C1
-to pledge mutually,to pledge mutually,词,VERB,C1
-to plot,to plot,密谋,VERB,B2
-to pluck,to pluck,词,VERB,C1
-to pluck a string,to pluck a string,弹,VERB,A2
-to plug in,to plug in,插入,VERB,B2
-to plunder,to plunder,掠夺,VERB,B2
-to point a gun,to point a gun,词,VERB,C1
-to point to clock in,to point to clock in,指 / 打卡,VERB,B2
-to polarize,to polarize,使两极分化,VERB,B2
-to pole (verb),to pole,词,VERB,C1
-to polemicize,to polemicize,词,VERB,C1
-to pollute,to pollute,词,VERB,B2
-to portend,to portend,词,VERB,B2
-to position,to position,定位 / 安置,VERB,B2
-to post,to post,张贴,VERB,B2
-to postpone to carry over,to postpone to carry over,推迟,VERB,B2
-to postulate,to postulate,假定,VERB,B2
-to pound (verb),to pound,词,VERB,B2
-to pour out,to pour out,倾诉,VERB,B2
-to powder,to powder,撒粉,VERB,B2
-to practice fraud,to practice fraud,作弊,VERB,B2
-to practice sword,to practice sword,练剑,VERB,B2
-to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
-to prejudge,to prejudge,词,VERB,B2
-to premiere (verb),to premiere,词,VERB,C1
-to preserve to protect,to preserve to protect,词,VERB,C1
-to preside,to preside,主持,VERB,B2
-to pressurize,to pressurize,逼迫,VERB,B2
-to presuppose,to presuppose,词,VERB,B2
-to prick,to prick,扎,VERB,B2
-to prioritize,to prioritize,优先考虑,VERB,B2
-to privatize,to privatize,私有化,VERB,B2
-to proceed in an orderly way,to proceed in an orderly way,循序渐进,VERB,C1
-to profile (verb),to profile,词,VERB,C1
-to program,to program,编程,VERB,B2
-to project,to project,投射,VERB,B2
-to prop up,to prop up,支撑,VERB,B2
-to propagate,to propagate,传播,VERB,B2
-to prosper,to prosper,繁荣,VERB,B2
-to protect oneself,to protect oneself,自保,VERB,C1
-to protect to defend,to protect to defend,词,VERB,A2
-to provide to supply,to provide to supply,词,VERB,B1
-to publicize,to publicize,宣传,VERB,B1
-to publish edit,to publish edit,词,VERB,B2
-to publish to spread to hang laundry,to publish to spread to hang laundry,词,VERB,A2
-to pucker,to pucker,噘,VERB,B2
-to pull out hair,to pull out hair,词,VERB,C1
-to pull through,to pull through,词,VERB,B2
-to pump (verb),to pump,词,VERB,C1
-to purge,to purge,清除,VERB,B2
-to purify,to purify,净化,VERB,B2
-to purify certify,to purify certify,词,VERB,C1
-to pursue to continue,to pursue to continue,词,VERB,B1
-to push back,to push back,词,VERB,B2
-to push to grow,to push to grow,推/生长,VERB,B2
-to put away,to put away,收拾,VERB,B2
-to put back,to put back,放回,VERB,B2
-to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
-to put on makeup,to put on makeup,化妆,VERB,B2
-to put on track,to put on track,使走上正轨,VERB,B2
-to put standing,to put standing,词,VERB,A2
-to put to bed,to put to bed,词,VERB,A1
-to put to sleep,to put to sleep,词,VERB,B2
-to puzzle (verb),to puzzle,迷惑,VERB,B2
-to quantify,to quantify,词,VERB,B2
-to question officially,to question officially,词,VERB,C1
-to queue,to queue,排队,VERB,B2
-to quit smoking,to quit smoking,戒烟,VERB,B1
-to race (verb),to race,词,VERB,B1
-to race down,to race down,词,VERB,C1
-to rage (verb),to rage,怒,VERB,B2
-to raise a child,to raise a child,抚养孩子,VERB,B1
-to raise awareness,to raise awareness,提高意识,VERB,B2
-to raise funds,to raise funds,筹资,VERB,B2
-to raise seedlings,to raise seedlings,育苗,VERB,B2
-to rally,to rally,团结,VERB,B2
-to ram (verb),to ram,词,VERB,C1
-to rant,to rant,咆哮,VERB,B2
-to ratify,to ratify,批准,VERB,B2
-to ratify to approve,to ratify to approve,词,VERB,C1
-to rationalize,to rationalize,合理化,VERB,B2
-to ravage,to ravage,破坏,VERB,B2
-to rave,to rave,词,VERB,C1
-to reach achieve,to reach achieve,词,VERB,B1
-to reach out,to reach out,伸出,VERB,B2
-to react reaction,to react reaction,反应,VERB,B1
-to read aloud,to read aloud,词,VERB,B2
-to read to be,to read to be,词,VERB,B1
-to rebuke,to rebuke,斥责,VERB,B2
-to receive a bonus,to receive a bonus,分红,VERB,B2
-to receive payment,to receive payment,词,VERB,B1
-to recharge,to recharge,充电,VERB,B2
-to recommend for admission,to recommend for admission,保送,VERB,B2
-to reconquer,to reconquer,词,VERB,C1
-to record save,to record save,词,VERB,B2
-to record sound,to record sound,录音,VERB,B2
-to recover to retrieve,to recover to retrieve,词,VERB,A2
-to recover to wake up,to recover to wake up,词,VERB,A2
-to redden,to redden,变红,VERB,B2
-to redeem,to redeem,赎回,VERB,B2
-to rediscover,to rediscover,重新发现,VERB,B2
-to redo,to redo,词,VERB,B1
-to reduce sentence,to reduce sentence,减刑,VERB,B2
-to reelect,to reelect,词,VERB,C1
-to refine,to refine,提炼,VERB,B2
-to reflect deeply,to reflect deeply,词,VERB,B2
-to reflect on,to reflect on,思考,VERB,B2
-to regionalize,to regionalize,区域化,VERB,B2
-to register one's name,to register one's name,登记,VERB,B1
-to register to record,to register to record,词,VERB,A2
-to rehabilitate,to rehabilitate,使康复,VERB,B2
-to reign (verb),to reign,词,VERB,B2
-to rein in,to rein in,词,VERB,C1
-to reinstate,to reinstate,恢复,VERB,B1
-to reinvent,to reinvent,词,VERB,C1
-to relapse into crime,to relapse into crime,词,VERB,B2
-to relate to,to relate to,有关,VERB,C1
-to relativize,to relativize,词,VERB,C1
-to relaunch,to relaunch,重启,VERB,B2
-to relay,to relay,转达,VERB,B2
-to release from prison,to release from prison,释放,VERB,B2
-to release me,to release me,放我,VERB,B2
-to remain to stay,to remain to stay,词,VERB,A2
-to remediate,to remediate,整治,VERB,B2
-to remove makeup,to remove makeup,词,VERB,C1
-to remove to pull out,to remove to pull out,词,VERB,A2
-to remunerate,to remunerate,词,VERB,C1
-to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
-to rent out,to rent out,出租,VERB,B2
-to reoffend,to reoffend,重犯,VERB,B2
-to reopen,to reopen,重新开放,VERB,B2
-to repeal,to repeal,废除,VERB,B2
-to repeat a grade,to repeat a grade,留级,VERB,B2
-to repel,to repel,击退,VERB,B2
-to replace you,to replace you,替你,VERB,C1
-to replicate,to replicate,复制,VERB,B2
-to report to authorities,to report to authorities,举报,VERB,B2
-to reproach,to reproach,责备,VERB,B2
-to request leave,to request leave,请假,VERB,A2
-to resell,to resell,转售,VERB,B2
-to resemble (adj),to resemble,相似,ADJ,B1
-to resonate,to resonate,共鸣,VERB,B2
-to respect and love,to respect and love,敬爱,VERB,B1
-to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
-to restructure,to restructure,词,VERB,C1
-to result,to result,产生,VERB,B2
-to resume studies,to resume studies,复学,VERB,B2
-to resurrect,to resurrect,复活,VERB,B2
-to resurrect to revive,to resurrect to revive,词,VERB,C1
-to retort,to retort,反驳,VERB,B2
-to retrace,to retrace,追溯,VERB,B2
-to retract,to retract,撤回,VERB,B2
-to return a car,to return a car,送车,VERB,B2
-to return home,to return home,词,VERB,B1
-to return something,to return something,词,VERB,A2
-to return to restore,to return to restore,词,VERB,C1
-to revalue,to revalue,重新估值,VERB,B2
-to reverse,to reverse,反转,VERB,B2
-to revitalize,to revitalize,使复苏,VERB,B2
-to revolutionize,to revolutionize,革命化,VERB,B2
-to revolve around,to revolve around,围绕,VERB,B2
-to rewrite,to rewrite,词,VERB,C1
-to riddle,to riddle,使布满孔洞,VERB,B2
-to ride along,to ride along,词,VERB,B1
-to ridicule (verb),to ridicule,词,VERB,C1
-to ring (verb),to ring,响,VERB,B2
-to rinse,to rinse,冲洗,VERB,B2
-to roar with laughter,to roar with laughter,哄,VERB,B2
-to rock (verb),to rock,词,VERB,C1
-to roll up,to roll up,卷,VERB,B1
-to roll up sleeves,to roll up sleeves,词,VERB,B1
-to root out,to root out,词,VERB,C1
-to rotate,to rotate,轮,VERB,C1
-to rough-hew,to rough-hew,粗加工,VERB,B2
-to round (verb),to round,词,VERB,A2
-to ruffle,to ruffle,词,VERB,C1
-to rule out,to rule out,词,VERB,C1
-to run about,to run about,乱跑,VERB,C1
-to run away,to run away,逃跑,VERB,B2
-to sadden,to sadden,使悲伤,VERB,B2
-to safeguard,to safeguard,保障,VERB,B2
-to sanctify,to sanctify,使神圣,VERB,B2
-to sanction to punish,to sanction to punish,词,VERB,C1
-to satiate,to satiate,使饱足,VERB,B2
-to saturate,to saturate,使饱和,VERB,B2
-to save seeds,to save seeds,留种,VERB,B2
-to save you,to save you,救你,VERB,B1
-to savor,to savor,品味,VERB,B2
-to saw,to saw,锯,VERB,B2
-to say goodbye fire,to say goodbye fire,词,VERB,B1
-to scamper,to scamper,词,VERB,B2
-to scan,to scan,扫描,VERB,B2
-to scare away,to scare away,惊飞,VERB,B2
-to scent,to scent,词,VERB,B2
-to schematize,to schematize,词,VERB,C1
-to scheme (verb),to scheme,词,VERB,C1
-to score (verb),to score,词,VERB,B2
-to scourge (verb),to scourge,词,VERB,C1
-to scram,to scram,词,VERB,B2
-to scrape,to scrape,词,VERB,B2
-to scratch to rub,to scratch to rub,词,VERB,A2
-to scribble (verb),to scribble,词,VERB,C1
-to scrimp,to scrimp,词,VERB,C1
-to scrub,to scrub,擦洗,VERB,B2
-to sculpt,to sculpt,词,VERB,C1
-to seat,to seat,使坐下,VERB,B2
-to second (verb),to second,词,VERB,C1
-to secrete,to secrete,分泌,VERB,B2
-to secularize,to secularize,词,VERB,C1
-to see emperor,to see emperor,面圣,VERB,C1
-to seek clarification,to seek clarification,词,VERB,B2
-to seek death,to seek death,求死,VERB,C1
-to seek peace,to seek peace,主和,VERB,B2
-to seek you,to seek you,寻你,VERB,B2
-to seep,to seep,词,VERB,B2
-to segment,to segment,细分,VERB,B2
-to segregate,to segregate,隔离,VERB,B2
-to sell dispose,to sell dispose,词,VERB,B2
-to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
-to send (noun),to send,送去,NOUN,C1
-to send back,to send back,传回,VERB,B2
-to send mail,to send mail,寄件,VERB,B2
-to send out,to send out,发出,VERB,B2
-to sensitize,to sensitize,提高意识,VERB,B2
-to sequester,to sequester,隔离,VERB,B2
-to sermonize,to sermonize,词,VERB,B2
-to serve a route,to serve a route,为...提供交通服务,VERB,B2
-to serve as,to serve as,充当,VERB,B2
-to set aside,to set aside,移开,VERB,B2
-to set off again,to set off again,词,VERB,B2
-to set on fire,to set on fire,词,VERB,C1
-to set out,to set out,上路,VERB,B2
-to set out on a journey,to set out on a journey,启程,VERB,B2
-to set rates,to set rates,定价,VERB,B2
-to settle up,to settle up,结账,VERB,B2
-to sever ties,to sever ties,断义,VERB,C1
-to sew again,to sew again,词,VERB,B1
-to sew in,to sew in,词,VERB,C1
-to sexualize,to sexualize,词,VERB,C1
-to shade,to shade,词,VERB,C1
-to share divide,to share divide,分享,VERB,B2
-to shed tears,to shed tears,流泪,VERB,A2
-to shell (verb),to shell,词,VERB,C1
-to shelter,to shelter,庇护,VERB,B2
-to shelter house,to shelter house,词,VERB,B2
-to shield (verb),to shield,包庇,VERB,B2
-to shiver (verb),to shiver,词,VERB,B1
-to shoe (verb),to shoe,词,VERB,C1
-to shoot dead,to shoot dead,击毙,VERB,B2
-to shoot through,to shoot through,射穿,VERB,C1
-to shop for groceries,to shop for groceries,词,VERB,A2
-to shout oneself hoarse,to shout oneself hoarse,词,VERB,C1
-to show off,to show off,词,VERB,C1
-to show partiality,to show partiality,偏袒,VERB,C1
-to shroud,to shroud,覆盖,VERB,B2
-to shuffle,to shuffle,词,VERB,B2
-to shunt,to shunt,分流,VERB,B2
-to shut up,to shut up,闭嘴,VERB,B2
-to sicken,to sicken,词,VERB,C1
-to sidestep,to sidestep,词,VERB,C1
-to sigh (verb),to sigh,词,VERB,B2
-to sight (verb),to sight,词,VERB,C1
-to sightsee,to sightsee,游览,VERB,B2
-to sign up,to sign up,报名,VERB,A2
-to signal (verb),to signal,暗讯,VERB,B2
-to simmer,to simmer,词,VERB,B1
-to simper,to simper,词,VERB,C1
-to simulate,to simulate,模拟,VERB,B2
-to singe,to singe,词,VERB,B2
-to sit (noun),to sit,坐坐,NOUN,C1
-to situate,to situate,定位,VERB,B2
-to skein,to skein,绕成线团,VERB,B2
-to sketch,to sketch,勾勒,VERB,B2
-to skewer,to skewer,串起,VERB,B2
-to skin,to skin,剥皮,VERB,B2
-to slam to snap,to slam to snap,词,VERB,C1
-to slap (verb),to slap,词,VERB,B2
-to slash,to slash,猛砍,VERB,B2
-to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
-to slay,to slay,词,VERB,C1
-to slice (verb),to slice,词,VERB,C1
-to slide,to slide,滑动,VERB,B2
-to slight (verb),to slight,怠慢,VERB,B2
-to slip away,to slip away,词,VERB,C1
-to slope down,to slope down,词,VERB,B2
-to smooth (verb),to smooth,抚平,VERB,B2
-to snack (verb),to snack,词,VERB,C1
-to snack eat sweets,to snack eat sweets,词,VERB,A1
-to snort (verb),to snort,词,VERB,B2
-to snub,to snub,冷落,VERB,B2
-to soften,to soften,使灵活,VERB,B2
-to soil (verb),to soil,词,VERB,C1
-to solder,to solder,焊接,VERB,B2
-to solidify,to solidify,凝固,VERB,B2
-to someone's face,to someone's face,当面,ADV,C1
-to sort out,to sort out,词,VERB,B2
-to sour (verb),to sour,词,VERB,C1
-to spam,to spam,发垃圾信息,VERB,B2
-to sparkle,to sparkle,闪耀,VERB,B2
-to spatter,to spatter,血溅,VERB,C1
-to spawn,to spawn,产卵,VERB,B2
-to specialize,to specialize,专攻,VERB,B2
-to spectacularize,to spectacularize,词,VERB,C1
-to spell,to spell,拼写,VERB,B2
-to spend time,to spend time,词,VERB,A2
-to spend time to judge to fulfill,to spend time to judge to fulfill,词,VERB,B1
-to spend to exchange,to spend to exchange,词,VERB,A2
-to spill,to spill,溢出,VERB,B2
-to spirit away,to spirit away,变走,VERB,B2
-to splash,to splash,溅,VERB,B2
-to splint,to splint,用夹板固定,VERB,B2
-to splinter (verb),to splinter,词,VERB,C1
-to split one's sides,to split one's sides,词,VERB,C1
-to sponsor,to sponsor,赞助,VERB,B2
-to spot,to spot,看见,VERB,B2
-to spout,to spout,喷射,VERB,B2
-to spread to make a bed,to spread to make a bed,词,VERB,A2
-to sprout,to sprout,发芽,VERB,B2
-to spy on,to spy on,词,VERB,C1
-to squeak,to squeak,吱吱叫,VERB,B2
-to stack (verb),to stack,词,VERB,B2
-to stage (verb),to stage,词,VERB,C1
-to stalk,to stalk,跟踪,VERB,B2
-to stammer,to stammer,结巴,VERB,B2
-to stamp (verb),to stamp,词,VERB,B2
-to stand by,to stand by,词,VERB,B2
-to stand out to differentiate,to stand out to differentiate,词,VERB,C1
-to standardize,to standardize,标准化,VERB,B2
-to stare blankly,to stare blankly,发呆,VERB,B2
-to start a business,to start a business,创业,VERB,B2
-to start again,to start again,重新开始,VERB,B2
-to statistics,to statistics,统计,VERB,B2
-to stay here,to stay here,留在这里,VERB,B2
-to stay overnight,to stay overnight,词,VERB,B2
-to steal away,to steal away,偷走,VERB,B2
-to steal sword,to steal sword,偷剑,NOUN,B2
-to steep (verb),to steep,词,VERB,C1
-to stem,to stem,起源于,VERB,B2
-to stem from,to stem from,源于,VERB,B2
-to step in,to step in,介入,VERB,B2
-to step on,to step on,踩,VERB,B2
-to sterilize,to sterilize,词,VERB,C1
-to stick out,to stick out,伸出,VERB,B2
-to stiffen,to stiffen,词,VERB,C1
-to stifle smother,to stifle smother,词,VERB,B2
-to stint,to stint,吝啬,VERB,B2
-to stir up trouble,to stir up trouble,惹祸,VERB,C1
-to stitch,to stitch,缝,VERB,B2
-to stock up,to stock up,进货,VERB,B2
-to stone (verb),to stone,词,VERB,C1
-to stop down,to stop down,词,VERB,C1
-to store (verb),to store,词,VERB,B2
-to straighten up,to straighten up,词,VERB,B2
-to stratify,to stratify,分层,VERB,B2
-to stress (verb),to stress,词,VERB,C1
-to stride (verb),to stride,词,VERB,B2
-to strike down,to strike down,击倒,VERB,B2
-to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
-to string (verb),to string,词,VERB,C1
-to string together,to string together,串,VERB,B2
-to strip bare,to strip bare,洗劫,VERB,B2
-to strip of leaves,to strip of leaves,词,VERB,C1
-to strive for,to strive for,争取,VERB,B2
-to study abroad,to study abroad,留学,VERB,A2
-to study at university,to study at university,词,VERB,A2
-to study deeply,to study deeply,钻研,VERB,B2
-to study jointly,to study jointly,共同研究,VERB,C1
-to study to learn,to study to learn,学习,VERB,B2
-to stuff (verb),to stuff,塞,VERB,B2
-to stun,to stun,词,VERB,C1
-to stutter,to stutter,词,VERB,B2
-to stylize,to stylize,风格化,VERB,B2
-to subject (verb),to subject,词,VERB,C1
-to sublimate,to sublimate,升华,VERB,B2
-to subordinate,to subordinate,从属,VERB,B2
-to suborn,to suborn,教唆,VERB,B2
-to subsist,to subsist,存在,VERB,B2
-to substantiate,to substantiate,证实,VERB,B2
-to subtract,to subtract,词,VERB,C1
-to succeed to pass,to succeed to pass,词,VERB,A2
-to such an extent as to,to such an extent as to,以致,SCONJ,B2
-to suck up,to suck up,词,VERB,C1
-to suddenly realize,to suddenly realize,恍然大悟,VERB,C1
-to suffer from,to suffer from,词,VERB,B2
-to suffer losses,to suffer losses,吃亏,VERB,B2
-to suffice to reach,to suffice to reach,词,VERB,B1
-to suit agree,to suit agree,词,VERB,B2
-to sulk,to sulk,生闷气,VERB,B2
-to sum up,to sum up,总括,VERB,B2
-to sunbathe,to sunbathe,词,VERB,B2
-to supplement (verb),to supplement,补充,VERB,B2
-to supplicate,to supplicate,恳求,VERB,B2
-to support lean,to support lean,词,VERB,B1
-to support with the hand,to support with the hand,扶,VERB,B2
-to surf,to surf,词,VERB,C1
-to surge (verb),to surge,词,VERB,B2
-to surname (verb),to surname,词,VERB,B2
-to survey (verb),to survey,调研,VERB,B2
-to sustain injuries,to sustain injuries,受伤,VERB,B1
-to suture (verb),to suture,缝合,VERB,B2
-to swagger,to swagger,大摇大摆,VERB,B2
-to swallow up,to swallow up,词,VERB,B2
-to sway hips,to sway hips,词,VERB,C1
-to swear an oath,to swear an oath,宣誓,VERB,C1
-to swell,to swell,使肿胀,VERB,B2
-to swing,to swing,荡秋千,VERB,B2
-to swipe,to swipe,词,VERB,C1
-to switch,to switch,切换,VERB,B2
-to switch off,to switch off,关掉,VERB,B2
-to switch on,to switch on,开启,VERB,B2
-to synchronize,to synchronize,词,VERB,C1
-to tack,to tack,词,VERB,C1
-to tackle approach,to tackle approach,词,VERB,B2
-to tag (verb),to tag,词,VERB,C1
-to taint,to taint,玷污,VERB,B2
-to take a bath,to take a bath,洗澡,VERB,A1
-to take a course,to take a course,词,VERB,B2
-to take a shower,to take a shower,词,VERB,A2
-to take a walk,to take a walk,散步,VERB,A2
-to take action,to take action,出手,VERB,B2
-to take advantage of,to take advantage of,词,VERB,B1
-to take amiss,to take amiss,词,VERB,C1
-to take back,to take back,拿回,VERB,B2
-to take bribes,to take bribes,词,VERB,C1
-to take care of oneself,to take care of oneself,保重,VERB,B2
-to take charge of,to take charge of,主持,VERB,B1
-to take communion,to take communion,词,VERB,B2
-to take down,to take down,词,VERB,C1
-to take drugs,to take drugs,吸毒,VERB,B2
-to take leave,to take leave,告辞,VERB,B2
-to take minutes,to take minutes,记录,VERB,B2
-to take off to remove,to take off to remove,词,VERB,A2
-to take on,to take on,词,VERB,C1
-to take one's time,to take one's time,词,VERB,B2
-to take possession of,to take possession of,词,VERB,B2
-to take precautions,to take precautions,戒备,NOUN,C1
-to take risks,to take risks,冒险,VERB,B1
-to take root,to take root,词,VERB,B2
-to take time,to take time,词,VERB,B1
-to take to bed,to take to bed,词,VERB,C1
-to tap to type,to tap to type,词,VERB,C1
-to tarnish,to tarnish,词,VERB,C1
-to task (verb),to task,词,VERB,C1
-to tax to accuse of,to tax to accuse of,词,VERB,C1
-to tax to burden,to tax to burden,征税,VERB,B2
-to teach reading,to teach reading,词,VERB,B2
-to tear out,to tear out,拔出,VERB,B2
-to tear to pieces,to tear to pieces,词,VERB,C1
-to technologize,to technologize,技术化,VERB,B2
-to telework,to telework,远程办公,VERB,B2
-to tell to narrate,to tell to narrate,词,VERB,A2
-to temper (verb),to temper,词,VERB,B2
-to temporize,to temporize,拖延,VERB,B2
-to tense (verb),to tense,词,VERB,B2
-to text,to text,发短信,VERB,B2
-to theatricalize,to theatricalize,戏剧化,VERB,B2
-to thicken,to thicken,词,VERB,C1
-to thin (verb),to thin,词,VERB,C1
-to think back over sth,to think back over sth,反思,VERB,B2
-to think it over,to think it over,思考,VERB,B2
-to think of,to think of,想到,VERB,C1
-to think up every possible method idiom to devise ways and means,to think up every possible method idiom to devise ways and means,想方设法,VERB,C1
-to this (adv),to this,对此,ADV,C1
-to thresh,to thresh,脱粒,VERB,B2
-to thrill,to thrill,使兴奋,VERB,B2
-to throw in,to throw in,词,VERB,B2
-to throw oneself at,to throw oneself at,词,VERB,C1
-to thrust (verb),to thrust,词,VERB,C1
-to thunder (verb),to thunder,词,VERB,B2
-to tidy,to tidy,整理,VERB,B2
-to tidy to order,to tidy to order,词,VERB,B1
-to tinker,to tinker,词,VERB,B1
-to tip over,to tip over,翻倒,VERB,B2
-to title,to title,命名,VERB,B2
-to title to be titled,to title to be titled,词,VERB,B1
-to toast (verb),to toast,词,VERB,B2
-to toil (verb),to toil,词,VERB,C1
-to topple,to topple,词,VERB,C1
-to total (verb),to total,共计,VERB,B2
-to totalize,to totalize,词,VERB,C1
-to tow,to tow,词,VERB,C1
-to trace,to trace,描绘；标出,VERB,B2
-to transcribe,to transcribe,转录,VERB,B2
-to transfer schools,to transfer schools,转学,VERB,B2
-to transgress,to transgress,违背,VERB,B2
-to trap (verb),to trap,词,VERB,C1
-to traumatize,to traumatize,词,VERB,C1
-to travel far,to travel far,千里迢迢,VERB,C1
-to travel trip,to travel trip,旅游,VERB,A1
-to treasure (verb),to treasure,词,VERB,B2
-to treat as,to treat as,当作,VERB,C1
-to treat sb unfairly,to treat sb unfairly,亏待,VERB,B2
-to treat wound,to treat wound,治伤,VERB,B2
-to trek (verb),to trek,词,VERB,C1
-to trivialize,to trivialize,使平庸,VERB,B2
-to try to try on,to try to try on,尝试 / 试穿,VERB,A2
-to tumble,to tumble,跌倒,VERB,B2
-to tune,to tune,调谐,VERB,B2
-to turn away,to turn away,转开,VERB,B2
-to turn back,to turn back,词,VERB,B2
-to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
-to turn on to employ,to turn on to employ,词,VERB,A2
-to turn out to be,to turn out to be,词,VERB,C1
-to turn over,to turn over,翻,VERB,B1
-to tweet,to tweet,发推文,VERB,B2
-to twinkle,to twinkle,词,VERB,B2
-to type,to type,打字,VERB,B2
-to tyrannize,to tyrannize,词,VERB,C1
-to unbalance,to unbalance,词,VERB,C1
-to unbend,to unbend,润滑,VERB,B2
-to unblind,to unblind,使醒悟,VERB,B2
-to unblock,to unblock,词,VERB,C1
-to unbridle,to unbridle,解开,VERB,B2
-to unbutton,to unbutton,解开纽扣,VERB,B2
-to uncage,to uncage,词,VERB,C1
-to uncouple,to uncouple,词,VERB,C1
-to uncover to reveal,to uncover to reveal,词,VERB,A2
-to understand by listening,to understand by listening,听懂,VERB,B2
-to undo,to undo,解开,VERB,B2
-to undress,to undress,脱衣,VERB,B2
-to unearth,to unearth,发掘,VERB,B2
-to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
-to unhinge,to unhinge,词,VERB,C1
-to unhook,to unhook,摘下,VERB,B2
-to unmask,to unmask,揭穿,VERB,B2
-to unplug,to unplug,词,VERB,C1
-to unravel,to unravel,解开,VERB,B2
-to unroll,to unroll,词,VERB,C1
-to unscrew,to unscrew,词,VERB,B2
-to unseat,to unseat,词,VERB,C1
-to unshackle,to unshackle,词,VERB,C1
-to unsheathe,to unsheathe,词,VERB,C1
-to unstitch,to unstitch,词,VERB,B2
-to untangle,to untangle,词,VERB,C1
-to unwrap,to unwrap,词,VERB,B1
-to uproot,to uproot,根除,VERB,B2
-to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
-to use force,to use force,动武,VERB,B2
-to use up,to use up,用完,VERB,B2
-to usually do,to usually do,词,VERB,C1
-to vacuum (verb),to vacuum,词,VERB,A2
-to validate,to validate,验证,VERB,B2
-to valorize,to valorize,词,VERB,C1
-to vampirize,to vampirize,吸血,VERB,B2
-to vary,to vary,改变,VERB,B2
-to vegetate,to vegetate,苟活,VERB,B2
-to venerate,to venerate,崇敬,VERB,B2
-to vent,to vent,倾诉,VERB,B2
-to venture (verb),to venture,词,VERB,B2
-to vibrate,to vibrate,振动,VERB,B2
-to view,to view,参观,VERB,B2
-to vilify,to vilify,诽谤,VERB,B2
-to vouch for,to vouch for,词,VERB,B2
-to vow (verb),to vow,发誓,VERB,B2
-to wait and see,to wait and see,等待观望,VERB,B2
-to walk around,to walk around,四处走动,VERB,B2
-to walk to go,to walk to go,走,VERB,A1
-to wall up,to wall up,词,VERB,C1
-to wane,to wane,减弱,VERB,B2
-to want alive,to want alive,活要,VERB,C1
-to wanted,to wanted,通缉,VERB,B2
-to warm up,to warm up,词,VERB,B2
-to warp,to warp,弯曲,VERB,B2
-to wash and iron,to wash and iron,洗熨,VERB,B2
-to wash up,to wash up,词,VERB,A2
-to wash with water,to wash with water,水洗,VERB,B2
-to watch for,to watch for,词,VERB,C1
-to watch tv,to watch tv,看电视,VERB,B2
-to water give drink,to water give drink,词,VERB,B2
-to wax (verb),to wax,词,VERB,A1
-to wear down,to wear down,词,VERB,B2
-to wear out,to wear out,磨损,VERB,B2
-to wear to get dressed,to wear to get dressed,词,VERB,A2
-to wear to put on,to wear to put on,穿,VERB,A1
-to weary to tire,to weary to tire,使厌倦,VERB,B2
-to wed,to wed,词,VERB,C1
-to weed (verb),to weed,词,VERB,C1
-to weigh down,to weigh down,词,VERB,C1
-to weigh options,to weigh options,词,VERB,B2
-to whimper,to whimper,呜咽,VERB,B2
-to whistle (verb),to whistle,呼啸,VERB,B2
-to whiten,to whiten,词,VERB,B2
-to wield,to wield,行使,VERB,B2
-to wilt,to wilt,枯萎,VERB,B2
-to win inevitably,to win inevitably,必胜,VERB,B2
-to wipe to clean,to wipe to clean,词,VERB,A2
-to wiretap,to wiretap,监听,VERB,B2
-to wish one could,to wish one could,恨不得,VERB,B2
-to withdraw to sample,to withdraw to sample,词,VERB,C1
-to wither,to wither,,VERB,B2
-to withhold,to withhold,扣留,VERB,B2
-to woo,to woo,词,VERB,B2
-to word (verb),to word,词,VERB,C1
-to work hard,to work hard,努力,VERB,A1
-to work hard for,to work hard for,力争,VERB,B2
-to work overtime,to work overtime,加点,VERB,C1
-to work part-time,to work part-time,打工,VERB,B2
-to worry (adj),to worry,着急,ADJ,A1
-to worry anxiety,to worry anxiety,词,VERB,A2
-to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
-to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
-to wrap up,to wrap up,词,VERB,B2
-to wrestle,to wrestle,词,VERB,B2
-to wriggle,to wriggle,词,VERB,B2
-to wring,to wring,拧干,VERB,B2
-to wrinkle (verb),to wrinkle,词,VERB,C1
-to write down,to write down,词,VERB,B2
-to wrong (verb),to wrong,冤,VERB,B2
-to wrong someone,to wrong someone,冤枉,VERB,B2
-to yearn,to yearn,渴望,VERB,B2
-to yell at,to yell at,词,VERB,B1
-to yelp,to yelp,词,VERB,C1
-toad,toad,蟾蜍,NOUN,B2
-toast,toast,你敬酒,NOUN,B2
-tobacco,tobacco,烟草,NOUN,B2
-today (noun),today,今,NOUN,B2
-today's,today's,词,ADJ,C1
-tofu,tofu,豆腐,NOUN,B2
-tofu skin,tofu skin,腐竹,NOUN,C1
-togetherness,togetherness,词,NOUN,C1
-toilet paper,toilet paper,卫生纸,NOUN,C1
-toiling,toiling,词,ADJ,C1
-tolerance dependence,tolerance dependence,词,NOUN,C1
-tolerans,tolerance,宽容,NOUN,B2
-tolerant,tolerant,宽容的,ADJ,B2
-toll,toll,通行费,NOUN,B2
-tomb monument,tomb monument,墓碑,NOUN,B2
-tombstone,tombstone,词,NOUN,C1
-tome,tome,词,NOUN,C1
-tomhet,emptiness,空虚,NOUN,B2
-tomorrow (noun),tomorrow,明天,NOUN,B2
-tomorrow night,tomorrow night,明晚,ADV,B2
-tomt rykte,empty fame,虚名,NOUN,B2
-ton,ton,吨,NOUN,B2
-tonality,tonality,词,NOUN,C1
-tonfisk,tuna,金枪鱼,NOUN,B2
-tonic (adj),tonic,词,ADJ,C1
-tonic (noun),tonic,词,NOUN,C1
-tonsil,tonsil,词,NOUN,B2
-too big,too big,太大,ADJ,B2
-too heavy,too heavy,太重,ADJ,B2
-too particular,too particular,太介,ADJ,C1
-too reckless,too reckless,太莽撞,NOUN,C1
-too small,too small,太小,ADJ,B2
-tooling,tooling,词,NOUN,C1
-toothbrush,toothbrush,牙刷,NOUN,B2
-toothless,toothless,无齿的,ADJ,B2
-top priority,top priority,当务之急,NOUN,C1
-top scorer,top scorer,词,NOUN,B2
-topografi,topography,地形,NOUN,B2
-topographical,topographical,词,ADJ,C1
-topp,peak,顶峰,NOUN,B2
-topp,summit,顶峰,NOUN,B2
-tork,drought,干旱,NOUN,B2
-torka,to wipe,擦,VERB,B2
-torkare,wiper,雨刷,NOUN,B2
-torment (noun),torment,词,NOUN,C1
-tormentor,tormentor,词,NOUN,B2
-torments,torments,词,NOUN,B2
-torn,thorn,刺,NOUN,B2
-tornado,tornado,龙卷风,NOUN,B2
-torpid,torpid,词,ADJ,C1
-torpor,torpor,词,NOUN,C1
-torque,torque,词,NOUN,C1
-torrid,torrid,词,ADJ,C1
-torsion,torsion,扭转,NOUN,B2
-tortious,tortious,词,ADJ,C1
-tortoise,tortoise,词,NOUN,B1
-tortuous,tortuous,词,ADJ,C1
-torture ordeal,torture ordeal,词,NOUN,C1
-toss,toss,词,VERB,B2
-total,total,完全的,ADJ,B2
-totalitarian,totalitarian,极权主义的,ADJ,B2
-totalitarianism,totalitarianism,词,NOUN,C1
-totality,totality,词,NOUN,C1
-totalt,total,总数,NOUN,B2
-totem,totem,词,NOUN,C1
-totemism,totemism,词,NOUN,C1
-touching,touching,动人的,ADJ,B2
-touchstone,touchstone,词,NOUN,C1
-touchy,touchy,易怒的,ADJ,B2
-tour guide,tour guide,导游,NOUN,A2
-tourist,tourist,旅游的,ADJ,B2
-tout,tout,词,VERB,C1
-towards,towards,迎向,ADV,B2
-towering,towering,词,ADJ,B2
-town hall,town hall,市政厅,NOUN,B2
-town mayor,town mayor,镇长,NOUN,B2
-township,township,乡镇,NOUN,B2
-township road,township road,乡道,NOUN,B2
-toxicity,toxicity,词,NOUN,C1
-toxin,toxin,词,NOUN,C1
-toys,toys,玩具,NOUN,B2
-trace element,trace element,微量元素,NOUN,C1
-track and field,track and field,田径,NOUN,C1
-tracking,tracking,词,NOUN,C1
-tracksuit,tracksuit,词,NOUN,C1
-tractable,tractable,词,ADJ,C1
-trade (verb),trade,词,VERB,A2
-trade barrier,trade barrier,贸易壁垒,NOUN,B2
-trade fair,trade fair,展销会,NOUN,C1
-trade unionist,trade unionist,词,NOUN,C1
-trade-off,trade-off,词,NOUN,C1
-trademark,trademark,商标,NOUN,B2
-trading practice,trading practice,词,NOUN,C1
-traditional chinese painting,traditional chinese painting,国画,NOUN,B2
-traditional costume,traditional costume,传统服饰,NOUN,B2
-traditional female singers,traditional female singers,词,NOUN,B1
-traditionalism,traditionalism,词,NOUN,C1
-traditionally,traditionally,传统地,ADV,B2
-traditionell,traditional,传统的,ADJ,B2
-traditions,traditions,词,NOUN,B1
-traduce,traduce,词,VERB,C1
-traffic light,traffic light,红绿灯,NOUN,B2
-traffic ticket,traffic ticket,词,NOUN,C1
-trafficker,trafficker,词,NOUN,C1
-trafficking,trafficking,词,NOUN,C1
-trafikbegränsning,traffic restriction,限行,NOUN,B2
-trafikstockning,traffic jam,交通堵塞,NOUN,B2
-tragicness,tragicness,词,NOUN,C1
-trail,trail,词,NOUN,B1
-train ride,train ride,词,NOUN,A1
-train ticket,train ticket,词,NOUN,A1
-trained,trained,词,ADJ,C1
-trainee,trainee,实习生,NOUN,B2
-training center,training center,培训中心,NOUN,C1
-traits qualities,traits qualities,词,NOUN,C1
-trajectory,trajectory,轨迹,NOUN,B2
-trakassera,to harass,骚扰,VERB,B2
-traktor,tractor,拖拉机,NOUN,B2
-tram,tram,有轨电车,NOUN,B2
-trance,trance,词,NOUN,C1
-tranquil,tranquil,宁静的,ADJ,B2
-tranquility,tranquility,词,NOUN,B1
-trans-above,trans-above,超上,NOUN,C1
-trans-abstraction,trans-abstraction,超抽,NOUN,B2
-trans-analysis,trans-analysis,超分,NOUN,C1
-trans-concept,trans-concept,超概,NOUN,C1
-trans-decision,trans-decision,超断,NOUN,B2
-trans-deduction,trans-deduction,超演,NOUN,B2
-trans-dialectic,trans-dialectic,超辩,NOUN,B2
-trans-er,trans-er,超而,NOUN,B2
-trans-faith,trans-faith,超信,NOUN,C1
-trans-guest,trans-guest,超客,NOUN,B2
-trans-host,trans-host,超主,NOUN,C1
-trans-idealism,trans-idealism,超唯,NOUN,B2
-trans-inclusion,trans-inclusion,超纳,NOUN,C1
-trans-induction,trans-induction,超归,NOUN,B2
-trans-inference,trans-inference,超推,NOUN,B2
-trans-judgment,trans-judgment,超判,NOUN,C1
-trans-logic,trans-logic,超辑,NOUN,C1
-trans-matter,trans-matter,超物,NOUN,B2
-trans-mind,trans-mind,超心,NOUN,C1
-trans-reality,trans-reality,超现,NOUN,C1
-trans-synthesis,trans-synthesis,超合,NOUN,C1
-transaction,transaction,交易,NOUN,B2
-transatlantic,transatlantic,词,ADJ,C1
-transcend,transcend,词,VERB,C1
-transcendence,transcendence,超越,NOUN,B2
-transcendent,transcendent,卓越的,ADJ,B2
-transcendental,transcendental,先验的,ADJ,B2
-transcript,transcript,词,NOUN,C1
-transfer,transfer,转移,NOUN,B2
-transfer to another hospital,transfer to another hospital,转院,VERB,C1
-transfer window,transfer window,词,NOUN,B2
-transferee,transferee,词,NOUN,C1
-transferor,transferor,词,NOUN,C1
-transferred,transferred,词,ADJ,C1
-transfers,transfers,转会,NOUN,B2
-transfix,transfix,词,VERB,C1
-transformation,transformation,تحول,NOUN,B2
-transformer converter,transformer converter,词,NOUN,C1
-transgression,transgression,违犯,NOUN,B2
-transhumance,transhumance,词,NOUN,B2
-transient,transient,词,ADJ,C1
-transistor,transistor,词,NOUN,C1
-transit,transit,运输,NOUN,C1
-transition,transition,过渡,NOUN,B2
-transitional,transitional,过渡的,ADJ,B2
-transitivity,transitivity,及物性,NOUN,C1
-transitory,transitory,词,ADJ,C1
-translatology,translatology,词,NOUN,C1
-translator,translator,译者,NOUN,B2
-translucent,translucent,词,ADJ,C1
-transmission,transmission,传输,NOUN,B2
-transmission to you,transmission to you,传你,NOUN,B2
-transmit,to transmit,传输,VERB,B2
-transmute,transmute,词,VERB,C1
-transnational,transnational,跨国性,ADJ,C1
-transparency,transparency,透明度,NOUN,B2
-transparent,transparent,透明的,ADJ,B2
-transpire,transpire,词,VERB,C1
-transplant (noun),transplant,移植,NOUN,C1
-transplant (verb),transplant,移栽,VERB,C1
-transport,to transport,运输,VERB,B2
-transport (adj),transport,词,ADJ,C1
-transport (noun),transport,运输,NOUN,B2
-transport service,transport service,词,NOUN,C1
-transportation,transportation,词,NOUN,C1
-transporter,transporter,词,NOUN,C1
-transpose,transpose,词,VERB,C1
-transregional,transregional,词,ADJ,C1
-trapdoor,trapdoor,活板门,NOUN,B2
-trapped,trapped,词,ADJ,A2
-trapping,trapping,词,NOUN,C1
-trash bag,trash bag,垃圾袋,NOUN,B2
-trash can,trash can,词,NOUN,A2
-trasig,ragged,破烂的,ADJ,B2
-trassla in,to entangle,使纠缠,VERB,B2
-trauma,trauma,创伤,NOUN,B2
-traumatic,traumatic,创伤的,ADJ,B2
-travail,travail,词,NOUN,C1
-travel,travel,出行,NOUN,B2
-travel fatigue,travel fatigue,车马劳顿,NOUN,B2
-travel guide,travel guide,词,NOUN,A1
-traveled,traveled,词,ADJ,C1
-traveler,traveler,旅行家,NOUN,B2
-travesty,travesty,词,NOUN,C1
-tre,these three,这三,NOUN,B2
-treacherous,treacherous,背叛的,ADJ,B2
-treacherous minister,treacherous minister,奸臣,NOUN,B2
-treacherously,treacherously,词,ADV,C1
-treacherousness,treacherousness,阴险,NOUN,B2
-treachery,treachery,背叛,NOUN,B2
-tread,to tread,踏上,VERB,B2
-treasure,treasure,财宝,NOUN,B2
-treasure land,treasure land,宝地,NOUN,C1
-treasure room,treasure room,词,NOUN,C1
-treasury,treasury,国库,NOUN,B2
-treat,treat,盛宴,NOUN,B2
-treat guests,to treat guests,请客,VERB,B2
-treatise,treatise,词,NOUN,C1
+lår,thigh,大腿,NOUN,B2
+vilja,to think to want,想,VERB,B2
+tänka,to think up,构思,VERB,B2
+tunnhet,thinness,瘦,NOUN,B2
 tredje,third,三分之一,NOUN,B2
-tredubbel,triple,三倍的,ADJ,B2
-trek (noun),trek,词,NOUN,C1
-tremble,to tremble,颤抖,VERB,B2
-trembling,trembling,颤抖的,ADJ,B2
-tremendous,tremendous,词,ADJ,B2
-tremor,tremor,颤抖,NOUN,B2
-trench,trench,沟渠,NOUN,B2
-trench coat,trench coat,词,NOUN,C1
-trenchant,trenchant,词,ADJ,C1
-trend,trend,趋势,NOUN,B2
-trending,trending,词,ADJ,C1
-trepidation,trepidation,词,NOUN,C1
-trespass (noun),trespass,擅闯,NOUN,C1
-trespass (verb),trespass,词,VERB,C1
-triangle,triangle,三角形,NOUN,B2
-triangular,triangular,三角形的,ADJ,B2
-tribalism (adj),tribalism,词,ADJ,C1
-tribalism (noun),tribalism,词,NOUN,C1
-tribulation,tribulation,词,NOUN,C1
-tribunal,tribunal,词,NOUN,C1
-tribune,tribune,词,NOUN,C1
-tribut,tribute,贡品,NOUN,B2
-tributary,tributary,支流,NOUN,B2
-tricky,tricky,词,ADJ,B2
-tricolor,tricolor,词,ADJ,C1
-trifling,trifling,微不足道的,ADJ,B2
-trigger (adj),trigger,词,ADJ,C1
-trigonometry,trigonometry,词,NOUN,C1
-trilemma,trilemma,三难困境,NOUN,B2
-trill,trill,词,NOUN,C1
-trillion,trillion,词,NUM,B2
-trilogy,trilogy,词,NOUN,B2
-trim,trim,词,VERB,C1
-trinket,trinket,小饰品,NOUN,B2
-tristess,dullness,迟钝,NOUN,B2
-trite,trite,陈腐的,ADJ,B2
-triumph,triumph,胜利,NOUN,B2
-trivia,trivia,词,NOUN,C1
-trivial,trivial,琐碎的,ADJ,B2
-trivialisering,trivialization,浅薄化,NOUN,B2
-trivialitet,triviality,琐碎,NOUN,B2
-trivializable,trivializable,可轻描淡写的,ADJ,B2
-tro,faith,信仰,NOUN,B2
-trocar,trocar,词,NOUN,C1
-trofé,trophy,奖杯,NOUN,B2
-troglodyte,troglodyte,词,NOUN,C1
-tronbestigning,enthronement,登基,NOUN,B2
-troop dispatch,troop dispatch,出兵,NOUN,B2
-tropic,tropic,词,NOUN,C1
-tropical,tropical,热带的,ADJ,B2
-trosbekännelse,creed,信条,NOUN,B2
-trotta,to defy,违抗,VERB,B2
-trottoar,sidewalk,人行道,NOUN,B2
-trotts,to in spite of,不顾,VERB,B2
-trouble entry,trouble entry,麻烦进,NOUN,C1
-trouble spot,trouble spot,词,NOUN,C1
-troublemaker,troublemaker,词,NOUN,B2
-troubling,troubling,令人担忧的,ADJ,B2
-trout,trout,词,NOUN,C1
-trovärdighet,credibility,可信度,NOUN,B2
-trowel,trowel,词,NOUN,B2
-truculent,truculent,词,ADJ,C1
-true qi,true qi,真气,NOUN,C1
-truism,truism,自明之理,NOUN,B2
-trummor,drum,鼓,NOUN,B2
-trumpet,trumpet,小号,NOUN,B2
-truncate,truncate,词,VERB,C1
-truncheon,truncheon,词,NOUN,C1
-trupp,squad,小队,NOUN,B2
-trupp,troop,部队,NOUN,B2
-trupp,troupe,剧团,NOUN,B2
-trust in God,trust in God,词,NOUN,C1
-trusting,trusting,信任的,ADJ,B2
-trustworthiness,trustworthiness,讲信,NOUN,B2
-truthful,truthful,忠于事实的,ADJ,B2
-try out,try out,词,VERB,C1
-trycka,print,印记,NOUN,B2
-trycka,to print,打印,VERB,B2
-träda in,to enter,进入,VERB,B2
-träda in,to take office,就职,VERB,B2
-trädgårdsmästare,gardener,园丁,NOUN,B2
-träff,rendezvous,约会,NOUN,B2
-träna,to train,训练,VERB,B2
-träör,wood ear mushroom,木耳,NOUN,B2
-tråd,wire,电线,NOUN,B2
-trådlös,wireless,无线的,ADJ,B2
-tråka,to bore,使厌烦,VERB,B2
-tråkig,tedious,乏味的,ADJ,B2
-tråkighet,boredom,无聊,NOUN,B2
-tröghet,inertia,惯性,NOUN,B2
+gåva,third bestowal,三授,NOUN,B2
+denna,this,您这,NOUN,B2
+strid,this battle,此战,NOUN,B2
+punkt,this item,这件,NOUN,B2
+så,this way,这样,PRON,B2
+läger,this-camp,这营,NOUN,B2
+torn,thorn,刺,NOUN,B2
+grundlig,thorough,彻底的,ADJ,B2
+de,those,那些,DET,B2
+hotfull,threatening,具有威胁性的,ADJ,B2
+3D-utskrift,three-d printing,3D打印,NOUN,B2
 tröskel,threshold,门槛,NOUN,B2
-tröst,consolation,安慰,NOUN,B2
-tröst,solace,安慰,NOUN,B2
-trösta,to console,安慰,VERB,B2
+sparsam,thrifty,节俭的,ADJ,B2
+stöt,thrust,猛推,NOUN,B2
+drift mot,thrust toward,插向,NOUN,B2
+brut,thug,暴徒,NOUN,B2
+åska,thunder,雷,NOUN,B2
+så,thus,因此,ADV,B2
+hindra,to thwart,阻挠,VERB,B2
+tidvatten,tidal,潮汐,ADJ,B2
+tidvatten,tide,潮汐,NOUN,B2
+binda,to tie up,绑,VERB,B2
+stram,tight,紧的,ADJ,B2
+fast grepp,tight grip,手握紧,NOUN,B2
+klinka,tile,瓦片,NOUN,B2
+klinkning,tiling,铺瓷砖,NOUN,B2
+tider,times,倍,NOUN,B2
+feghet,timidity,胆怯,NOUN,B2
+timing,timing,时机,NOUN,B2
+tenn,tin,锡,NOUN,B2
+klåda,tingling,麻木感,NOUN,B2
+liten,tiny,微小的,ADJ,B2
 trötta,tire,轮胎,NOUN,B2
 trötta,to tire,使疲倦,VERB,B2
 trötthet,tiredness,疲劳,NOUN,B2
-trötthet,weariness,疲倦,NOUN,B2
-tsunami,tsunami,海啸,NOUN,C1
-tub,tube,أنبوب,NOUN,B2
-tuberculosis,tuberculosis,结核病,NOUN,B2
-tug,tug,词,VERB,C1
-tum,inch,بوصة,NOUN,B2
-tumble (noun),tumble,词,NOUN,C1
-tumoral,tumoral,词,ADJ,C1
-tumult,tumult,词,NOUN,C1
-tumultuous,tumultuous,词,ADJ,C1
-tung etikett,heavy etiquette,礼太重,NOUN,B2
-tung knut,heavy knot,重结,NOUN,B2
-tung maskin,heavy machine,重机,NOUN,B2
-tung typ,heavy type,重型,NOUN,B2
-tungt arbete,heavy work,重功,NOUN,B2
-tunika,tunic,束腰外衣,NOUN,B2
-tuning,tuning,词,NOUN,C1
-tunnel,tunnel,隧道,NOUN,B2
-tunnhet,thinness,瘦,NOUN,B2
-tur,good luck,好运,NOUN,B2
-turban,turban,词,NOUN,B2
-turbid,turbid,词,ADJ,C1
-turbine,turbine,词,NOUN,C1
-turbulence,turbulence,词,NOUN,C1
-turbulent,turbulent,动荡的,ADJ,B2
-turgid,turgid,词,ADJ,C1
+väv,tissue,组织,NOUN,B2
+tiodel,tithe,什一税,NOUN,B2
+idag,today,今天,NOUN,B2
+tofu,tofu,豆腐,NOUN,B2
+slit,toil,苦工,NOUN,B2
+tolerans,tolerance,宽容,NOUN,B2
+gravkammare,tomb,坟墓,NOUN,B2
+imorgon,tomorrow,غد,NOUN,B2
+ton,ton,吨,NOUN,B2
+idag kväll,tonight,今晚,NOUN,B2
+för mycket,too much,太,ADV,B2
+för mjuk,too soft,太软,NOUN,B2
+verktygsrum,tool room,工具间,NOUN,B2
+verktyg,tools,工具,NOUN,B2
+tandvärk,toothache,牙痛,NOUN,B2
+tandkräm,toothpaste,牙膏,NOUN,B2
+tilläggsgödsel,top dressing,追肥,NOUN,B2
+ämne,topic,话题,NOUN,B2
+topografi,topography,地形,NOUN,B2
+fackla,torch,手电筒,NOUN,B2
+tornado,tornado,龙卷风,NOUN,B2
+ström,torrent,激流,NOUN,B2
+torsion,torsion,扭转,NOUN,B2
+totalt,total,总数,NOUN,B2
+beröring,touch,接触,NOUN,B2
+berörbarhet,touchability,能触摸,NOUN,B2
 turism,tourism,旅游业,NOUN,B2
 turistisk,touristic,旅游的,ADJ,B2
-turkish,turkish,土耳其的,ADJ,B2
-turmeric,turmeric,词,NOUN,B2
-turn of phrase,turn of phrase,词,NOUN,C1
-turnaround,turnaround,转胜,NOUN,C1
-turncoat,turncoat,词,NOUN,C1
 turnering,tournament,锦标赛,NOUN,B2
-turnoff,turnoff,词,NOUN,B2
-turpitude,turpitude,词,NOUN,C1
-tutelary,tutelary,词,ADJ,C1
-tutor,tutor,导师,NOUN,C1
-tv movie,tv movie,电视电影,NOUN,B2
-tv viewer,tv viewer,电视观众,NOUN,B2
-tvinga,to compel,强迫,VERB,B2
-tvist,dispute,争论,NOUN,B2
-tvivelaktig,questionable,可疑的,ADJ,B2
-tvärtom,conversely,相反地,ADV,B2
-tvätt,washing,洗涤,NOUN,B2
-tvång,coercion,胁迫,NOUN,B2
-tvångsvis,forcibly,强制地,ADV,B2
-tweezers,tweezers,词,NOUN,C1
-twenty-five,twenty-five,词,NUM,C1
+mot,toward,朝向,ADP,B2
+stad,town,城镇,NOUN,B2
+kommunchef,township head,乡长,NOUN,B2
+spår,trace,痕迹,NOUN,B2
+traktor,tractor,拖拉机,NOUN,B2
+fackförening,trade union,工会,NOUN,B2
+traditionell,traditional,传统的,ADJ,B2
+trafikstockning,traffic jam,交通堵塞,NOUN,B2
+trafikbegränsning,traffic restriction,限行,NOUN,B2
+släpvagn,trailer,预告片,NOUN,B2
+träna,to train,训练,VERB,B2
+tänkflöde,train of thought,思路,NOUN,B2
+tågstation,train station,火车站,NOUN,B2
+trainee,trainee,实习生,NOUN,B2
+tranquil,tranquil,宁静的,ADJ,B2
+trans-decision,trans-decision,超断,NOUN,B2
+trans-guest,trans-guest,超客,NOUN,B2
+trans-matter,trans-matter,超物,NOUN,B2
+transaction,transaction,交易,NOUN,B2
+transcendence,transcendence,超越,NOUN,B2
+transcendent,transcendent,卓越的,ADJ,B2
+transcendental,transcendental,先验的,ADJ,B2
+transfer,transfer,转移,NOUN,B2
+transformation,transformation,تحول,NOUN,B2
+transgression,transgression,违犯,NOUN,B2
+transitional,transitional,过渡的,ADJ,B2
+translator,translator,译者,NOUN,B2
+transmission,transmission,传输,NOUN,B2
+transmission to you,transmission to you,传你,NOUN,B2
+transmit,to transmit,传输,VERB,B2
+transparency,transparency,透明度,NOUN,B2
+transparent,transparent,透明的,ADJ,B2
+transport,to transport,运输,VERB,B2
+travel,travel,出行,NOUN,B2
+travel fatigue,travel fatigue,车马劳顿,NOUN,B2
+traveler,traveler,旅行家,NOUN,B2
+treacherous,treacherous,背叛的,ADJ,B2
+treachery,treachery,背叛,NOUN,B2
+tread,to tread,踏上,VERB,B2
+treasure,treasure,财宝,NOUN,B2
+treasury,treasury,国库,NOUN,B2
+treat guests,to treat guests,请客,VERB,B2
+tremble,to tremble,颤抖,VERB,B2
+tremor,tremor,颤抖,NOUN,B2
+trench,trench,沟渠,NOUN,B2
+trend,trend,趋势,NOUN,B2
+triangle,triangle,三角形,NOUN,B2
+tributary,tributary,支流,NOUN,B2
+tribut,tribute,贡品,NOUN,B2
+bagatell,trifle,琐事,NOUN,B2
+avtryckare,trigger,触发器,NOUN,B2
+tredubbel,triple,三倍的,ADJ,B2
+trivial,trivial,琐碎的,ADJ,B2
+trivialitet,triviality,琐碎,NOUN,B2
+trivialisering,trivialization,浅薄化,NOUN,B2
+trupp,troop,部队,NOUN,B2
+trofé,trophy,奖杯,NOUN,B2
+besvära,to trouble,有劳,VERB,B2
+trupp,troupe,剧团,NOUN,B2
+byxor,trousers,裤子,NOUN,B2
+vapenvila,truce,休战,NOUN,B2
+verklig eftergift,true concession,真让,NOUN,B2
+sann form,true form,原形,NOUN,B2
+sant hjärta,true heart,本心,NOUN,B2
+trumpet,trumpet,小号,NOUN,B2
+pålitlig,trustworthy,值得信赖的,ADJ,B2
+anstränga sig,to try hard to,力图,VERB,B2
+tub,tube,أنبوب,NOUN,B2
+tonfisk,tuna,金枪鱼,NOUN,B2
+tunika,tunic,束腰外衣,NOUN,B2
+tunnel,tunnel,隧道,NOUN,B2
+oro,turmoil,混乱,NOUN,B2
+vända,to turn around,转身,VERB,B2
+stänga av,to turn off,关闭,VERB,B2
+slå på,to turn on,打开,VERB,B2
+visa sig,to turn out,结果是,VERB,B2
+blinkers,turn signal,转向灯,NOUN,B2
+vändpunkt,turning point,转折点,NOUN,B2
+kålrot,turnip,芜菁,NOUN,B2
+deltagande,turnout,出席率,NOUN,B2
+sköldpadda,turtle,海龟,NOUN,B2
+förmyndarskap,tutelage,监护,NOUN,B2
+handledning,tutoring,补习,NOUN,B2
 twice,twice,两次,ADV,B2
 twilight,twilight,暮光,NOUN,B2
-twinning,twinning,词,NOUN,B2
-twins,twins,双胞胎,NOUN,A2
 twist,to twist,扭曲,VERB,B2
-twist (noun),twist,词,NOUN,C1
 twisted,twisted,扭曲的,ADJ,B2
-twitching,twitching,抽搐的,ADJ,B2
 two animals,two animals,两只,NUM,B2
-two days,two days,两天,NUM,B2
-two jin,two jin,两斤,NOUN,C1
-two kinds,two kinds,两种,NUM,B2
-two minutes,two minutes,两分钟,NUM,B2
-two people,two people,两名,NUM,B2
-two polite,two polite,两位,NUM,B2
-two sons,two sons,儿俩,NOUN,B2
-two thousand coins,two thousand coins,两千贯,NOUN,C1
-two weeks,two weeks,两周,NUM,B2
-two years,two years,两年,NUM,B2
-two-dimensional,two-dimensional,二维的,ADJ,B2
-two-headed,two-headed,双头的,ADJ,B2
 two-way street,two-way street,双行道,NOUN,B2
-twofold,twofold,双重的,ADJ,B2
-tycoon,tycoon,词,NOUN,C1
-tydlig,clear-cut,明确的,ADJ,B2
-tydlig,evident,明显的,ADJ,B2
-tydlighet,clarity,清晰,NOUN,B2
-tydligt,clearly,清楚地,ADV,B2
-tyg,cloth,布,NOUN,B2
-tyg,fabric,织物,NOUN,B2
-tyngd,heaviness,沉重 / 笨重,NOUN,B2
-tyngdkraft,gravity,重力,NOUN,B2
 type,type,类型,NOUN,B2
 typhoon,typhoon,台风,NOUN,B2
-typically,typically,词,ADV,C1
-typographical,typographical,排版的,ADJ,B2
-typography,typography,词,NOUN,C1
-typology,typology,类型学,NOUN,B2
-tyrannical,tyrannical,专横的,ADJ,B2
-tyrannical might,tyrannical might,词,NOUN,C1
-tyrannically haughty,tyrannically haughty,词,ADJ,C1
 tyranny,tyranny,暴政,NOUN,B2
 tyrant,tyrant,暴君,NOUN,B2
-tyst,silent,沉默的,ADJ,B2
-tyst,taciturn,沉默寡言的,ADJ,B2
-tysta,to silence,خرس,VERB,B2
-tänka,to think up,构思,VERB,B2
-tänkflöde,train of thought,思路,NOUN,B2
-tänksam,contemplative,沉思的,ADJ,B2
-tärning,dice,骰子,NOUN,B2
-tät,close,近的,ADJ,B2
-tävling,contest,比赛,NOUN,B2
-tågstation,train station,火车站,NOUN,B2
-tåla,to bear,忍受,VERB,B2
-tåra,to tear,撕碎,VERB,B2
-ubiquitous,ubiquitous,词,ADJ,C1
-uggla,owl,猫头鹰,NOUN,B2
 ugliness,ugliness,丑陋,NOUN,B2
-ukrainian,ukrainian,乌克兰的,ADJ,B2
 ulcer,ulcer,溃疡,NOUN,B2
 ulceration,ulceration,溃疡,NOUN,B2
-ull,wool,羊毛,NOUN,B2
-ulterior,ulterior,词,ADJ,C1
-ultimate art,ultimate art,绝学,NOUN,B2
-ultimate outcome,ultimate outcome,词,NOUN,C1
 ultimately,ultimately,最终,ADV,B2
-ultimatum,ultimatum,词,NOUN,C1
-ultrasound,ultrasound,B超,NOUN,C1
-ultraviolet radiation,ultraviolet radiation,紫外线,NOUN,C1
-ululate,ululate,词,VERB,B2
-ululation,ululation,词,NOUN,C1
-ululations,ululations,欢呼声,NOUN,B1
-um,um,嗯,INTJ,B2
-umbrage,umbrage,词,NOUN,C1
 umbrella,umbrella,雨伞,NOUN,B2
-umgänglig,sociable,好交际的,ADJ,B2
-unabated,unabated,词,ADJ,C1
-unable,unable,词,ADJ,B2
-unaccustomed,unaccustomed,词,ADJ,C1
-unaffected,unaffected,词,ADJ,C1
-unaffectionate,unaffectionate,词,ADJ,C1
-unalterable,unalterable,词,ADJ,C1
-unambiguous,unambiguous,明确的,ADJ,B2
-unanimity,unanimity,词,NOUN,C1
-unappealable,unappealable,词,ADJ,C1
-unapproachable,unapproachable,词,ADJ,C1
 unattainable,unattainable,难以获得的,ADJ,B2
-unavoidable,unavoidable,不可避免,ADJ,C1
-unaware,unaware,词,ADJ,B2
 unbearable,unbearable,难以忍受的,ADJ,B2
-unbeatable,unbeatable,词,ADJ,C1
 unbelievable,unbelievable,难以置信的,ADJ,B2
-unbelieving,unbelieving,词,ADJ,C1
-unbridled,unbridled,肆无忌惮的,ADJ,B2
-uncanny,uncanny,词,ADJ,C1
-unceasing,unceasing,不断,ADV,B2
 uncertainty,uncertainty,不确定性,NOUN,B2
-unchanging,unchanging,词,ADJ,C1
-uncivil,uncivil,词,ADJ,C1
-unclassifiable,unclassifiable,词,ADJ,C1
 unclear,unclear,不清楚的,ADJ,B2
-uncompromising,uncompromising,词,ADJ,B2
-unconditional,unconditional,无条件的,ADJ,B2
-unconquerable,unconquerable,词,ADJ,C1
-unconscious (noun),unconscious,词,NOUN,C1
-unconsciousness,unconsciousness,词,NOUN,C1
 uncontrollable,uncontrollable,无法控制的,ADJ,B2
 uncooled,uncooled,未寒,NOUN,B2
-uncountable,uncountable,词,ADJ,C1
-uncouth,uncouth,粗俗的,ADJ,B2
 uncover,to uncover,揭露,VERB,B2
-uncovered,uncovered,词,ADJ,A2
-uncovering,uncovering,破获,NOUN,B2
-uncritical,uncritical,不加批判的,ADJ,B2
-unctuous,unctuous,谄媚的,ADJ,B2
-uncultivated,uncultivated,词,ADJ,B2
-undantag,exemption,豁免,NOUN,B2
-undantagslös,exceptional,杰出的,ADJ,B2
-undaunted,undaunted,词,ADJ,C1
-undead,undead,词,NOUN,C1
-undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
 undeniable,undeniable,不可否认的,ADJ,B2
-undeniably,undeniably,词,ADV,B2
-under,during,在...期间,ADP,B2
-under below,under below,在...下方,ADP,A2
-under dagen,during the day,在白天,ADV,B2
-under the,under the,词,ADP,B2
-undercover agent,undercover agent,卧底,NOUN,B2
 underestimation,underestimation,小看,NOUN,B2
-underförstådd,tacit,心照不宣的,ADJ,B2
-underförstått,tacitly,默不作声地,ADV,B2
 undergo,to undergo,经历,VERB,B2
 undergraduate,undergraduate,本科生,NOUN,B2
-undergraduate course,undergraduate course,本科,NOUN,B1
 underground,underground,地铁,NOUN,B2
-underground (adj),underground,地下的,ADJ,B1
-underground canal,underground canal,词,NOUN,B2
-underground garage,underground garage,地下车库,NOUN,C1
-underhåll,alimony,赡养费,NOUN,B2
-underhålla,to entertain,娱乐,VERB,B2
-underhållningscenter,entertainment center,娱乐中心,NOUN,B2
-underkastelse,submission,顺从,NOUN,B2
-underkuva,to subdue,制服,VERB,B2
-underkuva,to subjugate,征服,VERB,B2
-underlig,weird,奇怪的,ADJ,B2
-underling,underling,词,NOUN,C1
-underlying,underlying,词,ADJ,B2
-underlägsen,inferior,低等的,ADJ,B2
-underlägsenhet,inferiority,劣势,NOUN,B2
-underlätta,to facilitate,促进,VERB,B2
 undermine,to undermine,破坏,VERB,B2
-undermining authority,undermining authority,削弱权威,NOUN,B2
 underneath,underneath,在下面,ADV,B2
-underneath (adp),underneath,词,ADP,B1
-underneath (noun),underneath,底下,NOUN,C1
-underordnad,subordinate,下属,NOUN,B2
-underpass,underpass,地下通道,NOUN,C1
-underpin,underpin,词,VERB,C1
-underscore,underscore,词,VERB,C1
-underside,underside,下方,NOUN,C1
-underskott,deficit,赤字,NOUN,B2
 understandable,understandable,可理解的,ADJ,B2
-understood,understood,词,ADJ,A1
-undersökning,survey,调查,NOUN,B2
 undertake,to undertake,承担,VERB,B2
 undertaking,undertaking,事业,NOUN,B2
-undertext,subtitle,字幕,NOUN,B2
-undertrycka,to suppress,压制,VERB,B2
-undertryckning,suppression,抑,NOUN,B2
-undervaluing,undervaluing,词,NOUN,C1
-underwater,underwater,词,ADJ,B2
 underwrite,to underwrite,承保,VERB,B2
-undeserved,undeserved,词,ADJ,C1
-undisturbed,undisturbed,词,ADJ,C1
-undo (adj),undo,词,ADJ,C1
-undoubted,undoubted,词,ADJ,C1
-undoubtedly,undoubtedly,无疑地,ADV,B2
-undulate,undulate,词,VERB,C1
-undvika,to dodge,躲避,VERB,B2
-undvika,to evade,逃避,VERB,B2
-undvikande,evasive,回避的,ADJ,B2
-unearned,unearned,浪得,NOUN,C1
 unease,unease,不安,NOUN,B2
 uneasy,uneasy,不安的,ADJ,B2
-unemployed person,unemployed person,词,NOUN,B2
-unending flow,unending flow,川流不息,ADJ,C1
 unequal,unequal,不平等的,ADJ,B2
-unequivocal,unequivocal,词,ADJ,C1
-unerring,unerring,词,ADJ,C1
-unerziehung,unerziehung,词,NOUN,B2
-uneven,uneven,不均,ADJ,C1
-unevenness,unevenness,词,NOUN,C1
-unexpected event,unexpected event,变故,NOUN,B2
 unexpectedly,unexpectedly,出乎意料地,ADV,B2
-unfahrt,unfahrt,词,NOUN,B2
-unfair prejudice,unfair prejudice,词,NOUN,C1
-unfairness,unfairness,词,NOUN,C1
-unfaithful infidel,unfaithful infidel,词,ADJ,C1
-unfamiliar,unfamiliar,生疏,ADJ,C1
-unfamiliarity,unfamiliarity,不熟,NOUN,C1
-unfassung,unfassung,词,NOUN,B2
-unfathomable,unfathomable,词,ADJ,C1
-unfavorable,unfavorable,词,ADJ,C1
-unfettered,unfettered,词,ADJ,C1
-unfinished,unfinished,词,ADJ,C1
 unfold,to unfold,展开,VERB,B2
-unfolding,unfolding,词,NOUN,C1
-unforderung,unforderung,词,NOUN,C1
-unforeseeable,unforeseeable,词,ADJ,C1
-unforeseen,unforeseen,意外的,ADJ,B2
-unforgettable,unforgettable,词,ADJ,C1
-unforgivable,unforgivable,不可原谅的,ADJ,B2
 unfortunate,unfortunate,不幸的,ADJ,B2
-unfounded,unfounded,词,ADJ,C1
-unfriendly,unfriendly,不友好的,ADJ,B2
-ung dam,young lady,小姐,NOUN,B2
-ung herre,young master,少庄主,NOUN,B2
-ung man,young man,年轻人,NOUN,B2
-ungabe,ungabe,词,NOUN,C1
-ungainly,ungainly,笨拙的,ADJ,B2
-ungdom,young person,年轻人,NOUN,B2
-unge,cub,幼兽,NOUN,B2
-unge,youngster,年少者,NOUN,B2
-ungestaltung,ungestaltung,词,NOUN,C1
-ungodliness,ungodliness,词,NOUN,C1
-ungrateful,ungrateful,忘恩负义的,ADJ,B2
-unhappiness,unhappiness,词,NOUN,C1
-unhealthy,unhealthy,词,ADJ,C1
-unhurried patience,unhurried patience,词,NOUN,C1
-unicorn,unicorn,词,NOUN,C1
-unification,unification,统一,NOUN,B2
-unified examination,unified examination,统考,NOUN,B2
-uniformity,uniformity,统一性,NOUN,B2
 unify,to unify,统一,VERB,B2
-unilateral,unilateral,单方面的,ADJ,B2
-unilateralism,unilateralism,词,NOUN,C1
 unimaginable,unimaginable,难以想象的,ADJ,B2
-unimpeachable,unimpeachable,词,ADJ,C1
-unimpeded,unimpeded,词,ADJ,C1
-uninhabited,uninhabited,词,ADJ,C1
-uninhibited,uninhibited,词,ADJ,C1
-unintelligible,unintelligible,词,ADJ,C1
-uninterrupted,uninterrupted,词,ADJ,C1
 union,union,工会,NOUN,B2
-union (adj),union,词,ADJ,C1
 unionism,unionism,工会主义,NOUN,B2
-unionist,unionist,词,ADJ,B2
-unique (noun),unique,词,NOUN,B2
 uniqueness,uniqueness,独特,NOUN,B2
 united,united,联合的,ADJ,B2
-universal,universal,普遍的,ADJ,B2
 universal applicability,universal applicability,普适性,NOUN,B2
-universal total,universal total,词,ADJ,C1
 universality,universality,普遍性,NOUN,B2
-universities,universities,大学,NOUN,B2
-university (adj),university,词,ADJ,C1
-university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
-university student,university student,大学生,NOUN,B2
 unjust,unjust,不公正的,ADJ,B2
-unjust death,unjust death,死得冤,NOUN,C1
-unkempt,unkempt,词,ADJ,C1
-unknown,unknown,未知数,NOUN,B2
-unkunft,unkunft,词,NOUN,C1
-unlawful,unlawful,非法的,ADJ,B2
 unleash,to unleash,释放,VERB,B2
-unleashed,unleashed,词,ADJ,C1
-unlike (adp),unlike,词,ADP,B2
-unlike (verb),unlike,不像,VERB,B2
-unlimited,unlimited,无限的,ADJ,B2
 unlucky,unlucky,倒霉的,ADJ,B2
-unmentionable,unmentionable,词,ADJ,C1
-unmissable,unmissable,词,ADJ,C1
-unmistakable,unmistakable,词,ADJ,C1
-unmitigated,unmitigated,词,ADJ,C1
-unnahme,unnahme,词,NOUN,B2
-unnatural,unnatural,不自然的,ADJ,B2
-unnoticed,unnoticed,词,ADJ,C1
-unobtrusive,unobtrusive,词,ADJ,C1
-unoccupied,unoccupied,词,ADJ,C1
-unofficially,unofficially,非正式地,ADV,B2
 unpack,to unpack,拆包,VERB,B2
-unparalleled (adj),unparalleled,词,ADJ,C1
-unparalleled (noun),unparalleled,绝世,NOUN,C1
-unpflegung,unpflegung,词,NOUN,B2
-unpopular,unpopular,词,ADJ,C1
-unpostponable,unpostponable,词,ADJ,C1
-unprecedented,unprecedented,史无前例的,ADJ,B2
 unpredictable,unpredictable,不可预测的,ADJ,B2
-unprepared,unprepared,词,ADJ,C1
-unproductive,unproductive,词,ADJ,C1
-unpublished,unpublished,词,ADJ,B2
-unpunished,unpunished,未受惩罚的,ADJ,B2
-unreachable,unreachable,词,ADJ,C1
-unreal,unreal,词,ADJ,C1
-unreality,unreality,虚幻,NOUN,B2
 unreasonable,unreasonable,不合理的,ADJ,B2
-unreasonable (noun),unreasonable,不情,NOUN,B2
-unreasonableness,unreasonableness,无理,NOUN,C1
-unrecognized,unrecognized,词,ADJ,C1
-unreflective,unreflective,词,ADJ,C1
-unregelung,unregelung,词,NOUN,C1
-unrelated,unrelated,词,ADJ,C1
-unreliable,unreliable,词,ADJ,C1
-unremitting,unremitting,词,ADJ,C1
-unrepeatable,unrepeatable,词,ADJ,C1
-unrepentant,unrepentant,词,ADJ,C1
-unrequited,unrequited,词,ADJ,C1
 unrest,unrest,动荡,NOUN,B2
-unrichtung,unrichtung,词,NOUN,C1
 unruffled,unruffled,从容,ADJ,B2
-unsafe,unsafe,词,ADJ,B1
-unscathed,unscathed,未受伤害的,ADJ,B2
-unschaft,unschaft,词,NOUN,B2
-unschrift,unschrift,词,NOUN,C1
-unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
-unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
-unseemly,unseemly,词,ADJ,C1
-unseen realities,unseen realities,词,NOUN,C1
-unsetzung,unsetzung,词,NOUN,C1
-unshakable,unshakable,词,ADJ,C1
-unsicht,unsicht,词,NOUN,C1
-unsinnung,unsinnung,词,NOUN,C1
-unsociable,unsociable,词,ADJ,C1
-unsolved case,unsolved case,疑案,NOUN,B2
-unspeakable,unspeakable,词,ADJ,C1
-unsprache,unsprache,词,NOUN,C1
 unstable,unstable,不稳定的,ADJ,B2
-unsteady,unsteady,词,ADJ,C1
-unstinting,unstinting,词,ADJ,C1
-unstoppable,unstoppable,不可阻挡,ADJ,B2
-unsubscription,unsubscription,词,NOUN,B1
-unsuccessful,unsuccessful,词,ADJ,C1
-unsucht,unsucht,词,NOUN,C1
-unsuchung,unsuchung,词,NOUN,C1
-unsustainability,unsustainability,玩不长,NOUN,C1
-unsustainable,unsustainable,难以持续,ADJ,C1
-unteilung,unteilung,词,NOUN,C1
-untenable,untenable,词,ADJ,C1
-untererziehung,untererziehung,词,NOUN,C1
-unterfahrt,unterfahrt,词,NOUN,C1
-unterfassung,unterfassung,词,NOUN,C1
-unterforderung,unterforderung,词,NOUN,C1
-untergabe,untergabe,词,NOUN,C1
-untergestaltung,untergestaltung,词,NOUN,C1
-unternahme,unternahme,词,NOUN,C1
-unterpflegung,unterpflegung,词,NOUN,B2
-unterregelung,unterregelung,词,NOUN,C1
-unterrichtung,unterrichtung,词,NOUN,C1
-unterschaft,unterschaft,词,NOUN,C1
-unterschrift,unterschrift,词,NOUN,C1
-untersetzung,untersetzung,词,NOUN,B2
-untersicht,untersicht,词,NOUN,C1
-untersinnung,untersinnung,词,NOUN,B2
-untersprache,untersprache,词,NOUN,C1
-untersucht,untersucht,词,NOUN,C1
-untersuchung,untersuchung,词,NOUN,C1
-unterteilung,unterteilung,词,NOUN,C1
-untertheilung,untertheilung,词,NOUN,C1
-untertreibung,untertreibung,词,NOUN,B2
-unterwandel,unterwandel,词,NOUN,C1
-unterweisung,unterweisung,词,NOUN,C1
-unterwirkung,unterwirkung,词,NOUN,C1
-untheilung,untheilung,词,NOUN,C1
-unthinkable,unthinkable,不可想象的,ADJ,B2
-untidiness,untidiness,凌乱,NOUN,B2
-untidy,untidy,词,ADJ,C1
 untie,to untie,解开,VERB,B2
 until,until,直到,ADP,B2
-until to,until to,词,ADP,A2
-until up to,until up to,词,ADP,A1
-untimely (adj),untimely,词,ADJ,C1
-untimely (noun),untimely,词,NOUN,C1
-untouchable,untouchable,不可触碰的,ADJ,B2
-untouched,untouched,词,ADJ,C1
-untoward,untoward,词,ADJ,C1
-untreibung,untreibung,词,NOUN,B2
 unveiling ceremony,unveiling ceremony,揭幕仪式,NOUN,B2
-unviable,unviable,词,ADJ,C1
-unwandel,unwandel,词,NOUN,B2
-unwanted,unwanted,不受欢迎的,ADJ,B2
-unwarranted,unwarranted,词,ADJ,C1
-unwashed,unwashed,洗不,NOUN,C1
-unweisung,unweisung,词,NOUN,B2
-unwell,unwell,词,ADJ,C1
-unwieldy,unwieldy,词,ADJ,C1
-unwilling,unwilling,不愿,VERB,B2
 unwillingness,unwillingness,不甘,NOUN,B2
-unwinnable,unwinnable,打不赢,NOUN,B2
-unwirkung,unwirkung,词,NOUN,C1
-unwise,unwise,词,ADJ,C1
-unwitting,unwitting,词,ADJ,C1
-unwonted,unwonted,词,ADJ,C1
 unworthy,unworthy,你不配,NOUN,B2
-up above,up above,上,ADP,A1
 up to,up to,为止,ADP,B2
-up to a time,up to a time,截至,VERB,C1
-up-down,up-down,上下,NOUN,C1
-upbeat,upbeat,轻快的,ADJ,B2
-upbraid,upbraid,词,VERB,C1
 upcoming,upcoming,مقبل,ADJ,B2
 update,to update,更新,VERB,B2
-update (noun),update,词,NOUN,B1
-updated,updated,词,ADJ,C1
 upgrade,to upgrade,升级,VERB,B2
-upgrade (noun),upgrade,词,NOUN,C1
-upgraded,upgraded,词,ADJ,C1
-upheaval,upheaval,剧变,NOUN,B2
-uphold,uphold,词,VERB,C1
-upholding of rights,upholding of rights,词,NOUN,C1
 upload,to upload,上传,VERB,B2
-upload (noun),upload,词,NOUN,C1
-upper part,upper part,上部,NOUN,B2
-upper reaches,upper reaches,上游,NOUN,B2
-upper residence,upper residence,上住,NOUN,C1
-upper voice,upper voice,词,NOUN,C1
-uppföljning,follow-up,跟进,NOUN,B2
-uppgång,rise,上涨,NOUN,B2
-uppgång,upturn,好转,NOUN,B2
-upphovsrätt,copyright,版权,NOUN,B2
-upphäva,to revoke,撤销,VERB,B2
-upphörande,cessation,终止,NOUN,B2
-uppkomst,emergence,涌现,NOUN,B2
-upplag,stockpile,储备,NOUN,B2
-upplaga,edition,版本,NOUN,B2
-upplysa,to enlighten,启发,VERB,B2
-upplysning,enlightenment,澄清,NOUN,B2
-upplysning,piece of information,信息,NOUN,B2
-upplyst,enlightened,开明的,ADJ,B2
-upplösa,to dissolve,溶解,VERB,B2
-upplösning,dissolution,溶解,NOUN,B2
-uppmana,to urge,强烈要求,VERB,B2
-uppmuntra,to encourage,鼓励,VERB,B2
-uppror,defiance,挑衅,NOUN,B2
-upprorisk,defiant,挑衅的,ADJ,B2
-upproriskt hjärta,rebellious heart,反心,NOUN,B2
-upprymd,elated,兴高采烈的,ADJ,B2
-upprätthålla,to enforce,执行,VERB,B2
-upprör,commotion,骚动,NOUN,B2
-uppröra,to excite,使兴奋,VERB,B2
-uppröra,to upset,使生气,VERB,B2
-upprörande,outrage,愤怒,NOUN,B2
-upprörhet,excitement,兴奋,NOUN,B2
-upprötande,uprooting,背井离乡,NOUN,B2
-uppskatta,estimate,估计,NOUN,B2
-uppskatta,to estimate,估计,VERB,B2
-upptagen,occupied,被占用的,ADJ,B2
-upptäcka,to detect,探测,VERB,B2
-upptäckare,explorer,探险家,NOUN,B2
-uppvigla,to incite,煽动,VERB,B2
-uppvigling,incitement,煽动,NOUN,B2
-uppväcka,to arouse,引起,VERB,B2
-uppvärmning,heating,供暖,NOUN,B2
 upright,upright,正直的,ADJ,B2
-upright (adv),upright,直立地,ADV,B2
-uprightness,uprightness,词,NOUN,B2
 uprising,uprising,起义,NOUN,B2
 uproar,uproar,骚动,NOUN,B2
-uprooted,uprooted,词,ADJ,C1
-ups and downs,ups and downs,词,NOUN,B2
-upshot,upshot,词,NOUN,C1
-upstart,upstart,暴发户,NOUN,B2
-upstart (adj),upstart,词,ADJ,C1
-upwards,upwards,向上,ADV,B2
+upprötande,uprooting,背井离乡,NOUN,B2
+uppröra,to upset,使生气,VERB,B2
+uppgång,upturn,好转,NOUN,B2
 urban,urban,城市的,ADJ,B2
-urban area,urban area,词,NOUN,C1
-urbane,urbane,词,ADJ,C1
-urbanism,urbanism,词,NOUN,B2
 urbanitet,urbanity,都市风度,NOUN,B2
-urbanization,urbanization,城市化,NOUN,B2
-urerziehung,urerziehung,词,NOUN,C1
-urfahrt,urfahrt,词,NOUN,C1
-urfassung,urfassung,词,NOUN,C1
-urforderung,urforderung,词,NOUN,C1
-urgabe,urgabe,词,NOUN,B2
-urgent camp report,urgent camp report,营急报,NOUN,C1
-urgent message,urgent message,急讯,NOUN,C1
-urgestaltung,urgestaltung,词,NOUN,B2
-urine,urine,尿,NOUN,C1
-urkunft,urkunft,词,NOUN,C1
-urnahme,urnahme,词,NOUN,B2
-urpflegung,urpflegung,词,NOUN,C1
-urregelung,urregelung,词,NOUN,C1
-urrichtung,urrichtung,词,NOUN,C1
-urschaft,urschaft,词,NOUN,C1
-urschrift,urschrift,词,NOUN,B2
-ursetzung,ursetzung,词,NOUN,B2
-ursicht,ursicht,词,NOUN,B2
-ursinnung,ursinnung,词,NOUN,C1
-ursprache,ursprache,词,NOUN,C1
-ursprungligen,originally,最初,ADV,B2
-ursucht,ursucht,词,NOUN,C1
-ursuchung,ursuchung,词,NOUN,C1
-ursäkt,apology,道歉,NOUN,B2
-urteilung,urteilung,词,NOUN,B2
-urtheilung,urtheilung,词,NOUN,C1
-urtreibung,urtreibung,词,NOUN,C1
-urval,excerpt,摘录,NOUN,B2
-urval,selection,选择,NOUN,B2
-urwandel,urwandel,词,NOUN,B2
-urweisung,urweisung,词,NOUN,C1
-urwirkung,urwirkung,词,NOUN,C1
-usable,usable,可用的,ADJ,B2
-usage,usage,还用,NOUN,C1
-usage-based,usage-based,词,ADJ,C1
-usb flash drive,usb flash drive,U盘,NOUN,B2
-used,used,词,ADJ,C1
-usefulness avail,usefulness avail,效用,NOUN,C1
-useless zero,useless zero,词,ADJ,A2
-uselessly,uselessly,词,ADV,C1
-using this,using this,用这,NOUN,C1
-usual thing,usual thing,惯例,NOUN,B2
-usufructuary,usufructuary,词,NOUN,C1
-usurer,usurer,词,NOUN,C1
-usurpation,usurpation,词,NOUN,C1
+uppmana,to urge,强烈要求,VERB,B2
+brådska,urgency,紧急,NOUN,B2
+vi,us,你我,NOUN,B2
+använda pinnar,to use chopsticks,动筷,VERB,B2
+använda kryckkor,to use crutches,拄拐,VERB,B2
+värdelös,useless,无用的,ADJ,B2
+användare,user,用户,NOUN,B2
+vanlig,usual,通常的,ADJ,B2
+nyttjanderätt,usufruct,用益权,NOUN,B2
 usurpera,to usurp,篡夺,VERB,B2
-usury,usury,词,NOUN,C1
-utandas,to exhale,呼气,VERB,B2
-utanför,outside,在外面,ADV,B2
-utbilda,to educate,教育,VERB,B2
-utblottning,destitution,贫困,NOUN,B2
-utbredd,widespread,广泛的,ADJ,B2
-utbrott,eruption,爆发,NOUN,B2
-utbrott,outburst,迸发,NOUN,B2
-utbyta,to exchange,交换,VERB,B2
-utdela medicin,to dispense medicine,配药,VERB,B2
-utdöende,extinction,灭绝,NOUN,B2
-utelämna,to omit,省略,VERB,B2
-utensil,utensil,词,NOUN,C1
-uterine,uterine,词,ADJ,C1
-utesluten,excluded,排除在外的,ADJ,B2
-uteslutning,exclusion,排除,NOUN,B2
-utettoalett,outhouse,茅房,NOUN,B2
-utforma,to devise,设计,VERB,B2
-utgift,expenditure,支出,NOUN,B2
-utgifter,expenses,费用,NOUN,B2
-utgräva,to excavate,挖掘,VERB,B2
-utgång,expiry,失效,NOUN,B2
-uthärda,to endure,忍受,VERB,B2
-uthärdlig,bearable,可忍受的,ADJ,B2
-uthållighet,endurance,坚忍,NOUN,B2
-utilitarism,utilitarianism,功利主义,NOUN,B2
 utilitaristisk,utilitarian,功利的,ADJ,B2
-utility,utility,效用,NOUN,B2
-utility meter,utility meter,公用事业表,NOUN,B1
-utility room,utility room,杂物间,NOUN,C1
-utkontraktering,outsourcing,外包,NOUN,B2
-utlandet,abroad,国外,NOUN,B2
-utlandskineser,overseas chinese,华侨,NOUN,B2
-utlopp,outlet,出口,NOUN,B2
-utlämna,to extradite,引渡,VERB,B2
-utlämning,extradition,引渡,NOUN,B2
-utlänning,foreigner,外国人,NOUN,B2
-utmatta,to exhaust,耗尽,VERB,B2
-utmattning,exhaustion,疲惫,NOUN,B2
-utmattning,fatigue,疲劳,NOUN,B2
-utmost extreme end,utmost extreme end,词,NOUN,C1
-utmärka,to excel,擅长,VERB,B2
-utmärka,to stand out,引人注目,VERB,B2
-utnyttja,to utilize,利用,VERB,B2
+utilitarism,utilitarianism,功利主义,NOUN,B2
 utnyttjande,utilization,利用,NOUN,B2
+utnyttja,to utilize,利用,VERB,B2
+yttersta,utmost,你尽,NOUN,B2
 utopi,utopia,乌托邦,NOUN,B2
 utopisk,utopian,乌托邦式的,ADJ,B2
-utpressa,to blackmail,勒索,VERB,B2
-utpressa,to extort,敲诈,VERB,B2
-utpressning,extortion,勒索,NOUN,B2
-utrop,exclamation,感叹,NOUN,B2
-utrota,to eradicate,根除,VERB,B2
-utrota,to exterminate,消灭,VERB,B2
-utrotning,eradication,根除,NOUN,B2
-utrotning,extermination,灭绝,NOUN,B2
-utrusta,to equip,装备,VERB,B2
-utrusta,to furnish,提供,VERB,B2
-utrustad,equipped,配备的,ADJ,B2
-utrustning,gear,齿轮,NOUN,B2
-utsikt,outlook,前景,NOUN,B2
-utsikt,prospect,前景,NOUN,B2
-utsläpp,discharge,放电,NOUN,B2
-utspridd,scattered,分散的,ADJ,B2
-utställning,display,展示,NOUN,B2
-utstött,outcast,被遗弃者,NOUN,B2
-uttal,enunciation,发音,NOUN,B2
-uttal,pronunciation,发音,NOUN,B2
-utter,utter,词,ADJ,C1
-utterance-related,utterance-related,词,ADJ,C1
-uttrycklig,explicit,明确的,ADJ,B2
-utträda,to secede,脱离,VERB,B2
-utveckla,elaborate,详尽的,ADJ,B2
-utveckla,to elaborate,制定,VERB,B2
-utvecklad,developed,发达的,ADJ,B2
-utvecklare,developer,开发商,NOUN,B2
-utvecklas,to evolve,进化,VERB,B2
-utvisa,to banish,流放,VERB,B2
-utvisa,to evict,驱逐,VERB,B2
-utvisa,to expel,开除,VERB,B2
-utvisning,eviction,驱逐,NOUN,B2
-utvisning,expulsion,驱逐,NOUN,B2
-utvärdering,evaluation,评估,NOUN,B2
-va,huh,哈,INTJ,B2
-vacant lot,vacant lot,空地,NOUN,C1
-vacate,vacate,词,VERB,C1
-vacation (verb),vacation,度假,VERB,C1
-vaccin,vaccine,疫苗,NOUN,B2
-vaccinal,vaccinal,词,ADJ,C1
-vaccination,vaccination,疫苗接种,NOUN,B2
-vaccine-related,vaccine-related,疫苗的,ADJ,B2
-vaccinera,to vaccinate,接种疫苗,VERB,B2
-vacillate,vacillate,词,VERB,C1
-vackla,to stagger,蹒跚,VERB,B2
-vacuous,vacuous,词,ADJ,C1
-vacuum,vacuum,真空的,ADJ,B2
-vacuum (noun),vacuum,词,NOUN,B2
-vacuum cleaner,vacuum cleaner,词,NOUN,B2
-vacuum pump,vacuum pump,词,NOUN,C1
-vag,vague,含糊的,ADJ,B2
-vagabond,vagabond,词,NOUN,C1
-vagabond-poet life,vagabond-poet life,词,NOUN,C1
-vagary,vagary,词,NOUN,C1
-vagrancy,vagrancy,词,NOUN,C1
-vagrant,vagrant,词,NOUN,C1
-vaguely,vaguely,词,ADV,C1
-vagueness,vagueness,模糊,NOUN,C1
-vain,vain,徒劳的,ADJ,B2
-vain (noun),vain,白白,NOUN,C1
-vainglorious,vainglorious,词,ADJ,C1
-vainglory,vainglory,词,NOUN,C1
+yttrande,utterance,话语,NOUN,B2
 vakans,vacancy,空缺,NOUN,B2
 vakant,vacant,空缺的,ADJ,B2
-vakla,to wobble,摇晃,VERB,B2
-vaktel,quail,鹌鹑,NOUN,B2
-vaktmästare,warden,看守人,NOUN,B2
-val,whale,鲸鱼,NOUN,B2
-vald,to be elected,当选,VERB,B2
-vale of tears,vale of tears,词,NOUN,C1
-valedictory,valedictory,词,ADJ,C1
-valfri,optional,可选的,ADJ,B2
-valiance,valiance,骁勇,NOUN,C1
-valiantly,valiantly,词,ADV,C1
-valid,valid,有效的,ADJ,B2
-vallfart,pilgrimage,朝圣,NOUN,B2
-value chain,value chain,价值链,NOUN,C1
-value change,value change,改值,NOUN,B2
-valued,valued,词,ADJ,C1
-valve,valve,词,NOUN,C1
-vana sig vid,to get used to,习惯于,VERB,B2
-vandra,to roam,漫游,VERB,B2
-vandring,wandering,漫游,NOUN,B2
-vanilla,vanilla,词,NOUN,C1
+vaccinera,to vaccinate,接种疫苗,VERB,B2
+vaccination,vaccination,疫苗接种,NOUN,B2
+vaccin,vaccine,疫苗,NOUN,B2
+vag,vague,含糊的,ADJ,B2
+tapper,valiant,英勇的,ADJ,B2
+giltighet,validity,有效期,NOUN,B2
+dal,valley,山谷,NOUN,B2
+tapperhet,valor,勇气,NOUN,B2
+värdering,valuation,估值,NOUN,B2
+förtrupp,vanguard,先锋,NOUN,B2
 vanish,to vanish,消失,VERB,B2
-vanishing,vanishing,词,NOUN,C1
 vanity,vanity,虚荣,NOUN,B2
-vanlig,ordinary,普通的,ADJ,B2
-vanlig,usual,通常的,ADJ,B2
-vanlig dag,ordinary day,平日,NOUN,B2
-vanliga människor,ordinary people,老百姓,NOUN,B2
-vanligtvis,ordinarily,通常,ADV,B2
-vanquish,vanquish,词,VERB,C1
-vapenvila,truce,休战,NOUN,B2
-vapid,vapid,词,ADJ,C1
-vapor,vapor,词,NOUN,C1
-vaporizer,vaporizer,词,NOUN,C1
-vara,commodity,商品,NOUN,B2
-vara,to was,是,VERB,B2
-vara försiktig,to take care,照顾,VERB,B2
-varaktighet,duration,持续时间,NOUN,B2
-vardag,every day,天天,ADV,B2
-vardag,weekday,工作日,NOUN,B2
-varförhållanden,whereabouts,行踪,NOUN,B2
 variable,variable,变量,NOUN,B2
-variable (adj),variable,词,ADJ,C1
-variables,variables,词,NOUN,C1
 variance,variance,方差,NOUN,B2
-variant,variant,变体,NOUN,B2
-variation,variation,变化,NOUN,B2
-variegate,variegate,词,VERB,C1
 variety,variety,种类,NOUN,B2
-varigenom,whereby,其中,ADV,B2
-various,various,各种各样的,ADJ,B2
 various departments,various departments,各部,NOUN,B2
-varje,each,每个,DET,B2
-varmluftballong,hot air balloon,热气球,NOUN,B2
-varnish,varnish,清漆,NOUN,B2
-varv,shipyard,造船厂,NOUN,B2
-varying,varying,词,ADJ,B2
-vase,vase,花瓶,NOUN,B2
-vask,sink,水槽,NOUN,B2
-vass,sharp,锋利的,ADJ,B2
-vassal,vassal,之臣,NOUN,C1
 vast,vast,巨大的,ADJ,B2
-vastness,vastness,词,NOUN,B2
+vegetable garden,vegetable garden,果园,NOUN,B2
+vehicle registration,vehicle registration,行驶证,NOUN,B2
+vein,vein,静脉,NOUN,B2
+venerable,venerable,值得尊敬的,ADJ,B2
+veneration,veneration,崇敬,NOUN,B2
+vengeance,vengeance,报复,NOUN,B2
+ventilation,ventilation,通风,NOUN,B2
+venue,venue,场地,NOUN,B2
+verbose,verbose,冗长的,ADJ,B2
+verbosity,verbosity,冗长,NOUN,B2
+verify,to verify,核实,VERB,B2
+vermin,vermin,害兽,NOUN,B2
+vernal,vernal,春季的,ADJ,B2
+versed,versed,精通的,ADJ,B2
+version,version,版本,NOUN,B2
+vertical,vertical,垂直的,ADJ,B2
+vest,vest,背心,NOUN,B2
+veteran,veteran,老手,NOUN,B2
+veto,veto,否决,NOUN,B2
+vibration,vibration,振动,NOUN,B2
+vice versa,vice versa,反之亦然,ADV,B2
+vicinity,vicinity,附近,NOUN,B2
+video,video,视频,NOUN,B2
+video disc,video disc,影碟,NOUN,B2
+video recording,video recording,录像,NOUN,B2
+vie,to vie,竞争,VERB,B2
+vigil,vigil,守夜,NOUN,B2
+vigilance,vigilance,警惕,NOUN,B2
+vigor,vigor,活力,NOUN,B2
+villa,villa,别墅,NOUN,B2
+village head,village head,村长,NOUN,B2
+villainy,villainy,邪恶,NOUN,B2
+vine,vine,藤蔓,NOUN,B2
+vinegar,vinegar,醋,NOUN,B2
+violate,to violate,违反,VERB,B2
+violate discipline,to violate discipline,违纪,VERB,B2
+violation,violation,侵越,NOUN,B2
+violin,violin,小提琴,NOUN,B2
+virtual,virtual,虚拟的,ADJ,B2
+virtually,virtually,几乎,ADV,B2
+virus,virus,病毒,NOUN,B2
+visa,visa,签证,NOUN,B2
+viscous,viscous,黏稠的,ADJ,B2
+visual,visual,视觉的,ADJ,B2
+vitamin,vitamin,维生素,NOUN,B2
+vivid,vivid,生动的,ADJ,B2
+vocal,vocal,直言的,ADJ,B2
+volatile,volatile,易变的,ADJ,B2
+volcano,volcano,火山,NOUN,B2
+vortex,vortex,漩涡,NOUN,B2
+voter,voter,选民,NOUN,B2
+voucher,voucher,代金券,NOUN,B2
+vow,vow,誓言,NOUN,B2
+vulgar,vulgar,粗俗的,ADJ,B2
+vulgarity,vulgarity,粗俗,NOUN,B2
+wage,wage,工资,NOUN,B2
+wages,wages,工资,NOUN,B2
+wail,to wail,哀号,VERB,B2
+waist,waist,腰,NOUN,B2
+wait for me,wait for me,等我,NOUN,B2
+wait long,to wait long,久等,VERB,B2
+waiter,waiter,服务员,NOUN,B2
+waiting room,waiting room,候诊室,NOUN,B2
+vandring,wandering,漫游,NOUN,B2
+lockbete,want to lure,想引,NOUN,B2
+vilja,to want to need will,要,VERB,B2
+avdelning,ward,病房,NOUN,B2
+vaktmästare,warden,看守人,NOUN,B2
+lager,warehouse,仓库,NOUN,B2
+garanti,warranty,保修单,NOUN,B2
+vara,to was,是,VERB,B2
+tvätt,washing,洗涤,NOUN,B2
+slöserig,wasteful,浪费的,ADJ,B2
+brakmark,wasteland,荒地,NOUN,B2
+titta,watch,手表,NOUN,B2
+titta,to watch,观看,VERB,B2
+vattna,to water,浇水,VERB,B2
 vattenfall,water falling,水落,NOUN,B2
-vattenfall,waterfall,瀑布,NOUN,B2
-vattenfärg,watercolor,水彩画,NOUN,B2
-vattenkraft,hydro energy,水能,NOUN,B2
 vattenkål,water spinach,空心菜,NOUN,B2
+vattenfärg,watercolor,水彩画,NOUN,B2
+vattenfall,waterfall,瀑布,NOUN,B2
 vattenmelon,watermelon,西瓜,NOUN,B2
 vattenmelonsskärna,watermelon seed,西瓜子,NOUN,B2
 vattentät,waterproof,防水的,ADJ,B2
-vattna,to water,浇水,VERB,B2
-vaulting pole,vaulting pole,词,NOUN,C1
-vaunt,vaunt,词,VERB,C1
-vaunted,vaunted,词,ADJ,B2
-veckonummer,week number,周次,NOUN,B2
-veckotest,weekly test,周测,NOUN,B2
-veckovis,weekly,每周的,ADJ,B2
-vector,vector,词,NOUN,C1
-vederlägga,to rebut,反驳,VERB,B2
-veer,veer,词,VERB,C1
-vegetable garden,vegetable garden,果园,NOUN,B2
-vegetable selling,vegetable selling,卖菜,NOUN,C1
-vegetables,vegetables,菜吧,NOUN,C1
-vegetarian,vegetarian,素食者,NOUN,B2
-vegetarian (adj),vegetarian,词,ADJ,A1
-vehemence,vehemence,词,NOUN,C1
-vehement,vehement,激烈的,ADJ,B2
-vehicle registration,vehicle registration,行驶证,NOUN,B2
-vehicular,vehicular,词,ADJ,C1
-veil,veil,词,NOUN,C1
-veiled,veiled,隐晦的,ADJ,B2
-vein,vein,静脉,NOUN,B2
-velarization,velarization,词,NOUN,C1
-vem,whom,谁,PRON,B2
-veneer,veneer,词,NOUN,C1
-venerable,venerable,值得尊敬的,ADJ,B2
-veneration,veneration,崇敬,NOUN,B2
-venereal disease,venereal disease,性病,NOUN,B2
-vengeance,vengeance,报复,NOUN,B2
-venial,venial,词,ADJ,C1
-venom,venom,词,NOUN,C1
-venomous,venomous,词,ADJ,C1
-venomous dragon,venomous dragon,毒龙,NOUN,C1
-vent (noun),vent,词,NOUN,B2
-ventilation,ventilation,通风,NOUN,B2
-venting,venting,出气,NOUN,C1
-venting anger,venting anger,泄愤,NOUN,C1
-venture (noun),venture,词,NOUN,B2
-venue,venue,场地,NOUN,B2
-veracity,veracity,词,NOUN,C1
-veranda,porch,门廊,NOUN,B2
-verbal,verbal,词,ADJ,B2
-verbal sparring,verbal sparring,词,NOUN,C1
-verbalize,verbalize,词,VERB,B2
-verbatim,verbatim,词,ADV,C1
-verbose,verbose,冗长的,ADJ,B2
-verbosely,verbosely,词,ADV,C1
-verbosity,verbosity,冗长,NOUN,B2
-verdant,verdant,词,ADJ,C1
-vererziehung,vererziehung,词,NOUN,C1
-verfahrt,verfahrt,词,NOUN,C1
-verforderung,verforderung,词,NOUN,C1
-vergabe,vergabe,词,NOUN,C1
-verge,verge,词,NOUN,C1
-vergestaltung,vergestaltung,词,NOUN,C1
-verifiable,verifiable,词,ADJ,C1
-verification,verification,词,NOUN,C1
-verify,to verify,核实,VERB,B2
-veritable,veritable,词,ADJ,C1
-verity,verity,词,NOUN,C1
-verkan,efficacy,功效,NOUN,B2
-verklig eftergift,true concession,真让,NOUN,B2
-verklig önskan,really want,真要,NOUN,B2
-verkställa,to enact,颁布,VERB,B2
-verkställighet,enforcement,执行,NOUN,B2
-verktyg,tools,工具,NOUN,B2
-verktygsrum,tool room,工具间,NOUN,B2
-verkunft,verkunft,词,NOUN,C1
-vermilion,vermilion,词,NOUN,B2
-vermin,vermin,害兽,NOUN,B2
-vernacular,vernacular,词,NOUN,C1
-vernahme,vernahme,词,NOUN,C1
-vernal,vernal,春季的,ADJ,B2
-vernier,vernier,词,NOUN,C1
-verpflegung,verpflegung,词,NOUN,C1
-verregelung,verregelung,词,NOUN,C1
-verrichtung,verrichtung,词,NOUN,C1
-versatile,versatile,多才多艺的,ADJ,B2
-versatility,versatility,词,NOUN,B2
-verschaft,verschaft,词,NOUN,B2
-verschrift,verschrift,词,NOUN,C1
-verse,verse,词,NOUN,C1
-verse of Quran,verse of Quran,词,NOUN,B2
-versed,versed,精通的,ADJ,B2
-versetzung,versetzung,词,NOUN,C1
-versicht,versicht,词,NOUN,C1
-versification,versification,词,NOUN,C1
-versinnung,versinnung,词,NOUN,B2
-version,version,版本,NOUN,B2
-versprache,versprache,词,NOUN,C1
-versucht,versucht,词,NOUN,C1
-versuchung,versuchung,词,NOUN,C1
-versus,versus,对,ADP,B2
-vertebra,vertebra,词,NOUN,B2
-verteilung,verteilung,词,NOUN,C1
-vertex,vertex,词,NOUN,C1
-vertheilung,vertheilung,词,NOUN,C1
-vertical,vertical,垂直的,ADJ,B2
-vertigo,vertigo,词,NOUN,C1
-vertigo dizziness,vertigo dizziness,词,NOUN,C1
-vertreibung,vertreibung,词,NOUN,C1
-verwandel,verwandel,词,NOUN,C1
-verweisung,verweisung,词,NOUN,C1
-verwirkung,verwirkung,词,NOUN,C1
-very best,very best,最好的,ADJ,B2
-very deep,very deep,很深,ADJ,B2
-very fine,very fine,极细的,ADJ,B2
-very good,very good,很好,ADJ,B2
-very hard,very hard,极硬的,ADJ,B2
-very heavy,very heavy,很重,ADJ,C1
-very much,very much,万分,ADV,B2
-very well,very well,词,ADV,B2
-vest,vest,背心,NOUN,B2
-vestige,vestige,词,NOUN,C1
-vete,wheat,小麦,NOUN,B2
-veteran,veteran,老手,NOUN,B2
-veterinarian,veterinarian,词,NOUN,C1
-veto,veto,否决,NOUN,B2
-vex,vex,词,VERB,C1
-vexation,vexation,词,NOUN,C1
-vi,us,你我,NOUN,B2
 vi,we or us including both the speaker and the person s spoken to,咱们,PRON,B2
 vi,we two,我俩,PRON,B2
-viable,viable,可行的,ADJ,B2
-vial,vial,词,NOUN,C1
-vibrant,vibrant,词,ADJ,C1
-vibration,vibration,振动,NOUN,B2
-vicarious,vicarious,词,ADJ,C1
-vice versa,vice versa,反之亦然,ADV,B2
-vice versa (adj),vice versa,词,ADJ,B2
-vice-minister,vice-minister,侍郎,NOUN,B2
-vicinity,vicinity,附近,NOUN,B2
-vicious,vicious,词,ADJ,B2
-vicissitude,vicissitude,变迁,NOUN,B2
-victory banquet,victory banquet,庆功宴,NOUN,B2
-vidare,further,进一步的,ADJ,B2
-video,video,视频,NOUN,B2
-video clip,video clip,词,NOUN,C1
-video disc,video disc,影碟,NOUN,B2
-video on demand,video on demand,点播,NOUN,C1
-video recording,video recording,录像,NOUN,B2
-videotape,videotape,词,NOUN,C1
-vidrig,gross,总的,ADJ,B2
-vidskepelse,superstition,迷信,NOUN,B2
-vie,to vie,竞争,VERB,B2
-viewer,viewer,观众,NOUN,B2
-viewing,viewing,词,NOUN,B1
-views,views,观看次数,NOUN,B2
-vigil,vigil,守夜,NOUN,B2
-vigilance,vigilance,警惕,NOUN,B2
-vigilant,vigilant,警惕的,ADJ,B2
-vignette,vignette,词,NOUN,C1
-vigor,vigor,活力,NOUN,B2
-vigor of prime,vigor of prime,词,NOUN,C1
-vigorous,vigorous,词,ADJ,C1
-vik,bay,海湾,NOUN,B2
-vika,to wrap,包裹,VERB,B2
-vildhet,ferocity,凶猛,NOUN,B2
-vilja,willing,肯,AUX,B2
-vilja,willingness,乐意,NOUN,B2
-vilja,to think to want,想,VERB,B2
-vilja,to want to need will,要,VERB,B2
-viljefull,willful,任性的,ADJ,B2
-vilken,which one,哪一个,PRON,B2
-villa,villa,别墅,NOUN,B2
-village head,village head,村长,NOUN,B2
-village road,village road,村道,NOUN,C1
-villager,villager,村民,NOUN,C1
-villainous,villainous,恶棍的,ADJ,B2
-villainy,villainy,邪恶,NOUN,B2
-vind,in wind,临风,NOUN,B2
-vinda,to wind,缠绕,VERB,B2
-vindicate,vindicate,词,VERB,C1
-vindictive,vindictive,词,ADJ,C1
-vindruva,grape,葡萄,NOUN,B2
-vindtät,windproof,挡风的,ADJ,B2
-vine,vine,藤蔓,NOUN,B2
-vinegar,vinegar,醋,NOUN,B2
-vineyard,vineyard,葡萄园,NOUN,C1
-vinka,to wink,眨眼,VERB,B2
-vinkelrät,perpendicular,垂直的,ADJ,B2
-vinkopp,wine cup,这酒盏,NOUN,B2
-vinst,gain,收益,NOUN,B2
-vinstgivande,profit-making,营利性,ADJ,B2
-vintage,vintage,佳酿,NOUN,B2
-violate,to violate,违反,VERB,B2
-violate discipline,to violate discipline,违纪,VERB,B2
-violate regulations,violate regulations,违规,VERB,C1
-violation,violation,侵越,NOUN,B2
-violations,violations,词,NOUN,C1
-violent act,violent act,词,NOUN,C1
-violet (adj),violet,词,ADJ,C1
-violet (noun),violet,词,NOUN,B2
-violin,violin,小提琴,NOUN,B2
-viper,viper,词,NOUN,B2
-viral,viral,病毒性的,ADJ,C1
-virginal,virginal,处女的,ADJ,B2
-virrig,muddled,混乱的,ADJ,B2
-virtual,virtual,虚拟的,ADJ,B2
-virtual reality,virtual reality,虚拟现实,NOUN,B2
-virtually,virtually,几乎,ADV,B2
-virtuoso,virtuoso,词,NOUN,C1
-virtuous,virtuous,有德行的,ADJ,B2
-virulent,virulent,恶性的,ADJ,B2
-virus,virus,病毒,NOUN,B2
-virvelvind,whirlwind,旋风；漩涡,NOUN,B2
-visa,visa,签证,NOUN,B2
-visa,to exhibit,展览,VERB,B2
-visa sig,to turn out,结果是,VERB,B2
-viscosity,viscosity,词,NOUN,C1
-viscount,viscount,词,NOUN,C1
-viscous,viscous,黏稠的,ADJ,B2
-visibility,visibility,能见度,NOUN,B2
-visible,visible,可见的,ADJ,B2
-visionary,visionary,词,NOUN,C1
-viskning,whisper,低语,NOUN,B2
-visor,visor,词,NOUN,B2
-visserligen,admittedly,诚然,ADV,B2
-vistelse,sojourn,逗留,NOUN,B2
-visual,visual,视觉的,ADJ,B2
-visualize,visualize,词,VERB,C1
-vital,vital,词,ADJ,B2
-vital point,vital point,要害,NOUN,B2
-vitality,vitality,词,NOUN,B2
-vitality powder,vitality powder,元散,NOUN,C1
-vitamin,vitamin,维生素,NOUN,B2
-vitiate,vitiate,词,VERB,C1
-vitriolic,vitriolic,词,ADJ,C1
-vitt,wits,心眼,NOUN,B2
-vittig,witty,机智的,ADJ,B2
-vittnesmål,witness testimony,人证,NOUN,B2
-vituperate,vituperate,词,VERB,C1
-vivacious,vivacious,词,ADJ,C1
-vivid,vivid,生动的,ADJ,B2
-vocabulary,vocabulary,词,NOUN,C1
-vocal,vocal,直言的,ADJ,B2
-vocal range,vocal range,词,NOUN,C1
-vocalization,vocalization,词,NOUN,C1
-vocation,vocation,词,NOUN,C1
-vocationalization,vocationalization,词,NOUN,C1
-vociferous,vociferous,词,ADJ,C1
-vodka,vodka,词,NOUN,C1
-vogue,vogue,流行,NOUN,B2
-voice command,voice command,声令,NOUN,B2
-voiceover,voiceover,词,NOUN,C1
-voicing,voicing,词,NOUN,C1
-void,void,最无,NOUN,B2
-volatile,volatile,易变的,ADJ,B2
-volatility,volatility,词,NOUN,C1
-volcanic,volcanic,词,ADJ,C1
-volcano,volcano,火山,NOUN,B2
-volition,volition,词,NOUN,C1
-volleyball,volleyball,排球,NOUN,B2
-voltage,voltage,词,NOUN,C1
-voluble,voluble,词,ADJ,C1
-volume measure,volume measure,词,NOUN,B2
-volumetric,volumetric,词,ADJ,C1
-voluminous,voluminous,词,ADJ,C1
-voluntariness,voluntariness,词,NOUN,C1
-voluntarist,voluntarist,词,ADJ,C1
-volunteer work,volunteer work,志愿工作,NOUN,B2
-volunteering,volunteering,志愿服务,NOUN,B2
-voluptuous,voluptuous,词,ADJ,C1
-vomiting,vomiting,词,NOUN,C1
-voracious,voracious,词,ADJ,C1
-voracity,voracity,词,NOUN,C1
-vorderbildung,vorderbildung,词,NOUN,C1
-vordererziehung,vordererziehung,词,NOUN,C1
-vorderfahrt,vorderfahrt,词,NOUN,C1
-vorderfassung,vorderfassung,词,NOUN,B2
-vorderforderung,vorderforderung,词,NOUN,C1
-vordergabe,vordergabe,词,NOUN,C1
-vordergestaltung,vordergestaltung,词,NOUN,C1
-vorderkunft,vorderkunft,词,NOUN,C1
-vorderleitung,vorderleitung,词,NOUN,B2
-vordermessung,vordermessung,词,NOUN,C1
-vordernahme,vordernahme,词,NOUN,C1
-vorderordnung,vorderordnung,词,NOUN,C1
-vorderpflegung,vorderpflegung,词,NOUN,C1
-vorderrechnung,vorderrechnung,词,NOUN,C1
-vorderregelung,vorderregelung,词,NOUN,C1
-vorderrichtung,vorderrichtung,词,NOUN,B2
-vorderschaft,vorderschaft,词,NOUN,C1
-vorderschrift,vorderschrift,词,NOUN,C1
-vordersetzung,vordersetzung,词,NOUN,B2
-vordersicht,vordersicht,词,NOUN,C1
-vordersinnung,vordersinnung,词,NOUN,B2
-vordersprache,vordersprache,词,NOUN,C1
-vorderstellung,vorderstellung,词,NOUN,C1
-vordersucht,vordersucht,词,NOUN,C1
-vordersuchung,vordersuchung,词,NOUN,C1
-vorderteilung,vorderteilung,词,NOUN,C1
-vordertheilung,vordertheilung,词,NOUN,C1
-vordertreibung,vordertreibung,词,NOUN,C1
-vorderwandel,vorderwandel,词,NOUN,B2
-vorderwandlung,vorderwandlung,词,NOUN,C1
-vorderweisung,vorderweisung,词,NOUN,B2
-vorderwendung,vorderwendung,词,NOUN,C1
-vorderwirkung,vorderwirkung,词,NOUN,C1
-vorerziehung,vorerziehung,词,NOUN,B2
-vorfahrt,vorfahrt,词,NOUN,C1
-vorfassung,vorfassung,词,NOUN,C1
-vorforderung,vorforderung,词,NOUN,C1
-vorgabe,vorgabe,词,NOUN,C1
-vorgestaltung,vorgestaltung,词,NOUN,C1
-vorkunft,vorkunft,词,NOUN,C1
-vornahme,vornahme,词,NOUN,C1
-vorpflegung,vorpflegung,词,NOUN,C1
-vorregelung,vorregelung,词,NOUN,C1
-vorrichtung,vorrichtung,词,NOUN,C1
-vorschaft,vorschaft,词,NOUN,C1
-vorsetzung,vorsetzung,词,NOUN,C1
-vorsicht,vorsicht,词,NOUN,C1
-vorsinnung,vorsinnung,词,NOUN,C1
-vorsprache,vorsprache,词,NOUN,C1
-vorsucht,vorsucht,词,NOUN,C1
-vorsuchung,vorsuchung,词,NOUN,C1
-vorteilung,vorteilung,词,NOUN,B2
-vortex,vortex,漩涡,NOUN,B2
-vortheilung,vortheilung,词,NOUN,B2
-vortreibung,vortreibung,词,NOUN,C1
-vorwandel,vorwandel,词,NOUN,B2
-vorweisung,vorweisung,词,NOUN,C1
-vorwirkung,vorwirkung,词,NOUN,C1
-votary,votary,词,NOUN,C1
-vote counting austerity,vote counting austerity,词,NOUN,C1
-voter,voter,选民,NOUN,B2
-votive offering,votive offering,词,NOUN,C1
-vouch,vouch,词,VERB,C1
-voucher,voucher,代金券,NOUN,B2
-vouchsafe,vouchsafe,词,VERB,C1
-vow,vow,誓言,NOUN,B2
-vowel,vowel,词,NOUN,C1
-vowel inclination,vowel inclination,词,NOUN,C1
-voyage,voyage,词,NOUN,B2
-voyeur,voyeur,词,NOUN,C1
-vrak,wreck,残骸,NOUN,B2
-vrist,ankle,脚踝,NOUN,B2
-vs,vs,与...相对,ADP,B2
-vulgar,vulgar,粗俗的,ADJ,B2
-vulgarity,vulgarity,粗俗,NOUN,B2
-vulnerability,vulnerability,漏洞,NOUN,C1
-vulture,vulture,词,NOUN,B2
-vägenomtänkt,well-considered,深思熟虑的,ADJ,B2
-vägskylt,road sign,路标,NOUN,B2
-välfärd,prosperity,繁荣,NOUN,B2
-välfärd,welfare,福利,NOUN,B2
-välja,to elect,选举,VERB,B2
-väljarkår,electorate,选民,NOUN,B2
-välkomstmiddag,welcome banquet,欢迎宴,NOUN,B2
-välkänd,well-known,众所周知的,ADJ,B2
-välmående,prosperous,繁荣的,ADJ,B2
-välmående,well-being,健康,NOUN,B2
-vända,to turn around,转身,VERB,B2
-vändpunkt,turning point,转折点,NOUN,B2
-värd,to be worth,值得,VERB,B2
-värdelös,useless,无用的,ADJ,B2
-värdering,valuation,估值,NOUN,B2
-världsbild,worldview,世界观,NOUN,B2
-världskrig,world war,世界大战,NOUN,B2
-världsomspännande,worldwide,全世界的,ADJ,B2
-värma,to heat,加热,VERB,B2
-värva,to enlist,征募,VERB,B2
-väsentlig,essential,必要的,ADJ,B2
-väsentlig,substantial,大量的,ADJ,B2
-väsentligen,essentially,主要地,ADV,B2
-västra regioner,western regions,西域,NOUN,B2
-väte,hydrogen,氢,NOUN,B2
-väv,tissue,组织,NOUN,B2
+avvänja,to wean,断奶,VERB,B2
+avvänjning,weaning,断奶,NOUN,B2
+trötthet,weariness,疲倦,NOUN,B2
 väva,to weave,编织,VERB,B2
 vävning,weaving,编织,NOUN,B2
-växa upp,to grow up,成长,VERB,B2
-växel,switch,开关,NOUN,B2
-växlingsal,switch room,配电室,NOUN,B2
-växthus,greenhouse,温室,NOUN,B2
-våga,crest,顶峰,NOUN,B2
-vårdnad,custody,监护,NOUN,B2
-vårdslös,negligent,疏忽的,ADJ,B2
-vårdslös,reckless,鲁莽的,ADJ,B2
-vårdslöshet,negligence,疏忽；过失,NOUN,B2
-vårdslöshet,recklessness,轻率,NOUN,B2
-våtmark,wetland,湿地,NOUN,B2
-wading,wading,词,NOUN,B2
-waffle,waffle,词,NOUN,A2
-waft,waft,词,VERB,C1
-wage,wage,工资,NOUN,B2
-wage earner,wage earner,词,NOUN,C1
-wage labor,wage labor,雇佣劳动,NOUN,B2
-wage-related,wage-related,词,ADJ,C1
-wager,wager,词,NOUN,C1
-wages,wages,工资,NOUN,B2
-waggish,waggish,词,ADJ,C1
-wagon,wagon,词,NOUN,B2
-wahhabism,wahhabism,词,NOUN,C1
-wail,to wail,哀号,VERB,B2
-wailing,wailing,词,NOUN,B2
-waist,waist,腰,NOUN,B2
-waist token,waist token,腰牌,NOUN,B2
-wait for me,wait for me,等我,NOUN,B2
-wait for opportunity,wait for opportunity,伺机,VERB,C1
-wait inside,wait inside,里候,NOUN,B2
-wait long,to wait long,久等,VERB,B2
-wait-and-see,wait-and-see,观望的,ADJ,B2
-waiter,waiter,服务员,NOUN,B2
-waiter attendant,waiter attendant,服务员,NOUN,B2
-waiting,waiting,等他,NOUN,C1
-waiting hall,waiting hall,候车室,NOUN,B2
-waiting room,waiting room,候诊室,NOUN,B2
-waive,waive,词,VERB,C1
-wake (noun),wake,词,NOUN,C1
-wake up (noun),wake up,你醒醒,NOUN,C1
-waken,waken,词,VERB,B2
-walker,walker,词,NOUN,C1
-walking,walking,词,NOUN,B1
-wall fence,wall fence,词,NOUN,A2
-wall-mounted,wall-mounted,词,ADJ,C1
-wallow,wallow,词,VERB,C1
-walnut,walnut,核桃,NOUN,B2
-walnuts,walnuts,词,NOUN,B2
-wan,wan,词,ADJ,B2
-wanderer,wanderer,词,NOUN,C1
-wandering (adj),wandering,词,ADJ,C1
-wandering monk,wandering monk,游方,NOUN,B2
-want (adp),want,我要,ADP,A2
-wanted one,wanted one,词,NOUN,B2
-wanted person,wanted person,词,NOUN,C1
-wanting you,wanting you,要你,NOUN,B2
-wanton,wanton,词,ADJ,C1
-wantonly,wantonly,大肆,ADV,B2
-wantonness,wantonness,肆意,NOUN,C1
-war cessation,war cessation,战息,NOUN,B2
-war-related,war-related,词,ADJ,B2
-warble (noun),warble,词,NOUN,C1
-warble (verb),warble,词,VERB,C1
-warehouse store,warehouse store,词,NOUN,B1
-warm-up,warm-up,词,NOUN,B1
-warm-up match,warm-up match,热身赛,NOUN,C1
-warmly,warmly,热情地,ADV,B2
-warmonger,warmonger,词,NOUN,C1
-warning (adj),warning,词,ADJ,C1
-warning sign,warning sign,警示牌,NOUN,C1
-warrant,warrant,令状,NOUN,B2
-warrior (part),warrior,士,PART,B2
-warship,warship,词,NOUN,C1
-wary,wary,谨慎的,ADJ,B2
-wash (noun),wash,冲走,NOUN,C1
-wash clothes,wash clothes,词,VERB,A1
-washer,washer,词,NOUN,B2
-waste disposal site,waste disposal site,词,NOUN,B1
-waste of time,waste of time,浪费时间,NOUN,B2
-waste residue,waste residue,废渣,NOUN,B2
-waste sorting,waste sorting,垃圾分类,NOUN,C1
-wastewater,wastewater,废水,NOUN,C1
-watch (noun),watch,你看好小,NOUN,B2
-watch of the night,watch of the night,词,NOUN,C1
-watch over,watch over,词,VERB,C1
-watched,watched,词,NOUN,B2
-watchmaking,watchmaking,词,NOUN,C1
-watchtower,watchtower,词,NOUN,B2
-water caltrop,water caltrop,菱角,NOUN,C1
-water chestnut,water chestnut,荸荠,NOUN,C1
-water garment,water garment,水衣,NOUN,C1
-water heater,water heater,热水器,NOUN,B2
-water jug,water jug,词,NOUN,B2
-water phase,water phase,水相,NOUN,C1
-water polo,water polo,水球,NOUN,C1
-water source,water source,水源,NOUN,C1
-watercourse,watercourse,河道,NOUN,B1
-watering,watering,词,NOUN,B2
-waterproof (verb),waterproof,词,VERB,C1
-watershed,watershed,词,NOUN,C1
-waterskin,waterskin,词,NOUN,B2
-waterwheel,waterwheel,词,NOUN,C1
-wave (adj),wave,词,ADJ,C1
-waver,waver,动摇,VERB,C1
-waves,waves,词,NOUN,B1
-wax,wax,蜡,NOUN,B2
-waxen,waxen,词,ADJ,C1
-way home,way home,词,NOUN,C1
-way of thinking,way of thinking,词,NOUN,B2
-waylay,waylay,词,VERB,C1
-we two (noun),we two,们俩,NOUN,C1
-we us,we us,词,PRON,A2
-weak point,weak point,弱点,NOUN,C1
-weakened,weakened,词,ADJ,C1
-weakening,weakening,减弱,NOUN,B2
-weakly,weakly,词,ADV,C1
-weal,weal,词,NOUN,C1
-wealthy,wealthy,富有的,ADJ,B2
-wealthy easy,wealthy easy,词,ADJ,C1
-wealthy nation,wealthy nation,富国,NOUN,C1
-weapon arms,weapon arms,词,NOUN,A1
-wear,wear,磨损,NOUN,B2
-wearily,wearily,词,ADV,C1
-wearisome,wearisome,词,ADJ,C1
-weary,weary,疲倦的,ADJ,B2
-weather forecast,weather forecast,词,NOUN,B1
-weather institute,weather institute,词,NOUN,B2
-weathering,weathering,词,NOUN,C1
-weaver,weaver,词,NOUN,B1
 webbkamera,webcam,网络摄像头,NOUN,B2
-webbläsare,browser,浏览器,NOUN,B2
 webbplats,website,网站,NOUN,B2
-wedding banquet,wedding banquet,喜酒,NOUN,C1
-wedding ceremony,wedding ceremony,婚礼,NOUN,B2
-wedding date,wedding date,婚期,NOUN,C1
-weeding,weeding,词,NOUN,C1
-weeds,weeds,词,NOUN,C1
-weekly (adv),weekly,按周,ADV,C1
-weekly (noun),weekly,周刊,NOUN,B2
-weekly newspaper,weekly newspaper,周报,NOUN,C1
-weeping,weeping,痛哭,NOUN,C1
-weighing,weighing,词,NOUN,B2
-weight training,weight training,词,NOUN,C1
-weightlifting,weightlifting,举重,NOUN,B2
-weiterziehung,weiterziehung,词,NOUN,C1
-weitfahrt,weitfahrt,词,NOUN,C1
-weitfassung,weitfassung,词,NOUN,C1
-weitforderung,weitforderung,词,NOUN,C1
-weitgabe,weitgabe,词,NOUN,C1
-weitgestaltung,weitgestaltung,词,NOUN,C1
-weitkunft,weitkunft,词,NOUN,C1
-weitnahme,weitnahme,词,NOUN,C1
-weitpflegung,weitpflegung,词,NOUN,C1
-weitregelung,weitregelung,词,NOUN,B2
-weitrichtung,weitrichtung,词,NOUN,C1
-weitschaft,weitschaft,词,NOUN,C1
-weitschrift,weitschrift,词,NOUN,C1
-weitsetzung,weitsetzung,词,NOUN,C1
-weitsicht,weitsicht,词,NOUN,B2
-weitsinnung,weitsinnung,词,NOUN,C1
-weitsprache,weitsprache,词,NOUN,C1
-weitsucht,weitsucht,词,NOUN,C1
-weitsuchung,weitsuchung,词,NOUN,B2
-weitteilung,weitteilung,词,NOUN,B2
-weittheilung,weittheilung,词,NOUN,C1
-weittreibung,weittreibung,词,NOUN,C1
-weitwandel,weitwandel,词,NOUN,B2
-weitweisung,weitweisung,词,NOUN,B2
-weitwirkung,weitwirkung,词,NOUN,C1
-welcome (intj),welcome,词,INTJ,A1
-welcoming,welcoming,舒适的,ADJ,B2
-weld,weld,词,VERB,C1
-welder,welder,词,NOUN,C1
-welfare home,welfare home,福利院,NOUN,C1
-well known,well known,家喻户晓,ADJ,C1
-well-behaved,well-behaved,词,ADJ,B2
-well-crafted,well-crafted,词,ADJ,B2
-well-disposed,well-disposed,善意的,ADJ,B2
-well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
-well-groomed,well-groomed,整洁的,ADJ,B2
-well-liked,well-liked,词,ADJ,B2
-well-read,well-read,词,ADJ,C1
-well-received,well-received,喜闻乐见,ADJ,B2
-well-timed,well-timed,合时,ADJ,B2
-wellness,wellness,我好,NOUN,C1
-welter,welter,词,NOUN,C1
-wend,wend,词,VERB,C1
-westerner,westerner,词,NOUN,B2
-westward,westward,往西,NOUN,B2
-wet nurse,wet nurse,词,NOUN,B1
-wet shoes,wet shoes,鞋子湿,NOUN,C1
-wet wipe,wet wipe,湿巾,NOUN,C1
-wharf,wharf,码头,NOUN,B2
-what (noun),what,有何,NOUN,C1
-what about you,what about you,那你呢,NOUN,C1
-what for,what for,词,ADV,A2
-what is known,what is known,所知,NOUN,C1
-what is said,what is said,所说,NOUN,C1
-what is wrong,what is wrong,咋了,NOUN,C1
-what kind,what kind,什么样,PRON,B2
-what manner,what manner,成何,NOUN,C1
-whatsoever,whatsoever,词,DET,B2
-wheedle,wheedle,词,VERB,C1
-wheel hub,wheel hub,轮毂,NOUN,C1
-when (adp),when,之时,ADP,B2
-when (sconj),when,当,SCONJ,A1
-when than,when than,词,SCONJ,A2
-when the time comes,when the time comes,到时候,ADV,B2
-whenever,whenever,词,NOUN,B2
-where (pron),where,哪儿,PRON,B2
-where from,where from,哪来,PRON,B2
-where person,where person,人哪,NOUN,C1
-where to,where to,词,ADV,A2
-whereas (cconj),whereas,词,CCONJ,B2
-whereas (sconj),whereas,词,SCONJ,C1
-whereas since,whereas since,词,SCONJ,A2
-wherever (adv),wherever,词,ADV,B1
-wherever (cconj),wherever,词,CCONJ,C1
-whet,whet,词,VERB,C1
-whether,whether,是否,SCONJ,B2
-whether (part),whether,词,PART,A1
-whey,whey,乳清,NOUN,B2
-which (det),which,哪个,DET,B2
-which ones,which ones,哪些,PRON,B2
-which seat,which seat,哪座,NOUN,B2
-whimsical,whimsical,词,ADJ,C1
-whimsy,whimsy,词,NOUN,C1
-whiny,whiny,词,ADJ,C1
-whip (noun),whip,鞭,NOUN,B2
-whirl,whirl,词,VERB,C1
-whirring,whirring,词,NOUN,C1
-whisk,whisk,打蛋器,NOUN,B2
-whisk whip,whisk whip,词,NOUN,B1
-whistleblower,whistleblower,词,NOUN,C1
-whistling,whistling,词,NOUN,C1
-white blood cell,white blood cell,白细胞,NOUN,B2
-whitewash,whitewash,词,VERB,C1
-whiting,whiting,词,NOUN,B2
-whittle,whittle,词,VERB,C1
-who (noun),who,谁敢,NOUN,B2
-who believes,who believes,谁信,NOUN,C1
-who polite,who polite,哪位,PRON,B2
-who takes,who takes,谁拿,NOUN,C1
-whoever,whoever,词,PRON,B2
-whole body,whole body,全身,NOUN,B2
-whole family,whole family,一家人,NOUN,B2
-whole night,whole night,整夜,ADV,C1
-wholehearted,wholehearted,词,ADJ,C1
-wholesale (adv),wholesale,词,ADV,B1
-wholesome,wholesome,词,ADJ,C1
-whose (det),whose,词,DET,B2
-why bother,why bother,何必,ADV,B2
-why not,why not,何不,ADV,B2
-wick,wick,词,NOUN,C1
-wicked,wicked,邪恶的,ADJ,B2
-wide-awake,wide-awake,词,ADJ,C1
-widening,widening,加宽,NOUN,B2
-widower,widower,词,NOUN,C1
-widowhood,widowhood,词,NOUN,C1
-wiederbildung,wiederbildung,词,NOUN,C1
-wiedererziehung,wiedererziehung,词,NOUN,B2
-wiederfahrt,wiederfahrt,词,NOUN,B2
-wiederfassung,wiederfassung,词,NOUN,C1
-wiederforderung,wiederforderung,词,NOUN,C1
-wiedergabe,wiedergabe,词,NOUN,C1
-wiedergestaltung,wiedergestaltung,词,NOUN,C1
-wiederkunft,wiederkunft,词,NOUN,B2
-wiederleitung,wiederleitung,词,NOUN,B2
-wiedermessung,wiedermessung,词,NOUN,C1
-wiedernahme,wiedernahme,词,NOUN,C1
-wiederordnung,wiederordnung,词,NOUN,B2
-wiederpflegung,wiederpflegung,词,NOUN,C1
-wiederrechnung,wiederrechnung,词,NOUN,C1
-wiederregelung,wiederregelung,词,NOUN,C1
-wiederrichtung,wiederrichtung,词,NOUN,C1
-wiederschaft,wiederschaft,词,NOUN,C1
-wiederschrift,wiederschrift,词,NOUN,C1
-wiedersetzung,wiedersetzung,词,NOUN,C1
-wiedersicht,wiedersicht,词,NOUN,B2
-wiedersinnung,wiedersinnung,词,NOUN,B2
-wiedersprache,wiedersprache,词,NOUN,B2
-wiederstellung,wiederstellung,词,NOUN,C1
-wiedersucht,wiedersucht,词,NOUN,B2
-wiedersuchung,wiedersuchung,词,NOUN,B2
-wiederteilung,wiederteilung,词,NOUN,C1
-wiedertheilung,wiedertheilung,词,NOUN,C1
-wiedertreibung,wiedertreibung,词,NOUN,B2
-wiederwandel,wiederwandel,词,NOUN,C1
-wiederwandlung,wiederwandlung,词,NOUN,C1
-wiederweisung,wiederweisung,词,NOUN,C1
-wiederwendung,wiederwendung,词,NOUN,C1
-wiederwirkung,wiederwirkung,词,NOUN,C1
-wild beast,wild beast,猛兽,NOUN,B2
-wild boar,wild boar,词,NOUN,C1
-wild ghost,wild ghost,野鬼……,NOUN,C1
-wild ones,wild ones,词,NOUN,C1
-wildlife,wildlife,词,NOUN,C1
-wile,wile,词,NOUN,C1
-will (adv),will,将,ADV,C1
-will give majesty,will give majesty,会给陛,NOUN,C1
-will not (aux),will not,不会,AUX,B2
-will not (part),will not,词,PART,A1
-will surely,will surely,定会,AUX,B2
-will surely (adv),will surely,总会,ADV,C1
-will willpower,will willpower,词,NOUN,B2
-willing to hear,willing to hear,愿闻,NOUN,C1
-willow,willow,词,NOUN,B2
-willowy,willowy,词,ADJ,C1
-wily,wily,词,ADJ,C1
-win bid,win bid,中标,VERB,C1
-wince,wince,词,VERB,C1
-wind (adj),wind,词,ADJ,C1
-wind direction,wind direction,风向,NOUN,C1
-wind energy,wind energy,风能,NOUN,C1
-wind force,wind force,风力,NOUN,B2
-wind speed,wind speed,风速,NOUN,B2
-windfall,windfall,意外之财,NOUN,B2
-winding,winding,蜿蜒的,ADJ,B2
-windless,windless,无风的,ADJ,B2
-windmill,windmill,词,NOUN,B2
-window frame,window frame,窗框,NOUN,C1
-windowsill,windowsill,窗台,NOUN,C1
-windy,windy,有风的,ADJ,B2
-windy day,windy day,风天,NOUN,B2
-wings,wings,翅子,NOUN,C1
-winning,winning,词,ADJ,C1
-winning bid price,winning bid price,中标价,NOUN,B2
-winsome,winsome,词,ADJ,C1
-winter melon,winter melon,冬瓜,NOUN,C1
-winter vacation,winter vacation,寒假,NOUN,B2
-winter worm,winter worm,冬虫,NOUN,C1
-wintering,wintering,连过冬,NOUN,C1
-wintry,wintry,冬天的,ADJ,B2
-wired,wired,词,ADJ,C1
-wishful thinking,wishful thinking,你休想,NOUN,C1
-wistful,wistful,词,ADJ,C1
-wit,wit,词,NOUN,C1
-witch hunt,witch hunt,词,NOUN,C1
-witchcraft,witchcraft,巫术,NOUN,B2
-with each other,with each other,词,ADV,A2
-with it,with it,在其中,ADV,B2
-with me,with me,词,PRON,A1
-with that,with that,以此,ADV,B2
-with the aim of,with the aim of,词,ADP,C1
-with this,with this,以此,ADV,B2
-with what,with what,用什么,ADV,B2
-with which,with which,词,PRON,A2
-with you,with you,词,PRON,A1
-withdraw a lawsuit,withdraw a lawsuit,撤诉,VERB,B2
-withdrawal fold,withdrawal fold,词,NOUN,C1
-withdrawn,withdrawn,词,ADJ,B2
-withering,withering,词,NOUN,C1
-within one's power,within one's power,力所能及,ADJ,B2
-without (sconj),without,词,SCONJ,B1
-without exception,without exception,无例外的,ADV,B2
-without further ado,without further ado,毫不犹豫地,ADV,B2
-withstand,withstand,词,VERB,C1
-witness examination,witness examination,证人询问,NOUN,B2
-witness female,witness female,词,NOUN,B2
-witticism,witticism,词,NOUN,C1
-wittiness,wittiness,风趣,NOUN,B2
-witty saying,witty saying,词,NOUN,C1
-wizened,wizened,词,ADJ,C1
-woe (intj),woe,词,INTJ,B2
-woe (noun),woe,词,NOUN,C1
-woman-like,woman-like,妇似,NOUN,C1
-women,women,词,NOUN,B2
-women and children,women and children,妇孺,NOUN,C1
-women's quarters,women's quarters,词,NOUN,C1
-won't do (adj),won't do,不行,ADJ,B2
-wont,wont,词,NOUN,C1
-wonton,wonton,馄饨,NOUN,C1
-wooded,wooded,树木茂盛的,ADJ,B2
-wooden,wooden,木制的,ADJ,B2
-woods,woods,林子,NOUN,B2
-woody,woody,词,ADJ,C1
-words,words,多说,NOUN,C1
-work and rest,work and rest,作息,NOUN,B2
-work book,work book,词,NOUN,B1
-work to work,work to work,工作,NOUN,A1
-workable,workable,可加工的,ADJ,B2
-workday,workday,词,NOUN,C1
-worker laborer,worker laborer,词,NOUN,B1
-workforce,workforce,词,NOUN,B2
-working,working,词,ADJ,C1
-working day,working day,工作日,NOUN,B2
-workout,workout,词,NOUN,C1
-works,works,词,NOUN,B2
-workshops,workshops,词,NOUN,B2
-world champion,world champion,世界冠军,NOUN,B2
-world famous,world famous,举世闻名,ADJ,B2
-world record,world record,世界纪录,NOUN,B2
-world-famous,world-famous,词,ADJ,C1
-worldliness,worldliness,词,NOUN,C1
-worldly,worldly,世俗的,ADJ,B2
-wormwood,wormwood,词,NOUN,A2
-worn,worn,磨损的,ADJ,B2
-worn out,worn out,词,ADJ,C1
-worries about the rear,worries about the rear,后顾之忧,NOUN,B2
-worry relief,worry relief,排忧,NOUN,B2
-worry-free,worry-free,无忧,NOUN,B2
-worrying,worrying,令人担忧的,ADJ,B2
-worse,worse,更糟的事,NOUN,B2
-worsening,worsening,词,NOUN,C1
-worst (noun),worst,词,NOUN,C1
-worst thing,worst thing,最坏的事,NOUN,B2
-worth mentioning,worth mentioning,值得一提的,ADJ,B2
-worth seeing,worth seeing,词,ADJ,C1
-worthiness,worthiness,真配,NOUN,C1
-worthwhile (adj),worthwhile,词,ADJ,C1
-worthwhile (noun),worthwhile,合算,NOUN,B2
-worthy of the name,worthy of the name,名副其实,ADJ,B2
-would like,would like,词,AUX,A2
-would rather (adv),would rather,宁可,ADV,B1
-would rather (sconj),would rather,宁愿,SCONJ,B2
-wounded (noun),wounded,伤兵,NOUN,B2
-woven rug,woven rug,词,NOUN,C1
-wow,wow,哇,INTJ,B2
-wraith,wraith,词,NOUN,C1
-wrangle,wrangle,词,VERB,C1
-wrapper,wrapper,词,NOUN,C1
-wrathful,wrathful,词,ADJ,C1
-wreckage,wreckage,词,NOUN,C1
-wrench,wrench,词,NOUN,C1
-wretched,wretched,词,ADJ,C1
-wretchedness,wretchedness,悲惨,NOUN,C1
-wrinkled crumpled,wrinkled crumpled,词,ADJ,B1
-wrinkles,wrinkles,词,NOUN,B2
-wrinkling,wrinkling,起皱,NOUN,C1
-writ,writ,词,NOUN,C1
-writhe,writhe,词,VERB,C1
-written claim,written claim,词,NOUN,C1
-written instruction,written instruction,批示,NOUN,C1
-wrong,wrong,错误的事,NOUN,B2
-wrongdoer,wrongdoer,罪犯,NOUN,B2
-wrongful conviction,wrongful conviction,冤案,NOUN,B2
-wry,wry,词,ADJ,C1
+bröllopsfoto,wedding photo,婚纱照,NOUN,B2
+ogräs,weed,杂草,NOUN,B2
+veckonummer,week number,周次,NOUN,B2
+vardag,weekday,工作日,NOUN,B2
+veckovis,weekly,每周的,ADJ,B2
+veckotest,weekly test,周测,NOUN,B2
+gråta,to weep,哭泣,VERB,B2
+underlig,weird,奇怪的,ADJ,B2
+nörd,weirdo,怪人,NOUN,B2
+välkomstmiddag,welcome banquet,欢迎宴,NOUN,B2
+svetsning,welding,焊接,NOUN,B2
+välfärd,welfare,福利,NOUN,B2
+brunn,well,井,NOUN,B2
+välmående,well-being,健康,NOUN,B2
+vägenomtänkt,well-considered,深思熟虑的,ADJ,B2
+välkänd,well-known,众所周知的,ADJ,B2
+västra regioner,western regions,西域,NOUN,B2
+våtmark,wetland,湿地,NOUN,B2
+val,whale,鲸鱼,NOUN,B2
+i vilken utsträckning,what extent,在何种程度上,ADV,B2
+vete,wheat,小麦,NOUN,B2
+när,when,当...时,SCONJ,B2
+varförhållanden,whereabouts,行踪,NOUN,B2
+varigenom,whereby,其中,ADV,B2
+om,whether,能否,NOUN,B2
+om eller inte,whether or not,是否,SCONJ,B2
+vilken,which one,哪一个,PRON,B2
+stund,while,一会儿,NOUN,B2
+kaprice,whim,突发奇想,NOUN,B2
+piska,to whip,鞭打,VERB,B2
+virvelvind,whirlwind,旋风；漩涡,NOUN,B2
+viskning,whisper,低语,NOUN,B2
+pipa,whistle,口哨,NOUN,B2
+pipa,to whistle,吹口哨,VERB,B2
+hela världen,whole world,全世界,NOUN,B2
+grosshandel,wholesale,批发,NOUN,B2
+vem,whom,谁,PRON,B2
+utbredd,widespread,广泛的,ADJ,B2
+bredd,width,宽度,NOUN,B2
+ska,will,将要,AUX,B2
+viljefull,willful,任性的,ADJ,B2
+vilja,willing,肯,AUX,B2
+vilja,willingness,乐意,NOUN,B2
+vinda,to wind,缠绕,VERB,B2
+fönsterruta,window glass,窗玻璃,NOUN,B2
+vindtät,windproof,挡风的,ADJ,B2
+vinkopp,wine cup,这酒盏,NOUN,B2
+vinka,to wink,眨眼,VERB,B2
+silta,to winnow,筛选,VERB,B2
+torka,to wipe,擦,VERB,B2
+torkare,wiper,雨刷,NOUN,B2
+tråd,wire,电线,NOUN,B2
+trådlös,wireless,无线的,ADJ,B2
+med svårighet,with difficulty,困难地,ADV,B2
+avbryta,to withdraw,撤回,VERB,B2
+avbrott,withdrawal,撤回,NOUN,B2
+vittnesmål,witness testimony,人证,NOUN,B2
+vitt,wits,心眼,NOUN,B2
+vittig,witty,机智的,ADJ,B2
+vakla,to wobble,摇晃,VERB,B2
+gå,won't do,不行,ADJ,B2
+gå,to won't do,不成,VERB,B2
+träör,wood ear mushroom,木耳,NOUN,B2
+skog,woodland,林地,NOUN,B2
+ull,wool,羊毛,NOUN,B2
+sträva,to work hard for sth to strive for success,争气,VERB,B2
+fungera,to work out,成功,VERB,B2
+världskrig,world war,世界大战,NOUN,B2
+världsbild,worldview,世界观,NOUN,B2
+världsomspännande,worldwide,全世界的,ADJ,B2
+förvärra,to worsen,恶化,VERB,B2
+tillbedjan,worship,崇拜,NOUN,B2
+sär,to wound,使受伤,VERB,B2
+vika,to wrap,包裹,VERB,B2
+inpackning,wrapping,包装,NOUN,B2
+vrak,wreck,残骸,NOUN,B2
+rycka,to wrest,强行夺取,VERB,B2
+bryting,wrestling,摔跤,NOUN,B2
+rynka,wrinkle,皱纹,NOUN,B2
+rynkresistent,wrinkle-resistant,防皱,ADJ,B2
+handled,wrist,手腕,NOUN,B2
+författare,writer,作家,NOUN,B2
+skrift,writing,文字,NOUN,B2
+skriven,written,书面的,ADJ,B2
+fel,wrong,错误的,ADJ,B2
 wudang,wudang,武当,NOUN,B2
-xerography,xerography,词,NOUN,C1
-xiao,xiao,箫,NOUN,C1
-xiulian,xiulian,秀莲,NOUN,B2
-yacht,yacht,词,NOUN,B2
-yeah,yeah,词,INTJ,A1
-year after year,year after year,年复一年,ADV,C1
-year beginning,year beginning,年初,NOUN,C1
-year by year,year by year,逐年,ADV,B2
-year of age,year of age,岁,NOUN,A1
-year-old,year-old,词,ADJ,A1
-year-round,year-round,常年,NOUN,C1
-yearling sheep,yearling sheep,词,NOUN,B2
-yeoman,yeoman,词,NOUN,C1
-yes,yes,是的,PART,B2
-yes (noun),yes,是啊,NOUN,B2
-yes indeed (adv),yes indeed,词,ADV,B2
-yesterday (noun),yesterday,昨天,NOUN,B2
-yesteryear,yesteryear,词,NOUN,C1
-yield (noun),yield,再让,NOUN,B2
-yikes,yikes,哎呀,INTJ,B2
-yin needle,yin needle,阴针,NOUN,C1
-yla,to howl,嚎叫,VERB,B2
-ymp,graft,嫁接,NOUN,B2
-yo,yo,哟,PART,B2
+gård,yard,院子,NOUN,B2
+gäspa,to yawn,打哈欠,VERB,B2
+längta,to yearn for,渴望,VERB,B2
+längtan,yearning,向往,NOUN,B2
+jäst,yeast,酵母,NOUN,B2
+skrika,to yell,大吼,VERB,B2
+ja,yes,是啊,NOUN,B2
+igår,yesterday,بارحة,NOUN,B2
+ge,yield,产量,NOUN,B2
+ge,to yield,产出,VERB,B2
 yoga,yoga,瑜伽,NOUN,B2
-yoga practice,yoga practice,瑜伽练习,NOUN,B2
 yogurt,yogurt,酸奶,NOUN,B2
-yoke,yoke,枷锁,NOUN,B2
-yore,yore,词,NOUN,C1
-you (noun),you,你刚,NOUN,C1
-you accusative,you accusative,词,PRON,A2
-you and I,you and I,我和你,NOUN,B2
-you are,you are,您在,NOUN,C1
-you dative,you dative,词,PRON,A2
-you except,you except,你除,NOUN,B2
-you female,you female,妳,PRON,C1
-you feminine,you feminine,词,PRON,A1
-you formal,you formal,您,PRON,B2
-you masculine,you masculine,词,PRON,A1
-you scared me,you scared me,你吓死我,NOUN,B2
-you take,you take,你拿,NOUN,B2
-you two,you two,你俩,NOUN,C1
-you want sword,you want sword,你要剑……,NOUN,B2
-you're welcome,you're welcome,不客气,INTJ,A1
-young hero,young hero,少侠,NOUN,C1
-young wife,young wife,小媳,NOUN,B2
-younger brother,younger brother,弟弟,NOUN,B2
-younger sibling,younger sibling,词,NOUN,C1
-younger sister,younger sister,妹妹,NOUN,A1
-your,your,你的,PRON,B2
-your arrow,your arrow,若非你一箭,NOUN,B2
-your escort,your escort,您押,NOUN,C1
-your excess,your excess,你多,NOUN,C1
-your head,your head,你头上,NOUN,B2
-your parents,your parents,你爹娘,NOUN,B2
-your photo,your photo,照你,NOUN,B2
-your pl,your pl,你们的,DET,B2
-your plural (pron),your plural,词,PRON,A2
-your reckoning,your reckoning,你算,NOUN,C1
-your son,your son,儿臣,NOUN,B1
-your trouble,your trouble,有劳你,NOUN,B2
-your word,your word,听你,NOUN,B2
-your wound,your wound,你这伤,NOUN,B2
-yours,yours,你的,PRON,B2
-yourself,yourself,你自己,PRON,B2
-youth culture,youth culture,词,NOUN,C1
-youth people,youth people,词,NOUN,C1
-youth trauma,youth trauma,童年创伤,NOUN,B2
-youthful,youthful,词,ADJ,C1
-youthful vigor,youthful vigor,词,NOUN,C1
-yrke,occupation,职业,NOUN,B2
-ytlig,superficial,表面的,ADJ,B2
-ytterligare,additional,额外的,ADJ,B2
-yttersta,utmost,你尽,NOUN,B2
-yttrande,utterance,话语,NOUN,B2
-yuan Chinese currency,yuan Chinese currency,元,NOUN,A1
+du kan,you can,您能,NOUN,B2
+du kan inte leva,you cannot live,你也活不,NOUN,B2
+du,you polite,您,PRON,B2
+ung dam,young lady,小姐,NOUN,B2
+ung man,young man,年轻人,NOUN,B2
+ung herre,young master,少庄主,NOUN,B2
+ungdom,young person,年轻人,NOUN,B2
+unge,youngster,年少者,NOUN,B2
+ditt skratt,your laugh,你笑,NOUN,B2
+er majestät,your majesty,陛下,NOUN,B2
 yuanxiao,yuanxiao,元宵,NOUN,B2
-zajal,zajal,词,NOUN,B2
-zany,zany,词,ADJ,C1
-zeal,zeal,热情,NOUN,B2
-zealot,zealot,词,NOUN,C1
-zealous,zealous,词,ADJ,C1
-zellige tiles,zellige tiles,词,NOUN,A2
-zen master,zen master,禅师,NOUN,B2
 zenit,zenith,顶点,NOUN,B2
-zephyr,zephyr,词,NOUN,C1
-zererziehung,zererziehung,词,NOUN,C1
-zerfahrt,zerfahrt,词,NOUN,C1
-zerfassung,zerfassung,词,NOUN,C1
-zerforderung,zerforderung,词,NOUN,C1
-zergabe,zergabe,词,NOUN,C1
-zergestaltung,zergestaltung,词,NOUN,C1
-zerkunft,zerkunft,词,NOUN,C1
-zernahme,zernahme,词,NOUN,B2
-zeroing,zeroing,词,NOUN,C1
-zerpflegung,zerpflegung,词,NOUN,C1
-zerregelung,zerregelung,词,NOUN,B2
-zerrichtung,zerrichtung,词,NOUN,C1
-zerschaft,zerschaft,词,NOUN,C1
-zerschrift,zerschrift,词,NOUN,C1
-zersetzung,zersetzung,词,NOUN,C1
-zersicht,zersicht,词,NOUN,B2
-zersinnung,zersinnung,词,NOUN,C1
-zersprache,zersprache,词,NOUN,C1
-zersucht,zersucht,词,NOUN,B2
-zersuchung,zersuchung,词,NOUN,B2
-zerteilung,zerteilung,词,NOUN,B2
-zertheilung,zertheilung,词,NOUN,C1
-zertreibung,zertreibung,词,NOUN,C1
-zerwandel,zerwandel,词,NOUN,C1
-zerweisung,zerweisung,词,NOUN,C1
-zerwirkung,zerwirkung,词,NOUN,C1
-zest,zest,词,NOUN,C1
-zesty,zesty,词,ADJ,C1
+Zhuanghe,zhuang he,庄郃,NOUN,B2
 zink,zinc,锌,NOUN,B2
+stjärntecken,zodiac sign,属相,NOUN,B2
 zombie,zombie,僵尸,NOUN,B2
-zongzi,zongzi,粽子,NOUN,B2
-zoo,zoo,动物园,NOUN,B2
 zucchini,zucchini,西葫芦,NOUN,B2
-zuerziehung,zuerziehung,词,NOUN,C1
-zufahrt,zufahrt,词,NOUN,B2
-zufassung,zufassung,词,NOUN,C1
-zuforderung,zuforderung,词,NOUN,C1
-zugabe,zugabe,词,NOUN,C1
-zugestaltung,zugestaltung,词,NOUN,C1
-zukunft,zukunft,词,NOUN,C1
-zunahme,zunahme,词,NOUN,C1
-zupflegung,zupflegung,词,NOUN,C1
-zuregelung,zuregelung,词,NOUN,C1
-zurichtung,zurichtung,词,NOUN,B2
-zuschaft,zuschaft,词,NOUN,B2
-zuschrift,zuschrift,词,NOUN,C1
-zusetzung,zusetzung,词,NOUN,C1
+be allowed,be allowed,允许,AUX,B2
+wrong,wrong,错误的事,NOUN,B2
+far,far,远,ADV,B2
+detection,detection,检测,NOUN,B2
+disputed,disputed,有争议的,ADJ,B2
+so much,so much,那么多,DET,B2
+to attribute,to attribute,归因于,VERB,B2
+that,that,（引导从句）,SCONJ,B2
+pop music,pop music,流行音乐,NOUN,B2
+or rather,or rather,或者,ADV,B2
+pity,pity,遗憾,NOUN,B2
+metallic,metallic,金属的,ADJ,B2
+abscess,abscess,脓肿,NOUN,B2
+real estate,real estate,不动产,NOUN,B2
+linguistic,linguistic,语言的,ADJ,B2
+liberal,liberal,自由的,ADJ,B2
+sir,sir,郎,PART,B2
+prevention,prevention,预防,NOUN,B2
+specimen,specimen,标本,NOUN,B2
+to refine,to refine,提炼,VERB,B2
+in between,in between,在中间,ADV,B2
+to simulate,to simulate,模拟,VERB,B2
+nuanced,nuanced,细微差别的,ADJ,B2
+stupor,stupor,昏迷,NOUN,B2
+to depress,to depress,使沮丧,VERB,B2
+to globalize,to globalize,使全球化,VERB,B2
+concrete,concrete,混凝土,NOUN,B2
+jail,jail,监狱,NOUN,B2
+archetype,archetype,原型,NOUN,B2
+illicit,illicit,违禁的,ADJ,B2
+to devour,to devour,吞食,VERB,B2
+patrol,patrol,巡逻,NOUN,B2
+divine,divine,如神,NOUN,B2
+to abdicate,to abdicate,退位,VERB,B2
+injunction,injunction,禁令,NOUN,B2
+unambiguous,unambiguous,明确的,ADJ,B2
+each,each,每个,PRON,B2
+to marginalize,to marginalize,使边缘化,VERB,B2
+to withhold,to withhold,扣留,VERB,B2
+right,right,右边,ADV,B2
+reign,reign,统治,NOUN,B2
+to amplify,to amplify,放大,VERB,B2
+gallant,gallant,英勇的,ADJ,B2
+chandelier,chandelier,吊灯,NOUN,B2
+usable,usable,可用的,ADJ,B2
+to evoke,to evoke,唤起,VERB,B2
+anatomy,anatomy,解剖学,NOUN,B2
+to despoil,to despoil,掠夺,VERB,B2
+atheist,atheist,无神论者,NOUN,B2
+monthly,monthly,每月的,ADV,B2
+to debase,to debase,贬低,VERB,B2
+indictment,indictment,起诉,NOUN,B2
+lethal,lethal,致命的,ADJ,B2
+hurrah,hurrah,万岁,INTJ,B2
+discontent,discontent,不满,NOUN,B2
+to ravage,to ravage,破坏,VERB,B2
+to emerge,to emerge,出现,VERB,B2
+ditch,ditch,沟渠,NOUN,B2
+to differ,to differ,不同,VERB,B2
+polish,polish,波兰的,ADJ,B2
+puddle,puddle,水坑,NOUN,B2
+incidence,incidence,发生率,NOUN,B2
+emblematic,emblematic,象征性的,ADJ,B2
+of which,of which,关于哪个,PRON,B2
+show,show,表演,NOUN,B2
+disarmament,disarmament,裁军,NOUN,B2
+spatial,spatial,空间的,ADJ,B2
+monstrous,monstrous,怪异的,ADJ,B2
+impartiality,impartiality,公正,NOUN,B2
+to build up,to build up,构建,VERB,B2
+ungrateful,ungrateful,忘恩负义的,ADJ,B2
+literal,literal,字面的,ADJ,B2
+shamelessness,shamelessness,无耻,NOUN,B2
+to give birth,to give birth,分娩,VERB,B2
+duplicity,duplicity,口是心非,NOUN,B2
+divergence,divergence,分歧,NOUN,B2
+to incur,to incur,招致,VERB,B2
+nevertheless,nevertheless,尽管如此,ADV,B2
+to bleat,to bleat,哀叫,VERB,B2
+congenital,congenital,先天的,ADJ,B2
+to border,to border,接壤,VERB,B2
+to conjecture,to conjecture,猜测,VERB,B2
+to slide,to slide,滑动,VERB,B2
+irregularity,irregularity,不规则,NOUN,B2
+to sadden,to sadden,使悲伤,VERB,B2
+wear,wear,磨损,NOUN,B2
+erudition,erudition,博学,NOUN,B2
+entropy,entropy,熵,NOUN,B2
+dilatory,dilatory,拖延的,ADJ,B2
+partially,partially,部分地,ADV,B2
+figurative,figurative,比喻的,ADJ,B2
+looting,looting,掠夺,NOUN,B2
+meteorological,meteorological,气象的,ADJ,B2
+nor,nor,也不,CCONJ,B2
+paternal,paternal,父亲的,ADJ,B2
+fallibility,fallibility,易错性,NOUN,B2
+to hail,to hail,下冰雹,VERB,B2
+to diverge,to diverge,分歧,VERB,B2
+to privatize,to privatize,私有化,VERB,B2
+to alert,to alert,警告,VERB,B2
+canadian,canadian,加拿大的,ADJ,B2
+monarch,monarch,君主,NOUN,B2
+welcoming,welcoming,舒适的,ADJ,B2
+cashier,cashier,出纳员,NOUN,B2
+to sponsor,to sponsor,赞助,VERB,B2
+daddy,daddy,爸爸,NOUN,B2
+to abort,to abort,流产,VERB,B2
+reunification,reunification,重新统一,NOUN,B2
+illustrious,illustrious,著名的,ADJ,B2
+fortuitous,fortuitous,偶然的,ADJ,B2
+homonymy,homonymy,同音异义,NOUN,B2
+rebellious,rebellious,叛逆的,ADJ,B2
+unthinkable,unthinkable,不可想象的,ADJ,B2
+toll,toll,通行费,NOUN,B2
+embolism,embolism,栓塞,NOUN,B2
+to numb,to numb,使麻木,VERB,B2
+daycare,daycare,托儿所,NOUN,B2
+general practitioner,general practitioner,全科医生,NOUN,B2
+to desert,to desert,擅离职守,VERB,B2
+flourishing,flourishing,繁荣的,ADJ,B2
+inefficiency,inefficiency,低效,NOUN,B2
+to put back,to put back,放回,VERB,B2
+imposing,imposing,宏伟的,ADJ,B2
+draftsman,draftsman,绘图员,NOUN,B2
+manifesto,manifesto,宣言,NOUN,B2
+epigraph,epigraph,题词,NOUN,B2
+explicitly,explicitly,明确地,ADV,B2
+competitive,competitive,竞争的,ADJ,B2
+to dispense,to dispense,分发,VERB,B2
+embryo,embryo,胚胎,NOUN,B2
+psychological,psychological,心理的,ADJ,B2
+to project,to project,投射,VERB,B2
+consanguinity,consanguinity,血缘,NOUN,B2
+nomad,nomad,游牧者,NOUN,B2
+literary,literary,文学的,ADJ,B2
+hydrocarbon,hydrocarbon,碳氢化合物,NOUN,B2
+paroxysm,paroxysm,发作,NOUN,B2
+guild,guild,行会,NOUN,B2
+noodle,noodle,面条,NOUN,B2
+brutality,brutality,残暴,NOUN,B2
+schematic,schematic,概要的,ADJ,B2
+languor,languor,倦怠,NOUN,B2
+cosmopolitan,cosmopolitan,世界主义的,ADJ,B2
+administrator,administrator,管理员,NOUN,B2
+catholic,catholic,天主教的,ADJ,B2
+prestigious,prestigious,有声望的,ADJ,B2
+indoctrination,indoctrination,灌输,NOUN,B2
+invader,invader,入侵者,NOUN,B2
+commiseration,commiseration,同情,NOUN,B2
+partial,partial,部分的,ADJ,B2
+hundred,hundred,一百,NOUN,B2
+rehabilitation,rehabilitation,康复,NOUN,B2
+conservatory,conservatory,音乐学院,NOUN,B2
+little,little,少,DET,B2
+balloon,balloon,气球,NOUN,B2
+cardinal,cardinal,枢机主教,NOUN,B2
+dignitary,dignitary,高官,NOUN,B2
+to uproot,to uproot,根除,VERB,B2
+thematic,thematic,主题的,ADJ,B2
+eccentricity,eccentricity,古怪,NOUN,B2
+humanist,humanist,人文主义者,NOUN,B2
+gruff,gruff,阴沉的,ADJ,B2
+indiscretion,indiscretion,轻率,NOUN,B2
+to relaunch,to relaunch,重启,VERB,B2
+fauna,fauna,动物群,NOUN,B2
+philosophical,philosophical,哲学的,ADJ,B2
+infidelity,infidelity,不忠,NOUN,B2
+comparable,comparable,可比较的,ADJ,B2
+hotelier,hotelier,旅馆老板,NOUN,B2
+instructive,instructive,有教育意义的,ADJ,B2
+to tear out,to tear out,拔出,VERB,B2
+to rough-hew,to rough-hew,粗加工,VERB,B2
+philologist,philologist,语言学家,NOUN,B2
+law firm,law firm,律师事务所,NOUN,B2
+manhunt,manhunt,搜捕,NOUN,B2
+elocution,elocution,演讲术,NOUN,B2
+infamy,infamy,恶名,NOUN,B2
+devilish,devilish,恶魔般的,ADJ,B2
+graphology,graphology,笔迹学,NOUN,B2
+on top,on top,在上面,ADV,B2
+to experiment,to experiment,实验,VERB,B2
+to seat,to seat,使坐下,VERB,B2
+cosmetic,cosmetic,化妆品的,ADJ,B2
+tax authorities,tax authorities,税务机关,NOUN,B2
+to title,to title,命名,VERB,B2
+complement,complement,补充物,NOUN,B2
+mobility,mobility,流动性,NOUN,B2
+to benefit,to benefit,受益,VERB,B2
+medieval,medieval,中世纪的,ADJ,B2
+dependence,dependence,依赖,NOUN,B2
+grumpy,grumpy,脾气坏的,ADJ,B2
+generality,generality,普遍性,NOUN,B2
+carefree,carefree,无忧无虑的,ADJ,B2
+desirable,desirable,可取的,ADJ,B2
+laxity,laxity,松弛,NOUN,B2
+to whimper,to whimper,呜咽,VERB,B2
+latin,latin,拉丁的,ADJ,B2
+sunflower,sunflower,向日葵,NOUN,B2
+to anger,to anger,使生气,VERB,B2
+to have at one's disposal,to have at one's disposal,拥有/处置,VERB,B2
+conciliatory,conciliatory,调和的,ADJ,B2
+rodent,rodent,啮齿动物,NOUN,B2
+physiological,physiological,生理的,ADJ,B2
+insensitive,insensitive,麻木的,ADJ,B2
+self-denial,self-denial,自我牺牲,NOUN,B2
+witchcraft,witchcraft,巫术,NOUN,B2
+to gain weight,to gain weight,变胖,VERB,B2
+muzzle,muzzle,口套,NOUN,B2
+relocation,relocation,搬家,NOUN,B2
+to wear out,to wear out,磨损,VERB,B2
+pornography,pornography,色情,NOUN,B2
+diffusion,diffusion,传播,NOUN,B2
+trajectory,trajectory,轨迹,NOUN,B2
+credulity,credulity,轻信,NOUN,B2
+to camouflage,to camouflage,伪装,VERB,B2
+to harden,to harden,使经受锻炼,VERB,B2
+imprint,imprint,印记,NOUN,B2
+to strike down,to strike down,击倒,VERB,B2
+exuberant,exuberant,繁茂的,ADJ,B2
+spinning mill,spinning mill,纺纱厂,NOUN,B2
+to perfect,to perfect,精修,VERB,B2
+to abstract,to abstract,抽象,VERB,B2
+ribbon,ribbon,丝带,NOUN,B2
+fellow citizen,fellow citizen,同胞,NOUN,B2
+pronounced,pronounced,显著的,ADJ,B2
+theological,theological,神学的,ADJ,B2
+proselytism,proselytism,传教,NOUN,B2
+to access,to access,进入,VERB,B2
+since then,since then,从那以后,ADV,B2
+coproduction,coproduction,联合制作,NOUN,B2
+located,located,位于,ADJ,B2
+rapture,rapture,狂喜,NOUN,B2
+reticent,reticent,沉默寡言的,ADJ,B2
+novelty,novelty,新奇事物,NOUN,B2
+guided tour,guided tour,导游,NOUN,B2
+concerned,concerned,担忧的,ADJ,B2
+scholarship holder,scholarship holder,奖学金生,NOUN,B2
+generic,generic,通用的,ADJ,B2
+to overflow,to overflow,溢出,VERB,B2
+to bristle,to bristle,使竖起,VERB,B2
+cardboard,cardboard,硬纸板,NOUN,B2
+targeted,targeted,有针对性的,ADJ,B2
+unconditional,unconditional,无条件的,ADJ,B2
+childbirth,childbirth,分娩,NOUN,B2
+taxpayer,taxpayer,纳税人,NOUN,B2
+pharaoh,pharaoh,法老,NOUN,B2
+to long for,to long for,渴望,VERB,B2
+to prop up,to prop up,支撑,VERB,B2
+propeller,propeller,螺旋桨,NOUN,B2
+apostate,apostate,叛教者,NOUN,B2
+erotic,erotic,色情的,ADJ,B2
+cognition,cognition,认知,NOUN,B2
+last name,last name,姓,NOUN,B2
+cavity,cavity,腔,NOUN,B2
+presumably,presumably,据推测,ADV,B2
+eroticism,eroticism,色情,NOUN,B2
+immodesty,immodesty,不贞,NOUN,B2
+narrow-minded,narrow-minded,狭隘的,ADJ,B2
+census,census,人口普查,NOUN,B2
+become,become,成为,AUX,B2
+bread roll,bread roll,小圆面包,NOUN,B2
+flagrancy,flagrancy,现行,NOUN,B2
+olympic,olympic,奥林匹克的,ADJ,B2
+thunderstorm,thunderstorm,雷阵雨,NOUN,B2
+turkish,turkish,土耳其的,ADJ,B2
+to nail,to nail,钉,VERB,B2
+tap,tap,水龙头,NOUN,B2
+gastronomy,gastronomy,美食学,NOUN,B2
+puff,puff,一口烟,NOUN,B2
+itinerary,itinerary,行程,NOUN,B2
+insulin,insulin,胰岛素,NOUN,B2
+with it,with it,在其中,ADV,B2
+cynicism,cynicism,犬儒主义,NOUN,B2
+to standardize,to standardize,标准化,VERB,B2
+undoubtedly,undoubtedly,无疑地,ADV,B2
+instantaneous,instantaneous,瞬间的,ADJ,B2
+to distill,to distill,蒸馏,VERB,B2
+town hall,town hall,市政厅,NOUN,B2
+on purpose,on purpose,故意地,ADV,B2
+to implant,to implant,植入,VERB,B2
+scandalous,scandalous,可耻的,ADJ,B2
+to be based on,to be based on,基于,VERB,B2
+extract,extract,摘录,NOUN,B2
+gravitation,gravitation,引力,NOUN,B2
+disconsolate,disconsolate,悲痛欲绝的,ADJ,B2
+squall,squall,骤雨,NOUN,B2
+feminine,feminine,女性的,ADJ,B2
+insecurity,insecurity,不安全感,NOUN,B2
+consecutively,consecutively,连续地,ADV,B2
+conversion,conversion,转换,NOUN,B2
+metric,metric,公制的,ADJ,B2
+gutter,gutter,路沟,NOUN,B2
+complexion,complexion,肤色,NOUN,B2
+corrosive,corrosive,腐蚀性的,ADJ,B2
+fetish,fetish,恋物,NOUN,B2
+coat of arms,coat of arms,纹章,NOUN,B2
+ellipsis,ellipsis,省略,NOUN,B2
+documentary,documentary,纪录片,NOUN,B2
+incorrect,incorrect,不正确的,ADJ,B2
+frugality,frugality,节俭,NOUN,B2
+conception,conception,概念,NOUN,B2
+hedonism,hedonism,享乐主义,NOUN,B2
+mechanical,mechanical,机械的,ADJ,B2
+desertion,desertion,逃亡,NOUN,B2
+about it,about it,关于它,ADV,B2
+combativeness,combativeness,好斗性,NOUN,B2
+to minimize,to minimize,最小化,VERB,B2
+funereal,funereal,丧葬的,ADJ,B2
+to ally,to ally,结盟,VERB,B2
+festive,festive,节日的,ADJ,B2
+impotence,impotence,无力,NOUN,B2
+to plug in,to plug in,插入,VERB,B2
+steep,steep,陡峭的,ADJ,B2
+clemency,clemency,仁慈,NOUN,B2
+depravity,depravity,堕落,NOUN,B2
+to intercede,to intercede,调停,VERB,B2
+fatalism,fatalism,宿命论,NOUN,B2
+seated,seated,坐着的,ADJ,B2
+deplorable,deplorable,可悲的,ADJ,B2
+kiosk,kiosk,亭子,NOUN,B2
+exploration,exploration,探索,NOUN,B2
+defensive,defensive,防御的,ADJ,B2
+flowery,flowery,华丽的,ADJ,B2
+carbohydrate,carbohydrate,碳水化合物,NOUN,B2
+insufficiency,insufficiency,不足,NOUN,B2
+formulation,formulation,配方,NOUN,B2
+condescension,condescension,屈尊,NOUN,B2
+to engrave,to engrave,雕刻,VERB,B2
+to move away,to move away,移开,VERB,B2
+belgian,belgian,比利时的,ADJ,B2
+to parade,to parade,游行,VERB,B2
+wintry,wintry,冬天的,ADJ,B2
+infirmary,infirmary,医务室,NOUN,B2
+to dishonor,to dishonor,使蒙羞,VERB,B2
+irritating,irritating,令人恼火的,ADJ,B2
+cigarette butt,cigarette butt,烟头,NOUN,B2
+historicity,historicity,历史性,NOUN,B2
+seal,seal,海豹,NOUN,B2
+those,those,那些,PRON,B2
+symbolic,symbolic,象征的,ADJ,B2
+parliamentary,parliamentary,议会的/议员,ADJ,B2
+fragmentary,fragmentary,零碎的,ADJ,B2
+illumination,illumination,照明,NOUN,B2
+metaphorical,metaphorical,隐喻的,ADJ,B2
+fictitious,fictitious,虚构的,ADJ,B2
+mythical,mythical,神话般的,ADJ,B2
+congruent,congruent,一致的,ADJ,B2
+school,school,学校的,ADJ,B2
+discernment,discernment,洞察力,NOUN,B2
+insolvent,insolvent,无偿还能力的,ADJ,B2
+to indoctrinate,to indoctrinate,灌输,VERB,B2
+hypertrophy,hypertrophy,肥大,NOUN,B2
+finnish,finnish,芬兰的,ADJ,B2
+rag,rag,破布,NOUN,B2
+cyclist,cyclist,骑自行车的人,NOUN,B2
+to giggle,to giggle,咯咯笑,VERB,B2
+superstitious,superstitious,迷信的,ADJ,B2
+diabolical,diabolical,恶魔般的,ADJ,B2
+to insinuate,to insinuate,暗示,VERB,B2
+to consent,to consent,同意,VERB,B2
+brief,brief,近点说,NOUN,B2
+lowest,lowest,最低的,ADJ,B2
+inconceivable,inconceivable,不可想象的,ADJ,B2
+prey,prey,猎物,NOUN,B2
+didactic,didactic,教学的,ADJ,B2
+offspring,offspring,幼崽,NOUN,B2
+frigate,frigate,护卫舰,NOUN,B2
+sorcerer,sorcerer,巫师,NOUN,B2
+to trace,to trace,描绘；标出,VERB,B2
+magistrate,magistrate,法官,NOUN,B2
+canonical,canonical,规范的,ADJ,B2
+to knit,to knit,编织,VERB,B2
+to spot,to spot,看见,VERB,B2
+wooded,wooded,树木茂盛的,ADJ,B2
+desolation,desolation,荒凉,NOUN,B2
+deposition,deposition,证词,NOUN,B2
+lapse,lapse,疏忽,NOUN,B2
+hood,hood,兜帽,NOUN,B2
+to idealize,to idealize,理想化,VERB,B2
+impunity,impunity,逍遥法外,NOUN,B2
+about,about,大约,ADV,B2
+city council,city council,市议会,NOUN,B2
+choleric,choleric,易怒的,ADJ,B2
+to bring closer,to bring closer,靠近,VERB,B2
+him her,him her,他/她,PRON,B2
+trembling,trembling,颤抖的,ADJ,B2
+to plot,to plot,密谋,VERB,B2
+teaching,teaching,教学的,ADJ,B2
+to sketch,to sketch,勾勒,VERB,B2
+to corroborate,to corroborate,证实,VERB,B2
+artillery,artillery,炮兵,NOUN,B2
+evocation,evocation,唤起,NOUN,B2
+to result,to result,产生,VERB,B2
+controllable,controllable,可控制的,ADJ,B2
+mistreatment,mistreatment,虐待,NOUN,B2
+chronology,chronology,年表,NOUN,B2
+to wring,to wring,拧干,VERB,B2
+extremist,extremist,极端主义者,NOUN,B2
+to irrigate,to irrigate,灌溉,VERB,B2
+carpet rug,carpet rug,地毯,NOUN,B2
+jewelry store,jewelry store,珠宝店,NOUN,B2
+disc,disc,光盘,NOUN,B2
+imperfect,imperfect,不完美的,ADJ,B2
+moratorium,moratorium,暂停,NOUN,B2
+jubilation,jubilation,欢欣,NOUN,B2
+to indict,to indict,控告,VERB,B2
+inhuman,inhuman,不人道的,ADJ,B2
+excursion,excursion,郊游,NOUN,B2
+to inconvenience,to inconvenience,使不便,VERB,B2
+homogeneity,homogeneity,同质性,NOUN,B2
+navel,navel,肚脐,NOUN,B2
+die,die,骰子,NOUN,B2
+circumspect,circumspect,谨慎的,ADJ,B2
+broadcaster,broadcaster,广播公司,NOUN,B2
+regularity,regularity,规律性,NOUN,B2
+to flash,to flash,闪烁,VERB,B2
+prior,prior,先前的,ADJ,B2
+exponential,exponential,指数的,ADJ,B2
+gardening,gardening,园艺,NOUN,B2
+to undress,to undress,脱衣,VERB,B2
+counterfeiting,counterfeiting,伪造,NOUN,B2
+hermit,hermit,隐士,NOUN,B2
+revolt,revolt,叛乱,NOUN,B2
+corollary,corollary,推论,NOUN,B2
+disloyal,disloyal,不忠的,ADJ,B2
+homily,homily,布道,NOUN,B2
+deference,deference,敬意,NOUN,B2
+flammable,flammable,易燃的,ADJ,B2
+to draw up,to draw up,起草,VERB,B2
+incompetent,incompetent,无能的,ADJ,B2
+idiosyncrasy,idiosyncrasy,特质,NOUN,B2
+diffuse,diffuse,模糊的,ADJ,B2
+cognitive,cognitive,认知的,ADJ,B2
+councilor,councilor,市议员,NOUN,B2
+holocaust,holocaust,浩劫,NOUN,B2
+fascism,fascism,法西斯主义,NOUN,B2
+inquisition,inquisition,宗教裁判所,NOUN,B2
+long-lasting,long-lasting,持久的,ADJ,B2
+unlimited,unlimited,无限的,ADJ,B2
+to lighten,to lighten,减轻,VERB,B2
+that one,that one,那个,PRON,B2
+to wilt,to wilt,枯萎,VERB,B2
+contestable,contestable,可质疑的,ADJ,B2
+calamitous,calamitous,灾难性的,ADJ,B2
+to impute,to impute,归咎,VERB,B2
+categorical,categorical,绝对的,ADJ,B2
+precisely,precisely,确切地; 正好,ADV,B2
+rubble,rubble,瓦砾,NOUN,B2
+redemption,redemption,救赎,NOUN,B2
+unreality,unreality,虚幻,NOUN,B2
+loved,loved,被爱的,ADJ,B2
+influx,influx,涌入,NOUN,B2
+to nickname,to nickname,给...起绰号,VERB,B2
+confessional,confessional,宗派的,ADJ,B2
+to overstep,to overstep,越权,VERB,B2
+have to,have to,必须,AUX,B2
+motionless,motionless,静止的,ADJ,B2
+to sanctify,to sanctify,使神圣,VERB,B2
+grandpa,grandpa,爷爷,NOUN,B2
+to position,to position,定位 / 安置,VERB,B2
+to undo,to undo,解开,VERB,B2
+devastating,devastating,毁灭性的,ADJ,B2
+devaluation,devaluation,贬值,NOUN,B2
+holidays,holidays,假期,NOUN,B2
+endowment,endowment,配备,NOUN,B2
+gerontocracy,gerontocracy,老人政治,NOUN,B2
+incoherent,incoherent,不连贯的,ADJ,B2
+circumlocution,circumlocution,迂回说法,NOUN,B2
+illustration,illustration,插图,NOUN,B2
+descriptive,descriptive,描述性的,ADJ,B2
+to neutralize,to neutralize,中和,VERB,B2
+anything,anything,任何事,PRON,B2
+to invoke,to invoke,援引,VERB,B2
+drool,drool,口水,NOUN,B2
+immovable,immovable,不可移动的,ADJ,B2
+remote control,remote control,遥控器,NOUN,B2
+duchess,duchess,公爵夫人,NOUN,B2
+inadmissible,inadmissible,不可接受的,ADJ,B2
+barely,barely,几乎不,ADV,B2
+shiver,shiver,寒战,NOUN,B2
+eminent,eminent,杰出的,ADJ,B2
+jurist,jurist,法学家,NOUN,B2
+to intoxicate,to intoxicate,使中毒,VERB,B2
+fragility,fragility,脆弱,NOUN,B2
+to narrow,to narrow,使变窄,VERB,B2
+picturesque,picturesque,如画的；别致的,ADJ,B2
+express,express,明确的,ADJ,B2
+to trivialize,to trivialize,使平庸,VERB,B2
+behind it,behind it,在后面,ADV,B2
+islamic,islamic,伊斯兰的,ADJ,B2
+free of charge,free of charge,免费,NOUN,B2
+hose,hose,软管,NOUN,B2
+theatrical,theatrical,戏剧的,ADJ,B2
+marble,marble,大理石,NOUN,B2
+to group,to group,分组,VERB,B2
+gravely,gravely,严重地,ADV,B2
+to swing,to swing,荡秋千,VERB,B2
+to delight,to delight,使高兴,VERB,B2
+to rinse,to rinse,冲洗,VERB,B2
+to inflame,to inflame,使发炎,VERB,B2
+emblem,emblem,徽章,NOUN,B2
+to make proud,to make proud,使自豪,VERB,B2
+renowned,renowned,著名的,ADJ,B2
+to instill,to instill,灌输,VERB,B2
+prophet,prophet,先知,NOUN,B2
+to unmask,to unmask,揭穿,VERB,B2
+casuistry,casuistry,决疑法,NOUN,B2
+to expatriate,to expatriate,使移居国外,VERB,B2
+to swell,to swell,使肿胀,VERB,B2
+to infuse,to infuse,泡制,VERB,B2
+to redden,to redden,变红,VERB,B2
+duvet,duvet,羽绒被,NOUN,B2
+to have to,to have to,必须,VERB,B2
+two-headed,two-headed,双头的,ADJ,B2
+to stammer,to stammer,结巴,VERB,B2
+dictator,dictator,独裁者,NOUN,B2
+fatuity,fatuity,愚昧,NOUN,B2
+to spawn,to spawn,产卵,VERB,B2
+comic strip,comic strip,连环画,NOUN,B2
+to repeal,to repeal,废除,VERB,B2
+to skin,to skin,剥皮,VERB,B2
+dissident,dissident,异见者,NOUN,B2
+industrialization,industrialization,工业化,NOUN,B2
+weakening,weakening,减弱,NOUN,B2
+self-employed person,self-employed person,个体经营者,NOUN,B2
+contingent,contingent,偶然的,ADJ,B2
+manufacture,manufacture,制造,NOUN,B2
+symmetrical,symmetrical,对称的,ADJ,B2
+to riddle,to riddle,使布满孔洞,VERB,B2
+skylight,skylight,天窗,NOUN,B2
+pathology,pathology,病理学,NOUN,B2
+defective,defective,有缺陷的,ADJ,B2
+premonition,premonition,预感,NOUN,B2
+stopover,stopover,中途停留,NOUN,B2
+to switch,to switch,切换,VERB,B2
+to dissipate,to dissipate,消散,VERB,B2
+minimal,minimal,微小的,ADJ,B2
+atmospheric,atmospheric,大气的,ADJ,B2
+infantry,infantry,步兵,NOUN,B2
+doubtful,doubtful,可疑的,ADJ,B2
+hinge,hinge,合页,NOUN,B2
+to detail,to detail,详述,VERB,B2
+to assault,to assault,袭击,VERB,B2
+gymnast,gymnast,体操运动员,NOUN,B2
+to fall silent,to fall silent,沉默,VERB,B2
+to move house,to move house,搬家,VERB,B2
+to sulk,to sulk,生闷气,VERB,B2
+to post,to post,张贴,VERB,B2
+fidelity,fidelity,忠诚,NOUN,B2
+report card,report card,成绩单,NOUN,B2
+hydraulic,hydraulic,液压的,ADJ,B2
+recognizable,recognizable,可辨认的,ADJ,B2
+nape,nape,后颈,NOUN,B2
+fussy,fussy,挑剔的,ADJ,B2
+counterproductive,counterproductive,适得其反的,ADJ,B2
+endemic,endemic,地方性的,ADJ,B2
+to ironize,to ironize,讽刺,VERB,B2
+synthetic,synthetic,合成的,ADJ,B2
+to set aside,to set aside,移开,VERB,B2
+detriment,detriment,损害,NOUN,B2
+diminutive,diminutive,指小词,NOUN,B2
+to infest,to infest,滋生,VERB,B2
+contrast,contrast,对比,NOUN,B2
+to oblige,to oblige,强迫,VERB,B2
+humanitarian,humanitarian,人道主义的,ADJ,B2
+minority,minority,少数派的,ADJ,B2
+jurisprudence,jurisprudence,法理学,NOUN,B2
+gladly,gladly,乐意地,ADV,B2
+scrupulously,scrupulously,一丝不苟地,ADV,B2
+objective,objective,目标,NOUN,B2
+stripe,stripe,条纹,NOUN,B2
+adjustment,adjustment,调节,NOUN,B2
+overview,overview,概览,NOUN,B2
+warmly,warmly,热情地,ADV,B2
+frieze,frieze,檐壁,NOUN,B2
+to program,to program,编程,VERB,B2
+educational,educational,教育的,ADJ,B2
+lyrical,lyrical,抒情的,ADJ,B2
+to leaf through,to leaf through,翻阅,VERB,B2
+perplexed,perplexed,困惑的,ADJ,B2
+grandiosity,grandiosity,宏伟,NOUN,B2
+postage,postage,邮资,NOUN,B2
+to oust,to oust,推翻,VERB,B2
+to prioritize,to prioritize,优先考虑,VERB,B2
+to camp,to camp,露营,VERB,B2
+disproportion,disproportion,不成比例,NOUN,B2
+bragging,bragging,吹嘘,NOUN,B2
+fang,fang,犬齿,NOUN,B2
+deterioration,deterioration,恶化,NOUN,B2
+total,total,完全的,ADJ,B2
+telephone number,telephone number,电话号码,NOUN,B2
+grid,grid,网格,NOUN,B2
+wow,wow,哇,INTJ,B2
+explosive,explosive,炸药,NOUN,B2
+canteen,canteen,食堂,NOUN,B2
+scooter,scooter,踏板摩托车,NOUN,B2
+to give as a gift,to give as a gift,赠送,VERB,B2
+skillful,skillful,熟练的,ADJ,B2
+the anform,the anform,复合词,NOUN,B2
+in view of,in view of,鉴于,ADP,B2
+the anbruch,the anbruch,名词,NOUN,B2
+getheilung,getheilung,词,NOUN,B2
+fernsucht,fernsucht,词,NOUN,B2
+to cope,to cope,应付,VERB,B2
+the missbildung,the missbildung,复合词,NOUN,B2
+grown,grown,长大的,ADJ,B2
+unterpflegung,unterpflegung,词,NOUN,B2
+getreibung,getreibung,词,NOUN,B2
+emergency doctor,emergency doctor,急诊医生,NOUN,B2
+einteilung,einteilung,词,NOUN,B2
+the abmessung,the abmessung,复合词,NOUN,B2
+untersinnung,untersinnung,词,NOUN,B2
+lord god,lord god,上帝,NOUN,B2
+hintersucht,hintersucht,词,NOUN,B2
+gerichtung,gerichtung,词,NOUN,B2
+the adressat,the adressat,名词,NOUN,B2
+the weitmischung,the weitmischung,复合词,NOUN,B2
+nimble,nimble,敏捷的,ADJ,B2
+scratch,scratch,抓痕,NOUN,B2
+the verwandlung,the verwandlung,复合词,NOUN,B2
+creepy,creepy,令人毛骨悚然的,ADJ,B2
+the verstleitung,the verstleitung,复合词,NOUN,B2
+the tiefbindung,the tiefbindung,复合词,NOUN,B2
+einweisung,einweisung,词,NOUN,B2
+the aktnadel,the aktnadel,名词,NOUN,B2
+the auserweiterung,the auserweiterung,复合词,NOUN,B2
+college,college,学院,NOUN,B2
+sting,sting,刺,NOUN,B2
+to anesthetize,to anesthetize,麻醉,VERB,B2
+emerald,emerald,祖母绿,NOUN,B2
+to fell,to fell,砍倒,VERB,B2
+zersucht,zersucht,词,NOUN,B2
+the berechnung,the berechnung,复合词,NOUN,B2
+the anreiz,the anreiz,名词,NOUN,B2
+the erzheilung,the erzheilung,复合词,NOUN,B2
+the akademie,the akademie,名词,NOUN,B2
+guards,guards,警卫,NOUN,B2
+to switch off,to switch off,关掉,VERB,B2
+telegram,telegram,电报,NOUN,B2
+firstly,firstly,首先,ADV,B2
+beteilung,beteilung,词,NOUN,B2
+the anwerk,the anwerk,复合词,NOUN,B2
+concerning,concerning,关于,ADP,B2
+mania,mania,狂躁症,NOUN,B2
+the hochleitung,the hochleitung,复合词,NOUN,B2
+the weitstoff,the weitstoff,复合词,NOUN,B2
+einsprache,einsprache,词,NOUN,B2
+the hochordnung,the hochordnung,复合词,NOUN,B2
+erfahrt,erfahrt,词,NOUN,B2
+eingabe,eingabe,词,NOUN,B2
+the beminderung,the beminderung,复合词,NOUN,B2
+nahfahrt,nahfahrt,词,NOUN,B2
+burdened,burdened,负担重的,ADJ,B2
+the nachleitung,the nachleitung,复合词,NOUN,B2
+oddball,oddball,怪人,NOUN,B2
+to breathe again,to breathe again,松口气,VERB,B2
+the gewendung,the gewendung,复合词,NOUN,B2
+fickleness,fickleness,反复无常,NOUN,B2
+aussinnung,aussinnung,词,NOUN,B2
+the grundstoff,the grundstoff,复合词,NOUN,B2
+to countersign,to countersign,副署,VERB,B2
+bum,bum,流浪汉,NOUN,B2
+aufweisung,aufweisung,词,NOUN,B2
+but rather,but rather,而是,CCONJ,B2
+the erzwendung,the erzwendung,复合词,NOUN,B2
+the vorerweiterung,the vorerweiterung,复合词,NOUN,B2
+the unleitung,the unleitung,复合词,NOUN,B2
+oberleitung,oberleitung,词,NOUN,B2
+whether,whether,是否,SCONJ,B2
+the aushandlung,the aushandlung,复合词,NOUN,B2
+einerziehung,einerziehung,词,NOUN,B2
+so to speak,so to speak,可以说,ADV,B2
+the ausstellung,the ausstellung,复合词,NOUN,B2
+the ansage,the ansage,名词,NOUN,B2
+to share divide,to share divide,分享,VERB,B2
+theme music,theme music,主题曲,NOUN,B2
+nachsuchung,nachsuchung,词,NOUN,B2
+christmas tree,christmas tree,圣诞树,NOUN,B2
+thin-walled,thin-walled,隔音差的,ADJ,B2
+the vorrechnung,the vorrechnung,复合词,NOUN,B2
+the mitstellung,the mitstellung,复合词,NOUN,B2
+the tiefleitung,the tiefleitung,复合词,NOUN,B2
+crap,crap,屎,NOUN,B2
+to vibrate,to vibrate,振动,VERB,B2
+einwirkung,einwirkung,词,NOUN,B2
+the untererweiterung,the untererweiterung,复合词,NOUN,B2
+the abweisung,the abweisung,名词,NOUN,B2
+nachsinnung,nachsinnung,词,NOUN,B2
+unfassung,unfassung,词,NOUN,B2
+to break out,to break out,爆发,VERB,B2
+the ursammlung,the ursammlung,复合词,NOUN,B2
+to bump,to bump,碰撞,VERB,B2
+fishing rod,fishing rod,钓竿,NOUN,B2
+the nachbindung,the nachbindung,复合词,NOUN,B2
+from it,from it,从中,ADV,B2
+weitweisung,weitweisung,词,NOUN,B2
+the abkraft,the abkraft,复合词,NOUN,B2
+the aufleitung,the aufleitung,复合词,NOUN,B2
+to queue,to queue,排队,VERB,B2
+annual wage,annual wage,年薪,NOUN,B2
+erzregelung,erzregelung,词,NOUN,B2
+people nation,people nation,人民 / 民族,NOUN,B2
+prank,prank,恶作剧,NOUN,B2
+learning curve,learning curve,学习曲线,NOUN,B2
+the erwendung,the erwendung,复合词,NOUN,B2
+moor,moor,荒野,NOUN,B2
+benahme,benahme,词,NOUN,B2
+to stint,to stint,吝啬,VERB,B2
+the erzwerk,the erzwerk,复合词,NOUN,B2
+thousands,thousands,数千,NOUN,B2
+the erzmischung,the erzmischung,复合词,NOUN,B2
+to lay down,to lay down,放下,VERB,B2
+vorderfassung,vorderfassung,词,NOUN,B2
+everyday life,everyday life,日常生活,NOUN,B2
+city map,city map,城市地图,NOUN,B2
+host of angels,host of angels,天使群,NOUN,B2
+wage labor,wage labor,雇佣劳动,NOUN,B2
+to step in,to step in,介入,VERB,B2
+sort,sort,种类,NOUN,B2
+ausweisung,ausweisung,词,NOUN,B2
+vorwandel,vorwandel,词,NOUN,B2
+the abwert,the abwert,复合词,NOUN,B2
+the vorwert,the vorwert,复合词,NOUN,B2
+german class,german class,德语课,NOUN,B2
+the adoption,the adoption,名词,NOUN,B2
+hearts,hearts,心,NOUN,B2
+crook,crook,骗子,NOUN,B2
+hochweisung,hochweisung,词,NOUN,B2
+to make sense,to make sense,讲得通,VERB,B2
+opposite,opposite,对面,ADP,B2
+to keep secret,to keep secret,隐瞒,VERB,B2
+bitch,bitch,母狗,NOUN,B2
+the zurechnung,the zurechnung,复合词,NOUN,B2
+semicolon,semicolon,分号,PUNCT,B2
+the gebindung,the gebindung,复合词,NOUN,B2
+sky blue,sky blue,天蓝色,ADJ,B2
+vegetarian,vegetarian,素食者,NOUN,B2
+she they,she they,她,PRON,B2
+chain mail,chain mail,锁子甲,NOUN,B2
+the missordnung,the missordnung,复合词,NOUN,B2
+the verstwerk,the verstwerk,复合词,NOUN,B2
+twitching,twitching,抽搐的,ADJ,B2
 zusicht,zusicht,词,NOUN,B2
-zusinnung,zusinnung,词,NOUN,C1
+urgestaltung,urgestaltung,词,NOUN,B2
+to overlook,to overlook,忽视,VERB,B2
+the mitbildung,the mitbildung,复合词,NOUN,B2
+motherfucker,motherfucker,混蛋,NOUN,B2
+the mitverbesserung,the mitverbesserung,复合词,NOUN,B2
+the alpinismus,the alpinismus,名词,NOUN,B2
+yikes,yikes,哎呀,INTJ,B2
+sow,sow,母猪,NOUN,B2
+urgabe,urgabe,词,NOUN,B2
+erweisung,erweisung,词,NOUN,B2
+virtuous,virtuous,有德行的,ADJ,B2
+to go blind,to go blind,失明,VERB,B2
+zufahrt,zufahrt,词,NOUN,B2
+backdrop,backdrop,背景,NOUN,B2
+probation,probation,缓刑,NOUN,B2
+comma,comma,逗号,PUNCT,B2
+seamless,seamless,无缝的,ADJ,B2
+distorted image,distorted image,扭曲的形象,NOUN,B2
+sagittarius,sagittarius,射手座,NOUN,B2
+to stay here,to stay here,留在这里,VERB,B2
+verschaft,verschaft,词,NOUN,B2
+unweisung,unweisung,词,NOUN,B2
+the abholung,the abholung,名词,NOUN,B2
+gay,gay,快乐的,ADJ,B2
+ausgestaltung,ausgestaltung,词,NOUN,B2
+hinterleitung,hinterleitung,词,NOUN,B2
+to pick out,to pick out,挑选,VERB,B2
+president female,president female,女总统,NOUN,B2
+to abschweifen,to abschweifen,动词,VERB,B2
+the aufwandlung,the aufwandlung,复合词,NOUN,B2
+the erzkraft,the erzkraft,复合词,NOUN,B2
+cleaning,cleaning,清洁,NOUN,B2
+timetable,timetable,时刻表,NOUN,B2
+einnahme,einnahme,词,NOUN,B2
+the zerbildung,the zerbildung,复合词,NOUN,B2
+drinking glass,drinking glass,水杯,NOUN,B2
+weitsuchung,weitsuchung,词,NOUN,B2
+the hochstoff,the hochstoff,复合词,NOUN,B2
+to brood,to brood,沉思,VERB,B2
+the antrag,the antrag,名词,NOUN,B2
+tasteless,tasteless,无味的,ADJ,B2
+sample rehearsal,sample rehearsal,样品 / 排练,NOUN,B2
+to bullshit,to bullshit,胡扯,VERB,B2
+any,any,任何,PRON,B2
+university student,university student,大学生,NOUN,B2
+to growl,to growl,咆哮,VERB,B2
+the aufwendung,the aufwendung,复合词,NOUN,B2
+serve markup,serve markup,发球/加价,NOUN,B2
+the weitminderung,the weitminderung,复合词,NOUN,B2
+the erzsteigerung,the erzsteigerung,复合词,NOUN,B2
+the einmessung,the einmessung,复合词,NOUN,B2
+the urheilung,the urheilung,复合词,NOUN,B2
+rake,rake,耙子,NOUN,B2
+to spell,to spell,拼写,VERB,B2
+sacrificed,sacrificed,牺牲,ADJ,B2
+to get by,to get by,过得去,VERB,B2
+hintertheilung,hintertheilung,词,NOUN,B2
+the vorordnung,the vorordnung,复合词,NOUN,B2
+to align,to align,使一致,VERB,B2
+geteilung,geteilung,词,NOUN,B2
+urwandel,urwandel,词,NOUN,B2
+the mitheilung,the mitheilung,复合词,NOUN,B2
+precinct,precinct,辖区,NOUN,B2
+the verststoff,the verststoff,复合词,NOUN,B2
+romanian,romanian,罗马尼亚人,NOUN,B2
+the vorstellung,the vorstellung,复合词,NOUN,B2
+helper,helper,助手,NOUN,B2
+the andrang,the andrang,名词,NOUN,B2
+hinterrechnung,hinterrechnung,词,NOUN,B2
+the abhang,the abhang,名词,NOUN,B2
+weitwandel,weitwandel,词,NOUN,B2
+investigated,investigated,被调查的,ADJ,B2
+auswandel,auswandel,词,NOUN,B2
+unnahme,unnahme,词,NOUN,B2
+the ervereinfachung,the ervereinfachung,复合词,NOUN,B2
+hinterrichtung,hinterrichtung,词,NOUN,B2
+the bemessung,the bemessung,复合词,NOUN,B2
+misstreibung,misstreibung,词,NOUN,B2
+bodily harm,bodily harm,人身伤害,NOUN,B2
+that yonder,that yonder,那个,DET,B2
+vortheilung,vortheilung,词,NOUN,B2
+the aktivist,the aktivist,名词,NOUN,B2
+naherziehung,naherziehung,词,NOUN,B2
+pastime,pastime,爱好,NOUN,B2
+the aufstoff,the aufstoff,复合词,NOUN,B2
+refreshing,refreshing,令人清爽的,ADJ,B2
+ausforderung,ausforderung,词,NOUN,B2
+the unmischung,the unmischung,复合词,NOUN,B2
+the beleitung,the beleitung,复合词,NOUN,B2
+the bewendung,the bewendung,复合词,NOUN,B2
+the aufheilung,the aufheilung,复合词,NOUN,B2
+to elapse,to elapse,流逝,VERB,B2
+mortal fear,mortal fear,极度恐惧,NOUN,B2
+the aktion,the aktion,名词,NOUN,B2
+trash bag,trash bag,垃圾袋,NOUN,B2
+the anbeginn,the anbeginn,名词,NOUN,B2
+worst thing,worst thing,最坏的事,NOUN,B2
+usual thing,usual thing,惯例,NOUN,B2
+per,per,每,ADP,B2
+the hochbindung,the hochbindung,复合词,NOUN,B2
+to abtrocken,to abtrocken,动词,VERB,B2
+to pressurize,to pressurize,逼迫,VERB,B2
+at the,at the,在...时,ADP,B2
+the zuwandlung,the zuwandlung,复合词,NOUN,B2
+groan,groan,呻吟,NOUN,B2
+to shunt,to shunt,分流,VERB,B2
+bulldog,bulldog,斗牛犬,NOUN,B2
+to play along,to play along,配合,VERB,B2
+agreed,agreed,一致的,ADJ,B2
+ursicht,ursicht,词,NOUN,B2
+hideous,hideous,丑陋的,ADJ,B2
+the ausbildung,the ausbildung,复合词,NOUN,B2
+the gemischung,the gemischung,复合词,NOUN,B2
+drive,drive,动力,NOUN,B2
+wiedertreibung,wiedertreibung,词,NOUN,B2
+urteilung,urteilung,词,NOUN,B2
+fernrechnung,fernrechnung,词,NOUN,B2
+unfahrt,unfahrt,词,NOUN,B2
+separated,separated,分开的,ADJ,B2
+the unbildung,the unbildung,复合词,NOUN,B2
+the zuhandlung,the zuhandlung,复合词,NOUN,B2
+anteilung,anteilung,词,NOUN,B2
+anrichtung,anrichtung,词,NOUN,B2
+erschaft,erschaft,词,NOUN,B2
+interpersonal,interpersonal,人际的,ADJ,B2
+the allianz,the allianz,名词,NOUN,B2
+the anteil,the anteil,名词,NOUN,B2
+hothead,hothead,急性子的人,NOUN,B2
+tiefsuchung,tiefsuchung,词,NOUN,B2
+the zererweiterung,the zererweiterung,复合词,NOUN,B2
+the aktuar,the aktuar,名词,NOUN,B2
+nahfassung,nahfassung,词,NOUN,B2
+the vorverbesserung,the vorverbesserung,复合词,NOUN,B2
+billion,billion,十亿,NOUN,B2
+the anheilung,the anheilung,复合词,NOUN,B2
+to turn away,to turn away,转开,VERB,B2
+to get into,to get into,陷入,VERB,B2
+the abheilung,the abheilung,复合词,NOUN,B2
+without exception,without exception,无例外的,ADV,B2
+to view,to view,参观,VERB,B2
+vordersinnung,vordersinnung,词,NOUN,B2
+to deregister,to deregister,注销,VERB,B2
+how much,how much,多少,ADV,B2
+ran,ran,跑,ADJ,B2
+the day after tomorrow,the day after tomorrow,后天,ADV,B2
+the absteigerung,the absteigerung,复合词,NOUN,B2
+ausschrift,ausschrift,词,NOUN,B2
+the abgrund,the abgrund,名词,NOUN,B2
+to subordinate,to subordinate,从属,VERB,B2
+zersicht,zersicht,词,NOUN,B2
+the urvertiefung,the urvertiefung,复合词,NOUN,B2
+the mitkraft,the mitkraft,复合词,NOUN,B2
+the urverbesserung,the urverbesserung,复合词,NOUN,B2
+deliberate malicious,deliberate malicious,故意的/恶意的,ADJ,B2
+causal,causal,因果的,ADJ,B2
+windy,windy,有风的,ADJ,B2
+office work,office work,办公室工作,NOUN,B2
 zusprache,zusprache,词,NOUN,B2
-zusucht,zusucht,词,NOUN,C1
-zusuchung,zusuchung,词,NOUN,C1
-zuteilung,zuteilung,词,NOUN,C1
-zutheilung,zutheilung,词,NOUN,C1
-zutreibung,zutreibung,词,NOUN,C1
-zuwandel,zuwandel,词,NOUN,C1
-zuweisung,zuweisung,词,NOUN,C1
-zuwirkung,zuwirkung,词,NOUN,C1
-äktenskapsallians,marriage alliance,联姻,NOUN,B2
-äktenskapsbar,marriageable,适婚,NOUN,B2
-äldre,elderly,年长的,ADJ,B2
-äldre bror,older brother,大哥哥,NOUN,B2
-äldste son,eldest son,长子,NOUN,B2
-ämne,topic,话题,NOUN,B2
-ändrad politik,changed policy,改策,NOUN,B2
-äng,meadow,草地,NOUN,B2
-ärende,errand,差事,NOUN,B2
-ärlighet,sincerity,真诚,NOUN,B2
-ärvlighet,heredity,遗传,NOUN,B2
-även om,even if,即使,SCONJ,B2
-äventyra,to endanger,危及,VERB,B2
-å andra sidan,on the other hand,另一方面,ADV,B2
-åh,ah,啊,INTJ,B2
-åh,oh,哇,PART,B2
-ålderdom,old age,老年,NOUN,B2
-ånga,to steam,蒸,VERB,B2
-ångad bulle,steamed stuffed bun,包子,NOUN,B2
-ångest,agony,极度痛苦,NOUN,B2
-ångest,anguish,痛苦,NOUN,B2
-årligen,annually,每年,ADV,B2
-årsdag,anniversary,周年纪念,NOUN,B2
-årsredovisning,annual report,年报,NOUN,B2
-åska,thunder,雷,NOUN,B2
-åtalad,defendant,被告,NOUN,B2
-återbana,re-path,重径,NOUN,B2
-återbegränsning,re-limit,重限,NOUN,B2
-återbetydelse,re-meaning,再义,NOUN,B2
-återbevisning,re-evidence,重据,NOUN,B2
-återbringa,to bring back,带回,VERB,B2
-återbygga,to rebuild,重建,VERB,B2
-återfall,recurrence,往复,NOUN,B2
-återfrukt,re-fruit,再果,NOUN,B2
-återhämta sig,to recuperate,恢复,VERB,B2
-återhämtning,recovery,恢复,NOUN,B2
-återinlämning,re-submission,再上,NOUN,B2
-återinner,re-inner,再内,NOUN,B2
-återkoppling,feedback,反馈,NOUN,B2
-återkräva,to reclaim,收回,VERB,B2
-återkvantitet,re-quantity,再量,NOUN,B2
-återlogik,re-logic,再逻,NOUN,B2
-återoperation,reoperation,再术,NOUN,B2
-återresonemang,re-reason,重理,NOUN,B2
-återse,to see again,再见,VERB,B2
-återtakt,re-pace,重骤,NOUN,B2
-återvinna,to recycle,回收利用,VERB,B2
-återvinning,recycling,回收利用,NOUN,B2
-åtfölja,to accompany,陪伴,VERB,B2
-öde,desolate,荒凉的,ADJ,B2
-öde,destiny,命运,NOUN,B2
-ödelägga,to devastate,摧毁,VERB,B2
-ödmjukhet,humility,谦逊,NOUN,B2
-ögonbryn,eyebrow,眉毛,NOUN,B2
-ögonfrans,eyelash,睫毛,NOUN,B2
-ögonvittne,eyewitness,目击,NOUN,B2
-ögrupp,archipelago,群岛,NOUN,B2
-öka stadigt,to increase steadily,与日俱增,VERB,B2
-ökning,increase,增加,NOUN,B2
-ömklig,pitiful,可怜的,ADJ,B2
-ömsesidig,reciprocal,互惠的,ADJ,B2
-öppensinnad,open-minded,思想开明的,ADJ,B2
-öppet,openly,公开地,ADV,B2
-öppning,opening,开口,NOUN,B2
-örn,eagle,鹰,NOUN,B2
-ört,herb,草药,NOUN,B2
-över,across,穿过,ADP,B2
-över natten,overnight,一夜之间,ADV,B2
-överanvändning,hyper-use,超用,NOUN,B2
-överbliven,to be left over,剩余,VERB,B2
-överdomän,over-domain,超畴,NOUN,B2
-överdra,to overdraw,透支,VERB,B2
-överdrift,exaggeration,夸张,NOUN,B2
-överdriven,exaggerated,夸张的,ADJ,B2
-överdriven,excessive,过度的,ADJ,B2
-överensstämmelse,accord with,合乎,NOUN,B2
-överflödande,abundant,丰富的,ADJ,B2
-överflöde,overflow,溢出,NOUN,B2
-överflödig,superfluous,多余的,ADJ,B2
-överge,surrender,投降,NOUN,B2
-överge,to surrender,投降,VERB,B2
-övergå,to defect,叛变,VERB,B2
-överlag,overall,总体上,ADV,B2
-överlappning,overlap,重叠,NOUN,B2
-överlåta,to pass on,转交,VERB,B2
-övermod,arrogance,傲慢,NOUN,B2
-övermodig,arrogant,傲慢的,ADJ,B2
-överordnad,superior,上级,NOUN,B2
-överraskad,to be surprised,感到惊讶,VERB,B2
-överrumpla,to overwhelm,使不知所措,VERB,B2
-överskott,excess,过量,NOUN,B2
-överskott,surplus,过剩,NOUN,B2
-överskrida,to exceed,超过,VERB,B2
-överstrategi,over-strategy,超策,NOUN,B2
-överstryk,over-stroke,超程,NOUN,B2
-översvämning,deluge,洪水,NOUN,B2
-översvämning,flood,洪水,NOUN,B2
-övertalning,coaxing,哄得,NOUN,B2
-överträda,to contravene,违反,VERB,B2
-överträdelse,breach,违反,NOUN,B2
-överträffa,to surpass,超过,VERB,B2
-övervaka,to surveil,监视,VERB,B2
-övervakning,monitoring,监控,NOUN,B2
-övervakningsrum,monitoring room,监控室,NOUN,B2
-övervinna,to overcome,克服,VERB,B2
-överväga,to contemplate,沉思,VERB,B2
-övervända,to overturn,打翻,VERB,B2
+the nachbildung,the nachbildung,复合词,NOUN,B2
+untreibung,untreibung,词,NOUN,B2
+besprache,besprache,词,NOUN,B2
+many things,many things,许多事物,PRON,B2
+the bevertiefung,the bevertiefung,复合词,NOUN,B2
+the bevereinfachung,the bevereinfachung,复合词,NOUN,B2
+the weitsteigerung,the weitsteigerung,复合词,NOUN,B2
+unwandel,unwandel,词,NOUN,B2
+hinterfassung,hinterfassung,词,NOUN,B2
+to watch tv,to watch tv,看电视,VERB,B2
+to wait and see,to wait and see,等待观望,VERB,B2
+noises,noises,噪音,NOUN,B2
+grandparents,grandparents,祖父母,NOUN,B2
+to move out,to move out,搬出,VERB,B2
+next door,next door,在隔壁,ADV,B2
+the grundverbesserung,the grundverbesserung,复合词,NOUN,B2
+the aktpunkt,the aktpunkt,名词,NOUN,B2
+the hochvertiefung,the hochvertiefung,复合词,NOUN,B2
+the akkumulator,the akkumulator,名词,NOUN,B2
+the ererweiterung,the ererweiterung,复合词,NOUN,B2
+mitsetzung,mitsetzung,词,NOUN,B2
+bullshitted,bullshitted,被愚弄的,ADJ,B2
+upbeat,upbeat,轻快的,ADJ,B2
+the einwerk,the einwerk,复合词,NOUN,B2
+vorderweisung,vorderweisung,词,NOUN,B2
+nachrichtung,nachrichtung,词,NOUN,B2
+to abdanken,to abdanken,动词,VERB,B2
+scarce commodity,scarce commodity,紧缺商品,NOUN,B2
+lunch break,lunch break,午休,NOUN,B2
+wiedersprache,wiedersprache,词,NOUN,B2
+the erleitung,the erleitung,复合词,NOUN,B2
+to absagen,to absagen,动词,VERB,B2
+vordersetzung,vordersetzung,词,NOUN,B2
+in front of before,in front of before,在...前,ADP,B2
+misstheilung,misstheilung,词,NOUN,B2
+test of courage,test of courage,勇气测试,NOUN,B2
+the unwandlung,the unwandlung,复合词,NOUN,B2
+gesinnung,gesinnung,词,NOUN,B2
+shit,shit,恐惧,NOUN,B2
+hinterwandel,hinterwandel,词,NOUN,B2
+the anschlag,the anschlag,名词,NOUN,B2
+the altruismus,the altruismus,名词,NOUN,B2
+the verhandlung,the verhandlung,复合词,NOUN,B2
+song of praise,song of praise,赞歌,NOUN,B2
+aufforderung,aufforderung,词,NOUN,B2
+the urstoff,the urstoff,复合词,NOUN,B2
+the weitverbesserung,the weitverbesserung,复合词,NOUN,B2
+on what,on what,在什么上面,ADV,B2
+unpflegung,unpflegung,词,NOUN,B2
+stupid things,stupid things,蠢事,NOUN,B2
+itching powder,itching powder,痒痒粉,NOUN,B2
+to be delayed,to be delayed,迟到,VERB,B2
+urschrift,urschrift,词,NOUN,B2
+to abschlafen,to abschlafen,动词,VERB,B2
+affected,affected,受影响的,ADJ,B2
+hintersuchung,hintersuchung,词,NOUN,B2
+zernahme,zernahme,词,NOUN,B2
+glib,glib,伶牙俐齿的,ADJ,B2
+wiedersucht,wiedersucht,词,NOUN,B2
+to abzwecken,to abzwecken,动词,VERB,B2
+the bekraft,the bekraft,复合词,NOUN,B2
+the alpen,the alpen,名词,NOUN,B2
+like,like,点赞,NOUN,B2
+besuchung,besuchung,词,NOUN,B2
+interrogation room,interrogation room,审讯室,NOUN,B2
+aussetzung,aussetzung,词,NOUN,B2
+hinterwendung,hinterwendung,词,NOUN,B2
+fernschaft,fernschaft,词,NOUN,B2
+obersuchung,obersuchung,词,NOUN,B2
+yes,yes,是的,PART,B2
+the unterordnung,the unterordnung,复合词,NOUN,B2
+most important thing,most important thing,最重要的事,NOUN,B2
+the aufordnung,the aufordnung,复合词,NOUN,B2
+main reason,main reason,主要原因,NOUN,B2
+no,no,不,PART,B2
+to play down,to play down,淡化,VERB,B2
+the geverbesserung,the geverbesserung,复合词,NOUN,B2
+oberbildung,oberbildung,词,NOUN,B2
+the zervereinfachung,the zervereinfachung,复合词,NOUN,B2
+weitsicht,weitsicht,词,NOUN,B2
+the aufwert,the aufwert,复合词,NOUN,B2
+to run away,to run away,逃跑,VERB,B2
+delivery van,delivery van,厢式送货车,NOUN,B2
+the amboss,the amboss,名词,NOUN,B2
+einschaft,einschaft,词,NOUN,B2
+the gebildung,the gebildung,复合词,NOUN,B2
+antheilung,antheilung,词,NOUN,B2
+the beerweiterung,the beerweiterung,复合词,NOUN,B2
+the missstoff,the missstoff,复合词,NOUN,B2
+the weitordnung,the weitordnung,复合词,NOUN,B2
+to commission,to commission,委托,VERB,B2
+zersuchung,zersuchung,词,NOUN,B2
+wiedersicht,wiedersicht,词,NOUN,B2
+hochkunft,hochkunft,词,NOUN,B2
+the aufbewegung,the aufbewegung,复合词,NOUN,B2
+of all things,of all things,偏偏,ADV,B2
+the unterleitung,the unterleitung,复合词,NOUN,B2
+nachtheilung,nachtheilung,词,NOUN,B2
+untertreibung,untertreibung,词,NOUN,B2
+the tiefrechnung,the tiefrechnung,复合词,NOUN,B2
+personal,personal,私事,NOUN,B2
+missschrift,missschrift,词,NOUN,B2
+the erzvertiefung,the erzvertiefung,复合词,NOUN,B2
+vorderrichtung,vorderrichtung,词,NOUN,B2
+to abstimmen,to abstimmen,动词,VERB,B2
+wiederordnung,wiederordnung,词,NOUN,B2
+the missbewegung,the missbewegung,复合词,NOUN,B2
+vorteilung,vorteilung,词,NOUN,B2
+unerziehung,unerziehung,词,NOUN,B2
+to do harm,to do harm,伤害,VERB,B2
+the weitheilung,the weitheilung,复合词,NOUN,B2
+the akkord,the akkord,名词,NOUN,B2
+unlawful,unlawful,非法的,ADJ,B2
+oberwandlung,oberwandlung,词,NOUN,B2
+kidnapper,kidnapper,绑架者,NOUN,B2
+the weitwendung,the weitwendung,复合词,NOUN,B2
+clear as day,clear as day,一清二楚的,ADJ,B2
+the tiefverbesserung,the tiefverbesserung,复合词,NOUN,B2
+to abteilen,to abteilen,动词,VERB,B2
+the ackerbau,the ackerbau,名词,NOUN,B2
+the missvertiefung,the missvertiefung,复合词,NOUN,B2
+geforderung,geforderung,词,NOUN,B2
+to oversleep,to oversleep,睡过头,VERB,B2
+the gestoff,the gestoff,复合词,NOUN,B2
+loudspeaker,loudspeaker,扬声器,NOUN,B2
+the mitordnung,the mitordnung,复合词,NOUN,B2
+goodbye phone,goodbye phone,再见（电话用语）,NOUN,B2
+the tiefstoff,the tiefstoff,复合词,NOUN,B2
+erforderung,erforderung,词,NOUN,B2
+missschaft,missschaft,词,NOUN,B2
+wiederkunft,wiederkunft,词,NOUN,B2
+the unminderung,the unminderung,复合词,NOUN,B2
+ausfahrt,ausfahrt,词,NOUN,B2
+oblique weird,oblique weird,倾斜的 / 古怪的,ADJ,B2
+the nachmessung,the nachmessung,复合词,NOUN,B2
+game rule,game rule,游戏规则,NOUN,B2
+aufrichtung,aufrichtung,词,NOUN,B2
+mitfahrt,mitfahrt,词,NOUN,B2
+obererziehung,obererziehung,词,NOUN,B2
+the anbindung,the anbindung,复合词,NOUN,B2
+with what,with what,用什么,ADV,B2
+handyman,handyman,工匠,NOUN,B2
+urnahme,urnahme,词,NOUN,B2
+devices,devices,设备,NOUN,B2
+detective force,detective force,刑警,NOUN,B2
+the alphabet,the alphabet,名词,NOUN,B2
+the vorbindung,the vorbindung,复合词,NOUN,B2
+wiedersinnung,wiedersinnung,词,NOUN,B2
+weitregelung,weitregelung,词,NOUN,B2
+the hochsammlung,the hochsammlung,复合词,NOUN,B2
+zuschaft,zuschaft,词,NOUN,B2
+the anbieter,the anbieter,名词,NOUN,B2
+the albatros,the albatros,名词,NOUN,B2
+letter mail,letter mail,信,NOUN,B2
+once again,once again,再次,ADV,B2
+the abwurf,the abwurf,名词,NOUN,B2
+wiedererziehung,wiedererziehung,词,NOUN,B2
+the verform,the verform,复合词,NOUN,B2
+the nachstoff,the nachstoff,复合词,NOUN,B2
+the misskraft,the misskraft,复合词,NOUN,B2
+ferntheilung,ferntheilung,词,NOUN,B2
+cheers,cheers,欢呼,NOUN,B2
+emergency call,emergency call,紧急呼叫,NOUN,B2
+eleven,eleven,十一,NOUN,B2
+german person,german person,德国人,NOUN,B2
+hectic,hectic,忙乱,NOUN,B2
+to be added,to be added,加入,VERB,B2
+hintersicht,hintersicht,词,NOUN,B2
+to switch on,to switch on,开启,VERB,B2
+the zerrechnung,the zerrechnung,复合词,NOUN,B2
+the verstellung,the verstellung,复合词,NOUN,B2
+wiedersuchung,wiedersuchung,词,NOUN,B2
+sick nauseous,sick nauseous,恶心的,ADJ,B2
+you formal,you formal,您,PRON,B2
+congratulations,congratulations,祝贺,NOUN,B2
+zurichtung,zurichtung,词,NOUN,B2
+bepflegung,bepflegung,词,NOUN,B2
+hinterregelung,hinterregelung,词,NOUN,B2
+gesucht,gesucht,词,NOUN,B2
+zerteilung,zerteilung,词,NOUN,B2
+vorderleitung,vorderleitung,词,NOUN,B2
+nachweisung,nachweisung,词,NOUN,B2
+nachwirkung,nachwirkung,词,NOUN,B2
+the ausvertiefung,the ausvertiefung,复合词,NOUN,B2
+the zerhandlung,the zerhandlung,复合词,NOUN,B2
+the abstoff,the abstoff,复合词,NOUN,B2
+straight,straight,直的,NOUN,B2
+over about,over about,在...上方,ADP,B2
+squeak,squeak,吱吱声,NOUN,B2
+the unterheilung,the unterheilung,复合词,NOUN,B2
+some things,some things,一些事情,PRON,B2
+most,most,大多数,DET,B2
+no not any,no not any,没有,DET,B2
+ursetzung,ursetzung,词,NOUN,B2
+at it,at it,靠近,ADV,B2
+the ausleitung,the ausleitung,复合词,NOUN,B2
+expert opinion,expert opinion,专家意见,NOUN,B2
+the auswendung,the auswendung,复合词,NOUN,B2
+to descend from,to descend from,起源于,VERB,B2
+the hochminderung,the hochminderung,复合词,NOUN,B2
+your pl,your pl,你们的,DET,B2
+yours,yours,你的,PRON,B2
+pelvis basin,pelvis basin,骨盆/盆地,NOUN,B2
+erwirkung,erwirkung,词,NOUN,B2
+abfassung,abfassung,词,NOUN,B2
+the abhandlung,the abhandlung,复合词,NOUN,B2
+the alias,the alias,名词,NOUN,B2
+yoga practice,yoga practice,瑜伽练习,NOUN,B2
+the urmischung,the urmischung,复合词,NOUN,B2
+aussuchung,aussuchung,词,NOUN,B2
+nachfassung,nachfassung,词,NOUN,B2
+unschaft,unschaft,词,NOUN,B2
+anschrift,anschrift,词,NOUN,B2
+erztheilung,erztheilung,词,NOUN,B2
+at night,at night,夜间,ADV,B2
+the anordnung,the anordnung,复合词,NOUN,B2
+untersetzung,untersetzung,词,NOUN,B2
+the verstvereinfachung,the verstvereinfachung,复合词,NOUN,B2
+the nachheilung,the nachheilung,复合词,NOUN,B2
+the missrechnung,the missrechnung,复合词,NOUN,B2
+the unwendung,the unwendung,复合词,NOUN,B2
+hochforderung,hochforderung,词,NOUN,B2
+the beordnung,the beordnung,复合词,NOUN,B2
+to abtun,to abtun,动词,VERB,B2
+vorderwandel,vorderwandel,词,NOUN,B2
+the zerordnung,the zerordnung,复合词,NOUN,B2
+aussucht,aussucht,词,NOUN,B2
+the anbettlung,the anbettlung,名词,NOUN,B2
+wiederleitung,wiederleitung,词,NOUN,B2
+to circumcise,to circumcise,割礼,VERB,B2
+the vermacht,the vermacht,复合词,NOUN,B2
+justified,justified,有根据的,ADJ,B2
+the geform,the geform,复合词,NOUN,B2
+hinterweisung,hinterweisung,词,NOUN,B2
+mitsicht,mitsicht,词,NOUN,B2
+nachsucht,nachsucht,词,NOUN,B2
+passed,passed,递,ADJ,B2
+nachschaft,nachschaft,词,NOUN,B2
+the ververbesserung,the ververbesserung,复合词,NOUN,B2
+vorerziehung,vorerziehung,词,NOUN,B2
+weitteilung,weitteilung,词,NOUN,B2
+the hochsteigerung,the hochsteigerung,复合词,NOUN,B2
+the urrechnung,the urrechnung,复合词,NOUN,B2
+different,different,不同地,ADV,B2
+period,period,句号,PUNCT,B2
+the zerkraft,the zerkraft,复合词,NOUN,B2
+misssicht,misssicht,词,NOUN,B2
+joie de vivre,joie de vivre,生活乐趣,NOUN,B2
+the anvereinfachung,the anvereinfachung,复合词,NOUN,B2
+the urstellung,the urstellung,复合词,NOUN,B2
+for each other,for each other,相互,ADV,B2
+hochgabe,hochgabe,词,NOUN,B2
+kitten,kitten,小猫,NOUN,B2
+outside of,outside of,在...之外,ADP,B2
+fernkunft,fernkunft,词,NOUN,B2
+to be valid,to be valid,有效,VERB,B2
+wiederfahrt,wiederfahrt,词,NOUN,B2
+to be liable,to be liable,负责,VERB,B2
+the vorkraft,the vorkraft,复合词,NOUN,B2
+the verminderung,the verminderung,复合词,NOUN,B2
+to abwandeln,to abwandeln,动词,VERB,B2
+the urbewegung,the urbewegung,复合词,NOUN,B2
+to absichern,to absichern,动词,VERB,B2
+the grundbildung,the grundbildung,复合词,NOUN,B2
+the ververtiefung,the ververtiefung,复合词,NOUN,B2
+ersetzung,ersetzung,词,NOUN,B2
+all the more,all the more,更加,ADV,B2
+to squeak,to squeak,吱吱叫,VERB,B2
+aberziehung,aberziehung,词,NOUN,B2
+mittheilung,mittheilung,词,NOUN,B2
+the altertum,the altertum,名词,NOUN,B2
+zerregelung,zerregelung,词,NOUN,B2
+mitpflegung,mitpflegung,词,NOUN,B2
+worse,worse,更糟的事,NOUN,B2
+the versthandlung,the versthandlung,复合词,NOUN,B2
+gefahrt,gefahrt,词,NOUN,B2
+managing director,managing director,总经理,NOUN,B2
+erzfahrt,erzfahrt,词,NOUN,B2
+coke,coke,可卡因,NOUN,B2
+as possible,as possible,尽可能地,ADV,B2
+waste of time,waste of time,浪费时间,NOUN,B2
+the unstellung,the unstellung,复合词,NOUN,B2
+fatality,fatality,致命性,NOUN,B2
+campsite,campsite,露营地,NOUN,B2
+enviable,enviable,令人羡慕的,ADJ,B2
+heterogeneity,heterogeneity,异质性,NOUN,B2
+to gloss,to gloss,注释,VERB,B2
+parsimony,parsimony,吝啬,NOUN,B2
+extended,extended,广泛的,ADJ,B2
+curly,curly,卷曲的,ADJ,B2
+decidedly,decidedly,坚决地,ADV,B2
+junk,junk,破烂货,NOUN,B2
+to shelter,to shelter,庇护,VERB,B2
+english-speaking,english-speaking,讲英语的,ADJ,B2
+exegete,exegete,注释家,NOUN,B2
+inclusion,inclusion,包含,NOUN,B2
+by chance,by chance,偶然地,ADV,B2
+to eclipse,to eclipse,使失色,VERB,B2
+consultative,consultative,咨询的,ADJ,B2
+entrails,entrails,内脏,NOUN,B2
+disagreeing,disagreeing,不同意的,ADJ,B2
+feminist,feminist,女权主义者,NOUN,B2
+enumeration,enumeration,列举,NOUN,B2
+floating,floating,漂浮的,ADJ,B2
+gangrene,gangrene,坏疽,NOUN,B2
+lizard,lizard,蜥蜴,NOUN,B2
+stabilization,stabilization,稳定化,NOUN,B2
+railway,railway,铁路的,ADJ,B2
+massively,massively,大量地,ADV,B2
+curative,curative,有疗效的,ADJ,B2
+press release,press release,公报,NOUN,B2
+stimulus,stimulus,刺激,NOUN,B2
+to stem,to stem,起源于,VERB,B2
+etymology,etymology,词源学,NOUN,B2
+self-taught,self-taught,自学的,ADJ,B2
+universal,universal,普遍的,ADJ,B2
+terrace,terrace,露台,NOUN,B2
+to divulge,to divulge,泄露,VERB,B2
+offensive,offensive,冒犯的,ADJ,B2
+fort,fort,堡垒,NOUN,B2
+hemp,hemp,大麻,NOUN,B2
+apathetic,apathetic,冷漠的,ADJ,B2
+to collate,to collate,核对,VERB,B2
+lucrative,lucrative,有利可图的,ADJ,B2
+profitability,profitability,盈利能力,NOUN,B2
+peat,peat,泥炭,NOUN,B2
+supremacy,supremacy,霸权,NOUN,B2
+strident,strident,刺耳的,ADJ,B2
+further on,further on,更远处,ADV,B2
+windfall,windfall,意外之财,NOUN,B2
+annals,annals,编年史,NOUN,B2
+staunch,staunch,坚定的,ADJ,B2
+contractualization,contractualization,契约化,NOUN,B2
+inert,inert,惰性的,ADJ,B2
+brittle,brittle,易碎的,ADJ,B2
+nameable,nameable,可命名的,ADJ,B2
+neonatal,neonatal,新生儿的,ADJ,B2
+tourist,tourist,旅游的,ADJ,B2
+on which,on which,在其上,PRON,B2
+tidal movement,tidal movement,潮汐运动,NOUN,B2
+existential,existential,存在主义的,ADJ,B2
+bare ownership,bare ownership,虚有权,NOUN,B2
+humble,humble,谦逊的,ADJ,B2
+national coach,national coach,国家队教练,NOUN,B2
+neophyte,neophyte,新手；初学者,NOUN,B2
+athletic,athletic,运动的,ADJ,B2
+urbanization,urbanization,城市化,NOUN,B2
+antibiotic,antibiotic,抗生素,NOUN,B2
+at the top,at the top,在最上面,ADV,B2
+forensic,forensic,法医的,ADJ,B2
+to complement,to complement,补充,VERB,B2
+totalitarian,totalitarian,极权主义的,ADJ,B2
+e-reader,e-reader,电子阅读器,NOUN,B2
+religiosity,religiosity,笃信宗教,NOUN,B2
+reformulation,reformulation,重新表述,NOUN,B2
+to encroach,to encroach,侵蚀,VERB,B2
+counterproductivity,counterproductivity,适得其反,NOUN,B2
+liable,liable,有责任的,ADJ,B2
+disrespect,disrespect,不敬,NOUN,B2
+indexing,indexing,指数化,NOUN,B2
+to incriminate,to incriminate,归罪,VERB,B2
+spice,spice,香料,NOUN,B2
+public holiday,public holiday,公共假日,ADJ,B2
+to vary,to vary,改变,VERB,B2
+symbolism,symbolism,象征主义,NOUN,B2
+to spill,to spill,溢出,VERB,B2
+to transgress,to transgress,违背,VERB,B2
+airs,airs,摆架子,NOUN,B2
+trade barrier,trade barrier,贸易壁垒,NOUN,B2
+feeble-minded,feeble-minded,弱智的,ADJ,B2
+to deprave,to deprave,使堕落,VERB,B2
+caring,caring,关怀的,ADJ,B2
+viable,viable,可行的,ADJ,B2
+anathema,anathema,深恶痛绝之物,NOUN,B2
+implicitly,implicitly,含蓄地,ADV,B2
+ascetic,ascetic,苦行的,ADJ,B2
+paralympic,paralympic,残奥会的,ADJ,B2
+sulfur,sulfur,硫,NOUN,B2
+demonstrativeness,demonstrativeness,! 表现欲,NOUN,B2
+lethargic,lethargic,昏睡的,ADJ,B2
+approximate,approximate,近似的,ADJ,B2
+deceit,deceit,欺骗,NOUN,B2
+unknown,unknown,未知数,NOUN,B2
+to auscultate,to auscultate,听诊,VERB,B2
+bumpy,bumpy,凹凸不平的,ADJ,B2
+intended,intended,预定的,ADJ,B2
+scrupulous,scrupulous,一丝不苟的,ADJ,B2
+habitual behavior,habitual behavior,习惯行为,NOUN,B2
+bulwark,bulwark,壁垒,NOUN,B2
+distorted,distorted,歪曲的,ADJ,B2
+humane,humane,人道的,ADJ,B2
+cerebral,cerebral,大脑的,ADJ,B2
+shrimp,shrimp,虾,NOUN,B2
+to substantiate,to substantiate,证实,VERB,B2
+methodological,methodological,方法论的,ADJ,B2
+connective,connective,连接的,ADJ,B2
+eczema,eczema,湿疹,NOUN,B2
+buffoon,buffoon,小丑,NOUN,B2
+triumph,triumph,胜利,NOUN,B2
+tandem duo,tandem duo,双人自行车 / 搭档,NOUN,B2
+socialization,socialization,社会化,NOUN,B2
+prognosis,prognosis,预后,NOUN,B2
+lifeless,lifeless,无生命的,ADJ,B2
+buoyant,buoyant,有浮力的,ADJ,B2
+all,all,جميع,NOUN,B2
+fissure,fissure,裂缝,NOUN,B2
+to deafen,to deafen,使聋,VERB,B2
+supplication,supplication,恳求,NOUN,B2
+temerity,temerity,鲁莽,NOUN,B2
+drag,drag,拖曳,NOUN,B2
+hair bun,hair bun,发髻,NOUN,B2
+complementarity,complementarity,互补性,NOUN,B2
+line of conduct,line of conduct,行为方针,NOUN,B2
+to vegetate,to vegetate,苟活,VERB,B2
+beautifully,beautifully,美丽地,ADV,B2
+fare,fare,车费,NOUN,B2
+to consummate,to consummate,完成,VERB,B2
+to allege,to allege,宣称,VERB,B2
+numb,numb,麻木的,ADJ,B2
+to worry to preoccupy,to worry to preoccupy,使担心,VERB,B2
+outlaw,outlaw,歹徒,NOUN,B2
+every,every,每个,PRON,B2
+conductivity,conductivity,导电性,NOUN,B2
+to retrace,to retrace,追溯,VERB,B2
+compound,compound,化合物,NOUN,B2
+to perpetuate,to perpetuate,使永存,VERB,B2
+to dishevel,to dishevel,弄乱,VERB,B2
+to depilate,to depilate,脱毛,VERB,B2
+to disenchant,to disenchant,使清醒,VERB,B2
+brawl,brawl,斗殴,NOUN,B2
+tyrannical,tyrannical,专横的,ADJ,B2
+punctually occasionally,punctually occasionally,准时地 / 偶尔地,ADV,B2
+seldom,seldom,很少,ADV,B2
+to situate,to situate,定位,VERB,B2
+guilt-ridden,guilt-ridden,内疚的,ADJ,B2
+to deal,to deal,处理,VERB,B2
+to specialize,to specialize,专攻,VERB,B2
+to vampirize,to vampirize,吸血,VERB,B2
+premeditation,premeditation,预谋,NOUN,B2
+swimming,swimming,游泳,NOUN,B2
+short film,short film,短片,NOUN,B2
+to disrupt,to disrupt,扰乱,VERB,B2
+soundtrack,soundtrack,! 音轨,NOUN,B2
+buccaneer,buccaneer,海盗,NOUN,B2
+hatch,hatch,舱口,NOUN,B2
+fictional character,fictional character,虚构角色,NOUN,B2
+vain,vain,徒劳的,ADJ,B2
+motif,motif,主题,NOUN,B2
+to absolve,to absolve,赦免,VERB,B2
+trinket,trinket,小饰品,NOUN,B2
+costs,costs,费用,NOUN,B2
+shuttle,shuttle,穿梭巴士,NOUN,B2
+variant,variant,变体,NOUN,B2
+nonprofit,nonprofit,非营利的,ADJ,B2
+to recharge,to recharge,充电,VERB,B2
+roadway,roadway,路面,NOUN,B2
+precarization,precarization,不稳定化,NOUN,B2
+culture of greed,culture of greed,贪得无厌文化,NOUN,B2
+to buy back,to buy back,赎回,VERB,B2
+chauvinistic,chauvinistic,沙文主义的,ADJ,B2
+to adore,to adore,爱慕,VERB,B2
+to reopen,to reopen,重新开放,VERB,B2
+latent,latent,潜在的,ADJ,B2
+omnipresent,omnipresent,无所不在的,ADJ,B2
+slum,slum,贫民窟,NOUN,B2
+resuscitation,resuscitation,复苏,NOUN,B2
+shyness,shyness,羞怯,NOUN,B2
+surreptitious,surreptitious,秘密的,ADJ,B2
+to allude,to allude,暗指,VERB,B2
+damageable,damageable,易损的,ADJ,B2
+to extirpate,to extirpate,根除,VERB,B2
+plenitude,plenitude,充足,NOUN,B2
+to eternalize,to eternalize,使永恒,VERB,B2
+fulfillment,fulfillment,满足,NOUN,B2
+to dismay,to dismay,使沮丧,VERB,B2
+mp,mp,国会议员,NOUN,B2
+cudgel,cudgel,棍棒,NOUN,B2
+sadistic,sadistic,施虐的,ADJ,B2
+to decant,to decant,倾析,VERB,B2
+incorporation,incorporation,纳入,NOUN,B2
+to decouple,to decouple,分离,VERB,B2
+airtight,airtight,密封的,ADJ,B2
+group member,group member,群体成员,NOUN,B2
+acerbic,acerbic,尖刻的,ADJ,B2
+cloister,cloister,回廊,NOUN,B2
+domain,domain,领域,NOUN,B2
+palliative,palliative,缓和的,ADJ,B2
+veiled,veiled,隐晦的,ADJ,B2
+obliged,obliged,被迫的,ADJ,B2
+vigilant,vigilant,警惕的,ADJ,B2
+appeasement,appeasement,平息,NOUN,B2
+thetic,thetic,正题的,ADJ,B2
+to disfigure,to disfigure,毁容,VERB,B2
+attributive,attributive,定语的,ADJ,B2
+ideally,ideally,理想地,ADV,B2
+crusade,crusade,运动,NOUN,B2
+outcome ending,outcome ending,结局，解决,NOUN,B2
+villainous,villainous,恶棍的,ADJ,B2
+playwright,playwright,剧作家,NOUN,B2
+acculturation,acculturation,文化涵化,NOUN,B2
+to dawdle,to dawdle,闲逛,VERB,B2
+to saturate,to saturate,使饱和,VERB,B2
+cradle,cradle,摇篮,NOUN,B2
+mammal,mammal,哺乳动物,NOUN,B2
+photon,photon,光子,NOUN,B2
+cheapness,cheapness,廉价,NOUN,B2
+autism,autism,自闭症,NOUN,B2
+superb,superb,极好的,ADJ,B2
+to bungle,to bungle,搞砸,VERB,B2
+numismatic,numismatic,钱币学的,ADJ,B2
+faint,faint,微弱的,ADJ,B2
+demagogy,demagogy,蛊惑,NOUN,B2
+enamel,enamel,珐琅,NOUN,B2
+meticulously,meticulously,一丝不苟地,ADV,B2
+phlegmatic,phlegmatic,冷静的,ADJ,B2
+to do sports,to do sports,运动,VERB,B2
+side,side,骄傲的,ADJ,B2
+to freshen,to freshen,使清新,VERB,B2
+solecism,solecism,语法错误,NOUN,B2
+to log in,to log in,登录,VERB,B2
+iranian,iranian,伊朗的,ADJ,B2
+to navigate,to navigate,导航；航行,VERB,B2
+family circle,family circle,家庭圈子,NOUN,B2
+ago,ago,以前,ADV,B2
+cooked,cooked,熟的,ADJ,B2
+thicket,thicket,灌木丛,NOUN,B2
+emotional experience,emotional experience,情感体验,NOUN,B2
+depot,depot,仓库,NOUN,B2
+tropical,tropical,热带的,ADJ,B2
+to stitch,to stitch,缝,VERB,B2
+asylum seeker,asylum seeker,寻求庇护者,NOUN,B2
+historicism,historicism,历史主义,NOUN,B2
+racist,racist,种族主义者,NOUN,B2
+to slash,to slash,猛砍,VERB,B2
+full of life,full of life,充满活力的,ADJ,B2
+sinister,sinister,不祥的,ADJ,B2
+deleveraging,deleveraging,去杠杆化,NOUN,B2
+tax exemption,tax exemption,免税,NOUN,B2
+to digitize,to digitize,数字化,VERB,B2
+city centre,city centre,市中心,NOUN,B2
+implacably,implacably,毫不留情地,ADV,B2
+skilful,skilful,熟练的,ADJ,B2
+splash,splash,扑通,NOUN,B2
+on behalf of,on behalf of,代表,ADP,B2
+repertoire,repertoire,全部曲目,NOUN,B2
+bog,bog,沼泽,NOUN,B2
+instructor,instructor,讲师,NOUN,B2
+filthy,filthy,肮脏的,ADJ,B2
+to overshadow,to overshadow,使黯然失色,VERB,B2
+to familiarize,to familiarize,使熟悉,VERB,B2
+corporate,corporate,公司的,ADJ,B2
+wait-and-see,wait-and-see,观望的,ADJ,B2
+landmark reference point,landmark reference point,标记 / 参考点,NOUN,B2
+dent,dent,凹痕,NOUN,B2
+impromptu,impromptu,即兴的,ADJ,B2
+genital,genital,生殖器,NOUN,B2
+to beget,to beget,引起,VERB,B2
+to manifest,to manifest,表明,VERB,B2
+breach of contract,breach of contract,违约,NOUN,B2
+to purify,to purify,净化,VERB,B2
+spinning,spinning,纺纱,NOUN,B2
+to postulate,to postulate,假定,VERB,B2
+guffaw,guffaw,哄笑,NOUN,B2
+to venerate,to venerate,崇敬,VERB,B2
+by now,by now,此时,ADV,B2
+basal,basal,基本的,ADJ,B2
+averse,averse,厌恶的,ADJ,B2
+to preside,to preside,主持,VERB,B2
+syllable,syllable,音节,NOUN,B2
+sanitation,sanitation,卫生,NOUN,B2
+checkup,checkup,体检,NOUN,B2
+psychoanalysis,psychoanalysis,精神分析,NOUN,B2
+unfriendly,unfriendly,不友好的,ADJ,B2
+graveyard,graveyard,墓地,NOUN,B2
+capital gain,capital gain,增值,NOUN,B2
+increased,increased,增加的,ADJ,B2
+arson,arson,纵火,NOUN,B2
+royalty,royalty,王室,NOUN,B2
+comparative,comparative,比较的,ADJ,B2
+to placate,to placate,安抚,VERB,B2
+how long,how long,多久,ADV,B2
+optimization,optimization,优化,NOUN,B2
+to type,to type,打字,VERB,B2
+libertinism,libertinism,放荡,NOUN,B2
+dossier,dossier,档案,NOUN,B2
+journalism,journalism,新闻业,NOUN,B2
+reluctance,reluctance,不情愿,NOUN,B2
+monolithic,monolithic,单一的,ADJ,B2
+duplicate,duplicate,! 副本,NOUN,B2
+surcharge,surcharge,附加费,NOUN,B2
+binoculars,binoculars,双筒望远镜,NOUN,B2
+extraterrestrial,extraterrestrial,外星的,ADJ,B2
+all kinds,all kinds,各种各样的,DET,B2
+extravagant,extravagant,奢侈的,ADJ,B2
+to attest,to attest,证明,VERB,B2
+declinable,declinable,可变格的,ADJ,B2
+to rant,to rant,咆哮,VERB,B2
+to fatten,to fatten,养肥,VERB,B2
+antagonism,antagonism,对抗,NOUN,B2
+volunteer work,volunteer work,志愿工作,NOUN,B2
+optimal,optimal,最佳的,ADJ,B2
+state secretary,state secretary,国务秘书,NOUN,B2
+articulation,articulation,清晰表达,NOUN,B2
+reduction,reduction,减少,NOUN,B2
+about that,about that,关于那个,ADV,B2
+orange,orange,橙色的,ADJ,B2
+grand duke,grand duke,大公,NOUN,B2
+aloofness,aloofness,冷漠,NOUN,B2
+wooden,wooden,木制的,ADJ,B2
+tired of,tired of,,NOUN,B2
+determine,determine,确定,VER! B,B2
+to disqualify,to disqualify,取消资格,VERB,B2
+to elide,to elide,省略,VERB,B2
+to meditate,to meditate,沉思,VERB,B2
+overdraft,overdraft,透支,NOUN,B2
+existentialism,existentialism,存在主义,NOUN,B2
+ratio,ratio,比率,NOUN,B2
+infrastructure,infrastructure,基础设施,NOUN,B2
+to extol,to extol,赞美,VERB,B2
+vaccine-related,vaccine-related,疫苗的,ADJ,B2
+little son,little son,小儿子,NOUN,B2
+antidote,antidote,解毒剂,NOUN,B2
+pernicious,pernicious,有害的,ADJ,B2
+exceptionality,exceptionality,特殊性,NOUN,B2
+christianity,christianity,基督教,NOUN,B2
+having a birthday,having a birthday,过生日的,ADJ,B2
+speculator,speculator,投机者,NOUN,B2
+to exorcise,to exorcise,驱魔,VERB,B2
+lucidity,lucidity,清醒 / 明晰,NOUN,B2
+synoptic,synoptic,概要的,ADJ,B2
+to asphalt,to asphalt,铺沥青,VERB,B2
+beleaguered,beleaguered,受围困的,ADJ,B2
+humid,humid,潮湿的,ADJ,B2
+infant,infant,婴儿,NOUN,B2
+satisfying,satisfying,令人满意的,ADJ,B2
+to blaspheme,to blaspheme,亵渎,VERB,B2
+conceptual,conceptual,概念的,ADJ,B2
+honorable,honorable,可敬的,ADJ,B2
+bejeweled,bejeweled,镶满宝石的,ADJ,B2
+intricate,intricate,错综复杂的,ADJ,B2
+remaining,remaining,,NOUN,B2
+holder,holder,持有者,NOUN,B2
+danish,danish,丹麦的,ADJ,B2
+grand duchy,grand duchy,大公国,NOUN,B2
+ataxia,ataxia,共济失调,NOUN,B2
+norwegian,norwegian,挪威的,ADJ,B2
+basic income,basic income,基本收入,NOUN,B2
+exclusionary,exclusionary,排他性的,ADJ,B2
+slowdown,slowdown,减速,NOUN,B2
+disrepute,disrepute,坏名声,NOUN,B2
+concessionary,concessionary,让步的,ADJ,B2
+to culminate,to culminate,达到顶点,VERB,B2
+continual,continual,持续的,ADJ,B2
+mosquito net,mosquito net,蚊帐,NOUN,B2
+furrow,furrow,犁沟,NOUN,B2
+unscathed,unscathed,未受伤害的,ADJ,B2
+prayer room,prayer room,祈祷室,NOUN,B2
+except for,except for,除了,ADP,B2
+rubber,rubber,橡胶,NOUN,B2
+thrilling,thrilling,令人兴奋的,ADJ,B2
+egyptian,egyptian,埃及的,ADJ,B2
+to wane,to wane,减弱,VERB,B2
+foal,foal,马驹,NOUN,B2
+diverse,diverse,多样的,ADJ,B2
+asp,asp,角蝰,NOUN,B2
+gay man,gay man,男同性恋者,NOUN,B2
+depicting,depicting,描绘的,ADJ,B2
+fluid,fluid,液体,NOUN,B2
+religiousness,religiousness,虔诚,NOUN,B2
+dissociation,dissociation,解离,NOUN,B2
+unilateral,unilateral,单方面的,ADJ,B2
+timeline,timeline,时间线,NOUN,B2
+corporation,corporation,公司,NOUN,B2
+perennial,perennial,长期的,ADJ,B2
+directorship,directorship,董事职位,NOUN,B2
+bud,bud,芽,NOUN,B2
+cricket,cricket,板球,NOUN,B2
+bleak,bleak,无望的,ADJ,B2
+din,din,喧嚣,NOUN,B2
+bridle,bridle,马勒,NOUN,B2
+to captivate,to captivate,迷住,VERB,B2
+slothful,slothful,懒惰的,ADJ,B2
+philippic,philippic,猛烈的抨击,NOUN,B2
+baggage,baggage,行李,NOUN,B2
+orderliness,orderliness,有序性,NOUN,B2
+to embolden,to embolden,使大胆,VERB,B2
+to appear to seem,to appear to seem,出现/显得,VERB,B2
+to creak,to creak,嘎吱作响,VERB,B2
+fluency,fluency,流利,NOUN,B2
+retranslation,retranslation,重译,NOUN,B2
+to coerce,to coerce,强迫,VERB,B2
+painstakingly,painstakingly,细致地,ADV,B2
+decor,decor,布景,NOUN,B2
+truthful,truthful,忠于事实的,ADJ,B2
+scheduling,scheduling,调度；排序,NOUN,B2
+to tweet,to tweet,发推文,VERB,B2
+editing,editing,剪辑,NOUN,B2
+member state,member state,成员国,NOUN,B2
+youth trauma,youth trauma,童年创伤,NOUN,B2
+concave,concave,凹的,ADJ,B2
+provincial,provincial,地方的,ADJ,B2
+to enunciate,to enunciate,阐明,VERB,B2
+to bisect,to bisect,平分,VERB,B2
+compulsiveness,compulsiveness,强迫性,NOUN,B2
+to calibrate,to calibrate,校准,VERB,B2
+windless,windless,无风的,ADJ,B2
+to blossom,to blossom,开花,VERB,B2
+furnishing,furnishing,室内布置,NOUN,B2
+to discern,to discern,辨别,VERB,B2
+oppressive,oppressive,压迫的,ADJ,B2
+extinct,extinct,灭绝的,ADJ,B2
+assurance,assurance,保证,NOUN,B2
+to plane,to plane,刨,VERB,B2
+liquid,liquid,液态的,ADJ,B2
+itinerant,itinerant,巡回的,ADJ,B2
+to flog,to flog,鞭打,VERB,B2
+position of authority,position of authority,! 权威地位,NOUN,B2
+to sparkle,to sparkle,闪耀,VERB,B2
+to keep silent,to keep silent,保持沉默,VERB,B2
+miserly,miserly,吝啬的,ADJ,B2
+sordid,sordid,肮脏的,ADJ,B2
+in which,in which,在其中,PRON,B2
+outlandish,outlandish,古怪的,ADJ,B2
+arid,arid,干旱的,ADJ,B2
+dismal,dismal,令人失望的,ADJ,B2
+to emasculate,to emasculate,使无力,VERB,B2
+gloriousness,gloriousness,光荣,NOUN,B2
+trusting,trusting,信任的,ADJ,B2
+valid,valid,有效的,ADJ,B2
+costly,costly,昂贵的,ADJ,B2
+to unearth to track down,to unearth to track down,寻觅，找到,VERB,B2
+to demarcate,to demarcate,划定界限,VERB,B2
+male,male,男性,NOUN,B2
+to connote,to connote,暗示,VERB,B2
+obtaining,obtaining,获得,NOUN,B2
+luminous,luminous,发光的,ADJ,B2
+grandparenthood,grandparenthood,祖父母身份,NOUN,B2
+prodigy,prodigy,神童,NOUN,B2
+tobacco,tobacco,烟草,NOUN,B2
+multinational,multinational,跨国公司,NOUN,B2
+explicable,explicable,可解释的,ADJ,B2
+disrespectful,disrespectful,无礼的,ADJ,B2
+one hundred,one hundred,一百,NUM,B2
+to externalize,to externalize,使外在化,VERB,B2
+split secession,split secession,分裂,NOUN,B2
+group culture,group culture,群体文化,NOUN,B2
+notarized,notarized,经公证的,ADJ,B2
+constructivism,constructivism,建构主义,NOUN,B2
+minuscule,minuscule,极小的,ADJ,B2
+catalogue,catalogue,目录,NOUN,B2
+psychiatric,psychiatric,精神病的,ADJ,B2
+gosh,gosh,天哪,INTJ,B2
+unctuous,unctuous,谄媚的,ADJ,B2
+contaminated,contaminated,受污染的,ADJ,B2
+to enthrone,to enthrone,立为王,VERB,B2
+insatiable,insatiable,不知足的,ADJ,B2
+fluctuating,fluctuating,波动的,ADJ,B2
+to soften,to soften,使灵活,VERB,B2
+to conjugate,to conjugate,变位,VERB,B2
+to set rates,to set rates,定价,VERB,B2
+to bully,to bully,欺凌,VERB,B2
+ajar,ajar,半开的,ADJ,B2
+abominable,abominable,可憎的,ADJ,B2
+spelling,spelling,拼写,NOUN,B2
+informedness,informedness,知情度,NOUN,B2
+dungeon,dungeon,地牢,NOUN,B2
+polar,polar,极地的,ADJ,B2
+little hand,little hand,小手,NOUN,B2
+to declaim,to declaim,慷慨陈词,VERB,B2
+respondent,respondent,被上诉人,NOUN,B2
+to dethrone,to dethrone,废黜,VERB,B2
+to drip,to drip,滴,VERB,B2
+lust,lust,欲望,NOUN,B2
+metabolic,metabolic,代谢的,ADJ,B2
+to amaze,to amaze,使吃惊,VERB,B2
+southeast,southeast,东南,NOUN,B2
+catachresis,catachresis,词语误用,NOUN,B2
+tv movie,tv movie,电视电影,NOUN,B2
+to commentate,to commentate,评论,VERB,B2
+gracious,gracious,亲切的,ADJ,B2
+to calm down,to calm down,使平静,VERB,B2
+gratuity,gratuity,酬金,NOUN,B2
+sophisticated,sophisticated,复杂的,ADJ,B2
+to supplicate,to supplicate,恳求,VERB,B2
+limb,limb,肢体,NOUN,B2
+audacious,audacious,大胆的,ADJ,B2
+aged,aged,年老的,ADJ,B2
+respectful,respectful,恭敬的,ADJ,B2
+to fossilize,to fossilize,石化,VERB,B2
+steering,steering,掌舵的,ADJ,B2
+charismatic,charismatic,有魅力的,ADJ,B2
+constancy,constancy,恒定,NOUN,B2
+to mess about,to mess about,胡搞,VERB,B2
+to denigrate,to denigrate,诋毁,VERB,B2
+integral,integral,不可或缺的,ADJ,B2
+intangible,intangible,无形的,ADJ,B2
+bloodthirsty,bloodthirsty,嗜血的,ADJ,B2
+famine,famine,饥荒,NOUN,B2
+maximal,maximal,最大的,ADJ,B2
+to relay,to relay,转达,VERB,B2
+to reproach,to reproach,责备,VERB,B2
+tolerant,tolerant,宽容的,ADJ,B2
+bubbling,bubbling,冒泡的,ADJ,B2
+sporty,sporty,运动的,ADJ,B2
+to contend,to contend,主张,VERB,B2
+drunkenness,drunkenness,醉酒,NOUN,B2
+enforcement policy,enforcement policy,执法政策,NOUN,B2
+australian,australian,澳大利亚的,ADJ,B2
+for this purpose,for this purpose,为此,ADV,B2
+finance,finance,金融,NOUN,B2
+to democratize,to democratize,民主化,VERB,B2
+shading,shading,阴影,NOUN,B2
+anachronistic,anachronistic,时代错误的,ADJ,B2
+igneous,igneous,火成的,ADJ,B2
+to disabuse,to disabuse,纠正错误想法,VERB,B2
+reprieve,reprieve,暂缓执行,NOUN,B2
+marvelous,marvelous,极好的,ADJ,B2
+to objectify,to objectify,客观化,VERB,B2
+systemless,systemless,无系统的,ADJ,B2
+doe,doe,雌鹿,NOUN,B2
+larva,larva,幼虫,NOUN,B2
+bicameral,bicameral,两院制的,ADJ,B2
+jet,jet,喷气式飞机,NOUN,B2
+to theatricalize,to theatricalize,戏剧化,VERB,B2
+spot,spot,地点,NOUN,B2
+demographic,demographic,人口统计的,ADJ,B2
+anaphora,anaphora,首语重复修辞,NOUN,B2
+to goad,to goad,刺激,VERB,B2
+showing,showing,表现,NOUN,B2
+to equate,to equate,等同,VERB,B2
+opacity,opacity,不透明性,NOUN,B2
+wicked,wicked,邪恶的,ADJ,B2
+taxonomy,taxonomy,分类学,NOUN,B2
+advertising,advertising,广告的,ADJ,B2
+pathogenic,pathogenic,致病的,ADJ,B2
+bookcase,bookcase,书柜,NOUN,B2
+virginal,virginal,处女的,ADJ,B2
+line-up,line-up,阵容,NOUN,B2
+to yearn,to yearn,渴望,VERB,B2
+relentlessness,relentlessness,不懈 / 猛烈,NOUN,B2
+kindred spirit,kindred spirit,志同道合者,NOUN,B2
+cadaverous,cadaverous,瘦骨嶙峋的,ADJ,B2
+attractiveness,attractiveness,吸引力,NOUN,B2
+to use up,to use up,用完,VERB,B2
+selfish,selfish,,NOUN,B2
+tilt,tilt,倾斜,NOUN,B2
+redundant,redundant,多余的,ADJ,B2
+amendable,amendable,可修正的,ADJ,B2
+to segregate,to segregate,隔离,VERB,B2
+to make stupid,to make stupid,使愚蠢,VERB,B2
+incision,incision,切口,NOUN,B2
+to annul,to annul,废除,VERB,B2
+incandescent,incandescent,白炽的,ADJ,B2
+to embark,to embark,上船,VERB,B2
+cornice,cornice,檐口,NOUN,B2
+to accentuate,to accentuate,强调,VERB,B2
+altercation,altercation,争执,NOUN,B2
+glimpse,glimpse,一瞥,NOUN,B2
+budgetable,budgetable,可预算的,ADJ,B2
+phenomenal,phenomenal,非凡的,ADJ,B2
+trapdoor,trapdoor,活板门,NOUN,B2
+colour,colour,颜色,NOUN,B2
+higher professional education,higher professional education,高等专业教育,NOUN,B2
+prosody,prosody,韵律学,NOUN,B2
+others,others,他人,PRON,B2
+to decode,to decode,解码,VERB,B2
+reproachable,reproachable,应受责备的,ADJ,B2
+courteous,courteous,有礼貌的,ADJ,B2
+light brown,light brown,浅棕色的,ADJ,B2
+ballot,ballot,选票,NOUN,B2
+minus,minus,减,NOUN,B2
+boastful,boastful,自夸的,ADJ,B2
+jointly,jointly,共同地,ADV,B2
+predominance,predominance,主导地位,NOUN,B2
+accessible,accessible,易接近的,ADJ,B2
+balm,balm,香脂,NOUN,B2
+leading role,leading role,主角,NOUN,B2
+invincible,invincible,无敌的,ADJ,B2
+bard,bard,吟游诗人,NOUN,B2
+disobedient,disobedient,不服从的,ADJ,B2
+scorn,scorn,轻蔑,NOUN,B2
+to encircle,to encircle,环绕,VERB,B2
+to splash,to splash,溅,VERB,B2
+to daunt,to daunt,使气馁,VERB,B2
+bastion,bastion,堡垒,NOUN,B2
+schism,schism,分裂,NOUN,B2
+to alleviate,to alleviate,缓解,VERB,B2
+jury,jury,陪审团,NOUN,B2
+rival,rival,对手,NOUN,B2
+to expurgate,to expurgate,删节,VERB,B2
+ethereal,ethereal,飘渺的,ADJ,B2
+to bifurcate,to bifurcate,分叉,VERB,B2
+plundering,plundering,掠夺,NOUN,B2
+to capitulate,to capitulate,投降,VERB,B2
+virulent,virulent,恶性的,ADJ,B2
+stew,stew,炖菜,NOUN,B2
+inadequate,inadequate,不足的,ADJ,B2
+malnutrition,malnutrition,营养不良,NOUN,B2
+alibi,alibi,不在场证明,NOUN,B2
+feeble,feeble,虚弱的,ADJ,B2
+displacement,displacement,位移,NOUN,B2
+byzantine,byzantine,错综复杂的,ADJ,B2
+to depreciate,to depreciate,贬值,VERB,B2
+intransigent,intransigent,不妥协的,ADJ,B2
+apologist,apologist,辩护者,NOUN,B2
+inflammation,inflammation,炎症,NOUN,B2
+ambidextrous,ambidextrous,双手灵巧的,ADJ,B2
+to enervate,to enervate,使衰弱,VERB,B2
+to vilify,to vilify,诽谤,VERB,B2
+to fluster,to fluster,使慌乱,VERB,B2
+to disarrange,to disarrange,弄乱,VERB,B2
+incongruous,incongruous,不协调的,ADJ,B2
+to fraternize,to fraternize,勾结,VERB,B2
+to edify,to edify,启发,VERB,B2
+abstemious,abstemious,有节制的,ADJ,B2
+prize,prize,奖品,NOUN,B2
+to augur,to augur,预言,VERB,B2
+hepatic,hepatic,肝脏的,ADJ,B2
+postponement,postponement,延期,NOUN,B2
+humiliating,humiliating,令人羞辱的,ADJ,B2
+pious,pious,虔诚的,ADJ,B2
+freight,freight,货物,NOUN,B2
+to daze,to daze,使茫然,VERB,B2
+incessant,incessant,持续的,ADJ,B2
+spurious,spurious,虚假的,ADJ,B2
+abject,abject,悲惨的,ADJ,B2
+nosy,nosy,爱打听的,ADJ,B2
+promiscuous,promiscuous,滥交的,ADJ,B2
+to denote,to denote,表示,VERB,B2
+to exculpate,to exculpate,开脱,VERB,B2
+import,import,进口,NOUN,B2
+to scrub,to scrub,擦洗,VERB,B2
+to disconcert,to disconcert,使惊慌,VERB,B2
+dexterity,dexterity,灵巧,NOUN,B2
+corroboration,corroboration,证实,NOUN,B2
+to ascribe,to ascribe,归因于,VERB,B2
+stagnant,stagnant,停滞的,ADJ,B2
+format,format,格式,NOUN,B2
+craving,craving,渴求,NOUN,B2
+bonfire,bonfire,篝火,NOUN,B2
+gargoyle,gargoyle,滴水嘴兽,NOUN,B2
+gunshot,gunshot,枪声,NOUN,B2
+to acclaim,to acclaim,称赞,VERB,B2
+stoic,stoic,坚忍的,ADJ,B2
+equivalent,equivalent,相等的,ADJ,B2
+tick,tick,滴答声,NOUN,B2
+sane,sane,神志正常的,ADJ,B2
+to rebuke,to rebuke,斥责,VERB,B2
+to ail,to ail,使苦恼,VERB,B2
+atrocity,atrocity,暴行,NOUN,B2
+oracle,oracle,神谕,NOUN,B2
+wealthy,wealthy,富有的,ADJ,B2
+irrational,irrational,非理性的,ADJ,B2
+deportation,deportation,驱逐出境,NOUN,B2
+bracket,bracket,括号,NOUN,B2
+terse,terse,简练的,ADJ,B2
+to enslave,to enslave,奴役,VERB,B2
+to flap,to flap,拍打,VERB,B2
+inhibition,inhibition,抑制,NOUN,B2
+to snub,to snub,冷落,VERB,B2
+to extricate,to extricate,使摆脱,VERB,B2
+frigid,frigid,寒冷的,ADJ,B2
+evocative,evocative,引起回忆的,ADJ,B2
+impeccable,impeccable,无瑕疵的,ADJ,B2
+to commercialize,to commercialize,商业化,VERB,B2
+to enrapture,to enrapture,使狂喜,VERB,B2
+apologetic,apologetic,道歉的,ADJ,B2
+opulent,opulent,豪华的,ADJ,B2
+barge,barge,驳船,NOUN,B2
+cultivation,cultivation,培养,NOUN,B2
+infamous,infamous,声名狼藉的,ADJ,B2
+to fortify,to fortify,加强,VERB,B2
+reverent,reverent,虔诚的,ADJ,B2
+to divest,to divest,剥夺,VERB,B2
+to disinherit,to disinherit,剥夺继承权,VERB,B2
+hyperbole,hyperbole,夸张,NOUN,B2
+to boost,to boost,促进,VERB,B2
+to fertilize,to fertilize,施肥,VERB,B2
+to satiate,to satiate,使饱足,VERB,B2
+arcane,arcane,神秘的,ADJ,B2
+discrepancy,discrepancy,差异,NOUN,B2
+to deport,to deport,驱逐出境,VERB,B2
+to cram,to cram,填鸭式学习,VERB,B2
+to fumigate,to fumigate,熏蒸,VERB,B2
+cramp,cramp,抽筋,NOUN,B2
+touching,touching,动人的,ADJ,B2
+immature,immature,不成熟的,ADJ,B2
+bacchanal,bacchanal,狂欢,NOUN,B2
+feast,feast,盛宴,NOUN,B2
+to botch,to botch,搞砸,VERB,B2
+scarcely,scarcely,几乎不,ADV,B2
+evasion,evasion,逃避,NOUN,B2
+to disperse,to disperse,分散,VERB,B2
+behaviorist,behaviorist,行为主义者,NOUN,B2
+to elude,to elude,逃避,VERB,B2
+bohemian,bohemian,放荡不羁的,ADJ,B2
+akin,akin,相似的,ADJ,B2
+brainwasher,brainwasher,洗脑者,NOUN,B2
+bossism,bossism,老板主义,NOUN,B2
+weary,weary,疲倦的,ADJ,B2
+apathy,apathy,冷漠,NOUN,B2
+skirmish,skirmish,小规模战斗,NOUN,B2
+shrill,shrill,尖锐的,ADJ,B2
+affront,affront,冒犯,NOUN,B2
+to deify,to deify,神化,VERB,B2
+garland,garland,花环,NOUN,B2
+brow,brow,眉毛,NOUN,B2
+to covet,to covet,觊觎,VERB,B2
+to sprout,to sprout,发芽,VERB,B2
+funnel,funnel,漏斗,NOUN,B2
+to gravitate,to gravitate,受吸引,VERB,B2
+to disintegrate,to disintegrate,瓦解,VERB,B2
+incoherence,incoherence,不连贯,NOUN,B2
+to ensnare,to ensnare,诱捕,VERB,B2
+constituent,constituent,成分,NOUN,B2
+fratricide,fratricide,杀兄弟,NOUN,B2
+ardent,ardent,热情的,ADJ,B2
+to forebode,to forebode,预兆,VERB,B2
+acceptable,acceptable,可接受的,ADJ,B2
+exotic,exotic,异国情调的,ADJ,B2
+to dilute,to dilute,稀释,VERB,B2
+cistern,cistern,蓄水池,NOUN,B2
+badge,badge,徽章,NOUN,B2
+to enrage,to enrage,激怒,VERB,B2
+ashen,ashen,灰白的,ADJ,B2
+aging,aging,老化,NOUN,B2
+diaphragm,diaphragm,横膈膜,NOUN,B2
+magnanimous,magnanimous,宽宏大量的,ADJ,B2
+sorcery,sorcery,巫术,NOUN,B2
+excrement,excrement,排泄物,NOUN,B2
+belligerent,belligerent,好战的,ADJ,B2
+detergent,detergent,洗涤剂,NOUN,B2
+sniper,sniper,狙击手,NOUN,B2
+bourgeois,bourgeois,资产阶级的,ADJ,B2
+to shroud,to shroud,覆盖,VERB,B2
+demagoguery,demagoguery,煽动性,NOUN,B2
+to erode,to erode,侵蚀,VERB,B2
+to denature,to denature,使变性,VERB,B2
+to alter,to alter,改变,VERB,B2
+to exude,to exude,散发,VERB,B2
+betrothal,betrothal,订婚,NOUN,B2
+to adhere,to adhere,坚持,VERB,B2
+to deign,to deign,屈尊,VERB,B2
+to allocate,to allocate,分配,VERB,B2
+antipode,antipode,对跖点,NOUN,B2
+anachronism,anachronism,时代错误,NOUN,B2
+docile,docile,温顺的,ADJ,B2
+to cloy,to cloy,使厌烦,VERB,B2
+to delineate,to delineate,描绘,VERB,B2
+to flatten,to flatten,使平坦,VERB,B2
+stipend,stipend,津贴,NOUN,B2
+to dispose,to dispose,处理,VERB,B2
+worn,worn,磨损的,ADJ,B2
+to gratify,to gratify,使满足,VERB,B2
+uncouth,uncouth,粗俗的,ADJ,B2
+disuse,disuse,废弃,NOUN,B2
+to galvanize,to galvanize,激励,VERB,B2
+to retract,to retract,撤回,VERB,B2
+aforementioned,aforementioned,上述的,ADJ,B2
+convertibility,convertibility,可兑换性,NOUN,B2
+absorbed,absorbed,全神贯注的,ADJ,B2
+to beautify,to beautify,美化,VERB,B2
+sore,sore,疼痛的,ADJ,B2
+vogue,vogue,流行,NOUN,B2
+elusive,elusive,难以捉摸的,ADJ,B2
+to confine,to confine,限制,VERB,B2
+to cauterize,to cauterize,烧灼,VERB,B2
+to unearth,to unearth,发掘,VERB,B2
+to dishearten,to dishearten,使沮丧,VERB,B2
+unscrupulous,unscrupulous,肆无忌惮的,ADJ,B2
+amorphous,amorphous,无定形的,ADJ,B2
+attribution,attribution,归因,NOUN,B2
+to stratify,to stratify,分层,VERB,B2
+frivolous,frivolous,轻浮的,ADJ,B2
+wax,wax,蜡,NOUN,B2
+soccer,soccer,足球,NOUN,B2
+mezzanine,mezzanine,夹层,NOUN,B2
+saving,saving,储蓄,NOUN,B2
+apprehensive,apprehensive,忧虑的,ADJ,B2
+to unravel,to unravel,解开,VERB,B2
+to overthrow,to overthrow,推翻,VERB,B2
+buttress,buttress,扶壁,NOUN,B2
+assertion,assertion,断言,NOUN,B2
+to germinate,to germinate,发芽,VERB,B2
+unprecedented,unprecedented,史无前例的,ADJ,B2
+bloodless,bloodless,不流血的,ADJ,B2
+remorseful,remorseful,悔恨的,ADJ,B2
+shipment,shipment,货物,NOUN,B2
+to engross,to engross,使全神贯注,VERB,B2
+chronicle,chronicle,编年史,NOUN,B2
+phony,phony,假的,ADJ,B2
+oblique,oblique,斜的,ADJ,B2
+to glean,to glean,搜集,VERB,B2
+to eject,to eject,弹出,VERB,B2
+vase,vase,花瓶,NOUN,B2
+vicissitude,vicissitude,变迁,NOUN,B2
+burner,burner,燃烧器,NOUN,B2
+stratagem,stratagem,策略,NOUN,B2
+to bewitch,to bewitch,迷住,VERB,B2
+shotgun,shotgun,猎枪,NOUN,B2
+adverse,adverse,不利的,ADJ,B2
+mistaken,mistaken,错误的,ADJ,B2
+bower,bower,凉亭,NOUN,B2
+unforgivable,unforgivable,不可原谅的,ADJ,B2
+ancillary,ancillary,辅助的,ADJ,B2
+bagpiper,bagpiper,风笛手,NOUN,B2
+to amalgamate,to amalgamate,合并,VERB,B2
+den,den,兽穴,NOUN,B2
+reluctant,reluctant,不情愿的,ADJ,B2
+spine,spine,脊柱,NOUN,B2
+to exclaim,to exclaim,呼喊,VERB,B2
+to condescend,to condescend,屈尊,VERB,B2
+ephemeral,ephemeral,短暂的,ADJ,B2
+immoral,immoral,不道德的,ADJ,B2
+inspired,inspired,受启发的,ADJ,B2
+to deflate,to deflate,使泄气,VERB,B2
+wary,wary,谨慎的,ADJ,B2
+abstinence,abstinence,节制,NOUN,B2
+sacrilege,sacrilege,亵渎,NOUN,B2
+to gauge,to gauge,测量,VERB,B2
+erudite,erudite,博学的,ADJ,B2
+spite,spite,恶意,NOUN,B2
+to depopulate,to depopulate,使人口减少,VERB,B2
+favoritism,favoritism,偏袒,NOUN,B2
+auspice,auspice,赞助,NOUN,B2
+confederate,confederate,同盟者,NOUN,B2
+sublime,sublime,崇高的,ADJ,B2
+misanthrope,misanthrope,厌世者,NOUN,B2
+equity,equity,公平,NOUN,B2
+hemisphere,hemisphere,半球,NOUN,B2
+deceptive,deceptive,欺骗性的,ADJ,B2
+exponent,exponent,指数,NOUN,B2
+cacophony,cacophony,刺耳的声音,NOUN,B2
+battlement,battlement,城垛,NOUN,B2
+enigmatic,enigmatic,神秘的,ADJ,B2
+froth,froth,泡沫,NOUN,B2
+aptitude,aptitude,天资,NOUN,B2
+to enthrall,to enthrall,迷住,VERB,B2
+balustrade,balustrade,栏杆,NOUN,B2
+barricade,barricade,路障,NOUN,B2
+to gain,to gain,获得,VERB,B2
+to assent,to assent,同意,VERB,B2
+concord,concord,和谐,NOUN,B2
+avid,avid,热切的,ADJ,B2
+zeal,zeal,热情,NOUN,B2
+to elucidate,to elucidate,阐明,VERB,B2
+decorum,decorum,礼仪,NOUN,B2
+to embarrass,to embarrass,使尴尬,VERB,B2
+asparagus,asparagus,芦笋,NOUN,B2
+dapper,dapper,整洁的,ADJ,B2
+alienable,alienable,可转让的,ADJ,B2
+fabulous,fabulous,极好的,ADJ,B2
+to equalize,to equalize,使相等,VERB,B2
+cast,cast,演员阵容,NOUN,B2
+to attenuate,to attenuate,减弱,VERB,B2
+gregarious,gregarious,爱社交的,ADJ,B2
+apotheotic,apotheotic,神化的,ADJ,B2
+apex,apex,顶点,NOUN,B2
+contrition,contrition,悔罪,NOUN,B2
+ruthless,ruthless,无情的,ADJ,B2
+crystalline,crystalline,水晶般的,ADJ,B2
+burdensome,burdensome,繁重的,ADJ,B2
+to disunite,to disunite,使分裂,VERB,B2
+to exfoliate,to exfoliate,去角质,VERB,B2
+risque,risque,有伤风化的,ADJ,B2
+cumbersome,cumbersome,笨重的,ADJ,B2
+bilious,bilious,易怒的,ADJ,B2
+gin,gin,金酒,NOUN,B2
+biweekly,biweekly,双周的,ADJ,B2
+brooding,brooding,忧思,NOUN,B2
+to decompress,to decompress,解压,VERB,B2
+intellect,intellect,智力,NOUN,B2
+contraband,contraband,违禁品,NOUN,B2
+autocratic,autocratic,专制的,ADJ,B2
+to condone,to condone,宽恕,VERB,B2
+stolid,stolid,冷漠的,ADJ,B2
+to swagger,to swagger,大摇大摆,VERB,B2
+to declassify,to declassify,解密,VERB,B2
+binge,binge,放纵,NOUN,B2
+trifling,trifling,微不足道的,ADJ,B2
+frantic,frantic,狂乱的,ADJ,B2
+to asphyxiate,to asphyxiate,使窒息,VERB,B2
+to foist,to foist,强加,VERB,B2
+sedentary,sedentary,久坐的,ADJ,B2
+dishonor,dishonor,耻辱,NOUN,B2
+humorous,humorous,幽默的,ADJ,B2
+to consign,to consign,移交,VERB,B2
+immense,immense,巨大的,ADJ,B2
+erratic,erratic,不稳定的,ADJ,B2
+haughty,haughty,傲慢的,ADJ,B2
+cabinetmaker,cabinetmaker,细木工匠,NOUN,B2
+to beatify,to beatify,宣福,VERB,B2
+to redeem,to redeem,赎回,VERB,B2
+inquisitive,inquisitive,好奇的,ADJ,B2
+incisive,incisive,深刻的,ADJ,B2
+conciseness,conciseness,简洁,NOUN,B2
+brazen,brazen,厚颜无耻的,ADJ,B2
+to adduce,to adduce,引证,VERB,B2
+to temporize,to temporize,拖延,VERB,B2
+brochure,brochure,小册子,NOUN,B2
+tireless,tireless,不知疲倦的,ADJ,B2
+matriarch,matriarch,女家长,NOUN,B2
+vehement,vehement,激烈的,ADJ,B2
+to curtail,to curtail,削减,VERB,B2
+to expectorate,to expectorate,吐痰,VERB,B2
+to stalk,to stalk,跟踪,VERB,B2
+astonished,astonished,惊讶的,ADJ,B2
+catapult,catapult,投石机,NOUN,B2
+disparate,disparate,截然不同的,ADJ,B2
+brusqueness,brusqueness,唐突,NOUN,B2
+entertaining,entertaining,有趣的,ADJ,B2
+to alienate,to alienate,使疏远,VERB,B2
+pensive,pensive,沉思的,ADJ,B2
+atonement,atonement,赎罪,NOUN,B2
+to corrode,to corrode,腐蚀,VERB,B2
+to afforest,to afforest,造林,VERB,B2
+altitude,altitude,海拔,NOUN,B2
+plausible,plausible,似是而非的,ADJ,B2
+to brandish,to brandish,挥舞,VERB,B2
+sanctimonious,sanctimonious,伪善的,ADJ,B2
+boisterous,boisterous,喧闹的,ADJ,B2
+iconoclast,iconoclast,偶像破坏者,NOUN,B2
+blunder,blunder,大错,NOUN,B2
+ungainly,ungainly,笨拙的,ADJ,B2
+upstart,upstart,暴发户,NOUN,B2
+to defame,to defame,诽谤,VERB,B2
+biting,biting,咬人,NOUN,B2
+to exalt,to exalt,颂扬,VERB,B2
+dichotomy,dichotomy,二分法,NOUN,B2
+bargain,bargain,便宜货,NOUN,B2
+attainable,attainable,可获得的,ADJ,B2
+oversight,oversight,疏忽,NOUN,B2
+gem,gem,宝石,NOUN,B2
+to detract,to detract,贬低,VERB,B2
+contemplation,contemplation,沉思,NOUN,B2
+graduation,graduation,毕业,NOUN,B2
+to skein,to skein,绕成线团,VERB,B2
+slenderness,slenderness,纤细,NOUN,B2
+hygienic,hygienic,卫生的,ADJ,B2
+curator,curator,策展人,NOUN,B2
+horrified,horrified,惊骇的,ADJ,B2
+scandinavian,scandinavian,斯堪的纳维亚的,ADJ,B2
+reclamation,reclamation,收复,NOUN,B2
+bungler,bungler,笨手笨脚的人,NOUN,B2
+to lead astray,to lead astray,使入歧途,VERB,B2
+to spirit away,to spirit away,变走,VERB,B2
+appreciable,appreciable,可观的,ADJ,B2
+deteriorated,deteriorated,恶化的,ADJ,B2
+cove,cove,小海湾,NOUN,B2
+intermediate,intermediate,中级的,ADJ,B2
+gamete,gamete,配子,NOUN,B2
+scythe,scythe,镰刀,NOUN,B2
+idiot,idiot,傻瓜,ADJ,B2
+to ascend to promote,to ascend to promote,上升 / 晋升,VERB,B2
+to humanize,to humanize,使人性化,VERB,B2
+fractional,fractional,分数的,ADJ,B2
+centipede,centipede,蜈蚣,NOUN,B2
+to idolize,to idolize,崇拜,VERB,B2
+set of ideals,set of ideals,思想体系,NOUN,B2
+epithet,epithet,绰号,NOUN,B2
+autocracy,autocracy,专制,NOUN,B2
+to plunder,to plunder,掠夺,VERB,B2
+equestrian,equestrian,马术的,ADJ,B2
+celerity,celerity,迅速,NOUN,B2
+musk,musk,麝香,NOUN,B2
+to splint,to splint,用夹板固定,VERB,B2
+seaplane,seaplane,水上飞机,NOUN,B2
+to go numb,to go numb,麻木,VERB,B2
+to turn off extinguish,to turn off extinguish,关闭/熄灭,VERB,B2
+insinuation,insinuation,暗示,NOUN,B2
+cane,cane,手杖,NOUN,B2
+shameless person,shameless person,厚颜无耻的人,NOUN,B2
+excitability,excitability,兴奋性,NOUN,B2
+inflection,inflection,词尾,NOUN,B2
+hooligan,hooligan,流氓,NOUN,B2
+disquisition,disquisition,论述,NOUN,B2
+to fail to fulfill,to fail to fulfill,未履行,VERB,B2
+to gush,to gush,涌出,VERB,B2
+annotation,annotation,注释,NOUN,B2
+fanatic,fanatic,狂热的,ADJ,B2
+gatekeeper,gatekeeper,道口看守员,NOUN,B2
+emulation,emulation,模仿,NOUN,B2
+charitable,charitable,慈善的,ADJ,B2
+cattle rancher,cattle rancher,牧场主,NOUN,B2
+to codify,to codify,编纂,VERB,B2
+narrowing,narrowing,变窄,NOUN,B2
+countercurrent,countercurrent,逆流,NOUN,B2
+inclement,inclement,严酷的,ADJ,B2
+every other sunday,every other sunday,每隔一周的星期日,NOUN,B2
+confinement,confinement,禁闭,NOUN,B2
+sparrowhawk,sparrowhawk,雀鹰,NOUN,B2
+to put on track,to put on track,使走上正轨,VERB,B2
+stampede,stampede,溃逃,NOUN,B2
+to gray,to gray,变白,VERB,B2
+confidant,confidant,知己,NOUN,B2
+wharf,wharf,码头,NOUN,B2
+brute,brute,粗野的,ADJ,B2
+to elevate,to elevate,提升,VERB,B2
+babble,babble,结巴,NOUN,B2
+to dispossess,to dispossess,剥夺,VERB,B2
+to crowd together,to crowd together,挤在一起,VERB,B2
+to guess right,to guess right,猜中,VERB,B2
+to espy,to espy,窥探,VERB,B2
+collusion,collusion,串通,NOUN,B2
+concordance,concordance,一致,NOUN,B2
+colossal,colossal,巨大的,ADJ,B2
+fortune teller,fortune teller,占卜者,NOUN,B2
+devourer,devourer,吞噬者,NOUN,B2
+flat-nosed,flat-nosed,扁鼻子的,ADJ,B2
+contiguous,contiguous,相邻的,ADJ,B2
+widening,widening,加宽,NOUN,B2
+to unbutton,to unbutton,解开纽扣,VERB,B2
+to defer,to defer,推迟,VERB,B2
+spatula,spatula,刮刀,NOUN,B2
+to disentangle,to disentangle,解开,VERB,B2
+to apostatize,to apostatize,叛教,VERB,B2
+untidiness,untidiness,凌乱,NOUN,B2
+governability,governability,可治理性,NOUN,B2
+discredit,discredit,丧失信誉,NOUN,B2
+to handcuff,to handcuff,给…戴手铐,VERB,B2
+to fluctuate,to fluctuate,波动,VERB,B2
+generatrix,generatrix,母线,NOUN,B2
+long-distance runner,long-distance runner,长跑运动员,NOUN,B2
+prolific,prolific,多产的,ADJ,B2
+galician,galician,加利西亚的,ADJ,B2
+to meddle,to meddle,干涉,VERB,B2
+exalted,exalted,狂热的,ADJ,B2
+involuntary,involuntary,无意识的,ADJ,B2
+ferret,ferret,雪貂,NOUN,B2
+ballast,ballast,压舱物,NOUN,B2
+illogical,illogical,不合逻辑的,ADJ,B2
+to guillotine,to guillotine,斩首,VERB,B2
+bunch,bunch,一群,NOUN,B2
+justness,justness,公正,NOUN,B2
+disenchantment,disenchantment,幻灭,NOUN,B2
+grandiloquent,grandiloquent,夸张的,ADJ,B2
+fruit tree,fruit tree,果树的,ADJ,B2
+hide-and-seek,hide-and-seek,捉迷藏,NOUN,B2
+suicidal,suicidal,自杀的,ADJ,B2
+doctrinaire,doctrinaire,教条主义的,ADJ,B2
+quotable,quotable,可估价的,ADJ,B2
+tickle,tickle,发痒,NOUN,B2
+compendium,compendium,纲要,NOUN,B2
+tackling,tackling,马具,NOUN,B2
+leafy,leafy,枝叶茂密的,ADJ,B2
+to vent,to vent,倾诉,VERB,B2
+to gird,to gird,束紧,VERB,B2
+furtive,furtive,鬼鬼祟祟的,ADJ,B2
+exculpation,exculpation,开脱,NOUN,B2
+countenance,countenance,面容,NOUN,B2
+falconry,falconry,猎鹰术,NOUN,B2
+conic,conic,圆锥曲线,NOUN,B2
+disloyalty,disloyalty,不忠,NOUN,B2
+to thrill,to thrill,使兴奋,VERB,B2
+herbaceous,herbaceous,草本的,ADJ,B2
+alien,alien,外星人的,ADJ,B2
+inflamed,inflamed,激烈的,ADJ,B2
+informative,informative,提供信息的,ADJ,B2
+aridity,aridity,干旱,NOUN,B2
+to encode,to encode,编码,VERB,B2
+epitaph,epitaph,墓志铭,NOUN,B2
+indistinct,indistinct,模糊的,ADJ,B2
+expeditious,expeditious,迅速的,ADJ,B2
+varnish,varnish,清漆,NOUN,B2
+to go deep into,to go deep into,深入,VERB,B2
+duet,duet,二重奏,NOUN,B2
+home-loving,home-loving,顾家的,ADJ,B2
+to coax,to coax,哄骗,VERB,B2
+pharisee,pharisee,法利赛人,NOUN,B2
+gravid,gravid,怀孕的,ADJ,B2
+condemned,condemned,被定罪的,ADJ,B2
+delirious,delirious,谵妄的,ADJ,B2
+apotheosis,apotheosis,神化,NOUN,B2
+squid,squid,鱿鱼,NOUN,B2
+unbridled,unbridled,肆无忌惮的,ADJ,B2
+grotesque,grotesque,怪诞的,ADJ,B2
+blazing,blazing,炽热的,ADJ,B2
+to be unaware,to be unaware,不知道,VERB,B2
+out of place,out of place,格格不入的,ADJ,B2
+revelry,revelry,狂欢,NOUN,B2
+to wield,to wield,行使,VERB,B2
+excavator,excavator,挖掘机,NOUN,B2
+to powder,to powder,撒粉,VERB,B2
+flaccid,flaccid,松弛的,ADJ,B2
+egalitarian,egalitarian,平等主义的,ADJ,B2
+cord,cord,绳索,NOUN,B2
+disadvantageous,disadvantageous,不利的,ADJ,B2
+foliage,foliage,枝叶,NOUN,B2
+winding,winding,蜿蜒的,ADJ,B2
+to antagonize,to antagonize,使对立,VERB,B2
+apoplexy,apoplexy,中风,NOUN,B2
+land register,land register,地籍,NOUN,B2
+intolerant,intolerant,不容忍的,ADJ,B2
+to release from prison,to release from prison,释放,VERB,B2
+conformist,conformist,墨守成规者,NOUN,B2
+empirically,empirically,凭经验地,ADV,B2
+incongruity,incongruity,不协调,NOUN,B2
+slender,slender,纤细的,ADJ,B2
+to harmonize,to harmonize,使和谐,VERB,B2
+wild beast,wild beast,猛兽,NOUN,B2
+to mutiny,to mutiny,煽动叛乱,VERB,B2
+brakeman,brakeman,刹车员,NOUN,B2
+bureaucratic,bureaucratic,官僚的,ADJ,B2
+disorganization,disorganization,无组织,NOUN,B2
+horoscope,horoscope,星座运势,NOUN,B2
+copious,copious,丰富的,ADJ,B2
+dissolute,dissolute,放荡的,ADJ,B2
+disheveled,disheveled,蓬乱的,ADJ,B2
+to skewer,to skewer,串起,VERB,B2
+concordat,concordat,政教协定,NOUN,B2
+to mud,to mud,弄脏,VERB,B2
+incipient,incipient,初期的,ADJ,B2
+corrigible,corrigible,可改正的,ADJ,B2
+germicidal,germicidal,杀菌的,ADJ,B2
+effervescent,effervescent,沸腾的,ADJ,B2
+high school graduate,high school graduate,高中毕业生,NOUN,B2
+phlebitis,phlebitis,静脉炎,NOUN,B2
+ferrule,ferrule,箍,NOUN,B2
+unnatural,unnatural,不自然的,ADJ,B2
+heterodox,heterodox,异端的,ADJ,B2
+burlesque,burlesque,滑稽的,ADJ,B2
+exaltation,exaltation,狂热,NOUN,B2
+mannish,mannish,像男人的,ADJ,B2
+exuberance,exuberance,繁茂,NOUN,B2
+to armor,to armor,装甲,VERB,B2
+slimy,slimy,粘滑的,ADJ,B2
+ski,ski,滑雪板,NOUN,B2
+consummate,consummate,熟练的,ADJ,B2
+choirboy,choirboy,唱诗班男孩,NOUN,B2
+to lean out,to lean out,探出身体,VERB,B2
+maroon,maroon,深红色,ADJ,B2
+industrious,industrious,勤劳的,ADJ,B2
+geometer,geometer,几何学家,NOUN,B2
+exorbitant,exorbitant,过高的,ADJ,B2
+consequent,consequent,随之发生的,ADJ,B2
+sweepings,sweepings,扫出的垃圾,NOUN,B2
+to curve,to curve,弯曲,VERB,B2
+discretionary,discretionary,自由裁量的,ADJ,B2
+to pacify,to pacify,平息,VERB,B2
+very fine,very fine,极细的,ADJ,B2
+to jam,to jam,堵塞,VERB,B2
+tacky thing,tacky thing,俗气的事,NOUN,B2
+deserter,deserter,逃兵,NOUN,B2
+extirpation,extirpation,切除,NOUN,B2
+amends,amends,补偿,NOUN,B2
+defenseless,defenseless,无防御的,ADJ,B2
+imperialist,imperialist,帝国主义的,ADJ,B2
+germanic,germanic,日耳曼的,ADJ,B2
+scaly,scaly,有鳞的,ADJ,B2
+short news item,short news item,短新闻,NOUN,B2
+hispanic,hispanic,西班牙的,ADJ,B2
+flashlight,flashlight,手电筒,NOUN,B2
+endogenous,endogenous,内生的,ADJ,B2
+to stylize,to stylize,风格化,VERB,B2
+swarm,swarm,蜂群,NOUN,B2
+loose thread,loose thread,线头,NOUN,B2
+imbecility,imbecility,愚蠢,NOUN,B2
+conch,conch,海螺壳,NOUN,B2
+maladjusted,maladjusted,适应不良的,ADJ,B2
+historicist,historicist,历史主义者,NOUN,B2
+gossipy,gossipy,爱传流言的,ADJ,B2
+t-shirt,t-shirt,T 恤衫,NOUN,B2
+hexagon,hexagon,六边形,NOUN,B2
+floorboard,floorboard,木地板,NOUN,B2
+exhumation,exhumation,掘墓,NOUN,B2
+parishioner,parishioner,教区居民,NOUN,B2
+to make independent,to make independent,使独立,VERB,B2
+to pair,to pair,配对,VERB,B2
+unpunished,unpunished,未受惩罚的,ADJ,B2
+figuratively,figuratively,比喻地,ADV,B2
+distinctive,distinctive,独特的,ADJ,B2
+fittings,fittings,水龙头配件,NOUN,B2
+pompous,pompous,浮夸的,ADJ,B2
+euphonic,euphonic,悦耳的,ADJ,B2
+equilateral,equilateral,等边的,ADJ,B2
+masonry,masonry,砌体,NOUN,B2
+political party,political party,政党,NOUN,B2
+chore,chore,家务,NOUN,B2
+iatrogenic,iatrogenic,医源性的,ADJ,B2
+prerogative,prerogative,特权,NOUN,B2
+to put back to reposition,to put back to reposition,放回 / 重新定位,VERB,B2
+choreographer,choreographer,编舞者,NOUN,B2
+to burnish,to burnish,擦亮,VERB,B2
+amnesia,amnesia,健忘症,NOUN,B2
+to bequeath,to bequeath,遗赠,VERB,B2
+subtle,subtle,微妙的,ADJ,B2
+to carve,to carve,雕刻,VERB,B2
+to savor,to savor,品味,VERB,B2
+corporatism,corporatism,法团主义,NOUN,B2
+to lament,to lament,哀叹,VERB,B2
+minimalism,minimalism,极简主义,NOUN,B2
+security-related,security-related,安全的，安保的,ADJ,B2
+atrophy,atrophy,萎缩,NOUN,B2
+to frolic,to frolic,嬉戏,VERB,B2
+to defuse,to defuse,缓和,VERB,B2
+delicately,delicately,巧妙地,ADV,B2
+to fraction,to fraction,分割,VERB,B2
+to deviate,to deviate,偏离,VERB,B2
+personalized,personalized,个性化的,ADJ,B2
+to drape,to drape,悬挂,VERB,B2
+fold,fold,折痕,NOUN,B2
+rustic,rustic,乡村的,ADJ,B2
+doubling,doubling,加倍,NOUN,B2
+breast,breast,乳房,NOUN,B2
+to flout,to flout,蔑视,VERB,B2
+particularly,particularly,特别地,ADV,B2
+upheaval,upheaval,剧变,NOUN,B2
+to serve a route,to serve a route,为...提供交通服务,VERB,B2
+mound,mound,土堆,NOUN,B2
+pallor,pallor,苍白,NOUN,B2
+rout,rout,溃败,NOUN,B2
+resourceful,resourceful,机灵的,ADJ,B2
+awareness raising,awareness raising,提高意识,NOUN,B2
+granny,granny,奶奶,NOUN,B2
+sheaf,sheaf,捆,NOUN,B2
+locality,locality,地点,NOUN,B2
+facies,facies,面貌,NOUN,B2
+aphasia,aphasia,失语症,NOUN,B2
+feature film,feature film,故事片,NOUN,B2
+perpetual,perpetual,永久的,ADJ,B2
+probe,probe,探测器,NOUN,B2
+to commute,to commute,通勤,VERB,B2
+to reverse,to reverse,反转,VERB,B2
+water heater,water heater,热水器,NOUN,B2
+proliferation,proliferation,增殖,NOUN,B2
+pantheon,pantheon,先贤祠,NOUN,B2
+detainee,detainee,被拘留者,NOUN,B2
+summarily,summarily,草率地,ADV,B2
+to defrost,to defrost,除霜,VERB,B2
+perilous,perilous,危险的,ADJ,B2
+to renounce to disown,to renounce to disown,否认 / 抛弃,VERB,B2
+to execrate,to execrate,痛恨,VERB,B2
+to resonate,to resonate,共鸣,VERB,B2
+factoring,factoring,保理,NOUN,B2
+detached house,detached house,独栋房屋,NOUN,B2
+to amass,to amass,积聚,VERB,B2
+independently,independently,独立地,ADV,B2
+severely,severely,严厉地,ADV,B2
+traditionally,traditionally,传统地,ADV,B2
+tenacity,tenacity,坚韧,NOUN,B2
+politely,politely,礼貌地,ADV,B2
+paper clip,paper clip,回形针,NOUN,B2
+to unbridle,to unbridle,解开,VERB,B2
+yoke,yoke,枷锁,NOUN,B2
+cohort,cohort,队列,NOUN,B2
+respective,respective,各自的,ADJ,B2
+newcomer,newcomer,新来者,NOUN,B2
+bookplate,bookplate,藏书票,NOUN,B2
+frankly,frankly,坦率地,ADV,B2
+passionate,passionate,热情的,ADJ,B2
+panther,panther,豹,NOUN,B2
+antisemitism,antisemitism,反犹太主义,NOUN,B2
+to generate engender,to generate engender,产生,VERB,B2
+to sequester,to sequester,隔离,VERB,B2
+invariably,invariably,不变地,ADV,B2
+stall,stall,包厢座位,NOUN,B2
+expatriate,expatriate,移居国外者,NOUN,B2
+gallop,gallop,疾驰,NOUN,B2
+array,array,排列,NOUN,B2
+malfeasance,malfeasance,渎职,NOUN,B2
+to ratify,to ratify,批准,VERB,B2
+to defray,to defray,支付,VERB,B2
+to gratinate,to gratinate,烤成焦皮,VERB,B2
+various,various,各种各样的,ADJ,B2
+to flock,to flock,群集,VERB,B2
+to appal,to appal,使惊恐,VERB,B2
+to crash into,to crash into,撞击,VERB,B2
+lymphatic,lymphatic,淋巴的,ADJ,B2
+paradoxical,paradoxical,矛盾的,ADJ,B2
+supreme,supreme,最高的,ADJ,B2
+bump,bump,肿块,NOUN,B2
+librarian,librarian,图书管理员,NOUN,B2
+craze,craze,狂热,NOUN,B2
+pedantry,pedantry,迂腐,NOUN,B2
+bulgarian,bulgarian,保加利亚的,ADJ,B2
+syllogism,syllogism,三段论,NOUN,B2
+to conserve,to conserve,保存,VERB,B2
+grumbler,grumbler,爱抱怨的人,NOUN,B2
+prophylaxis,prophylaxis,预防,NOUN,B2
+to invalidate,to invalidate,证明无效,VERB,B2
+to suborn,to suborn,教唆,VERB,B2
+solipsism,solipsism,唯我论,NOUN,B2
+to curl,to curl,卷曲,VERB,B2
+to start again,to start again,重新开始,VERB,B2
+detrimental,detrimental,有害的,ADJ,B2
+mortality,mortality,死亡率,NOUN,B2
+to prosper,to prosper,繁荣,VERB,B2
+televised,televised,电视播出的,ADJ,B2
+tirade,tirade,长篇抨击,NOUN,B2
+rainy,rainy,多雨的,ADJ,B2
+hesitant,hesitant,犹豫的,ADJ,B2
+fit,fit,适合的,ADJ,B2
+preliminary,preliminary,初步的,ADJ,B2
+semantics,semantics,语义学,NOUN,B2
+kindly,kindly,亲切地,ADV,B2
+to tumble,to tumble,跌倒,VERB,B2
+truism,truism,自明之理,NOUN,B2
+civility,civility,礼貌,NOUN,B2
+to dye,to dye,染色,VERB,B2
+respite,respite,喘息,NOUN,B2
+annexation,annexation,吞并,NOUN,B2
+oligarchy,oligarchy,寡头政治,NOUN,B2
+disciplinary,disciplinary,纪律的,ADJ,B2
+to dither,to dither,犹豫不决,VERB,B2
+bailiff,bailiff,法警,NOUN,B2
+to croak,to croak,呱呱叫,VERB,B2
+accuracy,accuracy,准确性,NOUN,B2
+calmly,calmly,平静地,ADV,B2
+predictable,predictable,可预测的,ADJ,B2
+to hail inspect,to hail inspect,盘查,VERB,B2
+narcissistic,narcissistic,自恋的,ADJ,B2
+mash,mash,泥状食物,NOUN,B2
+nostalgia,nostalgia,怀旧,NOUN,B2
+inexorably,inexorably,不可阻挡地,ADV,B2
+vintage,vintage,佳酿,NOUN,B2
+solitary,solitary,孤独的,ADJ,B2
+to make heavier,to make heavier,加重,VERB,B2
+to rally,to rally,团结,VERB,B2
+relentless,relentless,无情的,ADJ,B2
+pioneer,pioneer,先驱,NOUN,B2
+frequently,frequently,经常,ADV,B2
+pleura,pleura,胸膜,NOUN,B2
+mascot,mascot,吉祥物,NOUN,B2
+accessibility,accessibility,可达性,NOUN,B2
+penalty,penalty,惩罚,NOUN,B2
+damaging,damaging,有害的,ADJ,B2
+trauma,trauma,创伤,NOUN,B2
+merchandise,merchandise,商品,NOUN,B2
+to demonize,to demonize,妖魔化,VERB,B2
+not subject to limitation,not subject to limitation,不受时效限制的,ADJ,B2
+prosecution service,prosecution service,检察院,NOUN,B2
+to ferret,to ferret,搜寻,VERB,B2
+to crumple,to crumple,弄皱,VERB,B2
+to acquiesce,to acquiesce,默许,VERB,B2
+to caper,to caper,跳跃,VERB,B2
+balance sheet,balance sheet,资产负债表,NOUN,B2
+filming,filming,拍摄,NOUN,B2
+separately,separately,分开地，单独地,ADV,B2
+preponderant,preponderant,占优势的,ADJ,B2
+pretentious,pretentious,自命不凡的,ADJ,B2
+hike,hike,徒步旅行,NOUN,B2
+potentially,potentially,潜在地,ADV,B2
+straw,straw,稻草,NOUN,B2
+acoustic,acoustic,声学的,ADJ,B2
+naturally,naturally,自然地,ADV,B2
+know-how,know-how,诀窍,NOUN,B2
+to behead,to behead,斩首,VERB,B2
+to cuddle,to cuddle,拥抱,VERB,B2
+to chastise,to chastise,严惩,VERB,B2
+to decry,to decry,谴责,VERB,B2
+precarious,precarious,不稳定的,ADJ,B2
+flesh,flesh,肉,NOUN,B2
+lubricity,lubricity,好色 / 淫荡,NOUN,B2
+talented,talented,有才华的,ADJ,B2
+apocalyptic,apocalyptic,启示录的,ADJ,B2
+to disjoin,to disjoin,分离,VERB,B2
+offense,offense,冒犯,NOUN,B2
+rain shower,rain shower,阵雨,NOUN,B2
+peritoneum,peritoneum,腹膜,NOUN,B2
+this,this,这,PRON,B2
+hacking,hacking,黑客行为,NOUN,B2
+layperson,layperson,外行,NOUN,B2
+fulfilled,fulfilled,满足的,ADJ,B2
+awful,awful,糟糕的,ADJ,B2
+to chain to link together,to chain to link together,用链条锁住；连贯,VERB,B2
+braggadocio,braggadocio,吹牛,NOUN,B2
+tertiary,tertiary,第三的,ADJ,B2
+planning,planning,规划,NOUN,B2
+screenwriter,screenwriter,编剧,NOUN,B2
+to concoct,to concoct,编造,VERB,B2
+to dislodge,to dislodge,逐出,VERB,B2
+to dupe,to dupe,欺骗,VERB,B2
+tenor,tenor,男高音,NOUN,B2
+resonant,resonant,共鸣的,ADJ,B2
+supporting document,supporting document,证明文件,NOUN,B2
+touchy,touchy,易怒的,ADJ,B2
+to dispel,to dispel,消除,VERB,B2
+antiquated,antiquated,过时的,ADJ,B2
+unforeseen,unforeseen,意外的,ADJ,B2
+to slaughter shoot down,to slaughter shoot down,屠宰/击落,VERB,B2
+occult,occult,神秘的,ADJ,B2
+probable likely,probable likely,可能的,ADJ,B2
+to blush,to blush,脸红,VERB,B2
+to bloom,to bloom,开花,VERB,B2
+to feign,to feign,假装,VERB,B2
+notch,notch,刻痕,NOUN,B2
+summer visitor,summer visitor,暑期游客,NOUN,B2
+subcontracting,subcontracting,分包,NOUN,B2
+volunteering,volunteering,志愿服务,NOUN,B2
+to break into,to break into,撬开,VERB,B2
+spade,spade,铲子,NOUN,B2
+subtlety,subtlety,微妙,NOUN,B2
+abusive,abusive,滥用的,ADJ,B2
+persistence,persistence,坚持,NOUN,B2
+cutting,cutting,切割,NOUN,B2
+revival,revival,复兴,NOUN,B2
+to praise lavishly,to praise lavishly,大肆吹捧,VERB,B2
+precocious,precocious,早熟的,ADJ,B2
+regulatory,regulatory,监管的,ADJ,B2
+versatile,versatile,多才多艺的,ADJ,B2
+gently,gently,轻轻地,ADV,B2
+microwave,microwave,微波炉,NOUN,B2
+harsh,harsh,严厉的,ADJ,B2
+to purge,to purge,清除,VERB,B2
+taxable,taxable,应纳税的,ADJ,B2
+flow rate,flow rate,流量,NOUN,B2
+financing funding,financing funding,融资,NOUN,B2
+breakup,breakup,分手,NOUN,B2
+historically,historically,历史上,ADV,B2
+preferable,preferable,更可取的,ADJ,B2
+elation,elation,兴高采烈,NOUN,B2
+to pamper,to pamper,纵容,VERB,B2
+to persecute,to persecute,迫害,VERB,B2
+deeply moving,deeply moving,令人感动的,ADJ,B2
+onomatopoeia,onomatopoeia,拟声词,NOUN,B2
+resumption,resumption,恢复,NOUN,B2
+pusillanimous,pusillanimous,怯懦的,ADJ,B2
+decontamination,decontamination,去污,NOUN,B2
+to launder,to launder,洗钱,VERB,B2
+to concede,to concede,承认,VERB,B2
+perceptibly,perceptibly,明显地,ADV,B2
+closing argument,closing argument,辩护词,NOUN,B2
+sentinel,sentinel,哨兵,NOUN,B2
+precision,precision,精确,NOUN,B2
+parsimonious,parsimonious,吝啬的,ADJ,B2
+quiddity,quiddity,本质,NOUN,B2
+bodywork,bodywork,车身,NOUN,B2
+renunciation,renunciation,放弃,NOUN,B2
+canvas,canvas,帆布,NOUN,B2
+formally,formally,正式地,ADV,B2
+loop,loop,循环,NOUN,B2
+mercenary,mercenary,雇佣兵,NOUN,B2
+angelic,angelic,天使般的,ADJ,B2
+disdainfully,disdainfully,轻蔑地,ADV,B2
+lesion,lesion,病变,NOUN,B2
+residual,residual,残留的,ADJ,B2
+cooking,cooking,烹饪,NOUN,B2
+sorting,sorting,分类,NOUN,B2
+to castigate,to castigate,严厉批评,VERB,B2
+innocuous,innocuous,无害的,ADJ,B2
+perverse,perverse,任性的,ADJ,B2
+dishonest,dishonest,不诚实的,ADJ,B2
+to transcribe,to transcribe,转录,VERB,B2
+posthumous,posthumous,死后的,ADJ,B2
+freely,freely,自由地,ADV,B2
+recreation,recreation,娱乐,NOUN,B2
+oxymoron,oxymoron,矛盾修辞法,NOUN,B2
+redundancy,redundancy,冗余,NOUN,B2
+angular,angular,有角的,ADJ,B2
+sedition,sedition,煽动叛乱,NOUN,B2
+to warp,to warp,弯曲,VERB,B2
+pickaxe,pickaxe,镐；锄,NOUN,B2
+notably,notably,显著地,ADV,B2
+semolina,semolina,粗面粉,NOUN,B2
+antecedent,antecedent,先行词,NOUN,B2
+acclimatization,acclimatization,适应环境,NOUN,B2
+probity,probity,正直,NOUN,B2
+sensual,sensual,感官的,ADJ,B2
+malevolence,malevolence,恶意,NOUN,B2
+theologian,theologian,神学家,NOUN,B2
+remote work,remote work,远程办公,NOUN,B2
+specious,specious,似是而非的,ADJ,B2
+drawback,drawback,缺点,NOUN,B2
+to conform,to conform,符合,VERB,B2
+to confer,to confer,授予,VERB,B2
+to strip bare,to strip bare,洗劫,VERB,B2
+practicing believer,practicing believer,信徒,NOUN,B2
+to make bland,to make bland,使乏味,VERB,B2
+pursuit lawsuit,pursuit lawsuit,追求/诉讼,NOUN,B2
+peroration,peroration,结语,NOUN,B2
+indeterminate unspecified,indeterminate unspecified,未确定的,ADJ,B2
+food-processing,food-processing,食品加工的,ADJ,B2
+parataxis,parataxis,意合,NOUN,B2
+to strike to offend,to strike to offend,撞击 / 冒犯,VERB,B2
+hostess,hostess,女服务员,NOUN,B2
+obstetrics,obstetrics,产科学,NOUN,B2
+wrongdoer,wrongdoer,罪犯,NOUN,B2
+to pour out,to pour out,倾诉,VERB,B2
+guru,guru,精神导师,NOUN,B2
+freshly,freshly,新鲜地,ADV,B2
+perfidy,perfidy,背信弃义,NOUN,B2
+cordially,cordially,亲切地,ADV,B2
+street interview,street interview,街头采访,NOUN,B2
+manually,manually,手动地,ADV,B2
+slang,slang,俚语,NOUN,B2
+eight-line stanza,eight-line stanza,八行诗,NOUN,B2
+diagonal,diagonal,对角线,NOUN,B2
+customs officer,customs officer,海关官员,NOUN,B2
+depressive,depressive,抑郁的，压抑的,ADJ,B2
+lawnmower,lawnmower,割草机,NOUN,B2
+proportional,proportional,成比例的,ADJ,B2
+picking,picking,采摘,NOUN,B2
+airfield,airfield,飞机场,NOUN,B2
+apodictic,apodictic,确证的,ADJ,B2
+indirectly,indirectly,间接地,ADV,B2
+to lodge an appeal,to lodge an appeal,提出上诉,VERB,B2
+to fall to,to fall to,落到...身上,VERB,B2
+magnesium,magnesium,镁,NOUN,B2
+quashing,quashing,撤销,NOUN,B2
+recruiter,recruiter,招聘人员,NOUN,B2
+toad,toad,蟾蜍,NOUN,B2
+sovereigntist,sovereigntist,主权主义者,NOUN,B2
+clumsiness,clumsiness,笨拙,NOUN,B2
+media library,media library,多媒体图书馆,NOUN,B2
+caterpillar,caterpillar,毛毛虫,NOUN,B2
+sincerely,sincerely,真诚地,ADV,B2
+to move to pity,to move to pity,使怜悯,VERB,B2
+typology,typology,类型学,NOUN,B2
+heatwave,heatwave,热浪,NOUN,B2
+stressful,stressful,有压力的,ADJ,B2
+unofficially,unofficially,非正式地,ADV,B2
+to chill,to chill,使冰冻,VERB,B2
+triangular,triangular,三角形的,ADJ,B2
+pitchfork,pitchfork,叉子,NOUN,B2
+french-speaking,french-speaking,讲法语的,ADJ,B2
+symptomatology,symptomatology,症状学,NOUN,B2
+dementia madness,dementia madness,痴呆，疯狂,NOUN,B2
+to raise awareness,to raise awareness,提高意识,VERB,B2
+about sixty,about sixty,六十来个,NOUN,B2
+indiscriminately,indiscriminately,不加区别地,ADV,B2
+the blues,the blues,忧郁,NOUN,B2
+legatee,legatee,受遗赠人,NOUN,B2
+to resell,to resell,转售,VERB,B2
+juvenile,juvenile,青少年的,ADJ,B2
+consecutive,consecutive,连续的,ADJ,B2
+penal,penal,刑事的,ADJ,B2
+pamphleteer,pamphleteer,小册子作者,NOUN,B2
+segregation,segregation,隔离，分离,NOUN,B2
+moralism,moralism,道德主义,NOUN,B2
+sexism,sexism,性别歧视,NOUN,B2
+case law,case law,判例法,NOUN,B2
+to nuance,to nuance,使具有细微差别,VERB,B2
+setting sun,setting sun,夕阳,NOUN,B2
+to subsist,to subsist,存在,VERB,B2
+coastal,coastal,沿海的,ADJ,B2
+lukewarm,lukewarm,微温的,ADJ,B2
+marrow,marrow,骨髓,NOUN,B2
+bistro,bistro,小酒馆,NOUN,B2
+untouchable,untouchable,不可触碰的,ADJ,B2
+alternatively,alternatively,交替地,ADV,B2
+stage fright,stage fright,怯场,NOUN,B2
+socialist,socialist,社会主义者,NOUN,B2
+obsequiousness,obsequiousness,谄媚,NOUN,B2
+heartening,heartening,令人高兴的,ADJ,B2
+roman,roman,罗马的,ADJ,B2
+heroically,heroically,英勇地,ADV,B2
+flint,flint,燧石,NOUN,B2
+delinquent offender,delinquent offender,违法者，不良分子,NOUN,B2
+ah,ah,水 水,PART,B2
+to maltreat,to maltreat,虐待,VERB,B2
+obsequiously,obsequiously,谄媚地,ADV,B2
+telephony,telephony,电话学,NOUN,B2
+food,food,食品的,ADJ,B2
+carcass,carcass,骨架,NOUN,B2
+faithful loyal,faithful loyal,忠诚的,ADJ,B2
+symphonic,symphonic,交响乐的,ADJ,B2
+undecided indecisive,undecided indecisive,犹豫不决的,ADJ,B2
+treat,treat,盛宴,NOUN,B2
+generational,generational,代际的,ADJ,B2
+alpine,alpine,高山的,ADJ,B2
+servilely,servilely,奴性地,ADV,B2
+checkbook,checkbook,支票簿,NOUN,B2
+productive,productive,多产的,ADJ,B2
+tv viewer,tv viewer,电视观众,NOUN,B2
+release of lien,release of lien,解除扣押,NOUN,B2
+asphyxia,asphyxia,窒息,NOUN,B2
+registered mail,registered mail,挂号信,NOUN,B2
+to push to grow,to push to grow,推/生长,VERB,B2
+a lot,a lot,很多,ADV,B2
+populist,populist,民粹主义者,NOUN,B2
+rapper,rapper,说唱歌手,NOUN,B2
+greek,greek,希腊的,ADJ,B2
+marshal,marshal,元帅,NOUN,B2
+purely,purely,纯粹地,ADV,B2
+currant,currant,醋栗,NOUN,B2
+anarchist,anarchist,无政府主义者,NOUN,B2
+manifestly,manifestly,明显地,ADV,B2
+irregular,irregular,不规则的,ADJ,B2
+jurisconsult,jurisconsult,法学专家,NOUN,B2
+lymph node,lymph node,淋巴结,NOUN,B2
+litter bedding,litter bedding,垫草 / 猫砂,NOUN,B2
+worrying,worrying,令人担忧的,ADJ,B2
+to dirty to tarnish,to dirty to tarnish,弄脏,VERB,B2
+oyster,oyster,牡蛎,NOUN,B2
+retiree,retiree,退休人员,NOUN,B2
+reproducibility,reproducibility,可重复性,NOUN,B2
+agitated,agitated,焦躁的,ADJ,B2
+nationalist,nationalist,民族主义者,NOUN,B2
+fawning flattery,fawning flattery,阿谀奉承,NOUN,B2
+productivist,productivist,生产至上主义的,ADJ,B2
+pictorial,pictorial,绘画的,ADJ,B2
+to taint,to taint,玷污,VERB,B2
+fingernail,fingernail,指甲,NOUN,B2
+marginally,marginally,边缘地,ADV,B2
+biologist,biologist,生物学家,NOUN,B2
+polysyndeton,polysyndeton,连词叠用,NOUN,B2
+recourse,recourse,求助,NOUN,B2
+subject to the law,subject to the law,受法律管辖的,ADJ,B2
+deluge flood,deluge flood,洪水，倾盆大雨,NOUN,B2
+remains spoils,remains spoils,遗体，战利品,NOUN,B2
+to mark out,to mark out,标示,VERB,B2
+sedentary lifestyle,sedentary lifestyle,久坐的生活方式,NOUN,B2
+geriatrics,geriatrics,老年医学,NOUN,B2
+playable,playable,可演奏的,ADJ,B2
+to commune,to commune,交融,VERB,B2
+hyperthermia,hyperthermia,体温过高,NOUN,B2
+to multiply tenfold,to multiply tenfold,增至十倍,VERB,B2
+preterition,preterition,假托,NOUN,B2
+nitrogen,nitrogen,氮,NOUN,B2
+preacher,preacher,传教士,NOUN,B2
+about thirty,about thirty,三十左右,NOUN,B2
+to spout,to spout,喷射,VERB,B2
+traumatic,traumatic,创伤的,ADJ,B2
+parable,parable,寓言,NOUN,B2
+to stem from,to stem from,源于,VERB,B2
+priority,priority,优先的,ADJ,B2
+to tip over,to tip over,翻倒,VERB,B2
+foreclosure of rights,foreclosure of rights,权利丧失,NOUN,B2
+be tender,be tender,温柔的,ADJ,B2
+fistula,fistula,瘘管,NOUN,B2
+to catch sight of,to catch sight of,瞥见,VERB,B2
+artificially,artificially,人为地,ADV,B2
+forfeiture,forfeiture,丧失,NOUN,B2
+recruit,recruit,新兵,NOUN,B2
+genetically,genetically,遗传地,ADV,B2
+scouting locating,scouting locating,定位 / 侦察,NOUN,B2
+subsidiarity,subsidiarity,辅助性原则,NOUN,B2
+dish towel,dish towel,抹布,NOUN,B2
+co-ownership,co-ownership,共有产权,NOUN,B2
+momentarily,momentarily,暂时地,ADV,B2
+to rediscover,to rediscover,重新发现,VERB,B2
+paralogism,paralogism,谬误推理,NOUN,B2
+cyst,cyst,囊肿,NOUN,B2
+resection,resection,切除术,NOUN,B2
+patently,patently,显然地,ADV,B2
+ticket window,ticket window,售票窗口,NOUN,B2
+to weary to tire,to weary to tire,使厌倦,VERB,B2
+tuberculosis,tuberculosis,结核病,NOUN,B2
+overtaking exceeding,overtaking exceeding,超越，超出,NOUN,B2
+blender,blender,搅拌机,NOUN,B2
+degenerative,degenerative,退化的,ADJ,B2
+fresco,fresco,壁画,NOUN,B2
+receiving stolen goods,receiving stolen goods,窝赃,NOUN,B2
+on upon,on upon,在...上,ADP,B2
+to unhook,to unhook,摘下,VERB,B2
+footage,footage,镜头长度,NOUN,B2
+droppings,droppings,粪便,NOUN,B2
+computer specialist,computer specialist,计算机专家,NOUN,B2
+cruelly,cruelly,残酷地,ADV,B2
+progressive,progressive,进步人士,NOUN,B2
+selectively,selectively,有选择地,ADV,B2
+lily,lily,百合,NOUN,B2
+illuminator,illuminator,彩饰画家,NOUN,B2
+acronym,acronym,首字母缩略词,NOUN,B2
+similarly,similarly,同样地,ADV,B2
+bedsheet,bedsheet,床单,NOUN,B2
+surplus,surplus,过剩的,ADJ,B2
+to mast,to mast,降伏,VERB,B2
+to drive lead,to drive lead,驾驶,VERB,B2
+fishing,fishing,钓鱼,NOUN,B2
+lucky find,lucky find,意外发现,NOUN,B2
+cross-border,cross-border,边境的,ADJ,B2
+community-related,community-related,社区的,ADJ,B2
+dynamism,dynamism,活力,NOUN,B2
+great-grandfather,great-grandfather,曾祖父,NOUN,B2
+supportive,supportive,团结的,ADJ,B2
+tarragon,tarragon,龙蒿,NOUN,B2
+regeneration,regeneration,再生,NOUN,B2
+scales,scales,秤,NOUN,B2
+trilemma,trilemma,三难困境,NOUN,B2
+indebted,indebted,负债的,ADJ,B2
+skating,skating,滑冰,NOUN,B2
+malaria,malaria,疟疾,NOUN,B2
+boastfulness,boastfulness,吹嘘,NOUN,B2
+anagram,anagram,字谜游戏,NOUN,B2
+cinematographic,cinematographic,电影的,ADJ,B2
+fake news,fake news,假新闻,NOUN,B2
+derisory paltry,derisory paltry,可笑的，微不足道的,ADJ,B2
+hematoma,hematoma,血肿,NOUN,B2
+malefic,malefic,邪恶的,ADJ,B2
+enslavement,enslavement,奴役,NOUN,B2
+chauvinism,chauvinism,沙文主义,NOUN,B2
+striped,striped,有条纹的,ADJ,B2
+oligopoly,oligopoly,寡头垄断,NOUN,B2
+breathing,breathing,呼吸,NOUN,B2
+laundering,laundering,洗钱,NOUN,B2
+systematically,systematically,系统地,ADV,B2
+accordion,accordion,手风琴,NOUN,B2
+naturalization,naturalization,入籍,NOUN,B2
+to postpone to carry over,to postpone to carry over,推迟,VERB,B2
+suburbs,suburbs,郊区,NOUN,B2
+ignominy,ignominy,耻辱,NOUN,B2
+neuron,neuron,神经元,NOUN,B2
+psalm,psalm,诗篇,NOUN,B2
+signatory,signatory,签署者,NOUN,B2
+solicitude,solicitude,关怀,NOUN,B2
+teratogenic,teratogenic,致畸的,ADJ,B2
+radically,radically,彻底地,ADV,B2
+masculine,masculine,男性的,ADJ,B2
+to join to adhere,to join to adhere,加入 / 附着,VERB,B2
+ravine,ravine,沟壑,NOUN,B2
+barracks,barracks,兵营,NOUN,B2
+distinctly,distinctly,清楚地,ADV,B2
+presumed,presumed,推定的,ADJ,B2
+to dry up,to dry up,使干枯,VERB,B2
+breach of duty,breach of duty,渎职,NOUN,B2
+occultism,occultism,神秘学,NOUN,B2
+peri-urban,peri-urban,城市周边的,ADJ,B2
+eddy,eddy,漩涡,NOUN,B2
+accused person,accused person,被告,NOUN,B2
+punctuality,punctuality,守时,NOUN,B2
+impostor,impostor,骗子,NOUN,B2
+asyndeton,asyndeton,连词省略,NOUN,B2
+saucepan,saucepan,平底锅,NOUN,B2
+current events,current events,时事,NOUN,B2
+rerun,rerun,重播,NOUN,B2
+laconism,laconism,简洁,NOUN,B2
+shared boundary ownership,shared boundary ownership,共有边界权,NOUN,B2
+to make up for substitute,to make up for substitute,弥补/替代,VERB,B2
+about fifty,about fifty,五十左右,NOUN,B2
+herbal tea,herbal tea,花草茶,NOUN,B2
+to point to clock in,to point to clock in,指 / 打卡,VERB,B2
+capping,capping,封顶,NOUN,B2
+to incarcerate,to incarcerate,监禁,VERB,B2
+paintbrush,paintbrush,画笔；毛笔,NOUN,B2
+magnetic,magnetic,磁的,ADJ,B2
+clandestinity,clandestinity,秘密状态,NOUN,B2
+beatitude,beatitude,至福,NOUN,B2
+clumsily,clumsily,笨拙地,ADV,B2
+to inflict to impose,to inflict to impose,施加,VERB,B2
+amalgam conflation,amalgam conflation,混合 / 混淆,NOUN,B2
+amphitheater lecture hall,amphitheater lecture hall,阶梯教室 / 圆形剧场,NOUN,B2
+small boat,small boat,小船,NOUN,B2
+ok,ok,好的,INTJ,B2
+sophist,sophist,诡辩家,NOUN,B2
+measured,measured,克制的,ADJ,B2
+deeply profoundly,deeply profoundly,深刻地,ADV,B2
+ticket validation,ticket validation,检票,NOUN,B2
+divide cleavage,divide cleavage,分裂 / 分歧,NOUN,B2
+cosmology,cosmology,宇宙学,NOUN,B2
+funerary,funerary,丧葬的,ADJ,B2
+to unbend,to unbend,润滑,VERB,B2
+bookstore,bookstore,书店,NOUN,B2
+to unblind,to unblind,使醒悟,VERB,B2
+coin purse,coin purse,零钱包,NOUN,B2
+buyer purchaser,buyer purchaser,买方,NOUN,B2
+succinctly,succinctly,简洁地,ADV,B2
+striking,striking,惊人的,ADJ,B2
+activism,activism,激进主义,NOUN,B2
+cider,cider,苹果酒,NOUN,B2
+portion serving,portion serving,部分 / 一份,NOUN,B2
+each one,each one,每人,PRON,B2
+to scare away,to scare away,惊飞,VERB,B2
+duct pipe,duct pipe,管道,NOUN,B2
+continually,continually,不断地,ADV,B2
+award auction,award auction,裁定 / 拍卖,NOUN,B2
+time clock,time clock,打卡机,NOUN,B2
+legislature,legislature,立法机关,NOUN,B2
+flowering,flowering,开花,NOUN,B2
+quantum,quantum,量子的,ADJ,B2
+stationery shop,stationery shop,文具店,NOUN,B2
+exceptionally,exceptionally,例外地,ADV,B2
+fed up,fed up,受够了,NOUN,B2
+pleonasm,pleonasm,赘述,NOUN,B2
+opportunity used,opportunity used,机会,NOUN,B2
+patronage,patronage,赞助,NOUN,B2
+laundry detergent,laundry detergent,洗衣液/脏衣服,NOUN,B2
+millionaire,millionaire,百万富翁,NOUN,B2
+obese,obese,肥胖的,ADJ,B2
+viewer,viewer,观众,NOUN,B2
+to revitalize,to revitalize,使复苏,VERB,B2
+to play football,to play football,踢足球,VERB,B2
+correctness,correctness,正确性,NOUN,B2
+audible,audible,听得见的,ADJ,B2
+collegial,collegial,同事的,ADJ,B2
+to demilitarize,to demilitarize,非军事化,VERB,B2
+mannerly,mannerly,有礼貌的,ADJ,B2
+hollowed,hollowed,掏空的,ADJ,B2
+crystal clear,crystal clear,清澈的,ADJ,B2
+zoo,zoo,动物园,NOUN,B2
+syndrome,syndrome,综合征,NOUN,B2
+gynaecology,gynaecology,妇科,NOUN,B2
+border post,border post,边防哨所,NOUN,B2
+paired accompanied,paired accompanied,成对的 / 伴随的,ADJ,B2
+curbing,curbing,遏制,NOUN,B2
+remarkable,remarkable,非凡的,ADJ,B2
+embargo,embargo,禁运,NOUN,B2
+technocratic,technocratic,技术官僚的,ADJ,B2
+moralizing,moralizing,说教的,ADJ,B2
+expressiveness,expressiveness,表现力,NOUN,B2
+versus,versus,对,ADP,B2
+to play sports,to play sports,做运动,VERB,B2
+border community,border community,边境社区,NOUN,B2
+life's work,life's work,毕生事业,NOUN,B2
+yourself,yourself,你自己,PRON,B2
+malicious,malicious,恶意的,ADJ,B2
+to revalue,to revalue,重新估值,VERB,B2
+closer,closer,更近的,ADJ,B2
+conspiratorial,conspiratorial,阴谋的,ADJ,B2
+guidance,guidance,指导,NOUN,B2
+benignity,benignity,良性,NOUN,B2
+class struggle,class struggle,阶级斗争,NOUN,B2
+desirability,desirability,可取性,NOUN,B2
+liberalize,liberalize,自由化,! VERB,B2
+group mentality,group mentality,群体心态,NOUN,B2
+member of parliament,member of parliament,议员,NOUN,B2
+grammaticality,grammaticality,合语法性,NOUN,B2
+alienating,alienating,使人疏远的,ADJ,B2
+avoidable,avoidable,可避免的,ADJ,B2
+criminal law,criminal law,刑法,NOUN,B2
+group solidarity,group solidarity,群体团结,NOUN,B2
+surgical,surgical,外科的,ADJ,B2
+to solder,to solder,焊接,VERB,B2
+irish,irish,爱尔兰的,ADJ,B2
+universities,universities,大学,NOUN,B2
+entranced,entranced,痴迷的,ADJ,B2
+aghast,aghast,惊骇的,ADJ,B2
+diction,diction,措辞,NOUN,B2
+to technologize,to technologize,技术化,VERB,B2
+gallows humor,gallows humor,绞刑架幽默,NOUN,B2
+cycle path,cycle path,自行车道,NOUN,B2
+misplaced,misplaced,不合时宜的,ADJ,B2
+presidential election,presidential election,总统选举,NOUN,B2
+marginal,marginal,边缘的,ADJ,B2
+place of residence,place of residence,居住地,NOUN,B2
+to pauperize,to pauperize,使贫困,VERB,B2
+healing power,healing power,疗效,NOUN,B2
+to draw water,to draw water,打水,VERB,B2
+cohort-based,cohort-based,队列的,ADJ,B2
+publicity,publicity,宣传,NOUN,B2
+to walk around,to walk around,四处走动,VERB,B2
+spiritual,spiritual,精神的,ADJ,B2
+towards,towards,迎向,ADV,B2
+physiotherapy,physiotherapy,物理治疗,NOUN,B2
+founding,founding,成立,NOUN,B2
+family reunification,family reunification,家庭团聚,NOUN,B2
+to validate,to validate,验证,VERB,B2
+unscrupulousness,unscrupulousness,毫无良知,NOUN,B2
+exemplary country,exemplary country,模范国家,NOUN,B2
+consolidating,consolidating,巩固的,ADJ,B2
+eclecticism,eclecticism,折衷主义,NOUN,B2
+statistic,statistic,统计数据,NOUN,B2
+hazard report,hazard report,危险报告,NOUN,B2
+dentition,dentition,牙齿,NOUN,B2
+front line,front line,前线,NOUN,B2
+conference-based,conference-based,会议的,ADJ,B2
+court case,court case,诉讼,NOUN,B2
+plucky,plucky,勇敢的,ADJ,B2
+two-dimensional,two-dimensional,二维的,ADJ,B2
+purifying,purifying,净化的,ADJ,B2
+to be correct,to be correct,正确,VERB,B2
+to rehabilitate,to rehabilitate,使康复,VERB,B2
+factual,factual,事实的,ADJ,B2
+sighing,sighing,叹息的,ADJ,B2
+to tune,to tune,调谐,VERB,B2
+collective labor agreement,collective labor agreement,集体劳动协议,NOUN,B2
+little brother,little brother,小弟弟,NOUN,B2
+one-way traffic,one-way traffic,单向通行,NOUN,B2
+national anthem,national anthem,国歌,NOUN,B2
+to replicate,to replicate,复制,VERB,B2
+to catalyze,to catalyze,催化,VERB,B2
+nauseous,nauseous,恶心的,ADJ,B2
+to modulate,to modulate,调节,VERB,B2
+cult,cult,邪教,NOUN,B2
+grave desecration,grave desecration,亵渎坟墓,NOUN,B2
+effortless,effortless,不费力的,ADJ,B2
+worth mentioning,worth mentioning,值得一提的,ADJ,B2
+to settle up,to settle up,结账,VERB,B2
+portuguese,portuguese,葡萄牙语,NOUN,B2
+meaningful,meaningful,有意义的,ADJ,B2
+moreover,moreover,而且,CCONJ,B2
+contested,contested,有争议的,ADJ,B2
+to instrumentalize,to instrumentalize,工具化,VERB,B2
+labor market,labor market,劳动力市场,NOUN,B2
+to lug,to lug,搬运,VERB,B2
+convertible,convertible,可兑换的,ADJ,B2
+upwards,upwards,向上,ADV,B2
+altruistic,altruistic,利他的,ADJ,B2
+hence,hence,因此,ADV,B2
+new construction,new construction,新建建筑,NOUN,B2
+jaded,jaded,厌倦的,ADJ,B2
+dominance,dominance,威权,NOUN,B2
+immanence,immanence,内在性,NOUN,B2
+well-groomed,well-groomed,整洁的,ADJ,B2
+hassle,hassle,麻烦,NOUN,B2
+to text,to text,发短信,VERB,B2
+headscarf,headscarf,头巾,NOUN,B2
+courageous,courageous,勇敢的,ADJ,B2
+posh,posh,上流的,ADJ,B2
+daft,daft,傻的,ADJ,B2
+abolition,abolition,废除,NOUN,B2
+knowledge transfer,knowledge transfer,知识传授,NOUN,B2
+merger,merger,合并,NOUN,B2
+to stick out,to stick out,伸出,VERB,B2
+emaciating,emaciating,消耗的,ADJ,B2
+bisexual,bisexual,双性恋的,ADJ,B2
+with this,with this,以此,ADV,B2
+to decentralize,to decentralize,去中心化,VERB,B2
+contact person,contact person,联系人,NOUN,B2
+connecting,connecting,连接的,ADJ,B2
+proliferate,proliferate,扩散,! VERB,B2
+milky,milky,乳白色的,ADJ,B2
+to rent out,to rent out,出租,VERB,B2
+to retort,to retort,反驳,VERB,B2
+variation,variation,变化,NOUN,B2
+april,april,四月,NOUN,B2
+mysticism,mysticism,神秘主义,NOUN,B2
+humanities,humanities,人文学科,NOUN,B2
+power station,power station,发电厂,NOUN,B2
+bit,bit,一点,NOUN,B2
+peddler,peddler,小贩,NOUN,B2
+broadening,broadening,拓宽,NOUN,B2
+this evening,this evening,今晚,ADV,B2
+pregnant woman,pregnant woman,孕妇,NOUN,B2
+rest assured,rest assured,放心的,ADJ,B2
+to tax to burden,to tax to burden,征税,VERB,B2
+radius,radius,半径,NOUN,B2
+decibel,decibel,分贝,NOUN,B2
+small gift,small gift,小礼物,NOUN,B2
+museum piece,museum piece,博物馆藏品,NOUN,B2
+florid,florid,辞藻华丽的,ADJ,B2
+crisis situation,crisis situation,危机局势,NOUN,B2
+to ostracize,to ostracize,排斥,VERB,B2
+dislike,dislike,厌恶,NOUN,B2
+syrian,syrian,叙利亚的,ADJ,B2
+to scan,to scan,扫描,VERB,B2
+worldly,worldly,世俗的,ADJ,B2
+contentious,contentious,有争议的,ADJ,B2
+communautarization,communautarization,社群化,NOUN,B2
+connotative,connotative,内涵的,ADJ,B2
+to spam,to spam,发垃圾信息,VERB,B2
+macroeconomic,macroeconomic,宏观经济学的,ADJ,B2
+at the back,at the back,在后面,ADV,B2
+neighbour,neighbour,邻居,NOUN,B2
+schoolboy,schoolboy,学生,NOUN,B2
+to sublimate,to sublimate,升华,VERB,B2
+for this,for this,为此,ADV,B2
+witness examination,witness examination,证人询问,NOUN,B2
+climate denial,climate denial,气候否认,NOUN,B2
+turbulent,turbulent,动荡的,ADJ,B2
+to sensitize,to sensitize,提高意识,VERB,B2
+microscopic,microscopic,微观的,ADJ,B2
+toothless,toothless,无齿的,ADJ,B2
+to telework,to telework,远程办公,VERB,B2
+venereal disease,venereal disease,性病,NOUN,B2
+to persevere,to persevere,坚持,VERB,B2
+to lead to put forward,to lead to put forward,率领 / 提出,VERB,B2
+heath,heath,石楠荒原,NOUN,B2
+guilder,guilder,盾,NOUN,B2
+financier,financier,资助者,NOUN,B2
+filipino,filipino,菲律宾的,ADJ,B2
+to agitate,to agitate,鼓动,VERB,B2
+multipart,multipart,多部分的,ADJ,B2
+all-round,all-round,全面的,ADJ,B2
+her,her,她的,DET,B2
+vacuum,vacuum,真空的,ADJ,B2
+newsletter,newsletter,简报,NOUN,B2
+whisk,whisk,打蛋器,NOUN,B2
+very hard,very hard,极硬的,ADJ,B2
+to regionalize,to regionalize,区域化,VERB,B2
+suspended,suspended,悬浮的,ADJ,B2
+to plagiarize,to plagiarize,剽窃,VERB,B2
+axiomatic,axiomatic,公理的,ADJ,B2
+antisocial,antisocial,反社会的,ADJ,B2
+transition,transition,过渡,NOUN,B2
+to drop off,to drop off,放下,VERB,B2
+such a,such a,这样的,DET,B2
+noise nuisance,noise nuisance,噪音扰民,NOUN,B2
+amicable,amicable,友好的,ADJ,B2
+fatsoenlijk,fatsoenlijk,体面的,ADJ,B2
+vs,vs,与...相对,ADP,B2
+mayoral,mayoral,市长的,ADJ,B2
+health policy,health policy,健康政策,NOUN,B2
+inheritance law,inheritance law,继承法,NOUN,B2
+bent,bent,弯的,ADJ,B2
+inventorying,inventorying,清点,NOUN,B2
+religious war,religious war,宗教战争,NOUN,B2
+to immunize,to immunize,免疫,VERB,B2
+analytical,analytical,分析的,ADJ,B2
+to invoice,to invoice,开票,VERB,B2
+life-size,life-size,真人大小的,ADJ,B2
+bilateral,bilateral,双边的,ADJ,B2
+little sun,little sun,小太阳,NOUN,B2
+collectomania,collectomania,收藏癖,NOUN,B2
+workable,workable,可加工的,ADJ,B2
+composable,composable,可组合的,ADJ,B2
+disco,disco,迪厅,NOUN,B2
+laptop,laptop,笔记本电脑,NOUN,B2
+legation,legation,公使馆,NOUN,B2
+group norm,group norm,群体规范,NOUN,B2
+inflexibility,inflexibility,僵化,NOUN,B2
+to enrol,to enrol,注册,VERB,B2
+insightfulness,insightfulness,洞察,NOUN,B2
+catastrophic,catastrophic,灾难性的,ADJ,B2
+to industrialize,to industrialize,工业化,VERB,B2
+fossil fuel,fossil fuel,化石燃料,NOUN,B2
+megalomanic,megalomanic,狂妄自大的,ADJ,B2
+contractual,contractual,合同的,ADJ,B2
+school year,school year,学年,NOUN,B2
+to persist,to persist,坚持,VERB,B2
+postal code,postal code,邮政编码,NOUN,B2
+property right,property right,所有权,NOUN,B2
+customer service,customer service,客户服务,NOUN,B2
+aloud,aloud,出声地,ADV,B2
+court fee,court fee,诉讼费,NOUN,B2
+globalization process,globalization process,全球化进程,NOUN,B2
+film star,film star,,NOUN,B2
+memorable,memorable,难忘的,ADJ,B2
+factionalism,factionalism,派系主义,NOUN,B2
+austrian,austrian,奥地利的,ADJ,B2
+family composition,family composition,家庭构成,NOUN,B2
+frictionless,frictionless,无摩擦的,ADJ,B2
+off,off,关,ADP,B2
+fatty,fatty,脂肪的,ADJ,B2
+ceremonial,ceremonial,仪式的,ADJ,B2
+ice cold,ice cold,冰冷的,ADJ,B2
+heated,heated,激昂的,ADJ,B2
+constitutive,constitutive,构成的,ADJ,B2
+character assassination,character assassination,人格谋杀,NOUN,B2
+meek,meek,温顺的,ADJ,B2
+contaminating,contaminating,污染的,ADJ,B2
+conversional,conversional,转换的,ADJ,B2
+federalization,federalization,联邦化,NOUN,B2
+gravitational,gravitational,引力的,ADJ,B2
+amusement,amusement,娱乐,NOUN,B2
+paralysed,paralysed,瘫痪的,ADJ,B2
+energy crisis,energy crisis,能源危机,NOUN,B2
+search engine,search engine,搜索引擎,NOUN,B2
+parliamentary elections,parliamentary elections,议会选举,NOUN,B2
+petrol,petrol,汽油,NOUN,B2
+final score,final score,最终比分,NOUN,B2
+holism,holism,整体论,NOUN,B2
+from which,from which,从中,ADV,B2
+family tension,family tension,家庭紧张,NOUN,B2
+drinking water,drinking water,饮用水,NOUN,B2
+state of mind,state of mind,精神状态,NOUN,B2
+destined,destined,,NOUN,B2
+tens of thousands,tens of thousands,数万,NUM,B2
+licentious,licentious,放荡的,ADJ,B2
+visible,visible,可见的,ADJ,B2
+few,few,几下,NOUN,B2
+schooled person,schooled person,受过培训者,NOUN,B2
+swiss,swiss,瑞士的,ADJ,B2
+to polarize,to polarize,使两极分化,VERB,B2
+atheistic,atheistic,无神论的,ADJ,B2
+accountable,accountable,负责任的,ADJ,B2
+guideline,guideline,指导方针,NOUN,B2
+native american,native american,印第安人,NOUN,B2
+provisional,provisional,临时的,ADJ,B2
+lacunary,lacunary,残缺的,ADJ,B2
+to hold accountable,to hold accountable,问责,VERB,B2
+utility,utility,效用,NOUN,B2
+data processing,data processing,数据处理,NOUN,B2
+irrelevance,irrelevance,无关,NOUN,B2
+to repel,to repel,击退,VERB,B2
+one and a half,one and a half,一个半,NUM,B2
+loyalty to authority,loyalty to authority,服从权威,NOUN,B2
+associated,associated,相关的,ADJ,B2
+southwest,southwest,西南的,ADJ,B2
+emotional expression,emotional expression,! 情感表达,NOUN,B2
+commencement,commencement,开始,NOUN,B2
+to propagate,to propagate,传播,VERB,B2
+religious strife,religious strife,宗教纷争,NOUN,B2
+heartfelt,heartfelt,衷心的,ADJ,B2
+trivializable,trivializable,可轻描淡写的,ADJ,B2
+bombardment,bombardment,轰炸,NOUN,B2
+to mystify,to mystify,神秘化,VERB,B2
+dutchman,dutchman,荷兰人,NOUN,B2
+bicycle repairer,bicycle repairer,修车匠,NOUN,B2
+to,to,去,PART,B2
+egocentrism,egocentrism,自我中心,NOUN,B2
+palestinian,palestinian,巴勒斯坦的,ADJ,B2
+toys,toys,玩具,NOUN,B2
+endowed,endowed,有天赋的,ADJ,B2
+hungarian,hungarian,匈牙利的,ADJ,B2
+expertise center,expertise center,专业中心,NOUN,B2
+sympathetic,sympathetic,同情的,ADJ,B2
+run-up,run-up,助跑,NOUN,B2
+to aggravate,to aggravate,加重,VERB,B2
+manual,manual,手工的,ADJ,B2
+flemish,flemish,佛兰芒的,ADJ,B2
+toothbrush,toothbrush,牙刷,NOUN,B2
+to emigrate,to emigrate,移居国外,VERB,B2
+email address,email address,电子邮件地址,NOUN,B2
+the one,the one,,NOUN,B2
+grand officer,grand officer,大官,NOUN,B2
+ukrainian,ukrainian,乌克兰的,ADJ,B2
+border arrangement,border arrangement,边境安排,NOUN,B2
+metamorphic,metamorphic,变质的,ADJ,B2
+to localize,to localize,本地化,VERB,B2
+undermining authority,undermining authority,削弱权威,NOUN,B2
+group individual,group individual,群体个体,NOUN,B2
+elderly,elderly,老年人,NOUN,B2
+brazilian,brazilian,巴西的,ADJ,B2
+nuts,nuts,疯狂的,ADJ,B2
+coloredness,coloredness,有色性,NOUN,B2
+berlijns,berlijns,柏林的,ADJ,B2
+judgement,judgement,评估,NOUN,B2
+manipulable,manipulable,可操纵的,ADJ,B2
+depicted,depicted,描绘的,ADJ,B2
+cosmetics,cosmetics,化妆品,NOUN,B2
+diplomatic relations,diplomatic relations,外交关系,NOUN,B2
+to pucker,to pucker,噘,VERB,B2
+how come,how come,怎么会,INTJ,B2
+structuredness,structuredness,结构性,NOUN,B2
+to break off,to break off,中断,VERB,B2
+to tidy,to tidy,整理,VERB,B2
+solemn,solemn,,NOUN,B2
+habitlessness,habitlessness,无习惯,NOUN,B2
+increasing,increasing,增加的,ADJ,B2
+south african,south african,南非的,ADJ,B2
+your,your,你的,PRON,B2
+folksy,folksy,乡土的,ADJ,B2
+redrawing,redrawing,重新绘制,NOUN,B2
+largely,largely,主要地,ADV,B2
+to contextualize,to contextualize,置于语境,VERB,B2
+editor-in-chief,editor-in-chief,主编,NOUN,B2
+documentation,documentation,文献,NOUN,B2
+traditional costume,traditional costume,传统服饰,NOUN,B2
+special offer,special offer,特价,NOUN,B2
+balancing,balancing,平衡的,ADJ,B2
+dispirited,dispirited,沮丧的,ADJ,B2
+ourselves,ourselves,我们自己,PRON,B2
+explanatory,explanatory,解释的,ADJ,B2
+source citation,source citation,出处注明,NOUN,B2
+bleeding,bleeding,流血的,ADJ,B2
+children's rights,children's rights,儿童权利,NOUN,B2
+arabic,arabic,阿拉伯的,ADJ,B2
+demotion,demotion,降职,NOUN,B2
+to revolutionize,to revolutionize,革命化,VERB,B2
+with that,with that,以此,ADV,B2
+parish priest,parish priest,本堂神父,NOUN,B2
+tram,tram,有轨电车,NOUN,B2
+for a moment,for a moment,片刻,ADV,B2
+provable,provable,可证明的,ADJ,B2
+owed,owed,欠下的,ADJ,B2
+midfielder,midfielder,中场球员,NOUN,B2
+solar panel,solar panel,太阳能电池板,NOUN,B2
+church community,church community,教会,NOUN,B2
+liberating,liberating,解放的,ADJ,B2
+healthcare,healthcare,医疗保健,NOUN,B2
+figuration,figuration,群演,NOUN,B2
+inactivity,inactivity,不活跃,NOUN,B2
+by means of,by means of,凭借,NOUN,B2
+in the back,in the back,在后面,ADV,B2
+series of conversations,series of conversations,系列对话,NOUN,B2
+day after tomorrow,day after tomorrow,后天,NOUN,B2
+plenty,plenty,充足地,ADV,B2
+disharmony,disharmony,不和谐,NOUN,B2
+barbarization,barbarization,野蛮化,NOUN,B2
+land policy,land policy,土地政策,NOUN,B2
+governable,governable,可管理的,ADJ,B2
+just like that,just like that,随便地,ADV,B2
+paving,paving,铺路,NOUN,B2
+fabulist,fabulist,幻想家,NOUN,B2
+regardless,regardless,不管,ADP,B2
+hospitality industry,hospitality industry,餐饮酒店业,NOUN,B2
+twofold,twofold,双重的,ADJ,B2
+sentences,sentences,句子,NOUN,B2
+alternating,alternating,交替的,ADJ,B2
+sports park,sports park,运动公园,NOUN,B2
+removed,removed,移除的,ADJ,B2
+nearby,nearby,附近,NOUN,B2
+world champion,world champion,世界冠军,NOUN,B2
+hem,hem,边缘,NOUN,B2
+border check,border check,边境检查,NOUN,B2
+rightly,rightly,正确地,ADV,B2
+brabant,brabant,布拉班特的,ADJ,B2
+group work,group work,群体工作,NOUN,B2
+domineeringness,domineeringness,支配欲,NOUN,B2
+lifelong,lifelong,终身,ADJ,B2
+authority structure,authority structure,权威结构,NOUN,B2
+deputation,deputation,代表团,NOUN,B2
+people,people,人们,PRON,B2
+meandering,meandering,蜿蜒的,ADJ,B2
+both,both,两者的,ADJ,B2
+past,past,过去,ADP,B2
+dutch,dutch,荷兰语,NOUN,B2
+tomorrow night,tomorrow night,明晚,ADV,B2
+grand master,grand master,大师,NOUN,B2
+to saw,to saw,锯,VERB,B2
+full-time,full-time,全职,ADJ,B2
+subject field,subject field,科目 / 领域,NOUN,B2
+conviviality,conviviality,温馨,NOUN,B2
+film industry,film industry,电影业,NOUN,B2
+primary school,primary school,小学,NOUN,B2
+song festival,song festival,音乐节,NOUN,B2
+little heart,little heart,小心脏,NOUN,B2
+lawless,lawless,无法的,ADJ,B2
+in unison,in unison,齐声,ADV,B2
+neatly,neatly,整洁地,ADV,B2
+contactual,contactual,接触的,ADJ,B2
+compostable,compostable,可堆肥的,ADJ,B2
+as many,as many,一样多,NUM,B2
+century-old,century-old,世纪的,ADJ,B2
+self-interest,self-interest,私利,NOUN,B2
+collectivization,collectivization,集体化,NOUN,B2
+fishery,fishery,渔业,NOUN,B2
+liminal,liminal,阈限的,ADJ,B2
+tactless,tactless,不得体的,ADJ,B2
+without further ado,without further ado,毫不犹豫地,ADV,B2
+as a result of which,as a result of which,由此,ADV,B2
+euphemistic,euphemistic,委婉的,ADJ,B2
+to reoffend,to reoffend,重犯,VERB,B2
+border region,border region,边境地区,NOUN,B2
+patricide,patricide,弑父,NOUN,B2
+on the one hand,on the one hand,一方面,ADV,B2
+duty of confidentiality,duty of confidentiality,保密义务,NOUN,B2
+graphic designer,graphic designer,图形设计师,NOUN,B2
+megalomania,megalomania,狂妄自大,NOUN,B2
+to shoot dead,to shoot dead,击毙,VERB,B2
+lingual,lingual,语言的,ADJ,B2
+light grey,light grey,浅灰色的,ADJ,B2
+classicist,classicist,古典主义的,ADJ,B2
+tiring,tiring,令人疲倦的,ADJ,B2
+intellectual life,intellectual life,精神生活,NOUN,B2
+middle,middle,中间,ADV,B2
+nonviolence,nonviolence,非暴力,NOUN,B2
+inherence,inherence,固有,NOUN,B2
+conscientious objection,conscientious objection,良知抗拒,NOUN,B2
+spirit world,spirit world,灵界,NOUN,B2
+convolutional,convolutional,卷积的,ADJ,B2
+argentinian,argentinian,阿根廷的,ADJ,B2
+predisposition,predisposition,天赋,NOUN,B2
+authority figure,authority figure,权威人士,NOUN,B2
+marshy,marshy,沼泽般的,ADJ,B2
+whey,whey,乳清,NOUN,B2
+for that purpose,for that purpose,为此,ADV,B2
+brainy,brainy,聪明的,ADJ,B2
+to archive,to archive,归档,VERB,B2
+collectie,collectie,收藏,NOUN,B2
+unwanted,unwanted,不受欢迎的,ADJ,B2
+good-naturedness,good-naturedness,温和,NOUN,B2
+for what purpose,for what purpose,为了什么目的,ADV,B2
+labile,labile,不稳定的,ADJ,B2
+consumptive,consumptive,消费的,ADJ,B2
+incompleteness,incompleteness,不完整,NOUN,B2
+to take minutes,to take minutes,记录,VERB,B2
+czech,czech,捷克的,ADJ,B2
+backyard,backyard,后院,NOUN,B2
+self,self,自己,ADV,B2
+indonesian,indonesian,印度尼西亚的,ADJ,B2
+processing,processing,处理,NOUN,B2
+outside world,outside world,外界,NOUN,B2
+tomb monument,tomb monument,墓碑,NOUN,B2
+care worker,care worker,护理人员,NOUN,B2
+to email,to email,发邮件,VERB,B2
+mercy blow,mercy blow,致命一击,NOUN,B2
+co-,co-,共同,ADV,B2
+purchase price,purchase price,购买价,NOUN,B2
+machine,machine,机械的,ADJ,B2
+campus-like,campus-like,校园式的,ADJ,B2
+well-disposed,well-disposed,善意的,ADJ,B2
+offence,offence,罪行,NOUN,B2
+lapidary,lapidary,简略的,ADJ,B2
+uniformity,uniformity,统一性,NOUN,B2
+to graspen,to graspen,抓住,VERB,B2
+editorial office,editorial office,编辑部,NOUN,B2
+quaternary,quaternary,第四的,ADJ,B2
+marbly,marbly,大理石般的,ADJ,B2
+reasoned,reasoned,经过推理的,ADJ,B2
+out,out,出,ADP,B2
+little finger,little finger,小指,NOUN,B2
+uncritical,uncritical,不加批判的,ADJ,B2
+very best,very best,最好的,ADJ,B2
+family tie,family tie,家庭纽带,NOUN,B2
+impoverished,impoverished,贫困的,ADJ,B2
+little boy,little boy,小男孩,NOUN,B2
+to lodge,to lodge,借宿,VERB,B2
+expression of opinion,expression of opinion,意见表达,NOUN,B2
+cool-headed,cool-headed,冷静的,ADJ,B2
+tax rate,tax rate,税率,NOUN,B2
+genetic modification,genetic modification,基因改造,NOUN,B2
+engrossing,engrossing,引人入胜的,ADJ,B2
+image formation,image formation,形象塑造,NOUN,B2
+sound clip,sound clip,音频片段,NOUN,B2
+film studio,film studio,电影制片厂,NOUN,B2
+manifold,manifold,多方面的,ADJ,B2
+to think it over,to think it over,思考,VERB,B2
+esotericism,esotericism,秘教,NOUN,B2
+averageness,averageness,平庸,NOUN,B2
+microeconomic,microeconomic,微观经济学的,ADJ,B2
+above-mentioned,above-mentioned,上述的,ADJ,B2
+combining,combining,结合的,ADJ,B2
+artwork,artwork,艺术品,NOUN,B2
+either,either,或者,ADV,B2
+unification,unification,统一,NOUN,B2
+household,household,家庭的,ADJ,B2
+heartlessness,heartlessness,无情,NOUN,B2
+of it,of it,其中,ADV,B2
+punishable,punishable,可处罚的,ADJ,B2
+to put away,to put away,收拾,VERB,B2
+troubling,troubling,令人担忧的,ADJ,B2
+laugh,laugh,笑,NOUN,B2
+photo model,photo model,模特,NOUN,B2
+exoticism,exoticism,异国情调,NOUN,B2
+as well as,as well as,以及,SCONJ,B2
+apolitical,apolitical,非政治的,ADJ,B2
+groundwater pollution,groundwater pollution,地下水污染,NOUN,B2
+indian,indian,印度的,ADJ,B2
+cremation,cremation,火化,NOUN,B2
+confronting,confronting,对峙的,ADJ,B2
+appropriation,appropriation,挪用,NOUN,B2
+motorway,motorway,高速公路,NOUN,B2
+border legislation,border legislation,边境立法,NOUN,B2
+blackbird,blackbird,乌鸫,NOUN,B2
+telephones,telephones,电话,NOUN,B2
+divisible,divisible,可分的,ADJ,B2
+professional formation,professional formation,职业养成,NOUN,B2
+scholing,scholing,受过训练,NOUN,B2
+moisture,moisture,湿气,NOUN,B2
+teleological,teleological,目的论的,ADJ,B2
+about which,about which,关于什么,PRON,B2
+economic cycle,economic cycle,经济周期,NOUN,B2
+ineffectiveness,ineffectiveness,! 无效,NOUN,B2
+capital flight,capital flight,资本外逃,NOUN,B2
+scottish,scottish,苏格兰的,ADJ,B2
+alteration,alteration,改变,NOUN,B2
+prejudiced,prejudiced,有偏见的,ADJ,B2
+shall will,shall will,将要,AUX,B2
+one-sidedness,one-sidedness,片面性,NOUN,B2
+to orient,to orient,定向,VERB,B2
+land use,land use,土地利用,NOUN,B2
+university of applied sciences,university of applied sciences,应用科学大学,NOUN,B2
+observable,observable,可观测的,ADJ,B2
+crossing the border,crossing the border,越境,NOUN,B2
+working day,working day,工作日,NOUN,B2
+day out,day out,一日游,NOUN,B2
+misconception,misconception,误解,NOUN,B2
+minivan,minivan,小型货车,NOUN,B2
+conforming,conforming,遵从的,ADJ,B2
+of utrecht,of utrecht,乌得勒支的,ADJ,B2
+about this,about this,关于这个,ADV,B2
+something like that,something like that,类似的事物,PRON,B2
+fief,fief,封地,NOUN,B2
+at the bottom,at the bottom,在底部,ADV,B2
+customer orientation,customer orientation,客户导向,NOUN,B2
+to license,to license,许可,VERB,B2
+the rich,the rich,富人,NOUN,B2
+runaway,runaway,,NOUN,B2
+frisian,frisian,弗里斯兰的,ADJ,B2
+to wither,to wither,,VERB,B2
+collected,collected,收集的,ADJ,B2
+civil war,civil war,内战,NOUN,B2
+grey area,grey area,灰色地带,NOUN,B2
+combinatorial,combinatorial,组合的,ADJ,B2
+from this,from this,由此,ADV,B2
+typographical,typographical,排版的,ADJ,B2
+to segment,to segment,细分,VERB,B2
+partial norm,partial norm,分范,NOUN,B2
+one machine,one machine,一架,NUM,B2
+proactive,proactive,积极主动的,ADJ,B2
+domestic debt,domestic debt,内债,NOUN,B2
+sufficient flight,sufficient flight,飞够,NOUN,B2
+he she,he she,伊,PRON,B2
+mangosteen,mangosteen,山竹,NOUN,B2
+meridian,meridian,经脉,NOUN,B2
+toast,toast,你敬酒,NOUN,B2
+social custom,social custom,社会习俗,NOUN,B2
+amended generality,amended generality,改般,NOUN,B2
+jeans,jeans,牛仔裤,NOUN,B2
+crafty,crafty,狡猾,ADJ,B2
+trite,trite,陈腐的,ADJ,B2
+to wash with water,to wash with water,水洗,VERB,B2
+half-day,half-day,半天,NOUN,B2
+to extort a bribe,to extort a bribe,索贿,VERB,B2
+sub-reality,sub-reality,分实,NOUN,B2
+hard to measure,hard to measure,难以衡量,ADJ,B2
+to for example,to for example,比如,VERB,B2
+rethinking,rethinking,重想,NOUN,B2
+warrant,warrant,令状,NOUN,B2
+recounting,recounting,再叙,NOUN,B2
+to concern all,to concern all,凡事,VERB,B2
+timely,timely,适时,ADJ,B2
+dissimilarity,dissimilarity,相异性,NOUN,B2
+foul smell,foul smell,骚味,NOUN,B2
+human life,human life,人命,NOUN,B2
+social value,social value,社会价值,NOUN,B2
+to donate blood,to donate blood,献血,VERB,B2
+hardship,hardship,艰难,NOUN,B2
+rehearsal,rehearsal,排练,NOUN,B2
+otherwise,otherwise,要不,PART,B2
+shooting star,shooting star,流星,NOUN,B2
+changed work,changed work,改工,NOUN,B2
+to wash and iron,to wash and iron,洗熨,VERB,B2
+to be pregnant,to be pregnant,怀孕,VERB,B2
+your arrow,your arrow,若非你一箭,NOUN,B2
+social development,social development,社会发展,NOUN,B2
+to raise seedlings,to raise seedlings,育苗,VERB,B2
+amended synthesis,amended synthesis,改综,NOUN,B2
+no wonder,no wonder,难怪,ADV,B2
+feudal ethics,feudal ethics,礼教,NOUN,B2
+very deep,very deep,很深,ADJ,B2
+bungee jumping,bungee jumping,蹦极,NOUN,B2
+non-knot,non-knot,非结,NOUN,B2
+bizarre case,bizarre case,奇案,NOUN,B2
+provocative,provocative,挑衅的,ADJ,B2
+non-possible,non-possible,非可,NOUN,B2
+main camp,main camp,大营,NOUN,B2
+imperial father,imperial father,父皇,NOUN,B2
+tendering,tendering,招标,NOUN,B2
+characteristic feature,characteristic feature,特点,NOUN,B2
+adversity,adversity,逆境,NOUN,B2
+partial basis,partial basis,分据,NOUN,B2
+waist token,waist token,腰牌,NOUN,B2
+sister yu,sister yu,俞姐,NOUN,B2
+no matter what,no matter what,无论,ADV,B2
+one building,one building,一座,NUM,B2
+to finally,to finally,你可算,VERB,B2
+how enough,how enough,哪够,NOUN,B2
+which seat,which seat,哪座,NOUN,B2
+succinct,succinct,简明的,ADJ,B2
+to seek peace,to seek peace,主和,VERB,B2
+case details,case details,案情,NOUN,B2
+motto,motto,座右铭,NOUN,B2
+thundershower,thundershower,雷阵雨,NOUN,B2
+social activity,social activity,社会活动,NOUN,B2
+survival of the fittest,survival of the fittest,优胜劣汰,NOUN,B2
+malicious words,malicious words,恶言,NOUN,B2
+social mediation,social mediation,社会调解,NOUN,B2
+gearbox,gearbox,变速箱,NOUN,B2
+hyper-target,hyper-target,超的,NOUN,B2
+uncovering,uncovering,破获,NOUN,B2
+departure lounge,departure lounge,候机室,NOUN,B2
+social fairness,social fairness,社会公平,NOUN,B2
+to hope for,to hope for,盼望,VERB,B2
+great victory,great victory,大胜,NOUN,B2
+not bad,not bad,不错,ADJ,B2
+amended particular,amended particular,改特,NOUN,B2
+shopping mall,shopping mall,商场,NOUN,B2
+to lose one's temper,to lose one's temper,发火,VERB,B2
+to reduce sentence,to reduce sentence,减刑,VERB,B2
+wanting you,wanting you,要你,NOUN,B2
+to be afraid,to be afraid,害怕,VERB,B2
+re-criterion,re-criterion,重准,NOUN,B2
+non-technique,non-technique,非术,NOUN,B2
+cautious and solemn idiom very carefully,cautious and solemn idiom very carefully,小心翼翼,ADJ,B2
+earnest sincere,earnest sincere,恳切,ADJ,B2
+town mayor,town mayor,镇长,NOUN,B2
+traditional chinese painting,traditional chinese painting,国画,NOUN,B2
+acrobatics,acrobatics,杂技,NOUN,B2
+disposable diaper,disposable diaper,纸尿裤,NOUN,B2
+prudent,prudent,谨慎的,ADJ,B2
+inner heart,inner heart,内心,NOUN,B2
+walnut,walnut,核桃,NOUN,B2
+affordability,affordability,得起,NOUN,B2
+how dare,how dare,岂敢,NOUN,B2
+non-iron,non-iron,免烫,ADJ,B2
+to do what,to do what,干嘛,VERB,B2
+virtual reality,virtual reality,虚拟现实,NOUN,B2
+to bring about,to bring about,促成,VERB,B2
+foliar fertilizer,foliar fertilizer,叶面肥,NOUN,B2
+kneeling,kneeling,跪,NOUN,B2
+reverse result,reverse result,反果,NOUN,B2
+dense forest,dense forest,密林,NOUN,B2
+outpatient,outpatient,门诊,NOUN,B2
+changed route,changed route,改路,NOUN,B2
+to thresh,to thresh,脱粒,VERB,B2
+in the middle of doing,in the middle of doing,正在,ADV,B2
+overthinking,overthinking,你想多,NOUN,B2
+non-necessary,non-necessary,非必,NOUN,B2
+incremental,incremental,渐进性,ADJ,B2
+outer-gate,outer-gate,外门,NOUN,B2
+star search,star search,找星,NOUN,B2
+reverse origin,reverse origin,反原,NOUN,B2
+adequacy,adequacy,也不错,NOUN,B2
+inversion,inversion,反演,NOUN,B2
+from away from,from away from,离,ADP,B2
+tire pressure,tire pressure,胎压,NOUN,B2
+to exchange currency,to exchange currency,换汇,VERB,B2
+that evening,that evening,当晚,NOUN,B2
+film roll,film roll,胶卷,NOUN,B2
+upper part,upper part,上部,NOUN,B2
+to shut up,to shut up,闭嘴,VERB,B2
+not good,not good,不好,ADJ,B2
+social progress,social progress,社会进步,NOUN,B2
+altogether,altogether,共,ADV,B2
+modified ability,modified ability,改能,NOUN,B2
+sucking,sucking,嗦,NOUN,B2
+not very good,not very good,不太好,ADJ,B2
+spiral pattern,spiral pattern,旋纹,NOUN,B2
+sticky note,sticky note,便签,NOUN,B2
+could it be,could it be,难不成,ADJ,B2
+outfit,outfit,服装,NOUN,B2
+meridians,meridians,筋脉,NOUN,B2
+re-grading,re-grading,改级,NOUN,B2
+my scrutiny,my scrutiny,我看你,NOUN,B2
+it is a pity,it is a pity,可惜,ADJ,B2
+polytunnel,polytunnel,大棚,NOUN,B2
+summer grass,summer grass,夏草,NOUN,B2
+now,now,此刻,NOUN,B2
+brook no delay,brook no delay,刻不容缓,ADJ,B2
+cilantro,cilantro,香菜,NOUN,B2
+further debate,further debate,再辩,NOUN,B2
+to act rashly,to act rashly,妄动,VERB,B2
+will surely,will surely,定会,AUX,B2
+heavy snow,heavy snow,大雪,NOUN,B2
+foot-warming,foot-warming,捂脚,NOUN,B2
+floating dust,floating dust,浮尘,NOUN,B2
+fractal,fractal,分形,NOUN,B2
+cut off,cut off,割下,NOUN,B2
+surfing,surfing,冲浪,NOUN,B2
+well-fitting of clothes,well-fitting of clothes,合身,NOUN,B2
+not intentional,not intentional,不是故意,ADJ,B2
+all day,all day,整天,ADV,B2
+modern dance,modern dance,现代舞,NOUN,B2
+to sell foreign exchange,to sell foreign exchange,售汇,VERB,B2
+to ambush,to ambush,埋伏,VERB,B2
+alumnus,alumnus,校友,NOUN,B2
+to transfer schools,to transfer schools,转学,VERB,B2
+um,um,嗯,INTJ,B2
+altered art,altered art,改艺,NOUN,B2
+as quickly as possible,as quickly as possible,尽快,ADV,B2
+heart disease,heart disease,心脏病,NOUN,B2
+to win inevitably,to win inevitably,必胜,VERB,B2
+singularity,singularity,单一性,NOUN,B2
+shadow guard,shadow guard,暗卫,NOUN,B2
+big data,big data,大数据,NOUN,B2
+charades,charades,打哑谜,NOUN,B2
+this matter,this matter,这事,NOUN,B2
+to go on a business trip,to go on a business trip,出差,VERB,B2
+to be tired of,to be tired of,厌倦,VERB,B2
+bloodshed,bloodshed,血腥,NOUN,B2
+re-argument,re-argument,重论,NOUN,B2
+foreign debt,foreign debt,外债,NOUN,B2
+to hold a record,to hold a record,保持纪录,VERB,B2
+side effect,side effect,副作用,NOUN,B2
+measure word flat objects,measure word flat objects,张,NOUN,B2
+hyper-origin,hyper-origin,超原,NOUN,B2
+but also,but also,但也,NOUN,B2
+captive,captive,俘虏,NOUN,B2
+cannot stay,cannot stay,不住,PART,B2
+moisture-proof,moisture-proof,防潮,ADJ,B2
+taking command,taking command,挂帅,NOUN,B2
+re-sole,re-sole,再唯,NOUN,B2
+re-concretization,re-concretization,再具,NOUN,B2
+jianghu world,jianghu world,江湖上,NOUN,B2
+as expected,as expected,果然,ADV,B2
+to return a car,to return a car,送车,VERB,B2
+for to,for to,为,ADP,B2
+to suffer losses,to suffer losses,吃亏,VERB,B2
+to act as host,to act as host,做东,VERB,B2
+entrapment,entrapment,身陷,NOUN,B2
+amended inclusion,amended inclusion,改纳,NOUN,B2
+running around,running around,跑遍,NOUN,B2
+this indeed,this indeed,这倒,NOUN,B2
+quick lie-down,quick lie-down,快躺,NOUN,B2
+notepad,notepad,记事本,NOUN,B2
+courtyard guard,courtyard guard,护院,NOUN,B2
+major case,major case,大案,NOUN,B2
+elective course,elective course,选修课,NOUN,B2
+tactile paving,tactile paving,盲道,NOUN,B2
+to befriend,to befriend,与...交朋友,VERB,B2
+to not run,to not run,别跑,VERB,B2
+to raise funds,to raise funds,筹资,VERB,B2
+anti-universality,anti-universality,反普,NOUN,B2
+credentials,credentials,国书,NOUN,B2
+enoki mushroom,enoki mushroom,金针菇,NOUN,B2
+gratitude and resentment personal feud,gratitude and resentment personal feud,恩怨,NOUN,B2
+shh,shh,嘘,INTJ,B2
+to file for record,to file for record,备案,VERB,B2
+bound to,bound to,势必,ADV,B2
+grab,grab,揪,NOUN,B2
+non-nature,non-nature,非性,NOUN,B2
+to pay tribute,to pay tribute,致敬,VERB,B2
+sports exercise,sports exercise,运动,NOUN,B2
+red robe,red robe,红衣,NOUN,B2
+inconceivable unimaginable,inconceivable unimaginable,不可思议,ADJ,B2
+borrowed knife,borrowed knife,借刀,NOUN,B2
+sound sleep,sound sleep,你踏实睡,NOUN,B2
+reincarnation,reincarnation,再体,NOUN,B2
+express car,express car,快车,NOUN,B2
+non-view,non-view,非观,NOUN,B2
+to make persistent efforts,to make persistent efforts,再接再厉,VERB,B2
+to lose bid,to lose bid,落标,VERB,B2
+super-form,super-form,超形,NOUN,B2
+car wash,car wash,洗车,NOUN,B2
+can be at,can be at,可在,NOUN,B2
+to fall behind,to fall behind,落后,VERB,B2
+void,void,最无,NOUN,B2
+older sister,older sister,姐姐,NOUN,B2
+fax,fax,传真,NOUN,B2
+sha dynasty,sha dynasty,砂朝,NOUN,B2
+multi-level garage,multi-level garage,立体车库,NOUN,B2
+heaven and earth,heaven and earth,天地,NOUN,B2
+capping ceremony,capping ceremony,冠礼,NOUN,B2
+to patrol,to patrol,巡逻,VERB,B2
+to statistics,to statistics,统计,VERB,B2
+dignified manner,dignified manner,威仪,NOUN,B2
+hard to operate,hard to operate,难以操作,ADJ,B2
+emphasize,emphasize,着重,ADV,B2
+to reflect on,to reflect on,思考,VERB,B2
+that pair,that pair,那付,NOUN,B2
+your photo,your photo,照你,NOUN,B2
+loud and clear,loud and clear,响亮,ADJ,B2
+cause of defeat,cause of defeat,败因,NOUN,B2
+good medicine,good medicine,好药,NOUN,B2
+that which,that which,所,PART,B2
+counter-boundary,counter-boundary,反界,NOUN,B2
+classifier for documents portions,classifier for documents portions,份,NOUN,B2
+plain and simple,plain and simple,朴素,ADJ,B2
+too small,too small,太小,ADJ,B2
+all night,all night,通宵,NOUN,B2
+plasma,plasma,血浆,NOUN,B2
+subcategory,subcategory,分目,NOUN,B2
+year by year,year by year,逐年,ADV,B2
+i,i,我连,NOUN,B2
+latin dance,latin dance,拉丁舞,NOUN,B2
+to lack basis,to lack basis,无据,VERB,B2
+cantaloupe,cantaloupe,哈密瓜,NOUN,B2
+to not lose,to not lose,别丢,VERB,B2
+worry-free,worry-free,无忧,NOUN,B2
+at the appointed time,at the appointed time,届时,ADV,B2
+breakthrough,breakthrough,突破性,ADJ,B2
+lover sweetheart,lover sweetheart,情人,NOUN,B2
+to inventory,to inventory,盘点,VERB,B2
+traffic light,traffic light,红绿灯,NOUN,B2
+audio equipment,audio equipment,音响,NOUN,B2
+neighborhood head,neighborhood head,里长,NOUN,B2
+paternity leave,paternity leave,陪产假,NOUN,B2
+exchange goods,exchange goods,换货,NOUN,B2
+next week,next week,下周,NOUN,B2
+to be taken in,to be taken in,上当,VERB,B2
+to linkage,to linkage,联动,VERB,B2
+eyes,eyes,眼中,NOUN,B2
+nadir,nadir,最低点,NOUN,B2
+social morality,social morality,社会公德,NOUN,B2
+to die for,to die for,死要,VERB,B2
+quick removal,quick removal,赶快脱,NOUN,B2
+i'm afraid,i'm afraid,恐怕,ADV,B2
+extreme height,extreme height,极高,NOUN,B2
+marriage leave,marriage leave,婚假,NOUN,B2
+special-purpose trip,special-purpose trip,专程,ADV,B2
+housework,housework,家务,NOUN,B2
+i-than,i-than,我比,NOUN,B2
+mulberry,mulberry,桑葚,NOUN,B2
+inner side,inner side,内侧,NOUN,B2
+sex appeal,sex appeal,性感,NOUN,B2
+trans-idealism,trans-idealism,超唯,NOUN,B2
+to recommend for admission,to recommend for admission,保送,VERB,B2
+usb flash drive,usb flash drive,U盘,NOUN,B2
+holy decree,holy decree,圣令,NOUN,B2
+to study deeply,to study deeply,钻研,VERB,B2
+why not,why not,何不,ADV,B2
+super-distinction,super-distinction,超殊,NOUN,B2
+my taking,my taking,我拿,NOUN,B2
+foe,foe,敌友,NOUN,B2
+explosion-proof,explosion-proof,防爆,ADJ,B2
+this route,this route,这路,NOUN,B2
+birthmark,birthmark,胎记,NOUN,B2
+financial center,financial center,金融中心,NOUN,B2
+pounding,pounding,捶,NOUN,B2
+pine forest,pine forest,松林,NOUN,B2
+be sorry,be sorry,抱歉,ADJ,B2
+trans-induction,trans-induction,超归,NOUN,B2
+to seek you,to seek you,寻你,VERB,B2
+eldest brother,eldest brother,做大哥,NOUN,B2
+second letter,second letter,再信,NOUN,B2
+counter-belief,counter-belief,反信,NOUN,B2
+past events,past events,往事,NOUN,B2
+swordsmanship,swordsmanship,剑术,NOUN,B2
+class lesson,class lesson,课,NOUN,B2
+logic modification,logic modification,改逻,NOUN,B2
+crowded,crowded,拥挤,ADJ,B2
+super-internal,super-internal,超内,NOUN,B2
+mixed forest,mixed forest,混交林,NOUN,B2
+nuclear energy,nuclear energy,核能,NOUN,B2
+to resume studies,to resume studies,复学,VERB,B2
+law,law,法,PART,B2
+zen master,zen master,禅师,NOUN,B2
+bluntness,bluntness,直说,NOUN,B2
+intravenous drip,intravenous drip,输液,NOUN,B2
+for a time,for a time,一度,ADV,B2
+cause of change,cause of change,改因,NOUN,B2
+equally matched,equally matched,不相上下,ADJ,B2
+external hard drive,external hard drive,移动硬盘,NOUN,B2
+immobility,immobility,都无动,NOUN,B2
+land expansion,land expansion,拓土,NOUN,B2
+pushover,pushover,善茬,NOUN,B2
+family background,family background,出身,NOUN,B2
+on the spot,on the spot,当场,ADV,B2
+sea level rise,sea level rise,海平面上升,NOUN,B2
+no not,no not,不,ADV,B2
+nephews,nephews,子侄,NOUN,B2
+common sense,common sense,常识,NOUN,B2
+capable,capable,有本事,NOUN,B2
+revised image,revised image,改影,NOUN,B2
+super-unity,super-unity,超一,NOUN,B2
+according to,according to,要照,NOUN,B2
+spending,spending,行用,NOUN,B2
+re-analysis,re-analysis,重析,NOUN,B2
+homestay,homestay,民宿,NOUN,B2
+at worst,at worst,大不了,ADV,B2
+stuffed crab,stuffed crab,蟹酿,NOUN,B2
+to secrete,to secrete,分泌,VERB,B2
+creditor's rights,creditor's rights,债权,NOUN,B2
+incurable,incurable,不可救药,ADJ,B2
+sick leave,sick leave,病假,NOUN,B2
+month ago,month ago,月前,NOUN,B2
+altered path,altered path,改径,NOUN,B2
+to pay off,to pay off,清偿,VERB,B2
+medal awarding,medal awarding,授勋,NOUN,B2
+in other words,in other words,换言之,ADV,B2
+in those days,in those days,当年,NOUN,B2
+cutting grass,cutting grass,斩草,NOUN,B2
+main street,main street,大街,NOUN,B2
+quick speech,quick speech,快说,NOUN,B2
+exchange meeting,exchange meeting,交流会,NOUN,B2
+high-speed,high-speed,高速,ADJ,B2
+senior male student,senior male student,学长,NOUN,B2
+trans-er,trans-er,超而,NOUN,B2
+over-skill,over-skill,超技,NOUN,B2
+westward,westward,往西,NOUN,B2
+can-exit,can-exit,还出得来,NOUN,B2
+polyester,polyester,涤纶,NOUN,B2
+retrial,retrial,再审,NOUN,B2
+then he,then he,那他,NOUN,B2
+to eavesdrop,to eavesdrop,偷听,VERB,B2
+tie mansion,tie mansion,铁府,NOUN,B2
+not catch up,not catch up,非赶,NOUN,B2
+to give oneself up,to give oneself up,投案,VERB,B2
+good faith,good faith,信义,NOUN,B2
+recycled item,recycled item,再物,NOUN,B2
+non-number,non-number,非数,NOUN,B2
+amended possibility,amended possibility,改可,NOUN,B2
+initial stage,initial stage,初期,NOUN,B2
+social awareness,social awareness,社会觉悟,NOUN,B2
+coral reef,coral reef,珊瑚礁,NOUN,B2
+to send mail,to send mail,寄件,VERB,B2
+death news,death news,死讯,NOUN,B2
+able to play,able to play,能下,NOUN,B2
+supreme fate,supreme fate,上缘,NOUN,B2
+re-tolerance,re-tolerance,再容,NOUN,B2
+white blood cell,white blood cell,白细胞,NOUN,B2
+mock exam,mock exam,模拟考,NOUN,B2
+heavy effect,heavy effect,重效,NOUN,B2
+hearth,hearth,壁炉,NOUN,B2
+to wanted,to wanted,通缉,VERB,B2
+to dry clean,to dry clean,干洗,VERB,B2
+return destination,return destination,回哪,NOUN,B2
+historical site,historical site,古迹,NOUN,B2
+patient sufferer,patient sufferer,患者,NOUN,B2
+simple pure,simple pure,单纯,ADJ,B2
+re-basis,re-basis,再据,NOUN,B2
+taro,taro,芋头,NOUN,B2
+re-route,re-route,重路,NOUN,B2
+listening,listening,也听,NOUN,B2
+stone,stone,石,PART,B2
+main road,main road,主路,NOUN,B2
+sub-method,sub-method,分法,NOUN,B2
+to repeat a grade,to repeat a grade,留级,VERB,B2
+to be proper,to be proper,体统,VERB,B2
+moonlight,moonlight,月色,NOUN,B2
+your word,your word,听你,NOUN,B2
+happy event,happy event,喜事,NOUN,B2
+this sword,this sword,这剑,NOUN,B2
+jujube,jujube,枣子,NOUN,B2
+proclamation,proclamation,宣大,NOUN,B2
+eavesdropping,eavesdropping,偷听,NOUN,B2
+procedural,procedural,程序的,ADJ,B2
+medical care,medical care,医疗,NOUN,B2
+missile,missile,导弹,NOUN,B2
+inside in,inside in,里,NOUN,B2
+great joy,great joy,大喜,NOUN,B2
+direct sales,direct sales,直销,NOUN,B2
+radiotherapy,radiotherapy,放疗,NOUN,B2
+you except,you except,你除,NOUN,B2
+herbicide,herbicide,除草剂,NOUN,B2
+over-degree,over-degree,超阶,NOUN,B2
+core course,core course,核心课,NOUN,B2
+makeup leave,makeup leave,补休,NOUN,B2
+non-theory,non-theory,非论,NOUN,B2
+to not seen,to not seen,不见,VERB,B2
+all at once,all at once,一下子,ADV,B2
+re-verification,re-verification,改证,NOUN,B2
+mutual treatment,mutual treatment,相待,NOUN,B2
+too big,too big,太大,ADJ,B2
+to break a record,to break a record,打破纪录,VERB,B2
+final exam,final exam,期末考,NOUN,B2
+anti-static,anti-static,防静电,ADJ,B2
+boundless,boundless,无疆,NOUN,B2
+to serve as,to serve as,充当,VERB,B2
+to worsen to deteriorate,to worsen to deteriorate,恶化,VERB,B2
+re-substance,re-substance,再质,NOUN,B2
+light rain,light rain,小雨,NOUN,B2
+undercover agent,undercover agent,卧底,NOUN,B2
+little bitch,little bitch,小婊子,NOUN,B2
+who polite,who polite,哪位,PRON,B2
+to pioneer,to pioneer,首创,VERB,B2
+lifelong promise,lifelong promise,许白首不离,NOUN,B2
+over-model,over-model,超模,NOUN,B2
+short rest,short rest,歇一,NOUN,B2
+certain fall,certain fall,必倒,NOUN,B2
+anticyclone,anticyclone,反气旋,NOUN,B2
+safe haven,safe haven,避风港,NOUN,B2
+supply does not meet demand,supply does not meet demand,供不应求,ADJ,B2
+reordering,reordering,改序,NOUN,B2
+grand theater,grand theater,大剧院,NOUN,B2
+air raid,air raid,空袭,NOUN,B2
+to fall down,to fall down,倒下,VERB,B2
+historical record,historical record,历史纪录,NOUN,B2
+re-possibility,re-possibility,重可,NOUN,B2
+larger,larger,再大,NOUN,B2
+wind speed,wind speed,风速,NOUN,B2
+award ceremony,award ceremony,颁奖典礼,NOUN,B2
+super-special,super-special,超特,NOUN,B2
+graduate student,graduate student,研究生,NOUN,B2
+machine learning,machine learning,机器学习,NOUN,B2
+random posting,random posting,乱贴,NOUN,B2
+unwinnable,unwinnable,打不赢,NOUN,B2
+postwar,postwar,战后,NOUN,B2
+crowdfunding,crowdfunding,众筹,NOUN,B2
+antifreeze,antifreeze,防冻剂,NOUN,B2
+third place,third place,季军,NOUN,B2
+family happiness,family happiness,天伦之乐,NOUN,B2
+hot water,hot water,热水,NOUN,B2
+social credit,social credit,社会信用,NOUN,B2
+two days,two days,两天,NUM,B2
+guqin,guqin,古琴,NOUN,B2
+to stock up,to stock up,进货,VERB,B2
+table grape,table grape,提子,NOUN,B2
+reverse thought,reverse thought,反念,NOUN,B2
+over-order,over-order,超序,NOUN,B2
+everyone,everyone,各位,NOUN,B2
+heavy capacity,heavy capacity,重容,NOUN,B2
+mountaineering,mountaineering,登山,NOUN,B2
+pipa,pipa,琵琶,NOUN,B2
+so as not to,so as not to,免得,SCONJ,B2
+war cessation,war cessation,战息,NOUN,B2
+to esteem,to esteem,推崇,VERB,B2
+postdoctoral researcher,postdoctoral researcher,博士后,NOUN,B2
+perilla,perilla,紫苏,NOUN,B2
+re-specialization,re-specialization,重特,NOUN,B2
+panda,panda,熊猫,NOUN,B2
+sum total,sum total,总而,NOUN,B2
+adolescent,adolescent,青少年,NOUN,B2
+rights and interests,rights and interests,权益,NOUN,B2
+you scared me,you scared me,你吓死我,NOUN,B2
+unstoppable,unstoppable,不可阻挡,ADJ,B2
+why bother,why bother,何必,ADV,B2
+overthrow,overthrow,扳倒,NOUN,B2
+chest stab,chest stab,胸刺,NOUN,B2
+to use a wheelchair,to use a wheelchair,坐轮椅,VERB,B2
+rashly,rashly,轻举,ADV,B2
+social structure,social structure,社会结构,NOUN,B2
+revealing,revealing,现出,NOUN,B2
+amended unity,amended unity,改一,NOUN,B2
+hedonistic,hedonistic,享乐主义的,ADJ,B2
+to strive for,to strive for,争取,VERB,B2
+two people,two people,两名,NUM,B2
+social movement,social movement,社会运动,NOUN,B2
+dare gamble,dare gamble,敢赌,NOUN,B2
+change of mind,change of mind,改念,NOUN,B2
+push further,push further,进尺,NOUN,B2
+non-so,non-so,非然,NOUN,B2
+hyper-intent,hyper-intent,超意,NOUN,B2
+to send back,to send back,传回,VERB,B2
+social ethos,social ethos,社会风气,NOUN,B2
+non-observation,non-observation,非察,NOUN,B2
+ceramic art,ceramic art,陶艺,NOUN,B2
+re-observation,re-observation,再观,NOUN,B2
+young wife,young wife,小媳,NOUN,B2
+visibility,visibility,能见度,NOUN,B2
+excretion,excretion,排泄,NOUN,B2
+eavesdrop,eavesdrop,营听,NOUN,B2
+senior,senior,前辈,NOUN,B2
+to wiretap,to wiretap,监听,VERB,B2
+entering home,entering home,进家,NOUN,B2
+hundred million,hundred million,亿,NUM,B2
+ginseng,ginseng,人参,NOUN,B2
+non-sudden,non-sudden,非骤,NOUN,B2
+later stage,later stage,后期,NOUN,B2
+windy day,windy day,风天,NOUN,B2
+nickel,nickel,镍,NOUN,B2
+scenic spot,scenic spot,名胜,NOUN,B2
+great merit,great merit,大功,NOUN,B2
+super-observation,super-observation,超察,NOUN,B2
+big dipper,big dipper,北斗七星,NOUN,B2
+quite good,quite good,挺好,NOUN,B2
+limbs,limbs,手脚,NOUN,B2
+antiseptic,antiseptic,防腐,ADJ,B2
+unsolved case,unsolved case,疑案,NOUN,B2
+golf,golf,高尔夫,NOUN,B2
+xiulian,xiulian,秀莲,NOUN,B2
+to love dearly,to love dearly,心疼,VERB,B2
+military pay,military pay,军饷,NOUN,B2
+over-side,over-side,超方,NOUN,B2
+annual leave,annual leave,年假,NOUN,B2
+to be far from,to be far from,绝非,VERB,B2
+substantive,substantive,实质性的,ADJ,B2
+empress mother,empress mother,你母后,NOUN,B2
+both eyes,both eyes,双眼,NOUN,B2
+rust inhibitor,rust inhibitor,防锈剂,NOUN,B2
+waiter attendant,waiter attendant,服务员,NOUN,B2
+your head,your head,你头上,NOUN,B2
+but majesty,but majesty,可陛,NOUN,B2
+energy saving,energy saving,节能,NOUN,B2
+to use force,to use force,动武,VERB,B2
+to be careful,to be careful,小心,VERB,B2
+national record,national record,全国纪录,NOUN,B2
+to plant trees,to plant trees,植树,VERB,B2
+feel embarrassed or awkward,feel embarrassed or awkward,为难,ADJ,B2
+to work part-time,to work part-time,打工,VERB,B2
+social phenomenon,social phenomenon,社会现象,NOUN,B2
+super-number,super-number,超数,NOUN,B2
+king,king,王,PART,B2
+flanking,flanking,包抄,NOUN,B2
+coincidentally by chance,coincidentally by chance,恰巧,ADV,B2
+snow lotus,snow lotus,雪莲,NOUN,B2
+personal effort,personal effort,亲力,NOUN,B2
+at the instant sth happens,at the instant sth happens,临时,ADV,B2
+next meeting,next meeting,下回遇,NOUN,B2
+to await orders,to await orders,待命,VERB,B2
+equal size,equal size,等大,NOUN,B2
+polar technology,polar technology,极地技术,NOUN,B2
+re-generalization,re-generalization,重般,NOUN,B2
+project report,project report,项目报告,NOUN,B2
+local tyrant,local tyrant,豪强,NOUN,B2
+chinese cabbage,chinese cabbage,白菜,NOUN,B2
+to accounting,to accounting,核算,VERB,B2
+bamboo shoot,bamboo shoot,竹笋,NOUN,B2
+peephole,peephole,门镜,NOUN,B2
+treacherous minister,treacherous minister,奸臣,NOUN,B2
+army morale,army morale,军心,NOUN,B2
+social hierarchy,social hierarchy,社会等级,NOUN,B2
+that is to say,that is to say,也就是说,SCONJ,B2
+value change,value change,改值,NOUN,B2
+what kind,what kind,什么样,PRON,B2
+punitive,punitive,惩罚性的,ADJ,B2
+mediocrity,mediocrity,庸庸碌碌,NOUN,B2
+to follow up,to follow up,追问,VERB,B2
+non-righteousness,non-righteousness,非义,NOUN,B2
+re-admission,re-admission,重纳,NOUN,B2
+your parents,your parents,你爹娘,NOUN,B2
+two sons,two sons,儿俩,NOUN,B2
+re-opportunity,re-opportunity,再机,NOUN,B2
+over-form,over-form,超式,NOUN,B2
+hard to determine,hard to determine,难以确定,ADJ,B2
+outstanding merit,outstanding merit,奇功,NOUN,B2
+don't,don't,可别,AUX,B2
+to be located at,to be located at,位于,VERB,B2
+to commit fraud,to commit fraud,舞弊,VERB,B2
+amber,amber,琥珀,NOUN,B2
+to respond to a lawsuit,to respond to a lawsuit,应诉,VERB,B2
+architecture photo,architecture photo,建筑照,NOUN,B2

--- a/tests/test_build_contract_delivery.py
+++ b/tests/test_build_contract_delivery.py
@@ -109,9 +109,9 @@ def test_build_delivery_rows_dedups_and_ranks_and_keys(tmp_path: Path) -> None:
     assert len(de) == 1  # duplicate merged, lowest level kept
     assert de[0].cefr == "A1"
     assert de[0].rank == 1
-    assert len(es) == 1
     assert es[0].rank == 1
-    assert es[0].concept_key == de[0].concept_key
+    assert es[1].rank == 2
+    assert es[0].concept_key == es[1].concept_key == de[0].concept_key
     assert de[0].concept_key  # non-empty, stable
 
 

--- a/tests/test_check_data_contract.py
+++ b/tests/test_check_data_contract.py
@@ -11,6 +11,7 @@ from check_data_contract import (
     check_ascii,
     check_duplicates,
     check_rank_gaps,
+    check_script_and_substance,
     check_shrunken_glosses,
     load_csv_rows,
     load_delivery_rows,
@@ -219,3 +220,26 @@ def test_load_csv_rows_with_expansion(tmp_path: Path) -> None:
     rows = load_csv_rows(tmp_path)
     assert len(rows) == 2
     assert rows[1].lemma == "Katze"
+
+
+def test_check_script_and_substance_flags_wrong_scripts_and_junk() -> None:
+    valid_rows = [
+        Row("ar", "كتاب", "NOUN", "book", 1),
+        Row("zh", "书", "NOUN", "book", 1),
+        Row("de", "Buch", "NOUN", "book", 1),
+        Row("en", "book", "NOUN", "book", 1),
+    ]
+    assert check_script_and_substance(valid_rows) == []
+
+    invalid_rows = [
+        Row("ar", "book", "NOUN", "book", 1),  # Latin in Arabic
+        Row("zh", "book", "NOUN", "book", 1),  # Latin in Chinese
+        Row("zh", "复合词", "NOUN", "word", 1),  # Junk placeholder
+        Row("de", "", "NOUN", "book", 1),  # Empty lemma
+    ]
+    violations = check_script_and_substance(invalid_rows)
+    assert len(violations) == 4
+    assert any("ar:non_arabic_script:'book'" in v for v in violations)
+    assert any("zh:non_chinese_script:'book'" in v for v in violations)
+    assert any("zh:junk_lemma:'复合词'" in v for v in violations)
+    assert any("de:empty_lemma:'book'" in v for v in violations)


### PR DESCRIPTION
## Summary

Closes #58.

- Reverted fabricated concept completions from PR #57 (commit `0cdb752`).
- Restored authentic multi-rank delivery ranking in `build_contract_delivery.py` and tests.
- Hardened `check_data_contract.py` with **Criterion 6**:
  - Script verification per target language (requires Arabic script for `ar`, Hanzi for `zh`).
  - Blocked forbidden placeholder junk tokens (`复合词`, `名词`, etc.).
  - Blocked empty lemmas.
- Added comprehensive unit tests in `tests/test_check_data_contract.py` covering Criterion 6.
- All 472 unit tests pass green with 86.23% branch coverage.